### PR TITLE
Lambda region nodes now show region name instead of region code

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,22 +7,27 @@ import { LambdaProvider } from './lambda/lambdaProvider';
 import { AWSClientBuilder } from './shared/awsClientBuilder';
 import { ext } from './shared/extensionGlobals';
 import { extensionSettingsPrefix } from './shared/constants';
-import { AWSContext } from './shared/awsContext';
+import { DefaultAwsContext } from './shared/defaultAwsContext';
 import { SettingsConfiguration } from './shared/settingsConfiguration';
 import { AWSStatusBar } from './shared/statusBar';
 import { AWSContextCommands } from './shared/awsContextCommands';
 import { RegionNode } from './lambda/explorer/regionNode';
 import { safeGet } from './shared/extensionUtilities';
+import { AwsContextTreeCollection } from './shared/awsContextTreeCollection';
+import { RegionHelpers } from './shared/regions/regionHelpers';
 
 export async function activate(context: vscode.ExtensionContext) {
 
     nls.config(process.env.VSCODE_NLS_CONFIG)();
 
     ext.context = context;
-    ext.awsContext = new AWSContext(new SettingsConfiguration(extensionSettingsPrefix));
-    ext.awsContextCommands = new AWSContextCommands();
-    ext.sdkClientBuilder = new AWSClientBuilder(ext.awsContext);
-    ext.statusBar = new AWSStatusBar(context);
+    const awsContext = new DefaultAwsContext(new SettingsConfiguration(extensionSettingsPrefix));
+    const awsContextTrees = new AwsContextTreeCollection();
+    const regionProvider = new RegionHelpers();
+
+    ext.awsContextCommands = new AWSContextCommands(awsContext, awsContextTrees, regionProvider);
+    ext.sdkClientBuilder = new AWSClientBuilder(awsContext);
+    ext.statusBar = new AWSStatusBar(awsContext, context);
 
     vscode.commands.registerCommand('aws.login', async () => { await ext.awsContextCommands.onCommandLogin(); });
     vscode.commands.registerCommand('aws.logout', async () => { await ext.awsContextCommands.onCommandLogout(); });
@@ -31,7 +36,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('aws.hideRegion', async (node?: RegionNode) => { await ext.awsContextCommands.onCommandHideRegion(safeGet(node, x => x.regionCode)); });
 
     const providers = [
-        new LambdaProvider()
+        new LambdaProvider(awsContext, awsContextTrees, regionProvider)
     ];
 
     providers.forEach( (p) => {

--- a/src/lambda/commands/getLambdaConfig.ts
+++ b/src/lambda/commands/getLambdaConfig.ts
@@ -7,10 +7,11 @@ import { BaseTemplates } from "../../shared/templates/baseTemplates";
 import { LambdaTemplates } from "../templates/lambdaTemplates";
 import { AWSError } from "aws-sdk";
 import { getSelectedLambdaNode } from "../utils";
+import { AwsContext } from '../../shared/awsContext';
 
-export async function getLambdaConfig(element?: FunctionNode) {
+export async function getLambdaConfig(awsContext: AwsContext, element?: FunctionNode) {
     try {
-        const fn: FunctionNode = await getSelectedLambdaNode(element);
+        const fn: FunctionNode = await getSelectedLambdaNode(awsContext, element);
 
         const view = vscode.window.createWebviewPanel('html', `Getting config for ${fn.functionConfiguration.FunctionName}`, -1);
 

--- a/src/lambda/commands/getLambdaPolicy.ts
+++ b/src/lambda/commands/getLambdaPolicy.ts
@@ -7,10 +7,11 @@ import { BaseTemplates } from "../../shared/templates/baseTemplates";
 import { LambdaTemplates } from "../templates/lambdaTemplates";
 import { AWSError } from "aws-sdk";
 import { getSelectedLambdaNode } from "../utils";
+import { AwsContext } from '../../shared/awsContext';
 
-export async function getLambdaPolicy(element?: FunctionNode) {
+export async function getLambdaPolicy(awsContext:AwsContext, element?: FunctionNode) {
     try {
-        const fn: FunctionNode = await getSelectedLambdaNode(element);
+        const fn: FunctionNode = await getSelectedLambdaNode(awsContext, element);
 
         const view = vscode.window.createWebviewPanel('html', `Getting policy for ${fn.functionConfiguration.FunctionName}`, -1);
         const baseTemplateFn = _.template(BaseTemplates.SimpleHTML);

--- a/src/lambda/commands/invokeLambda.ts
+++ b/src/lambda/commands/invokeLambda.ts
@@ -14,10 +14,11 @@ import { ResourceFetcher } from "../../shared/resourceFetcher";
 import { sampleRequestManifestPath, sampleRequestPath } from "../constants";
 import { SampleRequest } from '../models/sampleRequest';
 import { ExtensionUtilities } from '../../shared/extensionUtilities';
+import { AwsContext } from '../../shared/awsContext';
 
-export async function invokeLambda(element?: FunctionNode) {
+export async function invokeLambda(awsContext:AwsContext, element?: FunctionNode) {
     try {
-        const fn: FunctionNode = await getSelectedLambdaNode(element);
+        const fn: FunctionNode = await getSelectedLambdaNode(awsContext, element);
 
         const view = vscode.window.createWebviewPanel(
             'html',

--- a/src/lambda/explorer/regionNode.ts
+++ b/src/lambda/explorer/regionNode.ts
@@ -23,7 +23,7 @@ export class RegionNode extends AWSRegionTreeNode {
     }
 
     protected getTooltip(): string | undefined {
-        return `${this.getLabel} (${this.regionCode})`;
+        return `${this.getLabel()} [${this.regionCode}]`;
     }
 
     public getChildren(): Thenable<AWSTreeNodeBase[]> {

--- a/src/lambda/utils.ts
+++ b/src/lambda/utils.ts
@@ -6,8 +6,9 @@ import { ext } from '../shared/extensionGlobals';
 import { FunctionNode } from './explorer/functionNode';
 import { quickPickLambda } from './commands/quickPickLambda';
 import Lambda = require('aws-sdk/clients/lambda');
+import { AwsContext } from '../shared/awsContext';
 
-export async function getSelectedLambdaNode(element?: FunctionNode): Promise<FunctionNode> {
+export async function getSelectedLambdaNode(awsContext: AwsContext, element?: FunctionNode): Promise<FunctionNode> {
     if (element && element.functionConfiguration) {
         console.log('returning preselected node...');
         return element;
@@ -17,7 +18,7 @@ export async function getSelectedLambdaNode(element?: FunctionNode): Promise<Fun
 
     // TODO: we need to change this into a multi-step command to first obtain the region,
     // then query the lambdas in the region
-    const regions = await ext.awsContext.getExplorerRegions();
+    const regions = await awsContext.getExplorerRegions();
     if (regions.length === 0) {
         throw new Error('No regions defined for explorer, required until we have a multi-stage picker');
     }

--- a/src/shared/awsClientBuilder.ts
+++ b/src/shared/awsClientBuilder.ts
@@ -1,23 +1,23 @@
 'use strict';
 
-import { AWSContext } from './awsContext';
+import { AwsContext } from './awsContext';
 
 export class AWSClientBuilder {
 
-    private awsContext: AWSContext;
+    private _awsContext: AwsContext;
 
-    constructor(awsContext: AWSContext) {
-        this.awsContext = awsContext;
+    constructor(awsContext: AwsContext) {
+        this._awsContext = awsContext;
 
     }
 
     // centralized construction of transient AWS service clients, allowing us
     // to customize requests and/or user agent
-    public async createAndConfigureSdkClient(awsService: any, awsServiceOpts: any | undefined, region: string | undefined) : Promise<any> {
+    public async createAndConfigureSdkClient(awsService: any, awsServiceOpts: any | undefined, region: string | undefined): Promise<any> {
 
         if (awsServiceOpts) {
             if (!awsServiceOpts.credentials) {
-                awsServiceOpts.credentials = await this.awsContext.getCredentials();
+                awsServiceOpts.credentials = await this._awsContext.getCredentials();
             }
             if (!awsServiceOpts.region && region) {
                 awsServiceOpts.region = region;
@@ -27,7 +27,7 @@ export class AWSClientBuilder {
         }
 
         return new awsService({
-            credentials: await this.awsContext.getCredentials(),
+            credentials: await this._awsContext.getCredentials(),
             region: region
         });
     }

--- a/src/shared/awsContext.ts
+++ b/src/shared/awsContext.ts
@@ -1,96 +1,24 @@
 'use strict';
 
-import * as AWS from 'aws-sdk';
 import * as vscode from 'vscode';
-import { regionSettingKey, profileSettingKey } from './constants';
-import { ISettingsConfiguration } from './settingsConfiguration';
+import { ContextChangeEventsArgs } from './defaultAwsContext';
 
-// Carries the current context data on events
-export class ContextChangeEventsArgs {
-    constructor(public profileName: string | undefined, public regions: string[]) {
-    }
-}
+// Represents a credential profile and zero or more regions.
+export interface AwsContext {
 
-// Wraps an AWS context in terms of credential profile and zero or more regions. The
-// context listens for configuration updates and resets the context accordingly.
-export class AWSContext {
+    onDidChangeContext: vscode.Event<ContextChangeEventsArgs>;
 
-    private _onDidChangeContext: vscode.EventEmitter<ContextChangeEventsArgs> = new vscode.EventEmitter<ContextChangeEventsArgs>();
-    public readonly onDidChangeContext: vscode.Event<ContextChangeEventsArgs> = this._onDidChangeContext.event;
-
-    // the collection of regions the user has expressed an interest in working with in
-    // the current workspace
-    private explorerRegions: string[];
-
-    // the user's credential context (currently this maps to an sdk/cli credential profile)
-    private profileName: string | undefined;
-
-    constructor(public settingsConfiguration: ISettingsConfiguration) {
-
-        this.profileName = settingsConfiguration.readSetting(profileSettingKey, '');
-        const persistedRegions = settingsConfiguration.readSetting(regionSettingKey, undefined);
-        if (persistedRegions) {
-            this.explorerRegions = persistedRegions.split(',');
-        } else {
-            this.explorerRegions = [];
-        }
-    }
-
-    // async so that we could *potentially* support other ways of obtaining
-    // credentials in future - for example from instance metadata if the
-    // user was running Code on an EC2 instance.
-    public async getCredentials() : Promise<AWS.Credentials | undefined> {
-        if (this.profileName) {
-            return new AWS.SharedIniFileCredentials({profile: this.profileName});
-        }
-
-        return undefined;
-    }
+    getCredentials(): Promise<AWS.Credentials | undefined>;
 
     // returns the configured profile, if any
-    public getCredentialProfileName() : string | undefined {
-        return this.profileName;
-    }
-
+    getCredentialProfileName(): string | undefined;
     // resets the context to the indicated profile, saving it into settings
-    public async setCredentialProfileName(profileName?: string) : Promise<void> {
-        this.profileName = profileName;
-        await this.settingsConfiguration.writeSetting(profileSettingKey, profileName, vscode.ConfigurationTarget.Global);
-        this._onDidChangeContext.fire(new ContextChangeEventsArgs(this.profileName, this.explorerRegions));
-    }
+    setCredentialProfileName(profileName?: string): Promise<void>;
 
-    // async so that we could *potentially* support other ways of obtaining
-    // region in future - for example from instance metadata if the
-    // user was running Code on an EC2 instance.
-    public async getExplorerRegions(): Promise<string[]> {
-        return this.explorerRegions;
-    }
+    getExplorerRegions(): Promise<string[]>;
 
-    // adds one or more regions into the preferred set, persisting the set afterwards as a
-    // comma-separated string.
-    public async addExplorerRegion(region: string | string[]) : Promise<void> {
-        const regionsToProcess: string[] = region instanceof Array ? region : [region];
-        regionsToProcess.forEach(r => {
-            const index = this.explorerRegions.findIndex(r => r === region);
-            if (index === -1) {
-                this.explorerRegions.push(r);
-            }
-        });
-        await this.settingsConfiguration.writeSetting(regionSettingKey, this.explorerRegions, vscode.ConfigurationTarget.Global);
-        this._onDidChangeContext.fire(new ContextChangeEventsArgs(this.profileName, this.explorerRegions));
-    }
-
-    // removes one or more regions from the user's preferred set, persisting the set afterwards as a
-    // comma-separated string.
-    public async removeExplorerRegion(region: string | string[]) : Promise<void> {
-        const regionsToProcess: string[] = region instanceof Array ? region : [region];
-        regionsToProcess.forEach(r => {
-            const index = this.explorerRegions.findIndex(r => r === region);
-            if (index >= 0) {
-                this.explorerRegions.splice(index, 1);
-            }
-        });
-        await this.settingsConfiguration.writeSetting(regionSettingKey, this.explorerRegions, vscode.ConfigurationTarget.Global);
-        this._onDidChangeContext.fire(new ContextChangeEventsArgs(this.profileName, this.explorerRegions));
-    }
+    // adds one or more regions into the preferred set
+    addExplorerRegion(region: string | string[]): Promise<void>;
+    // removes one or more regions from the user's preferred set
+    removeExplorerRegion(region: string | string[]): Promise<void>;
 }

--- a/src/shared/awsContextTreeCollection.ts
+++ b/src/shared/awsContextTreeCollection.ts
@@ -1,0 +1,22 @@
+'use strict';
+
+import { AwsContext } from './awsContext';
+import { IRefreshableAWSTreeProvider } from '../shared/treeview/IAWSTreeProvider';
+
+export class AwsContextTreeCollection {
+    private _trees: IRefreshableAWSTreeProvider[];
+
+    constructor() {
+        this._trees = [];
+    }
+
+    public addTree(tree: IRefreshableAWSTreeProvider): void {
+        this._trees.push(tree);
+    }
+
+    public refreshTrees(awsContext: AwsContext): void {
+        this._trees.forEach(t => {
+            t.refresh(awsContext);
+        });
+    }
+}

--- a/src/shared/defaultAwsContext.ts
+++ b/src/shared/defaultAwsContext.ts
@@ -1,0 +1,97 @@
+'use strict';
+
+import * as AWS from 'aws-sdk';
+import * as vscode from 'vscode';
+import { regionSettingKey, profileSettingKey } from './constants';
+import { AwsContext } from './awsContext';
+import { ISettingsConfiguration } from './settingsConfiguration';
+
+// Carries the current context data on events
+export class ContextChangeEventsArgs {
+    constructor(public profileName: string | undefined, public regions: string[]) {
+    }
+}
+
+// Wraps an AWS context in terms of credential profile and zero or more regions. The
+// context listens for configuration updates and resets the context accordingly.
+export class DefaultAwsContext implements AwsContext {
+
+    private _onDidChangeContext: vscode.EventEmitter<ContextChangeEventsArgs> = new vscode.EventEmitter<ContextChangeEventsArgs>();
+    public readonly onDidChangeContext: vscode.Event<ContextChangeEventsArgs> = this._onDidChangeContext.event;
+
+    // the collection of regions the user has expressed an interest in working with in
+    // the current workspace
+    private explorerRegions: string[];
+
+    // the user's credential context (currently this maps to an sdk/cli credential profile)
+    private profileName: string | undefined;
+
+    constructor(public settingsConfiguration: ISettingsConfiguration) {
+
+        this.profileName = settingsConfiguration.readSetting(profileSettingKey, '');
+        const persistedRegions = settingsConfiguration.readSetting(regionSettingKey, undefined);
+        if (persistedRegions) {
+            this.explorerRegions = persistedRegions.split(',');
+        } else {
+            this.explorerRegions = [];
+        }
+    }
+
+    // async so that we could *potentially* support other ways of obtaining
+    // credentials in future - for example from instance metadata if the
+    // user was running Code on an EC2 instance.
+    public async getCredentials() : Promise<AWS.Credentials | undefined> {
+        if (this.profileName) {
+            return new AWS.SharedIniFileCredentials({profile: this.profileName});
+        }
+
+        return undefined;
+    }
+
+    // returns the configured profile, if any
+    public getCredentialProfileName() : string | undefined {
+        return this.profileName;
+    }
+
+    // resets the context to the indicated profile, saving it into settings
+    public async setCredentialProfileName(profileName?: string) : Promise<void> {
+        this.profileName = profileName;
+        await this.settingsConfiguration.writeSetting(profileSettingKey, profileName, vscode.ConfigurationTarget.Global);
+        this._onDidChangeContext.fire(new ContextChangeEventsArgs(this.profileName, this.explorerRegions));
+    }
+
+    // async so that we could *potentially* support other ways of obtaining
+    // region in future - for example from instance metadata if the
+    // user was running Code on an EC2 instance.
+    public async getExplorerRegions(): Promise<string[]> {
+        return this.explorerRegions;
+    }
+
+    // adds one or more regions into the preferred set, persisting the set afterwards as a
+    // comma-separated string.
+    public async addExplorerRegion(region: string | string[]) : Promise<void> {
+        const regionsToProcess: string[] = region instanceof Array ? region : [region];
+        regionsToProcess.forEach(r => {
+            const index = this.explorerRegions.findIndex(r => r === region);
+            if (index === -1) {
+                this.explorerRegions.push(r);
+            }
+        });
+        await this.settingsConfiguration.writeSetting(regionSettingKey, this.explorerRegions, vscode.ConfigurationTarget.Global);
+        this._onDidChangeContext.fire(new ContextChangeEventsArgs(this.profileName, this.explorerRegions));
+    }
+
+    // removes one or more regions from the user's preferred set, persisting the set afterwards as a
+    // comma-separated string.
+    public async removeExplorerRegion(region: string | string[]) : Promise<void> {
+        const regionsToProcess: string[] = region instanceof Array ? region : [region];
+        regionsToProcess.forEach(r => {
+            const index = this.explorerRegions.findIndex(r => r === region);
+            if (index >= 0) {
+                this.explorerRegions.splice(index, 1);
+            }
+        });
+        await this.settingsConfiguration.writeSetting(regionSettingKey, this.explorerRegions, vscode.ConfigurationTarget.Global);
+        this._onDidChangeContext.fire(new ContextChangeEventsArgs(this.profileName, this.explorerRegions));
+    }
+}

--- a/src/shared/extensionGlobals.ts
+++ b/src/shared/extensionGlobals.ts
@@ -2,7 +2,6 @@
 
 import { ExtensionContext, OutputChannel } from 'vscode';
 import { AWSClientBuilder } from './awsClientBuilder';
-import { AWSContext } from './awsContext';
 import { IRefreshableAWSTreeProvider } from './treeview/IAWSTreeProvider';
 import { AWSStatusBar } from './statusBar';
 import { AWSContextCommands } from './awsContextCommands';
@@ -14,7 +13,6 @@ import { AWSContextCommands } from './awsContextCommands';
 export namespace ext {
     export let context: ExtensionContext;
     export let outputChannel: OutputChannel;
-    export let awsContext: AWSContext;
     export let awsContextCommands: AWSContextCommands;
     export let sdkClientBuilder: AWSClientBuilder;
     export let statusBar: AWSStatusBar;

--- a/src/shared/regions/regionHelpers.ts
+++ b/src/shared/regions/regionHelpers.ts
@@ -4,6 +4,7 @@ import path = require('path');
 import { ResourceFetcher } from "../resourceFetcher";
 import { endpointsFileUrl } from '../constants';
 import { ext } from "../extensionGlobals";
+import { RegionProvider } from "./regionProvider";
 
 export class RegionInfo {
 
@@ -11,12 +12,12 @@ export class RegionInfo {
     }
 }
 
-export abstract class RegionHelpers {
+export class RegionHelpers implements RegionProvider {
 
     // Returns an object whose keys are the region codes (us-east-1 etc) and
     // the values are the long-form names.
     // TODO: implement some form of cache?
-    public static async fetchLatestRegionData(): Promise<RegionInfo[]> {
+    public async fetchLatestRegionData(): Promise<RegionInfo[]> {
         let availableRegions: RegionInfo[] = [];
 
         try {

--- a/src/shared/regions/regionProvider.ts
+++ b/src/shared/regions/regionProvider.ts
@@ -1,0 +1,8 @@
+'use strict';
+
+import { RegionInfo } from "./regionHelpers";
+
+// Provides AWS Region Information
+export interface RegionProvider {
+    fetchLatestRegionData(): Promise<RegionInfo[]>;
+}

--- a/src/shared/statusBar.ts
+++ b/src/shared/statusBar.ts
@@ -4,20 +4,24 @@ import * as nls from 'vscode-nls';
 let localize = nls.loadMessageBundle();
 
 import { ExtensionContext, window, StatusBarItem, StatusBarAlignment } from 'vscode';
-import { ext } from './extensionGlobals';
-import { ContextChangeEventsArgs } from './awsContext';
+import { ContextChangeEventsArgs } from './defaultAwsContext';
+import { AwsContext } from './awsContext';
 
 // may want to have multiple elements of data on the status bar,
 // so wrapping in a class to allow for per-element update capability
 export class AWSStatusBar {
 
+    private _awsContext: AwsContext;
+
     public readonly credentialContext: StatusBarItem;
 
-    constructor(context: ExtensionContext) {
+    constructor(awsContext: AwsContext, context: ExtensionContext) {
+        this._awsContext = awsContext;
+
         this.credentialContext = window.createStatusBarItem(StatusBarAlignment.Right, 100);
         context.subscriptions.push(this.credentialContext);
 
-        ext.awsContext.onDidChangeContext((context) => {
+        this._awsContext.onDidChangeContext((context) => {
             this.updateContext(context);
         });
     }
@@ -29,7 +33,7 @@ export class AWSStatusBar {
             profileName = eventContext.profileName;
         }
         else {
-            profileName = ext.awsContext.getCredentialProfileName();
+            profileName = this._awsContext.getCredentialProfileName();
         }
 
         if (profileName) {

--- a/src/shared/treeview/IAWSTreeProvider.ts
+++ b/src/shared/treeview/IAWSTreeProvider.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { AWSContext } from "../awsContext";
+import { AwsContext } from "../awsContext";
 
 export interface IAWSTreeProvider {
     viewProviderId: string;
@@ -9,6 +9,6 @@ export interface IAWSTreeProvider {
 }
 
 export interface IRefreshableAWSTreeProvider extends IAWSTreeProvider {
-    refresh(newContext?: AWSContext): void;
+    refresh(newContext?: AwsContext): void;
 }
 

--- a/src/shared/treeview/awsTreeNodeBase.ts
+++ b/src/shared/treeview/awsTreeNodeBase.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import { Command, Disposable, TreeItem } from 'vscode';
-import { AWSContext } from '../awsContext';
+import { AwsContext } from '../awsContext';
 
 export abstract class AWSTreeNodeBase extends Disposable {
 
@@ -31,7 +31,7 @@ export abstract class AWSTreeNodeBase extends Disposable {
         return undefined;
     }
 
-    public refresh(newContext: AWSContext): void { }
+    public refresh(newContext: AwsContext): void { }
 
     public resetChildren(): void {
         if (this.children !== undefined) {

--- a/src/test/defaultAwsContext.test.ts
+++ b/src/test/defaultAwsContext.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { AWSContext } from '../shared/awsContext';
+import { DefaultAwsContext } from '../shared/defaultAwsContext';
 import { ISettingsConfiguration } from '../shared/settingsConfiguration';
 import { ConfigurationTarget } from 'vscode';
 import { regionSettingKey, profileSettingKey } from '../shared/constants';
@@ -33,7 +33,7 @@ suite("AWSContext Tests", function (): void {
 
         }
 
-        const testContext = new AWSContext(new TestConfiguration());
+        const testContext = new DefaultAwsContext(new TestConfiguration());
         assert.equal(testContext.getCredentialProfileName(), testProfileValue);
     });
 
@@ -50,7 +50,7 @@ suite("AWSContext Tests", function (): void {
         }
 
 
-        const testContext = new AWSContext(new TestConfiguration());
+        const testContext = new DefaultAwsContext(new TestConfiguration());
         const regions = await testContext.getExplorerRegions();
         assert.equal(regions.length, 1);
         assert.equal(regions[0], testRegion1Value);
@@ -69,7 +69,7 @@ suite("AWSContext Tests", function (): void {
         }
 
 
-        const testContext = new AWSContext(new TestConfiguration());
+        const testContext = new DefaultAwsContext(new TestConfiguration());
         const regions = await testContext.getExplorerRegions();
         assert.equal(regions.length, 2);
         assert.equal(regions[0], testRegion1Value);
@@ -86,7 +86,7 @@ suite("AWSContext Tests", function (): void {
             }
         }
 
-        const testContext = new AWSContext(new TestConfiguration());
+        const testContext = new DefaultAwsContext(new TestConfiguration());
         testContext.addExplorerRegion(testRegion1Value);
     });
 
@@ -100,7 +100,7 @@ suite("AWSContext Tests", function (): void {
             }
         }
 
-        const testContext = new AWSContext(new TestConfiguration());
+        const testContext = new DefaultAwsContext(new TestConfiguration());
         testContext.addExplorerRegion([ testRegion1Value, testRegion2Value ]);
     });
 
@@ -121,7 +121,7 @@ suite("AWSContext Tests", function (): void {
             }
         }
 
-        const testContext = new AWSContext(new TestConfiguration());
+        const testContext = new DefaultAwsContext(new TestConfiguration());
         testContext.removeExplorerRegion([ testRegion2Value ]);
     });
 
@@ -135,13 +135,13 @@ suite("AWSContext Tests", function (): void {
             }
         }
 
-        const testContext = new AWSContext(new TestConfiguration());
+        const testContext = new DefaultAwsContext(new TestConfiguration());
         testContext.addExplorerRegion(testRegion1Value);
     });
 
     test('context fires event on single region change', function(done) {
 
-        const testContext = new AWSContext(new ContextTestsSettingsConfigurationBase());
+        const testContext = new DefaultAwsContext(new ContextTestsSettingsConfigurationBase());
 
         testContext.onDidChangeContext((c) => {
             assert.equal(c.regions.length, 1);
@@ -154,7 +154,7 @@ suite("AWSContext Tests", function (): void {
 
     test('context fires event on multi region change', function(done) {
 
-        const testContext = new AWSContext(new ContextTestsSettingsConfigurationBase());
+        const testContext = new DefaultAwsContext(new ContextTestsSettingsConfigurationBase());
 
         testContext.onDidChangeContext((c) => {
             assert.equal(c.regions.length, 2);
@@ -168,7 +168,7 @@ suite("AWSContext Tests", function (): void {
 
     test('context fires event on profile change', function(done) {
 
-        const testContext = new AWSContext(new ContextTestsSettingsConfigurationBase());
+        const testContext = new DefaultAwsContext(new ContextTestsSettingsConfigurationBase());
 
         testContext.onDidChangeContext((c) => {
             assert.equal(c.profileName, testProfileValue);

--- a/src/test/lambdaProvider.test.ts
+++ b/src/test/lambdaProvider.test.ts
@@ -1,0 +1,70 @@
+import * as assert from 'assert';
+import * as AWS from 'aws-sdk';
+import * as vscode from 'vscode';
+import { LambdaProvider } from '../lambda/lambdaProvider';
+import { RegionNode } from '../lambda/explorer/regionNode';
+import { ContextChangeEventsArgs } from '../shared/defaultAwsContext';
+import { AwsContextTreeCollection } from '../shared/awsContextTreeCollection';
+import { AwsContext } from '../shared/awsContext';
+import { RegionInfo } from '../shared/regions/regionHelpers';
+import { RegionProvider } from '../shared/regions/regionProvider';
+
+suite("LambdaProvider Tests", function (): void {
+
+    test('region nodes display the user-friendly region name', function () {
+
+        const regionCode = "regionQuerty";
+        const regionName = "The Querty Region";
+
+        // TODO : Introduce Mocking instead of stub implementations
+        class FakeRegionProvider implements RegionProvider {
+            fetchLatestRegionData(): Promise<RegionInfo[]> {
+                return Promise.resolve([new RegionInfo(regionCode, regionName)]);
+            }
+        }
+
+        class FakeAwsContext implements AwsContext {
+            onDidChangeContext: vscode.Event<ContextChangeEventsArgs> = new vscode.EventEmitter<ContextChangeEventsArgs>().event;
+            getCredentials(): Promise<AWS.Credentials | undefined> {
+                throw new Error("Method not implemented.");
+            }
+            getCredentialProfileName(): string | undefined {
+                return "qwerty";
+            }
+            setCredentialProfileName(profileName?: string | undefined): Promise<void> {
+                throw new Error("Method not implemented.");
+            }
+            getExplorerRegions(): Promise<string[]> {
+                const regions = [];
+                regions.push(regionCode);
+
+                return Promise.resolve(regions);
+            }
+            addExplorerRegion(region: string | string[]): Promise<void> {
+                throw new Error("Method not implemented.");
+            }
+            removeExplorerRegion(region: string | string[]): Promise<void> {
+                throw new Error("Method not implemented.");
+            }
+        }
+
+        const awsContext = new FakeAwsContext();
+        const regionProvider = new FakeRegionProvider();
+        const awsContextTreeCollection = new AwsContextTreeCollection();
+
+        const lambdaProvider = new LambdaProvider(awsContext, awsContextTreeCollection, regionProvider);
+
+        const treeNodes = lambdaProvider.getChildren();
+
+        assert(treeNodes);
+        treeNodes.then(treeNodes => {
+            assert(treeNodes);
+            assert.equal(treeNodes.length, 1);
+
+            const regionNode = treeNodes[0] as RegionNode;
+            assert(regionNode);
+            assert.equal(regionNode.regionCode, regionCode);
+            assert.equal(regionNode.regionName, regionName);
+        });
+    });
+});


### PR DESCRIPTION
Also:
* Fixed issue where tooltip wasn't properly showing region name and code
* Started shifting some code to make codebase easier to unit test
  * `AWSContext` has `IAWSContext` interface
  * `RegionHelpers` has `IRegionProvider` interface
  * Encapsulate `IRefreshableAWSTreeProvider` collection in `AwsContextTreeCollection`

*Issue #, if available:*
Issue #32 

*Description of changes:*

![image](https://user-images.githubusercontent.com/39839589/45316277-7c44d480-b4eb-11e8-8dfc-03e2c12eb68a.png)

You can see the region name in the tree, and the tooltip contains both region name and code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
