### PR TITLE
Prompts for access key and secret key no longer disappear on focus loss or application change

### DIFF
--- a/src/shared/credentials/credentialProfileSelector.ts
+++ b/src/shared/credentials/credentialProfileSelector.ts
@@ -65,6 +65,7 @@ export class CredentialSelectionDataProvider implements ICredentialSelectionData
             value: '',
             prompt: localize('AWS.placeHolder.inputAccessKey', 'Input the AWS Access Key'),
             validate: this.validateAccessKey,
+            ignoreFocusOut: true,
             shouldResume: this.shouldResume
         });
     }
@@ -77,6 +78,7 @@ export class CredentialSelectionDataProvider implements ICredentialSelectionData
             value: '',
             prompt: localize('AWS.placeHolder.inputSecretKey', 'Input the AWS Secret Key'),
             validate: this.validateSecretKey,
+            ignoreFocusOut: true,
             shouldResume: this.shouldResume
         });
     }

--- a/src/shared/multiStepInputFlowController.ts
+++ b/src/shared/multiStepInputFlowController.ts
@@ -33,6 +33,7 @@ interface InputBoxParameters {
     prompt: string;
     validate: (value: string) => Promise<string | undefined>;
     buttons?: QuickInputButton[];
+    ignoreFocusOut?: boolean;
     shouldResume: () => Thenable<boolean>;
 }
 
@@ -118,7 +119,7 @@ export class MultiStepInputFlowController {
         }
     }
 
-    async showInputBox<P extends InputBoxParameters>({ title, step, totalSteps, value, prompt, validate, buttons, shouldResume }: P) {
+    async showInputBox<P extends InputBoxParameters>({ title, step, totalSteps, value, prompt, validate, buttons, ignoreFocusOut, shouldResume }: P) {
         const disposables: Disposable[] = [];
         try {
             return await new Promise<string | (P extends { buttons: (infer I)[] } ? I : never)>((resolve, reject) => {
@@ -132,6 +133,7 @@ export class MultiStepInputFlowController {
                     ...(this.steps.length > 1 ? [QuickInputButtons.Back] : []),
                     ...(buttons || [])
                 ];
+                input.ignoreFocusOut = ignoreFocusOut ? ignoreFocusOut : false;
                 let validating = validate('');
                 disposables.push(
                     input.onDidTriggerButton(item => {


### PR DESCRIPTION
*Description of changes:*
When users enter the "Add credentials" flow, the input box would disappear if you switched applications to copy credentials from another location. The input boxes now remain for access key and secret key.

I decided to keep the initial input that prompts for a profile name as-is (it will disappear on focus loss), as the user has not invested any effort at this point (there is no entry data to lose), and it is the initial stage of a multi-question input.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
