### PR TITLE
Remove EOL semicolons, and enforce through tslint.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,52 +1,52 @@
-'use strict';
+'use strict'
 
-import * as vscode from 'vscode';
-import * as nls from 'vscode-nls';
+import * as vscode from 'vscode'
+import * as nls from 'vscode-nls'
 
-import { LambdaProvider } from './lambda/lambdaProvider';
-import { AWSClientBuilder } from './shared/awsClientBuilder';
-import { ext } from './shared/extensionGlobals';
-import { extensionSettingsPrefix } from './shared/constants';
-import { DefaultAwsContext } from './shared/defaultAwsContext';
-import { DefaultSettingsConfiguration } from './shared/settingsConfiguration';
-import { AWSStatusBar } from './shared/statusBar';
-import { AWSContextCommands } from './shared/awsContextCommands';
-import { RegionNode } from './lambda/explorer/regionNode';
-import { safeGet } from './shared/extensionUtilities';
-import { AwsContextTreeCollection } from './shared/awsContextTreeCollection';
-import { DefaultRegionProvider } from './shared/regions/defaultRegionProvider';
-import { DefaultResourceFetcher } from './shared/defaultResourceFetcher';
+import { LambdaProvider } from './lambda/lambdaProvider'
+import { AWSClientBuilder } from './shared/awsClientBuilder'
+import { ext } from './shared/extensionGlobals'
+import { extensionSettingsPrefix } from './shared/constants'
+import { DefaultAwsContext } from './shared/defaultAwsContext'
+import { DefaultSettingsConfiguration } from './shared/settingsConfiguration'
+import { AWSStatusBar } from './shared/statusBar'
+import { AWSContextCommands } from './shared/awsContextCommands'
+import { RegionNode } from './lambda/explorer/regionNode'
+import { safeGet } from './shared/extensionUtilities'
+import { AwsContextTreeCollection } from './shared/awsContextTreeCollection'
+import { DefaultRegionProvider } from './shared/regions/defaultRegionProvider'
+import { DefaultResourceFetcher } from './shared/defaultResourceFetcher'
 
 export async function activate(context: vscode.ExtensionContext) {
 
-    nls.config(process.env.VSCODE_NLS_CONFIG)();
+    nls.config(process.env.VSCODE_NLS_CONFIG)()
 
-    ext.context = context;
-    const awsContext = new DefaultAwsContext(new DefaultSettingsConfiguration(extensionSettingsPrefix));
-    const awsContextTrees = new AwsContextTreeCollection();
-    const resourceFetcher = new DefaultResourceFetcher();
-    const regionProvider = new DefaultRegionProvider(context, resourceFetcher);
+    ext.context = context
+    const awsContext = new DefaultAwsContext(new DefaultSettingsConfiguration(extensionSettingsPrefix))
+    const awsContextTrees = new AwsContextTreeCollection()
+    const resourceFetcher = new DefaultResourceFetcher()
+    const regionProvider = new DefaultRegionProvider(context, resourceFetcher)
 
-    ext.awsContextCommands = new AWSContextCommands(awsContext, awsContextTrees, regionProvider);
-    ext.sdkClientBuilder = new AWSClientBuilder(awsContext);
-    ext.statusBar = new AWSStatusBar(awsContext, context);
+    ext.awsContextCommands = new AWSContextCommands(awsContext, awsContextTrees, regionProvider)
+    ext.sdkClientBuilder = new AWSClientBuilder(awsContext)
+    ext.statusBar = new AWSStatusBar(awsContext, context)
 
-    vscode.commands.registerCommand('aws.login', async () => { await ext.awsContextCommands.onCommandLogin(); });
-    vscode.commands.registerCommand('aws.logout', async () => { await ext.awsContextCommands.onCommandLogout(); });
+    vscode.commands.registerCommand('aws.login', async () => { await ext.awsContextCommands.onCommandLogin() })
+    vscode.commands.registerCommand('aws.logout', async () => { await ext.awsContextCommands.onCommandLogout() })
 
-    vscode.commands.registerCommand('aws.showRegion', async () => { await ext.awsContextCommands.onCommandShowRegion(); });
-    vscode.commands.registerCommand('aws.hideRegion', async (node?: RegionNode) => { await ext.awsContextCommands.onCommandHideRegion(safeGet(node, x => x.regionCode)); });
+    vscode.commands.registerCommand('aws.showRegion', async () => { await ext.awsContextCommands.onCommandShowRegion() })
+    vscode.commands.registerCommand('aws.hideRegion', async (node?: RegionNode) => { await ext.awsContextCommands.onCommandHideRegion(safeGet(node, x => x.regionCode)) })
 
     const providers = [
         new LambdaProvider(awsContext, awsContextTrees, regionProvider, resourceFetcher)
-    ];
+    ]
 
     providers.forEach((p) => {
-        p.initialize();
-        context.subscriptions.push(vscode.window.registerTreeDataProvider(p.viewProviderId, p));
-    });
+        p.initialize()
+        context.subscriptions.push(vscode.window.registerTreeDataProvider(p.viewProviderId, p))
+    })
 
-    ext.statusBar.updateContext(undefined);
+    ext.statusBar.updateContext(undefined)
 }
 
 export function deactivate() {

--- a/src/lambda/commands/deployLambda.ts
+++ b/src/lambda/commands/deployLambda.ts
@@ -1,14 +1,14 @@
-'use strict';
+'use strict'
 
-import * as vscode from 'vscode';
-import { FunctionNode } from "../explorer/functionNode";
+import * as vscode from 'vscode'
+import { FunctionNode } from "../explorer/functionNode"
 
 export async function deployLambda(element?: FunctionNode) {
     try {
         // TODO: trigger build/package and deploy sequence appropriate to
         // the implementation language. We'll need some form of controller
         // abstraction around the various implementations.
-        vscode.window.showInformationMessage('Not yet implemented!');
+        vscode.window.showInformationMessage('Not yet implemented!')
     } catch (err) {
 
     }

--- a/src/lambda/commands/getLambdaConfig.ts
+++ b/src/lambda/commands/getLambdaConfig.ts
@@ -1,33 +1,33 @@
-'use strict';
+'use strict'
 
-import { FunctionNode } from "../explorer/functionNode";
-import * as vscode from 'vscode';
-import _ = require("lodash");
-import { BaseTemplates } from "../../shared/templates/baseTemplates";
-import { LambdaTemplates } from "../templates/lambdaTemplates";
-import { AWSError } from "aws-sdk";
-import { getSelectedLambdaNode } from "../utils";
-import { AwsContext } from '../../shared/awsContext';
+import { FunctionNode } from "../explorer/functionNode"
+import * as vscode from 'vscode'
+import _ = require("lodash")
+import { BaseTemplates } from "../../shared/templates/baseTemplates"
+import { LambdaTemplates } from "../templates/lambdaTemplates"
+import { AWSError } from "aws-sdk"
+import { getSelectedLambdaNode } from "../utils"
+import { AwsContext } from '../../shared/awsContext'
 
 export async function getLambdaConfig(awsContext: AwsContext, element?: FunctionNode) {
     try {
-        const fn: FunctionNode = await getSelectedLambdaNode(awsContext, element);
+        const fn: FunctionNode = await getSelectedLambdaNode(awsContext, element)
 
-        const view = vscode.window.createWebviewPanel('html', `Getting config for ${fn.functionConfiguration.FunctionName}`, -1);
+        const view = vscode.window.createWebviewPanel('html', `Getting config for ${fn.functionConfiguration.FunctionName}`, -1)
 
-        const baseTemplateFn = _.template(BaseTemplates.SimpleHTML);
-        view.webview.html = baseTemplateFn({ content: `<h1>Loading...</h1>` });
+        const baseTemplateFn = _.template(BaseTemplates.SimpleHTML)
+        view.webview.html = baseTemplateFn({ content: `<h1>Loading...</h1>` })
         const funcResponse = await fn.lambda.getFunctionConfiguration({
             FunctionName: fn.functionConfiguration.FunctionName!
-        }).promise();
+        }).promise()
 
-        const getConfigTemplateFn = _.template(LambdaTemplates.GetConfigTemplate);
+        const getConfigTemplateFn = _.template(LambdaTemplates.GetConfigTemplate)
         view.webview.html = baseTemplateFn({
             content: getConfigTemplateFn(funcResponse)
-        });
+        })
     }
     catch (err) {
-        const ex: AWSError = err;
-        console.log(ex.message);
+        const ex: AWSError = err
+        console.log(ex.message)
     }
 }

--- a/src/lambda/commands/getLambdaPolicy.ts
+++ b/src/lambda/commands/getLambdaPolicy.ts
@@ -1,32 +1,32 @@
-'use strict';
+'use strict'
 
-import { FunctionNode } from "../explorer/functionNode";
-import * as vscode from 'vscode';
-import _ = require("lodash");
-import { BaseTemplates } from "../../shared/templates/baseTemplates";
-import { LambdaTemplates } from "../templates/lambdaTemplates";
-import { AWSError } from "aws-sdk";
-import { getSelectedLambdaNode } from "../utils";
-import { AwsContext } from '../../shared/awsContext';
+import { FunctionNode } from "../explorer/functionNode"
+import * as vscode from 'vscode'
+import _ = require("lodash")
+import { BaseTemplates } from "../../shared/templates/baseTemplates"
+import { LambdaTemplates } from "../templates/lambdaTemplates"
+import { AWSError } from "aws-sdk"
+import { getSelectedLambdaNode } from "../utils"
+import { AwsContext } from '../../shared/awsContext'
 
 export async function getLambdaPolicy(awsContext:AwsContext, element?: FunctionNode) {
     try {
-        const fn: FunctionNode = await getSelectedLambdaNode(awsContext, element);
+        const fn: FunctionNode = await getSelectedLambdaNode(awsContext, element)
 
-        const view = vscode.window.createWebviewPanel('html', `Getting policy for ${fn.functionConfiguration.FunctionName}`, -1);
-        const baseTemplateFn = _.template(BaseTemplates.SimpleHTML);
-        view.webview.html = baseTemplateFn({ content: `<h1>Loading...</h1>` });
+        const view = vscode.window.createWebviewPanel('html', `Getting policy for ${fn.functionConfiguration.FunctionName}`, -1)
+        const baseTemplateFn = _.template(BaseTemplates.SimpleHTML)
+        view.webview.html = baseTemplateFn({ content: `<h1>Loading...</h1>` })
 
-        const funcResponse = await fn.lambda.getPolicy({ FunctionName: fn.functionConfiguration.FunctionName! }).promise();
-        const getPolicyTemplateFn = _.template(LambdaTemplates.GetPolicyTemplate);
+        const funcResponse = await fn.lambda.getPolicy({ FunctionName: fn.functionConfiguration.FunctionName! }).promise()
+        const getPolicyTemplateFn = _.template(LambdaTemplates.GetPolicyTemplate)
         view.webview.html = baseTemplateFn({
             content: getPolicyTemplateFn({
                 FunctionName: fn.functionConfiguration.FunctionName,
                 Policy: funcResponse.Policy!
             })
-        });
+        })
     } catch (err) {
-        const ex: AWSError = err;
-        console.log(ex.message);
+        const ex: AWSError = err
+        console.log(ex.message)
     }
 }

--- a/src/lambda/commands/invokeLambda.ts
+++ b/src/lambda/commands/invokeLambda.ts
@@ -1,25 +1,25 @@
-'use strict';
+'use strict'
 
-import xml2js = require('xml2js');
-import path = require('path');
-import { FunctionNode } from "../explorer/functionNode";
-import { getSelectedLambdaNode } from '../utils';
-import { BaseTemplates } from "../../shared/templates/baseTemplates";
-import * as vscode from 'vscode';
-import _ = require("lodash");
-import { ext } from "../../shared/extensionGlobals";
-import { LambdaTemplates } from "../templates/lambdaTemplates";
-import { AWSError } from "aws-sdk";
-import { ResourceFetcher } from "../../shared/resourceFetcher";
-import { sampleRequestManifestPath, sampleRequestPath } from "../constants";
-import { SampleRequest } from '../models/sampleRequest';
-import { ExtensionUtilities } from '../../shared/extensionUtilities';
-import { AwsContext } from '../../shared/awsContext';
-import { WebResourceLocation, FileResourceLocation } from '../../shared/resourceLocation';
+import xml2js = require('xml2js')
+import path = require('path')
+import { FunctionNode } from "../explorer/functionNode"
+import { getSelectedLambdaNode } from '../utils'
+import { BaseTemplates } from "../../shared/templates/baseTemplates"
+import * as vscode from 'vscode'
+import _ = require("lodash")
+import { ext } from "../../shared/extensionGlobals"
+import { LambdaTemplates } from "../templates/lambdaTemplates"
+import { AWSError } from "aws-sdk"
+import { ResourceFetcher } from "../../shared/resourceFetcher"
+import { sampleRequestManifestPath, sampleRequestPath } from "../constants"
+import { SampleRequest } from '../models/sampleRequest'
+import { ExtensionUtilities } from '../../shared/extensionUtilities'
+import { AwsContext } from '../../shared/awsContext'
+import { WebResourceLocation, FileResourceLocation } from '../../shared/resourceLocation'
 
 export async function invokeLambda(awsContext:AwsContext, resourceFetcher: ResourceFetcher, element?: FunctionNode) {
     try {
-        const fn: FunctionNode = await getSelectedLambdaNode(awsContext, element);
+        const fn: FunctionNode = await getSelectedLambdaNode(awsContext, element)
 
         const view = vscode.window.createWebviewPanel(
             'html',
@@ -29,32 +29,32 @@ export async function invokeLambda(awsContext:AwsContext, resourceFetcher: Resou
                 // Enable scripts in the webview
                 enableScripts: true
             }
-        );
-        const baseTemplateFn = _.template(BaseTemplates.SimpleHTML);
+        )
+        const baseTemplateFn = _.template(BaseTemplates.SimpleHTML)
         view.webview.html = baseTemplateFn({
             content: `<h1>Loading...</h1>`
-        });
+        })
 
         // ideally need to get the client from the explorer, but the context will do for now
-        console.log('building template...');
-        const invokeTemplateFn = _.template(LambdaTemplates.InvokeTemplate);
-        const resourcePath = path.join(ext.context.extensionPath, 'resources', 'vs-lambda-sample-request-manifest.xml');
-        console.log(sampleRequestManifestPath);
-        console.log(resourcePath);
+        console.log('building template...')
+        const invokeTemplateFn = _.template(LambdaTemplates.InvokeTemplate)
+        const resourcePath = path.join(ext.context.extensionPath, 'resources', 'vs-lambda-sample-request-manifest.xml')
+        console.log(sampleRequestManifestPath)
+        console.log(resourcePath)
         try {
-            const sampleInput = await resourceFetcher.getResource([new WebResourceLocation(sampleRequestManifestPath), new FileResourceLocation(resourcePath)]);
-            const inputs: SampleRequest[] = [];
-            console.log('querying manifest url');
+            const sampleInput = await resourceFetcher.getResource([new WebResourceLocation(sampleRequestManifestPath), new FileResourceLocation(resourcePath)])
+            const inputs: SampleRequest[] = []
+            console.log('querying manifest url')
             xml2js.parseString(sampleInput, { explicitArray: false }, (err, result) => {
-                console.log(result);
-                if (err) { return; }
+                console.log(result)
+                if (err) { return }
                 _.forEach(result.requests.request, (r) => {
-                    inputs.push({ name: r.name, filename: r.filename });
-                });
-            });
-            const loadScripts = ExtensionUtilities.getScriptsForHtml(['invokeLambdaVue.js']);
-            const loadLibs = ExtensionUtilities.getLibrariesForHtml(['vue.min.js']);
-            console.log(loadLibs);
+                    inputs.push({ name: r.name, filename: r.filename })
+                })
+            })
+            const loadScripts = ExtensionUtilities.getScriptsForHtml(['invokeLambdaVue.js'])
+            const loadLibs = ExtensionUtilities.getLibrariesForHtml(['vue.min.js'])
+            console.log(loadLibs)
             view.webview.html = baseTemplateFn({
                 content: invokeTemplateFn({
                     FunctionName: fn.functionConfiguration.FunctionName,
@@ -62,56 +62,56 @@ export async function invokeLambda(awsContext:AwsContext, resourceFetcher: Resou
                     Scripts: loadScripts,
                     Libraries: loadLibs
                 }),
-            });
+            })
 
             view.webview.onDidReceiveMessage(async message => {
                 switch (message.command) {
                     case 'sampleRequestSelected':
-                        console.log('selected the following sample:');
-                        console.log(message.value);
-                        const sample = await resourceFetcher.getResource([new WebResourceLocation(sampleRequestPath + message.value), new FileResourceLocation(resourcePath)]);
-                        console.log(sample);
-                        view.webview.postMessage({ command: 'loadedSample', sample: sample });
-                        return;
+                        console.log('selected the following sample:')
+                        console.log(message.value)
+                        const sample = await resourceFetcher.getResource([new WebResourceLocation(sampleRequestPath + message.value), new FileResourceLocation(resourcePath)])
+                        console.log(sample)
+                        view.webview.postMessage({ command: 'loadedSample', sample: sample })
+                        return
                     case 'invokeLambda':
-                        console.log('got the following payload:');
-                        console.log(message.value);
-                        const lambdaClient = fn.lambda;
+                        console.log('got the following payload:')
+                        console.log(message.value)
+                        const lambdaClient = fn.lambda
                         let funcRequest = {
                             FunctionName: fn.functionConfiguration.FunctionArn!,
                             LogType: 'Tail'
-                        } as AWS.Lambda.InvocationRequest;
+                        } as AWS.Lambda.InvocationRequest
                         if (message.value) {
-                            console.log('found a payload');
-                            funcRequest.Payload = message.value;
+                            console.log('found a payload')
+                            funcRequest.Payload = message.value
                         }
                         try {
-                            const funcResponse = await lambdaClient.invoke(funcRequest).promise();
-                            const logs = funcResponse.LogResult ? Buffer.from(funcResponse.LogResult, 'base64').toString() : "";
-                            const payload = funcResponse.Payload ? funcResponse.Payload : JSON.stringify({});
+                            const funcResponse = await lambdaClient.invoke(funcRequest).promise()
+                            const logs = funcResponse.LogResult ? Buffer.from(funcResponse.LogResult, 'base64').toString() : ""
+                            const payload = funcResponse.Payload ? funcResponse.Payload : JSON.stringify({})
                             view.webview.postMessage({
                                 command: 'invokedLambda',
                                 logs,
                                 payload,
                                 statusCode: funcResponse.StatusCode
-                            });
+                            })
                         } catch (e) {
                             view.webview.postMessage({
                                 command: 'invokedLambda',
                                 error: e
-                            });
+                            })
                         }
-                        break;
+                        break
                 }
-            }, undefined, ext.context.subscriptions);
+            }, undefined, ext.context.subscriptions)
         }
         catch (err) {
-            console.log('Error getting manifest data..');
-            console.log(err);
+            console.log('Error getting manifest data..')
+            console.log(err)
         }
     }
     catch (err) {
-        const ex: AWSError = err;
-        console.log(ex.message);
+        const ex: AWSError = err
+        console.log(ex.message)
     }
 }

--- a/src/lambda/commands/newLambda.ts
+++ b/src/lambda/commands/newLambda.ts
@@ -1,13 +1,13 @@
-'use strict';
+'use strict'
 
-import * as vscode from 'vscode';
+import * as vscode from 'vscode'
 
 export async function newLambda() {
     try {
         // TODO: trigger multistep command sequence to select type (lamba/serverless).
         // language, blueprint and output location. See the multiStepInput.ts file in
         // the quickinput-sample for ideas.
-        vscode.window.showInformationMessage('Not yet implemented!');
+        vscode.window.showInformationMessage('Not yet implemented!')
     } catch (err) {
 
     }

--- a/src/lambda/commands/quickPickLambda.ts
+++ b/src/lambda/commands/quickPickLambda.ts
@@ -1,32 +1,32 @@
-'use strict';
+'use strict'
 
-import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
+import * as nls from 'vscode-nls'
+let localize = nls.loadMessageBundle()
 
-import * as vscode from 'vscode';
-import { FunctionNode } from '../explorer/functionNode';
+import * as vscode from 'vscode'
+import { FunctionNode } from '../explorer/functionNode'
 
 class QuickPickLambda extends FunctionNode implements vscode.QuickPickItem {
-    label: string; description?: string | undefined;
-    detail?: string | undefined;
-    picked?: boolean | undefined;
+    label: string; description?: string | undefined
+    detail?: string | undefined
+    picked?: boolean | undefined
     constructor(fn: FunctionNode) {
-        super(fn.functionConfiguration, fn.lambda);
-        this.label = fn.functionConfiguration.FunctionName!;
+        super(fn.functionConfiguration, fn.lambda)
+        this.label = fn.functionConfiguration.FunctionName!
     }
 }
 
 export async function quickPickLambda(lambdas: FunctionNode[]): Promise<FunctionNode | undefined> {
     try {
         if (!lambdas || lambdas.length === 0) {
-            vscode.window.showInformationMessage(localize('AWS.explorerNode.lambda.noFunctions', '..no functions in this region...'));
+            vscode.window.showInformationMessage(localize('AWS.explorerNode.lambda.noFunctions', '..no functions in this region...'))
         } else {
-            const qpLambdas = lambdas.map(l => new QuickPickLambda(l));
-            return await vscode.window.showQuickPick(qpLambdas, { placeHolder: 'Choose a lambda' });
+            const qpLambdas = lambdas.map(l => new QuickPickLambda(l))
+            return await vscode.window.showQuickPick(qpLambdas, { placeHolder: 'Choose a lambda' })
         }
-        throw new Error('No lambdas to work with.');
+        throw new Error('No lambdas to work with.')
     } catch (error) {
-        vscode.window.showErrorMessage('Unable to connect to AWS.');
+        vscode.window.showErrorMessage('Unable to connect to AWS.')
     }
 
 }

--- a/src/lambda/constants.ts
+++ b/src/lambda/constants.ts
@@ -1,7 +1,7 @@
-'use strict';
-import { hostedFilesBaseUrl } from "../shared/constants";
+'use strict'
+import { hostedFilesBaseUrl } from "../shared/constants"
 
-export const blueprintsManifestPath: string = 'LambdaSampleFunctions/NETCore/msbuild-v4/vs-lambda-blueprint-manifest.xml';
-export const sampleRequestBase: string = 'LambdaSampleFunctions/SampleRequests';
-export const sampleRequestPath: string = `${hostedFilesBaseUrl}${sampleRequestBase}/`;
-export const sampleRequestManifestPath: string = `${hostedFilesBaseUrl}${sampleRequestBase}/manifest.xml`;
+export const blueprintsManifestPath: string = 'LambdaSampleFunctions/NETCore/msbuild-v4/vs-lambda-blueprint-manifest.xml'
+export const sampleRequestBase: string = 'LambdaSampleFunctions/SampleRequests'
+export const sampleRequestPath: string = `${hostedFilesBaseUrl}${sampleRequestBase}/`
+export const sampleRequestManifestPath: string = `${hostedFilesBaseUrl}${sampleRequestBase}/manifest.xml`

--- a/src/lambda/explorer/functionNode.ts
+++ b/src/lambda/explorer/functionNode.ts
@@ -1,36 +1,36 @@
-'use strict';
+'use strict'
 
-import { TreeItem, Uri, ThemeIcon } from 'vscode';
-import * as path from 'path';
-import { AWSTreeNodeBase } from '../../shared/treeview/awsTreeNodeBase';
-import Lambda = require('aws-sdk/clients/lambda');
+import { TreeItem, Uri, ThemeIcon } from 'vscode'
+import * as path from 'path'
+import { AWSTreeNodeBase } from '../../shared/treeview/awsTreeNodeBase'
+import Lambda = require('aws-sdk/clients/lambda')
 
 export class FunctionNode extends AWSTreeNodeBase implements TreeItem {
-    public static contextValue: string = 'awsLambdaFn';
-    public contextValue: string = FunctionNode.contextValue;
+    public static contextValue: string = 'awsLambdaFn'
+    public contextValue: string = FunctionNode.contextValue
 
-    public label?: string;
-    public tooltip?: string;
-    public iconPath?: string | Uri | { light: string | Uri; dark: string | Uri } | ThemeIcon;
+    public label?: string
+    public tooltip?: string
+    public iconPath?: string | Uri | { light: string | Uri; dark: string | Uri } | ThemeIcon
 
     constructor(
         public readonly functionConfiguration: Lambda.FunctionConfiguration,
         public readonly lambda: Lambda
     ) {
-        super();
-        this.label = `${this.functionConfiguration.FunctionName!}`;
-        this.tooltip = `${this.functionConfiguration.FunctionName}-${this.functionConfiguration.FunctionArn}`;
+        super()
+        this.label = `${this.functionConfiguration.FunctionName!}`
+        this.tooltip = `${this.functionConfiguration.FunctionName}-${this.functionConfiguration.FunctionArn}`
         this.iconPath = {
             light: path.join(__filename, '..', '..', '..', 'resources', 'light', 'lambda_function.svg'),
             dark: path.join(__filename, '..', '..', '..', 'resources', 'dark', 'lambda_function.svg')
-        };
+        }
     }
 
     public getChildren(): Thenable<AWSTreeNodeBase[]> {
-        return new Promise(resolve => resolve([]));
+        return new Promise(resolve => resolve([]))
     }
 
     public getTreeItem(): TreeItem {
-        return this;
+        return this
     }
 }

--- a/src/lambda/explorer/noFunctionsNode.ts
+++ b/src/lambda/explorer/noFunctionsNode.ts
@@ -1,21 +1,21 @@
-'use strict';
+'use strict'
 
-import { TreeItem } from 'vscode';
-import { AWSTreeNodeBase } from '../../shared/treeview/awsTreeNodeBase';
+import { TreeItem } from 'vscode'
+import { AWSTreeNodeBase } from '../../shared/treeview/awsTreeNodeBase'
 
 // Can be used to add a child node in an explorer when a region has no resources
 // relevant to the explorer type.
 export class NoFunctionsNode extends AWSTreeNodeBase implements TreeItem {
 
     constructor(public label: string, public contextValue?: string, public tooltip?: string) {
-        super();
+        super()
     }
 
     public getChildren(): Thenable<AWSTreeNodeBase[]> {
-        return new Promise(resolve => resolve([]));
+        return new Promise(resolve => resolve([]))
     }
 
     public getTreeItem(): TreeItem {
-        return this;
+        return this
     }
 }

--- a/src/lambda/explorer/regionNode.ts
+++ b/src/lambda/explorer/regionNode.ts
@@ -1,12 +1,12 @@
-'use strict';
+'use strict'
 
-import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
+import * as nls from 'vscode-nls'
+let localize = nls.loadMessageBundle()
 
-import { AWSRegionTreeNode } from '../../shared/treeview/awsRegionTreeNode';
-import { AWSTreeNodeBase } from '../../shared/treeview/awsTreeNodeBase';
-import { getLambdaFunctionsForRegion } from '../utils';
-import { NoFunctionsNode } from './noFunctionsNode';
+import { AWSRegionTreeNode } from '../../shared/treeview/awsRegionTreeNode'
+import { AWSTreeNodeBase } from '../../shared/treeview/awsTreeNodeBase'
+import { getLambdaFunctionsForRegion } from '../utils'
+import { NoFunctionsNode } from './noFunctionsNode'
 
 // Collects the regions the user has declared they want to work with;
 // on expansion each region lists the functions the user has available
@@ -15,28 +15,28 @@ import { NoFunctionsNode } from './noFunctionsNode';
 export class RegionNode extends AWSRegionTreeNode {
 
     constructor(regionCode:string, public regionName: string) {
-        super(regionCode);
+        super(regionCode)
     }
 
     protected getLabel(): string {
-        return this.regionName;
+        return this.regionName
     }
 
     protected getTooltip(): string | undefined {
-        return `${this.getLabel()} [${this.regionCode}]`;
+        return `${this.getLabel()} [${this.regionCode}]`
     }
 
     public getChildren(): Thenable<AWSTreeNodeBase[]> {
         return new Promise(resolve => {
             getLambdaFunctionsForRegion(this.regionCode).then((result) => {
-                const arr: AWSTreeNodeBase[] = result;
+                const arr: AWSTreeNodeBase[] = result
                 if (arr.length === 0) {
                     arr.push(new NoFunctionsNode(localize('AWS.explorerNode.lambda.noFunctions', '...no functions in this region...'),
-                                                 'awsLambdaNoFns'));
+                                                 'awsLambdaNoFns'))
                 }
-                resolve(arr);
-            });
-        });
+                resolve(arr)
+            })
+        })
     }
 
 }

--- a/src/lambda/lambdaProvider.ts
+++ b/src/lambda/lambdaProvider.ts
@@ -1,97 +1,97 @@
-'use strict';
+'use strict'
 
-import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
+import * as nls from 'vscode-nls'
+let localize = nls.loadMessageBundle()
 
-import * as vscode from 'vscode';
-import { AWSTreeNodeBase } from '../shared/treeview/awsTreeNodeBase';
-import { RefreshableAwsTreeProvider } from '../shared/treeview/refreshableAwsTreeProvider';
-import { FunctionNode } from './explorer/functionNode';
-import { getLambdaPolicy } from './commands/getLambdaPolicy';
-import { invokeLambda } from './commands/invokeLambda';
-import { newLambda } from './commands/newLambda';
-import { deployLambda } from './commands/deployLambda';
-import { getLambdaConfig } from './commands/getLambdaConfig';
-import { AwsContext } from '../shared/awsContext';
-import { AWSCommandTreeNode } from '../shared/treeview/awsCommandTreeNode';
-import { RegionNode } from './explorer/regionNode';
-import { RegionProvider } from "../shared/regions/regionProvider";
-import { AwsContextTreeCollection } from '../shared/awsContextTreeCollection';
-import { ResourceFetcher } from '../shared/resourceFetcher';
+import * as vscode from 'vscode'
+import { AWSTreeNodeBase } from '../shared/treeview/awsTreeNodeBase'
+import { RefreshableAwsTreeProvider } from '../shared/treeview/refreshableAwsTreeProvider'
+import { FunctionNode } from './explorer/functionNode'
+import { getLambdaPolicy } from './commands/getLambdaPolicy'
+import { invokeLambda } from './commands/invokeLambda'
+import { newLambda } from './commands/newLambda'
+import { deployLambda } from './commands/deployLambda'
+import { getLambdaConfig } from './commands/getLambdaConfig'
+import { AwsContext } from '../shared/awsContext'
+import { AWSCommandTreeNode } from '../shared/treeview/awsCommandTreeNode'
+import { RegionNode } from './explorer/regionNode'
+import { RegionProvider } from "../shared/regions/regionProvider"
+import { AwsContextTreeCollection } from '../shared/awsContextTreeCollection'
+import { ResourceFetcher } from '../shared/resourceFetcher'
 
 export class LambdaProvider implements vscode.TreeDataProvider<AWSTreeNodeBase>, RefreshableAwsTreeProvider {
-    private _awsContext: AwsContext;
-    private _awsContextTrees: AwsContextTreeCollection;
-    private _regionProvider: RegionProvider;
-    private readonly _resourceFetcher: ResourceFetcher;
-    private _onDidChangeTreeData: vscode.EventEmitter<FunctionNode | undefined> = new vscode.EventEmitter<FunctionNode | undefined>();
-    readonly onDidChangeTreeData: vscode.Event<FunctionNode | undefined> = this._onDidChangeTreeData.event;
+    private _awsContext: AwsContext
+    private _awsContextTrees: AwsContextTreeCollection
+    private _regionProvider: RegionProvider
+    private readonly _resourceFetcher: ResourceFetcher
+    private _onDidChangeTreeData: vscode.EventEmitter<FunctionNode | undefined> = new vscode.EventEmitter<FunctionNode | undefined>()
+    readonly onDidChangeTreeData: vscode.Event<FunctionNode | undefined> = this._onDidChangeTreeData.event
 
-    public viewProviderId: string = 'lambda';
+    public viewProviderId: string = 'lambda'
 
     public initialize(): void {
-        vscode.commands.registerCommand('aws.newLambda', async () => await newLambda());
-        vscode.commands.registerCommand('aws.deployLambda', async (node: FunctionNode) => await deployLambda(node));
-        vscode.commands.registerCommand('aws.invokeLambda', async (node: FunctionNode) => await invokeLambda(this._awsContext, this._resourceFetcher, node));
-        vscode.commands.registerCommand('aws.getLambdaConfig', async (node: FunctionNode) => await getLambdaConfig(this._awsContext, node));
-        vscode.commands.registerCommand('aws.getLambdaPolicy', async (node: FunctionNode) => await getLambdaPolicy(this._awsContext, node));
+        vscode.commands.registerCommand('aws.newLambda', async () => await newLambda())
+        vscode.commands.registerCommand('aws.deployLambda', async (node: FunctionNode) => await deployLambda(node))
+        vscode.commands.registerCommand('aws.invokeLambda', async (node: FunctionNode) => await invokeLambda(this._awsContext, this._resourceFetcher, node))
+        vscode.commands.registerCommand('aws.getLambdaConfig', async (node: FunctionNode) => await getLambdaConfig(this._awsContext, node))
+        vscode.commands.registerCommand('aws.getLambdaPolicy', async (node: FunctionNode) => await getLambdaPolicy(this._awsContext, node))
 
-        this._awsContextTrees.addTree(this);
+        this._awsContextTrees.addTree(this)
     }
 
     getTreeItem(element: AWSTreeNodeBase): vscode.TreeItem {
-        return element.getTreeItem();
+        return element.getTreeItem()
     }
 
     getChildren(element?: AWSTreeNodeBase): Thenable<AWSTreeNodeBase[]> {
         if (element) {
-            return element.getChildren();
+            return element.getChildren()
         }
 
         return new Promise(resolve => {
-            const profileName = this._awsContext.getCredentialProfileName();
+            const profileName = this._awsContext.getCredentialProfileName()
             if (!profileName) {
                 resolve([
                     new AWSCommandTreeNode(localize('AWS.explorerNode.signIn', 'Sign in to AWS...'),
                         'aws.login',
                         localize('AWS.explorerNode.signIn.tooltip', 'Connect to AWS using a credential profile'))
-                ]);
+                ])
             }
 
             this._regionProvider.getRegionData().then(regionDefinitions => {
                 this._awsContext.getExplorerRegions().then(explorerRegionCodes => {
 
                     if (explorerRegionCodes.length !== 0) {
-                        let regionNodes: RegionNode[] = [];
+                        let regionNodes: RegionNode[] = []
 
                         explorerRegionCodes.forEach(explorerRegionCode => {
-                            let region = regionDefinitions.find(region => region.regionCode === explorerRegionCode);
-                            let regionName = region ? region.regionName : explorerRegionCode;
-                            regionNodes.push(new RegionNode(explorerRegionCode, regionName));
-                        });
+                            let region = regionDefinitions.find(region => region.regionCode === explorerRegionCode)
+                            let regionName = region ? region.regionName : explorerRegionCode
+                            regionNodes.push(new RegionNode(explorerRegionCode, regionName))
+                        })
 
-                        resolve(regionNodes);
+                        resolve(regionNodes)
                     } else {
                         resolve([
                             new AWSCommandTreeNode(localize('AWS.explorerNode.addRegion', 'Click to add a region to view functions...'),
                                 'aws.showRegion',
                                 localize('AWS.explorerNode.addRegion.tooltip', 'Configure a region to show available functions'))
-                        ]);
+                        ])
                     }
-                });
-            });
-        });
+                })
+            })
+        })
     }
 
     refresh(context?: AwsContext) {
-        this._onDidChangeTreeData.fire();
+        this._onDidChangeTreeData.fire()
     }
 
     constructor(awsContext: AwsContext, awsContextTreeCollection: AwsContextTreeCollection, regionProvider: RegionProvider, resourceFetcher: ResourceFetcher) {
-        this._awsContext = awsContext;
-        this._awsContextTrees = awsContextTreeCollection;
-        this._regionProvider = regionProvider;
-        this._resourceFetcher = resourceFetcher;
+        this._awsContext = awsContext
+        this._awsContextTrees = awsContextTreeCollection
+        this._regionProvider = regionProvider
+        this._resourceFetcher = resourceFetcher
     }
 }
 

--- a/src/lambda/models/blueprint.ts
+++ b/src/lambda/models/blueprint.ts
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 export enum BlueprintOrigin {
     vsToolkit,
@@ -10,11 +10,11 @@ export enum BlueprintOrigin {
 export class Blueprint {
 
     // data members from the Visual Studio blueprint model
-    public sortOrder: number | undefined;
+    public sortOrder: number | undefined
 
-    public tags: string[] | undefined;
+    public tags: string[] | undefined
 
-    public hiddenTags: string[] | undefined;
+    public hiddenTags: string[] | undefined
 
     constructor(public name: string, public description: string, public filename: string, public origin: BlueprintOrigin) {
     }
@@ -25,14 +25,14 @@ export class Blueprint {
             if (this.hiddenTags) {
                 for (let i: number = 0; i < this.hiddenTags.length; i++) {
                     if (this.hiddenTags[i] === language) {
-                        return true;
+                        return true
                     }
                 }
             }
 
-            return false;
+            return false
         }
 
-        throw new Error('Other blueprint stores are not yet implemented');
+        throw new Error('Other blueprint stores are not yet implemented')
     }
 }

--- a/src/lambda/models/blueprintsCollection.ts
+++ b/src/lambda/models/blueprintsCollection.ts
@@ -1,29 +1,29 @@
-'use strict';
+'use strict'
 
-import xml2js = require('xml2js');
-import path = require('path');
-import { hostedFilesBaseUrl } from "../../shared/constants";
-import { blueprintsManifestPath } from "../constants";
-import { ResourceFetcher } from "../../shared/resourceFetcher";
-import { Blueprint, BlueprintOrigin } from "./blueprint";
-import { ExtensionContext } from 'vscode';
-import { WebResourceLocation, FileResourceLocation } from '../../shared/resourceLocation';
+import xml2js = require('xml2js')
+import path = require('path')
+import { hostedFilesBaseUrl } from "../../shared/constants"
+import { blueprintsManifestPath } from "../constants"
+import { ResourceFetcher } from "../../shared/resourceFetcher"
+import { Blueprint, BlueprintOrigin } from "./blueprint"
+import { ExtensionContext } from 'vscode'
+import { WebResourceLocation, FileResourceLocation } from '../../shared/resourceLocation'
 
 // Represents a collection of blueprints, potentially from multiple sources
 export class BlueprintsCollection {
 
-    private availableBlueprints: Blueprint[] = [];
-    private readonly _context: ExtensionContext;
-    private readonly _resourceFetcher: ResourceFetcher;
+    private availableBlueprints: Blueprint[] = []
+    private readonly _context: ExtensionContext
+    private readonly _resourceFetcher: ResourceFetcher
 
     constructor(context: ExtensionContext, resourceFetcher: ResourceFetcher) {
-        this._context = context;
-        this._resourceFetcher = resourceFetcher;
+        this._context = context
+        this._resourceFetcher = resourceFetcher
     }
 
     public async loadAllBlueprints(): Promise<void> {
-        this.availableBlueprints = [];
-        await this.loadVisualStudioBlueprints();
+        this.availableBlueprints = []
+        await this.loadVisualStudioBlueprints()
         // TODO: load additional blueprints from SAR?
     }
 
@@ -31,82 +31,82 @@ export class BlueprintsCollection {
     // available for. This does rely on us normalizing all blueprint data sources
     // at load time.
     public filterBlueprintLanguages(): string[] {
-        let languages: string[] = [];
+        let languages: string[] = []
 
         // hack for now! Unfortunately language is encoded in amongst other tag
         // values for VS
-        languages.push('C#');
-        languages.push('F#');
+        languages.push('C#')
+        languages.push('F#')
 
-        return languages;
+        return languages
     }
 
     public filterBlueprintsForLanguage(language: string): Blueprint[] {
-        let filteredBlueprints: Blueprint[] = [];
+        let filteredBlueprints: Blueprint[] = []
 
         this.availableBlueprints.forEach((b: Blueprint) => {
             if (b.isForLanguage(language)) {
-                filteredBlueprints.push(b);
+                filteredBlueprints.push(b)
             }
-        });
+        })
 
-        return filteredBlueprints;
+        return filteredBlueprints
     }
 
     private async loadVisualStudioBlueprints(): Promise<void> {
-        const manifestUrl = hostedFilesBaseUrl + blueprintsManifestPath;
+        const manifestUrl = hostedFilesBaseUrl + blueprintsManifestPath
         await this.listBlueprintsVSToolkitFromManifest(manifestUrl)
             .then(results => {
                 results.forEach((b: Blueprint) => {
-                    this.availableBlueprints.push(b);
-            });
-        });
+                    this.availableBlueprints.push(b)
+            })
+        })
     }
 
     private async listBlueprintsVSToolkitFromManifest(manifestUrl: string): Promise<Blueprint[]> {
-        const resourcePath = path.join(this._context.extensionPath, 'resources', 'vs-lambda-blueprint-manifest.xml');
-        const manifest = await this._resourceFetcher.getResource([new WebResourceLocation(manifestUrl), new FileResourceLocation(resourcePath)]);
+        const resourcePath = path.join(this._context.extensionPath, 'resources', 'vs-lambda-blueprint-manifest.xml')
+        const manifest = await this._resourceFetcher.getResource([new WebResourceLocation(manifestUrl), new FileResourceLocation(resourcePath)])
         return new Promise<Blueprint[]>((resolve, reject) => {
             xml2js.parseString(manifest, {explicitArray: false}, function (err, result) {
                 if (err) {
                     // TODO: fall back to resource version before giving up
-                    reject(err);
+                    reject(err)
                 } else {
                     // this is a short term hack to figure out how to do this!
                     let blueprints: Blueprint[] = [];
                     (result.BlueprintManifest.Blueprints.Blueprint).forEach((b: any) => {
-                        const blueprint = new Blueprint(b.Name, b.Description, b.File, BlueprintOrigin.vsToolkit);
+                        const blueprint = new Blueprint(b.Name, b.Description, b.File, BlueprintOrigin.vsToolkit)
 
                         // post optional data
                         if (b.SortOrder) {
-                            blueprint.sortOrder = b.SortOrder;
+                            blueprint.sortOrder = b.SortOrder
                         }
 
                         // both tag collections could have deserialized as one string or an array
                         if (b.Tags && b.Tags.Tag) {
-                            blueprint.tags = BlueprintsCollection.stringOrArrayToStringArray(b.Tags.Tag);
+                            blueprint.tags = BlueprintsCollection.stringOrArrayToStringArray(b.Tags.Tag)
                         }
                         if (b.HiddenTags && b.HiddenTags.HiddenTag) {
-                            blueprint.hiddenTags = BlueprintsCollection.stringOrArrayToStringArray(b.HiddenTags.HiddenTag);
+                            blueprint.hiddenTags = BlueprintsCollection.stringOrArrayToStringArray(b.HiddenTags.HiddenTag)
                         }
 
-                        blueprints.push(blueprint);
-                    });
-                    resolve(blueprints);
+                        blueprints.push(blueprint)
+                    })
+                    resolve(blueprints)
                 }
-            });
-        });
+            })
+        })
     }
 
     private static stringOrArrayToStringArray(input: string | string[]): string[] {
-        let output: string[] = [];
+        let output: string[] = []
         if (Array.isArray(input)){
             input.forEach((i:any) => {
-                output.push(i);
-            });
+                output.push(i)
+            })
         } else {
-            output.push(input);
+            output.push(input)
         }
-        return output;
+        return output
     }
 }

--- a/src/lambda/models/sampleRequest.ts
+++ b/src/lambda/models/sampleRequest.ts
@@ -1,4 +1,4 @@
 export class SampleRequest {
-    public name: string | undefined;
-    public filename: string | undefined;
+    public name: string | undefined
+    public filename: string | undefined
 }

--- a/src/lambda/models/scriptResource.ts
+++ b/src/lambda/models/scriptResource.ts
@@ -1,5 +1,5 @@
-import * as vscode from 'vscode';
+import * as vscode from 'vscode'
 export class ScriptResource {
-    public Uri: vscode.Uri | undefined;
-    public Nonce: string | undefined;
+    public Uri: vscode.Uri | undefined
+    public Nonce: string | undefined
 }

--- a/src/lambda/templates/lambdaTemplates.ts
+++ b/src/lambda/templates/lambdaTemplates.ts
@@ -57,7 +57,7 @@ export class LambdaTemplates {
     <% Scripts.forEach(function(scr) { %>
         <script nonce="<%= scr.Nonce %>" src="<%= scr.Uri %>"></script>
     <% }); %>
-    `;
+    `
     static readonly GetPolicyTemplate = `
     <h1>
         Policy for <%= FunctionName %>...
@@ -65,7 +65,7 @@ export class LambdaTemplates {
     <p>Policy:
         <pre><%- JSON.stringify(JSON.parse(Policy), null, 4) %></pre>
     </p>
-    `;
+    `
     static readonly GetConfigTemplate = `
     <h1>
         Configuration for <%= FunctionName %>...
@@ -79,5 +79,5 @@ export class LambdaTemplates {
     <p>Role: <%= Role %>
     <p>Timeout: <%= Timeout %>
     <p>Version: <%= Version %>
-    `;
+    `
 }

--- a/src/lambda/utils.ts
+++ b/src/lambda/utils.ts
@@ -1,72 +1,72 @@
-'use strict';
+'use strict'
 
-import * as vscode from 'vscode';
-import { isNullOrUndefined } from 'util';
-import { ext } from '../shared/extensionGlobals';
-import { FunctionNode } from './explorer/functionNode';
-import { quickPickLambda } from './commands/quickPickLambda';
-import Lambda = require('aws-sdk/clients/lambda');
-import { AwsContext } from '../shared/awsContext';
+import * as vscode from 'vscode'
+import { isNullOrUndefined } from 'util'
+import { ext } from '../shared/extensionGlobals'
+import { FunctionNode } from './explorer/functionNode'
+import { quickPickLambda } from './commands/quickPickLambda'
+import Lambda = require('aws-sdk/clients/lambda')
+import { AwsContext } from '../shared/awsContext'
 
 export async function getSelectedLambdaNode(awsContext: AwsContext, element?: FunctionNode): Promise<FunctionNode> {
     if (element && element.functionConfiguration) {
-        console.log('returning preselected node...');
-        return element;
+        console.log('returning preselected node...')
+        return element
     }
 
-    console.log('prompting for lambda selection...');
+    console.log('prompting for lambda selection...')
 
     // TODO: we need to change this into a multi-step command to first obtain the region,
     // then query the lambdas in the region
-    const regions = await awsContext.getExplorerRegions();
+    const regions = await awsContext.getExplorerRegions()
     if (regions.length === 0) {
-        throw new Error('No regions defined for explorer, required until we have a multi-stage picker');
+        throw new Error('No regions defined for explorer, required until we have a multi-stage picker')
     }
-    const lambdas = await listLambdas(await ext.sdkClientBuilder.createAndConfigureSdkClient(Lambda, undefined, regions[0]));
+    const lambdas = await listLambdas(await ext.sdkClientBuilder.createAndConfigureSdkClient(Lambda, undefined, regions[0]))
 
     // used to show a list of lambdas and allow user to select.
     // this is useful for calling commands from the command palette
-    const selection = await quickPickLambda(lambdas);
+    const selection = await quickPickLambda(lambdas)
     if (selection && selection.functionConfiguration) {
-        return selection;
+        return selection
     }
 
-    throw new Error('No lambda found.');
+    throw new Error('No lambda found.')
 }
 
 export async function getLambdaFunctionsForRegion(regionCode: string): Promise<FunctionNode[]> {
-    const client = await ext.sdkClientBuilder.createAndConfigureSdkClient(Lambda, undefined, regionCode);
-    return listLambdas(client);
+    const client = await ext.sdkClientBuilder.createAndConfigureSdkClient(Lambda, undefined, regionCode)
+    return listLambdas(client)
 }
 
 export async function listLambdas(lambda: Lambda): Promise<FunctionNode[]> {
     // TODO: this 'loading' message needs to go under each regional entry
     // in the explorer, and be removed when that region's query completes
-    const status = vscode.window.setStatusBarMessage('Loading lambdas...');
-    let arr: FunctionNode[] = [];
+    const status = vscode.window.setStatusBarMessage('Loading lambdas...')
+    let arr: FunctionNode[] = []
 
     try {
-        const request: Lambda.ListFunctionsRequest = {};
+        const request: Lambda.ListFunctionsRequest = {}
         do {
             await lambda.listFunctions(request)
                 .promise()
                 .then((r: Lambda.ListFunctionsResponse) => {
-                    request.Marker = r.NextMarker;
+                    request.Marker = r.NextMarker
                     if (r.Functions) {
                         r.Functions.forEach((f: Lambda.FunctionConfiguration) => {
-                            const func = new FunctionNode(f, lambda);
-                            func.contextValue = 'awsLambdaFn';
-                            arr.push(func);
-                        });
+                            const func = new FunctionNode(f, lambda)
+                            func.contextValue = 'awsLambdaFn'
+                            arr.push(func)
+                        })
                     }
 
-                });
-        } while (!isNullOrUndefined(request.Marker));
+                })
+        } while (!isNullOrUndefined(request.Marker))
     } catch (error) {
         // TODO:
     }
 
-    status.dispose();
-    return arr;
+    status.dispose()
+    return arr
 }
 

--- a/src/shared/awsClientBuilder.ts
+++ b/src/shared/awsClientBuilder.ts
@@ -1,14 +1,14 @@
-'use strict';
+'use strict'
 
-import { AwsContext } from './awsContext';
-import { env, version } from 'vscode';
+import { AwsContext } from './awsContext'
+import { env, version } from 'vscode'
 
 export class AWSClientBuilder {
 
-    private _awsContext: AwsContext;
+    private _awsContext: AwsContext
 
     constructor(awsContext: AwsContext) {
-        this._awsContext = awsContext;
+        this._awsContext = awsContext
 
     }
 
@@ -22,19 +22,19 @@ export class AWSClientBuilder {
         
 
         if (!awsServiceOpts.credentials) {
-            awsServiceOpts.credentials = await this._awsContext.getCredentials();
+            awsServiceOpts.credentials = await this._awsContext.getCredentials()
         }
 
         if (!awsServiceOpts.region && region) {
-            awsServiceOpts.region = region;
+            awsServiceOpts.region = region
         }
 
         if (!awsServiceOpts.customUserAgent) {
-            const pluginVersion: string = require('../../package.json').version;
-            const platformName = env.appName.replace(/\s/g, '-');
-            awsServiceOpts.customUserAgent = `AWS-Toolkit-For-VisualStudio/${pluginVersion} ${platformName}/${version}`;
+            const pluginVersion: string = require('../../package.json').version
+            const platformName = env.appName.replace(/\s/g, '-')
+            awsServiceOpts.customUserAgent = `AWS-Toolkit-For-VisualStudio/${pluginVersion} ${platformName}/${version}`
         }
 
-        return new awsService(awsServiceOpts);
+        return new awsService(awsServiceOpts)
     }
 }

--- a/src/shared/awsContext.ts
+++ b/src/shared/awsContext.ts
@@ -1,24 +1,24 @@
-'use strict';
+'use strict'
 
-import * as vscode from 'vscode';
-import { ContextChangeEventsArgs } from './defaultAwsContext';
+import * as vscode from 'vscode'
+import { ContextChangeEventsArgs } from './defaultAwsContext'
 
 // Represents a credential profile and zero or more regions.
 export interface AwsContext {
 
-    onDidChangeContext: vscode.Event<ContextChangeEventsArgs>;
+    onDidChangeContext: vscode.Event<ContextChangeEventsArgs>
 
-    getCredentials(): Promise<AWS.Credentials | undefined>;
+    getCredentials(): Promise<AWS.Credentials | undefined>
 
     // returns the configured profile, if any
-    getCredentialProfileName(): string | undefined;
+    getCredentialProfileName(): string | undefined
     // resets the context to the indicated profile, saving it into settings
-    setCredentialProfileName(profileName?: string): Promise<void>;
+    setCredentialProfileName(profileName?: string): Promise<void>
 
-    getExplorerRegions(): Promise<string[]>;
+    getExplorerRegions(): Promise<string[]>
 
     // adds one or more regions into the preferred set
-    addExplorerRegion(region: string | string[]): Promise<void>;
+    addExplorerRegion(region: string | string[]): Promise<void>
     // removes one or more regions from the user's preferred set
-    removeExplorerRegion(region: string | string[]): Promise<void>;
+    removeExplorerRegion(region: string | string[]): Promise<void>
 }

--- a/src/shared/awsContextCommands.ts
+++ b/src/shared/awsContextCommands.ts
@@ -1,86 +1,86 @@
-'use strict';
+'use strict'
 
-import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
+import * as nls from 'vscode-nls'
+let localize = nls.loadMessageBundle()
 
-import { window } from 'vscode';
-import { ext } from './extensionGlobals';
-import { RegionProvider } from './regions/regionProvider';
-import { credentialProfileSelector, DefaultCredentialSelectionDataProvider } from './credentials/defaultCredentialSelectionDataProvider';
-import { DefaultCredentialsFileReaderWriter } from './credentials/defaultCredentialsFileReaderWriter';
-import { AwsContext } from './awsContext';
-import { AwsContextTreeCollection } from './awsContextTreeCollection';
-import { RegionInfo } from './regions/regionInfo';
+import { window } from 'vscode'
+import { ext } from './extensionGlobals'
+import { RegionProvider } from './regions/regionProvider'
+import { credentialProfileSelector, DefaultCredentialSelectionDataProvider } from './credentials/defaultCredentialSelectionDataProvider'
+import { DefaultCredentialsFileReaderWriter } from './credentials/defaultCredentialsFileReaderWriter'
+import { AwsContext } from './awsContext'
+import { AwsContextTreeCollection } from './awsContextTreeCollection'
+import { RegionInfo } from './regions/regionInfo'
 
 export class AWSContextCommands {
 
-    private _awsContext: AwsContext;
-    private _awsContextTrees: AwsContextTreeCollection;
-    private _regionProvider: RegionProvider;
+    private _awsContext: AwsContext
+    private _awsContextTrees: AwsContextTreeCollection
+    private _regionProvider: RegionProvider
 
     constructor(awsContext: AwsContext, awsContextTrees: AwsContextTreeCollection, regionProvider: RegionProvider) {
-        this._awsContext = awsContext;
-        this._awsContextTrees = awsContextTrees;
-        this._regionProvider = regionProvider;
+        this._awsContext = awsContext
+        this._awsContextTrees = awsContextTrees
+        this._regionProvider = regionProvider
     }
 
     public async onCommandLogin() {
-        var newProfile = await this.promptForProfileName();
+        var newProfile = await this.promptForProfileName()
         if (newProfile) {
-            this._awsContext.setCredentialProfileName(newProfile);
-            this.refresh();
+            this._awsContext.setCredentialProfileName(newProfile)
+            this.refresh()
         }
     }
 
     public async onCommandLogout() {
-        this._awsContext.setCredentialProfileName();
-        this.refresh();
+        this._awsContext.setCredentialProfileName()
+        this.refresh()
     }
 
     public async onCommandShowRegion() {
-        const explorerRegions = new Set(await this._awsContext.getExplorerRegions());
-        const newRegion = await this.promptForFilteredRegion(candidateRegion => !explorerRegions.has(candidateRegion.regionCode));
+        const explorerRegions = new Set(await this._awsContext.getExplorerRegions())
+        const newRegion = await this.promptForFilteredRegion(candidateRegion => !explorerRegions.has(candidateRegion.regionCode))
 
         if (newRegion) {
-            this._awsContext.addExplorerRegion(newRegion);
-            this.refresh();
+            this._awsContext.addExplorerRegion(newRegion)
+            this.refresh()
         }
     }
 
     public async onCommandHideRegion(regionCode?: string) {
-        var region = regionCode || await this._awsContext.getExplorerRegions().then(r => this.promptForRegion(r));
+        var region = regionCode || await this._awsContext.getExplorerRegions().then(r => this.promptForRegion(r))
         if (region) {
-            this._awsContext.removeExplorerRegion(region);
-            this.refresh();
+            this._awsContext.removeExplorerRegion(region)
+            this.refresh()
         }
     }
 
     private refresh() {
-        this._awsContextTrees.refreshTrees(this._awsContext);
+        this._awsContextTrees.refreshTrees(this._awsContext)
     }
 
     private async promptForProfileName(): Promise<string | undefined> {
-        const credentialReaderWriter = new DefaultCredentialsFileReaderWriter();
-        const profileNames = await credentialReaderWriter.getProfileNames();
-        const dataProvider = new DefaultCredentialSelectionDataProvider(profileNames, ext.context);
-        const state = await credentialProfileSelector(dataProvider);
+        const credentialReaderWriter = new DefaultCredentialsFileReaderWriter()
+        const profileNames = await credentialReaderWriter.getProfileNames()
+        const dataProvider = new DefaultCredentialSelectionDataProvider(profileNames, ext.context)
+        const state = await credentialProfileSelector(dataProvider)
         if (state) {
             if (state.credentialProfile) {
-                return state.credentialProfile.label;
+                return state.credentialProfile.label
             }
 
             if (state.profileName) {
-                window.showInformationMessage(localize('AWS.title.creatingCredentialProfile', 'Creating credential profile {0}', state.profileName));
+                window.showInformationMessage(localize('AWS.title.creatingCredentialProfile', 'Creating credential profile {0}', state.profileName))
 
                 // TODO: using save code written for POC demos only -- need more production resiliance around this
                 // REMOVE_BEFORE_RELEASE
-                await credentialReaderWriter.addProfileToFile(state.profileName, state.accesskey, state.secretKey);
+                await credentialReaderWriter.addProfileToFile(state.profileName, state.accesskey, state.secretKey)
 
-                return state.profileName;
+                return state.profileName
             }
         }
 
-        return undefined;
+        return undefined
     }
 
     /**
@@ -91,9 +91,9 @@ export class AWSContextCommands {
      * @param filter Filter to apply to the available regions 
      */
     private async promptForFilteredRegion(filter: (region: RegionInfo) => boolean): Promise<string | undefined> {
-        const availableRegions = await this._regionProvider.getRegionData();
-        const regionsToShow = availableRegions.filter(r => filter(r)).map(r => r.regionCode);
-        return this.promptForRegion(regionsToShow);
+        const availableRegions = await this._regionProvider.getRegionData()
+        const regionsToShow = availableRegions.filter(r => filter(r)).map(r => r.regionCode)
+        return this.promptForRegion(regionsToShow)
     }
 
     /**
@@ -103,19 +103,19 @@ export class AWSContextCommands {
      * regions are shown. Regions provided must exist in the available regions to be shown.
      */
     private async promptForRegion(regions?: string[]): Promise<string | undefined> {
-        const availableRegions = await this._regionProvider.getRegionData();
+        const availableRegions = await this._regionProvider.getRegionData()
         const regionsToShow = availableRegions.filter(r => {
             if (regions) {
-                return regions.some(x => x === r.regionCode);
+                return regions.some(x => x === r.regionCode)
             }
-            return true;
+            return true
         }).map(r => ({
             label: r.regionName,
             detail: r.regionCode
-        }));
+        }))
         const input = await window.showQuickPick(regionsToShow, {
             placeHolder: localize('AWS.message.selectRegion', 'Select an AWS region')
-        });
-        return input ? input.detail : undefined;
+        })
+        return input ? input.detail : undefined
     }
 }

--- a/src/shared/awsContextTreeCollection.ts
+++ b/src/shared/awsContextTreeCollection.ts
@@ -1,22 +1,22 @@
-'use strict';
+'use strict'
 
-import { AwsContext } from './awsContext';
-import { RefreshableAwsTreeProvider } from './treeview/refreshableAwsTreeProvider';
+import { AwsContext } from './awsContext'
+import { RefreshableAwsTreeProvider } from './treeview/refreshableAwsTreeProvider'
 
 export class AwsContextTreeCollection {
-    private _trees: RefreshableAwsTreeProvider[];
+    private _trees: RefreshableAwsTreeProvider[]
 
     constructor() {
-        this._trees = [];
+        this._trees = []
     }
 
     public addTree(tree: RefreshableAwsTreeProvider): void {
-        this._trees.push(tree);
+        this._trees.push(tree)
     }
 
     public refreshTrees(awsContext: AwsContext): void {
         this._trees.forEach(t => {
-            t.refresh(awsContext);
-        });
+            t.refresh(awsContext)
+        })
     }
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,9 +1,9 @@
-'use strict';
+'use strict'
 
-export const extensionSettingsPrefix: string = 'aws';
-export const regionSettingKey: string = 'region';
-export const profileSettingKey: string = 'profile';
+export const extensionSettingsPrefix: string = 'aws'
+export const regionSettingKey: string = 'region'
+export const profileSettingKey: string = 'profile'
 
-export const hostedFilesBaseUrl: string = 'https://d3rrggjwfhwld2.cloudfront.net/';
-export const endpointsFileUrl:string = 'https://aws-toolkit-endpoints.s3.amazonaws.com/endpoints.json';
+export const hostedFilesBaseUrl: string = 'https://d3rrggjwfhwld2.cloudfront.net/'
+export const endpointsFileUrl:string = 'https://aws-toolkit-endpoints.s3.amazonaws.com/endpoints.json'
 

--- a/src/shared/credentials/credentialSelectionDataProvider.ts
+++ b/src/shared/credentials/credentialSelectionDataProvider.ts
@@ -1,17 +1,17 @@
-'use strict';
+'use strict'
 
-import { QuickPickItem, QuickInputButton, Uri } from "vscode";
-import { CredentialSelectionState } from "./credentialSelectionState";
-import { MultiStepInputFlowController } from "../multiStepInputFlowController";
+import { QuickPickItem, QuickInputButton, Uri } from "vscode"
+import { CredentialSelectionState } from "./credentialSelectionState"
+import { MultiStepInputFlowController } from "../multiStepInputFlowController"
 
 export class AddProfileButton implements QuickInputButton {
     constructor(public iconPath: { light: Uri; dark: Uri; }, public tooltip: string) { }
 }
 
 export interface CredentialSelectionDataProvider {
-    existingProfileNames: string[];
-    pickCredentialProfile(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>): Promise<QuickPickItem | AddProfileButton>;
-    inputProfileName(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>) : Promise<string | undefined>;
-    inputAccessKey(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>) : Promise<string | undefined>;
-    inputSecretKey(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>) : Promise<string | undefined>;
+    existingProfileNames: string[]
+    pickCredentialProfile(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>): Promise<QuickPickItem | AddProfileButton>
+    inputProfileName(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>) : Promise<string | undefined>
+    inputAccessKey(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>) : Promise<string | undefined>
+    inputSecretKey(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>) : Promise<string | undefined>
 }

--- a/src/shared/credentials/credentialSelectionState.ts
+++ b/src/shared/credentials/credentialSelectionState.ts
@@ -1,13 +1,13 @@
-'use strict';
+'use strict'
 
-import { QuickPickItem } from "vscode";
+import { QuickPickItem } from "vscode"
 
 export interface CredentialSelectionState {
-    title: string;
-    step: number;
-    totalSteps: number;
-    credentialProfile: QuickPickItem | undefined;
-    accesskey: string;
-    secretKey: string;
-    profileName: string;
+    title: string
+    step: number
+    totalSteps: number
+    credentialProfile: QuickPickItem | undefined
+    accesskey: string
+    secretKey: string
+    profileName: string
 }

--- a/src/shared/credentials/credentialsFile.ts
+++ b/src/shared/credentials/credentialsFile.ts
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 //***************************************************************************
 // Note: Supplied by the AWS Javascript SDK team, from their upcoming v3 SDK.
@@ -6,13 +6,13 @@
 // their version.
 //***************************************************************************
 
-import {homedir} from 'os';
-import {join, sep} from 'path';
-import {readFile, writeFile} from 'fs';
-import { copy } from 'fs-extra';
+import {homedir} from 'os'
+import {join, sep} from 'path'
+import {readFile, writeFile} from 'fs'
+import { copy } from 'fs-extra'
 
-export const ENV_CREDENTIALS_PATH = 'AWS_SHARED_CREDENTIALS_FILE';
-export const ENV_CONFIG_PATH = 'AWS_CONFIG_FILE';
+export const ENV_CREDENTIALS_PATH = 'AWS_SHARED_CREDENTIALS_FILE'
+export const ENV_CONFIG_PATH = 'AWS_CONFIG_FILE'
 
 export interface SharedConfigInit {
     /**
@@ -20,30 +20,30 @@ export interface SharedConfigInit {
      * value of the `AWS_SHARED_CREDENTIALS_FILE` environment variable (if
      * defined) or `~/.aws/credentials` otherwise.
      */
-    filepath?: string;
+    filepath?: string
 
     /**
      * The path at which to locate the ini config file. Defaults to the value of
      * the `AWS_CONFIG_FILE` environment variable (if defined) or
      * `~/.aws/config` otherwise.
      */
-    configFilepath?: string;
+    configFilepath?: string
 }
 
 export interface Profile {
-    [key: string]: string|undefined;
+    [key: string]: string|undefined
 }
 
 export interface ParsedIniData {
-    [key: string]: Profile;
+    [key: string]: Profile
 }
 
 export interface SharedConfigFiles {
-    credentialsFile: ParsedIniData;
-    configFile: ParsedIniData;
+    credentialsFile: ParsedIniData
+    configFile: ParsedIniData
 }
 
-const swallowError = () => ({});
+const swallowError = () => ({})
 
 export function loadSharedConfigFiles(
     init: SharedConfigInit = {}
@@ -53,7 +53,7 @@ export function loadSharedConfigFiles(
             || join(getHomeDir(), '.aws', 'credentials'),
         configFilepath = process.env[ENV_CONFIG_PATH]
             || join(getHomeDir(), '.aws', 'config'),
-    } = init;
+    } = init
 
     return Promise.all([
         slurpFile(configFilepath)
@@ -64,12 +64,12 @@ export function loadSharedConfigFiles(
             .then(parseIni)
             .catch(swallowError),
     ]).then((parsedFiles: Array<ParsedIniData>) => {
-        const [configFile, credentialsFile] = parsedFiles;
+        const [configFile, credentialsFile] = parsedFiles
         return {
             configFile,
             credentialsFile,
-        };
-    });
+        }
+    })
 }
 
 // TODO: FOR POC-DEMOS ONLY, NOT FOR PRODUCTION USE!
@@ -83,77 +83,77 @@ export function saveProfile(
 
     return new Promise((resolve, reject) => {
         const filepath = process.env[ENV_CREDENTIALS_PATH]
-                || join(getHomeDir(), '.aws', 'credentials');
+                || join(getHomeDir(), '.aws', 'credentials')
 
         // even though poc concept code, let's preserve the user's file!
-        copy(filepath, filepath + '.bak_vscode', { overwrite: true});
+        copy(filepath, filepath + '.bak_vscode', { overwrite: true})
 
         slurpFile(filepath).then(data => {
-            data += '\r\n';
-            data += `[${name}]\r\n`;
-            data += `aws_access_key_id=${accessKey}\r\n`;
-            data += `aws_secret_access_key=${secretKey}\r\n`;
+            data += '\r\n'
+            data += `[${name}]\r\n`
+            data += `aws_access_key_id=${accessKey}\r\n`
+            data += `aws_secret_access_key=${secretKey}\r\n`
 
             writeFile(filepath, data, 'utf8', (err) => {
                 if (err) {
-                    reject(err);
+                    reject(err)
                 } else {
-                    resolve();
+                    resolve()
                 }
-            });
-        });
-    });
+            })
+        })
+    })
 }
 
-const profileKeyRegex = /^profile\s(["'])?([^\1]+)\1$/;
+const profileKeyRegex = /^profile\s(["'])?([^\1]+)\1$/
 function normalizeConfigFile(data: ParsedIniData): ParsedIniData {
-    const map: ParsedIniData = {};
+    const map: ParsedIniData = {}
     for (let key of Object.keys(data)) {
-        let matches: Array<string>|null;
+        let matches: Array<string>|null
         if (key === 'default') {
-            map.default = data.default;
+            map.default = data.default
         } else if (matches = profileKeyRegex.exec(key)) {
             // @ts-ignore
-            const [_1, _2, normalizedKey] = matches;
+            const [_1, _2, normalizedKey] = matches
             if (normalizedKey) {
-                map[normalizedKey] = data[key];
+                map[normalizedKey] = data[key]
             }
         }
     }
 
-    return map;
+    return map
 }
 
 function parseIni(iniData: string): ParsedIniData {
-    const map: ParsedIniData = {};
-    let currentSection: string|undefined;
+    const map: ParsedIniData = {}
+    let currentSection: string|undefined
     for (let line of iniData.split(/\r?\n/)) {
-        line = line.split(/(^|\s)[;#]/)[0]; // remove comments
-        const section = line.match(/^\s*\[([^\[\]]+)]\s*$/);
+        line = line.split(/(^|\s)[;#]/)[0] // remove comments
+        const section = line.match(/^\s*\[([^\[\]]+)]\s*$/)
         if (section) {
-            currentSection = section[1];
+            currentSection = section[1]
         } else if (currentSection) {
-            const item = line.match(/^\s*(.+?)\s*=\s*(.+?)\s*$/);
+            const item = line.match(/^\s*(.+?)\s*=\s*(.+?)\s*$/)
             if (item) {
-                map[currentSection] = map[currentSection] || {};
-                map[currentSection][item[1]] = item[2];
+                map[currentSection] = map[currentSection] || {}
+                map[currentSection][item[1]] = item[2]
             }
         }
     }
 
-    return map;
+    return map
 }
 
 function slurpFile(path: string): Promise<string> {
     return new Promise((resolve, reject) => {
         readFile(path, 'utf8', (err, data) => {
             if (err) {
-                reject(err);
+                reject(err)
             } else {
-                resolve(data);
+                resolve(data)
             }
-        });
-    });
+        })
+    })
 }
 
 function getHomeDir(): string {
@@ -162,11 +162,11 @@ function getHomeDir(): string {
         USERPROFILE,
         HOMEPATH,
         HOMEDRIVE = `C:${sep}`,
-    } = process.env;
+    } = process.env
 
-    if (HOME) { return HOME; }
-    if (USERPROFILE) { return USERPROFILE; }
-    if (HOMEPATH) { return `${HOMEDRIVE}${HOMEPATH}`; }
+    if (HOME) { return HOME }
+    if (USERPROFILE) { return USERPROFILE }
+    if (HOMEPATH) { return `${HOMEDRIVE}${HOMEPATH}` }
 
-    return homedir();
+    return homedir()
 }

--- a/src/shared/credentials/credentialsFileReaderWriter.ts
+++ b/src/shared/credentials/credentialsFileReaderWriter.ts
@@ -1,9 +1,9 @@
-'use strict';
+'use strict'
 
 export interface CredentialsFileReaderWriter {
     // returns the list of available profile names
-    getProfileNames(): Promise<string[]>;
+    getProfileNames(): Promise<string[]>
 
     // writes a new profile to the credential file
-    addProfileToFile(profileName: string, accessKey: string, secretKet: string): Promise<void>;
+    addProfileToFile(profileName: string, accessKey: string, secretKet: string): Promise<void>
 }

--- a/src/shared/credentials/defaultCredentialSelectionDataProvider.ts
+++ b/src/shared/credentials/defaultCredentialSelectionDataProvider.ts
@@ -6,33 +6,33 @@
 //
 // Based on the multiStepInput code in the QuickInput VSCode extension sample.
 
-'use strict';
+'use strict'
 
-import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
+import * as nls from 'vscode-nls'
+let localize = nls.loadMessageBundle()
 
-import { QuickPickItem, Uri, ExtensionContext } from 'vscode';
-import { MultiStepInputFlowController } from '../multiStepInputFlowController';
-import { CredentialSelectionState } from './credentialSelectionState';
-import { AddProfileButton, CredentialSelectionDataProvider } from './credentialSelectionDataProvider';
+import { QuickPickItem, Uri, ExtensionContext } from 'vscode'
+import { MultiStepInputFlowController } from '../multiStepInputFlowController'
+import { CredentialSelectionState } from './credentialSelectionState'
+import { AddProfileButton, CredentialSelectionDataProvider } from './credentialSelectionDataProvider'
 
 export class DefaultCredentialSelectionDataProvider implements CredentialSelectionDataProvider {
 
-    newProfileButton: AddProfileButton;
+    newProfileButton: AddProfileButton
 
     constructor(public readonly existingProfileNames: string[], protected context: ExtensionContext) {
         this.newProfileButton = new AddProfileButton({
             dark: Uri.file(context.asAbsolutePath('resources/dark/add.svg')),
             light: Uri.file(context.asAbsolutePath('resources/light/add.svg')),
-        }, localize('AWS.tooltip.createCredentialProfile', 'Create a new credential profile'));
+        }, localize('AWS.tooltip.createCredentialProfile', 'Create a new credential profile'))
     }
 
     async pickCredentialProfile(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>): Promise<QuickPickItem | AddProfileButton> {
-        let existingProfiles: QuickPickItem[] = [];
+        let existingProfiles: QuickPickItem[] = []
 
         this.existingProfileNames.forEach(element => {
-            existingProfiles.push({ label: element });
-        });
+            existingProfiles.push({ label: element })
+        })
 
         return await input.showQuickPick({
             title: localize('AWS.title.selectCredentialProfile', 'Select an AWS credential profile'),
@@ -43,7 +43,7 @@ export class DefaultCredentialSelectionDataProvider implements CredentialSelecti
             activeItem: state.credentialProfile,
             buttons: [this.newProfileButton],
             shouldResume: this.shouldResume
-        });
+        })
     }
 
     async inputProfileName(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>) : Promise<string | undefined> {
@@ -55,7 +55,7 @@ export class DefaultCredentialSelectionDataProvider implements CredentialSelecti
             prompt: localize('AWS.placeHolder.newProfileName', 'Choose a unique name for the new profile'),
             validate: this.validateNameIsUnique,
             shouldResume: this.shouldResume
-        });
+        })
     }
 
     async inputAccessKey(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>) : Promise<string | undefined> {
@@ -68,7 +68,7 @@ export class DefaultCredentialSelectionDataProvider implements CredentialSelecti
             validate: this.validateAccessKey,
             ignoreFocusOut: true,
             shouldResume: this.shouldResume
-        });
+        })
     }
 
     async inputSecretKey(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>) : Promise<string | undefined> {
@@ -81,62 +81,62 @@ export class DefaultCredentialSelectionDataProvider implements CredentialSelecti
             validate: this.validateSecretKey,
             ignoreFocusOut: true,
             shouldResume: this.shouldResume
-        });
+        })
     }
 
     validateNameIsUnique = (name: string): Promise<string | undefined> => {
         return new Promise<string | undefined>(resolve => {
-            const duplicate = this.existingProfileNames.find(k => k === name);
-            resolve(duplicate ? 'Name not unique' : undefined);
-        });
+            const duplicate = this.existingProfileNames.find(k => k === name)
+            resolve(duplicate ? 'Name not unique' : undefined)
+        })
     }
 
     validateAccessKey = (accessKey: string) : Promise<string | undefined> => {
         // TODO: is there a regex pattern we could use?
-        return new Promise<string|undefined>(resolve => resolve(undefined));
+        return new Promise<string|undefined>(resolve => resolve(undefined))
     }
 
     validateSecretKey = (accessKey: string) : Promise<string | undefined> => {
         // TODO: don't believe there is a regex but at this point we could try a 'safe' call
-        return new Promise<string|undefined>(resolve => resolve(undefined));
+        return new Promise<string|undefined>(resolve => resolve(undefined))
     }
 
     shouldResume = () : Promise<boolean> => {
         // Could show a notification with the option to resume.
         return new Promise<boolean>((resolve, reject) => {
-        });
+        })
     }
 }
 
 export async function credentialProfileSelector(dataProvider: CredentialSelectionDataProvider) : Promise<CredentialSelectionState | undefined> {
 
     async function pickCredentialProfile(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>) {
-        const pick = await dataProvider.pickCredentialProfile(input, state);
+        const pick = await dataProvider.pickCredentialProfile(input, state)
         if (pick instanceof AddProfileButton) {
-            return (input: MultiStepInputFlowController) => inputProfileName(input, state);
+            return (input: MultiStepInputFlowController) => inputProfileName(input, state)
         }
-        state.credentialProfile = pick;
+        state.credentialProfile = pick
     }
 
     async function inputProfileName(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>) {
-        state.profileName = await dataProvider.inputProfileName(input, state);
-        return (input: MultiStepInputFlowController) => inputAccessKey(input, state);
+        state.profileName = await dataProvider.inputProfileName(input, state)
+        return (input: MultiStepInputFlowController) => inputAccessKey(input, state)
     }
 
     async function inputAccessKey(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>) {
-        state.accesskey = await dataProvider.inputAccessKey(input, state);
-        return (input: MultiStepInputFlowController) => inputSecretKey(input, state);
+        state.accesskey = await dataProvider.inputAccessKey(input, state)
+        return (input: MultiStepInputFlowController) => inputSecretKey(input, state)
     }
 
     async function inputSecretKey(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>) {
-        state.secretKey = await dataProvider.inputSecretKey(input, state);
+        state.secretKey = await dataProvider.inputSecretKey(input, state)
     }
 
     async function collectInputs() {
-        const state = {} as Partial<CredentialSelectionState>;
-        await MultiStepInputFlowController.run(input => pickCredentialProfile(input, state));
-        return state as CredentialSelectionState;
+        const state = {} as Partial<CredentialSelectionState>
+        await MultiStepInputFlowController.run(input => pickCredentialProfile(input, state))
+        return state as CredentialSelectionState
     }
 
-    return await collectInputs();
+    return await collectInputs()
 }

--- a/src/shared/credentials/defaultCredentialsFileReaderWriter.ts
+++ b/src/shared/credentials/defaultCredentialsFileReaderWriter.ts
@@ -1,22 +1,22 @@
-'use strict';
+'use strict'
 
-import { CredentialsFileReaderWriter } from "./credentialsFileReaderWriter";
-import { loadSharedConfigFiles, saveProfile } from "./credentialsFile";
+import { CredentialsFileReaderWriter } from "./credentialsFileReaderWriter"
+import { loadSharedConfigFiles, saveProfile } from "./credentialsFile"
 
 export class DefaultCredentialsFileReaderWriter implements CredentialsFileReaderWriter {
     async getProfileNames(): Promise<string[]> {
-        let profileNames: string[] = [];
+        let profileNames: string[] = []
 
         // TODO: cache the file and attach a watcher to it
-        const credentialFiles = await loadSharedConfigFiles();
-        profileNames = Object.keys(credentialFiles.credentialsFile);
+        const credentialFiles = await loadSharedConfigFiles()
+        profileNames = Object.keys(credentialFiles.credentialsFile)
 
         return new Promise<string[]>(resolve => {
-            resolve(profileNames);
-        });
+            resolve(profileNames)
+        })
     }
 
     async addProfileToFile(profileName: string, accessKey: string, secretKey: string): Promise<void> {
-        await saveProfile(profileName, accessKey, secretKey);
+        await saveProfile(profileName, accessKey, secretKey)
     }
 }

--- a/src/shared/defaultAwsContext.ts
+++ b/src/shared/defaultAwsContext.ts
@@ -1,10 +1,10 @@
-'use strict';
+'use strict'
 
-import * as AWS from 'aws-sdk';
-import * as vscode from 'vscode';
-import { regionSettingKey, profileSettingKey } from './constants';
-import { AwsContext } from './awsContext';
-import { SettingsConfiguration } from './settingsConfiguration';
+import * as AWS from 'aws-sdk'
+import * as vscode from 'vscode'
+import { regionSettingKey, profileSettingKey } from './constants'
+import { AwsContext } from './awsContext'
+import { SettingsConfiguration } from './settingsConfiguration'
 
 // Carries the current context data on events
 export class ContextChangeEventsArgs {
@@ -16,24 +16,24 @@ export class ContextChangeEventsArgs {
 // context listens for configuration updates and resets the context accordingly.
 export class DefaultAwsContext implements AwsContext {
 
-    private _onDidChangeContext: vscode.EventEmitter<ContextChangeEventsArgs> = new vscode.EventEmitter<ContextChangeEventsArgs>();
-    public readonly onDidChangeContext: vscode.Event<ContextChangeEventsArgs> = this._onDidChangeContext.event;
+    private _onDidChangeContext: vscode.EventEmitter<ContextChangeEventsArgs> = new vscode.EventEmitter<ContextChangeEventsArgs>()
+    public readonly onDidChangeContext: vscode.Event<ContextChangeEventsArgs> = this._onDidChangeContext.event
 
     // the collection of regions the user has expressed an interest in working with in
     // the current workspace
-    private explorerRegions: string[];
+    private explorerRegions: string[]
 
     // the user's credential context (currently this maps to an sdk/cli credential profile)
-    private profileName: string | undefined;
+    private profileName: string | undefined
 
     constructor(public settingsConfiguration: SettingsConfiguration) {
 
-        this.profileName = settingsConfiguration.readSetting(profileSettingKey, '');
-        const persistedRegions = settingsConfiguration.readSetting(regionSettingKey, undefined);
+        this.profileName = settingsConfiguration.readSetting(profileSettingKey, '')
+        const persistedRegions = settingsConfiguration.readSetting(regionSettingKey, undefined)
         if (persistedRegions) {
-            this.explorerRegions = persistedRegions.split(',');
+            this.explorerRegions = persistedRegions.split(',')
         } else {
-            this.explorerRegions = [];
+            this.explorerRegions = []
         }
     }
 
@@ -42,56 +42,56 @@ export class DefaultAwsContext implements AwsContext {
     // user was running Code on an EC2 instance.
     public async getCredentials() : Promise<AWS.Credentials | undefined> {
         if (this.profileName) {
-            return new AWS.SharedIniFileCredentials({profile: this.profileName});
+            return new AWS.SharedIniFileCredentials({profile: this.profileName})
         }
 
-        return undefined;
+        return undefined
     }
 
     // returns the configured profile, if any
     public getCredentialProfileName() : string | undefined {
-        return this.profileName;
+        return this.profileName
     }
 
     // resets the context to the indicated profile, saving it into settings
     public async setCredentialProfileName(profileName?: string) : Promise<void> {
-        this.profileName = profileName;
-        await this.settingsConfiguration.writeSetting(profileSettingKey, profileName, vscode.ConfigurationTarget.Global);
-        this._onDidChangeContext.fire(new ContextChangeEventsArgs(this.profileName, this.explorerRegions));
+        this.profileName = profileName
+        await this.settingsConfiguration.writeSetting(profileSettingKey, profileName, vscode.ConfigurationTarget.Global)
+        this._onDidChangeContext.fire(new ContextChangeEventsArgs(this.profileName, this.explorerRegions))
     }
 
     // async so that we could *potentially* support other ways of obtaining
     // region in future - for example from instance metadata if the
     // user was running Code on an EC2 instance.
     public async getExplorerRegions(): Promise<string[]> {
-        return this.explorerRegions;
+        return this.explorerRegions
     }
 
     // adds one or more regions into the preferred set, persisting the set afterwards as a
     // comma-separated string.
     public async addExplorerRegion(region: string | string[]) : Promise<void> {
-        const regionsToProcess: string[] = region instanceof Array ? region : [region];
+        const regionsToProcess: string[] = region instanceof Array ? region : [region]
         regionsToProcess.forEach(r => {
-            const index = this.explorerRegions.findIndex(r => r === region);
+            const index = this.explorerRegions.findIndex(r => r === region)
             if (index === -1) {
-                this.explorerRegions.push(r);
+                this.explorerRegions.push(r)
             }
-        });
-        await this.settingsConfiguration.writeSetting(regionSettingKey, this.explorerRegions, vscode.ConfigurationTarget.Global);
-        this._onDidChangeContext.fire(new ContextChangeEventsArgs(this.profileName, this.explorerRegions));
+        })
+        await this.settingsConfiguration.writeSetting(regionSettingKey, this.explorerRegions, vscode.ConfigurationTarget.Global)
+        this._onDidChangeContext.fire(new ContextChangeEventsArgs(this.profileName, this.explorerRegions))
     }
 
     // removes one or more regions from the user's preferred set, persisting the set afterwards as a
     // comma-separated string.
     public async removeExplorerRegion(region: string | string[]) : Promise<void> {
-        const regionsToProcess: string[] = region instanceof Array ? region : [region];
+        const regionsToProcess: string[] = region instanceof Array ? region : [region]
         regionsToProcess.forEach(r => {
-            const index = this.explorerRegions.findIndex(r => r === region);
+            const index = this.explorerRegions.findIndex(r => r === region)
             if (index >= 0) {
-                this.explorerRegions.splice(index, 1);
+                this.explorerRegions.splice(index, 1)
             }
-        });
-        await this.settingsConfiguration.writeSetting(regionSettingKey, this.explorerRegions, vscode.ConfigurationTarget.Global);
-        this._onDidChangeContext.fire(new ContextChangeEventsArgs(this.profileName, this.explorerRegions));
+        })
+        await this.settingsConfiguration.writeSetting(regionSettingKey, this.explorerRegions, vscode.ConfigurationTarget.Global)
+        this._onDidChangeContext.fire(new ContextChangeEventsArgs(this.profileName, this.explorerRegions))
     }
 }

--- a/src/shared/defaultResourceFetcher.ts
+++ b/src/shared/defaultResourceFetcher.ts
@@ -1,37 +1,37 @@
-'use strict';
+'use strict'
 
-import request = require('request');
-import * as fse from 'fs-extra';
-import { ResourceFetcher } from './resourceFetcher';
-import { WebResourceLocation, FileResourceLocation, ResourceLocation } from './resourceLocation';
+import request = require('request')
+import * as fse from 'fs-extra'
+import { ResourceFetcher } from './resourceFetcher'
+import { WebResourceLocation, FileResourceLocation, ResourceLocation } from './resourceLocation'
 
 export class DefaultResourceFetcher implements ResourceFetcher {
     // Attempts to retrieve a resource from the given locations in order, stopping on the first success.
     async getResource(resourceLocations: ResourceLocation[]): Promise<string> {
         if (resourceLocations.length === 0) {
-            throw new Error("no locations provided to get resource from");
+            throw new Error("no locations provided to get resource from")
         }
 
         for (let resourceLocation of resourceLocations) {
             try {
-                let result: string;
+                let result: string
                 if (resourceLocation instanceof WebResourceLocation) {
-                    result = await this.getWebResource(resourceLocation);
+                    result = await this.getWebResource(resourceLocation)
                 }
                 else if (resourceLocation instanceof FileResourceLocation) {
-                    result = await this.getFileResource(resourceLocation);
+                    result = await this.getFileResource(resourceLocation)
                 }
                 else {
-                    throw new Error(`Unknown resource location type: ${typeof resourceLocation}`);
+                    throw new Error(`Unknown resource location type: ${typeof resourceLocation}`)
                 }
-                return Promise.resolve(result);
+                return Promise.resolve(result)
             } catch (err) {
                 // Log error, then try the next fallback location if there is one.
-                console.log(`Error getting resource from ${resourceLocation.getLocationUri()} : ${err}`);
+                console.log(`Error getting resource from ${resourceLocation.getLocationUri()} : ${err}`)
             }
         }
 
-        return Promise.reject(new Error("Resource could not be found"));
+        return Promise.reject(new Error("Resource could not be found"))
     }
 
     // Http based file retriever
@@ -43,12 +43,12 @@ export class DefaultResourceFetcher implements ResourceFetcher {
             request(resourceLocation.getLocationUri(), {}, (err, res, body) => {
 
                 if (err) {
-                    reject(err);
+                    reject(err)
                 } else {
-                    resolve(body);
+                    resolve(body)
                 }
-            });
-        });
+            })
+        })
     }
 
     // Local file retriever
@@ -56,12 +56,12 @@ export class DefaultResourceFetcher implements ResourceFetcher {
         return new Promise<string>((resolve, reject) => {
 
             try {
-                const content = fse.readFileSync(resourceLocation.getLocationUri()).toString();
-                resolve(content);
+                const content = fse.readFileSync(resourceLocation.getLocationUri()).toString()
+                resolve(content)
             } catch (err) {
-                reject(err);
+                reject(err)
             }
-        });
+        })
     }
 }
 

--- a/src/shared/extensionGlobals.ts
+++ b/src/shared/extensionGlobals.ts
@@ -1,18 +1,18 @@
-'use strict';
+'use strict'
 
-import { ExtensionContext, OutputChannel } from 'vscode';
-import { AWSClientBuilder } from './awsClientBuilder';
-import { AWSStatusBar } from './statusBar';
-import { AWSContextCommands } from './awsContextCommands';
+import { ExtensionContext, OutputChannel } from 'vscode'
+import { AWSClientBuilder } from './awsClientBuilder'
+import { AWSStatusBar } from './statusBar'
+import { AWSContextCommands } from './awsContextCommands'
 
 /**
  * Namespace for common variables used globally in the extension.
  * All variables here must be initialized in the activate() method of extension.ts
  */
 export namespace ext {
-    export let context: ExtensionContext;
-    export let outputChannel: OutputChannel;
-    export let awsContextCommands: AWSContextCommands;
-    export let sdkClientBuilder: AWSClientBuilder;
-    export let statusBar: AWSStatusBar;
+    export let context: ExtensionContext
+    export let outputChannel: OutputChannel
+    export let awsContextCommands: AWSContextCommands
+    export let sdkClientBuilder: AWSClientBuilder
+    export let statusBar: AWSStatusBar
 }

--- a/src/shared/extensionUtilities.ts
+++ b/src/shared/extensionUtilities.ts
@@ -1,37 +1,37 @@
-import * as vscode from 'vscode';
-import * as path from 'path';
-import { ext } from "../shared/extensionGlobals";
-import { ScriptResource } from '../lambda/models/scriptResource';
-import * as _ from 'lodash';
+import * as vscode from 'vscode'
+import * as path from 'path'
+import { ext } from "../shared/extensionGlobals"
+import { ScriptResource } from '../lambda/models/scriptResource'
+import * as _ from 'lodash'
 
 export class ExtensionUtilities {
     public static getLibrariesForHtml(names: string[]): ScriptResource[] {
-        const basePath = path.join(ext.context.extensionPath, 'media', 'libs');
-        return this.resolveResourceURIs(basePath, names);
+        const basePath = path.join(ext.context.extensionPath, 'media', 'libs')
+        return this.resolveResourceURIs(basePath, names)
     }
     public static getScriptsForHtml(names: string[]): ScriptResource[] {
-        const basePath = path.join(ext.context.extensionPath, 'media', 'js');
-        return this.resolveResourceURIs(basePath, names);
+        const basePath = path.join(ext.context.extensionPath, 'media', 'js')
+        return this.resolveResourceURIs(basePath, names)
     }
 
     private static resolveResourceURIs(basePath: string, names: string[]): ScriptResource[] {
-        const scripts: ScriptResource[] = [];
+        const scripts: ScriptResource[] = []
         _.forEach(names, (scriptName) => {
-            const scriptPathOnDisk = vscode.Uri.file(path.join(basePath, scriptName));
-            const scriptUri = scriptPathOnDisk.with({ scheme: 'vscode-resource' });
-            const nonce = ExtensionUtilities.getNonce();
-            scripts.push({ Nonce: nonce, Uri: scriptUri });
-        });
-        return scripts;
+            const scriptPathOnDisk = vscode.Uri.file(path.join(basePath, scriptName))
+            const scriptUri = scriptPathOnDisk.with({ scheme: 'vscode-resource' })
+            const nonce = ExtensionUtilities.getNonce()
+            scripts.push({ Nonce: nonce, Uri: scriptUri })
+        })
+        return scripts
     }
 
     public static getNonce(): string {
-        let text = "";
-        const possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        let text = ""
+        const possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
         for (let i = 0; i < 32; i++) {
-            text += possible.charAt(Math.floor(Math.random() * possible.length));
+            text += possible.charAt(Math.floor(Math.random() * possible.length))
         }
-        return text;
+        return text
     }
 }
 
@@ -51,10 +51,10 @@ export class ExtensionUtilities {
 export function safeGet<O, T>(obj: O | undefined, getFn: (x: O) => T): T | undefined {
     if (obj) {
         try {
-            return getFn(obj);
+            return getFn(obj)
         } catch (error) {
             //ignore
         }
     }
-    return undefined;
+    return undefined
 }

--- a/src/shared/multiStepInputFlowController.ts
+++ b/src/shared/multiStepInputFlowController.ts
@@ -1,181 +1,181 @@
-'use strict';
+'use strict'
 
-import { Disposable, QuickInput, QuickInputButton, QuickInputButtons, QuickPickItem, window } from 'vscode';
+import { Disposable, QuickInput, QuickInputButton, QuickInputButtons, QuickPickItem, window } from 'vscode'
 
 // Taken from the VSCode QuickInput sample, coordinates flows through
 // a multi-step input sequence.
 
 class InputFlowAction {
     private constructor() { }
-    static back = new InputFlowAction();
-    static cancel = new InputFlowAction();
-    static resume = new InputFlowAction();
+    static back = new InputFlowAction()
+    static cancel = new InputFlowAction()
+    static resume = new InputFlowAction()
 }
 
-type InputStep = (input: MultiStepInputFlowController) => Thenable<InputStep | void>;
+type InputStep = (input: MultiStepInputFlowController) => Thenable<InputStep | void>
 
 interface QuickPickParameters<T extends QuickPickItem> {
-    title: string;
-    step: number;
-    totalSteps: number;
-    items: T[];
-    activeItem?: T;
-    placeholder: string;
-    buttons?: QuickInputButton[];
-    shouldResume: () => Thenable<boolean>;
+    title: string
+    step: number
+    totalSteps: number
+    items: T[]
+    activeItem?: T
+    placeholder: string
+    buttons?: QuickInputButton[]
+    shouldResume: () => Thenable<boolean>
 }
 
 interface InputBoxParameters {
-    title: string;
-    step: number;
-    totalSteps: number;
-    value: string;
-    prompt: string;
-    validate: (value: string) => Promise<string | undefined>;
-    buttons?: QuickInputButton[];
-    ignoreFocusOut?: boolean;
-    shouldResume: () => Thenable<boolean>;
+    title: string
+    step: number
+    totalSteps: number
+    value: string
+    prompt: string
+    validate: (value: string) => Promise<string | undefined>
+    buttons?: QuickInputButton[]
+    ignoreFocusOut?: boolean
+    shouldResume: () => Thenable<boolean>
 }
 
 export class MultiStepInputFlowController {
 
     static async run<T>(start: InputStep) {
-        const input = new MultiStepInputFlowController();
-        return input.stepThrough(start);
+        const input = new MultiStepInputFlowController()
+        return input.stepThrough(start)
     }
 
-    private current?: QuickInput;
-    private steps: InputStep[] = [];
+    private current?: QuickInput
+    private steps: InputStep[] = []
 
     private async stepThrough<T>(start: InputStep) {
-        let step: InputStep | void = start;
+        let step: InputStep | void = start
         while (step) {
-            this.steps.push(step);
+            this.steps.push(step)
             if (this.current) {
-                this.current.enabled = false;
-                this.current.busy = true;
+                this.current.enabled = false
+                this.current.busy = true
             }
             try {
-                step = await step(this);
+                step = await step(this)
             } catch (err) {
                 if (err === InputFlowAction.back) {
-                    this.steps.pop();
-                    step = this.steps.pop();
+                    this.steps.pop()
+                    step = this.steps.pop()
                 } else if (err === InputFlowAction.resume) {
-                    step = this.steps.pop();
+                    step = this.steps.pop()
                 } else if (err === InputFlowAction.cancel) {
-                    step = undefined;
+                    step = undefined
                 } else {
-                    throw err;
+                    throw err
                 }
             }
         }
         if (this.current) {
-            this.current.dispose();
+            this.current.dispose()
         }
     }
 
     async showQuickPick<T extends QuickPickItem, P extends QuickPickParameters<T>>({ title, step, totalSteps, items, activeItem, placeholder, buttons, shouldResume }: P) {
-        const disposables: Disposable[] = [];
+        const disposables: Disposable[] = []
         try {
             return await new Promise<T | (P extends { buttons: (infer I)[] } ? I : never)>((resolve, reject) => {
-                const input = window.createQuickPick<T>();
-                input.title = title;
-                input.step = step;
-                input.totalSteps = totalSteps;
-                input.placeholder = placeholder;
-                input.items = items;
+                const input = window.createQuickPick<T>()
+                input.title = title
+                input.step = step
+                input.totalSteps = totalSteps
+                input.placeholder = placeholder
+                input.items = items
                 if (activeItem) {
-                    input.activeItems = [activeItem];
+                    input.activeItems = [activeItem]
                 }
                 input.buttons = [
                     ...(this.steps.length > 1 ? [QuickInputButtons.Back] : []),
                     ...(buttons || [])
-                ];
+                ]
                 disposables.push(
                     input.onDidTriggerButton(item => {
                         if (item === QuickInputButtons.Back) {
-                            reject(InputFlowAction.back);
+                            reject(InputFlowAction.back)
                         } else {
-                            resolve(<any>item);
+                            resolve(<any>item)
                         }
                     }),
                     input.onDidChangeSelection(items => resolve(items[0])),
                     input.onDidHide(() => {
                         (async () => {
-                            reject(shouldResume && await shouldResume() ? InputFlowAction.resume : InputFlowAction.cancel);
+                            reject(shouldResume && await shouldResume() ? InputFlowAction.resume : InputFlowAction.cancel)
                         })()
-                            .catch(reject);
+                            .catch(reject)
                     })
-                );
+                )
                 if (this.current) {
-                    this.current.dispose();
+                    this.current.dispose()
                 }
-                this.current = input;
-                this.current.show();
-            });
+                this.current = input
+                this.current.show()
+            })
         } finally {
-            disposables.forEach(d => d.dispose());
+            disposables.forEach(d => d.dispose())
         }
     }
 
     async showInputBox<P extends InputBoxParameters>({ title, step, totalSteps, value, prompt, validate, buttons, ignoreFocusOut, shouldResume }: P) {
-        const disposables: Disposable[] = [];
+        const disposables: Disposable[] = []
         try {
             return await new Promise<string | (P extends { buttons: (infer I)[] } ? I : never)>((resolve, reject) => {
-                const input = window.createInputBox();
-                input.title = title;
-                input.step = step;
-                input.totalSteps = totalSteps;
-                input.value = value || '';
-                input.prompt = prompt;
+                const input = window.createInputBox()
+                input.title = title
+                input.step = step
+                input.totalSteps = totalSteps
+                input.value = value || ''
+                input.prompt = prompt
                 input.buttons = [
                     ...(this.steps.length > 1 ? [QuickInputButtons.Back] : []),
                     ...(buttons || [])
-                ];
-                input.ignoreFocusOut = ignoreFocusOut ? ignoreFocusOut : false;
-                let validating = validate('');
+                ]
+                input.ignoreFocusOut = ignoreFocusOut ? ignoreFocusOut : false
+                let validating = validate('')
                 disposables.push(
                     input.onDidTriggerButton(item => {
                         if (item === QuickInputButtons.Back) {
-                            reject(InputFlowAction.back);
+                            reject(InputFlowAction.back)
                         } else {
-                            resolve(<any>item);
+                            resolve(<any>item)
                         }
                     }),
                     input.onDidAccept(async () => {
-                        const value = input.value;
-                        input.enabled = false;
-                        input.busy = true;
+                        const value = input.value
+                        input.enabled = false
+                        input.busy = true
                         if (!(await validate(value))) {
-                            resolve(value);
+                            resolve(value)
                         }
-                        input.enabled = true;
-                        input.busy = false;
+                        input.enabled = true
+                        input.busy = false
                     }),
                     input.onDidChangeValue(async text => {
-                        const current = validate(text);
-                        validating = current;
-                        const validationMessage = await current;
+                        const current = validate(text)
+                        validating = current
+                        const validationMessage = await current
                         if (current === validating) {
-                            input.validationMessage = validationMessage;
+                            input.validationMessage = validationMessage
                         }
                     }),
                     input.onDidHide(() => {
                         (async () => {
-                            reject(shouldResume && await shouldResume() ? InputFlowAction.resume : InputFlowAction.cancel);
+                            reject(shouldResume && await shouldResume() ? InputFlowAction.resume : InputFlowAction.cancel)
                         })()
-                            .catch(reject);
+                            .catch(reject)
                     })
-                );
+                )
                 if (this.current) {
-                    this.current.dispose();
+                    this.current.dispose()
                 }
-                this.current = input;
-                this.current.show();
-            });
+                this.current = input
+                this.current.show()
+            })
         } finally {
-            disposables.forEach(d => d.dispose());
+            disposables.forEach(d => d.dispose())
         }
     }
 }

--- a/src/shared/quickPickNode.ts
+++ b/src/shared/quickPickNode.ts
@@ -1,15 +1,15 @@
-'use strict';
+'use strict'
 
-import {QuickPickItem} from 'vscode';
+import {QuickPickItem} from 'vscode'
 
 export class QuickPickNode implements QuickPickItem {
-    label: string;
-    description?: string | undefined;
-    detail?: string | undefined;
-    picked?: boolean | undefined;
+    label: string
+    description?: string | undefined
+    detail?: string | undefined
+    picked?: boolean | undefined
     constructor(
         readonly id: string
     ) {
-        this.label = id;
+        this.label = id
     }
 }

--- a/src/shared/regions/defaultRegionProvider.ts
+++ b/src/shared/regions/defaultRegionProvider.ts
@@ -1,57 +1,57 @@
-'use strict';
+'use strict'
 
-import path = require('path');
-import { ResourceFetcher } from "../resourceFetcher";
-import { endpointsFileUrl } from '../constants';
-import { RegionInfo } from "./regionInfo";
-import { RegionProvider } from "./regionProvider";
-import { ExtensionContext } from 'vscode';
-import { WebResourceLocation, FileResourceLocation } from '../resourceLocation';
+import path = require('path')
+import { ResourceFetcher } from "../resourceFetcher"
+import { endpointsFileUrl } from '../constants'
+import { RegionInfo } from "./regionInfo"
+import { RegionProvider } from "./regionProvider"
+import { ExtensionContext } from 'vscode'
+import { WebResourceLocation, FileResourceLocation } from '../resourceLocation'
 
 export class DefaultRegionProvider implements RegionProvider {
 
-    private _areRegionsLoaded: boolean = false;
-    private _loadedRegions: RegionInfo[];
-    private readonly _context: ExtensionContext;
-    private readonly _resourceFetcher: ResourceFetcher;
+    private _areRegionsLoaded: boolean = false
+    private _loadedRegions: RegionInfo[]
+    private readonly _context: ExtensionContext
+    private readonly _resourceFetcher: ResourceFetcher
 
     constructor(context: ExtensionContext, resourceFetcher: ResourceFetcher) {
-        this._loadedRegions = [];
-        this._context = context;
-        this._resourceFetcher = resourceFetcher;
+        this._loadedRegions = []
+        this._context = context
+        this._resourceFetcher = resourceFetcher
     }
 
     // Returns an array of Regions, and caches them in memory.
     public async getRegionData(): Promise<RegionInfo[]> {
         if (this._areRegionsLoaded) {
-            return this._loadedRegions;
+            return this._loadedRegions
         }
 
-        let availableRegions: RegionInfo[] = [];
+        let availableRegions: RegionInfo[] = []
         try {
-            console.log('> Downloading latest toolkits endpoint data');
+            console.log('> Downloading latest toolkits endpoint data')
 
-            const resourcePath = path.join(this._context.extensionPath, 'resources', 'endpoints.json');
-            const endpointsSource = await this._resourceFetcher.getResource([new WebResourceLocation(endpointsFileUrl), new FileResourceLocation(resourcePath)]);
-            var allEndpoints = JSON.parse(endpointsSource);
+            const resourcePath = path.join(this._context.extensionPath, 'resources', 'endpoints.json')
+            const endpointsSource = await this._resourceFetcher.getResource([new WebResourceLocation(endpointsFileUrl), new FileResourceLocation(resourcePath)])
+            var allEndpoints = JSON.parse(endpointsSource)
 
             for (var p = 0; p < allEndpoints.partitions.length; p++) {
-                var partition = allEndpoints.partitions[p];
+                var partition = allEndpoints.partitions[p]
 
-                var regionKeys = Object.keys(partition.regions);
+                var regionKeys = Object.keys(partition.regions)
                 regionKeys.forEach((rk) => {
-                    availableRegions.push(new RegionInfo(rk, `${partition.regions[rk].description}`));
-                });
+                    availableRegions.push(new RegionInfo(rk, `${partition.regions[rk].description}`))
+                })
             }
-            this._areRegionsLoaded = true;
-            this._loadedRegions = availableRegions;
+            this._areRegionsLoaded = true
+            this._loadedRegions = availableRegions
         } catch (err) {
-            this._areRegionsLoaded = false;
-            console.log(`...error downloading endpoints: ${err}`); // TODO: now what, oneline + local failed...?
-            availableRegions = [];
-            this._loadedRegions = [];
+            this._areRegionsLoaded = false
+            console.log(`...error downloading endpoints: ${err}`) // TODO: now what, oneline + local failed...?
+            availableRegions = []
+            this._loadedRegions = []
         }
 
-        return availableRegions;
+        return availableRegions
     }
 }

--- a/src/shared/regions/regionInfo.ts
+++ b/src/shared/regions/regionInfo.ts
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 export class RegionInfo {
 

--- a/src/shared/regions/regionProvider.ts
+++ b/src/shared/regions/regionProvider.ts
@@ -1,9 +1,9 @@
-'use strict';
+'use strict'
 
-import { RegionInfo } from "./regionInfo";
+import { RegionInfo } from "./regionInfo"
 
 // Provides AWS Region Information
 export interface RegionProvider {
     // Returns an array of Regions
-    getRegionData(): Promise<RegionInfo[]>;
+    getRegionData(): Promise<RegionInfo[]>
 }

--- a/src/shared/resourceFetcher.ts
+++ b/src/shared/resourceFetcher.ts
@@ -1,8 +1,8 @@
-'use strict';
+'use strict'
 
-import { ResourceLocation } from "./resourceLocation";
+import { ResourceLocation } from "./resourceLocation"
 
 export interface ResourceFetcher {
     // Attempts to retrieve a resource from the given locations in order, stopping on the first success.
-    getResource(resourceLocations: ResourceLocation[]): Promise<string>;
+    getResource(resourceLocations: ResourceLocation[]): Promise<string>
 }

--- a/src/shared/resourceLocation.ts
+++ b/src/shared/resourceLocation.ts
@@ -1,29 +1,29 @@
-'use strict';
+'use strict'
 
 export interface ResourceLocation {
-    getLocationUri(): string;
+    getLocationUri(): string
 }
 
 export class WebResourceLocation implements ResourceLocation {
-    private readonly _uri: string;
+    private readonly _uri: string
 
     constructor(uri: string) {
-        this._uri = uri;
+        this._uri = uri
     }
 
     public getLocationUri(): string {
-        return this._uri;
+        return this._uri
     }
 }
 
 export class FileResourceLocation implements ResourceLocation {
-    private readonly _filename: string;
+    private readonly _filename: string
 
     constructor(filename: string) {
-        this._filename = filename;
+        this._filename = filename
     }
 
     public getLocationUri(): string {
-        return this._filename;
+        return this._filename
     }
 }

--- a/src/shared/settingsConfiguration.ts
+++ b/src/shared/settingsConfiguration.ts
@@ -1,43 +1,43 @@
-'use strict';
+'use strict'
 
-import * as vscode from 'vscode';
+import * as vscode from 'vscode'
 
 // defines helper methods for interacting with VSCode's configuration
 // persistence mechanisms, allowing us to test with mocks.
 export interface SettingsConfiguration {
-    readSetting(settingKey: string, defaultValue?:string) : string | undefined;
+    readSetting(settingKey: string, defaultValue?:string) : string | undefined
 
     // array values are serialized as a comma-delimited string
-    writeSetting(settingKey: string, value: string | string[] | undefined, target: vscode.ConfigurationTarget) : void;
+    writeSetting(settingKey: string, value: string | string[] | undefined, target: vscode.ConfigurationTarget) : void
 }
 
 // default configuration settings handler for production release
 export class DefaultSettingsConfiguration implements SettingsConfiguration {
     readSetting(settingKey: string, defaultValue?: string): string | undefined {
-        const settings = vscode.workspace.getConfiguration(this.extensionSettingsPrefix);
+        const settings = vscode.workspace.getConfiguration(this.extensionSettingsPrefix)
         if (settings) {
-            const val = settings.get<string>(settingKey);
+            const val = settings.get<string>(settingKey)
             if (val) {
-                return val;
+                return val
             }
         }
 
         if (defaultValue) {
-            return defaultValue;
+            return defaultValue
         }
 
-        return undefined;
+        return undefined
     }
     async writeSetting(settingKey: string, value: string | string[], target: vscode.ConfigurationTarget): Promise<void> {
-        const settings = vscode.workspace.getConfiguration(this.extensionSettingsPrefix);
-        let persistedValue: string;
+        const settings = vscode.workspace.getConfiguration(this.extensionSettingsPrefix)
+        let persistedValue: string
         if (value && value instanceof Array) {
-            persistedValue = value.join();
+            persistedValue = value.join()
         } else {
-            persistedValue = value;
+            persistedValue = value
         }
 
-        await settings.update(settingKey, persistedValue, target);
+        await settings.update(settingKey, persistedValue, target)
     }
 
     constructor(public extensionSettingsPrefix: string) {

--- a/src/shared/statusBar.ts
+++ b/src/shared/statusBar.ts
@@ -1,46 +1,46 @@
-'use strict';
+'use strict'
 
-import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
+import * as nls from 'vscode-nls'
+let localize = nls.loadMessageBundle()
 
-import { ExtensionContext, window, StatusBarItem, StatusBarAlignment } from 'vscode';
-import { ContextChangeEventsArgs } from './defaultAwsContext';
-import { AwsContext } from './awsContext';
+import { ExtensionContext, window, StatusBarItem, StatusBarAlignment } from 'vscode'
+import { ContextChangeEventsArgs } from './defaultAwsContext'
+import { AwsContext } from './awsContext'
 
 // may want to have multiple elements of data on the status bar,
 // so wrapping in a class to allow for per-element update capability
 export class AWSStatusBar {
 
-    private _awsContext: AwsContext;
+    private _awsContext: AwsContext
 
-    public readonly credentialContext: StatusBarItem;
+    public readonly credentialContext: StatusBarItem
 
     constructor(awsContext: AwsContext, context: ExtensionContext) {
-        this._awsContext = awsContext;
+        this._awsContext = awsContext
 
-        this.credentialContext = window.createStatusBarItem(StatusBarAlignment.Right, 100);
-        context.subscriptions.push(this.credentialContext);
+        this.credentialContext = window.createStatusBarItem(StatusBarAlignment.Right, 100)
+        context.subscriptions.push(this.credentialContext)
 
         this._awsContext.onDidChangeContext((context) => {
-            this.updateContext(context);
-        });
+            this.updateContext(context)
+        })
     }
 
     public async updateContext(eventContext: ContextChangeEventsArgs | undefined) {
-        let profileName: string | undefined;
+        let profileName: string | undefined
 
         if (eventContext) {
-            profileName = eventContext.profileName;
+            profileName = eventContext.profileName
         }
         else {
-            profileName = this._awsContext.getCredentialProfileName();
+            profileName = this._awsContext.getCredentialProfileName()
         }
 
         if (profileName) {
-            this.credentialContext.text = localize('AWS.title', 'AWS') + ':' + profileName;
-            this.credentialContext.show();
+            this.credentialContext.text = localize('AWS.title', 'AWS') + ':' + profileName
+            this.credentialContext.show()
         } else {
-            this.credentialContext.hide();
+            this.credentialContext.hide()
         }
     }
 }

--- a/src/shared/templates/baseTemplates.ts
+++ b/src/shared/templates/baseTemplates.ts
@@ -9,5 +9,5 @@ export class BaseTemplates {
             <body>
                 <%= content %>
             </body>
-        </html>`;
+        </html>`
 }

--- a/src/shared/treeview/awsCommandTreeNode.ts
+++ b/src/shared/treeview/awsCommandTreeNode.ts
@@ -1,7 +1,7 @@
-'use strict';
+'use strict'
 
-import { TreeItem, TreeItemCollapsibleState } from 'vscode';
-import { AWSTreeNodeBase } from '../treeview/awsTreeNodeBase';
+import { TreeItem, TreeItemCollapsibleState } from 'vscode'
+import { AWSTreeNodeBase } from '../treeview/awsTreeNodeBase'
 
 export class AWSCommandTreeNode extends AWSTreeNodeBase {
 
@@ -11,23 +11,23 @@ export class AWSCommandTreeNode extends AWSTreeNodeBase {
         public tooltip?: string,
         public contextValue?: string,
     ) {
-        super();
+        super()
     }
 
     public getChildren(): Thenable<AWSTreeNodeBase[]> {
-       return new Promise(resolve => resolve([]));
+       return new Promise(resolve => resolve([]))
     }
 
     public getTreeItem(): TreeItem {
-        const item = new TreeItem(`${this.label}`, TreeItemCollapsibleState.None);
-        item.tooltip = this.tooltip;
-        item.contextValue = this.contextValue;
+        const item = new TreeItem(`${this.label}`, TreeItemCollapsibleState.None)
+        item.tooltip = this.tooltip
+        item.contextValue = this.contextValue
         item.command = {
             title: this.label,
             command: this.commandId
-        };
+        }
 
-        return item;
+        return item
     }
 }
 

--- a/src/shared/treeview/awsRegionTreeNode.ts
+++ b/src/shared/treeview/awsRegionTreeNode.ts
@@ -1,26 +1,26 @@
-'use strict';
+'use strict'
 
-import { TreeItem, TreeItemCollapsibleState } from 'vscode';
-import { AWSTreeNodeBase } from '../treeview/awsTreeNodeBase';
+import { TreeItem, TreeItemCollapsibleState } from 'vscode'
+import { AWSTreeNodeBase } from '../treeview/awsTreeNodeBase'
 
 export abstract class AWSRegionTreeNode extends AWSTreeNodeBase {
-    public readonly contextValue: string = 'awsRegion';
+    public readonly contextValue: string = 'awsRegion'
 
     constructor(public regionCode:string) {
-        super();
+        super()
     }
 
-    protected abstract getLabel(): string;
+    protected abstract getLabel(): string
 
     protected getTooltip(): string | undefined {
-        return undefined;
+        return undefined
     }
 
     public getTreeItem(): TreeItem {
-        const item = new TreeItem(this.getLabel(), TreeItemCollapsibleState.Expanded);
-        item.tooltip = this.getTooltip();
-        item.contextValue = this.contextValue;
+        const item = new TreeItem(this.getLabel(), TreeItemCollapsibleState.Expanded)
+        item.tooltip = this.getTooltip()
+        item.contextValue = this.contextValue
 
-        return item;
+        return item
     }
 }

--- a/src/shared/treeview/awsTreeNodeBase.ts
+++ b/src/shared/treeview/awsTreeNodeBase.ts
@@ -1,42 +1,42 @@
-'use strict';
+'use strict'
 
-import { Command, Disposable, TreeItem } from 'vscode';
-import { AwsContext } from '../awsContext';
+import { Command, Disposable, TreeItem } from 'vscode'
+import { AwsContext } from '../awsContext'
 
 export abstract class AWSTreeNodeBase extends Disposable {
 
-    public readonly supportsPaging: boolean = false;
+    public readonly supportsPaging: boolean = false
 
-    protected children: AWSTreeNodeBase[] | undefined;
-    protected disposable: Disposable | undefined;
+    protected children: AWSTreeNodeBase[] | undefined
+    protected disposable: Disposable | undefined
 
     constructor() {
-        super(() => this.dispose());
+        super(() => this.dispose())
     }
 
     dispose() {
         if (this.disposable !== undefined) {
-            this.disposable.dispose();
-            this.disposable = undefined;
+            this.disposable.dispose()
+            this.disposable = undefined
         }
 
-        this.resetChildren();
+        this.resetChildren()
     }
 
-    public abstract getTreeItem(): TreeItem;
+    public abstract getTreeItem(): TreeItem
 
-    public abstract getChildren(): Thenable<AWSTreeNodeBase[]>;
+    public abstract getChildren(): Thenable<AWSTreeNodeBase[]>
 
     public getCommand(): Command | undefined {
-        return undefined;
+        return undefined
     }
 
     public refresh(newContext: AwsContext): void { }
 
     public resetChildren(): void {
         if (this.children !== undefined) {
-            this.children.forEach(c => c.dispose());
-            this.children = undefined;
+            this.children.forEach(c => c.dispose())
+            this.children = undefined
         }
     }
 }

--- a/src/shared/treeview/awsTreeProvider.ts
+++ b/src/shared/treeview/awsTreeProvider.ts
@@ -1,7 +1,7 @@
-'use strict';
+'use strict'
 
 export interface AwsTreeProvider {
-    viewProviderId: string;
+    viewProviderId: string
 
-    initialize(): void;
+    initialize(): void
 }

--- a/src/shared/treeview/refreshableAwsTreeProvider.ts
+++ b/src/shared/treeview/refreshableAwsTreeProvider.ts
@@ -1,9 +1,9 @@
-'use strict';
+'use strict'
 
-import { AwsTreeProvider } from "./awsTreeProvider";
-import { AwsContext } from "../awsContext";
+import { AwsTreeProvider } from "./awsTreeProvider"
+import { AwsContext } from "../awsContext"
 
 export interface RefreshableAwsTreeProvider extends AwsTreeProvider {
-    refresh(newContext?: AwsContext): void;
+    refresh(newContext?: AwsContext): void
 }
 

--- a/src/test/awsClientBuilder.test.ts
+++ b/src/test/awsClientBuilder.test.ts
@@ -1,29 +1,29 @@
-import * as assert from 'assert';
-import * as vscode from 'vscode';
-import { ContextChangeEventsArgs } from '../shared/defaultAwsContext';
-import { AwsContext } from '../shared/awsContext';
-import { AWSClientBuilder } from '../shared/awsClientBuilder';
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import { ContextChangeEventsArgs } from '../shared/defaultAwsContext'
+import { AwsContext } from '../shared/awsContext'
+import { AWSClientBuilder } from '../shared/awsClientBuilder'
 
 suite('AwsClientBuilder Tests', () => {
     class FakeAwsContext implements AwsContext {
-        onDidChangeContext: vscode.Event<ContextChangeEventsArgs> = new vscode.EventEmitter<ContextChangeEventsArgs>().event;
+        onDidChangeContext: vscode.Event<ContextChangeEventsArgs> = new vscode.EventEmitter<ContextChangeEventsArgs>().event
         getCredentials(): Promise<AWS.Credentials | undefined> {
-            return Promise.resolve(undefined);
+            return Promise.resolve(undefined)
         }
         getCredentialProfileName(): string | undefined {
-            throw new Error('Method not implemented.');
+            throw new Error('Method not implemented.')
         }
         setCredentialProfileName(profileName?: string | undefined): Promise<void> {
-            throw new Error('Method not implemented.');
+            throw new Error('Method not implemented.')
         }
         getExplorerRegions(): Promise<string[]> {
-            throw new Error('Method not implemented.');
+            throw new Error('Method not implemented.')
         }
         addExplorerRegion(region: string | string[]): Promise<void> {
-            throw new Error('Method not implemented.');
+            throw new Error('Method not implemented.')
         }
         removeExplorerRegion(region: string | string[]): Promise<void> {
-            throw new Error('Method not implemented.');
+            throw new Error('Method not implemented.')
         }
     }
 
@@ -36,27 +36,27 @@ suite('AwsClientBuilder Tests', () => {
     // what the product code does, so these tests would still pass with bad versions. Instead, we
     // verify that a valid semver is used. This protects us against things like `null`, `undefined`,
     // or other unexpected values.
-    const semverRegex = require('semver-regex')() as RegExp;
-    const userAgentRegex = new RegExp("^AWS-Toolkit-For-VisualStudio\\/" + semverRegex.source + " Visual-Studio-Code\\/" + semverRegex.source);
+    const semverRegex = require('semver-regex')() as RegExp
+    const userAgentRegex = new RegExp("^AWS-Toolkit-For-VisualStudio\\/" + semverRegex.source + " Visual-Studio-Code\\/" + semverRegex.source)
 
     test('createAndConfigureSdkClient includes custom user-agent if no options are specified', async () => {
-        const builder = new AWSClientBuilder(new FakeAwsContext());
-        const service = await builder.createAndConfigureSdkClient(FakeService);
+        const builder = new AWSClientBuilder(new FakeAwsContext())
+        const service = await builder.createAndConfigureSdkClient(FakeService)
         
-        assert.equal(userAgentRegex.test(service.config.customUserAgent), true);
-    });
+        assert.equal(userAgentRegex.test(service.config.customUserAgent), true)
+    })
 
     test('createAndConfigureSdkClient includes custom user-agent if not specified in options', async () => {
-        const builder = new AWSClientBuilder(new FakeAwsContext());
-        const service = await builder.createAndConfigureSdkClient(FakeService, {});
+        const builder = new AWSClientBuilder(new FakeAwsContext())
+        const service = await builder.createAndConfigureSdkClient(FakeService, {})
 
-        assert.equal(userAgentRegex.test(service.config.customUserAgent), true);
-    });
+        assert.equal(userAgentRegex.test(service.config.customUserAgent), true)
+    })
 
     test('createAndConfigureSdkClient does not override custom user-agent if specified in options', async () => {
-        const builder = new AWSClientBuilder(new FakeAwsContext());
-        const service = await builder.createAndConfigureSdkClient(FakeService, { customUserAgent: 'CUSTOM USER AGENT' });
+        const builder = new AWSClientBuilder(new FakeAwsContext())
+        const service = await builder.createAndConfigureSdkClient(FakeService, { customUserAgent: 'CUSTOM USER AGENT' })
 
-        assert.equal(service.config.customUserAgent, 'CUSTOM USER AGENT');
-    });
-});
+        assert.equal(service.config.customUserAgent, 'CUSTOM USER AGENT')
+    })
+})

--- a/src/test/defaultAwsContext.test.ts
+++ b/src/test/defaultAwsContext.test.ts
@@ -1,18 +1,18 @@
-import * as assert from 'assert';
-import { DefaultAwsContext } from '../shared/defaultAwsContext';
-import { SettingsConfiguration } from '../shared/settingsConfiguration';
-import { ConfigurationTarget } from 'vscode';
-import { regionSettingKey, profileSettingKey } from '../shared/constants';
+import * as assert from 'assert'
+import { DefaultAwsContext } from '../shared/defaultAwsContext'
+import { SettingsConfiguration } from '../shared/settingsConfiguration'
+import { ConfigurationTarget } from 'vscode'
+import { regionSettingKey, profileSettingKey } from '../shared/constants'
 
 suite("AWSContext Tests", function (): void {
 
-    const testRegion1Value: string = 're-gion-1';
-    const testRegion2Value: string = 're-gion-2';
-    const testProfileValue: string = 'profile1';
+    const testRegion1Value: string = 're-gion-1'
+    const testRegion2Value: string = 're-gion-2'
+    const testProfileValue: string = 'profile1'
 
     class ContextTestsSettingsConfigurationBase implements SettingsConfiguration {
         readSetting(settingKey: string, defaultValue?: string | undefined): string | undefined {
-            return undefined;
+            return undefined
         }
 
         writeSetting(settingKey: string, value: string, target: ConfigurationTarget): void {
@@ -25,156 +25,156 @@ suite("AWSContext Tests", function (): void {
         class TestConfiguration extends ContextTestsSettingsConfigurationBase {
             readSetting(settingKey: string, defaultValue?: string | undefined): string | undefined {
                 if(settingKey === profileSettingKey) {
-                    return testProfileValue;
+                    return testProfileValue
                 }
 
-                return super.readSetting(settingKey, defaultValue);
+                return super.readSetting(settingKey, defaultValue)
             }
 
         }
 
-        const testContext = new DefaultAwsContext(new TestConfiguration());
-        assert.equal(testContext.getCredentialProfileName(), testProfileValue);
-    });
+        const testContext = new DefaultAwsContext(new TestConfiguration())
+        assert.equal(testContext.getCredentialProfileName(), testProfileValue)
+    })
 
     test('context gets single region from config on startup', async function() {
 
         class TestConfiguration extends ContextTestsSettingsConfigurationBase {
             readSetting(settingKey: string, defaultValue?: string | undefined): string | undefined {
                 if(settingKey === regionSettingKey) {
-                    return testRegion1Value;
+                    return testRegion1Value
                 }
 
-                return super.readSetting(settingKey, defaultValue);
+                return super.readSetting(settingKey, defaultValue)
             }
         }
 
 
-        const testContext = new DefaultAwsContext(new TestConfiguration());
-        const regions = await testContext.getExplorerRegions();
-        assert.equal(regions.length, 1);
-        assert.equal(regions[0], testRegion1Value);
-    });
+        const testContext = new DefaultAwsContext(new TestConfiguration())
+        const regions = await testContext.getExplorerRegions()
+        assert.equal(regions.length, 1)
+        assert.equal(regions[0], testRegion1Value)
+    })
 
     test('context gets multiple regions from config on startup', async function() {
 
         class TestConfiguration extends ContextTestsSettingsConfigurationBase {
             readSetting(settingKey: string, defaultValue?: string | undefined): string | undefined {
                 if(settingKey === regionSettingKey) {
-                    return `${testRegion1Value},${testRegion2Value}`;
+                    return `${testRegion1Value},${testRegion2Value}`
                 }
 
-                return super.readSetting(settingKey, defaultValue);
+                return super.readSetting(settingKey, defaultValue)
             }
         }
 
 
-        const testContext = new DefaultAwsContext(new TestConfiguration());
-        const regions = await testContext.getExplorerRegions();
-        assert.equal(regions.length, 2);
-        assert.equal(regions[0], testRegion1Value);
-        assert.equal(regions[1], testRegion2Value);
-    });
+        const testContext = new DefaultAwsContext(new TestConfiguration())
+        const regions = await testContext.getExplorerRegions()
+        assert.equal(regions.length, 2)
+        assert.equal(regions[0], testRegion1Value)
+        assert.equal(regions[1], testRegion2Value)
+    })
 
     test('context updates config on single region change', function() {
 
         class TestConfiguration extends ContextTestsSettingsConfigurationBase {
             writeSetting(settingKey: string, value: string, target: ConfigurationTarget): void {
-                assert.equal(settingKey, regionSettingKey);
-                assert.equal(value, testRegion1Value);
-                assert.equal(target, ConfigurationTarget.Global);
+                assert.equal(settingKey, regionSettingKey)
+                assert.equal(value, testRegion1Value)
+                assert.equal(target, ConfigurationTarget.Global)
             }
         }
 
-        const testContext = new DefaultAwsContext(new TestConfiguration());
-        testContext.addExplorerRegion(testRegion1Value);
-    });
+        const testContext = new DefaultAwsContext(new TestConfiguration())
+        testContext.addExplorerRegion(testRegion1Value)
+    })
 
     test('context updates config on multiple region change', function() {
 
         class TestConfiguration extends ContextTestsSettingsConfigurationBase {
             writeSetting(settingKey: string, value: string, target: ConfigurationTarget): void {
-                assert.equal(settingKey, regionSettingKey);
-                assert.equal(value, `${testRegion1Value}${testRegion2Value}`);
-                assert.equal(target, ConfigurationTarget.Global);
+                assert.equal(settingKey, regionSettingKey)
+                assert.equal(value, `${testRegion1Value}${testRegion2Value}`)
+                assert.equal(target, ConfigurationTarget.Global)
             }
         }
 
-        const testContext = new DefaultAwsContext(new TestConfiguration());
-        testContext.addExplorerRegion([ testRegion1Value, testRegion2Value ]);
-    });
+        const testContext = new DefaultAwsContext(new TestConfiguration())
+        testContext.addExplorerRegion([ testRegion1Value, testRegion2Value ])
+    })
 
     test('context updates on region removal', function() {
 
         class TestConfiguration extends ContextTestsSettingsConfigurationBase {
             readSetting(settingKey: string, defaultValue?: string | undefined): string | undefined {
                 if(settingKey === regionSettingKey) {
-                    return `${testRegion1Value},${testRegion2Value}`;
+                    return `${testRegion1Value},${testRegion2Value}`
                 }
 
-                return super.readSetting(settingKey, defaultValue);
+                return super.readSetting(settingKey, defaultValue)
             }
             writeSetting(settingKey: string, value: string, target: ConfigurationTarget): void {
-                assert.equal(settingKey, regionSettingKey);
-                assert.equal(value, `${testRegion2Value}`);
-                assert.equal(target, ConfigurationTarget.Global);
+                assert.equal(settingKey, regionSettingKey)
+                assert.equal(value, `${testRegion2Value}`)
+                assert.equal(target, ConfigurationTarget.Global)
             }
         }
 
-        const testContext = new DefaultAwsContext(new TestConfiguration());
-        testContext.removeExplorerRegion([ testRegion2Value ]);
-    });
+        const testContext = new DefaultAwsContext(new TestConfiguration())
+        testContext.removeExplorerRegion([ testRegion2Value ])
+    })
 
     test('context updates config on profile change', function() {
 
         class TestConfiguration extends ContextTestsSettingsConfigurationBase {
             writeSetting(settingKey: string, value: string, target: ConfigurationTarget): void {
-                assert.equal(settingKey, profileSettingKey);
-                assert.equal(value, testProfileValue);
-                assert.equal(target, ConfigurationTarget.Global);
+                assert.equal(settingKey, profileSettingKey)
+                assert.equal(value, testProfileValue)
+                assert.equal(target, ConfigurationTarget.Global)
             }
         }
 
-        const testContext = new DefaultAwsContext(new TestConfiguration());
-        testContext.addExplorerRegion(testRegion1Value);
-    });
+        const testContext = new DefaultAwsContext(new TestConfiguration())
+        testContext.addExplorerRegion(testRegion1Value)
+    })
 
     test('context fires event on single region change', function(done) {
 
-        const testContext = new DefaultAwsContext(new ContextTestsSettingsConfigurationBase());
+        const testContext = new DefaultAwsContext(new ContextTestsSettingsConfigurationBase())
 
         testContext.onDidChangeContext((c) => {
-            assert.equal(c.regions.length, 1);
-            assert.equal(c.regions[0], testRegion1Value);
-            done();
-        });
+            assert.equal(c.regions.length, 1)
+            assert.equal(c.regions[0], testRegion1Value)
+            done()
+        })
 
-        testContext.addExplorerRegion(testRegion1Value);
-    });
+        testContext.addExplorerRegion(testRegion1Value)
+    })
 
     test('context fires event on multi region change', function(done) {
 
-        const testContext = new DefaultAwsContext(new ContextTestsSettingsConfigurationBase());
+        const testContext = new DefaultAwsContext(new ContextTestsSettingsConfigurationBase())
 
         testContext.onDidChangeContext((c) => {
-            assert.equal(c.regions.length, 2);
-            assert.equal(c.regions[0], testRegion1Value);
-            assert.equal(c.regions[1], testRegion2Value);
-            done();
-        });
+            assert.equal(c.regions.length, 2)
+            assert.equal(c.regions[0], testRegion1Value)
+            assert.equal(c.regions[1], testRegion2Value)
+            done()
+        })
 
-        testContext.addExplorerRegion([ testRegion1Value, testRegion2Value ]);
-    });
+        testContext.addExplorerRegion([ testRegion1Value, testRegion2Value ])
+    })
 
     test('context fires event on profile change', function(done) {
 
-        const testContext = new DefaultAwsContext(new ContextTestsSettingsConfigurationBase());
+        const testContext = new DefaultAwsContext(new ContextTestsSettingsConfigurationBase())
 
         testContext.onDidChangeContext((c) => {
-            assert.equal(c.profileName, testProfileValue);
-            done();
-        });
+            assert.equal(c.profileName, testProfileValue)
+            done()
+        })
 
-        testContext.setCredentialProfileName(testProfileValue);
-    });
-});
+        testContext.setCredentialProfileName(testProfileValue)
+    })
+})

--- a/src/test/defaultCredentialSelectionDataProvider.test.ts
+++ b/src/test/defaultCredentialSelectionDataProvider.test.ts
@@ -1,9 +1,9 @@
-import * as assert from 'assert';
-import { credentialProfileSelector } from '../shared/credentials/defaultCredentialSelectionDataProvider';
-import { CredentialSelectionState } from '../shared/credentials/credentialSelectionState';
-import { CredentialSelectionDataProvider, AddProfileButton } from '../shared/credentials/credentialSelectionDataProvider';
-import { MultiStepInputFlowController } from '../shared/multiStepInputFlowController';
-import { QuickPickItem, Uri } from 'vscode';
+import * as assert from 'assert'
+import { credentialProfileSelector } from '../shared/credentials/defaultCredentialSelectionDataProvider'
+import { CredentialSelectionState } from '../shared/credentials/credentialSelectionState'
+import { CredentialSelectionDataProvider, AddProfileButton } from '../shared/credentials/credentialSelectionDataProvider'
+import { MultiStepInputFlowController } from '../shared/multiStepInputFlowController'
+import { QuickPickItem, Uri } from 'vscode'
 
 suite("CredentialProfileSelector Tests", function (): void {
 
@@ -16,17 +16,17 @@ suite("CredentialProfileSelector Tests", function (): void {
 
             async pickCredentialProfile(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>): Promise<QuickPickItem | AddProfileButton> {
                 return new Promise<QuickPickItem | AddProfileButton>(resolve => {
-                    resolve({ label: this.existingProfileNames[1] });
-                });
+                    resolve({ label: this.existingProfileNames[1] })
+                })
             }
             async inputProfileName(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>) : Promise<string | undefined> {
-                return "shouldNeverGetHere";
+                return "shouldNeverGetHere"
             }
             async inputAccessKey(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>) : Promise<string | undefined> {
-                return undefined;
+                return undefined
             }
             async inputSecretKey(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>) : Promise<string | undefined> {
-                return undefined;
+                return undefined
             }
         }
 
@@ -34,20 +34,20 @@ suite("CredentialProfileSelector Tests", function (): void {
             'profile1',
             'profile2',
             'profile3'
-        ];
+        ]
 
-        const dataProvider = new MockCredentialSelectionDataProvider(profileNames);
-        const state = await credentialProfileSelector(dataProvider);
+        const dataProvider = new MockCredentialSelectionDataProvider(profileNames)
+        const state = await credentialProfileSelector(dataProvider)
         return new Promise((resolve, reject) => {
             if (state && state.credentialProfile) {
-                assert.equal(state.credentialProfile.label, profileNames[1]);
-                assert.equal(state.profileName, undefined);
-                resolve();
+                assert.equal(state.credentialProfile.label, profileNames[1])
+                assert.equal(state.profileName, undefined)
+                resolve()
             } else {
-                reject('state or the credentialProfile member is undefined, expected a profile name');
+                reject('state or the credentialProfile member is undefined, expected a profile name')
             }
-        });
-    });
+        })
+    })
 
     test('selector returns new profile details', async function() {
 
@@ -56,7 +56,7 @@ suite("CredentialProfileSelector Tests", function (): void {
             dark: Uri.file('resources/dontcare'),
             light: Uri.file('resources/dontcare')
         },
-        'dontcare');
+        'dontcare')
 
         class MockCredentialSelectionDataProvider implements CredentialSelectionDataProvider {
             constructor(public readonly existingProfileNames: string[]) {
@@ -64,35 +64,35 @@ suite("CredentialProfileSelector Tests", function (): void {
 
             async pickCredentialProfile(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>): Promise<QuickPickItem | AddProfileButton> {
                 return new Promise<QuickPickItem | AddProfileButton>(resolve => {
-                    resolve(button);
-                });
+                    resolve(button)
+                })
             }
             async inputProfileName(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>) : Promise<string | undefined> {
-                return 'newProfileName';
+                return 'newProfileName'
             }
             async inputAccessKey(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>) : Promise<string | undefined> {
-                return 'newAccesskey';
+                return 'newAccesskey'
             }
             async inputSecretKey(input: MultiStepInputFlowController, state: Partial<CredentialSelectionState>) : Promise<string | undefined> {
-                return 'newSecretkey';
+                return 'newSecretkey'
             }
         }
 
         const profileNames: string[] = [
-        ];
+        ]
 
-        const dataProvider = new MockCredentialSelectionDataProvider(profileNames);
-        const state = await credentialProfileSelector(dataProvider);
+        const dataProvider = new MockCredentialSelectionDataProvider(profileNames)
+        const state = await credentialProfileSelector(dataProvider)
         return new Promise((resolve, reject) => {
             if (state) {
-                assert.equal(state.credentialProfile, undefined);
-                assert.equal(state.profileName, 'newProfileName');
-                assert.equal(state.accesskey, 'newAccesskey');
-                assert.equal(state.secretKey, 'newSecretkey');
-                resolve();
+                assert.equal(state.credentialProfile, undefined)
+                assert.equal(state.profileName, 'newProfileName')
+                assert.equal(state.accesskey, 'newAccesskey')
+                assert.equal(state.secretKey, 'newSecretkey')
+                resolve()
             } else {
-                reject('state is undefined');
+                reject('state is undefined')
             }
-        });
-    });
-});
+        })
+    })
+})

--- a/src/test/extensionUtilities.test.ts
+++ b/src/test/extensionUtilities.test.ts
@@ -1,18 +1,18 @@
-import * as assert from 'assert';
-import { safeGet } from '../shared/extensionUtilities';
+import * as assert from 'assert'
+import { safeGet } from '../shared/extensionUtilities'
 
 suite('Extension Utilities Tests', function (): void {
     class Blah {
-        public someProp?: string;
+        public someProp?: string
 
         constructor(someProp?: string) {
-            this.someProp = someProp;
+            this.someProp = someProp
         }
     }
 
     test('nullSafeGet can access sub-property', function () {
-        assert.equal(safeGet(new Blah('hello!'), x => x.someProp), 'hello!');
-        assert.equal(safeGet(new Blah(), x => x.someProp), undefined);
-        assert.equal(safeGet(undefined as Blah | undefined, x => x.someProp), undefined);
-    });
-});
+        assert.equal(safeGet(new Blah('hello!'), x => x.someProp), 'hello!')
+        assert.equal(safeGet(new Blah(), x => x.someProp), undefined)
+        assert.equal(safeGet(undefined as Blah | undefined, x => x.someProp), undefined)
+    })
+})

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -10,13 +10,13 @@
 // to report the results back to the caller. When the tests are finished, return
 // a possible error to the callback or null if none.
 
-import * as testRunner from 'vscode/lib/testrunner';
+import * as testRunner from 'vscode/lib/testrunner'
 
 // You can directly control Mocha options by uncommenting the following lines
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
 testRunner.configure({
     ui: 'tdd', 		// the TDD UI is being used in extension.test.ts (suite, test, etc.)
     useColors: true // colored output from test results
-});
+})
 
-module.exports = testRunner;
+module.exports = testRunner

--- a/src/test/lambdaProvider.test.ts
+++ b/src/test/lambdaProvider.test.ts
@@ -1,79 +1,79 @@
-import * as assert from 'assert';
-import * as AWS from 'aws-sdk';
-import * as vscode from 'vscode';
-import { LambdaProvider } from '../lambda/lambdaProvider';
-import { RegionNode } from '../lambda/explorer/regionNode';
-import { ContextChangeEventsArgs } from '../shared/defaultAwsContext';
-import { AwsContextTreeCollection } from '../shared/awsContextTreeCollection';
-import { AwsContext } from '../shared/awsContext';
-import { RegionInfo } from '../shared/regions/regionInfo';
-import { RegionProvider } from '../shared/regions/regionProvider';
-import { ResourceFetcher } from '../shared/resourceFetcher';
-import { ResourceLocation } from '../shared/resourceLocation';
+import * as assert from 'assert'
+import * as AWS from 'aws-sdk'
+import * as vscode from 'vscode'
+import { LambdaProvider } from '../lambda/lambdaProvider'
+import { RegionNode } from '../lambda/explorer/regionNode'
+import { ContextChangeEventsArgs } from '../shared/defaultAwsContext'
+import { AwsContextTreeCollection } from '../shared/awsContextTreeCollection'
+import { AwsContext } from '../shared/awsContext'
+import { RegionInfo } from '../shared/regions/regionInfo'
+import { RegionProvider } from '../shared/regions/regionProvider'
+import { ResourceFetcher } from '../shared/resourceFetcher'
+import { ResourceLocation } from '../shared/resourceLocation'
 
 suite("LambdaProvider Tests", function (): void {
 
     test('region nodes display the user-friendly region name', function () {
 
-        const regionCode = "regionQuerty";
-        const regionName = "The Querty Region";
+        const regionCode = "regionQuerty"
+        const regionName = "The Querty Region"
 
         // TODO : Introduce Mocking instead of stub implementations
         class FakeRegionProvider implements RegionProvider {
             getRegionData(): Promise<RegionInfo[]> {
-                return Promise.resolve([new RegionInfo(regionCode, regionName)]);
+                return Promise.resolve([new RegionInfo(regionCode, regionName)])
             }
         }
 
         class FakeAwsContext implements AwsContext {
-            onDidChangeContext: vscode.Event<ContextChangeEventsArgs> = new vscode.EventEmitter<ContextChangeEventsArgs>().event;
+            onDidChangeContext: vscode.Event<ContextChangeEventsArgs> = new vscode.EventEmitter<ContextChangeEventsArgs>().event
             getCredentials(): Promise<AWS.Credentials | undefined> {
-                throw new Error("Method not implemented.");
+                throw new Error("Method not implemented.")
             }
             getCredentialProfileName(): string | undefined {
-                return "qwerty";
+                return "qwerty"
             }
             setCredentialProfileName(profileName?: string | undefined): Promise<void> {
-                throw new Error("Method not implemented.");
+                throw new Error("Method not implemented.")
             }
             getExplorerRegions(): Promise<string[]> {
-                const regions = [];
-                regions.push(regionCode);
+                const regions = []
+                regions.push(regionCode)
 
-                return Promise.resolve(regions);
+                return Promise.resolve(regions)
             }
             addExplorerRegion(region: string | string[]): Promise<void> {
-                throw new Error("Method not implemented.");
+                throw new Error("Method not implemented.")
             }
             removeExplorerRegion(region: string | string[]): Promise<void> {
-                throw new Error("Method not implemented.");
+                throw new Error("Method not implemented.")
             }
         }
 
         class FakeResourceFetcher implements ResourceFetcher {
             getResource(resourceLocations: ResourceLocation[]): Promise<string> {
-                throw new Error("Method not implemented.");
+                throw new Error("Method not implemented.")
             }
         }
 
-        const awsContext = new FakeAwsContext();
-        const regionProvider = new FakeRegionProvider();
-        const awsContextTreeCollection = new AwsContextTreeCollection();
-        const resourceFetcher = new FakeResourceFetcher();
+        const awsContext = new FakeAwsContext()
+        const regionProvider = new FakeRegionProvider()
+        const awsContextTreeCollection = new AwsContextTreeCollection()
+        const resourceFetcher = new FakeResourceFetcher()
 
-        const lambdaProvider = new LambdaProvider(awsContext, awsContextTreeCollection, regionProvider, resourceFetcher);
+        const lambdaProvider = new LambdaProvider(awsContext, awsContextTreeCollection, regionProvider, resourceFetcher)
 
-        const treeNodes = lambdaProvider.getChildren();
+        const treeNodes = lambdaProvider.getChildren()
 
-        assert(treeNodes);
+        assert(treeNodes)
         treeNodes.then(treeNodes => {
-            assert(treeNodes);
-            assert.equal(treeNodes.length, 1);
+            assert(treeNodes)
+            assert.equal(treeNodes.length, 1)
 
-            const regionNode = treeNodes[0] as RegionNode;
-            assert(regionNode);
-            assert.equal(regionNode.regionCode, regionCode);
-            assert.equal(regionNode.regionName, regionName);
-        });
-    });
-});
+            const regionNode = treeNodes[0] as RegionNode
+            assert(regionNode)
+            assert.equal(regionNode.regionCode, regionCode)
+            assert.equal(regionNode.regionName, regionName)
+        })
+    })
+})

--- a/src/test/regionHelpers.test.ts
+++ b/src/test/regionHelpers.test.ts
@@ -1,66 +1,66 @@
-'use strict';
+'use strict'
 
-import * as assert from 'assert';
-import * as vscode from 'vscode';
-import { ResourceFetcher } from '../shared/resourceFetcher';
-import { ResourceLocation } from '../shared/resourceLocation';
-import { DefaultRegionProvider } from '../shared/regions/defaultRegionProvider';
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import { ResourceFetcher } from '../shared/resourceFetcher'
+import { ResourceLocation } from '../shared/resourceLocation'
+import { DefaultRegionProvider } from '../shared/regions/defaultRegionProvider'
 
 suite("ResourceFetcherBase Tests", function (): void {
 
     class ResourceFetcherCounter implements ResourceFetcher {
-        timesCalled = 0;
+        timesCalled = 0
 
         getResource(resourceLocations: ResourceLocation[]): Promise<string> {
-            this.timesCalled++;
+            this.timesCalled++
             return Promise.resolve(JSON.stringify({
                 partitions: []
-            }));
+            }))
         }
     }
 
     class FakeMemento implements vscode.Memento {
-        get<T>(key: string): T | undefined; get<T>(key: string, defaultValue: T): T;
+        get<T>(key: string): T | undefined; get<T>(key: string, defaultValue: T): T
         get(key: any, defaultValue?: any) {
-            throw new Error("Method not implemented.");
+            throw new Error("Method not implemented.")
         }
         update(key: string, value: any): Thenable<void> {
-            throw new Error("Method not implemented.");
+            throw new Error("Method not implemented.")
         }
     }
 
     class FakeExtensionContext implements vscode.ExtensionContext {
         subscriptions: {
             dispose(): any;
-        }[] = [];
-        workspaceState: vscode.Memento = new FakeMemento();
-        globalState: vscode.Memento = new FakeMemento();
-        extensionPath: string = "";
+        }[] = []
+        workspaceState: vscode.Memento = new FakeMemento()
+        globalState: vscode.Memento = new FakeMemento()
+        extensionPath: string = ""
         asAbsolutePath(relativePath: string): string {
-            throw new Error("Method not implemented.");
+            throw new Error("Method not implemented.")
         }
-        storagePath: string | undefined;
+        storagePath: string | undefined
     }
 
     test('Fetches something', async function () {
-        const fetchCounter = new ResourceFetcherCounter();
-        const context = new FakeExtensionContext();
-        const regionProvider = new DefaultRegionProvider(context, fetchCounter);
+        const fetchCounter = new ResourceFetcherCounter()
+        const context = new FakeExtensionContext()
+        const regionProvider = new DefaultRegionProvider(context, fetchCounter)
 
-        await regionProvider.getRegionData();
+        await regionProvider.getRegionData()
 
-        assert.equal(fetchCounter.timesCalled, 1);
-    });
+        assert.equal(fetchCounter.timesCalled, 1)
+    })
 
     test('Fetches something the first time only', async function () {
-        const fetchCounter = new ResourceFetcherCounter();
-        const context = new FakeExtensionContext();
-        const regionProvider = new DefaultRegionProvider(context, fetchCounter);
+        const fetchCounter = new ResourceFetcherCounter()
+        const context = new FakeExtensionContext()
+        const regionProvider = new DefaultRegionProvider(context, fetchCounter)
 
-        await regionProvider.getRegionData();
-        await regionProvider.getRegionData();
+        await regionProvider.getRegionData()
+        await regionProvider.getRegionData()
 
-        assert.equal(fetchCounter.timesCalled, 1);
-    });
+        assert.equal(fetchCounter.timesCalled, 1)
+    })
 
-});
+})

--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,7 @@
 		"interface-name": [true, "never-prefix"],
 		"semicolon": [
 			true,
-			"always"
+			"never"
 		],
 		"triple-equals": true
 	},


### PR DESCRIPTION
*Description of changes:*

Semicolons add little-to-no value to TypeScript. While JavaScript (especially early versions) has some odd behavior that is avoided by semicolons, the `tsc` compiler will throw errors in these uncommon circumstances.

Additionally, semi-colons aren't free:

* They add visual noise.
* They add keystrokes, and slow down some common editor operations (for example, w/o semiclons, you can just click anywhere to the right of a line to put the cursor at EOL).
* They're one more annoyance if you forget one and must recompile.

[Here](https://medium.com/@eugenkiss/dont-use-semicolons-in-typescript-474ccfe4bdb3) is an excellent article on the topic.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
