### PR TITLE
Enable eslint rule: no-unexpected-multiline.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -609,6 +609,30 @@
             "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
             "dev": true
         },
+        "doctrine": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+            "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
+            "dev": true,
+            "requires": {
+                "esutils": "1.1.6",
+                "isarray": "0.0.1"
+            },
+            "dependencies": {
+                "esutils": {
+                    "version": "1.1.6",
+                    "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+                    "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
+                    "dev": true
+                },
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                }
+            }
+        },
         "duplexer": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -7962,6 +7986,34 @@
                 "semver": "5.5.0",
                 "tslib": "1.9.3",
                 "tsutils": "2.29.0"
+            }
+        },
+        "tslint-eslint-rules": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-5.4.0.tgz",
+            "integrity": "sha512-WlSXE+J2vY/VPgIcqQuijMQiel+UtmXS+4nvK4ZzlDiqBfXse8FAvkNnTcYhnQyOTW5KFM+uRRGXxYhFpuBc6w==",
+            "dev": true,
+            "requires": {
+                "doctrine": "0.7.2",
+                "tslib": "1.9.0",
+                "tsutils": "3.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+                    "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+                    "dev": true
+                },
+                "tsutils": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.0.0.tgz",
+                    "integrity": "sha512-LjHBWR0vWAUHWdIAoTjoqi56Kz+FDKBgVEuL+gVPG/Pv7QW5IdaDDeK9Txlr6U0Cmckp5EgCIq1T25qe3J6hyw==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "1.9.0"
+                    }
+                }
             }
         },
         "tsutils": {

--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
         "@types/xml2js": "^0.4.3",
         "semver-regex": "^2.0.0",
         "tslint": "^5.11.0",
+        "tslint-eslint-rules": "^5.4.0",
         "typescript": "^3.0.1",
         "vscode": "^1.1.21",
         "vscode-nls-dev": "^3.2.2"

--- a/tslint.json
+++ b/tslint.json
@@ -1,4 +1,5 @@
 {
+	"extends": "tslint-eslint-rules",
 	"rules": {
 		"no-string-throw": true,
 		"no-unused-expression": true,
@@ -10,6 +11,7 @@
 			true,
 			"never"
 		],
+		"no-unexpected-multiline": true,
 		"triple-equals": true
 	},
 	"defaultSeverity": "warning"


### PR DESCRIPTION
*Description of changes:*

In both JavaScript and TypeScript, semicolon-insertion leads to unexpected behavior in these cases:

```typescript
// Incorrect
const foo = bar //; The interpreter inserts a semicolon here
(myArgument)

// Correct
const foo = bar(
    myArgument)

// Incorrect
const foo = //; The interpreter inserts a semicolon here
[
    myItem1,
    myItem2
]

// Correct
const foo = [
    myItem1,
    myItem2,
]
```

The `no-unexpected-multiline` rule will detect these cases. Note that this is unrelated to #60.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
