### PR TITLE
Removed double MRU Lookup when loading Profiles for selection

### DIFF
--- a/src/shared/credentials/defaultCredentialSelectionDataProvider.ts
+++ b/src/shared/credentials/defaultCredentialSelectionDataProvider.ts
@@ -93,7 +93,8 @@ export class DefaultCredentialSelectionDataProvider implements CredentialSelecti
         })
 
         // Add default if it hasn't been, and is an existing profile name
-        if (!orderedNames.has(DefaultCredentialSelectionDataProvider.DefaultCredentialsProfileName) && this.existingProfileNames.indexOf(DefaultCredentialSelectionDataProvider.DefaultCredentialsProfileName) !== -1) {
+        if (!orderedNames.has(DefaultCredentialSelectionDataProvider.DefaultCredentialsProfileName)
+            && this.existingProfileNames.indexOf(DefaultCredentialSelectionDataProvider.DefaultCredentialsProfileName) !== -1) {
             orderedProfiles.push({ profileName: DefaultCredentialSelectionDataProvider.DefaultCredentialsProfileName, isRecentlyUsed: false })
             orderedNames.add(DefaultCredentialSelectionDataProvider.DefaultCredentialsProfileName)
         }


### PR DESCRIPTION
*Issue #, if available:*
~#72~ #67  

*Description of changes:*
MRU list was fetched twice when getting the profile list together. Now its once.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
