### PR TITLE
Prefer await to Promise.then

### DIFF
--- a/src/lambda/models/blueprintsCollection.ts
+++ b/src/lambda/models/blueprintsCollection.ts
@@ -60,12 +60,9 @@ export class BlueprintsCollection {
 
     private async loadVisualStudioBlueprints(): Promise<void> {
         const manifestUrl = hostedFilesBaseUrl + blueprintsManifestPath
-        await this.listBlueprintsVSToolkitFromManifest(manifestUrl)
-            .then(results => {
-                results.forEach((b: Blueprint) => {
-                    this.availableBlueprints.push(b)
-            })
-        })
+        const results = await this.listBlueprintsVSToolkitFromManifest(manifestUrl)
+        
+        results.forEach((b: Blueprint) => this.availableBlueprints.push(b))
     }
 
     private async listBlueprintsVSToolkitFromManifest(manifestUrl: string): Promise<Blueprint[]> {

--- a/src/lambda/utils.ts
+++ b/src/lambda/utils.ts
@@ -53,19 +53,15 @@ export async function listLambdas(lambda: Lambda): Promise<FunctionNode[]> {
     try {
         const request: Lambda.ListFunctionsRequest = {}
         do {
-            await lambda.listFunctions(request)
-                .promise()
-                .then((r: Lambda.ListFunctionsResponse) => {
-                    request.Marker = r.NextMarker
-                    if (r.Functions) {
-                        r.Functions.forEach((f: Lambda.FunctionConfiguration) => {
-                            const func = new FunctionNode(f, lambda)
-                            func.contextValue = 'awsLambdaFn'
-                            arr.push(func)
-                        })
-                    }
-
+            const response: Lambda.ListFunctionsResponse = await lambda.listFunctions(request).promise()
+            request.Marker = response.NextMarker
+            if (response.Functions) {
+                response.Functions.forEach(f => {
+                    const func = new FunctionNode(f, lambda)
+                    func.contextValue = 'awsLambdaFn'
+                    arr.push(func)
                 })
+            }
         } while (!isNullOrUndefined(request.Marker))
     } catch (error) {
         // TODO: Handle error gracefully, possibly add a node that can attempt to retry the operation

--- a/src/shared/defaultAwsContextCommands.ts
+++ b/src/shared/defaultAwsContextCommands.ts
@@ -84,7 +84,7 @@ export class DefaultAWSContextCommands {
     }
 
     public async onCommandHideRegion(regionCode?: string) {
-        var region = regionCode || await this._awsContext.getExplorerRegions().then(r => this.promptForRegion(r))
+        var region = regionCode || await this.promptForRegion(await this._awsContext.getExplorerRegions())
         if (region) {
             this._awsContext.removeExplorerRegion(region)
             this.refresh()

--- a/src/test/lambdaProvider.test.ts
+++ b/src/test/lambdaProvider.test.ts
@@ -17,7 +17,7 @@ import { ResourceLocation } from '../shared/resourceLocation'
 
 suite("LambdaProvider Tests", function (): void {
 
-    test('region nodes display the user-friendly region name', function () {
+    test('region nodes display the user-friendly region name', async function () {
 
         const regionCode = "regionQuerty"
         const regionName = "The Querty Region"
@@ -67,17 +67,16 @@ suite("LambdaProvider Tests", function (): void {
 
         const lambdaProvider = new LambdaProvider(awsContext, awsContextTreeCollection, regionProvider, resourceFetcher)
 
-        const treeNodes = lambdaProvider.getChildren()
+        const treeNodesPromise = lambdaProvider.getChildren()
 
+        assert(treeNodesPromise)
+        const treeNodes = await treeNodesPromise
         assert(treeNodes)
-        treeNodes.then(treeNodes => {
-            assert(treeNodes)
-            assert.equal(treeNodes.length, 1)
+        assert.equal(treeNodes.length, 1)
 
-            const regionNode = treeNodes[0] as RegionNode
-            assert(regionNode)
-            assert.equal(regionNode.regionCode, regionCode)
-            assert.equal(regionNode.regionName, regionName)
-        })
+        const regionNode = treeNodes[0] as RegionNode
+        assert(regionNode)
+        assert.equal(regionNode.regionCode, regionCode)
+        assert.equal(regionNode.regionName, regionName)
     })
 })


### PR DESCRIPTION
*Issue #, if available:* #70

*Description of changes:*

Replace most uses of `Promise.then` with `await`. I left the calls to `then` in `loadSharedConfigFiles` in `credentialsFile.ts`, which I think are appropriate uses of `then`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
