### PR TITLE
Hooking up code coverage reports to CodeCov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,6 @@ script:
   - npm install
   - npm run vscode:prepublish
   - npm test
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash) -s .coverage

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![TravisCI Build Status - develop branch](https://travis-ci.org/aws/aws-toolkit-vscode.svg?branch=develop)](https://travis-ci.org/aws/aws-toolkit-vscode)
 ![CodeBuild Build Status - develop branch](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiMlluaDRTMnZLdmMvcFREQVQ4RjFoK0FUSTZPdlRVcWJlQ2gwRElLT2gxZDhMeno5MThZZnlXdURDVFFjOWdqSEQ5QjVBYm0xSURoU3E1RTVHejltcnZrPSIsIml2UGFyYW1ldGVyU3BlYyI6IkY3SE9CaG1oMHhJUmsyakkiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=develop)
+[![Coverage](https://img.shields.io/codecov/c/github/aws/aws-toolkit-vscode/develop.svg)](https://codecov.io/gh/aws/aws-toolkit-vscode/branch/develop)
 
 The AWS Toolkit for Visual Studio Code is an extension for working with AWS services such as AWS Lambda.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description

When TravisCI build script is successful, the code coverage reports are uploaded to CodeCov.
Added a badge to README.md to show coverage of the develop branch.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)

#86
#114

## Testing

* Created PR, watched TravisCI build logs to see that coverage reports are processed by CodeCov
* Looked for this branch in CodeCov underneath https://codecov.io/gh/aws/aws-toolkit-vscode

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
