### PR TITLE
Fix case where Extension startup tries to load a profile and the config file does not exist

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,7 @@ export async function activate(context: vscode.ExtensionContext) {
     ext.lambdaOutputChannel = vscode.window.createOutputChannel('AWS Lambda')
     ext.context = context
 
-    new DefaultCredentialsFileReaderWriter().setCanUseConfigFile(true)
+    await new DefaultCredentialsFileReaderWriter().setCanUseConfigFileOnFileExistance()
 
     const awsContext = new DefaultAwsContext(new DefaultSettingsConfiguration(extensionSettingsPrefix))
     const awsContextTrees = new AwsContextTreeCollection()

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,7 @@ export async function activate(context: vscode.ExtensionContext) {
     ext.lambdaOutputChannel = vscode.window.createOutputChannel('AWS Lambda')
     ext.context = context
 
-    await new DefaultCredentialsFileReaderWriter().setCanUseConfigFileOnFileExistance()
+    await new DefaultCredentialsFileReaderWriter().setCanUseConfigFileIfExists()
 
     const awsContext = new DefaultAwsContext(new DefaultSettingsConfiguration(extensionSettingsPrefix))
     const awsContextTrees = new AwsContextTreeCollection()

--- a/src/shared/credentials/defaultCredentialsFileReaderWriter.ts
+++ b/src/shared/credentials/defaultCredentialsFileReaderWriter.ts
@@ -65,7 +65,7 @@ export class DefaultCredentialsFileReaderWriter implements CredentialsFileReader
     /**
      * @description Calls setCanUseConfigFile , setting it to true if the config file exists, false otherwise
      */
-    public async setCanUseConfigFileOnFileExistance(): Promise<void> {
+    public async setCanUseConfigFileIfExists(): Promise<void> {
         this.setCanUseConfigFile(
             await SystemUtilities.fileExists(UserCredentialsUtils.getConfigFilename())
         )

--- a/src/shared/credentials/defaultCredentialsFileReaderWriter.ts
+++ b/src/shared/credentials/defaultCredentialsFileReaderWriter.ts
@@ -6,8 +6,10 @@
 'use strict'
 
 import { EnvironmentVariables } from '../environmentVariables'
+import { SystemUtilities } from '../systemUtilities'
 import { loadSharedConfigFiles, Profile, saveProfile } from './credentialsFile'
 import { CredentialsFileReaderWriter } from './credentialsFileReaderWriter'
+import { UserCredentialsUtils } from './userCredentialsUtils'
 
 export class DefaultCredentialsFileReaderWriter implements CredentialsFileReaderWriter {
     public async getProfileNames(): Promise<string[]> {
@@ -58,6 +60,15 @@ export class DefaultCredentialsFileReaderWriter implements CredentialsFileReader
         const env = process.env as EnvironmentVariables
 
         env.AWS_SDK_LOAD_CONFIG = allow ? true : ''
+    }
+
+    /**
+     * @description Calls setCanUseConfigFile , setting it to true if the config file exists, false otherwise
+     */
+    public async setCanUseConfigFileOnFileExistance(): Promise<void> {
+        this.setCanUseConfigFile(
+            await SystemUtilities.fileExists(UserCredentialsUtils.getConfigFilename())
+        )
     }
 
     /**

--- a/src/shared/defaultAwsContextCommands.ts
+++ b/src/shared/defaultAwsContextCommands.ts
@@ -27,7 +27,6 @@ import {
 import { ext } from './extensionGlobals'
 import { RegionInfo } from './regions/regionInfo'
 import { RegionProvider } from './regions/regionProvider'
-import { SystemUtilities } from './systemUtilities'
 
 /**
  * The actions that can be taken when we discover that a profile's default region is not
@@ -199,9 +198,7 @@ export class DefaultAWSContextCommands {
      */
     private async getProfileNameFromUser(): Promise<string | undefined> {
 
-        new DefaultCredentialsFileReaderWriter().setCanUseConfigFile(
-            await SystemUtilities.fileExists(UserCredentialsUtils.getConfigFilename())
-        )
+        await new DefaultCredentialsFileReaderWriter().setCanUseConfigFileOnFileExistance()
 
         const responseYes: string = localize('AWS.generic.response.yes', 'Yes')
         const responseNo: string = localize('AWS.generic.response.no', 'No')

--- a/src/shared/defaultAwsContextCommands.ts
+++ b/src/shared/defaultAwsContextCommands.ts
@@ -198,7 +198,7 @@ export class DefaultAWSContextCommands {
      */
     private async getProfileNameFromUser(): Promise<string | undefined> {
 
-        await new DefaultCredentialsFileReaderWriter().setCanUseConfigFileOnFileExistance()
+        await new DefaultCredentialsFileReaderWriter().setCanUseConfigFileIfExists()
 
         const responseYes: string = localize('AWS.generic.response.yes', 'Yes')
         const responseNo: string = localize('AWS.generic.response.no', 'No')

--- a/src/test/defaultCredentialsFileReaderWriter.test.ts
+++ b/src/test/defaultCredentialsFileReaderWriter.test.ts
@@ -101,7 +101,7 @@ suite('DefaultCredentialsFileReaderWriter Tests', () => {
         })
     })
 
-    test('setCanUseConfigFileOnFileExistance with config file that exists', async () => {
+    test('setCanUseConfigFileIfExists with config file that exists', async () => {
         let canUseState: boolean | undefined
 
         const writer = new DefaultCredentialsFileReaderWriter()
@@ -109,12 +109,12 @@ suite('DefaultCredentialsFileReaderWriter Tests', () => {
             canUseState = allow
         }
 
-        await writer.setCanUseConfigFileOnFileExistance()
+        await writer.setCanUseConfigFileIfExists()
 
         assert.equal(canUseState, true)
     })
 
-    test('setCanUseConfigFileOnFileExistance with config file that does not exist', async () => {
+    test('setCanUseConfigFileIfExists with config file that does not exist', async () => {
         let canUseState: boolean | undefined
 
         const env = process.env as EnvironmentVariables
@@ -125,7 +125,7 @@ suite('DefaultCredentialsFileReaderWriter Tests', () => {
             canUseState = allow
         }
 
-        await writer.setCanUseConfigFileOnFileExistance()
+        await writer.setCanUseConfigFileIfExists()
 
         assert.equal(canUseState, false)
     })

--- a/src/test/defaultCredentialsFileReaderWriter.test.ts
+++ b/src/test/defaultCredentialsFileReaderWriter.test.ts
@@ -10,13 +10,13 @@ import * as path from 'path'
 import { DefaultCredentialsFileReaderWriter } from '../shared/credentials/defaultCredentialsFileReaderWriter'
 import { EnvironmentVariables } from '../shared/environmentVariables'
 
-suite('DefaultCredentialsFileReaderWriter Tests', function(): void {
+suite('DefaultCredentialsFileReaderWriter Tests', () => {
 
     let tempFolder: string
     const credentialsProfileNames: string[] = ['default', 'apple', 'orange']
     const configProfileNames: string[] = ['banana', 'mango']
 
-    suiteSetup(function() {
+    suiteSetup(() => {
         // Make a temp folder for all these tests
         // Stick some temp credentials files in there to load from
         tempFolder = fs.mkdtempSync('vsctk')
@@ -35,23 +35,23 @@ suite('DefaultCredentialsFileReaderWriter Tests', function(): void {
         env.AWS_CONFIG_FILE = configFilename
     })
 
-    suiteTeardown(function() {
+    suiteTeardown(() => {
         del.sync([tempFolder])
     })
 
-    test('Can use Config File', async function() {
+    test('Can use Config File', async () => {
         const writer = new DefaultCredentialsFileReaderWriter()
         writer.setCanUseConfigFile(true)
         assert.equal(writer.getCanUseConfigFile(), true)
     })
 
-    test('Can not use Config File', async function() {
+    test('Can not use Config File', async () => {
         const writer = new DefaultCredentialsFileReaderWriter()
         writer.setCanUseConfigFile(false)
         assert.equal(writer.getCanUseConfigFile(), false)
     })
 
-    test('Does load profiles from Config', async function() {
+    test('Does load profiles from Config', async () => {
         const writer = new DefaultCredentialsFileReaderWriter()
         writer.setCanUseConfigFile(true)
 
@@ -62,7 +62,7 @@ suite('DefaultCredentialsFileReaderWriter Tests', function(): void {
                 profileNames.has(profileName),
                 true,
                 `ERROR: profileNames [ ${[...profileNames].map(n => `'${n}'`).join(', ')} ]` +
-                    ` does not contain '${profileName}'`
+                ` does not contain '${profileName}'`
             )
         })
 
@@ -71,12 +71,12 @@ suite('DefaultCredentialsFileReaderWriter Tests', function(): void {
                 profileNames.has(profileName),
                 true,
                 `ERROR: configProfileNames [ ${[...configProfileNames].map(n => `'${n}'`).join(', ')} ]` +
-                    `does not contain '${profileName}'`
+                `does not contain '${profileName}'`
             )
         })
     })
 
-    test('Refrains from loading profiles from Config', async function() {
+    test('Refrains from loading profiles from Config', async () => {
         const writer = new DefaultCredentialsFileReaderWriter()
         writer.setCanUseConfigFile(false)
 
@@ -87,7 +87,7 @@ suite('DefaultCredentialsFileReaderWriter Tests', function(): void {
                 profileNames.has(profileName),
                 true,
                 `ERROR: profileNames [ ${[...profileNames].map(n => `'${n}'`).join(', ')} ]` +
-                    ` does not contain '${profileName}'`
+                ` does not contain '${profileName}'`
             )
         })
 
@@ -96,9 +96,38 @@ suite('DefaultCredentialsFileReaderWriter Tests', function(): void {
                 profileNames.has(profileName),
                 false,
                 `ERROR: configProfileNames [ ${[...configProfileNames].map(n => `'${n}'`).join(', ')} ]` +
-                    ` contains '${profileName}'`
+                ` contains '${profileName}'`
             )
         })
+    })
+
+    test('setCanUseConfigFileOnFileExistance with config file that exists', async () => {
+        let canUseState: boolean | undefined
+
+        const writer = new DefaultCredentialsFileReaderWriter()
+        writer.setCanUseConfigFile = (allow) => {
+            canUseState = allow
+        }
+
+        await writer.setCanUseConfigFileOnFileExistance()
+
+        assert.equal(canUseState, true)
+    })
+
+    test('setCanUseConfigFileOnFileExistance with config file that does not exist', async () => {
+        let canUseState: boolean | undefined
+
+        const env = process.env as EnvironmentVariables
+        env.AWS_CONFIG_FILE = path.join(tempFolder, 'config-not-exist-file')
+
+        const writer = new DefaultCredentialsFileReaderWriter()
+        writer.setCanUseConfigFile = (allow) => {
+            canUseState = allow
+        }
+
+        await writer.setCanUseConfigFileOnFileExistance()
+
+        assert.equal(canUseState, false)
     })
 
     function createCredentialsFile(filename: string, profileNames: string[]): void {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [ ] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description

If you've previously connected to AWS with a credentials profile and closed VS Code, the next time you open VS Code it uses the same profile. On startup, if the user does not have a config file, a "file does not exist" error shows up. This change prevents the code from trying to load profiles from the (non-existent) config file.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing

* Connect to AWS with a profile, then close VS Code
* delete (or rename) .aws/config file
* Reopen VS Code, select AWS Explorer
* Extension will attempt to re-connect to AWS with the same profile
* expect no error message

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
