### PR TITLE
Add refresh button to explorer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
                     "group": "navigation@4"
                 },
                 {
-                    "command": "aws.refreshLambdaExplorer",
+                    "command": "aws.refreshAwsExplorer",
                     "when": "view == lambda",
                     "group": "navigation@5"
                 }
@@ -208,8 +208,8 @@
                 "category": "AWS"
             },
             {
-                "command": "aws.refreshLambdaExplorer",
-                "title": "%AWS.command.refreshLambdaExplorer%",
+                "command": "aws.refreshAwsExplorer",
+                "title": "%AWS.command.refreshAwsExplorer%",
                 "category": "AWS",
                 "icon": {
                     "light": "resources/light/invoke_lambda.svg",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,11 @@
                     "command": "aws.invokeLambda",
                     "when": "view == lambda",
                     "group": "navigation@4"
+                },
+                {
+                    "command": "aws.refreshLambdaExplorer",
+                    "when": "view == lambda",
+                    "group": "navigation@5"
                 }
             ],
             "view/item/context": [
@@ -201,6 +206,15 @@
                 "command": "aws.deleteLambda",
                 "title": "%AWS.command.deleteLambda%",
                 "category": "AWS"
+            },
+            {
+                "command": "aws.refreshLambdaExplorer",
+                "title": "%AWS.command.refreshLambdaExplorer%",
+                "category": "AWS",
+                "icon": {
+                    "light": "resources/light/invoke_lambda.svg",
+                    "dark": "resources/dark/invoke_lambda.svg"
+                }
             },
             {
                 "command": "aws.getLambdaConfig",

--- a/package.nls.json
+++ b/package.nls.json
@@ -19,7 +19,7 @@
     "AWS.command.deleteLambda.error": "There was an error deleting lambda function '{0}'",
     "AWS.command.deployLambda": "Deploy",
     "AWS.command.invokeLambda": "Invoke",
-    "AWS.command.refreshLambdaExplorer": "Refresh",
+    "AWS.command.refreshAwsExplorer": "Refresh",
     "AWS.command.getLambdaConfig": "Get Configuration",
     "AWS.command.getLambdaPolicy": "Get Policy",
     "AWS.command.samcli.detect": "Detect SAM CLI",

--- a/package.nls.json
+++ b/package.nls.json
@@ -19,6 +19,7 @@
     "AWS.command.deleteLambda.error": "There was an error deleting lambda function '{0}'",
     "AWS.command.deployLambda": "Deploy",
     "AWS.command.invokeLambda": "Invoke",
+    "AWS.command.refreshLambdaExplorer": "Refresh",
     "AWS.command.getLambdaConfig": "Get Configuration",
     "AWS.command.getLambdaPolicy": "Get Policy",
     "AWS.command.samcli.detect": "Detect SAM CLI",

--- a/src/lambda/lambdaTreeDataProvider.ts
+++ b/src/lambda/lambdaTreeDataProvider.ts
@@ -49,7 +49,7 @@ export class LambdaTreeDataProvider implements vscode.TreeDataProvider<AWSTreeNo
     }
 
     public initialize(): void {
-        vscode.commands.registerCommand('aws.refreshLambdaExplorer', async () => this.refresh())
+        vscode.commands.registerCommand('aws.refreshAwsExplorer', async () => this.refresh())
         vscode.commands.registerCommand('aws.newLambda', async () => await newLambda())
         vscode.commands.registerCommand(
             'aws.deployLambda',

--- a/src/lambda/lambdaTreeDataProvider.ts
+++ b/src/lambda/lambdaTreeDataProvider.ts
@@ -47,6 +47,7 @@ export class LambdaTreeDataProvider implements vscode.TreeDataProvider<AWSTreeNo
     }
 
     public initialize(): void {
+        vscode.commands.registerCommand('aws.refreshLambdaExplorer', async () => this.refresh())
         vscode.commands.registerCommand('aws.newLambda', async () => await newLambda())
         vscode.commands.registerCommand(
             'aws.deployLambda',


### PR DESCRIPTION
Allow user to manually refresh the entire contents of the explorer.

Note: This change uses an existing icon as a placeholder for the 'refresh' icon.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [ ] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The user's AWS resources may be changed outside of the toolkit. In this case, we don't have a mechanism to detect the change and automatically refresh. As a workaround, this change allows the user to manually refresh the explorer.

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
