### PR TITLE
Add code lens for configuring lambda handlers for local invoke.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2240,6 +2240,11 @@
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
         },
+        "jsonc-parser": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.0.2.tgz",
+            "integrity": "sha512-TSU435K5tEKh3g7bam1AFf+uZrISheoDsLlpmAo6wWZYqjsnd09lHYK1Qo+moK4Ikifev1Gdpa69g4NELKnCrQ=="
+        },
         "jsonfile": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
         "onView:lambda",
         "onCommand:aws.newLambda",
         "onCommand:aws.invokeLambda",
-        "onCommand:aws.configureLambda",
         "onCommand:aws.deployLambda",
         "onCommand:aws.getLambdaConfig",
         "onCommand:aws.getLambdaPolicy",
@@ -240,11 +239,6 @@
             {
                 "command": "aws.deleteCloudFormation",
                 "title": "%AWS.command.deleteCloudFormation%",
-                "category": "AWS"
-            },
-            {
-                "command": "aws.configureLambda",
-                "title": "%AWS.command.configureLambda%",
                 "category": "AWS"
             }
         ]

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "onView:lambda",
         "onCommand:aws.newLambda",
         "onCommand:aws.invokeLambda",
+        "onCommand:aws.configureLambda",
         "onCommand:aws.deployLambda",
         "onCommand:aws.getLambdaConfig",
         "onCommand:aws.getLambdaPolicy",
@@ -240,6 +241,11 @@
                 "command": "aws.deleteCloudFormation",
                 "title": "%AWS.command.deleteCloudFormation%",
                 "category": "AWS"
+            },
+            {
+                "command": "aws.configureLambda",
+                "title": "%AWS.command.configureLambda%",
+                "category": "AWS"
             }
         ]
     },
@@ -291,6 +297,7 @@
         "fs-extra": "^6.0.1",
         "handlebars": "^4.0.12",
         "js-yaml": "^3.12.0",
+        "jsonc-parser": "^2.0.2",
         "jszip": "^3.1.5",
         "lodash": "^4.17.10",
         "npm": "^6.4.1",

--- a/package.nls.json
+++ b/package.nls.json
@@ -22,6 +22,7 @@
     "AWS.command.deleteLambda.error": "There was an error deleting lambda function '{0}'",
     "AWS.command.deployLambda": "Deploy",
     "AWS.command.invokeLambda": "Invoke",
+    "AWS.command.configureLambda": "Configure",
     "AWS.command.refreshAwsExplorer": "Refresh",
     "AWS.command.getLambdaConfig": "Get Configuration",
     "AWS.command.getLambdaPolicy": "Get Policy",

--- a/src/lambda/lambdaTreeDataProvider.ts
+++ b/src/lambda/lambdaTreeDataProvider.ts
@@ -29,6 +29,7 @@ import { FunctionNodeBase } from './explorer/functionNode'
 import { RegionNode } from './explorer/regionNode'
 import { StandaloneFunctionNode } from './explorer/standaloneNodes'
 import { DefaultLambdaPolicyProvider, LambdaPolicyView } from './lambdaPolicy'
+import { configureLocalLambda } from './local/configureLocalLambda'
 import * as utils from './utils'
 
 export class LambdaTreeDataProvider implements vscode.TreeDataProvider<AWSTreeNodeBase>, RefreshableAwsTreeProvider {
@@ -74,6 +75,7 @@ export class LambdaTreeDataProvider implements vscode.TreeDataProvider<AWSTreeNo
             'aws.invokeLambda',
             async (node: FunctionNodeBase) => await invokeLambda(this.awsContext, this.resourceFetcher, node)
         )
+        vscode.commands.registerCommand('aws.configureLambda', configureLocalLambda)
         vscode.commands.registerCommand(
             'aws.getLambdaConfig',
             async (node: FunctionNodeBase) => await getLambdaConfig(

--- a/src/lambda/local/configureLocalLambda.ts
+++ b/src/lambda/local/configureLocalLambda.ts
@@ -5,6 +5,8 @@
 
 'use strict'
 
+// Use jsonc-parser.parse instead of JSON.parse, as JSONC can handle comments. VS Code uses jsonc-parser
+// under the hood to provide symbols for JSON documents, so this will keep us consistent with VS code.
 import { parse } from 'jsonc-parser'
 import * as os from 'os'
 import * as path from 'path'
@@ -22,38 +24,14 @@ export interface HandlersConfig {
     }
 }
 
-export async function configureLocalLambda(sourceUri: vscode.Uri, handler: string): Promise<void> {
-    // Handler will be the fully-qualified name, so we also allow '.' despite it being forbidden in handler names.
-    if (/[^\w\-\.]/.test(handler)) {
-        throw new Error(
-            `Invalid handler name: '${handler}'. ` +
-            'Handler names can contain only letters, numbers, hyphens, and underscores.'
-        )
-    }
-
-    const workspaceFolder: vscode.WorkspaceFolder | undefined = vscode.workspace.getWorkspaceFolder(sourceUri)
-    if (!workspaceFolder) {
-        console.error(`Source file ${sourceUri} is external to the current workspace.`)
-
-        return
-    }
-
+// Precondition: `handler` is a valid lambda handler name.
+export async function configureLocalLambda(workspaceFolder: vscode.WorkspaceFolder, handler: string): Promise<void> {
     // Preserve the scheme, etc of the workspace uri.
     const uri = workspaceFolder.uri.with({
         path: path.join(workspaceFolder.uri.fsPath, '.aws', 'handlers.json')
     })
 
-    try {
-        await accessAsync(path.dirname(uri.fsPath))
-    } catch {
-        await mkdirAsync(path.dirname(uri.fsPath), { recursive: true })
-    }
-
-    try {
-        await accessAsync(uri.fsPath)
-    } catch {
-        await writeFileAsync(uri.fsPath, JSON.stringify(buildHandlersConfig(handler), undefined, getTabSize()))
-    }
+    await ensureHandlersConfigFileExists(uri, handler)
 
     const editor: vscode.TextEditor = await vscode.window.showTextDocument(uri)
     if (await prepareConfig(editor, handler)) {
@@ -65,8 +43,22 @@ export async function configureLocalLambda(sourceUri: vscode.Uri, handler: strin
 
     await vscode.window.showTextDocument(
         editor.document,
-        { selection: await getFocusRange(editor, handler) }
+        { selection: await getEventRange(editor, handler) }
     )
+}
+
+async function ensureHandlersConfigFileExists(uri: vscode.Uri, handler: string): Promise<void> {
+    try {
+        await accessAsync(path.dirname(uri.fsPath))
+    } catch {
+        await mkdirAsync(path.dirname(uri.fsPath), { recursive: true })
+    }
+
+    try {
+        await accessAsync(uri.fsPath)
+    } catch {
+        await writeFileAsync(uri.fsPath, JSON.stringify(buildHandlersConfig(handler), undefined, getTabSize()))
+    }
 }
 
 function buildHandlersConfig(handler?: string): HandlersConfig {
@@ -87,7 +79,9 @@ function buildHandlerConfig(): HandlerConfig {
     }
 }
 
-function getTabSize(tabSize?: string | number | undefined): number {
+function getTabSize(editor?: vscode.TextEditor): number {
+    const tabSize = !editor ? undefined : editor.options.tabSize
+
     switch (typeof tabSize) {
         case 'number':
             return tabSize
@@ -99,50 +93,58 @@ function getTabSize(tabSize?: string | number | undefined): number {
     }
 }
 
-async function prepareConfig(editor: vscode.TextEditor, handler: string): Promise<boolean> {
+async function getSymbols(uri: vscode.Uri): Promise<vscode.DocumentSymbol[] | undefined> {
     // Awaiting this command is required because without it, symbols for a newly created document might not yet
     // be available, in which case vscode.executeDocumentSymbolProvider will return an empty list.
-    await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
-        'editor.action.wordHighlight.trigger',
-        editor.document.uri
-    )
-    const symbols: vscode.DocumentSymbol[] | undefined = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
-        'vscode.executeDocumentSymbolProvider',
-        editor.document.uri
-    )
+    await vscode.commands.executeCommand<vscode.DocumentSymbol[]>('editor.action.wordHighlight.trigger', uri)
 
-    const entireDocumentRange: vscode.Range = new vscode.Range(
-        new vscode.Position(0, 0),
-        editor.document.positionAt(editor.document.getText().length)
-    )
+    return await vscode.commands.executeCommand<vscode.DocumentSymbol[]>('vscode.executeDocumentSymbolProvider', uri)
+}
 
+async function prepareConfig(editor: vscode.TextEditor, handler: string): Promise<boolean> {
+    const symbols: vscode.DocumentSymbol[] | undefined = await getSymbols(editor.document.uri)
+
+    // If the file is empty, or if it is non-empty but cannot be even partially parsed as JSON, build it from scratch.
     if (!symbols || symbols.length < 1) {
-        return await editor.edit(editBuilder => {
-            const config: HandlersConfig = buildHandlersConfig(handler)
-
-            editBuilder.replace(
-                entireDocumentRange,
-                JSON.stringify(config, undefined, getTabSize(editor.options.tabSize))
-            )
-        })
+        return await editor.edit(editBuilder => editBuilder.replace(
+            // The jsonc-parser API does not provide a safe way to insert a child into an empty list, so in the case
+            // that the config file is missing or empty, we need to replace the entire document.
+            new vscode.Range(
+                new vscode.Position(0, 0),
+                editor.document.positionAt(editor.document.getText().length)
+            ),
+            JSON.stringify(buildHandlersConfig(handler), undefined, getTabSize(editor))
+        ))
     }
 
+    // If the config file exists, but `root.handlers` is undefined or empty, initial it with an empty
+    // config section for this handler.
     const handlersSymbol: vscode.DocumentSymbol | undefined = symbols.find(c => c.name === 'handlers')
     if (!handlersSymbol || handlersSymbol.children.length < 1) {
         const config: HandlersConfig = {
-            // Use jsonc-parser.parse instead of JSON.parse, as JSONC can handle comments. VS Code uses jsonc-parser
-            // under the hood to provide symbols for JSON documents, so this will keep us consistent with VS code.
             ...parse(editor.document.getText()),
             ...buildHandlersConfig(handler)
         }
-        const configString = JSON.stringify(config, undefined, getTabSize(editor.options.tabSize))
+        const configString = JSON.stringify(config, undefined, getTabSize(editor))
 
-        return await editor.edit(editBuilder => editBuilder.replace(entireDocumentRange, configString))
+        return await editor.edit(
+                // The jsonc-parser API does not provide a safe way to insert a child into an empty list, so in the case
+                // that the config file exists, but has an empty or undefined `handlers` property, we need to replace
+                // the entire document.
+                editBuilder => editBuilder.replace(
+                new vscode.Range(
+                    new vscode.Position(0, 0),
+                    editor.document.positionAt(editor.document.getText().length)
+                ),
+                configString
+            )
+        )
     }
 
+    // If `root.handlers` and is non-empty, but does not include an entry for this handler, create and insert one.
     const handlerSymbol: vscode.DocumentSymbol | undefined = handlersSymbol.children.find(c => c.name === handler)
     if (!handlerSymbol || handlerSymbol.children.length < 1) {
-        // At this point we know that handlersSymbol has at least one child.
+        // At this point we know that `root.handlers` has at least one child.
         const lastChildEnd: vscode.Position = handlersSymbol.children.reduce(
             (lastSoFar: vscode.Position, current: vscode.DocumentSymbol) =>
                 current.range.end.isAfter(lastSoFar) ? current.range.end : lastSoFar,
@@ -155,7 +157,7 @@ async function prepareConfig(editor: vscode.TextEditor, handler: string): Promis
         //             event: {}
         //         }
         // [END]
-        const tabSize = getTabSize(editor.options.tabSize)
+        const tabSize = getTabSize(editor)
         const baseIndentation: string = ' '.repeat(tabSize).repeat(2)
         // We have already validated that handler contains only letters, numbers, hyphens, and underscores.
         let snippet: string = `"${handler}": ${JSON.stringify(buildHandlerConfig(), undefined, tabSize)}`
@@ -165,6 +167,8 @@ async function prepareConfig(editor: vscode.TextEditor, handler: string): Promis
         return await editor.edit(editBuilder => editBuilder.insert(lastChildEnd, snippet))
     }
 
+    // If there is a config section for this handler, but it doesn't specify a sample event, create and insert
+    // an empty sample event.
     const eventSymbol: vscode.DocumentSymbol | undefined = handlerSymbol.children.find(c => c.name === 'event')
     if (!eventSymbol) {
         // At this point we know that handlerSymbol has at least one child.
@@ -174,7 +178,7 @@ async function prepareConfig(editor: vscode.TextEditor, handler: string): Promis
             new vscode.Position(0, 0)
         )
 
-        const baseIndentation: string = ' '.repeat(getTabSize(editor.options.tabSize)).repeat(3)
+        const baseIndentation: string = ' '.repeat(getTabSize(editor)).repeat(3)
         const snippet: string = `,${os.EOL}${baseIndentation}"event": {}${os.EOL}`
 
         return await editor.edit(editBuilder => editBuilder.insert(lastChildEnd, snippet))
@@ -183,7 +187,7 @@ async function prepareConfig(editor: vscode.TextEditor, handler: string): Promis
     return true
 }
 
-async function getFocusRange(editor: vscode.TextEditor, handler: string): Promise<vscode.Range> {
+async function getEventRange(editor: vscode.TextEditor, handler: string): Promise<vscode.Range> {
     const symbols: vscode.DocumentSymbol[] | undefined = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
         'vscode.executeDocumentSymbolProvider',
         editor.document.uri

--- a/src/lambda/local/configureLocalLambda.ts
+++ b/src/lambda/local/configureLocalLambda.ts
@@ -1,0 +1,245 @@
+/*!
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+import { parse } from 'jsonc-parser'
+import * as os from 'os'
+import * as path from 'path'
+import * as vscode from 'vscode'
+import { accessAsync, mkdirAsync, writeFileAsync } from '../../shared/filesystem'
+import { DefaultSettingsConfiguration } from '../../shared/settingsConfiguration'
+
+export interface HandlerConfig {
+    event: any
+}
+
+export interface HandlersConfig {
+    handlers: {
+        [ handler: string ]: HandlerConfig | undefined
+    }
+}
+
+export async function configureLocalLambda(sourceUri: vscode.Uri, handler: string): Promise<void> {
+    // Handler will be the fully-qualified name, so we also allow '.' despite it being forbidden in handler names.
+    if (/[^\w\-\.]/.test(handler)) {
+        throw new Error(
+            `Invalid handler name: '${handler}'. ` +
+            'Handler names can contain only letters, numbers, hyphens, and underscores.'
+        )
+    }
+
+    const workspaceFolder: vscode.WorkspaceFolder | undefined = vscode.workspace.getWorkspaceFolder(sourceUri)
+    if (!workspaceFolder) {
+        console.error(`Source file ${sourceUri} is external to the current workspace.`)
+
+        return
+    }
+
+    // Preserve the scheme, etc of the workspace uri.
+    const uri = workspaceFolder.uri.with({
+        path: path.join(workspaceFolder.uri.fsPath, '.aws', 'handlers.json')
+    })
+
+    try {
+        await accessAsync(path.dirname(uri.fsPath))
+    } catch {
+        await mkdirAsync(path.dirname(uri.fsPath), { recursive: true })
+    }
+
+    try {
+        await accessAsync(uri.fsPath)
+    } catch {
+        await writeFileAsync(uri.fsPath, JSON.stringify(buildHandlersConfig(handler), undefined, getTabSize()))
+    }
+
+    const editor: vscode.TextEditor = await vscode.window.showTextDocument(uri)
+    if (await prepareConfig(editor, handler)) {
+        // Perf: TextDocument.save is smart enough to no-op if the document is not dirty.
+        await editor.document.save()
+    } else {
+        throw new Error(`Could not update config file '${uri.fsPath}'`)
+    }
+
+    await vscode.window.showTextDocument(
+        editor.document,
+        { selection: await getFocusRange(editor, handler) }
+    )
+}
+
+function buildHandlersConfig(handler?: string): HandlersConfig {
+    const config: HandlersConfig = {
+        handlers: {}
+    }
+
+    if (!!handler) {
+        config.handlers[handler] = buildHandlerConfig()
+    }
+
+    return config
+}
+
+function buildHandlerConfig(): HandlerConfig {
+    return {
+        event: {}
+    }
+}
+
+function getTabSize(tabSize?: string | number | undefined): number {
+    switch (typeof tabSize) {
+        case 'number':
+            return tabSize
+        case 'string':
+            return Number.parseInt(tabSize, 10)
+        default:
+            // If we couldn't determine the tabSize at the document, workspace, or user level, default to 4.
+            return new DefaultSettingsConfiguration('editor').readSetting<number>('tabSize') || 4
+    }
+}
+
+async function prepareConfig(editor: vscode.TextEditor, handler: string): Promise<boolean> {
+    // Awaiting this command is required because without it, symbols for a newly created document might not yet
+    // be available, in which case vscode.executeDocumentSymbolProvider will return an empty list.
+    await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+        'editor.action.wordHighlight.trigger',
+        editor.document.uri
+    )
+    const symbols: vscode.DocumentSymbol[] | undefined = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+        'vscode.executeDocumentSymbolProvider',
+        editor.document.uri
+    )
+
+    const entireDocumentRange: vscode.Range = new vscode.Range(
+        new vscode.Position(0, 0),
+        editor.document.positionAt(editor.document.getText().length)
+    )
+
+    if (!symbols || symbols.length < 1) {
+        return await editor.edit(editBuilder => {
+            const config: HandlersConfig = buildHandlersConfig(handler)
+
+            editBuilder.replace(
+                entireDocumentRange,
+                JSON.stringify(config, undefined, getTabSize(editor.options.tabSize))
+            )
+        })
+    }
+
+    const handlersSymbol: vscode.DocumentSymbol | undefined = symbols.find(c => c.name === 'handlers')
+    if (!handlersSymbol || handlersSymbol.children.length < 1) {
+        const config: HandlersConfig = {
+            // Use jsonc-parser.parse instead of JSON.parse, as JSONC can handle comments. VS Code uses jsonc-parser
+            // under the hood to provide symbols for JSON documents, so this will keep us consistent with VS code.
+            ...parse(editor.document.getText()),
+            ...buildHandlersConfig(handler)
+        }
+        const configString = JSON.stringify(config, undefined, getTabSize(editor.options.tabSize))
+
+        return await editor.edit(editBuilder => editBuilder.replace(entireDocumentRange, configString))
+    }
+
+    const handlerSymbol: vscode.DocumentSymbol | undefined = handlersSymbol.children.find(c => c.name === handler)
+    if (!handlerSymbol || handlerSymbol.children.length < 1) {
+        // At this point we know that handlersSymbol has at least one child.
+        const lastChildEnd: vscode.Position = handlersSymbol.children.reduce(
+            (lastSoFar: vscode.Position, current: vscode.DocumentSymbol) =>
+                current.range.end.isAfter(lastSoFar) ? current.range.end : lastSoFar,
+            new vscode.Position(0, 0)
+        )
+
+        // For example (tabWidth = 4):
+        // [START],
+        //         "myHandler": {
+        //             event: {}
+        //         }
+        // [END]
+        const tabSize = getTabSize(editor.options.tabSize)
+        const baseIndentation: string = ' '.repeat(tabSize).repeat(2)
+        // We have already validated that handler contains only letters, numbers, hyphens, and underscores.
+        let snippet: string = `"${handler}": ${JSON.stringify(buildHandlerConfig(), undefined, tabSize)}`
+            .split(/\r?\n/).map(line => `${baseIndentation}${line}`).join(os.EOL)
+        snippet = `,${os.EOL}${snippet}${os.EOL}`
+
+        return await editor.edit(editBuilder => editBuilder.insert(lastChildEnd, snippet))
+    }
+
+    const eventSymbol: vscode.DocumentSymbol | undefined = handlerSymbol.children.find(c => c.name === 'event')
+    if (!eventSymbol) {
+        // At this point we know that handlerSymbol has at least one child.
+        const lastChildEnd: vscode.Position = handlerSymbol.children.reduce(
+            (lastSoFar: vscode.Position, current: vscode.DocumentSymbol) =>
+                current.range.end.isAfter(lastSoFar) ? current.range.end : lastSoFar,
+            new vscode.Position(0, 0)
+        )
+
+        const baseIndentation: string = ' '.repeat(getTabSize(editor.options.tabSize)).repeat(3)
+        const snippet: string = `,${os.EOL}${baseIndentation}"event": {}${os.EOL}`
+
+        return await editor.edit(editBuilder => editBuilder.insert(lastChildEnd, snippet))
+    }
+
+    return true
+}
+
+async function getFocusRange(editor: vscode.TextEditor, handler: string): Promise<vscode.Range> {
+    const symbols: vscode.DocumentSymbol[] | undefined = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+        'vscode.executeDocumentSymbolProvider',
+        editor.document.uri
+    )
+
+    const defaultRange = new vscode.Range(
+        new vscode.Position(0, 0),
+        new vscode.Position(0, 0)
+    )
+
+    if (!symbols || symbols.length < 1) {
+        return defaultRange
+    }
+
+    const handlersSymbol: vscode.DocumentSymbol | undefined = symbols.find(c => c.name === 'handlers')
+    if (!handlersSymbol) {
+        console.error(`Invalid format for document ${editor.document.uri}`)
+
+        return defaultRange
+    }
+
+    const handlerSymbol: vscode.DocumentSymbol | undefined = handlersSymbol.children.find(c => c.name === handler)
+    if (!handlerSymbol) {
+        console.error(`Unable to find config for handler ${handler}`)
+
+        return defaultRange
+    }
+
+    const eventSymbol: vscode.DocumentSymbol | undefined = handlerSymbol.children.find(c => c.name === 'event')
+    if (!eventSymbol) {
+        return handlerSymbol.range
+    }
+
+    return getChildrenRange(eventSymbol)
+}
+
+async function getChildrenRange(symbol: vscode.DocumentSymbol) {
+    const ranges: vscode.Range[] = symbol.children.map(c => c.range)
+
+    let start: vscode.Position | undefined
+    let end: vscode.Position | undefined
+
+    for (const range of ranges) {
+        if (!start || range.start.isBefore(start)) {
+            start = range.start
+        }
+
+        if (!end || range.end.isAfter(end)) {
+            end = range.end
+        }
+    }
+
+    if (!start || !end) {
+        // If symbol has no children, default ito
+        return symbol.range
+    }
+
+    return new vscode.Range(start, end)
+}

--- a/src/shared/codelens/typescriptCodeLensProvider.ts
+++ b/src/shared/codelens/typescriptCodeLensProvider.ts
@@ -53,6 +53,7 @@ export class TypescriptCodeLensProvider implements vscode.CodeLensProvider {
 
             lenses.push(this.generateLocalInvokeCodeLens(document, range, handler.handlerName, false))
             lenses.push(this.generateLocalInvokeCodeLens(document, range, handler.handlerName, true))
+            lenses.push(this.generateConfigureCodeLens(document, range, handler.handlerName))
         })
 
         return lenses
@@ -63,6 +64,20 @@ export class TypescriptCodeLensProvider implements vscode.CodeLensProvider {
         token: vscode.CancellationToken
     ): vscode.ProviderResult<vscode.CodeLens> {
         throw new Error('not implemented')
+    }
+
+    private generateConfigureCodeLens(
+        document: vscode.TextDocument,
+        range: vscode.Range,
+        handlerName: string
+    ) {
+        const command = {
+            arguments: [ document.uri, handlerName ],
+            command: 'aws.configureLambda',
+            title: localize('AWS.command.configureLambda', 'Configure')
+        }
+
+        return new vscode.CodeLens(range, command)
     }
 
     private generateLocalInvokeCodeLens(

--- a/src/shared/codelens/typescriptCodeLensProvider.ts
+++ b/src/shared/codelens/typescriptCodeLensProvider.ts
@@ -94,7 +94,7 @@ export class TypescriptCodeLensProvider implements vscode.CodeLensProvider {
         }
 
         const command = {
-            arguments: [ document.uri, handlerName ],
+            arguments: [ workspaceFolder, handlerName ],
             command: 'aws.configureLambda',
             title: localize('AWS.command.configureLambda', 'Configure')
         }

--- a/src/shared/filesystem.ts
+++ b/src/shared/filesystem.ts
@@ -7,9 +7,8 @@
 
 import * as fs from 'fs'
 
-/* tslint:disable promise-function-async */
-export function accessAsync(path: string | Buffer): Promise<void> {
-    return new Promise((resolve, reject) => fs.access(path, err => {
+export async function accessAsync(path: string | Buffer): Promise<void> {
+    await new Promise<void>((resolve, reject) => fs.access(path, err => {
         if (!err) {
             resolve()
         } else {
@@ -18,28 +17,21 @@ export function accessAsync(path: string | Buffer): Promise<void> {
     }))
 }
 
-export function mkdirAsync(path: string | Buffer, mode?: number | string) {
-    return new Promise<void>((resolve, reject) => {
-        const handler = (err?: NodeJS.ErrnoException) => {
-            if (!err) {
-                resolve()
-            } else {
-                reject(err)
-            }
-        }
-
-        if (!mode) {
-            fs.mkdir(path, handler)
-        } else if (typeof mode === 'number') {
-            fs.mkdir(path, mode as number, handler)
+export async function mkdirAsync(
+    path: fs.PathLike,
+    options?: number | string | fs.MakeDirectoryOptions | undefined | null
+): Promise<void> {
+    await new Promise<void>((resolve, reject) => fs.mkdir(path, options, err => {
+        if (!err) {
+            resolve()
         } else {
-            fs.mkdir(path, mode as string, handler)
+            reject(err)
         }
-    })
+    }))
 }
 
-export function mkdtempAsync(prefix: string): Promise<string> {
-    return new Promise((resolve, reject) => {
+export async function mkdtempAsync(prefix: string): Promise<string> {
+    return await new Promise<string>((resolve, reject) => {
         fs.mkdtemp(prefix, (err, folder) => {
             if (!err) {
                 resolve(folder)
@@ -50,32 +42,26 @@ export function mkdtempAsync(prefix: string): Promise<string> {
     })
 }
 
-export function readdirAsync(
+export async function readdirAsync(
     path: string | Buffer,
     options?: {
         encoding: BufferEncoding | null
         withFileTypes?: false
     } | BufferEncoding | undefined | null
 ): Promise<string[]> {
-    return new Promise((resolve, reject) => {
-        const handler = (err: NodeJS.ErrnoException, files: string[]) => {
+    return await new Promise<string[]>((resolve, reject) => {
+        fs.readdir(path, options, (err, files) => {
             if (!err) {
                 resolve(files)
             } else {
                 reject(err)
             }
-        }
-
-        if (!!options) {
-            fs.readdir(path, options, handler)
-        } else {
-            fs.readdir(path, handler)
-        }
+        })
     })
 }
 
-export function readFileAsync(filename: string, encoding: string | null): Promise<string | Buffer> {
-    return new Promise((resolve, reject) => {
+export async function readFileAsync(filename: string, encoding: string | null): Promise<string | Buffer> {
+    return await new Promise<string | Buffer>((resolve, reject) => {
         fs.readFile(filename, encoding, (err, data) => {
             if (!err) {
                 resolve(data)
@@ -86,8 +72,8 @@ export function readFileAsync(filename: string, encoding: string | null): Promis
     })
 }
 
-export function statAsync(path: string | Buffer): Promise<fs.Stats> {
-    return new Promise((resolve, reject) => {
+export async function statAsync(path: string | Buffer): Promise<fs.Stats> {
+    return await new Promise<fs.Stats>((resolve, reject) => {
         fs.stat(path, (err, stats) => {
             if (!err) {
                 resolve(stats)
@@ -98,36 +84,20 @@ export function statAsync(path: string | Buffer): Promise<fs.Stats> {
     })
 }
 
-interface WriteFileOptions<TMode extends number | string> {
-    encoding?: string
-    mode?: TMode
-    flag?: string
-}
-
-export function writeFileAsync(
+export async function writeFileAsync(
     filename: string,
     data: any,
-    options?: string | WriteFileOptions<number> | WriteFileOptions<string>
+    // fs.WriteFileOptions includes null, but not undefined.
+    // tslint:disable-next-line:no-null-keyword
+    options: fs.WriteFileOptions = null
 ): Promise<void> {
-    return new Promise((resolve, reject) => {
-        const callback = (err: NodeJS.ErrnoException) => {
+    await new Promise<void>((resolve, reject) => {
+        fs.writeFile(filename, data, options, err => {
             if (!err) {
                 resolve()
             } else {
                 reject(err)
             }
-        }
-
-        if (!options) {
-            fs.writeFile(filename, data, callback)
-        } else if (typeof options === 'string') {
-            fs.writeFile(filename, data, options, callback)
-        } else if (!!options.mode && typeof options.mode === 'number')  {
-            fs.writeFile(filename, data, options as WriteFileOptions<number>, callback)
-        } else {
-            fs.writeFile(filename, data, options as WriteFileOptions<string>, callback)
-        }
+        })
     })
 }
-
-/* tslint:enable promise-function-async */


### PR DESCRIPTION
Currently, when a lambda handler is invoked through a code lens, the event payload is always `{}`. This change adds a new code lens labeled `configure`, that allows the user to specify a custom event payload for the handler.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [ ] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description

Currently, when a lambda handler is invoked through a code lens, the event payload is always `{}`. This change adds a new code lens labeled `configure`, that allows the user to specify a custom event payload for the handler.

This code lens opens a new configuration file (`.aws/handlers.json`) and selects the configuration for the handler in question.

## Motivation and Context

In the real world, lambda handlers are triggered by events. To be able to usefully debug handlers, the customer must be able to provide realistic event payloads.

## Related Issue(s)

#149

## Testing

Tests are not included in this PR. Immediately after this PR is merged, I will submit a PR to merge `pirocchi/code-lens/vscode`, which make the code in this current PR testable. Then I will submit tests for the code in this current PR.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
