### PR TITLE
Bugfix: Avoid clobbering `handlers.json` before JSON document symbol provider is ready.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5929,6 +5929,11 @@
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
             "dev": true
         },
+        "sleep-promise": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/sleep-promise/-/sleep-promise-8.0.1.tgz",
+            "integrity": "sha1-jXlaJ+ojlT32tSuRCB5eImZZk8U="
+        },
         "source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -257,6 +257,7 @@
         "opn": "^5.4.0",
         "request": "^2.88.0",
         "semver": "^5.6.0",
+        "sleep-promise": "^8.0.1",
         "tcp-port-used": "^1.0.1",
         "typescript": "^3.1.3",
         "vscode-nls": "^3.2.4",

--- a/src/lambda/local/configureLocalLambda.ts
+++ b/src/lambda/local/configureLocalLambda.ts
@@ -130,7 +130,7 @@ function getTabSize(editor?: vscode.TextEditor): number {
 async function loadSymbols(
     uri: vscode.Uri,
     maxAttempts = 3,
-    retryDelayMillis = 500 // milliseconds
+    retryDelayMillis = 500
 ): Promise<vscode.DocumentSymbol[] | undefined> {
     if (maxAttempts <= 0) {
         return undefined

--- a/src/lambda/local/configureLocalLambda.ts
+++ b/src/lambda/local/configureLocalLambda.ts
@@ -10,6 +10,7 @@
 import { parse } from 'jsonc-parser'
 import * as os from 'os'
 import * as path from 'path'
+import * as sleep from 'sleep-promise'
 import * as vscode from 'vscode'
 import { accessAsync, mkdirAsync, writeFileAsync } from '../../shared/filesystem'
 import { readFileAsString } from '../../shared/filesystemUtilities'
@@ -126,16 +127,23 @@ function getTabSize(editor?: vscode.TextEditor): number {
     }
 }
 
-async function getSymbols(uri: vscode.Uri): Promise<vscode.DocumentSymbol[] | undefined> {
-    // Awaiting this command is required because without it, symbols for a newly created document might not yet
-    // be available, in which case vscode.executeDocumentSymbolProvider will return an empty list.
-    await vscode.commands.executeCommand<vscode.DocumentSymbol[]>('editor.action.wordHighlight.trigger', uri)
+async function loadSymbols(
+    uri: vscode.Uri,
+    maxAttempts = 3,
+    retryDelay = 500 // milliseconds
+): Promise<vscode.DocumentSymbol[] | undefined> {
+    if (maxAttempts <= 0) {
+        return undefined
+    }
 
-    return await vscode.commands.executeCommand<vscode.DocumentSymbol[]>('vscode.executeDocumentSymbolProvider', uri)
+    return await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+        'vscode.executeDocumentSymbolProvider',
+        uri
+    ) || await sleep(retryDelay).then(async () => await loadSymbols(uri, maxAttempts - 1, retryDelay))
 }
 
 async function prepareConfig(editor: vscode.TextEditor, handler: string): Promise<boolean> {
-    const symbols: vscode.DocumentSymbol[] | undefined = await getSymbols(editor.document.uri)
+    const symbols: vscode.DocumentSymbol[] | undefined = await loadSymbols(editor.document.uri)
 
     // If the file is empty, or if it is non-empty but cannot be even partially parsed as JSON, build it from scratch.
     if (!symbols || symbols.length < 1) {

--- a/src/lambda/local/configureLocalLambda.ts
+++ b/src/lambda/local/configureLocalLambda.ts
@@ -130,16 +130,23 @@ function getTabSize(editor?: vscode.TextEditor): number {
 async function loadSymbols(
     uri: vscode.Uri,
     maxAttempts = 3,
-    retryDelay = 500 // milliseconds
+    retryDelayMillis = 500 // milliseconds
 ): Promise<vscode.DocumentSymbol[] | undefined> {
     if (maxAttempts <= 0) {
         return undefined
     }
 
-    return await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+    const symbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
         'vscode.executeDocumentSymbolProvider',
         uri
-    ) || await sleep(retryDelay).then(async () => await loadSymbols(uri, maxAttempts - 1, retryDelay))
+    )
+    if (symbols) {
+        return symbols
+    }
+
+    await sleep(retryDelayMillis)
+
+    return await loadSymbols(uri, maxAttempts - 1, retryDelayMillis)
 }
 
 async function prepareConfig(editor: vscode.TextEditor, handler: string): Promise<boolean> {


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [ ] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description

When symbols are not available for `.aws/handlers.json`, retry with a delay. This handles the case in which the document symbol provider has not yet finished loading during the first attempt.

## Motivation and Context

If the user invokes the 'Configure' code lens, and no JSON documents have previously been opened since VS Code was started, there is a brief window where symbols are not available for that document.

If symbols are unavailable, we consider the document to be invalid (the parser we use, `jsonc-parser`, is highly fault tolerant, so the lack of any symbols indicates a hopelessly malformed document) and create its contents from scratch. But if the symbols are missing due to the document symbol provider still loading, we will unnecessarily clobber the file.

## Checklist

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
