### PR TITLE
Set permissions for new creds file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .vscode-test/
 *.vsix
 **/.DS_Store
+.idea

--- a/src/shared/credentials/userCredentialsUtils.ts
+++ b/src/shared/credentials/userCredentialsUtils.ts
@@ -93,7 +93,10 @@ export class UserCredentialsUtils {
             throw new Error('Credentials file exists. Not overwriting it.')
         }
 
-        await writeFileAsync(this.getCredentialsFilename(), credentialsFileContents, 'utf8')
+        await writeFileAsync(this.getCredentialsFilename(), credentialsFileContents, {
+            encoding: 'utf8',
+            mode: 0o100600 // basic file (type 100) with 600 permissions
+        })
     }
 
     /**


### PR DESCRIPTION
## Types of changes

Ensured user can read/write newly created credentials file

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [ ] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description

Ensured user can read/write newly created credentials file
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)

https://github.com/aws/aws-toolkit-vscode/issues/153

## Testing

Created test for file permissions after creation

## Screenshots (if appropriate)

## Checklist


- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
