### PR TITLE
Fix `asyncIteratorShim` to work with latest VS Code update, and fix typedef version mismatch for `js-yaml`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,9 +76,9 @@
             "dev": true
         },
         "@types/js-yaml": {
-            "version": "3.11.2",
-            "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.11.2.tgz",
-            "integrity": "sha512-JRDtMPEqXrzfuYAdqbxLot1GvAr/QvicIZAnOAigZaj8xVMhuSJTg/xsv9E1TvyL+wujYhRLx9ZsQ0oFOSmwyA==",
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.0.tgz",
+            "integrity": "sha512-UGEe/6RsNAxgWdknhzFZbCxuYc5I7b/YEKlfKbo+76SM8CJzGs7XKCj7zyugXViRbKYpXhSXhCYVQZL5tmDbpQ==",
             "dev": true
         },
         "@types/lodash": {

--- a/package.json
+++ b/package.json
@@ -228,7 +228,7 @@
         "@types/fs-extra": "^5.0.4",
         "@types/glob": "^7.1.1",
         "@types/handlebars": "^4.0.39",
-        "@types/js-yaml": "^3.11.2",
+        "@types/js-yaml": "^3.12.0",
         "@types/lodash": "^4.14.110",
         "@types/mocha": "^2.2.48",
         "@types/node": "^10.12.12",

--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -34,7 +34,7 @@ export namespace CloudFormation {
         return yaml.safeLoad(
             templateAsYaml,
             {
-                schema
+                schema: schema as yaml.SchemaDefinition
             }
         ) as Template
     }

--- a/src/shared/utilities/asyncIteratorShim.ts
+++ b/src/shared/utilities/asyncIteratorShim.ts
@@ -5,7 +5,12 @@
 
 'use strict'
 
-const symbol: {
-    asyncIterator: symbol
-} = Symbol
-symbol.asyncIterator = Symbol.asyncIterator || Symbol.for('Symbol.asyncIterator')
+if (!Symbol.asyncIterator) {
+    Object.defineProperty(
+        Symbol,
+        'asyncIterator',
+        {
+            value: Symbol.for('Symbol.asyncIterator')
+        }
+    )
+}


### PR DESCRIPTION
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [ ] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description

<!--- Describe your changes in detail -->
1. The latest VS Code update breaks our `asyncIterator` shim because `Symbol.asyncIterator` is now readonly. This change fixes the shim to correctly handle this case.
2. The latest update `@types/js-yaml` changes the signature of `yaml.safeLoad`, causing a linter error. We did not catch this earlier because npm 6+ defaults to the earliest matching version, which contains the old signature.

## Testing

* Ran all existing tests
* Manually tested basic E2E scenarios.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
