### PR TITLE
Hide commands from the Command Palette that are intended to be invoked with UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,8 @@
         "onCommand:aws.showRegion",
         "onCommand:aws.hideRegion",
         "onView:lambda",
-        "onCommand:aws.invokeLambda",
-        "onCommand:aws.getLambdaConfig",
-        "onCommand:aws.getLambdaPolicy",
         "onCommand:aws.samcli.detect",
         "onCommand:aws.samcli.validate.version",
-        "onCommand:aws.deleteCloudFormation",
-        "onCommand:aws.showErrorDetails",
         "onCommand:aws.lambda.createNewSamApp",
         "onDebugInitialConfigurations"
     ],
@@ -88,6 +83,36 @@
             ]
         },
         "menus": {
+            "commandPalette": [
+                {
+                    "command": "aws.deleteCloudFormation",
+                    "when": "false"
+                },
+                {
+                    "command": "aws.deleteLambda",
+                    "when": "false"
+                },
+                {
+                    "command": "aws.getLambdaConfig",
+                    "when": "false"
+                },
+                {
+                    "command": "aws.getLambdaPolicy",
+                    "when": "false"
+                },
+                {
+                    "command": "aws.invokeLambda",
+                    "when": "false"
+                },
+                {
+                    "command": "aws.refreshAwsExplorer",
+                    "when": "false"
+                },
+                {
+                    "command": "aws.showErrorDetails",
+                    "when": "false"
+                }
+            ],
             "view/title": [
                 {
                     "command": "aws.refreshAwsExplorer",


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [ ] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description

<!--- Describe your changes in detail -->

Commands that are hooked up to the UI end up showing in the Command Palette by default. This isn't ideal, because these command usually is contextually relevant to Ui gestures, like the node that a context menu was associated with. The result was that the command palette contained extension commands that generally did nothing, raised errors (expecting parametered input), or messaged that the command was not found (due to the extension not being loaded). It turns out we did not understand how to hide these commands from the command palette, but this is possible. Result is cleaner experience in the command palette.

Commands hidden:
* Explorer Context Menu Items for CloudFormation, Lambda, Error nodes
* Refresh Explorer


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

#242 #244  #245 #246 

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
