### PR TITLE
Lambda delete confirm 219

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,8 +218,8 @@
         "watch": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install",
         "test": "npm run compile && node ./test-scripts/test.js",
-        "lint": "tslint --project ."
-
+        "lint": "tslint --project .",
+        "package": "vsce package"
     },
     "devDependencies": {
         "@types/async-lock": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -219,7 +219,8 @@
         "postinstall": "node ./node_modules/vscode/bin/install",
         "test": "npm run compile && node ./test-scripts/test.js",
         "lint": "tslint --project .",
-        "package": "vsce package"
+        "package": "vsce package",
+        "install-plugin": "vsce package -o aws-toolkit-vscode-test.vsix && code --install-extension aws-toolkit-vscode-test.vsix"
     },
     "devDependencies": {
         "@types/async-lock": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -218,9 +218,8 @@
         "watch": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install",
         "test": "npm run compile && node ./test-scripts/test.js",
-        "lint": "tslint --project .",
-        "package": "vsce package",
-        "install-plugin": "vsce package -o aws-toolkit-vscode-test.vsix && code --install-extension aws-toolkit-vscode-test.vsix"
+        "lint": "tslint --project ."
+
     },
     "devDependencies": {
         "@types/async-lock": "^1.1.0",

--- a/package.nls.json
+++ b/package.nls.json
@@ -20,6 +20,7 @@
     "AWS.command.showRegion": "Show region in the Explorer",
     "AWS.command.hideRegion": "Hide region from the Explorer",
     "AWS.command.deleteLambda": "Delete",
+    "AWS.command.deleteLambda.confirm": "Are you sure you want to delete lambda function '{0}'?",
     "AWS.command.deleteLambda.error": "There was an error deleting lambda function '{0}'",
     "AWS.command.invokeLambda": "Invoke",
     "AWS.command.configureLambda": "Configure",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
     const localize = nls.loadMessageBundle()
 
-    ext.lambdaOutputChannel = vscode.window.createOutputChannel('AWS Lambda')
     ext.context = context
 
     const toolkitOutputChannel: vscode.OutputChannel = vscode.window.createOutputChannel(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,6 +42,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
     const localize = nls.loadMessageBundle()
 
+    ext.lambdaOutputChannel = vscode.window.createOutputChannel('AWS Lambda')
+
     ext.context = context
 
     const toolkitOutputChannel: vscode.OutputChannel = vscode.window.createOutputChannel(

--- a/src/lambda/commands/deleteLambda.ts
+++ b/src/lambda/commands/deleteLambda.ts
@@ -51,6 +51,7 @@ export async function deleteLambda({
         const isConfirmed = await onConfirm()
         if (isConfirmed) {
             await restParams.lambdaClient.deleteFunction(restParams.node.configuration.FunctionName)
+            restParams.onRefresh()
         }
     } catch (err) {
         restParams.outputChannel.show(true)
@@ -61,7 +62,6 @@ export async function deleteLambda({
         ))
         restParams.outputChannel.appendLine(String(err)) // linter hates toString on type any
         restParams.outputChannel.appendLine('')
-    } finally {
-      restParams.onRefresh()
+        restParams.onRefresh() // Refresh in case it was already deleted.
     }
 }

--- a/src/lambda/commands/deleteLambda.ts
+++ b/src/lambda/commands/deleteLambda.ts
@@ -5,37 +5,63 @@
 
 'use strict'
 
-import * as nls from 'vscode-nls'
-const localize = nls.loadMessageBundle()
+import { OutputChannel, window } from 'vscode'
+import { loadMessageBundle } from 'vscode-nls'
+const localize = loadMessageBundle()
 
 import { LambdaClient } from '../../shared/clients/lambdaClient'
-import { ext } from '../../shared/extensionGlobals'
 import { StandaloneFunctionNode } from '../explorer/standaloneNodes'
 
-export async function deleteLambda(
-    node: StandaloneFunctionNode,
-    refresh: () => void
-): Promise<void> {
-    const client: LambdaClient = ext.toolkitClientBuilder.createLambdaClient(node.regionCode)
+export async function deleteLambda({
+                           lambdaClient,
+                           node,
+                           outputChannel,
+                           onRefresh,
+                           onConfirm = async () => {
+                               const responseNo: string = localize('AWS.generic.response.no', 'No')
+                               const responseYes: string = localize('AWS.generic.response.yes', 'Yes')
+                               const response = await window.showWarningMessage(
+                                 localize(
+                                   'AWS.command.deleteLambda.confirm',
+                                   "Are you sure you want to delete lambda function '{0}'?",
+                                   node.configuration.FunctionName
+                                 ),
+                                 responseYes,
+                                 responseNo
+                               )
+
+                               return response === responseYes
+                           },
+                           onError = (error: any) => {
+                               outputChannel.show(true)
+                               outputChannel.appendLine(localize(
+                                   'AWS.command.deleteLambda.error',
+                                   "There was an error deleting lambda function '{0}'",
+                                   node.configuration.FunctionArn
+                                 ))
+                               outputChannel.appendLine(String(error)) // linter hates toString on type any
+                               outputChannel.appendLine('')
+                           }
+}: {
+  lambdaClient: LambdaClient
+  node: StandaloneFunctionNode,
+  outputChannel: OutputChannel,
+  onError?(err: any): void
+  onRefresh(): void,
+  onConfirm?(): Promise<boolean>,
+}): Promise<void> {
 
     if (!node.configuration.FunctionName) {
         return
     }
-
     try {
-        await client.deleteFunction(node.configuration.FunctionName)
+        const isConfirmed = await onConfirm()
+        if (isConfirmed) {
+            await lambdaClient.deleteFunction(node.configuration.FunctionName)
+        }
     } catch (err) {
-        const error = err as Error
-
-        ext.lambdaOutputChannel.show(true)
-        ext.lambdaOutputChannel.appendLine(localize(
-            'AWS.command.deleteLambda.error',
-            "There was an error deleting lambda function '{0}'",
-            node.configuration.FunctionArn
-        ))
-        ext.lambdaOutputChannel.appendLine(error.toString())
-        ext.lambdaOutputChannel.appendLine('')
+        onError(err)
     } finally {
-        refresh()
+        onRefresh()
     }
 }

--- a/src/lambda/commands/deleteLambda.ts
+++ b/src/lambda/commands/deleteLambda.ts
@@ -44,7 +44,7 @@ export async function deleteLambda({
                            }
 }: {
   lambdaClient: LambdaClient
-  node: StandaloneFunctionNode,
+  node: StandaloneFunctionNode, // TODO: Change to deleteParams: Lambda.Types.DeleteFunctionRequest
   outputChannel: OutputChannel,
   onError?(err: any): void
   onRefresh(): void,

--- a/src/lambda/commands/deleteLambda.ts
+++ b/src/lambda/commands/deleteLambda.ts
@@ -12,21 +12,28 @@ const localize = nls.loadMessageBundle()
 import { LambdaClient } from '../../shared/clients/lambdaClient'
 import { StandaloneFunctionNode } from '../explorer/standaloneNodes'
 
+/**
+ * @param message: Message displayed to user
+ */
+const confirm = async (message: string): Promise<boolean> => {
+    // TODO: Re-use `confirm` throughout package (rather than cutting and pasting logic).
+    const responseNo: string = localize('AWS.generic.response.no', 'No')
+    const responseYes: string = localize('AWS.generic.response.yes', 'Yes')
+    const response = await vscode.window.showWarningMessage(
+      message,
+      responseYes,
+      responseNo
+    )
+
+    return response === responseYes
+}
 export async function deleteLambda({
     onConfirm = async () => {
-        const responseNo: string = localize('AWS.generic.response.no', 'No')
-        const responseYes: string = localize('AWS.generic.response.yes', 'Yes')
-        const response = await vscode.window.showWarningMessage(
-          localize(
-            'AWS.command.deleteLambda.confirm',
-            "Are you sure you want to delete lambda function '{0}'?",
-            restParams.node.configuration.FunctionName
-          ),
-          responseYes,
-          responseNo
-        )
-
-        return response === responseYes
+        return await confirm(localize(
+          'AWS.command.deleteLambda.confirm',
+          "Are you sure you want to delete lambda function '{0}'?",
+          restParams.node.configuration.FunctionName
+        ))
     },
     ...restParams
 }: {

--- a/src/lambda/commands/deleteLambda.ts
+++ b/src/lambda/commands/deleteLambda.ts
@@ -7,10 +7,11 @@
 
 import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
-const localize = nls.loadMessageBundle()
 
 import { LambdaClient } from '../../shared/clients/lambdaClient'
 import { StandaloneFunctionNode } from '../explorer/standaloneNodes'
+
+const localize = nls.loadMessageBundle()
 
 /**
  * @param message: Message displayed to user
@@ -27,15 +28,16 @@ const confirm = async (message: string): Promise<boolean> => {
 
     return response === responseYes
 }
+
 export async function deleteLambda({
-    onConfirm = async () => {
-        return await confirm(localize(
-          'AWS.command.deleteLambda.confirm',
-          "Are you sure you want to delete lambda function '{0}'?",
-          restParams.node.configuration.FunctionName
-        ))
-    },
-    ...restParams
+   onConfirm = async () => {
+       return await confirm(localize(
+           'AWS.command.deleteLambda.confirm',
+           "Are you sure you want to delete lambda function '{0}'?",
+           restParams.node.configuration.FunctionName
+       ))
+   },
+   ...restParams
 }: {
     lambdaClient: LambdaClient
     node: StandaloneFunctionNode, // TODO: Change to deleteParams: Lambda.Types.DeleteFunctionRequest

--- a/src/lambda/commands/deleteLambda.ts
+++ b/src/lambda/commands/deleteLambda.ts
@@ -20,9 +20,9 @@ const confirm = async (message: string): Promise<boolean> => {
     const responseNo: string = localize('AWS.generic.response.no', 'No')
     const responseYes: string = localize('AWS.generic.response.yes', 'Yes')
     const response = await vscode.window.showWarningMessage(
-      message,
-      responseYes,
-      responseNo
+        message,
+        responseYes,
+        responseNo
     )
 
     return response === responseYes

--- a/src/lambda/lambdaTreeDataProvider.ts
+++ b/src/lambda/lambdaTreeDataProvider.ts
@@ -44,15 +44,10 @@ export class LambdaTreeDataProvider implements vscode.TreeDataProvider<AWSTreeNo
         private readonly awsContextTrees: AwsContextTreeCollection,
         private readonly regionProvider: RegionProvider,
         private readonly resourceFetcher: ResourceFetcher,
-        private readonly  outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel('AWS Lambda')
     ) {
         this._onDidChangeTreeData = new vscode.EventEmitter<AWSTreeNodeBase | undefined>()
         this.onDidChangeTreeData = this._onDidChangeTreeData.event
         this.regionNodes = new Map<string, RegionNode>()
-        if (!ext.lambdaOutputChannel) {
-            // TODO: Update each lambda commands to take this as in input and remove ext.lambdaOutputChannel
-            ext.lambdaOutputChannel = this.outputChannel
-        }
     }
 
     public initialize(): void {
@@ -62,7 +57,7 @@ export class LambdaTreeDataProvider implements vscode.TreeDataProvider<AWSTreeNo
             async (node: StandaloneFunctionNode) => await deleteLambda({
                 node,
                 lambdaClient: ext.toolkitClientBuilder.createLambdaClient(node.regionCode),
-                outputChannel: this.outputChannel,
+                outputChannel: ext.lambdaOutputChannel,
                 onRefresh: () => this.refresh(node.parent)
             })
         )

--- a/src/test/lambda/commands/deleteLambda.test.ts
+++ b/src/test/lambda/commands/deleteLambda.test.ts
@@ -96,7 +96,7 @@ describe('deleteLambda', async () => {
             `Expected delete count ${expectedDeleteCount}, actual count ${deleteCount}`
         )
 
-        const expectedRefreshCount = 1
+        const expectedRefreshCount = confirmationResponse ? 1 : 0
         assert.strictEqual(
             refreshCount,
             expectedRefreshCount,

--- a/src/test/lambda/commands/deleteLambda.test.ts
+++ b/src/test/lambda/commands/deleteLambda.test.ts
@@ -68,8 +68,8 @@ describe('deleteLambda', async () => {
                 const expectedMessagePart = String(errorToThrowDuringDelete)
                 assert(!outputChannel.isHidden, 'output channel should not be hidden after error')
                 assert(
-                  outputChannel.value && outputChannel.value.indexOf(expectedMessagePart) > 0,
-                  `output channel should contain "${expectedMessagePart}"`
+                    outputChannel.value && outputChannel.value.indexOf(expectedMessagePart) > 0,
+                    `output channel should contain "${expectedMessagePart}"`
                 )
             }
         })
@@ -79,9 +79,9 @@ describe('deleteLambda', async () => {
         onAssertOutputChannel = ((channel: MockOutputChannel) => {
             // Defaults to expecting no output. Should verify output when expected.
             assert.strictEqual(
-              channel.value,
-              '',
-              'expect no output since output testing was omitted'
+                channel.value,
+                '',
+                'expect no output since output testing was omitted'
             )
         }),
         ...params
@@ -96,35 +96,35 @@ describe('deleteLambda', async () => {
         let isDeleteCalled = false
         let isRefreshCalled = false
         const lambdaClient = new MockLambdaClient(
-          undefined,
-          async (name) => {
-              isDeleteCalled = true
-              assert.strictEqual(
-                name,
-                params.functionName,
-                `expected lambda name "${params.functionName}", not "${name}"`
-              )
-              if (params.errorToThrowDuringDelete) {
-                  throw params.errorToThrowDuringDelete
-              }
-          }
+            undefined,
+            async (name) => {
+                isDeleteCalled = true
+                assert.strictEqual(
+                    name,
+                    params.functionName,
+                    `expected lambda name "${params.functionName}", not "${name}"`
+                )
+                if (params.errorToThrowDuringDelete) {
+                    throw params.errorToThrowDuringDelete
+                }
+            }
         )
 
         const parent = new MockStandaloneFunctionGroupNode(
-          undefined,
-          undefined,
-          async () => assert.fail(),
-          async () => assert.fail()
+            undefined,
+            undefined,
+            async () => assert.fail(),
+            async () => assert.fail()
         )
 
         const node = new MockStandaloneFunctionNode(
-          undefined,
-          parent,
-          {
-              FunctionName: params.functionName
-          },
-          async () => assert.fail(),
-          async configuration => assert.fail()
+            undefined,
+            parent,
+            {
+                FunctionName: params.functionName
+            },
+            async () => assert.fail(),
+            async configuration => assert.fail()
         )
         const outputChannel = new MockOutputChannel()
 
@@ -147,15 +147,15 @@ describe('deleteLambda', async () => {
         }
 
         assert.strictEqual(
-          isDeleteCalled,
-          params.expectDeleteIsCalled,
-          `delete should ${params.expectDeleteIsCalled ? '' : ' not'} be called.`
+            isDeleteCalled,
+            params.expectDeleteIsCalled,
+            `delete should ${params.expectDeleteIsCalled ? '' : ' not'} be called.`
         )
 
         assert.strictEqual(
-          isRefreshCalled,
-          params.expectRefreshIsCalled,
-          `refresh should${params.expectRefreshIsCalled ? '' : ' not'} be called`
+            isRefreshCalled,
+            params.expectRefreshIsCalled,
+            `refresh should${params.expectRefreshIsCalled ? '' : ' not'} be called`
         )
 
         onAssertOutputChannel.bind({}) // Make linter happy

--- a/src/test/mockOutputChannel.ts
+++ b/src/test/mockOutputChannel.ts
@@ -32,10 +32,17 @@ export class MockOutputChannel implements OutputChannel {
     this.isHidden = true
   }
 
+  /**
+   * This is overloaded by VS Code but viewColumn version is deprecated thus
+   * show(preserveFocus?: boolean) is really what we should consider.
+   * @param args
+   */
   public show(...args: any[] /* viewColumn?: ViewColumn, preserveFocus?: boolean */) {
-    this.isHidden = true
+    this.isHidden = false
     if (args && typeof args[0] === 'boolean') {
-      this.preserveFocus = !!args[0] // Making linter happy
+      this.preserveFocus = !!args[0] // Linter doesn't know it's a boolean
+    } else if (args[0]) {
+      throw new TypeError('1st argument must be a boolean if provided')
     }
   }
 }

--- a/src/test/mockOutputChannel.ts
+++ b/src/test/mockOutputChannel.ts
@@ -6,42 +6,42 @@
 import * as vscode from 'vscode'
 
 export class MockOutputChannel implements vscode.OutputChannel {
-  public value: string = ''
-  public isHidden: boolean = false
-  public preserveFocus: boolean = false
+    public value: string = ''
+    public isHidden: boolean = false
+    public preserveFocus: boolean = false
 
-  public readonly name = 'Mock channel'
+    public readonly name = 'Mock channel'
 
-  public append(value: string): void {
-    this.value += value
-  }
+    public append(value: string): void {
+        this.value += value
+    }
 
-  public appendLine(value: string) {
-    this.value += value + '\n'
-  }
+    public appendLine(value: string) {
+        this.value += value + '\n'
+    }
 
-  public clear(): void {
-    this.value = ''
-  }
+    public clear(): void {
+        this.value = ''
+    }
 
-  public dispose(): void {
-    this.value = ''
-  }
+    public dispose(): void {
+        this.value = ''
+    }
 
-  public hide(): void {
-    this.isHidden = true
-  }
+    public hide(): void {
+        this.isHidden = true
+    }
 
-  /**
-   * This is overloaded by VS Code but viewColumn version is deprecated thus
-   * show(preserveFocus?: boolean) is really what we should consider.
-   */
-  public show(columnOrPreserveFocus?: vscode.ViewColumn | boolean, preserveFocus?: boolean): void {
-      if (typeof columnOrPreserveFocus === 'boolean') {
-          this.preserveFocus = columnOrPreserveFocus
-      } else if (typeof columnOrPreserveFocus !== 'undefined') {
-          throw new TypeError('1st argument must be a boolean if provided. ViewColumn is deprecated')
-      }
-      this.isHidden = false
-  }
+    /**
+     * This is overloaded by VS Code but viewColumn version is deprecated thus
+     * show(preserveFocus?: boolean) is really what we should consider.
+     */
+    public show(columnOrPreserveFocus?: vscode.ViewColumn | boolean, preserveFocus?: boolean): void {
+        if (typeof columnOrPreserveFocus === 'boolean') {
+            this.preserveFocus = columnOrPreserveFocus
+        } else if (typeof columnOrPreserveFocus !== 'undefined') {
+            throw new TypeError('1st argument must be a boolean if provided. ViewColumn is deprecated')
+        }
+        this.isHidden = false
+    }
 }

--- a/src/test/mockOutputChannel.ts
+++ b/src/test/mockOutputChannel.ts
@@ -1,0 +1,41 @@
+/*!
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { OutputChannel } from 'vscode'
+
+export class MockOutputChannel implements OutputChannel {
+  public value: string = ''
+  public isHidden: boolean = false
+  public preserveFocus: boolean = false
+
+  public readonly name = 'Mock channel'
+
+  public append(value: string): void {
+    this.value += value
+  }
+
+  public appendLine(value: string) {
+    this.value += value + '\n'
+  }
+
+  public clear(): void {
+    this.value = ''
+  }
+
+  public dispose(): void {
+    this.value = ''
+  }
+
+  public hide(): void {
+    this.isHidden = true
+  }
+
+  public show(...args: any[] /* viewColumn?: ViewColumn, preserveFocus?: boolean */) {
+    this.isHidden = true
+    if (args && typeof args[0] === 'boolean') {
+      this.preserveFocus = !!args[0] // Making linter happy
+    }
+  }
+}

--- a/src/test/mockOutputChannel.ts
+++ b/src/test/mockOutputChannel.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OutputChannel } from 'vscode'
+import * as vscode from 'vscode'
 
-export class MockOutputChannel implements OutputChannel {
+export class MockOutputChannel implements vscode.OutputChannel {
   public value: string = ''
   public isHidden: boolean = false
   public preserveFocus: boolean = false
@@ -35,14 +35,13 @@ export class MockOutputChannel implements OutputChannel {
   /**
    * This is overloaded by VS Code but viewColumn version is deprecated thus
    * show(preserveFocus?: boolean) is really what we should consider.
-   * @param args
    */
-  public show(...args: any[] /* viewColumn?: ViewColumn, preserveFocus?: boolean */) {
-    this.isHidden = false
-    if (args && typeof args[0] === 'boolean') {
-      this.preserveFocus = !!args[0] // Linter doesn't know it's a boolean
-    } else if (args[0]) {
-      throw new TypeError('1st argument must be a boolean if provided')
-    }
+  public show(columnOrPreserveFocus?: vscode.ViewColumn | boolean, preserveFocus?: boolean): void {
+      if (typeof columnOrPreserveFocus === 'boolean') {
+          this.preserveFocus = columnOrPreserveFocus
+      } else if (typeof columnOrPreserveFocus !== 'undefined') {
+          throw new TypeError('1st argument must be a boolean if provided. ViewColumn is deprecated')
+      }
+      this.isHidden = false
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added confirmation when deleting Lambda

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [x] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description

* Added confirmation when deleting Lambda
* Removed use of globals from deleteLambda

## Motivation and Context

In response to issue.

## Related Issue(s)

https://github.com/aws/aws-toolkit-vscode/issues/219

## Testing

Updated test to:
* Check that delete is called when confirmed
* Check that delete is not called when cancelled
* Refresh is called on both confirm and cancel

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
