### PR TITLE
Fix SAM template detection during local invoke.

### DIFF
--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -12,16 +12,45 @@ import * as filesystemUtilities from '../filesystemUtilities'
 import { SystemUtilities } from '../systemUtilities'
 
 export namespace CloudFormation {
+    export function validateProperties(
+        {
+            Handler,
+            CodeUri,
+            Runtime,
+            ...rest
+        }: Partial<ResourceProperties>
+    ): ResourceProperties {
+        if (!Handler) {
+            throw new Error('Missing value: Handler')
+        }
+
+        if (!CodeUri) {
+            throw new Error('Missing value: CodeUri')
+        }
+
+        if (!Runtime) {
+            throw new Error('Missing value: Runtime')
+        }
+
+        return {
+            Handler,
+            CodeUri,
+            Runtime,
+            ...rest
+        }
+    }
+
+    export interface ResourceProperties {
+        Handler: string,
+        CodeUri: string,
+        Runtime: string,
+        Timeout?: number,
+        Environment?: Environment
+    }
 
     export interface Resource {
         Type: string,
-        Properties?: {
-            Handler: string,
-            CodeUri: string,
-            Runtime?: string,
-            Timeout?: number,
-            Environment?: Environment
-        }
+        Properties?: ResourceProperties
     }
 
     export interface Template {

--- a/src/shared/codelens/typescriptCodeLensProvider.ts
+++ b/src/shared/codelens/typescriptCodeLensProvider.ts
@@ -282,7 +282,6 @@ class LocalLambdaRunner {
     ): Promise<string> {
         const buildFolder: string = await this.getBaseBuildFolder()
         const inputTemplatePath: string = path.join(buildFolder, 'input', 'input-template.yaml')
-        let existingTemplateResource: CloudFormation.Resource | undefined
 
         // Make function handler relative to baseDir
         const handlerFileRelativePath = path.relative(
@@ -296,10 +295,11 @@ class LocalLambdaRunner {
         ).replace('\\', '/')
 
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(this.localInvokeArgs.workspaceFolder.uri)
+        let existingTemplateResource: CloudFormation.Resource | undefined
         if (workspaceFolder) {
             const lambdas = await detectLocalLambdas([workspaceFolder])
             const existingLambda = lambdas.find(lambda => lambda.handler === relativeFunctionHandler)
-            existingTemplateResource = (existingLambda ? existingLambda.resource : undefined)
+            existingTemplateResource = existingLambda ? existingLambda.resource : undefined
         }
 
         let newTemplate = new SamTemplateGenerator()

--- a/src/shared/templates/sam/samTemplateGenerator.ts
+++ b/src/shared/templates/sam/samTemplateGenerator.ts
@@ -12,133 +12,58 @@ import * as filesystemUtilities from '../../../shared/filesystemUtilities'
 import { CloudFormation } from '../../cloudformation/cloudformation'
 
 export class SamTemplateGenerator {
-    private _resourceName?: string
-    private _functionHandler?: string
-    private _codeUri?: string
-    private _runtime?: string
-    private _existingTemplateFilename?: string
-    private _environment?: CloudFormation.Environment
+    private resourceName?: string
+    private readonly properties: Partial<CloudFormation.ResourceProperties> = {}
 
     public withResourceName(resourceName: string): SamTemplateGenerator {
-        this._resourceName = resourceName
+        this.resourceName = resourceName
 
         return this
     }
 
     public withFunctionHandler(handlerName: string): SamTemplateGenerator {
-        this._functionHandler = handlerName
+        this.properties.Handler = handlerName
 
         return this
     }
 
     public withCodeUri(codeUri: string): SamTemplateGenerator {
-        this._codeUri = codeUri
+        this.properties.CodeUri = codeUri
 
         return this
     }
 
     public withRuntime(runtime: string): SamTemplateGenerator {
-        this._runtime = runtime
-
-        return this
-    }
-
-    public withExistingTemplate(templateFilename: string): SamTemplateGenerator {
-        this._existingTemplateFilename = templateFilename
+        this.properties.Runtime = runtime
 
         return this
     }
 
     public withEnvironment(env: CloudFormation.Environment): SamTemplateGenerator {
-        this._environment = env
+        this.properties.Environment = env
 
         return this
     }
 
     public async generate(filename: string): Promise<void> {
-        await this.validate()
+        if (!this.resourceName) {
+            throw new Error('Missing value: ResourceName')
+        }
 
-        const template: CloudFormation.Template = !!this._existingTemplateFilename
-            ? await this.createTemplateFromExistingTemplate()
-            : this.createTemplateFromScratch()
-
-        const templateAsYaml: string = yaml.safeDump(template)
+        const template: CloudFormation.Template = {
+            Resources: {
+                [this.resourceName!]: {
+                    Type: 'AWS::Serverless::Function',
+                    Properties: CloudFormation.validateProperties(this.properties)
+                }
+            }
+        }
+        const templateAsYaml: string = yaml.safeDump(template, { skipInvalid: true })
 
         const parentDirectory: string = path.dirname(filename)
         if (!await filesystemUtilities.fileExists(parentDirectory)) {
-            await filesystem.mkdirAsync(parentDirectory)
+            await filesystem.mkdirAsync(parentDirectory, { recursive: true })
         }
         await filesystem.writeFileAsync(filename, templateAsYaml, 'utf8')
-    }
-
-    /**
-     * Throws an error if state is not valid
-     */
-    private async validate(): Promise<void> {
-        if (!this._codeUri) { throw new Error('Missing value: CodeUri') }
-        if (!this._resourceName) { throw new Error('Missing value: ResourceName') }
-
-        if (!this._existingTemplateFilename) {
-            if (!this._functionHandler) { throw new Error('Missing value: FunctionHandler') }
-            if (!this._runtime) { throw new Error('Missing value: Runtime') }
-        }
-    }
-
-    private validateExistingTemplate(template: CloudFormation.Template): void {
-        const templateResourceNames: Set<string> = !!template.Resources
-            ? new Set(Object.keys(template.Resources))
-            : new Set()
-
-        if (!!this._resourceName && !templateResourceNames.has(this._resourceName)) {
-            throw new Error(`Resource not found: ${this._resourceName}`)
-        }
-
-        const resource: CloudFormation.Resource = template.Resources![this._resourceName!]
-        if (!this._functionHandler && (!resource.Properties || !resource.Properties.Handler)) {
-            if (!this._functionHandler) { throw new Error('Missing value: FunctionHandler') }
-        }
-
-        if (!this._runtime && (!resource.Properties || !resource.Properties.Runtime)) {
-            if (!this._runtime) { throw new Error('Missing value: Runtime') }
-        }
-
-    }
-
-    private createTemplateFromScratch(): CloudFormation.Template {
-        const resources: {
-            [key: string]: CloudFormation.Resource
-        } = {}
-
-        resources[this._resourceName!] = {
-            Type: 'AWS::Serverless::Function',
-            Properties: {
-                Handler: this._functionHandler!,
-                CodeUri: this._codeUri!,
-                Runtime: this._runtime!,
-                Environment: this._environment!
-            }
-        }
-
-        return {
-            Resources: resources
-        }
-    }
-
-    private async createTemplateFromExistingTemplate(): Promise<CloudFormation.Template> {
-        const template: CloudFormation.Template = await CloudFormation.load(this._existingTemplateFilename!)
-        this.validateExistingTemplate(template)
-        const resource: CloudFormation.Resource = template.Resources![this._resourceName!]
-
-        resource.Properties!.CodeUri = this._codeUri!
-
-        if (!!this._functionHandler) {
-            resource.Properties!.Handler = this._functionHandler
-        }
-
-        if (!!this._runtime) {
-            resource.Properties!.Runtime = this._runtime
-        }
-
-        return template
     }
 }

--- a/src/test/templates/sam/samTemplateGenerator.test.ts
+++ b/src/test/templates/sam/samTemplateGenerator.test.ts
@@ -15,330 +15,109 @@ import { SystemUtilities } from '../../../shared/systemUtilities'
 import { SamTemplateGenerator } from '../../../shared/templates/sam/samTemplateGenerator'
 
 describe('SamTemplateGenerator', () => {
-
+    const sampleCodeUriValue: string = 'sampleCodeUri'
+    const sampleFunctionHandlerValue: string = 'sampleFunctionHandler'
+    const sampleResourceNameValue: string = 'sampleResourceName'
+    const sampleRuntimeValue: string = 'sampleRuntime'
+    const sampleEnvironment: CloudFormation.Environment = {
+        Variables: {
+            key: 'value'
+        }
+    }
+    let templateFilename: string
     let tempFolder: string
 
     beforeEach(async () => {
         tempFolder = await filesystem.mkdtempAsync(path.join(os.tmpdir(), 'vsctk-'))
+        templateFilename = path.join(tempFolder, 'template.yml')
+
     })
 
     afterEach(async () => {
         await del([tempFolder], { force: true })
     })
 
-    describe('from scratch', () => {
+    it('Produces a minimal template', async () => {
+        await new SamTemplateGenerator()
+            .withCodeUri(sampleCodeUriValue)
+            .withFunctionHandler(sampleFunctionHandlerValue)
+            .withRuntime(sampleRuntimeValue)
+            .withResourceName(sampleResourceNameValue)
+            .withEnvironment(sampleEnvironment)
+            .generate(templateFilename)
 
-        const sampleCodeUriValue: string = 'sampleCodeUri'
-        const sampleFunctionHandlerValue: string = 'sampleFunctionHandler'
-        const sampleResourceNameValue: string = 'sampleResourceName'
-        const sampleRuntimeValue: string = 'sampleRuntime'
-        const sampleEnvironment: CloudFormation.Environment = {
-            Variables: {
-                key: 'value'
-            }
-        }
-        let templateFilename: string
+        assert.strictEqual(await SystemUtilities.fileExists(templateFilename), true)
 
-        beforeEach(() => {
-            templateFilename = path.join(tempFolder, 'template.yml')
-        })
+        const template: CloudFormation.Template = await CloudFormation.load(templateFilename)
+        assert.ok(template.Resources)
+        assert.notStrictEqual(Object.keys(template.Resources!).length, 0)
 
-        it('Produces a minimal template', async () => {
-            await new SamTemplateGenerator()
-                .withCodeUri(sampleCodeUriValue)
-                .withFunctionHandler(sampleFunctionHandlerValue)
-                .withRuntime(sampleRuntimeValue)
-                .withResourceName(sampleResourceNameValue)
-                .withEnvironment(sampleEnvironment)
-                .generate(templateFilename)
-
-            assert.strictEqual(await SystemUtilities.fileExists(templateFilename), true)
-
-            const template: CloudFormation.Template = await CloudFormation.load(templateFilename)
-            assert.ok(template.Resources)
-            assert.notStrictEqual(Object.keys(template.Resources!).length, 0)
-
-            const resource: CloudFormation.Resource = template.Resources![sampleResourceNameValue]
-            assert.strictEqual(resource.Properties!.CodeUri, sampleCodeUriValue)
-            assert.strictEqual(resource.Properties!.Handler, sampleFunctionHandlerValue)
-            assert.strictEqual(resource.Properties!.Runtime, sampleRuntimeValue)
-            assert.deepStrictEqual(resource.Properties!.Environment, sampleEnvironment)
-        })
-
-        it('errs if resource name is missing', async () => {
-            const error: Error = await assertThrowsError(
-                async () => {
-                    await new SamTemplateGenerator()
-                        .withCodeUri(sampleCodeUriValue)
-                        .withFunctionHandler(sampleFunctionHandlerValue)
-                        .withRuntime(sampleRuntimeValue)
-                        .generate(templateFilename)
-                })
-
-            assert.ok(error)
-            assert.strictEqual(error.message, 'Missing value: ResourceName')
-            assert.strictEqual(await SystemUtilities.fileExists(templateFilename), false)
-        })
-
-        it('errs if function handler is missing', async () => {
-            const error: Error = await assertThrowsError(
-                async () => {
-                    await new SamTemplateGenerator()
-                        .withCodeUri(sampleCodeUriValue)
-                        .withRuntime(sampleRuntimeValue)
-                        .withResourceName(sampleResourceNameValue)
-                        .generate(templateFilename)
-                })
-
-            assert.ok(error)
-            assert.strictEqual(error.message, 'Missing value: FunctionHandler')
-            assert.strictEqual(await SystemUtilities.fileExists(templateFilename), false)
-        })
-
-        it('errs if code uri is missing', async () => {
-            const error: Error = await assertThrowsError(
-                async () => {
-                    await new SamTemplateGenerator()
-                        .withFunctionHandler(sampleFunctionHandlerValue)
-                        .withRuntime(sampleRuntimeValue)
-                        .withResourceName(sampleResourceNameValue)
-                        .generate(templateFilename)
-                })
-
-            assert.ok(error)
-            assert.strictEqual(error.message, 'Missing value: CodeUri')
-            assert.strictEqual(await SystemUtilities.fileExists(templateFilename), false)
-        })
-
-        it('errs if runtime is missing', async () => {
-            const error: Error = await assertThrowsError(
-                async () => {
-                    await new SamTemplateGenerator()
-                        .withCodeUri(sampleCodeUriValue)
-                        .withFunctionHandler(sampleFunctionHandlerValue)
-                        .withResourceName(sampleResourceNameValue)
-                        .generate(templateFilename)
-                })
-
-            assert.ok(error)
-            assert.strictEqual(error.message, 'Missing value: Runtime')
-            assert.strictEqual(await SystemUtilities.fileExists(templateFilename), false)
-        })
+        const resource: CloudFormation.Resource = template.Resources![sampleResourceNameValue]
+        assert.strictEqual(resource.Properties!.CodeUri, sampleCodeUriValue)
+        assert.strictEqual(resource.Properties!.Handler, sampleFunctionHandlerValue)
+        assert.strictEqual(resource.Properties!.Runtime, sampleRuntimeValue)
+        assert.deepStrictEqual(resource.Properties!.Environment, sampleEnvironment)
     })
 
-    describe('from a preexisting template', () => {
+    it('errs if resource name is missing', async () => {
+        const error: Error = await assertThrowsError(
+            async () => {
+                await new SamTemplateGenerator()
+                    .withCodeUri(sampleCodeUriValue)
+                    .withFunctionHandler(sampleFunctionHandlerValue)
+                    .withRuntime(sampleRuntimeValue)
+                    .generate(templateFilename)
+            })
 
-        const sampleCodeUriValue: string = 'sampleCodeUri'
-        const sampleFunctionHandlerValue: string = 'sampleFunctionHandler'
-        const sampleResourceNameValue: string = 'sampleResourceName'
-        const sampleRuntimeValue: string = 'sampleRuntime'
-        let sourceTemplateFilename: string
-        let destinationTemplateFilename: string
-
-        beforeEach(async () => {
-            sourceTemplateFilename = path.join(tempFolder, 'src-template.yml')
-            destinationTemplateFilename = path.join(tempFolder, 'dst-template.yml')
-
-            const templateContents: CloudFormation.Template = createSampleTemplate(
-                [sampleResourceNameValue]
-            )
-
-            await CloudFormation.save(templateContents, sourceTemplateFilename)
-        })
-
-        it('Produces a template given valid inputs', async () => {
-            const expectedTemplateContents: CloudFormation.Template = createSampleTemplate(
-                [sampleResourceNameValue, 'Function2']
-            )
-            const expectedTemplateResourceKeys: string[] = Object.keys(expectedTemplateContents.Resources!)
-
-            await CloudFormation.save(expectedTemplateContents, sourceTemplateFilename)
-
-            await new SamTemplateGenerator()
-                .withCodeUri(sampleCodeUriValue)
-                .withFunctionHandler(sampleFunctionHandlerValue)
-                .withRuntime(sampleRuntimeValue)
-                .withResourceName(sampleResourceNameValue)
-                .withExistingTemplate(sourceTemplateFilename)
-                .generate(destinationTemplateFilename)
-
-            assert.strictEqual(await SystemUtilities.fileExists(destinationTemplateFilename), true)
-
-            const template: CloudFormation.Template = await CloudFormation.load(destinationTemplateFilename)
-            assert.ok(template.Resources)
-            const actualTemplateResourceKeys: string[] = Object.keys(template.Resources!)
-            assert.strictEqual(actualTemplateResourceKeys.length, expectedTemplateResourceKeys.length)
-            assert.strictEqual(
-                expectedTemplateResourceKeys
-                    .every(expectedKey => actualTemplateResourceKeys.some(actualKey => actualKey === expectedKey)),
-                true
-            )
-
-            const resource: CloudFormation.Resource = template.Resources![sampleResourceNameValue]
-            assert.strictEqual(resource.Properties!.CodeUri, sampleCodeUriValue)
-            assert.strictEqual(resource.Properties!.Handler, sampleFunctionHandlerValue)
-            assert.strictEqual(resource.Properties!.Runtime, sampleRuntimeValue)
-        })
-
-        it('Produces a template using existing function handler value', async () => {
-            const expectedTemplateContents: CloudFormation.Template = createSampleTemplate(
-                [sampleResourceNameValue]
-            )
-
-            await CloudFormation.save(expectedTemplateContents, sourceTemplateFilename)
-
-            await new SamTemplateGenerator()
-                .withCodeUri(sampleCodeUriValue)
-                .withRuntime(sampleRuntimeValue)
-                .withResourceName(sampleResourceNameValue)
-                .withExistingTemplate(sourceTemplateFilename)
-                .generate(destinationTemplateFilename)
-
-            assert.strictEqual(await SystemUtilities.fileExists(destinationTemplateFilename), true)
-
-            const template: CloudFormation.Template = await CloudFormation.load(destinationTemplateFilename)
-            const resource: CloudFormation.Resource = template.Resources![sampleResourceNameValue]
-            assert.strictEqual(resource.Properties!.CodeUri, sampleCodeUriValue)
-            assert.strictEqual(resource.Properties!.Handler, `${sampleResourceNameValue}-handler`)
-        })
-
-        it('errs if code uri is missing', async () => {
-            const error: Error = await assertThrowsError(
-                async () => {
-                    await new SamTemplateGenerator()
-                        .withFunctionHandler(sampleFunctionHandlerValue)
-                        .withRuntime(sampleRuntimeValue)
-                        .withResourceName(sampleResourceNameValue)
-                        .withExistingTemplate(sourceTemplateFilename)
-                        .generate(destinationTemplateFilename)
-                })
-
-            assert.ok(error)
-            assert.strictEqual(error.message, 'Missing value: CodeUri')
-            assert.strictEqual(await SystemUtilities.fileExists(destinationTemplateFilename), false)
-        })
-
-        it('errs if function handler is not provided', async () => {
-            const expectedTemplateContents: CloudFormation.Template = createSampleTemplate(
-                [sampleResourceNameValue]
-            )
-
-            delete expectedTemplateContents.Resources![sampleResourceNameValue].Properties!.Handler
-
-            await CloudFormation.save(expectedTemplateContents, sourceTemplateFilename)
-
-            const error: Error = await assertThrowsError(
-                async () => {
-                    await new SamTemplateGenerator()
-                        .withCodeUri(sampleCodeUriValue)
-                        .withRuntime(sampleRuntimeValue)
-                        .withResourceName(sampleResourceNameValue)
-                        .withExistingTemplate(sourceTemplateFilename)
-                        .generate(destinationTemplateFilename)
-                })
-
-            assert.ok(error)
-            assert.strictEqual(error.message, 'Missing or invalid value in Template for key: Handler')
-            assert.strictEqual(await SystemUtilities.fileExists(destinationTemplateFilename), false)
-        })
-
-        it('errs if runtime is not in existing template and not provided', async () => {
-            const expectedTemplateContents: CloudFormation.Template = createSampleTemplate(
-                [sampleResourceNameValue]
-            )
-
-            delete expectedTemplateContents.Resources![sampleResourceNameValue].Properties!.Runtime
-
-            await CloudFormation.save(expectedTemplateContents, sourceTemplateFilename)
-
-            const error: Error = await assertThrowsError(
-                async () => {
-                    await new SamTemplateGenerator()
-                        .withCodeUri(sampleCodeUriValue)
-                        .withFunctionHandler(sampleFunctionHandlerValue)
-                        .withResourceName(sampleResourceNameValue)
-                        .withExistingTemplate(sourceTemplateFilename)
-                        .generate(destinationTemplateFilename)
-                })
-
-            assert.ok(error)
-            assert.strictEqual(error.message, 'Missing value: Runtime')
-            assert.strictEqual(await SystemUtilities.fileExists(destinationTemplateFilename), false)
-        })
-
-        it('errs if resource name is missing', async () => {
-            const error: Error = await assertThrowsError(
-                async () => {
-                    await new SamTemplateGenerator()
-                        .withCodeUri(sampleCodeUriValue)
-                        .withFunctionHandler(sampleFunctionHandlerValue)
-                        .withRuntime(sampleRuntimeValue)
-                        .withExistingTemplate(sourceTemplateFilename)
-                        .generate(destinationTemplateFilename)
-                })
-
-            assert.ok(error)
-            assert.strictEqual(error.message, 'Missing value: ResourceName')
-            assert.strictEqual(await SystemUtilities.fileExists(destinationTemplateFilename), false)
-        })
-
-        it('errs if resource name is not found in the existing template', async () => {
-            const error: Error = await assertThrowsError(
-                async () => {
-                    await new SamTemplateGenerator()
-                        .withCodeUri(sampleCodeUriValue)
-                        .withFunctionHandler(sampleFunctionHandlerValue)
-                        .withRuntime(sampleRuntimeValue)
-                        .withResourceName(`nonExistent${sampleResourceNameValue}`)
-                        .withExistingTemplate(sourceTemplateFilename)
-                        .generate(destinationTemplateFilename)
-                })
-
-            assert.ok(error)
-            assert.notStrictEqual(error.message.indexOf('Resource not found'), -1)
-            assert.strictEqual(await SystemUtilities.fileExists(destinationTemplateFilename), false)
-        })
-
-        it('errs if existing template does not exist', async () => {
-            const fakeSourceTemplateFilename: string = path.join(tempFolder, 'fake-src-template.yml')
-
-            const error: Error = await assertThrowsError(
-                async () => {
-                    await new SamTemplateGenerator()
-                        .withCodeUri(sampleCodeUriValue)
-                        .withFunctionHandler(sampleFunctionHandlerValue)
-                        .withRuntime(sampleRuntimeValue)
-                        .withResourceName(sampleResourceNameValue)
-                        .withExistingTemplate(fakeSourceTemplateFilename)
-                        .generate(destinationTemplateFilename)
-                })
-
-            assert.ok(error)
-            assert.notStrictEqual(error.message.indexOf('Template file not found'), -1)
-            assert.strictEqual(await SystemUtilities.fileExists(destinationTemplateFilename), false)
-        })
+        assert.ok(error)
+        assert.strictEqual(error.message, 'Missing value: ResourceName')
+        assert.strictEqual(await SystemUtilities.fileExists(templateFilename), false)
     })
 
-    function createSampleTemplate(resourceNames: string[]): CloudFormation.Template {
-        const resources: {
-            [key: string]: CloudFormation.Resource
-        } = {}
+    it('errs if function handler is missing', async () => {
+        const error: Error = await assertThrowsError(
+            async () => {
+                await new SamTemplateGenerator()
+                    .withCodeUri(sampleCodeUriValue)
+                    .withRuntime(sampleRuntimeValue)
+                    .withResourceName(sampleResourceNameValue)
+                    .generate(templateFilename)
+            })
 
-        resourceNames.forEach(resourceName => {
-            resources[resourceName] = {
-                Type: 'AWS::Serverless::Function',
-                Properties: {
-                    Handler: `${resourceName}-handler`,
-                    CodeUri: `${resourceName}-codeuri`,
-                    Runtime: `${resourceName}-runtime`,
-                }
-            }
-        })
+        assert.ok(error)
+        assert.strictEqual(error.message, 'Missing value: Handler')
+        assert.strictEqual(await SystemUtilities.fileExists(templateFilename), false)
+    })
 
-        return {
-            Resources: resources
-        }
-    }
+    it('errs if code uri is missing', async () => {
+        const error: Error = await assertThrowsError(
+            async () => {
+                await new SamTemplateGenerator()
+                    .withFunctionHandler(sampleFunctionHandlerValue)
+                    .withRuntime(sampleRuntimeValue)
+                    .withResourceName(sampleResourceNameValue)
+                    .generate(templateFilename)
+            })
+
+        assert.ok(error)
+        assert.strictEqual(error.message, 'Missing value: CodeUri')
+        assert.strictEqual(await SystemUtilities.fileExists(templateFilename), false)
+    })
+
+    it('errs if runtime is missing', async () => {
+        const error: Error = await assertThrowsError(
+            async () => {
+                await new SamTemplateGenerator()
+                    .withCodeUri(sampleCodeUriValue)
+                    .withFunctionHandler(sampleFunctionHandlerValue)
+                    .withResourceName(sampleResourceNameValue)
+                    .generate(templateFilename)
+            })
+
+        assert.ok(error)
+        assert.strictEqual(error.message, 'Missing value: Runtime')
+        assert.strictEqual(await SystemUtilities.fileExists(templateFilename), false)
+    })
 
     async function assertThrowsError(fn: () => Thenable<any>): Promise<Error> {
         try {


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [ ] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description

1. Fix error on local invoke when there is no existing template by configuring our YAML dumper to ignore undefined values (instead of throwing).
2. Remove unused code from `SamTemplateGenerator`, and increase its type-safety.
3. Update `invoke locally` to search the same folders as `deploy`.
   Previously it only searched the root of each workspace folder. Now
   it also searchs their *direct* children.

## Motivation and Context

1. Previously, if the user invoked a CodeLens without an existing template, the toolkit would throw when trying to save the generated template.
2. Templates inside a child folder of each workspace folder were detected by `Deploy to AWS`, but not by `Invoke Locally`.

## Related Issue(s)

## Testing

* Manual testing:
1. Run the toolkit without opening a folder in VS Code.
2. Run the 'Create New Sam Application' command with nodejs8.10.
3. Open app.js
4. Click 'Invoke Locally' and verify results
5. Click 'Debug Locally' and verify results.
* Ran all new and existing tests.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
