### PR TITLE
Fix delete CloudFormation to use stack name instead of label

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -58,6 +58,7 @@
     "AWS.message.enterProfileName": "Enter the name of the credential profile to use",
     "AWS.message.info.cloudFormation.delete": "Deleted CloudFormation Stack {0}",
     "AWS.message.error.cloudFormation.delete": "An error occurred while deleting CloudFormation Stack {0}. Please check the stack events on the AWS Console",
+    "AWS.message.error.cloudFormation.unsupported": "Unable to delete a CloudFormation Stack. No stack provided.",
     "AWS.message.selectRegion": "Select an AWS region",
     "AWS.message.selectProfile": "Select an AWS credential profile",
     "AWS.message.statusBar.loading.cloudFormation": "Loading CloudFormations...",

--- a/src/lambda/commands/deleteCloudFormation.ts
+++ b/src/lambda/commands/deleteCloudFormation.ts
@@ -18,10 +18,17 @@ export async function deleteCloudFormation(
     node?: CloudFormationStackNode
 ) {
     if (!node) {
+        vscode.window.showErrorMessage(
+            localize(
+                'AWS.message.error.cloudFormation.unsupported',
+                'Unable to delete a CloudFormation Stack. No stack provided.',
+            )
+        )
+
         return
     }
 
-    const stackName = node.label || localize('AWS.lambda.policy.unknown.function', 'Unknown')
+    const stackName = node.stackName
 
     const responseYes: string = localize('AWS.generic.response.yes', 'Yes')
     const responseNo: string = localize('AWS.generic.response.no', 'No')

--- a/src/lambda/explorer/cloudFormationNodes.ts
+++ b/src/lambda/explorer/cloudFormationNodes.ts
@@ -85,6 +85,8 @@ export class DefaultCloudFormationNode extends AWSTreeErrorHandlerNode implement
 
 export interface CloudFormationStackNode extends AWSTreeErrorHandlerNode {
     readonly regionCode: string
+    readonly stackId?: CloudFormation.StackId
+    readonly stackName: CloudFormation.StackName
 
     readonly parent: CloudFormationNode
 
@@ -116,6 +118,14 @@ export class DefaultCloudFormationStackNode extends AWSTreeErrorHandlerNode impl
         }
     }
 
+    public get stackId(): CloudFormation.StackId | undefined {
+        return this.stackSummary.StackId
+    }
+
+    public get stackName(): CloudFormation.StackName {
+        return this.stackSummary.StackName
+    }
+
     public async getChildren(): Promise<(CloudFormationFunctionNode | PlaceholderNode)[]> {
         await this.handleErrorProneOperation(
             async () => this.updateChildren(),
@@ -142,8 +152,8 @@ export class DefaultCloudFormationStackNode extends AWSTreeErrorHandlerNode impl
 
     public update(stackSummary: CloudFormation.StackSummary): void {
         this.stackSummary = stackSummary
-        this.label = `${stackSummary.StackName} [${stackSummary.StackStatus}]`
-        this.tooltip = `${stackSummary.StackName}${os.EOL}${stackSummary.StackId}`
+        this.label = `${this.stackName} [${stackSummary.StackStatus}]`
+        this.tooltip = `${this.stackName}${os.EOL}${this.stackId}`
     }
 
     private async updateChildren(): Promise<void> {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [ ] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description

<!--- Describe your changes in detail -->
You cannot delete CloudFormation stacks from the Explorer, because the label says `stackname stackStatus`, and the label is passed into SDK calls to delete cf stacks. Fixed this, so the actual stack name is passed in. 

While there, I added an error message when the command has no cloudFormation information to work with, to improve the feedback loop (otherwise there is no indication that processing has stopped).


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deleted a CF Stack using the Explorer.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
