### PR TITLE
Open the main source code file on project creation

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -129,6 +129,7 @@
     "AWS.samcli.initWizard.name.error.empty": "Application name cannot be empty",
     "AWS.samcli.initWizard.name.error.pathSep": "The path separator ({0}) is not allowed in application names",
     "AWS.samcli.initWizard.runtime.prompt": "Select a SAM Application Runtime",
+    "AWS.samcli.initWizard.source.error.notFound": "Project created successfully, but main source code file not found: {0}",
     "AWS.generic.response.no": "No",
     "AWS.generic.response.yes": "Yes",
     "AWS.template.error.showErrorDetails.title": "Error details for",

--- a/package.nls.json
+++ b/package.nls.json
@@ -131,6 +131,7 @@
     "AWS.samcli.initWizard.name.error.pathSep": "The path separator ({0}) is not allowed in application names",
     "AWS.samcli.initWizard.runtime.prompt": "Select a SAM Application Runtime",
     "AWS.samcli.initWizard.source.error.notFound": "Project created successfully, but main source code file not found: {0}",
+    "AWS.samcli.initWizard.source.error.notInWorkspace": "Could not open file '{0}'. If this file exists on disk, try adding it to your workspace.",
     "AWS.generic.response.no": "No",
     "AWS.generic.response.yes": "Yes",
     "AWS.template.error.showErrorDetails.title": "Error details for",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@
 import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 
+import { resumeCreateNewSamApp } from './lambda/commands/createNewSamApp'
 import { RegionNode } from './lambda/explorer/regionNode'
 import { LambdaTreeDataProvider } from './lambda/lambdaTreeDataProvider'
 import { DefaultAWSClientBuilder } from './shared/awsClientBuilder'
@@ -88,7 +89,7 @@ export async function activate(context: vscode.ExtensionContext) {
     ]
 
     providers.forEach((p) => {
-        p.initialize()
+        p.initialize(context)
         context.subscriptions.push(vscode.window.registerTreeDataProvider(p.viewProviderId, p))
     })
 
@@ -97,6 +98,8 @@ export async function activate(context: vscode.ExtensionContext) {
     await initializeSamCli()
 
     await ExtensionDisposableFiles.initialize(context)
+
+    await resumeCreateNewSamApp(context)
 }
 
 export function deactivate() {

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -5,24 +5,134 @@
 
 'use strict'
 
+import * as nls from 'vscode-nls'
+const localize = nls.loadMessageBundle()
+
 import * as path from 'path'
 import * as vscode from 'vscode'
-import { SamCliInitInvocation } from '../../shared/sam/cli/samCliInit'
+import { SamCliInitArgs, SamCliInitInvocation } from '../../shared/sam/cli/samCliInit'
+import { getMainSourceFileUri } from '../utilities/getMainSourceFile'
 import { CreateNewSamAppWizard } from '../wizards/samInitWizard'
 
-export async function createNewSamApp() {
-    const config = await new CreateNewSamAppWizard().run()
-    if (config) {
-        const invocation = new SamCliInitInvocation(config)
-        await invocation.execute()
+export const MAIN_SOURCE_FILE_URI = 'MAIN_SOURCE_FILE_URI'
 
-        vscode.workspace.updateWorkspaceFolders(
-            vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders.length : 0,
-            0,
-            {
-                uri: config.location,
-                name: path.basename(config.location.fsPath)
-            }
-        )
+export async function resumeCreateNewSamApp(context: Pick<vscode.ExtensionContext, 'globalState'>) {
+    const rawUri = context.globalState.get<string>(MAIN_SOURCE_FILE_URI)
+    if (!rawUri) {
+        return
     }
+
+    const uri = vscode.Uri.file(rawUri)
+    if (!vscode.workspace.getWorkspaceFolder(uri)) {
+        vscode.window.showErrorMessage(`Document '${uri.fsPath}' is not in any active workspace folder`)
+
+        return
+    }
+
+    await vscode.window.showTextDocument(uri)
+
+    context.globalState.update(MAIN_SOURCE_FILE_URI, undefined)
+}
+
+export async function createNewSamApp(context: Pick<vscode.ExtensionContext, 'globalState'>): Promise<void> {
+    const config = await new CreateNewSamAppWizard().run()
+    if (!config) {
+        return
+    }
+
+    const invocation = new SamCliInitInvocation(config)
+    await invocation.execute()
+
+    const uri = await getMainUri(config)
+    if (!uri) {
+        return
+    }
+
+    if (await addWorkspaceFolder(
+        {
+            uri: config.location,
+            name: path.basename(config.location.fsPath)
+        },
+        uri
+    )) {
+        context.globalState.update(MAIN_SOURCE_FILE_URI, uri!.fsPath)
+    } else {
+        await vscode.window.showTextDocument(uri)
+    }
+}
+
+async function getMainUri(config: Pick<SamCliInitArgs, 'location' | 'name'>): Promise<vscode.Uri | undefined> {
+    try {
+        return await getMainSourceFileUri({
+            root: vscode.Uri.file(path.join(config.location.fsPath, config.name))
+        })
+    } catch (err) {
+        vscode.window.showErrorMessage(localize(
+            'AWS.samcli.initWizard.source.error.notFound',
+            'Project created successfully, but main source code file not found: {0}'
+        ))
+    }
+}
+
+async function addWorkspaceFolder(
+    folder: {
+        uri: vscode.Uri,
+        name?: string
+    },
+    fileToOpen: vscode.Uri
+): Promise<boolean> {
+    const disposables: vscode.Disposable[] = []
+
+    // No-op if the folder is already in the workspace.
+    if (vscode.workspace.getWorkspaceFolder(folder.uri)) {
+        return false
+    }
+
+    let updateExistingWorkspacePromise: Promise<void> | undefined
+    try {
+        if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
+            updateExistingWorkspacePromise = new Promise<void>((resolve, reject) => {
+                try {
+                    const watcher = vscode.workspace.createFileSystemWatcher(fileToOpen.fsPath)
+                    const listener = (uri: vscode.Uri) => {
+                        try {
+                            if (path.relative(uri.fsPath, fileToOpen.fsPath)) {
+                                resolve()
+                                watcher.dispose()
+                            }
+                        } catch (err) {
+                            reject(err)
+                            watcher.dispose()
+                        }
+                    }
+
+                    watcher.onDidCreate(listener)
+                    watcher.onDidChange(listener)
+                } catch (err) {
+                    reject(err)
+                }
+            })
+        }
+
+        if (!vscode.workspace.updateWorkspaceFolders(
+            // Add new folder to the end of the list rather than the beginning, to avoid VS Code
+            // terminating and reinitializing our extension.
+            (vscode.workspace.workspaceFolders || []).length,
+            0,
+            folder
+        )) {
+            console.error('Could not update workspace folders')
+        }
+
+        if (updateExistingWorkspacePromise) {
+            await updateExistingWorkspacePromise
+        }
+    } finally {
+        for (const disposable of disposables) {
+            disposable.dispose()
+        }
+    }
+
+    // Return true if the current process will be terminated by VS Code (because the first workspaceFolder was changed)
+    return !updateExistingWorkspacePromise
 }

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -101,20 +101,20 @@ async function addWorkspaceFolder(
             updateExistingWorkspacePromise = new Promise<void>((resolve, reject) => {
                 try {
                     const watcher = vscode.workspace.createFileSystemWatcher(fileToOpen.fsPath)
+                    disposables.push(watcher)
+
                     const listener = (uri: vscode.Uri) => {
                         try {
                             if (path.relative(uri.fsPath, fileToOpen.fsPath)) {
                                 resolve()
-                                watcher.dispose()
                             }
                         } catch (err) {
                             reject(err)
-                            watcher.dispose()
                         }
                     }
 
-                    watcher.onDidCreate(listener)
-                    watcher.onDidChange(listener)
+                    watcher.onDidCreate(listener, undefined, disposables)
+                    watcher.onDidChange(listener, undefined, disposables)
                 } catch (err) {
                     reject(err)
                 }

--- a/src/lambda/lambdaTreeDataProvider.ts
+++ b/src/lambda/lambdaTreeDataProvider.ts
@@ -54,11 +54,11 @@ export class LambdaTreeDataProvider implements vscode.TreeDataProvider<AWSTreeNo
         this.regionNodes = new Map<string, RegionNode>()
     }
 
-    public initialize(): void {
+    public initialize(context: Pick<vscode.ExtensionContext, 'globalState'>): void {
         vscode.commands.registerCommand('aws.refreshAwsExplorer', async () => this.refresh())
         vscode.commands.registerCommand(
             'aws.lambda.createNewSamApp',
-            async () => await createNewSamApp()
+            async () => await createNewSamApp(context)
         )
 
         vscode.commands.registerCommand(

--- a/src/lambda/local/detectLocalLambdas.ts
+++ b/src/lambda/local/detectLocalLambdas.ts
@@ -41,7 +41,7 @@ async function detectLambdasFromWorkspaceFolder(
 ): Promise<LocalLambda[]> {
     const result = []
 
-    for await (const templateUri of detectLocalTemplates({ workspaceFolders: [workspaceFolder.uri] })) {
+    for await (const templateUri of detectLocalTemplates({ workspaceUris: [workspaceFolder.uri] })) {
         result.push(...await detectLambdasFromTemplate(workspaceFolder, templateUri.fsPath))
     }
 
@@ -63,7 +63,7 @@ async function detectLambdasFromTemplate(
         return []
     }
 
-    return Object.keys(resources)
+    return Object.getOwnPropertyNames(resources)
         .filter(key => resources[key].Type === 'AWS::Serverless::Function')
         .map(key => ({
             lambda: key,

--- a/src/lambda/local/detectLocalTemplates.ts
+++ b/src/lambda/local/detectLocalTemplates.ts
@@ -21,13 +21,13 @@ class DefaultDetectLocalTemplatesContext implements DetectLocalTemplatesContext 
 }
 
 export async function* detectLocalTemplates({
-    workspaceFolders,
+    workspaceUris,
     context = new DefaultDetectLocalTemplatesContext()
 }: {
-    workspaceFolders: vscode.Uri[]
+    workspaceUris: vscode.Uri[]
     context?: DetectLocalTemplatesContext
 }): AsyncIterableIterator<vscode.Uri> {
-    for (const workspaceFolder of workspaceFolders) {
+    for (const workspaceFolder of workspaceUris) {
         for await (const folder of getFolderCandidates(context, workspaceFolder)) {
             yield* detectTemplatesInFolder(context, folder)
         }

--- a/src/lambda/models/samLambdaRuntime.ts
+++ b/src/lambda/models/samLambdaRuntime.ts
@@ -43,3 +43,15 @@ export const samLambdaRuntimes: immutable.Set<SamLambdaRuntime> = immutable.Set(
     'java8',
     'java'
 ] as SamLambdaRuntime[])
+
+export function isNodeJS(runtime: string): boolean {
+    switch (runtime) {
+        case 'nodejs6.10':
+        case 'nodejs8.10':
+        case 'nodejs4.3':
+        case 'nodejs':
+            return true
+        default:
+            return false
+    }
+}

--- a/src/lambda/utilities/getMainSourceFile.ts
+++ b/src/lambda/utilities/getMainSourceFile.ts
@@ -1,0 +1,120 @@
+/*!
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+import * as os from 'os'
+import * as path from 'path'
+import * as vscode from 'vscode'
+import { CloudFormation } from '../../shared/cloudformation/cloudformation'
+import * as fs from '../../shared/filesystemUtilities'
+import { filterAsync, first } from '../../shared/utilities/collectionUtils'
+import { detectLocalTemplates } from '../local/detectLocalTemplates'
+import { isNodeJS } from '../models/samLambdaRuntime'
+
+export interface OpenMainSourceFileUriContext {
+    getLocalTemplates(...workspaceUris: vscode.Uri[]): AsyncIterable<vscode.Uri>
+    loadSamTemplate(uri: vscode.Uri): Promise<CloudFormation.Template>
+    fileExists(path: string): Promise<boolean>
+}
+
+export async function getMainSourceFileUri(
+    {
+        root,
+        getLocalTemplates = (...workspaceUris: vscode.Uri[]) => detectLocalTemplates({ workspaceUris }),
+        loadSamTemplate = async uri => await CloudFormation.load(uri.fsPath),
+        fileExists = fs.fileExists
+    }: Partial<OpenMainSourceFileUriContext> & {
+        root: vscode.Uri
+    }
+): Promise<vscode.Uri> {
+    const templateUri = await first(getLocalTemplates(root))
+    if (!templateUri) {
+        throw new Error(`Invalid project format: '${root.fsPath}' does not contain a SAM template.`)
+    }
+
+    const lambdaResource: CloudFormation.Resource = await getFirstLambdaResource({
+        templateUri,
+        loadSamTemplate,
+        fileExists
+    })
+
+    return await getSourceFileUri({
+        root: vscode.Uri.file(path.dirname(templateUri.fsPath)),
+        resource: lambdaResource,
+        fileExists
+    })
+}
+
+async function getFirstLambdaResource(
+    {
+        templateUri,
+        loadSamTemplate
+    }: Pick<OpenMainSourceFileUriContext, 'loadSamTemplate' | 'fileExists'> & {
+        templateUri: vscode.Uri
+    }
+): Promise<CloudFormation.Resource> {
+    const template = await loadSamTemplate(templateUri)
+    if (!template.Resources) {
+        throw new Error(`SAM Template '${templateUri.fsPath}' does not contain any resources`)
+    }
+
+    const lambdaResources = Object.getOwnPropertyNames(template.Resources)
+        .map(property => template.Resources![property])
+        .filter(resource => resource.Type === 'AWS::Serverless::Function')
+
+    if (lambdaResources.length <= 0) {
+        throw new Error(`SAM Template '${templateUri.fsPath}' does not contain any lambda resources`)
+    }
+
+    return lambdaResources[0]
+}
+
+async function getSourceFileUri({
+    root,
+    resource,
+    fileExists
+}: Pick<OpenMainSourceFileUriContext, 'fileExists'> & {
+    root: vscode.Uri,
+    resource: CloudFormation.Resource
+}) {
+    if (!resource.Properties) {
+        throw new Error(
+            `Lambda resource is missing the 'Properties' property:${os.EOL}` +
+            JSON.stringify(resource, undefined, 4)
+        )
+    }
+
+    const { Handler, Runtime } = resource.Properties
+    if (Runtime && isNodeJS(Runtime)) {
+        return await getNodeSourceFileUri({ root, resource, fileExists })
+    }
+
+    throw new Error(`Lambda resource '${Handler}' has unknown runtime ${Runtime}`)
+}
+
+async function getNodeSourceFileUri({
+    fileExists,
+    root,
+    resource,
+}: Pick<OpenMainSourceFileUriContext, 'fileExists'> & {
+    root: vscode.Uri,
+    resource: CloudFormation.Resource
+}): Promise<vscode.Uri> {
+    const handler = resource.Properties!.Handler
+    const tokens = handler.split('.', 1) || [handler]
+    const basePath = path.join(root.fsPath, resource.Properties!.CodeUri, tokens[0])
+
+    const file = await first(filterAsync(
+        ['.ts', '.jsx', '.js'].map(extension => `${basePath}${extension}`),
+        async (p: string) => await fileExists(p)
+    ))
+
+    if (file) {
+        return vscode.Uri.file(file)
+    }
+
+    throw new Error(`Javascript file expected at ${basePath}.(ts|jsx|js), but no file was found`)
+}

--- a/src/lambda/wizards/samDeployWizard.ts
+++ b/src/lambda/wizards/samDeployWizard.ts
@@ -216,7 +216,7 @@ async function getTemplateChoices(
     ...workspaceFolders: vscode.Uri[]
 ): Promise<SamTemplateQuickPickItem[]> {
     const result: SamTemplateQuickPickItem[] = []
-    for await (const uri of onDetectLocalTemplates({ workspaceFolders })) {
+    for await (const uri of onDetectLocalTemplates({ workspaceUris: workspaceFolders })) {
         result.push(new SamTemplateQuickPickItem(uri))
     }
 

--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -43,20 +43,14 @@ export namespace CloudFormation {
     export interface ResourceProperties {
         Handler: string,
         CodeUri: string,
-        Runtime: string,
+        Runtime?: string,
         Timeout?: number,
         Environment?: Environment
     }
 
-    export interface Resource  {
+    export interface Resource {
         Type: 'AWS::Serverless::Function',
-        Properties?: {
-            Handler: string,
-            CodeUri: string,
-            Runtime?: string,
-            Timeout?: number,
-            Environment?: Environment
-        }
+        Properties?: ResourceProperties
     }
 
     export interface Template {

--- a/src/shared/sam/cli/samCliInvoker.ts
+++ b/src/shared/sam/cli/samCliInvoker.ts
@@ -41,9 +41,8 @@ export class DefaultSamCliProcessInvoker implements SamCliProcessInvoker {
         }
 
         const childProcess: ChildProcess = new ChildProcess(samCliLocation, options, ...args)
-        childProcess.start()
 
-        return await childProcess.promise()
+        return await childProcess.run()
     }
 }
 

--- a/src/shared/treeview/awsTreeProvider.ts
+++ b/src/shared/treeview/awsTreeProvider.ts
@@ -5,10 +5,12 @@
 
 'use strict'
 
+import * as vscode from 'vscode'
+
 interface AwsTreeProvider {
     viewProviderId: string
 
-    initialize(): void
+    initialize(context: Pick<vscode.ExtensionContext, 'globalState'>): void
 }
 
 export interface RefreshableAwsTreeProvider extends AwsTreeProvider {

--- a/src/shared/utilities/collectionUtils.ts
+++ b/src/shared/utilities/collectionUtils.ts
@@ -39,16 +39,11 @@ export function complement<T>(sequence1: Iterable<T>, sequence2: Iterable<T>): S
     return filter(sequence2, item => !set1.has(item))
 }
 
-export async function toArrayAsync<T>(
-    items: AsyncIterableIterator<T>,
-    predicate?: (item: T) => boolean
-): Promise<T[]> {
+export async function toArrayAsync<T>(items: AsyncIterable<T>): Promise<T[]> {
     const result: T[] = []
 
     for await (const item of items) {
-        if (!predicate || predicate(item)) {
-            result.push(item)
-        }
+        result.push(item)
     }
 
     return result
@@ -121,6 +116,41 @@ function filter<T>(sequence: Iterable<T>, condition: (item: T) => boolean): Set<
     for (const item of sequence) {
         if (condition(item)) {
             result.add(item)
+        }
+    }
+
+    return result
+}
+
+export async function* filterAsync<T>(
+    sequence: Iterable<T>,
+    condition: (item: T) => Promise<boolean>
+): AsyncIterable<T> {
+    for (const item of sequence) {
+        if (await condition(item)) {
+            yield item
+        }
+    }
+}
+
+export async function first<T>(sequence: AsyncIterable<T>): Promise<T | undefined> {
+    const head = await take(sequence, 1)
+
+    return head.length > 0 ? head[0] : undefined
+}
+
+export async function take<T>(sequence: AsyncIterable<T>, count: number): Promise<T[]> {
+    if (count <= 0) {
+        return []
+    }
+
+    const result: T[] = []
+
+    for await (const item of sequence) {
+        result.push(item)
+
+        if (result.length >= count) {
+            break
         }
     }
 

--- a/src/test/lambda/lambdaTreeDataProvider.test.ts
+++ b/src/test/lambda/lambdaTreeDataProvider.test.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+'use strict'
+
 import * as assert from 'assert'
 import * as AWS from 'aws-sdk'
 import * as vscode from 'vscode'

--- a/src/test/lambda/local/detectLocalTemplates.test.ts
+++ b/src/test/lambda/local/detectLocalTemplates.test.ts
@@ -17,7 +17,7 @@ function normalizePath(...paths: string[]): string {
 
 describe('detectLocalTemplates', async () => {
     it('Detects no templates when there are no workspace folders', async () => {
-        for await (const template of detectLocalTemplates({ workspaceFolders: []})) {
+        for await (const template of detectLocalTemplates({ workspaceUris: []})) {
             assert.fail(`Expected no templates, but found '${template.fsPath}'`)
         }
     })
@@ -26,7 +26,7 @@ describe('detectLocalTemplates', async () => {
         const workspaceFolderPath = normalizePath('my', 'workspace', 'folder')
 
         const result = detectLocalTemplates({
-            workspaceFolders: [ vscode.Uri.file(workspaceFolderPath) ],
+            workspaceUris: [ vscode.Uri.file(workspaceFolderPath) ],
             context: {
                 async access(_path: filesystem.PathLike): Promise<void> {
                     if (_path !== normalizePath(workspaceFolderPath, 'template.yaml')) {
@@ -70,7 +70,7 @@ describe('detectLocalTemplates', async () => {
         const workspaceFolderChildPath = normalizePath(workspaceFolderPath, 'child')
 
         const result = detectLocalTemplates({
-            workspaceFolders: [ vscode.Uri.file(workspaceFolderPath) ],
+            workspaceUris: [ vscode.Uri.file(workspaceFolderPath) ],
             context: {
                 async access(_path: filesystem.PathLike): Promise<void> {
                     if (_path !== normalizePath(workspaceFolderChildPath, 'template.yaml')) {
@@ -118,7 +118,7 @@ describe('detectLocalTemplates', async () => {
         const workspaceFolderGrandchildPath = normalizePath(workspaceFolderChildPath, 'grandchild')
 
         const result = detectLocalTemplates({
-            workspaceFolders: [ vscode.Uri.file(workspaceFolderPath) ],
+            workspaceUris: [ vscode.Uri.file(workspaceFolderPath) ],
             context: {
                 async access(_path: filesystem.PathLike): Promise<void> {
                     if (_path !== normalizePath(workspaceFolderGrandchildPath, 'template.yaml')) {
@@ -163,7 +163,7 @@ describe('detectLocalTemplates', async () => {
         const workspaceFolderChildPath2 = normalizePath(workspaceFolderPath, 'child2')
 
         const result = detectLocalTemplates({
-            workspaceFolders: [ vscode.Uri.file(workspaceFolderPath) ],
+            workspaceUris: [ vscode.Uri.file(workspaceFolderPath) ],
             context: {
                 async access(_path: filesystem.PathLike): Promise<void> {
                     switch (_path) {
@@ -215,7 +215,7 @@ describe('detectLocalTemplates', async () => {
         const workspaceFolderChildPath = normalizePath(workspaceFolderPath, 'child')
 
         const result = detectLocalTemplates({
-            workspaceFolders: [ vscode.Uri.file(workspaceFolderPath) ],
+            workspaceUris: [ vscode.Uri.file(workspaceFolderPath) ],
             context: {
                 async access(_path: filesystem.PathLike): Promise<void> {
                     switch (_path) {

--- a/src/test/lambda/utilities/getMainSourceFile.test.ts
+++ b/src/test/lambda/utilities/getMainSourceFile.test.ts
@@ -1,0 +1,272 @@
+/*!
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+import '../../../shared/utilities/asyncIteratorShim'
+
+import * as assert from 'assert'
+import * as os from 'os'
+import * as path from 'path'
+import * as vscode from 'vscode'
+import { getMainSourceFileUri } from '../../../lambda/utilities/getMainSourceFile'
+import { CloudFormation } from '../../../shared/cloudformation/cloudformation'
+
+async function* toAsyncIterable<T>(array: T[]): AsyncIterable<T> {
+    yield *array
+}
+
+describe('getMainSourceFile', async () => {
+    describe('nodejs', async () => {
+        function createTestTemplate(): CloudFormation.Template {
+            return {
+                Resources: {
+                    HelloWorld: {
+                        Type: 'AWS::Serverless::Function',
+                        Properties: {
+                            Handler: 'app.handler',
+                            CodeUri: 'my_app',
+                            Runtime: 'nodejs'
+                        }
+                    }
+                }
+            }
+        }
+
+        it('returns the URI of the main source file for a valid template', async () => {
+            const actual: vscode.Uri = await getMainSourceFileUri({
+                root: vscode.Uri.file('/dir'),
+                getLocalTemplates: (...workspaceUris: vscode.Uri[]) => toAsyncIterable([
+                    vscode.Uri.file('/dir/template.yaml')
+                ]),
+                loadSamTemplate: async uri => createTestTemplate(),
+                fileExists: async p => ['.ts'].indexOf(path.extname(p)) >= 0
+            })
+
+            assert.strictEqual(actual.fsPath, path.join(path.sep, 'dir', 'my_app', 'app.ts'))
+        })
+
+        it('throws when no template is found', async () => {
+            const root = vscode.Uri.file('/dir')
+            try {
+                await getMainSourceFileUri({
+                    root,
+                    getLocalTemplates: (...workspaceUris: vscode.Uri[]) => toAsyncIterable([]),
+                })
+            } catch (err) {
+                assert.strictEqual(
+                    String(err),
+                    `Error: Invalid project format: '${root.fsPath}' does not contain a SAM template.`
+                )
+
+                return
+            }
+
+            assert.fail('Expected an exception, but none was thrown.')
+        })
+
+        it('throws when template is empty', async () => {
+            const templateUri = vscode.Uri.file(path.join('/dir', 'template.yaml'))
+            try {
+                await getMainSourceFileUri({
+                    root: vscode.Uri.file('/dir'),
+                    getLocalTemplates: (...workspaceUris: vscode.Uri[]) => toAsyncIterable([templateUri]),
+                    loadSamTemplate: async uri => {
+                        const template = createTestTemplate()
+                        delete template.Resources
+
+                        return template
+                    },
+                    fileExists: async p => ['.ts'].indexOf(path.extname(p)) >= 0
+                })
+            } catch (err) {
+                assert.strictEqual(
+                    String(err),
+                    `Error: SAM Template '${templateUri.fsPath}' does not contain any resources`
+                )
+
+                return
+            }
+
+            assert.fail('Expected an exception, but none was thrown.')
+        })
+
+        it('throws when template only contains non-lambda resources', async () => {
+            const templateUri = vscode.Uri.file(path.join('/dir', 'template.yaml'))
+            try {
+                await getMainSourceFileUri({
+                    root: vscode.Uri.file('/dir'),
+                    getLocalTemplates: (...workspaceUris: vscode.Uri[]) => toAsyncIterable([templateUri]),
+                    loadSamTemplate: async uri =>  ({
+                        Resources: {
+                            HelloWorld: {
+                                Type: 'AWS::Serverless:NotAFunction'
+                            } as any as CloudFormation.Resource
+                        }
+                    }),
+                    fileExists: async p => ['.ts'].indexOf(path.extname(p)) >= 0
+                })
+            } catch (err) {
+                assert.strictEqual(
+                    String(err),
+                    `Error: SAM Template '${templateUri.fsPath}' does not contain any lambda resources`
+                )
+
+                return
+            }
+
+            assert.fail('Expected an exception, but none was thrown.')
+        })
+
+        it('throws when lambda resource has no properties', async () => {
+            const templateUri = vscode.Uri.file(path.join('/dir', 'template.yaml'))
+            try {
+                await getMainSourceFileUri({
+                    root: vscode.Uri.file('/dir'),
+                    getLocalTemplates: (...workspaceUris: vscode.Uri[]) => toAsyncIterable([templateUri]),
+                    loadSamTemplate: async uri => {
+                        const template = createTestTemplate()
+                        delete template.Resources!.HelloWorld.Properties
+
+                        return template
+                    },
+                    fileExists: async p => ['.ts'].indexOf(path.extname(p)) >= 0
+                })
+            } catch (err) {
+                assert.strictEqual(
+                    String(err),
+                    // JSON.stringify always uses `\n` regardless of os.EOL.
+                    // tslint:disable-next-line:prefer-template
+                    `Error: Lambda resource is missing the 'Properties' property:${os.EOL}` +
+                    '{\n' +
+                    '    "Type": "AWS::Serverless::Function"\n' +
+                    '}'
+                )
+
+                return
+            }
+
+            assert.fail('Expected an exception, but none was thrown.')
+        })
+
+        it('throws when runtime is unknown or unsupported', async () => {
+            async function test(runtime?: string): Promise<void> {
+                const templateUri = vscode.Uri.file(path.join('/dir', 'template.yaml'))
+                try {
+                    await getMainSourceFileUri({
+                        root: vscode.Uri.file('/dir'),
+                        getLocalTemplates: (...workspaceUris: vscode.Uri[]) => toAsyncIterable([templateUri]),
+                        loadSamTemplate: async uri => {
+                            const template = createTestTemplate()
+                            template.Resources!.HelloWorld.Properties!.Runtime = runtime
+
+                            return template
+                        },
+                        fileExists: async p => ['.ts'].indexOf(path.extname(p)) >= 0
+                    })
+                } catch (err) {
+                    assert.strictEqual(
+                        String(err),
+                        `Error: Lambda resource 'app.handler' has unknown runtime ${runtime}`
+                    )
+
+                    return
+                }
+
+                assert.fail('Expected an exception, but none was thrown.')
+            }
+
+            await test(undefined)
+            await test('fakeruntime')
+            await test('go')
+        })
+
+        it('recognizes all NodeJS runtimes', async () => {
+            async function test(runtime?: string): Promise<void> {
+                const templateUri = vscode.Uri.file(path.join('/dir', 'template.yaml'))
+                const actual: vscode.Uri = await getMainSourceFileUri({
+                    root: vscode.Uri.file('/dir'),
+                    getLocalTemplates: (...workspaceUris: vscode.Uri[]) => toAsyncIterable([templateUri]),
+                    loadSamTemplate: async uri => {
+                        const template = createTestTemplate()
+                        template.Resources!.HelloWorld.Properties!.Runtime = runtime
+
+                        return template
+                    },
+                    fileExists: async p => ['.ts'].indexOf(path.extname(p)) >= 0
+                })
+
+                assert.strictEqual(actual.fsPath, path.join('/dir', 'my_app', 'app.ts'))
+            }
+
+            await test('nodejs')
+            await test('nodejs4.3')
+            await test('nodejs6.10')
+            await test('nodejs8.10')
+        })
+
+        it('prefers TypeScript files over javascript files', async () => {
+            const actual: vscode.Uri = await getMainSourceFileUri({
+                root: vscode.Uri.file('/dir'),
+                getLocalTemplates: (...workspaceUris: vscode.Uri[]) => toAsyncIterable([
+                    vscode.Uri.file('/dir/template.yaml')
+                ]),
+                loadSamTemplate: async uri => createTestTemplate(),
+                fileExists: async p => ['.ts', '.js'].indexOf(path.extname(p)) >= 0
+            })
+
+            assert.strictEqual(actual.fsPath, path.join(path.sep, 'dir', 'my_app', 'app.ts'))
+        })
+
+        it('prefers JSX files over javascript files', async () => {
+            const actual: vscode.Uri = await getMainSourceFileUri({
+                root: vscode.Uri.file('/dir'),
+                getLocalTemplates: (...workspaceUris: vscode.Uri[]) => toAsyncIterable([
+                    vscode.Uri.file('/dir/template.yaml')
+                ]),
+                loadSamTemplate: async uri => createTestTemplate(),
+                fileExists: async p => ['.jsx', '.js'].indexOf(path.extname(p)) >= 0
+            })
+
+            assert.strictEqual(actual.fsPath, path.join(path.sep, 'dir', 'my_app', 'app.jsx'))
+        })
+
+        it('finds javascript file if no TS or JSX file exists', async () => {
+            const actual: vscode.Uri = await getMainSourceFileUri({
+                root: vscode.Uri.file('/dir'),
+                getLocalTemplates: (...workspaceUris: vscode.Uri[]) => toAsyncIterable([
+                    vscode.Uri.file('/dir/template.yaml')
+                ]),
+                loadSamTemplate: async uri => createTestTemplate(),
+                fileExists: async p => ['.js'].indexOf(path.extname(p)) >= 0
+            })
+
+            assert.strictEqual(actual.fsPath, path.join(path.sep, 'dir', 'my_app', 'app.js'))
+        })
+
+        it('fails when no source file is found at the expected location', async () => {
+            try {
+                await getMainSourceFileUri({
+                    root: vscode.Uri.file('/dir'),
+                    getLocalTemplates: (...workspaceUris: vscode.Uri[]) => toAsyncIterable([
+                        vscode.Uri.file('/dir/template.yaml')
+                    ]),
+                    loadSamTemplate: async uri => createTestTemplate(),
+                    fileExists: async p => false
+                })
+            } catch (err) {
+                const expectedBasePath = path.join('/dir', 'my_app', 'app')
+                assert.strictEqual(
+                    String(err),
+                    `Error: Javascript file expected at ${expectedBasePath}.(ts|jsx|js), but no file was found`
+                )
+
+                return
+            }
+
+            assert.fail('Expected an exception, but none was thrown.')
+        })
+    })
+})

--- a/src/test/shared/cloudformation/cloudformation.test.ts
+++ b/src/test/shared/cloudformation/cloudformation.test.ts
@@ -140,14 +140,20 @@ describe ('CloudFormation', () => {
     it ('can detect an invalid template', () => {
         const badTemplate = createBaseTemplate()
         delete badTemplate.Resources!.TestResource!.Type
-        assert.throws(() => CloudFormation.validateTemplate(badTemplate),
-                      Error, 'Missing or invalid value in Template for key: Type')
+        assert.throws(
+            () => CloudFormation.validateTemplate(badTemplate),
+            Error,
+            'Template does not contain any Lambda resources'
+        )
     })
 
     it ('can detect an invalid resource', () => {
         const badResource = createBaseResource()
         delete badResource.Properties!.CodeUri
-        assert.throws(() => CloudFormation.validateResource(badResource),
-                      Error, 'Missing or invalid value in Template for key: CodeUri')
+        assert.throws(
+            () => CloudFormation.validateResource(badResource),
+            Error,
+            'Missing or invalid value in Template for key: CodeUri'
+        )
     })
 })

--- a/src/test/utilities/childProcess.test.ts
+++ b/src/test/utilities/childProcess.test.ts
@@ -115,13 +115,18 @@ describe('ChildProcess', async () => {
                 scriptFile
             )
 
-            // We want to verify that the error is thrown immediately, so we don't await the promises.
+            // We want to verify that the error is thrown even if the first
+            // invocation is still in progress, so we don't await the promise.
             // tslint:disable-next-line:no-floating-promises
             childProcess.run()
-            assert.throws(() => {
-                // tslint:disable-next-line:no-floating-promises
-                childProcess.run()
-            })
+
+            try {
+                await childProcess.run()
+            } catch (err) {
+                return
+            }
+
+            assert.fail('Expected exception, but none was thrown.')
         })
     } // END Linux only tests
 

--- a/src/test/utilities/childProcess.test.ts
+++ b/src/test/utilities/childProcess.test.ts
@@ -36,9 +36,7 @@ describe('ChildProcess', async () => {
                 batchFile
             )
 
-            childProcess.start()
-
-            const result = await childProcess.promise()
+            const result = await childProcess.run()
 
             validateChildProcessResult({
                 childProcessResult: result,
@@ -59,9 +57,7 @@ describe('ChildProcess', async () => {
                 command
             )
 
-            childProcess.start()
-
-            const result = await childProcess.promise()
+            const result = await childProcess.run()
 
             validateChildProcessResult({
                 childProcessResult: result,
@@ -78,11 +74,18 @@ describe('ChildProcess', async () => {
                 batchFile
             )
 
-            childProcess.start()
+            // We want to verify that the error is thrown even if the first
+            // invocation is still in progress, so we don't await the promise.
+            // tslint:disable-next-line:no-floating-promises
+            childProcess.run()
 
-            assert.throws(() => {
-                childProcess.start()
-            })
+            try {
+                await childProcess.run()
+            } catch (err) {
+                return
+            }
+
+            assert.fail('Expected exception, but none was thrown.')
         })
     } // END Windows only tests
 
@@ -95,9 +98,7 @@ describe('ChildProcess', async () => {
                 scriptFile
             )
 
-            childProcess.start()
-
-            const result = await childProcess.promise()
+            const result = await childProcess.run()
 
             validateChildProcessResult({
                 childProcessResult: result,
@@ -114,10 +115,12 @@ describe('ChildProcess', async () => {
                 scriptFile
             )
 
-            childProcess.start()
-
+            // We want to verify that the error is thrown immediately, so we don't await the promises.
+            // tslint:disable-next-line:no-floating-promises
+            childProcess.run()
             assert.throws(() => {
-                childProcess.start()
+                // tslint:disable-next-line:no-floating-promises
+                childProcess.run()
             })
         })
     } // END Linux only tests
@@ -140,31 +143,13 @@ describe('ChildProcess', async () => {
             command
         )
 
-        childProcess.start()
-
-        const result = await childProcess.promise()
+        const result = await childProcess.run()
 
         validateChildProcessResult({
             childProcessResult: result,
             expectedExitCode: 0,
             expectedOutput: 'hi'
         })
-    })
-
-    it('errs when getting promise without starting', async () => {
-        const batchFile = path.join(tempFolder, 'test-script.bat')
-        writeBatchFile(batchFile)
-
-        const childProcess = new ChildProcess(
-            batchFile
-        )
-
-        try {
-            await childProcess.promise()
-            assert.strictEqual(true, false, 'error expected')
-        } catch (err) {
-            assert.notStrictEqual(err, undefined)
-        }
     })
 
     it('reports error for missing executable', async () => {
@@ -174,9 +159,7 @@ describe('ChildProcess', async () => {
             batchFile
         )
 
-        childProcess.start()
-
-        const result = await childProcess.promise()
+        const result = await childProcess.run()
 
         assert.notStrictEqual(result.exitCode, 0)
         assert.notStrictEqual(result.error, undefined)


### PR DESCRIPTION
## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [ ] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description

After a new SAM application is created, open its default code file (`app.js`, `Program.cs`, `app.py`, etc.).

* This change supports the NodeJS family of runtimes.
* A follow-up change will add support for the .NET family of runtimes.

<!--- Describe your changes in detail -->

## Motivation and Context

Currently, when the user creates a new SAM application using our toolkit, it is unclear when the operation has completed. If the user has the 'file explorer' viewlet open, they will see a new folder appear in the viewlet, but that's it.

This change opens the default code file for a SAM app once creation completes. This serves the dual purpose of providing feedback to the user, and saving them time searching for the file.

Additional context: VS Code has the following unfortunate behavior when updating workspace folders:

> ```
> If the first workspace folder is added, removed or changed, the currently executing extensions (including the
> one that called this method) will be terminated and restarted so that the (deprecated) `rootPath` property is
> updated to point to the first workspace folder.
> ```

Because of this, we must handle two cases:
1. There was already at least one workspace folder open. In this case, we use a `FileSystemWatcher` to wait for VS Code to recognize the newly created file.
2. There was no existing workspace folder open. In this case, the extension is about to be terminated and restarted. So we store the URI-to-open in VS Code's key-value store for our extension. On extension initialization, if this key is set, we open the file.

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
