### PR TITLE
Region selector now filters by friendly name and by region code

### DIFF
--- a/src/shared/defaultAwsContextCommands.ts
+++ b/src/shared/defaultAwsContextCommands.ts
@@ -326,7 +326,8 @@ export class DefaultAWSContextCommands {
             detail: r.regionCode
         }))
         const input = await window.showQuickPick(regionsToShow, {
-            placeHolder: localize('AWS.message.selectRegion', 'Select an AWS region')
+            placeHolder: localize('AWS.message.selectRegion', 'Select an AWS region'),
+            matchOnDetail: true,
         })
 
         return input ? input.detail : undefined


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [ ] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description
When selecting regions to show/hide from the AWS Explorer, the filter would only apply against the region's friendly name. It now applies to the region code as well.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->
#239 

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
