### PR TITLE
Update list of supported runtimes.

### DIFF
--- a/src/lambda/models/samLambdaRuntime.ts
+++ b/src/lambda/models/samLambdaRuntime.ts
@@ -19,6 +19,7 @@ export type SamLambdaRuntime =
     'nodejs4.3' |
     'nodejs' |
     'dotnetcore2.1' |
+    'dotnetcore2.0' |
     'dotnetcore1.0' |
     'dotnetcore' |
     'dotnet' |

--- a/src/lambda/models/samLambdaRuntime.ts
+++ b/src/lambda/models/samLambdaRuntime.ts
@@ -10,6 +10,7 @@ import * as immutable from 'immutable'
 // TODO: Can we dynamically determine the available runtimes? We could theoretically parse the
 // output of `sam init --help`, but that's a hack.
 export type SamLambdaRuntime =
+    'python3.7' |
     'python3.6' |
     'python2.7' |
     'python' |
@@ -17,16 +18,18 @@ export type SamLambdaRuntime =
     'nodejs8.10' |
     'nodejs4.3' |
     'nodejs' |
-    'dotnetcore2.0' |
+    'dotnetcore2.1' |
     'dotnetcore1.0' |
     'dotnetcore' |
     'dotnet' |
     'go1.x' |
     'go' |
     'java8' |
-    'java'
+    'java' |
+    'ruby2.5'
 
 export const samLambdaRuntimes: immutable.Set<SamLambdaRuntime> = immutable.Set([
+    'python3.7',
     'python3.6',
     'python2.7',
     'python',
@@ -34,6 +37,7 @@ export const samLambdaRuntimes: immutable.Set<SamLambdaRuntime> = immutable.Set(
     'nodejs8.10',
     'nodejs4.3',
     'nodejs',
+    'dotnetcore2.1',
     'dotnetcore2.0',
     'dotnetcore1.0',
     'dotnetcore',
@@ -41,7 +45,8 @@ export const samLambdaRuntimes: immutable.Set<SamLambdaRuntime> = immutable.Set(
     'go1.x',
     'go',
     'java8',
-    'java'
+    'java',
+    'ruby2.5'
 ] as SamLambdaRuntime[])
 
 export enum SamLambdaRuntimeFamily {
@@ -49,11 +54,13 @@ export enum SamLambdaRuntimeFamily {
     NodeJS,
     DotNet,
     Go,
-    Java
+    Java,
+    Ruby
 }
 
 export function getFamily(runtime: string | undefined): SamLambdaRuntimeFamily {
     switch (runtime) {
+        case 'python3.7':
         case 'python3.6':
         case 'python2.7':
         case 'python':
@@ -63,6 +70,7 @@ export function getFamily(runtime: string | undefined): SamLambdaRuntimeFamily {
         case 'nodejs4.3':
         case 'nodejs':
             return SamLambdaRuntimeFamily.NodeJS
+        case 'dotnetcore2.1':
         case 'dotnetcore2.0':
         case 'dotnetcore1.0':
         case 'dotnetcore':
@@ -74,6 +82,8 @@ export function getFamily(runtime: string | undefined): SamLambdaRuntimeFamily {
         case 'java8':
         case 'java':
             return SamLambdaRuntimeFamily.Java
+        case 'ruby2.5':
+            return SamLambdaRuntimeFamily.Ruby
         default:
             throw new Error(`Unrecognized runtime: '${runtime}'`)
 


### PR DESCRIPTION
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [ ] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description

Update list of supported runtimes to include `python3.7`, `ruby2.5`, and `dotnetcore2.1`.

## Motivation and Context

SAM CLI has added support for three additional runtimes since our last refresh. We don't currently auto-detect available runtimes (we should probably at least add a test that does this), so a manual update is required.

## Related Issue(s)

Follow-up to #326.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
