### PR TITLE
Allow command callbacks to return values

### DIFF
--- a/src/lambda/lambdaTreeDataProvider.ts
+++ b/src/lambda/lambdaTreeDataProvider.ts
@@ -14,7 +14,7 @@ import { AwsContextTreeCollection } from '../shared/awsContextTreeCollection'
 import { ext } from '../shared/extensionGlobals'
 import { RegionProvider } from '../shared/regions/regionProvider'
 import { ResourceFetcher } from '../shared/resourceFetcher'
-import { ResultWithTelemetry } from '../shared/telemetry/telemetryEvent'
+import { Datum } from '../shared/telemetry/telemetryEvent'
 import { defaultMetricDatum, registerCommand } from '../shared/telemetry/telemetryUtils'
 import { AWSCommandTreeNode } from '../shared/treeview/awsCommandTreeNode'
 import { AWSTreeNodeBase } from '../shared/treeview/awsTreeNodeBase'
@@ -65,7 +65,7 @@ export class LambdaTreeDataProvider implements vscode.TreeDataProvider<AWSTreeNo
         const createNewSamAppCommand = 'aws.lambda.createNewSamApp'
         registerCommand({
             command: createNewSamAppCommand,
-            callback: async (): Promise<ResultWithTelemetry<void>> => {
+            callback: async (): Promise<{ datum: Datum }> => {
                 const metadata = await createNewSamApp(context)
                 const datum = defaultMetricDatum(createNewSamAppCommand)
                 datum.metadata = metadata ? new Map([
@@ -73,7 +73,7 @@ export class LambdaTreeDataProvider implements vscode.TreeDataProvider<AWSTreeNo
                 ]) : undefined
 
                 return {
-                    telemetryDatum: datum
+                    datum
                 }
             }
         })

--- a/src/shared/codelens/typescriptCodeLensProvider.ts
+++ b/src/shared/codelens/typescriptCodeLensProvider.ts
@@ -19,7 +19,7 @@ import {
     SamCliTaskInvoker
 } from '../sam/cli/samCliInvoker'
 import { SettingsConfiguration } from '../settingsConfiguration'
-import { ResultWithTelemetry } from '../telemetry/telemetryEvent'
+import { Datum } from '../telemetry/telemetryEvent'
 import { defaultMetricDatum, registerCommand } from '../telemetry/telemetryUtils'
 import { TypescriptLambdaHandlerSearch } from '../typescriptLambdaHandlerSearch'
 import { LambdaLocalInvokeArguments, LocalLambdaRunner } from './localLambdaRunner'
@@ -135,7 +135,7 @@ export class TypescriptCodeLensProvider implements vscode.CodeLensProvider {
 
         registerCommand({
             command: command,
-            callback: async (args: LambdaLocalInvokeArguments): Promise<ResultWithTelemetry<void>> => {
+            callback: async (args: LambdaLocalInvokeArguments): Promise<{ datum: Datum }> => {
 
                 let debugPort: number | undefined
 
@@ -162,7 +162,7 @@ export class TypescriptCodeLensProvider implements vscode.CodeLensProvider {
                 ])
 
                 return {
-                    telemetryDatum: datum
+                    datum
                 }
             }
         })

--- a/src/shared/telemetry/telemetryEvent.ts
+++ b/src/shared/telemetry/telemetryEvent.ts
@@ -9,11 +9,6 @@ import { MetadataEntry, MetricDatum, Unit } from './clienttelemetry'
 
 const NAME_ILLEGAL_CHARS_REGEX = new RegExp('[^\\w+-.:]', 'g')
 
-export interface ResultWithTelemetry<T> {
-    result?: T,
-    telemetryDatum?: Datum
-}
-
 export interface Datum {
     name: string
     value: number


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [x] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description


Changes the return type of `registerCommand`'s callback from

```typescript
 {
    result?: T,
    datum?: Datum
} | void
```

to

```typescript
T & { datum?: Datum } | void
```

And returns the result of the the callback to the vscode command system.

## Motivation and Context

Currently, `registerCommand`:

1. Swallows the return value of the command callback.
2. Forces commands that return values to include a telemetry datum (rather than using the default datum).

This change addresses those two issues, allowing callbacks with no custom telemetry data to return `T` instead of `{ result: T; datum: Datum }`.

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
