### PR TITLE
Support for use-container, docker-network, skip-pull-image in calls to sam local invoke

### DIFF
--- a/src/shared/codelens/localLambdaRunner.ts
+++ b/src/shared/codelens/localLambdaRunner.ts
@@ -251,14 +251,14 @@ export class LocalLambdaRunner {
             JSON.stringify(this.getEnvironmentVariables(config))
         )
 
-        const command = new SamCliLocalInvokeInvocation(
-            LocalLambdaRunner.TEMPLATE_RESOURCE_NAME,
-            samTemplatePath,
+        const command = new SamCliLocalInvokeInvocation({
+            templateResourceName: LocalLambdaRunner.TEMPLATE_RESOURCE_NAME,
+            templatePath: samTemplatePath,
             eventPath,
-            environmentVariablePath,
-            (!!this._debugPort) ? this._debugPort.toString() : undefined,
-            this.taskInvoker
-        )
+            environmentVariablePath: environmentVariablePath,
+            debugPort: (!!this._debugPort) ? this._debugPort.toString() : undefined,
+            invoker: this.taskInvoker
+        })
 
         await command.execute()
 

--- a/src/shared/codelens/localLambdaRunner.ts
+++ b/src/shared/codelens/localLambdaRunner.ts
@@ -255,7 +255,7 @@ export class LocalLambdaRunner {
             templateResourceName: LocalLambdaRunner.TEMPLATE_RESOURCE_NAME,
             templatePath: samTemplatePath,
             eventPath,
-            environmentVariablePath: environmentVariablePath,
+            environmentVariablePath,
             debugPort: (!!this._debugPort) ? this._debugPort.toString() : undefined,
             invoker: this.taskInvoker
         })

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -9,15 +9,34 @@ import * as vscode from 'vscode'
 import { fileExists } from '../../filesystemUtilities'
 import { DefaultSamCliTaskInvoker, SamCliTaskInvoker } from './samCliInvoker'
 
+export interface SamCliLocalInvokeInvocationArguments {
+    templateResourceName: string,
+    templatePath: string,
+    eventPath: string,
+    environmentVariablePath: string,
+    debugPort?: string,
+    invoker: SamCliTaskInvoker,
+}
+
 export class SamCliLocalInvokeInvocation {
-    public constructor(
-        private readonly templateResourceName: string,
-        private readonly templatePath: string,
-        private readonly eventPath: string,
-        private readonly environmentVariablePath: string,
-        private readonly debugPort?: string,
-        private readonly invoker: SamCliTaskInvoker = new DefaultSamCliTaskInvoker()
+    private readonly templateResourceName: string
+    private readonly templatePath: string
+    private readonly eventPath: string
+    private readonly environmentVariablePath: string
+    private readonly debugPort?: string
+    private readonly invoker: SamCliTaskInvoker
+
+    public constructor({
+        invoker = new DefaultSamCliTaskInvoker(),
+        ...params
+    }: SamCliLocalInvokeInvocationArguments
     ) {
+        this.templateResourceName = params.templateResourceName
+        this.templatePath = params.templatePath
+        this.eventPath = params.eventPath
+        this.environmentVariablePath = params.environmentVariablePath
+        this.debugPort = params.debugPort
+        this.invoker = invoker
     }
 
     public async execute(): Promise<void> {

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -10,6 +10,7 @@ import { fileExists } from '../../filesystemUtilities'
 import { DefaultSamCliTaskInvoker, SamCliTaskInvoker } from './samCliInvoker'
 
 export interface SamCliLocalInvokeInvocationArguments {
+    // Todo : comments incoming...
     templateResourceName: string,
     templatePath: string,
     eventPath: string,
@@ -32,6 +33,12 @@ export class SamCliLocalInvokeInvocation {
     private readonly dockerNetwork?: string
     private readonly skipPullImage: boolean
 
+    /**
+     * @see SamCliLocalInvokeInvocationArguments for parameter info
+     * invoker - Defaults to DefaultSamCliTaskInvoker
+     * useContainer - Defaults to false (function will be built on local machine instead of in a docker image)
+     * skipPullImage - Defaults to false (the latest Docker image will be pulled down if necessary)
+     */
     public constructor({
         invoker = new DefaultSamCliTaskInvoker(),
         useContainer = false,

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -10,15 +10,44 @@ import { fileExists } from '../../filesystemUtilities'
 import { DefaultSamCliTaskInvoker, SamCliTaskInvoker } from './samCliInvoker'
 
 export interface SamCliLocalInvokeInvocationArguments {
-    // Todo : comments incoming...
+    /**
+     * The name of the resource in the SAM Template to be invoked.
+     */
     templateResourceName: string,
+    /**
+     * Location of the SAM Template to invoke locally against.
+     */
     templatePath: string,
+    /**
+     * Location of the file containing the Lambda Function event payload.
+     */
     eventPath: string,
+    /**
+     * Location of the file containing the environment variables to invoke the Lambda Function against.
+     */
     environmentVariablePath: string,
+    /**
+     * When specified, starts the Lambda function container in debug mode and exposes this port on the local host.
+     */
     debugPort?: string,
+    /**
+     * Manages the sam cli execution.
+     */
     invoker: SamCliTaskInvoker,
+    /**
+     * If your functions depend on packages that have natively compiled dependencies,
+     * use this flag to build your function inside an AWS Lambda-like Docker container.
+     */
     useContainer?: boolean,
+    /**
+     * Specifies the name or id of an existing Docker network to Lambda Docker containers should connect to,
+     * along with the default bridge network.
+     * If not specified, the Lambda containers will only connect to the default bridge Docker network.
+     */
     dockerNetwork?: string,
+    /**
+     * Specifies whether the command should skip pulling down the latest Docker image for Lambda runtime.
+     */
     skipPullImage?: boolean,
 }
 

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -16,6 +16,9 @@ export interface SamCliLocalInvokeInvocationArguments {
     environmentVariablePath: string,
     debugPort?: string,
     invoker: SamCliTaskInvoker,
+    useContainer?: boolean,
+    dockerNetwork?: string,
+    skipPullImage?: boolean,
 }
 
 export class SamCliLocalInvokeInvocation {
@@ -25,9 +28,14 @@ export class SamCliLocalInvokeInvocation {
     private readonly environmentVariablePath: string
     private readonly debugPort?: string
     private readonly invoker: SamCliTaskInvoker
+    private readonly useContainer: boolean
+    private readonly dockerNetwork?: string
+    private readonly skipPullImage: boolean
 
     public constructor({
         invoker = new DefaultSamCliTaskInvoker(),
+        useContainer = false,
+        skipPullImage = false,
         ...params
     }: SamCliLocalInvokeInvocationArguments
     ) {
@@ -37,6 +45,9 @@ export class SamCliLocalInvokeInvocation {
         this.environmentVariablePath = params.environmentVariablePath
         this.debugPort = params.debugPort
         this.invoker = invoker
+        this.useContainer = useContainer
+        this.dockerNetwork = params.dockerNetwork
+        this.skipPullImage = skipPullImage
     }
 
     public async execute(): Promise<void> {
@@ -53,9 +64,11 @@ export class SamCliLocalInvokeInvocation {
             '--env-vars',
             this.environmentVariablePath
         ]
-        if (!!this.debugPort) {
-            args.push('-d', this.debugPort)
-        }
+
+        this.addArgumentIf(args, !!this.debugPort, '-d', this.debugPort!)
+        this.addArgumentIf(args, !!this.dockerNetwork, '--docker-network', this.dockerNetwork!)
+        this.addArgumentIf(args, !!this.useContainer, '--use-container')
+        this.addArgumentIf(args, !!this.skipPullImage, '--skip-pull-image')
 
         const execution = new vscode.ShellExecution('sam', args)
 
@@ -81,6 +94,12 @@ export class SamCliLocalInvokeInvocation {
 
         if (!await fileExists(this.eventPath)) {
             throw new Error(`event path does not exist: ${this.eventPath}`)
+        }
+    }
+
+    private addArgumentIf(args: string[], addIfConditional: boolean, ...argsToAdd: string[]) {
+        if (addIfConditional) {
+            args.push(...argsToAdd)
         }
     }
 }

--- a/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
+++ b/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
@@ -12,7 +12,7 @@ import * as vscode from 'vscode'
 import { writeFile } from '../../../../shared/filesystem'
 import { mkdtemp } from '../../../../shared/filesystemUtilities'
 import { TestLogger } from '../../../../shared/loggerUtils'
-import { DefaultSamCliTaskInvoker } from '../../../../shared/sam/cli/samCliInvoker'
+import { SamCliTaskInvoker } from '../../../../shared/sam/cli/samCliInvoker'
 import { SamCliLocalInvokeInvocation } from '../../../../shared/sam/cli/samCliLocalInvoke'
 
 describe('SamCliLocalInvokeInvocation', async () => {
@@ -26,7 +26,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
         }
     }
 
-    class TestTaskInvoker implements DefaultSamCliTaskInvoker {
+    class TestTaskInvoker implements SamCliTaskInvoker {
         public constructor(
             private readonly onInvoke: (...args: any[]) => void
         ) {
@@ -68,7 +68,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
     })
 
     it('Passes local invoke command to sam cli', async () => {
-        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+        const taskInvoker: SamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
             assert.ok(args.length >= 2, 'Expected args to be present')
             assert.strictEqual(args[0], 'local', 'Expected first arg to be local')
             assert.strictEqual(args[1], 'invoke', 'Expected second arg to be invoke')
@@ -85,7 +85,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
 
     it('Passes template resource name to sam cli', async () => {
         const expectedResourceName = 'HelloWorldResource'
-        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+        const taskInvoker: SamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
             assertArgIsPresent(args, expectedResourceName)
         })
 
@@ -99,7 +99,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
     })
 
     it('Passes template path to sam cli', async () => {
-        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+        const taskInvoker: SamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
             assertArgsContainArgument(args, '--template', placeholderTemplateFile)
         })
 
@@ -113,7 +113,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
     })
 
     it('Passes event path to sam cli', async () => {
-        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+        const taskInvoker: SamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
             assertArgsContainArgument(args, '--event', placeholderEventFile)
         })
 
@@ -128,7 +128,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
 
     it('Passes env-vars path to sam cli', async () => {
         const expectedEnvVarsPath = 'envvars.json'
-        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+        const taskInvoker: SamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
             assertArgsContainArgument(args, '--env-vars', expectedEnvVarsPath)
         })
 
@@ -143,7 +143,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
 
     it('Passes debug port to sam cli', async () => {
         const expectedDebugPort = '1234'
-        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+        const taskInvoker: SamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
             assertArgsContainArgument(args, '-d', expectedDebugPort)
         })
 
@@ -158,7 +158,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
     })
 
     it('undefined debug port does not pass to sam cli', async () => {
-        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+        const taskInvoker: SamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
             assertArgNotPresent(args, '-d')
         })
 
@@ -173,7 +173,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
     })
 
     it('passes --use-container to sam cli if useContainer is true', async () => {
-        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+        const taskInvoker: SamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
             assertArgIsPresent(args, '--use-container')
         })
 
@@ -188,7 +188,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
     })
 
     it('does not pass --use-container to sam cli if useContainer is false', async () => {
-        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+        const taskInvoker: SamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
             assertArgNotPresent(args, '--use-container')
         })
 
@@ -203,7 +203,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
     })
 
     it('does not pass --use-container to sam cli if useContainer is undefined', async () => {
-        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+        const taskInvoker: SamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
             assertArgNotPresent(args, '--use-container')
         })
 
@@ -220,7 +220,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
     it('Passes docker network to sam cli', async () => {
         const expectedDockerNetwork = 'hello-world'
 
-        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+        const taskInvoker: SamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
             assertArgsContainArgument(args, '--docker-network', expectedDockerNetwork)
         })
 
@@ -235,7 +235,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
     })
 
     it('Does not pass docker network to sam cli when undefined', async () => {
-        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+        const taskInvoker: SamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
             assertArgNotPresent(args, '--docker-network')
         })
 
@@ -250,7 +250,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
     })
 
     it('passes --skip-pull-image to sam cli if skipPullImage is true', async () => {
-        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+        const taskInvoker: SamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
             assertArgIsPresent(args, '--skip-pull-image')
         })
 
@@ -265,7 +265,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
     })
 
     it('does not pass --skip-pull-image to sam cli if skipPullImage is false', async () => {
-        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+        const taskInvoker: SamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
             assertArgNotPresent(args, '--skip-pull-image')
         })
 
@@ -280,7 +280,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
     })
 
     it('does not pass --skip-pull-image to sam cli if skipPullImage is undefined', async () => {
-        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+        const taskInvoker: SamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
             assertArgNotPresent(args, '--skip-pull-image')
         })
 

--- a/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
+++ b/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
@@ -1,0 +1,212 @@
+/*!
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+import * as assert from 'assert'
+import * as del from 'del'
+import * as path from 'path'
+import * as vscode from 'vscode'
+import { writeFile } from '../../../../shared/filesystem'
+import { mkdtemp } from '../../../../shared/filesystemUtilities'
+import { TestLogger } from '../../../../shared/loggerUtils'
+import { DefaultSamCliTaskInvoker } from '../../../../shared/sam/cli/samCliInvoker'
+import { SamCliLocalInvokeInvocation } from '../../../../shared/sam/cli/samCliLocalInvoke'
+
+describe('SamCliLocalInvokeInvocation', async () => {
+
+    class FakeTaskExecution implements vscode.TaskExecution {
+        public constructor(public readonly task: vscode.Task) {
+        }
+
+        public terminate(): void {
+            throw new Error('Method not implemented.')
+        }
+    }
+
+    class TestTaskInvoker implements DefaultSamCliTaskInvoker {
+        public constructor(
+            private readonly onInvoke: (...args: any[]) => void
+        ) {
+        }
+
+        public async invoke(task: vscode.Task): Promise<vscode.TaskExecution> {
+            const shellExecution: vscode.ShellExecution = task.execution as vscode.ShellExecution
+
+            this.onInvoke(shellExecution.args)
+
+            return Promise.resolve(new FakeTaskExecution(task))
+        }
+    }
+
+    let logger: TestLogger
+    let tempFolder: string
+    let placeholderTemplateFile: string
+    let placeholderEventFile: string
+    const nonRelevantArg = 'arg is not of interest to this test'
+
+    before(async () => {
+        logger = await TestLogger.createTestLogger()
+    })
+
+    beforeEach(async () => {
+        tempFolder = await mkdtemp()
+        placeholderTemplateFile = path.join(tempFolder, 'template.yaml')
+        placeholderEventFile = path.join(tempFolder, 'event.json')
+        await writeFile(placeholderTemplateFile, '')
+        await writeFile(placeholderEventFile, '')
+    })
+
+    after(async () => {
+        await logger.cleanupLogger()
+    })
+
+    afterEach(async () => {
+        await del([tempFolder], { force: true })
+    })
+
+    it('Passes local invoke command to sam cli', async () => {
+        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+            assert.ok(args.length >= 2, 'Expected args to be present')
+            assert.strictEqual(args[0], 'local', 'Expected first arg to be local')
+            assert.strictEqual(args[1], 'invoke', 'Expected second arg to be invoke')
+        })
+
+        await new SamCliLocalInvokeInvocation(
+            nonRelevantArg,
+            placeholderTemplateFile,
+            placeholderEventFile,
+            nonRelevantArg,
+            undefined,
+            taskInvoker
+        ).execute()
+    })
+
+    it('Passes template resource name to sam cli', async () => {
+        const expectedResourceName = 'HelloWorldResource'
+        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+            assertArgIsPresent(args, expectedResourceName)
+        })
+
+        await new SamCliLocalInvokeInvocation(
+            expectedResourceName,
+            placeholderTemplateFile,
+            placeholderEventFile,
+            nonRelevantArg,
+            undefined,
+            taskInvoker
+        ).execute()
+    })
+
+    it('Passes template path to sam cli', async () => {
+        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+            assertArgsContainArgument(args, '--template', placeholderTemplateFile)
+        })
+
+        await new SamCliLocalInvokeInvocation(
+            nonRelevantArg,
+            placeholderTemplateFile,
+            placeholderEventFile,
+            nonRelevantArg,
+            undefined,
+            taskInvoker
+        ).execute()
+    })
+
+    it('Passes event path to sam cli', async () => {
+        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+            assertArgsContainArgument(args, '--event', placeholderEventFile)
+        })
+
+        await new SamCliLocalInvokeInvocation(
+            nonRelevantArg,
+            placeholderTemplateFile,
+            placeholderEventFile,
+            nonRelevantArg,
+            undefined,
+            taskInvoker
+        ).execute()
+    })
+
+    it('Passes env-vars path to sam cli', async () => {
+        const expectedEnvVarsPath = 'envvars.json'
+        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+            assertArgsContainArgument(args, '--env-vars', expectedEnvVarsPath)
+        })
+
+        await new SamCliLocalInvokeInvocation(
+            nonRelevantArg,
+            placeholderTemplateFile,
+            placeholderEventFile,
+            expectedEnvVarsPath,
+            undefined,
+            taskInvoker
+        ).execute()
+    })
+
+    it('Passes debug port to sam cli', async () => {
+        const expectedDebugPort = '1234'
+        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+            assertArgsContainArgument(args, '-d', expectedDebugPort)
+        })
+
+        await new SamCliLocalInvokeInvocation(
+            nonRelevantArg,
+            placeholderTemplateFile,
+            placeholderEventFile,
+            nonRelevantArg,
+            expectedDebugPort,
+            taskInvoker
+        ).execute()
+    })
+
+    it('undefined debug port does not pass to sam cli', async () => {
+        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+            assertArgNotPresent(args, '-d')
+        })
+
+        await new SamCliLocalInvokeInvocation(
+            nonRelevantArg,
+            placeholderTemplateFile,
+            placeholderEventFile,
+            nonRelevantArg,
+            undefined,
+            taskInvoker
+        ).execute()
+    })
+
+    function assertArgsContainArgument(
+        args: any[],
+        argOfInterest: string,
+        expectedArgValue: string
+    ) {
+        const argPos = args.indexOf(argOfInterest)
+        assert.notStrictEqual(argPos, -1, `Expected arg ${argOfInterest} was not found`)
+        assert.ok(args.length >= argPos + 2, `Args does not contain a value for ${argOfInterest}`)
+        assert.strictEqual(args[argPos + 1], expectedArgValue, `Arg ${argOfInterest} did not have expected value`)
+    }
+
+    function assertArgIsPresent(
+        args: any[],
+        argOfInterest: string,
+    ) {
+        assert.notStrictEqual(
+            args.indexOf(argOfInterest),
+            -1,
+            `Expected ${argOfInterest} arg`
+        )
+    }
+
+    function assertArgNotPresent(
+        args: any[],
+        argOfInterest: string,
+    ) {
+        assert.strictEqual(
+            args.indexOf(argOfInterest),
+            -1,
+            `Did not expect ${argOfInterest} arg`
+        )
+    }
+})

--- a/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
+++ b/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
@@ -172,6 +172,128 @@ describe('SamCliLocalInvokeInvocation', async () => {
         }).execute()
     })
 
+    it('passes --use-container to sam cli if useContainer is true', async () => {
+        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+            assertArgIsPresent(args, '--use-container')
+        })
+
+        await new SamCliLocalInvokeInvocation({
+            templateResourceName: nonRelevantArg,
+            templatePath: placeholderTemplateFile,
+            eventPath: placeholderEventFile,
+            environmentVariablePath: nonRelevantArg,
+            invoker: taskInvoker,
+            useContainer: true,
+        }).execute()
+    })
+
+    it('does not pass --use-container to sam cli if useContainer is false', async () => {
+        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+            assertArgNotPresent(args, '--use-container')
+        })
+
+        await new SamCliLocalInvokeInvocation({
+            templateResourceName: nonRelevantArg,
+            templatePath: placeholderTemplateFile,
+            eventPath: placeholderEventFile,
+            environmentVariablePath: nonRelevantArg,
+            invoker: taskInvoker,
+            useContainer: false,
+        }).execute()
+    })
+
+    it('does not pass --use-container to sam cli if useContainer is undefined', async () => {
+        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+            assertArgNotPresent(args, '--use-container')
+        })
+
+        await new SamCliLocalInvokeInvocation({
+            templateResourceName: nonRelevantArg,
+            templatePath: placeholderTemplateFile,
+            eventPath: placeholderEventFile,
+            environmentVariablePath: nonRelevantArg,
+            invoker: taskInvoker,
+            useContainer: undefined,
+        }).execute()
+    })
+
+    it('Passes docker network to sam cli', async () => {
+        const expectedDockerNetwork = 'hello-world'
+
+        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+            assertArgsContainArgument(args, '--docker-network', expectedDockerNetwork)
+        })
+
+        await new SamCliLocalInvokeInvocation({
+            templateResourceName: nonRelevantArg,
+            templatePath: placeholderTemplateFile,
+            eventPath: placeholderEventFile,
+            environmentVariablePath: nonRelevantArg,
+            invoker: taskInvoker,
+            dockerNetwork: expectedDockerNetwork
+        }).execute()
+    })
+
+    it('Does not pass docker network to sam cli when undefined', async () => {
+        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+            assertArgNotPresent(args, '--docker-network')
+        })
+
+        await new SamCliLocalInvokeInvocation({
+            templateResourceName: nonRelevantArg,
+            templatePath: placeholderTemplateFile,
+            eventPath: placeholderEventFile,
+            environmentVariablePath: nonRelevantArg,
+            invoker: taskInvoker,
+            dockerNetwork: undefined
+        }).execute()
+    })
+
+    it('passes --skip-pull-image to sam cli if skipPullImage is true', async () => {
+        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+            assertArgIsPresent(args, '--skip-pull-image')
+        })
+
+        await new SamCliLocalInvokeInvocation({
+            templateResourceName: nonRelevantArg,
+            templatePath: placeholderTemplateFile,
+            eventPath: placeholderEventFile,
+            environmentVariablePath: nonRelevantArg,
+            invoker: taskInvoker,
+            skipPullImage: true,
+        }).execute()
+    })
+
+    it('does not pass --skip-pull-image to sam cli if skipPullImage is false', async () => {
+        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+            assertArgNotPresent(args, '--skip-pull-image')
+        })
+
+        await new SamCliLocalInvokeInvocation({
+            templateResourceName: nonRelevantArg,
+            templatePath: placeholderTemplateFile,
+            eventPath: placeholderEventFile,
+            environmentVariablePath: nonRelevantArg,
+            invoker: taskInvoker,
+            skipPullImage: false,
+        }).execute()
+    })
+
+    it('does not pass --skip-pull-image to sam cli if skipPullImage is undefined', async () => {
+        const taskInvoker: DefaultSamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
+            assertArgNotPresent(args, '--skip-pull-image')
+        })
+
+        await new SamCliLocalInvokeInvocation({
+            templateResourceName: nonRelevantArg,
+            templatePath: placeholderTemplateFile,
+            eventPath: placeholderEventFile,
+            environmentVariablePath: nonRelevantArg,
+            invoker: taskInvoker,
+            skipPullImage: undefined,
+        }).execute()
+    })
+
     function assertArgsContainArgument(
         args: any[],
         argOfInterest: string,

--- a/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
+++ b/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
@@ -74,14 +74,13 @@ describe('SamCliLocalInvokeInvocation', async () => {
             assert.strictEqual(args[1], 'invoke', 'Expected second arg to be invoke')
         })
 
-        await new SamCliLocalInvokeInvocation(
-            nonRelevantArg,
-            placeholderTemplateFile,
-            placeholderEventFile,
-            nonRelevantArg,
-            undefined,
-            taskInvoker
-        ).execute()
+        await new SamCliLocalInvokeInvocation({
+            templateResourceName: nonRelevantArg,
+            templatePath: placeholderTemplateFile,
+            eventPath: placeholderEventFile,
+            environmentVariablePath: nonRelevantArg,
+            invoker: taskInvoker
+        }).execute()
     })
 
     it('Passes template resource name to sam cli', async () => {
@@ -90,14 +89,13 @@ describe('SamCliLocalInvokeInvocation', async () => {
             assertArgIsPresent(args, expectedResourceName)
         })
 
-        await new SamCliLocalInvokeInvocation(
-            expectedResourceName,
-            placeholderTemplateFile,
-            placeholderEventFile,
-            nonRelevantArg,
-            undefined,
-            taskInvoker
-        ).execute()
+        await new SamCliLocalInvokeInvocation({
+            templateResourceName: expectedResourceName,
+            templatePath: placeholderTemplateFile,
+            eventPath: placeholderEventFile,
+            environmentVariablePath: nonRelevantArg,
+            invoker: taskInvoker
+        }).execute()
     })
 
     it('Passes template path to sam cli', async () => {
@@ -105,14 +103,13 @@ describe('SamCliLocalInvokeInvocation', async () => {
             assertArgsContainArgument(args, '--template', placeholderTemplateFile)
         })
 
-        await new SamCliLocalInvokeInvocation(
-            nonRelevantArg,
-            placeholderTemplateFile,
-            placeholderEventFile,
-            nonRelevantArg,
-            undefined,
-            taskInvoker
-        ).execute()
+        await new SamCliLocalInvokeInvocation({
+            templateResourceName: nonRelevantArg,
+            templatePath: placeholderTemplateFile,
+            eventPath: placeholderEventFile,
+            environmentVariablePath: nonRelevantArg,
+            invoker: taskInvoker
+        }).execute()
     })
 
     it('Passes event path to sam cli', async () => {
@@ -120,14 +117,13 @@ describe('SamCliLocalInvokeInvocation', async () => {
             assertArgsContainArgument(args, '--event', placeholderEventFile)
         })
 
-        await new SamCliLocalInvokeInvocation(
-            nonRelevantArg,
-            placeholderTemplateFile,
-            placeholderEventFile,
-            nonRelevantArg,
-            undefined,
-            taskInvoker
-        ).execute()
+        await new SamCliLocalInvokeInvocation({
+            templateResourceName: nonRelevantArg,
+            templatePath: placeholderTemplateFile,
+            eventPath: placeholderEventFile,
+            environmentVariablePath: nonRelevantArg,
+            invoker: taskInvoker
+        }).execute()
     })
 
     it('Passes env-vars path to sam cli', async () => {
@@ -136,14 +132,13 @@ describe('SamCliLocalInvokeInvocation', async () => {
             assertArgsContainArgument(args, '--env-vars', expectedEnvVarsPath)
         })
 
-        await new SamCliLocalInvokeInvocation(
-            nonRelevantArg,
-            placeholderTemplateFile,
-            placeholderEventFile,
-            expectedEnvVarsPath,
-            undefined,
-            taskInvoker
-        ).execute()
+        await new SamCliLocalInvokeInvocation({
+            templateResourceName: nonRelevantArg,
+            templatePath: placeholderTemplateFile,
+            eventPath: placeholderEventFile,
+            environmentVariablePath: expectedEnvVarsPath,
+            invoker: taskInvoker
+        }).execute()
     })
 
     it('Passes debug port to sam cli', async () => {
@@ -152,14 +147,14 @@ describe('SamCliLocalInvokeInvocation', async () => {
             assertArgsContainArgument(args, '-d', expectedDebugPort)
         })
 
-        await new SamCliLocalInvokeInvocation(
-            nonRelevantArg,
-            placeholderTemplateFile,
-            placeholderEventFile,
-            nonRelevantArg,
-            expectedDebugPort,
-            taskInvoker
-        ).execute()
+        await new SamCliLocalInvokeInvocation({
+            templateResourceName: nonRelevantArg,
+            templatePath: placeholderTemplateFile,
+            eventPath: placeholderEventFile,
+            environmentVariablePath: nonRelevantArg,
+            debugPort: expectedDebugPort,
+            invoker: taskInvoker
+        }).execute()
     })
 
     it('undefined debug port does not pass to sam cli', async () => {
@@ -167,14 +162,14 @@ describe('SamCliLocalInvokeInvocation', async () => {
             assertArgNotPresent(args, '-d')
         })
 
-        await new SamCliLocalInvokeInvocation(
-            nonRelevantArg,
-            placeholderTemplateFile,
-            placeholderEventFile,
-            nonRelevantArg,
-            undefined,
-            taskInvoker
-        ).execute()
+        await new SamCliLocalInvokeInvocation({
+            templateResourceName: nonRelevantArg,
+            templatePath: placeholderTemplateFile,
+            eventPath: placeholderEventFile,
+            environmentVariablePath: nonRelevantArg,
+            debugPort: undefined,
+            invoker: taskInvoker
+        }).execute()
     })
 
     function assertArgsContainArgument(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [ ] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description

<!--- Describe your changes in detail -->
This is one of the initial changes for #349 and #350 - setting up `sam local invoke` calls to support the following args:
* use-container
* docker-network
* skip-pull-image

Previous PR #355 did the same for `sam build` calls.

For now, these args are not hooked into the Toolkit. A follow-up change will integrate them, pending design for #323 (which will influence where these are configured)


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)

#349 and #350 
<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
