### PR TITLE
Fix regression where running locally does not bring up the output channel while preparing to invoke

### DIFF
--- a/src/shared/codelens/localLambdaRunner.ts
+++ b/src/shared/codelens/localLambdaRunner.ts
@@ -69,6 +69,9 @@ export class LocalLambdaRunner {
 
     public async run(): Promise<void> {
         try {
+            // Switch over to the output channel so the user has feedback that we're getting things ready
+            this.outputChannel.show(true)
+
             this.channelLogger.info(
                 'AWS.output.sam.local.start',
                 'Preparing to run {0} locally...',

--- a/src/shared/codelens/localLambdaRunner.ts
+++ b/src/shared/codelens/localLambdaRunner.ts
@@ -70,7 +70,7 @@ export class LocalLambdaRunner {
     public async run(): Promise<void> {
         try {
             // Switch over to the output channel so the user has feedback that we're getting things ready
-            this.outputChannel.show(true)
+            this.channelLogger.channel.show(true)
 
             this.channelLogger.info(
                 'AWS.output.sam.local.start',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [ ] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description

<!--- Describe your changes in detail -->
After clicking a Run/Debug CodeLens, the output channel is supposed to be shown, so the user can see that the toolkit is building and preparing to invoke the lambda locally. This PR fixes a regression to that behavior.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Ran toolkit, used run/debug Node and run Python CodeLenses
* Ran tests

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
