### PR TITLE
Allowing unbounded amount of callbackArgs for registered commands

### DIFF
--- a/src/shared/telemetry/telemetryUtils.ts
+++ b/src/shared/telemetry/telemetryUtils.ts
@@ -30,13 +30,13 @@ export function registerCommand<T>({
 }): vscode.Disposable {
     return register(
         command,
-        async (callbackArgs) => {
+        async (...callbackArgs: any[]) => {
             const startTime = new Date()
             let hasException = false
             let result: T & { datum?: Datum } | void
 
             try {
-                result = await callback(callbackArgs)
+                result = await callback(...callbackArgs)
             } catch (e) {
                 hasException = true
                 throw e


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [ ] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description
Telemetry registerCommand broke commands registered with multiple parameters.

## Motivation and Context

Bugfix

## Related Issue(s)
https://github.com/aws/aws-toolkit-vscode/issues/366

## Testing
Tests pass, manual checking works

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
