### PR TITLE
Simplify tests for SamParameterCompletionItemProvider.

### DIFF
--- a/src/test/lambda/config/samParameterCompletionItemProvider.test.ts
+++ b/src/test/lambda/config/samParameterCompletionItemProvider.test.ts
@@ -15,6 +15,65 @@ import {
 import { CloudFormation } from '../../../shared/cloudformation/cloudformation'
 import { Logger } from '../../../shared/logger'
 
+function createTemplatesSymbol({
+    uri = vscode.Uri.file(path.join('my', 'template', 'uri')),
+    includeOverrides = false,
+    parameterName
+}: {
+    uri?: vscode.Uri,
+    includeOverrides?: boolean,
+    parameterName?: string
+}) {
+    const templatesSymbol = new vscode.DocumentSymbol(
+        'templates',
+        'myDetail',
+        vscode.SymbolKind.Object,
+        new vscode.Range(0, 0, 10, 0),
+        new vscode.Range(0, 0, 0, 10)
+    )
+
+    if (!uri) {
+        return templatesSymbol
+    }
+
+    const templateSymbol = new vscode.DocumentSymbol(
+        uri.fsPath,
+        'myDetail',
+        vscode.SymbolKind.Object,
+        new vscode.Range(1, 0, 9, 0),
+        new vscode.Range(1, 0, 1, 10)
+    )
+    templatesSymbol.children.push(templateSymbol)
+
+    if (!includeOverrides) {
+        return templatesSymbol
+    }
+
+    const parameterOverridesSymbol = new vscode.DocumentSymbol(
+        'parameterOverrides',
+        'myDetail',
+        vscode.SymbolKind.Object,
+        new vscode.Range(2, 0, 8, 0),
+        new vscode.Range(2, 0, 2, 10)
+    )
+    templateSymbol.children.push(parameterOverridesSymbol)
+
+    if (!parameterName) {
+        return templatesSymbol
+    }
+
+    const parameterOverrideSymbol = new vscode.DocumentSymbol(
+        parameterName,
+        'myDetail',
+        vscode.SymbolKind.Property,
+        new vscode.Range(3, 0, 7, 0),
+        new vscode.Range(3, 0, 3, 10)
+    )
+    parameterOverridesSymbol.children.push(parameterOverrideSymbol)
+
+    return templatesSymbol
+}
+
 class MockSamParameterCompletionItemProviderContext implements SamParameterCompletionItemProviderContext {
     public readonly logger: Pick<Logger, 'warn'>
     public readonly getWorkspaceFolder: typeof vscode.workspace.getWorkspaceFolder
@@ -108,38 +167,10 @@ describe('SamParameterCompletionItemProvider', async () => {
     })
 
     it('suggests all parameter names if user has not started typing the parameter name', async () => {
-        const templatesSymbol = new vscode.DocumentSymbol(
-            'templates',
-            'myDetail',
-            vscode.SymbolKind.Object,
-            new vscode.Range(0, 0, 10, 0),
-            new vscode.Range(0, 0, 0, 10)
-        )
-        const templateSymbol = new vscode.DocumentSymbol(
-            path.join('my', 'template', 'uri'),
-            'myDetail',
-            vscode.SymbolKind.Object,
-            new vscode.Range(1, 0, 9, 0),
-            new vscode.Range(1, 0, 1, 10)
-        )
-        const parameterOverridesSymbol = new vscode.DocumentSymbol(
-            'parameterOverrides',
-            'myDetail',
-            vscode.SymbolKind.Object,
-            new vscode.Range(2, 0, 8, 0),
-            new vscode.Range(2, 0, 2, 10)
-        )
-        const parameterOverrideSymbol = new vscode.DocumentSymbol(
-            'myParamName',
-            'myDetail',
-            vscode.SymbolKind.Property,
-            new vscode.Range(3, 0, 7, 0),
-            new vscode.Range(3, 0, 3, 10)
-        )
-
-        parameterOverridesSymbol.children.push(parameterOverrideSymbol)
-        templateSymbol.children.push(parameterOverridesSymbol)
-        templatesSymbol.children.push(templateSymbol)
+        const templatesSymbol = createTemplatesSymbol({
+            includeOverrides: true,
+            parameterName: 'myParamName'
+        })
 
         const provider = new SamParameterCompletionItemProvider(new MockSamParameterCompletionItemProviderContext({
             executeCommand: async <T>() => [ templatesSymbol ] as any as T,
@@ -176,38 +207,10 @@ describe('SamParameterCompletionItemProvider', async () => {
     })
 
     it('suggests only matching parameter names if user has started typing the parameter name', async () => {
-        const templatesSymbol = new vscode.DocumentSymbol(
-            'templates',
-            'myDetail',
-            vscode.SymbolKind.Object,
-            new vscode.Range(0, 0, 10, 0),
-            new vscode.Range(0, 0, 0, 10)
-        )
-        const templateSymbol = new vscode.DocumentSymbol(
-            vscode.Uri.file(path.join('my', 'template', 'uri')).fsPath,
-            'myDetail',
-            vscode.SymbolKind.Object,
-            new vscode.Range(1, 0, 9, 0),
-            new vscode.Range(1, 0, 1, 10)
-        )
-        const parameterOverridesSymbol = new vscode.DocumentSymbol(
-            'parameterOverrides',
-            'myDetail',
-            vscode.SymbolKind.Object,
-            new vscode.Range(2, 0, 8, 0),
-            new vscode.Range(2, 0, 2, 10)
-        )
-        const parameterOverrideSymbol = new vscode.DocumentSymbol(
-            'MyParamName',
-            'myDetail',
-            vscode.SymbolKind.Property,
-            new vscode.Range(3, 0, 7, 0),
-            new vscode.Range(3, 0, 3, 10)
-        )
-
-        parameterOverridesSymbol.children.push(parameterOverrideSymbol)
-        templateSymbol.children.push(parameterOverridesSymbol)
-        templatesSymbol.children.push(templateSymbol)
+        const templatesSymbol = createTemplatesSymbol({
+            includeOverrides: true,
+            parameterName: 'myParamName'
+        })
 
         const provider = new SamParameterCompletionItemProvider(new MockSamParameterCompletionItemProviderContext({
             executeCommand: async <T>() => [ templatesSymbol ] as any as T,
@@ -264,38 +267,10 @@ describe('SamParameterCompletionItemProvider', async () => {
     })
 
     it('recovers gracefully if cursor is not within the `templates` property', async () => {
-        const templatesSymbol = new vscode.DocumentSymbol(
-            'templates',
-            'myDetail',
-            vscode.SymbolKind.Object,
-            new vscode.Range(0, 0, 10, 0),
-            new vscode.Range(0, 0, 0, 10)
-        )
-        const templateSymbol = new vscode.DocumentSymbol(
-            path.join('my', 'template', 'uri'),
-            'myDetail',
-            vscode.SymbolKind.Object,
-            new vscode.Range(1, 0, 9, 0),
-            new vscode.Range(1, 0, 1, 10)
-        )
-        const parameterOverridesSymbol = new vscode.DocumentSymbol(
-            'parameterOverrides',
-            'myDetail',
-            vscode.SymbolKind.Object,
-            new vscode.Range(2, 0, 8, 0),
-            new vscode.Range(2, 0, 2, 10)
-        )
-        const parameterOverrideSymbol = new vscode.DocumentSymbol(
-            'MyParamName',
-            'myDetail',
-            vscode.SymbolKind.Property,
-            new vscode.Range(3, 0, 7, 0),
-            new vscode.Range(3, 0, 3, 10)
-        )
-
-        parameterOverridesSymbol.children.push(parameterOverrideSymbol)
-        templateSymbol.children.push(parameterOverridesSymbol)
-        templatesSymbol.children.push(templateSymbol)
+        const templatesSymbol = createTemplatesSymbol({
+            includeOverrides: true,
+            parameterName: 'myParamName'
+        })
 
         const provider = new SamParameterCompletionItemProvider(new MockSamParameterCompletionItemProviderContext({
             executeCommand: async <T>() => [ templatesSymbol ] as any as T,
@@ -333,23 +308,7 @@ describe('SamParameterCompletionItemProvider', async () => {
     })
 
     it('recovers gracefully if `parameterOverrides` is not defined for this template', async () => {
-        const templatesSymbol = new vscode.DocumentSymbol(
-            'templates',
-            'myDetail',
-            vscode.SymbolKind.Object,
-            new vscode.Range(0, 0, 10, 0),
-            new vscode.Range(0, 0, 0, 10)
-        )
-        const templateSymbol = new vscode.DocumentSymbol(
-            path.join('my', 'template', 'uri'),
-            'myDetail',
-            vscode.SymbolKind.Object,
-            new vscode.Range(1, 0, 9, 0),
-            new vscode.Range(1, 0, 1, 10)
-        )
-
-        templatesSymbol.children.push(templateSymbol)
-
+        const templatesSymbol = createTemplatesSymbol({})
         const provider = new SamParameterCompletionItemProvider(new MockSamParameterCompletionItemProviderContext({
             executeCommand: async <T>() => [ templatesSymbol ] as any as T,
             getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
@@ -386,38 +345,10 @@ describe('SamParameterCompletionItemProvider', async () => {
     })
 
     it('recovers gracefully if cursor is not within the `parameterOverrides` property', async () => {
-        const templatesSymbol = new vscode.DocumentSymbol(
-            'templates',
-            'myDetail',
-            vscode.SymbolKind.Object,
-            new vscode.Range(0, 0, 10, 0),
-            new vscode.Range(0, 0, 0, 10)
-        )
-        const templateSymbol = new vscode.DocumentSymbol(
-            path.join('my', 'template', 'uri'),
-            'myDetail',
-            vscode.SymbolKind.Object,
-            new vscode.Range(1, 0, 9, 0),
-            new vscode.Range(1, 0, 1, 10)
-        )
-        const parameterOverridesSymbol = new vscode.DocumentSymbol(
-            'parameterOverrides',
-            'myDetail',
-            vscode.SymbolKind.Object,
-            new vscode.Range(2, 0, 8, 0),
-            new vscode.Range(2, 0, 2, 10)
-        )
-        const parameterOverrideSymbol = new vscode.DocumentSymbol(
-            'MyParamName',
-            'myDetail',
-            vscode.SymbolKind.Property,
-            new vscode.Range(3, 0, 7, 0),
-            new vscode.Range(3, 0, 3, 10)
-        )
-
-        parameterOverridesSymbol.children.push(parameterOverrideSymbol)
-        templateSymbol.children.push(parameterOverridesSymbol)
-        templatesSymbol.children.push(templateSymbol)
+        const templatesSymbol = createTemplatesSymbol({
+            includeOverrides: true,
+            parameterName: 'myParamName'
+        })
 
         const provider = new SamParameterCompletionItemProvider(new MockSamParameterCompletionItemProviderContext({
             executeCommand: async <T>() => [ templatesSymbol ] as any as T,
@@ -455,38 +386,10 @@ describe('SamParameterCompletionItemProvider', async () => {
     })
 
     it('recovers gracefully if cursor is not within a property name within `parameterOverrides`', async () => {
-        const templatesSymbol = new vscode.DocumentSymbol(
-            'templates',
-            'myDetail',
-            vscode.SymbolKind.Object,
-            new vscode.Range(0, 0, 10, 0),
-            new vscode.Range(0, 0, 0, 10)
-        )
-        const templateSymbol = new vscode.DocumentSymbol(
-            path.join('my', 'template', 'uri'),
-            'myDetail',
-            vscode.SymbolKind.Object,
-            new vscode.Range(1, 0, 9, 0),
-            new vscode.Range(1, 0, 1, 10)
-        )
-        const parameterOverridesSymbol = new vscode.DocumentSymbol(
-            'parameterOverrides',
-            'myDetail',
-            vscode.SymbolKind.Object,
-            new vscode.Range(2, 0, 8, 0),
-            new vscode.Range(2, 0, 2, 10)
-        )
-        const parameterOverrideSymbol = new vscode.DocumentSymbol(
-            'MyParamName',
-            'myDetail',
-            vscode.SymbolKind.Property,
-            new vscode.Range(3, 0, 7, 0),
-            new vscode.Range(3, 0, 3, 10)
-        )
-
-        parameterOverridesSymbol.children.push(parameterOverrideSymbol)
-        templateSymbol.children.push(parameterOverridesSymbol)
-        templatesSymbol.children.push(templateSymbol)
+        const templatesSymbol = createTemplatesSymbol({
+            includeOverrides: true,
+            parameterName: 'myParamName'
+        })
 
         const provider = new SamParameterCompletionItemProvider(new MockSamParameterCompletionItemProviderContext({
             executeCommand: async <T>() => [ templatesSymbol ] as any as T,


### PR DESCRIPTION
## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [x] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description

Consolidate test symbol creation into a helper function, which shortens and simplifies test code.

## Motivation and Context

These tests contain a lot of identical boilerplate. This makes it hard to pick out the relevant bits while reading/debugging tests.

## Related Issue(s)

#331

## Checklist

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
