### PR TITLE
Removed useContainer from sam local invoke calls, it isn't supported there

### DIFF
--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -35,11 +35,6 @@ export interface SamCliLocalInvokeInvocationArguments {
      */
     invoker: SamCliTaskInvoker,
     /**
-     * If your functions depend on packages that have natively compiled dependencies,
-     * use this flag to build your function inside an AWS Lambda-like Docker container.
-     */
-    useContainer?: boolean,
-    /**
      * Specifies the name or id of an existing Docker network to Lambda Docker containers should connect to,
      * along with the default bridge network.
      * If not specified, the Lambda containers will only connect to the default bridge Docker network.
@@ -58,19 +53,16 @@ export class SamCliLocalInvokeInvocation {
     private readonly environmentVariablePath: string
     private readonly debugPort?: string
     private readonly invoker: SamCliTaskInvoker
-    private readonly useContainer: boolean
     private readonly dockerNetwork?: string
     private readonly skipPullImage: boolean
 
     /**
      * @see SamCliLocalInvokeInvocationArguments for parameter info
      * invoker - Defaults to DefaultSamCliTaskInvoker
-     * useContainer - Defaults to false (function will be built on local machine instead of in a docker image)
      * skipPullImage - Defaults to false (the latest Docker image will be pulled down if necessary)
      */
     public constructor({
         invoker = new DefaultSamCliTaskInvoker(),
-        useContainer = false,
         skipPullImage = false,
         ...params
     }: SamCliLocalInvokeInvocationArguments
@@ -81,7 +73,6 @@ export class SamCliLocalInvokeInvocation {
         this.environmentVariablePath = params.environmentVariablePath
         this.debugPort = params.debugPort
         this.invoker = invoker
-        this.useContainer = useContainer
         this.dockerNetwork = params.dockerNetwork
         this.skipPullImage = skipPullImage
     }
@@ -103,7 +94,6 @@ export class SamCliLocalInvokeInvocation {
 
         this.addArgumentIf(args, !!this.debugPort, '-d', this.debugPort!)
         this.addArgumentIf(args, !!this.dockerNetwork, '--docker-network', this.dockerNetwork!)
-        this.addArgumentIf(args, !!this.useContainer, '--use-container')
         this.addArgumentIf(args, !!this.skipPullImage, '--skip-pull-image')
 
         const execution = new vscode.ShellExecution('sam', args)

--- a/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
+++ b/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
@@ -172,51 +172,6 @@ describe('SamCliLocalInvokeInvocation', async () => {
         }).execute()
     })
 
-    it('passes --use-container to sam cli if useContainer is true', async () => {
-        const taskInvoker: SamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
-            assertArgIsPresent(args, '--use-container')
-        })
-
-        await new SamCliLocalInvokeInvocation({
-            templateResourceName: nonRelevantArg,
-            templatePath: placeholderTemplateFile,
-            eventPath: placeholderEventFile,
-            environmentVariablePath: nonRelevantArg,
-            invoker: taskInvoker,
-            useContainer: true,
-        }).execute()
-    })
-
-    it('does not pass --use-container to sam cli if useContainer is false', async () => {
-        const taskInvoker: SamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
-            assertArgNotPresent(args, '--use-container')
-        })
-
-        await new SamCliLocalInvokeInvocation({
-            templateResourceName: nonRelevantArg,
-            templatePath: placeholderTemplateFile,
-            eventPath: placeholderEventFile,
-            environmentVariablePath: nonRelevantArg,
-            invoker: taskInvoker,
-            useContainer: false,
-        }).execute()
-    })
-
-    it('does not pass --use-container to sam cli if useContainer is undefined', async () => {
-        const taskInvoker: SamCliTaskInvoker = new TestTaskInvoker((args: any[]) => {
-            assertArgNotPresent(args, '--use-container')
-        })
-
-        await new SamCliLocalInvokeInvocation({
-            templateResourceName: nonRelevantArg,
-            templatePath: placeholderTemplateFile,
-            eventPath: placeholderEventFile,
-            environmentVariablePath: nonRelevantArg,
-            invoker: taskInvoker,
-            useContainer: undefined,
-        }).execute()
-    })
-
     it('Passes docker network to sam cli', async () => {
         const expectedDockerNetwork = 'hello-world'
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [ ] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description

<!--- Describe your changes in detail -->
use-container is not supported by calls to `sam local invoke`. This change removes support for this option from the sam local invoke wrapping code.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Unit Tests
* locally ran/debugged a node function

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
