### PR TITLE
Creates the .aws dir if it doesn't already exist

### DIFF
--- a/src/shared/credentials/userCredentialsUtils.ts
+++ b/src/shared/credentials/userCredentialsUtils.ts
@@ -80,7 +80,7 @@ export class UserCredentialsUtils {
     public static async generateCredentialDirectoryIfNonexistent(): Promise<void> {
         const filepath = path.dirname(this.getCredentialsFilename())
         if (!await fileExists(filepath)) {
-            await mkdir(filepath)
+            await mkdir(filepath, { recursive: true })
         }
     }
 

--- a/src/shared/credentials/userCredentialsUtils.ts
+++ b/src/shared/credentials/userCredentialsUtils.ts
@@ -11,8 +11,8 @@ import * as path from 'path'
 import { STS } from 'aws-sdk'
 import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
 import { EnvironmentVariables } from '../environmentVariables'
-import { writeFile } from '../filesystem'
-import { readFileAsString } from '../filesystemUtilities'
+import { mkdir, writeFile } from '../filesystem'
+import { fileExists, readFileAsString } from '../filesystemUtilities'
 import { getLogger, Logger } from '../logger'
 import { SystemUtilities } from '../systemUtilities'
 
@@ -70,6 +70,18 @@ export class UserCredentialsUtils {
 
         return env.AWS_CONFIG_FILE
             || path.join(SystemUtilities.getHomeDirectory(), '.aws', 'config')
+    }
+
+    /**
+     * @description Determines if credentials directory exists
+     * If it doesn't, creates credentials directory at:
+     * path.join(SystemUtilities.getHomeDirectory(), '.aws')
+     */
+    public static async generateCredentialDirectoryIfNonexistent(): Promise<void> {
+        const filepath = path.join(SystemUtilities.getHomeDirectory(), '.aws')
+        if (!await fileExists(filepath)) {
+            await mkdir(filepath)
+        }
     }
 
     /**

--- a/src/shared/credentials/userCredentialsUtils.ts
+++ b/src/shared/credentials/userCredentialsUtils.ts
@@ -74,11 +74,11 @@ export class UserCredentialsUtils {
 
     /**
      * @description Determines if credentials directory exists
-     * If it doesn't, creates credentials directory at:
-     * path.join(SystemUtilities.getHomeDirectory(), '.aws')
+     * If it doesn't, creates credentials directory
+     * at directory from this.getCredentialsFilename()
      */
     public static async generateCredentialDirectoryIfNonexistent(): Promise<void> {
-        const filepath = path.join(SystemUtilities.getHomeDirectory(), '.aws')
+        const filepath = path.dirname(this.getCredentialsFilename())
         if (!await fileExists(filepath)) {
             await mkdir(filepath)
         }

--- a/src/shared/defaultAwsContextCommands.ts
+++ b/src/shared/defaultAwsContextCommands.ts
@@ -157,6 +157,7 @@ export class DefaultAWSContextCommands {
             )
 
             if (validationResult.isValid) {
+                await UserCredentialsUtils.generateCredentialDirectoryIfNonexistent()
                 await UserCredentialsUtils.generateCredentialsFile(
                     ext.context.extensionPath,
                     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [ ] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description
We now create the `~/.aws` dir if it doesn't exist

## Motivation and Context
Users who didn't have this directory were getting blocked from adding credentials via our wizard

## Related Issue(s)
N/A

## Testing
Manual testing (ran wizard with no `~/.aws` directory and with an empty `~/.aws` directory, the two cases that pop the credential addition wizard.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
