### PR TITLE
Removing onWillAttachDebugger - it is no longer used

### DIFF
--- a/src/shared/codelens/localLambdaRunner.ts
+++ b/src/shared/codelens/localLambdaRunner.ts
@@ -73,7 +73,6 @@ export class LocalLambdaRunner {
         private readonly codeRootDirectoryPath: string,
         private readonly telemetryService: TelemetryService,
         private readonly onDidSamBuild?: (params: OnDidSamBuildParams) => Promise<void>,
-        private readonly onWillAttachDebugger?: () => Promise<void>,
         private readonly channelLogger = getChannelLogger(outputChannel),
     ) {
         if (localInvokeParams.isDebug && !debugPort) {
@@ -261,10 +260,6 @@ export class LocalLambdaRunner {
                 configuration: this.configuration,
                 channelLogger: this.channelLogger
             })
-
-            if (this.onWillAttachDebugger) {
-                await this.onWillAttachDebugger()
-            }
 
             await attachDebugger({
                 debugConfig: this.debugConfig,
@@ -463,7 +458,6 @@ export const invokeLambdaFunction = async (params: {
     samTaskInvoker: SamCliTaskInvoker,
     telemetryService: TelemetryService,
     runtime: string,
-    onWillAttachDebugger?(): Promise<void>,
 }): Promise<void> => {
     params.channelLogger.info(
         'AWS.output.starting.sam.app.locally',
@@ -518,10 +512,6 @@ export const invokeLambdaFunction = async (params: {
             configuration: params.configuration,
             channelLogger: params.channelLogger
         })
-
-        if (params.onWillAttachDebugger) {
-            await params.onWillAttachDebugger()
-        }
 
         await attachDebugger({
             debugConfig: params.debugConfig,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [x] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description

<!--- Describe your changes in detail -->
Removed `onWillAttachDebugger` now that attach debugger `onWillRetry` is in place

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
