### PR TITLE
Remember selections for sam deploy wizzard

### DIFF
--- a/src/shared/utilities/projectDefaults.ts
+++ b/src/shared/utilities/projectDefaults.ts
@@ -1,0 +1,87 @@
+/*!
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+import * as path from 'path'
+import { mkdir, writeFile } from '../filesystem'
+import { fileExists } from '../filesystemUtilities'
+
+export interface SamDeployDefaults {
+    region?: string
+    s3BucketName?: string
+    stackName?: string
+}
+
+export interface AllDafaults {
+    samDeploy: {
+        [samTemplatePath: string]: SamDeployDefaults
+    }
+}
+
+export interface ProjectDefaultsManager {
+    readonly filePath: string
+    refresh(): void
+    getAllDefaults(): AllDafaults
+    save(): Promise<void>
+    setSamDeployDefaults(params: SamDeployDefaults): Promise<void>
+    getSamDeployDefaults(): SamDeployDefaults | undefined
+}
+
+export function makeProjectDefaultsManager({samTemplatePath}: {
+    samTemplatePath: string
+}): ProjectDefaultsManager {
+    let allDefaults: AllDafaults
+    const samProjectDir = path.dirname(samTemplatePath)
+    const filePath = path.resolve(samProjectDir, '.aws-toolkit-vscode/user-prefs.json')
+    const prefsDir = path.dirname(filePath)
+    const save = async () => {
+        if (!await fileExists(prefsDir)) {
+            await mkdir(prefsDir)
+        }
+        await writeFile(filePath, JSON.stringify(allDefaults, undefined, 2) )
+    }
+
+    const getAllDefaults = (): AllDafaults => { // Mostly for testing
+        return Object.freeze(allDefaults)
+    }
+
+    const getSamDeployDefaults = (): SamDeployDefaults | undefined => {
+        return allDefaults.samDeploy[samTemplatePath]
+    }
+
+    const setSamDeployDefaults = async (params: SamDeployDefaults) => {
+        const priorDefaults = getSamDeployDefaults()
+        const mergedParams: SamDeployDefaults = {
+            ...priorDefaults,
+            ...params
+        }
+        if (JSON.stringify(mergedParams) !== JSON.stringify(priorDefaults)) {
+            allDefaults.samDeploy[samTemplatePath] = mergedParams
+            await save()
+        }
+    }
+
+    const refresh = () => {
+        try {
+            allDefaults = require(filePath)
+        } catch (err) {
+            allDefaults = {
+                samDeploy: {}
+            }
+        }
+    }
+    const mgr: ProjectDefaultsManager = {
+        filePath,
+        getAllDefaults,
+        getSamDeployDefaults,
+        setSamDeployDefaults,
+        refresh,
+        save,
+    }
+    mgr.refresh() // initialize from persistent store
+
+    return mgr
+}

--- a/src/shared/utilities/projectDefaults.ts
+++ b/src/shared/utilities/projectDefaults.ts
@@ -15,7 +15,7 @@ export interface SamDeployDefaults {
     stackName?: string
 }
 
-export interface AllDafaults {
+export interface AllDefaults {
     samDeploy: {
         [samTemplatePath: string]: SamDeployDefaults
     }
@@ -24,7 +24,7 @@ export interface AllDafaults {
 export interface ProjectDefaultsManager {
     readonly filePath: string
     refresh(): void
-    getAllDefaults(): AllDafaults
+    getAllDefaults(): AllDefaults
     save(): Promise<void>
     setSamDeployDefaults(params: SamDeployDefaults): Promise<void>
     getSamDeployDefaults(): SamDeployDefaults | undefined
@@ -33,7 +33,7 @@ export interface ProjectDefaultsManager {
 export function makeProjectDefaultsManager({samTemplatePath}: {
     samTemplatePath: string
 }): ProjectDefaultsManager {
-    let allDefaults: AllDafaults
+    let allDefaults: AllDefaults
     const samProjectDir = path.dirname(samTemplatePath)
     const filePath = path.resolve(samProjectDir, '.aws-toolkit-vscode/user-prefs.json')
     const prefsDir = path.dirname(filePath)
@@ -44,7 +44,7 @@ export function makeProjectDefaultsManager({samTemplatePath}: {
         await writeFile(filePath, JSON.stringify(allDefaults, undefined, 2) )
     }
 
-    const getAllDefaults = (): AllDafaults => { // Mostly for testing
+    const getAllDefaults = (): AllDefaults => { // Mostly for testing
         return Object.freeze(allDefaults)
     }
 
@@ -66,7 +66,7 @@ export function makeProjectDefaultsManager({samTemplatePath}: {
 
     const refresh = () => {
         try {
-            allDefaults = require(filePath)
+            allDefaults = require(filePath) as AllDefaults
         } catch (err) {
             allDefaults = {
                 samDeploy: {}

--- a/src/test/shared/utilities/projectDefaults.test.ts
+++ b/src/test/shared/utilities/projectDefaults.test.ts
@@ -8,7 +8,7 @@
 import * as assert from 'assert'
 import * as path from 'path'
 import {
-    AllDafaults,
+    AllDefaults,
     makeProjectDefaultsManager,
     ProjectDefaultsManager,
     SamDeployDefaults,
@@ -37,7 +37,7 @@ describe('ProjectDefaultsManager', () => {
     it('should have proper initial defaults', () => {
         const defaultsMgr: ProjectDefaultsManager = makeProjectDefaultsManager({samTemplatePath})
         const allDefaults = defaultsMgr.getAllDefaults()
-        const expectedVal: AllDafaults = {
+        const expectedVal: AllDefaults = {
             samDeploy: {}
         }
         assert.deepStrictEqual(

--- a/src/test/shared/utilities/projectDefaults.test.ts
+++ b/src/test/shared/utilities/projectDefaults.test.ts
@@ -17,7 +17,7 @@ import {
 import { readFile, writeFile } from '../../../shared/filesystem'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 
-describe.only('ProjectDefaultsManager', () => {
+describe('ProjectDefaultsManager', () => {
     let samProjectDir: string
     let samTemplatePath: string
     let expectedSamDeployDefaults: SamDeployDefaults

--- a/src/test/shared/utilities/projectDefaults.test.ts
+++ b/src/test/shared/utilities/projectDefaults.test.ts
@@ -1,0 +1,153 @@
+/*!
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+import * as assert from 'assert'
+import * as path from 'path'
+import {
+    AllDafaults,
+    makeProjectDefaultsManager,
+    ProjectDefaultsManager,
+    SamDeployDefaults,
+} from '../../../shared/utilities/projectDefaults'
+
+import { readFile, writeFile } from '../../../shared/filesystem'
+import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
+
+describe.only('ProjectDefaultsManager', () => {
+    let samProjectDir: string
+    let samTemplatePath: string
+    let expectedSamDeployDefaults: SamDeployDefaults
+
+    before(async () => {
+        samProjectDir = await makeTemporaryToolkitFolder()
+        samTemplatePath = path.join(samProjectDir, 'template.yaml')
+        await writeFile(samTemplatePath, samTemplateText)
+        expectedSamDeployDefaults = {
+            region: 'us-west-2',
+            s3BucketName: 'ma-bucket',
+            // samTemplatePath,
+            stackName: 'ma-stack'
+        }
+    })
+
+    it('should have proper initial defaults', () => {
+        const defaultsMgr: ProjectDefaultsManager = makeProjectDefaultsManager({samTemplatePath})
+        const allDefaults = defaultsMgr.getAllDefaults()
+        const expectedVal: AllDafaults = {
+            samDeploy: {}
+        }
+        assert.deepStrictEqual(
+            allDefaults,
+            expectedVal,
+        )
+    })
+
+    it('should properly get, set and persist to file', async () => {
+        const defaultsMgr: ProjectDefaultsManager = makeProjectDefaultsManager({samTemplatePath})
+
+        await defaultsMgr.setSamDeployDefaults(expectedSamDeployDefaults)
+        const actualSamDeplyDefaults = defaultsMgr.getSamDeployDefaults()
+
+        assert.deepStrictEqual(
+            expectedSamDeployDefaults,
+            actualSamDeplyDefaults,
+            `getSamDeployDefaults: ${JSON.stringify({expectedSamDeployDefaults, actualSamDeplyDefaults})}`
+        )
+        const expectedDataFromFile = {
+            samDeploy: {
+                [samTemplatePath]: expectedSamDeployDefaults
+            }
+        }
+        const actualDataFromFile = await readFile(defaultsMgr.filePath)
+        assert.deepStrictEqual(
+            expectedSamDeployDefaults,
+            actualSamDeplyDefaults,
+            `readFile: ${JSON.stringify({expectedDataFromFile, actualDataFromFile})}`
+        )
+    })
+
+    it('should load previously saved values', async () => {
+        const defaultsMgr: ProjectDefaultsManager = makeProjectDefaultsManager({samTemplatePath})
+        const expectedDataFromFile = {
+            samDeploy: {
+                [samTemplatePath]: expectedSamDeployDefaults
+            }
+        }
+        const actualDataFromFile = defaultsMgr.getAllDefaults()
+        assert.deepStrictEqual(
+            expectedDataFromFile,
+            actualDataFromFile,
+            `readFile: ${JSON.stringify({expectedDataFromFile, actualDataFromFile})}`
+        )
+    })
+
+    it('should merge previous values with newly added', async () => {
+        const defaultsMgr: ProjectDefaultsManager = makeProjectDefaultsManager({samTemplatePath})
+        const newDefaultsToMerge: SamDeployDefaults = {
+            s3BucketName: 'newBucketName'
+        }
+        const expectedResult: SamDeployDefaults = {
+            ...defaultsMgr.getSamDeployDefaults(),
+            ...newDefaultsToMerge,
+        }
+        await defaultsMgr.setSamDeployDefaults(newDefaultsToMerge)
+        const actualResult = defaultsMgr.getSamDeployDefaults()
+        assert.deepStrictEqual(
+            expectedResult,
+            actualResult,
+            JSON.stringify({expectedResult, actualResult})
+        )
+
+        const actualDataFromFile = JSON.parse(String(await readFile(defaultsMgr.filePath)))
+        const expectedDataFromFile = defaultsMgr.getAllDefaults()
+        assert.deepStrictEqual(
+            expectedDataFromFile,
+            actualDataFromFile,
+            `readFile: ${JSON.stringify({expectedDataFromFile, actualDataFromFile})}`
+        )
+    })
+})
+
+const samTemplateText = `# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+ python-debugging2.1_01
+
+ Sample SAM Template for python-debugging2.1_01
+
+Globals:
+ Function:
+   Timeout: 3
+
+Resources:
+ HelloWorldFunction:
+   Type: AWS::Serverless::Function
+   Properties:
+     CodeUri: hello_world/
+     Handler: app.lambda_handler
+     Runtime: python2.7
+     Events:
+       HelloWorld:
+         Type: Api
+         Properties:
+           Path: /hello
+           Method: get
+
+Outputs:
+HelloWorldApi:
+   Description: "API Gateway endpoint URL for Prod stage for Hello World function"
+   Value: !Sub "https://\${ServerlessRestApi}.execute-api.\${AWS::Region}.amazonaws.com/Prod/hello/"
+ HelloWorldFunction:
+   Description: "Hello World Lambda Function ARN"
+   Value: !GetAtt HelloWorldFunction.Arn
+ HelloWorldFunctionIamRole:
+   Description: "Implicit IAM Role created for Hello World function"
+   Value: !GetAtt HelloWorldFunctionRole.Arn
+`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [ ] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description

After a user deploys a SAM template, the wizard should remember the selections they specified and use them as defaults. The deployment workflow doesn't change. User can accept the defaults or specify different value at each step in the deployment process. Defaults are stored in hidden directory in their SAM project folder named `.aws-toolkit-vscode` similar to and in the same directory as SAM's own `.aws-sam`. 

```
const filePath = path.resolve(samProjectDir, '.aws-toolkit-vscode/user-prefs.json')
```

## Motivation and Context

Improve user-friendliness.

## Related Issue(s)

https://github.com/aws/aws-toolkit-vscode/issues/310

## Testing

Created new unit tests for `ProjectDefaultsManager`

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
