### PR TITLE
Select handler when initializing C# project

### DIFF
--- a/src/lambda/utilities/getMainSourceFile.ts
+++ b/src/lambda/utilities/getMainSourceFile.ts
@@ -93,6 +93,8 @@ async function getSourceFileUri({
             return await getNodeSourceFileUri({ root, resource, fileExists })
         case SamLambdaRuntimeFamily.Python:
             return await getPythonSourceFileUri({ root, resource, fileExists })
+        case SamLambdaRuntimeFamily.DotNet:
+            return await getDotnetSourceFileUri({ root, resource, fileExists })
         default:
             throw new Error(`Lambda resource '${Handler}' has unknown runtime '${Runtime}'`)
 
@@ -145,4 +147,22 @@ async function getPythonSourceFileUri({
     }
 
     throw new Error(`Python file expected at ${basePath}.py, but no file was found`)
+}
+
+async function getDotnetSourceFileUri({
+    fileExists,
+    root,
+    resource,
+}: Pick<OpenMainSourceFileUriContext, 'fileExists'> & {
+    root: vscode.Uri,
+    resource: CloudFormation.Resource
+}): Promise<vscode.Uri> {
+    const handler = resource.Properties!.Handler
+    const [packageName] = handler.split('::')
+    const handlerFilePath = path.join(root.fsPath, 'src', packageName, 'Program.cs')
+    if (await fileExists(handlerFilePath)) {
+        return vscode.Uri.file(handlerFilePath)
+    }
+
+    throw new Error(`C# file expected at ${handlerFilePath}, but no file was found`)
 }

--- a/src/test/lambda/utilities/getMainSourceFile.test.ts
+++ b/src/test/lambda/utilities/getMainSourceFile.test.ts
@@ -15,7 +15,7 @@ import { getMainSourceFileUri } from '../../../lambda/utilities/getMainSourceFil
 import { CloudFormation } from '../../../shared/cloudformation/cloudformation'
 
 async function* toAsyncIterable<T>(array: T[]): AsyncIterable<T> {
-    yield *array
+    yield* array
 }
 
 describe('getMainSourceFile', async () => {
@@ -65,7 +65,7 @@ describe('getMainSourceFile', async () => {
             await getMainSourceFileUri({
                 root: vscode.Uri.file('/dir'),
                 getLocalTemplates: (...workspaceUris: vscode.Uri[]) => toAsyncIterable([templateUri]),
-                loadSamTemplate: async uri =>  ({
+                loadSamTemplate: async uri => ({
                     Resources: {
                         HelloWorld: {
                             Type: 'AWS::Serverless:NotAFunction'
@@ -317,7 +317,8 @@ describe('getMainSourceFile', async () => {
             await test('python')
             await test('python2.7')
             await test('python3.6')
-       })
+            await test('python3.7')
+        })
 
         it('fails when no source file is found at the expected location', async () => {
             try {
@@ -334,6 +335,83 @@ describe('getMainSourceFile', async () => {
                 assert.strictEqual(
                     String(err),
                     `Error: Python file expected at ${expectedBasePath}.py, but no file was found`
+                )
+
+                return
+            }
+
+            assert.fail('Expected an exception, but none was thrown.')
+        })
+    })
+
+    describe('dotnet', async () => {
+        function createTestTemplate(): CloudFormation.Template {
+            return {
+                Resources: {
+                    HelloWorld: {
+                        Type: 'AWS::Serverless::Function',
+                        Properties: {
+                            Handler: 'HelloWorld::HelloWorld.Function::FunctionHandler',
+                            CodeUri: './artifacts/HelloWorld.zip',
+                            Runtime: 'dotnet'
+                        }
+                    }
+                }
+            }
+        }
+        const expectedHandlerPath = path.join(path.sep, 'dir', 'src', 'HelloWorld', 'Program.cs')
+        it('returns the URI of the main source file for a valid template', async () => {
+            const actual: vscode.Uri = await getMainSourceFileUri({
+                root: vscode.Uri.file('/dir'),
+                getLocalTemplates: (...workspaceUris: vscode.Uri[]) => toAsyncIterable([
+                    vscode.Uri.file('/dir/template.yaml')
+                ]),
+                loadSamTemplate: async uri => createTestTemplate(),
+                fileExists: async p => path.extname(p) === '.cs'
+            })
+
+            assert.strictEqual(actual.fsPath, expectedHandlerPath)
+        })
+
+        it('recognizes all Dotnet runtimes', async () => {
+            async function test(runtime?: string): Promise<void> {
+                const templateUri = vscode.Uri.file(path.join('/dir', 'template.yaml'))
+                const actual: vscode.Uri = await getMainSourceFileUri({
+                    root: vscode.Uri.file('/dir'),
+                    getLocalTemplates: (...workspaceUris: vscode.Uri[]) => toAsyncIterable([templateUri]),
+                    loadSamTemplate: async uri => {
+                        const template = createTestTemplate()
+                        template.Resources!.HelloWorld!.Properties!.Runtime = runtime
+
+                        return template
+                    },
+                    fileExists: async p => path.extname(p) === '.cs'
+                })
+
+                assert.strictEqual(actual.fsPath, expectedHandlerPath)
+            }
+
+            await test('dotnet')
+            await test('dotnetcore1.0')
+            await test('dotnetcore2.0')
+            await test('dotnetcore2.1')
+        })
+
+        it('fails when no source file is found at the expected location', async () => {
+            try {
+                await getMainSourceFileUri({
+                    root: vscode.Uri.file('/dir'),
+                    getLocalTemplates: (...workspaceUris: vscode.Uri[]) => toAsyncIterable([
+                        vscode.Uri.file('/dir/template.yaml')
+                    ]),
+                    loadSamTemplate: async uri => createTestTemplate(),
+                    fileExists: async p => false
+                })
+            } catch (err) {
+                // const expectedBasePath = path.join('/dir', 'my_app', 'app')
+                assert.strictEqual(
+                    String(err),
+                    `Error: C# file expected at ${expectedHandlerPath}, but no file was found`
                 )
 
                 return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [ ] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description

When a new C# project is initialized,  the handler file should be opened for editing.


## Related Issue(s)

https://github.com/aws/aws-toolkit-vscode/issues/288

## Testing

Tested `getMainSourceFileUri` for Dotnet projects

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
