### PR TITLE
Prevent AWS Explorer context menu items from getting added to other extension/view menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the "aws-vscode-tools" extension will be documented in th
 ## NEXT (Developer Preview)
 
 * Local Run/Debug of SAM Lambda Functions now outputs to the Output and Debug Console, and reduces timing issues for attaching the debugger
+* The AWS Explorer menu items no longer appear on other VS Code panel menus
 
 ## 0.1.1 (Developer Preview)
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "onCommand:aws.logout",
         "onCommand:aws.showRegion",
         "onCommand:aws.hideRegion",
-        "onView:lambda",
+        "onView:aws.explorer",
         "onCommand:aws.deploySamApplication",
         "onCommand:aws.samcli.detect",
         "onCommand:aws.samcli.validate.version",
@@ -120,7 +120,7 @@
         "views": {
             "aws-explorer": [
                 {
-                    "id": "lambda",
+                    "id": "aws.explorer",
                     "name": "%AWS.lambda.explorerTitle%"
                 }
             ]
@@ -159,32 +159,32 @@
             "view/title": [
                 {
                     "command": "aws.refreshAwsExplorer",
-                    "when": "view == lambda",
+                    "when": "view == aws.explorer",
                     "group": "navigation@5"
                 },
                 {
                     "command": "aws.login",
-                    "when": "view == lambda",
+                    "when": "view == aws.explorer",
                     "group": "1_account@1"
                 },
                 {
                     "command": "aws.showRegion",
-                    "when": "view == lambda",
+                    "when": "view == aws.explorer",
                     "group": "2_region@1"
                 },
                 {
                     "command": "aws.hideRegion",
-                    "when": "view == lambda",
+                    "when": "view == aws.explorer",
                     "group": "2_region@2"
                 },
                 {
                     "command": "aws.help",
-                    "when": "view == lambda",
+                    "when": "view == aws.explorer",
                     "group": "z_help@1"
                 },
                 {
                     "command": "aws.github",
-                    "when": "view == lambda",
+                    "when": "view == aws.explorer",
                     "group": "z_help@2"
                 }
             ],

--- a/package.json
+++ b/package.json
@@ -164,22 +164,27 @@
                 },
                 {
                     "command": "aws.login",
+                    "when": "view == lambda",
                     "group": "1_account@1"
                 },
                 {
                     "command": "aws.showRegion",
+                    "when": "view == lambda",
                     "group": "2_region@1"
                 },
                 {
                     "command": "aws.hideRegion",
+                    "when": "view == lambda",
                     "group": "2_region@2"
                 },
                 {
                     "command": "aws.help",
+                    "when": "view == lambda",
                     "group": "z_help@1"
                 },
                 {
                     "command": "aws.github",
+                    "when": "view == lambda",
                     "group": "z_help@2"
                 }
             ],

--- a/src/lambda/lambdaTreeDataProvider.ts
+++ b/src/lambda/lambdaTreeDataProvider.ts
@@ -36,7 +36,7 @@ import { configureLocalLambda } from './local/configureLocalLambda'
 import * as utils from './utils'
 
 export class LambdaTreeDataProvider implements vscode.TreeDataProvider<AWSTreeNodeBase>, RefreshableAwsTreeProvider {
-    public viewProviderId: string = 'lambda'
+    public viewProviderId: string = 'aws.explorer'
     public readonly onDidChangeTreeData: vscode.Event<AWSTreeNodeBase | undefined>
     private readonly _onDidChangeTreeData: vscode.EventEmitter<AWSTreeNodeBase | undefined>
     private readonly regionNodes: Map<string, RegionNode>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Description

Fixes a case where the AWS Explorer Context menu is leaking into other places in VS Code.

AWS Explorer Context Menu: 
![image](https://user-images.githubusercontent.com/39839589/56674348-baec6100-666e-11e9-8c06-52a25b2b5468.png)

One of the GitLens Extension Panels (as an example)

Before:
![image](https://user-images.githubusercontent.com/39839589/56674366-c63f8c80-666e-11e9-81fe-c7861bc476b1.png)

After:
![image](https://user-images.githubusercontent.com/39839589/56674378-cb044080-666e-11e9-830f-f7e690a74a89.png)



## Testing

* Verified the menu items no longer appear on other extension panels
* Verified the affected menu items still function
* Verified the commands backing the affected menu items still function from the Command Palette

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
