### PR TITLE
Removing unused runtimes

### DIFF
--- a/src/lambda/models/samLambdaRuntime.ts
+++ b/src/lambda/models/samLambdaRuntime.ts
@@ -13,50 +13,27 @@ export type SamLambdaRuntime =
     'python3.7' |
     'python3.6' |
     'python2.7' |
-    'python' |
     'nodejs6.10' |
     'nodejs8.10' |
-    'nodejs' |
     'dotnetcore2.1' |
     'dotnetcore2.0' |
-    'dotnetcore1.0' |
-    'dotnetcore' |
-    'dotnet' |
-    'go1.x' |
-    'go' |
-    'java8' |
-    'java' |
-    'ruby' |
-    'ruby2.5'
+    'dotnetcore1.0'
 
 export const samLambdaRuntimes: immutable.Set<SamLambdaRuntime> = immutable.Set([
     'python3.7',
     'python3.6',
     'python2.7',
-    'python',
     'nodejs6.10',
     'nodejs8.10',
-    'nodejs',
     'dotnetcore2.1',
     'dotnetcore2.0',
-    'dotnetcore1.0',
-    'dotnetcore',
-    'dotnet',
-    'go1.x',
-    'go',
-    'java8',
-    'java',
-    'ruby',
-    'ruby2.5'
+    'dotnetcore1.0'
 ] as SamLambdaRuntime[])
 
 export enum SamLambdaRuntimeFamily {
     Python,
     NodeJS,
     DotNetCore,
-    Go,
-    Java,
-    Ruby
 }
 
 export function getFamily(runtime: string | undefined): SamLambdaRuntimeFamily {
@@ -76,15 +53,6 @@ export function getFamily(runtime: string | undefined): SamLambdaRuntimeFamily {
         case 'dotnetcore':
         case 'dotnet':
             return SamLambdaRuntimeFamily.DotNetCore
-        case 'go1.x':
-        case 'go':
-            return SamLambdaRuntimeFamily.Go
-        case 'java8':
-        case 'java':
-            return SamLambdaRuntimeFamily.Java
-        case 'ruby2.5':
-        case 'ruby':
-            return SamLambdaRuntimeFamily.Ruby
         default:
             throw new Error(`Unrecognized runtime: '${runtime}'`)
 

--- a/src/lambda/models/samLambdaRuntime.ts
+++ b/src/lambda/models/samLambdaRuntime.ts
@@ -16,8 +16,7 @@ export type SamLambdaRuntime =
     'nodejs6.10' |
     'nodejs8.10' |
     'dotnetcore2.1' |
-    'dotnetcore2.0' |
-    'dotnetcore1.0'
+    'dotnetcore2.0'
 
 export const samLambdaRuntimes: immutable.Set<SamLambdaRuntime> = immutable.Set([
     'python3.7',
@@ -26,8 +25,7 @@ export const samLambdaRuntimes: immutable.Set<SamLambdaRuntime> = immutable.Set(
     'nodejs6.10',
     'nodejs8.10',
     'dotnetcore2.1',
-    'dotnetcore2.0',
-    'dotnetcore1.0'
+    'dotnetcore2.0'
 ] as SamLambdaRuntime[])
 
 export enum SamLambdaRuntimeFamily {
@@ -49,7 +47,6 @@ export function getFamily(runtime: string | undefined): SamLambdaRuntimeFamily {
             return SamLambdaRuntimeFamily.NodeJS
         case 'dotnetcore2.1':
         case 'dotnetcore2.0':
-        case 'dotnetcore1.0':
         case 'dotnetcore':
         case 'dotnet':
             return SamLambdaRuntimeFamily.DotNetCore

--- a/src/shared/codelens/localLambdaRunner.ts
+++ b/src/shared/codelens/localLambdaRunner.ts
@@ -711,11 +711,8 @@ export function shouldAppendRelativePathToFunctionHandler(runtime: string): bool
     switch (getFamily(runtime)) {
         case SamLambdaRuntimeFamily.NodeJS:
         case SamLambdaRuntimeFamily.Python:
-        case SamLambdaRuntimeFamily.Ruby:
             return true
         case SamLambdaRuntimeFamily.DotNetCore:
-        case SamLambdaRuntimeFamily.Java:
-        case SamLambdaRuntimeFamily.Go:
             return false
         // if the runtime exists but for some reason we forgot to cover it here, throw anyway so we remember to cover it
         default:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)
- [x] Technical debt (change which improves the maintainability of the codebase, but does not change functionality)
- [ ] Testing (change which modifies or adds test coverage, but does not change functionality)
- [ ] Documentation (change which modifies or adds documentation, but does not change functionality)

## Description

Removed runtimes that are unsupported by the current version of the AWS Toolkit for VS Code

## Motivation and Context

Having additional runtimes in our Create Sam Application wizard gives the impression that we have full-stack support. Removing these removes the confusion; will add these back in as we add support.

## Related Issue(s)
https://github.com/aws/aws-toolkit-vscode/issues/322

## Testing

Tests pass successfully. List only presents currently-supported options (see screenshot)


## Screenshots (if appropriate)

![culledlist](https://user-images.githubusercontent.com/29374703/57248111-6219b280-6ff6-11e9-8e55-998e55bd9921.PNG)
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
