### PR TITLE
Metrics overrides for result and duration

### DIFF
--- a/src/shared/telemetry/telemetryEvent.ts
+++ b/src/shared/telemetry/telemetryEvent.ts
@@ -10,6 +10,14 @@ import { MetadataEntry, MetricDatum, Unit } from './clienttelemetry'
 const NAME_ILLEGAL_CHARS_REGEX = new RegExp('[^\\w+-.:]', 'g')
 const REMOVE_UNDERSCORES_REGEX = new RegExp('_', 'g')
 
+export const METADATA_FIELD_NAME = {
+    RESULT: 'result',
+    DURATION: 'duration',
+}
+
+export const METADATA_RESULT_PASS = 'Succeeded'
+export const METADATA_RESULT_FAIL = 'Failed'
+
 export interface Datum {
     name: string
     value: number
@@ -25,12 +33,12 @@ export interface TelemetryEvent {
 
 export function toMetricData(array: TelemetryEvent[]): MetricDatum[] {
     return ([] as MetricDatum[]).concat(
-        ...array.map( metricEvent => {
+        ...array.map(metricEvent => {
 
             const namespace = metricEvent.namespace.replace(REMOVE_UNDERSCORES_REGEX, '')
 
             if (metricEvent.data !== undefined) {
-                const mappedEventData = metricEvent.data.map( datum => {
+                const mappedEventData = metricEvent.data.map(datum => {
                     let metadata: MetadataEntry[] | undefined
                     let unit = datum.unit
 

--- a/src/shared/telemetry/telemetryUtils.ts
+++ b/src/shared/telemetry/telemetryUtils.ts
@@ -66,8 +66,8 @@ export function registerCommand<T>({
                 if (!datum.metadata) {
                     datum.metadata = new Map()
                 }
-                datum.metadata.set('result', hasException ? 'Failed' : 'Succeeded')
-                datum.metadata.set('duration', `${endTime.getTime() - startTime.getTime()}`)
+                setMetadataIfNotExists(datum.metadata, 'result', hasException ? 'Failed' : 'Succeeded')
+                setMetadataIfNotExists(datum.metadata, 'duration', `${endTime.getTime() - startTime.getTime()}`)
 
                 ext.telemetry.record({
                     namespace: telemetryName.namespace,
@@ -84,4 +84,10 @@ export function registerCommand<T>({
         },
         thisArg
     )
+}
+
+function setMetadataIfNotExists(metadata: Map<string, string>, key: string, value: string) {
+    if (!metadata.has(key)) {
+        metadata.set(key, value)
+    }
 }

--- a/src/shared/telemetry/telemetryUtils.ts
+++ b/src/shared/telemetry/telemetryUtils.ts
@@ -7,7 +7,7 @@
 
 import * as vscode from 'vscode'
 import { ext } from '../extensionGlobals'
-import { Datum } from './telemetryEvent'
+import { Datum, METADATA_FIELD_NAME, METADATA_RESULT_FAIL, METADATA_RESULT_PASS } from './telemetryEvent'
 
 export interface TelemetryName {
     namespace: TelemetryNamespace | OldTelemetryNamespace
@@ -66,7 +66,10 @@ export function registerCommand<T>({
                 if (!datum.metadata) {
                     datum.metadata = new Map()
                 }
-                setMetadataIfNotExists(datum.metadata, 'result', hasException ? 'Failed' : 'Succeeded')
+                setMetadataIfNotExists(
+                    datum.metadata,
+                    METADATA_FIELD_NAME.RESULT,
+                    hasException ? METADATA_RESULT_FAIL : METADATA_RESULT_PASS)
                 setMetadataIfNotExists(datum.metadata, 'duration', `${endTime.getTime() - startTime.getTime()}`)
 
                 ext.telemetry.record({

--- a/src/test/shared/telemetry/telemetryUtils.test.ts
+++ b/src/test/shared/telemetry/telemetryUtils.test.ts
@@ -8,7 +8,13 @@
 import * as assert from 'assert'
 import { Disposable } from 'vscode'
 import { ext } from '../../../shared/extensionGlobals'
-import { Datum, TelemetryEvent } from '../../../shared/telemetry/telemetryEvent'
+import {
+    Datum,
+    METADATA_FIELD_NAME,
+    METADATA_RESULT_FAIL,
+    METADATA_RESULT_PASS,
+    TelemetryEvent
+} from '../../../shared/telemetry/telemetryEvent'
 import { TelemetryService } from '../../../shared/telemetry/telemetryService'
 import { defaultMetricDatum, registerCommand, TelemetryNamespace } from '../../../shared/telemetry/telemetryUtils'
 
@@ -48,7 +54,8 @@ describe('telemetryUtils', () => {
                         assert.notStrictEqual(mockService.lastEvent!.data![0].metadata!.get('duration'), undefined)
 
                         assert.strictEqual(
-                            mockService.lastEvent!.data![0].metadata!.get('result'), 'Succeeded'
+                            mockService.lastEvent!.data![0].metadata!.get(METADATA_FIELD_NAME.RESULT),
+                            METADATA_RESULT_PASS
                         )
                         assert.strictEqual(mockService.lastEvent!.namespace, 'Command')
                         assert.strictEqual(mockService.lastEvent!.data![0].name, 'command')
@@ -79,7 +86,7 @@ describe('telemetryUtils', () => {
 
                         assert.notStrictEqual(metadata.get('duration'), undefined)
 
-                        assert.strictEqual(metadata.get('result'), 'Succeeded')
+                        assert.strictEqual(metadata.get(METADATA_FIELD_NAME.RESULT), METADATA_RESULT_PASS)
                         assert.strictEqual(metadata.get('foo'), 'bar')
                         assert.strictEqual(metadata.get('hitcount'), '5')
 
@@ -115,8 +122,12 @@ describe('telemetryUtils', () => {
                         const data = mockService.lastEvent!.data![0]
                         const metadata = data.metadata!
 
-                        assert.strictEqual(metadata.get('result'), 'bananas', 'Unexpected value for metadata.result')
-                        assert.strictEqual(metadata.get('duration'), '999999', 'Unexpected value for metadata.duration')
+                        assert.strictEqual(
+                            metadata.get(METADATA_FIELD_NAME.RESULT), 'bananas',
+                            'Unexpected value for metadata.result')
+                        assert.strictEqual(
+                            metadata.get('duration'), '999999',
+                            'Unexpected value for metadata.duration')
 
                         done()
                     }).catch(err => {
@@ -129,7 +140,7 @@ describe('telemetryUtils', () => {
                 callback: async () => {
                     const datum: Datum = defaultMetricDatum('somemetric')
                     datum.metadata = new Map([
-                        ['result', 'bananas'],
+                        [METADATA_FIELD_NAME.RESULT, 'bananas'],
                         ['duration', '999999'],
                     ])
 
@@ -152,7 +163,8 @@ describe('telemetryUtils', () => {
                         assert.notStrictEqual(mockService.lastEvent!.data![0].metadata!.get('duration'), undefined)
 
                         assert.strictEqual(
-                            mockService.lastEvent!.data![0].metadata!.get('result'), 'Succeeded'
+                            mockService.lastEvent!.data![0].metadata!.get(METADATA_FIELD_NAME.RESULT),
+                            METADATA_RESULT_PASS
                         )
                         assert.strictEqual(mockService.lastEvent!.namespace, TelemetryNamespace.Aws)
                         assert.strictEqual(mockService.lastEvent!.data![0].name, 'thisAintYourFathersNameField')
@@ -188,7 +200,8 @@ describe('telemetryUtils', () => {
                         assert.notStrictEqual(mockService.lastEvent!.data![0].metadata!.get('duration'), undefined)
 
                         assert.strictEqual(
-                            mockService.lastEvent!.data![0].metadata!.get('result'), 'Failed'
+                            mockService.lastEvent!.data![0].metadata!.get(METADATA_FIELD_NAME.RESULT),
+                            METADATA_RESULT_FAIL
                         )
                         assert.strictEqual(mockService.lastEvent!.namespace, 'Command')
                         assert.strictEqual(mockService.lastEvent!.data![0].name, 'command')

--- a/src/test/shared/telemetry/telemetryUtils.test.ts
+++ b/src/test/shared/telemetry/telemetryUtils.test.ts
@@ -107,6 +107,39 @@ describe('telemetryUtils', () => {
             })
         })
 
+        it('records telemetry with metadata overriding result and duration', (done) => {
+            registerCommand({
+                register: (_command, callback: (...args: any[]) => Promise<void>, _thisArg) => {
+                    // vscode.commands.registerCommand is not async, but we can't check until the callback is complete
+                    callback().then(() => {
+                        const data = mockService.lastEvent!.data![0]
+                        const metadata = data.metadata!
+
+                        assert.strictEqual(metadata.get('result'), 'bananas', 'Unexpected value for metadata.result')
+                        assert.strictEqual(metadata.get('duration'), '999999', 'Unexpected value for metadata.duration')
+
+                        done()
+                    }).catch(err => {
+                        throw err
+                    })
+
+                    return Disposable.from()
+                },
+                command: 'command',
+                callback: async () => {
+                    const datum: Datum = defaultMetricDatum('somemetric')
+                    datum.metadata = new Map([
+                        ['result', 'bananas'],
+                        ['duration', '999999'],
+                    ])
+
+                    return {
+                        datum
+                    }
+                }
+            })
+        })
+
         it('records telemetry with custom names and namespaces', (done) => {
             registerCommand({
                 register: (_command, callback: (...args: any[]) => Promise<void>, _thisArg) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Infrastructure (change which improves the lifecycle management (CI/CD, build, package, deploy, lint, etc) of the application, but does not change functionality.)

## Description

Two changes to the telemetry system:
* Added constants for standard metadata field names and values
* `result` and `duration` will now retain existing metadata values if they exist

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
