### PR TITLE
addUserDataToContext throws an error if a profile's credentials are nonexistent

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -61,7 +61,7 @@
     "AWS.log.fileLocation": "Error logs for this session are permanently stored in {0}",
     "AWS.log.invalidLevel": "Invalid log level: {0}",
     "AWS.message.loading": "Loading...",
-    "AWS.message.credentials.error": "There was an issue trying to use credentials profile {0}.\nYou will be disconnected from AWS.\n\n{1}",
+    "AWS.message.credentials.error": "There was an issue trying to use credentials profile {0}: {1}",
     "AWS.message.enterProfileName": "Enter the name of the credential profile to use",
     "AWS.message.info.cloudFormation.delete": "Deleted CloudFormation Stack {0}",
     "AWS.message.error.cloudFormation.delete": "An error occurred while deleting CloudFormation Stack {0}. Please check the stack events on the AWS Console",

--- a/src/shared/credentials/userCredentialsUtils.ts
+++ b/src/shared/credentials/userCredentialsUtils.ts
@@ -165,7 +165,8 @@ export class UserCredentialsUtils {
     }
 
     /**
-     * Adds valid profiles to the AWS context and settings. Returns false if invalid.
+     * Adds valid profiles to the AWS context and settings.
+     * Wipes set profile data and returns false if invalid.
      *
      * @param profileName Profile name to add to AWS Context/AWS settings
      * @param awsContext Current AWS Context
@@ -179,14 +180,23 @@ export class UserCredentialsUtils {
         awsContext: AwsContext,
         sts?: StsClient
     ): Promise<boolean> {
-        const credentials = await awsContext.getCredentials(profileName)
-        const account = credentials ? await this.validateCredentials(credentials, sts) : undefined
-        if (account && account.isValid) {
-            await awsContext.setCredentialProfileName(profileName)
-            await awsContext.setCredentialAccountId(account.account)
+        let credentials: Credentials | undefined
+        try {
+            credentials = await awsContext.getCredentials(profileName)
+            const account = credentials ? await this.validateCredentials(credentials, sts) : undefined
+            if (account && account.isValid) {
+                await awsContext.setCredentialProfileName(profileName)
+                await awsContext.setCredentialAccountId(account.account)
 
-            return true
+                return true
+            }
+        } catch (err) {
+            // swallow any errors--anything that isn't a success should end in the same state:
+            // no set profile + return false
         }
+        // wipe any set profile data
+        await awsContext.setCredentialProfileName()
+        await awsContext.setCredentialAccountId()
 
         return false
     }

--- a/src/test/shared/credentials/userCredentialsUtils.test.ts
+++ b/src/test/shared/credentials/userCredentialsUtils.test.ts
@@ -273,7 +273,7 @@ describe('UserCredentialsUtils', () => {
             assert.strictEqual(mockAws.getCredentialAccountId(), testAccount)
         })
 
-        it ('does not add new profile data if credentials are invalid', async () => {
+        it ('wipes profile data if credentials are invalid', async () => {
 
             const testProfile = 'testprofile'
             const mockSts = new MockStsClient({
@@ -289,8 +289,8 @@ describe('UserCredentialsUtils', () => {
 
             const returnValue = await UserCredentialsUtils.addUserDataToContext(testProfile, mockAws, mockSts)
             assert.strictEqual(returnValue, false)
-            assert.strictEqual(mockAws.getCredentialProfileName(), DEFAULT_TEST_PROFILE_NAME)
-            assert.strictEqual(mockAws.getCredentialAccountId(), DEFAULT_TEST_ACCOUNT_ID)
+            assert.strictEqual(mockAws.getCredentialProfileName(), undefined)
+            assert.strictEqual(mockAws.getCredentialAccountId(), undefined)
         })
     })
 

--- a/src/test/shared/defaultAwsContext.test.ts
+++ b/src/test/shared/defaultAwsContext.test.ts
@@ -119,7 +119,7 @@ describe('DefaultAwsContext', () => {
         assert.strictEqual(creds, undefined)
     })
 
-    it('returns undefined if no profile is provided', async () => {
+    it('returns undefined if no profile is provided and no profile was previously saved to settings', async () => {
         class TestConfiguration extends ContextTestsSettingsConfigurationBase {
             public readSetting<T>(settingKey: string, defaultValue?: T): T | undefined {
                 if (settingKey === profileSettingKey) {
@@ -134,7 +134,7 @@ describe('DefaultAwsContext', () => {
             new TestConfiguration(),
             new FakeExtensionContext()
         )
-        const creds = await testContext.getCredentials(testProfileValue)
+        const creds = await testContext.getCredentials()
         assert.strictEqual(creds, undefined)
     })
 

--- a/src/test/utilities/testSettingsConfiguration.ts
+++ b/src/test/utilities/testSettingsConfiguration.ts
@@ -18,7 +18,7 @@ export class TestSettingsConfiguration implements SettingsConfiguration {
         return this._data[settingKey] as T
     }
 
-    public async writeSetting<T>(settingKey: string, value: T, target: any): Promise<void> {
+    public async writeSetting<T>(settingKey: string, value: T, target?: any): Promise<void> {
         this._data[settingKey] = value
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Description

addUserDataToContext throws an error if a profile's credentials are nonexistent.

## Motivation and Context

This was causing issues on extension load if a nonexistent profile was selected since the extension load was not handling the error.

## Related Issue(s)
Fix for #557 

## Testing

Added new tests, everything passes. 
Testing with fixes from #577 works as expected (loads if profile exists, resets to default state if profile doesn't)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
