### PR TITLE
Ensure log folder exists prior to initialization

### DIFF
--- a/src/shared/filesystem.ts
+++ b/src/shared/filesystem.ts
@@ -21,6 +21,9 @@ export interface Stats extends fs.Stats {
 export const access = promisify(fs.access)
 
 const _mkdir = promisify(fs.mkdir)
+interface ErrorWithCode {
+    code?: string
+}
 
 export async function mkdir(
     path: PathLike,
@@ -31,7 +34,8 @@ export async function mkdir(
     } catch (err) {
         // mkdir calls with recurse do not work as expected when called through electron.
         // See: https://github.com/nodejs/node/issues/24698#issuecomment-486405542
-        if (err.code && err.code === 'ENOENT') {
+        const error = err as ErrorWithCode
+        if (error.code && error.code === 'ENOENT') {
             if (options && typeof options === 'object' && options.recursive && typeof path === 'string') {
                 await mkdirRecursive(path, options)
 

--- a/src/shared/filesystem.ts
+++ b/src/shared/filesystem.ts
@@ -33,7 +33,8 @@ export async function mkdir(
         await _mkdir(path, options)
     } catch (err) {
         // mkdir calls with recurse do not work as expected when called through electron.
-        // See: https://github.com/nodejs/node/issues/24698#issuecomment-486405542
+        // See: https://github.com/nodejs/node/issues/24698#issuecomment-486405542 for info.
+        // TODO : When VS Code uses Electron 5+, remove this custom mkdir implementation.
         const error = err as ErrorWithCode
         if (error.code && error.code === 'ENOENT') {
             if (options && typeof options === 'object' && options.recursive && typeof path === 'string') {
@@ -51,20 +52,12 @@ async function mkdirRecursive(
     path: string,
     options: MakeDirectoryOptions,
 ): Promise<void> {
-    try {
-        await access(path)
-
-        // path exists, nothing left to do
-        return
-    } catch (err) {
-        // path does not exist, recurse to parent folder before trying to make path of interest
-        const parent = _path.dirname(path)
-        if (parent !== path) {
-            await mkdir(parent, options)
-        }
-
-        await mkdir(path, options)
+    const parent = _path.dirname(path)
+    if (parent !== path) {
+        await mkdir(parent, options)
     }
+
+    await mkdir(path, options)
 }
 
 export const mkdtemp = promisify(fs.mkdtemp)

--- a/src/shared/filesystemUtilities.ts
+++ b/src/shared/filesystemUtilities.ts
@@ -72,7 +72,7 @@ export async function findFileInParentPaths(searchFolder: string, fileToFind: st
 }
 
 const mkdtemp = promisify(fs.mkdtemp)
-export const  makeTemporaryToolkitFolder = async (...relativePathParts: string[]) => {
+export const makeTemporaryToolkitFolder = async (...relativePathParts: string[]) => {
     const _relativePathParts = relativePathParts || ['vsctk']
     const tmpPath = path.join(tempDirPath, ..._relativePathParts)
     const tmpPathParent = path.dirname(tmpPath)
@@ -83,4 +83,21 @@ export const  makeTemporaryToolkitFolder = async (...relativePathParts: string[]
     }
 
     return mkdtemp(tmpPath)
+}
+
+/**
+ * Convenience method -- mkdir calls with recurse do not work as expected when called through electron.
+ * See: https://github.com/nodejs/node/issues/24698#issuecomment-486405542
+ */
+export async function mkdirRecursive(folder: string): Promise<void> {
+    if (await fileExists(folder)) {
+        return
+    }
+
+    const parent = path.dirname(folder)
+    if (parent !== folder) {
+        await mkdirRecursive(parent)
+    }
+
+    await mkdir(folder)
 }

--- a/src/shared/filesystemUtilities.ts
+++ b/src/shared/filesystemUtilities.ts
@@ -84,20 +84,3 @@ export const makeTemporaryToolkitFolder = async (...relativePathParts: string[])
 
     return mkdtemp(tmpPath)
 }
-
-/**
- * Convenience method -- mkdir calls with recurse do not work as expected when called through electron.
- * See: https://github.com/nodejs/node/issues/24698#issuecomment-486405542
- */
-export async function mkdirRecursive(folder: string): Promise<void> {
-    if (await fileExists(folder)) {
-        return
-    }
-
-    const parent = path.dirname(folder)
-    if (parent !== folder) {
-        await mkdirRecursive(parent)
-    }
-
-    await mkdir(folder)
-}

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -12,6 +12,7 @@ import * as nls from 'vscode-nls'
 import * as winston from 'winston'
 import * as Transport from 'winston-transport'
 import { extensionSettingsPrefix } from './constants'
+import { mkdirRecursive } from './filesystemUtilities'
 import { DefaultSettingsConfiguration, SettingsConfiguration } from './settingsConfiguration'
 
 const localize = nls.loadMessageBundle()
@@ -58,9 +59,13 @@ export interface LoggerParams {
  */
 export async function initialize(params?: LoggerParams): Promise<Logger> {
     if (!params) {
+        const logPath = getDefaultLogPath()
+        const logFolder = path.dirname(logPath)
+        await mkdirRecursive(logFolder)
+
         defaultLogger = createLogger({
             outputChannel: DEFAULT_OUTPUT_CHANNEL,
-            logPath: getDefaultLogPath()
+            logPath
         })
         // only the default logger (with default params) gets a registered command
         // check list of registered commands to see if aws.viewLogs has already been registered.
@@ -95,7 +100,7 @@ export function getLogger(): Logger {
     if (defaultLogger) {
         return defaultLogger
     }
-    throw new Error ('Default Logger not initialized. Call logger.initialize() first.')
+    throw new Error('Default Logger not initialized. Call logger.initialize() first.')
 }
 
 /**
@@ -227,7 +232,7 @@ function generateWriteParams(
     level: LogLevel,
     message: ErrorOrString[],
     outputChannel?: vscode.OutputChannel
- ): WriteToLogParams {
+): WriteToLogParams {
     return { logger: logger, level: level, message: message, outputChannel: outputChannel }
 }
 

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -12,7 +12,8 @@ import * as nls from 'vscode-nls'
 import * as winston from 'winston'
 import * as Transport from 'winston-transport'
 import { extensionSettingsPrefix } from './constants'
-import { mkdirRecursive } from './filesystemUtilities'
+import { mkdir } from './filesystem'
+import { fileExists } from './filesystemUtilities'
 import { DefaultSettingsConfiguration, SettingsConfiguration } from './settingsConfiguration'
 
 const localize = nls.loadMessageBundle()
@@ -61,7 +62,9 @@ export async function initialize(params?: LoggerParams): Promise<Logger> {
     if (!params) {
         const logPath = getDefaultLogPath()
         const logFolder = path.dirname(logPath)
-        await mkdirRecursive(logFolder)
+        if (!await fileExists(logFolder)) {
+            await mkdir(logFolder, { recursive: true })
+        }
 
         defaultLogger = createLogger({
             outputChannel: DEFAULT_OUTPUT_CHANNEL,

--- a/src/test/shared/filesystem.test.ts
+++ b/src/test/shared/filesystem.test.ts
@@ -6,10 +6,13 @@
 'use strict'
 
 import * as assert from 'assert'
+import * as del from 'del'
 import * as fs from 'fs'
+import * as path from 'path'
 import { CustomPromisify, promisify } from 'util'
 
 import * as filesystem from '../../shared/filesystem'
+import { fileExists, makeTemporaryToolkitFolder } from '../../shared/filesystemUtilities'
 import { getPropAs } from '../../shared/utilities/tsUtils'
 
 const functionsToTest = [
@@ -18,7 +21,6 @@ const functionsToTest = [
     'readdir',
     'rename',
     'stat',
-    'mkdir',
     'mkdtemp',
     'unlink',
     'writeFile',
@@ -35,6 +37,40 @@ describe('filesystem', () => {
                 `filesystem.${fxName} should be a "function" but is "${actualType}"`
             )
             assert.strictEqual(String(filesystemFunction), String(promisify(fsFunction)))
+        })
+    })
+
+    describe('mkdir', async () => {
+        let tempFolder: string
+
+        beforeEach(async () => {
+            // Make a temp folder for all these tests
+            tempFolder = await makeTemporaryToolkitFolder()
+        })
+
+        afterEach(async () => {
+            await del([tempFolder], { force: true })
+        })
+
+        it('makes subfolder to existing folder', async () => {
+            const dstFolder = path.join(tempFolder, 'level1')
+            await filesystem.mkdir(dstFolder, { recursive: true })
+
+            assert.ok(fileExists(dstFolder), 'expected folder to exist')
+        })
+
+        it('makes two levels of subfolders', async () => {
+            const dstFolder = path.join(tempFolder, 'level1', 'level2')
+            await filesystem.mkdir(dstFolder, { recursive: true })
+
+            assert.ok(fileExists(dstFolder), 'expected folder to exist')
+        })
+
+        it('makes many levels of subfolders', async () => {
+            const dstFolder = path.join(tempFolder, 'level1', 'level2', 'level3', 'level4', 'level5')
+            await filesystem.mkdir(dstFolder, { recursive: true })
+
+            assert.ok(fileExists(dstFolder), 'expected folder to exist')
         })
     })
 })

--- a/src/test/shared/filesystemUtilities.test.ts
+++ b/src/test/shared/filesystemUtilities.test.ts
@@ -13,7 +13,6 @@ import {
     fileExists,
     findFileInParentPaths,
     makeTemporaryToolkitFolder,
-    mkdirRecursive,
     tempDirPath
 } from '../../shared/filesystemUtilities'
 
@@ -105,33 +104,6 @@ describe('filesystemUtilities', () => {
             assert.strictEqual(
                 await findFileInParentPaths(childFolder, targetFilename),
                 targetFilePath)
-        })
-    })
-
-    describe('mkdirRecursive', async () => {
-        it('does not err on existing folders', async () => {
-            await mkdirRecursive(tempFolder)
-        })
-
-        it('makes subfolder to existing folder', async () => {
-            const dstFolder = path.join(tempFolder, 'level1')
-            await mkdirRecursive(dstFolder)
-
-            assert.ok(fileExists(dstFolder), 'expected folder to exist')
-        })
-
-        it('makes two levels of subfolders', async () => {
-            const dstFolder = path.join(tempFolder, 'level1', 'level2')
-            await mkdirRecursive(dstFolder)
-
-            assert.ok(fileExists(dstFolder), 'expected folder to exist')
-        })
-
-        it('makes many levels of subfolders', async () => {
-            const dstFolder = path.join(tempFolder, 'level1', 'level2', 'level3', 'level4', 'level5')
-            await mkdirRecursive(dstFolder)
-
-            assert.ok(fileExists(dstFolder), 'expected folder to exist')
         })
     })
 })

--- a/src/test/shared/filesystemUtilities.test.ts
+++ b/src/test/shared/filesystemUtilities.test.ts
@@ -13,6 +13,7 @@ import {
     fileExists,
     findFileInParentPaths,
     makeTemporaryToolkitFolder,
+    mkdirRecursive,
     tempDirPath
 } from '../../shared/filesystemUtilities'
 
@@ -104,6 +105,33 @@ describe('filesystemUtilities', () => {
             assert.strictEqual(
                 await findFileInParentPaths(childFolder, targetFilename),
                 targetFilePath)
+        })
+    })
+
+    describe('mkdirRecursive', async () => {
+        it('does not err on existing folders', async () => {
+            await mkdirRecursive(tempFolder)
+        })
+
+        it('makes subfolder to existing folder', async () => {
+            const dstFolder = path.join(tempFolder, 'level1')
+            await mkdirRecursive(dstFolder)
+
+            assert.ok(fileExists(dstFolder), 'expected folder to exist')
+        })
+
+        it('makes two levels of subfolders', async () => {
+            const dstFolder = path.join(tempFolder, 'level1', 'level2')
+            await mkdirRecursive(dstFolder)
+
+            assert.ok(fileExists(dstFolder), 'expected folder to exist')
+        })
+
+        it('makes many levels of subfolders', async () => {
+            const dstFolder = path.join(tempFolder, 'level1', 'level2', 'level3', 'level4', 'level5')
+            await mkdirRecursive(dstFolder)
+
+            assert.ok(fileExists(dstFolder), 'expected folder to exist')
         })
     })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Description

When the logger starts up, the logging folder is created prior to initialization. This eliminates a situation (#566) where the logging platform threw an error on initialization, which crashes extension activation.

To support this, I found out that electron apps throw an error if `mkdir` tries to recursively create more than one folder, so I added a drop-in clause that explicitly creates each folder one parent at a time.

## Related Issue(s)

#566 
<!--- What is the related issue you are trying to fix? -->

## Testing

* Regular startup
* started extension in remote WSL session
* ran tests

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
