### PR TITLE
Fix issue that caused templates.json to be ignored when invoking .NET Core functions.

### DIFF
--- a/src/shared/codelens/csharpCodeLensProvider.ts
+++ b/src/shared/codelens/csharpCodeLensProvider.ts
@@ -199,7 +199,7 @@ async function onLocalInvokeCommand(
             documentUri,
             originalHandlerName: handlerName,
             handlerName,
-            originalSamTemplatePath: inputTemplatePath,
+            originalSamTemplatePath: lambdaLocalInvokeParams.samTemplate.fsPath,
             samTemplatePath,
             runtime,
         }


### PR DESCRIPTION
## Description

For .NET Core functions, we were looking at the wrong key in `templates.json`, which caused `event` and `environmentVariables` to be empty. This change uses the right key instead.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
