### PR TITLE
Disable code lenses for 'raw' (template-less) lambdas

### DIFF
--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -269,9 +269,11 @@ export namespace CloudFormation {
         return resource &&
             resource.Type === SERVERLESS_FUNCTION_TYPE &&
             resource.Properties &&
-            // TODO: resource.Properties.Handler is relative to CodeUri,
-            // but handlerName is relative to the source file.
-            // Normalize before comparing.
+            // TODO: `resource.Properties.Handler` is relative to `CodeUri`, but
+            //       `handlerName` is relative to the directory containing the source
+            //       file. To fix, update lambda handler candidate searches for
+            //       interpreted languages to return a handler name relative to the
+            //       `CodeUri`, rather than to the directory containing the source file.
             resource.Properties.Handler === handlerName
     }
 }

--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -269,6 +269,9 @@ export namespace CloudFormation {
         return resource &&
             resource.Type === SERVERLESS_FUNCTION_TYPE &&
             resource.Properties &&
+            // TODO: resource.Properties.Handler is relative to CodeUri,
+            // but handlerName is relative to the source file.
+            // Normalize before comparing.
             resource.Properties.Handler === handlerName
     }
 }

--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -5,10 +5,10 @@
 
 'use strict'
 
-import * as path from 'path'
 import * as vscode from 'vscode'
 
 import { detectLocalTemplates } from '../../lambda/local/detectLocalTemplates'
+import { CloudFormation } from '../cloudformation/cloudformation'
 import { LambdaHandlerCandidate } from '../lambdaHandlerSearch'
 import { getLogger } from '../logger'
 import { SamCliProcessInvoker } from '../sam/cli/samCliInvokerUtils'
@@ -17,7 +17,6 @@ import { SettingsConfiguration } from '../settingsConfiguration'
 import { TelemetryService } from '../telemetry/telemetryService'
 import { Datum } from '../telemetry/telemetryTypes'
 import { defaultMetricDatum } from '../telemetry/telemetryUtils'
-import { toArrayAsync } from '../utilities/collectionUtils'
 import { localize } from '../utilities/vsCodeUtils'
 
 export type Language = 'python' | 'javascript' | 'csharp'
@@ -54,28 +53,31 @@ export async function makeCodeLenses({ document, token, handlers, language }: {
         throw new Error(`Source file ${document.uri} is external to the current workspace.`)
     }
 
-    const associatedTemplate: vscode.Uri = await getAssociatedSamTemplate(document.uri, workspaceFolder.uri)
     const lenses: vscode.CodeLens[] = []
-
-    handlers.forEach(handler => {
+    for (const handler of handlers) {
         // handler.range is a RangeOrCharOffset union type. Extract vscode.Range.
         const range = (handler.range instanceof vscode.Range) ? handler.range : new vscode.Range(
             document.positionAt(handler.range.positionStart),
             document.positionAt(handler.range.positionEnd),
         )
 
-        const baseParams: MakeConfigureCodeLensParams = {
-            document,
-            handlerName: handler.handlerName,
-            range,
-            workspaceFolder,
-            samTemplate: associatedTemplate,
-            language
-        }
-        lenses.push(makeLocalInvokeCodeLens({ ...baseParams, isDebug: false }))
-        lenses.push(makeLocalInvokeCodeLens({ ...baseParams, isDebug: true }))
-
         try {
+            const associatedTemplate = await getAssociatedSamTemplate(
+                document.uri,
+                workspaceFolder.uri,
+                handler.handlerName
+            )
+            const baseParams: MakeConfigureCodeLensParams = {
+                document,
+                handlerName: handler.handlerName,
+                range,
+                workspaceFolder,
+                samTemplate: associatedTemplate,
+                language
+            }
+            lenses.push(makeLocalInvokeCodeLens({ ...baseParams, isDebug: false }))
+            lenses.push(makeLocalInvokeCodeLens({ ...baseParams, isDebug: true }))
+
             lenses.push(makeConfigureCodeLens(baseParams))
         } catch (err) {
             getLogger().error(
@@ -83,7 +85,7 @@ export async function makeCodeLenses({ document, token, handlers, language }: {
                 err as Error
             )
         }
-    })
+    }
 
     return lenses
 }
@@ -148,33 +150,27 @@ export function getMetricDatum({ command, isDebug, runtime }: {
 
 async function getAssociatedSamTemplate(
     documentUri: vscode.Uri,
-    workspaceFolderUri: vscode.Uri
+    workspaceFolderUri: vscode.Uri,
+    handlerName: string
 ): Promise<vscode.Uri> {
-
-    // Get Template files in Workspace
-    const templatesAsync: AsyncIterableIterator<vscode.Uri> = detectLocalTemplates({
+    const templates = detectLocalTemplates({
         workspaceUris: [workspaceFolderUri]
     })
 
-    // See which templates (if any) are in a folder, or parent folder, of the document of interest
-    const templates = await toArrayAsync(templatesAsync)
-    const candidateTemplates = templates
-        .filter(template => {
-            const folder = path.dirname(template.fsPath)
+    for await (const template of templates) {
+        try {
+            // Throws if template does not contain a resource for this handler.
+            await CloudFormation.getResourceFromTemplate({
+                templatePath: template.fsPath,
+                handlerName
+            })
+        } catch {
+            continue
+        }
 
-            return documentUri.fsPath.indexOf(folder) === 0
-        })
-
-    if (candidateTemplates.length === 0) {
-        throw new Error(
-            `Unable to find a sam template associated with ${documentUri.fsPath}. Skipping CodeLens generation.`
-        )
-    } else if (candidateTemplates.length > 1) {
-        throw new Error(
-            `More than one sam template associated with ${documentUri.fsPath}. Skipping CodeLens generation.`
-            + ` Templates detected: ${candidateTemplates.map(t => t.fsPath).join(', ')}`
-        )
+        // If there are multiple matching templates, use the first one.
+        return template
     }
 
-    return candidateTemplates[0]
+    throw new Error(`Unable to find a sam template associated with handler '${handlerName}' in ${documentUri.fsPath}.`)
 }


### PR DESCRIPTION
## Description

* Do not render codelenses for 'raw' lambdas (which will throw if invoked).
* Fix Python Code Lens Provider to support SAM templates that are in an ancestor directory of the source file.

## Motivation and Context

We removed support for 'raw' lambdas several months ago, but never disabled the rendering of code lenses for this scenario. We will eventually re-enable support for 'raw' lambdas, but for now the code lenses should not be rendered.

## Testing

* Ran all new and existing tests.
* Manually tried the following:
1. Create a new Python SAM app, verify that code lenses appear.
2. Close and re-open VS Code, verify that code lenses appear.
3. Add a 'raw' handler to the source file, verify that code lenses appear for the original handler, but not the raw handler.

## Checklist

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
