### PR TITLE
Fix rendering of Python code lenses when JEDI is enabled.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3305,7 +3305,7 @@
         },
         "tunnel": {
             "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+            "resolved": "http://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
             "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
             "dev": true
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -228,7 +228,7 @@ async function activateCodeLensProviders(
     await pyLensProvider.initialize(providerParams)
     disposables.push(vscode.languages.registerCodeLensProvider(
         pyLensProvider.PYTHON_ALLFILES,
-        await pyLensProvider.makePythonCodeLensProvider()
+        await pyLensProvider.makePythonCodeLensProvider(new DefaultSettingsConfiguration('python'))
     ))
 
     await csLensProvider.initialize(providerParams)

--- a/src/shared/codelens/pythonCodeLensProvider.ts
+++ b/src/shared/codelens/pythonCodeLensProvider.ts
@@ -60,14 +60,22 @@ async function getLambdaHandlerCandidates({
     pythonSettings: SettingsConfiguration
 }): Promise<LambdaHandlerCandidate[]> {
     const PYTHON_JEDI_ENABLED_KEY = 'jediEnabled'
+    const RETRY_INTERVAL_MS = 1000
+    const MAX_RETRIES = 10
 
     const logger = getLogger()
     const filename = uri.fsPath
 
-    const RETRY_INTERVAL_MS = 1000
-    const MAX_RETRIES = 10
     let symbols: vscode.DocumentSymbol[] =
         await vscode.commands.executeCommand<vscode.DocumentSymbol[]>('vscode.executeDocumentSymbolProvider', uri) || []
+
+    // A recent regression in vscode-python stops codelenses from rendering if we first return an empty array
+    // (because symbols have not yet been loaded), then a non-empty array (when our codelens provider is re-invoked
+    // upon symbols loading). To work around this, we attempt to wait for symbols to load before returning. We cannot
+    // distinguish between "the document does not contain any symbols" and "the symbols have not yet been loaded", so
+    // we stop retrying if we are still getting an empty result after several retries.
+    //
+    // This issue only surfaces when the setting `python.jediEnabled` is not set to false.
     const jediEnabled = pythonSettings.readSetting<boolean>(PYTHON_JEDI_ENABLED_KEY, true)
     if (jediEnabled) {
         for (let i = 0; i < MAX_RETRIES && !symbols.length; i++) {

--- a/src/shared/codelens/pythonCodeLensProvider.ts
+++ b/src/shared/codelens/pythonCodeLensProvider.ts
@@ -76,6 +76,9 @@ async function getLambdaHandlerCandidates({
     // we stop retrying if we are still getting an empty result after several retries.
     //
     // This issue only surfaces when the setting `python.jediEnabled` is not set to false.
+    // TODO: When the above issue is resolved, remove this workaround AND bump the minimum
+    //       required VS Code version and/or add a minimum supported version for the Python
+    //       extension.
     const jediEnabled = pythonSettings.readSetting<boolean>(PYTHON_JEDI_ENABLED_KEY, true)
     if (jediEnabled) {
         for (let i = 0; i < MAX_RETRIES && !symbols.length; i++) {

--- a/src/shared/codelens/pythonCodeLensProvider.ts
+++ b/src/shared/codelens/pythonCodeLensProvider.ts
@@ -16,6 +16,7 @@ import { LambdaHandlerCandidate } from '../lambdaHandlerSearch'
 import { getLogger } from '../logger'
 import { DefaultValidatingSamCliProcessInvoker } from '../sam/cli/defaultValidatingSamCliProcessInvoker'
 import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../sam/cli/samCliLocalInvoke'
+import { SettingsConfiguration } from '../settingsConfiguration'
 import { Datum, TelemetryNamespace } from '../telemetry/telemetryTypes'
 import { registerCommand } from '../telemetry/telemetryUtils'
 import { getChannelLogger, getDebugPort } from '../utilities/vsCodeUtils'
@@ -51,12 +52,32 @@ const getSamProjectDirPathForFile = async (filepath: string): Promise<string> =>
     return path.dirname(filepath)
 }
 
-const getLambdaHandlerCandidates = async ({ uri }: { uri: vscode.Uri }): Promise<LambdaHandlerCandidate[]> => {
+async function getLambdaHandlerCandidates({
+    uri,
+    pythonSettings
+}: {
+    uri: vscode.Uri
+    pythonSettings: SettingsConfiguration
+}): Promise<LambdaHandlerCandidate[]> {
+    const PYTHON_JEDI_ENABLED_KEY = 'jediEnabled'
+
     const logger = getLogger()
     const filename = uri.fsPath
-    const symbols: vscode.DocumentSymbol[] =
-        (await vscode.commands.executeCommand<vscode.DocumentSymbol[]>('vscode.executeDocumentSymbolProvider', uri)) ||
-        []
+
+    const RETRY_INTERVAL_MS = 1000
+    const MAX_RETRIES = 10
+    let symbols: vscode.DocumentSymbol[] =
+        await vscode.commands.executeCommand<vscode.DocumentSymbol[]>('vscode.executeDocumentSymbolProvider', uri) || []
+    const jediEnabled = pythonSettings.readSetting<boolean>(PYTHON_JEDI_ENABLED_KEY, true)
+    if (jediEnabled) {
+        for (let i = 0; i < MAX_RETRIES && !symbols.length; i++) {
+            await new Promise<void>(resolve => setTimeout(resolve, RETRY_INTERVAL_MS))
+            symbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+                'vscode.executeDocumentSymbolProvider',
+                uri
+            ) || []
+        }
+    }
 
     return symbols
         .filter(sym => sym.kind === vscode.SymbolKind.Function)
@@ -358,7 +379,9 @@ async function deleteFile(filePath: string): Promise<void> {
     }
 }
 
-export async function makePythonCodeLensProvider(): Promise<vscode.CodeLensProvider> {
+export async function makePythonCodeLensProvider(
+    pythonSettings: SettingsConfiguration
+): Promise<vscode.CodeLensProvider> {
     const logger = getLogger()
 
     return {
@@ -367,7 +390,10 @@ export async function makePythonCodeLensProvider(): Promise<vscode.CodeLensProvi
             document: vscode.TextDocument,
             token: vscode.CancellationToken
         ): Promise<vscode.CodeLens[]> => {
-            const handlers: LambdaHandlerCandidate[] = await getLambdaHandlerCandidates({ uri: document.uri })
+            const handlers: LambdaHandlerCandidate[] = await getLambdaHandlerCandidates({
+                uri: document.uri,
+                pythonSettings
+            })
             logger.debug(
                 'pythonCodeLensProvider.makePythonCodeLensProvider handlers:',
                 JSON.stringify(handlers, undefined, 2)


### PR DESCRIPTION
## Description

If JEDI is enabled and the python document symbol provider returns an empty result, retry until symbols are found or polling times out.

## Motivation and Context

A recent regression in the Python extension for VS Code breaks rendering of code lenses in some cases when JEDI is enabled. If a code lens provider is called twice, and returns `[]` the first time, and a non-empty result the second time, the second result is ignored.

This causes issues because when we first query VS Code for document symbols, they have not yet been loaded, so VS Code returns an empty result. To work around this, when JEDI is enabled, poll the symbol provider until it returns symbols instead of immediately returning if no symbols are found. Include a timeout, in case there truly are no symbols in the document.

This workaround should be removed when the underlying bug is fixed.

## Testing

1. Ran all new and existing tests.
2. Manual scenarios:

* Activate extension with a python file already open and JEDI enabled.
* Activate extension with a python file already open and JEDI disabled.
* Open a python file with the extension already active and JEDI enabled.
* Open a python file with the extension already active and JEDI disabled.

## Checklist

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
