### PR TITLE
Fix session token login issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the "aws-vscode-tools" extension will be documented in th
 
 ## NEXT (Developer Preview)
 
-* Fixed MFA login (https://github.com/aws/aws-toolkit-vscode/issues/620)
+* Fixed issue preventing users from connecting with assumed roles (#620)
 
 ## 0.2.0 (Developer Preview)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "aws-vscode-tools" extension will be documented in this file.
 
+## NEXT (Developer Preview)
+
+* Fixed MFA login (https://github.com/aws/aws-toolkit-vscode/issues/620)
+
 ## 0.2.0 (Developer Preview)
 
 * Local Run/Debug is now available for .NET Core 2.1 functions within SAM Applications

--- a/src/shared/credentials/userCredentialsUtils.ts
+++ b/src/shared/credentials/userCredentialsUtils.ts
@@ -142,7 +142,8 @@ export class UserCredentialsUtils {
             const transformedCredentials: ServiceConfigurationOptions = {
                 credentials: {
                     accessKeyId: credentials.accessKeyId,
-                    secretAccessKey: credentials.secretAccessKey
+                    secretAccessKey: credentials.secretAccessKey,
+                    sessionToken: credentials.sessionToken
                 }
             }
             try {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix MFA login by passing the session token to our `sts.getCallerIdentity` calls. Other calls should be unaffected.

## Motivation and Context

Broke MFA users

## Related Issue(s)

https://github.com/aws/aws-toolkit-vscode/issues/620

## Testing

Tested logging in as an MFA user. Soon: test other AWS calls (list and deploy operations)

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
