### PR TITLE
Use MemorySize from Sam Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "aws-vscode-tools" extension will be documented in this file.
 
+## NEXT (Developer Preview)
+
+* Local Run/Debug now honors MemorySize values from SAM Template file
+
 ## 0.2.0 (Developer Preview)
 
 * Local Run/Debug is now available for .NET Core 2.1 functions within SAM Applications

--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -46,6 +46,7 @@ export namespace CloudFormation {
         Handler: string,
         CodeUri: string,
         Runtime?: string,
+        MemorySize?: number,
         Timeout?: number,
         Environment?: Environment
     }

--- a/src/shared/codelens/localLambdaRunner.ts
+++ b/src/shared/codelens/localLambdaRunner.ts
@@ -167,10 +167,15 @@ export class LocalLambdaRunner {
 
         if (
             existingTemplateResource &&
-            existingTemplateResource.Properties &&
-            existingTemplateResource.Properties.Environment
+            existingTemplateResource.Properties
         ) {
-            newTemplate = newTemplate.withEnvironment(existingTemplateResource.Properties.Environment)
+            if (existingTemplateResource.Properties.Environment) {
+                newTemplate = newTemplate.withEnvironment(existingTemplateResource.Properties.Environment)
+            }
+
+            if (existingTemplateResource.Properties.MemorySize) {
+                newTemplate = newTemplate.withMemorySize(existingTemplateResource.Properties.MemorySize)
+            }
         }
 
         await newTemplate.generate(inputTemplatePath)

--- a/src/shared/codelens/localLambdaRunner.ts
+++ b/src/shared/codelens/localLambdaRunner.ts
@@ -139,7 +139,6 @@ export class LocalLambdaRunner {
      */
     private async generateInputTemplate(rootCodeFolder: string): Promise<string> {
         const buildFolder: string = await this.getBaseBuildFolder()
-        const inputTemplatePath: string = path.join(buildFolder, 'input', 'input-template.yaml')
 
         // Make function handler relative to baseDir
         const handlerFileRelativePath = path.relative(
@@ -152,35 +151,23 @@ export class LocalLambdaRunner {
             .replace('\\', '/')
 
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(this.localInvokeParams.workspaceFolder.uri)
-        let existingTemplateResource: CloudFormation.Resource | undefined
+        let properties: CloudFormation.ResourceProperties | undefined
         if (workspaceFolder) {
             const lambdas = await detectLocalLambdas([workspaceFolder])
             const existingLambda = lambdas.find(lambda => lambda.handler === relativeFunctionHandler)
-            existingTemplateResource = existingLambda ? existingLambda.resource : undefined
-        }
 
-        let newTemplate = new SamTemplateGenerator()
-            .withCodeUri(rootCodeFolder)
-            .withFunctionHandler(relativeFunctionHandler)
-            .withResourceName(TEMPLATE_RESOURCE_NAME)
-            .withRuntime(this.runtime)
-
-        if (
-            existingTemplateResource &&
-            existingTemplateResource.Properties
-        ) {
-            if (existingTemplateResource.Properties.Environment) {
-                newTemplate = newTemplate.withEnvironment(existingTemplateResource.Properties.Environment)
-            }
-
-            if (existingTemplateResource.Properties.MemorySize) {
-                newTemplate = newTemplate.withMemorySize(existingTemplateResource.Properties.MemorySize)
+            if (existingLambda && existingLambda.resource && existingLambda.resource.Properties) {
+                properties = existingLambda.resource.Properties
             }
         }
 
-        await newTemplate.generate(inputTemplatePath)
-
-        return inputTemplatePath
+        return await makeInputTemplate({
+            baseBuildDir: buildFolder,
+            codeDir: rootCodeFolder,
+            relativeFunctionHandler,
+            properties,
+            runtime: this.runtime,
+        })
     }
 
     private async executeSamBuild(rootCodeFolder: string, inputTemplatePath: string): Promise<string> {
@@ -360,8 +347,15 @@ export async function makeInputTemplate(params: {
         .withResourceName(TEMPLATE_RESOURCE_NAME)
         .withRuntime(params.runtime)
         .withCodeUri(params.codeDir)
-    if (params.properties && params.properties.Environment) {
-        newTemplate.withEnvironment(params.properties.Environment)
+
+    if (params.properties) {
+        if (params.properties.Environment) {
+            newTemplate.withEnvironment(params.properties.Environment)
+        }
+
+        if (params.properties.MemorySize) {
+            newTemplate.withMemorySize(params.properties.MemorySize)
+        }
     }
 
     const inputTemplatePath: string = path.join(params.baseBuildDir, 'input', 'input-template.yaml')

--- a/src/shared/templates/sam/samTemplateGenerator.ts
+++ b/src/shared/templates/sam/samTemplateGenerator.ts
@@ -39,6 +39,12 @@ export class SamTemplateGenerator {
         return this
     }
 
+    public withMemorySize(memorySize: number): SamTemplateGenerator {
+        this.properties.MemorySize = memorySize
+
+        return this
+    }
+
     public withEnvironment(env: CloudFormation.Environment): SamTemplateGenerator {
         this.properties.Environment = env
 

--- a/src/test/templates/sam/samTemplateGenerator.test.ts
+++ b/src/test/templates/sam/samTemplateGenerator.test.ts
@@ -17,6 +17,7 @@ describe('SamTemplateGenerator', () => {
     const sampleCodeUriValue: string = 'sampleCodeUri'
     const sampleFunctionHandlerValue: string = 'sampleFunctionHandler'
     const sampleResourceNameValue: string = 'sampleResourceName'
+    const sampleMemorySize: number = 256
     const sampleRuntimeValue: string = 'sampleRuntime'
     const sampleEnvironment: CloudFormation.Environment = {
         Variables: {
@@ -41,6 +42,7 @@ describe('SamTemplateGenerator', () => {
             .withFunctionHandler(sampleFunctionHandlerValue)
             .withRuntime(sampleRuntimeValue)
             .withResourceName(sampleResourceNameValue)
+            .withMemorySize(sampleMemorySize)
             .withEnvironment(sampleEnvironment)
             .generate(templateFilename)
 
@@ -54,6 +56,7 @@ describe('SamTemplateGenerator', () => {
         assert.ok(resource)
         assert.strictEqual(resource!.Properties!.CodeUri, sampleCodeUriValue)
         assert.strictEqual(resource!.Properties!.Handler, sampleFunctionHandlerValue)
+        assert.strictEqual(resource!.Properties!.MemorySize, sampleMemorySize)
         assert.strictEqual(resource!.Properties!.Runtime, sampleRuntimeValue)
         assert.deepStrictEqual(resource!.Properties!.Environment, sampleEnvironment)
     })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Local Run and Debug of SAM Applications now uses the MemorySize value if one is set in the SAM Template Resource.

## Related Issue(s)

#509 

## Testing

* ran tests
* Windows: local run/debug of node8, dotnet21, python3.6 with custom `MemorySize` values in the template.yaml file
* Mac: local run/debug of node8, dotnet21, python3.6 with custom `MemorySize` values in the template.yaml file

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
