### PR TITLE
Removed DebugAttach* metrics and moved values to metadata for lambda_…

### DIFF
--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -132,18 +132,41 @@ function makeConfigureCodeLens({
     return new vscode.CodeLens(range, command)
 }
 
-export function getMetricDatum({ command, isDebug, runtime }: {
+export function getMetricDatum({
+    command,
+    isDebug,
+    runtime,
+    samVersion,
+    duration,
+    attempts
+}: {
     command: string,
     isDebug: boolean,
     runtime: string,
+    samVersion?: string,
+    duration?: number,
+    attempts?: number
+
 }): { datum: Datum } {
+    const metadata = new Map([
+        ['runtime', runtime],
+        ['debug', `${isDebug}`]
+    ])
+    // TODO: Capture this information (Jetbrains captures this)
+    if (samVersion) {
+        metadata.set('samVersion', samVersion)
+    }
+    if (duration) {
+        metadata.set('duration', duration.toString())
+    }
+    if (attempts) {
+        metadata.set('attempts', attempts.toString())
+    }
+
     return {
         datum: {
             ...defaultMetricDatum(command),
-            metadata: new Map([
-                ['runtime', runtime],
-                ['debug', `${isDebug}`]
-            ])
+            metadata
         }
     }
 }

--- a/src/shared/codelens/csharpCodeLensProvider.ts
+++ b/src/shared/codelens/csharpCodeLensProvider.ts
@@ -34,6 +34,7 @@ import {
     makeCodeLenses,
 } from './codeLensUtils'
 import {
+    DebuggerMetadata,
     executeSamBuild,
     ExecuteSamBuildArguments,
     invokeLambdaFunction,
@@ -172,6 +173,7 @@ async function onLocalInvokeCommand(
         handlerName: lambdaLocalInvokeParams.handlerName,
     })
     const runtime = CloudFormation.getRuntime(resource)
+    let debugMetadata: DebuggerMetadata | undefined
 
     try {
         // Switch over to the output channel so the user has feedback that we're getting things ready
@@ -244,7 +246,7 @@ async function onLocalInvokeCommand(
                 codeUri
             })
 
-            await invokeLambdaFunction(
+            debugMetadata = await invokeLambdaFunction(
                 {
                     ...invokeArgs,
                     debugArgs: {
@@ -274,6 +276,8 @@ async function onLocalInvokeCommand(
         isDebug: lambdaLocalInvokeParams.isDebug,
         command: commandName,
         runtime,
+        attempts: debugMetadata ? debugMetadata.attempts : undefined,
+        duration: debugMetadata ? debugMetadata.duration : undefined,
     })
 }
 

--- a/src/test/shared/codelens/localLambdaRunner.test.ts
+++ b/src/test/shared/codelens/localLambdaRunner.test.ts
@@ -140,12 +140,14 @@ describe('localLambdaRunner', async () => {
                 maxRetries: 0,
                 onStartDebugging: startDebuggingReturnsTrue,
                 onWillRetry,
-                onRecordAttachDebuggerMetric: (
+                onProvideDebuggerMetadata: (
                     attachResult: boolean | undefined,
                     attempts: number
                 ) => {
                     assert.ok(attachResult, 'Expected to be logging an attach success metric')
                     assert.strictEqual(attempts, 1, 'Unexpected Attempt count')
+
+                    return {success: true}
                 }
             })
         })
@@ -199,11 +201,13 @@ describe('localLambdaRunner', async () => {
                 maxRetries: 0,
                 onStartDebugging: startDebuggingReturnsFalse,
                 onWillRetry,
-                onRecordAttachDebuggerMetric: (
+                onProvideDebuggerMetadata: (
                     attachResult: boolean | undefined,
                     attempts: number
                 ) => {
                     assert.strictEqual(attachResult, false, 'Expected to be logging an attach failure metric')
+
+                    return {success: false}
                 }
             })
         })
@@ -261,11 +265,13 @@ describe('localLambdaRunner', async () => {
                 channelLogger,
                 maxRetries: 2,
                 onStartDebugging: startDebuggingReturnsUndefined,
-                onRecordAttachDebuggerMetric: (
+                onProvideDebuggerMetadata: (
                     attachResult: boolean | undefined, attempts: number
-                ): void => {
+                ) => {
                     assert.strictEqual(actualRetries, 2, 'Metrics should only be recorded once')
                     assert.notStrictEqual(attachResult, undefined, 'attachResult should not be undefined')
+
+                    return { success: false }
                 },
                 onWillRetry,
             })


### PR DESCRIPTION
…invokelocal

<!--- Provide a general summary of your changes in the Title above -->

## Description

Removed the following metrics:
```
DebugAttachSuccess_attempts
DebugAttachSuccess_duration
DebugAttachFailure_attempts
DebugAttachFailure_duration
```
Append this data to `lambda_invokelocal` or equivalent calls (see https://github.com/aws/aws-toolkit-vscode/issues/632) in the following format:
```
{
...
    metadata.isDebug: true
    metadata.attempts: # 
    metadata.duration: #####
...
}
```

## Motivation and Context
Metrics tied to a local invoke should not have their own event metadata. This moves this metric in line with Jetbrains.

## Related Issue(s)
https://github.com/aws/aws-toolkit-vscode/issues/635

## Testing

Inspected return values for debugger data and confirmed metric appears for debug on all runtimes. Existing tests pass.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
