### PR TITLE
Fix telemetry names for lambda_localinvoke and project_new.

### DIFF
--- a/src/lambda/lambdaTreeDataProvider.ts
+++ b/src/lambda/lambdaTreeDataProvider.ts
@@ -70,7 +70,7 @@ export class LambdaTreeDataProvider implements vscode.TreeDataProvider<AWSTreeNo
                     this.channelLogger,
                     context
                 )
-                const datum = defaultMetricDatum(createNewSamAppCommand)
+                const datum = defaultMetricDatum('new')
                 datum.metadata = new Map()
                 applyResultsToMetadata(createNewSamApplicationResults, datum.metadata)
 

--- a/src/lambda/lambdaTreeDataProvider.ts
+++ b/src/lambda/lambdaTreeDataProvider.ts
@@ -62,9 +62,8 @@ export class LambdaTreeDataProvider implements vscode.TreeDataProvider<AWSTreeNo
             callback: async () => this.refresh()
         })
 
-        const createNewSamAppCommand = 'aws.lambda.createNewSamApp'
         registerCommand({
-            command: createNewSamAppCommand,
+            command: 'aws.lambda.createNewSamApp',
             callback: async (): Promise<{ datum: Datum }> => {
                 const createNewSamApplicationResults: CreateNewSamApplicationResults = await createNewSamApplication(
                     this.channelLogger,

--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -132,14 +132,13 @@ function makeConfigureCodeLens({
     return new vscode.CodeLens(range, command)
 }
 
-export function getMetricDatum({ command, isDebug, runtime }: {
-    command: string,
+export function getMetricDatum({ isDebug, runtime }: {
     isDebug: boolean,
     runtime: string,
 }): { datum: Datum } {
     return {
         datum: {
-            ...defaultMetricDatum(command),
+            ...defaultMetricDatum('invokelocal'),
             metadata: new Map([
                 ['runtime', runtime],
                 ['debug', `${isDebug}`]

--- a/src/shared/codelens/csharpCodeLensProvider.ts
+++ b/src/shared/codelens/csharpCodeLensProvider.ts
@@ -78,7 +78,6 @@ export async function initialize({
         command,
         callback: async (params: LambdaLocalInvokeParams): Promise<{ datum: Datum }> => {
             return await onLocalInvokeCommand({
-                commandName: command,
                 lambdaLocalInvokeParams: params,
                 configuration,
                 toolkitOutputChannel,
@@ -138,7 +137,6 @@ async function onLocalInvokeCommand(
     {
         configuration,
         toolkitOutputChannel,
-        commandName,
         lambdaLocalInvokeParams,
         processInvoker,
         localInvokeCommand,
@@ -148,7 +146,6 @@ async function onLocalInvokeCommand(
     }: {
         configuration: SettingsConfiguration
         toolkitOutputChannel: vscode.OutputChannel,
-        commandName: string,
         lambdaLocalInvokeParams: LambdaLocalInvokeParams,
         processInvoker: SamCliProcessInvoker,
         localInvokeCommand: SamLocalInvokeCommand
@@ -272,7 +269,6 @@ async function onLocalInvokeCommand(
 
     return getMetricDatum({
         isDebug: lambdaLocalInvokeParams.isDebug,
-        command: commandName,
         runtime,
     })
 }

--- a/src/shared/codelens/pythonCodeLensProvider.ts
+++ b/src/shared/codelens/pythonCodeLensProvider.ts
@@ -356,7 +356,7 @@ export async function initialize({
 
     const command = getInvokeCmdKey('python')
     registerCommand({
-        command: command,
+        command,
         callback: async (params: LambdaLocalInvokeParams): Promise<{ datum: Datum }> => {
             const resource = await CloudFormation.getResourceFromTemplate({
                 handlerName: params.handlerName,
@@ -371,7 +371,6 @@ export async function initialize({
 
             return getMetricDatum({
                 isDebug: params.isDebug,
-                command,
                 runtime
             })
         },

--- a/src/shared/codelens/typescriptCodeLensProvider.ts
+++ b/src/shared/codelens/typescriptCodeLensProvider.ts
@@ -106,7 +106,7 @@ export function initialize({
 
     const command = getInvokeCmdKey('javascript')
     registerCommand({
-        command: command,
+        command,
         callback: async (params: LambdaLocalInvokeParams): Promise<{ datum: Datum }> => {
             const resource = await CloudFormation.getResourceFromTemplate({
                 handlerName: params.handlerName,
@@ -131,7 +131,6 @@ export function initialize({
 
             return getMetricDatum({
                 isDebug: params.isDebug,
-                command,
                 runtime,
             })
         },


### PR DESCRIPTION

## Description

We are using outdated telemetry names for "invoke locally" and "create new SAM app". This is because the telemetry name passed to `registerCommand` is only used if no datum is provided. If a datum is provided, its name takes precedence.

## Motivation and Context

Our telemetry for this event does not match the other toolkits, nor our own conventions.

## Related Issue(s)

#632

## Testing

* Ran all existing tests.
* Put a breakpoint in `TelemetryService.record`, created a new SAM app. Verified that the correct telemetry name is used.
* Invoked the code lens on the new app. Verified that the correct telemetry name is used.

## Checklist

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
