### PR TITLE
Ensure that all commands record telemetry.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -143,25 +143,22 @@ export async function activate(context: vscode.ExtensionContext) {
         })
 
         // register URLs in extension menu
-        vscode.commands.registerCommand(
-            'aws.help',
-            () => { vscode.env.openExternal(vscode.Uri.parse(documentationUrl)) }
-        )
-        vscode.commands.registerCommand(
-            'aws.github',
-            () => { vscode.env.openExternal(vscode.Uri.parse(githubUrl)) }
-        )
-        vscode.commands.registerCommand(
-            'aws.reportIssue',
-            () => { vscode.env.openExternal(vscode.Uri.parse(reportIssueUrl)) }
-        )
-
-        // TODO: Move to Telemetry registerCommand and add a metric:
-        // https://github.com/aws/aws-toolkit-vscode/issues/625
-        vscode.commands.registerCommand(
-            'aws.quickStart',
-            async () => { await showQuickStartWebview(context) }
-        )
+        registerCommand({
+            command: 'aws.help',
+            callback: async () => { vscode.env.openExternal(vscode.Uri.parse(documentationUrl)) }
+        })
+        registerCommand({
+            command: 'aws.github',
+            callback: async () => { vscode.env.openExternal(vscode.Uri.parse(githubUrl)) }
+        })
+        registerCommand({
+            command: 'aws.reportIssue',
+            callback: async () => { vscode.env.openExternal(vscode.Uri.parse(reportIssueUrl)) }
+        })
+        registerCommand({
+            command: 'aws.quickStart',
+            callback: async () => { await showQuickStartWebview(context) }
+        })
 
         const providers = [
             new LambdaTreeDataProvider(

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -15,6 +15,7 @@ import { extensionSettingsPrefix } from './constants'
 import { mkdir } from './filesystem'
 import { fileExists } from './filesystemUtilities'
 import { DefaultSettingsConfiguration, SettingsConfiguration } from './settingsConfiguration'
+import { registerCommand } from './telemetry/telemetryUtils'
 
 const localize = nls.loadMessageBundle()
 
@@ -78,10 +79,10 @@ export async function initialize(params?: LoggerParams): Promise<Logger> {
                 return defaultLogger
             }
         }
-        vscode.commands.registerCommand(
-            'aws.viewLogs',
-            async () => await openLogFile()
-        )
+        registerCommand({
+            command: 'aws.viewLogs',
+            callback: async () => await openLogFile()
+        })
     } else {
         defaultLogger = createLogger(params)
     }


### PR DESCRIPTION
## Description

Ensure that all commands record a telemetry event when invoked.

## Motivation and Context

Some of our commands were not registered using our `registerCommand` util, and therefore lacked associated telemetry.

## Related Issue(s)

#625 
#634 

## Testing

* Ran all existing tests.
* Put a breakpoint in TelemetryService.record, and ensured the updated commands record events.

## Checklist

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
