### PR TITLE
Adding SAM App commands to the AWS Explorer menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the "aws-vscode-tools" extension will be documented in th
 * Local Run/Debug now honors the Globals section from SAM Template file
 * Fixed issue preventing users from connecting with assumed roles (#620)
 * Added ability to report an issue from the AWS Explorer menu (#613)
+* Added SAM Application-related commands to the AWS Explorer menu
 
 ## 0.2.0 (Developer Preview)
 

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
                 {
                     "command": "aws.deploySamApplication",
                     "when": "view == aws.explorer",
-                    "group": "3_lambda@1"
+                    "group": "3_lambda@2"
                 },
                 {
                     "command": "aws.quickStart",

--- a/package.json
+++ b/package.json
@@ -173,6 +173,16 @@
                     "group": "2_region@2"
                 },
                 {
+                    "command": "aws.lambda.createNewSamApp",
+                    "when": "view == aws.explorer",
+                    "group": "3_lambda@1"
+                },
+                {
+                    "command": "aws.deploySamApplication",
+                    "when": "view == aws.explorer",
+                    "group": "3_lambda@1"
+                },
+                {
                     "command": "aws.quickStart",
                     "when": "view == aws.explorer",
                     "group": "y_quickStart@1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding SAM Application commands to the AWS Explorer menu

## Motivation and Context

Users unfamiliar with the Command Palette may not be able to find SAM application-related commands (which make up the majority of the AWS Toolkit's current functionality). This places these items in a location that is more conventional to non-VS Code power users.

## Testing

Menu items appear and function correctly--created and deployed a SAM app through these menus.

## Screenshots (if appropriate)
![menu](https://user-images.githubusercontent.com/29374703/60207810-a0b83600-980b-11e9-8616-4eacba9dc122.png)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
