### PR TITLE
Create Sam App Wizard - Canceling open folder dialog takes user back to folder picker

### DIFF
--- a/src/lambda/wizards/samInitWizard.ts
+++ b/src/lambda/wizards/samInitWizard.ts
@@ -126,9 +126,20 @@ export class DefaultCreateNewSamAppWizardContext implements CreateNewSamAppWizar
                 }
             }
         })
-        const val = picker.verifySinglePickerOutput<FolderQuickPickItem>(choices)
+        const pickerResponse = picker.verifySinglePickerOutput<FolderQuickPickItem>(choices)
 
-        return val ? val.getUri() : undefined
+        if (!pickerResponse) {
+            return undefined
+        }
+
+        if (pickerResponse instanceof BrowseFolderQuickPickItem) {
+            const browseFolderResult = await pickerResponse.getUri()
+
+            // If user cancels from Open Folder dialog, send them back to the folder picker.
+            return browseFolderResult ? browseFolderResult : this.promptUserForLocation()
+        }
+
+        return pickerResponse.getUri()
     }
 
     public async promptUserForName(): Promise<string | undefined> {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Pressing Cancel on the "Open Folder" dialog would return the user back to the runtime selection step. To reduce confusion in the workflow, pressing cancel now returns the user to the folder selection step.

![open-folder-back-to-picker](https://user-images.githubusercontent.com/39839589/60529080-b06fc880-9caa-11e9-93f6-3b64e6a51026.gif)


## Testing

* Enter Create SAM App workflow. Progress to the folder selection stage.
  * ensure back button returns to the runtime step
  * ensure pressing ESC returns to the runtime step
  * ensure selecting a folder advances to the app name step
  * bringing up the open folder dialog, ensure pressing cancel returns to the folder selection step
  * bringing up the open folder dialog, ensure selecting a folder advances to the app name step

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
