### PR TITLE
Local Invoke (JS) - unsupported runtime is logged, and error message was made more clear

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -144,7 +144,7 @@
     "AWS.samcli.local.invoke.ended": "Local invoke of SAM Application has ended.",
     "AWS.samcli.local.invoke.error": "Error encountered running local SAM Application",
     "AWS.samcli.local.invoke.port.not.open": "The debug port doesn't appear to be open. The debugger might not succeed when attaching to your SAM Application.",
-    "AWS.samcli.local.invoke.runtime.unsupported": "Local invoke with {0} is not supported",
+    "AWS.samcli.local.invoke.runtime.unsupported": "Unsupported {0} runtime: {1}",
     "AWS.samcli.local.invoke.debugger.install": "Installing .NET Core Debugger to {0}...",
     "AWS.samcli.local.invoke.debugger.install.failed": "Error installing .NET Core Debugger: {0}",
     "AWS.samcli.local.invoke.debugger.timeout": "The SAM process did not make the debugger available within the time limit",


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

If you run a Javascript function, but have your template's runtime set a non-javascript runtime (eg: `python3.7`), the message says the runtime is unsupported, which is misleading. The message has been changed to indicate it is not a valid _javascript_ runtime in order to reduce confusion.
![image](https://user-images.githubusercontent.com/39839589/60555972-0321a280-9cf4-11e9-8608-c584906d3a56.png)

## Testing

Starting with a new node 8 sam application:
* press run/debug codelenses, see the function run/debug
* change template.yaml resource runtime to `python3.7`, try to run/debug, see new error message, and logged text
* change template.yaml resource runtime to `nodejs8.10x`, try to run/debug, see new error message, and logged text


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
