### PR TITLE
Remove regions that aren't in the standard AWS partition (until they can be supported)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the "aws-vscode-tools" extension will be documented in th
 * Added ability to report an issue from the AWS Explorer menu (#613)
 * Added SAM Application-related commands to the AWS Explorer menu
 * Removed support for nodejs6.10 SAM Applications
+* Regions that are not in the standard AWS partition have been removed from the UI until proper partition support can be added
 
 ## 0.2.1 (Developer Preview)
 

--- a/src/shared/regions/defaultRegionProvider.ts
+++ b/src/shared/regions/defaultRegionProvider.ts
@@ -14,18 +14,18 @@ import { FileResourceLocation, WebResourceLocation } from '../resourceLocation'
 import { RegionInfo } from './regionInfo'
 import { RegionProvider } from './regionProvider'
 
-interface RawRegion {
+export interface RawRegion {
     description: string
 }
 
-interface RawPartition {
+export interface RawPartition {
     partition: string
     regions: {
         [regionKey: string]: RawRegion
     }
 }
 
-interface RawEndpoints {
+export interface RawEndpoints {
     partitions: RawPartition[]
 }
 
@@ -65,9 +65,7 @@ export class DefaultRegionProvider implements RegionProvider {
                 .filter(partition => partition.partition && partition.partition === 'aws')
                 .reduce(
                     (accumulator: RegionInfo[], partition: RawPartition) => {
-                        accumulator.push(...Object.keys(partition.regions).map(
-                            regionKey => new RegionInfo(regionKey, `${partition.regions[regionKey].description}`)
-                        ))
+                        accumulator.push(...getRegionsFromPartition(partition))
 
                         return accumulator
                     },
@@ -86,4 +84,10 @@ export class DefaultRegionProvider implements RegionProvider {
 
         return availableRegions
     }
+}
+
+export function getRegionsFromPartition(partition: RawPartition): RegionInfo[] {
+    return Object.keys(partition.regions).map(
+        regionKey => new RegionInfo(regionKey, `${partition.regions[regionKey].description}`)
+    )
 }

--- a/src/shared/regions/defaultRegionProvider.ts
+++ b/src/shared/regions/defaultRegionProvider.ts
@@ -19,8 +19,9 @@ interface RawRegion {
 }
 
 interface RawPartition {
+    partition: string
     regions: {
-        [ regionKey: string ]: RawRegion
+        [regionKey: string]: RawRegion
     }
 }
 
@@ -59,16 +60,19 @@ export class DefaultRegionProvider implements RegionProvider {
             ])
             const allEndpoints = JSON.parse(endpointsSource) as RawEndpoints
 
-            availableRegions = allEndpoints.partitions.reduce(
-                (accumulator: RegionInfo[], partition: RawPartition) => {
-                    accumulator.push(...Object.keys(partition.regions).map(
-                        regionKey => new RegionInfo(regionKey, `${partition.regions[regionKey].description}`)
-                    ))
+            availableRegions = allEndpoints.partitions
+                // TODO : Support other Partition regions : https://github.com/aws/aws-toolkit-vscode/issues/188
+                .filter(partition => partition.partition && partition.partition === 'aws')
+                .reduce(
+                    (accumulator: RegionInfo[], partition: RawPartition) => {
+                        accumulator.push(...Object.keys(partition.regions).map(
+                            regionKey => new RegionInfo(regionKey, `${partition.regions[regionKey].description}`)
+                        ))
 
-                    return accumulator
-                },
-                []
-            )
+                        return accumulator
+                    },
+                    []
+                )
 
             this._areRegionsLoaded = true
             this._loadedRegions = availableRegions

--- a/src/shared/regions/defaultRegionProvider.ts
+++ b/src/shared/regions/defaultRegionProvider.ts
@@ -60,17 +60,7 @@ export class DefaultRegionProvider implements RegionProvider {
             ])
             const allEndpoints = JSON.parse(endpointsSource) as RawEndpoints
 
-            availableRegions = allEndpoints.partitions
-                // TODO : Support other Partition regions : https://github.com/aws/aws-toolkit-vscode/issues/188
-                .filter(partition => partition.partition && partition.partition === 'aws')
-                .reduce(
-                    (accumulator: RegionInfo[], partition: RawPartition) => {
-                        accumulator.push(...getRegionsFromPartition(partition))
-
-                        return accumulator
-                    },
-                    []
-                )
+            availableRegions = getRegionsFromEndpoints(allEndpoints)
 
             this._areRegionsLoaded = true
             this._loadedRegions = availableRegions
@@ -90,4 +80,18 @@ export function getRegionsFromPartition(partition: RawPartition): RegionInfo[] {
     return Object.keys(partition.regions).map(
         regionKey => new RegionInfo(regionKey, `${partition.regions[regionKey].description}`)
     )
+}
+
+export function getRegionsFromEndpoints(endpoints: RawEndpoints): RegionInfo[] {
+    return endpoints.partitions
+        // TODO : Support other Partition regions : https://github.com/aws/aws-toolkit-vscode/issues/188
+        .filter(partition => partition.partition && partition.partition === 'aws')
+        .reduce(
+            (accumulator: RegionInfo[], partition: RawPartition) => {
+                accumulator.push(...getRegionsFromPartition(partition))
+
+                return accumulator
+            },
+            []
+        )
 }

--- a/src/test/shared/regions/defaultRegionProvider.test.ts
+++ b/src/test/shared/regions/defaultRegionProvider.test.ts
@@ -1,0 +1,40 @@
+/*!
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+import * as assert from 'assert'
+import { getRegionsFromPartition, RawPartition } from '../../../shared/regions/defaultRegionProvider'
+
+describe('getRegionsFromPartition', async () => {
+    it('pulls region data from partition', async () => {
+        const partition: RawPartition = {
+            partition: 'qwerty',
+            regions: {
+                region1: {
+                    description: 'region one'
+                },
+                region2: {
+                    description: 'region two'
+                },
+                region3: {
+                    description: 'region three'
+                },
+            }
+        }
+
+        const regions = getRegionsFromPartition(partition)
+        assert.ok(regions, 'Expected to get regions')
+        assert.strictEqual(regions.length, 3, 'Expected 3 regions')
+        regions.forEach(region => {
+            assert.ok(partition.regions[region.regionCode], `Expected region for ${region.regionCode}`)
+            assert.strictEqual(
+                partition.regions[region.regionCode].description,
+                region.regionName,
+                'Region name mismatch'
+            )
+        })
+    })
+})

--- a/src/test/shared/regions/defaultRegionProvider.test.ts
+++ b/src/test/shared/regions/defaultRegionProvider.test.ts
@@ -6,35 +6,84 @@
 'use strict'
 
 import * as assert from 'assert'
-import { getRegionsFromPartition, RawPartition } from '../../../shared/regions/defaultRegionProvider'
+import {
+    getRegionsFromEndpoints,
+    getRegionsFromPartition,
+    RawEndpoints,
+    RawPartition
+} from '../../../shared/regions/defaultRegionProvider'
+import { RegionInfo } from '../../../shared/regions/regionInfo'
 
-describe('getRegionsFromPartition', async () => {
-    it('pulls region data from partition', async () => {
-        const partition: RawPartition = {
-            partition: 'qwerty',
+const sampleEndpoints: RawEndpoints = {
+    partitions: [
+        {
+            partition: 'aws',
             regions: {
                 region1: {
-                    description: 'region one'
+                    description: 'aws region one'
                 },
                 region2: {
-                    description: 'region two'
+                    description: 'aws region two'
                 },
                 region3: {
-                    description: 'region three'
+                    description: 'aws region three'
+                },
+            }
+        },
+        {
+            partition: 'aws-cn',
+            regions: {
+                awscnregion1: {
+                    description: 'aws-cn region one'
+                },
+            }
+        },
+        {
+            partition: 'fake',
+            regions: {
+                fakeregion1: {
+                    description: 'fake region one'
                 },
             }
         }
+    ]
+}
 
+describe('getRegionsFromPartition', async () => {
+    it('pulls region data from partition', async () => {
+        const partition = sampleEndpoints.partitions.filter(p => p.partition === 'aws')[0]
         const regions = getRegionsFromPartition(partition)
+
         assert.ok(regions, 'Expected to get regions')
         assert.strictEqual(regions.length, 3, 'Expected 3 regions')
-        regions.forEach(region => {
-            assert.ok(partition.regions[region.regionCode], `Expected region for ${region.regionCode}`)
-            assert.strictEqual(
-                partition.regions[region.regionCode].description,
-                region.regionName,
-                'Region name mismatch'
-            )
-        })
+        assertPartitionRegionsExist(partition, regions)
     })
 })
+
+describe('getRegionsFromEndpoints', async () => {
+    it('returns expected regions', async () => {
+        // TODO : Support other Partition regions : https://github.com/aws/aws-toolkit-vscode/issues/188
+        const partition = sampleEndpoints.partitions.filter(p => p.partition === 'aws')[0]
+        const regions = getRegionsFromEndpoints(sampleEndpoints)
+
+        assert.ok(regions, 'Expected to get regions')
+        assert.strictEqual(regions.length, 3, 'Expected 3 regions')
+        assertPartitionRegionsExist(partition, regions)
+    })
+})
+
+/**
+ * Assert that all regions in expectedPartition exist in actualRegions
+ */
+function assertPartitionRegionsExist(expectedPartition: RawPartition, actualRegions: RegionInfo[]) {
+    Object.keys(expectedPartition.regions).forEach(regionCode => {
+        const expectedRegion = expectedPartition.regions[regionCode]
+        const candidateRegions = actualRegions.filter(region => region.regionCode === regionCode)
+        assert.strictEqual(candidateRegions.length, 1, `Region not found for ${regionCode}`)
+        assert.strictEqual(
+            candidateRegions[0].regionName,
+            expectedRegion.description,
+            `Unexpected Region name for ${regionCode}`
+        )
+    })
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Until the Toolkit can support accounts in other partitions, it is confusing to surface regions for those partitions in the UI. All regions from other partitions have been removed.

The only logic change is to check for `partiton === 'aws'`, however I moved some existing code into functions and put tests around them, primarily to validate this change.

## Related Issue(s)

#660 

## Testing

* existing and new tests pass
* Ran the "Show Regions" command, the govcloud and china partition regions aren't listed
* Ran the "Deploy SAM Application" command, the govcloud and china partition regions aren't listed

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
