### PR TITLE
Fix case where app file would not load into editor after SAM App creation

### DIFF
--- a/.changes/next-release/Bug Fix-56d4c3e7-0079-4eba-a5b3-b43f278b1032.json
+++ b/.changes/next-release/Bug Fix-56d4c3e7-0079-4eba-a5b3-b43f278b1032.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Creating SAM Applications into a different folder than the current VS Code workspaces will now open an application file after app creation"
+	"description": "Creating SAM Applications into a different folder than the current VS Code workspaces will now open an application file after app creation (#678)"
 }

--- a/.changes/next-release/Bug Fix-56d4c3e7-0079-4eba-a5b3-b43f278b1032.json
+++ b/.changes/next-release/Bug Fix-56d4c3e7-0079-4eba-a5b3-b43f278b1032.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Creating SAM Applications into a different folder than the current VS Code workspaces will now open an application file after app creation"
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -195,7 +195,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
         toastNewUser(context, logFactory.getLogger())
 
-        await resumeCreateNewSamApp(context)
+        await resumeCreateNewSamApp()
     } catch (error) {
         const channelLogger = getChannelLogger(toolkitOutputChannel)
         channelLogger.error(

--- a/src/shared/activationLaunchPath.ts
+++ b/src/shared/activationLaunchPath.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-'use strict'
-
 import * as vscode from 'vscode'
 import { ext } from './extensionGlobals'
 

--- a/src/shared/activationLaunchPath.ts
+++ b/src/shared/activationLaunchPath.ts
@@ -1,0 +1,32 @@
+/*!
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+import * as vscode from 'vscode'
+import { ext } from './extensionGlobals'
+
+const ACTIVATION_LAUNCH_PATH_KEY = 'ACTIVATION_LAUNCH_PATH_KEY'
+
+/**
+ * Manages a setting to represent what path should be opened on extension activation.
+ */
+export class ActivationLaunchPath {
+    public getLaunchPath(): string | undefined {
+        return this.extensionContext.globalState.get<string>(ACTIVATION_LAUNCH_PATH_KEY)
+    }
+
+    public setLaunchPath(path: string): void {
+        this.extensionContext.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, path)
+    }
+
+    public clearLaunchPath(): void {
+        this.extensionContext.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, undefined)
+    }
+
+    protected get extensionContext(): vscode.ExtensionContext {
+        return ext.context
+    }
+}

--- a/src/shared/utilities/workspaceUtils.ts
+++ b/src/shared/utilities/workspaceUtils.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-'use strict'
-
 import * as vscode from 'vscode'
 import { getLogger } from '../logger'
 

--- a/src/shared/utilities/workspaceUtils.ts
+++ b/src/shared/utilities/workspaceUtils.ts
@@ -64,7 +64,7 @@ export async function addFolderToWorkspace(
             }
         })
     } catch (err) {
-        logger.error(`Unexpected error adding folder ${folder.uri.fsPath} to workspace`, err)
+        logger.error(`Unexpected error adding folder ${folder.uri.fsPath} to workspace`, err as Error)
 
         return false
     } finally {

--- a/src/shared/utilities/workspaceUtils.ts
+++ b/src/shared/utilities/workspaceUtils.ts
@@ -1,0 +1,75 @@
+/*!
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+import * as vscode from 'vscode'
+import { getLogger } from '../logger'
+
+/**
+ * VS Code API for updateWorkspaceFolders does not define a type for this parameter,
+ * so we will as a convenience.
+ */
+export interface NewWorkspaceFolder {
+    uri: vscode.Uri,
+    name?: string,
+}
+
+/**
+ * Encapsulates adding a folder to the VS Code Workspace.
+ *
+ * After the folder is added, this method waits until VS Code signals that the workspace has been updated.
+ *
+ * CALLER BEWARE: As of VS Code 1.36.00, any behavior that changes the first workspace folder causes VS Code to restart
+ * in order to reopen the "workspace", which halts code and re-activates the extension. In this case, this function
+ * will not return.
+ *
+ * Caller is responsible for validating whether or not the folder should be added to the workspace.
+ *
+ * @param folder - Folder to add to the VS Code Workspace
+ *
+ * @returns true if folder was added, false otherwise
+ */
+export async function addFolderToWorkspace(
+    folder: NewWorkspaceFolder,
+): Promise<boolean> {
+    const disposables: vscode.Disposable[] = []
+    const logger = getLogger()
+
+    try {
+        // Wait for the WorkspaceFolders changed notification for the folder of interest before returning to caller
+        return await new Promise<boolean>(resolve => {
+            vscode.workspace.onDidChangeWorkspaceFolders(
+                (workspaceFoldersChanged) => {
+                    if (workspaceFoldersChanged.added.some(
+                        addedFolder => addedFolder.uri.fsPath === folder.uri.fsPath
+                    )) {
+                        resolve(true)
+                    }
+                },
+                undefined,
+                disposables
+            )
+
+            if (!vscode.workspace.updateWorkspaceFolders(
+                // Add new folder to the end of the list rather than the beginning, to avoid VS Code
+                // terminating and reinitializing our extension.
+                (vscode.workspace.workspaceFolders || []).length,
+                0,
+                folder
+            )) {
+                resolve(false)
+            }
+        })
+    } catch (err) {
+        logger.error(`Unexpected error adding folder ${folder.uri.fsPath} to workspace`, err)
+
+        return false
+    } finally {
+        for (const disposable of disposables) {
+            disposable.dispose()
+        }
+    }
+}

--- a/src/test/shared/activationLaunchPath.test.ts
+++ b/src/test/shared/activationLaunchPath.test.ts
@@ -1,0 +1,64 @@
+/*!
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import { ActivationLaunchPath } from '../../shared/activationLaunchPath'
+import { FakeExtensionContext } from '../fakeExtensionContext'
+
+const GLOBAL_STATE_KEY = 'ACTIVATION_LAUNCH_PATH_KEY'
+
+class TestActivationLaunchPath extends ActivationLaunchPath {
+    public constructor(private readonly context: vscode.ExtensionContext) {
+        super()
+    }
+
+    protected get extensionContext(): vscode.ExtensionContext {
+        return this.context
+    }
+}
+
+describe('ActivationLaunchPath', async () => {
+    let extensionContext: FakeExtensionContext
+    let activationLaunchPath: ActivationLaunchPath
+
+    beforeEach(() => {
+        extensionContext = new FakeExtensionContext()
+        activationLaunchPath = new TestActivationLaunchPath(extensionContext)
+    })
+
+    it('setLaunchPath', async () => {
+        activationLaunchPath.setLaunchPath('somepath')
+
+        assert.strictEqual(
+            extensionContext.globalState.get(GLOBAL_STATE_KEY),
+            'somepath',
+            'Unexpected Launch Path value was set'
+        )
+    })
+
+    it('getLaunchPath', async () => {
+        await extensionContext.globalState.update(GLOBAL_STATE_KEY, 'getsomepath')
+
+        assert.strictEqual(
+            activationLaunchPath.getLaunchPath(),
+            'getsomepath',
+            'Unexpected Launch Path value was retrieved'
+        )
+    })
+
+    it('clearLaunchPath', async () => {
+        activationLaunchPath.setLaunchPath('somepath')
+        activationLaunchPath.clearLaunchPath()
+
+        assert.strictEqual(
+            extensionContext.globalState.get(GLOBAL_STATE_KEY),
+            undefined,
+            'Expected value to be cleared (undefined)'
+        )
+    })
+})


### PR DESCRIPTION

## Description

After creating a SAM App, a file from the application is supposed to auto-load into the editor.
If an app was created, but you selected a different folder instead of choosing one of the existing workspace folders, a file would not be loaded into the editor.

The root cause was attempting to set up a workspace filesystemwatcher on the new folder, but the documentation states that you can only do this against workspace folders. The code was sitting in a promise waiting for an event that would never happen.

I took the opportunity to add a few abstractions in related code.

## Related Issue(s)

#678 

## Testing

* Start with no workspace open, create a SAM App
* Start with a workspace open, create a SAM App to the workspace folder
* Start with a workspace open, create a SAM App to a different folder not contained in the workspace
In each of these scenarios, the desired outcome is that a file from the application is loaded into the editor

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
