### PR TITLE
Fix sporadic test failures by adding missing test logger setup

### DIFF
--- a/src/test/shared/codelens/localLambdaRunner.test.ts
+++ b/src/test/shared/codelens/localLambdaRunner.test.ts
@@ -12,6 +12,7 @@ import * as localLambdaRunner from '../../../shared/codelens/localLambdaRunner'
 import * as fs from '../../../shared/filesystem'
 import * as fsUtils from '../../../shared/filesystemUtilities'
 import { BasicLogger, ErrorOrString } from '../../../shared/logger'
+import { TestLogger } from '../../../shared/loggerUtils'
 import { ChildProcessResult } from '../../../shared/utilities/childProcess'
 import { ExtensionDisposableFiles } from '../../../shared/utilities/disposableFiles'
 import { ChannelLogger } from '../../../shared/utilities/vsCodeUtils'
@@ -58,14 +59,23 @@ class FakeBasicLogger implements BasicLogger {
 
 describe('localLambdaRunner', async () => {
 
+    let logger: TestLogger
     let tempDir: string
     before(async () => {
-        tempDir = await fsUtils.makeTemporaryToolkitFolder()
+        logger = await TestLogger.createTestLogger()
         await ExtensionDisposableFiles.initialize(new FakeExtensionContext())
     })
 
-    after(async () => {
+    beforeEach(async () => {
+        tempDir = await fsUtils.makeTemporaryToolkitFolder()
+    })
+
+    afterEach(async () => {
         await del(tempDir, { force: true })
+    })
+
+    after(async () => {
+        await logger.cleanupLogger()
     })
 
     describe('attachDebugger', async () => {
@@ -335,7 +345,7 @@ describe('localLambdaRunner', async () => {
     })
 
     describe('makeBuildDir', () => {
-        it ('creates a temp directory', async () => {
+        it('creates a temp directory', async () => {
             const dir = await localLambdaRunner.makeBuildDir()
             assert.ok(dir)
             assert.strictEqual(await fsUtils.fileExists(dir), true)
@@ -375,11 +385,11 @@ describe('localLambdaRunner', async () => {
             }
         }
 
-        it ('fails when the child process returns a nonzero exit code', async () => {
+        it('fails when the child process returns a nonzero exit code', async () => {
             await assertRejects(async () => localLambdaRunner.executeSamBuild(generateSamBuildParams(false)))
         })
 
-        it ('succeeds when the child process returns with an exit code of 0', async () => {
+        it('succeeds when the child process returns with an exit code of 0', async () => {
             const samBuildResult = await localLambdaRunner.executeSamBuild(generateSamBuildParams(true))
             assert.strictEqual(samBuildResult, path.join(tempDir, 'output', 'template.yaml'))
         })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This week the commit triggered builds have started sporadically failing. This set of tests was missing some logger initialization. Fixed.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
