### PR TITLE
Updated travis build script to use bionic and their supported headless browser testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,11 @@ node_js:
 matrix:
   include:
     - os: linux
+      dist: bionic
     - os: osx
 
-before_install:
-  # Set up X Virtual Framebuffer because an instance of VS Code runs the tests
-  # See https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui
-  - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
-      sh -e /etc/init.d/xvfb start;
-      sleep 3;
-    fi
+services:
+  - xvfb
 
 script:
   - npm install


### PR DESCRIPTION

## Description

Updating the Travis build scripts:
* switching from trusty (Ubuntu 14.04) to bionic (18.04)
* using the Travis supported headless testing (xvfb) approach

See: https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
