### PR TITLE
Renaming and reorganizing Lambda nodes

### DIFF
--- a/src/awsexplorer/awsExplorer.ts
+++ b/src/awsexplorer/awsExplorer.ts
@@ -8,9 +8,8 @@ import { deleteCloudFormation } from '../lambda/commands/deleteCloudFormation'
 import { deleteLambda } from '../lambda/commands/deleteLambda'
 import { invokeLambda } from '../lambda/commands/invokeLambda'
 import { CloudFormationStackNode } from '../lambda/explorer/cloudFormationNodes'
-import { DefaultRegionNode } from '../lambda/explorer/defaultRegionNode'
 import { FunctionNodeBase } from '../lambda/explorer/functionNode'
-import { StandaloneFunctionNode } from '../lambda/explorer/standaloneNodes'
+import { LambdaFunctionNode } from '../lambda/explorer/lambdaNodes'
 import { configureLocalLambda } from '../lambda/local/configureLocalLambda'
 import { AwsContext } from '../shared/awsContext'
 import { AwsContextTreeCollection } from '../shared/awsContextTreeCollection'
@@ -27,6 +26,7 @@ import { RegionNode } from '../shared/treeview/nodes/regionNode'
 import { showErrorDetails } from '../shared/treeview/webviews/showErrorDetails'
 import { intersection, toMap, updateInPlace } from '../shared/utilities/collectionUtils'
 import { localize } from '../shared/utilities/vsCodeUtils'
+import { DefaultRegionNode } from './defaultRegionNode'
 
 export class AwsExplorer implements vscode.TreeDataProvider<AWSTreeNodeBase>, RefreshableAwsTreeProvider {
     public viewProviderId: string = 'aws.explorer'
@@ -55,7 +55,7 @@ export class AwsExplorer implements vscode.TreeDataProvider<AWSTreeNodeBase>, Re
 
         registerCommand({
             command: 'aws.deleteLambda',
-            callback: async (node: StandaloneFunctionNode) => await deleteLambda({
+            callback: async (node: LambdaFunctionNode) => await deleteLambda({
                 deleteParams: { functionName: node.configuration.FunctionName || '' },
                 lambdaClient: ext.toolkitClientBuilder.createLambdaClient(node.regionCode),
                 outputChannel: this.lambdaOutputChannel,

--- a/src/awsexplorer/defaultRegionNode.ts
+++ b/src/awsexplorer/defaultRegionNode.ts
@@ -4,15 +4,15 @@
  */
 
 import { TreeItemCollapsibleState } from 'vscode'
-import { RegionInfo } from '../../shared/regions/regionInfo'
-import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
-import { RegionNode } from '../../shared/treeview/nodes/regionNode'
-import { toMap, updateInPlace } from '../../shared/utilities/collectionUtils'
-import { CloudFormationNode, DefaultCloudFormationNode } from './cloudFormationNodes'
+import { CloudFormationNode, DefaultCloudFormationNode } from '../lambda/explorer/cloudFormationNodes'
 import {
-    DefaultStandaloneFunctionGroupNode,
-    StandaloneFunctionGroupNode
-} from './standaloneNodes'
+    DefaultLambdaFunctionGroupNode,
+    LambdaFunctionGroupNode
+} from '../lambda/explorer/lambdaNodes'
+import { RegionInfo } from '../shared/regions/regionInfo'
+import { AWSTreeNodeBase } from '../shared/treeview/nodes/awsTreeNodeBase'
+import { RegionNode } from '../shared/treeview/nodes/regionNode'
+import { toMap, updateInPlace } from '../shared/utilities/collectionUtils'
 
 // Collects the regions the user has declared they want to work with;
 // on expansion each region lists the functions and CloudFormation Stacks
@@ -20,7 +20,7 @@ import {
 export class DefaultRegionNode extends AWSTreeNodeBase implements RegionNode {
     private info: RegionInfo
     private readonly cloudFormationNode: CloudFormationNode
-    private readonly standaloneFunctionGroupNode: StandaloneFunctionGroupNode
+    private readonly lambdaFunctionGroupNode: LambdaFunctionGroupNode
 
     public get regionCode(): string {
         return this.info.regionCode
@@ -40,13 +40,13 @@ export class DefaultRegionNode extends AWSTreeNodeBase implements RegionNode {
         this.update(info)
 
         this.cloudFormationNode = new DefaultCloudFormationNode(this, getExtensionAbsolutePath)
-        this.standaloneFunctionGroupNode = new DefaultStandaloneFunctionGroupNode(this, getExtensionAbsolutePath)
+        this.lambdaFunctionGroupNode = new DefaultLambdaFunctionGroupNode(this, getExtensionAbsolutePath)
     }
 
     public async getChildren(): Promise<AWSTreeNodeBase[]> {
         return [
             this.cloudFormationNode,
-            this.standaloneFunctionGroupNode
+            this.lambdaFunctionGroupNode
         ]
     }
 

--- a/src/lambda/explorer/lambdaNodes.ts
+++ b/src/lambda/explorer/lambdaNodes.ts
@@ -17,18 +17,18 @@ import { toArrayAsync, toMap, updateInPlace } from '../../shared/utilities/colle
 import { listLambdaFunctions } from '../utils'
 import { FunctionNodeBase } from './functionNode'
 
-export interface StandaloneFunctionGroupNode extends AWSTreeErrorHandlerNode {
+export interface LambdaFunctionGroupNode extends AWSTreeErrorHandlerNode {
     readonly regionCode: string
 
     readonly parent: RegionNode
 
-    getChildren(): Thenable<(StandaloneFunctionNode | ErrorNode)[]>
+    getChildren(): Thenable<(LambdaFunctionNode | ErrorNode)[]>
 
     updateChildren(): Thenable<void>
 }
 
-export class DefaultStandaloneFunctionGroupNode extends AWSTreeErrorHandlerNode implements StandaloneFunctionGroupNode {
-    private readonly functionNodes: Map<string, StandaloneFunctionNode>
+export class DefaultLambdaFunctionGroupNode extends AWSTreeErrorHandlerNode implements LambdaFunctionGroupNode {
+    private readonly functionNodes: Map<string, LambdaFunctionNode>
 
     public get regionCode(): string {
         return this.parent.regionCode
@@ -39,10 +39,10 @@ export class DefaultStandaloneFunctionGroupNode extends AWSTreeErrorHandlerNode 
         private readonly getExtensionAbsolutePath: (relativeExtensionPath: string) => string
     ) {
         super('Lambda', vscode.TreeItemCollapsibleState.Collapsed)
-        this.functionNodes = new Map<string, StandaloneFunctionNode>()
+        this.functionNodes = new Map<string, LambdaFunctionNode>()
     }
 
-    public async getChildren(): Promise<(StandaloneFunctionNode | ErrorNode)[]> {
+    public async getChildren(): Promise<(LambdaFunctionNode | ErrorNode)[]> {
         await this.handleErrorProneOperation(
             async () => this.updateChildren(),
             localize(
@@ -72,7 +72,7 @@ export class DefaultStandaloneFunctionGroupNode extends AWSTreeErrorHandlerNode 
             this.functionNodes,
             functions.keys(),
             key => this.functionNodes.get(key)!.update(functions.get(key)!),
-            key => new DefaultStandaloneFunctionNode(
+            key => new DefaultLambdaFunctionNode(
                 this,
                 functions.get(key)!,
                 relativeExtensionPath => this.getExtensionAbsolutePath(relativeExtensionPath)
@@ -81,17 +81,17 @@ export class DefaultStandaloneFunctionGroupNode extends AWSTreeErrorHandlerNode 
     }
 }
 
-export interface StandaloneFunctionNode extends FunctionNodeBase {
-    readonly parent: StandaloneFunctionGroupNode
+export interface LambdaFunctionNode extends FunctionNodeBase {
+    readonly parent: LambdaFunctionGroupNode
 }
 
-export class DefaultStandaloneFunctionNode extends FunctionNodeBase implements StandaloneFunctionNode {
+export class DefaultLambdaFunctionNode extends FunctionNodeBase implements LambdaFunctionNode {
     public get regionCode(): string {
         return this.parent.regionCode
     }
 
     public constructor(
-        public readonly parent: StandaloneFunctionGroupNode,
+        public readonly parent: LambdaFunctionGroupNode,
         configuration: Lambda.FunctionConfiguration,
         getExtensionAbsolutePath: (relativeExtensionPath: string) => string
     ) {

--- a/src/test/awsExplorer/defaultRegionNode.test.ts
+++ b/src/test/awsExplorer/defaultRegionNode.test.ts
@@ -4,8 +4,8 @@
  */
 
 import * as assert from 'assert'
-import { DefaultRegionNode } from '../../../lambda/explorer/defaultRegionNode'
-import { RegionInfo } from '../../../shared/regions/regionInfo'
+import { DefaultRegionNode } from '../../awsexplorer/defaultRegionNode'
+import { RegionInfo } from '../../shared/regions/regionInfo'
 
 // TODO: create test for getChildren() after mocking is introduced
 describe('DefaultRegionNode', () => {

--- a/src/test/lambda/explorer/cloudFormationNodes.test.ts
+++ b/src/test/lambda/explorer/cloudFormationNodes.test.ts
@@ -7,13 +7,13 @@ import * as assert from 'assert'
 import { CloudFormation, Lambda } from 'aws-sdk'
 import * as os from 'os'
 import { TreeItem, Uri } from 'vscode'
+import { DefaultRegionNode } from '../../../awsexplorer/defaultRegionNode'
 import {
     CloudFormationStackNode,
     DefaultCloudFormationFunctionNode,
     DefaultCloudFormationNode,
     DefaultCloudFormationStackNode
 } from '../../../lambda/explorer/cloudFormationNodes'
-import { DefaultRegionNode } from '../../../lambda/explorer/defaultRegionNode'
 import { CloudFormationClient } from '../../../shared/clients/cloudFormationClient'
 import { EcsClient } from '../../../shared/clients/ecsClient'
 import { LambdaClient } from '../../../shared/clients/lambdaClient'

--- a/src/test/lambda/explorer/lambdaNodes.test.ts
+++ b/src/test/lambda/explorer/lambdaNodes.test.ts
@@ -7,12 +7,12 @@ import * as assert from 'assert'
 import { Lambda } from 'aws-sdk'
 import * as os from 'os'
 import { TreeItem, Uri } from 'vscode'
-import { DefaultRegionNode } from '../../../lambda/explorer/defaultRegionNode'
+import { DefaultRegionNode } from '../../../awsexplorer/defaultRegionNode'
 import {
-    DefaultStandaloneFunctionGroupNode,
-    DefaultStandaloneFunctionNode,
-    StandaloneFunctionNode
-} from '../../../lambda/explorer/standaloneNodes'
+    DefaultLambdaFunctionGroupNode,
+    DefaultLambdaFunctionNode,
+    LambdaFunctionNode
+} from '../../../lambda/explorer/lambdaNodes'
 import { CloudFormationClient } from '../../../shared/clients/cloudFormationClient'
 import { EcsClient } from '../../../shared/clients/ecsClient'
 import { LambdaClient } from '../../../shared/clients/lambdaClient'
@@ -28,10 +28,10 @@ async function* asyncGenerator<T>(items: T[]): AsyncIterableIterator<T> {
     yield* items
 }
 
-describe('DefaultStandaloneFunctionNode', () => {
+describe('DefaultLambdaFunctionNode', () => {
 
     let fakeFunctionConfig: Lambda.FunctionConfiguration
-    const fakeIconPathPrefix: string = 'DefaultStandaloneFunctionNode'
+    const fakeIconPathPrefix: string = 'DefaultLambdaFunctionNode'
     let logger: TestLogger
 
     before(async () => {
@@ -119,9 +119,9 @@ describe('DefaultStandaloneFunctionNode', () => {
         )
     }
 
-    function generateTestNode(): DefaultStandaloneFunctionNode {
-        return new DefaultStandaloneFunctionNode(
-            new DefaultStandaloneFunctionGroupNode(
+    function generateTestNode(): DefaultLambdaFunctionNode {
+        return new DefaultLambdaFunctionNode(
+            new DefaultLambdaFunctionGroupNode(
                 new DefaultRegionNode(new RegionInfo('code', 'name'), iconPathMaker),
                 iconPathMaker
             ),
@@ -135,7 +135,7 @@ describe('DefaultStandaloneFunctionNode', () => {
     }
 })
 
-describe('DefaultStandaloneFunctionGroupNode', () => {
+describe('DefaultLambdaFunctionGroupNode', () => {
 
     let logger: TestLogger
 
@@ -168,7 +168,7 @@ describe('DefaultStandaloneFunctionGroupNode', () => {
         }
     }
 
-    class ThrowErrorDefaultStandaloneFunctionGroupNode extends DefaultStandaloneFunctionGroupNode {
+    class ThrowErrorDefaultLambdaFunctionGroupNode extends DefaultLambdaFunctionGroupNode {
         public constructor(
             public readonly parent: DefaultRegionNode
         ) {
@@ -207,7 +207,7 @@ describe('DefaultStandaloneFunctionGroupNode', () => {
             }
         }
 
-        const functionGroupNode = new DefaultStandaloneFunctionGroupNode(
+        const functionGroupNode = new DefaultLambdaFunctionGroupNode(
             new DefaultRegionNode(new RegionInfo('code', 'name'), stubPathResolver),
             stubPathResolver
         )
@@ -222,7 +222,7 @@ describe('DefaultStandaloneFunctionGroupNode', () => {
         )
 
         function assertChildNodeFunctionName(
-            actualChildNode: StandaloneFunctionNode | ErrorNode,
+            actualChildNode: LambdaFunctionNode | ErrorNode,
             expectedNodeText: string) {
 
             assert.strictEqual(
@@ -231,7 +231,7 @@ describe('DefaultStandaloneFunctionGroupNode', () => {
                 'Child node expected to contain functionName property'
             )
 
-            const node: DefaultStandaloneFunctionNode = actualChildNode as DefaultStandaloneFunctionNode
+            const node: DefaultLambdaFunctionNode = actualChildNode as DefaultLambdaFunctionNode
             assert.strictEqual(
                 node.functionName,
                 expectedNodeText,
@@ -246,7 +246,7 @@ describe('DefaultStandaloneFunctionGroupNode', () => {
     })
 
     it('handles error', async () => {
-        const testNode = new ThrowErrorDefaultStandaloneFunctionGroupNode(
+        const testNode = new ThrowErrorDefaultLambdaFunctionGroupNode(
             new DefaultRegionNode(new RegionInfo('code', 'name'), unusedPathResolver)
         )
 

--- a/src/test/lambda/explorer/mockLambdaNodes.ts
+++ b/src/test/lambda/explorer/mockLambdaNodes.ts
@@ -5,18 +5,18 @@
 
 import { Lambda } from 'aws-sdk'
 import {
-    StandaloneFunctionGroupNode,
-    StandaloneFunctionNode
-} from '../../../lambda/explorer/standaloneNodes'
+    LambdaFunctionGroupNode,
+    LambdaFunctionNode
+} from '../../../lambda/explorer/lambdaNodes'
 import { AWSTreeErrorHandlerNode } from '../../../shared/treeview/nodes/awsTreeErrorHandlerNode'
 import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
 import { RegionNode } from '../../../shared/treeview/nodes/regionNode'
 
-export class MockStandaloneFunctionGroupNode extends AWSTreeErrorHandlerNode implements StandaloneFunctionGroupNode {
+export class MockLambdaFunctionGroupNode extends AWSTreeErrorHandlerNode implements LambdaFunctionGroupNode {
     public constructor(
         public readonly regionCode: string = '',
         public readonly parent: RegionNode = {} as any as RegionNode,
-        public readonly getChildren: () => Thenable<StandaloneFunctionNode[]> = async () => [],
+        public readonly getChildren: () => Thenable<LambdaFunctionNode[]> = async () => [],
         public readonly updateChildren: () => Thenable<void> = async () => { },
         public readonly doErrorProneOperation: () => Promise<void> = async () => { },
     ) {
@@ -24,17 +24,17 @@ export class MockStandaloneFunctionGroupNode extends AWSTreeErrorHandlerNode imp
     }
 }
 
-export class MockStandaloneFunctionNode implements StandaloneFunctionNode {
+export class MockLambdaFunctionNode implements LambdaFunctionNode {
 
     public constructor(
         public readonly regionCode: string = '',
         public readonly functionName: string = '',
-        public readonly parent: StandaloneFunctionGroupNode = {} as any as StandaloneFunctionGroupNode,
+        public readonly parent: LambdaFunctionGroupNode = {} as any as LambdaFunctionGroupNode,
         public readonly configuration: Lambda.FunctionConfiguration = {},
         public readonly getChildren: () => Thenable<AWSTreeNodeBase[]> = async () => [],
         public readonly update: (configuration: Lambda.FunctionConfiguration) => void = config => { },
         public readonly getExtensionAbsolutePath: (relativeExtensionPath: string) => string =
-            (relativeExtensionPath) => 'MockStandaloneFunctionNode'
+            (relativeExtensionPath) => 'MockLambdaFunctionNode'
     ) {
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Renamed `standaloneNodes` to `lambdaNodes`. `standalone` was shorthand for `standalone Lambda functions`, which is less descriptive than directly relating it to Lambdas.

Moved `defaultRegionNode` out of the `lambda` directory structure. This represents the root AWS Explorer node; moving this to a more generic location means it will make more sense when we start building additional non-Lambda-related explorers.

## Motivation and Context

Makes our codebase less confusing

## Related Issue(s)

N/A

## Testing

Existing tests and a manual check work.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
