### PR TITLE
listTaskDefinitions -> listTaskDefinitionFamilies

### DIFF
--- a/src/shared/clients/defaultEcsClient.ts
+++ b/src/shared/clients/defaultEcsClient.ts
@@ -39,16 +39,14 @@ export class DefaultEcsClient implements EcsClient {
         } while (request.nextToken)
     }
 
-    public async *listTaskDefinitions(): AsyncIterableIterator<string> {
+    public async *listTaskDefinitionFamilies(): AsyncIterableIterator<string> {
         const sdkClient = await this.createSdkClient()
         // do we also want to cover inactive? If so, would we want to use a separate function?
-        const request: ECS.ListTaskDefinitionsRequest = {
-            status: 'ACTIVE'
-        }
+        const request: ECS.ListTaskDefinitionFamiliesRequest = {}
         do {
-            const response = await this.invokeListTaskDefinitions(request, sdkClient)
-            if (response.taskDefinitionArns) {
-                yield* response.taskDefinitionArns
+            const response = await this.invokeListTaskDefinitionFamilies(request, sdkClient)
+            if (response.families) {
+                yield* response.families
             }
             request.nextToken = response.nextToken
         } while (request.nextToken)
@@ -64,9 +62,9 @@ export class DefaultEcsClient implements EcsClient {
         return sdkClient.listServices(request).promise()
     }
 
-    protected async invokeListTaskDefinitions(request: ECS.ListTaskDefinitionsRequest, sdkClient: ECS)
-        : Promise<ECS.ListTaskDefinitionsResponse> {
-        return sdkClient.listTaskDefinitions(request).promise()
+    protected async invokeListTaskDefinitionFamilies(request: ECS.ListTaskDefinitionFamiliesRequest, sdkClient: ECS)
+        : Promise<ECS.ListTaskDefinitionFamiliesResponse> {
+        return sdkClient.listTaskDefinitionFamilies(request).promise()
     }
 
     protected async createSdkClient(): Promise<ECS> {

--- a/src/shared/clients/ecsClient.ts
+++ b/src/shared/clients/ecsClient.ts
@@ -10,5 +10,5 @@ export interface EcsClient {
 
     listServices(cluster: string): AsyncIterableIterator<string>
 
-    listTaskDefinitions(): AsyncIterableIterator<string>
+    listTaskDefinitionFamilies(): AsyncIterableIterator<string>
 }

--- a/src/test/shared/clients/defaultEcsClient.test.ts
+++ b/src/test/shared/clients/defaultEcsClient.test.ts
@@ -120,14 +120,14 @@ describe('defaultEcsClient', async () => {
         })
     })
 
-    describe('ListTaskDefinitions', async () => {
+    describe('ListTaskDefinitionFamilies', async () => {
 
-        it('lists task definitions from a single page', async () => {
-            const targetArr = ['arn1', 'arn2', 'arn3']
-            testClient.listTaskDefinitionsResponses = [{
-                taskDefinitionArns: targetArr
+        it('lists task definition families from a single page', async () => {
+            const targetArr = ['fam1', 'fam2', 'fam3']
+            testClient.listTaskDefinitionFamiliesResponses = [{
+                families: targetArr
             }]
-            const iterator = testClient.listTaskDefinitions()
+            const iterator = testClient.listTaskDefinitionFamilies()
             const arr = []
             for await (const item of iterator) {
                 arr.push(item)
@@ -135,24 +135,24 @@ describe('defaultEcsClient', async () => {
             assert.deepStrictEqual(targetArr, arr)
         })
 
-        it('lists task definitions from multiple pages', async () => {
-            const targetArr1 = ['arn1', 'arn2', 'arn3']
-            const targetArr2 = ['arn4', 'arn5', 'arn6']
-            const targetArr3 = ['arn7', 'arn8', 'arn9']
-            testClient.listTaskDefinitionsResponses = [
+        it('lists task definition families from multiple pages', async () => {
+            const targetArr1 = ['fam1', 'fam2', 'fam3']
+            const targetArr2 = ['fam4', 'fam5', 'fam6']
+            const targetArr3 = ['fam7', 'fam8', 'fam9']
+            testClient.listTaskDefinitionFamiliesResponses = [
                 {
-                    taskDefinitionArns: targetArr1,
+                    families: targetArr1,
                     nextToken: 'there i go, turn the page'
                 },
                 {
-                    taskDefinitionArns: targetArr2,
+                    families: targetArr2,
                     nextToken: 'you can write a book with all these pages'
                 },
                 {
-                    taskDefinitionArns: targetArr3
+                    families: targetArr3
                 }
             ]
-            const iterator = testClient.listTaskDefinitions()
+            const iterator = testClient.listTaskDefinitionFamilies()
             const arr = []
             for await (const item of iterator) {
                 arr.push(item)
@@ -161,9 +161,9 @@ describe('defaultEcsClient', async () => {
         })
 
         it('handles errors', async () => {
-            testClient.listTaskDefinitionsResponses = new Error() as AWSError
+            testClient.listTaskDefinitionFamiliesResponses = new Error() as AWSError
             await assertThrowsError(async () => {
-                const iterator = testClient.listTaskDefinitions()
+                const iterator = testClient.listTaskDefinitionFamilies()
                 const arr = []
                 for await (const item of iterator) {
                     arr.push(item)
@@ -179,7 +179,7 @@ class TestEcsClient extends DefaultEcsClient {
 
     public listServicesResponses: ECS.ListServicesResponse[] | AWSError = [{}]
 
-    public listTaskDefinitionsResponses: ECS.ListTaskDefinitionsResponse[] | AWSError = [{}]
+    public listTaskDefinitionFamiliesResponses: ECS.ListTaskDefinitionFamiliesResponse[] | AWSError = [{}]
 
     private pageNum: number = 0
 
@@ -213,10 +213,13 @@ class TestEcsClient extends DefaultEcsClient {
         }
     }
 
-    protected async invokeListTaskDefinitions(request: ECS.ListTaskDefinitionsRequest)
-        : Promise<ECS.ListTaskDefinitionsResponse> {
+    protected async invokeListTaskDefinitionFamilies(request: ECS.ListTaskDefinitionFamiliesRequest)
+        : Promise<ECS.ListTaskDefinitionFamiliesResponse> {
         const responseDatum =
-            this.getResponseDatum<ECS.ListTaskDefinitionsResponse>(this.listTaskDefinitionsResponses, request.nextToken)
+            this.getResponseDatum<ECS.ListTaskDefinitionFamiliesResponse>(
+                this.listTaskDefinitionFamiliesResponses,
+                request.nextToken
+            )
 
         if (responseDatum instanceof Error) {
             throw responseDatum

--- a/src/test/shared/clients/mockClients.ts
+++ b/src/test/shared/clients/mockClients.ts
@@ -67,23 +67,23 @@ export class MockEcsClient implements EcsClient {
     public readonly regionCode: string
     public readonly listClusters: () => AsyncIterableIterator<string>
     public readonly listServices: (cluster: string) => AsyncIterableIterator<string>
-    public readonly listTaskDefinitions: () => AsyncIterableIterator<string>
+    public readonly listTaskDefinitionFamilies: () => AsyncIterableIterator<string>
 
     public constructor({
         regionCode = '',
         listClusters = () => asyncGenerator([]),
         listServices = (cluster: string) => asyncGenerator([]),
-        listTaskDefinitions = () => asyncGenerator([])
+        listTaskDefinitionFamilies = () => asyncGenerator([])
     }: {
         regionCode?: string
         listClusters?(): AsyncIterableIterator<string>
         listServices?(cluster: string): AsyncIterableIterator<string>
-        listTaskDefinitions?(): AsyncIterableIterator<string>
+        listTaskDefinitionFamilies?(): AsyncIterableIterator<string>
     }) {
         this.regionCode = regionCode
         this.listClusters = listClusters
         this.listServices = listServices
-        this.listTaskDefinitions = listTaskDefinitions
+        this.listTaskDefinitionFamilies = listTaskDefinitionFamilies
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
listTaskDefinitions returns individual instances of task definitions. listTaskDefinitionFamilies returns top-level names.

## Motivation and Context

We want to display task definition families, not individual instances

## Related Issue(s)

https://github.com/aws/aws-toolkit-vscode/issues/714

## Testing
Reconfigured and ran tests

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
