### PR TITLE
Added retry logic to assertLogContainsBadExitInformation in case logger is still writing/flushing

### DIFF
--- a/src/shared/loggerUtils.ts
+++ b/src/shared/loggerUtils.ts
@@ -31,10 +31,8 @@ export class TestLogger {
         }
     }
 
-    public async logContainsText(str: string): Promise<boolean> {
-        const logText = await filesystemUtilities.readFileAsString(TestLogger.getLogPath(this.logFolder))
-
-        return logText.includes(str)
+    public get logPath(): string {
+        return TestLogger.getLogPath(this.logFolder)
     }
 
     public static async createTestLogger(): Promise<TestLogger> {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

The goal is to cut down on the sporadic test failures. I suspect the cause is some tests are checking log files for contents before the logger has finished writing those contents.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
