### PR TITLE
Changed Retries from describe scope to CodeLens test scope

### DIFF
--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -193,9 +193,8 @@ for (const runtime of runtimes) {
                 ...command.arguments!
             )
             validateRunResult(runResult, projectSDK, 'true')
-            // This timeout is significantly longer, mostly to accommodate the long first time .net debugger
         })
-            .timeout(TIMEOUT * 2)
+            .timeout(TIMEOUT * 2) // This timeout is significantly longer, mostly to accommodate the long first time .net debugger
             .retries(maxCodeLensTestAttempts) // Retry tests because CodeLenses do not reliably get produced in the tests
     })
 }


### PR DESCRIPTION

## Description

The retry attempt in #736 was not set up in the correct place. This change retries and console-logs the retry attempts for CodeLens related tests.


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
