### PR TITLE
Load AWS credentials from credential_process

### DIFF
--- a/.changes/next-release/Feature-2ddb11de-7b8f-40d6-9cdb-87bae1c83d3e.json
+++ b/.changes/next-release/Feature-2ddb11de-7b8f-40d6-9cdb-87bae1c83d3e.json
@@ -1,0 +1,4 @@
+{
+    "type": "Feature",
+    "description": "Support credential_process (#317)"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -336,9 +336,9 @@
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "aws-sdk": {
-            "version": "2.318.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.318.0.tgz",
-            "integrity": "sha512-w2XT+DOKOczoRaB9R0cRCZSwHkw4JfngMlUKeRhMbzOvW9orOZB2SeMgz+Pz1jKU3VSJDMpvB/Z3P68nvDxb8Q==",
+            "version": "2.522.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.522.0.tgz",
+            "integrity": "sha512-JNUVaBqXwzDVqR/9dDw4a55aVsdDQYlf/cBM5bSj/g95wbuNWMzrY1TfAxEfSKwH0llp/1/xdXP75AKKp2UoSg==",
             "requires": {
                 "buffer": "4.9.1",
                 "events": "1.1.1",
@@ -347,15 +347,8 @@
                 "querystring": "0.2.0",
                 "sax": "1.2.1",
                 "url": "0.10.3",
-                "uuid": "3.1.0",
+                "uuid": "3.3.2",
                 "xml2js": "0.4.19"
-            },
-            "dependencies": {
-                "uuid": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-                    "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
-                }
             }
         },
         "aws-sign2": {
@@ -412,9 +405,9 @@
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "base64-js": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-            "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
         },
         "bcrypt-pbkdf": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -397,7 +397,7 @@
     },
     "dependencies": {
         "async-lock": "^1.1.3",
-        "aws-sdk": "^2.317.0",
+        "aws-sdk": "^2.429.0",
         "cloudformation-schema-js-yaml": "^1.0.1",
         "cross-spawn": "^6.0.5",
         "del": "^3.0.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Bump aws-sdk version to 2.429
2. Add credential "fallback". If ini credentials do not work, try credential_process

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Enables additional authentication method for AWS accounts.

## Related Issue(s)

https://github.com/aws/aws-toolkit-vscode/issues/317

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. `npm run tests`: `542 passing (7s)`
2. Added valid credential_process to `~/aws/credentials` and step through code to validate that:
  1. ini credentials fail
  2. credential process credentials successfully load
3. AWS toolkit view shows services from account

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
