### PR TITLE
Added missing npm install before call to create changelog

### DIFF
--- a/buildspec/bumpVersion.yml
+++ b/buildspec/bumpVersion.yml
@@ -32,6 +32,7 @@ phases:
                 else
                   npm version minor
                 fi
+                npm install
                 npm run createRelease
                 git commit -m "Update version to $VERSION"
                 echo "tagging commit"

--- a/buildspec/bumpVersion.yml
+++ b/buildspec/bumpVersion.yml
@@ -32,6 +32,7 @@ phases:
                 else
                   npm version minor
                 fi
+                # Call npm install because 'createRelease' uses ts-node
                 npm install
                 npm run createRelease
                 git commit -m "Update version to $VERSION"


### PR DESCRIPTION

Without `npm install` the changelog script cannot run (it uses ts-node)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
