### PR TITLE
Icon path retrieval has been centralized

### DIFF
--- a/src/awsexplorer/awsExplorer.ts
+++ b/src/awsexplorer/awsExplorer.ts
@@ -39,7 +39,6 @@ export class AwsExplorer implements vscode.TreeDataProvider<AWSTreeNodeBase>, Re
         private readonly awsContextTrees: AwsContextTreeCollection,
         private readonly regionProvider: RegionProvider,
         private readonly resourceFetcher: ResourceFetcher,
-        private readonly getExtensionAbsolutePath: (relativeExtensionPath: string) => string,
         private readonly lambdaOutputChannel: vscode.OutputChannel = vscode.window.createOutputChannel('AWS Lambda')
     ) {
         this._onDidChangeTreeData = new vscode.EventEmitter<AWSTreeNodeBase | undefined>()
@@ -160,10 +159,7 @@ export class AwsExplorer implements vscode.TreeDataProvider<AWSTreeNodeBase>, Re
             this.regionNodes,
             intersection(regionMap.keys(), explorerRegionCodes),
             key => this.regionNodes.get(key)!.update(regionMap.get(key)!),
-            key =>
-                new DefaultRegionNode(regionMap.get(key)!, relativeExtensionPath =>
-                    this.getExtensionAbsolutePath(relativeExtensionPath)
-                )
+            key => new DefaultRegionNode(regionMap.get(key)!)
         )
 
         if (this.regionNodes.size > 0) {

--- a/src/awsexplorer/defaultRegionNode.ts
+++ b/src/awsexplorer/defaultRegionNode.ts
@@ -34,7 +34,7 @@ export class DefaultRegionNode extends AWSTreeNodeBase implements RegionNode {
         this.update(info)
 
         this.cloudFormationNode = new DefaultCloudFormationNode(this, getExtensionAbsolutePath)
-        this.lambdaFunctionGroupNode = new DefaultLambdaFunctionGroupNode(this, getExtensionAbsolutePath)
+        this.lambdaFunctionGroupNode = new DefaultLambdaFunctionGroupNode(this)
     }
 
     public async getChildren(): Promise<AWSTreeNodeBase[]> {

--- a/src/awsexplorer/defaultRegionNode.ts
+++ b/src/awsexplorer/defaultRegionNode.ts
@@ -27,13 +27,13 @@ export class DefaultRegionNode extends AWSTreeNodeBase implements RegionNode {
         return this.info.regionName
     }
 
-    public constructor(info: RegionInfo, getExtensionAbsolutePath: (relativeExtensionPath: string) => string) {
+    public constructor(info: RegionInfo) {
         super(info.regionName, TreeItemCollapsibleState.Expanded)
         this.contextValue = 'awsRegionNode'
         this.info = info
         this.update(info)
 
-        this.cloudFormationNode = new DefaultCloudFormationNode(this, getExtensionAbsolutePath)
+        this.cloudFormationNode = new DefaultCloudFormationNode(this)
         this.lambdaFunctionGroupNode = new DefaultLambdaFunctionGroupNode(this)
     }
 
@@ -51,7 +51,7 @@ export class DefaultRegionNode extends AWSTreeNodeBase implements RegionNode {
 export class RegionNodeCollection {
     private readonly regionNodes: Map<string, RegionNode>
 
-    public constructor(private readonly getExtensionAbsolutePath: (relativeExtensionPath: string) => string) {
+    public constructor() {
         this.regionNodes = new Map<string, RegionNode>()
     }
 
@@ -62,10 +62,7 @@ export class RegionNodeCollection {
             this.regionNodes,
             regionMap.keys(),
             key => this.regionNodes.get(key)!.update(regionMap.get(key)!),
-            key =>
-                new DefaultRegionNode(regionMap.get(key)!, relativeExtensionPath =>
-                    this.getExtensionAbsolutePath(relativeExtensionPath)
-                )
+            key => new DefaultRegionNode(regionMap.get(key)!)
         )
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -186,4 +186,10 @@ function getExtensionAbsolutePath(context: vscode.ExtensionContext, relativeExte
 function initializeIconPaths(context: vscode.ExtensionContext) {
     ext.iconPaths.dark.help = context.asAbsolutePath('resources/dark/help.svg')
     ext.iconPaths.light.help = context.asAbsolutePath('resources/light/help.svg')
+
+    ext.iconPaths.dark.cloudFormation = context.asAbsolutePath('resources/dark/cloudformation.svg')
+    ext.iconPaths.light.cloudFormation = context.asAbsolutePath('resources/light/cloudformation.svg')
+
+    ext.iconPaths.dark.lambda = context.asAbsolutePath('resources/dark/lambda.svg')
+    ext.iconPaths.light.lambda = context.asAbsolutePath('resources/light/lambda.svg')
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -143,11 +143,7 @@ export async function activate(context: vscode.ExtensionContext) {
             }
         })
 
-        const providers = [
-            new AwsExplorer(awsContext, awsContextTrees, regionProvider, resourceFetcher, relativeExtensionPath =>
-                getExtensionAbsolutePath(context, relativeExtensionPath)
-            )
-        ]
+        const providers = [new AwsExplorer(awsContext, awsContextTrees, regionProvider, resourceFetcher)]
 
         providers.forEach(p => {
             p.initialize(context)
@@ -177,10 +173,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export async function deactivate() {
     await ext.telemetry.shutdown()
-}
-
-function getExtensionAbsolutePath(context: vscode.ExtensionContext, relativeExtensionPath: string): string {
-    return context.asAbsolutePath(relativeExtensionPath)
 }
 
 function initializeIconPaths(context: vscode.ExtensionContext) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,6 +48,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     try {
         await new DefaultCredentialsFileReaderWriter().setCanUseConfigFileIfExists()
+        initializeIconPaths(context)
 
         const toolkitSettings = new DefaultSettingsConfiguration(extensionSettingsPrefix)
         const awsContext = new DefaultAwsContext(toolkitSettings, context)
@@ -180,4 +181,9 @@ export async function deactivate() {
 
 function getExtensionAbsolutePath(context: vscode.ExtensionContext, relativeExtensionPath: string): string {
     return context.asAbsolutePath(relativeExtensionPath)
+}
+
+function initializeIconPaths(context: vscode.ExtensionContext) {
+    ext.iconPaths.helpDark = context.asAbsolutePath('resources/dark/help.svg')
+    ext.iconPaths.helpLight = context.asAbsolutePath('resources/light/help.svg')
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -184,6 +184,6 @@ function getExtensionAbsolutePath(context: vscode.ExtensionContext, relativeExte
 }
 
 function initializeIconPaths(context: vscode.ExtensionContext) {
-    ext.iconPaths.helpDark = context.asAbsolutePath('resources/dark/help.svg')
-    ext.iconPaths.helpLight = context.asAbsolutePath('resources/light/help.svg')
+    ext.iconPaths.dark.help = context.asAbsolutePath('resources/dark/help.svg')
+    ext.iconPaths.light.help = context.asAbsolutePath('resources/light/help.svg')
 }

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -63,7 +63,6 @@ export interface CreateNewSamApplicationResults {
  */
 export async function createNewSamApplication(
     channelLogger: ChannelLogger,
-    extensionContext: Pick<vscode.ExtensionContext, 'asAbsolutePath' | 'globalState'>,
     samCliContext: SamCliContext = getSamCliContext(),
     activationLaunchPath: ActivationLaunchPath = new ActivationLaunchPath()
 ): Promise<CreateNewSamApplicationResults> {
@@ -76,7 +75,7 @@ export async function createNewSamApplication(
     try {
         await validateSamCli(samCliContext.validator)
 
-        const wizardContext = new DefaultCreateNewSamAppWizardContext(extensionContext)
+        const wizardContext = new DefaultCreateNewSamAppWizardContext()
         const config: CreateNewSamAppWizardResponse | undefined = await new CreateNewSamAppWizard(wizardContext).run()
         if (!config) {
             results.result = 'cancel'

--- a/src/lambda/commands/deploySamApplication.ts
+++ b/src/lambda/commands/deploySamApplication.ts
@@ -303,7 +303,7 @@ function getDefaultSamDeployWizardResponseProvider(
 ): SamDeployWizardResponseProvider {
     return {
         getSamDeployWizardResponse: async (): Promise<SamDeployWizardResponse | undefined> => {
-            const wizard = new SamDeployWizard(regionProvider, new DefaultSamDeployWizardContext(context))
+            const wizard = new SamDeployWizard(regionProvider, new DefaultSamDeployWizardContext())
 
             return wizard.run()
         }

--- a/src/lambda/explorer/cloudFormationNodes.ts
+++ b/src/lambda/explorer/cloudFormationNodes.ts
@@ -155,10 +155,7 @@ export class DefaultCloudFormationStackNode extends AWSTreeErrorHandlerNode impl
             this.functionNodes,
             intersection(resources, functions.keys()),
             key => this.functionNodes.get(key)!.update(functions.get(key)!),
-            key =>
-                new DefaultCloudFormationFunctionNode(this, functions.get(key)!, relativeExtensionPath =>
-                    this.getExtensionAbsolutePath(relativeExtensionPath)
-                )
+            key => new DefaultCloudFormationFunctionNode(this, functions.get(key)!)
         )
     }
 
@@ -185,12 +182,8 @@ export class DefaultCloudFormationFunctionNode extends FunctionNodeBase {
         return this.parent.regionCode
     }
 
-    public constructor(
-        public readonly parent: CloudFormationStackNode,
-        configuration: Lambda.FunctionConfiguration,
-        getExtensionAbsolutePath: (relativeExtensionPath: string) => string
-    ) {
-        super(configuration, getExtensionAbsolutePath)
+    public constructor(public readonly parent: CloudFormationStackNode, configuration: Lambda.FunctionConfiguration) {
+        super(configuration)
         this.contextValue = 'awsCloudFormationFunctionNode'
     }
 }

--- a/src/lambda/explorer/cloudFormationNodes.ts
+++ b/src/lambda/explorer/cloudFormationNodes.ts
@@ -37,10 +37,7 @@ export class DefaultCloudFormationNode extends AWSTreeErrorHandlerNode implement
         return this.parent.regionCode
     }
 
-    public constructor(
-        public readonly parent: RegionNode,
-        private readonly getExtensionAbsolutePath: (relativeExtensionPath: string) => string
-    ) {
+    public constructor(public readonly parent: RegionNode) {
         super('CloudFormation', vscode.TreeItemCollapsibleState.Collapsed)
         this.stackNodes = new Map<string, CloudFormationStackNode>()
     }
@@ -64,10 +61,7 @@ export class DefaultCloudFormationNode extends AWSTreeErrorHandlerNode implement
             this.stackNodes,
             stacks.keys(),
             key => this.stackNodes.get(key)!.update(stacks.get(key)!),
-            key =>
-                new DefaultCloudFormationStackNode(this, stacks.get(key)!, relativeExtensionPath =>
-                    this.getExtensionAbsolutePath(relativeExtensionPath)
-                )
+            key => new DefaultCloudFormationStackNode(this, stacks.get(key)!)
         )
     }
 }
@@ -91,19 +85,15 @@ export class DefaultCloudFormationStackNode extends AWSTreeErrorHandlerNode impl
         return this.parent.regionCode
     }
 
-    public constructor(
-        public readonly parent: CloudFormationNode,
-        private stackSummary: CloudFormation.StackSummary,
-        private readonly getExtensionAbsolutePath: (relativeExtensionPath: string) => string
-    ) {
+    public constructor(public readonly parent: CloudFormationNode, private stackSummary: CloudFormation.StackSummary) {
         super('', vscode.TreeItemCollapsibleState.Collapsed)
 
         this.update(stackSummary)
         this.contextValue = 'awsCloudFormationNode'
         this.functionNodes = new Map<string, CloudFormationFunctionNode>()
         this.iconPath = {
-            dark: vscode.Uri.file(this.getExtensionAbsolutePath('resources/dark/cloudformation.svg')),
-            light: vscode.Uri.file(this.getExtensionAbsolutePath('resources/light/cloudformation.svg'))
+            dark: vscode.Uri.file(ext.iconPaths.dark.cloudFormation),
+            light: vscode.Uri.file(ext.iconPaths.light.cloudFormation)
         }
     }
 

--- a/src/lambda/explorer/functionNode.ts
+++ b/src/lambda/explorer/functionNode.ts
@@ -6,20 +6,18 @@
 import { Lambda } from 'aws-sdk'
 import * as os from 'os'
 import { Uri } from 'vscode'
+import { ext } from '../../shared/extensionGlobals'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 
 export abstract class FunctionNodeBase extends AWSTreeNodeBase {
     public abstract readonly regionCode: string
 
-    protected constructor(
-        public configuration: Lambda.FunctionConfiguration,
-        public readonly getExtensionAbsolutePath: (relativeExtensionPath: string) => string
-    ) {
+    protected constructor(public configuration: Lambda.FunctionConfiguration) {
         super('')
         this.update(configuration)
         this.iconPath = {
-            dark: Uri.file(this.getExtensionAbsolutePath('resources/dark/lambda.svg')),
-            light: Uri.file(this.getExtensionAbsolutePath('resources/light/lambda.svg'))
+            dark: Uri.file(ext.iconPaths.dark.lambda),
+            light: Uri.file(ext.iconPaths.light.lambda)
         }
     }
 

--- a/src/lambda/explorer/lambdaNodes.ts
+++ b/src/lambda/explorer/lambdaNodes.ts
@@ -34,10 +34,7 @@ export class DefaultLambdaFunctionGroupNode extends AWSTreeErrorHandlerNode impl
         return this.parent.regionCode
     }
 
-    public constructor(
-        public readonly parent: RegionNode,
-        private readonly getExtensionAbsolutePath: (relativeExtensionPath: string) => string
-    ) {
+    public constructor(public readonly parent: RegionNode) {
         super('Lambda', vscode.TreeItemCollapsibleState.Collapsed)
         this.functionNodes = new Map<string, LambdaFunctionNode>()
     }
@@ -66,10 +63,7 @@ export class DefaultLambdaFunctionGroupNode extends AWSTreeErrorHandlerNode impl
             this.functionNodes,
             functions.keys(),
             key => this.functionNodes.get(key)!.update(functions.get(key)!),
-            key =>
-                new DefaultLambdaFunctionNode(this, functions.get(key)!, relativeExtensionPath =>
-                    this.getExtensionAbsolutePath(relativeExtensionPath)
-                )
+            key => new DefaultLambdaFunctionNode(this, functions.get(key)!)
         )
     }
 }
@@ -83,12 +77,8 @@ export class DefaultLambdaFunctionNode extends FunctionNodeBase implements Lambd
         return this.parent.regionCode
     }
 
-    public constructor(
-        public readonly parent: LambdaFunctionGroupNode,
-        configuration: Lambda.FunctionConfiguration,
-        getExtensionAbsolutePath: (relativeExtensionPath: string) => string
-    ) {
-        super(configuration, getExtensionAbsolutePath)
+    public constructor(public readonly parent: LambdaFunctionGroupNode, configuration: Lambda.FunctionConfiguration) {
+        super(configuration)
         this.contextValue = 'awsRegionFunctionNode'
     }
 }

--- a/src/lambda/wizards/samDeployWizard.ts
+++ b/src/lambda/wizards/samDeployWizard.ts
@@ -121,9 +121,9 @@ export class DefaultSamDeployWizardContext implements SamDeployWizardContext {
     public readonly onDetectLocalTemplates = detectLocalTemplates
     public readonly getParameters = getParameters
     public readonly getOverriddenParameters = getOverriddenParameters
-    private readonly helpButton = createHelpButton(this.extContext, localize('AWS.command.help', 'View Documentation'))
+    private readonly helpButton = createHelpButton(localize('AWS.command.help', 'View Documentation'))
 
-    public constructor(private readonly extContext: Pick<vscode.ExtensionContext, 'asAbsolutePath'>) {}
+    public constructor() {}
 
     public get workspaceFolders(): vscode.Uri[] | undefined {
         return (vscode.workspace.workspaceFolders || []).map(f => f.uri)

--- a/src/lambda/wizards/samInitWizard.ts
+++ b/src/lambda/wizards/samInitWizard.ts
@@ -35,9 +35,9 @@ export interface CreateNewSamAppWizardContext {
 export class DefaultCreateNewSamAppWizardContext implements CreateNewSamAppWizardContext {
     public readonly lambdaRuntimes = lambdaRuntime.samLambdaRuntimes
     public readonly showOpenDialog = vscode.window.showOpenDialog
-    private readonly helpButton = createHelpButton(this.extContext, localize('AWS.command.help', 'View Documentation'))
+    private readonly helpButton = createHelpButton(localize('AWS.command.help', 'View Documentation'))
 
-    public constructor(private readonly extContext: Pick<vscode.ExtensionContext, 'asAbsolutePath'>) {}
+    public constructor() {}
 
     public get workspaceFolders(): vscode.WorkspaceFolder[] | undefined {
         return vscode.workspace.workspaceFolders

--- a/src/shared/extensionGlobals.ts
+++ b/src/shared/extensionGlobals.ts
@@ -32,10 +32,14 @@ export namespace ext {
 
 export interface IconPaths {
     help: string
+    cloudFormation: string
+    lambda: string
 }
 
 function makeIconPathsObject(): IconPaths {
     return {
-        help: ''
+        help: '',
+        cloudFormation: '',
+        lambda: ''
     }
 }

--- a/src/shared/extensionGlobals.ts
+++ b/src/shared/extensionGlobals.ts
@@ -25,7 +25,17 @@ export namespace ext {
     export let telemetry: TelemetryService
 
     export namespace iconPaths {
-        export let helpLight: string
-        export let helpDark: string
+        export const dark: IconPaths = makeIconPathsObject()
+        export const light: IconPaths = makeIconPathsObject()
+    }
+}
+
+export interface IconPaths {
+    help: string
+}
+
+function makeIconPathsObject(): IconPaths {
+    return {
+        help: ''
     }
 }

--- a/src/shared/extensionGlobals.ts
+++ b/src/shared/extensionGlobals.ts
@@ -23,4 +23,9 @@ export namespace ext {
     export let toolkitClientBuilder: ToolkitClientBuilder
     export let statusBar: AWSStatusBar
     export let telemetry: TelemetryService
+
+    export namespace iconPaths {
+        export let helpLight: string
+        export let helpDark: string
+    }
 }

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -98,8 +98,7 @@ async function registerServerlessCommands(params: {
             command: 'aws.lambda.createNewSamApp',
             callback: async (): Promise<{ datum: Datum }> => {
                 const createNewSamApplicationResults: CreateNewSamApplicationResults = await createNewSamApplication(
-                    params.channelLogger,
-                    params.extensionContext
+                    params.channelLogger
                 )
                 const datum = defaultMetricDatum('new')
                 datum.metadata = new Map()

--- a/src/shared/ui/buttons.ts
+++ b/src/shared/ui/buttons.ts
@@ -15,8 +15,8 @@ import { ext } from '../extensionGlobals'
 export function createHelpButton(tooltip?: string): QuickInputButton {
     return {
         iconPath: {
-            light: Uri.file(ext.iconPaths.helpLight),
-            dark: Uri.file(ext.iconPaths.helpDark)
+            light: Uri.file(ext.iconPaths.light.help),
+            dark: Uri.file(ext.iconPaths.dark.help)
         },
         tooltip
     }

--- a/src/shared/ui/buttons.ts
+++ b/src/shared/ui/buttons.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as path from 'path'
-import { ExtensionContext, QuickInputButton, Uri } from 'vscode'
+import { QuickInputButton, Uri } from 'vscode'
+import { ext } from '../extensionGlobals'
 
 /**
  * Creates a QuickInputButton with a predefined help button (dark and light theme compatible)
@@ -12,17 +12,11 @@ import { ExtensionContext, QuickInputButton, Uri } from 'vscode'
  * button will exist regardless of image loading (UI tests will still see this)
  * @param tooltip Optional tooltip for button
  */
-export function createHelpButton(
-    context: Pick<ExtensionContext, 'asAbsolutePath'>,
-    tooltip?: string
-): QuickInputButton {
-    const light = path.join(context.asAbsolutePath('resources'), 'light', 'help.svg')
-    const dark = path.join(context.asAbsolutePath('resources'), 'dark', 'help.svg')
-
+export function createHelpButton(tooltip?: string): QuickInputButton {
     return {
         iconPath: {
-            light: Uri.file(light),
-            dark: Uri.file(dark)
+            light: Uri.file(ext.iconPaths.helpLight),
+            dark: Uri.file(ext.iconPaths.helpDark)
         },
         tooltip
     }

--- a/src/test/awsExplorer/awsExplorer.test.ts
+++ b/src/test/awsExplorer/awsExplorer.test.ts
@@ -40,9 +40,6 @@ describe('AwsExplorer', () => {
             awsContextTreeCollection,
             regionProvider,
             resourceFetcher,
-            path => {
-                throw new Error('unused')
-            },
             mockChannel
         )
 

--- a/src/test/awsExplorer/defaultRegionNode.test.ts
+++ b/src/test/awsExplorer/defaultRegionNode.test.ts
@@ -14,9 +14,7 @@ describe('DefaultRegionNode', () => {
 
     // Validates we tagged the node correctly
     it('initializes name and tooltip', async () => {
-        const testNode = new DefaultRegionNode(new RegionInfo(regionCode, regionName), () => {
-            throw new Error('unused')
-        })
+        const testNode = new DefaultRegionNode(new RegionInfo(regionCode, regionName))
 
         assert.strictEqual(testNode.label, regionName)
         assert.strictEqual(testNode.tooltip, `${regionName} [${regionCode}]`)

--- a/src/test/lambda/explorer/cloudFormationNodes.test.ts
+++ b/src/test/lambda/explorer/cloudFormationNodes.test.ts
@@ -23,7 +23,7 @@ import { RegionInfo } from '../../../shared/regions/regionInfo'
 import { ErrorNode } from '../../../shared/treeview/nodes/errorNode'
 import { PlaceholderNode } from '../../../shared/treeview/nodes/placeholderNode'
 import { MockCloudFormationClient } from '../../shared/clients/mockClients'
-import { IconPath } from '../../shared/utilities/iconPathUtils'
+import { clearTestIconPaths, IconPath, setupTestIconPaths } from '../../shared/utilities/iconPathUtils'
 
 async function* asyncGenerator<T>(items: T[]): AsyncIterableIterator<T> {
     yield* items
@@ -34,6 +34,7 @@ describe('DefaultCloudFormationStackNode', () => {
     let logger: TestLogger
 
     before(async () => {
+        setupTestIconPaths()
         logger = await TestLogger.createTestLogger()
         fakeStackSummary = {
             CreationTime: new Date(),
@@ -44,6 +45,7 @@ describe('DefaultCloudFormationStackNode', () => {
     })
 
     after(async () => {
+        clearTestIconPaths()
         await logger.cleanupLogger()
     })
 

--- a/src/test/lambda/explorer/lambdaNodes.test.ts
+++ b/src/test/lambda/explorer/lambdaNodes.test.ts
@@ -22,6 +22,7 @@ import { TestLogger } from '../../../shared/loggerUtils'
 import { RegionInfo } from '../../../shared/regions/regionInfo'
 import { ErrorNode } from '../../../shared/treeview/nodes/errorNode'
 import { MockLambdaClient } from '../../shared/clients/mockClients'
+import { clearTestIconPaths, IconPath, setupTestIconPaths } from '../../shared/utilities/iconPathUtils'
 
 // TODO : Consolidate all asyncGenerator calls into a shared utility method
 async function* asyncGenerator<T>(items: T[]): AsyncIterableIterator<T> {
@@ -34,6 +35,7 @@ describe('DefaultLambdaFunctionNode', () => {
     let logger: TestLogger
 
     before(async () => {
+        setupTestIconPaths()
         logger = await TestLogger.createTestLogger()
         fakeFunctionConfig = {
             FunctionName: 'testFunctionName',
@@ -42,6 +44,7 @@ describe('DefaultLambdaFunctionNode', () => {
     })
 
     after(async () => {
+        clearTestIconPaths()
         await logger.cleanupLogger()
     })
 
@@ -59,7 +62,10 @@ describe('DefaultLambdaFunctionNode', () => {
     it('initializes icon', async () => {
         const testNode = generateTestNode()
 
-        validateIconPath(testNode)
+        const iconPath = testNode.iconPath as IconPath
+
+        assert.strictEqual(iconPath.dark.path, ext.iconPaths.dark.lambda, 'Unexpected dark icon path')
+        assert.strictEqual(iconPath.light.path, ext.iconPaths.light.lambda, 'Unexpected light icon path')
     })
 
     // Validates we don't yield some unexpected value that our command triggers
@@ -79,51 +85,10 @@ describe('DefaultLambdaFunctionNode', () => {
         assert.strictEqual(childNodes.length, 0)
     })
 
-    function validateIconPath(node: TreeItem) {
-        const fileScheme: string = 'file'
-        const expectedPrefix = `/${fakeIconPathPrefix}/`
-
-        assert(node.iconPath !== undefined)
-        const iconPath = node.iconPath! as {
-            light: Uri
-            dark: Uri
-        }
-
-        assert(iconPath.light !== undefined)
-        assert(iconPath.light instanceof Uri)
-        assert.strictEqual(iconPath.light.scheme, fileScheme)
-        const lightResourcePath: string = iconPath.light.path
-        assert(
-            lightResourcePath.indexOf(expectedPrefix) >= 0,
-            `expected light resource path ${lightResourcePath} to contain ${expectedPrefix}`
-        )
-        assert(
-            lightResourcePath.indexOf('/light/') >= 0,
-            `expected light resource path ${lightResourcePath} to contain '/light/'`
-        )
-
-        assert(iconPath.dark !== undefined)
-        assert(iconPath.dark instanceof Uri)
-        assert.strictEqual(iconPath.dark.scheme, fileScheme)
-        const darkResourcePath: string = iconPath.dark.path
-        assert(
-            darkResourcePath.indexOf(expectedPrefix) >= 0,
-            `expected dark resource path ${darkResourcePath} to contain ${expectedPrefix}`
-        )
-        assert(
-            darkResourcePath.indexOf('/dark/') >= 0,
-            `expected light resource path ${darkResourcePath} to contain '/dark/'`
-        )
-    }
-
     function generateTestNode(): DefaultLambdaFunctionNode {
         return new DefaultLambdaFunctionNode(
-            new DefaultLambdaFunctionGroupNode(
-                new DefaultRegionNode(new RegionInfo('code', 'name'), iconPathMaker),
-                iconPathMaker
-            ),
-            fakeFunctionConfig,
-            iconPathMaker
+            new DefaultLambdaFunctionGroupNode(new DefaultRegionNode(new RegionInfo('code', 'name'), iconPathMaker)),
+            fakeFunctionConfig
         )
     }
 
@@ -168,7 +133,7 @@ describe('DefaultLambdaFunctionGroupNode', () => {
 
     class ThrowErrorDefaultLambdaFunctionGroupNode extends DefaultLambdaFunctionGroupNode {
         public constructor(public readonly parent: DefaultRegionNode) {
-            super(parent, unusedPathResolver)
+            super(parent)
         }
 
         public async updateChildren(): Promise<void> {
@@ -199,8 +164,7 @@ describe('DefaultLambdaFunctionGroupNode', () => {
         }
 
         const functionGroupNode = new DefaultLambdaFunctionGroupNode(
-            new DefaultRegionNode(new RegionInfo('code', 'name'), stubPathResolver),
-            stubPathResolver
+            new DefaultRegionNode(new RegionInfo('code', 'name'), stubPathResolver)
         )
 
         const children = await functionGroupNode.getChildren()

--- a/src/test/lambda/explorer/lambdaNodes.test.ts
+++ b/src/test/lambda/explorer/lambdaNodes.test.ts
@@ -6,7 +6,6 @@
 import * as assert from 'assert'
 import { Lambda } from 'aws-sdk'
 import * as os from 'os'
-import { TreeItem, Uri } from 'vscode'
 import { DefaultRegionNode } from '../../../awsexplorer/defaultRegionNode'
 import {
     DefaultLambdaFunctionGroupNode,
@@ -31,7 +30,6 @@ async function* asyncGenerator<T>(items: T[]): AsyncIterableIterator<T> {
 
 describe('DefaultLambdaFunctionNode', () => {
     let fakeFunctionConfig: Lambda.FunctionConfiguration
-    const fakeIconPathPrefix: string = 'DefaultLambdaFunctionNode'
     let logger: TestLogger
 
     before(async () => {
@@ -87,13 +85,9 @@ describe('DefaultLambdaFunctionNode', () => {
 
     function generateTestNode(): DefaultLambdaFunctionNode {
         return new DefaultLambdaFunctionNode(
-            new DefaultLambdaFunctionGroupNode(new DefaultRegionNode(new RegionInfo('code', 'name'), iconPathMaker)),
+            new DefaultLambdaFunctionGroupNode(new DefaultRegionNode(new RegionInfo('code', 'name'))),
             fakeFunctionConfig
         )
-    }
-
-    function iconPathMaker(relativePath: string): string {
-        return `${fakeIconPathPrefix}/${relativePath}`
     }
 })
 
@@ -107,11 +101,6 @@ describe('DefaultLambdaFunctionGroupNode', () => {
     after(async () => {
         await logger.cleanupLogger()
     })
-
-    const stubPathResolver = (path: string): string => path
-    const unusedPathResolver = () => {
-        throw new Error('path resolver unused')
-    }
 
     class FunctionNamesMockLambdaClient extends MockLambdaClient {
         public constructor(
@@ -164,7 +153,7 @@ describe('DefaultLambdaFunctionGroupNode', () => {
         }
 
         const functionGroupNode = new DefaultLambdaFunctionGroupNode(
-            new DefaultRegionNode(new RegionInfo('code', 'name'), stubPathResolver)
+            new DefaultRegionNode(new RegionInfo('code', 'name'))
         )
 
         const children = await functionGroupNode.getChildren()
@@ -202,7 +191,7 @@ describe('DefaultLambdaFunctionGroupNode', () => {
 
     it('handles error', async () => {
         const testNode = new ThrowErrorDefaultLambdaFunctionGroupNode(
-            new DefaultRegionNode(new RegionInfo('code', 'name'), unusedPathResolver)
+            new DefaultRegionNode(new RegionInfo('code', 'name'))
         )
 
         const childNodes = await testNode.getChildren()

--- a/src/test/lambda/explorer/mockLambdaNodes.ts
+++ b/src/test/lambda/explorer/mockLambdaNodes.ts
@@ -28,8 +28,6 @@ export class MockLambdaFunctionNode implements LambdaFunctionNode {
         public readonly parent: LambdaFunctionGroupNode = ({} as any) as LambdaFunctionGroupNode,
         public readonly configuration: Lambda.FunctionConfiguration = {},
         public readonly getChildren: () => Thenable<AWSTreeNodeBase[]> = async () => [],
-        public readonly update: (configuration: Lambda.FunctionConfiguration) => void = config => {},
-        public readonly getExtensionAbsolutePath: (relativeExtensionPath: string) => string = relativeExtensionPath =>
-            'MockLambdaFunctionNode'
+        public readonly update: (configuration: Lambda.FunctionConfiguration) => void = config => {}
     ) {}
 }

--- a/src/test/shared/ui/buttons.test.ts
+++ b/src/test/shared/ui/buttons.test.ts
@@ -5,25 +5,40 @@
 
 import * as assert from 'assert'
 import * as vscode from 'vscode'
+import { ext } from '../../../shared/extensionGlobals'
 import * as buttons from '../../../shared/ui/buttons'
-import { FakeExtensionContext } from '../../fakeExtensionContext'
 
-describe('UI buttons', () => {
-    const extContext = new FakeExtensionContext()
+describe.only('UI buttons', () => {
+    const expectedHelpDarkPath = '/icons/dark/help'
+    const expectedHelpLightPath = '/icons/light/help'
 
-    it('creates a help button without a tooltip or icons', () => {
-        const help = buttons.createHelpButton(extContext)
-        const paths = help.iconPath as { light: vscode.Uri; dark: vscode.Uri }
+    before(() => {
+        ext.iconPaths.helpDark = expectedHelpDarkPath
+        ext.iconPaths.helpLight = expectedHelpLightPath
+    })
+
+    after(() => {
+        delete ext.iconPaths.helpDark
+        delete ext.iconPaths.helpLight
+    })
+
+    it('creates a help button without a tooltip', () => {
+        const help = buttons.createHelpButton()
 
         assert.strictEqual(help.tooltip, undefined)
-        assert.ok(paths.light)
-        assert.ok(paths.dark)
+        assertIconPath(help.iconPath as { light: vscode.Uri; dark: vscode.Uri })
     })
 
     it('creates a help button with a tooltip', () => {
         const tooltip = 'you must be truly desperate to come to me for help'
-        const help = buttons.createHelpButton(extContext, tooltip)
+        const help = buttons.createHelpButton(tooltip)
 
         assert.strictEqual(help.tooltip, tooltip)
+        assertIconPath(help.iconPath as { light: vscode.Uri; dark: vscode.Uri })
     })
+
+    function assertIconPath(iconPath: { light: vscode.Uri; dark: vscode.Uri }) {
+        assert.strictEqual(iconPath.dark.path, expectedHelpDarkPath)
+        assert.strictEqual(iconPath.light.path, expectedHelpLightPath)
+    }
 })

--- a/src/test/shared/ui/buttons.test.ts
+++ b/src/test/shared/ui/buttons.test.ts
@@ -8,18 +8,18 @@ import * as vscode from 'vscode'
 import { ext } from '../../../shared/extensionGlobals'
 import * as buttons from '../../../shared/ui/buttons'
 
-describe.only('UI buttons', () => {
+describe('UI buttons', () => {
     const expectedHelpDarkPath = '/icons/dark/help'
     const expectedHelpLightPath = '/icons/light/help'
 
     before(() => {
-        ext.iconPaths.helpDark = expectedHelpDarkPath
-        ext.iconPaths.helpLight = expectedHelpLightPath
+        ext.iconPaths.dark.help = expectedHelpDarkPath
+        ext.iconPaths.light.help = expectedHelpLightPath
     })
 
     after(() => {
-        delete ext.iconPaths.helpDark
-        delete ext.iconPaths.helpLight
+        ext.iconPaths.dark.help = ''
+        ext.iconPaths.light.help = ''
     })
 
     it('creates a help button without a tooltip', () => {

--- a/src/test/shared/ui/buttons.test.ts
+++ b/src/test/shared/ui/buttons.test.ts
@@ -4,29 +4,24 @@
  */
 
 import * as assert from 'assert'
-import * as vscode from 'vscode'
 import { ext } from '../../../shared/extensionGlobals'
 import * as buttons from '../../../shared/ui/buttons'
+import { clearTestIconPaths, IconPath, setupTestIconPaths } from '../utilities/iconPathUtils'
 
 describe('UI buttons', () => {
-    const expectedHelpDarkPath = '/icons/dark/help'
-    const expectedHelpLightPath = '/icons/light/help'
-
     before(() => {
-        ext.iconPaths.dark.help = expectedHelpDarkPath
-        ext.iconPaths.light.help = expectedHelpLightPath
+        setupTestIconPaths()
     })
 
     after(() => {
-        ext.iconPaths.dark.help = ''
-        ext.iconPaths.light.help = ''
+        clearTestIconPaths()
     })
 
     it('creates a help button without a tooltip', () => {
         const help = buttons.createHelpButton()
 
         assert.strictEqual(help.tooltip, undefined)
-        assertIconPath(help.iconPath as { light: vscode.Uri; dark: vscode.Uri })
+        assertIconPath(help.iconPath as IconPath)
     })
 
     it('creates a help button with a tooltip', () => {
@@ -34,11 +29,11 @@ describe('UI buttons', () => {
         const help = buttons.createHelpButton(tooltip)
 
         assert.strictEqual(help.tooltip, tooltip)
-        assertIconPath(help.iconPath as { light: vscode.Uri; dark: vscode.Uri })
+        assertIconPath(help.iconPath as IconPath)
     })
 
-    function assertIconPath(iconPath: { light: vscode.Uri; dark: vscode.Uri }) {
-        assert.strictEqual(iconPath.dark.path, expectedHelpDarkPath)
-        assert.strictEqual(iconPath.light.path, expectedHelpLightPath)
+    function assertIconPath(iconPath: IconPath) {
+        assert.strictEqual(iconPath.dark.path, ext.iconPaths.dark.help)
+        assert.strictEqual(iconPath.light.path, ext.iconPaths.light.help)
     }
 })

--- a/src/test/shared/utilities/iconPathUtils.ts
+++ b/src/test/shared/utilities/iconPathUtils.ts
@@ -1,0 +1,34 @@
+/*!
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { ext } from '../../../shared/extensionGlobals'
+
+export interface IconPath {
+    light: vscode.Uri
+    dark: vscode.Uri
+}
+
+export function setupTestIconPaths() {
+    ext.iconPaths.dark.help = '/icons/dark/help'
+    ext.iconPaths.light.help = '/icons/light/help'
+
+    ext.iconPaths.dark.cloudFormation = '/icons/dark/cloudformation'
+    ext.iconPaths.light.cloudFormation = '/icons/light/cloudformation'
+
+    ext.iconPaths.dark.lambda = '/icons/dark/lambda'
+    ext.iconPaths.light.lambda = '/icons/light/lambda'
+}
+
+export function clearTestIconPaths() {
+    ext.iconPaths.dark.help = ''
+    ext.iconPaths.light.help = ''
+
+    ext.iconPaths.dark.cloudFormation = ''
+    ext.iconPaths.light.cloudFormation = ''
+
+    ext.iconPaths.dark.lambda = ''
+    ext.iconPaths.light.lambda = ''
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

SAM and Explorer nodes passed a function down many layers to ultimately compute icon paths, which are fixed for the lifetime of the extension. The icon paths have been made central, and the function pass-down has been removed to help tidy up the code.


## Testing

* Tests were updated
* Ran the Toolkit to verify the Explorer icons still show
* Ran the Toolkit to verify the SAM Workflows still show the help icon

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
