### PR TITLE
Remove Ansi codes from SAM CLI local invoke output when writing to OutputChannel

### DIFF
--- a/.changes/next-release/Feature-32b6099e-a88c-4dc7-b67b-e8baf66f915d.json
+++ b/.changes/next-release/Feature-32b6099e-a88c-4dc7-b67b-e8baf66f915d.json
@@ -1,0 +1,4 @@
+{
+    "type": "Feature",
+    "description": "Ansi codes are removed from text shown in the Output tab when Locally Invoking Lambda handlers"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -457,6 +457,17 @@
                         "has-ansi": "^2.0.0",
                         "strip-ansi": "^3.0.0",
                         "supports-color": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^2.0.0"
+                            }
+                        }
                     }
                 }
             }
@@ -2695,12 +2706,18 @@
             }
         },
         "strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "dev": true,
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+            "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "^4.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+                }
             }
         },
         "strip-eof": {

--- a/package.json
+++ b/package.json
@@ -415,6 +415,7 @@
         "request": "^2.88.0",
         "semver": "^5.6.0",
         "sleep-promise": "^8.0.1",
+        "strip-ansi": "^5.2.0",
         "tcp-port-used": "^1.0.1",
         "triple-beam": "^1.3.0",
         "typescript": "^3.5.3",

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 import { fileExists } from '../../filesystemUtilities'
 import { ChildProcess } from '../../utilities/childProcess'
+import { removeAnsi } from '../../utilities/textUtilities'
 import { Timeout } from '../../utilities/timeoutUtils'
 import { ChannelLogger } from '../../utilities/vsCodeUtils'
 
@@ -128,7 +129,7 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
     private emitMessage(text: string): void {
         // From VS Code API: If no debug session is active, output sent to the debug console is not shown.
         // We send text to output channel and debug console to ensure no text is lost.
-        this.channelLogger.channel.append(text)
+        this.channelLogger.channel.append(removeAnsi(text))
         vscode.debug.activeDebugConsole.append(text)
     }
 }

--- a/src/shared/utilities/textUtilities.ts
+++ b/src/shared/utilities/textUtilities.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { default as stripAnsi } from 'strip-ansi'
+import { getLogger } from '../logger'
+
+export function removeAnsi(text: string): string {
+    try {
+        return stripAnsi(text)
+    } catch (err) {
+        getLogger().error('Unexpected error while removing Ansi from text', err as Error)
+
+        // Fall back to original text so callers aren't impacted
+        return text
+    }
+}

--- a/src/test/shared/utilities/textUtilities.test.ts
+++ b/src/test/shared/utilities/textUtilities.test.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { removeAnsi } from '../../../shared/utilities/textUtilities'
+
+describe('removeAnsi', async () => {
+    it('removes ansi code from text', async () => {
+        assert.strictEqual(removeAnsi('\u001b[31mHello World'), 'Hello World')
+    })
+
+    it('text without ansi code remains as-is', async () => {
+        const text = 'Hello World 123!'
+        assert.strictEqual(removeAnsi(text), text)
+    })
+})


### PR DESCRIPTION

## Description

The output of local invoke calls includes ansi codes to color the text. This text renders in the Debug Console, but not the Output tab. This change removes ansi codes from the SAM local invoke output that is sent to the Output tab.

![image](https://user-images.githubusercontent.com/39839589/65982085-53adb680-e42f-11e9-9572-fa5c9e191ae9.png)



## Testing

* Ran a local run and a local debug of a lambda handler, verified that the Output tab received cleaner text, and the debug console was still colored.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
