### PR TITLE
Encapsulating Winston Logger

### DIFF
--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -66,13 +66,10 @@ export async function initialize(params?: LoggerParams): Promise<Logger> {
         }
 
         // TODO : Determine log level here, then createLogger calls in this method can converge
-        const newLogger = createLogger({
+        defaultLogger = createLogger({
             outputChannel,
             logPath
         })
-
-        initializeDefaultLogger(newLogger)
-
         // only the default logger (with default params) gets a registered command
         // check list of registered commands to see if aws.viewLogs has already been registered.
         // if so, don't register again--this will cause an error visible to the user.
@@ -89,7 +86,7 @@ export async function initialize(params?: LoggerParams): Promise<Logger> {
         outputChannel = params.outputChannel
         logPath = params.logPath
 
-        initializeDefaultLogger(createLogger(params))
+        defaultLogger = createLogger(params)
     }
 
     if (outputChannel && logPath) {
@@ -99,10 +96,6 @@ export async function initialize(params?: LoggerParams): Promise<Logger> {
     }
 
     return defaultLogger
-}
-
-export function initializeDefaultLogger(logger: Logger) {
-    defaultLogger = logger
 }
 
 /**

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -83,10 +83,7 @@ export interface BasicLogger {
 export type LogLevel = keyof BasicLogger
 
 export interface Logger extends BasicLogger {
-    logPath?: string
-    outputChannel?: vscode.OutputChannel
     level: LogLevel
-    releaseLogger(): void
 }
 
 // TODO : CC : Phase out Logger retain only BasicLogger
@@ -108,15 +105,6 @@ export class WinstonToolkitLogger implements Logger, vscode.Disposable {
         })
 
         this.level = logLevel
-    }
-
-    // logPath?: string | undefined
-    // outputChannel?: vscode.OutputChannel | undefined
-
-    // TODO : CC : Remove releaseLogger from interface
-    public releaseLogger(): void {
-        // Remove all transports from Winston logger, retain logger
-        this.logger.clear()
     }
 
     public logToFile(logPath: string): void {
@@ -253,8 +241,6 @@ export function getLogger(): Logger {
  * @param params: LoggerParams--nothing is required, but a LogPath is highly recommended so Winston doesn't throw errors
  *
  * Outputs a logger object that isn't stored anywhere--it's up to the caller to keep track of this.
- * No cleanup is REQUIRED, but if you wish to directly manipulate the log file while VSCode is still active,
- * you need to call releaseLogger. This will end the ability to write to the logfile with this logger instance.
  */
 export function createLogger(params: LoggerParams): Logger {
     // TODO : CC : Determine log level in this method's caller

--- a/src/test/mockOutputChannel.ts
+++ b/src/test/mockOutputChannel.ts
@@ -12,12 +12,19 @@ export class MockOutputChannel implements vscode.OutputChannel {
 
     public readonly name = 'Mock channel'
 
+    private readonly onDidAppendTextEmitter: vscode.EventEmitter<string> = new vscode.EventEmitter<string>()
+
+    public get onDidAppendText(): vscode.Event<string> {
+        return this.onDidAppendTextEmitter.event
+    }
+
     public append(value: string): void {
         this.value += value
+        this.onDidAppendTextEmitter.fire(value)
     }
 
     public appendLine(value: string) {
-        this.value += value + '\n'
+        this.append(value + '\n')
     }
 
     public clear(): void {

--- a/src/test/shared/logger.test.ts
+++ b/src/test/shared/logger.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert'
 import * as del from 'del'
 import * as path from 'path'
 import * as filesystemUtilities from '../../shared/filesystemUtilities'
-import { createLogger, Logger, WinstonToolkitLogger } from '../../shared/logger'
+import { createLogger, Logger, OutputChannelTransport, WinstonToolkitLogger } from '../../shared/logger'
 import { MockOutputChannel } from '../mockOutputChannel'
 import { assertThrowsError } from './utilities/assertUtils'
 
@@ -169,7 +169,7 @@ describe('WinstonToolkitLogger', () => {
         }
     })
 
-    describe.only('logs to an OutputChannel', async () => {
+    describe('logs to an OutputChannel', async () => {
         let testLogger: WinstonToolkitLogger | undefined
         let outputChannel: MockOutputChannel
 
@@ -258,5 +258,40 @@ describe('WinstonToolkitLogger', () => {
                 })
             })
         }
+    })
+})
+
+describe('OutputChannelTransport', async () => {
+    let outputChannel: MockOutputChannel
+
+    beforeEach(async () => {
+        outputChannel = new MockOutputChannel()
+    })
+
+    it('logs content', async () => {
+        const loggedMessage = 'This is my logged message'
+        const transport = new OutputChannelTransport({
+            outputChannel
+        })
+
+        // OutputChannel is logged to in async manner
+        const waitForLoggedText = new Promise<void>(resolve => {
+            outputChannel.onDidAppendText(loggedText => {
+                if (loggedText === loggedMessage) {
+                    resolve()
+                }
+            })
+        })
+
+        transport.log(
+            {
+                level: 'info',
+                message: loggedMessage
+            },
+            async () => {
+                // Test will timeout if expected text is not encountered
+                await waitForLoggedText
+            }
+        )
     })
 })

--- a/src/test/shared/logger.test.ts
+++ b/src/test/shared/logger.test.ts
@@ -38,40 +38,40 @@ describe('logger', () => {
     it('logs debug info to a file', async () => {
         const text = 'logs debug info to a file'
         testLogger.debug(text)
-        await waitForLogFile(tempLogPath as string)
-        const logText = await filesystemUtilities.readFileAsString(tempLogPath as string)
+        await waitForLogFile(tempLogPath)
+        const logText = await filesystemUtilities.readFileAsString(tempLogPath)
         assert.strictEqual(logText.includes(`[DEBUG]: ${text}`), true)
     })
 
     it('logs verbose info to a file', async () => {
         const text = 'logs verbose info to a file'
         testLogger.verbose(text)
-        await waitForLogFile(tempLogPath as string)
-        const logText = await filesystemUtilities.readFileAsString(tempLogPath as string)
+        await waitForLogFile(tempLogPath)
+        const logText = await filesystemUtilities.readFileAsString(tempLogPath)
         assert.strictEqual(logText.includes(`[VERBOSE]: ${text}`), true)
     })
 
     it('logs info to a file', async () => {
         const text = 'logs info to a file'
         testLogger.info(text)
-        await waitForLogFile(tempLogPath as string)
-        const logText = await filesystemUtilities.readFileAsString(tempLogPath as string)
+        await waitForLogFile(tempLogPath)
+        const logText = await filesystemUtilities.readFileAsString(tempLogPath)
         assert.strictEqual(logText.includes(`[INFO]: ${text}`), true)
     })
 
     it('logs warnings to a file', async () => {
         const text = 'logs warning to a file'
         testLogger.warn(text)
-        await waitForLogFile(tempLogPath as string)
-        const logText = await filesystemUtilities.readFileAsString(tempLogPath as string)
+        await waitForLogFile(tempLogPath)
+        const logText = await filesystemUtilities.readFileAsString(tempLogPath)
         assert.strictEqual(logText.includes(`[WARN]: ${text}`), true)
     })
 
     it('logs errors to a file', async () => {
         const text = 'logs errors to a file'
         testLogger.error(new Error(text))
-        await waitForLogFile(tempLogPath as string)
-        const logText = await filesystemUtilities.readFileAsString(tempLogPath as string)
+        await waitForLogFile(tempLogPath)
+        const logText = await filesystemUtilities.readFileAsString(tempLogPath)
         assert.strictEqual(logText.includes(`[ERROR]: Error: ${text}`), true)
         // check stack trace
         assert.strictEqual(logText.includes('logger.test'), true)
@@ -79,21 +79,22 @@ describe('logger', () => {
 
     it('logs multiple pieces of info to a file', async () => {
         testLogger.info('logs', 'multiple', 'pieces', 'of', 'info', 'to', 'a', 'file')
-        await waitForLogFile(tempLogPath as string)
-        const logText = await filesystemUtilities.readFileAsString(tempLogPath as string)
+        await waitForLogFile(tempLogPath)
+        const logText = await filesystemUtilities.readFileAsString(tempLogPath)
         assert.strictEqual(logText.includes('[INFO]: logs multiple pieces of info to a file'), true)
     })
 
     it('does not log levels lower than the designated level', async () => {
+        const errorLogPath = path.join(tempFolder, 'errorsOnly.log')
         const text = 'does not log levels lower than the designated level'
         const errorOnlyLogger = logger.createLogger({
             logLevel: 'error',
-            logPath: path.join(tempFolder, 'errorsOnly.log')
+            logPath: errorLogPath
         })
         errorOnlyLogger.verbose(text)
         errorOnlyLogger.error(new Error(text))
-        await waitForLogFile(errorOnlyLogger.logPath as string)
-        const logText = await filesystemUtilities.readFileAsString(errorOnlyLogger.logPath as string)
+        await waitForLogFile(errorLogPath)
+        const logText = await filesystemUtilities.readFileAsString(errorLogPath)
         assert.strictEqual(logText.includes(`[VERBOSE]: ${text}`), false)
         assert.strictEqual(logText.includes(`[ERROR]: Error: ${text}`), true)
         errorOnlyLogger.releaseLogger()

--- a/src/test/shared/logger.test.ts
+++ b/src/test/shared/logger.test.ts
@@ -11,13 +11,15 @@ import * as logger from '../../shared/logger'
 
 describe('logger', () => {
     let tempFolder: string
+    let tempLogPath: string
     let testLogger: logger.Logger
 
     before(async () => {
         tempFolder = await filesystemUtilities.makeTemporaryToolkitFolder()
+        tempLogPath = path.join(tempFolder, 'temp.log')
         testLogger = logger.createLogger({
             // no output channel since we can't check the output channel's content...
-            logPath: path.join(tempFolder, 'temp.log'),
+            logPath: tempLogPath,
             logLevel: 'debug'
         })
     })
@@ -36,40 +38,40 @@ describe('logger', () => {
     it('logs debug info to a file', async () => {
         const text = 'logs debug info to a file'
         testLogger.debug(text)
-        await waitForLogFile(testLogger.logPath as string)
-        const logText = await filesystemUtilities.readFileAsString(testLogger.logPath as string)
+        await waitForLogFile(tempLogPath as string)
+        const logText = await filesystemUtilities.readFileAsString(tempLogPath as string)
         assert.strictEqual(logText.includes(`[DEBUG]: ${text}`), true)
     })
 
     it('logs verbose info to a file', async () => {
         const text = 'logs verbose info to a file'
         testLogger.verbose(text)
-        await waitForLogFile(testLogger.logPath as string)
-        const logText = await filesystemUtilities.readFileAsString(testLogger.logPath as string)
+        await waitForLogFile(tempLogPath as string)
+        const logText = await filesystemUtilities.readFileAsString(tempLogPath as string)
         assert.strictEqual(logText.includes(`[VERBOSE]: ${text}`), true)
     })
 
     it('logs info to a file', async () => {
         const text = 'logs info to a file'
         testLogger.info(text)
-        await waitForLogFile(testLogger.logPath as string)
-        const logText = await filesystemUtilities.readFileAsString(testLogger.logPath as string)
+        await waitForLogFile(tempLogPath as string)
+        const logText = await filesystemUtilities.readFileAsString(tempLogPath as string)
         assert.strictEqual(logText.includes(`[INFO]: ${text}`), true)
     })
 
     it('logs warnings to a file', async () => {
         const text = 'logs warning to a file'
         testLogger.warn(text)
-        await waitForLogFile(testLogger.logPath as string)
-        const logText = await filesystemUtilities.readFileAsString(testLogger.logPath as string)
+        await waitForLogFile(tempLogPath as string)
+        const logText = await filesystemUtilities.readFileAsString(tempLogPath as string)
         assert.strictEqual(logText.includes(`[WARN]: ${text}`), true)
     })
 
     it('logs errors to a file', async () => {
         const text = 'logs errors to a file'
         testLogger.error(new Error(text))
-        await waitForLogFile(testLogger.logPath as string)
-        const logText = await filesystemUtilities.readFileAsString(testLogger.logPath as string)
+        await waitForLogFile(tempLogPath as string)
+        const logText = await filesystemUtilities.readFileAsString(tempLogPath as string)
         assert.strictEqual(logText.includes(`[ERROR]: Error: ${text}`), true)
         // check stack trace
         assert.strictEqual(logText.includes('logger.test'), true)
@@ -77,8 +79,8 @@ describe('logger', () => {
 
     it('logs multiple pieces of info to a file', async () => {
         testLogger.info('logs', 'multiple', 'pieces', 'of', 'info', 'to', 'a', 'file')
-        await waitForLogFile(testLogger.logPath as string)
-        const logText = await filesystemUtilities.readFileAsString(testLogger.logPath as string)
+        await waitForLogFile(tempLogPath as string)
+        const logText = await filesystemUtilities.readFileAsString(tempLogPath as string)
         assert.strictEqual(logText.includes('[INFO]: logs multiple pieces of info to a file'), true)
     })
 


### PR DESCRIPTION

## Description

I went to write some tests that verified log contents, and it turns out that tests currently have to poll for a log file to materialize, then poll for the log file to get updated, then scrape the contents of the log files. This isn't ideal. It turns out the toolkit's logging could benefit from some encapsulations.

I've tried to make this change disrupt as few files as possible, with plans to make subsequent, incremental changes that will bring logging into a more ideal state.

What's in this change:
* The Toolkit now uses Winston logger to output to the "Toolkit Log" OutputChannel
* The Winston logger, and corresponding concerns from the `Logger` interface, have been encapsulated (in `WinstonToolkitLogger`)
* Ideally these two things would have been separate changes, but they were too coupled together

Future planned changes (separate changes to keep PRs smaller):
* Introduce a simple in-memory logger which doesn't use the Winston Logger for tests to use
* Consolidate the Toolkit's Logger interface
* rearrange the logging code from `logger.ts` into separate files

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
