### PR TITLE
Add --no-interactive to init

### DIFF
--- a/.changes/next-release/Bug Fix-ef3fc182-9d97-47af-9633-72d09d8622b9.json
+++ b/.changes/next-release/Bug Fix-ef3fc182-9d97-47af-9633-72d09d8622b9.json
@@ -1,0 +1,4 @@
+{
+    "type": "Bug Fix",
+    "description": "Add '--no-interactive' flag to 'sam init' calls when SAM CLI version is greater than or equal to 0.30.0"
+}

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -136,7 +136,7 @@ for (const runtime of runtimes) {
                 runtime: projectSDK as SamLambdaRuntime
             }
             const samCliContext = getSamCliContext()
-            await runSamCliInit(initArguments, samCliContext.invoker)
+            await runSamCliInit(initArguments, samCliContext)
             // Activate the relevent extensions if needed
             if (projectSDK.includes('dotnet')) {
                 await activateExtension('ms-vscode.csharp')
@@ -165,7 +165,7 @@ for (const runtime of runtimes) {
             }
             console.log(initArguments.location)
             const samCliContext = getSamCliContext()
-            const err = await assertThrowsError(async () => runSamCliInit(initArguments, samCliContext.invoker))
+            const err = await assertThrowsError(async () => runSamCliInit(initArguments, samCliContext))
             assert(err.message.includes('directory already exists'))
         }).timeout(TIMEOUT)
 

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -91,7 +91,7 @@ export async function createNewSamApplication(
             location: config.location.fsPath,
             runtime: config.runtime
         }
-        await runSamCliInit(initArguments, samCliContext.invoker)
+        await runSamCliInit(initArguments, samCliContext)
 
         results.result = 'pass'
 

--- a/src/shared/sam/cli/samCliContext.ts
+++ b/src/shared/sam/cli/samCliContext.ts
@@ -8,6 +8,7 @@ import { DefaultSamCliConfiguration } from './samCliConfiguration'
 import { DefaultSamCliProcessInvoker, SamCliProcessInvokerContext } from './samCliInvoker'
 import { SamCliProcessInvoker } from './samCliInvokerUtils'
 import { DefaultSamCliLocationProvider } from './samCliLocator'
+import { throwAndNotifyIfInvalid } from './samCliValidationUtils'
 import { DefaultSamCliValidator, DefaultSamCliValidatorContext, SamCliValidator } from './samCliValidator'
 
 export interface SamCliContext {
@@ -43,6 +44,13 @@ export function getSamCliContext() {
     }
 
     return samCliContext
+}
+
+export async function getSamCliVersion(context: SamCliContext): Promise<string> {
+    const result = await context.validator.detectValidSamCli()
+    throwAndNotifyIfInvalid(result)
+
+    return result.versionValidation!.version!
 }
 
 function makeSamCliContext(): SamCliContext {

--- a/src/shared/sam/cli/samCliInit.ts
+++ b/src/shared/sam/cli/samCliInit.ts
@@ -7,6 +7,7 @@ import * as semver from 'semver'
 import { SamLambdaRuntime } from '../../../lambda/models/samLambdaRuntime'
 import { getSamCliVersion, SamCliContext } from './samCliContext'
 import { logAndThrowIfUnexpectedExitCode } from './samCliInvokerUtils'
+import { SAM_CLI_VERSION_0_30 } from './samCliValidator'
 
 export interface SamCliInitArgs {
     runtime: SamLambdaRuntime
@@ -18,7 +19,7 @@ export async function runSamCliInit(initArguments: SamCliInitArgs, context: SamC
     const args = ['init', '--name', initArguments.name, '--runtime', initArguments.runtime]
     const samCliVersion = await getSamCliVersion(context)
 
-    if (semver.gte(samCliVersion, '0.30.0')) {
+    if (semver.gte(samCliVersion, SAM_CLI_VERSION_0_30)) {
         args.push('--no-interactive')
     }
 

--- a/src/shared/sam/cli/samCliValidator.ts
+++ b/src/shared/sam/cli/samCliValidator.ts
@@ -10,7 +10,8 @@ import { SamCliInfoInvocation, SamCliInfoResponse } from './samCliInfo'
 import { SamCliProcessInvoker } from './samCliInvokerUtils'
 
 export const MINIMUM_SAM_CLI_VERSION_INCLUSIVE = '0.16.0'
-export const MAXIMUM_SAM_CLI_VERSION_EXCLUSIVE = '0.40.0'
+export const MAXIMUM_SAM_CLI_VERSION_EXCLUSIVE = '0.30.0'
+export const SAM_CLI_VERSION_0_30 = '0.30.0'
 
 // Errors
 export class InvalidSamCliError extends Error {

--- a/src/shared/sam/cli/samCliValidator.ts
+++ b/src/shared/sam/cli/samCliValidator.ts
@@ -10,7 +10,7 @@ import { SamCliInfoInvocation, SamCliInfoResponse } from './samCliInfo'
 import { SamCliProcessInvoker } from './samCliInvokerUtils'
 
 export const MINIMUM_SAM_CLI_VERSION_INCLUSIVE = '0.16.0'
-export const MAXIMUM_SAM_CLI_VERSION_EXCLUSIVE = '0.30.0'
+export const MAXIMUM_SAM_CLI_VERSION_EXCLUSIVE = '0.40.0'
 
 // Errors
 export class InvalidSamCliError extends Error {

--- a/src/test/shared/sam/cli/samCliInit.test.ts
+++ b/src/test/shared/sam/cli/samCliInit.test.ts
@@ -10,6 +10,7 @@ import { runSamCliInit, SamCliInitArgs } from '../../../../shared/sam/cli/samCli
 import { SamCliProcessInvoker } from '../../../../shared/sam/cli/samCliInvokerUtils'
 import {
     MINIMUM_SAM_CLI_VERSION_INCLUSIVE,
+    SAM_CLI_VERSION_0_30,
     SamCliValidator,
     SamCliValidatorResult,
     SamCliVersionValidation
@@ -156,7 +157,7 @@ describe('runSamCliInit', async () => {
         )
 
         const context: SamCliContext = {
-            validator: new FakeSamCliValidator('0.30.0'),
+            validator: new FakeSamCliValidator(SAM_CLI_VERSION_0_30),
             invoker: processInvoker
         }
 

--- a/src/test/shared/sam/cli/samCliInit.test.ts
+++ b/src/test/shared/sam/cli/samCliInit.test.ts
@@ -5,12 +5,19 @@
 
 import * as assert from 'assert'
 import { SpawnOptions } from 'child_process'
+import { SamCliContext } from '../../../../shared/sam/cli/samCliContext'
 import { runSamCliInit, SamCliInitArgs } from '../../../../shared/sam/cli/samCliInit'
 import { SamCliProcessInvoker } from '../../../../shared/sam/cli/samCliInvokerUtils'
+import {
+    MINIMUM_SAM_CLI_VERSION_INCLUSIVE,
+    SamCliValidator,
+    SamCliValidatorResult,
+    SamCliVersionValidation
+} from '../../../../shared/sam/cli/samCliValidator'
 import { ChildProcessResult } from '../../../../shared/utilities/childProcess'
 import { getTestLogger } from '../../../globalSetup.test'
 import { assertThrowsError } from '../../utilities/assertUtils'
-import { assertArgsContainArgument } from './samCliTestUtils'
+import { assertArgIsPresent, assertArgsContainArgument } from './samCliTestUtils'
 import {
     assertErrorContainsBadExitMessage,
     assertLogContainsBadExitInformation,
@@ -37,6 +44,24 @@ describe('runSamCliInit', async () => {
         }
     }
 
+    class FakeSamCliValidator implements SamCliValidator {
+        private readonly version: string
+        public constructor(version: string = MINIMUM_SAM_CLI_VERSION_INCLUSIVE) {
+            this.version = version
+        }
+        public async detectValidSamCli(): Promise<SamCliValidatorResult> {
+            return {
+                samCliFound: true,
+                versionValidation: {
+                    version: this.version,
+                    validation: SamCliVersionValidation.Valid
+                }
+            }
+        }
+    }
+
+    const defaultFakeValidator = new FakeSamCliValidator()
+
     const sampleSamInitArgs: SamCliInitArgs = {
         name: 'qwerty',
         location: '/some/path/to/code.js',
@@ -51,7 +76,12 @@ describe('runSamCliInit', async () => {
             }
         )
 
-        await runSamCliInit(sampleSamInitArgs, processInvoker)
+        const context: SamCliContext = {
+            validator: defaultFakeValidator,
+            invoker: processInvoker
+        }
+
+        await runSamCliInit(sampleSamInitArgs, context)
     })
 
     it('Passes name to sam cli', async () => {
@@ -61,7 +91,12 @@ describe('runSamCliInit', async () => {
             }
         )
 
-        await runSamCliInit(sampleSamInitArgs, processInvoker)
+        const context: SamCliContext = {
+            validator: defaultFakeValidator,
+            invoker: processInvoker
+        }
+
+        await runSamCliInit(sampleSamInitArgs, context)
     })
 
     it('Passes location to sam cli', async () => {
@@ -71,7 +106,12 @@ describe('runSamCliInit', async () => {
             }
         )
 
-        await runSamCliInit(sampleSamInitArgs, processInvoker)
+        const context: SamCliContext = {
+            validator: defaultFakeValidator,
+            invoker: processInvoker
+        }
+
+        await runSamCliInit(sampleSamInitArgs, context)
     })
 
     it('Passes runtime to sam cli', async () => {
@@ -81,14 +121,23 @@ describe('runSamCliInit', async () => {
             }
         )
 
-        await runSamCliInit(sampleSamInitArgs, processInvoker)
+        const context: SamCliContext = {
+            validator: defaultFakeValidator,
+            invoker: processInvoker
+        }
+
+        await runSamCliInit(sampleSamInitArgs, context)
     })
 
     it('throws on unexpected exit code', async () => {
         const badExitCodeProcessInvoker = new BadExitCodeSamCliProcessInvoker({})
+        const context: SamCliContext = {
+            validator: defaultFakeValidator,
+            invoker: badExitCodeProcessInvoker
+        }
 
         const error = await assertThrowsError(async () => {
-            await runSamCliInit(sampleSamInitArgs, badExitCodeProcessInvoker)
+            await runSamCliInit(sampleSamInitArgs, context)
         }, 'Expected an error to be thrown')
 
         assertErrorContainsBadExitMessage(error, badExitCodeProcessInvoker.error.message)
@@ -97,5 +146,20 @@ describe('runSamCliInit', async () => {
             badExitCodeProcessInvoker.makeChildProcessResult(),
             0
         )
+    })
+
+    it('Passes --no-interactive if version >= 0.30.0', async () => {
+        const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker(
+            (spawnOptions: SpawnOptions, args: any[]) => {
+                assertArgIsPresent(args, '--no-interactive')
+            }
+        )
+
+        const context: SamCliContext = {
+            validator: new FakeSamCliValidator('0.30.0'),
+            invoker: processInvoker
+        }
+
+        await runSamCliInit(sampleSamInitArgs, context)
     })
 })


### PR DESCRIPTION
Errors out as expected with:
```
2019-10-14 16:56:09 [ERROR]: Unexpected exitcode (1), expecting (0)
2019-10-14 16:56:09 [ERROR]: Error: undefined
2019-10-14 16:56:09 [ERROR]: stderr: Error: 
ERROR: Missing required parameters, with --no-interactive set.

Must provide one of the following required parameter combinations:
    --name and --runtime and --dependency-manager and --app-template
    --location

```
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
