### PR TITLE
Remove interfaces related to CloudFormation Explorer Nodes

### DIFF
--- a/src/awsexplorer/regionNode.ts
+++ b/src/awsexplorer/regionNode.ts
@@ -4,7 +4,7 @@
  */
 
 import { TreeItemCollapsibleState } from 'vscode'
-import { CloudFormationNode, DefaultCloudFormationNode } from '../lambda/explorer/cloudFormationNodes'
+import { CloudFormationNode } from '../lambda/explorer/cloudFormationNodes'
 import { DefaultLambdaFunctionGroupNode, LambdaFunctionGroupNode } from '../lambda/explorer/lambdaNodes'
 import { RegionInfo } from '../shared/regions/regionInfo'
 import { AWSTreeNodeBase } from '../shared/treeview/nodes/awsTreeNodeBase'
@@ -34,7 +34,7 @@ export class RegionNode extends AWSTreeNodeBase {
         this.info = info
         this.update(info)
 
-        this.cloudFormationNode = new DefaultCloudFormationNode(this.regionCode)
+        this.cloudFormationNode = new CloudFormationNode(this.regionCode)
         this.lambdaFunctionGroupNode = new DefaultLambdaFunctionGroupNode(this.regionCode)
     }
 

--- a/src/lambda/explorer/cloudFormationNodes.ts
+++ b/src/lambda/explorer/cloudFormationNodes.ts
@@ -20,13 +20,7 @@ import { intersection, toArrayAsync, toMap, toMapAsync, updateInPlace } from '..
 import { listCloudFormationStacks, listLambdaFunctions } from '../utils'
 import { FunctionNodeBase } from './functionNode'
 
-export interface CloudFormationNode extends AWSTreeErrorHandlerNode {
-    getChildren(): Thenable<(CloudFormationStackNode | ErrorNode)[]>
-
-    updateChildren(): Thenable<void>
-}
-
-export class DefaultCloudFormationNode extends AWSTreeErrorHandlerNode implements CloudFormationNode {
+export class CloudFormationNode extends AWSTreeErrorHandlerNode {
     private readonly stackNodes: Map<string, CloudFormationStackNode>
 
     public constructor(private readonly regionCode: string) {
@@ -53,24 +47,12 @@ export class DefaultCloudFormationNode extends AWSTreeErrorHandlerNode implement
             this.stackNodes,
             stacks.keys(),
             key => this.stackNodes.get(key)!.update(stacks.get(key)!),
-            key => new DefaultCloudFormationStackNode(this, this.regionCode, stacks.get(key)!)
+            key => new CloudFormationStackNode(this, this.regionCode, stacks.get(key)!)
         )
     }
 }
 
-export interface CloudFormationStackNode extends AWSTreeErrorHandlerNode {
-    readonly regionCode: string
-    readonly stackId?: CloudFormation.StackId
-    readonly stackName: CloudFormation.StackName
-
-    readonly parent: AWSTreeNodeBase
-
-    getChildren(): Thenable<(CloudFormationFunctionNode | PlaceholderNode)[]>
-
-    update(stackSummary: CloudFormation.StackSummary): void
-}
-
-export class DefaultCloudFormationStackNode extends AWSTreeErrorHandlerNode implements CloudFormationStackNode {
+export class CloudFormationStackNode extends AWSTreeErrorHandlerNode {
     private readonly functionNodes: Map<string, CloudFormationFunctionNode>
 
     public constructor(
@@ -137,7 +119,7 @@ export class DefaultCloudFormationStackNode extends AWSTreeErrorHandlerNode impl
             this.functionNodes,
             intersection(resources, functions.keys()),
             key => this.functionNodes.get(key)!.update(functions.get(key)!),
-            key => new DefaultCloudFormationFunctionNode(this, this.regionCode, functions.get(key)!)
+            key => new CloudFormationFunctionNode(this, this.regionCode, functions.get(key)!)
         )
     }
 
@@ -155,11 +137,7 @@ export class DefaultCloudFormationStackNode extends AWSTreeErrorHandlerNode impl
     }
 }
 
-export interface CloudFormationFunctionNode extends FunctionNodeBase {
-    readonly parent: CloudFormationStackNode
-}
-
-export class DefaultCloudFormationFunctionNode extends FunctionNodeBase {
+export class CloudFormationFunctionNode extends FunctionNodeBase {
     public constructor(
         public readonly parent: AWSTreeNodeBase,
         public readonly regionCode: string,

--- a/src/test/lambda/explorer/cloudFormationNodes.test.ts
+++ b/src/test/lambda/explorer/cloudFormationNodes.test.ts
@@ -26,7 +26,7 @@ async function* asyncGenerator<T>(items: T[]): AsyncIterableIterator<T> {
     yield* items
 }
 
-describe('DefaultCloudFormationStackNode', () => {
+describe('CloudFormationStackNode', () => {
     let fakeStackSummary: CloudFormation.StackSummary
 
     before(async () => {
@@ -205,7 +205,7 @@ describe('DefaultCloudFormationStackNode', () => {
     }
 })
 
-describe('DefaultCloudFormationNode', () => {
+describe('CloudFormationNode', () => {
     class StackNamesMockCloudFormationClient extends MockCloudFormationClient {
         public constructor(
             public readonly stackNames: string[] = [],
@@ -286,7 +286,7 @@ describe('DefaultCloudFormationNode', () => {
     })
 
     it('handles error', async () => {
-        class ThrowErrorDefaultCloudFormationNode extends CloudFormationNode {
+        class ThrowErrorCloudFormationNode extends CloudFormationNode {
             public constructor() {
                 super('someregioncode')
             }
@@ -296,7 +296,7 @@ describe('DefaultCloudFormationNode', () => {
             }
         }
 
-        const testNode: ThrowErrorDefaultCloudFormationNode = new ThrowErrorDefaultCloudFormationNode()
+        const testNode: ThrowErrorCloudFormationNode = new ThrowErrorCloudFormationNode()
 
         const childNodes = await testNode.getChildren()
         assert(childNodes !== undefined)

--- a/src/test/lambda/explorer/cloudFormationNodes.test.ts
+++ b/src/test/lambda/explorer/cloudFormationNodes.test.ts
@@ -7,10 +7,9 @@ import * as assert from 'assert'
 import { CloudFormation, Lambda } from 'aws-sdk'
 import * as os from 'os'
 import {
-    CloudFormationStackNode,
-    DefaultCloudFormationFunctionNode,
-    DefaultCloudFormationNode,
-    DefaultCloudFormationStackNode
+    CloudFormationFunctionNode,
+    CloudFormationNode,
+    CloudFormationStackNode
 } from '../../../lambda/explorer/cloudFormationNodes'
 import { CloudFormationClient } from '../../../shared/clients/cloudFormationClient'
 import { EcsClient } from '../../../shared/clients/ecsClient'
@@ -192,17 +191,17 @@ describe('DefaultCloudFormationStackNode', () => {
         assert(childNodes !== undefined)
         assert.strictEqual(childNodes.length, 2)
 
-        assert(childNodes[0] instanceof DefaultCloudFormationFunctionNode)
-        assert.strictEqual((childNodes[0] as DefaultCloudFormationFunctionNode).label, lambda1Name)
+        assert(childNodes[0] instanceof CloudFormationFunctionNode)
+        assert.strictEqual((childNodes[0] as CloudFormationFunctionNode).label, lambda1Name)
 
-        assert(childNodes[1] instanceof DefaultCloudFormationFunctionNode)
-        assert.strictEqual((childNodes[1] as DefaultCloudFormationFunctionNode).label, lambda3Name)
+        assert(childNodes[1] instanceof CloudFormationFunctionNode)
+        assert.strictEqual((childNodes[1] as CloudFormationFunctionNode).label, lambda3Name)
     })
 
     function generateTestNode(): CloudFormationStackNode {
         const parentNode = new TestAWSTreeNode('test node')
 
-        return new DefaultCloudFormationStackNode(parentNode, 'someregioncode', fakeStackSummary)
+        return new CloudFormationStackNode(parentNode, 'someregioncode', fakeStackSummary)
     }
 })
 
@@ -251,7 +250,7 @@ describe('DefaultCloudFormationNode', () => {
             }
         }
 
-        const cloudFormationNode = new DefaultCloudFormationNode('someregioncode')
+        const cloudFormationNode = new CloudFormationNode('someregioncode')
 
         const children = await cloudFormationNode.getChildren()
 
@@ -267,12 +266,12 @@ describe('DefaultCloudFormationNode', () => {
             expectedNodeText: string
         ) {
             assert.strictEqual(
-                actualChildNode instanceof DefaultCloudFormationStackNode,
+                actualChildNode instanceof CloudFormationStackNode,
                 true,
                 'Child node was not a Stack Node'
             )
 
-            const node: DefaultCloudFormationStackNode = actualChildNode as DefaultCloudFormationStackNode
+            const node = actualChildNode as CloudFormationStackNode
             assert.strictEqual(
                 node.stackName,
                 expectedNodeText,
@@ -287,7 +286,7 @@ describe('DefaultCloudFormationNode', () => {
     })
 
     it('handles error', async () => {
-        class ThrowErrorDefaultCloudFormationNode extends DefaultCloudFormationNode {
+        class ThrowErrorDefaultCloudFormationNode extends CloudFormationNode {
             public constructor() {
                 super('someregioncode')
             }


### PR DESCRIPTION

## Description

The interface definitions representing CloudFormation related items in the Explorer only have one implementation. They have been removed to help make the code more understandable by removing unnecessary abstractions.

To keep each PR manageable, a separate change is planned with similar changes for the Lambda related Nodes.

## Testing

* test suite
* ran extension, exercised the CloudFormation related nodes in the Explorer

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
