### PR TITLE
Remove interfaces related to Lambda Explorer Nodes

### DIFF
--- a/src/awsexplorer/regionNode.ts
+++ b/src/awsexplorer/regionNode.ts
@@ -5,7 +5,7 @@
 
 import { TreeItemCollapsibleState } from 'vscode'
 import { CloudFormationNode } from '../lambda/explorer/cloudFormationNodes'
-import { DefaultLambdaFunctionGroupNode, LambdaFunctionGroupNode } from '../lambda/explorer/lambdaNodes'
+import { LambdaFunctionGroupNode } from '../lambda/explorer/lambdaNodes'
 import { RegionInfo } from '../shared/regions/regionInfo'
 import { AWSTreeNodeBase } from '../shared/treeview/nodes/awsTreeNodeBase'
 import { toMap, updateInPlace } from '../shared/utilities/collectionUtils'
@@ -35,7 +35,7 @@ export class RegionNode extends AWSTreeNodeBase {
         this.update(info)
 
         this.cloudFormationNode = new CloudFormationNode(this.regionCode)
-        this.lambdaFunctionGroupNode = new DefaultLambdaFunctionGroupNode(this.regionCode)
+        this.lambdaFunctionGroupNode = new LambdaFunctionGroupNode(this.regionCode)
     }
 
     public async getChildren(): Promise<AWSTreeNodeBase[]> {

--- a/src/awsexplorer/regionNode.ts
+++ b/src/awsexplorer/regionNode.ts
@@ -5,7 +5,7 @@
 
 import { TreeItemCollapsibleState } from 'vscode'
 import { CloudFormationNode } from '../lambda/explorer/cloudFormationNodes'
-import { LambdaFunctionGroupNode } from '../lambda/explorer/lambdaNodes'
+import { LambdaNode } from '../lambda/explorer/lambdaNodes'
 import { RegionInfo } from '../shared/regions/regionInfo'
 import { AWSTreeNodeBase } from '../shared/treeview/nodes/awsTreeNodeBase'
 import { toMap, updateInPlace } from '../shared/utilities/collectionUtils'
@@ -18,7 +18,7 @@ import { toMap, updateInPlace } from '../shared/utilities/collectionUtils'
 export class RegionNode extends AWSTreeNodeBase {
     private info: RegionInfo
     private readonly cloudFormationNode: CloudFormationNode
-    private readonly lambdaFunctionGroupNode: LambdaFunctionGroupNode
+    private readonly lambdaNode: LambdaNode
 
     public get regionCode(): string {
         return this.info.regionCode
@@ -35,11 +35,11 @@ export class RegionNode extends AWSTreeNodeBase {
         this.update(info)
 
         this.cloudFormationNode = new CloudFormationNode(this.regionCode)
-        this.lambdaFunctionGroupNode = new LambdaFunctionGroupNode(this.regionCode)
+        this.lambdaNode = new LambdaNode(this.regionCode)
     }
 
     public async getChildren(): Promise<AWSTreeNodeBase[]> {
-        return [this.cloudFormationNode, this.lambdaFunctionGroupNode]
+        return [this.cloudFormationNode, this.lambdaNode]
     }
 
     public update(info: RegionInfo): void {

--- a/src/lambda/explorer/lambdaNodes.ts
+++ b/src/lambda/explorer/lambdaNodes.ts
@@ -17,7 +17,11 @@ import { toArrayAsync, toMap, updateInPlace } from '../../shared/utilities/colle
 import { listLambdaFunctions } from '../utils'
 import { FunctionNodeBase } from './functionNode'
 
-export class LambdaFunctionGroupNode extends AWSTreeErrorHandlerNode {
+/**
+ * An AWS Explorer node representing the Lambda Service.
+ * Contains Lambda Functions for a specific region as child nodes.
+ */
+export class LambdaNode extends AWSTreeErrorHandlerNode {
     private readonly functionNodes: Map<string, LambdaFunctionNode>
 
     public constructor(private readonly regionCode: string) {

--- a/src/lambda/explorer/lambdaNodes.ts
+++ b/src/lambda/explorer/lambdaNodes.ts
@@ -17,13 +17,7 @@ import { toArrayAsync, toMap, updateInPlace } from '../../shared/utilities/colle
 import { listLambdaFunctions } from '../utils'
 import { FunctionNodeBase } from './functionNode'
 
-export interface LambdaFunctionGroupNode extends AWSTreeErrorHandlerNode {
-    getChildren(): Thenable<(LambdaFunctionNode | ErrorNode)[]>
-
-    updateChildren(): Thenable<void>
-}
-
-export class DefaultLambdaFunctionGroupNode extends AWSTreeErrorHandlerNode implements LambdaFunctionGroupNode {
+export class LambdaFunctionGroupNode extends AWSTreeErrorHandlerNode {
     private readonly functionNodes: Map<string, LambdaFunctionNode>
 
     public constructor(private readonly regionCode: string) {
@@ -55,16 +49,12 @@ export class DefaultLambdaFunctionGroupNode extends AWSTreeErrorHandlerNode impl
             this.functionNodes,
             functions.keys(),
             key => this.functionNodes.get(key)!.update(functions.get(key)!),
-            key => new DefaultLambdaFunctionNode(this, this.regionCode, functions.get(key)!)
+            key => new LambdaFunctionNode(this, this.regionCode, functions.get(key)!)
         )
     }
 }
 
-export interface LambdaFunctionNode extends FunctionNodeBase {
-    readonly parent: AWSTreeNodeBase
-}
-
-export class DefaultLambdaFunctionNode extends FunctionNodeBase implements LambdaFunctionNode {
+export class LambdaFunctionNode extends FunctionNodeBase {
     public constructor(
         public readonly parent: AWSTreeNodeBase,
         public readonly regionCode: string,

--- a/src/test/lambda/explorer/lambdaNodes.test.ts
+++ b/src/test/lambda/explorer/lambdaNodes.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert'
 import { Lambda } from 'aws-sdk'
 import * as os from 'os'
-import { LambdaFunctionGroupNode, LambdaFunctionNode } from '../../../lambda/explorer/lambdaNodes'
+import { LambdaFunctionNode, LambdaNode } from '../../../lambda/explorer/lambdaNodes'
 import { CloudFormationClient } from '../../../shared/clients/cloudFormationClient'
 import { EcsClient } from '../../../shared/clients/ecsClient'
 import { LambdaClient } from '../../../shared/clients/lambdaClient'
@@ -81,7 +81,7 @@ describe('DefaultLambdaFunctionNode', () => {
     }
 })
 
-describe('DefaultLambdaFunctionGroupNode', () => {
+describe('LambdaNode', () => {
     class FunctionNamesMockLambdaClient extends MockLambdaClient {
         public constructor(
             public readonly functionNames: string[] = [],
@@ -100,7 +100,7 @@ describe('DefaultLambdaFunctionGroupNode', () => {
         }
     }
 
-    class ThrowErrorDefaultLambdaFunctionGroupNode extends LambdaFunctionGroupNode {
+    class ThrowErrorLambdaNode extends LambdaNode {
         public constructor() {
             super('someregioncode')
         }
@@ -132,9 +132,9 @@ describe('DefaultLambdaFunctionGroupNode', () => {
             }
         }
 
-        const functionGroupNode = new LambdaFunctionGroupNode('someregioncode')
+        const lambdaNode = new LambdaNode('someregioncode')
 
-        const children = await functionGroupNode.getChildren()
+        const children = await lambdaNode.getChildren()
 
         assert.ok(children, 'Expected to get Lambda function nodes as children')
         assert.strictEqual(
@@ -168,7 +168,7 @@ describe('DefaultLambdaFunctionGroupNode', () => {
     })
 
     it('handles error', async () => {
-        const testNode = new ThrowErrorDefaultLambdaFunctionGroupNode()
+        const testNode = new ThrowErrorLambdaNode()
 
         const childNodes = await testNode.getChildren()
         assert(childNodes !== undefined)

--- a/src/test/lambda/explorer/lambdaNodes.test.ts
+++ b/src/test/lambda/explorer/lambdaNodes.test.ts
@@ -22,7 +22,7 @@ async function* asyncGenerator<T>(items: T[]): AsyncIterableIterator<T> {
     yield* items
 }
 
-describe('DefaultLambdaFunctionNode', () => {
+describe('LambdaFunctionNode', () => {
     let fakeFunctionConfig: Lambda.FunctionConfiguration
 
     before(async () => {

--- a/src/test/lambda/explorer/lambdaNodes.test.ts
+++ b/src/test/lambda/explorer/lambdaNodes.test.ts
@@ -6,11 +6,7 @@
 import * as assert from 'assert'
 import { Lambda } from 'aws-sdk'
 import * as os from 'os'
-import {
-    DefaultLambdaFunctionGroupNode,
-    DefaultLambdaFunctionNode,
-    LambdaFunctionNode
-} from '../../../lambda/explorer/lambdaNodes'
+import { LambdaFunctionGroupNode, LambdaFunctionNode } from '../../../lambda/explorer/lambdaNodes'
 import { CloudFormationClient } from '../../../shared/clients/cloudFormationClient'
 import { EcsClient } from '../../../shared/clients/ecsClient'
 import { LambdaClient } from '../../../shared/clients/lambdaClient'
@@ -78,10 +74,10 @@ describe('DefaultLambdaFunctionNode', () => {
         assert.strictEqual(childNodes.length, 0)
     })
 
-    function generateTestNode(): DefaultLambdaFunctionNode {
+    function generateTestNode(): LambdaFunctionNode {
         const parentNode = new TestAWSTreeNode('test node')
 
-        return new DefaultLambdaFunctionNode(parentNode, 'someregioncode', fakeFunctionConfig)
+        return new LambdaFunctionNode(parentNode, 'someregioncode', fakeFunctionConfig)
     }
 })
 
@@ -104,7 +100,7 @@ describe('DefaultLambdaFunctionGroupNode', () => {
         }
     }
 
-    class ThrowErrorDefaultLambdaFunctionGroupNode extends DefaultLambdaFunctionGroupNode {
+    class ThrowErrorDefaultLambdaFunctionGroupNode extends LambdaFunctionGroupNode {
         public constructor() {
             super('someregioncode')
         }
@@ -136,7 +132,7 @@ describe('DefaultLambdaFunctionGroupNode', () => {
             }
         }
 
-        const functionGroupNode = new DefaultLambdaFunctionGroupNode('someregioncode')
+        const functionGroupNode = new LambdaFunctionGroupNode('someregioncode')
 
         const children = await functionGroupNode.getChildren()
 
@@ -157,7 +153,7 @@ describe('DefaultLambdaFunctionGroupNode', () => {
                 'Child node expected to contain functionName property'
             )
 
-            const node: DefaultLambdaFunctionNode = actualChildNode as DefaultLambdaFunctionNode
+            const node = actualChildNode as LambdaFunctionNode
             assert.strictEqual(
                 node.functionName,
                 expectedNodeText,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The interface definitions representing Lambda related items in the Explorer only have one implementation. They have been removed to help make the code more understandable by removing unnecessary abstractions.

To improve clarity in naming, `LambdaFunctionGroupNode` has also been renamed to `LambdaNode`

## Testing

* Test suite
* ran extension and exercised the Lambda nodes in the Explorer (Expand, Collapse, Refresh, Context menus)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
