### PR TITLE
Converge CloudFormationFunctionNode and LambdaFunctionNode

### DIFF
--- a/src/awsexplorer/awsExplorer.ts
+++ b/src/awsexplorer/awsExplorer.ts
@@ -8,8 +8,7 @@ import { deleteCloudFormation } from '../lambda/commands/deleteCloudFormation'
 import { deleteLambda } from '../lambda/commands/deleteLambda'
 import { invokeLambda } from '../lambda/commands/invokeLambda'
 import { CloudFormationStackNode } from '../lambda/explorer/cloudFormationNodes'
-import { FunctionNodeBase } from '../lambda/explorer/functionNode'
-import { LambdaFunctionNode } from '../lambda/explorer/lambdaNodes'
+import { LambdaFunctionNode } from '../lambda/explorer/lambdaFunctionNode'
 import { configureLocalLambda } from '../lambda/local/configureLocalLambda'
 import { AwsContext } from '../shared/awsContext'
 import { AwsContextTreeCollection } from '../shared/awsContextTreeCollection'
@@ -83,7 +82,7 @@ export class AwsExplorer implements vscode.TreeDataProvider<AWSTreeNodeBase>, Re
 
         registerCommand({
             command: 'aws.invokeLambda',
-            callback: async (node: FunctionNodeBase) =>
+            callback: async (node: LambdaFunctionNode) =>
                 await invokeLambda({
                     awsContext: this.awsContext,
                     functionNode: node,

--- a/src/lambda/commands/invokeLambda.ts
+++ b/src/lambda/commands/invokeLambda.ts
@@ -17,7 +17,7 @@ import { ResourceFetcher } from '../../shared/resourceFetcher'
 import { FileResourceLocation, WebResourceLocation } from '../../shared/resourceLocation'
 import { BaseTemplates } from '../../shared/templates/baseTemplates'
 import { sampleRequestManifestPath, sampleRequestPath } from '../constants'
-import { FunctionNodeBase } from '../explorer/functionNode'
+import { LambdaFunctionNode } from '../explorer/lambdaFunctionNode'
 import { SampleRequest } from '../models/sampleRequest'
 import { LambdaTemplates } from '../templates/lambdaTemplates'
 
@@ -45,7 +45,7 @@ export async function invokeLambda(params: {
     awsContext: AwsContext // TODO: Consider replacing 'awsContext' with something specific and meaningful
     outputChannel: vscode.OutputChannel
     resourceFetcher: ResourceFetcher
-    functionNode: FunctionNodeBase // TODO: Consider replacing 'element'' with something specific and meaningful
+    functionNode: LambdaFunctionNode
 }) {
     const logger: Logger = getLogger()
 
@@ -136,7 +136,7 @@ function createMessageReceivedFunc({
     ...restParams
 }: {
     // TODO: Consider passing lambdaClient: LambdaClient
-    fn: FunctionNodeBase // TODO: Replace w/ invokeParams: {functionArn: string} // or Lambda.Types.InvocationRequest
+    fn: LambdaFunctionNode // TODO: Replace w/ invokeParams: {functionArn: string} // or Lambda.Types.InvocationRequest
     outputChannel: vscode.OutputChannel
     resourceFetcher: ResourceFetcher
     resourcePath: string

--- a/src/lambda/explorer/lambdaFunctionNode.ts
+++ b/src/lambda/explorer/lambdaFunctionNode.ts
@@ -9,10 +9,12 @@ import { Uri } from 'vscode'
 import { ext } from '../../shared/extensionGlobals'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 
-export abstract class FunctionNodeBase extends AWSTreeNodeBase {
-    public abstract readonly regionCode: string
-
-    protected constructor(public readonly parent: AWSTreeNodeBase, public configuration: Lambda.FunctionConfiguration) {
+export class LambdaFunctionNode extends AWSTreeNodeBase {
+    public constructor(
+        public readonly parent: AWSTreeNodeBase,
+        public readonly regionCode: string,
+        public configuration: Lambda.FunctionConfiguration
+    ) {
         super('')
         this.update(configuration)
         this.iconPath = {

--- a/src/lambda/explorer/lambdaNodes.ts
+++ b/src/lambda/explorer/lambdaNodes.ts
@@ -15,7 +15,9 @@ import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 import { ErrorNode } from '../../shared/treeview/nodes/errorNode'
 import { toArrayAsync, toMap, updateInPlace } from '../../shared/utilities/collectionUtils'
 import { listLambdaFunctions } from '../utils'
-import { FunctionNodeBase } from './functionNode'
+import { LambdaFunctionNode } from './lambdaFunctionNode'
+
+export const CONTEXT_VALUE_LAMBDA_FUNCTION = 'awsRegionFunctionNode'
 
 /**
  * An AWS Explorer node representing the Lambda Service.
@@ -53,18 +55,18 @@ export class LambdaNode extends AWSTreeErrorHandlerNode {
             this.functionNodes,
             functions.keys(),
             key => this.functionNodes.get(key)!.update(functions.get(key)!),
-            key => new LambdaFunctionNode(this, this.regionCode, functions.get(key)!)
+            key => makeLambdaFunctionNode(this, this.regionCode, functions.get(key)!)
         )
     }
 }
 
-export class LambdaFunctionNode extends FunctionNodeBase {
-    public constructor(
-        public readonly parent: AWSTreeNodeBase,
-        public readonly regionCode: string,
-        configuration: Lambda.FunctionConfiguration
-    ) {
-        super(parent, configuration)
-        this.contextValue = 'awsRegionFunctionNode'
-    }
+function makeLambdaFunctionNode(
+    parent: AWSTreeNodeBase,
+    regionCode: string,
+    configuration: Lambda.FunctionConfiguration
+): LambdaFunctionNode {
+    const node = new LambdaFunctionNode(parent, regionCode, configuration)
+    node.contextValue = CONTEXT_VALUE_LAMBDA_FUNCTION
+
+    return node
 }

--- a/src/test/lambda/explorer/cloudFormationNodes.test.ts
+++ b/src/test/lambda/explorer/cloudFormationNodes.test.ts
@@ -7,15 +7,17 @@ import * as assert from 'assert'
 import { CloudFormation, Lambda } from 'aws-sdk'
 import * as os from 'os'
 import {
-    CloudFormationFunctionNode,
     CloudFormationNode,
-    CloudFormationStackNode
+    CloudFormationStackNode,
+    CONTEXT_VALUE_CLOUDFORMATION_LAMBDA_FUNCTION
 } from '../../../lambda/explorer/cloudFormationNodes'
+import { LambdaFunctionNode } from '../../../lambda/explorer/lambdaFunctionNode'
 import { CloudFormationClient } from '../../../shared/clients/cloudFormationClient'
 import { EcsClient } from '../../../shared/clients/ecsClient'
 import { LambdaClient } from '../../../shared/clients/lambdaClient'
 import { StsClient } from '../../../shared/clients/stsClient'
 import { ext } from '../../../shared/extensionGlobals'
+import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
 import { ErrorNode } from '../../../shared/treeview/nodes/errorNode'
 import { PlaceholderNode } from '../../../shared/treeview/nodes/placeholderNode'
 import { MockCloudFormationClient } from '../../shared/clients/mockClients'
@@ -188,20 +190,27 @@ describe('CloudFormationStackNode', () => {
         const testNode: CloudFormationStackNode = generateTestNode()
 
         const childNodes = await testNode.getChildren()
-        assert(childNodes !== undefined)
+        assert.ok(childNodes)
         assert.strictEqual(childNodes.length, 2)
 
-        assert(childNodes[0] instanceof CloudFormationFunctionNode)
-        assert.strictEqual((childNodes[0] as CloudFormationFunctionNode).label, lambda1Name)
-
-        assert(childNodes[1] instanceof CloudFormationFunctionNode)
-        assert.strictEqual((childNodes[1] as CloudFormationFunctionNode).label, lambda3Name)
+        assertCloudFormationLambdaFunctionNode(childNodes[0], lambda1Name)
+        assertCloudFormationLambdaFunctionNode(childNodes[1], lambda3Name)
     })
 
     function generateTestNode(): CloudFormationStackNode {
         const parentNode = new TestAWSTreeNode('test node')
 
         return new CloudFormationStackNode(parentNode, 'someregioncode', fakeStackSummary)
+    }
+
+    function assertCloudFormationLambdaFunctionNode(actualNode: AWSTreeNodeBase, expectedLabel: string) {
+        assert.ok(actualNode instanceof LambdaFunctionNode)
+        assert.strictEqual(actualNode.label, expectedLabel, 'unexpected label for Lambda Function Node')
+        assert.strictEqual(
+            actualNode.contextValue,
+            CONTEXT_VALUE_CLOUDFORMATION_LAMBDA_FUNCTION,
+            'expected the node to have a CloudFormation contextValue'
+        )
     }
 })
 

--- a/src/test/lambda/explorer/lambdaFunctionNode.test.ts
+++ b/src/test/lambda/explorer/lambdaFunctionNode.test.ts
@@ -1,0 +1,72 @@
+/*!
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { Lambda } from 'aws-sdk'
+import * as os from 'os'
+import { LambdaFunctionNode } from '../../../lambda/explorer/lambdaFunctionNode'
+import { ext } from '../../../shared/extensionGlobals'
+import { TestAWSTreeNode } from '../../shared/treeview/nodes/testAWSTreeNode'
+import { clearTestIconPaths, IconPath, setupTestIconPaths } from '../../shared/utilities/iconPathUtils'
+
+describe('LambdaFunctionNode', () => {
+    const parentNode = new TestAWSTreeNode('test node')
+    let testNode: LambdaFunctionNode
+    let fakeFunctionConfig: Lambda.FunctionConfiguration
+
+    before(async () => {
+        setupTestIconPaths()
+        fakeFunctionConfig = {
+            FunctionName: 'testFunctionName',
+            FunctionArn: 'testFunctionARN'
+        }
+
+        testNode = new LambdaFunctionNode(parentNode, 'someregioncode', fakeFunctionConfig)
+    })
+
+    after(async () => {
+        clearTestIconPaths()
+    })
+
+    it('instantiates without issue', async () => {
+        assert.ok(testNode)
+    })
+
+    it('initializes the parent node', async () => {
+        assert.strictEqual(testNode.parent, parentNode, 'unexpected parent node')
+    })
+
+    it('initializes the region code', async () => {
+        assert.strictEqual(testNode.regionCode, 'someregioncode')
+    })
+
+    it('initializes the label', async () => {
+        assert.strictEqual(testNode.label, fakeFunctionConfig.FunctionName)
+    })
+
+    it('initializes the functionName', async () => {
+        assert.strictEqual(testNode.functionName, fakeFunctionConfig.FunctionName)
+    })
+
+    it('initializes the tooltip', async () => {
+        assert.strictEqual(
+            testNode.tooltip,
+            `${fakeFunctionConfig.FunctionName}${os.EOL}${fakeFunctionConfig.FunctionArn}`
+        )
+    })
+
+    it('initializes the icon', async () => {
+        const iconPath = testNode.iconPath as IconPath
+
+        assert.strictEqual(iconPath.dark.path, ext.iconPaths.dark.lambda, 'Unexpected dark icon path')
+        assert.strictEqual(iconPath.light.path, ext.iconPaths.light.lambda, 'Unexpected light icon path')
+    })
+
+    it('has no children', async () => {
+        const childNodes = await testNode.getChildren()
+        assert.ok(childNodes)
+        assert.strictEqual(childNodes.length, 0, 'Expected node to have no children')
+    })
+})


### PR DESCRIPTION

## Description

Changes to improve code clarity:
* `CloudFormationFunctionNode` and `LambdaFunctionNode` were identical, and there is no need to have two different classes. They have been removed, and the parent class `FunctionNodeBase` has been made non-abstract.
* `FunctionNodeBase` has been renamed to `LambdaFunctionNode`, making it more consistent with other Lambda related nodes

Not in scope for this change:
* Now that the Lambda node classes are cleaner (due to this change and #800), it is easier to reason about their behavior. There is opportunity to clean up and simplify the test cases.

## Testing

* Test suite
* Launched the toolkit and exercised the AWS Explorer
  * checked that Lambda nodes can be deleted, but CloudFormation Lambda nodes cannot
  * checked that all Lambda nodes can invoke, and display correctly

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
