### PR TITLE
AWS Explorer indicates when CloudFormation Stacks cannot be found

### DIFF
--- a/.changes/next-release/Bug Fix-57668a32-9c81-4fce-9356-42780cc147c7.json
+++ b/.changes/next-release/Bug Fix-57668a32-9c81-4fce-9356-42780cc147c7.json
@@ -1,0 +1,4 @@
+{
+    "type": "Bug Fix",
+    "description": "AWS Explorer now shows a node indicating when CloudFormation Stacks cannot be found in a region"
+}

--- a/package.nls.json
+++ b/package.nls.json
@@ -50,6 +50,7 @@
     "AWS.explorerNode.addRegion.tooltip": "Click to add a region to view functions...",
     "AWS.explorerNode.lambda.noFunctions": "[No Functions found]",
     "AWS.explorerNode.cloudFormation.noFunctions": "[no functions in this CloudFormation]",
+    "AWS.explorerNode.cloudformation.noStacks": "[No Stacks found]",
     "AWS.explorerNode.cloudFormation.error": "Error loading CloudFormation resources",
     "AWS.explorerNode.container.noItems": "[no items]",
     "AWS.explorerNode.lambda.retry": "Unable to load Lambda Functions, click here to retry",

--- a/src/test/lambda/explorer/cloudFormationNodes.test.ts
+++ b/src/test/lambda/explorer/cloudFormationNodes.test.ts
@@ -260,7 +260,23 @@ describe('CloudFormationNode', () => {
         assert.deepStrictEqual(actualChildOrder, expectedChildOrder, 'Unexpected child sort order')
     })
 
-    it('handles error', async () => {
+    it('returns placeholder node if no children are present', async () => {
+        const cloudFormationClient = makeCloudFormationClient([])
+
+        const clientBuilder = {
+            createCloudFormationClient: sandbox.stub().returns(cloudFormationClient)
+        }
+
+        ext.toolkitClientBuilder = (clientBuilder as any) as ToolkitClientBuilder
+
+        const cloudFormationNode = new CloudFormationNode(FAKE_REGION_CODE)
+
+        const children = await cloudFormationNode.getChildren()
+
+        assertNodeListOnlyContainsPlaceholderNode(children)
+    })
+
+    it('has an error node for a child if an error happens during loading', async () => {
         const testNode = new CloudFormationNode(FAKE_REGION_CODE)
         sandbox.stub(testNode, 'updateChildren').callsFake(() => {
             throw new Error('Update Children error!')


### PR DESCRIPTION

## Description

CloudFormation nodes don't show the user anything when CloudFormation Stacks are not found. They now have a child node indicating that stacks could not be found:
![image](https://user-images.githubusercontent.com/39839589/68958856-c83f7900-0781-11ea-9cc4-a53b646802fb.png)


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
