### PR TITLE
Sort CloudFormation Stack Resource nodes

### DIFF
--- a/.changes/next-release/Bug Fix-7bac53bb-d8cb-42a8-9d31-b268eacc32dc.json
+++ b/.changes/next-release/Bug Fix-7bac53bb-d8cb-42a8-9d31-b268eacc32dc.json
@@ -1,0 +1,4 @@
+{
+    "type": "Bug Fix",
+    "description": "AWS Explorer now sorts the resources that belong to each CloudFormation Stack"
+}

--- a/package.nls.json
+++ b/package.nls.json
@@ -49,7 +49,7 @@
     "AWS.explorerNode.addRegion": "Add a region to view functions...",
     "AWS.explorerNode.addRegion.tooltip": "Click to add a region to view functions...",
     "AWS.explorerNode.lambda.noFunctions": "[No Functions found]",
-    "AWS.explorerNode.cloudFormation.noFunctions": "[no functions in this CloudFormation]",
+    "AWS.explorerNode.cloudFormation.noFunctions": "[Stack has no Lambda Functions]",
     "AWS.explorerNode.cloudformation.noStacks": "[No Stacks found]",
     "AWS.explorerNode.cloudFormation.error": "Error loading CloudFormation resources",
     "AWS.explorerNode.container.noItems": "[no items]",

--- a/src/lambda/explorer/cloudFormationNodes.ts
+++ b/src/lambda/explorer/cloudFormationNodes.ts
@@ -12,7 +12,6 @@ import * as vscode from 'vscode'
 import { CloudFormationClient } from '../../shared/clients/cloudFormationClient'
 import { LambdaClient } from '../../shared/clients/lambdaClient'
 import { ext } from '../../shared/extensionGlobals'
-import { AWSTreeErrorHandlerNode } from '../../shared/treeview/nodes/awsTreeErrorHandlerNode'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 import { ErrorNode } from '../../shared/treeview/nodes/errorNode'
 import { PlaceholderNode } from '../../shared/treeview/nodes/placeholderNode'
@@ -64,7 +63,7 @@ export class CloudFormationNode extends AWSTreeNodeBase {
     }
 }
 
-export class CloudFormationStackNode extends AWSTreeErrorHandlerNode {
+export class CloudFormationStackNode extends AWSTreeNodeBase {
     private readonly functionNodes: Map<string, LambdaFunctionNode>
 
     public constructor(
@@ -91,26 +90,27 @@ export class CloudFormationStackNode extends AWSTreeErrorHandlerNode {
         return this.stackSummary.StackName
     }
 
-    public async getChildren(): Promise<(LambdaFunctionNode | PlaceholderNode)[]> {
-        await this.handleErrorProneOperation(
-            async () => this.updateChildren(),
-            localize('AWS.explorerNode.cloudFormation.error', 'Error loading CloudFormation resources')
-        )
+    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+        return await makeChildrenNodes({
+            getChildNodes: async () => {
+                await this.updateChildren()
 
-        if (!!this.errorNode) {
-            return [this.errorNode]
-        }
-
-        if (this.functionNodes.size > 0) {
-            return [...this.functionNodes.values()]
-        }
-
-        return [
-            new PlaceholderNode(
-                this,
-                localize('AWS.explorerNode.cloudFormation.noFunctions', '[no functions in this CloudFormation]')
-            )
-        ]
+                return [...this.functionNodes.values()]
+            },
+            getErrorNode: async (error: Error) =>
+                new ErrorNode(
+                    this,
+                    error,
+                    localize('AWS.explorerNode.cloudFormation.error', 'Error loading CloudFormation resources')
+                ),
+            getNoChildrenPlaceholderNode: async () =>
+                new PlaceholderNode(
+                    this,
+                    localize('AWS.explorerNode.cloudFormation.noFunctions', '[Stack has no Lambda Functions]')
+                ),
+            sort: (nodeA: LambdaFunctionNode, nodeB: LambdaFunctionNode) =>
+                nodeA.functionName.localeCompare(nodeB.functionName)
+        })
     }
 
     public update(stackSummary: CloudFormation.StackSummary): void {

--- a/src/shared/treeview/treeNodeUtilities.ts
+++ b/src/shared/treeview/treeNodeUtilities.ts
@@ -29,7 +29,7 @@ export async function makeChildrenNodes(parameters: {
         }
     } catch (err) {
         const error = err as Error
-        getLogger().error(`Error whlie getting Child nodes: ${error.message}`)
+        getLogger().error(`Error while getting Child nodes: ${error.message}`)
 
         childNodes.push(await parameters.getErrorNode(error))
     }

--- a/src/test/lambda/explorer/cloudFormationNodes.test.ts
+++ b/src/test/lambda/explorer/cloudFormationNodes.test.ts
@@ -132,17 +132,15 @@ describe('CloudFormationStackNode', () => {
         )
     })
 
-    // TODO : CloudFormation Stack Nodes don't sort their child nodes
-    // TODO : https://github.com/aws/aws-toolkit-vscode/issues/813
-    // it('sorts child nodes', async () => {
-    //     lambdaFunctionNames = UNSORTED_TEXT
-    //     cloudFormationStacklambdaFunctionNames = UNSORTED_TEXT
+    it('sorts child nodes', async () => {
+        lambdaFunctionNames = UNSORTED_TEXT
+        cloudFormationStacklambdaFunctionNames = UNSORTED_TEXT
 
-    //     const childNodes = await testNode.getChildren()
+        const childNodes = await testNode.getChildren()
 
-    //     const actualChildOrder = childNodes.map(node => node.label)
-    //     assert.deepStrictEqual(actualChildOrder, SORTED_TEXT, 'Unexpected child sort order')
-    // })
+        const actualChildOrder = childNodes.map(node => node.label)
+        assert.deepStrictEqual(actualChildOrder, SORTED_TEXT, 'Unexpected child sort order')
+    })
 
     it('has an error node for a child if an error happens during loading', async () => {
         const lambdaClient = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

CloudFormation Stack child nodes were not explicitly sorted. This change sorts the child nodes and standardizes the child node creation with how Lambda (#814) and CloudFormation (#815) handle their child nodes.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
