### PR TITLE
fix: use the fsPath instead of path to ensure that the tree path is valid for Windows

### DIFF
--- a/src/cdk/explorer/detectCdkProjects.ts
+++ b/src/cdk/explorer/detectCdkProjects.ts
@@ -33,7 +33,7 @@ async function detectCdkProjectsFromWorkspaceFolder(
     const result = []
 
     for await (const cdkJson of detectLocalCdkProjects({ workspaceUris: [workspaceFolder.uri] })) {
-        const treeJsonPath = path.join(path.dirname(cdkJson.path), 'cdk.out', 'tree.json')
+        const treeJsonPath = path.join(path.dirname(cdkJson.fsPath), 'cdk.out', 'tree.json')
         const project = { workspaceFolder: workspaceFolder, cdkJsonPath: cdkJson.fsPath, treePath: treeJsonPath }
         result.push(project)
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Addresses a bug where the `path` was being used instead of `fsPath` when determining the location of the CDK construct tree. 


## Motivation and Context

bug was reported by @awschristou 

Using the path works for 

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing

* tested on a Windows machine.
* tests do access the filesystem but we might need to be more rigorous with testing the Windows experience in general

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
