### PR TITLE
cdk explorer telemetry

### DIFF
--- a/src/cdk/activation.ts
+++ b/src/cdk/activation.ts
@@ -29,14 +29,16 @@ export async function activate(activateArguments: { extensionContext: vscode.Ext
     // Indicates workspace includes a CDK app and user has expanded the Node
     view.onDidExpandElement(e => {
         if (e.element.contextValue === 'awsCdkAppNode') {
-            ext.telemetry.record(getTelemetryEvent('appNodeExpanded'))
+            ext.telemetry.record(getTelemetryEvent('appExpanded'))
         }
     })
 
-    // Indicates configuration setting to enable the CDK explorer was toggled
+    // Indicates CDK explorer was disabled
     vscode.workspace.onDidChangeConfiguration(e => {
         if (e.affectsConfiguration('aws.cdk.explorer.enabled')) {
-            ext.telemetry.record(getTelemetryEvent('explorerEnabledToggled'))
+            if (!vscode.workspace.getConfiguration().get('aws.cdk.explorer.enabled')) {
+                ext.telemetry.record(getTelemetryEvent('explorerDisabled'))
+            }
         }
     })
 

--- a/src/cdk/activation.ts
+++ b/src/cdk/activation.ts
@@ -35,8 +35,9 @@ export async function activate(activateArguments: { extensionContext: vscode.Ext
 
     // Indicates CDK explorer was disabled
     vscode.workspace.onDidChangeConfiguration(e => {
-        if (e.affectsConfiguration('aws.cdk.explorer.enabled')) {
-            if (!vscode.workspace.getConfiguration().get('aws.cdk.explorer.enabled')) {
+        const explorerEnabled = 'aws.cdk.explorer.enabled'
+        if (e.affectsConfiguration(explorerEnabled)) {
+            if (!vscode.workspace.getConfiguration().get(explorerEnabled)) {
                 ext.telemetry.record(getTelemetryEvent('explorerDisabled'))
             }
         }

--- a/src/cdk/activation.ts
+++ b/src/cdk/activation.ts
@@ -36,10 +36,8 @@ export async function activate(activateArguments: { extensionContext: vscode.Ext
     // Indicates CDK explorer was disabled
     vscode.workspace.onDidChangeConfiguration(e => {
         const explorerEnabled = 'aws.cdk.explorer.enabled'
-        if (e.affectsConfiguration(explorerEnabled)) {
-            if (!vscode.workspace.getConfiguration().get(explorerEnabled)) {
-                ext.telemetry.record(getTelemetryEvent('explorerDisabled'))
-            }
+        if (e.affectsConfiguration(explorerEnabled) && !vscode.workspace.getConfiguration().get(explorerEnabled)) {
+            ext.telemetry.record(getTelemetryEvent('explorerDisabled'))
         }
     })
 

--- a/src/cdk/explorer/nodes/appNode.ts
+++ b/src/cdk/explorer/nodes/appNode.ts
@@ -21,6 +21,7 @@ import { ConstructNode } from './constructNode'
  * Existence of apps is determined by the presence of `cdk.json` in a workspace folder
  */
 export class AppNode extends AWSTreeNodeBase {
+    public expandMetricRecorded: boolean = false
     get tooltip(): string {
         return this.app.cdkJsonPath
     }

--- a/src/shared/telemetry/telemetryTypes.ts
+++ b/src/shared/telemetry/telemetryTypes.ts
@@ -22,6 +22,7 @@ export const ACCOUNT_METADATA_KEY = 'awsAccount'
 
 export enum TelemetryNamespace {
     Aws = 'aws',
+    Cdk = 'cdk',
     Cloudformation = 'cloudformation',
     Lambda = 'lambda',
     Project = 'project',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding 2 events that we want to add Telemetry for
* Expansions of `CDK App` Nodes
* Disabling the CDK Explorer

## Motivation and Context

* CDK App node expansion- helps us determine if CDK applications are being opened and that there is interaction with the explorer
* Disabling the CDK Explorer - helps us refine defaults to deliver a great experience


## Related Issue(s)

--

## Testing

* Tested in the explorer locally
* Re-ran the extension tests

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
