### PR TITLE
fix windows tests

### DIFF
--- a/src/test/cdk/detectCdkProjects.test.ts
+++ b/src/test/cdk/detectCdkProjects.test.ts
@@ -50,7 +50,7 @@ describe('detectCdkProjects', () => {
         assert.strictEqual(actual.length, 0)
     })
 
-    it('detects CDK project when cdk.json exists', async () => {
+    it('`detects CDK` project when cdk.json exists', async () => {
         const cdkJsonPath = path.join(workspaceFolders[0].uri.fsPath, 'cdk.json')
         await saveCdkJson(cdkJsonPath)
         const actual = await detectCdkProjects(workspaceFolders)
@@ -60,7 +60,7 @@ describe('detectCdkProjects', () => {
         const project = actual[0]
         assert.ok(project)
         assert.strictEqual(project.cdkJsonPath, cdkJsonPath)
-        assert.strictEqual(project.workspaceFolder.uri.path, workspaceFolders[0].uri.fsPath)
+        assert.strictEqual(project.workspaceFolder.uri.fsPath, workspaceFolders[0].uri.fsPath)
         assert.strictEqual(project.treePath, path.join(cdkJsonPath, '..', 'cdk.out', 'tree.json'))
     })
 
@@ -88,11 +88,11 @@ describe('detectCdkProjects', () => {
 
         assert.ok(project1)
         assert.strictEqual(project1.cdkJsonPath, projectPath1)
-        assert.strictEqual(project1.workspaceFolder.uri.path, workspaceFolders[0].uri.fsPath)
+        assert.strictEqual(project1.workspaceFolder.uri.fsPath, workspaceFolders[0].uri.fsPath)
         assert.strictEqual(project1.treePath, path.join(projectPath1, '..', 'cdk.out', 'tree.json'))
         assert.ok(project2)
         assert.strictEqual(project2.cdkJsonPath, projectPath2)
-        assert.strictEqual(project2.workspaceFolder.uri.path, workspaceFolders[1].uri.fsPath)
+        assert.strictEqual(project2.workspaceFolder.uri.fsPath, workspaceFolders[1].uri.fsPath)
         assert.strictEqual(project2.treePath, path.join(projectPath2, '..', 'cdk.out', 'tree.json'))
     })
 })

--- a/src/test/cdk/detectCdkProjects.test.ts
+++ b/src/test/cdk/detectCdkProjects.test.ts
@@ -50,7 +50,7 @@ describe('detectCdkProjects', () => {
         assert.strictEqual(actual.length, 0)
     })
 
-    it('`detects CDK` project when cdk.json exists', async () => {
+    it('detects CDK project when cdk.json exists', async () => {
         const cdkJsonPath = path.join(workspaceFolders[0].uri.fsPath, 'cdk.json')
         await saveCdkJson(cdkJsonPath)
         const actual = await detectCdkProjects(workspaceFolders)

--- a/src/test/cdk/explorer/appNode.test.ts
+++ b/src/test/cdk/explorer/appNode.test.ts
@@ -41,7 +41,7 @@ describe('AppNode', () => {
     it('initializes label and tooltip', async () => {
         const testNode = getTestNode()
 
-        assert.strictEqual(testNode.label, `${workspaceFolderPath}/${workspaceFolderName}`)
+        assert.strictEqual(testNode.label, path.relative(path.dirname(workspaceFolderPath), path.dirname(cdkJsonPath)))
         assert.strictEqual(testNode.tooltip, `${cdkJsonPath}`)
     })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Some tests were failing on windows because of the usage of `path` instead of `fsPath`

## Motivation and Context

Extension tests were working fine on OS X, but not on Windows

## Related Issue(s)

--

## Testing

Ran all the extension tests on a Windows desktop

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
