### PR TITLE
Bump version script no longer tags on version increment.

### DIFF
--- a/buildspec/bumpVersion.yml
+++ b/buildspec/bumpVersion.yml
@@ -26,11 +26,11 @@ phases:
                 git reset HEAD --hard
                 git checkout -b release/v$VERSION
                 if [ "$BUMP_TYPE" = "MAJOR" ]; then
-                  npm version major
+                  npm --no-git-tag-version version major
                 elif [ "$BUMP_TYPE" = "PATCH" ]; then
-                  npm version patch
+                  npm --no-git-tag-version version patch
                 else
-                  npm version minor
+                  npm --no-git-tag-version version minor
                 fi
                 # Call npm install because 'createRelease' uses ts-node
                 npm install

--- a/buildspec/bumpVersion.yml
+++ b/buildspec/bumpVersion.yml
@@ -8,10 +8,6 @@ phases:
     build:
         commands:
             - |
-                if [ $STAGE != "prod" ]; then
-                  echo "Stage is not production, version does not need bumping"
-                  exit 0
-                fi
                 echo "bumping version, BUMP_TYPE set to \"$BUMP_TYPE\""
                 git config --global user.name "aws-toolkit-automation"
                 git config --global user.email "<>"


### PR DESCRIPTION
Tagging occurs after release notes are processed now.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
