### PR TITLE
Use built in AWS SDK runtimes instead of our own type

### DIFF
--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -4,10 +4,11 @@
  */
 
 import * as assert from 'assert'
+import { Runtime } from 'aws-sdk/clients/lambda'
 import { mkdirpSync, readFileSync, removeSync } from 'fs-extra'
 import * as path from 'path'
 import * as vscode from 'vscode'
-import { getDependencyManager, SamLambdaRuntime } from '../../src/lambda/models/samLambdaRuntime'
+import { getDependencyManager } from '../../src/lambda/models/samLambdaRuntime'
 import { getSamCliContext } from '../../src/shared/sam/cli/samCliContext'
 import { runSamCliInit, SamCliInitArgs } from '../../src/shared/sam/cli/samCliInit'
 import { assertThrowsError } from '../../src/test/shared/utilities/assertUtils'
@@ -130,7 +131,7 @@ for (const runtime of runtimes) {
             tryRemoveProjectFolder()
             mkdirpSync(projectFolder)
             // this is really test 1, but since it has to run before everything it's in the before section
-            const runtimeArg = projectSDK as SamLambdaRuntime
+            const runtimeArg = projectSDK as Runtime
             const initArguments: SamCliInitArgs = {
                 name: 'testProject',
                 location: projectFolder,
@@ -160,7 +161,7 @@ for (const runtime of runtimes) {
         })
 
         it('Fails to create template when it already exists', async () => {
-            const runtimeArg = projectSDK as SamLambdaRuntime
+            const runtimeArg = projectSDK as Runtime
             const initArguments: SamCliInitArgs = {
                 name: 'testProject',
                 location: projectFolder,

--- a/src/lambda/models/samLambdaRuntime.ts
+++ b/src/lambda/models/samLambdaRuntime.ts
@@ -3,76 +3,61 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Runtime } from 'aws-sdk/clients/lambda'
 import * as immutable from 'immutable'
 
-// TODO: Can we dynamically determine the available runtimes? We could theoretically parse the
-// output of `sam init --help`, but that's a hack.
-export type SamLambdaRuntime = 'python3.7' | 'python3.6' | 'python2.7' | 'nodejs8.10' | 'nodejs10.x' | 'dotnetcore2.1'
+export const nodeJsRuntimes: Set<Runtime> = new Set<Runtime>(['nodejs8.10', 'nodejs10.x'])
+export const pythonRuntimes: Set<Runtime> = new Set<Runtime>(['python3.7', 'python3.6', 'python2.7'])
+export const dotNetRuntimes: Set<Runtime> = new Set<Runtime>(['dotnetcore2.1'])
 
-export const samLambdaRuntimes: immutable.Set<SamLambdaRuntime> = immutable.Set([
-    'python3.7',
-    'python3.6',
-    'python2.7',
-    'nodejs8.10',
-    'nodejs10.x',
-    'dotnetcore2.1'
-] as SamLambdaRuntime[])
+export const samLambdaRuntimes: immutable.Set<Runtime> = immutable.Set([
+    ...pythonRuntimes,
+    ...nodeJsRuntimes,
+    ...dotNetRuntimes
+] as Runtime[])
 
 export type DependencyManager = 'cli-package' | 'mod' | 'gradle' | 'pip' | 'npm' | 'maven' | 'bundler'
 
 // TODO: Make this return an array of DependencyManagers when we add runtimes with multiple dependency managers
-export function getDependencyManager (runtime: SamLambdaRuntime): DependencyManager {
-    switch (runtime) {
-        case 'nodejs10.x':
-        case 'nodejs8.10':
-            return 'npm'
-        case 'python2.7':
-        case 'python3.6':
-        case 'python3.7':
-            return 'pip'
-        case 'dotnetcore2.1':
-            return 'cli-package'
-        default:
-            throw new Error(`Runtime ${runtime} does not have an associated DependencyManager`)
+export function getDependencyManager(runtime: Runtime): DependencyManager {
+    if (nodeJsRuntimes.has(runtime)) {
+        return 'npm'
+    } else if (pythonRuntimes.has(runtime)) {
+        return 'pip'
+    } else if (dotNetRuntimes.has(runtime)) {
+        return 'cli-package'
     }
+    throw new Error(`Runtime ${runtime} does not have an associated DependencyManager`)
 }
 
-export enum SamLambdaRuntimeFamily {
+export enum RuntimeFamily {
     Python,
     NodeJS,
     DotNetCore
 }
 
-export function getFamily(runtime: string | undefined): SamLambdaRuntimeFamily {
-    switch (runtime) {
-        case 'python3.7':
-        case 'python3.6':
-        case 'python2.7':
-        case 'python':
-            return SamLambdaRuntimeFamily.Python
-        case 'nodejs8.10':
-        case 'nodejs10.x':
-        case 'nodejs':
-            return SamLambdaRuntimeFamily.NodeJS
-        case 'dotnetcore2.1':
-        case 'dotnetcore':
-        case 'dotnet':
-            return SamLambdaRuntimeFamily.DotNetCore
-        default:
-            throw new Error(`Unrecognized runtime: '${runtime}'`)
+export function getFamily(runtime: string | undefined): RuntimeFamily {
+    if (!runtime) {
+        throw new Error(`Unrecognized runtime: '${runtime}'`)
     }
+    if (nodeJsRuntimes.has(runtime)) {
+        return RuntimeFamily.NodeJS
+    } else if (pythonRuntimes.has(runtime)) {
+        return RuntimeFamily.Python
+    } else if (dotNetRuntimes.has(runtime)) {
+        return RuntimeFamily.DotNetCore
+    }
+    throw new Error(`Unrecognized runtime: '${runtime}'`)
 }
 
 // This allows us to do things like "sort" nodejs10.x after nodejs8.10
 // Map Values are used for comparisons, not for display
-const runtimeCompareText: Map<SamLambdaRuntime, string> = new Map<SamLambdaRuntime, string>([
-    ['nodejs8.10', 'nodejs08.10']
-])
+const runtimeCompareText: Map<Runtime, string> = new Map<Runtime, string>([['nodejs8.10', 'nodejs08.10']])
 
-function getSortableCompareText(runtime: SamLambdaRuntime): string {
+function getSortableCompareText(runtime: Runtime): string {
     return runtimeCompareText.get(runtime) || runtime.toString()
 }
 
-export function compareSamLambdaRuntime(a: SamLambdaRuntime, b: SamLambdaRuntime): number {
+export function compareSamLambdaRuntime(a: Runtime, b: Runtime): number {
     return getSortableCompareText(a).localeCompare(getSortableCompareText(b))
 }

--- a/src/shared/codelens/localLambdaRunner.ts
+++ b/src/shared/codelens/localLambdaRunner.ts
@@ -24,7 +24,7 @@ import { ExtensionDisposableFiles } from '../utilities/disposableFiles'
 
 import { generateDefaultHandlerConfig, HandlerConfig } from '../../lambda/config/templates'
 import { DebugConfiguration } from '../../lambda/local/debugConfiguration'
-import { getFamily, SamLambdaRuntimeFamily } from '../../lambda/models/samLambdaRuntime'
+import { getFamily, RuntimeFamily } from '../../lambda/models/samLambdaRuntime'
 import { Logger } from '../logger'
 import { TelemetryService } from '../telemetry/telemetryService'
 import { normalizeSeparator } from '../utilities/pathUtils'
@@ -641,10 +641,10 @@ function getAttachDebuggerMaxRetryLimit(configuration: SettingsConfiguration, de
 export function shouldAppendRelativePathToFunctionHandler(runtime: string): boolean {
     // getFamily will throw an error if the runtime doesn't exist
     switch (getFamily(runtime)) {
-        case SamLambdaRuntimeFamily.NodeJS:
-        case SamLambdaRuntimeFamily.Python:
+        case RuntimeFamily.NodeJS:
+        case RuntimeFamily.Python:
             return true
-        case SamLambdaRuntimeFamily.DotNetCore:
+        case RuntimeFamily.DotNetCore:
             return false
         // if the runtime exists but for some reason we forgot to cover it here, throw anyway so we remember to cover it
         default:

--- a/src/shared/codelens/typescriptCodeLensProvider.ts
+++ b/src/shared/codelens/typescriptCodeLensProvider.ts
@@ -15,13 +15,12 @@ import { registerCommand } from '../telemetry/telemetryUtils'
 import { TypescriptLambdaHandlerSearch } from '../typescriptLambdaHandlerSearch'
 import { getChannelLogger, getDebugPort, localize } from '../utilities/vsCodeUtils'
 
+import { nodeJsRuntimes } from '../../lambda/models/samLambdaRuntime'
 import { getLogger } from '../logger'
 import { DefaultValidatingSamCliProcessInvoker } from '../sam/cli/defaultValidatingSamCliProcessInvoker'
 import { normalizeSeparator } from '../utilities/pathUtils'
 import { CodeLensProviderParams, getInvokeCmdKey, getMetricDatum, makeCodeLenses } from './codeLensUtils'
 import { getHandlerRelativePath, LambdaLocalInvokeParams, LocalLambdaRunner } from './localLambdaRunner'
-
-const supportedNodeJsRuntimes: Set<string> = new Set<string>(['nodejs8.10', 'nodejs10.x'])
 
 async function getSamProjectDirPathForFile(filepath: string): Promise<string> {
     const packageJsonPath: string | undefined = await findFileInParentPaths(path.dirname(filepath), 'package.json')
@@ -96,7 +95,7 @@ export function initialize({
             })
             const runtime = CloudFormation.getRuntime(resource)
 
-            if (!supportedNodeJsRuntimes.has(runtime)) {
+            if (!nodeJsRuntimes.has(runtime)) {
                 logger.error(
                     `Javascript local invoke on ${params.document.uri.fsPath} encountered` +
                         ` unsupported runtime ${runtime}`

--- a/src/shared/sam/cli/samCliInit.ts
+++ b/src/shared/sam/cli/samCliInit.ts
@@ -3,14 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Runtime } from 'aws-sdk/clients/lambda'
 import * as semver from 'semver'
-import { DependencyManager, SamLambdaRuntime } from '../../../lambda/models/samLambdaRuntime'
+import { DependencyManager } from '../../../lambda/models/samLambdaRuntime'
 import { getSamCliVersion, SamCliContext } from './samCliContext'
 import { logAndThrowIfUnexpectedExitCode } from './samCliInvokerUtils'
 import { SAM_CLI_VERSION_0_30 } from './samCliValidator'
 
 export interface SamCliInitArgs {
-    runtime: SamLambdaRuntime
+    runtime: Runtime
     location: string
     name: string
     dependencyManager: DependencyManager

--- a/src/test/lambda/wizards/samInitWizard.test.ts
+++ b/src/test/lambda/wizards/samInitWizard.test.ts
@@ -4,10 +4,10 @@
  */
 
 import * as assert from 'assert'
+import { Runtime } from 'aws-sdk/clients/lambda'
 import * as immutable from 'immutable'
 import * as path from 'path'
 import * as vscode from 'vscode'
-import { SamLambdaRuntime } from '../../../lambda/models/samLambdaRuntime'
 import { CreateNewSamAppWizard, CreateNewSamAppWizardContext } from '../../../lambda/wizards/samInitWizard'
 
 function isMultiDimensionalArray(array: any[] | any[][] | undefined): boolean {
@@ -25,16 +25,16 @@ function isMultiDimensionalArray(array: any[] | any[][] | undefined): boolean {
 }
 
 class MockCreateNewSamAppWizardContext implements CreateNewSamAppWizardContext {
-    public get lambdaRuntimes(): immutable.Set<SamLambdaRuntime> {
+    public get lambdaRuntimes(): immutable.Set<Runtime> {
         if (Array.isArray(this._lambdaRuntimes)) {
             if (this._lambdaRuntimes!.length <= 0) {
                 throw new Error('lambdaRuntimes was called more times than expected')
             }
 
-            return (this._lambdaRuntimes as immutable.Set<SamLambdaRuntime>[]).pop() || immutable.Set()
+            return (this._lambdaRuntimes as immutable.Set<Runtime>[]).pop() || immutable.Set()
         }
 
-        return (this._lambdaRuntimes as immutable.Set<SamLambdaRuntime>) || immutable.Set()
+        return (this._lambdaRuntimes as immutable.Set<Runtime>) || immutable.Set()
     }
 
     public get workspaceFolders(): vscode.WorkspaceFolder[] {
@@ -64,7 +64,7 @@ class MockCreateNewSamAppWizardContext implements CreateNewSamAppWizardContext {
      */
     public constructor(
         private readonly _workspaceFolders: vscode.WorkspaceFolder[] | vscode.WorkspaceFolder[][],
-        private readonly _lambdaRuntimes: immutable.Set<SamLambdaRuntime> | immutable.Set<SamLambdaRuntime>[],
+        private readonly _lambdaRuntimes: immutable.Set<Runtime> | immutable.Set<Runtime>[],
         private readonly inputBoxResult: string | string[],
         private readonly openDialogResult: (vscode.Uri[] | undefined) | (vscode.Uri[] | undefined)[]
     ) {
@@ -72,7 +72,7 @@ class MockCreateNewSamAppWizardContext implements CreateNewSamAppWizardContext {
             this._workspaceFolders = (_workspaceFolders as vscode.WorkspaceFolder[][]).reverse()
         }
         if (Array.isArray(this._lambdaRuntimes)) {
-            this._lambdaRuntimes = (_lambdaRuntimes as immutable.Set<SamLambdaRuntime>[]).reverse()
+            this._lambdaRuntimes = (_lambdaRuntimes as immutable.Set<Runtime>[]).reverse()
         }
         if (Array.isArray(this.inputBoxResult)) {
             this.inputBoxResult = (inputBoxResult as string[]).reverse()
@@ -94,7 +94,7 @@ class MockCreateNewSamAppWizardContext implements CreateNewSamAppWizardContext {
         return this.openDialogResult as vscode.Uri[]
     }
 
-    public async promptUserForRuntime(currRuntime?: SamLambdaRuntime): Promise<SamLambdaRuntime | undefined> {
+    public async promptUserForRuntime(currRuntime?: Runtime): Promise<Runtime | undefined> {
         return this.lambdaRuntimes.toArray().pop()
     }
 
@@ -128,7 +128,7 @@ describe('CreateNewSamAppWizard', async () => {
         it('uses user response as runtime', async () => {
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
-                immutable.Set<SamLambdaRuntime>(['nodejs8.10']),
+                immutable.Set<Runtime>(['nodejs8.10']),
                 'myName',
                 [vscode.Uri.file(path.join('my', 'workspace', 'folder'))]
             )
@@ -142,7 +142,7 @@ describe('CreateNewSamAppWizard', async () => {
         it('exits when cancelled', async () => {
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
-                immutable.Set<SamLambdaRuntime>(),
+                immutable.Set<Runtime>(),
                 'myName',
                 [vscode.Uri.file(path.join('my', 'workspace', 'folder'))]
             )
@@ -158,7 +158,7 @@ describe('CreateNewSamAppWizard', async () => {
             const locationPath = path.join('my', 'quick', 'pick', 'result')
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
-                immutable.Set<SamLambdaRuntime>(['nodejs8.10']),
+                immutable.Set<Runtime>(['nodejs8.10']),
                 'myName',
                 [vscode.Uri.file(locationPath)]
             )
@@ -173,7 +173,7 @@ describe('CreateNewSamAppWizard', async () => {
             const locationPath = path.join('my', 'quick', 'pick', 'result')
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
-                [immutable.Set<SamLambdaRuntime>(['python3.6']), immutable.Set<SamLambdaRuntime>(['nodejs8.10'])],
+                [immutable.Set<Runtime>(['python3.6']), immutable.Set<Runtime>(['nodejs8.10'])],
                 'myName',
                 [undefined, [vscode.Uri.file(locationPath)]]
             )
@@ -191,7 +191,7 @@ describe('CreateNewSamAppWizard', async () => {
 
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
-                immutable.Set<SamLambdaRuntime>(['nodejs8.10']),
+                immutable.Set<Runtime>(['nodejs8.10']),
                 name,
                 [vscode.Uri.file(locationPath)]
             )
@@ -212,7 +212,7 @@ describe('CreateNewSamAppWizard', async () => {
                     name: path.basename(p),
                     index: index++
                 })),
-                immutable.Set<SamLambdaRuntime>(['nodejs8.10']),
+                immutable.Set<Runtime>(['nodejs8.10']),
                 'myName',
                 []
             )
@@ -228,7 +228,7 @@ describe('CreateNewSamAppWizard', async () => {
         it('uses user response as name', async () => {
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
-                immutable.Set<SamLambdaRuntime>(['nodejs8.10']),
+                immutable.Set<Runtime>(['nodejs8.10']),
                 'myName',
                 [vscode.Uri.file(path.join('my', 'quick', 'pick', 'result'))]
             )
@@ -242,7 +242,7 @@ describe('CreateNewSamAppWizard', async () => {
         it('backtracks when cancelled', async () => {
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
-                immutable.Set<SamLambdaRuntime>(['nodejs8.10']),
+                immutable.Set<Runtime>(['nodejs8.10']),
                 ['', 'myName'],
                 [
                     [vscode.Uri.file(path.join('my', 'quick', 'pick', 'result', '1'))],


### PR DESCRIPTION
- Reduce the duplication of runtimes and use the `Runtime` type from the AWS SDK
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
