### PR TITLE
Re-add lint to buildscripts

### DIFF
--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -11,6 +11,7 @@ phases:
     build:
         commands:
             - npm run testCompile
+            - npm run lint
             - xvfb-run npm test --silent
             - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
             - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g') # Encode `#` in the URL because otherwise the url is clipped in the Codecov.io site

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -11,6 +11,7 @@ phases:
     build:
         commands:
             - npm run testCompile
+            - npm run lint
             - npm run test
             - |
                 if(-Not($Env:CODEBUILD_BUILD_SUCCEEDING -eq "0" -Or $Env:CODE_COV_TOKEN -eq $null)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Lint was removed from `test` to speed up development time, but it was forgotten to be added to the new build scripts

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
