### PR TITLE
Added ability to change winston logger's log level

### DIFF
--- a/src/shared/logger/winstonToolkitLogger.ts
+++ b/src/shared/logger/winstonToolkitLogger.ts
@@ -44,6 +44,11 @@ export class WinstonToolkitLogger implements Logger, vscode.Disposable {
         })
     }
 
+    public setLogLevel(logLevel: LogLevel) {
+        this.logger.info(`Setting log level to: ${logLevel}`)
+        this.logger.level = logLevel
+    }
+
     public logToFile(logPath: string): void {
         this.logger.add(new winston.transports.File({ filename: logPath }))
     }

--- a/src/test/shared/logger/winstonToolkitLogger.test.ts
+++ b/src/test/shared/logger/winstonToolkitLogger.test.ts
@@ -111,6 +111,21 @@ describe('WinstonToolkitLogger', () => {
             assert.ok(await isTextInLogFile(tempLogPath, 'The quick brown fox'), 'Expected error message to be logged')
         })
 
+        it('supports updating the log type', async () => {
+            const nonLoggedVerboseEntry = 'verbose entry should not be logged'
+            const loggedVerboseEntry = 'verbose entry should be logged'
+
+            testLogger = new WinstonToolkitLogger('info')
+            testLogger.logToFile(tempLogPath)
+
+            testLogger.verbose(nonLoggedVerboseEntry)
+            testLogger.setLogLevel('verbose')
+            testLogger.verbose(loggedVerboseEntry)
+
+            assert.ok(!(await isTextInLogFile(tempLogPath, nonLoggedVerboseEntry)), 'unexpected message in log')
+            assert.ok(await isTextInLogFile(tempLogPath, loggedVerboseEntry), 'Expected error message to be logged')
+        })
+
         happyLogScenarios.forEach(scenario => {
             it(scenario.name, async () => {
                 const message = `message for ${scenario.name}`
@@ -190,6 +205,22 @@ describe('WinstonToolkitLogger', () => {
             testLogger.info('The', 'quick', 'brown', 'fox')
 
             assert.ok((await waitForMessage).includes('The quick brown fox'), 'Expected error message to be logged')
+        })
+
+        it('supports updating the log type', async () => {
+            const nonLoggedVerboseEntry = 'verbose entry should not be logged'
+            const loggedVerboseEntry = 'verbose entry should be logged'
+
+            testLogger = new WinstonToolkitLogger('info')
+            testLogger.logToOutputChannel(outputChannel)
+
+            testLogger.verbose(nonLoggedVerboseEntry)
+            testLogger.setLogLevel('verbose')
+            testLogger.verbose(loggedVerboseEntry)
+
+            const waitForMessage = waitForLoggedTextByContents(loggedVerboseEntry)
+            assert.ok((await waitForMessage).includes(loggedVerboseEntry), 'Expected error message to be logged')
+            assert.ok(!(await waitForMessage).includes(nonLoggedVerboseEntry), 'unexpected message in log')
         })
 
         happyLogScenarios.forEach(scenario => {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Added the ability to change the winston logger's log level.
Motivation: for future use with the integration tests, so that we can see the logged output.

Not in scope: wiring this support into the toolkit, so that configuration changes trigger an update to the logger's log level.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
