### PR TITLE
Made detectLocalLambdas parameter non-nullable.

### DIFF
--- a/src/lambda/local/detectLocalLambdas.ts
+++ b/src/lambda/local/detectLocalLambdas.ts
@@ -17,13 +17,7 @@ export interface LocalLambda {
     handler?: string
 }
 
-export async function detectLocalLambdas(
-    workspaceFolders: vscode.WorkspaceFolder[] | undefined = vscode.workspace.workspaceFolders
-): Promise<LocalLambda[]> {
-    if (!workspaceFolders) {
-        return []
-    }
-
+export async function detectLocalLambdas(workspaceFolders: vscode.WorkspaceFolder[]): Promise<LocalLambda[]> {
     return (await Promise.all(workspaceFolders.map(detectLambdasFromWorkspaceFolder))).reduce(
         (accumulator: LocalLambda[], current: LocalLambda[]) => {
             accumulator.push(...current)

--- a/src/test/lambda/local/detectLocalLambdas.test.ts
+++ b/src/test/lambda/local/detectLocalLambdas.test.ts
@@ -29,13 +29,6 @@ describe('detectLocalLambdas', () => {
         workspaceFolders.length = 0
     })
 
-    it('detects no lambdas when workspaceFolders is undefined', async () => {
-        const actual = await detectLocalLambdas(undefined)
-
-        assert.ok(actual)
-        assert.strictEqual(actual.length, 0)
-    })
-
     it('detects no lambdas when workspaceFolders is empty', async () => {
         const actual = await detectLocalLambdas([])
 


### PR DESCRIPTION
## Description

Removing unnecessary code.

The test was unreliable. The function swapped in 'vscode.workspace.workspaceFolders' for the parameter if undefined is passed in, and only the test passed in undefined. So, the test was working under flawed assumptions, for a case that is never used in the codebase.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
