### PR TITLE
Added telemetry to track quantity of active regions

### DIFF
--- a/src/awsexplorer/awsExplorer.ts
+++ b/src/awsexplorer/awsExplorer.ts
@@ -86,6 +86,10 @@ export class AwsExplorer implements vscode.TreeDataProvider<AWSTreeNodeBase>, Re
         }
     }
 
+    public getRegionNodesSize() {
+        return this.regionNodes.size
+    }
+
     public refresh(node?: AWSTreeNodeBase) {
         this._onDidChangeTreeData.fire(node)
     }

--- a/src/shared/telemetry/telemetryTypes.ts
+++ b/src/shared/telemetry/telemetryTypes.ts
@@ -27,7 +27,8 @@ export enum TelemetryNamespace {
     Lambda = 'lambda',
     Project = 'project',
     Schema = 'schemas',
-    Session = 'session'
+    Session = 'session',
+    VSCode = 'vscode'
 }
 
 export enum AccountStatus {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added a telemetry call to record the number of active regions.  This is called on activation of the AwsExplorer(on startup), showRegion, and hideRegion.  The value that is tracked is the quantity of regions that are currently active for the user.
<!--- Describe your changes in detail -->

## Motivation and Context
The purpose of this change is to collect data to help determine the need of having the multiple region feature.
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
N/A
<!--- What is the related issue you are trying to fix? -->

## Testing
Launched extension in the VS Code debugger with no errors.  Verified that telemetry was received and accurate.
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
