### PR TITLE
Centralize Extension IDs

### DIFF
--- a/src/integrationTest/codelens.js.test.ts
+++ b/src/integrationTest/codelens.js.test.ts
@@ -7,12 +7,8 @@ import * as assert from 'assert'
 import { join } from 'path'
 import * as vscode from 'vscode'
 import { LambdaLocalInvokeParams } from '../shared/codelens/localLambdaRunner'
-import {
-    activateExtension,
-    expectCodeLenses,
-    EXTENSION_NAME_AWS_TOOLKIT,
-    getTestWorkspaceFolder
-} from './integrationTestsUtilities'
+import { VSCODE_EXTENSION_ID } from '../shared/extensions'
+import { activateExtension, expectCodeLenses, getTestWorkspaceFolder } from './integrationTestsUtilities'
 
 const ACTIVATE_EXTENSION_TIMEOUT_MILLIS = 30000
 const CODELENS_TEST_TIMEOUT_MILLIS = 10000
@@ -24,7 +20,7 @@ describe('SAM Local CodeLenses (JS)', async () => {
     before(async function() {
         // tslint:disable-next-line:no-invalid-this
         this.timeout(ACTIVATE_EXTENSION_TIMEOUT_MILLIS)
-        await activateExtension(EXTENSION_NAME_AWS_TOOLKIT)
+        await activateExtension(VSCODE_EXTENSION_ID.awstoolkit)
 
         await vscode.workspace.getConfiguration('aws').update('sam.template.depth', 8, false)
     })

--- a/src/integrationTest/integrationTestsUtilities.ts
+++ b/src/integrationTest/integrationTestsUtilities.ts
@@ -6,8 +6,6 @@
 import * as assert from 'assert'
 import * as vscode from 'vscode'
 
-export const EXTENSION_NAME_AWS_TOOLKIT = 'amazonwebservices.aws-toolkit-vscode'
-
 const SECOND = 1000
 export const TIMEOUT = 30 * SECOND
 

--- a/src/integrationTest/integrationTestsUtilities.ts
+++ b/src/integrationTest/integrationTestsUtilities.ts
@@ -11,17 +11,17 @@ export const EXTENSION_NAME_AWS_TOOLKIT = 'amazonwebservices.aws-toolkit-vscode'
 const SECOND = 1000
 export const TIMEOUT = 30 * SECOND
 
-export async function activateExtension(extensionName: string): Promise<vscode.Extension<void>> {
-    console.log(`activateExtension request: ${extensionName}`)
-    const extension: vscode.Extension<void> | undefined = vscode.extensions.getExtension(extensionName)
-    assert.ok(extension)
+export async function activateExtension(extensionId: string): Promise<vscode.Extension<void>> {
+    console.log(`activateExtension request: ${extensionId}`)
+    const extension: vscode.Extension<void> | undefined = vscode.extensions.getExtension(extensionId)
+    assert.ok(extension, `Extension not found: ${extensionId}`)
 
     if (!extension) {
-        throw new Error(`Extension not found: ${extensionName}`)
+        throw new Error(`Extension not found: ${extensionId}`)
     }
 
     if (!extension.isActive) {
-        console.log(`Activating extension: ${extensionName}`)
+        console.log(`Activating extension: ${extensionId}`)
         await extension.activate()
     } else {
         console.log('Extension is already active')

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -12,14 +12,8 @@ import { getDependencyManager } from '../../src/lambda/models/samLambdaRuntime'
 import { getSamCliContext } from '../../src/shared/sam/cli/samCliContext'
 import { runSamCliInit, SamCliInitArgs } from '../../src/shared/sam/cli/samCliInit'
 import { assertThrowsError } from '../../src/test/shared/utilities/assertUtils'
-import {
-    activateExtension,
-    EXTENSION_NAME_AWS_TOOLKIT,
-    getCodeLenses,
-    getTestWorkspaceFolder,
-    sleep,
-    TIMEOUT
-} from './integrationTestsUtilities'
+import { VSCODE_EXTENSION_ID } from '../shared/extensions'
+import { activateExtension, getCodeLenses, getTestWorkspaceFolder, sleep, TIMEOUT } from './integrationTestsUtilities'
 
 const projectFolder = getTestWorkspaceFolder()
 // Retry tests because CodeLenses do not reliably get produced in the tests
@@ -128,7 +122,7 @@ for (const runtime of runtimes) {
             debugDisposable = vscode.debug.onDidChangeActiveDebugSession(async session =>
                 onDebugChanged(session, debuggerType)
             )
-            await activateExtension(EXTENSION_NAME_AWS_TOOLKIT)
+            await activateExtension(VSCODE_EXTENSION_ID.awstoolkit)
             console.log(`Using SDK ${projectSDK} with project in path ${projectPath}`)
             tryRemoveProjectFolder()
             mkdirpSync(projectFolder)

--- a/src/integrationTest/vscode.test.ts
+++ b/src/integrationTest/vscode.test.ts
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { activateExtension, EXTENSION_NAME_AWS_TOOLKIT, TIMEOUT } from './integrationTestsUtilities'
+import { VSCODE_EXTENSION_ID } from '../shared/extensions'
+import { activateExtension, TIMEOUT } from './integrationTestsUtilities'
 
 describe('VSCode tests', async () => {
     it('activates the extension', async () => {
-        await activateExtension(EXTENSION_NAME_AWS_TOOLKIT)
+        await activateExtension(VSCODE_EXTENSION_ID.awstoolkit)
     }).timeout(TIMEOUT)
 })

--- a/src/shared/extensions.ts
+++ b/src/shared/extensions.ts
@@ -1,0 +1,9 @@
+/*!
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const VSCODE_EXTENSION_ID = {
+    awstoolkit: 'amazonwebservices.aws-toolkit-vscode',
+    python: 'ms-python.python'
+}


### PR DESCRIPTION
## Description

Moving known Extension IDs to a central set of constants. Related to some upcoming integration test changes.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
