### PR TITLE
Install the Python Extension as part of the Integration Test setup

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -33,5 +33,6 @@ phases:
 
     build:
         commands:
+            - export AWS_TOOLKIT_TEST_USER_DIR=/tmp/
             - npm install --unsafe-perm
             - xvfb-run npm run integrationTest

--- a/test-scripts/integrationTest.ts
+++ b/test-scripts/integrationTest.ts
@@ -5,13 +5,23 @@
 
 import { join, resolve } from 'path'
 import { runTests } from 'vscode-test'
-import { setupVSCodeTestInstance } from './launchTestUtilities'
+import { VSCODE_EXTENSION_ID } from '../src/shared/extensions'
+import { installVSCodeExtension, setupVSCodeTestInstance } from './launchTestUtilities'
+
+async function setupVSCode(): Promise<string> {
+    console.log('Setting up VS Code Test instance...')
+    const vsCodeExecutablePath = await setupVSCodeTestInstance()
+    await installVSCodeExtension(vsCodeExecutablePath, VSCODE_EXTENSION_ID.python)
+    console.log('VS Code Test instance has been set up')
+
+    return vsCodeExecutablePath
+}
 
 // tslint:disable-next-line: no-floating-promises
 ;(async () => {
     try {
         console.log('Running Integration test suite...')
-        const vsCodeExecutablePath = await setupVSCodeTestInstance()
+        const vsCodeExecutablePath = await setupVSCode()
         const cwd = process.cwd()
         const testEntrypoint = resolve(cwd, 'dist', 'src', 'integrationTest', 'index.js')
         const workspacePath = join(cwd, 'dist', 'src', 'integrationTest-samples')

--- a/test-scripts/launchTestUtilities.ts
+++ b/test-scripts/launchTestUtilities.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { downloadAndUnzipVSCode } from 'vscode-test'
+import * as child_process from 'child_process'
+import { downloadAndUnzipVSCode, resolveCliPathFromVSCodeExecutablePath } from 'vscode-test'
 
 const ENVVAR_VSCODE_TEST_VERSION = 'VSCODE_TEST_VERSION'
 
@@ -23,4 +24,30 @@ export async function setupVSCodeTestInstance(): Promise<string> {
     console.log(`VS Code test instance location: ${vsCodeExecutablePath}`)
 
     return vsCodeExecutablePath
+}
+
+export async function installVSCodeExtension(vsCodeExecutablePath: string, extensionIdentifier: string): Promise<void> {
+    console.log(`Installing VS Code Extension: ${extensionIdentifier}`)
+    const vsCodeCliPath = resolveCliPathFromVSCodeExecutablePath(vsCodeExecutablePath)
+
+    const cmdArgs = ['--install-extension', extensionIdentifier]
+    if (process.env.AWS_TOOLKIT_TEST_USER_DIR) {
+        cmdArgs.push('--user-data-dir', process.env.AWS_TOOLKIT_TEST_USER_DIR)
+    }
+    const spawnResult = child_process.spawnSync(vsCodeCliPath, cmdArgs, {
+        encoding: 'utf-8',
+        stdio: 'inherit'
+    })
+
+    if (spawnResult.status !== 0) {
+        throw new Error(`Installing VS Code extension ${extensionIdentifier} had exit code ${spawnResult.status}`)
+    }
+
+    if (spawnResult.error) {
+        throw spawnResult.error
+    }
+
+    if (spawnResult.stdout) {
+        console.log(spawnResult.stdout)
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

An upcoming change aims to resume testing python SAM Applications in the integration tests. The Python extension is necessary for those tests. This change adds the support code to install the extension for the tests.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
