### PR TITLE
Add logging calls to SAM CLI detection and child process calls

### DIFF
--- a/src/shared/sam/cli/samCliLocator.ts
+++ b/src/shared/sam/cli/samCliLocator.ts
@@ -6,6 +6,7 @@
 import * as path from 'path'
 import { EnvironmentVariables } from '../../environmentVariables'
 import * as filesystemUtilities from '../../filesystemUtilities'
+import { getLogger, Logger } from '../../logger'
 
 export interface SamCliLocationProvider {
     getLocation(): Promise<string | undefined>
@@ -32,6 +33,8 @@ export class DefaultSamCliLocationProvider implements SamCliLocationProvider {
 }
 
 abstract class BaseSamCliLocator {
+    protected readonly logger: Logger = getLogger()
+
     public constructor() {
         this.verifyOs()
     }
@@ -45,6 +48,8 @@ abstract class BaseSamCliLocator {
         if (!location) {
             location = await this.getSystemPathLocation()
         }
+
+        this.logger.info(`SAM CLI location: ${location}`)
 
         return location
     }
@@ -63,6 +68,7 @@ abstract class BaseSamCliLocator {
             })
 
         for (const fullPath of fullPaths) {
+            this.logger.verbose(`Searching for SAM CLI in: ${fullPath}`)
             if (await filesystemUtilities.fileExists(fullPath)) {
                 return fullPath
             }

--- a/src/shared/utilities/childProcess.ts
+++ b/src/shared/utilities/childProcess.ts
@@ -5,6 +5,7 @@
 
 import * as child_process from 'child_process'
 import * as crossSpawn from 'cross-spawn'
+import { getLogger } from '../logger'
 
 export interface ChildProcessStartArguments {
     onStdout?(text: string): void
@@ -71,6 +72,7 @@ export class ChildProcess {
             throw new Error('process already started')
         }
 
+        getLogger().info(`Running command: ${this.process} ${this.args.join(' ')}`)
         this.childProcess = crossSpawn(this.process, this.args, this.options)
 
         this.childProcess.stdout?.on('data', (data: { toString(): string }) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add more logging calls to better diagnose
* Paths checked for SAM CLI
* SAM CLI Location found/used by toolkit
* command line calls made to programs like sam cli

This should help chase down situations like #658 / #701 


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
