### PR TITLE
Remove two Schema related search commands from the Command Palette.

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,14 @@
                     "when": "false"
                 },
                 {
+                    "command": "aws.searchSchema",
+                    "when": "false"
+                },
+                {
+                    "command": "aws.searchSchemaPerRegistry",
+                    "when": "false"
+                },
+                {
                     "command": "aws.refreshAwsExplorer",
                     "when": "false"
                 },


### PR DESCRIPTION

## Description

Two Schema Search related commands are associated with AWS Explorer node context menus, and operate against explorer nodes. They weren't intended to appear in the Command Palette. This change hides them from the Command Palette.

Fixes #881

## Testing

* Open the command palette and type "schema". Observe that the commands no longer appear in the list
* Exercised the search commands from the explorer context menus to ensure they still work as expected

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
