### PR TITLE
Remove some unnecessary RegionProvider usages

### DIFF
--- a/src/lambda/commands/deploySamApplication.ts
+++ b/src/lambda/commands/deploySamApplication.ts
@@ -11,7 +11,6 @@ import * as nls from 'vscode-nls'
 import { asEnvironmentVariables } from '../../credentials/credentialsUtilities'
 import { AwsContext, NoActiveCredentialError } from '../../shared/awsContext'
 import { makeTemporaryToolkitFolder } from '../../shared/filesystemUtilities'
-import { RegionProvider } from '../../shared/regions/regionProvider'
 import { SamCliBuildInvocation } from '../../shared/sam/cli/samCliBuild'
 import { getSamCliContext, SamCliContext } from '../../shared/sam/cli/samCliContext'
 import { runSamCliDeploy } from '../../shared/sam/cli/samCliDeploy'
@@ -20,7 +19,7 @@ import { runSamCliPackage } from '../../shared/sam/cli/samCliPackage'
 import { throwAndNotifyIfInvalid } from '../../shared/sam/cli/samCliValidationUtils'
 import { makeCheckLogsMessage } from '../../shared/utilities/messages'
 import { ChannelLogger } from '../../shared/utilities/vsCodeUtils'
-import { DefaultSamDeployWizardContext, SamDeployWizard, SamDeployWizardResponse } from '../wizards/samDeployWizard'
+import { SamDeployWizardResponse } from '../wizards/samDeployWizard'
 
 const localize = nls.loadMessageBundle()
 
@@ -48,13 +47,11 @@ export async function deploySamApplication(
     {
         samCliContext = getSamCliContext(),
         channelLogger,
-        regionProvider,
-        samDeployWizard = getDefaultSamDeployWizardResponseProvider(regionProvider)
+        samDeployWizard
     }: {
         samCliContext?: SamCliContext
         channelLogger: ChannelLogger
-        regionProvider: RegionProvider
-        samDeployWizard?: SamDeployWizardResponseProvider
+        samDeployWizard: SamDeployWizardResponseProvider
     },
     {
         awsContext,
@@ -287,15 +284,5 @@ function getDefaultWindowFunctions(): WindowFunctions {
         setStatusBarMessage: vscode.window.setStatusBarMessage,
         showErrorMessage: vscode.window.showErrorMessage,
         showInformationMessage: vscode.window.showInformationMessage
-    }
-}
-
-function getDefaultSamDeployWizardResponseProvider(regionProvider: RegionProvider): SamDeployWizardResponseProvider {
-    return {
-        getSamDeployWizardResponse: async (): Promise<SamDeployWizardResponse | undefined> => {
-            const wizard = new SamDeployWizard(new DefaultSamDeployWizardContext(regionProvider))
-
-            return wizard.run()
-        }
     }
 }

--- a/src/lambda/commands/deploySamApplication.ts
+++ b/src/lambda/commands/deploySamApplication.ts
@@ -293,7 +293,7 @@ function getDefaultWindowFunctions(): WindowFunctions {
 function getDefaultSamDeployWizardResponseProvider(regionProvider: RegionProvider): SamDeployWizardResponseProvider {
     return {
         getSamDeployWizardResponse: async (): Promise<SamDeployWizardResponse | undefined> => {
-            const wizard = new SamDeployWizard(regionProvider, new DefaultSamDeployWizardContext())
+            const wizard = new SamDeployWizard(new DefaultSamDeployWizardContext(regionProvider))
 
             return wizard.run()
         }

--- a/src/test/lambda/commands/deploySamApplication.test.ts
+++ b/src/test/lambda/commands/deploySamApplication.test.ts
@@ -16,7 +16,6 @@ import {
 import { SamDeployWizardResponse } from '../../../lambda/wizards/samDeployWizard'
 import { AwsContext } from '../../../shared/awsContext'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
-import { RegionProvider } from '../../../shared/regions/regionProvider'
 import { SamCliContext } from '../../../shared/sam/cli/samCliContext'
 import { SamCliProcessInvoker } from '../../../shared/sam/cli/samCliInvokerUtils'
 import {
@@ -150,7 +149,6 @@ describe('deploySamApplication', async () => {
             {
                 samCliContext: goodSamCliContext(),
                 channelLogger,
-                regionProvider: (undefined as any) as RegionProvider,
                 samDeployWizard
             },
             {
@@ -170,7 +168,6 @@ describe('deploySamApplication', async () => {
             {
                 samCliContext: goodSamCliContext(),
                 channelLogger,
-                regionProvider: (undefined as any) as RegionProvider,
                 samDeployWizard
             },
             {
@@ -187,7 +184,6 @@ describe('deploySamApplication', async () => {
             {
                 samCliContext: invalidSamCliContext,
                 channelLogger,
-                regionProvider: (undefined as any) as RegionProvider,
                 samDeployWizard
             },
             {
@@ -206,7 +202,6 @@ describe('deploySamApplication', async () => {
             {
                 samCliContext: goodSamCliContext(),
                 channelLogger,
-                regionProvider: (undefined as any) as RegionProvider,
                 samDeployWizard
             },
             {
@@ -236,7 +231,6 @@ describe('deploySamApplication', async () => {
             {
                 samCliContext: goodSamCliContext(),
                 channelLogger,
-                regionProvider: (undefined as any) as RegionProvider,
                 samDeployWizard
             },
             {
@@ -269,7 +263,6 @@ describe('deploySamApplication', async () => {
             {
                 samCliContext: goodSamCliContext(),
                 channelLogger,
-                regionProvider: (undefined as any) as RegionProvider,
                 samDeployWizard
             },
             {
@@ -302,7 +295,6 @@ describe('deploySamApplication', async () => {
             {
                 samCliContext: goodSamCliContext(),
                 channelLogger,
-                regionProvider: (undefined as any) as RegionProvider,
                 samDeployWizard
             },
             {

--- a/src/test/lambda/commands/deploySamApplication.test.ts
+++ b/src/test/lambda/commands/deploySamApplication.test.ts
@@ -16,7 +16,6 @@ import {
 import { SamDeployWizardResponse } from '../../../lambda/wizards/samDeployWizard'
 import { AwsContext } from '../../../shared/awsContext'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
-import { RegionInfo } from '../../../shared/regions/regionInfo'
 import { RegionProvider } from '../../../shared/regions/regionProvider'
 import { SamCliContext } from '../../../shared/sam/cli/samCliContext'
 import { SamCliProcessInvoker } from '../../../shared/sam/cli/samCliInvokerUtils'
@@ -106,18 +105,6 @@ describe('deploySamApplication', async () => {
     }
 
     // Other support stubs
-
-    const regionProvider: RegionProvider = {
-        getRegionData: async (): Promise<RegionInfo[]> => {
-            return [
-                {
-                    regionCode: 'us-west-2',
-                    regionName: 'TEST REGION'
-                }
-            ]
-        }
-    }
-
     const placeholderCredentials = ({} as any) as AWS.Credentials
     let testCredentials: AWS.Credentials | undefined
     const awsContext: Pick<AwsContext, 'getCredentials'> = {
@@ -163,7 +150,7 @@ describe('deploySamApplication', async () => {
             {
                 samCliContext: goodSamCliContext(),
                 channelLogger,
-                regionProvider,
+                regionProvider: (undefined as any) as RegionProvider,
                 samDeployWizard
             },
             {
@@ -183,7 +170,7 @@ describe('deploySamApplication', async () => {
             {
                 samCliContext: goodSamCliContext(),
                 channelLogger,
-                regionProvider,
+                regionProvider: (undefined as any) as RegionProvider,
                 samDeployWizard
             },
             {
@@ -200,7 +187,7 @@ describe('deploySamApplication', async () => {
             {
                 samCliContext: invalidSamCliContext,
                 channelLogger,
-                regionProvider,
+                regionProvider: (undefined as any) as RegionProvider,
                 samDeployWizard
             },
             {
@@ -219,7 +206,7 @@ describe('deploySamApplication', async () => {
             {
                 samCliContext: goodSamCliContext(),
                 channelLogger,
-                regionProvider,
+                regionProvider: (undefined as any) as RegionProvider,
                 samDeployWizard
             },
             {
@@ -249,7 +236,7 @@ describe('deploySamApplication', async () => {
             {
                 samCliContext: goodSamCliContext(),
                 channelLogger,
-                regionProvider,
+                regionProvider: (undefined as any) as RegionProvider,
                 samDeployWizard
             },
             {
@@ -282,7 +269,7 @@ describe('deploySamApplication', async () => {
             {
                 samCliContext: goodSamCliContext(),
                 channelLogger,
-                regionProvider,
+                regionProvider: (undefined as any) as RegionProvider,
                 samDeployWizard
             },
             {
@@ -315,7 +302,7 @@ describe('deploySamApplication', async () => {
             {
                 samCliContext: goodSamCliContext(),
                 channelLogger,
-                regionProvider,
+                regionProvider: (undefined as any) as RegionProvider,
                 samDeployWizard
             },
             {

--- a/src/test/lambda/wizards/samDeployWizard.test.ts
+++ b/src/test/lambda/wizards/samDeployWizard.test.ts
@@ -14,8 +14,6 @@ import {
     SamDeployWizardContext,
     validateS3Bucket
 } from '../../../lambda/wizards/samDeployWizard'
-import { RegionInfo } from '../../../shared/regions/regionInfo'
-import { RegionProvider } from '../../../shared/regions/regionProvider'
 import { asyncGenerator } from '../../utilities/collectionUtils'
 
 interface QuickPickUriResponseItem extends vscode.QuickPickItem {
@@ -37,17 +35,6 @@ function createQuickPickRegionResponseItem(detail: string): QuickPickRegionRespo
     return {
         label: '',
         detail: detail
-    }
-}
-
-class MockRegionProvider implements RegionProvider {
-    public async getRegionData(): Promise<RegionInfo[]> {
-        return [
-            {
-                regionCode: 'us-west-2',
-                regionName: 'TEST REGION'
-            }
-        ]
     }
 }
 
@@ -105,10 +92,7 @@ class MockSamDeployWizardContext implements SamDeployWizardContext {
         return this.promptForS3BucketResponses.pop()
     }
 
-    public async promptUserForRegion(
-        regionProvider: RegionProvider,
-        initialValue?: string
-    ): Promise<string | undefined> {
+    public async promptUserForRegion(initialValue?: string): Promise<string | undefined> {
         if (this.promptForRegionResponses.length <= 0) {
             throw new Error('promptUserForRegion was called more times than expected')
         }
@@ -151,7 +135,6 @@ describe('SamDeployWizard', async () => {
     describe('TEMPLATE', async () => {
         it('fails gracefully when no templates are found', async () => {
             const wizard = new SamDeployWizard(
-                new MockRegionProvider(),
                 new MockSamDeployWizardContext(
                     async function*() {
                         yield* []
@@ -171,7 +154,6 @@ describe('SamDeployWizard', async () => {
             const workspaceFolderPath = normalizePath('my', 'workspace', 'folder')
             const templatePath = normalizePath(workspaceFolderPath, 'template.yaml')
             const wizard = new SamDeployWizard(
-                new MockRegionProvider(),
                 new MockSamDeployWizardContext(
                     async function*() {
                         yield vscode.Uri.file(templatePath)
@@ -191,7 +173,6 @@ describe('SamDeployWizard', async () => {
             const workspaceFolderPath = normalizePath('my', 'workspace', 'folder')
             const templatePath = normalizePath(workspaceFolderPath, 'template.yaml')
             const wizard = new SamDeployWizard(
-                new MockRegionProvider(),
                 new MockSamDeployWizardContext(
                     async function*() {
                         yield vscode.Uri.file(templatePath)
@@ -256,7 +237,7 @@ describe('SamDeployWizard', async () => {
                     }
                 })
 
-                const wizard = new SamDeployWizard(new MockRegionProvider(), context)
+                const wizard = new SamDeployWizard(context)
                 const result = await wizard.run()
 
                 assert.ok(result)
@@ -275,7 +256,7 @@ describe('SamDeployWizard', async () => {
                     }
                 })
 
-                const wizard = new SamDeployWizard(new MockRegionProvider(), context)
+                const wizard = new SamDeployWizard(context)
                 const result = await wizard.run()
 
                 assert.ok(result)
@@ -291,7 +272,7 @@ describe('SamDeployWizard', async () => {
                     promptUserForParametersIfApplicable: async () => ParameterPromptResult.Continue
                 })
 
-                const wizard = new SamDeployWizard(new MockRegionProvider(), context)
+                const wizard = new SamDeployWizard(context)
                 const result = await wizard.run()
 
                 assert.ok(result)
@@ -316,7 +297,7 @@ describe('SamDeployWizard', async () => {
                     }
                 })
 
-                const wizard = new SamDeployWizard(new MockRegionProvider(), context)
+                const wizard = new SamDeployWizard(context)
                 const result = await wizard.run()
 
                 assert.strictEqual(result, undefined)
@@ -344,7 +325,7 @@ describe('SamDeployWizard', async () => {
                     }
                 })
 
-                const wizard = new SamDeployWizard(new MockRegionProvider(), context)
+                const wizard = new SamDeployWizard(context)
                 const result = await wizard.run()
 
                 assert.strictEqual(result, undefined)
@@ -371,7 +352,7 @@ describe('SamDeployWizard', async () => {
                     }
                 })
 
-                const wizard = new SamDeployWizard(new MockRegionProvider(), context)
+                const wizard = new SamDeployWizard(context)
                 const result = await wizard.run()
 
                 assert.strictEqual(result, undefined)
@@ -398,7 +379,7 @@ describe('SamDeployWizard', async () => {
                     }
                 })
 
-                const wizard = new SamDeployWizard(new MockRegionProvider(), context)
+                const wizard = new SamDeployWizard(context)
                 const result = await wizard.run()
 
                 assert.ok(result)
@@ -417,7 +398,6 @@ describe('SamDeployWizard', async () => {
             const region = 'us-east-1'
 
             const wizard = new SamDeployWizard(
-                new MockRegionProvider(),
                 new MockSamDeployWizardContext(
                     async function*() {
                         yield vscode.Uri.file(templatePath)
@@ -443,7 +423,6 @@ describe('SamDeployWizard', async () => {
             const region = 'us-east-1'
 
             const wizard = new SamDeployWizard(
-                new MockRegionProvider(),
                 new MockSamDeployWizardContext(
                     async function*() {
                         yield vscode.Uri.file(templatePath1)
@@ -479,7 +458,6 @@ describe('SamDeployWizard', async () => {
             const region2 = 'us-east-2'
 
             const wizard = new SamDeployWizard(
-                new MockRegionProvider(),
                 new MockSamDeployWizardContext(
                     async function*() {
                         yield vscode.Uri.file(templatePath1)
@@ -509,7 +487,6 @@ describe('SamDeployWizard', async () => {
             const workspaceFolderPath = normalizePath('my', 'workspace', 'folder')
             const templatePath = normalizePath(workspaceFolderPath, 'template.yaml')
             const wizard = new SamDeployWizard(
-                new MockRegionProvider(),
                 new MockSamDeployWizardContext(
                     async function*() {
                         yield vscode.Uri.file(templatePath)
@@ -533,7 +510,6 @@ describe('SamDeployWizard', async () => {
             const workspaceFolderPath = normalizePath('my', 'workspace', 'folder')
             const templatePath = normalizePath(workspaceFolderPath, 'template.yaml')
             const wizard = new SamDeployWizard(
-                new MockRegionProvider(),
                 new MockSamDeployWizardContext(
                     async function*() {
                         yield vscode.Uri.file(templatePath)
@@ -555,7 +531,6 @@ describe('SamDeployWizard', async () => {
             const workspaceFolderPath = normalizePath('my', 'workspace', 'folder')
             const templatePath = normalizePath(workspaceFolderPath, 'template.yaml')
             const wizard = new SamDeployWizard(
-                new MockRegionProvider(),
                 new MockSamDeployWizardContext(
                     async function*() {
                         yield vscode.Uri.file(templatePath)
@@ -580,7 +555,6 @@ describe('SamDeployWizard', async () => {
 
                 try {
                     await new SamDeployWizard(
-                        new MockRegionProvider(),
                         new MockSamDeployWizardContext(
                             async function*() {
                                 yield vscode.Uri.file(templatePath)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change removes some RegionProvider usages that are unnecessary, and are getting in the way of upcoming work involving RegionProvider.

The core of this change moves RegionProvider into DefaultSamDeployWizardContext where it is used, instead of through deploySamApplication, which doesn't directly use it.

## Testing

In toolkit:
* Go backwards and forwards through the Deploy Wizard, verify the pickers work as expected
* deploy a SAM application from the toolkit and verifying that SAM app deployed to my account

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
