### PR TITLE
AWS Explorer only shows Services that are available within a Region

### DIFF
--- a/src/awsexplorer/awsExplorer.ts
+++ b/src/awsexplorer/awsExplorer.ts
@@ -75,7 +75,7 @@ export class AwsExplorer implements vscode.TreeDataProvider<AWSTreeNodeBase>, Re
             this.regionNodes,
             intersection(regionMap.keys(), explorerRegionCodes),
             key => this.regionNodes.get(key)!.update(regionMap.get(key)!),
-            key => new RegionNode(regionMap.get(key)!)
+            key => new RegionNode(regionMap.get(key)!, this.regionProvider)
         )
 
         if (this.regionNodes.size > 0) {

--- a/src/awsexplorer/regionNode.ts
+++ b/src/awsexplorer/regionNode.ts
@@ -8,8 +8,8 @@ import { SchemasNode } from '../eventSchemas/explorer/schemasNode'
 import { CloudFormationNode } from '../lambda/explorer/cloudFormationNodes'
 import { LambdaNode } from '../lambda/explorer/lambdaNodes'
 import { RegionInfo } from '../shared/regions/regionInfo'
+import { RegionProvider } from '../shared/regions/regionProvider'
 import { AWSTreeNodeBase } from '../shared/treeview/nodes/awsTreeNodeBase'
-import { toMap, updateInPlace } from '../shared/utilities/collectionUtils'
 
 /**
  * An AWS Explorer node representing a region.
@@ -18,9 +18,7 @@ import { toMap, updateInPlace } from '../shared/utilities/collectionUtils'
  */
 export class RegionNode extends AWSTreeNodeBase {
     private info: RegionInfo
-    private readonly cloudFormationNode: CloudFormationNode
-    private readonly lambdaNode: LambdaNode
-    private readonly schemasNode: SchemasNode
+    private readonly childNodes: AWSTreeNodeBase[] = []
 
     public get regionCode(): string {
         return this.info.regionCode
@@ -30,43 +28,32 @@ export class RegionNode extends AWSTreeNodeBase {
         return this.info.regionName
     }
 
-    public constructor(info: RegionInfo) {
+    public constructor(info: RegionInfo, regionProvider: RegionProvider) {
         super(info.regionName, TreeItemCollapsibleState.Expanded)
         this.contextValue = 'awsRegionNode'
         this.info = info
         this.update(info)
 
-        this.cloudFormationNode = new CloudFormationNode(this.regionCode)
-        this.lambdaNode = new LambdaNode(this.regionCode)
-        this.schemasNode = new SchemasNode(this.regionCode)
+        if (regionProvider.isServiceInRegion('cloudformation', info.regionCode)) {
+            this.childNodes.push(new CloudFormationNode(this.regionCode))
+        }
+
+        if (regionProvider.isServiceInRegion('lambda', info.regionCode)) {
+            this.childNodes.push(new LambdaNode(this.regionCode))
+        }
+
+        if (regionProvider.isServiceInRegion('schemas', info.regionCode)) {
+            this.childNodes.push(new SchemasNode(this.regionCode))
+        }
     }
 
     public async getChildren(): Promise<AWSTreeNodeBase[]> {
-        return [this.cloudFormationNode, this.lambdaNode, this.schemasNode]
+        return this.childNodes
     }
 
     public update(info: RegionInfo): void {
         this.info = info
         this.label = info.regionName
         this.tooltip = `${info.regionName} [${info.regionCode}]`
-    }
-}
-
-export class RegionNodeCollection {
-    private readonly regionNodes: Map<string, RegionNode>
-
-    public constructor() {
-        this.regionNodes = new Map<string, RegionNode>()
-    }
-
-    public async updateChildren(regionDefinitions: RegionInfo[]): Promise<void> {
-        const regionMap = toMap(regionDefinitions, r => r.regionCode)
-
-        updateInPlace(
-            this.regionNodes,
-            regionMap.keys(),
-            key => this.regionNodes.get(key)!.update(regionMap.get(key)!),
-            key => new RegionNode(regionMap.get(key)!)
-        )
     }
 }

--- a/src/shared/regions/regionProvider.ts
+++ b/src/shared/regions/regionProvider.ts
@@ -11,4 +11,5 @@ export interface RegionProvider {
     onRegionProviderUpdated: vscode.Event<void>
 
     getRegionData(): Promise<RegionInfo[]>
+    isServiceInRegion(serviceId: string, regionId: string): boolean
 }

--- a/src/test/awsExplorer/regionNode.test.ts
+++ b/src/test/awsExplorer/regionNode.test.ts
@@ -5,11 +5,13 @@
 
 import * as assert from 'assert'
 import { RegionNode } from '../../awsexplorer/regionNode'
+import { SchemasNode } from '../../eventSchemas/explorer/schemasNode'
+import { DEFAULT_TEST_REGION_CODE, DEFAULT_TEST_REGION_NAME, FakeRegionProvider } from '../utilities/fakeAwsContext'
 
 describe('RegionNode', () => {
-    const regionCode = 'us-east-1'
-    const regionName = 'US East (N. Virginia)'
-    const testNode = new RegionNode({ regionCode, regionName })
+    const regionCode = DEFAULT_TEST_REGION_CODE
+    const regionName = DEFAULT_TEST_REGION_NAME
+    const testNode = new RegionNode({ regionCode, regionName }, new FakeRegionProvider())
 
     it('initializes name and tooltip', async () => {
         assert.strictEqual(testNode.label, regionName)
@@ -19,5 +21,17 @@ describe('RegionNode', () => {
     it('contains children', async () => {
         const childNodes = await testNode.getChildren()
         assert.ok(childNodes.length > 0, 'Expected region node to have child nodes')
+    })
+
+    it('does not have child nodes for services not available in a region', async () => {
+        const regionProvider = new FakeRegionProvider()
+        regionProvider.servicesNotInRegion.push('schemas')
+        const regionNode = new RegionNode({ regionCode, regionName }, regionProvider)
+
+        const childNodes = await regionNode.getChildren()
+        assert.ok(
+            childNodes.filter(node => node instanceof SchemasNode).length === 0,
+            'Expected Schemas node to be absent from child nodes'
+        )
     })
 })

--- a/src/test/utilities/fakeAwsContext.ts
+++ b/src/test/utilities/fakeAwsContext.ts
@@ -17,6 +17,7 @@ export const DEFAULT_TEST_REGION_NAME = 'The Querty Region'
 export class FakeRegionProvider implements RegionProvider {
     public readonly onRegionProviderUpdatedEmitter: vscode.EventEmitter<void> = new vscode.EventEmitter<void>()
     public readonly onRegionProviderUpdated: vscode.Event<void> = this.onRegionProviderUpdatedEmitter.event
+    public readonly servicesNotInRegion: string[] = []
 
     public async getRegionData(): Promise<RegionInfo[]> {
         return [
@@ -25,6 +26,10 @@ export class FakeRegionProvider implements RegionProvider {
                 regionName: DEFAULT_TEST_REGION_NAME
             }
         ]
+    }
+
+    public isServiceInRegion(serviceId: string, regionId: string): boolean {
+        return this.servicesNotInRegion.indexOf(serviceId) === -1
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

With this change, the AWS Explorer only displays service nodes that are available within a Region.

Fixes #850 , where Schema nodes were shown in all regions, but is currently only available in select regions.

## Testing

* Opened AWS Explorer, verified that Schema node appears in Virginia, but not in Canada (examples at this time of where the service is and is not available)

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/39839589/72643014-959d3280-3922-11ea-8cc4-d693c5a6293e.png)


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
