### PR TITLE
Added titles to show/hide region picker

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -141,6 +141,8 @@
     "AWS.message.prompt.credentials.definition.tryAgain": "The credentials do not appear to be valid. Check the AWS Toolkit Logs for details. Would you like to try again?",
     "AWS.message.prompt.selectLocalLambda.placeholder": "Select a lambda function",
     "AWS.message.prompt.quickStart.toastMessage": "You are now using the AWS Toolkit for Visual Studio Code, version {0}",
+    "AWS.message.prompt.region.hide.title": "Select a region to hide from the AWS Explorer",
+    "AWS.message.prompt.region.show.title": "Select a region to show in the AWS Explorer",
     "AWS.output.building.sam.application": "Building SAM Application...",
     "AWS.output.building.sam.application.complete": "Build complete.",
     "AWS.output.sam.local.attaching": "Attaching debugger to SAM Application...",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added titles to the pickers to show and hide regions, to better clarify the the prompt.

Was (is it hide or show???): 
![image](https://user-images.githubusercontent.com/39839589/72743676-68fc4b80-3bac-11ea-9ea9-e1b143f10355.png)

Now (Hide):
![image](https://user-images.githubusercontent.com/39839589/72743637-5b46c600-3bac-11ea-99a1-a45d1b784080.png)

Now (Show): 
![image](https://user-images.githubusercontent.com/39839589/72743660-64d02e00-3bac-11ea-8a56-886f317ce834.png)



## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
