### PR TITLE
Fix for missing json validation on local debug configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -447,7 +447,7 @@
         "jsonValidation": [
             {
                 "fileMatch": ".aws/templates.json",
-                "url": "./dist/src/schemas/templates.json"
+                "url": "./dist/src/templates/templates.json"
             },
             {
                 "fileMatch": "*ecs-task-def.json",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Json validation on templates.json (local debug configurations) stopped working when the validation file was moved, but the manifest was not updated. This change restores the validation behavior (intellisense and tooltips).

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
