### PR TITLE
Clean up logger usage

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -156,7 +156,7 @@ export async function activate(context: vscode.ExtensionContext) {
             toolkitSettings
         })
 
-        toastNewUser(context, getLogger())
+        toastNewUser(context)
 
         await loginWithMostRecentCredentials(toolkitSettings, loginManager)
     } catch (error) {

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -10,6 +10,7 @@ import * as path from 'path'
 import * as vscode from 'vscode'
 import { ActivationLaunchPath } from '../../shared/activationLaunchPath'
 import { fileExists } from '../../shared/filesystemUtilities'
+import { getLogger } from '../../shared/logger'
 import { getSamCliContext, SamCliContext } from '../../shared/sam/cli/samCliContext'
 import { runSamCliInit, SamCliInitArgs } from '../../shared/sam/cli/samCliInit'
 import { throwAndNotifyIfInvalid } from '../../shared/sam/cli/samCliValidationUtils'
@@ -132,7 +133,7 @@ export async function createNewSamApplication(
         )
 
         const error = err as Error
-        channelLogger.logger.error(error)
+        getLogger().error('Error creating new SAM Application', error)
         results.result = 'fail'
         results.reason = 'error'
 

--- a/src/lambda/commands/deploySamApplication.ts
+++ b/src/lambda/commands/deploySamApplication.ts
@@ -11,6 +11,7 @@ import * as nls from 'vscode-nls'
 import { asEnvironmentVariables } from '../../credentials/credentialsUtilities'
 import { AwsContext, NoActiveCredentialError } from '../../shared/awsContext'
 import { makeTemporaryToolkitFolder } from '../../shared/filesystemUtilities'
+import { getLogger } from '../../shared/logger'
 import { SamCliBuildInvocation } from '../../shared/sam/cli/samCliBuild'
 import { getSamCliContext, SamCliContext } from '../../shared/sam/cli/samCliContext'
 import { runSamCliDeploy } from '../../shared/sam/cli/samCliDeploy'
@@ -201,7 +202,7 @@ async function deployOperation(params: {
         // Handle sam deploy Errors to supplement the error message prior to writing it out
         const error = err as Error
 
-        params.channelLogger.logger.error(error)
+        getLogger().error(error)
 
         const errorMessage = enhanceAwsCloudFormationInstructions(String(err), params.deployParameters)
         params.channelLogger.channel.appendLine(errorMessage)
@@ -263,7 +264,7 @@ function enhanceAwsCloudFormationInstructions(
 }
 
 function outputDeployError(error: Error, channelLogger: ChannelLogger) {
-    channelLogger.logger.error(error)
+    getLogger().error(error)
 
     if (error.message) {
         channelLogger.channel.appendLine(error.message)

--- a/src/lambda/commands/deploySamApplication.ts
+++ b/src/lambda/commands/deploySamApplication.ts
@@ -168,8 +168,7 @@ async function packageOperation(params: {
             region: params.deployParameters.region,
             s3Bucket: params.deployParameters.packageBucketName
         },
-        params.invoker,
-        params.channelLogger.logger
+        params.invoker
     )
 }
 
@@ -195,8 +194,7 @@ async function deployOperation(params: {
                 region: params.deployParameters.region,
                 stackName: params.deployParameters.destinationStackName
             },
-            params.invoker,
-            params.channelLogger.logger
+            params.invoker
         )
     } catch (err) {
         // Handle sam deploy Errors to supplement the error message prior to writing it out

--- a/src/shared/codelens/localLambdaRunner.ts
+++ b/src/shared/codelens/localLambdaRunner.ts
@@ -25,7 +25,7 @@ import { writeFile } from 'fs-extra'
 import { generateDefaultHandlerConfig, HandlerConfig } from '../../lambda/config/templates'
 import { DebugConfiguration } from '../../lambda/local/debugConfiguration'
 import { getFamily, RuntimeFamily } from '../../lambda/models/samLambdaRuntime'
-import { getLogger, Logger } from '../logger'
+import { getLogger } from '../logger'
 import { TelemetryService } from '../telemetry/telemetryService'
 import { normalizeSeparator } from '../utilities/pathUtils'
 import { Timeout } from '../utilities/timeoutUtils'
@@ -480,7 +480,7 @@ export interface AttachDebuggerContext {
     debugConfig: DebugConfiguration
     maxRetries: number
     retryDelayMillis?: number
-    channelLogger: Pick<ChannelLogger, 'info' | 'error' | 'logger'>
+    channelLogger: Pick<ChannelLogger, 'info' | 'error'>
     onStartDebugging?: typeof vscode.debug.startDebugging
     onRecordAttachDebuggerMetric?(attachResult: boolean | undefined, attempts: number): void
     onWillRetry?(): Promise<void>

--- a/src/shared/codelens/localLambdaRunner.ts
+++ b/src/shared/codelens/localLambdaRunner.ts
@@ -220,9 +220,7 @@ export class LocalLambdaRunner {
             })
 
             if (attachResults.success) {
-                await showDebugConsole({
-                    logger: this.channelLogger.logger
-                })
+                await showDebugConsole()
             }
         }
     }
@@ -386,7 +384,7 @@ export async function invokeLambdaFunction(
         'AWS.output.starting.sam.app.locally',
         'Starting the SAM Application locally (see Terminal for output)'
     )
-    channelLogger.logger.debug(`localLambdaRunner.invokeLambdaFunction: ${JSON.stringify(invokeArgs, undefined, 2)}`)
+    getLogger().debug(`localLambdaRunner.invokeLambdaFunction: ${JSON.stringify(invokeArgs, undefined, 2)}`)
 
     const eventPath: string = path.join(invokeArgs.baseBuildDir, 'event.json')
     const environmentVariablePath = path.join(invokeArgs.baseBuildDir, 'env-vars.json')
@@ -442,9 +440,7 @@ export async function invokeLambdaFunction(
         })
 
         if (attachResults.success) {
-            await showDebugConsole({
-                logger: channelLogger.logger
-            })
+            await showDebugConsole()
         }
     }
 }
@@ -501,8 +497,7 @@ export async function attachDebugger({
     ...params
 }: AttachDebuggerContext): Promise<{ success: boolean }> {
     const channelLogger = params.channelLogger
-    const logger = params.channelLogger.logger
-    logger.debug(
+    getLogger().debug(
         `localLambdaRunner.attachDebugger: startDebugging with debugConfig: ${JSON.stringify(
             params.debugConfig,
             undefined,
@@ -636,18 +631,12 @@ function createInvokeTimer(configuration: SettingsConfiguration): Timeout {
  * If the OutputChannel is showing, focus does not consistently switch over to the debug console, so we're
  * helping make this happen.
  */
-async function showDebugConsole({
-    executeVsCodeCommand = vscode.commands.executeCommand,
-    ...params
-}: {
-    executeVsCodeCommand?: typeof vscode.commands.executeCommand
-    logger: Logger
-}): Promise<void> {
+async function showDebugConsole(): Promise<void> {
     try {
-        await executeVsCodeCommand('workbench.debug.action.toggleRepl')
+        await vscode.commands.executeCommand('workbench.debug.action.toggleRepl')
     } catch (err) {
         // in case the vs code command changes or misbehaves, swallow error
-        params.logger.verbose('Unable to switch to the Debug Console', err as Error)
+        getLogger().verbose('Unable to switch to the Debug Console', err as Error)
     }
 }
 

--- a/src/shared/extensionUtilities.ts
+++ b/src/shared/extensionUtilities.ts
@@ -11,7 +11,7 @@ import { ScriptResource } from '../lambda/models/scriptResource'
 import { ext } from '../shared/extensionGlobals'
 import { mostRecentVersionKey, pluginVersion } from './constants'
 import { readFileAsString } from './filesystemUtilities'
-import { Logger } from './logger'
+import { getLogger } from './logger'
 
 const localize = nls.loadMessageBundle()
 
@@ -189,7 +189,7 @@ async function promptQuickStart(): Promise<void> {
  *
  * @param context VS Code Extension Context
  */
-export function toastNewUser(context: vscode.ExtensionContext, logger: Logger): void {
+export function toastNewUser(context: vscode.ExtensionContext): void {
     try {
         if (isDifferentVersion(context)) {
             setMostRecentVersion(context)
@@ -199,6 +199,6 @@ export function toastNewUser(context: vscode.ExtensionContext, logger: Logger): 
         }
     } catch (err) {
         // swallow error and don't block extension load
-        logger.error(err as Error)
+        getLogger().error(err as Error)
     }
 }

--- a/src/shared/sam/cli/samCliDeploy.ts
+++ b/src/shared/sam/cli/samCliDeploy.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getLogger, Logger } from '../../logger'
 import { map } from '../../utilities/collectionUtils'
 import { logAndThrowIfUnexpectedExitCode, SamCliProcessInvoker } from './samCliInvokerUtils'
 
@@ -17,8 +16,7 @@ export interface SamCliDeployParameters {
 
 export async function runSamCliDeploy(
     deployArguments: SamCliDeployParameters,
-    invoker: SamCliProcessInvoker,
-    logger: Logger = getLogger()
+    invoker: SamCliProcessInvoker
 ): Promise<void> {
     const args = [
         'deploy',
@@ -41,5 +39,5 @@ export async function runSamCliDeploy(
         spawnOptions: { env: deployArguments.environmentVariables }
     })
 
-    logAndThrowIfUnexpectedExitCode(childProcessResult, 0, logger)
+    logAndThrowIfUnexpectedExitCode(childProcessResult, 0)
 }

--- a/src/shared/sam/cli/samCliInvokerUtils.ts
+++ b/src/shared/sam/cli/samCliInvokerUtils.ts
@@ -4,7 +4,7 @@
  */
 
 import { SpawnOptions } from 'child_process'
-import { getLogger, Logger } from '../../logger'
+import { getLogger } from '../../logger'
 import { ChildProcessResult } from '../../utilities/childProcess'
 
 export interface SamCliProcessInvokeOptions {
@@ -27,14 +27,12 @@ export interface SamCliProcessInvoker {
     invoke(options?: SamCliProcessInvokeOptions): Promise<ChildProcessResult>
 }
 
-export function logAndThrowIfUnexpectedExitCode(
-    processResult: ChildProcessResult,
-    expectedExitCode: number,
-    logger: Logger = getLogger()
-): void {
+export function logAndThrowIfUnexpectedExitCode(processResult: ChildProcessResult, expectedExitCode: number): void {
     if (processResult.exitCode === expectedExitCode) {
         return
     }
+
+    const logger = getLogger()
 
     logger.error(`Unexpected exitcode (${processResult.exitCode}), expecting (${expectedExitCode})`)
     logger.error(`Error: ${processResult.error}`)

--- a/src/shared/sam/cli/samCliPackage.ts
+++ b/src/shared/sam/cli/samCliPackage.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getLogger, Logger } from '../../logger'
 import { logAndThrowIfUnexpectedExitCode, SamCliProcessInvoker } from './samCliInvokerUtils'
 
 export interface SamCliPackageParameters {
@@ -22,8 +21,7 @@ export interface SamCliPackageParameters {
 
 export async function runSamCliPackage(
     packageArguments: SamCliPackageParameters,
-    invoker: SamCliProcessInvoker,
-    logger: Logger = getLogger()
+    invoker: SamCliProcessInvoker
 ): Promise<void> {
     const childProcessResult = await invoker.invoke({
         arguments: [
@@ -42,5 +40,5 @@ export async function runSamCliPackage(
         }
     })
 
-    logAndThrowIfUnexpectedExitCode(childProcessResult, 0, logger)
+    logAndThrowIfUnexpectedExitCode(childProcessResult, 0)
 }

--- a/src/shared/utilities/vsCodeUtils.ts
+++ b/src/shared/utilities/vsCodeUtils.ts
@@ -50,7 +50,6 @@ export function processTemplate<T extends TemplateParams>({
 
 export interface ChannelLogger {
     readonly channel: vscode.OutputChannel
-    readonly logger: Logger
     verbose: TemplateHandler
     debug: TemplateHandler
     info: TemplateHandler

--- a/src/shared/utilities/vsCodeUtils.ts
+++ b/src/shared/utilities/vsCodeUtils.ts
@@ -4,7 +4,7 @@
  */
 import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
-import { getLogger, Loggable, Logger, LogLevel } from '../logger'
+import { getLogger, Loggable, LogLevel } from '../logger'
 
 // TODO: Consider NLS initialization/configuration here & have packages to import localize from here
 export const localize = nls.loadMessageBundle()
@@ -61,7 +61,9 @@ export interface ChannelLogger {
  * Wrapper around normal logger that writes to output channel and normal logs.
  * Avoids making two log statements when writing to output channel and improves consistency
  */
-export function getChannelLogger(channel: vscode.OutputChannel, logger: Logger = getLogger()): ChannelLogger {
+export function getChannelLogger(channel: vscode.OutputChannel): ChannelLogger {
+    const logger = getLogger()
+
     function log({ nlsKey, nlsTemplate, templateTokens, level }: TemplateParams & { level: LogLevel }): void {
         if (level === 'error') {
             channel.show(true)
@@ -75,7 +77,6 @@ export function getChannelLogger(channel: vscode.OutputChannel, logger: Logger =
 
     return Object.freeze({
         channel,
-        logger,
         verbose: (nlsKey: string, nlsTemplate: string, ...templateTokens: Loggable[]) =>
             log({
                 level: 'verbose',

--- a/src/test/lambda/commands/deploySamApplication.test.ts
+++ b/src/test/lambda/commands/deploySamApplication.test.ts
@@ -24,6 +24,7 @@ import {
     SamCliVersionValidation
 } from '../../../shared/sam/cli/samCliValidator'
 import { ChildProcessResult } from '../../../shared/utilities/childProcess'
+import { getTestLogger } from '../../globalSetup.test'
 import { FakeChannelLogger } from '../../shared/fakeChannelLogger'
 import { FakeChildProcessResult, TestSamCliProcessInvoker } from '../../shared/sam/cli/testSamCliProcessInvoker'
 
@@ -241,7 +242,7 @@ describe('deploySamApplication', async () => {
 
         await waitForDeployToComplete()
         assert.strictEqual(invokerCalledCount, 1, 'Unexpected sam cli invoke count')
-        assertErrorLogsContain('broken build', channelLogger, false)
+        assertErrorLogsContain('broken build', false)
         assertGeneralErrorLogged(channelLogger)
     })
 
@@ -273,7 +274,7 @@ describe('deploySamApplication', async () => {
 
         await waitForDeployToComplete()
         assert.strictEqual(invokerCalledCount, 2, 'Unexpected sam cli invoke count')
-        assertErrorLogsContain('broken package', channelLogger, false)
+        assertErrorLogsContain('broken package', false)
         assertGeneralErrorLogged(channelLogger)
     })
 
@@ -305,7 +306,7 @@ describe('deploySamApplication', async () => {
 
         await waitForDeployToComplete()
         assert.strictEqual(invokerCalledCount, 3, 'Unexpected sam cli invoke count')
-        assertErrorLogsContain('broken deploy', channelLogger, false)
+        assertErrorLogsContain('broken deploy', false)
         assertGeneralErrorLogged(channelLogger)
     })
 
@@ -322,9 +323,9 @@ function assertGeneralErrorLogged(channelLogger: FakeChannelLogger) {
     )
 }
 
-function assertErrorLogsContain(text: string, channelLogger: FakeChannelLogger, exactMatch: boolean) {
+function assertErrorLogsContain(text: string, exactMatch: boolean) {
     assert.ok(
-        channelLogger.logger
+        getTestLogger()
             .getLoggedEntries('error')
             .some(e => e instanceof Error && (exactMatch ? e.message === text : e.message.indexOf(text) !== -1)),
         `Expected to find ${text} in the error logs`

--- a/src/test/shared/fakeChannelLogger.ts
+++ b/src/test/shared/fakeChannelLogger.ts
@@ -7,7 +7,6 @@ import * as vscode from 'vscode'
 import { Loggable } from '../../shared/logger'
 import { ChannelLogger } from '../../shared/utilities/vsCodeUtils'
 import { MockOutputChannel } from '../mockOutputChannel'
-import { TestLogger } from '../testLogger'
 
 export class FakeChannelLogger implements ChannelLogger {
     public readonly loggedInfoKeys: Set<string> = new Set<string>()
@@ -15,7 +14,6 @@ export class FakeChannelLogger implements ChannelLogger {
     public readonly loggedDebugKeys: Set<string> = new Set<string>()
     public readonly loggedWarnKeys: Set<string> = new Set<string>()
     public readonly loggedVerboseKeys: Set<string> = new Set<string>()
-    public readonly logger: TestLogger = new TestLogger()
 
     public channel: vscode.OutputChannel = new MockOutputChannel()
 

--- a/src/test/shared/utilities/vsCodeUtils.test.ts
+++ b/src/test/shared/utilities/vsCodeUtils.test.ts
@@ -14,20 +14,9 @@ import {
     TemplateHandler,
     TemplateParams
 } from '../../../shared/utilities/vsCodeUtils'
+import { getTestLogger } from '../../globalSetup.test'
 import { MockOutputChannel } from '../../mockOutputChannel'
 import { TestLogger } from '../../testLogger'
-
-interface TestCaseParams {
-    logLevel: LogLevel
-    testDataCase: TestData
-    expectedPrettyMsg: string
-    expectedPrettyTokens: string[]
-    expectedErrorTokens: Error[]
-}
-
-interface TestRunner {
-    (params: TestCaseParams): Promise<void>
-}
 
 const logLevels: LogLevel[] = ['verbose', 'debug', 'info', 'warn', 'error']
 
@@ -85,118 +74,88 @@ describe('getChannelLogger', function() {
     let outputChannel: MockOutputChannel
     let channelLogger: ChannelLogger
 
-    const runEachTestCase = async (onRunTest: TestRunner) => {
-        for (const logLevel of logLevels) {
-            for (const testDataCase of testData) {
-                // Reset loggers for each test case
-                logger = new TestLogger()
-                outputChannel = new MockOutputChannel()
-                channelLogger = getChannelLogger(outputChannel, logger)
-                console.debug(`         input ${JSON.stringify({ logLevel, ...testDataCase })}`)
-                const expectedPrettyTokens: Exclude<Loggable, Error>[] = []
-                const expectedErrorTokens: Error[] = []
-                if (testDataCase.templateTokens) {
-                    testDataCase.templateTokens.forEach(token => {
-                        if (token instanceof Error) {
-                            expectedPrettyTokens.push(token.message)
-                            expectedErrorTokens.push(token)
-                        } else {
-                            expectedPrettyTokens.push(token)
-                        }
-                    })
-                }
-                const expectedPrettyMsg = localize(
-                    testDataCase.nlsKey,
-                    testDataCase.nlsTemplate,
-                    ...expectedPrettyTokens
-                )
+    beforeEach(async () => {
+        logger = getTestLogger()
+        outputChannel = new MockOutputChannel()
+        channelLogger = getChannelLogger(outputChannel)
+    })
 
-                await onRunTest({
-                    logLevel,
-                    testDataCase,
-                    expectedPrettyMsg,
-                    expectedPrettyTokens,
-                    expectedErrorTokens
+    for (const logLevel of logLevels) {
+        describe(`log level ${logLevel}`, async () => {
+            for (const scenario of testData) {
+                describe(scenario.title, async () => {
+                    const expectedPrettyTokens = getFormattedLoggables(scenario.templateTokens)
+                    const expectedErrorTokens: Error[] = getErrorLoggables(scenario.templateTokens)
+                    const expectedPrettyMsg = localize(scenario.nlsKey, scenario.nlsTemplate, ...expectedPrettyTokens)
+
+                    beforeEach(async () => {
+                        // Log message to channel (eg: calls channelLogger.info(...))
+                        ;((channelLogger as unknown) as { [logLevel: string]: TemplateHandler })[logLevel](
+                            scenario.nlsKey,
+                            scenario.nlsTemplate,
+                            ...(scenario.templateTokens || [])
+                        )
+                    })
+
+                    it('writes to the logger', async () => {
+                        const actualLogEntries = logger.getLoggedEntries(logLevel)
+                        const loggedErrors = actualLogEntries.filter(isLoggableError)
+                        const loggedText = actualLogEntries.filter(x => !isLoggableError(x))
+
+                        assert.strictEqual(loggedText.length, 1, 'Expected to log only one string')
+                        assert.strictEqual(
+                            loggedErrors.length,
+                            expectedErrorTokens.length,
+                            'Unexpected amount of Error objects logged'
+                        )
+                        assert.strictEqual(loggedText[0], expectedPrettyMsg, 'Unexpected formatted message')
+                    })
+
+                    it('writes to the output channel', async () => {
+                        assert(
+                            outputChannel.value.indexOf(expectedPrettyMsg) >= 0,
+                            `channel missing msg: ${expectedPrettyMsg} in ${outputChannel.value}` +
+                                ` input: ${JSON.stringify({ ...scenario, expectedPrettyTokens })}`
+                        )
+                    })
+
+                    it('processTemplate handles this scenario', async () => {
+                        const { prettyMessage: actualPrettyMsg, errors: actualErrorTokens } = processTemplate(scenario)
+
+                        assert.strictEqual(
+                            expectedPrettyMsg,
+                            actualPrettyMsg,
+                            `input: ${JSON.stringify({ ...scenario })}`
+                        )
+                        assert.deepStrictEqual(
+                            expectedErrorTokens,
+                            actualErrorTokens,
+                            `expected error tokens to be ${expectedErrorTokens}, found ${actualErrorTokens}` +
+                                ` input: ${JSON.stringify({ ...scenario })}`
+                        )
+                    })
                 })
             }
-        }
+        })
     }
-
-    const assertCommonLoggerWorks: TestRunner = async ({
-        logLevel,
-        expectedPrettyMsg,
-        expectedPrettyTokens,
-        expectedErrorTokens,
-        testDataCase
-    }: TestCaseParams) => {
-        // Log message to channel
-        ;((channelLogger as unknown) as { [logLevel: string]: TemplateHandler })[logLevel](
-            testDataCase.nlsKey,
-            testDataCase.nlsTemplate,
-            ...(testDataCase.templateTokens || [])
-        )
-        const actualLogEntries = logger.getLoggedEntries(logLevel)
-        const loggedErrors = actualLogEntries.filter(isLoggableError)
-        const loggedText = actualLogEntries.filter(x => !isLoggableError(x))
-
-        assert.strictEqual(loggedText.length, 1, 'Expected to log only one string')
-        assert.strictEqual(loggedErrors.length, expectedErrorTokens.length, 'Unexpected amount of Error objects logged')
-        assert.strictEqual(loggedText[0], expectedPrettyMsg, 'Unexpected formatted message')
-    }
-
-    const assertChannelLoggerWorks: TestRunner = async ({
-        expectedPrettyMsg,
-        expectedPrettyTokens,
-        logLevel,
-        testDataCase
-    }: TestCaseParams) => {
-        // Log message to channel
-        ;((channelLogger as unknown) as { [logLevel: string]: TemplateHandler })[logLevel](
-            testDataCase.nlsKey,
-            testDataCase.nlsTemplate,
-            ...(testDataCase.templateTokens || [])
-        )
-
-        assert(
-            outputChannel.value.indexOf(expectedPrettyMsg) >= 0,
-            `channel missing msg: ${expectedPrettyMsg} in ${outputChannel.value}` +
-                ` input: ${JSON.stringify({ ...testDataCase, expectedPrettyTokens })}`
-        )
-    }
-
-    const assertProcessTemplateWorks: TestRunner = async ({
-        testDataCase,
-        expectedPrettyMsg,
-        expectedErrorTokens
-    }: TestCaseParams) => {
-        const { prettyMessage: actualPrettyMsg, errors: actualErrorTokens } = processTemplate(testDataCase)
-
-        assert(
-            expectedPrettyMsg === actualPrettyMsg,
-            `expected pretty msg to be ${expectedPrettyMsg}, found ${actualPrettyMsg}` +
-                ` input: ${JSON.stringify({ ...testDataCase })}`
-        )
-        assert.deepStrictEqual(
-            expectedErrorTokens,
-            actualErrorTokens,
-            `expected error tokens to be ${expectedErrorTokens}, found ${actualErrorTokens}` +
-                ` input: ${JSON.stringify({ ...testDataCase })}`
-        )
-    }
-
-    it('should log to common logger', async () => {
-        await runEachTestCase(assertCommonLoggerWorks)
-    })
-
-    it('should log to channel logger', async () => {
-        await runEachTestCase(assertChannelLoggerWorks)
-    })
-
-    it('should processTemplate', async () => {
-        await runEachTestCase(assertProcessTemplateWorks)
-    })
 
     it('should expose output channel', async () => {
         assert(channelLogger.channel === outputChannel, 'channelLogger.channel !== outputChannel')
     })
 })
+
+function getErrorLoggables(loggables?: Loggable[]): Error[] {
+    return loggables?.filter(x => x instanceof Error).map(x => x as Error) ?? []
+}
+
+function getFormattedLoggables(loggables?: Loggable[]): Exclude<Loggable, Error>[] {
+    return (
+        loggables?.map(loggable => {
+            if (loggable instanceof Error) {
+                return loggable.message
+            } else {
+                return loggable
+            }
+        }) ?? []
+    )
+}

--- a/src/test/shared/utilities/vsCodeUtils.test.ts
+++ b/src/test/shared/utilities/vsCodeUtils.test.ts
@@ -199,8 +199,4 @@ describe('getChannelLogger', function() {
     it('should expose output channel', async () => {
         assert(channelLogger.channel === outputChannel, 'channelLogger.channel !== outputChannel')
     })
-
-    it('should expose logger', async () => {
-        assert(channelLogger.logger === logger, 'channelLogger.logger !== logger')
-    })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change cleans up some old logger usage:

* removed all instances where a logger is passed around. Loggers should be obtained with `getLogger`
* ChannelLogger no longer exposes a logger. Calling code can get a logger as needed with `getLogger`
* ChannelLogger tests were rearranged so that each scenario is tested in isolation
* removed console log spam produced by ChannelLogger tests

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
