### PR TITLE
Rename Region description field to name

### DIFF
--- a/src/shared/regions/defaultRegionProvider.ts
+++ b/src/shared/regions/defaultRegionProvider.ts
@@ -89,6 +89,6 @@ function getRegionInfo(endpoints: Endpoints, partitionId: string): RegionInfo[] 
 function asRegionInfo(region: Region): RegionInfo {
     return {
         regionCode: region.id,
-        regionName: region.description
+        regionName: region.name
     }
 }

--- a/src/shared/regions/endpoints.ts
+++ b/src/shared/regions/endpoints.ts
@@ -19,8 +19,14 @@ export interface Partition {
 }
 
 export interface Region {
+    /**
+     * Region Code
+     */
     id: string
-    description: string
+    /**
+     * Friendly Name
+     */
+    name: string
 }
 
 export interface Service {
@@ -102,7 +108,7 @@ function convertJsonMap<TIn, TOut>(
 function convertToRegion(id: string, region: ManifestRegion): Region {
     return {
         id: id,
-        description: region.description
+        name: region.description
     }
 }
 

--- a/src/test/shared/regions/defaultRegionProvider.test.ts
+++ b/src/test/shared/regions/defaultRegionProvider.test.ts
@@ -86,7 +86,7 @@ describe('DefaultRegionProvider', async () => {
                         regions: [
                             {
                                 id: regionCode,
-                                description: ''
+                                name: ''
                             }
                         ],
                         services: [

--- a/src/test/shared/regions/endpoints.test.ts
+++ b/src/test/shared/regions/endpoints.test.ts
@@ -84,7 +84,7 @@ describe('loadEndpoints', async () => {
         assert.strictEqual(regions.length, 3, 'Unexpected amount of regions loaded')
         const region = regions[1]
         assert.strictEqual(region.id, 'region2')
-        assert.strictEqual(region.description, 'aws region two')
+        assert.strictEqual(region.name, 'aws region two')
     })
 
     it('loads services', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`Region` had a `description` field, paralleling the endpoints json structure. It isn't as intuitive to develop against, so this change renames it to `name`.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
