### PR TITLE
telemetry: avoid noisy error in logs

### DIFF
--- a/src/shared/telemetry/defaultTelemetryService.ts
+++ b/src/shared/telemetry/defaultTelemetryService.ts
@@ -246,6 +246,11 @@ export class DefaultTelemetryService implements TelemetryService {
 
     private static readEventsFromCache(cachePath: string): TelemetryEvent[] {
         try {
+            if (!fs.existsSync(cachePath)) {
+                getLogger().info(`telemetry cache not found: '${cachePath}'`)
+
+                return []
+            }
             const input = JSON.parse(fs.readFileSync(cachePath, 'utf-8'))
             const events = filterTelemetryCacheEvents(input)
             events.forEach((element: TelemetryEvent) => {


### PR DESCRIPTION
If the file doesn't exist it produces a log message like this, which is just noise:

```
2020-02-20 18:13:52 [ERROR]: Error: ENOENT: no such file or directory, open '/Users/jmkeyes/Library/Application Support/Code/User/globalStorage/amazonwebservices.aws-toolkit-vscode/telemetryCache'
	at Object.openSync (fs.js:447:3)
	at Object.func (electron/js2c/asar.js:138:31)
	at Object.func [as openSync] (electron/js2c/asar.js:138:31)
	at Object.readFileSync (fs.js:349:35)
	at Object.<anonymous> (electron/js2c/asar.js:580:40)
	at Object.readFileSync (electron/js2c/asar.js:580:40)
	at Function.readEventsFromCache (/Volumes/workplace/aws-toolkit-vscode/dist/src/shared/telemetry/defaultTelemetryService.js:226:41)
	at DefaultTelemetryService.<anonymous> (/Volumes/workplace/aws-toolkit-vscode/dist/src/shared/telemetry/defaultTelemetryService.js:50:62)
	at Generator.next (<anonymous>)
	at /Volumes/workplace/aws-toolkit-vscode/dist/src/shared/telemetry/defaultTelemetryService.js:12:71
	at new Promise (<anonymous>)
	at /Volumes/workplace/aws-toolkit-vscode/dist/src/shared/telemetry/defaultTelemetryService.js:8:12
	at DefaultTelemetryService.start (/Volumes/workplace/aws-toolkit-vscode/dist/src/shared/telemetry/defaultTelemetryService.js:49:16)
	at Object.<anonymous> (/Volumes/workplace/aws-toolkit-vscode/dist/src/extension.js:87:52)
	at Generator.next (<anonymous>)
	at fulfilled (/Volumes/workplace/aws-toolkit-vscode/dist/src/extension.js:9:58)
```

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
