### PR TITLE
CI: code-coverage configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+# To validate:
+#   cat codecov.yml | curl --data-binary @- https://codecov.io/validate
+
+codecov:
+  notify:
+    require_ci_to_pass: no
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default:
+        threshold: 1
+    patch:
+      default:
+        threshold: 1
+        only_pulls: true
+    changes: no
+
+comment: off


### PR DESCRIPTION
- Disable the bot comment on PRs.
- Adjust the acceptable threshhold.
- Don't fail PRs if coverage falls by a small amount.
- Overrides the [default yaml](https://docs.codecov.io/docs/codecov-yaml#section-default-yaml)

## Note

- waiting on @aws org owner to approve install request of the codecov GitHub app for this repo and aws-toolkit-vscode repo.
- codecov still posts a comment sometimes, even though we specify `comment: false`. That's just a codecov bug.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
