### PR TITLE
Write test logger output to a file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ There are also some integration tests, which can be run from the Debug pane, or 
 
     npm run integrationTest
 
-Tests will output log output to `./dist/src/test/testLog.log` for debugging
+Tests will output log output to `./.test-reports/testLog.log` for debugging
 
 #### Common Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,12 +59,14 @@ There are also some integration tests, which can be run from the Debug pane, or 
 
     npm run integrationTest
 
+Tests will output log output to `./dist/src/test/testLog.log` for debugging
+
 #### Common Issues
 
-- Consecutive test runs are currently impacted on VS Code v.1.42.0 due to caching issues. See [VS Code issue #90484](https://github.com/microsoft/vscode/issues/90484). (12 February 2020)
-  - Workarounds:
-    - Delete the `CachedData` directory for VS Code (`{path/to/VS/Code/App/Data}/CachedData/`) between tests, specifically the folder corresponding to VS Code 1.42.0 (`ae08d5460b5a45169385ff3fd44208f431992451`)
-    - Target a different version of VS Code for tests by adding the following environment variable: `VSCODE_TEST_VERSION = "1.41.1"`
+-   Consecutive test runs are currently impacted on VS Code v.1.42.0 due to caching issues. See [VS Code issue #90484](https://github.com/microsoft/vscode/issues/90484). (12 February 2020)
+    -   Workarounds:
+        -   Delete the `CachedData` directory for VS Code (`{path/to/VS/Code/App/Data}/CachedData/`) between tests, specifically the folder corresponding to VS Code 1.42.0 (`ae08d5460b5a45169385ff3fd44208f431992451`)
+        -   Target a different version of VS Code for tests by adding the following environment variable: `VSCODE_TEST_VERSION = "1.41.1"`
 
 #### Checking coverage report
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7679,7 +7679,7 @@
         },
         "tunnel": {
             "version": "0.0.4",
-            "resolved": "http://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
             "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
             "dev": true
         },

--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -43,7 +43,6 @@ before(async () => {
 
 beforeEach(async function() {
     // Set every test up so that TestLogger is the logger used by toolkit code
-    // tslint:disable-next-line: no-unsafe-any, no-invalid-this
     testLogger = setupTestLogger()
 })
 
@@ -81,6 +80,6 @@ function teardownTestLogger(testName: string) {
 function writeLogsToFile(testName: string) {
     const entries = testLogger?.getLoggedEntries()
     entries?.unshift(`=== Starting test "${testName}" ===`)
-    entries?.push(`=== Ending test "${testName}" ===\n`)
-    appendFileSync(testLogOutput, `${entries?.join('\n')}\n`, 'utf8')
+    entries?.push(`=== Ending test "${testName}" ===\n\n`)
+    appendFileSync(testLogOutput, entries?.join('\n'), 'utf8')
 }

--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -8,7 +8,7 @@
  */
 
 import * as assert from 'assert'
-import { appendFileSync } from 'fs-extra'
+import { appendFileSync, mkdirpSync } from 'fs-extra'
 import { join } from 'path'
 import { ext } from '../shared/extensionGlobals'
 import { rmrf } from '../shared/filesystem'
@@ -20,16 +20,19 @@ import { FakeExtensionContext } from './fakeExtensionContext'
 import { TestLogger } from './testLogger'
 import { FakeAwsContext } from './utilities/fakeAwsContext'
 
-const testLogOutput = join(__dirname, '../../../.test-reports/testLog.log')
+const testReportDir = join(__dirname, '../../../.test-reports')
+const testLogOutput = join(testReportDir, 'testLog.log')
 
 // Expectation: Tests are not run concurrently
 let testLogger: TestLogger | undefined
 
-// Set up global telemetry client
 before(async () => {
+    // Clean up and set up test logs
     try {
         await rmrf(testLogOutput)
     } catch (e) {}
+    mkdirpSync(testReportDir)
+    // Set up global telemetry client
     const mockContext = new FakeExtensionContext()
     const mockAws = new FakeAwsContext()
     const mockPublisher: TelemetryPublisher = {

--- a/src/test/lambda/commands/deleteLambda.test.ts
+++ b/src/test/lambda/commands/deleteLambda.test.ts
@@ -10,7 +10,7 @@ import { MockLambdaClient } from '../../shared/clients/mockClients'
 
 describe('deleteLambda', async () => {
     it('should do nothing if function name is not provided', async () => {
-        return assertLambdaDeleteWorksWhen({
+        await assertLambdaDeleteWorksWhen({
             // test variables
             functionName: '',
             onConfirm: async () => assert.fail('should not try to confirm w/o function name'),
@@ -22,7 +22,7 @@ describe('deleteLambda', async () => {
     })
 
     it('should delete lambda when confirmed', async () => {
-        return assertLambdaDeleteWorksWhen({
+        await assertLambdaDeleteWorksWhen({
             // test variables
             functionName: 'myFunctionName',
             onConfirm: async () => true,
@@ -34,7 +34,7 @@ describe('deleteLambda', async () => {
     })
 
     it('should not delete lambda when cancelled', async () => {
-        return assertLambdaDeleteWorksWhen({
+        await assertLambdaDeleteWorksWhen({
             // test variables
             functionName: 'myFunctionName',
             onConfirm: async () => false,
@@ -48,7 +48,7 @@ describe('deleteLambda', async () => {
     it('should handles errors gracefully', async () => {
         const errorToThrowDuringDelete = new SyntaxError('Fake error inserted to test error handling')
 
-        return assertLambdaDeleteWorksWhen({
+        await assertLambdaDeleteWorksWhen({
             // test variables
             errorToThrowDuringDelete,
             functionName: 'myFunctionName',

--- a/src/test/shared/systemUtilities.test.ts
+++ b/src/test/shared/systemUtilities.test.ts
@@ -4,12 +4,12 @@
  */
 
 import * as assert from 'assert'
-import * as del from 'del'
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 
 import { EnvironmentVariables } from '../../shared/environmentVariables'
+import { rmrf } from '../../shared/filesystem'
 import { makeTemporaryToolkitFolder } from '../../shared/filesystemUtilities'
 import { SystemUtilities } from '../../shared/systemUtilities'
 
@@ -22,8 +22,8 @@ describe('SystemUtilities', () => {
         tempFolder = await makeTemporaryToolkitFolder()
     })
 
-    after(() => {
-        del.sync([tempFolder], { force: true })
+    after(async () => {
+        await rmrf(tempFolder)
     })
 
     describe('getHomeDirectory', () => {

--- a/src/test/testLogger.ts
+++ b/src/test/testLogger.ts
@@ -3,7 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { appendFileSync } from 'fs-extra'
+import { join } from 'path'
 import { Loggable, Logger, LogLevel } from '../shared/logger'
+
+export const testLogOutput = join(__dirname, 'testLog.log')
 
 /**
  * In-memory Logger implementation suitable for use by tests.
@@ -40,12 +44,17 @@ export class TestLogger implements Logger {
             .map(loggedEntry => loggedEntry.entry)
     }
 
+    public writeLoggedEntriesToFile(entry: Loggable) {
+        appendFileSync(testLogOutput, `${entry}\n`, 'utf8')
+    }
+
     private addLoggedEntries(logLevel: LogLevel, entries: Loggable[]) {
         entries.forEach(entry => {
             this.loggedEntries.push({
                 logLevel,
                 entry
             })
+            this.writeLoggedEntriesToFile(entry)
         })
     }
 }

--- a/src/test/testLogger.ts
+++ b/src/test/testLogger.ts
@@ -3,11 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { appendFileSync } from 'fs-extra'
-import { join } from 'path'
 import { Loggable, Logger, LogLevel } from '../shared/logger'
-
-export const testLogOutput = join(__dirname, '..', '..', '..', '.test-reports', 'testLog.log')
 
 /**
  * In-memory Logger implementation suitable for use by tests.
@@ -44,17 +40,12 @@ export class TestLogger implements Logger {
             .map(loggedEntry => loggedEntry.entry)
     }
 
-    public writeLoggedEntriesToFile(entry: Loggable) {
-        appendFileSync(testLogOutput, `${entry}\n`, 'utf8')
-    }
-
     private addLoggedEntries(logLevel: LogLevel, entries: Loggable[]) {
         entries.forEach(entry => {
             this.loggedEntries.push({
                 logLevel,
                 entry
             })
-            this.writeLoggedEntriesToFile(entry)
         })
     }
 }

--- a/src/test/testLogger.ts
+++ b/src/test/testLogger.ts
@@ -7,7 +7,7 @@ import { appendFileSync } from 'fs-extra'
 import { join } from 'path'
 import { Loggable, Logger, LogLevel } from '../shared/logger'
 
-export const testLogOutput = join(__dirname, 'testLog.log')
+export const testLogOutput = join(__dirname, '..', '..', '..', '.test-reports', 'testLog.log')
 
 /**
  * In-memory Logger implementation suitable for use by tests.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Logs were not getting written to a file during tests which made it harder to debug, write logs to a file now
- example output:
```
...
=== Starting test "getChannelLogger log level error logs with 2 template params: error, error processTemplate handles this scenario" ===
1st Error 'Error zero'; 2nd error: 'Error one'
Error: Error zero
Error: Error one
=== Ending test "getChannelLogger log level error logs with 2 template params: error, error processTemplate handles this scenario" ===

...
```

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
