### PR TITLE
Adding support for CAPABILITY_NAMED_IAM

### DIFF
--- a/.changes/next-release/Bug Fix-10d87a21-1e86-4b17-b0cc-dc6ced1ac5f1.json
+++ b/.changes/next-release/Bug Fix-10d87a21-1e86-4b17-b0cc-dc6ced1ac5f1.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "SAM applications deployed through the toolkit now support IAM resources with custom names"
+}

--- a/src/shared/sam/cli/samCliDeploy.ts
+++ b/src/shared/sam/cli/samCliDeploy.ts
@@ -25,7 +25,7 @@ export async function runSamCliDeploy(
         '--stack-name',
         deployArguments.stackName,
         '--capabilities',
-        'CAPABILITY_IAM',
+        'CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM',
         '--region',
         deployArguments.region
     ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Toolkit now supports `CAPABILITY_NAMED_IAM`: https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html

## Motivation and Context
Fix https://github.com/aws/aws-toolkit-vscode/issues/943

## Related Issue(s)

https://github.com/aws/aws-toolkit-vscode/issues/943

## Testing
Added the following to a CloudFormation template:
```
Resources:
  NamedIam:
    Type: AWS::IAM::Role
    Properties:
      RoleName: 'thisisarole'
      AssumeRolePolicyDocument:
        Version: 2012-10-17
        Statement:
            Effect: Deny
            Principal:
              Service:
                ec2.amazonaws.com
            Action:
                'sts:AssumeRole'
```

Deployed unsuccessfully with the existing toolkit and deployed successfully with my changes. (the error is triggered by the addition of `RoleName: 'thisisarole'`).

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
