### PR TITLE
Fix lagging js CodeLens positions when adding/removing lines above a CodeLens

### DIFF
--- a/.changes/next-release/Bug Fix-f9ca4514-70f4-4ac0-8ed7-06bc56ddfc5b.json
+++ b/.changes/next-release/Bug Fix-f9ca4514-70f4-4ac0-8ed7-06bc56ddfc5b.json
@@ -1,0 +1,4 @@
+{
+    "type": "Bug Fix",
+    "description": "Fix issue where CodeLenses appeared on wrong lines in .js files when adding or removing lines"
+}

--- a/src/shared/codelens/typescriptCodeLensProvider.ts
+++ b/src/shared/codelens/typescriptCodeLensProvider.ts
@@ -84,48 +84,50 @@ export function initialize({
     }
 
     const command = getInvokeCmdKey('javascript')
-    context.subscriptions.push(vscode.commands.registerCommand(command, async (params: LambdaLocalInvokeParams) => {
-        const logger = getLogger()
+    context.subscriptions.push(
+        vscode.commands.registerCommand(command, async (params: LambdaLocalInvokeParams) => {
+            const logger = getLogger()
 
-        const resource = await CloudFormation.getResourceFromTemplate({
-            handlerName: params.handlerName,
-            templatePath: params.samTemplate.fsPath
-        })
-        const lambdaRuntime = CloudFormation.getRuntime(resource)
-        let invokeResult: Result = 'Succeeded'
-        try {
-            if (!nodeJsRuntimes.has(lambdaRuntime)) {
-                invokeResult = 'Failed'
-                logger.error(
-                    `Javascript local invoke on ${params.document.uri.fsPath} encountered` +
-                        ` unsupported runtime ${lambdaRuntime}`
-                )
-
-                vscode.window.showErrorMessage(
-                    localize(
-                        'AWS.samcli.local.invoke.runtime.unsupported',
-                        'Unsupported {0} runtime: {1}',
-                        'javascript',
-                        lambdaRuntime
+            const resource = await CloudFormation.getResourceFromTemplate({
+                handlerName: params.handlerName,
+                templatePath: params.samTemplate.fsPath
+            })
+            const lambdaRuntime = CloudFormation.getRuntime(resource)
+            let invokeResult: Result = 'Succeeded'
+            try {
+                if (!nodeJsRuntimes.has(lambdaRuntime)) {
+                    invokeResult = 'Failed'
+                    logger.error(
+                        `Javascript local invoke on ${params.document.uri.fsPath} encountered` +
+                            ` unsupported runtime ${lambdaRuntime}`
                     )
-                )
-            } else {
-                await invokeLambda({
-                    runtime: lambdaRuntime,
-                    ...params
+
+                    vscode.window.showErrorMessage(
+                        localize(
+                            'AWS.samcli.local.invoke.runtime.unsupported',
+                            'Unsupported {0} runtime: {1}',
+                            'javascript',
+                            lambdaRuntime
+                        )
+                    )
+                } else {
+                    await invokeLambda({
+                        runtime: lambdaRuntime,
+                        ...params
+                    })
+                }
+            } catch (err) {
+                invokeResult = 'Failed'
+                throw err
+            } finally {
+                recordLambdaInvokeLocal({
+                    result: invokeResult,
+                    runtime: lambdaRuntime as Runtime,
+                    debug: params.isDebug
                 })
             }
-        } catch (err) {
-            invokeResult = 'Failed'
-            throw err
-        } finally {
-            recordLambdaInvokeLocal({
-                result: invokeResult,
-                runtime: lambdaRuntime as Runtime,
-                debug: params.isDebug
-            })
-        }
-    }))
+        })
+    )
 }
 
 export function makeTypescriptCodeLensProvider(): vscode.CodeLensProvider {
@@ -134,7 +136,10 @@ export function makeTypescriptCodeLensProvider(): vscode.CodeLensProvider {
             document: vscode.TextDocument,
             token: vscode.CancellationToken
         ): Promise<vscode.CodeLens[]> => {
-            const search: TypescriptLambdaHandlerSearch = new TypescriptLambdaHandlerSearch(document.uri)
+            const search: TypescriptLambdaHandlerSearch = new TypescriptLambdaHandlerSearch(
+                document.uri.fsPath,
+                document.getText()
+            )
             const handlers: LambdaHandlerCandidate[] = await search.findCandidateLambdaHandlers()
 
             // For Javascript CodeLenses, store the complete relative pathed handler name

--- a/src/test/typescriptLambdaHandlerSearch.test.ts
+++ b/src/test/typescriptLambdaHandlerSearch.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert'
 import * as path from 'path'
-import * as vscode from 'vscode'
+import { readFileAsString } from '../shared/filesystemUtilities'
 import { LambdaHandlerCandidate } from '../shared/lambdaHandlerSearch'
 import { TypescriptLambdaHandlerSearch } from '../shared/typescriptLambdaHandlerSearch'
 
@@ -73,7 +73,9 @@ describe('TypescriptLambdaHandlerSearch', () => {
         filename: string,
         expectedHandlerNames: Set<string>
     ): Promise<void> {
-        const search: TypescriptLambdaHandlerSearch = new TypescriptLambdaHandlerSearch(vscode.Uri.file(filename))
+        const fileContents = await readFileAsString(filename)
+
+        const search: TypescriptLambdaHandlerSearch = new TypescriptLambdaHandlerSearch(filename, fileContents)
 
         const handlers: LambdaHandlerCandidate[] = await search.findCandidateLambdaHandlers()
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix for an issue where adding or removing a bunch of newlines before a function declaration in .js files causes CodeLens to position on the wrong lines until the file is saved.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
