### PR TITLE
Added guidance to bug report about the new About AWS Toolkit command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,7 +29,7 @@ Steps to reproduce the behavior:
 **Desktop (please complete the following information):**
 
 <!-- Tip: Use the 'About AWS Toolkit' option from the toolkit dropdown menu
- or 'AWS: About AWS Tooltkit' in the Command Palette. -->
+ or 'AWS: About AWS Toolkit' in the Command Palette. -->
  
 -   OS:
 -   Visual Studio Code Version:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,6 +28,9 @@ Steps to reproduce the behavior:
 
 **Desktop (please complete the following information):**
 
+<!-- Tip: Use the 'About AWS Toolkit' option from the toolkit dropdown menu
+ or 'AWS: About AWS Tooltkit' in the Command Palette. -->
+ 
 -   OS:
 -   Visual Studio Code Version:
 -   AWS Toolkit for Visual Studio Code Version:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a comment to the bug report template in the 'Desktop' section to let users know about the new 'About AWS Toolkit' command/option.

## Motivation and Context
The new feature makes it easier for the user to gather and copy the desktop information.  The intent is to lower the 'cost' of filling out the bug report.  This comment brings awareness to the new option.

## Related Issue(s)
The 'About AWS Toolkit' command was implemented in PR #932 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
