### PR TITLE
activation: auto-connect

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -78,6 +78,8 @@
     "AWS.explorerNode.registry.error": "Error loading registry schema items",
     "AWS.explorerNode.registry.noSchemas": "[No Registry Schemas]",
     "AWS.explorerNode.registry.registryName.Not.Found": "Registry name not found",
+    "AWS.explorerNode.connecting.label": "Connecting...",
+    "AWS.explorerNode.connecting.tooltip": "Connecting...",
     "AWS.explorerNode.signIn": "Connect to AWS...",
     "AWS.explorerNode.signIn.tooltip": "Click here to select credentials for the AWS Toolkit",
     "AWS.lambda.explorerTitle": "Explorer",

--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -39,7 +39,7 @@ export async function activate(activateArguments: {
     awsContextTrees: AwsContextTreeCollection
     regionProvider: RegionProvider
 }): Promise<void> {
-    const awsExplorer = new AwsExplorer(activateArguments.awsContext, activateArguments.regionProvider)
+    const awsExplorer = new AwsExplorer(activateArguments.context, activateArguments.awsContext, activateArguments.regionProvider)
 
     activateArguments.context.subscriptions.push(
         vscode.window.registerTreeDataProvider(awsExplorer.viewProviderId, awsExplorer)

--- a/src/credentials/loginManager.ts
+++ b/src/credentials/loginManager.ts
@@ -27,7 +27,7 @@ export class LoginManager {
      * Establishes a Credentials for the Toolkit to use. Essentially the Toolkit becomes "logged in".
      * If an error occurs while trying to set up and verify these credentials, the Toolkit is "logged out".
      */
-    public async login(credentialsProviderId: CredentialsProviderId): Promise<void> {
+    public async login(credentialsProviderId: CredentialsProviderId): Promise<string> {
         let loginResult: Result = 'Succeeded'
         try {
             const provider = await CredentialsProviderManager.getInstance().getCredentialsProvider(
@@ -56,6 +56,7 @@ export class LoginManager {
                 accountId: accountId,
                 defaultRegion: provider.getDefaultRegion()
             })
+            return storedCredentials.credentials.accessKeyId
         } catch (err) {
             loginResult = 'Failed'
             getLogger().error(
@@ -72,6 +73,7 @@ export class LoginManager {
         } finally {
             recordAwsSetCredentials({ result: loginResult })
         }
+        return ''
     }
 
     /**

--- a/src/credentials/loginManager.ts
+++ b/src/credentials/loginManager.ts
@@ -27,7 +27,7 @@ export class LoginManager {
      * Establishes a Credentials for the Toolkit to use. Essentially the Toolkit becomes "logged in".
      * If an error occurs while trying to set up and verify these credentials, the Toolkit is "logged out".
      */
-    public async login(credentialsProviderId: CredentialsProviderId): Promise<string> {
+    public async login(credentialsProviderId: CredentialsProviderId): Promise<void> {
         let loginResult: Result = 'Succeeded'
         try {
             const provider = await CredentialsProviderManager.getInstance().getCredentialsProvider(
@@ -56,7 +56,6 @@ export class LoginManager {
                 accountId: accountId,
                 defaultRegion: provider.getDefaultRegion()
             })
-            return storedCredentials.credentials.accessKeyId
         } catch (err) {
             loginResult = 'Failed'
             getLogger().error(
@@ -73,7 +72,6 @@ export class LoginManager {
         } finally {
             recordAwsSetCredentials({ result: loginResult })
         }
-        return ''
     }
 
     /**

--- a/src/credentials/providers/credentialsProviderManager.ts
+++ b/src/credentials/providers/credentialsProviderManager.ts
@@ -5,7 +5,7 @@
 
 import { CredentialsProvider } from './credentialsProvider'
 import { CredentialsProviderFactory } from './credentialsProviderFactory'
-import { CredentialsProviderId } from './credentialsProviderId'
+import { CredentialsProviderId, asString } from './credentialsProviderId'
 
 /**
  * Responsible for providing the Toolkit with all available CredentialsProviders.
@@ -24,6 +24,18 @@ export class CredentialsProviderManager {
         }
 
         return providers
+    }
+
+    /**
+     * Returns a map of profile names to credential ids from all credential
+     * sources.
+     */
+    public async getProfiles() {
+        const m: { [key: string]: CredentialsProviderId } = {}
+        for (const o of await this.getAllCredentialsProviders()) {
+            m[asString(o.getCredentialsProviderId())] = o.getCredentialsProviderId()
+        }
+        return m
     }
 
     public async getCredentialsProvider(

--- a/src/credentials/providers/credentialsProviderManager.ts
+++ b/src/credentials/providers/credentialsProviderManager.ts
@@ -5,7 +5,7 @@
 
 import { CredentialsProvider } from './credentialsProvider'
 import { CredentialsProviderFactory } from './credentialsProviderFactory'
-import { CredentialsProviderId, asString } from './credentialsProviderId'
+import { asString, CredentialsProviderId } from './credentialsProviderId'
 
 /**
  * Responsible for providing the Toolkit with all available CredentialsProviders.
@@ -30,11 +30,12 @@ export class CredentialsProviderManager {
      * Returns a map of profile names to credential ids from all credential
      * sources.
      */
-    public async getProfiles() {
+    public async getCredentials(): Promise<{ [key: string]: CredentialsProviderId }> {
         const m: { [key: string]: CredentialsProviderId } = {}
         for (const o of await this.getAllCredentialsProviders()) {
             m[asString(o.getCredentialsProviderId())] = o.getCredentialsProviderId()
         }
+
         return m
     }
 

--- a/src/credentials/providers/sharedCredentialsProviderFactory.ts
+++ b/src/credentials/providers/sharedCredentialsProviderFactory.ts
@@ -56,7 +56,9 @@ export class SharedCredentialsProviderFactory extends BaseCredentialsProviderFac
         this.loadedConfigModificationMillis = await this.getLastModifiedMillis(getConfigFilename())
         await updateAwsSdkLoadConfigEnvironmentVariable()
 
-        for (const profileName of allCredentialProfiles.keys()) {
+        let profileNames = Array.from(allCredentialProfiles.keys())
+        getLogger().verbose(`credentials: found profiles: ${profileNames}`)
+        for (const profileName of profileNames) {
             const provider = new SharedCredentialsProvider(profileName, allCredentialProfiles)
             await this.addProviderIfValid(profileName, provider)
         }

--- a/src/credentials/providers/sharedCredentialsProviderFactory.ts
+++ b/src/credentials/providers/sharedCredentialsProviderFactory.ts
@@ -56,7 +56,7 @@ export class SharedCredentialsProviderFactory extends BaseCredentialsProviderFac
         this.loadedConfigModificationMillis = await this.getLastModifiedMillis(getConfigFilename())
         await updateAwsSdkLoadConfigEnvironmentVariable()
 
-        let profileNames = Array.from(allCredentialProfiles.keys())
+        const profileNames = Array.from(allCredentialProfiles.keys())
         getLogger().verbose(`credentials: found profiles: ${profileNames}`)
         for (const profileName of profileNames) {
             const provider = new SharedCredentialsProvider(profileName, allCredentialProfiles)

--- a/src/shared/defaultAwsContextCommands.ts
+++ b/src/shared/defaultAwsContextCommands.ts
@@ -9,7 +9,7 @@ const localize = nls.loadMessageBundle()
 import { Credentials } from 'aws-sdk'
 import { env, QuickPickItem, Uri, ViewColumn, window } from 'vscode'
 import { LoginManager } from '../credentials/loginManager'
-import { asString, fromString } from '../credentials/providers/credentialsProviderId'
+import { fromString } from '../credentials/providers/credentialsProviderId'
 import { CredentialsProviderManager } from '../credentials/providers/credentialsProviderManager'
 import { AwsContext } from './awsContext'
 import { AwsContextTreeCollection } from './awsContextTreeCollection'
@@ -186,9 +186,8 @@ export class DefaultAWSContextCommands {
 
             return await this.promptAndCreateNewCredentialsFile()
         } else {
-            const profileNames = (
-                await CredentialsProviderManager.getInstance().getAllCredentialsProviders()
-            ).map(provider => asString(provider.getCredentialsProviderId()))
+            const profiles = await CredentialsProviderManager.getInstance().getProfiles()
+            const profileNames = Object.keys(profiles)
 
             // If no credentials were found, the user should be
             // encouraged to define some.

--- a/src/shared/defaultAwsContextCommands.ts
+++ b/src/shared/defaultAwsContextCommands.ts
@@ -186,7 +186,7 @@ export class DefaultAWSContextCommands {
 
             return await this.promptAndCreateNewCredentialsFile()
         } else {
-            const profiles = await CredentialsProviderManager.getInstance().getProfiles()
+            const profiles = await CredentialsProviderManager.getInstance().getCredentials()
             const profileNames = Object.keys(profiles)
 
             // If no credentials were found, the user should be

--- a/src/test/awsExplorer/awsExplorer.test.ts
+++ b/src/test/awsExplorer/awsExplorer.test.ts
@@ -7,12 +7,8 @@ import * as assert from 'assert'
 import * as sinon from 'sinon'
 import { AwsExplorer } from '../../awsexplorer/awsExplorer'
 import { RegionNode } from '../../awsexplorer/regionNode'
-import {
-    DEFAULT_TEST_REGION_CODE,
-    DEFAULT_TEST_REGION_NAME,
-    FakeRegionProvider,
-    makeFakeAwsContextWithPlaceholderIds
-} from '../utilities/fakeAwsContext'
+import { FakeExtensionContext } from '../fakeExtensionContext'
+import { DEFAULT_TEST_REGION_CODE, DEFAULT_TEST_REGION_NAME, FakeRegionProvider, makeFakeAwsContextWithPlaceholderIds } from '../utilities/fakeAwsContext'
 
 describe('AwsExplorer', () => {
     let sandbox: sinon.SinonSandbox
@@ -29,7 +25,8 @@ describe('AwsExplorer', () => {
         const awsContext = makeFakeAwsContextWithPlaceholderIds(({} as any) as AWS.Credentials)
         const regionProvider = new FakeRegionProvider()
 
-        const awsExplorer = new AwsExplorer(awsContext, regionProvider)
+        const fakeContext = new FakeExtensionContext()
+        const awsExplorer = new AwsExplorer(fakeContext, awsContext, regionProvider)
 
         const treeNodes = await awsExplorer.getChildren()
         assert.ok(treeNodes)
@@ -48,7 +45,8 @@ describe('AwsExplorer', () => {
         const awsContext = makeFakeAwsContextWithPlaceholderIds(({} as any) as AWS.Credentials)
         const regionProvider = new FakeRegionProvider()
 
-        const awsExplorer = new AwsExplorer(awsContext, regionProvider)
+        const fakeContext = new FakeExtensionContext()
+        const awsExplorer = new AwsExplorer(fakeContext, awsContext, regionProvider)
 
         const refreshStub = sandbox.stub(awsExplorer, 'refresh')
 

--- a/src/test/credentials/provider/credentialsProviderManager.test.ts
+++ b/src/test/credentials/provider/credentialsProviderManager.test.ts
@@ -56,6 +56,29 @@ describe('CredentialsProviderManager', async () => {
         sut = new CredentialsProviderManager()
     })
 
+    it('getCredentials()', async () => {
+        const factoryA = new TestCredentialsProviderFactory('credentialTypeA', ['one'])
+        const factoryB = new TestCredentialsProviderFactory('credentialTypeB', ['two', 'three'])
+        sut.addProviderFactory(factoryA)
+        sut.addProviderFactory(factoryB)
+
+        const expectedCredentials = {
+          'credentialTypeA:one': {
+            credentialType: 'credentialTypeA',
+            credentialTypeId: 'one',
+          },
+          'credentialTypeB:three': {
+            credentialType: 'credentialTypeB',
+            credentialTypeId: 'three',
+          },
+          'credentialTypeB:two': {
+            credentialType: 'credentialTypeB',
+            credentialTypeId: 'two',
+          }
+        }
+        assert.deepStrictEqual(expectedCredentials, await sut.getCredentials())
+    })
+
     describe('getAllCredentialsProviders', async () => {
         it('returns all providers', async () => {
             const factoryA = new TestCredentialsProviderFactory('credentialTypeA', ['one'])


### PR DESCRIPTION
## Description

1. Auto-connect: If there is exactly one profile, connect to it automatically.
2. Show "Connecting..." message in the AwsExplorer root-node during early init.
    - On init, the AwsExplorer root-node doesn't know yet if we will auto-connect. After attempting auto-connect (`loginWithMostRecentCredentials()`) we can then update the text to "Connect to AWS..." call-to-action.
3. TODO: avoid auto-connect for MFA/SSO.
    - Problem: doesn't look like `getMfaTokenFromUser()` is ever called, and I don't see any conditions that would lead to that.

## Testing

- Manual testing with different forms of `~/.aws/*` 
- Integration tests exercise the `loginWithMostRecentCredentials()` codepath. 
  - TODO: however, we should add explicit testing for all the login scenarios

## Screenshots (if appropriate)

<img width="407" alt="Screen Shot 2020-03-10 at 5 54 12 PM" src="https://user-images.githubusercontent.com/55561878/76371691-43f89f00-62f8-11ea-858f-966c755598af.png">

<img width="336" alt="Screen Shot 2020-03-10 at 6 03 28 PM" src="https://user-images.githubusercontent.com/55561878/76372267-157bc380-62fa-11ea-82c1-fbcb67f3efd3.png">



## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
