### PR TITLE
activation: do not auto-connect MFA credentials

### DIFF
--- a/src/credentials/providers/credentialsProvider.ts
+++ b/src/credentials/providers/credentialsProvider.ts
@@ -10,4 +10,5 @@ export interface CredentialsProvider {
     getDefaultRegion(): string | undefined
     getHashCode(): string
     getCredentials(): Promise<AWS.Credentials>
+    canAutoConnect(): boolean
 }

--- a/src/credentials/providers/credentialsProviderId.ts
+++ b/src/credentials/providers/credentialsProviderId.ts
@@ -10,6 +10,16 @@ export interface CredentialsProviderId {
     readonly credentialTypeId: string
 }
 
+/**
+ * Gets a user-friendly string represention of the given `CredentialsProvider`.
+ *
+ * For use in e.g. the statusbar, selecting profiles in a menu, etc.
+ * Includes information related to the credentials type, as well as
+ * instance-identifying information.
+ *
+ * @param credentialsProviderId  Value to be formatted.
+ *
+ */
 export function asString(credentialsProviderId: CredentialsProviderId): string {
     return [credentialsProviderId.credentialType, credentialsProviderId.credentialTypeId].join(
         CREDENTIALS_PROVIDER_ID_SEPARATOR

--- a/src/credentials/providers/credentialsProviderManager.ts
+++ b/src/credentials/providers/credentialsProviderManager.ts
@@ -27,10 +27,10 @@ export class CredentialsProviderManager {
     }
 
     /**
-     * Returns a map of profile names to credential ids from all credential
-     * sources.
+     * Returns a map of `CredentialsProviderId` "friendly names" to ids, from
+     * all credential sources.
      */
-    public async getCredentials(): Promise<{ [key: string]: CredentialsProviderId }> {
+    public async getCredentialProviderNames(): Promise<{ [key: string]: CredentialsProviderId }> {
         const m: { [key: string]: CredentialsProviderId } = {}
         for (const o of await this.getAllCredentialsProviders()) {
             m[asString(o.getCredentialsProviderId())] = o.getCredentialsProviderId()

--- a/src/credentials/providers/sharedCredentialsProvider.ts
+++ b/src/credentials/providers/sharedCredentialsProvider.ts
@@ -18,7 +18,8 @@ const SHARED_CREDENTIAL_PROPERTIES = {
     CREDENTIAL_PROCESS: 'credential_process',
     REGION: 'region',
     ROLE_ARN: 'role_arn',
-    SOURCE_PROFILE: 'source_profile'
+    SOURCE_PROFILE: 'source_profile',
+    MFA_SERIAL: 'mfa_serial',
 }
 
 /**
@@ -55,6 +56,15 @@ export class SharedCredentialsProvider implements CredentialsProvider {
 
     public getDefaultRegion(): string | undefined {
         return this.profile[SHARED_CREDENTIAL_PROPERTIES.REGION]
+    }
+
+    /**
+     * Decides if the credential is the kind that may be auto-connected at
+     * first use (in particular, credentials that may prompt, such as SSO/MFA,
+     * should _not_ attempt to auto-connect).
+     */
+    public canAutoConnect(): boolean {
+        return !this.hasProfileProperty(SHARED_CREDENTIAL_PROPERTIES.MFA_SERIAL)
     }
 
     /**

--- a/src/shared/defaultAwsContextCommands.ts
+++ b/src/shared/defaultAwsContextCommands.ts
@@ -186,8 +186,8 @@ export class DefaultAWSContextCommands {
 
             return await this.promptAndCreateNewCredentialsFile()
         } else {
-            const profiles = await CredentialsProviderManager.getInstance().getCredentials()
-            const profileNames = Object.keys(profiles)
+            const providerMap = await CredentialsProviderManager.getInstance().getCredentialProviderNames()
+            const profileNames = Object.keys(providerMap)
 
             // If no credentials were found, the user should be
             // encouraged to define some.

--- a/src/test/credentials/provider/credentialsProviderManager.test.ts
+++ b/src/test/credentials/provider/credentialsProviderManager.test.ts
@@ -56,7 +56,7 @@ describe('CredentialsProviderManager', async () => {
         sut = new CredentialsProviderManager()
     })
 
-    it('getCredentials()', async () => {
+    it('getCredentialProviderNames()', async () => {
         const factoryA = new TestCredentialsProviderFactory('credentialTypeA', ['one'])
         const factoryB = new TestCredentialsProviderFactory('credentialTypeB', ['two', 'three'])
         sut.addProviderFactory(factoryA)
@@ -76,7 +76,7 @@ describe('CredentialsProviderManager', async () => {
             credentialTypeId: 'two',
           }
         }
-        assert.deepStrictEqual(expectedCredentials, await sut.getCredentials())
+        assert.deepStrictEqual(expectedCredentials, await sut.getCredentialProviderNames())
     })
 
     describe('getAllCredentialsProviders', async () => {

--- a/src/test/credentials/provider/sharedCredentialsProvider.test.ts
+++ b/src/test/credentials/provider/sharedCredentialsProvider.test.ts
@@ -11,7 +11,7 @@ import { assertThrowsError } from '../../shared/utilities/assertUtils'
 const MISSING_PROPERTIES_FRAGMENT = 'missing properties'
 
 describe('SharedCredentialsProvider', async () => {
-    it('constructor errs if profile does not exist', async () => {
+    it('constructor fails if profile does not exist', async () => {
         await assertThrowsError(async () => {
             // @ts-ignore - sut is unused, we expect the constructor to throw
             const sut = new SharedCredentialsProvider(
@@ -33,7 +33,7 @@ describe('SharedCredentialsProvider', async () => {
         })
     })
 
-    it('retrieves the default region from the profile', async () => {
+    it('gets profile properties', async () => {
         const sut = new SharedCredentialsProvider(
             'default',
             new Map<string, Profile>([
@@ -42,9 +42,10 @@ describe('SharedCredentialsProvider', async () => {
         )
 
         assert.strictEqual(sut.getDefaultRegion(), 'foo')
+        assert.strictEqual(sut.canAutoConnect(), true)
     })
 
-    it('returns undefined if the region does not have a default region', async () => {
+    it('profile properties may be undefined', async () => {
         const sut = new SharedCredentialsProvider(
             'default',
             new Map<string, Profile>([['default', { aws_access_key_id: 'x', aws_secret_access_key: 'y' }]])

--- a/src/test/shared/credentials/loginManager.test.ts
+++ b/src/test/shared/credentials/loginManager.test.ts
@@ -39,7 +39,8 @@ describe('LoginManager', async () => {
             getCredentials: sandbox.stub().resolves(sampleCredentials),
             getCredentialsProviderId: sandbox.stub().returns(sampleCredentialsProviderId),
             getDefaultRegion: sandbox.stub().returns('someRegion'),
-            getHashCode: sandbox.stub().returns('1234')
+            getHashCode: sandbox.stub().returns('1234'),
+            canAutoConnect: sandbox.stub().returns(true),
         }
 
         getAccountIdStub = sandbox.stub(accountId, 'getAccountId')


### PR DESCRIPTION
test case:

1. add to `~/.aws/credentials`:
   ```
   mfa_serial=arn:aws:iam::1234567:mfa/cc2-toolkit-role-assumer
   ```
2. ensure that `…/Code/User/settings.json` has not stored `aws.profile`   from a previous login
3. invoke the Toolkit
4. Toolkit should _not_ auto-connect, because of the presence of `mfa_serial`

todo:
- check for SSO

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
