### PR TITLE
Show CodeLenses for SAM functions in CloudFormation templates

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -98,6 +98,7 @@
     "AWS.command.deleteLambda": "Delete",
     "AWS.command.deleteLambda.confirm": "Are you sure you want to delete lambda function '{0}'?",
     "AWS.command.deleteLambda.error": "There was an error deleting lambda function '{0}'",
+    "AWS.command.addSamDebugConfiguration": "Add Debug Configuration",
     "AWS.command.deploySamApplication": "Deploy SAM Application",
     "AWS.command.aboutToolkit": "About AWS Toolkit",
     "AWS.command.invokeLambda": "Invoke on AWS",

--- a/src/shared/cloudformation/templateSymbolResolver.ts
+++ b/src/shared/cloudformation/templateSymbolResolver.ts
@@ -1,0 +1,74 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { safeLoad } from 'js-yaml'
+import * as _ from 'lodash'
+import * as vscode from 'vscode'
+import { CloudFormation } from './cloudformation'
+
+export interface TemplateFunctionResource {
+    name: string
+    range: vscode.Range
+}
+
+/**
+ * Provides symbols for a TextDocument.
+ */
+export interface TemplateSymbolProvider {
+    getSymbols(document: vscode.TextDocument): Promise<vscode.DocumentSymbol[]>
+    getText(symbol: vscode.DocumentSymbol, document: vscode.TextDocument): string
+}
+
+/**
+ * Parses symbols in a CloudFormation text document.
+ */
+export class TemplateSymbolResolver {
+    public constructor(
+        private readonly document: vscode.TextDocument,
+        private readonly symbolProvider: TemplateSymbolProvider = new DefaultSymbolProvider()
+    ) {}
+
+    /**
+     * Extracts Function resources from the document.
+     */
+    public async getFunctionResources(): Promise<TemplateFunctionResource[]> {
+        const symbols = await this.symbolProvider.getSymbols(this.document)
+
+        const resources = _(symbols).find({ name: 'Resources', kind: vscode.SymbolKind.Module })?.children ?? []
+
+        return _(resources)
+            .filter({ kind: vscode.SymbolKind.Module })
+            .filter(resource => this.isFunctionResource(resource))
+            .map(resource => ({ name: resource.name, range: resource.range }))
+            .value()
+    }
+
+    private isFunctionResource(symbol: vscode.DocumentSymbol) {
+        const typeSymbol = _(symbol.children).find({ name: 'Type', kind: vscode.SymbolKind.String })
+
+        if (!typeSymbol) {
+            return false
+        }
+
+        const parsedSymbol = safeLoad(this.symbolProvider.getText(typeSymbol, this.document)) as { Type: string }
+
+        return parsedSymbol.Type === CloudFormation.SERVERLESS_FUNCTION_TYPE
+    }
+}
+
+class DefaultSymbolProvider implements TemplateSymbolProvider {
+    public async getSymbols(document: vscode.TextDocument): Promise<vscode.DocumentSymbol[]> {
+        const symbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+            'vscode.executeDocumentSymbolProvider',
+            document.uri
+        )
+
+        return symbols ?? []
+    }
+
+    public getText(symbol: vscode.DocumentSymbol, document: vscode.TextDocument): string {
+        return document.getText(symbol.range)
+    }
+}

--- a/src/shared/codelens/samTemplateCodeLensProvider.ts
+++ b/src/shared/codelens/samTemplateCodeLensProvider.ts
@@ -1,0 +1,66 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as _ from 'lodash'
+import * as vscode from 'vscode'
+import { TemplateFunctionResource, TemplateSymbolResolver } from '../cloudformation/templateSymbolResolver'
+import { LaunchConfiguration } from '../debug/launchConfiguration'
+import { isTemplateTargetProperties, TemplateTargetProperties } from '../sam/debugger/awsSamDebugConfiguration'
+import { AddSamDebugConfigurationInput } from '../sam/debugger/commands/addSamDebugConfiguration'
+import { localize } from '../utilities/vsCodeUtils'
+
+/**
+ * Provides Code Lenses for generating debug configurations for SAM templates.
+ */
+export class SamTemplateCodeLensProvider implements vscode.CodeLensProvider {
+    public async provideCodeLenses(
+        document: vscode.TextDocument,
+        token: vscode.CancellationToken,
+        symbolResolver = new TemplateSymbolResolver(document),
+        launchConfig = new LaunchConfiguration(document.uri)
+    ): Promise<vscode.CodeLens[]> {
+        const functionResources = await symbolResolver.getFunctionResources()
+        if (_(functionResources).isEmpty()) {
+            return []
+        }
+
+        const existingDebuggedResources = getExistingDebuggedResources(document.uri, launchConfig)
+
+        return _(functionResources)
+            .reject(functionResource => existingDebuggedResources.has(functionResource.name))
+            .map(functionResource => this.createCodeLens(functionResource, document.uri))
+            .value()
+    }
+
+    private createCodeLens(functionResource: TemplateFunctionResource, templateUri: vscode.Uri): vscode.CodeLens {
+        const input: AddSamDebugConfigurationInput = {
+            resourceName: functionResource.name,
+            templateUri: templateUri,
+        }
+
+        return new vscode.CodeLens(functionResource.range, {
+            title: localize('AWS.command.addSamDebugConfiguration', 'Add Debug Configuration'),
+            command: 'aws.addSamDebugConfiguration',
+            arguments: [input],
+        })
+    }
+}
+
+function getExistingDebuggedResources(templateUri: vscode.Uri, launchConfig: LaunchConfiguration): Set<string> {
+    const existingSamDebugTargets = getExistingSamDebugTargets(launchConfig)
+
+    return _(existingSamDebugTargets)
+        .filter(target => target.samTemplatePath === templateUri.fsPath)
+        .map(target => target.samTemplateResource)
+        .thru(array => new Set(array))
+        .value()
+}
+
+function getExistingSamDebugTargets(launchConfig: LaunchConfiguration): TemplateTargetProperties[] {
+    return _(launchConfig.getSamDebugConfigurations())
+        .map(samConfig => samConfig.invokeTarget)
+        .filter(isTemplateTargetProperties)
+        .value()
+}

--- a/src/shared/codelens/samTemplateCodeLensProvider.ts
+++ b/src/shared/codelens/samTemplateCodeLensProvider.ts
@@ -10,6 +10,7 @@ import { LaunchConfiguration } from '../debug/launchConfiguration'
 import { isTemplateTargetProperties, TemplateTargetProperties } from '../sam/debugger/awsSamDebugConfiguration'
 import { AddSamDebugConfigurationInput } from '../sam/debugger/commands/addSamDebugConfiguration'
 import { localize } from '../utilities/vsCodeUtils'
+import * as pathutils from '../utilities/pathUtils'
 
 /**
  * Provides Code Lenses for generating debug configurations for SAM templates.
@@ -52,7 +53,7 @@ function getExistingDebuggedResources(templateUri: vscode.Uri, launchConfig: Lau
     const existingSamDebugTargets = getExistingSamDebugTargets(launchConfig)
 
     return _(existingSamDebugTargets)
-        .filter(target => target.samTemplatePath === templateUri.fsPath)
+        .filter(target => pathutils.normalize(target.samTemplatePath) === pathutils.normalize(templateUri.fsPath))
         .map(target => target.samTemplateResource)
         .thru(array => new Set(array))
         .value()

--- a/src/shared/debug/launchConfiguration.ts
+++ b/src/shared/debug/launchConfiguration.ts
@@ -1,0 +1,71 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as _ from 'lodash'
+import * as vscode from 'vscode'
+import { AwsSamDebuggerConfiguration, isAwsSamDebugConfiguration } from '../sam/debugger/awsSamDebugConfiguration'
+import {
+    AwsSamDebugConfigurationValidator,
+    DefaultAwsSamDebugConfigurationValidator,
+} from '../sam/debugger/awsSamDebugConfigurationValidator'
+
+/**
+ * Reads and writes DebugConfigurations.
+ */
+export interface DebugConfigurationSource {
+    getDebugConfigurations(): vscode.DebugConfiguration[]
+    setDebugConfigurations(value: vscode.DebugConfiguration[]): Promise<void>
+}
+
+/**
+ * Wraps read and write operations on launch.json.
+ */
+export class LaunchConfiguration {
+    /**
+     * Creates a Launch Configuration scoped to the given resource.
+     */
+    public constructor(
+        resource: vscode.Uri,
+        private readonly configSource: DebugConfigurationSource = new DefaultDebugConfigSource(resource),
+        private readonly samValidator: AwsSamDebugConfigurationValidator = new DefaultAwsSamDebugConfigurationValidator()
+    ) {}
+
+    public getDebugConfigurations(): vscode.DebugConfiguration[] {
+        return this.configSource.getDebugConfigurations()
+    }
+
+    /**
+     * Returns all valid Sam Debug Configurations.
+     */
+    public getSamDebugConfigurations(): AwsSamDebuggerConfiguration[] {
+        return _(this.getDebugConfigurations())
+            .filter(isAwsSamDebugConfiguration)
+            .filter(config => this.samValidator.isValidSamDebugConfiguration(config))
+            .value()
+    }
+
+    /**
+     * Adds a debug configuration to the top of the list.
+     */
+    public async addDebugConfiguration(debugConfig: vscode.DebugConfiguration): Promise<void> {
+        await this.configSource.setDebugConfigurations([debugConfig, ...this.getDebugConfigurations()])
+    }
+}
+
+class DefaultDebugConfigSource implements DebugConfigurationSource {
+    private readonly launch: vscode.WorkspaceConfiguration
+
+    public constructor(resource: vscode.Uri) {
+        this.launch = vscode.workspace.getConfiguration('launch', resource)
+    }
+
+    public getDebugConfigurations(): vscode.DebugConfiguration[] {
+        return this.launch.get<vscode.DebugConfiguration[]>('configurations') ?? []
+    }
+
+    public async setDebugConfigurations(value: vscode.DebugConfiguration[]): Promise<void> {
+        await this.launch.update('configurations', value)
+    }
+}

--- a/src/shared/sam/debugger/awsSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfiguration.ts
@@ -3,4 +3,48 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as vscode from 'vscode'
+import {
+    AwsSamDebuggerConfiguration,
+    CodeTargetProperties,
+    TemplateTargetProperties,
+} from './awsSamDebugConfiguration.gen'
+
 export * from './awsSamDebugConfiguration.gen'
+
+export const AWS_SAM_DEBUG_TYPE = 'aws-sam'
+export const DIRECT_INVOKE_TYPE = 'direct-invoke'
+export const TEMPLATE_TARGET_TYPE: 'template' = 'template'
+export const CODE_TARGET_TYPE: 'code' = 'code'
+export const AWS_SAM_DEBUG_REQUEST_TYPES = [DIRECT_INVOKE_TYPE]
+export const AWS_SAM_DEBUG_TARGET_TYPES = [TEMPLATE_TARGET_TYPE, CODE_TARGET_TYPE]
+
+export type TargetProperties = AwsSamDebuggerConfiguration['invokeTarget']
+
+export function isAwsSamDebugConfiguration(config: vscode.DebugConfiguration): config is AwsSamDebuggerConfiguration {
+    return config.type === AWS_SAM_DEBUG_TYPE
+}
+
+export function isTemplateTargetProperties(props: TargetProperties): props is TemplateTargetProperties {
+    return props.target === TEMPLATE_TARGET_TYPE
+}
+
+export function isCodeTargetProperties(props: TargetProperties): props is CodeTargetProperties {
+    return props.target === CODE_TARGET_TYPE
+}
+
+export function createAwsSamDebugConfigurationForTemplate(
+    resourceName: string,
+    templatePath: string
+): AwsSamDebuggerConfiguration {
+    return {
+        type: AWS_SAM_DEBUG_TYPE,
+        request: DIRECT_INVOKE_TYPE,
+        name: resourceName,
+        invokeTarget: {
+            target: TEMPLATE_TARGET_TYPE,
+            samTemplateResource: resourceName,
+            samTemplatePath: templatePath,
+        },
+    }
+}

--- a/src/shared/sam/debugger/awsSamDebugConfigurationProvider.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfigurationProvider.ts
@@ -1,0 +1,70 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { CloudFormationTemplateRegistry } from '../../cloudformation/templateRegistry'
+
+import { localize } from '../../utilities/vsCodeUtils'
+import { AwsSamDebuggerConfiguration, createAwsSamDebugConfigurationForTemplate } from './awsSamDebugConfiguration'
+import {
+    AwsSamDebugConfigurationValidator,
+    DefaultAwsSamDebugConfigurationValidator,
+} from './awsSamDebugConfigurationValidator'
+import { isInDirectory } from '../../filesystemUtilities'
+
+export class AwsSamDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
+    public constructor(
+        private readonly cftRegistry = CloudFormationTemplateRegistry.getRegistry(),
+        private readonly validator: AwsSamDebugConfigurationValidator = new DefaultAwsSamDebugConfigurationValidator(
+            cftRegistry
+        )
+    ) {}
+
+    public async provideDebugConfigurations(
+        folder: vscode.WorkspaceFolder | undefined,
+        token?: vscode.CancellationToken
+    ): Promise<AwsSamDebuggerConfiguration[] | undefined> {
+        if (folder) {
+            const debugConfigurations: AwsSamDebuggerConfiguration[] = []
+            const folderPath = folder.uri.fsPath
+            const templates = this.cftRegistry.registeredTemplates
+
+            for (const templateDatum of templates) {
+                if (isInDirectory(folderPath, templateDatum.path) && templateDatum.template.Resources) {
+                    for (const resourceKey of Object.keys(templateDatum.template.Resources)) {
+                        const resource = templateDatum.template.Resources[resourceKey]
+                        if (resource) {
+                            debugConfigurations.push(
+                                createAwsSamDebugConfigurationForTemplate(resourceKey, templateDatum.path)
+                            )
+                        }
+                    }
+                }
+            }
+
+            return debugConfigurations
+        }
+    }
+
+    public async resolveDebugConfiguration(
+        folder: vscode.WorkspaceFolder | undefined,
+        debugConfiguration: AwsSamDebuggerConfiguration,
+        token?: vscode.CancellationToken
+    ): Promise<AwsSamDebuggerConfiguration | undefined> {
+        const validationResult = this.validator.validateSamDebugConfiguration(debugConfiguration)
+
+        if (!validationResult.isValid) {
+            if (validationResult.message) {
+                vscode.window.showErrorMessage(validationResult.message)
+            }
+
+            return undefined
+        }
+
+        vscode.window.showInformationMessage(localize('AWS.generic.notImplemented', 'Not implemented'))
+
+        return undefined
+    }
+}

--- a/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
@@ -1,0 +1,180 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { samLambdaRuntimes } from '../../../lambda/models/samLambdaRuntime'
+import { CloudFormation } from '../../cloudformation/cloudformation'
+import { CloudFormationTemplateRegistry } from '../../cloudformation/templateRegistry'
+import { localize } from '../../utilities/vsCodeUtils'
+import {
+    AWS_SAM_DEBUG_REQUEST_TYPES,
+    AWS_SAM_DEBUG_TARGET_TYPES,
+    AwsSamDebuggerConfiguration,
+    CODE_TARGET_TYPE,
+    isCodeTargetProperties,
+    isTemplateTargetProperties,
+    TemplateTargetProperties,
+} from './awsSamDebugConfiguration'
+
+export interface ValidationResult {
+    isValid: boolean
+    message?: string
+}
+
+export interface AwsSamDebugConfigurationValidator {
+    validateSamDebugConfiguration(debugConfiguration: AwsSamDebuggerConfiguration): ValidationResult
+    isValidSamDebugConfiguration(debugConfiguration: AwsSamDebuggerConfiguration): boolean
+}
+
+export class DefaultAwsSamDebugConfigurationValidator implements AwsSamDebugConfigurationValidator {
+    public constructor(private readonly cftRegistry = CloudFormationTemplateRegistry.getRegistry()) {}
+
+    public validateSamDebugConfiguration(debugConfiguration: AwsSamDebuggerConfiguration): ValidationResult {
+        const generalValidationResult = this.generalDebugConfigValidation(debugConfiguration)
+        if (!generalValidationResult.isValid) {
+            return generalValidationResult
+        }
+
+        if (isTemplateTargetProperties(debugConfiguration.invokeTarget)) {
+            return this.templateDebugConfigValidation(debugConfiguration, this.cftRegistry)
+        } else if (isCodeTargetProperties(debugConfiguration.invokeTarget)) {
+            return this.codeDebugConfigValidation(debugConfiguration)
+        }
+
+        return { isValid: false, message: localize('AWS.generic.notImplemented', 'Not implemented') }
+    }
+
+    public isValidSamDebugConfiguration(debugConfiguration: AwsSamDebuggerConfiguration): boolean {
+        return this.validateSamDebugConfiguration(debugConfiguration).isValid
+    }
+
+    private generalDebugConfigValidation(debugConfiguration: AwsSamDebuggerConfiguration): ValidationResult {
+        if (!AWS_SAM_DEBUG_REQUEST_TYPES.includes(debugConfiguration.request)) {
+            return {
+                isValid: false,
+                message: localize(
+                    'AWS.sam.debugger.invalidRequest',
+                    'Debug Configuration has an unsupported request type. Supported types: {0}',
+                    AWS_SAM_DEBUG_REQUEST_TYPES.join(', ')
+                ),
+            }
+        }
+
+        if (!AWS_SAM_DEBUG_TARGET_TYPES.includes(debugConfiguration.invokeTarget.target)) {
+            return {
+                isValid: false,
+                message: localize(
+                    'AWS.sam.debugger.invalidTarget',
+                    'Debug Configuration has an unsupported target type. Supported types: {0}',
+                    AWS_SAM_DEBUG_TARGET_TYPES.join(', ')
+                ),
+            }
+        }
+
+        return { isValid: true }
+    }
+
+    private templateDebugConfigValidation(
+        debugConfiguration: AwsSamDebuggerConfiguration,
+        cftRegistry: CloudFormationTemplateRegistry
+    ): ValidationResult {
+        const templateTarget = debugConfiguration.invokeTarget as TemplateTargetProperties
+
+        const template = cftRegistry.getRegisteredTemplate(templateTarget.samTemplatePath)
+
+        if (!template) {
+            return {
+                isValid: false,
+                message: localize(
+                    'AWS.sam.debugger.missingTemplate',
+                    'Unable to find the Template file {0}',
+                    templateTarget.samTemplatePath
+                ),
+            }
+        }
+
+        const resources = template.template.Resources
+
+        if (!resources || !Object.keys(resources).includes(templateTarget.samTemplateResource)) {
+            return {
+                isValid: false,
+                message: localize(
+                    'AWS.sam.debugger.missingResource',
+                    'Unable to find the Template Resource {0} in Template file {1}',
+                    templateTarget.samTemplateResource,
+                    templateTarget.samTemplatePath
+                ),
+            }
+        }
+
+        const resource = resources[templateTarget.samTemplateResource]
+
+        // TODO: Validate against `AWS::Lambda::Function`?
+        if (resource?.Type !== CloudFormation.SERVERLESS_FUNCTION_TYPE) {
+            return {
+                isValid: false,
+                message: localize(
+                    'AWS.sam.debugger.resourceNotAFunction',
+                    'Template Resource {0} in Template file {1} needs to be of type {2}',
+                    templateTarget.samTemplateResource,
+                    templateTarget.samTemplatePath,
+                    CloudFormation.SERVERLESS_FUNCTION_TYPE
+                ),
+            }
+        }
+
+        if (!resource?.Properties?.Runtime || !samLambdaRuntimes.has(resource?.Properties?.Runtime as string)) {
+            return {
+                isValid: false,
+                message: localize(
+                    'AWS.sam.debugger.unsupportedRuntime',
+                    'Runtime for Template Resource {0} in Template file {1} is either undefined or unsupported.',
+                    templateTarget.samTemplateResource,
+                    templateTarget.samTemplatePath
+                ),
+            }
+        }
+
+        const templateEnv = resource?.Properties.Environment
+        if (templateEnv?.Variables) {
+            const templateEnvVars = Object.keys(templateEnv.Variables)
+            const missingVars: string[] = []
+            if (debugConfiguration.lambda && debugConfiguration.lambda.environmentVariables) {
+                for (const key of Object.keys(debugConfiguration.lambda.environmentVariables)) {
+                    if (!templateEnvVars.includes(key)) {
+                        missingVars.push(key)
+                    }
+                }
+            }
+            if (missingVars.length > 0) {
+                // this check doesn't affect template validity.
+                return {
+                    isValid: true,
+                    message: localize(
+                        'AWS.sam.debugger.extraEnvVars',
+                        'The following environment variables are not found in the targeted template and will not be overridden: {0}',
+                        missingVars.join(', ')
+                    ),
+                }
+            }
+        }
+
+        return { isValid: true }
+    }
+
+    private codeDebugConfigValidation(debugConfiguration: AwsSamDebuggerConfiguration): ValidationResult {
+        if (!debugConfiguration.lambda?.runtime || !samLambdaRuntimes.has(debugConfiguration.lambda.runtime)) {
+            return {
+                isValid: false,
+                message: localize(
+                    'AWS.sam.debugger.missingRuntime',
+                    'Debug Configurations with an invoke target of "{0}" require a valid Lambda runtime value',
+                    CODE_TARGET_TYPE
+                ),
+            }
+        }
+
+        return { isValid: true }
+    }
+}

--- a/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
@@ -1,0 +1,39 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { LaunchConfiguration } from '../../../debug/launchConfiguration'
+import { createAwsSamDebugConfigurationForTemplate } from '../awsSamDebugConfiguration'
+
+export interface AddSamDebugConfigurationInput {
+    resourceName: string
+    templateUri: vscode.Uri
+}
+
+/**
+ * Adds a new debug configuration for the given sam function resource and template.
+ */
+export async function addSamDebugConfiguration({
+    resourceName,
+    templateUri,
+}: AddSamDebugConfigurationInput): Promise<void> {
+    // tslint:disable-next-line: no-floating-promises
+    emitCommandTelemetry()
+
+    const samDebugConfig = createAwsSamDebugConfigurationForTemplate(resourceName, templateUri.fsPath)
+
+    const launchConfig = new LaunchConfiguration(templateUri)
+    await launchConfig.addDebugConfiguration(samDebugConfig)
+
+    await showDebugConfiguration()
+}
+
+async function showDebugConfiguration(): Promise<void> {
+    vscode.commands.executeCommand('workbench.action.debug.configure')
+}
+
+async function emitCommandTelemetry(): Promise<void> {
+    // TODO add new metric for when command is executed
+}

--- a/src/test/shared/cloudformation/cloudformation.test.ts
+++ b/src/test/shared/cloudformation/cloudformation.test.ts
@@ -309,7 +309,7 @@ describe('CloudFormation', () => {
             const resource = createBaseResource()
             const runtime = CloudFormation.getRuntime(resource)
 
-            assert.strictEqual(runtime, 'runtime')
+            assert.strictEqual(runtime, 'nodejs12.x')
         })
     })
 
@@ -332,7 +332,7 @@ describe('CloudFormation', () => {
             const resource = createBaseResource()
             const codeUri = CloudFormation.getCodeUri(resource)
 
-            assert.strictEqual(codeUri, 'codeuri')
+            assert.strictEqual(codeUri, '/')
         })
     })
 })

--- a/src/test/shared/cloudformation/cloudformationTestUtils.ts
+++ b/src/test/shared/cloudformation/cloudformationTestUtils.ts
@@ -25,8 +25,8 @@ export function createBaseResource(): CloudFormation.Resource {
         Type: CloudFormation.SERVERLESS_FUNCTION_TYPE,
         Properties: {
             Handler: 'handler',
-            CodeUri: 'codeuri',
-            Runtime: 'runtime',
+            CodeUri: '/',
+            Runtime: 'nodejs12.x',
             Timeout: 12345,
             Environment: {
                 Variables: {
@@ -48,6 +48,7 @@ export function makeSampleSamTemplateYaml(
         resourceType?: string
         runtime?: string
         handler?: string
+        codeUri?: string
     } = {}
 ): string {
     const globalsYaml = `
@@ -65,6 +66,7 @@ export function makeSampleYamlResource(
         resourceType?: string
         runtime?: string
         handler?: string
+        codeUri?: string
     } = {}
 ): string {
     return `
@@ -72,8 +74,8 @@ export function makeSampleYamlResource(
         Type: ${subValues.resourceType ? subValues.resourceType : CloudFormation.SERVERLESS_FUNCTION_TYPE}
         Properties:
             Handler: ${subValues.handler ? subValues.handler : 'handler'}
-            CodeUri: codeuri
-            Runtime: ${subValues.runtime ? subValues.runtime : 'runtime'}
+            CodeUri: ${subValues.codeUri ? subValues.codeUri : '/'}
+            Runtime: ${subValues.runtime ? subValues.runtime : 'nodejs12.x'}
             Timeout: 12345
             Environment:
                 Variables:

--- a/src/test/shared/cloudformation/templateSymbolResolver.test.ts
+++ b/src/test/shared/cloudformation/templateSymbolResolver.test.ts
@@ -1,0 +1,94 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { instance, mock, when } from 'ts-mockito'
+import * as vscode from 'vscode'
+import {
+    TemplateFunctionResource,
+    TemplateSymbolProvider,
+    TemplateSymbolResolver,
+} from '../../../shared/cloudformation/templateSymbolResolver'
+
+const range = new vscode.Range(0, 0, 0, 0)
+
+const firstFunctionType = string('Type')
+const firstFunction = module('Function1', [firstFunctionType])
+
+const secondFunctionType = string('Type')
+const secondFunction = module('Function2', [secondFunctionType])
+
+const looksLikeFunctionType = string('Type')
+const looksLikeFunction = module('LooksLikeFunction', [looksLikeFunctionType])
+
+const symbols: vscode.DocumentSymbol[] = [
+    module('Globals'),
+    module('Resources', [
+        firstFunction,
+        module('NumberType', [number('Type')]),
+        secondFunction,
+        module('MissingType', [string('Missing')]),
+        module('AnotherResource'),
+        looksLikeFunction,
+    ]),
+]
+
+function module(name: string, children: vscode.DocumentSymbol[] = []) {
+    return symbol(name, vscode.SymbolKind.Module, children)
+}
+
+function string(name: string, children: vscode.DocumentSymbol[] = []) {
+    return symbol(name, vscode.SymbolKind.String, children)
+}
+
+function number(name: string, children: vscode.DocumentSymbol[] = []) {
+    return symbol(name, vscode.SymbolKind.Number, children)
+}
+
+function symbol(name: string, kind: vscode.SymbolKind, children: vscode.DocumentSymbol[] = []) {
+    const newSymbol = new vscode.DocumentSymbol(name, 'detail', kind, range, range)
+    newSymbol.children = children
+
+    return newSymbol
+}
+
+describe('TemplateSymbolResolver', () => {
+    let mockDocument: vscode.TextDocument
+    let document: vscode.TextDocument
+
+    let mockSymbolProvider: TemplateSymbolProvider
+    let symbolProvider: TemplateSymbolProvider
+
+    beforeEach(() => {
+        mockDocument = mock()
+        document = instance(mockDocument)
+
+        mockSymbolProvider = mock()
+        symbolProvider = instance(mockSymbolProvider)
+
+        when(mockSymbolProvider.getSymbols(document)).thenResolve(symbols)
+        when(mockSymbolProvider.getText(firstFunctionType, document)).thenReturn('"Type": "AWS::Serverless::Function"')
+        when(mockSymbolProvider.getText(secondFunctionType, document)).thenReturn('Type: AWS::Serverless::Function')
+        when(mockSymbolProvider.getText(looksLikeFunctionType, document)).thenReturn('Type: NotActuallyAFunction')
+    })
+
+    it('gets function resources', async () => {
+        const symbolResolver = new TemplateSymbolResolver(document, symbolProvider)
+        const functionResources = await symbolResolver.getFunctionResources()
+
+        const expectedResources: TemplateFunctionResource[] = [
+            {
+                name: firstFunction.name,
+                range: firstFunction.range,
+            },
+            {
+                name: secondFunction.name,
+                range: secondFunction.range,
+            },
+        ]
+
+        assert.deepStrictEqual(functionResources, expectedResources)
+    })
+})

--- a/src/test/shared/codelens/samTemplateCodeLensProvider.test.ts
+++ b/src/test/shared/codelens/samTemplateCodeLensProvider.test.ts
@@ -1,0 +1,104 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { instance, mock, when } from 'ts-mockito'
+import * as vscode from 'vscode'
+import { TemplateFunctionResource, TemplateSymbolResolver } from '../../../shared/cloudformation/templateSymbolResolver'
+import { SamTemplateCodeLensProvider } from '../../../shared/codelens/samTemplateCodeLensProvider'
+import { LaunchConfiguration } from '../../../shared/debug/launchConfiguration'
+import { AwsSamDebuggerConfiguration } from '../../../shared/sam/debugger/awsSamDebugConfiguration'
+import { AddSamDebugConfigurationInput } from '../../../shared/sam/debugger/commands/addSamDebugConfiguration'
+
+const range = new vscode.Range(0, 0, 0, 0)
+const functionResources: TemplateFunctionResource[] = [
+    {
+        name: 'existingResource',
+        range: range,
+    },
+    {
+        name: 'newResource',
+        range: range,
+    },
+]
+const debugConfigurations: AwsSamDebuggerConfiguration[] = [
+    {
+        type: 'type',
+        name: 'name',
+        request: 'request',
+        invokeTarget: {
+            target: 'template',
+            samTemplatePath: '/',
+            samTemplateResource: 'existingResource',
+        },
+    },
+    {
+        type: 'type',
+        name: 'name',
+        request: 'request',
+        invokeTarget: {
+            target: 'template',
+            samTemplatePath: '/some/other/template/with/the/same/resource/name',
+            samTemplateResource: 'newResource',
+        },
+    },
+]
+const templateUri = vscode.Uri.file('/')
+
+describe('SamTemplateCodeLensProvider', async () => {
+    const codeLensProvider = new SamTemplateCodeLensProvider()
+
+    let mockDocument: vscode.TextDocument
+    let mockCancellationToken: vscode.CancellationToken
+    let mockSymbolResolver: TemplateSymbolResolver
+    let mockLaunchConfig: LaunchConfiguration
+
+    beforeEach(() => {
+        mockDocument = mock()
+        mockCancellationToken = mock()
+        mockSymbolResolver = mock()
+        mockLaunchConfig = mock()
+
+        when(mockDocument.uri).thenReturn(templateUri)
+        when(mockLaunchConfig.getSamDebugConfigurations()).thenReturn(debugConfigurations)
+    })
+
+    it('provides a code lens for a file with a new resource', async () => {
+        when(mockSymbolResolver.getFunctionResources()).thenResolve(functionResources)
+
+        const codeLenses = await codeLensProvider.provideCodeLenses(
+            instance(mockDocument),
+            instance(mockCancellationToken),
+            instance(mockSymbolResolver),
+            instance(mockLaunchConfig)
+        )
+
+        const expectedInput: AddSamDebugConfigurationInput = {
+            resourceName: 'newResource',
+            templateUri: templateUri,
+        }
+
+        const expectedCodeLens: vscode.CodeLens = new vscode.CodeLens(range, {
+            title: 'Add Debug Configuration',
+            command: 'aws.addSamDebugConfiguration',
+            arguments: [expectedInput],
+        })
+
+        assert.deepStrictEqual(codeLenses, [expectedCodeLens])
+    })
+
+    it('provides no code lenses for a file with no resources', async () => {
+        when(mockSymbolResolver.getFunctionResources()).thenResolve([])
+
+        const codeLenses = await codeLensProvider.provideCodeLenses(
+            instance(mockDocument),
+            instance(mockCancellationToken),
+            instance(mockSymbolResolver),
+            instance(mockLaunchConfig)
+        )
+
+        assert.deepStrictEqual(codeLenses, [])
+    })
+})

--- a/src/test/shared/debug/launchConfiguration.test.ts
+++ b/src/test/shared/debug/launchConfiguration.test.ts
@@ -1,0 +1,79 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { deepEqual, instance, mock, verify, when } from 'ts-mockito'
+import * as vscode from 'vscode'
+import { DebugConfigurationSource, LaunchConfiguration } from '../../../shared/debug/launchConfiguration'
+import { AwsSamDebuggerConfiguration } from '../../../shared/sam/debugger/awsSamDebugConfiguration'
+import { AwsSamDebugConfigurationValidator } from '../../../shared/sam/debugger/awsSamDebugConfigurationValidator'
+
+const samDebugConfiguration: AwsSamDebuggerConfiguration = {
+    type: 'aws-sam',
+    name: 'name',
+    request: 'direct-invoke',
+    invokeTarget: {
+        target: 'template',
+        samTemplatePath: '/',
+        samTemplateResource: 'resource',
+    },
+}
+
+const debugConfigurations: vscode.DebugConfiguration[] = [
+    samDebugConfiguration,
+    {
+        ...samDebugConfiguration,
+        type: 'not-aws-sam',
+    },
+    {
+        ...samDebugConfiguration,
+        request: 'invalid-request',
+    },
+]
+
+const templateUri = vscode.Uri.file('/')
+
+describe('LaunchConfiguration', () => {
+    let mockConfigSource: DebugConfigurationSource
+    let mockSamValidator: AwsSamDebugConfigurationValidator
+
+    beforeEach(() => {
+        mockConfigSource = mock()
+        mockSamValidator = mock()
+
+        when(mockConfigSource.getDebugConfigurations()).thenReturn(debugConfigurations)
+        when(mockSamValidator.isValidSamDebugConfiguration(deepEqual(samDebugConfiguration))).thenReturn(true)
+    })
+
+    it('gets debug configurations', () => {
+        const launchConfig = new LaunchConfiguration(
+            templateUri,
+            instance(mockConfigSource),
+            instance(mockSamValidator)
+        )
+        assert.deepStrictEqual(launchConfig.getDebugConfigurations(), debugConfigurations)
+    })
+
+    it('gets sam debug configurations', () => {
+        const launchConfig = new LaunchConfiguration(
+            templateUri,
+            instance(mockConfigSource),
+            instance(mockSamValidator)
+        )
+        assert.deepStrictEqual(launchConfig.getSamDebugConfigurations(), [samDebugConfiguration])
+    })
+
+    it('adds debug configurations', async () => {
+        const launchConfig = new LaunchConfiguration(
+            templateUri,
+            instance(mockConfigSource),
+            instance(mockSamValidator)
+        )
+        await launchConfig.addDebugConfiguration(samDebugConfiguration)
+
+        const expected = [samDebugConfiguration, ...debugConfigurations]
+        verify(mockConfigSource.setDebugConfigurations(deepEqual(expected))).once()
+    })
+})

--- a/src/test/shared/sam/debugger/awsSamDebugConfigurationProvider.test.ts
+++ b/src/test/shared/sam/debugger/awsSamDebugConfigurationProvider.test.ts
@@ -1,0 +1,173 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import * as path from 'path'
+import * as vscode from 'vscode'
+
+import { CloudFormationTemplateRegistry } from '../../../../shared/cloudformation/templateRegistry'
+import { mkdir, rmrf } from '../../../../shared/filesystem'
+import { makeTemporaryToolkitFolder } from '../../../../shared/filesystemUtilities'
+import {
+    AWS_SAM_DEBUG_TYPE,
+    AwsSamDebuggerConfiguration,
+    CODE_TARGET_TYPE,
+} from '../../../../shared/sam/debugger/awsSamDebugConfiguration'
+import { AwsSamDebugConfigurationProvider } from '../../../../shared/sam/debugger/awsSamDebugConfigurationProvider'
+import {
+    AwsSamDebugConfigurationValidator,
+    ValidationResult,
+} from '../../../../shared/sam/debugger/awsSamDebugConfigurationValidator'
+import {
+    makeSampleSamTemplateYaml,
+    makeSampleYamlResource,
+    strToYamlFile,
+} from '../../cloudformation/cloudformationTestUtils'
+
+class AlwaysValidValidator implements AwsSamDebugConfigurationValidator {
+    public isValidSamDebugConfiguration(debugConfiguration: AwsSamDebuggerConfiguration): boolean {
+        return true
+    }
+
+    public validateSamDebugConfiguration(debugConfiguration: AwsSamDebuggerConfiguration): ValidationResult {
+        return { isValid: true }
+    }
+}
+
+class NeverValidValidator implements AwsSamDebugConfigurationValidator {
+    public isValidSamDebugConfiguration(debugConfiguration: AwsSamDebuggerConfiguration): boolean {
+        return false
+    }
+
+    public validateSamDebugConfiguration(debugConfiguration: AwsSamDebuggerConfiguration): ValidationResult {
+        return { isValid: false, message: 'Always false' }
+    }
+}
+
+// TODO!!!!! Remove all tests prefaced with 'TEMP!!! - '
+describe('AwsSamDebugConfigurationProvider', async () => {
+    const config: AwsSamDebuggerConfiguration = {
+        type: AWS_SAM_DEBUG_TYPE,
+        name: 'whats in a name',
+        request: 'not-direct-invoke',
+        invokeTarget: {
+            target: CODE_TARGET_TYPE,
+            lambdaHandler: 'sick handles',
+            projectRoot: 'root as in beer',
+        },
+    }
+
+    let debugConfigProvider: AwsSamDebugConfigurationProvider
+    let alwaysInvalidDebugConfigProvider: AwsSamDebugConfigurationProvider
+    let registry: CloudFormationTemplateRegistry
+    let tempFolder: string
+    let tempFolderSimilarName: string | undefined
+    let tempFile: vscode.Uri
+    let fakeWorkspaceFolder: vscode.WorkspaceFolder
+
+    beforeEach(async () => {
+        tempFolder = await makeTemporaryToolkitFolder()
+        tempFile = vscode.Uri.file(path.join(tempFolder, 'test.yaml'))
+        registry = new CloudFormationTemplateRegistry()
+        debugConfigProvider = new AwsSamDebugConfigurationProvider(registry, new AlwaysValidValidator())
+        alwaysInvalidDebugConfigProvider = new AwsSamDebugConfigurationProvider(registry, new NeverValidValidator())
+        fakeWorkspaceFolder = {
+            uri: vscode.Uri.file(tempFolder),
+            name: 'It was me, fakeWorkspaceFolder!',
+            index: 0,
+        }
+        tempFolderSimilarName = undefined
+    })
+
+    afterEach(async () => {
+        await rmrf(tempFolder)
+        if (tempFolderSimilarName) {
+            await rmrf(tempFolderSimilarName)
+        }
+    })
+
+    describe('provideDebugConfig', async () => {
+        it('returns undefined if no workspace folder is provided', async () => {
+            const provided = await debugConfigProvider.provideDebugConfigurations(undefined)
+            assert.strictEqual(provided, undefined)
+        })
+
+        it('returns a blank array if no templates are in the workspace', async () => {
+            const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
+            assert.deepStrictEqual(provided, [])
+        })
+
+        it('returns an array with a single item if a template with one resource is in the workspace', async () => {
+            await strToYamlFile(makeSampleSamTemplateYaml(true), tempFile.fsPath)
+            await registry.addTemplateToRegistry(tempFile)
+            const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
+            assert.notStrictEqual(provided, undefined)
+            if (provided) {
+                assert.strictEqual(provided.length, 1)
+                assert.strictEqual(provided[0].name, 'TestResource')
+            }
+        })
+
+        it('returns an array with multiple items if a template with more than one resource is in the workspace', async () => {
+            const resources = ['resource1', 'resource2']
+            const bigYamlStr = `${makeSampleSamTemplateYaml(true, {
+                resourceName: resources[0],
+            })}\n${makeSampleYamlResource({ resourceName: resources[1] })}`
+            await strToYamlFile(bigYamlStr, tempFile.fsPath)
+            await registry.addTemplateToRegistry(tempFile)
+            const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
+            assert.notStrictEqual(provided, undefined)
+            if (provided) {
+                assert.strictEqual(provided.length, 2)
+                assert.ok(resources.includes(provided[0].name))
+                assert.ok(resources.includes(provided[1].name))
+            }
+        })
+
+        it('only detects the specifically targeted workspace folder (and its subfolders)', async () => {
+            const resources = ['resource1', 'resource2']
+            const badResourceName = 'notIt'
+
+            const nestedDir = path.join(tempFolder, 'nested')
+            const nestedYaml = vscode.Uri.file(path.join(nestedDir, 'test.yaml'))
+            tempFolderSimilarName = tempFolder + 'SimilarName'
+            const similarNameYaml = vscode.Uri.file(path.join(tempFolderSimilarName, 'test.yaml'))
+
+            await mkdir(nestedDir)
+            await mkdir(tempFolderSimilarName)
+
+            await strToYamlFile(makeSampleSamTemplateYaml(true, { resourceName: resources[0] }), tempFile.fsPath)
+            await strToYamlFile(makeSampleSamTemplateYaml(true, { resourceName: resources[1] }), nestedYaml.fsPath)
+            await strToYamlFile(
+                makeSampleSamTemplateYaml(true, { resourceName: badResourceName }),
+                similarNameYaml.fsPath
+            )
+
+            await registry.addTemplateToRegistry(tempFile)
+            await registry.addTemplateToRegistry(nestedYaml)
+            await registry.addTemplateToRegistry(similarNameYaml)
+
+            const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
+            assert.notStrictEqual(provided, undefined)
+            if (provided) {
+                assert.strictEqual(provided.length, 2)
+                assert.ok(resources.includes(provided[0].name))
+                assert.ok(resources.includes(provided[1].name))
+                assert.ok(!resources.includes(badResourceName))
+            }
+        })
+    })
+
+    describe('resolveDebugConfiguration', async () => {
+        it('TEMP!!! - returns undefined when resolving a valid debug configuration', async () => {
+            const resolved = await debugConfigProvider.resolveDebugConfiguration(undefined, config)
+            assert.strictEqual(resolved, undefined)
+        })
+        it('returns undefined when resolving an invalid debug configuration', async () => {
+            const resolved = await alwaysInvalidDebugConfigProvider.resolveDebugConfiguration(undefined, config)
+            assert.strictEqual(resolved, undefined)
+        })
+    })
+})

--- a/src/test/shared/sam/debugger/awsSamDebugConfigurationValidator.test.ts
+++ b/src/test/shared/sam/debugger/awsSamDebugConfigurationValidator.test.ts
@@ -1,0 +1,136 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { instance, mock, when } from 'ts-mockito'
+
+import { CloudFormation } from '../../../../shared/cloudformation/cloudformation'
+import { CloudFormationTemplateRegistry, TemplateDatum } from '../../../../shared/cloudformation/templateRegistry'
+import {
+    AwsSamDebuggerConfiguration,
+    TemplateTargetProperties,
+} from '../../../../shared/sam/debugger/awsSamDebugConfiguration'
+import { DefaultAwsSamDebugConfigurationValidator } from '../../../../shared/sam/debugger/awsSamDebugConfigurationValidator'
+import { createBaseTemplate } from '../../cloudformation/cloudformationTestUtils'
+
+function createTemplateConfig(): AwsSamDebuggerConfiguration {
+    return {
+        type: 'aws-sam',
+        name: 'name',
+        request: 'direct-invoke',
+        invokeTarget: {
+            target: 'template',
+            samTemplatePath: '/',
+            samTemplateResource: 'TestResource',
+        },
+    }
+}
+
+function createCodeConfig(): AwsSamDebuggerConfiguration {
+    return {
+        type: 'aws-sam',
+        name: 'name',
+        request: 'direct-invoke',
+        invokeTarget: {
+            target: 'code',
+            lambdaHandler: 'foo',
+            projectRoot: 'bar',
+        },
+    }
+}
+
+function createTemplateData(): TemplateDatum {
+    return {
+        path: '/',
+        template: createBaseTemplate(),
+    }
+}
+
+describe('DefaultAwsSamDebugConfigurationValidator', () => {
+    const templateConfig = createTemplateConfig()
+    const codeConfig = createCodeConfig()
+    const templateData = createTemplateData()
+
+    const mockRegistry: CloudFormationTemplateRegistry = mock()
+
+    let validator: DefaultAwsSamDebugConfigurationValidator
+
+    beforeEach(() => {
+        when(mockRegistry.getRegisteredTemplate('/')).thenReturn(templateData)
+
+        validator = new DefaultAwsSamDebugConfigurationValidator(instance(mockRegistry))
+    })
+
+    it('returns valid when resolving a valid template debug configuration', () => {
+        const result = validator.validateSamDebugConfiguration(templateConfig)
+        assert.strictEqual(result.isValid, true)
+    })
+
+    it('returns valid when resolving a valid template debug configuration that specifies extraneous environment variables', () => {
+        templateConfig.lambda = {
+            environmentVariables: {
+                EXTRANEOUS: 'envvar',
+            },
+        }
+        const result = validator.validateSamDebugConfiguration(templateConfig)
+        assert.strictEqual(result.isValid, true)
+    })
+
+    it('returns invalid when resolving debug configurations with an invalid request type', () => {
+        templateConfig.request = 'not-direct-invoke'
+
+        const result = validator.validateSamDebugConfiguration(templateConfig)
+        assert.strictEqual(result.isValid, false)
+    })
+
+    it('returns invalid when resolving debug configurations with an invalid target type', () => {
+        templateConfig.invokeTarget.target = 'not-valid' as any
+
+        const result = validator.validateSamDebugConfiguration(templateConfig as any)
+        assert.strictEqual(result.isValid, false)
+    })
+
+    it("returns invalid when resolving template debug configurations with a template that isn't in the registry", () => {
+        const mockEmptyRegistry: CloudFormationTemplateRegistry = mock()
+        when(mockEmptyRegistry.getRegisteredTemplate('/')).thenReturn(undefined)
+
+        validator = new DefaultAwsSamDebugConfigurationValidator(instance(mockEmptyRegistry))
+
+        const result = validator.validateSamDebugConfiguration(templateConfig)
+        assert.strictEqual(result.isValid, false)
+    })
+
+    it("returns invalid when resolving template debug configurations with a template that doesn't have the set resource", () => {
+        const target = templateConfig.invokeTarget as TemplateTargetProperties
+        target.samTemplateResource = 'wrong'
+
+        const result = validator.validateSamDebugConfiguration(templateConfig)
+        assert.strictEqual(result.isValid, false)
+    })
+
+    it("returns invalid when resolving template debug configurations with a template that isn't serverless", () => {
+        const target = templateConfig.invokeTarget as TemplateTargetProperties
+        target.samTemplateResource = 'OtherResource'
+
+        const result = validator.validateSamDebugConfiguration(templateConfig)
+        assert.strictEqual(result.isValid, false)
+    })
+
+    it('returns undefined when resolving template debug configurations with a resource that has an invalid runtime in template', () => {
+        const properties = templateData.template.Resources?.TestResource
+            ?.Properties as CloudFormation.ResourceProperties
+        properties.Runtime = 'invalid'
+
+        const result = validator.validateSamDebugConfiguration(templateConfig)
+        assert.strictEqual(result.isValid, false)
+    })
+
+    it('returns invalid when resolving code debug configurations with invalid runtimes', () => {
+        codeConfig.lambda = { runtime: 'asd' }
+
+        const result = validator.validateSamDebugConfiguration(codeConfig)
+        assert.strictEqual(result.isValid, false)
+    })
+})

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -370,6 +370,7 @@ describe('AwsSamDebugConfigurationProvider', async () => {
                     resourceName: resourceName,
                     runtime: validRuntime,
                     handler: 'my.test.handler',
+                    codeUri: 'codeuri',
                 }),
                 tempFile.fsPath
             )
@@ -531,6 +532,7 @@ describe('AwsSamDebugConfigurationProvider', async () => {
                     resourceName: resourceName,
                     runtime: validRuntime,
                     handler: 'my.test.handler',
+                    codeUri: 'codeuri',
                 }),
                 tempFile.fsPath
             )


### PR DESCRIPTION
## Description

Register CodeLensProvider for SAM templates

 - Files must match the pattern *template.{yml/yaml/json}
 - For yaml, the yaml extension from RedHat must be installed

Show CodeLenses above Functions

 - Text is 'Add Debug Config'
 - Doesn't show if a config already exists in launch.json

Register `aws.addSamDebugConfiguration` command

 - Appends config to top of launch.json and opens in

Note: Telemetry and AWS::Lambda::Function are TODO

<!--- Describe your changes in detail -->

## Motivation and Context

This makes it easier to configure local debugging for SAM functions

## Related Issue(s)

[Design doc](https://github.com/aws/aws-toolkit-vscode/blob/master/designs/sam-debugging/local-sam-debugging.md)

## Testing

Unit tests for all changes.

## Screenshots (if appropriate)

![Codelens](https://user-images.githubusercontent.com/1410453/77486816-f139df80-6ded-11ea-8f5c-52ca66f04868.gif)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
