### PR TITLE
Workaround weird env behavior during testing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,7 +36,8 @@
                 "--extensionTestsPath=${workspaceFolder}/dist/src/test/index.js"
             ],
             "env": {
-                "TEST_REPORT_DIR": "${workspaceFolder}/.test-reports"
+                "TEST_REPORT_DIR": "${workspaceFolder}/.test-reports",
+                "TEST_FILE": null
             },
             "outFiles": ["${workspaceFolder}/dist/src/test/**/*.js"],
             "preLaunchTask": "npm: watch"
@@ -69,7 +70,8 @@
             ],
             "env": {
                 "AWS_TOOLKIT_IGNORE_WEBPACK_BUNDLE": "true",
-                "TEST_REPORT_DIR": "${workspaceFolder}/.test-reports"
+                "TEST_REPORT_DIR": "${workspaceFolder}/.test-reports",
+                "TEST_FILE": null
             },
             "outFiles": ["${workspaceFolder}/dist/src/integrationTest/**/*.js"],
             "preLaunchTask": "npm: testCompile"

--- a/third-party/test/index.ts
+++ b/third-party/test/index.ts
@@ -119,10 +119,12 @@ function run(testsRoot, clb): any {
     }
 
     // 2020-03-24: Amazon addition.
-    const testFile = process.env["TEST_FILE"]?.replace(/^src\/test\//, "")?.concat('.js')
-
+    // VSCode refuses to unset this value, so it gets set for each task and null is converted to a string
+    const testFile = process.env["TEST_FILE"] === 'null' ? undefined : process.env["TEST_FILE"]
+    const testFilePath = testFile?.replace(/^src\/test\//, "")?.concat('.js')
+    
     // Glob test files
-    glob(testFile ?? "**/**.test.js", { cwd: testsRoot }, (error, files): any => {
+    glob(testFilePath ?? "**/**.test.js", { cwd: testsRoot }, (error, files): any => {
         // END 2020-03-24: Amazon addition.
         if (error) {
             return clb(error);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

VSCode seems to refuse to unset an env var used in the test
Explicitly always passing it and checking for the string 'null'

<!--- Describe your changes in detail -->

## Motivation and Context

Switching between "single test" and "all test" launches creates problems with environment variables that hang around and it's unclear how to unset them.

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
