### PR TITLE
command/createNewSamApp: fix "Name" input step

### DIFF
--- a/src/lambda/wizards/samInitWizard.ts
+++ b/src/lambda/wizards/samInitWizard.ts
@@ -48,7 +48,7 @@ export interface CreateNewSamAppWizardContext {
     promptUserForSchema(currRegion: string, currRegistry: string, currSchema?: string): Promise<string | undefined>
 
     promptUserForLocation(): Promise<vscode.Uri | undefined>
-    promptUserForName(): Promise<string | undefined>
+    promptUserForName(defaultValue: string): Promise<string | undefined>
 
     showOpenDialog(options: vscode.OpenDialogOptions): Thenable<vscode.Uri[] | undefined>
 }
@@ -344,7 +344,7 @@ export class DefaultCreateNewSamAppWizardContext extends WizardContext implement
         return pickerResponse.getUri()
     }
 
-    public async promptUserForName(): Promise<string | undefined> {
+    public async promptUserForName(defaultValue: string): Promise<string | undefined> {
         const inputBox = input.createInputBox({
             options: {
                 title: localize('AWS.samcli.initWizard.name.prompt', 'Enter a name for your new application'),
@@ -352,8 +352,9 @@ export class DefaultCreateNewSamAppWizardContext extends WizardContext implement
             },
             buttons: [this.helpButton, vscode.QuickInputButtons.Back]
         })
+        inputBox.value = defaultValue
 
-        return await input.promptUser({
+        return input.promptUser({
             inputBox: inputBox,
             onValidateInput: (value: string) => {
                 if (!value) {
@@ -482,7 +483,9 @@ export class CreateNewSamAppWizard extends MultiStepWizard<CreateNewSamAppWizard
     }
 
     private readonly NAME: WizardStep = async () => {
-        this.name = await this.context.promptUserForName()
+        this.name = await this.context.promptUserForName(
+            this.name ?? (this.location ? path.basename(this.location.path) : '')
+        )
 
         return this.name ? undefined : this.LOCATION
     }

--- a/src/test/lambda/wizards/samInitWizard.test.ts
+++ b/src/test/lambda/wizards/samInitWizard.test.ts
@@ -175,7 +175,7 @@ class MockCreateNewSamAppWizardContext implements CreateNewSamAppWizardContext {
         }
     }
 
-    public async promptUserForName(): Promise<string | undefined> {
+    public async promptUserForName(defaultValue: string): Promise<string | undefined> {
         return this.getUserInput(this.inputBoxResult, 'inputBoxResult')
     }
 


### PR DESCRIPTION
- Problem: "Create new SAM app" command asks for "app name" in the final step of the wizard, but it just cycles
  - ... because `CreateNewSamAppWizard.name` never gets set
  - ... because promptUserForName() returns value instead of a Promise.
  - Solution: return Promise from promptUserForName().
- Also (unrelated enhancement): pre-populate the "app name" step with  the workspace/folder name.

Test case:

1. invoke the  `Create new SAM Application` command on a new, empty
   folder/workspace.
2. fill out the fields until the final step, which asks for an app name.
3. the wizard loops back to the "location" step instead of completing
   the action.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
