### PR TITLE
Use existing template for template invoke-targets

### DIFF
--- a/src/shared/codelens/localLambdaRunner.ts
+++ b/src/shared/codelens/localLambdaRunner.ts
@@ -191,7 +191,7 @@ export async function executeSamBuild({
 
     const samCliArgs: SamCliBuildInvocationArguments = {
         buildDir: samBuildOutputFolder,
-        baseDir: codeDir,
+        baseDir: path.dirname(inputTemplatePath),
         templatePath: inputTemplatePath,
         invoker: samProcessInvoker,
         manifestPath,
@@ -208,9 +208,7 @@ export async function executeSamBuild({
 /**
  * Prepares and invokes a lambda function via `sam local invoke`.
  */
-export async function invokeLambdaFunction(
-        ctx: ExtContext,
-        config: SamLaunchRequestArgs): Promise<void> {
+export async function invokeLambdaFunction(ctx: ExtContext, config: SamLaunchRequestArgs): Promise<void> {
     ctx.chanLogger.info(
         'AWS.output.starting.sam.app.locally',
         'Starting the SAM Application locally (see Terminal for output)'
@@ -231,10 +229,10 @@ export async function invokeLambdaFunction(
         templatePath: config.samTemplatePath,
         eventPath,
         environmentVariablePath,
-        invoker: config.samLocalInvokeCommand!!,  // ?? new DefaultValidatingSamCliProcessInvoker({})
+        invoker: config.samLocalInvokeCommand!!, // ?? new DefaultValidatingSamCliProcessInvoker({})
         dockerNetwork: config.sam?.dockerNetwork,
         debugPort: config.debugPort?.toString(),
-        debuggerPath: config.debuggerPath,
+        debuggerPath: config.debuggerPath
     }
     const command = new SamCliLocalInvokeInvocation(localInvokeArgs)
 

--- a/src/shared/codelens/typescriptCodeLensProvider.ts
+++ b/src/shared/codelens/typescriptCodeLensProvider.ts
@@ -8,7 +8,14 @@ import { findFileInParentPaths } from '../filesystemUtilities'
 import { LambdaHandlerCandidate } from '../lambdaHandlerSearch'
 import { normalizeSeparator } from '../utilities/pathUtils'
 import { localize } from '../utilities/vsCodeUtils'
-import { executeSamBuild, generateInputTemplate, getHandlerRelativePath, waitForDebugPort, makeBuildDir, invokeLambdaFunction } from './localLambdaRunner'
+import {
+    executeSamBuild,
+    generateInputTemplate,
+    getHandlerRelativePath,
+    waitForDebugPort,
+    makeBuildDir,
+    invokeLambdaFunction
+} from './localLambdaRunner'
 import { ExtContext } from '../extensions'
 import { NodejsDebugConfiguration, assertTargetKind } from '../../lambda/local/debugConfiguration'
 import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../sam/cli/samCliLocalInvoke'
@@ -20,11 +27,7 @@ export async function getSamProjectDirPathForFile(filepath: string): Promise<str
     const packageJsonPath: string | undefined = await findFileInParentPaths(path.dirname(filepath), 'package.json')
     if (!packageJsonPath) {
         throw new Error( // TODO: Do we want to localize errors? This might be confusing if we need to review logs.
-            localize(
-                'AWS.error.sam.local.package_json_not_found',
-                'Cannot find package.json related to: {0}',
-                filepath
-            )
+            localize('AWS.error.sam.local.package_json_not_found', 'Cannot find package.json related to: {0}', filepath)
         )
     }
 
@@ -36,7 +39,10 @@ export async function getSamProjectDirPathForFile(filepath: string): Promise<str
  * @param handlers Handlers to apply relative paths to
  * @param parentDocumentPath Path to the file containing these Lambda Handlers
  */
-export async function decorateHandlerNames(handlers: LambdaHandlerCandidate[], parentDocumentPath: string): Promise<void> {
+export async function decorateHandlerNames(
+    handlers: LambdaHandlerCandidate[],
+    parentDocumentPath: string
+): Promise<void> {
     const parentDir = path.dirname(parentDocumentPath)
     const packageJsonPath = await findFileInParentPaths(parentDir, 'package.json')
 
@@ -63,22 +69,19 @@ export async function decorateHandlerNames(handlers: LambdaHandlerCandidate[], p
  * Does NOT execute/invoke SAM, docker, etc.
  */
 export async function makeTypescriptConfig(
-        config: SamLaunchRequestArgs,
-        // isDebug: boolean,
-        // workspaceFolder: vscode.WorkspaceFolder,
-        // samProjectCodeRoot: string,
-        // runtime: string,
-        // handlerName: string,
-        // uri: vscode.Uri,
-        // samTemplatePath: string | undefined,
-        )
-        : Promise<NodejsDebugConfiguration> {
-
+    config: SamLaunchRequestArgs
+    // isDebug: boolean,
+    // workspaceFolder: vscode.WorkspaceFolder,
+    // samProjectCodeRoot: string,
+    // runtime: string,
+    // handlerName: string,
+    // uri: vscode.Uri,
+    // samTemplatePath: string | undefined,
+): Promise<NodejsDebugConfiguration> {
     if (!config.codeRoot) {
         // Last-resort attempt to discover the project root (when there is no
         // `launch.json` nor `template.yaml`).
-        config.codeRoot = await getSamProjectDirPathForFile(
-            config?.samTemplatePath ?? config.documentUri!!.fsPath)
+        config.codeRoot = await getSamProjectDirPathForFile(config?.samTemplatePath ?? config.documentUri!!.fsPath)
         if (!config.codeRoot) {
             // TODO: return error and show it at the caller.
             throw Error('missing launch.json, template.yaml, and failed to discover project root')
@@ -87,12 +90,13 @@ export async function makeTypescriptConfig(
 
     config.baseBuildDir = await makeBuildDir()
 
-    // Always generate a temporary template.yaml, don't use workspace one directly.
-    config.samTemplatePath = await generateInputTemplate(config)
+    if (config.invokeTarget.target === 'code') {
+        config.samTemplatePath = await generateInputTemplate(config)
+    }
 
     //  Make a python launch-config from the generic config.
     const nodejsLaunchConfig: NodejsDebugConfiguration = {
-        ...config,  // Compose.
+        ...config, // Compose.
         type: 'node',
         request: 'attach',
         runtimeFamily: RuntimeFamily.NodeJS,
@@ -103,7 +107,7 @@ export async function makeTypescriptConfig(
         localRoot: config.codeRoot,
         remoteRoot: '/var/task',
         protocol: 'inspector',
-        skipFiles: ['/var/runtime/node_modules/**/*.js', '<node_internals>/**/*.js'],
+        skipFiles: ['/var/runtime/node_modules/**/*.js', '<node_internals>/**/*.js']
     }
 
     return nodejsLaunchConfig
@@ -112,18 +116,13 @@ export async function makeTypescriptConfig(
 /**
  * Launches and attaches debugger to a SAM Node project.
  */
-export async function invokeTypescriptLambda(
-        ctx: ExtContext,
-        config: NodejsDebugConfiguration,
-        ) {
+export async function invokeTypescriptLambda(ctx: ExtContext, config: NodejsDebugConfiguration) {
     // Switch over to the output channel so the user has feedback that we're getting things ready
     ctx.chanLogger.channel.show(true)
     ctx.chanLogger.info('AWS.output.sam.local.start', 'Preparing to run {0} locally...', config.handlerName)
 
     const processInvoker = new DefaultValidatingSamCliProcessInvoker({})
-    config.samLocalInvokeCommand = new DefaultSamLocalInvokeCommand(ctx.chanLogger, [
-        WAIT_FOR_DEBUGGER_MESSAGES.NODEJS
-    ])
+    config.samLocalInvokeCommand = new DefaultSamLocalInvokeCommand(ctx.chanLogger, [WAIT_FOR_DEBUGGER_MESSAGES.NODEJS])
 
     // XXX: reassignment
     config.samTemplatePath = await executeSamBuild({


### PR DESCRIPTION
Still a WIP.

Obeservations: 
* Node works and the debugger connects!
* Python runs successfully but doesn't connect the debugger.
  * Python outputs the payload as if it were a run and the debugger keeps attempting to connect until VS Code times it out (~10 seconds).
* .NET builds successfully with the existing template but does not connect the debugger. The container does not automatically shut down and is instead waiting for the debugger to connect. This does not time out on the VS Code side.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
