### PR TITLE
visualizeStateMachine stability improvements

### DIFF
--- a/src/integrationTest/stepFunctions/visualizeStateMachine.test.ts
+++ b/src/integrationTest/stepFunctions/visualizeStateMachine.test.ts
@@ -9,9 +9,11 @@ import * as fs from 'fs-extra'
 import * as path from 'path'
 import { spy } from 'sinon'
 import * as vscode from 'vscode'
+import { VSCODE_EXTENSION_ID } from '../../shared/extensions'
 import { makeTemporaryToolkitFolder } from '../../shared/filesystemUtilities'
 import { messageObject } from '../../stepFunctions/commands/visualizeStateMachine'
 import { assertThrowsError } from '../../test/shared/utilities/assertUtils'
+import { activateExtension } from '../integrationTestsUtilities'
 
 const sampleStateMachine = `
 	 {
@@ -83,6 +85,12 @@ async function waitUntilWebviewIsVisible(webviewPanel: vscode.WebviewPanel | und
 }
 
 describe('visualizeStateMachine', async () => {
+    before(async function() {
+        // tslint:disable-next-line:no-invalid-this
+        this.timeout(600000)
+        await activateExtension(VSCODE_EXTENSION_ID.awstoolkit)
+    })
+
     beforeEach(async () => {
         // Make a temp folder for all these tests
         tempFolder = await makeTemporaryToolkitFolder()
@@ -105,7 +113,7 @@ describe('visualizeStateMachine', async () => {
         const result = await vscode.commands.executeCommand<vscode.WebviewPanel>('aws.previewStateMachine')
 
         assert.ok(result)
-    })
+    }).timeout(15000) // Give the first test that calls aws.previewStateMachine a chance to download the visualizer
 
     it('correctly displays content when given a sample state machine', async () => {
         const fileName = 'mysamplestatemachine.json'

--- a/src/stepFunctions/utils.ts
+++ b/src/stepFunctions/utils.ts
@@ -131,9 +131,14 @@ export class StateMachineGraphCache {
 }
 
 async function httpsGetRequestWrapper(url: string): Promise<string> {
+    const logger = getLogger()
+    logger.verbose(`Step Functions is getting content from ${url}`)
+
     return new Promise((resolve, reject) => {
         request.get(url, function(error, response) {
+            logger.verbose(`Step Functions finished getting content from ${url}`)
             if (error) {
+                logger.verbose(`Step Functions was unable to get content from ${url}`, error as Error)
                 reject(error)
             } else {
                 resolve((response.body as any) as string)


### PR DESCRIPTION

This change improves visualizeStateMachine test stability

* the test wasn't set up to run on its own, added a missing call to activate the extension, because it calls a command registered by the extension
* the first test that runs the visualizer command has been given a larger timeout, to give test machines (and other systems that don't have the visualizer cached) a chance to download the visualizer. This reveals a code smell -- perhaps the cache component can be isolated a little better than it is currently (@alanbo )


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
