### PR TITLE
test: run globalSetup when running single test

### DIFF
--- a/third-party/test/index.ts
+++ b/third-party/test/index.ts
@@ -124,6 +124,12 @@ function run(testsRoot, clb): any {
     const testFile = process.env["TEST_FILE"] === 'null' ? undefined : process.env["TEST_FILE"]
     const testFilePath = testFile?.replace(/^src\/test\//, "")?.concat('.js')
 
+    const globalSetupPath = paths.join(testsRoot, 'globalSetup.test.js')
+    if (testFilePath && fs.existsSync(globalSetupPath)) {
+        // XXX: explicitly add globalSetup, other tests depend on it.
+        mocha.addFile(globalSetupPath);
+    }
+
     // Glob test files
     glob(testFilePath ?? "**/**.test.js", { cwd: testsRoot }, (error, files): any => {
         // END 2020-03-24: Amazon addition.


### PR DESCRIPTION
`globalSetup` is required for various tests. Include it when running
a single test file (i.e. `$TEST_FILE` is defined via the "Extension
Tests (current file)" task in `launch.json`).

Note: to confirm that the before() and beforeEach() in globalSetup are
executed before any tests, create a test sibling to globalSetup.test.ts,
and observe that the globalSetup before/beforeEach are executed before
executing the "AAA" test:

    src/test/aaaa.test.ts:
        import { getLogger } from '../shared/logger'
        beforeEach(async function() {
            console.log('aaaaa BEFOREEACH')
        })
        describe('AAA', async () => {
            it('AAA test', async () => {
                getLogger()
            })
        })

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
