### PR TITLE
Rework into Manager and Visualizations so that existing visualization…

### DIFF
--- a/src/stepFunctions/activation.ts
+++ b/src/stepFunctions/activation.ts
@@ -11,7 +11,7 @@ import * as telemetry from '../shared/telemetry/telemetry'
 import { activate as activateASL } from './asl/client'
 import { createStateMachineFromTemplate } from './commands/createStateMachineFromTemplate'
 import { publishStateMachine } from './commands/publishStateMachine'
-import { visualizeStateMachine } from './commands/visualizeStateMachine'
+import { aslVisualizationManager } from './commands/visualizeStateMachine'
 
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
@@ -35,11 +35,12 @@ async function registerStepFunctionCommands(
     outputChannel: vscode.OutputChannel
 ): Promise<void> {
     initalizeWebviewPaths(extensionContext)
+    const visualizationManager = new aslVisualizationManager()
 
     extensionContext.subscriptions.push(
         vscode.commands.registerCommand('aws.previewStateMachine', async () => {
             try {
-                return await visualizeStateMachine(extensionContext.globalState)
+                return await visualizationManager.visualizeStateMachine(extensionContext.globalState)
             } finally {
                 telemetry.recordStepfunctionsPreviewstatemachine()
             }

--- a/src/stepFunctions/commands/visualizeStateMachine.ts
+++ b/src/stepFunctions/commands/visualizeStateMachine.ts
@@ -286,7 +286,7 @@ class aslVisualization {
             <link rel="stylesheet" href='${vsCodeCustomStyling}'>
             <script src='${graphStateMachineLibrary}'></script>
         </head>
-    
+
         <body>
             <div id="svgcontainer" class="workflowgraph">
                 <svg></svg>
@@ -320,7 +320,7 @@ class aslVisualization {
                     </svg>
                 </button>
             </div>
-    
+
             <script src='${webviewBodyScript}'></script>
         </body>
     </html>`

--- a/src/stepFunctions/commands/visualizeStateMachine.ts
+++ b/src/stepFunctions/commands/visualizeStateMachine.ts
@@ -29,257 +29,316 @@ export interface messageObject {
 const documentSettings: DocumentLanguageSettings = { comments: 'error', trailingCommas: 'error' }
 const languageService = getLanguageService({})
 
-async function isDocumentValid(textDocument?: vscode.TextDocument): Promise<boolean> {
-    if (!textDocument) {
-        return false
+export class aslVisualizationManager {
+    private readonly managedVisualizations: Set<aslVisualization>
+
+    public constructor() {
+        this.managedVisualizations = new Set<aslVisualization>()
     }
 
-    const text = textDocument.getText()
-    const doc = ASLTextDocument.create(textDocument.uri.path, textDocument.languageId, textDocument.version, text)
-    // tslint:disable-next-line: no-inferred-empty-object-type
-    const jsonDocument = languageService.parseJSONDocument(doc)
-    const diagnostics = await languageService.doValidation(doc, jsonDocument, documentSettings)
+    public async visualizeStateMachine(globalStorage: vscode.Memento): Promise<vscode.WebviewPanel | void> {
+        const logger: Logger = getLogger()
+        const cache = new StateMachineGraphCache()
 
-    const isValid = !diagnostics.some(diagnostic => diagnostic.severity === DiagnosticSeverity.Error)
+        /* TODO: Determine behaviour when command is run against bad input, or
+         * non-json files. Determine if we want to limit the command to only a
+         * specifc subset of file types ( .json only, custom .states extension, etc...)
+         * Ensure tests are written for this use case as well.
+         */
+        const activeTextEditor: vscode.TextEditor | undefined = vscode.window.activeTextEditor
 
-    return isValid
-}
+        let documentUri: vscode.Uri
+        let textDocument: vscode.TextDocument
 
-/**
- * Graphs the state machine defined in the current active editor
- */
-export async function visualizeStateMachine(globalStorage: vscode.Memento): Promise<vscode.WebviewPanel | void> {
-    const logger: Logger = getLogger()
-    const cache = new StateMachineGraphCache()
-
-    /* TODO: Determine behaviour when command is run against bad input, or
-     * non-json files. Determine if we want to limit the command to only a
-     * specifc subset of file types ( .json only, custom .states extension, etc...)
-     * Ensure tests are written for this use case as well.
-     */
-    const activeTextEditor: vscode.TextEditor | undefined = vscode.window.activeTextEditor
-
-    let documentUri: vscode.Uri
-    let textDocument: vscode.TextDocument
-
-    if (activeTextEditor) {
-        documentUri = activeTextEditor.document.uri
-        textDocument = activeTextEditor.document
-    } else {
-        logger.error('Could not get active text editor for state machine render.')
-        throw new Error('Could not get active text editor for state machine render.')
-    }
-
-    try {
-        await cache.updateCache(globalStorage)
-
-        return setupWebviewPanel(documentUri, textDocument)
-    } catch (err) {
-        vscode.window.showInformationMessage(
-            localize(
-                'AWS.stepfunctions.visualisation.errors.rendering',
-                'There was an error rendering State Machine Graph, check logs for details.'
-            )
-        )
-
-        logger.debug('Unable to setup webview panel.')
-        logger.error(err as Error)
-    }
-
-    return
-}
-
-async function setupWebviewPanel(
-    documentUri: vscode.Uri,
-    textDocument: vscode.TextDocument
-): Promise<vscode.WebviewPanel> {
-    const logger: Logger = getLogger()
-    let isPanelDisposed = false
-
-    // Create and show panel
-    const panel = vscode.window.createWebviewPanel(
-        'stateMachineVisualization',
-        makeWebviewTitle(documentUri),
-        {
-            preserveFocus: true,
-            viewColumn: vscode.ViewColumn.Beside,
-        },
-        {
-            enableScripts: true,
-            localResourceRoots: [
-                ext.visualizationResourcePaths.localWebviewScriptsPath,
-                ext.visualizationResourcePaths.visualizationLibraryCachePath,
-                ext.visualizationResourcePaths.stateMachineCustomThemePath,
-            ],
-            retainContextWhenHidden: true,
-        }
-    )
-
-    async function sendUpdateMessage(updatedTextDocument: vscode.TextDocument) {
-        const isValid = await isDocumentValid(updatedTextDocument)
-
-        if (isPanelDisposed || !panel.webview) {
-            return
+        if (activeTextEditor) {
+            documentUri = activeTextEditor.document.uri
+            textDocument = activeTextEditor.document
+        } else {
+            logger.error('Could not get active text editor for state machine render.')
+            throw new Error('Could not get active text editor for state machine render.')
         }
 
-        logger.debug('Sending update message to webview.')
+        // Attempt to retrieve existing visualization if it exists.
+        const existingVisualization = this.getExistingVisualization(documentUri)
+        if (existingVisualization) {
+            existingVisualization.showPanel()
 
-        panel.webview.postMessage({
-            command: 'update',
-            stateMachineData: updatedTextDocument.getText(),
-            isValid,
-        })
-    }
-
-    const debouncedUpdate = debounce(sendUpdateMessage, 500)
-
-    // Set the initial html for the webpage
-    panel.webview.html = getWebviewContent(
-        ext.visualizationResourcePaths.webviewBodyScript.with({ scheme: 'vscode-resource' }),
-        ext.visualizationResourcePaths.visualizationLibraryScript.with({ scheme: 'vscode-resource' }),
-        ext.visualizationResourcePaths.visualizationLibraryCSS.with({ scheme: 'vscode-resource' }),
-        ext.visualizationResourcePaths.stateMachineCustomThemeCSS.with({ scheme: 'vscode-resource' }),
-        {
-            inSync: localize(
-                'AWS.stepFunctions.graph.status.inSync',
-                'Previewing ASL document. <a href="" style="text-decoration:none;">View</a>'
-            ),
-            notInSync: localize('AWS.stepFunctions.graph.status.notInSync', 'Errors detected. Cannot preview.'),
-            syncing: localize('AWS.stepFunctions.graph.status.syncing', 'Rendering ASL graph...'),
+            return existingVisualization.getWebviewPanel()
         }
-    )
 
-    // Add listener function to update the graph on document save
-    const updateOnSaveDisposable = vscode.workspace.onDidSaveTextDocument(async savedTextDocument => {
-        if (savedTextDocument && savedTextDocument.uri.path === documentUri.path) {
-            await sendUpdateMessage(savedTextDocument)
-        }
-    })
+        // Existing visualization does not exist, construct new visualization
+        try {
+            await cache.updateCache(globalStorage)
 
-    const onDidCloseTextDocumentDisposable = vscode.workspace.onDidCloseTextDocument(documentWillSaveEvent => {
-        if (!trackedDocumentDoesExist(documentUri)) {
-            panel.dispose()
+            return this.createNewVisualization(textDocument)
+        } catch (err) {
             vscode.window.showInformationMessage(
                 localize(
-                    'AWS.stepfunctions.visualisation.errors.rename',
-                    'State machine visualization closed due to file renaming or closure.'
+                    'AWS.stepfunctions.visualisation.errors.rendering',
+                    'There was an error rendering State Machine Graph, check logs for details.'
                 )
             )
-        }
-    })
 
-    const updateOnChangeDisposable = vscode.workspace.onDidChangeTextDocument(async textDocumentEvent => {
-        if (textDocumentEvent.document.uri.path === documentUri.path) {
-            await debouncedUpdate(textDocumentEvent.document)
+            logger.debug('Unable to setup webview panel.')
+            logger.error(err as Error)
         }
-    })
 
-    // Handle messages from the webview
-    const receiveMessageDisposable = panel.webview.onDidReceiveMessage(async (message: messageObject) => {
-        switch (message.command) {
-            case 'updateResult':
-                logger.debug(message.text)
-                if (message.error) {
-                    logger.error(message.error)
-                }
-                break
-            case 'webviewRendered': {
-                // Webview has finished rendering, so now we can give it our
-                // initial state machine definition.
-                await sendUpdateMessage(textDocument)
-                break
+        return
+    }
+
+    public removeClosedPanel(visToDelete: aslVisualization): void {
+        this.managedVisualizations.delete(visToDelete)
+    }
+
+    private createNewVisualization(textDocument: vscode.TextDocument): vscode.WebviewPanel {
+        const newVisualization = new aslVisualization(textDocument, this)
+        this.managedVisualizations.add(newVisualization)
+
+        return newVisualization.getWebviewPanel()
+    }
+
+    private getExistingVisualization(uriToFind: vscode.Uri): aslVisualization | void {
+        for (const vis of this.managedVisualizations) {
+            if (vis.documentURI.path === uriToFind.path) {
+                return vis
+            }
+        }
+
+        return
+    }
+}
+
+class aslVisualization {
+    public readonly documentURI: vscode.Uri
+    public readonly webviewPanel: vscode.WebviewPanel
+    private readonly visualizationManager: aslVisualizationManager
+
+    public constructor(textDocument: vscode.TextDocument, visualizationManager: aslVisualizationManager) {
+        this.documentURI = textDocument.uri
+        this.visualizationManager = visualizationManager
+        this.webviewPanel = this.setupWebviewPanel(textDocument)
+    }
+
+    public getWebviewPanel(): vscode.WebviewPanel {
+        return this.webviewPanel
+    }
+
+    public showPanel(): void {
+        this.webviewPanel.reveal()
+    }
+
+    private setupWebviewPanel(textDocument: vscode.TextDocument): vscode.WebviewPanel {
+        const documentUri = textDocument.uri
+        const logger: Logger = getLogger()
+        let isPanelDisposed = false
+
+        // Create and show panel
+        const panel = this.createVisualizationWebviewPanel(documentUri)
+
+        async function sendUpdateMessage(updatedTextDocument: vscode.TextDocument) {
+            const isValid = await aslVisualization.isDocumentValid(updatedTextDocument)
+
+            if (isPanelDisposed || !panel.webview) {
+                return
             }
 
-            case 'viewDocument':
-                try {
-                    const document = await vscode.workspace.openTextDocument(documentUri)
-                    vscode.window.showTextDocument(document, vscode.ViewColumn.One)
-                } catch (e) {
-                    logger.error(e as Error)
-                }
-                break
+            logger.debug('Sending update message to webview.')
+
+            panel.webview.postMessage({
+                command: 'update',
+                stateMachineData: updatedTextDocument.getText(),
+                isValid,
+            })
         }
-    })
 
-    // When the panel is closed, dispose of any disposables/remove subscriptions
-    panel.onDidDispose(() => {
-        updateOnSaveDisposable.dispose()
-        onDidCloseTextDocumentDisposable.dispose()
-        updateOnChangeDisposable.dispose()
-        receiveMessageDisposable.dispose()
-        debouncedUpdate.cancel()
-        isPanelDisposed = true
-    })
+        const debouncedUpdate = debounce(sendUpdateMessage, 500)
 
-    return panel
-}
+        // Set the initial html for the webpage
+        panel.webview.html = this.getWebviewContent(
+            ext.visualizationResourcePaths.webviewBodyScript.with({ scheme: 'vscode-resource' }),
+            ext.visualizationResourcePaths.visualizationLibraryScript.with({ scheme: 'vscode-resource' }),
+            ext.visualizationResourcePaths.visualizationLibraryCSS.with({ scheme: 'vscode-resource' }),
+            ext.visualizationResourcePaths.stateMachineCustomThemeCSS.with({ scheme: 'vscode-resource' }),
+            {
+                inSync: localize(
+                    'AWS.stepFunctions.graph.status.inSync',
+                    'Previewing ASL document. <a href="" style="text-decoration:none;">View</a>'
+                ),
+                notInSync: localize('AWS.stepFunctions.graph.status.notInSync', 'Errors detected. Cannot preview.'),
+                syncing: localize('AWS.stepFunctions.graph.status.syncing', 'Rendering ASL graph...'),
+            }
+        )
 
-function trackedDocumentDoesExist(trackedDocumentURI: vscode.Uri): boolean {
-    const document = vscode.workspace.textDocuments.find(doc => doc.fileName === trackedDocumentURI.fsPath)
+        // Add listener function to update the graph on document save
+        const updateOnSaveDisposable = vscode.workspace.onDidSaveTextDocument(async savedTextDocument => {
+            if (savedTextDocument && savedTextDocument.uri.path === documentUri.path) {
+                await sendUpdateMessage(savedTextDocument)
+            }
+        })
 
-    return document !== undefined
-}
+        // If documentUri being tracked is no longer found (due to file closure or rename), close the panel.
+        const onDidCloseTextDocumentDisposable = vscode.workspace.onDidCloseTextDocument(documentWillSaveEvent => {
+            if (!this.trackedDocumentDoesExist(documentUri)) {
+                panel.dispose()
+                vscode.window.showInformationMessage(
+                    localize(
+                        'AWS.stepfunctions.visualisation.errors.rename',
+                        'State machine visualization closed due to file renaming or closure.'
+                    )
+                )
+            }
+        })
 
-function makeWebviewTitle(sourceDocumentUri: vscode.Uri): string {
-    return localize('AWS.stepFunctions.graph.titlePrefix', 'Graph: {0}', path.basename(sourceDocumentUri.fsPath))
-}
+        const updateOnChangeDisposable = vscode.workspace.onDidChangeTextDocument(async textDocumentEvent => {
+            if (textDocumentEvent.document.uri.path === documentUri.path) {
+                await debouncedUpdate(textDocumentEvent.document)
+            }
+        })
 
-function getWebviewContent(
-    webviewBodyScript: vscode.Uri,
-    graphStateMachineLibrary: vscode.Uri,
-    vsCodeCustomStyling: vscode.Uri,
-    graphStateMachineDefaultStyles: vscode.Uri,
-    statusTexts: {
-        syncing: string
-        notInSync: string
-        inSync: string
+        // Handle messages from the webview
+        const receiveMessageDisposable = panel.webview.onDidReceiveMessage(async (message: messageObject) => {
+            switch (message.command) {
+                case 'updateResult':
+                    logger.debug(message.text)
+                    if (message.error) {
+                        logger.error(message.error)
+                    }
+                    break
+                case 'webviewRendered': {
+                    // Webview has finished rendering, so now we can give it our
+                    // initial state machine definition.
+                    await sendUpdateMessage(textDocument)
+                    break
+                }
+
+                case 'viewDocument':
+                    try {
+                        const document = await vscode.workspace.openTextDocument(documentUri)
+                        vscode.window.showTextDocument(document, vscode.ViewColumn.One)
+                    } catch (e) {
+                        logger.error(e as Error)
+                    }
+                    break
+            }
+        })
+
+        // When the panel is closed, dispose of any disposables/remove subscriptions
+        panel.onDidDispose(() => {
+            updateOnSaveDisposable.dispose()
+            onDidCloseTextDocumentDisposable.dispose()
+            updateOnChangeDisposable.dispose()
+            receiveMessageDisposable.dispose()
+            debouncedUpdate.cancel()
+            isPanelDisposed = true
+            this.visualizationManager.removeClosedPanel(this)
+        })
+
+        return panel
     }
-): string {
-    return `
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <link rel="stylesheet" href='${graphStateMachineDefaultStyles}'>
-        <link rel="stylesheet" href='${vsCodeCustomStyling}'>
-        <script src='${graphStateMachineLibrary}'></script>
-    </head>
 
-    <body>
-        <div id="svgcontainer" class="workflowgraph">
-            <svg></svg>
-        </div>
-        <div class="status-info">
-            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-                <circle cx="50" cy="50" r="42" stroke-width="4" />
-            </svg>
-            <div class="status-messages">
-                <span class="previewing-asl-message">${statusTexts.inSync}</span>
-                <span class="rendering-asl-message">${statusTexts.syncing}</span>
-                <span class="error-asl-message">${statusTexts.notInSync}</span>
+    private trackedDocumentDoesExist(trackedDocumentURI: vscode.Uri): boolean {
+        const document = vscode.workspace.textDocuments.find(doc => doc.fileName === trackedDocumentURI.fsPath)
+
+        return document !== undefined
+    }
+
+    private createVisualizationWebviewPanel(documentUri: vscode.Uri): vscode.WebviewPanel {
+        return vscode.window.createWebviewPanel(
+            'stateMachineVisualization',
+            this.makeWebviewTitle(documentUri),
+            {
+                preserveFocus: true,
+                viewColumn: vscode.ViewColumn.Beside,
+            },
+            {
+                enableScripts: true,
+                localResourceRoots: [
+                    ext.visualizationResourcePaths.localWebviewScriptsPath,
+                    ext.visualizationResourcePaths.visualizationLibraryCachePath,
+                    ext.visualizationResourcePaths.stateMachineCustomThemePath,
+                ],
+                retainContextWhenHidden: true,
+            }
+        )
+    }
+
+    private makeWebviewTitle(sourceDocumentUri: vscode.Uri): string {
+        return localize('AWS.stepFunctions.graph.titlePrefix', 'Graph: {0}', path.basename(sourceDocumentUri.fsPath))
+    }
+
+    private getWebviewContent(
+        webviewBodyScript: vscode.Uri,
+        graphStateMachineLibrary: vscode.Uri,
+        vsCodeCustomStyling: vscode.Uri,
+        graphStateMachineDefaultStyles: vscode.Uri,
+        statusTexts: {
+            syncing: string
+            notInSync: string
+            inSync: string
+        }
+    ): string {
+        return `
+    <!DOCTYPE html>
+    <html>
+        <head>
+            <meta charset="UTF-8">
+            <link rel="stylesheet" href='${graphStateMachineDefaultStyles}'>
+            <link rel="stylesheet" href='${vsCodeCustomStyling}'>
+            <script src='${graphStateMachineLibrary}'></script>
+        </head>
+    
+        <body>
+            <div id="svgcontainer" class="workflowgraph">
+                <svg></svg>
             </div>
-        </div>
-        <div class="graph-buttons-container">
-            <button id="zoomin">
-                <svg focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-                    <line x1="8" y1="1" x2="8" y2="15"></line>
-                    <line x1="15" y1="8" x2="1" y2="8"></line>
+            <div class="status-info">
+                <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+                    <circle cx="50" cy="50" r="42" stroke-width="4" />
                 </svg>
-            </button>
-            <button id="zoomout">
-                <svg focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-                    <line x1="15" y1="8" x2="1" y2="8"></line>
-                </svg>
-            </button>
-            <button id="center">
-                <svg focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-                    <circle cx="8" cy="8" r="7" stroke-width="2" />
-                    <circle cx="8" cy="8" r="1" stroke-width="2" />
-                </svg>
-            </button>
-        </div>
+                <div class="status-messages">
+                    <span class="previewing-asl-message">${statusTexts.inSync}</span>
+                    <span class="rendering-asl-message">${statusTexts.syncing}</span>
+                    <span class="error-asl-message">${statusTexts.notInSync}</span>
+                </div>
+            </div>
+            <div class="graph-buttons-container">
+                <button id="zoomin">
+                    <svg focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+                        <line x1="8" y1="1" x2="8" y2="15"></line>
+                        <line x1="15" y1="8" x2="1" y2="8"></line>
+                    </svg>
+                </button>
+                <button id="zoomout">
+                    <svg focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+                        <line x1="15" y1="8" x2="1" y2="8"></line>
+                    </svg>
+                </button>
+                <button id="center">
+                    <svg focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+                        <circle cx="8" cy="8" r="7" stroke-width="2" />
+                        <circle cx="8" cy="8" r="1" stroke-width="2" />
+                    </svg>
+                </button>
+            </div>
+    
+            <script src='${webviewBodyScript}'></script>
+        </body>
+    </html>`
+    }
 
-        <script src='${webviewBodyScript}'></script>
-    </body>
-</html>`
+    private static async isDocumentValid(textDocument?: vscode.TextDocument): Promise<boolean> {
+        if (!textDocument) {
+            return false
+        }
+
+        const text = textDocument.getText()
+        const doc = ASLTextDocument.create(textDocument.uri.path, textDocument.languageId, textDocument.version, text)
+        // tslint:disable-next-line: no-inferred-empty-object-type
+        const jsonDocument = languageService.parseJSONDocument(doc)
+        const diagnostics = await languageService.doValidation(doc, jsonDocument, documentSettings)
+
+        const isValid = !diagnostics.some(diagnostic => diagnostic.severity === DiagnosticSeverity.Error)
+
+        return isValid
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Visualizations are now managed by a VisualizationManager which first checks if an existing visualization exists for a given documentURI before generating a new one.
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing
Performed manual testing of visualization behaviour when duplicate visualizations are requested.
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the **README** document
- [X] I have read the **CONTRIBUTING** document
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.