### PR TITLE
launch.json: disable extensions in test instance

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+            "args": ["--disable-extensions", "--extensionDevelopmentPath=${workspaceFolder}"],
             "env": {
                 "AWS_TOOLKIT_IGNORE_WEBPACK_BUNDLE": "true"
             },
@@ -40,6 +40,7 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": [
+                "--disable-extensions",
                 "--extensionDevelopmentPath=${workspaceFolder}",
                 "--extensionTestsPath=${workspaceFolder}/dist/src/test/index.js"
             ],
@@ -56,6 +57,7 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": [
+                "--disable-extensions",
                 "--extensionDevelopmentPath=${workspaceFolder}",
                 "--extensionTestsPath=${workspaceFolder}/dist/src/test/index.js"
             ],
@@ -73,6 +75,7 @@
             "runtimeExecutable": "${execPath}",
             "args": [
                 "${workspaceFolder}/dist/src/integrationTest-samples/",
+                "--disable-extensions",
                 "--extensionDevelopmentPath=${workspaceFolder}",
                 "--extensionTestsPath=${workspaceFolder}/dist/src/integrationTest/index.js"
             ],


### PR DESCRIPTION
By default vscode enables extensions from the current environment, in the test  instance.  Although that sometimes might be desirable, it makes sense for that choice to be opt-in rather than opt-out, because most of the time it gets in the way.

https://code.visualstudio.com/api/working-with-extensions/testing-extension#disabling-other-extensions-while-debugging

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
