### PR TITLE
UI: minimize statusbar verbiage

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -124,7 +124,7 @@
     "AWS.command.stepFunctions.previewStateMachine": "Render state machine graph",
     "AWS.stepFunctions.graph.titlePrefix": "Graph: {0}",
     "AWS.credentials.statusbar.no.credentials": "(not connected)",
-    "AWS.credentials.statusbar.text": "AWS Credentials: {0}",
+    "AWS.credentials.statusbar.text": "AWS: {0}",
     "AWS.credentials.statusbar.tooltip": "The current credentials used by the AWS Toolkit.\n\nClick this status bar item to use different credentials.",
     "AWS.error.during.sam.local": "An error occurred trying to run SAM Application locally: {0}",
     "AWS.command.showErrorDetails": "Show error details",

--- a/src/credentials/awsCredentialsStatusBarItem.ts
+++ b/src/credentials/awsCredentialsStatusBarItem.ts
@@ -36,7 +36,7 @@ export async function initializeAwsCredentialsStatusBarItem(
 export function updateCredentialsStatusBarItem(statusBarItem: vscode.StatusBarItem, credentialsId?: string) {
     statusBarItem.text = localize(
         'AWS.credentials.statusbar.text',
-        'AWS Credentials: {0}',
+        'AWS: {0}',
         credentialsId ?? STATUSBAR_TEXT_NO_CREDENTIALS
     )
 }


### PR DESCRIPTION


## Description

Change the statusbar text from `AWS Credentials: ...` to `AWS: ...`.

## Motivation and Context

Our statusbar widget occupies more space than most statusbar widgets, unnecessarily.

- "AWS" is enough to recognize the Toolkit statusbar widget.
- "AWS: Credentials" is hyper-specific, we should use this widget to   reveal more than just credentials (e.g. context-specific messages for  the current document).
- Users will appreciate allowing room for other statusbar widgets.
- Mentioning "Credentials" is redundant anyway, because usually  a "profile:" prefix is shown.

### Before

<img width="317" alt="Screen Shot 2020-04-10 at 4 50 54 PM" src="https://user-images.githubusercontent.com/55561878/79030279-17c97b80-7b4d-11ea-9206-959c6f1feeb2.png">


### After

<img width="250" alt="Screen Shot 2020-04-10 at 4 59 09 PM" src="https://user-images.githubusercontent.com/55561878/79030284-1d26c600-7b4d-11ea-99dc-1dd2d5d62e0f.png">


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
