### PR TITLE
Allows for state machine visualisation on invalid ARN

### DIFF
--- a/.changes/next-release/Feature-f8fd7312-74ee-44de-af95-d8a21bee8f48.json
+++ b/.changes/next-release/Feature-f8fd7312-74ee-44de-af95-d8a21bee8f48.json
@@ -1,0 +1,4 @@
+{
+    "type": "Feature",
+    "description": "Visualising of step functions step machines will be allowed when ARN strings within ASL definition are invalid."
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3829,7 +3829,7 @@
             "dependencies": {
                 "combined-stream": {
                     "version": "1.0.6",
-                    "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
                     "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
                     "requires": {
                         "delayed-stream": "~1.0.0"
@@ -4368,7 +4368,7 @@
                     "dependencies": {
                         "minimist": {
                             "version": "1.2.0",
-                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                            "resolved": false,
                             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                             "dev": true,
                             "optional": true
@@ -4726,7 +4726,7 @@
             "dependencies": {
                 "pify": {
                     "version": "2.3.0",
-                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
                 }
             }
@@ -5659,7 +5659,7 @@
             "dependencies": {
                 "async": {
                     "version": "1.5.2",
-                    "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
                     "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
                     "dev": true
                 },
@@ -7951,7 +7951,7 @@
                 },
                 "readable-stream": {
                     "version": "2.0.6",
-                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                     "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                     "dev": true,
                     "requires": {
@@ -9218,7 +9218,7 @@
         },
         "tunnel": {
             "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+            "resolved": "http://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
             "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
             "dev": true
         },

--- a/src/stepFunctions/commands/visualizeStateMachine.ts
+++ b/src/stepFunctions/commands/visualizeStateMachine.ts
@@ -2,12 +2,6 @@
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import {
-    DiagnosticSeverity,
-    DocumentLanguageSettings,
-    getLanguageService,
-    TextDocument as ASLTextDocument,
-} from 'amazon-states-language-service'
 
 import { debounce } from 'lodash'
 import * as nls from 'vscode-nls'
@@ -17,36 +11,13 @@ import * as path from 'path'
 import * as vscode from 'vscode'
 import { ext } from '../../shared/extensionGlobals'
 import { getLogger, Logger } from '../../shared/logger'
-import { StateMachineGraphCache } from '../utils'
-
-const ARN_REGEX_STRING = String.raw`^arn:aws([a-z]|\-)*:(states|lambda):([a-z]|\d|\-)*:([0-9]{12})?:.+:.+$`
+import { StateMachineGraphCache, isDocumentValid } from '../utils'
 
 export interface messageObject {
     command: string
     text: string
     error?: string
     stateMachineData: string
-}
-
-const documentSettings: DocumentLanguageSettings = { comments: 'error', trailingCommas: 'error' }
-const languageService = getLanguageService({})
-
-async function isDocumentValid(textDocument?: vscode.TextDocument): Promise<boolean> {
-    if (!textDocument) {
-        return false
-    }
-
-    const text = textDocument.getText()
-    const doc = ASLTextDocument.create(textDocument.uri.path, textDocument.languageId, textDocument.version, text)
-    // tslint:disable-next-line: no-inferred-empty-object-type
-    const jsonDocument = languageService.parseJSONDocument(doc)
-    const diagnostics = (await languageService.doValidation(doc, jsonDocument, documentSettings))
-        // Invalid ARN strings shouldn't prevent rendering of the state machine graph
-        .filter(diagnostic => !diagnostic.message.includes(ARN_REGEX_STRING))
-
-    const isValid = !diagnostics.some(diagnostic => diagnostic.severity === DiagnosticSeverity.Error)
-
-    return isValid
 }
 
 /**

--- a/src/test/stepFunctions/utils.test.ts
+++ b/src/test/stepFunctions/utils.test.ts
@@ -6,7 +6,8 @@
 import * as assert from 'assert'
 import { IAM } from 'aws-sdk'
 import * as sinon from 'sinon'
-import { isStepFunctionsRole, StateMachineGraphCache } from '../../stepFunctions/utils'
+import { isStepFunctionsRole, StateMachineGraphCache, isDocumentValid } from '../../stepFunctions/utils'
+import * as vscode from 'vscode'
 
 const REQUEST_BODY = 'request body string'
 const ASSET_URL = 'https://something'
@@ -215,5 +216,68 @@ describe('isStepFunctionsRole', () => {
             }),
         }
         assert.ok(!isStepFunctionsRole(role))
+    })
+})
+
+describe('isDocumentValid', async () => {
+    it('returns true for valid ASL', async () => {
+        const aslText = `
+            {
+                "StartAt": "FirstMatchState",
+                "States": {
+                    "FirstMatchState": {
+                        "Type": "Task",
+                        "Resource": "arn:aws:lambda:us-west-2:000000000000:function:OnFirstMatch",
+                        "End": true
+                    }
+                }
+            } `
+
+        let textDocument = await vscode.workspace.openTextDocument({ language: 'asl' })
+        textDocument = Object.assign({}, textDocument, { getText: () => aslText })
+
+        const isValid = await isDocumentValid(textDocument)
+        assert.ok(isValid)
+    })
+
+    it('returns true for ASL with invalid arns', async () => {
+        const aslText = `
+            {
+                "StartAt": "FirstMatchState",
+                "States": {
+                    "FirstMatchState": {
+                        "Type": "Task",
+                        "Resource": "arn:aws:lambda:REGION:ACCOUNT_ID:function:OnFirstMatch",
+                        "End": true
+                    }
+                }
+            } `
+
+        let textDocument = await vscode.workspace.openTextDocument({ language: 'asl' })
+        textDocument = Object.assign({}, textDocument, { getText: () => aslText })
+
+        const isValid = await isDocumentValid(textDocument)
+        assert.ok(isValid)
+    })
+
+    it('returns false for invalid ASL', async () => {
+        const aslText = `
+            {
+                "StartAt": "Does not exist",
+                "States": {
+                    "FirstMatchState": {
+                        "Type": "Task",
+                        "Resource": "arn:aws:lambda:us-west-2:000000000000:function:OnFirstMatch",
+                        "End": true
+                    }
+                }
+            } `
+
+        let textDocument = await vscode.workspace.openTextDocument({ language: 'asl' })
+        textDocument = Object.assign({}, textDocument, { getText: () => aslText })
+
+        const isValid = await isDocumentValid(textDocument)
+
+        assert.ok(!isValid)
     })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I'm filtering the diagnostics removing ones that contain reference to arn regex. This is a temporary solution. Ideally, in the future, amazon-states-language-service will output error codes that we will be able to use for filtering.

## Motivation and Context
Customers expect to be able to visualize state machines when ARN's are invalid in asl file. ARN's are often not known at the development time so the developers use placeholders. 

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->
#1017 
#1016 

## Testing
I've tested the change manually.
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
