### PR TITLE
Fix JSON validation issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,19 +148,6 @@
                     "direct-invoke": {
                         "$schema": "http://json-schema.org/draft-07/schema#",
                         "title": "AwsSamDebuggerConfiguration",
-                        "definitions": {
-                            "jsonObject": {
-                                "title": "ReadonlyJsonObject",
-                                "additionalProperties": {
-                                    "type": [
-                                        "string",
-                                        "number",
-                                        "boolean"
-                                    ]
-                                },
-                                "type": "object"
-                            }
-                        },
                         "additionalProperties": false,
                         "properties": {
                             "aws": {
@@ -245,13 +232,27 @@
                                 "properties": {
                                     "environmentVariables": {
                                         "description": "%AWS.configuration.description.awssam.debug.envvars%",
-                                        "$ref": "#/definitions/jsonObject"
+                                        "additionalProperties": {
+                                            "type": [
+                                                "string",
+                                                "number",
+                                                "boolean"
+                                            ]
+                                        },
+                                        "type": "object"
                                     },
                                     "event": {
                                         "description": "%AWS.configuration.description.awssam.debug.event%",
                                         "properties": {
                                             "json": {
-                                                "$ref": "#/definitions/jsonObject"
+                                                "additionalProperties": {
+                                                    "type": [
+                                                        "string",
+                                                        "number",
+                                                        "boolean"
+                                                    ]
+                                                },
+                                                "type": "object"
                                             },
                                             "path": {
                                                 "description": "%AWS.configuration.description.awssam.debug.event.path%",
@@ -304,7 +305,14 @@
                                     "template": {
                                         "properties": {
                                             "parameters": {
-                                                "$ref": "#/definitions/jsonObject"
+                                                "additionalProperties": {
+                                                    "type": [
+                                                        "string",
+                                                        "number",
+                                                        "boolean"
+                                                    ]
+                                                },
+                                                "type": "object"
                                             }
                                         },
                                         "type": "object",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes https://github.com/aws/aws-toolkit-vscode/issues/1027 .

VS Code apparently doesn't like `$ref` tags in the package.json file. Our use-case was narrow enough that we don't need to have `$ref` tags for now although I will reach out considering that it may be useful in the future.

## Testing

Built and tested a webpacked version: loading the extension did not cause errors in the `launch.json` or `settings.json` files.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
