### PR TITLE
Increase max SAM version from 0.50.0 to 0.60.0

### DIFF
--- a/.changes/next-release/Feature-bf18bc73-f20c-490e-8d2d-28669f945360.json
+++ b/.changes/next-release/Feature-bf18bc73-f20c-490e-8d2d-28669f945360.json
@@ -1,0 +1,4 @@
+{
+    "type": "Feature",
+    "description": "Bumped maximum (exclusive) supported SAM CLI version from 0.50.0 to 0.60.0."
+}

--- a/src/shared/sam/cli/samCliValidator.ts
+++ b/src/shared/sam/cli/samCliValidator.ts
@@ -10,7 +10,7 @@ import { SamCliInfoInvocation, SamCliInfoResponse } from './samCliInfo'
 import { SamCliProcessInvoker } from './samCliInvokerUtils'
 
 export const MINIMUM_SAM_CLI_VERSION_INCLUSIVE = '0.38.0'
-export const MAXIMUM_SAM_CLI_VERSION_EXCLUSIVE = '0.50.0'
+export const MAXIMUM_SAM_CLI_VERSION_EXCLUSIVE = '0.60.0'
 
 // Errors
 export class InvalidSamCliError extends Error {


### PR DESCRIPTION
## Description

Bump maximum (exclusive) supported SAM CLI version from 0.50.0 to 0.60.0

## Motivation and Context

SAM is currently on version 0.47.0 and will likely go into the fifties soon

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
