### PR TITLE
isInDirectory(): handle trailing slashes

### DIFF
--- a/src/shared/filesystemUtilities.ts
+++ b/src/shared/filesystemUtilities.ts
@@ -78,14 +78,22 @@ export const makeTemporaryToolkitFolder = async (...relativePathParts: string[])
 }
 
 /**
- * Returns whether or not a directory/file is a contained within a parent directory.
- * Also returns true if parent directory === subdirectory
- * @param parentDirectory Parent directory
- * @param containedPath Path to directory that may or may not be contained within the parentDirectory
+ * Returns `true` if path `p` is a descendant of directory `d` (or if they are
+ * identical).
+ *
+ * Only the logical structure is checked; the paths are not checked for
+ * existence on the filesystem.
+ *
+ * @param d  Path to a directory.
+ * @param p  Path to file or directory to test.
  */
-export function isContainedWithinDirectory(parentDirectory: string, containedPath: string): boolean {
-    const parentDirPieces = parentDirectory.split(path.sep)
-    const containedPathPieces = containedPath.split(path.sep)
+export function isInDirectory(d: string, p: string): boolean {
+    const parentDirPieces = d.split(path.sep)
+    const containedPathPieces = p.split(path.sep)
+    // Remove final empty element(s), if `d` ends with slash(es).
+    while (parentDirPieces.length > 0 && parentDirPieces[parentDirPieces.length - 1] === '') {
+        parentDirPieces.pop()
+    }
 
     return parentDirPieces.every((value, index) => {
         return value === containedPathPieces[index]

--- a/src/shared/filesystemUtilities.ts
+++ b/src/shared/filesystemUtilities.ts
@@ -7,6 +7,7 @@ import { access, mkdtemp, readFile } from 'fs-extra'
 import * as os from 'os'
 import * as path from 'path'
 import { mkdir } from './filesystem'
+import * as pathutils from './utilities/pathUtils'
 
 const DEFAULT_ENCODING: BufferEncoding = 'utf8'
 
@@ -88,14 +89,20 @@ export const makeTemporaryToolkitFolder = async (...relativePathParts: string[])
  * @param p  Path to file or directory to test.
  */
 export function isInDirectory(d: string, p: string): boolean {
-    const parentDirPieces = d.split(path.sep)
-    const containedPathPieces = p.split(path.sep)
+    if (d === '' || p === '') {
+        return true
+    }
+    const parentDirPieces = pathutils.normalizeSeparator(d).split('/')
+    const containedPathPieces = pathutils.normalizeSeparator(p).split('/')
     // Remove final empty element(s), if `d` ends with slash(es).
     while (parentDirPieces.length > 0 && parentDirPieces[parentDirPieces.length - 1] === '') {
         parentDirPieces.pop()
     }
+    const caseInsensitive = os.platform() === 'win32'
 
     return parentDirPieces.every((value, index) => {
-        return value === containedPathPieces[index]
+        return caseInsensitive
+            ? value.toLowerCase() === containedPathPieces[index].toLowerCase()
+            : value === containedPathPieces[index]
     })
 }

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -11,7 +11,7 @@ const localize = nls.loadMessageBundle()
 import { samLambdaRuntimes } from '../../../lambda/models/samLambdaRuntime'
 import { CloudFormation } from '../../cloudformation/cloudformation'
 import { CloudFormationTemplateRegistry } from '../../cloudformation/templateRegistry'
-import { isContainedWithinDirectory } from '../../filesystemUtilities'
+import { isInDirectory } from '../../filesystemUtilities'
 import { AwsSamDebuggerConfiguration, TemplateTargetProperties } from './awsSamDebugConfiguration'
 
 export const AWS_SAM_DEBUG_TYPE = 'aws-sam'
@@ -35,7 +35,7 @@ export class AwsSamDebugConfigurationProvider implements vscode.DebugConfigurati
             const templates = this.cftRegistry.registeredTemplates
 
             for (const templateDatum of templates) {
-                if (isContainedWithinDirectory(folderPath, templateDatum.path) && templateDatum.template.Resources) {
+                if (isInDirectory(folderPath, templateDatum.path) && templateDatum.template.Resources) {
                     for (const resourceKey of Object.keys(templateDatum.template.Resources)) {
                         const resource = templateDatum.template.Resources[resourceKey]
                         if (resource) {

--- a/src/test/shared/filesystemUtilities.test.ts
+++ b/src/test/shared/filesystemUtilities.test.ts
@@ -11,7 +11,7 @@ import { mkdir } from '../../shared/filesystem'
 import {
     fileExists,
     findFileInParentPaths,
-    isContainedWithinDirectory,
+    isInDirectory,
     makeTemporaryToolkitFolder,
     tempDirPath,
 } from '../../shared/filesystemUtilities'
@@ -101,33 +101,17 @@ describe('filesystemUtilities', () => {
         })
     })
 
-    describe('isContainedWithinDirectory', () => {
+    it('isInDirectory()', () => {
         const basePath = path.join('this', 'is', 'the', 'way')
         const extendedPath = path.join(basePath, 'forward')
         const filename = 'yadayadayada.log'
 
-        it('returns true for the same dir', () => {
-            assert.ok(isContainedWithinDirectory(basePath, basePath))
-        })
-
-        it('returns true for a subdir', () => {
-            assert.ok(isContainedWithinDirectory(basePath, extendedPath))
-        })
-
-        it('returns true for a file in the same dir', () => {
-            assert.ok(isContainedWithinDirectory(basePath, path.join(basePath, filename)))
-        })
-
-        it('returns true for a file in a subdir', () => {
-            assert.ok(isContainedWithinDirectory(basePath, path.join(extendedPath, filename)))
-        })
-
-        it('returns false for a completely different dir', () => {
-            assert.ok(!isContainedWithinDirectory(basePath, path.join('what', 'are', 'you', 'looking', 'at')))
-        })
-
-        it('returns false for a similarly named dir', () => {
-            assert.ok(!isContainedWithinDirectory(basePath, `${basePath}point`))
-        })
+        assert.ok(isInDirectory(basePath, basePath))
+        assert.ok(isInDirectory(basePath, extendedPath))
+        assert.ok(isInDirectory(basePath, path.join(basePath, filename)))
+        assert.ok(isInDirectory(basePath, path.join(extendedPath, filename)))
+        assert.ok(!isInDirectory(basePath, path.join('what', 'are', 'you', 'looking', 'at')))
+        assert.ok(!isInDirectory(basePath, `${basePath}point`))
+        assert.ok(isInDirectory('/foo/bar/baz/', '/foo/bar/baz/a.txt'))
     })
 })

--- a/src/test/shared/filesystemUtilities.test.ts
+++ b/src/test/shared/filesystemUtilities.test.ts
@@ -121,6 +121,8 @@ describe('filesystemUtilities', () => {
 
         if (os.platform() === 'win32') {
             assert.ok(isInDirectory('/foo/bar/baz/', '/FOO/BAR/BAZ/A.TXT'))
+            assert.ok(isInDirectory('C:\\foo\\bar\\baz\\', 'C:/FOO/BAR/BAZ/A.TXT'))
+            assert.ok(isInDirectory('C:\\foo\\bar\\baz', 'C:\\foo\\bar\\baz\\a.txt'))
         } else {
             assert.ok(!isInDirectory('/foo/bar/baz/', '/FOO/BAR/BAZ/A.TXT'))
         }

--- a/src/test/shared/filesystemUtilities.test.ts
+++ b/src/test/shared/filesystemUtilities.test.ts
@@ -4,6 +4,7 @@
  */
 
 import * as assert from 'assert'
+import * as os from 'os'
 import * as del from 'del'
 import { writeFile } from 'fs-extra'
 import * as path from 'path'
@@ -113,5 +114,15 @@ describe('filesystemUtilities', () => {
         assert.ok(!isInDirectory(basePath, path.join('what', 'are', 'you', 'looking', 'at')))
         assert.ok(!isInDirectory(basePath, `${basePath}point`))
         assert.ok(isInDirectory('/foo/bar/baz/', '/foo/bar/baz/a.txt'))
+        assert.ok(isInDirectory('/foo/bar/baz/', ''))
+        assert.ok(isInDirectory('/', ''))
+        assert.ok(isInDirectory('', 'foo'))
+        assert.ok(isInDirectory('foo', 'foo'))
+
+        if (os.platform() === 'win32') {
+            assert.ok(isInDirectory('/foo/bar/baz/', '/FOO/BAR/BAZ/A.TXT'))
+        } else {
+            assert.ok(!isInDirectory('/foo/bar/baz/', '/FOO/BAR/BAZ/A.TXT'))
+        }
     })
 })


### PR DESCRIPTION
If directory has trailing slashes, they do not change the logical question of whether some other path is a descendant of the directory.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
