### PR TITLE
Bumping VS Code minimum version: 1.31.1 => 1.42.0

### DIFF
--- a/.changes/next-release/Breaking Change-d7152d4c-71b8-445e-8900-a1349bf01a72.json
+++ b/.changes/next-release/Breaking Change-d7152d4c-71b8-445e-8900-a1349bf01a72.json
@@ -1,0 +1,4 @@
+{
+    "type": "Breaking Change",
+    "description": "Bumping VS Code minimum version: 1.31.1 => 1.42.0"
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "url": "https://github.com/aws/aws-toolkit-vscode"
     },
     "engines": {
-        "vscode": "^1.31.1"
+        "vscode": "^1.42.0"
     },
     "icon": "resources/aws-icon-256x256.png",
     "bugs": {


### PR DESCRIPTION
Toolkit version 1.8.0 introduced a unseen VS Code engine version requirement: the LSP client requires VS Code 1.42.0 or greater. Adding this dependency to our `package.json` so that way the extension can't be installed on lower versions of VS Code.

Brought to our attention in https://github.com/aws/aws-toolkit-vscode/issues/1041 .

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
