### PR TITLE
Fix issue where Telemetry preference is incorrectly changing

### DIFF
--- a/src/test/shared/telemetry/awsTelemetryOptOut.test.ts
+++ b/src/test/shared/telemetry/awsTelemetryOptOut.test.ts
@@ -4,11 +4,18 @@
  */
 
 import * as assert from 'assert'
-import { AwsTelemetryOptOut, TelemetryOptOutOptions } from '../../../shared/telemetry/awsTelemetryOptOut'
+import {
+    AwsTelemetryOptOut,
+    SETTINGS_TELEMETRY_VALUE_ENABLE,
+    SETTINGS_TELEMETRY_VALUE_DISABLE,
+    SETTINGS_TELEMETRY_VALUE_USEIDE,
+} from '../../../shared/telemetry/awsTelemetryOptOut'
 import { TelemetryEvent } from '../../../shared/telemetry/telemetryEvent'
 import { TelemetryFeedback } from '../../../shared/telemetry/telemetryFeedback'
 import { TelemetryService } from '../../../shared/telemetry/telemetryService'
 import { TestSettingsConfiguration } from '../../../test/utilities/testSettingsConfiguration'
+import { DefaultSettingsConfiguration } from '../../../shared/settingsConfiguration'
+import { extensionSettingsPrefix } from '../../../shared/constants'
 
 class MockTelemetryService implements TelemetryService {
     public persistFilePath: string = ''
@@ -42,33 +49,58 @@ describe('AwsTelemetryOptOut', () => {
     const mockSettings = new TestSettingsConfiguration()
     const telemetryOptOut = new AwsTelemetryOptOut(mockService, mockSettings)
 
-    it('updateTelemetryConfiguration saves settings', async () => {
-        await telemetryOptOut.updateTelemetryConfiguration(TelemetryOptOutOptions.Enable)
-        assert.strictEqual(mockSettings.readSetting<boolean>('telemetry'), true)
-        await telemetryOptOut.updateTelemetryConfiguration(TelemetryOptOutOptions.Disable)
-        assert.strictEqual(mockSettings.readSetting<boolean>('telemetry'), false)
-        await telemetryOptOut.updateTelemetryConfiguration(TelemetryOptOutOptions.SameAsVsCode)
-        assert.strictEqual(mockSettings.readSetting<boolean>('telemetry'), undefined)
-    })
-
-    it('updateTelemetryConfiguration(TelemetryOptOutOptions.Enable) enables telemetry', async () => {
-        await telemetryOptOut.updateTelemetryConfiguration(TelemetryOptOutOptions.Enable)
+    it('updateTelemetryConfiguration(Enable) enables telemetry', async () => {
+        await telemetryOptOut.updateTelemetryConfiguration(SETTINGS_TELEMETRY_VALUE_ENABLE)
         assert.strictEqual(mockService.telemetryEnabled, true)
     })
 
-    it('updateTelemetryConfiguration(TelemetryOptOutOptions.Disable) disables telemetry', async () => {
-        await telemetryOptOut.updateTelemetryConfiguration(TelemetryOptOutOptions.Disable)
+    it('updateTelemetryConfiguration(Disable) disables telemetry', async () => {
+        await telemetryOptOut.updateTelemetryConfiguration(SETTINGS_TELEMETRY_VALUE_DISABLE)
         assert.strictEqual(mockService.telemetryEnabled, false)
     })
 
     // VS Code tests use the same preferences as the host editor
-    it('updateTelemetryConfiguration(TelemetryOptOutOptions.SameAsVsCode) matches user setting', async () => {
+    it('updateTelemetryConfiguration(UseIde) matches user setting', async () => {
         const telemetryOptOutVsCodeOptionAlwaysTrue = new AwsTelemetryOptOut(mockService, mockSettings, () => true)
-        await telemetryOptOutVsCodeOptionAlwaysTrue.updateTelemetryConfiguration(TelemetryOptOutOptions.SameAsVsCode)
+        await telemetryOptOutVsCodeOptionAlwaysTrue.updateTelemetryConfiguration(SETTINGS_TELEMETRY_VALUE_USEIDE)
         assert.strictEqual(mockService.telemetryEnabled, true)
 
         const telemetryOptOutVsCodeOptionAlwaysFalse = new AwsTelemetryOptOut(mockService, mockSettings, () => false)
-        await telemetryOptOutVsCodeOptionAlwaysFalse.updateTelemetryConfiguration(TelemetryOptOutOptions.SameAsVsCode)
+        await telemetryOptOutVsCodeOptionAlwaysFalse.updateTelemetryConfiguration(SETTINGS_TELEMETRY_VALUE_USEIDE)
         assert.strictEqual(mockService.telemetryEnabled, false)
+    })
+})
+
+// TODO : separate out concerns in AwsTelemetryOptOut so we can test smaller portions of AwsTelemetryOptOut
+describe('AwsTelemetryOptOut VSCode configuration', () => {
+    const mockService = new MockTelemetryService()
+    // Must use the real settings because VS Code has explicit handling around enum values
+    const settings = new DefaultSettingsConfiguration(extensionSettingsPrefix)
+    const telemetryOptOut = new AwsTelemetryOptOut(mockService, settings, () => false)
+
+    const scenarios = [
+        {
+            optOutOption: SETTINGS_TELEMETRY_VALUE_ENABLE,
+            expectedSetting: SETTINGS_TELEMETRY_VALUE_ENABLE,
+        },
+        {
+            optOutOption: SETTINGS_TELEMETRY_VALUE_DISABLE,
+            expectedSetting: SETTINGS_TELEMETRY_VALUE_DISABLE,
+        },
+        {
+            optOutOption: SETTINGS_TELEMETRY_VALUE_USEIDE,
+            expectedSetting: SETTINGS_TELEMETRY_VALUE_USEIDE,
+        },
+        {
+            optOutOption: 'garbage',
+            expectedSetting: SETTINGS_TELEMETRY_VALUE_USEIDE,
+        },
+    ]
+
+    scenarios.forEach(scenario => {
+        it(`handles ${scenario.optOutOption}`, async () => {
+            await telemetryOptOut.updateTelemetryConfiguration(scenario.optOutOption)
+            assert.strictEqual(settings.readSetting<boolean>('telemetry'), scenario.expectedSetting)
+        })
     })
 })


### PR DESCRIPTION

The telemetry opt-in setting is an enum, but our code was reading/writing it as a nullable boolean. At some point, VS Code started to treat this as unexpected data, changing the setting to the default, which is "defer to the IDE".

This change stops the bleeding by adding correct reading/writing of the field going forward. Improving quality of code in adjacent areas is out of scope.

Test plan:
* manually set the setting to "Enabled", activated extension, saw that metrics are opted in
* manually set the setting to "Disabled", activated extension, saw that metrics are opted out
* manually set the setting to use the IDEs setting, activated extension, saw that metrics follow suit
* manually set the setting to garbage, activated extension, saw that metrics follow the default (use the IDE)


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
