### PR TITLE
`Run Local` and `Debug Local` Codelenses in .js, .py, and .cs files => `Add Debug Configuration` Codelenses

### DIFF
--- a/src/integrationTest/codelens.js.test.ts
+++ b/src/integrationTest/codelens.js.test.ts
@@ -4,11 +4,11 @@
  */
 
 import * as assert from 'assert'
-import { join } from 'path'
+import { dirname, join } from 'path'
 import * as vscode from 'vscode'
-import { LambdaLocalInvokeParams } from '../shared/codelens/localLambdaRunner'
 import { VSCODE_EXTENSION_ID } from '../shared/extensions'
 import { activateExtension, expectCodeLenses, getTestWorkspaceFolder } from './integrationTestsUtilities'
+import { AddSamDebugConfigurationInput } from '../shared/sam/debugger/commands/addSamDebugConfiguration'
 
 const ACTIVATE_EXTENSION_TIMEOUT_MILLIS = 30000
 const CODELENS_TEST_TIMEOUT_MILLIS = 10000
@@ -28,101 +28,78 @@ describe('SAM Local CodeLenses (JS)', async () => {
     it('appear when manifest in subfolder and app is beside manifest', async () => {
         const appRoot = join(workspaceFolder, 'js-plain-sam-app')
         const appCodePath = join(appRoot, 'src', 'app.js')
-        const samTemplatePath = join(appRoot, 'template.yaml')
         const expectedHandlerName = 'app.handlerBesidePackageJson'
         const document = await vscode.workspace.openTextDocument(appCodePath)
 
         const codeLenses = await expectCodeLenses(document.uri)
 
-        assertDebugCodeLensExists(codeLenses, expectedHandlerName, samTemplatePath)
-        assertRunCodeLensExists(codeLenses, expectedHandlerName, samTemplatePath)
+        assertAddDebugConfigCodeLensExists(codeLenses, expectedHandlerName, dirname(appCodePath))
     }).timeout(CODELENS_TEST_TIMEOUT_MILLIS)
 
     it('appear when manifest in root', async () => {
         const appRoot = join(workspaceFolder, 'js-manifest-in-root')
         const appCodePath = join(appRoot, 'src', 'subfolder', 'app.js')
-        const samTemplatePath = join(appRoot, 'template.yaml')
         const expectedHandlerName = 'src/subfolder/app.handlerTwoFoldersDeep'
         const document = await vscode.workspace.openTextDocument(appCodePath)
 
         const codeLenses = await expectCodeLenses(document.uri)
 
-        assertDebugCodeLensExists(codeLenses, expectedHandlerName, samTemplatePath)
-        assertRunCodeLensExists(codeLenses, expectedHandlerName, samTemplatePath)
+        assertAddDebugConfigCodeLensExists(codeLenses, expectedHandlerName, join(dirname(appCodePath), '..', '..'))
     }).timeout(CODELENS_TEST_TIMEOUT_MILLIS)
 
     it('appear when manifest in subfolder and app in subfolder to manifest', async () => {
         const appRoot = join(workspaceFolder, 'js-manifest-in-subfolder')
         const appCodePath = join(appRoot, 'src', 'subfolder', 'app.js')
-        const samTemplatePath = join(appRoot, 'template.yaml')
         const expectedHandlerName = 'subfolder/app.handlerInManifestSubfolder'
         const document = await vscode.workspace.openTextDocument(appCodePath)
 
         const codeLenses = await expectCodeLenses(document.uri)
 
-        assertDebugCodeLensExists(codeLenses, expectedHandlerName, samTemplatePath)
-        assertRunCodeLensExists(codeLenses, expectedHandlerName, samTemplatePath)
+        assertAddDebugConfigCodeLensExists(codeLenses, expectedHandlerName, join(dirname(appCodePath), '..'))
     }).timeout(CODELENS_TEST_TIMEOUT_MILLIS)
 
     it('appear when project is a few folders deep in the workspace', async () => {
         const appRoot = join(workspaceFolder, 'deeper-projects', 'js-plain-sam-app')
         const appCodePath = join(appRoot, 'src', 'app.js')
-        const samTemplatePath = join(appRoot, 'template.yaml')
         const expectedHandlerName = 'app.projectDeepInWorkspace'
         const document = await vscode.workspace.openTextDocument(appCodePath)
 
         const codeLenses = await expectCodeLenses(document.uri)
 
-        assertDebugCodeLensExists(codeLenses, expectedHandlerName, samTemplatePath)
-        assertRunCodeLensExists(codeLenses, expectedHandlerName, samTemplatePath)
+        assertAddDebugConfigCodeLensExists(codeLenses, expectedHandlerName, dirname(appCodePath))
     })
 
-    function assertDebugCodeLensExists(
+    function assertAddDebugConfigCodeLensExists(
         codeLenses: vscode.CodeLens[],
         expectedHandlerName: string,
-        expectedSamTemplatePath: string
+        manifestPath: string
     ) {
         const debugCodeLenses = getLocalInvokeCodeLenses(codeLenses).filter(codeLens =>
-            hasLocalInvokeArguments(codeLens, expectedHandlerName, expectedSamTemplatePath, true)
+            hasLocalInvokeArguments(codeLens, expectedHandlerName, manifestPath)
         )
 
-        assert.strictEqual(debugCodeLenses.length, 1, 'Debug CodeLens was not found')
-    }
-
-    function assertRunCodeLensExists(
-        codeLenses: vscode.CodeLens[],
-        expectedHandlerName: string,
-        expectedSamTemplatePath: string
-    ) {
-        const debugCodeLenses = getLocalInvokeCodeLenses(codeLenses).filter(codeLens =>
-            hasLocalInvokeArguments(codeLens, expectedHandlerName, expectedSamTemplatePath, false)
-        )
-
-        assert.strictEqual(debugCodeLenses.length, 1, 'Run CodeLens was not found')
+        assert.strictEqual(debugCodeLenses.length, 1, 'Add Debug Config CodeLens was not found')
     }
 
     function getLocalInvokeCodeLenses(codeLenses: vscode.CodeLens[]): vscode.CodeLens[] {
         return codeLenses.filter(
             codeLens =>
                 codeLens.command &&
-                codeLens.command.command === 'aws.lambda.local.invoke.javascript' &&
+                codeLens.command.command === 'aws.addSamDebugConfiguration' &&
                 codeLens.command.arguments &&
-                codeLens.command.arguments.length === 1
+                codeLens.command.arguments.length === 2
         )
     }
 
-    function hasLocalInvokeArguments(
-        codeLens: vscode.CodeLens,
-        handlerName: string,
-        templatePath: string,
-        isDebug: boolean
-    ): boolean {
-        if (!codeLens.command || !codeLens.command.arguments || codeLens.command.arguments.length !== 1) {
+    function hasLocalInvokeArguments(codeLens: vscode.CodeLens, handlerName: string, manifestPath: string): boolean {
+        if (!codeLens.command || !codeLens.command.arguments || codeLens.command.arguments.length !== 2) {
             return false
         }
 
-        const commandArguments = codeLens.command.arguments[0] as LambdaLocalInvokeParams
+        const commandArguments = codeLens.command.arguments[0] as AddSamDebugConfigurationInput
 
-        return commandArguments.handlerName === handlerName && commandArguments.isDebug === isDebug
+        return (
+            commandArguments.resourceName === handlerName && dirname(commandArguments.rootUri.fsPath) === manifestPath
+        )
     }
 })

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -379,7 +379,7 @@ describe('SAM Integration Tests', async () => {
         //     }
         // }
 
-        function assertCodeLensReferencesHasSameRoot(codeLens: vscode.CodeLens, expectedSamTemplatePath: vscode.Uri) {
+        function assertCodeLensReferencesHasSameRoot(codeLens: vscode.CodeLens, expectedUri: vscode.Uri) {
             assert.ok(codeLens.command, 'CodeLens did not have a command')
             const command = codeLens.command!
 
@@ -390,7 +390,7 @@ describe('SAM Integration Tests', async () => {
             const params: AddSamDebugConfigurationInput = commandArguments[0]
             assert.ok(params, 'unexpected non-defined command argument')
 
-            assert.strictEqual(path.dirname(params.rootUri.fsPath), path.dirname(expectedSamTemplatePath.fsPath))
+            assert.strictEqual(path.dirname(params.rootUri.fsPath), path.dirname(expectedUri.fsPath))
         }
     }
 })

--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -12,32 +12,28 @@ import { localize } from '../utilities/vsCodeUtils'
 import * as pythonDebug from './pythonCodeLensProvider'
 import * as csharpDebug from './csharpCodeLensProvider'
 import * as tsDebug from './typescriptCodeLensProvider'
-import { SettingsConfiguration } from '../settingsConfiguration'
 import { LambdaLocalInvokeParams } from './localLambdaRunner'
 import { ExtContext } from '../extensions'
 import { recordLambdaInvokeLocal, Result, Runtime } from '../telemetry/telemetry'
 import { nodeJsRuntimes } from '../../lambda/models/samLambdaRuntime'
+import { CODE_TARGET_TYPE } from '../sam/debugger/awsSamDebugConfiguration'
 
 export type Language = 'python' | 'javascript' | 'csharp'
 
-interface MakeConfigureCodeLensParams {
-    document: vscode.TextDocument
+interface MakeAddDebugConfigCodeLensParams {
     handlerName: string
     range: vscode.Range
-    workspaceFolder: vscode.WorkspaceFolder
-    language: Language
+    rootUri: vscode.Uri
 }
 
 export async function makeCodeLenses({
     document,
     token,
     handlers,
-    language,
 }: {
     document: vscode.TextDocument
     token: vscode.CancellationToken
     handlers: LambdaHandlerCandidate[]
-    language: Language
 }): Promise<vscode.CodeLens[]> {
     const workspaceFolder: vscode.WorkspaceFolder | undefined = vscode.workspace.getWorkspaceFolder(document.uri)
 
@@ -57,15 +53,12 @@ export async function makeCodeLenses({
                   )
 
         try {
-            const baseParams: MakeConfigureCodeLensParams = {
-                document,
+            const baseParams: MakeAddDebugConfigCodeLensParams = {
                 handlerName: handler.handlerName,
                 range,
-                workspaceFolder,
-                language,
+                rootUri: handler.projectRoot,
             }
-            lenses.push(makeLocalInvokeCodeLens({ ...baseParams, isDebug: false }))
-            lenses.push(makeLocalInvokeCodeLens({ ...baseParams, isDebug: true }))
+            lenses.push(makeAddCodeSamDebugCodeLens(baseParams))
         } catch (err) {
             getLogger().error(
                 `Could not generate 'configure' code lens for handler '${handler.handlerName}'`,
@@ -81,26 +74,23 @@ export function getInvokeCmdKey(language: Language) {
     return `aws.lambda.local.invoke.${language}`
 }
 
-// TODO: Morph into new debug config codelens
-function makeLocalInvokeCodeLens(
-    params: MakeConfigureCodeLensParams & { isDebug: boolean; language: Language }
-): vscode.CodeLens {
-    const title: string = params.isDebug
-        ? localize('AWS.codelens.lambda.invoke.debug', 'Debug Locally')
-        : localize('AWS.codelens.lambda.invoke', 'Run Locally')
-
+function makeAddCodeSamDebugCodeLens(params: MakeAddDebugConfigCodeLensParams): vscode.CodeLens {
     const command: vscode.Command = {
-        arguments: [params],
-        command: getInvokeCmdKey(params.language),
-        title,
+        title: localize('AWS.command.addSamDebugConfiguration', 'Add Debug Configuration'),
+        command: 'aws.addSamDebugConfiguration',
+        arguments: [
+            {
+                resourceName: params.handlerName,
+                rootUri: params.rootUri,
+            },
+            CODE_TARGET_TYPE,
+        ],
     }
 
     return new vscode.CodeLens(params.range, command)
 }
 
-export async function makePythonCodeLensProvider(
-    pythonSettings: SettingsConfiguration
-): Promise<vscode.CodeLensProvider> {
+export async function makePythonCodeLensProvider(): Promise<vscode.CodeLensProvider> {
     const logger = getLogger()
 
     return {
@@ -125,7 +115,6 @@ export async function makePythonCodeLensProvider(
                 document,
                 handlers,
                 token,
-                language: 'python',
             })
         },
     }
@@ -146,7 +135,6 @@ export async function makeCSharpCodeLensProvider(): Promise<vscode.CodeLensProvi
                 document,
                 handlers,
                 token,
-                language: 'csharp',
             })
         },
     }
@@ -167,7 +155,6 @@ export function makeTypescriptCodeLensProvider(): vscode.CodeLensProvider {
                 document,
                 handlers,
                 token,
-                language: 'javascript',
             })
         },
     }

--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -56,7 +56,7 @@ export async function makeCodeLenses({
             const baseParams: MakeAddDebugConfigCodeLensParams = {
                 handlerName: handler.handlerName,
                 range,
-                rootUri: handler.projectRoot,
+                rootUri: handler.manifestUri,
             }
             lenses.push(makeAddCodeSamDebugCodeLens(baseParams))
         } catch (err) {

--- a/src/shared/codelens/csharpCodeLensProvider.ts
+++ b/src/shared/codelens/csharpCodeLensProvider.ts
@@ -210,7 +210,7 @@ export async function getLambdaHandlerCandidates(document: vscode.TextDocument):
             return {
                 filename: document.uri.fsPath,
                 handlerName,
-                projectRoot: assemblyUri,
+                manifestUri: assemblyUri,
                 range: lambdaHandlerComponents.handlerRange,
             }
         }

--- a/src/shared/codelens/csharpCodeLensProvider.ts
+++ b/src/shared/codelens/csharpCodeLensProvider.ts
@@ -204,6 +204,7 @@ export async function getLambdaHandlerCandidates(document: vscode.TextDocument):
             return {
                 filename: document.uri.fsPath,
                 handlerName,
+                projectRoot: assemblyName,
                 range: lambdaHandlerComponents.handlerRange,
             }
         }

--- a/src/shared/codelens/csharpCodeLensProvider.ts
+++ b/src/shared/codelens/csharpCodeLensProvider.ts
@@ -186,10 +186,16 @@ export async function invokeCsharpLambda(ctx: ExtContext, config: SamLaunchReque
 }
 
 export async function getLambdaHandlerCandidates(document: vscode.TextDocument): Promise<LambdaHandlerCandidate[]> {
-    const assemblyName = await getAssemblyName(document.uri)
-    if (!assemblyName) {
+    // Limitation: If more than one .csproj file exists in the same directory,
+    // and the directory is the closest to the source file, the csproj file used will be random
+
+    // TODO : Perform an XPATH parse on the project file
+    // If Project/PropertyGroup/AssemblyName exists, use that. Otherwise use the file name.
+    const assemblyUri = await findParentProjectFile(document.uri, '*.csproj')
+    if (!assemblyUri) {
         return []
     }
+    const assemblyName = path.parse(assemblyUri.fsPath).name
 
     const symbols: vscode.DocumentSymbol[] =
         (await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
@@ -204,25 +210,11 @@ export async function getLambdaHandlerCandidates(document: vscode.TextDocument):
             return {
                 filename: document.uri.fsPath,
                 handlerName,
-                projectRoot: assemblyName,
+                projectRoot: assemblyUri,
                 range: lambdaHandlerComponents.handlerRange,
             }
         }
     )
-}
-
-async function getAssemblyName(sourceCodeUri: vscode.Uri): Promise<string | undefined> {
-    // Limitation: If more than one .csproj file exists in the same directory,
-    // and the directory is the closest to the source file, the csproj file used will be random
-    const projectFile = await findParentProjectFile(sourceCodeUri, '*.csproj')
-    if (!projectFile) {
-        return undefined
-    }
-
-    // TODO : Perform an XPATH parse on the project file
-    // If Project/PropertyGroup/AssemblyName exists, use that. Otherwise use the file name.
-
-    return path.parse(projectFile.fsPath).name
 }
 
 export function getLambdaHandlerComponents(

--- a/src/shared/codelens/pythonCodeLensProvider.ts
+++ b/src/shared/codelens/pythonCodeLensProvider.ts
@@ -65,7 +65,7 @@ export async function getLambdaHandlerCandidates(uri: vscode.Uri): Promise<Lambd
         return {
             filename,
             handlerName: `${handlerPath}.${symbol.name}`,
-            projectRoot: requirementsFile,
+            manifestUri: requirementsFile,
             range: symbol.range,
         }
     })

--- a/src/shared/codelens/pythonCodeLensProvider.ts
+++ b/src/shared/codelens/pythonCodeLensProvider.ts
@@ -65,6 +65,7 @@ export async function getLambdaHandlerCandidates(uri: vscode.Uri): Promise<Lambd
         return {
             filename,
             handlerName: `${handlerPath}.${symbol.name}`,
+            projectRoot: requirementsFile.fsPath,
             range: symbol.range,
         }
     })

--- a/src/shared/codelens/pythonCodeLensProvider.ts
+++ b/src/shared/codelens/pythonCodeLensProvider.ts
@@ -65,7 +65,7 @@ export async function getLambdaHandlerCandidates(uri: vscode.Uri): Promise<Lambd
         return {
             filename,
             handlerName: `${handlerPath}.${symbol.name}`,
-            projectRoot: requirementsFile.fsPath,
+            projectRoot: requirementsFile,
             range: symbol.range,
         }
     })

--- a/src/shared/codelens/samTemplateCodeLensProvider.ts
+++ b/src/shared/codelens/samTemplateCodeLensProvider.ts
@@ -7,7 +7,11 @@ import * as _ from 'lodash'
 import * as vscode from 'vscode'
 import { TemplateFunctionResource, TemplateSymbolResolver } from '../cloudformation/templateSymbolResolver'
 import { LaunchConfiguration } from '../debug/launchConfiguration'
-import { isTemplateTargetProperties, TemplateTargetProperties } from '../sam/debugger/awsSamDebugConfiguration'
+import {
+    isTemplateTargetProperties,
+    TemplateTargetProperties,
+    TEMPLATE_TARGET_TYPE,
+} from '../sam/debugger/awsSamDebugConfiguration'
 import { AddSamDebugConfigurationInput } from '../sam/debugger/commands/addSamDebugConfiguration'
 import { localize } from '../utilities/vsCodeUtils'
 import * as pathutils from '../utilities/pathUtils'
@@ -38,13 +42,13 @@ export class SamTemplateCodeLensProvider implements vscode.CodeLensProvider {
     private createCodeLens(functionResource: TemplateFunctionResource, templateUri: vscode.Uri): vscode.CodeLens {
         const input: AddSamDebugConfigurationInput = {
             resourceName: functionResource.name,
-            templateUri: templateUri,
+            rootUri: templateUri,
         }
 
         return new vscode.CodeLens(functionResource.range, {
             title: localize('AWS.command.addSamDebugConfiguration', 'Add Debug Configuration'),
             command: 'aws.addSamDebugConfiguration',
-            arguments: [input],
+            arguments: [input, TEMPLATE_TARGET_TYPE],
         })
     }
 }

--- a/src/shared/codelens/typescriptCodeLensProvider.ts
+++ b/src/shared/codelens/typescriptCodeLensProvider.ts
@@ -71,7 +71,7 @@ async function finalizeTsHandlers(
         return {
             filename: handler.filename,
             handlerName: normalizeSeparator(path.join(relativePath, handler.handlerName)),
-            projectRoot: packageJsonFileUri.fsPath,
+            projectRoot: packageJsonFileUri,
             range: handler.range,
         }
     })

--- a/src/shared/codelens/typescriptCodeLensProvider.ts
+++ b/src/shared/codelens/typescriptCodeLensProvider.ts
@@ -71,7 +71,7 @@ async function finalizeTsHandlers(
         return {
             filename: handler.filename,
             handlerName: normalizeSeparator(path.join(relativePath, handler.handlerName)),
-            projectRoot: packageJsonFileUri,
+            manifestUri: packageJsonFileUri,
             range: handler.range,
         }
     })

--- a/src/shared/lambdaHandlerSearch.ts
+++ b/src/shared/lambdaHandlerSearch.ts
@@ -2,7 +2,7 @@
  * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Range } from 'vscode'
+import { Range, Uri } from 'vscode'
 
 export interface AbsoluteCharOffset {
     positionStart: number
@@ -12,7 +12,7 @@ export interface AbsoluteCharOffset {
 export type RangeOrCharOffset = Range | AbsoluteCharOffset
 
 export interface LambdaHandlerCandidate extends RootlessLambdaHandlerCandidate {
-    projectRoot: string
+    projectRoot: Uri
 }
 
 export interface RootlessLambdaHandlerCandidate {

--- a/src/shared/lambdaHandlerSearch.ts
+++ b/src/shared/lambdaHandlerSearch.ts
@@ -11,7 +11,11 @@ export interface AbsoluteCharOffset {
 
 export type RangeOrCharOffset = Range | AbsoluteCharOffset
 
-export interface LambdaHandlerCandidate {
+export interface LambdaHandlerCandidate extends RootlessLambdaHandlerCandidate {
+    projectRoot: string
+}
+
+export interface RootlessLambdaHandlerCandidate {
     handlerName: string
     filename: string
     range: RangeOrCharOffset
@@ -22,5 +26,5 @@ export interface LambdaHandlerSearch {
      * @description Looks for functions that appear to be valid Lambda Function Handlers.
      * @returns A collection of information for each detected candidate.
      */
-    findCandidateLambdaHandlers(): Promise<LambdaHandlerCandidate[]>
+    findCandidateLambdaHandlers(): Promise<RootlessLambdaHandlerCandidate[]>
 }

--- a/src/shared/lambdaHandlerSearch.ts
+++ b/src/shared/lambdaHandlerSearch.ts
@@ -12,7 +12,7 @@ export interface AbsoluteCharOffset {
 export type RangeOrCharOffset = Range | AbsoluteCharOffset
 
 export interface LambdaHandlerCandidate extends RootlessLambdaHandlerCandidate {
-    projectRoot: Uri
+    manifestUri: Uri
 }
 
 export interface RootlessLambdaHandlerCandidate {

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -18,7 +18,7 @@ import * as csLensProvider from '../codelens/csharpCodeLensProvider'
 import * as pyLensProvider from '../codelens/pythonCodeLensProvider'
 import { SamTemplateCodeLensProvider } from '../codelens/samTemplateCodeLensProvider'
 import { ExtContext } from '../extensions'
-import { DefaultSettingsConfiguration, SettingsConfiguration } from '../settingsConfiguration'
+import { SettingsConfiguration } from '../settingsConfiguration'
 import { TelemetryService } from '../telemetry/telemetryService'
 import { PromiseSharer } from '../utilities/promiseUtilities'
 import { initialize as initializeSamCliContext } from './cli/samCliContext'
@@ -144,7 +144,7 @@ async function activateCodeLensProviders(
     disposables.push(
         vscode.languages.registerCodeLensProvider(
             pyLensProvider.PYTHON_ALLFILES,
-            await codelensUtils.makePythonCodeLensProvider(new DefaultSettingsConfiguration('python'))
+            await codelensUtils.makePythonCodeLensProvider()
         )
     )
 

--- a/src/shared/sam/debugger/awsSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfiguration.ts
@@ -84,3 +84,17 @@ export function createTemplateAwsSamDebugConfig(
 
     return response
 }
+
+export function createCodeAwsSamDebugConfig(lambdaHandler: string, projectRoot: string): AwsSamDebuggerConfiguration {
+    return {
+        type: AWS_SAM_DEBUG_TYPE,
+        request: DIRECT_INVOKE_TYPE,
+        // TODO: change the name?
+        name: lambdaHandler,
+        invokeTarget: {
+            target: CODE_TARGET_TYPE,
+            projectRoot,
+            lambdaHandler,
+        },
+    }
+}

--- a/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
@@ -3,68 +3,82 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as path from 'path'
 import * as vscode from 'vscode'
 import { LaunchConfiguration } from '../../../debug/launchConfiguration'
-import { createTemplateAwsSamDebugConfig } from '../awsSamDebugConfiguration'
+import {
+    AwsSamDebuggerConfiguration,
+    CODE_TARGET_TYPE,
+    createCodeAwsSamDebugConfig,
+    createTemplateAwsSamDebugConfig,
+    TEMPLATE_TARGET_TYPE,
+} from '../awsSamDebugConfiguration'
 import { CloudFormationTemplateRegistry } from '../../../cloudformation/templateRegistry'
 import { getExistingConfiguration } from '../../../../lambda/config/templates'
 import { localize } from '../../../utilities/vsCodeUtils'
 
 export interface AddSamDebugConfigurationInput {
     resourceName: string
-    templateUri: vscode.Uri
+    rootUri: vscode.Uri
 }
 
 /**
  * Adds a new debug configuration for the given sam function resource and template.
  */
-export async function addSamDebugConfiguration({
-    resourceName,
-    templateUri,
-}: AddSamDebugConfigurationInput): Promise<void> {
+export async function addSamDebugConfiguration(
+    { resourceName, rootUri }: AddSamDebugConfigurationInput,
+    type: typeof CODE_TARGET_TYPE | typeof TEMPLATE_TARGET_TYPE
+): Promise<void> {
     // tslint:disable-next-line: no-floating-promises
     emitCommandTelemetry()
 
-    const workspaceFolder = vscode.workspace.getWorkspaceFolder(templateUri)
-    let preloadedConfig = undefined
+    let samDebugConfig: AwsSamDebuggerConfiguration
 
-    if (workspaceFolder) {
-        const registry = CloudFormationTemplateRegistry.getRegistry()
-        const templateDatum = registry.getRegisteredTemplate(templateUri.fsPath)
-        if (templateDatum) {
-            const resource = templateDatum.template.Resources![resourceName]
-            if (resource && resource.Properties) {
-                const existingConfig = await getExistingConfiguration(
-                    workspaceFolder,
-                    resource.Properties.Handler,
-                    templateUri
-                )
-                if (existingConfig) {
-                    const responseYes: string = localize('AWS.generic.response.yes', 'Yes')
-                    const responseNo: string = localize('AWS.generic.response.no', 'No')
-                    const prompt = await vscode.window.showInformationMessage(
-                        localize(
-                            'AWS.sam.debugger.useExistingConfig',
-                            'The Toolkit has detected an existing legacy configuration for this function handler. Would you like it added to your Debug Configuration?'
-                        ),
-                        { modal: true },
-                        responseYes,
-                        responseNo
+    if (type === TEMPLATE_TARGET_TYPE) {
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(rootUri)
+        let preloadedConfig = undefined
+
+        if (workspaceFolder) {
+            const registry = CloudFormationTemplateRegistry.getRegistry()
+            const templateDatum = registry.getRegisteredTemplate(rootUri.fsPath)
+            if (templateDatum) {
+                const resource = templateDatum.template.Resources![resourceName]
+                if (resource && resource.Properties) {
+                    const existingConfig = await getExistingConfiguration(
+                        workspaceFolder,
+                        resource.Properties.Handler,
+                        rootUri
                     )
-                    if (!prompt) {
-                        // User selected "Cancel". Abandon config creation
-                        return
-                    } else if (prompt === responseYes) {
-                        preloadedConfig = existingConfig
+                    if (existingConfig) {
+                        const responseYes: string = localize('AWS.generic.response.yes', 'Yes')
+                        const responseNo: string = localize('AWS.generic.response.no', 'No')
+                        const prompt = await vscode.window.showInformationMessage(
+                            localize(
+                                'AWS.sam.debugger.useExistingConfig',
+                                'The Toolkit has detected an existing legacy configuration for this function handler. Would you like it added to your Debug Configuration?'
+                            ),
+                            { modal: true },
+                            responseYes,
+                            responseNo
+                        )
+                        if (!prompt) {
+                            // User selected "Cancel". Abandon config creation
+                            return
+                        } else if (prompt === responseYes) {
+                            preloadedConfig = existingConfig
+                        }
                     }
                 }
             }
         }
+        samDebugConfig = createTemplateAwsSamDebugConfig(resourceName, rootUri.fsPath, preloadedConfig)
+    } else if (type === CODE_TARGET_TYPE) {
+        samDebugConfig = createCodeAwsSamDebugConfig(resourceName, path.dirname(rootUri.fsPath))
+    } else {
+        throw new Error('Unrecognized debug target type')
     }
 
-    const samDebugConfig = createTemplateAwsSamDebugConfig(resourceName, templateUri.fsPath, preloadedConfig)
-
-    const launchConfig = new LaunchConfiguration(templateUri)
+    const launchConfig = new LaunchConfiguration(rootUri)
     await launchConfig.addDebugConfiguration(samDebugConfig)
 
     await showDebugConfiguration()

--- a/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
@@ -17,6 +17,11 @@ import { CloudFormationTemplateRegistry } from '../../../cloudformation/template
 import { getExistingConfiguration } from '../../../../lambda/config/templates'
 import { localize } from '../../../utilities/vsCodeUtils'
 
+/**
+ * Holds information required to create a launch config
+ * @field resourceName: Resource being used. For templates, this is the resource name in the CFN stack. For code, this is the handler's name
+ * @field rootUri: The code root. For templates, this is the CodeUri value. For code, this is the manifest's URI.
+ */
 export interface AddSamDebugConfigurationInput {
     resourceName: string
     rootUri: vscode.Uri
@@ -73,6 +78,7 @@ export async function addSamDebugConfiguration(
         }
         samDebugConfig = createTemplateAwsSamDebugConfig(resourceName, rootUri.fsPath, preloadedConfig)
     } else if (type === CODE_TARGET_TYPE) {
+        // strip the manifest's URI to the manifest's dir here. More reliable to do this here than converting back and forth between URI/string up the chain.
         samDebugConfig = createCodeAwsSamDebugConfig(resourceName, path.dirname(rootUri.fsPath))
     } else {
         throw new Error('Unrecognized debug target type')

--- a/src/shared/typescriptLambdaHandlerSearch.ts
+++ b/src/shared/typescriptLambdaHandlerSearch.ts
@@ -5,7 +5,7 @@
 
 import * as path from 'path'
 import * as ts from 'typescript'
-import { LambdaHandlerCandidate, LambdaHandlerSearch } from './lambdaHandlerSearch'
+import { LambdaHandlerSearch, RootlessLambdaHandlerCandidate } from './lambdaHandlerSearch'
 
 const getRange = (node: ts.Node) => ({
     positionStart: node.getStart(),
@@ -36,7 +36,7 @@ export class TypescriptLambdaHandlerSearch implements LambdaHandlerSearch {
      * @description Looks for functions that appear to be valid Lambda Function Handlers.
      * @returns A collection of information for each detected candidate.
      */
-    public async findCandidateLambdaHandlers(): Promise<LambdaHandlerCandidate[]> {
+    public async findCandidateLambdaHandlers(): Promise<RootlessLambdaHandlerCandidate[]> {
         this._candidateDeclaredFunctionNames.clear()
         this._candidateModuleExportsExpressions = []
         this._candidateExportDeclarations = []
@@ -45,10 +45,10 @@ export class TypescriptLambdaHandlerSearch implements LambdaHandlerSearch {
         return await this.getCandidateHandlers()
     }
 
-    private async getCandidateHandlers(): Promise<LambdaHandlerCandidate[]> {
+    private async getCandidateHandlers(): Promise<RootlessLambdaHandlerCandidate[]> {
         const sourceFile = ts.createSourceFile(this.filename, this.fileContents, ts.ScriptTarget.Latest, true)
 
-        const handlers: LambdaHandlerCandidate[] = this.processSourceFile(sourceFile)
+        const handlers: RootlessLambdaHandlerCandidate[] = this.processSourceFile(sourceFile)
 
         return handlers
     }
@@ -60,10 +60,10 @@ export class TypescriptLambdaHandlerSearch implements LambdaHandlerSearch {
      * @param sourceFile SourceFile child node to process
      * @returns Collection of candidate Lambda handler information, empty array otherwise
      */
-    private processSourceFile(sourceFile: ts.SourceFile): LambdaHandlerCandidate[] {
+    private processSourceFile(sourceFile: ts.SourceFile): RootlessLambdaHandlerCandidate[] {
         this.scanSourceFile(sourceFile)
 
-        const handlers: LambdaHandlerCandidate[] = []
+        const handlers: RootlessLambdaHandlerCandidate[] = []
 
         handlers.push(...this.findCandidateHandlersInModuleExports())
         handlers.push(...this.findCandidateHandlersInExportedFunctions())
@@ -130,7 +130,7 @@ export class TypescriptLambdaHandlerSearch implements LambdaHandlerSearch {
     /**
      * @description Looks at module.exports assignments to find candidate Lamdba handlers
      */
-    private findCandidateHandlersInModuleExports(): LambdaHandlerCandidate[] {
+    private findCandidateHandlersInModuleExports(): RootlessLambdaHandlerCandidate[] {
         return this._candidateModuleExportsExpressions
             .filter(expression => {
                 return TypescriptLambdaHandlerSearch.isEligibleLambdaHandlerAssignment(
@@ -158,8 +158,8 @@ export class TypescriptLambdaHandlerSearch implements LambdaHandlerSearch {
     /**
      * @description Looks at "export { xyz }" statements to find candidate Lambda handlers
      */
-    private findCandidateHandlersInExportDeclarations(): LambdaHandlerCandidate[] {
-        const handlers: LambdaHandlerCandidate[] = []
+    private findCandidateHandlersInExportDeclarations(): RootlessLambdaHandlerCandidate[] {
+        const handlers: RootlessLambdaHandlerCandidate[] = []
 
         this._candidateExportDeclarations.forEach(exportDeclaration => {
             if (exportDeclaration.exportClause) {
@@ -185,8 +185,8 @@ export class TypescriptLambdaHandlerSearch implements LambdaHandlerSearch {
     /**
      * @description Looks at export function declarations to find candidate Lamdba handlers
      */
-    private findCandidateHandlersInExportedFunctions(): LambdaHandlerCandidate[] {
-        const handlers: LambdaHandlerCandidate[] = []
+    private findCandidateHandlersInExportedFunctions(): RootlessLambdaHandlerCandidate[] {
+        const handlers: RootlessLambdaHandlerCandidate[] = []
 
         this._candidateExportNodes.forEach(exportNode => {
             if (

--- a/src/test/shared/codelens/samTemplateCodeLensProvider.test.ts
+++ b/src/test/shared/codelens/samTemplateCodeLensProvider.test.ts
@@ -9,7 +9,10 @@ import * as vscode from 'vscode'
 import { TemplateFunctionResource, TemplateSymbolResolver } from '../../../shared/cloudformation/templateSymbolResolver'
 import { SamTemplateCodeLensProvider } from '../../../shared/codelens/samTemplateCodeLensProvider'
 import { LaunchConfiguration } from '../../../shared/debug/launchConfiguration'
-import { AwsSamDebuggerConfiguration } from '../../../shared/sam/debugger/awsSamDebugConfiguration'
+import {
+    AwsSamDebuggerConfiguration,
+    TEMPLATE_TARGET_TYPE,
+} from '../../../shared/sam/debugger/awsSamDebugConfiguration'
 import { AddSamDebugConfigurationInput } from '../../../shared/sam/debugger/commands/addSamDebugConfiguration'
 
 const range = new vscode.Range(0, 0, 0, 0)
@@ -77,13 +80,13 @@ describe('SamTemplateCodeLensProvider', async () => {
 
         const expectedInput: AddSamDebugConfigurationInput = {
             resourceName: 'newResource',
-            templateUri: templateUri,
+            rootUri: templateUri,
         }
 
         const expectedCodeLens: vscode.CodeLens = new vscode.CodeLens(range, {
             title: 'Add Debug Configuration',
             command: 'aws.addSamDebugConfiguration',
-            arguments: [expectedInput],
+            arguments: [expectedInput, TEMPLATE_TARGET_TYPE],
         })
 
         assert.deepStrictEqual(codeLenses, [expectedCodeLens])

--- a/src/test/typescriptLambdaHandlerSearch.test.ts
+++ b/src/test/typescriptLambdaHandlerSearch.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert'
 import * as path from 'path'
 import { readFileAsString } from '../shared/filesystemUtilities'
-import { LambdaHandlerCandidate } from '../shared/lambdaHandlerSearch'
+import { RootlessLambdaHandlerCandidate } from '../shared/lambdaHandlerSearch'
 import { TypescriptLambdaHandlerSearch } from '../shared/typescriptLambdaHandlerSearch'
 
 describe('TypescriptLambdaHandlerSearch', () => {
@@ -77,7 +77,7 @@ describe('TypescriptLambdaHandlerSearch', () => {
 
         const search: TypescriptLambdaHandlerSearch = new TypescriptLambdaHandlerSearch(filename, fileContents)
 
-        const handlers: LambdaHandlerCandidate[] = await search.findCandidateLambdaHandlers()
+        const handlers: RootlessLambdaHandlerCandidate[] = await search.findCandidateLambdaHandlers()
 
         assertCandidateHandlers(handlers, expectedHandlerNames)
     }
@@ -86,7 +86,7 @@ describe('TypescriptLambdaHandlerSearch', () => {
         return path.join(__dirname, '..', '..', '..', 'src', 'test', 'samples')
     }
 
-    function assertCandidateHandlers(actual: LambdaHandlerCandidate[], expectedHandlerNames: Set<string>) {
+    function assertCandidateHandlers(actual: RootlessLambdaHandlerCandidate[], expectedHandlerNames: Set<string>) {
         assert.strictEqual(actual.length, expectedHandlerNames.size)
         assert.strictEqual(
             actual.map(handler => handler.handlerName).every(handlerName => expectedHandlerNames.has(handlerName)),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed the `Run Local` and `Debug Local` codelenses from potential SAM function handlers (see #1049) In their place, we now draw "Add Debug Configuration" codelenses which, when clicked, creates a launch config that looks like:
```
    {
        "type": "aws-sam",
        "request": "direct-invoke",
        "name": 'handler.name' // TODO: Something friendlier?,
        "invokeTarget": {
            "target": "code",
            "projectRoot": "/absolute/path/to/handler" // TODO: Relative to workspace?,
            "lambdaHandler": "handler.name" // same as 'name' field, although this will stay this way.
        }
    }
```

Also standardized some codepaths (JS and C# codelens drawing is a bit more uniform)

Next steps (out of scope for this PR):
* Implement `code`-type `aws-sam` launch config functionality
* Code cleanup (pruned pathways, commented-out code, etc., all handled in a separate PR/set of PRs)

## Motivation and Context
Giving the users a way to use this functionality quickly.

## Related Issue(s)
https://github.com/aws/aws-toolkit-vscode/blob/master/designs/sam-debugging/local-sam-debugging.md#codelenses-in-code-files

## Testing

Manually tested a fair amount of nesting scenarios.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
