### PR TITLE
Correcting Python handler parsing

### DIFF
--- a/src/shared/codelens/pythonCodeLensProvider.ts
+++ b/src/shared/codelens/pythonCodeLensProvider.ts
@@ -110,7 +110,7 @@ async function makeLambdaDebugFile(params: {
     // Last piece of the handler is the function name. Remove it before modifying for pathing.
     const splitHandlerName = params.handlerName.split('.')
     const handlerFunctionName = splitHandlerName[splitHandlerName.length - 1]
-    const handlerFiles = splitHandlerName.slice(0, splitHandlerName.length - 2)
+    const handlerFiles = splitHandlerName.slice(0, splitHandlerName.length - 1)
 
     // Handlers for Python imports must be joined by periods.
     // ./foo/bar.py => foo.bar

--- a/src/shared/codelens/pythonCodeLensProvider.ts
+++ b/src/shared/codelens/pythonCodeLensProvider.ts
@@ -98,14 +98,11 @@ async function makePythonDebugManifest(params: {
     // else we don't need to override the manifest. nothing to return
 }
 
-async function makeLambdaDebugFile(params: {
+export async function makeLambdaDebugFile(params: {
     handlerName: string
     debugPort: number
     outputDir: string
 }): Promise<{ outFilePath: string; debugHandlerName: string }> {
-    if (!params.outputDir) {
-        throw new Error('Must specify outputDir')
-    }
     const logger = getLogger()
 
     // Last piece of the handler is the function name. Remove it before modifying for pathing.

--- a/src/test/shared/codelens/pythonCodeLensProvider.test.ts
+++ b/src/test/shared/codelens/pythonCodeLensProvider.test.ts
@@ -4,71 +4,121 @@
  */
 
 import * as assert from 'assert'
+import * as path from 'path'
 import { getLocalRootVariants } from '../../../shared/utilities/pathUtils'
+import { makeTemporaryToolkitFolder, readFileAsString } from '../../../shared/filesystemUtilities'
+import { rmrf } from '../../../shared/filesystem'
+import { makeLambdaDebugFile } from '../../../shared/codelens/pythonCodeLensProvider'
 
-describe('getLocalRootVariants', async () => {
-    if (process.platform === 'win32') {
-        const testScenarios = [
-            {
-                situation: 'lower case drive letter',
-                inputText: 'c:\\src\\code.js',
-                asLower: 'c:\\src\\code.js',
-                asUpper: 'C:\\src\\code.js',
-            },
-            {
-                situation: 'upper case drive letter',
-                inputText: 'C:\\src\\code.js',
-                asLower: 'c:\\src\\code.js',
-                asUpper: 'C:\\src\\code.js',
-            },
-        ]
+describe('pythonCodeLensProvider', async () => {
+    describe('getLocalRootVariants', async () => {
+        if (process.platform === 'win32') {
+            const testScenarios = [
+                {
+                    situation: 'lower case drive letter',
+                    inputText: 'c:\\src\\code.js',
+                    asLower: 'c:\\src\\code.js',
+                    asUpper: 'C:\\src\\code.js',
+                },
+                {
+                    situation: 'upper case drive letter',
+                    inputText: 'C:\\src\\code.js',
+                    asLower: 'c:\\src\\code.js',
+                    asUpper: 'C:\\src\\code.js',
+                },
+            ]
 
-        testScenarios.forEach(test => {
-            it(`Returns cased-drive variants for windows platforms: ${test.situation}`, async () => {
-                const variants = getLocalRootVariants(test.inputText)
-                assert.ok(variants)
-                assert.strictEqual(variants.length, 2, 'Expected two variants')
-                assert.strictEqual(variants[0], test.asLower, 'Unexpected variant text')
-                assert.strictEqual(variants[1], test.asUpper, 'Unexpected variant text')
+            testScenarios.forEach(test => {
+                it(`Returns cased-drive variants for windows platforms: ${test.situation}`, async () => {
+                    const variants = getLocalRootVariants(test.inputText)
+                    assert.ok(variants)
+                    assert.strictEqual(variants.length, 2, 'Expected two variants')
+                    assert.strictEqual(variants[0], test.asLower, 'Unexpected variant text')
+                    assert.strictEqual(variants[1], test.asUpper, 'Unexpected variant text')
+                })
             })
-        })
 
-        it('Returns the same string for network location - windows', async () => {
-            const variants = getLocalRootVariants('//share/src/code.js')
-            assert.ok(variants)
-            assert.strictEqual(variants.length, 1, 'Only expected one variant')
-            assert.strictEqual(variants[0], '//share/src/code.js', 'Unexpected variant text')
-        })
-
-        it('Returns the same string for weird input - windows', async () => {
-            const variants = getLocalRootVariants('src/code.js')
-            assert.ok(variants)
-            assert.strictEqual(variants.length, 1, 'Only expected one variant')
-            assert.strictEqual(variants[0], 'src/code.js', 'Unexpected variant text')
-        })
-    } else {
-        const testScenarios = [
-            {
-                situation: 'Looks like a windows path - lower case drive',
-                inputText: 'c:\\src\\code.js',
-            },
-            {
-                situation: 'Looks like a windows path - upper case drive',
-                inputText: 'C:\\src\\code.js',
-            },
-            {
-                situation: 'non-windows path',
-                inputText: '/src/code.js',
-            },
-        ]
-
-        testScenarios.forEach(test => {
-            it(`Returns the same string for non-windows platforms: ${test.situation}`, async () => {
-                const variants = getLocalRootVariants(test.inputText)
+            it('Returns the same string for network location - windows', async () => {
+                const variants = getLocalRootVariants('//share/src/code.js')
                 assert.ok(variants)
                 assert.strictEqual(variants.length, 1, 'Only expected one variant')
-                assert.strictEqual(variants[0], test.inputText, 'Unexpected variant text')
+                assert.strictEqual(variants[0], '//share/src/code.js', 'Unexpected variant text')
+            })
+
+            it('Returns the same string for weird input - windows', async () => {
+                const variants = getLocalRootVariants('src/code.js')
+                assert.ok(variants)
+                assert.strictEqual(variants.length, 1, 'Only expected one variant')
+                assert.strictEqual(variants[0], 'src/code.js', 'Unexpected variant text')
+            })
+        } else {
+            const testScenarios = [
+                {
+                    situation: 'Looks like a windows path - lower case drive',
+                    inputText: 'c:\\src\\code.js',
+                },
+                {
+                    situation: 'Looks like a windows path - upper case drive',
+                    inputText: 'C:\\src\\code.js',
+                },
+                {
+                    situation: 'non-windows path',
+                    inputText: '/src/code.js',
+                },
+            ]
+
+            testScenarios.forEach(test => {
+                it(`Returns the same string for non-windows platforms: ${test.situation}`, async () => {
+                    const variants = getLocalRootVariants(test.inputText)
+                    assert.ok(variants)
+                    assert.strictEqual(variants.length, 1, 'Only expected one variant')
+                    assert.strictEqual(variants[0], test.inputText, 'Unexpected variant text')
+                })
+            })
+        }
+    })
+
+    describe('makeLambdaDebugFile', async () => {
+        let dir: string
+        const debugPort = 1357
+        const fileSuffix = `___vsctk___debug`
+        const defaultFnName = 'lambda_handler'
+
+        beforeEach(async () => {
+            dir = await makeTemporaryToolkitFolder()
+        })
+
+        afterEach(async () => {
+            await rmrf(dir)
+        })
+
+        it('handles a handler in the same dir (one period)', async () => {
+            await runDebugFileTests({
+                filepath: 'hands',
+                handler: 'off',
             })
         })
-    }
+
+        it('handles a handler in a nested dir (multiple periods)', async () => {
+            await runDebugFileTests({
+                filepath: 'take.a.look.at.these',
+                handler: 'hands',
+            })
+        })
+
+        async function runDebugFileTests({ filepath, handler }: { filepath: string; handler: string }) {
+            const handlerName = `${filepath}.${handler}`
+            const debugHandlerFileName = `${filepath.split('.').join('_')}${fileSuffix}`
+            const result = await makeLambdaDebugFile({
+                handlerName,
+                outputDir: dir,
+                debugPort,
+            })
+            assert.strictEqual(result.debugHandlerName, `${debugHandlerFileName}.${defaultFnName}`)
+            const outFile = path.join(dir, `${debugHandlerFileName}.py`)
+            assert.strictEqual(result.outFilePath, outFile)
+            const fileContents = await readFileAsString(outFile)
+            assert.ok(fileContents.includes(`from ${filepath} import ${handler} as _handler`))
+        }
+    })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Incorrect slice on the handler name. Found via manual testing. Confirmed working via manual testing.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
