### PR TITLE
Adding runtime field to code debug types

### DIFF
--- a/src/lambda/local/debugConfiguration.ts
+++ b/src/lambda/local/debugConfiguration.ts
@@ -5,9 +5,8 @@
 
 import * as path from 'path'
 import * as vscode from 'vscode'
-import { nodeJsRuntimes, compareSamLambdaRuntime } from '../../lambda/models/samLambdaRuntime'
 import { SamLaunchRequestArgs } from '../../shared/sam/debugger/samDebugSession'
-import { dotNetRuntimes, pythonRuntimes, RuntimeFamily } from '../models/samLambdaRuntime'
+import { RuntimeFamily } from '../models/samLambdaRuntime'
 import {
     CodeTargetProperties,
     TemplateTargetProperties,
@@ -63,39 +62,6 @@ export interface PipeTransport {
     pipeArgs: string[]
     debuggerPath: typeof DOTNET_CORE_DEBUGGER_PATH
     pipeCwd: string
-}
-
-/**
- * Maps vscode document languageId to `RuntimeFamily`.
- */
-export function getRuntimeFamily(langId: string): RuntimeFamily {
-    switch (langId) {
-        case 'typescript':
-        case 'javascript':
-            return RuntimeFamily.NodeJS
-        case 'csharp':
-            return RuntimeFamily.DotNetCore
-        case 'python':
-            return RuntimeFamily.Python
-        default:
-            return RuntimeFamily.Unknown
-    }
-}
-
-/**
- * Guesses a reasonable default runtime value for the given `RuntimeFamily`.
- */
-export function getDefaultRuntime(runtime: RuntimeFamily): string | undefined {
-    switch (runtime) {
-        case RuntimeFamily.NodeJS:
-            return nodeJsRuntimes.sort(compareSamLambdaRuntime).first()
-        case RuntimeFamily.DotNetCore:
-            return dotNetRuntimes.sort(compareSamLambdaRuntime).first()
-        case RuntimeFamily.Python:
-            return pythonRuntimes.sort(compareSamLambdaRuntime).first()
-        default:
-            return undefined
-    }
 }
 
 export function assertTargetKind(config: SamLaunchRequestArgs, expectedTarget: 'code' | 'template'): void {

--- a/src/lambda/models/samLambdaRuntime.ts
+++ b/src/lambda/models/samLambdaRuntime.ts
@@ -6,6 +6,7 @@
 import { Runtime } from 'aws-sdk/clients/lambda'
 import { Map, Set } from 'immutable'
 
+// NOTE: These are ORDERED! The newest runtime should always be placed first.
 export const nodeJsRuntimes: Set<Runtime> = Set<Runtime>(['nodejs12.x', 'nodejs10.x', 'nodejs8.10'])
 export const pythonRuntimes: Set<Runtime> = Set<Runtime>(['python3.8', 'python3.7', 'python3.6', 'python2.7'])
 export const dotNetRuntimes: Set<Runtime> = Set<Runtime>(['dotnetcore2.1'])

--- a/src/lambda/models/samLambdaRuntime.ts
+++ b/src/lambda/models/samLambdaRuntime.ts
@@ -6,7 +6,6 @@
 import { Runtime } from 'aws-sdk/clients/lambda'
 import { Map, Set } from 'immutable'
 
-// NOTE: These are ORDERED! The newest runtime should always be placed first.
 export const nodeJsRuntimes: Set<Runtime> = Set<Runtime>(['nodejs12.x', 'nodejs10.x', 'nodejs8.10'])
 export const pythonRuntimes: Set<Runtime> = Set<Runtime>(['python3.8', 'python3.7', 'python3.6', 'python2.7'])
 export const dotNetRuntimes: Set<Runtime> = Set<Runtime>(['dotnetcore2.1'])

--- a/src/lambda/models/samLambdaRuntime.ts
+++ b/src/lambda/models/samLambdaRuntime.ts
@@ -55,3 +55,36 @@ function getSortableCompareText(runtime: Runtime): string {
 export function compareSamLambdaRuntime(a: Runtime, b: Runtime): number {
     return getSortableCompareText(a).localeCompare(getSortableCompareText(b))
 }
+
+/**
+ * Maps vscode document languageId to `RuntimeFamily`.
+ */
+export function getRuntimeFamily(langId: string): RuntimeFamily {
+    switch (langId) {
+        case 'typescript':
+        case 'javascript':
+            return RuntimeFamily.NodeJS
+        case 'csharp':
+            return RuntimeFamily.DotNetCore
+        case 'python':
+            return RuntimeFamily.Python
+        default:
+            return RuntimeFamily.Unknown
+    }
+}
+
+/**
+ * Guesses a reasonable default runtime value for the given `RuntimeFamily`.
+ */
+export function getDefaultRuntime(runtime: RuntimeFamily): string | undefined {
+    switch (runtime) {
+        case RuntimeFamily.NodeJS:
+            return nodeJsRuntimes.sort(compareSamLambdaRuntime).first()
+        case RuntimeFamily.DotNetCore:
+            return dotNetRuntimes.sort(compareSamLambdaRuntime).first()
+        case RuntimeFamily.Python:
+            return pythonRuntimes.sort(compareSamLambdaRuntime).first()
+        default:
+            return undefined
+    }
+}

--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -15,7 +15,7 @@ import * as tsDebug from './typescriptCodeLensProvider'
 import { LambdaLocalInvokeParams } from './localLambdaRunner'
 import { ExtContext } from '../extensions'
 import { recordLambdaInvokeLocal, Result, Runtime } from '../telemetry/telemetry'
-import { nodeJsRuntimes } from '../../lambda/models/samLambdaRuntime'
+import { nodeJsRuntimes, RuntimeFamily } from '../../lambda/models/samLambdaRuntime'
 import { CODE_TARGET_TYPE } from '../sam/debugger/awsSamDebugConfiguration'
 
 export type Language = 'python' | 'javascript' | 'csharp'
@@ -24,16 +24,19 @@ interface MakeAddDebugConfigCodeLensParams {
     handlerName: string
     range: vscode.Range
     rootUri: vscode.Uri
+    runtimeFamily: RuntimeFamily
 }
 
 export async function makeCodeLenses({
     document,
     token,
     handlers,
+    runtimeFamily,
 }: {
     document: vscode.TextDocument
     token: vscode.CancellationToken
     handlers: LambdaHandlerCandidate[]
+    runtimeFamily: RuntimeFamily
 }): Promise<vscode.CodeLens[]> {
     const workspaceFolder: vscode.WorkspaceFolder | undefined = vscode.workspace.getWorkspaceFolder(document.uri)
 
@@ -57,6 +60,7 @@ export async function makeCodeLenses({
                 handlerName: handler.handlerName,
                 range,
                 rootUri: handler.manifestUri,
+                runtimeFamily,
             }
             lenses.push(makeAddCodeSamDebugCodeLens(baseParams))
         } catch (err) {
@@ -82,6 +86,7 @@ function makeAddCodeSamDebugCodeLens(params: MakeAddDebugConfigCodeLensParams): 
             {
                 resourceName: params.handlerName,
                 rootUri: params.rootUri,
+                runtimeFamily: params.runtimeFamily,
             },
             CODE_TARGET_TYPE,
         ],
@@ -115,6 +120,7 @@ export async function makePythonCodeLensProvider(): Promise<vscode.CodeLensProvi
                 document,
                 handlers,
                 token,
+                runtimeFamily: RuntimeFamily.Python,
             })
         },
     }
@@ -135,6 +141,7 @@ export async function makeCSharpCodeLensProvider(): Promise<vscode.CodeLensProvi
                 document,
                 handlers,
                 token,
+                runtimeFamily: RuntimeFamily.DotNetCore,
             })
         },
     }
@@ -155,6 +162,7 @@ export function makeTypescriptCodeLensProvider(): vscode.CodeLensProvider {
                 document,
                 handlers,
                 token,
+                runtimeFamily: RuntimeFamily.NodeJS,
             })
         },
     }

--- a/src/shared/sam/debugger/awsSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfiguration.ts
@@ -9,6 +9,7 @@ import {
     CodeTargetProperties,
     TemplateTargetProperties,
 } from './awsSamDebugConfiguration.gen'
+import { RuntimeFamily, dotNetRuntimes, nodeJsRuntimes, pythonRuntimes } from '../../../lambda/models/samLambdaRuntime'
 
 export * from './awsSamDebugConfiguration.gen'
 
@@ -85,7 +86,27 @@ export function createTemplateAwsSamDebugConfig(
     return response
 }
 
-export function createCodeAwsSamDebugConfig(lambdaHandler: string, projectRoot: string): AwsSamDebuggerConfiguration {
+export function createCodeAwsSamDebugConfig(
+    lambdaHandler: string,
+    projectRoot: string,
+    runtimeFamily?: RuntimeFamily
+): AwsSamDebuggerConfiguration {
+    let runtime: string
+
+    switch (runtimeFamily) {
+        case RuntimeFamily.DotNetCore:
+            runtime = dotNetRuntimes.first()
+            break
+        case RuntimeFamily.NodeJS:
+            runtime = nodeJsRuntimes.first()
+            break
+        case RuntimeFamily.Python:
+            runtime = pythonRuntimes.first()
+            break
+        default:
+            throw new Error('Invalid or missing runtime family')
+    }
+
     return {
         type: AWS_SAM_DEBUG_TYPE,
         request: DIRECT_INVOKE_TYPE,
@@ -95,6 +116,9 @@ export function createCodeAwsSamDebugConfig(lambdaHandler: string, projectRoot: 
             target: CODE_TARGET_TYPE,
             projectRoot,
             lambdaHandler,
+        },
+        lambda: {
+            runtime,
         },
     }
 }

--- a/src/shared/sam/debugger/awsSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfiguration.ts
@@ -9,7 +9,8 @@ import {
     CodeTargetProperties,
     TemplateTargetProperties,
 } from './awsSamDebugConfiguration.gen'
-import { RuntimeFamily, dotNetRuntimes, nodeJsRuntimes, pythonRuntimes } from '../../../lambda/models/samLambdaRuntime'
+import { RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
+import { getDefaultRuntime } from '../../../lambda/local/debugConfiguration'
 
 export * from './awsSamDebugConfiguration.gen'
 
@@ -91,20 +92,9 @@ export function createCodeAwsSamDebugConfig(
     projectRoot: string,
     runtimeFamily?: RuntimeFamily
 ): AwsSamDebuggerConfiguration {
-    let runtime: string
-
-    switch (runtimeFamily) {
-        case RuntimeFamily.DotNetCore:
-            runtime = dotNetRuntimes.first()
-            break
-        case RuntimeFamily.NodeJS:
-            runtime = nodeJsRuntimes.first()
-            break
-        case RuntimeFamily.Python:
-            runtime = pythonRuntimes.first()
-            break
-        default:
-            throw new Error('Invalid or missing runtime family')
+    const runtime = runtimeFamily ? getDefaultRuntime(runtimeFamily) : undefined
+    if (!runtime) {
+        throw new Error('Invalid or missing runtime family')
     }
 
     return {

--- a/src/shared/sam/debugger/awsSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfiguration.ts
@@ -9,8 +9,7 @@ import {
     CodeTargetProperties,
     TemplateTargetProperties,
 } from './awsSamDebugConfiguration.gen'
-import { RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
-import { getDefaultRuntime } from '../../../lambda/local/debugConfiguration'
+import { getDefaultRuntime, RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
 
 export * from './awsSamDebugConfiguration.gen'
 

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -7,14 +7,12 @@ import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 import {
     getCodeRoot,
-    getDefaultRuntime,
     getHandlerName,
     getTemplateResource,
     NodejsDebugConfiguration,
     PythonDebugConfiguration,
-    getRuntimeFamily,
 } from '../../../lambda/local/debugConfiguration'
-import { getFamily, RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
+import { getDefaultRuntime, getFamily, getRuntimeFamily, RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
 import { CloudFormationTemplateRegistry, getResourcesFromTemplateDatum } from '../../cloudformation/templateRegistry'
 import * as csharpDebug from '../../codelens/csharpCodeLensProvider'
 import * as pythonDebug from '../../codelens/pythonCodeLensProvider'

--- a/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
@@ -16,6 +16,7 @@ import {
 import { CloudFormationTemplateRegistry } from '../../../cloudformation/templateRegistry'
 import { getExistingConfiguration } from '../../../../lambda/config/templates'
 import { localize } from '../../../utilities/vsCodeUtils'
+import { RuntimeFamily } from '../../../../lambda/models/samLambdaRuntime'
 
 /**
  * Holds information required to create a launch config
@@ -25,13 +26,14 @@ import { localize } from '../../../utilities/vsCodeUtils'
 export interface AddSamDebugConfigurationInput {
     resourceName: string
     rootUri: vscode.Uri
+    runtimeFamily?: RuntimeFamily
 }
 
 /**
  * Adds a new debug configuration for the given sam function resource and template.
  */
 export async function addSamDebugConfiguration(
-    { resourceName, rootUri }: AddSamDebugConfigurationInput,
+    { resourceName, rootUri, runtimeFamily }: AddSamDebugConfigurationInput,
     type: typeof CODE_TARGET_TYPE | typeof TEMPLATE_TARGET_TYPE
 ): Promise<void> {
     // tslint:disable-next-line: no-floating-promises
@@ -79,7 +81,7 @@ export async function addSamDebugConfiguration(
         samDebugConfig = createTemplateAwsSamDebugConfig(resourceName, rootUri.fsPath, preloadedConfig)
     } else if (type === CODE_TARGET_TYPE) {
         // strip the manifest's URI to the manifest's dir here. More reliable to do this here than converting back and forth between URI/string up the chain.
-        samDebugConfig = createCodeAwsSamDebugConfig(resourceName, path.dirname(rootUri.fsPath))
+        samDebugConfig = createCodeAwsSamDebugConfig(resourceName, path.dirname(rootUri.fsPath), runtimeFamily)
     } else {
         throw new Error('Unrecognized debug target type')
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Missed in https://github.com/aws/aws-toolkit-vscode/pull/1054/ ; adds a runtime field to the code handlers.

Picks the first runtime in the runtime set for each language and added a note specifying that the runtimes are now ordered and should have the newest runtime first.

## Motivation and Context

Runtime is necessary to correctly interpret the code handlers.

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing

Shows up correctly for files of the three language types we target.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
