### PR TITLE
Launch configs created by the toolkit use relative paths instead of absolute

### DIFF
--- a/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
@@ -16,6 +16,7 @@ import {
 import { CloudFormationTemplateRegistry } from '../../../cloudformation/templateRegistry'
 import { getExistingConfiguration } from '../../../../lambda/config/templates'
 import { localize } from '../../../utilities/vsCodeUtils'
+import { getNormalizedRelativePath } from '../../../utilities/pathUtils'
 
 /**
  * Holds information required to create a launch config
@@ -38,9 +39,9 @@ export async function addSamDebugConfiguration(
     emitCommandTelemetry()
 
     let samDebugConfig: AwsSamDebuggerConfiguration
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(rootUri)
 
     if (type === TEMPLATE_TARGET_TYPE) {
-        const workspaceFolder = vscode.workspace.getWorkspaceFolder(rootUri)
         let preloadedConfig = undefined
 
         if (workspaceFolder) {
@@ -76,10 +77,19 @@ export async function addSamDebugConfiguration(
                 }
             }
         }
-        samDebugConfig = createTemplateAwsSamDebugConfig(resourceName, rootUri.fsPath, preloadedConfig)
+        samDebugConfig = createTemplateAwsSamDebugConfig(
+            resourceName,
+            workspaceFolder ? getNormalizedRelativePath(workspaceFolder.uri.fsPath, rootUri.fsPath) : rootUri.fsPath,
+            preloadedConfig
+        )
     } else if (type === CODE_TARGET_TYPE) {
         // strip the manifest's URI to the manifest's dir here. More reliable to do this here than converting back and forth between URI/string up the chain.
-        samDebugConfig = createCodeAwsSamDebugConfig(resourceName, path.dirname(rootUri.fsPath))
+        samDebugConfig = createCodeAwsSamDebugConfig(
+            resourceName,
+            workspaceFolder
+                ? getNormalizedRelativePath(workspaceFolder.uri.fsPath, path.dirname(rootUri.fsPath))
+                : path.dirname(rootUri.fsPath)
+        )
     } else {
         throw new Error('Unrecognized debug target type')
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`aws-sam` launch configs have relative paths instead of absolute ones

## Motivation and Context
Relative paths are smaller, make more contextual sense, and make it easier for users to share workspace configs.

## Testing

Manual testing for both template and code type codelenses.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
