### PR TITLE
project: tell vscode to ignore testFixtures

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 // Place your settings in this file to overwrite default and user settings.
 {
     "files.exclude": {
+        "src/testFixtures": true,
         "out": false // set this to true to hide the "out" folder with the compiled JS files
     },
     "search.exclude": {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,9 @@ There are also some integration tests, which can be run from the Debug pane, or 
 
 Tests will output log output to `./.test-reports/testLog.log` for debugging
 
+Note: `src/testFixtures/` is excluded in `.vscode/settings.json`, to prevent VS
+Code from treating its files as project files.
+
 #### Run a specific test
 
 To run a single test, change its `it()` call to `it.only(…)`.


### PR DESCRIPTION
vscode crawls the files in `testFixtures`, reports errors, tries to suggest plugins, etc.:

<img width="1140" alt="Screen Shot 2020-04-30 at 1 37 07 PM" src="https://user-images.githubusercontent.com/55561878/80756999-51582b80-8ae8-11ea-8331-990a702d3031.png">


Why doesn't the "exclude" in `tsconfig.json` suffice?


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
