### PR TITLE
SAM debugconfig: generate workspace-relative paths

### DIFF
--- a/src/shared/cloudformation/templateRegistry.ts
+++ b/src/shared/cloudformation/templateRegistry.ts
@@ -4,6 +4,7 @@
  */
 
 import * as vscode from 'vscode'
+import * as path_ from 'path'
 import { getLogger } from '../logger/logger'
 import { CloudFormation } from './cloudformation'
 import * as pathutils from '../utilities/pathUtils'
@@ -19,6 +20,12 @@ export class CloudFormationTemplateRegistry {
 
     public constructor() {
         this.templateRegistryData = new Map<string, CloudFormation.Template>()
+    }
+
+    private assertAbsolute(path: string) {
+        if (!path_.isAbsolute(path)) {
+            throw Error(`CloudFormationTemplateRegistry: path is relative: ${path}`)
+        }
     }
 
     /**
@@ -43,6 +50,7 @@ export class CloudFormationTemplateRegistry {
      */
     public async addTemplateToRegistry(templateUri: vscode.Uri, quiet?: boolean): Promise<void> {
         const pathAsString = pathutils.normalize(templateUri.fsPath)
+        this.assertAbsolute(pathAsString)
         try {
             const template = await CloudFormation.load(pathAsString)
             this.templateRegistryData.set(pathAsString, template)
@@ -60,6 +68,7 @@ export class CloudFormationTemplateRegistry {
      */
     public getRegisteredTemplate(path: string): TemplateDatum | undefined {
         const normalizedPath = pathutils.normalize(path)
+        this.assertAbsolute(normalizedPath)
         const template = this.templateRegistryData.get(normalizedPath)
         if (template) {
             return {
@@ -91,6 +100,7 @@ export class CloudFormationTemplateRegistry {
      */
     public removeTemplateFromRegistry(templateUri: vscode.Uri): void {
         const pathAsString = pathutils.normalize(templateUri.fsPath)
+        this.assertAbsolute(pathAsString)
         this.templateRegistryData.delete(pathAsString)
     }
 

--- a/src/shared/codelens/csharpCodeLensProvider.ts
+++ b/src/shared/codelens/csharpCodeLensProvider.ts
@@ -91,8 +91,8 @@ export async function makeCsharpConfig(config: SamLaunchRequestArgs): Promise<Sa
     config.codeRoot = pathutil.normalize(config.codeRoot)
 
     const baseBuildDir = await makeBuildDir()
-    const template = getTemplate(config)
-    const resource = getTemplateResource(config)
+    const template = getTemplate(config.workspaceFolder, config)
+    const resource = getTemplateResource(config.workspaceFolder, config)
     const codeUri = getCodeRoot(config.workspaceFolder, config)
     const handlerName = config.handlerName
 

--- a/src/shared/sam/debugger/awsSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfiguration.ts
@@ -10,6 +10,7 @@ import {
     TemplateTargetProperties,
 } from './awsSamDebugConfiguration.gen'
 import { getDefaultRuntime, RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
+import { getNormalizedRelativePath } from '../../utilities/pathUtils'
 
 export * from './awsSamDebugConfiguration.gen'
 
@@ -39,6 +40,7 @@ export function isCodeTargetProperties(props: TargetProperties): props is CodeTa
 }
 
 export function createTemplateAwsSamDebugConfig(
+    folder: vscode.WorkspaceFolder | undefined,
     resourceName: string,
     templatePath: string,
     preloadedConfig?: {
@@ -48,13 +50,14 @@ export function createTemplateAwsSamDebugConfig(
         useContainer?: boolean
     }
 ): AwsSamDebuggerConfiguration {
+    const workspaceRelativePath = folder ? getNormalizedRelativePath(folder.uri.fsPath, templatePath) : templatePath
     const response: AwsSamDebuggerConfiguration = {
         type: AWS_SAM_DEBUG_TYPE,
         request: DIRECT_INVOKE_TYPE,
         name: resourceName,
         invokeTarget: {
             target: TEMPLATE_TARGET_TYPE,
-            samTemplatePath: templatePath,
+            samTemplatePath: workspaceRelativePath,
             samTemplateResource: resourceName,
         },
     }
@@ -87,10 +90,12 @@ export function createTemplateAwsSamDebugConfig(
 }
 
 export function createCodeAwsSamDebugConfig(
+    folder: vscode.WorkspaceFolder | undefined,
     lambdaHandler: string,
     projectRoot: string,
     runtimeFamily?: RuntimeFamily
 ): AwsSamDebuggerConfiguration {
+    const workspaceRelativePath = folder ? getNormalizedRelativePath(folder.uri.fsPath, projectRoot) : projectRoot
     const runtime = runtimeFamily ? getDefaultRuntime(runtimeFamily) : undefined
     if (!runtime) {
         throw new Error('Invalid or missing runtime family')
@@ -103,8 +108,8 @@ export function createCodeAwsSamDebugConfig(
         name: lambdaHandler,
         invokeTarget: {
             target: CODE_TARGET_TYPE,
-            projectRoot,
-            lambdaHandler,
+            projectRoot: workspaceRelativePath,
+            lambdaHandler: lambdaHandler,
         },
         lambda: {
             runtime,

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -73,7 +73,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
                     }
                     const resources = getResourcesFromTemplateDatum(templateDatum)
                     for (const resourceKey of resources.keys()) {
-                        configs.push(createTemplateAwsSamDebugConfig(resourceKey, templateDatum.path))
+                        configs.push(createTemplateAwsSamDebugConfig(folder, resourceKey, templateDatum.path))
                     }
                 }
             }
@@ -161,9 +161,9 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
 
         const editor = vscode.window.activeTextEditor
         const templateInvoke = config.invokeTarget as TemplateTargetProperties
-        const templateResource = getTemplateResource(config)
+        const templateResource = getTemplateResource(folder, config)
         const codeRoot = getCodeRoot(folder, config)
-        const handlerName = getHandlerName(config)
+        const handlerName = getHandlerName(folder, config)
 
         if (templateInvoke?.samTemplatePath) {
             // Normalize to absolute path.

--- a/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
@@ -16,7 +16,6 @@ import {
 import { CloudFormationTemplateRegistry } from '../../../cloudformation/templateRegistry'
 import { getExistingConfiguration } from '../../../../lambda/config/templates'
 import { localize } from '../../../utilities/vsCodeUtils'
-import { getNormalizedRelativePath } from '../../../utilities/pathUtils'
 import { RuntimeFamily } from '../../../../lambda/models/samLambdaRuntime'
 
 /**
@@ -79,18 +78,13 @@ export async function addSamDebugConfiguration(
                 }
             }
         }
-        samDebugConfig = createTemplateAwsSamDebugConfig(
-            resourceName,
-            workspaceFolder ? getNormalizedRelativePath(workspaceFolder.uri.fsPath, rootUri.fsPath) : rootUri.fsPath,
-            preloadedConfig
-        )
+        samDebugConfig = createTemplateAwsSamDebugConfig(workspaceFolder, resourceName, rootUri.fsPath, preloadedConfig)
     } else if (type === CODE_TARGET_TYPE) {
         // strip the manifest's URI to the manifest's dir here. More reliable to do this here than converting back and forth between URI/string up the chain.
         samDebugConfig = createCodeAwsSamDebugConfig(
+            workspaceFolder,
             resourceName,
-            workspaceFolder
-                ? getNormalizedRelativePath(workspaceFolder.uri.fsPath, path.dirname(rootUri.fsPath))
-                : path.dirname(rootUri.fsPath),
+            path.dirname(rootUri.fsPath),
             runtimeFamily
         )
     } else {

--- a/src/test/shared/cloudformation/templateRegistry.test.ts
+++ b/src/test/shared/cloudformation/templateRegistry.test.ts
@@ -100,7 +100,7 @@ describe('CloudFormation Template Registry', async () => {
         // other get cases are tested in the add section
         describe('getRegisteredTemplate', async () => {
             it('returns undefined if the registry has no registered templates', () => {
-                assert.strictEqual(testRegistry.getRegisteredTemplate('template.yaml'), undefined)
+                assert.strictEqual(testRegistry.getRegisteredTemplate('/template.yaml'), undefined)
             })
 
             it('returns undefined if the registry does not contain the template in question', async () => {
@@ -108,7 +108,7 @@ describe('CloudFormation Template Registry', async () => {
                 await strToYamlFile(goodYaml1, filename.fsPath)
                 await testRegistry.addTemplateToRegistry(vscode.Uri.file(filename.fsPath))
 
-                assert.strictEqual(testRegistry.getRegisteredTemplate('not-the-template.yaml'), undefined)
+                assert.strictEqual(testRegistry.getRegisteredTemplate('/not-the-template.yaml'), undefined)
             })
         })
 

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -691,7 +691,7 @@ describe('createTemplateAwsSamDebugConfig', () => {
     const templatePath = path.join('two', 'roads', 'diverged', 'in', 'a', 'yellow', 'wood')
 
     it('creates a template-type SAM debugger configuration with minimal configurations', () => {
-        const config = createTemplateAwsSamDebugConfig(name, templatePath)
+        const config = createTemplateAwsSamDebugConfig(undefined, name, templatePath)
         assert.strictEqual(config.invokeTarget.target, TEMPLATE_TARGET_TYPE)
         const invokeTarget = config.invokeTarget as TemplateTargetProperties
         assert.strictEqual(config.name, name)
@@ -710,7 +710,7 @@ describe('createTemplateAwsSamDebugConfig', () => {
             },
             dockerNetwork: 'rockerFretwork',
         }
-        const config = createTemplateAwsSamDebugConfig(name, templatePath, params)
+        const config = createTemplateAwsSamDebugConfig(undefined, name, templatePath, params)
         assert.deepStrictEqual(config.lambda?.event?.json, params.eventJson)
         assert.deepStrictEqual(config.lambda?.environmentVariables, params.environmentVariables)
         assert.strictEqual(config.sam?.dockerNetwork, params.dockerNetwork)
@@ -804,7 +804,7 @@ describe('createTemplateAwsSamDebugConfig', () => {
     const templatePath = path.join('two', 'roads', 'diverged', 'in', 'a', 'yellow', 'wood')
 
     it('creates a template-type SAM debugger configuration with minimal configurations', () => {
-        const config = createTemplateAwsSamDebugConfig(name, templatePath)
+        const config = createTemplateAwsSamDebugConfig(undefined, name, templatePath)
         assert.strictEqual(config.invokeTarget.target, TEMPLATE_TARGET_TYPE)
         const invokeTarget = config.invokeTarget as TemplateTargetProperties
         assert.strictEqual(config.name, name)
@@ -823,7 +823,7 @@ describe('createTemplateAwsSamDebugConfig', () => {
             },
             dockerNetwork: 'rockerFretwork',
         }
-        const config = createTemplateAwsSamDebugConfig(name, templatePath, params)
+        const config = createTemplateAwsSamDebugConfig(undefined, name, templatePath, params)
         assert.deepStrictEqual(config.lambda?.event?.json, params.eventJson)
         assert.deepStrictEqual(config.lambda?.environmentVariables, params.environmentVariables)
         assert.strictEqual(config.sam?.dockerNetwork, params.dockerNetwork)
@@ -865,7 +865,7 @@ describe('debugConfiguration', () => {
             },
         }
 
-        assert.strictEqual(debugConfiguration.getHandlerName(config), 'my.test.handler')
+        assert.strictEqual(debugConfiguration.getHandlerName(folder, config), 'my.test.handler')
 
         // Config with relative path:
         config.invokeTarget.projectRoot = relativePath
@@ -899,7 +899,7 @@ describe('debugConfiguration', () => {
         await strToYamlFile(makeSampleSamTemplateYaml(true, { codeUri: relativePath }), tempFile.fsPath)
         await registry.addTemplateToRegistry(tempFile)
         assert.strictEqual(debugConfiguration.getCodeRoot(folder, config), fullPath)
-        assert.strictEqual(debugConfiguration.getHandlerName(config), 'handler')
+        assert.strictEqual(debugConfiguration.getHandlerName(folder, config), 'handler')
 
         // Template with absolute path:
         await strToYamlFile(makeSampleSamTemplateYaml(true, { codeUri: fullPath }), tempFile.fsPath)


### PR DESCRIPTION
Test case:
1. delete `launch.json` file
2. open `template.yaml`
3. select the Debug/Run sidebar in VSCode
4. click the "creat a launch.json file" link
5. select "AWS SAM: Debug Lambda ..."

the generated JSON should look like this:

    invokeTarget": {
        "samTemplatePath": "template.yaml",
        ...,
    }

previously it looked like like this:

    invokeTarget": {
        "samTemplatePath": "/full/path/to/template.yaml",
        ...,
    }

<!--- Provide a general summary of your changes in the Title above -->


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
