### PR TITLE
telemetry: handle stale onDidChangeConfiguration handler

### DIFF
--- a/src/shared/telemetry/activation.ts
+++ b/src/shared/telemetry/activation.ts
@@ -54,6 +54,9 @@ export async function activate(activateArguments: {
     // When there are configuration changes, update the telemetry service appropriately
     vscode.workspace.onDidChangeConfiguration(
         async event => {
+            if (!ext.telemetry) {
+                return
+            }
             if (
                 event.affectsConfiguration('telemetry.enableTelemetry') ||
                 event.affectsConfiguration('aws.telemetry')


### PR DESCRIPTION
Mitigate https://github.com/aws/aws-toolkit-vscode/issues/1071

- Exceptions like this are found in CodeBuild jobs `vscodeLinuxTests`
  and `vscodeWindowsTests` (and Travis) since 0e199e8727a6:
  ```
  rejected promise not handled within 1 second: TypeError: Cannot set property 'telemetryEnabled' of undefined
  stack trace: TypeError: Cannot set property 'telemetryEnabled' of undefined
      at applyTelemetryEnabledState (/Users/travis/build/aws/aws-toolkit-vscode/dist/src/shared/telemetry/activation.js:9:5779)
      at Object.<anonymous> (/Users/travis/build/aws/aws-toolkit-vscode/dist/src/shared/telemetry/activation.js:9:4573)
      at Generator.next (<anonymous>)
      at /Users/travis/build/aws/aws-toolkit-vscode/dist/src/shared/telemetry/activation.js:9:1746
      at new Promise (<anonymous>)
      at __awaiter (/Users/travis/build/aws/aws-toolkit-vscode/dist/src/shared/telemetry/activation.js:9:662)
      at /Users/travis/build/aws/aws-toolkit-vscode/dist/src/shared/telemetry/activation.js:9:4183
      at e.fire (/Users/travis/build/aws/aws-toolkit-vscode/.vscode-test/vscode-1.44.2/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:48:497)
      at E.$acceptConfigurationChanged (/Users/travis/build/aws/aws-toolkit-vscode/.vscode-test/vscode-1.44.2/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:778:32)
      at /Users/travis/build/aws/aws-toolkit-vscode/.vscode-test/vscode-1.44.2/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:777:262
        ✓ detects running processes and successfully sends a kill signal to a running process - Unix (127ms)
        ✓ can not kill previously killed processes - Unix (226ms)
    CollectionUtils
  ```
- Exception is logged  but (often) does not fail the build.
- Note: `vscode.workspace.onDidChangeConfiguration()` returns  a disposable, but we already pass `subscriptions` as the 3rd argument.  So this patch is unnecessary (and didn't help):
  ```diff
  diff --git a/src/shared/telemetry/activation.ts b/src/shared/telemetry/activation.ts
  index a6c75b99e5b4..3696cbd2f06a 100644
  --- a/src/shared/telemetry/activation.ts
  +++ b/src/shared/telemetry/activation.ts
  @@ -52,6 +52,7 @@ export async function activate(activateArguments: {
       }

       // When there are configuration changes, update the telemetry service appropriately
  +    activateArguments.extensionContext.subscriptions.push(
       vscode.workspace.onDidChangeConfiguration(
           async event => {
               if (
  @@ -63,6 +64,7 @@ export async function activate(activateArguments: {
           },
           undefined,
           activateArguments.extensionContext.subscriptions
  +        )
       )
   }
  ```


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
