### PR TITLE
SAM debugconfig: fix "Run Without Debugging"

### DIFF
--- a/src/lambda/local/debugConfiguration.ts
+++ b/src/lambda/local/debugConfiguration.ts
@@ -39,10 +39,9 @@ export interface PythonPathMapping {
 export interface PythonDebugConfiguration extends SamLaunchRequestArgs {
     readonly runtimeFamily: RuntimeFamily.Python
     readonly host: string
-    // TODO: remove, use `debugPort` instead?
     readonly port: number
     readonly pathMappings: PythonPathMapping[]
-    readonly manifestPath: string
+    readonly manifestPath: string | undefined
 }
 
 export interface DotNetCoreDebugConfiguration extends SamLaunchRequestArgs {

--- a/src/shared/codelens/localLambdaRunner.ts
+++ b/src/shared/codelens/localLambdaRunner.ts
@@ -223,9 +223,9 @@ export async function invokeLambdaFunction(ctx: ExtContext, config: SamLaunchReq
         templatePath: config.samTemplatePath,
         eventPath,
         environmentVariablePath,
-        invoker: config.samLocalInvokeCommand!!, // ?? new DefaultValidatingSamCliProcessInvoker({})
+        invoker: config.samLocalInvokeCommand!,
         dockerNetwork: config.sam?.dockerNetwork,
-        debugPort: config.debugPort?.toString(),
+        debugPort: !config.noDebug ? config.debugPort?.toString() : undefined,
         debuggerPath: config.debuggerPath,
     }
     const command = new SamCliLocalInvokeInvocation(localInvokeArgs)
@@ -236,7 +236,7 @@ export async function invokeLambdaFunction(ctx: ExtContext, config: SamLaunchReq
     if (!config.noDebug) {
         if (config.onWillAttachDebugger) {
             messageUserWaitingToAttach(ctx.chanLogger)
-            await config.onWillAttachDebugger(config.debugPort!!, timer.remainingTime, ctx.chanLogger)
+            await config.onWillAttachDebugger(config.debugPort!, timer.remainingTime, ctx.chanLogger)
         }
 
         // HACK: remove non-serializable properties before attaching.

--- a/src/shared/codelens/typescriptCodeLensProvider.ts
+++ b/src/shared/codelens/typescriptCodeLensProvider.ts
@@ -112,7 +112,7 @@ export async function makeTypescriptConfig(config: SamLaunchRequestArgs): Promis
         name: 'SamLocalDebug',
         preLaunchTask: undefined,
         address: 'localhost',
-        port: config.debugPort!!,
+        port: config.debugPort ?? -1,
         localRoot: config.codeRoot,
         remoteRoot: '/var/task',
         protocol: 'inspector',

--- a/src/shared/codelens/typescriptCodeLensProvider.ts
+++ b/src/shared/codelens/typescriptCodeLensProvider.ts
@@ -13,6 +13,7 @@ import {
     waitForDebugPort,
     makeBuildDir,
     invokeLambdaFunction,
+    ExecuteSamBuildArguments,
 } from './localLambdaRunner'
 import { ExtContext } from '../extensions'
 import { NodejsDebugConfiguration } from '../../lambda/local/debugConfiguration'
@@ -131,27 +132,27 @@ export async function invokeTypescriptLambda(ctx: ExtContext, config: NodejsDebu
 
     const processInvoker = new DefaultValidatingSamCliProcessInvoker({})
     config.samLocalInvokeCommand = new DefaultSamLocalInvokeCommand(ctx.chanLogger, [WAIT_FOR_DEBUGGER_MESSAGES.NODEJS])
-
-    // XXX: reassignment
-    config.samTemplatePath = await executeSamBuild({
+    const buildArgs: ExecuteSamBuildArguments = {
         baseBuildDir: config.baseBuildDir!!,
         channelLogger: ctx.chanLogger,
         codeDir: config.codeRoot,
         inputTemplatePath: config.samTemplatePath,
         samProcessInvoker: processInvoker,
         useContainer: config.sam?.containerBuild,
-    })
-    if (config.invokeTarget.target === 'template') {
-        // XXX: reassignment
-        config.invokeTarget.samTemplatePath = config.samTemplatePath
     }
+
+    // XXX: reassignment
+    config.samTemplatePath = await executeSamBuild(buildArgs)
+    delete config.invokeTarget // Must not be used beyond this point.
 
     ctx.chanLogger.info(
         'AWS.output.starting.sam.app.locally',
         'Starting the SAM Application locally (see Terminal for output)'
     )
 
-    config.onWillAttachDebugger = waitForDebugPort
+    if (!config.noDebug) {
+        config.onWillAttachDebugger = waitForDebugPort
+    }
 
     await invokeLambdaFunction(ctx, config)
 }

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -200,10 +200,8 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
             runtime: runtime,
             runtimeFamily: runtimeFamily,
             handlerName: handlerName,
-            originalHandlerName: handlerName,
             documentUri: documentUri,
             samTemplatePath: pathutil.normalize(templateInvoke?.samTemplatePath),
-            originalSamTemplatePath: pathutil.normalize(templateInvoke?.samTemplatePath),
             debugPort: config.noDebug ? -1 : await getStartPort(),
         }
 
@@ -224,7 +222,6 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
                 // Make a Python launch-config from the generic config.
                 launchConfig = await pythonDebug.makePythonDebugConfig(
                     launchConfig,
-                    !launchConfig.noDebug,
                     launchConfig.runtime,
                     launchConfig.handlerName
                 )

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -202,7 +202,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
             handlerName: handlerName,
             documentUri: documentUri,
             samTemplatePath: pathutil.normalize(templateInvoke?.samTemplatePath),
-            debugPort: config.noDebug ? -1 : await getStartPort(),
+            debugPort: config.noDebug ? undefined : await getStartPort(),
         }
 
         //

--- a/src/shared/sam/debugger/samDebugSession.ts
+++ b/src/shared/sam/debugger/samDebugSession.ts
@@ -48,8 +48,6 @@ export interface SamLaunchRequestArgs extends DebugProtocol.AttachRequestArgumen
      * Used as a last resort for deciding `codeRoot` (when there is no `launch.json` nor `template.yaml`)
      */
     documentUri: vscode.Uri
-    originalHandlerName: string // TODO: remove this hopefully
-    originalSamTemplatePath: string // TODO: remove this hopefully
     /**
      * SAM template absolute path used for SAM CLI invoke.
      * - For `target=code` this is the _generated_ template path.

--- a/src/test/lambda/local/debugConfiguration.test.ts
+++ b/src/test/lambda/local/debugConfiguration.test.ts
@@ -50,8 +50,6 @@ describe('makeCoreCLRDebugConfiguration', async () => {
 
             baseBuildDir: '/fake/build/dir/',
             documentUri: vscode.Uri.parse('/fake/path/foo.txt'),
-            originalHandlerName: 'fake-original-handler',
-            originalSamTemplatePath: '/fake/original/sam/path',
             samTemplatePath: '/fake/sam/path',
             samLocalInvokeCommand: new DefaultSamLocalInvokeCommand(fakeExtCtx.chanLogger),
 

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -371,6 +371,19 @@ describe('AwsSamDebugConfigurationProvider', async () => {
             }
 
             assertEqualLaunchConfigs(actual, expected, appDir)
+
+            //
+            // Test noDebug=true.
+            //
+            const expectedNoDebug: SamLaunchRequestArgs = {
+                ...expected,
+                noDebug: true,
+                debugPort: undefined,
+                port: -1,
+            }
+            ;(c as any).noDebug = true
+            const actualNoDebug = (await debugConfigProvider.resolveDebugConfiguration(folder, c))!
+            assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug, appDir)
         })
 
         it('target=template: javascript', async () => {
@@ -437,6 +450,19 @@ describe('AwsSamDebugConfigurationProvider', async () => {
             }
 
             assertEqualLaunchConfigs(actual, expected, appDir)
+
+            //
+            // Test noDebug=true.
+            //
+            const expectedNoDebug: SamLaunchRequestArgs = {
+                ...expected,
+                noDebug: true,
+                debugPort: undefined,
+                port: -1,
+            }
+            ;(c as any).noDebug = true
+            const actualNoDebug = (await debugConfigProvider.resolveDebugConfiguration(folder, c))!
+            assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug, appDir)
         })
 
         it('target=code: dotnet/csharp', async () => {
@@ -528,7 +554,7 @@ describe('AwsSamDebugConfigurationProvider', async () => {
                 ...expected,
                 noDebug: true,
                 debuggerPath: undefined,
-                debugPort: -1,
+                debugPort: undefined,
             }
             delete expectedNoDebug.processId
             delete expectedNoDebug.pipeTransport


### PR DESCRIPTION
- Handle the `noDebug` case. This is when the user invokes the debugconfig via the `Run: Start Without Debugging` vscode command.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
