### PR TITLE
SAM debugconfig: fix "Run: Start Without Debugging"

### DIFF
--- a/src/shared/codelens/csharpCodeLensProvider.ts
+++ b/src/shared/codelens/csharpCodeLensProvider.ts
@@ -108,7 +108,7 @@ export async function makeCsharpConfig(config: SamLaunchRequestArgs): Promise<Sa
     config = {
         ...config,
         type: 'coreclr',
-        request: 'attach',
+        request: config.noDebug ? 'launch' : 'attach',
         runtimeFamily: RuntimeFamily.DotNetCore,
         name: 'SamLocalDebug',
         baseBuildDir: baseBuildDir,

--- a/src/shared/codelens/pythonCodeLensProvider.ts
+++ b/src/shared/codelens/pythonCodeLensProvider.ts
@@ -224,7 +224,7 @@ export async function makePythonDebugConfig(
     return {
         ...config,
         type: 'python',
-        request: 'attach',
+        request: config.noDebug ? 'launch' : 'attach',
         runtimeFamily: RuntimeFamily.Python,
         outFilePath: pathutil.normalize(outFilePath ?? '') ?? undefined,
         baseBuildDir: baseBuildDir,

--- a/src/shared/codelens/typescriptCodeLensProvider.ts
+++ b/src/shared/codelens/typescriptCodeLensProvider.ts
@@ -107,7 +107,7 @@ export async function makeTypescriptConfig(config: SamLaunchRequestArgs): Promis
     const nodejsLaunchConfig: NodejsDebugConfiguration = {
         ...config, // Compose.
         type: 'node',
-        request: 'attach',
+        request: config.noDebug ? 'launch' : 'attach',
         runtimeFamily: RuntimeFamily.NodeJS,
         name: 'SamLocalDebug',
         preLaunchTask: undefined,

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -246,7 +246,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         // By this point launchConfig.request is now set to "attach" (not "direct-invoke").
         launchConfig.type = AWS_SAM_DEBUG_TYPE
 
-        if (launchConfig.request !== 'attach') {
+        if (launchConfig.request !== 'attach' && launchConfig.request !== 'launch') {
             // The "request" field must be updated so that it routes to the
             // DebugAdapter (SamDebugSession.attachRequest()), else this will
             // just cycle back (and it indicates a bug in the config logic).

--- a/src/shared/sam/debugger/samDebugSession.ts
+++ b/src/shared/sam/debugger/samDebugSession.ts
@@ -161,6 +161,9 @@ export class SamDebugSession extends DebugSession {
         }
     }
 
+    /**
+     * Invokes `sam build`, `sam invoke` _without_ debugging.
+     */
     protected async launchRequest(response: DebugProtocol.LaunchResponse, config: SamLaunchRequestArgs) {
         // make sure to 'Stop' the buffered logging if 'trace' is not set
         logger.setup(config.trace ? Logger.LogLevel.Verbose : Logger.LogLevel.Stop, false)
@@ -170,7 +173,7 @@ export class SamDebugSession extends DebugSession {
     }
 
     /**
-     * Invokes `sam build`, `sam invoke`, then attachs vscode debugger to the
+     * Invokes `sam build`, `sam invoke`, then attaches vscode debugger to the
      * debugger port.
      */
     protected async attachRequest(

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -378,6 +378,7 @@ describe('AwsSamDebugConfigurationProvider', async () => {
             const expectedNoDebug: SamLaunchRequestArgs = {
                 ...expected,
                 noDebug: true,
+                request: 'launch',
                 debugPort: undefined,
                 port: -1,
             }
@@ -457,6 +458,7 @@ describe('AwsSamDebugConfigurationProvider', async () => {
             const expectedNoDebug: SamLaunchRequestArgs = {
                 ...expected,
                 noDebug: true,
+                request: 'launch',
                 debugPort: undefined,
                 port: -1,
             }
@@ -553,6 +555,7 @@ describe('AwsSamDebugConfigurationProvider', async () => {
             const expectedNoDebug: SamLaunchRequestArgs = {
                 ...expected,
                 noDebug: true,
+                request: 'launch',
                 debuggerPath: undefined,
                 debugPort: undefined,
             }
@@ -652,6 +655,7 @@ describe('AwsSamDebugConfigurationProvider', async () => {
             const expectedNoDebug: SamLaunchRequestArgs = {
                 ...expected,
                 noDebug: true,
+                request: 'launch',
                 debugPort: undefined,
                 port: -1,
                 outFilePath: '',


### PR DESCRIPTION
Followup to ae0d28179b8d. The changes in that commit are "good enough" for python/nodejs, but the csharp codepath still attaches and starts debugging.

The full, proper fix is to set `request='launch'` instead of `request='attach'`.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
