### PR TITLE
SAM debugconfig: DRY

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -128,7 +128,7 @@
     "AWS.credentials.statusbar.no.credentials": "(not connected)",
     "AWS.credentials.statusbar.text": "AWS: {0}",
     "AWS.credentials.statusbar.tooltip": "The current credentials used by the AWS Toolkit.\n\nClick this status bar item to use different credentials.",
-    "AWS.error.during.sam.local": "An error occurred trying to run SAM Application locally: {0}",
+    "AWS.error.during.sam.local": "Failed to run SAM Application locally: {0}",
     "AWS.command.showErrorDetails": "Show error details",
     "AWS.error.endpoint.load.failure": "The AWS Toolkit was unable to load endpoints data. Toolkit functionality may be impacted until VS Code is restarted.",
     "AWS.error.mfa.userCancelled": "User cancelled entering authentication code",

--- a/src/shared/sam/debugger/samDebugSession.ts
+++ b/src/shared/sam/debugger/samDebugSession.ts
@@ -167,7 +167,7 @@ export class SamDebugSession extends DebugSession {
     protected async launchRequest(response: DebugProtocol.LaunchResponse, config: SamLaunchRequestArgs) {
         // make sure to 'Stop' the buffered logging if 'trace' is not set
         logger.setup(config.trace ? Logger.LogLevel.Verbose : Logger.LogLevel.Stop, false)
-        this.launchOrAttach(response, config)
+        await this.launchOrAttach(response, config)
         this.sendResponse(response)
         this.sendEvent(new TerminatedEvent())
     }
@@ -181,7 +181,7 @@ export class SamDebugSession extends DebugSession {
         config: SamLaunchRequestArgs,
         request?: DebugProtocol.Request
     ) {
-        this.launchOrAttach(response, config)
+        await this.launchOrAttach(response, config)
         this.sendResponse(response)
         this.sendEvent(new TerminatedEvent())
     }

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -375,6 +375,8 @@ describe('AwsSamDebugConfigurationProvider', async () => {
             //
             // Test noDebug=true.
             //
+            ;(c as any).noDebug = true
+            const actualNoDebug = (await debugConfigProvider.resolveDebugConfiguration(folder, c))!
             const expectedNoDebug: SamLaunchRequestArgs = {
                 ...expected,
                 noDebug: true,
@@ -382,8 +384,6 @@ describe('AwsSamDebugConfigurationProvider', async () => {
                 debugPort: undefined,
                 port: -1,
             }
-            ;(c as any).noDebug = true
-            const actualNoDebug = (await debugConfigProvider.resolveDebugConfiguration(folder, c))!
             assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug, appDir)
         })
 
@@ -455,6 +455,8 @@ describe('AwsSamDebugConfigurationProvider', async () => {
             //
             // Test noDebug=true.
             //
+            ;(c as any).noDebug = true
+            const actualNoDebug = (await debugConfigProvider.resolveDebugConfiguration(folder, c))!
             const expectedNoDebug: SamLaunchRequestArgs = {
                 ...expected,
                 noDebug: true,
@@ -462,8 +464,6 @@ describe('AwsSamDebugConfigurationProvider', async () => {
                 debugPort: undefined,
                 port: -1,
             }
-            ;(c as any).noDebug = true
-            const actualNoDebug = (await debugConfigProvider.resolveDebugConfiguration(folder, c))!
             assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug, appDir)
         })
 
@@ -489,6 +489,7 @@ describe('AwsSamDebugConfigurationProvider', async () => {
                 folder,
                 c
             ))! as DotNetCoreDebugConfiguration
+            const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
             const expected: SamLaunchRequestArgs = {
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'dotnetcore2.1', // lambdaModel.dotNetRuntimes[0],
@@ -500,7 +501,7 @@ describe('AwsSamDebugConfigurationProvider', async () => {
                     uri: vscode.Uri.file(appDir),
                 },
                 baseBuildDir: actual.baseBuildDir, // Random, sanity-checked by assertEqualLaunchConfigs().
-                codeRoot: pathutil.normalize(path.join(appDir, 'src/HelloWorld')), // Normalized to absolute path.
+                codeRoot: expectedCodeRoot, // Normalized to absolute path.
                 debugPort: 5858,
                 documentUri: vscode.Uri.file(''), // TODO: remove or test.
                 handlerName: 'HelloWorld::HelloWorld.Function::FunctionHandler',
@@ -513,29 +514,29 @@ describe('AwsSamDebugConfigurationProvider', async () => {
                     runtime: 'dotnetcore2.1',
                 },
                 name: 'SamLocalDebug',
-                samTemplatePath: pathutil.normalize(path.join(actual.baseBuildDir ?? '?', 'input/input-template.yaml')),
+                samTemplatePath: expectedCodeRoot + '/input-template.yaml',
 
                 //
                 // Csharp-related fields
                 //
-                debuggerPath: pathutil.normalize(path.join(path.join(appDir, 'src/HelloWorld'), '.vsdbg')),
+                debuggerPath: expectedCodeRoot + '/.vsdbg', // Normalized to absolute path.
                 processId: '1',
                 pipeTransport: {
                     debuggerPath: '/tmp/lambci_debug_files/vsdbg',
                     // tslint:disable-next-line: no-invalid-template-strings
                     pipeArgs: ['-c', 'docker exec -i $(docker ps -q -f publish=5858) ${debuggerCommand}'],
-                    pipeCwd: pathutil.normalize(path.join(appDir, 'src/HelloWorld')),
+                    pipeCwd: expectedCodeRoot,
                     pipeProgram: 'sh',
                 },
                 sourceFileMap: {
-                    '/var/task': pathutil.normalize(path.join(appDir, 'src/HelloWorld')),
+                    '/var/task': expectedCodeRoot,
                 },
                 windows: {
                     pipeTransport: {
                         debuggerPath: '/tmp/lambci_debug_files/vsdbg',
                         // tslint:disable-next-line: no-invalid-template-strings
                         pipeArgs: ['-c', 'docker exec -i $(docker ps -q -f publish=5858) ${debuggerCommand}'],
-                        pipeCwd: pathutil.normalize(path.join(appDir, 'src/HelloWorld')),
+                        pipeCwd: expectedCodeRoot,
                         pipeProgram: 'powershell',
                     },
                 },
@@ -552,8 +553,15 @@ describe('AwsSamDebugConfigurationProvider', async () => {
             //
             // Test noDebug=true.
             //
+            ;(c as any).noDebug = true
+            const actualNoDebug = (await debugConfigProvider.resolveDebugConfiguration(
+                folder,
+                c
+            ))! as DotNetCoreDebugConfiguration
+            const expectedCodeRootNoDebug = (actualNoDebug.baseBuildDir ?? 'fail') + '/input'
             const expectedNoDebug: SamLaunchRequestArgs = {
                 ...expected,
+                codeRoot: expectedCodeRootNoDebug,
                 noDebug: true,
                 request: 'launch',
                 debuggerPath: undefined,
@@ -563,11 +571,6 @@ describe('AwsSamDebugConfigurationProvider', async () => {
             delete expectedNoDebug.pipeTransport
             delete expectedNoDebug.sourceFileMap
             delete expectedNoDebug.windows
-            ;(c as any).noDebug = true
-            const actualNoDebug = (await debugConfigProvider.resolveDebugConfiguration(
-                folder,
-                c
-            ))! as DotNetCoreDebugConfiguration
             assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug, appDir)
         })
 
@@ -652,6 +655,11 @@ describe('AwsSamDebugConfigurationProvider', async () => {
             //
             // Test noDebug=true.
             //
+            ;(c as any).noDebug = true
+            const actualNoDebug = (await debugConfigProvider.resolveDebugConfiguration(
+                folder,
+                c
+            ))! as DotNetCoreDebugConfiguration
             const expectedNoDebug: SamLaunchRequestArgs = {
                 ...expected,
                 noDebug: true,
@@ -661,11 +669,6 @@ describe('AwsSamDebugConfigurationProvider', async () => {
                 outFilePath: '',
                 handlerName: 'app.lambda_handler',
             }
-            ;(c as any).noDebug = true
-            const actualNoDebug = (await debugConfigProvider.resolveDebugConfiguration(
-                folder,
-                c
-            ))! as DotNetCoreDebugConfiguration
             assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug, appDir)
         })
 


### PR DESCRIPTION
- The `invokeXXLambda` family of functions is mostly redundant.  Move the  common logic in to `invokeLambdaFunction()`.
- Eliminate `OnLocalInvokeCommandContext`.
- This also adds telemetry for the python/nodejs cases.
- 3f1b35b Avoid potential race between invoke, exit 
  - Wait before emitting TerminatedEvent.



## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
