### PR TITLE
ExtContext: fix vscode 1.45 activation failure

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,15 +106,15 @@ export async function activate(context: vscode.ExtensionContext) {
         })
         await ext.telemetry.start()
 
-        const extContext: ExtContext = {
-            ...context,
-            awsContext: awsContext,
-            regionProvider: regionProvider,
-            settings: toolkitSettings,
-            outputChannel: toolkitOutputChannel,
-            telemetryService: ext.telemetry,
-            chanLogger: getChannelLogger(toolkitOutputChannel),
-        }
+        const extContext = new ExtContext(
+            context,
+            awsContext,
+            regionProvider,
+            toolkitSettings,
+            toolkitOutputChannel,
+            ext.telemetry,
+            getChannelLogger(toolkitOutputChannel)
+        )
 
         context.subscriptions.push(
             vscode.commands.registerCommand('aws.login', async () => await ext.awsContextCommands.onCommandLogin())

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,15 +106,15 @@ export async function activate(context: vscode.ExtensionContext) {
         })
         await ext.telemetry.start()
 
-        const extContext = new ExtContext(
-            context,
-            awsContext,
-            regionProvider,
-            toolkitSettings,
-            toolkitOutputChannel,
-            ext.telemetry,
-            getChannelLogger(toolkitOutputChannel)
-        )
+        const extContext: ExtContext = {
+            extensionContext: context,
+            awsContext: awsContext,
+            regionProvider: regionProvider,
+            settings: toolkitSettings,
+            outputChannel: toolkitOutputChannel,
+            telemetryService: ext.telemetry,
+            chanLogger: getChannelLogger(toolkitOutputChannel),
+        }
 
         context.subscriptions.push(
             vscode.commands.registerCommand('aws.login', async () => await ext.awsContextCommands.onCommandLogin())
@@ -171,7 +171,7 @@ export async function activate(context: vscode.ExtensionContext) {
         await activateCloudFormationTemplateRegistry(context)
 
         await activateCdk({
-            extensionContext: extContext,
+            extensionContext: extContext.extensionContext,
         })
 
         await activateAwsExplorer({
@@ -183,7 +183,7 @@ export async function activate(context: vscode.ExtensionContext) {
         })
 
         await activateSchemas({
-            context: extContext,
+            context: extContext.extensionContext,
         })
 
         await ExtensionDisposableFiles.initialize(context)

--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -169,7 +169,7 @@ export function makeTypescriptCodeLensProvider(): vscode.CodeLensProvider {
 }
 
 export async function initializePythonCodelens(context: ExtContext): Promise<void> {
-    context.subscriptions.push(
+    context.extensionContext.subscriptions.push(
         vscode.commands.registerCommand(
             getInvokeCmdKey('python'),
             async (params: LambdaLocalInvokeParams): Promise<void> => {
@@ -180,7 +180,7 @@ export async function initializePythonCodelens(context: ExtContext): Promise<voi
 }
 
 export async function initializeCsharpCodelens(context: ExtContext): Promise<void> {
-    context.subscriptions.push(
+    context.extensionContext.subscriptions.push(
         vscode.commands.registerCommand(
             getInvokeCmdKey(csharpDebug.CSHARP_LANGUAGE),
             async (params: LambdaLocalInvokeParams) => {
@@ -236,7 +236,7 @@ export function initializeTypescriptCodelens(context: ExtContext): void {
     }
 
     const command = getInvokeCmdKey('javascript')
-    context.subscriptions.push(
+    context.extensionContext.subscriptions.push(
         vscode.commands.registerCommand(command, async (params: LambdaLocalInvokeParams) => {
             const logger = getLogger()
 

--- a/src/shared/extensions.ts
+++ b/src/shared/extensions.ts
@@ -18,29 +18,12 @@ export const VSCODE_EXTENSION_ID = {
 /**
  * Long-lived, extension-scoped, shared globals.
  */
-export class ExtContext implements vscode.ExtensionContext {
-    public asAbsolutePath(relativePath: string): string {
-        return this.vscodeContext.asAbsolutePath(relativePath)
-    }
-
-    public constructor(
-        private readonly vscodeContext: vscode.ExtensionContext,
-        public readonly awsContext: AwsContext,
-        public readonly regionProvider: RegionProvider,
-        public readonly settings: SettingsConfiguration,
-        public readonly outputChannel: vscode.OutputChannel,
-        public readonly telemetryService: TelemetryService,
-        public readonly chanLogger: ChannelLogger,
-
-        //
-        // Inherited properties:
-        //
-        readonly storagePath: string | undefined = vscodeContext.storagePath,
-        readonly globalStoragePath: string = vscodeContext.globalStoragePath,
-        readonly logPath: string = vscodeContext.logPath,
-        readonly subscriptions: { dispose(): any }[] = vscodeContext.subscriptions,
-        readonly workspaceState: vscode.Memento = vscodeContext.workspaceState,
-        readonly globalState: vscode.Memento = vscodeContext.globalState,
-        readonly extensionPath: string = vscodeContext.extensionPath
-    ) {}
+export interface ExtContext {
+    extensionContext: vscode.ExtensionContext
+    awsContext: AwsContext
+    regionProvider: RegionProvider
+    settings: SettingsConfiguration
+    outputChannel: vscode.OutputChannel
+    telemetryService: TelemetryService
+    chanLogger: ChannelLogger
 }

--- a/src/shared/extensions.ts
+++ b/src/shared/extensions.ts
@@ -18,11 +18,29 @@ export const VSCODE_EXTENSION_ID = {
 /**
  * Long-lived, extension-scoped, shared globals.
  */
-export interface ExtContext extends vscode.ExtensionContext {
-    awsContext: AwsContext
-    regionProvider: RegionProvider
-    settings: SettingsConfiguration
-    outputChannel: vscode.OutputChannel
-    telemetryService: TelemetryService
-    chanLogger: ChannelLogger
+export class ExtContext implements vscode.ExtensionContext {
+    public asAbsolutePath(relativePath: string): string {
+        return this.vscodeContext.asAbsolutePath(relativePath)
+    }
+
+    public constructor(
+        private readonly vscodeContext: vscode.ExtensionContext,
+        public readonly awsContext: AwsContext,
+        public readonly regionProvider: RegionProvider,
+        public readonly settings: SettingsConfiguration,
+        public readonly outputChannel: vscode.OutputChannel,
+        public readonly telemetryService: TelemetryService,
+        public readonly chanLogger: ChannelLogger,
+
+        //
+        // Inherited properties:
+        //
+        readonly storagePath: string | undefined = vscodeContext.storagePath,
+        readonly globalStoragePath: string = vscodeContext.globalStoragePath,
+        readonly logPath: string = vscodeContext.logPath,
+        readonly subscriptions: { dispose(): any }[] = vscodeContext.subscriptions,
+        readonly workspaceState: vscode.Memento = vscodeContext.workspaceState,
+        readonly globalState: vscode.Memento = vscodeContext.globalState,
+        readonly extensionPath: string = vscodeContext.extensionPath
+    ) {}
 }

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -34,13 +34,13 @@ import { AWS_SAM_DEBUG_TYPE } from './debugger/awsSamDebugConfiguration'
 export async function activate(ctx: ExtContext): Promise<void> {
     initializeSamCliContext({ settingsConfiguration: ctx.settings })
 
-    ctx.subscriptions.push(
+    ctx.extensionContext.subscriptions.push(
         ...(await activateCodeLensProviders(ctx, ctx.settings, ctx.outputChannel, ctx.telemetryService))
     )
 
     await registerServerlessCommands(ctx)
 
-    ctx.subscriptions.push(
+    ctx.extensionContext.subscriptions.push(
         vscode.debug.registerDebugConfigurationProvider(AWS_SAM_DEBUG_TYPE, new SamDebugConfigProvider(ctx))
     )
 
@@ -51,11 +51,11 @@ export async function activate(ctx: ExtContext): Promise<void> {
     // https://code.visualstudio.com/api/extension-guides/debugger-extension#alternative-approach-to-develop-a-debugger-extension
     //
     // XXX: requires the "debuggers.*.label" attribute in package.json!
-    ctx.subscriptions.push(
+    ctx.extensionContext.subscriptions.push(
         vscode.debug.registerDebugAdapterDescriptorFactory(AWS_SAM_DEBUG_TYPE, new InlineDebugAdapterFactory(ctx))
     )
 
-    ctx.subscriptions.push(
+    ctx.extensionContext.subscriptions.push(
         vscode.languages.registerCompletionItemProvider(
             {
                 language: 'json',
@@ -73,7 +73,7 @@ export async function activate(ctx: ExtContext): Promise<void> {
 }
 
 async function registerServerlessCommands(ctx: ExtContext): Promise<void> {
-    ctx.subscriptions.push(
+    ctx.extensionContext.subscriptions.push(
         vscode.commands.registerCommand(
             'aws.samcli.detect',
             async () =>

--- a/src/test/lambda/local/debugConfiguration.test.ts
+++ b/src/test/lambda/local/debugConfiguration.test.ts
@@ -34,8 +34,8 @@ describe('makeCoreCLRDebugConfiguration', async () => {
         await rmrf(tempFolder)
     })
 
-    function makeFakeSamLaunchConfig() {
-        const fakeExtCtx = new FakeExtensionContext()
+    async function makeFakeSamLaunchConfig() {
+        const fakeExtCtx = await FakeExtensionContext.getFakeExtContext()
         const config: SamLaunchRequestArgs = {
             name: 'fake-launch-config',
             workspaceFolder: fakeWorkspaceFolder,
@@ -65,7 +65,7 @@ describe('makeCoreCLRDebugConfiguration', async () => {
     }
 
     async function makeConfig({ codeUri = path.join('foo', 'bar') }: { codeUri?: string; port?: number }) {
-        const fakeLaunchConfig = makeFakeSamLaunchConfig()
+        const fakeLaunchConfig = await makeFakeSamLaunchConfig()
         return makeCoreCLRDebugConfiguration(fakeLaunchConfig, codeUri)
     }
 

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -85,7 +85,7 @@ describe('AwsSamDebugConfigurationProvider', async () => {
     const resourceName = 'myResource'
 
     beforeEach(async () => {
-        const fakeContext = await FakeExtensionContext.getNew()
+        const fakeContext = await FakeExtensionContext.getFakeExtContext()
         tempFolder = await makeTemporaryToolkitFolder()
         tempFile = vscode.Uri.file(path.join(tempFolder, 'test.yaml'))
         registry = CloudFormationTemplateRegistry.getRegistry()


### PR DESCRIPTION
VSCode 1.45 (but not 1.44 or earlier) seems to have a problem with this:

    const extContext: ExtContext = {
      ...context,
      
It throws an exception. ~~Use inheritance instead of destructuring/composition to workaround it.~~ edit: use a nested property instead.

Exception details:

    2020-05-06 14:02:36 [ERROR]: Error Activating AWS Toolkit Error: [amazonwebservices.aws-toolkit-vscode]:
       Proposed API is only available when running out of dev or with the following command line switch: --enable-proposed-api amazonwebservices.aws-toolkit-vscode
    at a (/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:591:810)
    at Object.t.checkProposedApiEnabled (/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:592:148)
    at Object.get environmentVariableCollection [as environmentVariableCollection] (/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:823:813)
    at Function.assign (<anonymous>)
    at Object.<anonymous> (/Users/werlla/.vscode-insiders/extensions/amazonwebservices.aws-toolkit-vscode-1.10.0-SNAPSHOT/dist/extension.js:2:1271543)
    at Generator.next (<anonymous>)
    at o (/Users/werlla/.vscode-insiders/extensions/amazonwebservices.aws-toolkit-vscode-1.10.0-SNAPSHOT/dist/extension.js:2:1268101)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
