### PR TITLE
SAM debugconfig: append runtime to generated config name

### DIFF
--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -73,7 +73,10 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
                     }
                     const resources = getResourcesFromTemplateDatum(templateDatum)
                     for (const resourceKey of resources.keys()) {
-                        configs.push(createTemplateAwsSamDebugConfig(folder, resourceKey, templateDatum.path))
+                        const runtimeName = resources.get(resourceKey)?.Properties?.Runtime
+                        configs.push(
+                            createTemplateAwsSamDebugConfig(folder, runtimeName, resourceKey, templateDatum.path)
+                        )
                     }
                 }
             }

--- a/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
@@ -5,7 +5,11 @@
 
 import * as path from 'path'
 import * as vscode from 'vscode'
+import { getExistingConfiguration } from '../../../../lambda/config/templates'
+import { getDefaultRuntime, RuntimeFamily } from '../../../../lambda/models/samLambdaRuntime'
+import { CloudFormationTemplateRegistry } from '../../../cloudformation/templateRegistry'
 import { LaunchConfiguration } from '../../../debug/launchConfiguration'
+import { localize } from '../../../utilities/vsCodeUtils'
 import {
     AwsSamDebuggerConfiguration,
     CODE_TARGET_TYPE,
@@ -13,10 +17,6 @@ import {
     createTemplateAwsSamDebugConfig,
     TEMPLATE_TARGET_TYPE,
 } from '../awsSamDebugConfiguration'
-import { CloudFormationTemplateRegistry } from '../../../cloudformation/templateRegistry'
-import { getExistingConfiguration } from '../../../../lambda/config/templates'
-import { localize } from '../../../utilities/vsCodeUtils'
-import { RuntimeFamily } from '../../../../lambda/models/samLambdaRuntime'
 
 /**
  * Holds information required to create a launch config
@@ -41,6 +41,7 @@ export async function addSamDebugConfiguration(
 
     let samDebugConfig: AwsSamDebuggerConfiguration
     const workspaceFolder = vscode.workspace.getWorkspaceFolder(rootUri)
+    const runtimeName = runtimeFamily ? getDefaultRuntime(runtimeFamily) : undefined
 
     if (type === TEMPLATE_TARGET_TYPE) {
         let preloadedConfig = undefined
@@ -78,7 +79,13 @@ export async function addSamDebugConfiguration(
                 }
             }
         }
-        samDebugConfig = createTemplateAwsSamDebugConfig(workspaceFolder, resourceName, rootUri.fsPath, preloadedConfig)
+        samDebugConfig = createTemplateAwsSamDebugConfig(
+            workspaceFolder,
+            runtimeName,
+            resourceName,
+            rootUri.fsPath,
+            preloadedConfig
+        )
     } else if (type === CODE_TARGET_TYPE) {
         // strip the manifest's URI to the manifest's dir here. More reliable to do this here than converting back and forth between URI/string up the chain.
         samDebugConfig = createCodeAwsSamDebugConfig(

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -124,7 +124,10 @@ describe('AwsSamDebugConfigurationProvider', async () => {
             const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
             assert.notStrictEqual(provided, undefined)
             assert.strictEqual(provided!.length, 1)
-            assert.strictEqual(provided![0].name, 'TestResource (nodejs12.x)')
+            assert.strictEqual(
+                provided![0].name,
+                `${path.basename(fakeWorkspaceFolder.uri.fsPath)}:TestResource (nodejs12.x)`
+            )
         })
 
         it('returns multiple items if a template with multiple resources is in the workspace', async () => {
@@ -762,13 +765,13 @@ describe('AwsSamDebugConfigurationProvider', async () => {
 
 describe('createTemplateAwsSamDebugConfig', () => {
     const name = 'my body is a template'
-    const templatePath = path.join('two', 'roads', 'diverged', 'in', 'a', 'yellow', 'wood')
+    const templatePath = path.join('two', 'roads', 'diverged', 'in', 'a', 'yellow', 'wood.yaml')
 
     it('creates a template-type SAM debugger configuration with minimal configurations', () => {
         const config = createTemplateAwsSamDebugConfig(undefined, undefined, name, templatePath)
         assert.strictEqual(config.invokeTarget.target, TEMPLATE_TARGET_TYPE)
         const invokeTarget = config.invokeTarget as TemplateTargetProperties
-        assert.strictEqual(config.name, name)
+        assert.strictEqual(config.name, `yellow:${name}`)
         assert.strictEqual(invokeTarget.samTemplateResource, name)
         assert.strictEqual(invokeTarget.samTemplatePath, templatePath)
         assert.ok(!config.hasOwnProperty('lambda'))
@@ -881,7 +884,7 @@ describe('createTemplateAwsSamDebugConfig', () => {
         const config = createTemplateAwsSamDebugConfig(undefined, undefined, name, templatePath)
         assert.strictEqual(config.invokeTarget.target, TEMPLATE_TARGET_TYPE)
         const invokeTarget = config.invokeTarget as TemplateTargetProperties
-        assert.strictEqual(config.name, name)
+        assert.strictEqual(config.name, `yellow:${name}`)
         assert.strictEqual(invokeTarget.samTemplateResource, name)
         assert.strictEqual(invokeTarget.samTemplatePath, templatePath)
         assert.ok(!config.hasOwnProperty('lambda'))

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -124,7 +124,7 @@ describe('AwsSamDebugConfigurationProvider', async () => {
             const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
             assert.notStrictEqual(provided, undefined)
             assert.strictEqual(provided!.length, 1)
-            assert.strictEqual(provided![0].name, 'TestResource')
+            assert.strictEqual(provided![0].name, 'TestResource (nodejs12.x)')
         })
 
         it('returns multiple items if a template with multiple resources is in the workspace', async () => {
@@ -138,8 +138,12 @@ describe('AwsSamDebugConfigurationProvider', async () => {
             assert.notStrictEqual(provided, undefined)
             if (provided) {
                 assert.strictEqual(provided.length, 2)
-                assert.ok(resources.includes(provided[0].name))
-                assert.ok(resources.includes(provided[1].name))
+                assert.ok(
+                    resources.includes((provided[0].invokeTarget as TemplateTargetProperties).samTemplateResource)
+                )
+                assert.ok(
+                    resources.includes((provided[1].invokeTarget as TemplateTargetProperties).samTemplateResource)
+                )
             }
         })
 
@@ -170,8 +174,12 @@ describe('AwsSamDebugConfigurationProvider', async () => {
             assert.notStrictEqual(provided, undefined)
             if (provided) {
                 assert.strictEqual(provided.length, 2)
-                assert.ok(resources.includes(provided[0].name))
-                assert.ok(resources.includes(provided[1].name))
+                assert.ok(
+                    resources.includes((provided[0].invokeTarget as TemplateTargetProperties).samTemplateResource)
+                )
+                assert.ok(
+                    resources.includes((provided[1].invokeTarget as TemplateTargetProperties).samTemplateResource)
+                )
                 assert.ok(!resources.includes(badResourceName))
             }
         })
@@ -757,7 +765,7 @@ describe('createTemplateAwsSamDebugConfig', () => {
     const templatePath = path.join('two', 'roads', 'diverged', 'in', 'a', 'yellow', 'wood')
 
     it('creates a template-type SAM debugger configuration with minimal configurations', () => {
-        const config = createTemplateAwsSamDebugConfig(undefined, name, templatePath)
+        const config = createTemplateAwsSamDebugConfig(undefined, undefined, name, templatePath)
         assert.strictEqual(config.invokeTarget.target, TEMPLATE_TARGET_TYPE)
         const invokeTarget = config.invokeTarget as TemplateTargetProperties
         assert.strictEqual(config.name, name)
@@ -776,7 +784,7 @@ describe('createTemplateAwsSamDebugConfig', () => {
             },
             dockerNetwork: 'rockerFretwork',
         }
-        const config = createTemplateAwsSamDebugConfig(undefined, name, templatePath, params)
+        const config = createTemplateAwsSamDebugConfig(undefined, undefined, name, templatePath, params)
         assert.deepStrictEqual(config.lambda?.event?.json, params.eventJson)
         assert.deepStrictEqual(config.lambda?.environmentVariables, params.environmentVariables)
         assert.strictEqual(config.sam?.dockerNetwork, params.dockerNetwork)
@@ -870,7 +878,7 @@ describe('createTemplateAwsSamDebugConfig', () => {
     const templatePath = path.join('two', 'roads', 'diverged', 'in', 'a', 'yellow', 'wood')
 
     it('creates a template-type SAM debugger configuration with minimal configurations', () => {
-        const config = createTemplateAwsSamDebugConfig(undefined, name, templatePath)
+        const config = createTemplateAwsSamDebugConfig(undefined, undefined, name, templatePath)
         assert.strictEqual(config.invokeTarget.target, TEMPLATE_TARGET_TYPE)
         const invokeTarget = config.invokeTarget as TemplateTargetProperties
         assert.strictEqual(config.name, name)
@@ -889,7 +897,7 @@ describe('createTemplateAwsSamDebugConfig', () => {
             },
             dockerNetwork: 'rockerFretwork',
         }
-        const config = createTemplateAwsSamDebugConfig(undefined, name, templatePath, params)
+        const config = createTemplateAwsSamDebugConfig(undefined, undefined, name, templatePath, params)
         assert.deepStrictEqual(config.lambda?.event?.json, params.eventJson)
         assert.deepStrictEqual(config.lambda?.environmentVariables, params.environmentVariables)
         assert.strictEqual(config.sam?.dockerNetwork, params.dockerNetwork)


### PR DESCRIPTION
Resource/lambda names may be generic. This is an attempt to help the user by adding a suffix to the generated config names.

<img width="754" alt="Screen Shot 2020-05-07 at 12 01 59 PM" src="https://user-images.githubusercontent.com/55561878/81361258-bbe20c00-9092-11ea-93a7-704d4914db46.png">


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
