### PR TITLE
Make SAM timeout dynamic so images can be pulled on slow connections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4368,7 +4368,7 @@
                     "dependencies": {
                         "minimist": {
                             "version": "1.2.0",
-                            "resolved": false,
+                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                             "dev": true,
                             "optional": true

--- a/package.nls.json
+++ b/package.nls.json
@@ -18,7 +18,7 @@
     "AWS.configuration.description.onDefaultRegionMissing": "Action to take when a Profile's default region is hidden in the Explorer. Possible values:\n* `add` - shows region in the explorer\n* `ignore` - does nothing with the region\n* `prompt` - (default) asks the user what they would like to do.",
     "AWS.configuration.sam.template.depth": "The maximum subfolder depth within a workspace that the Toolkit will search for SAM Template files",
     "AWS.configuration.description.samcli.debug.attach.retry.maximum": "If the Toolkit is unable to attach a debugger, this is the number of times to retry before giving up.",
-    "AWS.configuration.description.samcli.debug.attach.timeout": "Maximum amount of time to wait for text from a SAM Local debug (in milliseconds)",
+    "AWS.configuration.description.samcli.debug.attach.timeout": "Maximum amount of time to wait for text from SAM while doing a Local Lambda debug (in milliseconds)",
     "AWS.configuration.description.samcli.location": "Location of SAM CLI. SAM CLI is used to create, build, package, and deploy Serverless Applications. [Learn More](https://aws.amazon.com/serverless/sam/)",
     "AWS.configuration.description.telemetry": "Enable AWS Toolkit to send usage data to AWS.",
     "AWS.stepFunctions.asl.format.enable.desc": "Enables the default formatter used with Amazon States Language files",

--- a/package.nls.json
+++ b/package.nls.json
@@ -18,7 +18,7 @@
     "AWS.configuration.description.onDefaultRegionMissing": "Action to take when a Profile's default region is hidden in the Explorer. Possible values:\n* `add` - shows region in the explorer\n* `ignore` - does nothing with the region\n* `prompt` - (default) asks the user what they would like to do.",
     "AWS.configuration.sam.template.depth": "The maximum subfolder depth within a workspace that the Toolkit will search for SAM Template files",
     "AWS.configuration.description.samcli.debug.attach.retry.maximum": "If the Toolkit is unable to attach a debugger, this is the number of times to retry before giving up.",
-    "AWS.configuration.description.samcli.debug.attach.timeout": "Maximum amount of time to wait for text from SAM while doing a Local Lambda debug (in milliseconds)",
+    "AWS.configuration.description.samcli.debug.attach.timeout": "Maximum time (in milliseconds) to wait for SAM output while starting a Local Lambda session",
     "AWS.configuration.description.samcli.location": "Location of SAM CLI. SAM CLI is used to create, build, package, and deploy Serverless Applications. [Learn More](https://aws.amazon.com/serverless/sam/)",
     "AWS.configuration.description.telemetry": "Enable AWS Toolkit to send usage data to AWS.",
     "AWS.stepFunctions.asl.format.enable.desc": "Enables the default formatter used with Amazon States Language files",

--- a/package.nls.json
+++ b/package.nls.json
@@ -18,7 +18,7 @@
     "AWS.configuration.description.onDefaultRegionMissing": "Action to take when a Profile's default region is hidden in the Explorer. Possible values:\n* `add` - shows region in the explorer\n* `ignore` - does nothing with the region\n* `prompt` - (default) asks the user what they would like to do.",
     "AWS.configuration.sam.template.depth": "The maximum subfolder depth within a workspace that the Toolkit will search for SAM Template files",
     "AWS.configuration.description.samcli.debug.attach.retry.maximum": "If the Toolkit is unable to attach a debugger, this is the number of times to retry before giving up.",
-    "AWS.configuration.description.samcli.debug.attach.timeout": "Maximum amount of time to wait for debugger to connect to a SAM Local debug run (in milliseconds)",
+    "AWS.configuration.description.samcli.debug.attach.timeout": "Maximum amount of time to wait for text from a SAM Local debug (in milliseconds)",
     "AWS.configuration.description.samcli.location": "Location of SAM CLI. SAM CLI is used to create, build, package, and deploy Serverless Applications. [Learn More](https://aws.amazon.com/serverless/sam/)",
     "AWS.configuration.description.telemetry": "Enable AWS Toolkit to send usage data to AWS.",
     "AWS.stepFunctions.asl.format.enable.desc": "Enables the default formatter used with Amazon States Language files",

--- a/src/shared/codelens/pythonCodeLensProvider.ts
+++ b/src/shared/codelens/pythonCodeLensProvider.ts
@@ -33,6 +33,7 @@ import {
     makeInputTemplate,
 } from './localLambdaRunner'
 import { PythonDebugAdapterHeartbeat } from './pythonDebugAdapterHeartbeat'
+import { Timeout } from '../utilities/timeoutUtils'
 
 const PYTHON_DEBUG_ADAPTER_RETRY_DELAY_MS = 1000
 export const PYTHON_LANGUAGE = 'python'
@@ -352,13 +353,8 @@ export async function initialize({
     )
 }
 
-export async function waitForPythonDebugAdapter(
-    debugPort: number,
-    timeoutDurationMillis: number,
-    channelLogger: ChannelLogger
-) {
+export async function waitForPythonDebugAdapter(debugPort: number, timeout: Timeout, channelLogger: ChannelLogger) {
     const logger = getLogger()
-    const stopMillis = Date.now() + timeoutDurationMillis
 
     logger.verbose(`Testing debug adapter connection on port ${debugPort}`)
 
@@ -381,7 +377,7 @@ export async function waitForPythonDebugAdapter(
         }
 
         if (!debugServerAvailable) {
-            if (Date.now() > stopMillis) {
+            if (timeout.remainingTime === 0) {
                 break
             }
 

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -112,7 +112,7 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
 
         const awaitedPromises = params.timeout ? [debuggerPromise, params.timeout.timer] : [debuggerPromise]
 
-        const result = Promise.race(awaitedPromises).catch(async () => {
+        return Promise.race(awaitedPromises).catch(async () => {
             // did debugger promise resolve/reject? if not, this was a timeout: kill the process
             // otherwise, process closed out on its own; no need to kill the process
             if (!debuggerPromiseClosed) {
@@ -128,7 +128,6 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
                 throw err
             }
         })
-        return result
     }
 
     private emitMessage(text: string): void {

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -112,7 +112,7 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
 
         const awaitedPromises = params.timeout ? [debuggerPromise, params.timeout.timer] : [debuggerPromise]
 
-        await Promise.race(awaitedPromises).catch(async () => {
+        const result = Promise.race(awaitedPromises).catch(async () => {
             // did debugger promise resolve/reject? if not, this was a timeout: kill the process
             // otherwise, process closed out on its own; no need to kill the process
             if (!debuggerPromiseClosed) {
@@ -128,6 +128,7 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
                 throw err
             }
         })
+        return result
     }
 
     private emitMessage(text: string): void {

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -112,7 +112,7 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
 
         const awaitedPromises = params.timeout ? [debuggerPromise, params.timeout.timer] : [debuggerPromise]
 
-        return Promise.race(awaitedPromises).catch(async () => {
+        await Promise.race(awaitedPromises).catch(async () => {
             // did debugger promise resolve/reject? if not, this was a timeout: kill the process
             // otherwise, process closed out on its own; no need to kill the process
             if (!debuggerPromiseClosed) {

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -62,9 +62,13 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
             await childProcess.start({
                 onStdout: (text: string): void => {
                     this.emitMessage(text)
+                    // If we have a timeout (as we do on debug) refresh the timeout as we receive text
+                    params.timeout?.refresh()
                 },
                 onStderr: (text: string): void => {
                     this.emitMessage(text)
+                    // If we have a timeout (as we do on debug) refresh the timeout as we receive text
+                    params.timeout?.refresh()
                     if (checkForDebuggerAttachCue) {
                         // Look for messages like "Waiting for debugger to attach" before returning back to caller
                         if (this.debuggerAttachCues.some(cue => text.includes(cue))) {
@@ -75,7 +79,7 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
                         }
                     }
                 },
-                onClose: (code: number, signal: string): void => {
+                onClose: (code: number, _: string): void => {
                     this.logger.verbose(`The child process for sam local invoke closed with code ${code}`)
                     this.channelLogger.channel.appendLine(
                         localize('AWS.samcli.local.invoke.ended', 'Local invoke of SAM Application has ended.')

--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -8,17 +8,21 @@
  * @param timeoutLength Length of timeout duration (in ms)
  */
 export class Timeout {
-    private _startTime: number
-    private readonly _endTime: number
-    private readonly _timer: Promise<void>
-    private _timerTimeout?: NodeJS.Timeout
-    private _timerResolve?: (value?: void | PromiseLike<void> | undefined) => void
+    private originalStartTime: number
+    private startTime: number
+    private endTime: number
+    private readonly timeoutLength: number
+    private readonly timerPromise: Promise<void>
+    private timerTimeout?: NodeJS.Timeout
+    private timerResolve?: (value?: void | PromiseLike<void> | undefined) => void
     public constructor(timeoutLength: number) {
-        this._startTime = new Date().getTime()
-        this._endTime = this._startTime + timeoutLength
-        this._timer = new Promise<void>((resolve, reject) => {
-            this._timerTimeout = setTimeout(reject, timeoutLength)
-            this._timerResolve = resolve
+        this.startTime = new Date().getTime()
+        this.originalStartTime = this.startTime
+        this.endTime = this.startTime + timeoutLength
+        this.timeoutLength = timeoutLength
+        this.timerPromise = new Promise<void>((resolve, reject) => {
+            this.timerTimeout = setTimeout(reject, timeoutLength)
+            this.timerResolve = resolve
         })
     }
 
@@ -27,7 +31,7 @@ export class Timeout {
      * Bottoms out at 0
      */
     public get remainingTime(): number {
-        const remainingTime = this._endTime - new Date().getTime()
+        const remainingTime = this.endTime - new Date().getTime()
 
         return remainingTime > 0 ? remainingTime : 0
     }
@@ -39,8 +43,9 @@ export class Timeout {
         // These will not align, but we don't have visibility into a NodeJS.Timeout
         // so remainingtime will be approximate. Timers are approximate anyway and are
         // not highly accurate in when they fire.
-        this._startTime = new Date().getTime()
-        this._timerTimeout?.refresh()
+        this.startTime = new Date().getTime()
+        this.endTime = this.startTime + this.timeoutLength
+        this.timerTimeout?.refresh()
     }
 
     /**
@@ -49,27 +54,25 @@ export class Timeout {
      * Once this timer has finished, cannot be restarted
      */
     public get timer(): Promise<void> {
-        return this._timer
+        return this.timerPromise
     }
 
     /**
      * Returns the elapsed time from the initial Timeout object creation
-     * Useful for telemetry reporting!
      */
     public get elapsedTime(): number {
-        return new Date().getTime() - this._startTime
+        return new Date().getTime() - this.originalStartTime
     }
 
     /**
      * Kills the internal timer and resolves the timer's promise
-     * Helpful for tests!
      */
     public killTimer(): void {
-        if (this._timerTimeout) {
-            clearTimeout(this._timerTimeout)
+        if (this.timerTimeout) {
+            clearTimeout(this.timerTimeout)
         }
-        if (this._timerResolve) {
-            this._timerResolve()
+        if (this.timerResolve) {
+            this.timerResolve()
         }
     }
 }

--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -8,7 +8,7 @@
  * @param timeoutLength Length of timeout duration (in ms)
  */
 export class Timeout {
-    private readonly _startTime: number
+    private _startTime: number
     private readonly _endTime: number
     private readonly _timer: Promise<void>
     private _timerTimeout?: NodeJS.Timeout
@@ -30,6 +30,17 @@ export class Timeout {
         const remainingTime = this._endTime - new Date().getTime()
 
         return remainingTime > 0 ? remainingTime : 0
+    }
+
+    /**
+     * Updates the timer to timeout in timeout length from now
+     */
+    public refresh() {
+        // These will not align, but we don't have visibility into a NodeJS.Timeout
+        // so remainingtime will be approximate. Timers are approximate anyway and are
+        // not highly accurate in when they fire.
+        this._startTime = new Date().getTime()
+        this._timerTimeout?.refresh()
     }
 
     /**

--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -16,7 +16,7 @@ export class Timeout {
     private timerTimeout?: NodeJS.Timeout
     private timerResolve?: (value?: void | PromiseLike<void> | undefined) => void
     public constructor(timeoutLength: number) {
-        this.startTime = new Date().getTime()
+        this.startTime = Date.now()
         this.originalStartTime = this.startTime
         this.endTime = this.startTime + timeoutLength
         this.timeoutLength = timeoutLength
@@ -31,7 +31,7 @@ export class Timeout {
      * Bottoms out at 0
      */
     public get remainingTime(): number {
-        const remainingTime = this.endTime - new Date().getTime()
+        const remainingTime = this.endTime - Date.now()
 
         return remainingTime > 0 ? remainingTime : 0
     }
@@ -43,7 +43,7 @@ export class Timeout {
         // These will not align, but we don't have visibility into a NodeJS.Timeout
         // so remainingtime will be approximate. Timers are approximate anyway and are
         // not highly accurate in when they fire.
-        this.startTime = new Date().getTime()
+        this.startTime = Date.now()
         this.endTime = this.startTime + this.timeoutLength
         this.timerTimeout?.refresh()
     }
@@ -61,7 +61,7 @@ export class Timeout {
      * Returns the elapsed time from the initial Timeout object creation
      */
     public get elapsedTime(): number {
-        return new Date().getTime() - this.originalStartTime
+        return Date.now() - this.originalStartTime
     }
 
     /**

--- a/src/test/shared/utilities/timeoutUtils.test.ts
+++ b/src/test/shared/utilities/timeoutUtils.test.ts
@@ -81,11 +81,24 @@ describe('timeoutUtils', async () => {
             longTimer.killTimer()
         })
 
+        it('Correctly reports elapsed time with refresh', async () => {
+            const longTimer = new timeoutUtils.Timeout(10)
+            clock.tick(5)
+            longTimer.refresh()
+            clock.tick(5)
+            assert.strictEqual(longTimer.elapsedTime, 5)
+            assert.strictEqual(longTimer.remainingTime, 5)
+
+            // kill the timer to not mess with other tests
+            longTimer.killTimer()
+        })
+
         it('Refresh pushes back the start time', async () => {
             const longTimer = new timeoutUtils.Timeout(10)
             clock.tick(5)
             longTimer.refresh()
             assert.strictEqual(longTimer.elapsedTime, 0)
+            assert.strictEqual(longTimer.remainingTime, 10)
 
             // kill the timer to not mess with other tests
             longTimer.killTimer()

--- a/src/test/shared/utilities/timeoutUtils.test.ts
+++ b/src/test/shared/utilities/timeoutUtils.test.ts
@@ -72,10 +72,20 @@ describe('timeoutUtils', async () => {
             const checkTimerMs = 50
             const longTimer = new timeoutUtils.Timeout(checkTimerMs * 6)
 
-            // Simulate a small amount of time, then measulre elapsed time
+            // Simulate a small amount of time, then measure elapsed time
             clock.tick(checkTimerMs)
 
             assert.strictEqual(longTimer.elapsedTime, checkTimerMs)
+
+            // kill the timer to not mess with other tests
+            longTimer.killTimer()
+        })
+
+        it('Refresh pushes back the start time', async () => {
+            const longTimer = new timeoutUtils.Timeout(10)
+            clock.tick(5)
+            longTimer.refresh()
+            assert.strictEqual(longTimer.elapsedTime, 0)
 
             // kill the timer to not mess with other tests
             longTimer.killTimer()

--- a/src/test/shared/utilities/timeoutUtils.test.ts
+++ b/src/test/shared/utilities/timeoutUtils.test.ts
@@ -86,7 +86,7 @@ describe('timeoutUtils', async () => {
             clock.tick(5)
             longTimer.refresh()
             clock.tick(5)
-            assert.strictEqual(longTimer.elapsedTime, 5)
+            assert.strictEqual(longTimer.elapsedTime, 10)
             assert.strictEqual(longTimer.remainingTime, 5)
 
             // kill the timer to not mess with other tests

--- a/src/test/shared/utilities/timeoutUtils.test.ts
+++ b/src/test/shared/utilities/timeoutUtils.test.ts
@@ -97,7 +97,6 @@ describe('timeoutUtils', async () => {
             const longTimer = new timeoutUtils.Timeout(10)
             clock.tick(5)
             longTimer.refresh()
-            assert.strictEqual(longTimer.elapsedTime, 0)
             assert.strictEqual(longTimer.remainingTime, 10)
 
             // kill the timer to not mess with other tests


### PR DESCRIPTION
Problem: the default timeout of 30 seconds makes pulling images time out consistently on slow connections. So, reset the timer every time we get text from SAM which gives us an indication it's still trying to do something. We will still timeout if SAM hangs, but this way we can pull large images without customer confusion.
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
