### PR TITLE
SAM debugconfig: ensure relative paths

### DIFF
--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -82,6 +82,8 @@ function makeAddCodeSamDebugCodeLens(params: MakeAddDebugConfigCodeLensParams): 
     const command: vscode.Command = {
         title: localize('AWS.command.addSamDebugConfiguration', 'Add Debug Configuration'),
         command: 'aws.addSamDebugConfiguration',
+        // Values provided by makeTypescriptCodeLensProvider(),
+        // makeCSharpCodeLensProvider(), makePythonCodeLensProvider().
         arguments: [
             {
                 resourceName: params.handlerName,

--- a/src/shared/debug/launchConfiguration.ts
+++ b/src/shared/debug/launchConfiguration.ts
@@ -5,7 +5,11 @@
 
 import * as _ from 'lodash'
 import * as vscode from 'vscode'
-import { AwsSamDebuggerConfiguration, isAwsSamDebugConfiguration } from '../sam/debugger/awsSamDebugConfiguration'
+import {
+    AwsSamDebuggerConfiguration,
+    isAwsSamDebugConfiguration,
+    ensureRelativePaths,
+} from '../sam/debugger/awsSamDebugConfiguration'
 import {
     AwsSamDebugConfigurationValidator,
     DefaultAwsSamDebugConfigurationValidator,
@@ -37,7 +41,14 @@ export class LaunchConfiguration {
     ) {}
 
     public getDebugConfigurations(): vscode.DebugConfiguration[] {
-        return this.configSource.getDebugConfigurations()
+        return _(this.configSource.getDebugConfigurations())
+            .map(o => {
+                if (isAwsSamDebugConfiguration(o)) {
+                    ensureRelativePaths(undefined, o)
+                }
+                return o
+            })
+            .value()
     }
 
     /**

--- a/src/test/shared/debug/launchConfiguration.test.ts
+++ b/src/test/shared/debug/launchConfiguration.test.ts
@@ -16,7 +16,7 @@ const samDebugConfiguration: AwsSamDebuggerConfiguration = {
     request: 'direct-invoke',
     invokeTarget: {
         target: 'template',
-        samTemplatePath: '/',
+        samTemplatePath: '/template.yaml',
         samTemplateResource: 'resource',
     },
 }
@@ -33,7 +33,7 @@ const debugConfigurations: vscode.DebugConfiguration[] = [
     },
 ]
 
-const templateUri = vscode.Uri.file('/')
+const templateUri = vscode.Uri.file('/template.yaml')
 
 describe('LaunchConfiguration', () => {
     let mockConfigSource: DebugConfigurationSource

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -20,6 +20,9 @@ import {
     DIRECT_INVOKE_TYPE,
     TEMPLATE_TARGET_TYPE,
     createTemplateAwsSamDebugConfig,
+    ensureRelativePaths,
+    createCodeAwsSamDebugConfig,
+    CodeTargetProperties,
 } from '../../../../shared/sam/debugger/awsSamDebugConfiguration'
 import { SamDebugConfigProvider } from '../../../../shared/sam/debugger/awsSamDebugger'
 import { SamLaunchRequestArgs } from '../../../../shared/sam/debugger/samDebugSession'
@@ -793,6 +796,31 @@ describe('createTemplateAwsSamDebugConfig', () => {
         assert.strictEqual(config.sam?.dockerNetwork, params.dockerNetwork)
         assert.strictEqual(config.sam?.containerBuild, undefined)
     })
+})
+
+it('ensureRelativePaths', () => {
+    let workspace: vscode.WorkspaceFolder = {
+        uri: vscode.Uri.file('/test1/'),
+        name: 'test workspace',
+        index: 0,
+    }
+    const templateConfig = createTemplateAwsSamDebugConfig(undefined, undefined, 'test name 1', '/test1/template.yaml')
+    assert.strictEqual(
+        (templateConfig.invokeTarget as TemplateTargetProperties).samTemplatePath,
+        '/test1/template.yaml'
+    )
+    ensureRelativePaths(workspace, templateConfig)
+    assert.strictEqual((templateConfig.invokeTarget as TemplateTargetProperties).samTemplatePath, 'template.yaml')
+
+    const codeConfig = createCodeAwsSamDebugConfig(
+        undefined,
+        'testName1',
+        '/test1/project',
+        lambdaModel.RuntimeFamily.NodeJS
+    )
+    assert.strictEqual((codeConfig.invokeTarget as CodeTargetProperties).projectRoot, '/test1/project')
+    ensureRelativePaths(workspace, codeConfig)
+    assert.strictEqual((codeConfig.invokeTarget as CodeTargetProperties).projectRoot, 'project')
 })
 
 function createBaseCodeConfig(params: {


### PR DESCRIPTION
Test case:
1. with empty launch.json...
2. visit code file and click "add debug config"
   - the `projectRoot` is relative to workspace
3. visit template.yaml and click "add debug config"
4. BUG: the `projectRoot` added in (2) is now absolute
5. you can swap steps (2) and (4), same result

This happens because somehow `DefaultDebugConfigSource.getDebugConfigurations()`
returns the existing configs with *absolute* paths:

    class DefaultDebugConfigSource implements DebugConfigurationSource {
        ...
        public getDebugConfigurations(): vscode.DebugConfiguration[] {
            return this.launch.get<vscode.DebugConfiguration[]>('configurations') ?? []
        }
        ...
    }


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
