### PR TITLE
SAM debugconfig: fix for deep project trees

### DIFF
--- a/src/shared/codelens/pythonCodeLensProvider.ts
+++ b/src/shared/codelens/pythonCodeLensProvider.ts
@@ -175,9 +175,6 @@ export async function makePythonDebugConfig(
         }
     }
     config.codeRoot = pathutil.normalize(config.codeRoot)
-    if (config.invokeTarget.target === 'template') {
-        config.codeRoot = path.dirname(config.codeRoot)
-    }
 
     const baseBuildDir = await makeBuildDir()
     let debugPort: number | undefined


### PR DESCRIPTION
- SAM debugconfig: fix for deep project trees
- add `target=template` tests for dotnet
- cleanup tests: use actual `template.yaml` in `testFixtures/` instead of  creating a fake.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
