### PR TITLE
Adds visualisation of yaml state machine definitions

### DIFF
--- a/.changes/next-release/Feature-5efec0b4-52f8-465a-8cb2-6b9f7df38751.json
+++ b/.changes/next-release/Feature-5efec0b4-52f8-465a-8cb2-6b9f7df38751.json
@@ -1,0 +1,4 @@
+{
+    "type": "Feature",
+    "description": "Add basic visualisation capability for step function state machines defined in YAML."
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -201,6 +201,21 @@
                 "js-tokens": "^4.0.0"
             }
         },
+        "@babel/runtime": {
+            "version": "7.9.6",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+            "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+            "requires": {
+                "regenerator-runtime": "^0.13.4"
+            },
+            "dependencies": {
+                "regenerator-runtime": {
+                    "version": "0.13.5",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+                    "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+                }
+            }
+        },
         "@sinonjs/commons": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
@@ -10635,6 +10650,14 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
             "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
             "dev": true
+        },
+        "yaml": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.9.2.tgz",
+            "integrity": "sha512-HPT7cGGI0DuRcsO51qC1j9O16Dh1mZ2bnXwsi0jrSpsLz0WxOLSLXfkABVl6bZO629py3CU+OMJtpNHDLB97kg==",
+            "requires": {
+                "@babel/runtime": "^7.9.2"
+            }
         },
         "yargs": {
             "version": "13.3.0",

--- a/package.json
+++ b/package.json
@@ -944,7 +944,8 @@
         "vue": "^2.5.16",
         "winston": "^3.2.1",
         "winston-transport": "^4.3.0",
-        "xml2js": "^0.4.19"
+        "xml2js": "^0.4.19",
+        "yaml": "^1.9.2"
     },
     "prettier": {
         "printWidth": 120,

--- a/src/integrationTest/stepFunctions/visualizeStateMachine.test.ts
+++ b/src/integrationTest/stepFunctions/visualizeStateMachine.test.ts
@@ -47,7 +47,21 @@ const sampleStateMachine = `
 	             "End": true
 	         }
 	     }
-	 }`
+     }`
+
+const samleStateMachineYaml = `
+    Comment: "A Hello World example of the Amazon States Language using Pass states"
+    StartAt: Hello
+    States:
+    Hello:
+        Type: Pass
+        Result: Hello
+        Next: World
+    World:
+        Type: Pass
+        Result: \$\{Text\}
+        End: true
+`
 
 let tempFolder: string
 
@@ -118,6 +132,29 @@ describe('visualizeStateMachine', async () => {
     it('correctly displays content when given a sample state machine', async () => {
         const fileName = 'mysamplestatemachine.json'
         const textEditor = await openATextEditorWithText(sampleStateMachine, fileName)
+
+        const result = await vscode.commands.executeCommand<vscode.WebviewPanel>('aws.previewStateMachine')
+
+        assert.ok(result)
+
+        await waitUntilWebviewIsVisible(result)
+
+        let expectedViewColumn
+        if (textEditor.viewColumn) {
+            expectedViewColumn = textEditor.viewColumn.valueOf() + 1
+        }
+
+        if (result) {
+            assert.deepStrictEqual(result.title, 'Graph: ' + fileName)
+            assert.deepStrictEqual(result.viewColumn, expectedViewColumn)
+            assert.deepStrictEqual(result.viewType, 'stateMachineVisualization')
+            assert.ok(result.webview.html)
+        }
+    })
+
+    it('correctly displays content when given a sample state machine in yaml', async () => {
+        const fileName = 'mysamplestatemachine.yaml'
+        const textEditor = await openATextEditorWithText(samleStateMachineYaml, fileName)
 
         const result = await vscode.commands.executeCommand<vscode.WebviewPanel>('aws.previewStateMachine')
 

--- a/src/stepFunctions/commands/visualizeStateMachine/aslVisualization.ts
+++ b/src/stepFunctions/commands/visualizeStateMachine/aslVisualization.ts
@@ -60,6 +60,44 @@ export class AslVisualization {
         this.getPanel()?.reveal()
     }
 
+    public async sendUpdateMessage(updatedTextDocument: vscode.TextDocument) {
+        const logger: Logger = getLogger()
+        const isYaml = updatedTextDocument.languageId === 'yaml'
+        const text = updatedTextDocument.getText()
+        let stateMachineData = text
+        let yamlErrors: string[] = []
+
+        if (isYaml) {
+            const parsed = yaml.parseDocument(text, YAML_OPTIONS)
+            yamlErrors = parsed.errors.map(error => error.message)
+            let json: any
+
+            try {
+                json = parsed.toJSON()
+            } catch (e) {
+                yamlErrors.push(e.message)
+            }
+
+            stateMachineData = JSON.stringify(json)
+        }
+
+        const isValid = (await isDocumentValid(stateMachineData, updatedTextDocument)) && !yamlErrors.length
+
+        const webview = this.getWebview()
+        if (this.isPanelDisposed || !webview) {
+            return
+        }
+
+        logger.debug('Sending update message to webview.')
+
+        webview.postMessage({
+            command: 'update',
+            stateMachineData,
+            isValid,
+            errors: yamlErrors,
+        })
+    }
+
     private setupWebviewPanel(textDocument: vscode.TextDocument): vscode.WebviewPanel {
         const documentUri = textDocument.uri
         const logger: Logger = getLogger()
@@ -87,7 +125,7 @@ export class AslVisualization {
         this.disposables.push(
             vscode.workspace.onDidSaveTextDocument(async savedTextDocument => {
                 if (savedTextDocument && savedTextDocument.uri.path === documentUri.path) {
-                    await sendUpdateMessage(savedTextDocument)
+                    await this.sendUpdateMessage(savedTextDocument)
                 }
             })
         )
@@ -107,43 +145,7 @@ export class AslVisualization {
             })
         )
 
-        const sendUpdateMessage = async (updatedTextDocument: vscode.TextDocument) => {
-            const isYaml = updatedTextDocument.languageId === 'yaml'
-            const text = updatedTextDocument.getText()
-            let stateMachineData = text
-            let yamlErrors: string[] = []
-
-            if (isYaml) {
-                const parsed = yaml.parseDocument(text, YAML_OPTIONS)
-                yamlErrors = parsed.errors.map(error => error.message)
-                let json: any
-
-                try {
-                    json = parsed.toJSON()
-                } catch (e) {
-                    yamlErrors.push(e.message)
-                }
-
-                stateMachineData = JSON.stringify(json)
-            }
-
-            const isValid = (await isDocumentValid(stateMachineData, updatedTextDocument)) && !yamlErrors.length
-
-            const webview = this.getWebview()
-            if (this.isPanelDisposed || !webview) {
-                return
-            }
-
-            logger.debug('Sending update message to webview.')
-
-            webview.postMessage({
-                command: 'update',
-                stateMachineData,
-                isValid,
-                errors: yamlErrors,
-            })
-        }
-        const debouncedUpdate = debounce(sendUpdateMessage.bind(this), 500)
+        const debouncedUpdate = debounce(this.sendUpdateMessage.bind(this), 500)
 
         this.disposables.push(
             vscode.workspace.onDidChangeTextDocument(async textDocumentEvent => {
@@ -166,7 +168,7 @@ export class AslVisualization {
                     case 'webviewRendered': {
                         // Webview has finished rendering, so now we can give it our
                         // initial state machine definition.
-                        await sendUpdateMessage(textDocument)
+                        await this.sendUpdateMessage(textDocument)
                         break
                     }
 

--- a/src/stepFunctions/commands/visualizeStateMachine/aslVisualization.ts
+++ b/src/stepFunctions/commands/visualizeStateMachine/aslVisualization.ts
@@ -108,12 +108,12 @@ export class AslVisualization {
         )
 
         const sendUpdateMessage = async (updatedTextDocument: vscode.TextDocument) => {
-            const isYAML = updatedTextDocument.languageId === 'yaml'
+            const isYaml = updatedTextDocument.languageId === 'yaml'
             const text = updatedTextDocument.getText()
             let stateMachineData = text
             let yamlErrors: string[] = []
 
-            if (isYAML) {
+            if (isYaml) {
                 const parsed = yaml.parseDocument(text, YAML_OPTIONS)
                 yamlErrors = parsed.errors.map(error => error.message)
                 let json: any

--- a/src/stepFunctions/utils.ts
+++ b/src/stepFunctions/utils.ts
@@ -183,12 +183,11 @@ export function isStepFunctionsRole(role: IAM.Role): boolean {
     return !!assumeRolePolicyDocument?.includes(STEP_FUNCTIONS_SEVICE_PRINCIPAL)
 }
 
-export async function isDocumentValid(textDocument?: vscode.TextDocument): Promise<boolean> {
-    if (!textDocument) {
+export async function isDocumentValid(text: string, textDocument?: vscode.TextDocument): Promise<boolean> {
+    if (!textDocument || !text) {
         return false
     }
 
-    const text = textDocument.getText()
     const doc = ASLTextDocument.create(textDocument.uri.path, textDocument.languageId, textDocument.version, text)
     // tslint:disable-next-line: no-inferred-empty-object-type
     const jsonDocument = languageService.parseJSONDocument(doc)

--- a/src/test/stepFunctions/commands/visualizeStateMachine.test.ts
+++ b/src/test/stepFunctions/commands/visualizeStateMachine.test.ts
@@ -91,6 +91,78 @@ const mockTextDocumentTwo: vscode.TextDocument = {
     validateRange: sinon.spy(),
 }
 
+const mockUriThree: vscode.Uri = {
+    authority: 'MockAuthorityYaml',
+    fragment: 'MockFragmentYaml',
+    fsPath: 'MockFSPathYaml',
+    query: 'MockQueryYaml',
+    path: 'MockPathYaml',
+    scheme: 'MockSchemeYaml',
+    with: sinon.spy(),
+    toJSON: sinon.spy(),
+}
+
+const mockDataJson =
+    '{"Comment":"A Hello World example of the Amazon States Language using Pass states","StartAt":"Hello","States":{"Hello":{"Type":"Pass","Result":"Hello","Next":"World"},"World":{"Type":"Pass","Result":"${Text}","End":true}}}'
+
+const mockDataYaml = `
+Comment: "A Hello World example of the Amazon States Language using Pass states"
+StartAt: Hello
+States:
+  Hello:
+    Type: Pass
+    Result: Hello
+    Next: World
+  World:
+    Type: Pass
+    Result: \$\{Text\}
+    End: true
+`
+
+const mockTextDocumentYaml: vscode.TextDocument = {
+    eol: 1,
+    fileName: 'MockFileNameYaml',
+    isClosed: false,
+    isDirty: false,
+    isUntitled: false,
+    languageId: 'yaml',
+    lineCount: 0,
+    uri: mockUriThree,
+    version: 0,
+    getText: () => {
+        return mockDataYaml
+    },
+    getWordRangeAtPosition: sinon.spy(),
+    lineAt: sinon.spy(),
+    offsetAt: sinon.spy(),
+    positionAt: sinon.spy(),
+    save: sinon.spy(),
+    validatePosition: sinon.spy(),
+    validateRange: sinon.spy(),
+}
+
+const mockTextDocumentJson: vscode.TextDocument = {
+    eol: 1,
+    fileName: 'MockFileNameJson',
+    isClosed: false,
+    isDirty: false,
+    isUntitled: false,
+    languageId: 'asl',
+    lineCount: 0,
+    uri: mockUriThree,
+    version: 0,
+    getText: () => {
+        return mockDataJson
+    },
+    getWordRangeAtPosition: sinon.spy(),
+    lineAt: sinon.spy(),
+    offsetAt: sinon.spy(),
+    positionAt: sinon.spy(),
+    save: sinon.spy(),
+    validatePosition: sinon.spy(),
+    validateRange: sinon.spy(),
+}
+
 const mockPosition: vscode.Position = {
     line: 0,
     character: 0,
@@ -338,6 +410,52 @@ describe('StepFunctions VisualizeStateMachine', async () => {
         panel.dispose()
 
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 1)
+    })
+
+    it('Test AslVisualisation sendUpdateMessage posts a correct update message for YAML files', async () => {
+        const postMessage = sinon.spy()
+        class MockAslVisualizationYaml extends AslVisualization {
+            public getWebview(): vscode.Webview | undefined {
+                return ({ postMessage } as unknown) as vscode.Webview
+            }
+        }
+
+        const visualisation = new MockAslVisualizationYaml(mockTextDocumentYaml)
+
+        await visualisation.sendUpdateMessage(mockTextDocumentYaml)
+
+        const message = {
+            command: 'update',
+            stateMachineData: mockDataJson,
+            isValid: true,
+            errors: [],
+        }
+
+        assert.ok(postMessage.calledOnce)
+        assert.deepEqual(postMessage.firstCall.args, [message])
+    })
+
+    it('Test AslVisualisation sendUpdateMessage posts a correct update message for ASL files', async () => {
+        const postMessage = sinon.spy()
+        class MockAslVisualizationJson extends AslVisualization {
+            public getWebview(): vscode.Webview | undefined {
+                return ({ postMessage } as unknown) as vscode.Webview
+            }
+        }
+
+        const visualisation = new MockAslVisualizationJson(mockTextDocumentJson)
+
+        await visualisation.sendUpdateMessage(mockTextDocumentJson)
+
+        const message = {
+            command: 'update',
+            stateMachineData: mockDataJson,
+            isValid: true,
+            errors: [],
+        }
+
+        assert.ok(postMessage.calledOnce)
+        assert.deepEqual(postMessage.firstCall.args, [message])
     })
 })
 

--- a/src/test/stepFunctions/utils.test.ts
+++ b/src/test/stepFunctions/utils.test.ts
@@ -234,9 +234,8 @@ describe('isDocumentValid', async () => {
             } `
 
         let textDocument = await vscode.workspace.openTextDocument({ language: 'asl' })
-        textDocument = Object.assign({}, textDocument, { getText: () => aslText })
 
-        const isValid = await isDocumentValid(textDocument)
+        const isValid = await isDocumentValid(aslText, textDocument)
         assert.ok(isValid)
     })
 
@@ -254,9 +253,8 @@ describe('isDocumentValid', async () => {
             } `
 
         let textDocument = await vscode.workspace.openTextDocument({ language: 'asl' })
-        textDocument = Object.assign({}, textDocument, { getText: () => aslText })
 
-        const isValid = await isDocumentValid(textDocument)
+        const isValid = await isDocumentValid(aslText, textDocument)
         assert.ok(isValid)
     })
 
@@ -274,9 +272,8 @@ describe('isDocumentValid', async () => {
             } `
 
         let textDocument = await vscode.workspace.openTextDocument({ language: 'asl' })
-        textDocument = Object.assign({}, textDocument, { getText: () => aslText })
 
-        const isValid = await isDocumentValid(textDocument)
+        const isValid = await isDocumentValid(aslText, textDocument)
 
         assert.ok(!isValid)
     })


### PR DESCRIPTION
## Description
Basic visualization capability for state machines defined in yaml.  
<!--- Describe your changes in detail -->

## Motivation and Context
We want to give users basic capability to visualize valid state machines in yaml. This won't be an official release and we will not provide errors or linting when the state machine definition is incorrect. 

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
