### PR TITLE
SAM debugconfig: pass env vars and other fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,9 +227,7 @@
                                         "description": "%AWS.configuration.description.awssam.debug.envvars%",
                                         "additionalProperties": {
                                             "type": [
-                                                "string",
-                                                "number",
-                                                "boolean"
+                                                "string"
                                             ]
                                         },
                                         "type": "object"

--- a/package.nls.json
+++ b/package.nls.json
@@ -267,6 +267,7 @@
     "AWS.sam.debugger.useExistingConfig.doNotMigrate": "Create new config only",
     "AWS.sam.debugger.extraEnvVars": "The following environment variables are not found in the targeted template and will not be overridden: {0}",
     "AWS.sam.debugger.missingRuntime": "Debug Configurations with an invoke target of \"{0}\" require a valid Lambda runtime value, expected one of [{1}]",
+    "AWS.sam.debugger.missingPayloadFile": "Payload file not found: \"{0}\"",
     "AWS.sam.local.invoke.python.server.not.available": "Unable to communicate with the Python Debug Adapter. The debugger might not successfully attach to your SAM Application.",
     "AWS.samcli.detect.settings.updated": "Settings updated.",
     "AWS.samcli.detect.settings.not.updated": "No settings changes necessary.",

--- a/src/lambda/config/templates.ts
+++ b/src/lambda/config/templates.ts
@@ -415,7 +415,7 @@ export async function getExistingConfiguration(
 ): Promise<
     | {
           eventJson?: ReadonlyJsonObject
-          environmentVariables?: ReadonlyJsonObject
+          environmentVariables?: { [key: string]: string }
           dockerNetwork?: string
           useContainer?: boolean
       }

--- a/src/lambda/local/debugConfiguration.ts
+++ b/src/lambda/local/debugConfiguration.ts
@@ -5,19 +5,19 @@
 
 import * as path from 'path'
 import * as vscode from 'vscode'
-import { SamLaunchRequestArgs } from '../../shared/sam/debugger/samDebugSession'
-import { RuntimeFamily } from '../models/samLambdaRuntime'
-import {
-    CodeTargetProperties,
-    TemplateTargetProperties,
-    AwsSamDebuggerConfiguration,
-    AWS_SAM_DEBUG_TARGET_TYPES,
-} from '../../shared/sam/debugger/awsSamDebugConfiguration'
-import { tryGetAbsolutePath } from '../../shared/utilities/workspaceUtils'
-import { localize } from '../../shared/utilities/vsCodeUtils'
 import { CloudFormation } from '../../shared/cloudformation/cloudformation'
 import { CloudFormationTemplateRegistry } from '../../shared/cloudformation/templateRegistry'
+import {
+    AwsSamDebuggerConfiguration,
+    AWS_SAM_DEBUG_TARGET_TYPES,
+    CodeTargetProperties,
+    TemplateTargetProperties,
+} from '../../shared/sam/debugger/awsSamDebugConfiguration'
+import { SamLaunchRequestArgs } from '../../shared/sam/debugger/samDebugSession'
 import * as pathutil from '../../shared/utilities/pathUtils'
+import { localize } from '../../shared/utilities/vsCodeUtils'
+import { tryGetAbsolutePath } from '../../shared/utilities/workspaceUtils'
+import { RuntimeFamily } from '../models/samLambdaRuntime'
 
 export const DOTNET_CORE_DEBUGGER_PATH = '/tmp/lambci_debug_files/vsdbg'
 

--- a/src/lambda/local/detectLocalLambdas.ts
+++ b/src/lambda/local/detectLocalLambdas.ts
@@ -17,6 +17,8 @@ export interface LocalLambda {
     handler?: string
 }
 
+// TODO: remove?
+// Key difference: `detectLocalTemplates()` crawls workspace for template files...
 export async function detectLocalLambdas(workspaceFolders: vscode.WorkspaceFolder[]): Promise<LocalLambda[]> {
     return (await Promise.all(workspaceFolders.map(detectLambdasFromWorkspaceFolder))).reduce(
         (accumulator: LocalLambda[], current: LocalLambda[]) => {

--- a/src/shared/sam/debugger/awsSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfiguration.ts
@@ -105,7 +105,7 @@ export function createTemplateAwsSamDebugConfig(
     templatePath: string,
     preloadedConfig?: {
         eventJson?: ReadonlyJsonObject
-        environmentVariables?: ReadonlyJsonObject
+        environmentVariables?: { [key: string]: string }
         dockerNetwork?: string
         useContainer?: boolean
     }

--- a/src/shared/sam/debugger/awsSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfiguration.ts
@@ -122,6 +122,10 @@ export function createTemplateAwsSamDebugConfig(
             samTemplatePath: workspaceRelativePath,
             samTemplateResource: resourceName,
         },
+        lambda: {
+            event: {},
+            environmentVariables: {},
+        },
     }
 
     if (preloadedConfig) {
@@ -130,14 +134,13 @@ export function createTemplateAwsSamDebugConfig(
             lambda:
                 preloadedConfig.environmentVariables || preloadedConfig.eventJson
                     ? {
-                          event: preloadedConfig.eventJson
-                              ? {
-                                    json: preloadedConfig.eventJson,
-                                }
-                              : undefined,
+                          event: preloadedConfig.eventJson ? { json: preloadedConfig.eventJson } : {},
                           environmentVariables: preloadedConfig.environmentVariables,
                       }
-                    : undefined,
+                    : {
+                          event: {},
+                          environmentVariables: {},
+                      },
             sam:
                 preloadedConfig.dockerNetwork || preloadedConfig.useContainer
                     ? {
@@ -171,6 +174,8 @@ export function createCodeAwsSamDebugConfig(
         },
         lambda: {
             runtime,
+            event: {},
+            environmentVariables: {},
         },
     }
 }

--- a/src/shared/sam/debugger/csharpSamDebug.ts
+++ b/src/shared/sam/debugger/csharpSamDebug.ts
@@ -10,8 +10,6 @@ import {
     DotNetCoreDebugConfiguration,
     DOTNET_CORE_DEBUGGER_PATH,
     getCodeRoot,
-    getTemplate,
-    getTemplateResource,
 } from '../../../lambda/local/debugConfiguration'
 import { RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
 import * as pathutil from '../../../shared/utilities/pathUtils'
@@ -31,20 +29,11 @@ import { invokeLambdaFunction, makeBuildDir, makeInputTemplate, waitForDebugPort
  * Does NOT execute/invoke SAM, docker, etc.
  */
 export async function makeCsharpConfig(config: SamLaunchRequestArgs): Promise<SamLaunchRequestArgs> {
-    const baseBuildDir = await makeBuildDir()
-    const template = getTemplate(config.workspaceFolder, config)
-    const resource = getTemplateResource(config.workspaceFolder, config)
-    const codeUri = getCodeRoot(config.workspaceFolder, config)
-    const handlerName = config.handlerName
+    config.baseBuildDir = await makeBuildDir()
+    config.codeRoot = getCodeRoot(config.workspaceFolder, config)!
 
-    config.samTemplatePath = await makeInputTemplate({
-        baseBuildDir,
-        codeDir: codeUri!!,
-        relativeFunctionHandler: handlerName,
-        runtime: config.runtime,
-        globals: template?.Globals,
-        properties: resource?.Properties,
-    })
+    config.samTemplatePath = await makeInputTemplate(config)
+    // XXX: reassignment...
     // TODO: walk the tree to find .sln, .csproj ?
     config.codeRoot = getSamProjectDirPathForFile(config.samTemplatePath)
 
@@ -54,7 +43,6 @@ export async function makeCsharpConfig(config: SamLaunchRequestArgs): Promise<Sa
         request: config.noDebug ? 'launch' : 'attach',
         runtimeFamily: RuntimeFamily.DotNetCore,
         name: 'SamLocalDebug',
-        baseBuildDir: baseBuildDir,
     }
 
     if (!config.noDebug) {

--- a/src/shared/sam/debugger/csharpSamDebug.ts
+++ b/src/shared/sam/debugger/csharpSamDebug.ts
@@ -20,7 +20,7 @@ import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../../
 import { SamLaunchRequestArgs } from '../../sam/debugger/samDebugSession'
 import { getStartPort } from '../../utilities/debuggerUtils'
 import { ChannelLogger, getChannelLogger } from '../../utilities/vsCodeUtils'
-import { invokeLambdaFunction, makeBuildDir, makeInputTemplate, waitForDebugPort } from '../localLambdaRunner'
+import { invokeLambdaFunction, makeInputTemplate, waitForDebugPort } from '../localLambdaRunner'
 
 /**
  * Gathers and sets launch-config info by inspecting the workspace and creating
@@ -29,7 +29,9 @@ import { invokeLambdaFunction, makeBuildDir, makeInputTemplate, waitForDebugPort
  * Does NOT execute/invoke SAM, docker, etc.
  */
 export async function makeCsharpConfig(config: SamLaunchRequestArgs): Promise<SamLaunchRequestArgs> {
-    config.baseBuildDir = await makeBuildDir()
+    if (!config.baseBuildDir) {
+        throw Error('invalid state: config.baseBuildDir was not set')
+    }
     config.codeRoot = getCodeRoot(config.workspaceFolder, config)!
 
     config.samTemplatePath = await makeInputTemplate(config)

--- a/src/shared/sam/debugger/pythonSamDebug.ts
+++ b/src/shared/sam/debugger/pythonSamDebug.ts
@@ -19,7 +19,7 @@ import { getLocalRootVariants } from '../../utilities/pathUtils'
 import { Timeout } from '../../utilities/timeoutUtils'
 import { ChannelLogger } from '../../utilities/vsCodeUtils'
 import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
-import { invokeLambdaFunction, makeBuildDir, makeInputTemplate } from '../localLambdaRunner'
+import { invokeLambdaFunction, makeInputTemplate } from '../localLambdaRunner'
 import { SamLaunchRequestArgs } from './samDebugSession'
 
 const PYTHON_DEBUG_ADAPTER_RETRY_DELAY_MS = 1000
@@ -115,6 +115,9 @@ def ${debugHandlerFunctionName}(event, context):
  * Does NOT execute/invoke SAM, docker, etc.
  */
 export async function makePythonDebugConfig(config: SamLaunchRequestArgs): Promise<PythonDebugConfiguration> {
+    if (!config.baseBuildDir) {
+        throw Error('invalid state: config.baseBuildDir was not set')
+    }
     if (!config.codeRoot) {
         // Last-resort attempt to discover the project root (when there is no
         // `launch.json` nor `template.yaml`).
@@ -126,7 +129,6 @@ export async function makePythonDebugConfig(config: SamLaunchRequestArgs): Promi
     }
     config.codeRoot = pathutil.normalize(config.codeRoot)
 
-    config.baseBuildDir = await makeBuildDir()
     let debugPort: number | undefined
     let manifestPath: string | undefined
     let outFilePath: string | undefined

--- a/src/shared/sam/debugger/samDebugSession.ts
+++ b/src/shared/sam/debugger/samDebugSession.ts
@@ -3,19 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Runtime } from 'aws-sdk/clients/lambda'
 import * as vscode from 'vscode'
 import { DebugSession, InitializedEvent, Logger, logger, TerminatedEvent } from 'vscode-debugadapter'
 import { DebugProtocol } from 'vscode-debugprotocol'
 import { NodejsDebugConfiguration, PythonDebugConfiguration } from '../../../lambda/local/debugConfiguration'
 import { RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
-import * as csharpDebug from './csharpSamDebug'
-import * as pythonDebug from './pythonSamDebug'
-import * as invokeTypescriptLambda from './typescriptSamDebug'
 import { ExtContext } from '../../extensions'
+import { Timeout } from '../../utilities/timeoutUtils'
 import { ChannelLogger } from '../../utilities/vsCodeUtils'
 import { SamLocalInvokeCommand } from '../cli/samCliLocalInvoke'
 import { AwsSamDebuggerConfiguration } from './awsSamDebugConfiguration.gen'
-import { Timeout } from '../../utilities/timeoutUtils'
+import * as csharpDebug from './csharpSamDebug'
+import * as pythonDebug from './pythonSamDebug'
+import * as invokeTypescriptLambda from './typescriptSamDebug'
 
 /**
  * SAM-specific launch attributes (which are not part of the DAP).
@@ -30,8 +31,10 @@ export interface SamLaunchRequestArgs extends DebugProtocol.AttachRequestArgumen
     // readonly type: 'node' | 'python' | 'coreclr' | 'aws-sam'
     readonly request: 'attach' | 'launch' | 'direct-invoke'
 
-    runtime: string
+    /** Runtime id-name passed to vscode to select a debugger/launcher. */
+    runtime: Runtime
     runtimeFamily: RuntimeFamily
+    /** Resolved (potentinally generated) handler name. */
     handlerName: string
     workspaceFolder: vscode.WorkspaceFolder
     /**
@@ -50,7 +53,7 @@ export interface SamLaunchRequestArgs extends DebugProtocol.AttachRequestArgumen
      */
     documentUri: vscode.Uri
     /**
-     * SAM template absolute path used for SAM CLI invoke.
+     * SAM/CFN template absolute path used for SAM CLI invoke.
      * - For `target=code` this is the _generated_ template path.
      * - For `target=template` this is the template found in the workspace.
      */

--- a/src/shared/sam/debugger/samDebugSession.ts
+++ b/src/shared/sam/debugger/samDebugSession.ts
@@ -37,6 +37,7 @@ export interface SamLaunchRequestArgs extends DebugProtocol.AttachRequestArgumen
     /** Resolved (potentinally generated) handler name. */
     handlerName: string
     workspaceFolder: vscode.WorkspaceFolder
+
     /**
      * Absolute path to the SAM project root, calculated from any of:
      *  - `codeUri` in `template.yaml`
@@ -46,18 +47,36 @@ export interface SamLaunchRequestArgs extends DebugProtocol.AttachRequestArgumen
     codeRoot: string
     outFilePath?: string
 
+    /** Path to (generated) directory used as a working/staging area for SAM. */
     baseBuildDir?: string
+
     /**
      * URI of the current editor document.
      * Used as a last resort for deciding `codeRoot` (when there is no `launch.json` nor `template.yaml`)
      */
     documentUri: vscode.Uri
+
     /**
      * SAM/CFN template absolute path used for SAM CLI invoke.
      * - For `target=code` this is the _generated_ template path.
      * - For `target=template` this is the template found in the workspace.
      */
     samTemplatePath: string
+
+    /**
+     * Path to the (generated) `event.json` file placed in `baseBuildDir` for SAM to discover.
+     *
+     * The file contains the event payload JSON to be consumed by SAM.
+     */
+    eventPayloadFile: string
+
+    /**
+     * Path to the (generated) `env-vars.json` file placed in `baseBuildDir` for SAM to discover.
+     *
+     * The file contains a JSON map of environment variables to be consumed by
+     * SAM, resolved from `template.yaml` and/or `lambda.environmentVariables`.
+     */
+    envFile: string
 
     //
     // Debug properties (when user runs with debugging enabled).

--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -3,18 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as vscode from 'vscode'
 import * as path from 'path'
-
+import * as vscode from 'vscode'
 import { NodejsDebugConfiguration } from '../../../lambda/local/debugConfiguration'
-import { ExtContext } from '../../extensions'
-import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
-import { invokeLambdaFunction, waitForDebugPort } from '../localLambdaRunner'
 import { RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
 import * as pathutil from '../../../shared/utilities/pathUtils'
+import { ExtContext } from '../../extensions'
 import { SamLaunchRequestArgs } from '../../sam/debugger/samDebugSession'
-import { generateInputTemplate, makeBuildDir } from '../localLambdaRunner'
 import { findParentProjectFile } from '../../utilities/workspaceUtils'
+import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
+import { invokeLambdaFunction, makeBuildDir, makeInputTemplate, waitForDebugPort } from '../localLambdaRunner'
 
 /**
  * Launches and attaches debugger to a SAM Node project.
@@ -57,7 +55,7 @@ export async function makeTypescriptConfig(config: SamLaunchRequestArgs): Promis
     config.baseBuildDir = await makeBuildDir()
 
     // Always generate a temporary template.yaml, don't use workspace one directly.
-    config.samTemplatePath = pathutil.normalize(await generateInputTemplate(config))
+    config.samTemplatePath = await makeInputTemplate(config)
 
     //  Make a python launch-config from the generic config.
     const nodejsLaunchConfig: NodejsDebugConfiguration = {

--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -12,7 +12,7 @@ import { ExtContext } from '../../extensions'
 import { SamLaunchRequestArgs } from '../../sam/debugger/samDebugSession'
 import { findParentProjectFile } from '../../utilities/workspaceUtils'
 import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
-import { invokeLambdaFunction, makeBuildDir, makeInputTemplate, waitForDebugPort } from '../localLambdaRunner'
+import { invokeLambdaFunction, makeInputTemplate, waitForDebugPort } from '../localLambdaRunner'
 
 /**
  * Launches and attaches debugger to a SAM Node project.
@@ -39,6 +39,9 @@ export async function getSamProjectDirPathForFile(filepath: string): Promise<str
  * Does NOT execute/invoke SAM, docker, etc.
  */
 export async function makeTypescriptConfig(config: SamLaunchRequestArgs): Promise<NodejsDebugConfiguration> {
+    if (!config.baseBuildDir) {
+        throw Error('invalid state: config.baseBuildDir was not set')
+    }
     if (!config.codeRoot) {
         // Last-resort attempt to discover the project root (when there is no
         // `launch.json` nor `template.yaml`).
@@ -51,8 +54,6 @@ export async function makeTypescriptConfig(config: SamLaunchRequestArgs): Promis
         }
     }
     config.codeRoot = pathutil.normalize(config.codeRoot)
-
-    config.baseBuildDir = await makeBuildDir()
 
     // Always generate a temporary template.yaml, don't use workspace one directly.
     config.samTemplatePath = await makeInputTemplate(config)

--- a/src/shared/utilities/workspaceUtils.ts
+++ b/src/shared/utilities/workspaceUtils.ts
@@ -80,7 +80,6 @@ export async function addFolderToWorkspace(folder: { uri: vscode.Uri; name?: str
  * Returns undefined if the file isn't found in any directories between the sourceCodeUri directory and the workspace folder
  * @param sourceCodeUri Source file to look upwards from
  * @param projectFile File to find in same folder or parent, up until the source file's top level workspace folder. Accepts wildcards.
- * @param findWorkspaceFiles Only used for tests
  */
 export async function findParentProjectFile(
     sourceCodeUri: vscode.Uri,

--- a/src/test/lambda/local/debugConfiguration.test.ts
+++ b/src/test/lambda/local/debugConfiguration.test.ts
@@ -49,6 +49,8 @@ describe('makeCoreCLRDebugConfiguration', async () => {
             noDebug: false,
 
             baseBuildDir: '/fake/build/dir/',
+            envFile: '/fake/build/dir/env-vars.json',
+            eventPayloadFile: '/fake/build/dir/event.json',
             documentUri: vscode.Uri.parse('/fake/path/foo.txt'),
             samTemplatePath: '/fake/sam/path',
             samLocalInvokeCommand: new DefaultSamLocalInvokeCommand(fakeExtCtx.chanLogger),

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -917,38 +917,6 @@ describe('AwsSamDebugConfigurationProvider', async () => {
     })
 })
 
-describe('createTemplateAwsSamDebugConfig', () => {
-    const name = 'my body is a template'
-    const templatePath = path.join('two', 'roads', 'diverged', 'in', 'a', 'yellow', 'wood.yaml')
-
-    it('creates a template-type SAM debugger configuration with minimal configurations', () => {
-        const config = createTemplateAwsSamDebugConfig(undefined, undefined, name, templatePath)
-        assert.strictEqual(config.invokeTarget.target, TEMPLATE_TARGET_TYPE)
-        const invokeTarget = config.invokeTarget as TemplateTargetProperties
-        assert.strictEqual(config.name, `yellow:${name}`)
-        assert.strictEqual(invokeTarget.samTemplateResource, name)
-        assert.strictEqual(invokeTarget.samTemplatePath, templatePath)
-        assert.ok(!config.hasOwnProperty('lambda'))
-    })
-
-    it('creates a template-type SAM debugger configuration with additional params', () => {
-        const params = {
-            eventJson: {
-                event: 'uneventufl',
-            },
-            environmentVariables: {
-                varial: 'invert to fakie',
-            },
-            dockerNetwork: 'rockerFretwork',
-        }
-        const config = createTemplateAwsSamDebugConfig(undefined, undefined, name, templatePath, params)
-        assert.deepStrictEqual(config.lambda?.event?.json, params.eventJson)
-        assert.deepStrictEqual(config.lambda?.environmentVariables, params.environmentVariables)
-        assert.strictEqual(config.sam?.dockerNetwork, params.dockerNetwork)
-        assert.strictEqual(config.sam?.containerBuild, undefined)
-    })
-})
-
 it('ensureRelativePaths', () => {
     let workspace: vscode.WorkspaceFolder = {
         uri: vscode.Uri.file('/test1/'),
@@ -1061,12 +1029,20 @@ describe('createTemplateAwsSamDebugConfig', () => {
 
     it('creates a template-type SAM debugger configuration with minimal configurations', () => {
         const config = createTemplateAwsSamDebugConfig(undefined, undefined, name, templatePath)
-        assert.strictEqual(config.invokeTarget.target, TEMPLATE_TARGET_TYPE)
-        const invokeTarget = config.invokeTarget as TemplateTargetProperties
-        assert.strictEqual(config.name, `yellow:${name}`)
-        assert.strictEqual(invokeTarget.samTemplateResource, name)
-        assert.strictEqual(invokeTarget.samTemplatePath, templatePath)
-        assert.ok(!config.hasOwnProperty('lambda'))
+        assert.deepStrictEqual(config, {
+            name: `yellow:${name}`,
+            type: AWS_SAM_DEBUG_TYPE,
+            request: DIRECT_INVOKE_TYPE,
+            invokeTarget: {
+                target: TEMPLATE_TARGET_TYPE,
+                samTemplateResource: name,
+                samTemplatePath: templatePath,
+            },
+            lambda: {
+                event: {},
+                environmentVariables: {},
+            },
+        })
     })
 
     it('creates a template-type SAM debugger configuration with additional params', () => {

--- a/src/test/testUtil.ts
+++ b/src/test/testUtil.ts
@@ -6,8 +6,17 @@
 import * as assert from 'assert'
 import * as path from 'path'
 import * as vscode from 'vscode'
+import * as fsextra from 'fs-extra'
 
 import * as pathutil from '../shared/utilities/pathUtils'
+
+/**
+ * Writes the string form of `o` to `filepath` as UTF-8 text.
+ */
+export function toFile(o: any, filepath: string) {
+    const text = o ? o.toString() : ''
+    fsextra.writeFileSync(filepath, text, 'utf8')
+}
 
 /** Gets the full path to the project root directory. */
 export function getProjectDir(): string {
@@ -29,4 +38,12 @@ export function getWorkspaceFolder(dir: string): vscode.WorkspaceFolder {
  */
 export function assertEqualPaths(actual: string, expected: string, message?: string | Error) {
     assert.strictEqual(pathutil.normalize(actual), pathutil.normalize(expected), message)
+}
+
+/**
+ * Asserts that UTF-8 contents of `file` are equal to `expected`.
+ */
+export function assertFileText(file: string, expected: string, message?: string | Error) {
+    const actualContents = fsextra.readFileSync(file, 'utf-8')
+    assert.strictEqual(actualContents, expected, message)
 }

--- a/src/testFixtures/workspaceFolder/js-manifest-in-root/template.yaml
+++ b/src/testFixtures/workspaceFolder/js-manifest-in-root/template.yaml
@@ -5,3 +5,7 @@ Resources:
             CodeUri: .
             Handler: src/subfolder/app.handlerTwoFoldersDeep
             Runtime: nodejs10.x
+        Environment:
+            Variables:
+                SAMPLE1: 'value 1 from template.yaml'
+                SAMPLE2: 'value 2 from template.yaml'


### PR DESCRIPTION
- SAM debugconfig: always include "event", "environmentVariables"
  - When generating new debugconfigs, always include the "event" (aka payload) and "environmentVariables" fields. This improves discoverability and makes it clear that `{}` is sent as the payload.
- SAM debugconfig: pass env vars, memoryMb, timeout
- ~~Merge template.yaml env with env (if any) defined in the config (launch.json).~~ **Update:** Create `input-template.yaml` and `env-vars.json` [according to legacy/SAM rules](https://github.com/aws/aws-toolkit-vscode/pull/1100#discussion_r432213707).
- SAM debugconfig: support `event.path`


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
