### PR TITLE
Make codecov informational by default

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,22 +2,24 @@
 #   cat codecov.yml | curl --data-binary @- https://codecov.io/validate
 
 codecov:
-  notify:
-    require_ci_to_pass: no
+    notify:
+        require_ci_to_pass: no
 
 coverage:
-  precision: 2
-  round: down
-  range: "70...100"
+    precision: 2
+    round: down
+    range: '70...100'
 
-  status:
-    project:
-      default:
-        threshold: 1
-    patch:
-      default:
-        threshold: 1
-        only_pulls: true
-    changes: no
+    status:
+        project:
+            default:
+                threshold: 1
+                informational: true
+        patch:
+            default:
+                threshold: 1
+                only_pulls: true
+                informational: false
+        changes: no
 
 comment: off


### PR DESCRIPTION
PR's should only fail if coverage on the diff falls below threshold.