### PR TITLE
Switch to winston splat-style logging (printf-style)

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,13 +104,15 @@
                         "error",
                         "warn",
                         "info",
-                        "verbose"
+                        "verbose",
+                        "debug"
                     ],
                     "enumDescriptions": [
                         "Errors Only",
                         "Errors and Warnings",
                         "Errors, Warnings, and Info",
-                        "Errors, Warnings, Info, and Verbose"
+                        "Errors, Warnings, Info, and Verbose",
+                        "Errors, Warnings, Info, Verbose, and Debug"
                     ],
                     "markdownDescription": "%AWS.configuration.description.logLevel%"
                 },

--- a/src/awsexplorer/awsExplorer.ts
+++ b/src/awsexplorer/awsExplorer.ts
@@ -81,7 +81,7 @@ export class AwsExplorer implements vscode.TreeDataProvider<AWSTreeNodeBase>, Re
             }
         } catch (err) {
             const error = err as Error
-            this.logger.error(`Error getting children for node ${element?.label ?? 'Root Node'}`, error)
+            this.logger.error(`Error getting children for node ${element?.label ?? 'Root Node'}: %O`, error)
 
             childNodes.splice(
                 0,

--- a/src/cdk/explorer/detectCdkProjects.ts
+++ b/src/cdk/explorer/detectCdkProjects.ts
@@ -72,6 +72,6 @@ async function* detectCdkProjectsInFolder(folder: string): AsyncIterableIterator
         yield vscode.Uri.file(cdkJsonPath)
     } catch (err) {
         // This is usually because the file doesn't exist, but could also be a permissions issue.
-        getLogger().debug(`Error detecting CDK apps in ${folder}`, err as Error)
+        getLogger().debug(`Error detecting CDK apps in ${folder}: %O`, err as Error)
     }
 }

--- a/src/cdk/explorer/nodes/appNode.ts
+++ b/src/cdk/explorer/nodes/appNode.ts
@@ -77,7 +77,7 @@ export class AppNode extends AWSTreeNodeBase {
 
             return constructs
         } catch (error) {
-            getLogger().error(`Could not load the construct tree located at '${this.id}'`, error as Error)
+            getLogger().error(`Could not load the construct tree located at '${this.id}': %O`, error as Error)
 
             return [
                 new PlaceholderNode(

--- a/src/credentials/loginManager.ts
+++ b/src/credentials/loginManager.ts
@@ -61,7 +61,7 @@ export class LoginManager {
             getLogger().error(
                 `Error trying to connect to AWS with Credentials Provider ${asString(
                     credentialsProviderId
-                )}. Toolkit will now disconnect from AWS.`,
+                )}. Toolkit will now disconnect from AWS. %O`,
                 err as Error
             )
             this.credentialsStore.invalidateCredentials(credentialsProviderId)

--- a/src/eventSchemas/commands/downloadSchemaItemCode.ts
+++ b/src/eventSchemas/commands/downloadSchemaItemCode.ts
@@ -88,7 +88,7 @@ export async function downloadSchemaItemCode(node: SchemaItemNode, outputChannel
             errorMessage = error.message
         }
         vscode.window.showErrorMessage(errorMessage)
-        logger.error('Error downloading schema', error)
+        logger.error('Error downloading schema: %O', error)
     } finally {
         recordSchemasDownload({ result: downloadResult })
     }

--- a/src/eventSchemas/commands/searchSchemas.ts
+++ b/src/eventSchemas/commands/searchSchemas.ts
@@ -93,7 +93,7 @@ export async function createSearchSchemasWebView(params: {
     } catch (err) {
         webviewResult = 'Failed'
         const error = err as Error
-        logger.error('Error searching schemas', error)
+        logger.error('Error searching schemas: %O', error)
     } finally {
         // TODO make this telemetry actually record failures
         recordSchemasSearch({ result: webviewResult })

--- a/src/eventSchemas/commands/viewSchemaItem.ts
+++ b/src/eventSchemas/commands/viewSchemaItem.ts
@@ -29,7 +29,7 @@ export async function viewSchemaItem(node: SchemaItemNode) {
                 node.schemaName
             )
         )
-        logger.error('Error on schema preview', error)
+        logger.error('Error on schema preview: %O', error)
     } finally {
         recordSchemasView({ result: viewResult })
     }

--- a/src/eventSchemas/providers/schemasDataProvider.ts
+++ b/src/eventSchemas/providers/schemasDataProvider.ts
@@ -55,7 +55,7 @@ export class SchemasDataProvider {
             }
         } catch (err) {
             const error = err as Error
-            this.logger.error('Error retrieving registries', error)
+            this.logger.error('Error retrieving registries: %O', error)
 
             return undefined
         }
@@ -86,7 +86,7 @@ export class SchemasDataProvider {
             }
         } catch (err) {
             const error = err as Error
-            this.logger.error('Error retrieving schemas', error)
+            this.logger.error('Error retrieving schemas: %O', error)
 
             return undefined
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -249,7 +249,7 @@ function makeEndpointsProvider(): EndpointsProvider {
     const provider = new EndpointsProvider(localManifestFetcher, remoteManifestFetcher)
     // tslint:disable-next-line:no-floating-promises -- start the load without waiting. It raises events as fetchers retrieve data.
     provider.load().catch((err: Error) => {
-        getLogger().error('Failure while loading Endpoints Manifest', err)
+        getLogger().error('Failure while loading Endpoints Manifest: %O', err)
 
         vscode.window.showErrorMessage(
             localize(

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -201,7 +201,7 @@ export async function createNewSamApplication(
             checkLogsMessage
         )
 
-        getLogger().error('Error creating new SAM Application', err as Error)
+        getLogger().error('Error creating new SAM Application: %O', err as Error)
 
         // An error occured, so do not try to open any files during the next extension activation
         activationLaunchPath.clearLaunchPath()

--- a/src/lambda/commands/invokeLambda.ts
+++ b/src/lambda/commands/invokeLambda.ts
@@ -115,7 +115,7 @@ export async function invokeLambda(params: {
             )
         } catch (err) {
             invokeResult = 'Failed'
-            logger.error('Error getting manifest data..', err as Error)
+            logger.error('Error getting manifest data..: %O', err as Error)
         }
     } catch (err) {
         invokeResult = 'Failed'

--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -85,7 +85,7 @@ export async function makeCodeLenses({
             lenses.push(makeConfigureCodeLens(baseParams))
         } catch (err) {
             getLogger().error(
-                `Could not generate 'configure' code lens for handler '${handler.handlerName}'`,
+                `Could not generate 'configure' code lens for handler '${handler.handlerName}': %O`,
                 err as Error
             )
         }

--- a/src/shared/codelens/csharpCodeLensProvider.ts
+++ b/src/shared/codelens/csharpCodeLensProvider.ts
@@ -271,7 +271,7 @@ export async function makeCSharpCodeLensProvider(): Promise<vscode.CodeLensProvi
         ): Promise<vscode.CodeLens[]> => {
             const handlers: LambdaHandlerCandidate[] = await getLambdaHandlerCandidates(document)
             logger.debug(
-                'csharpCodeLensProvider.makeCSharpCodeLensProvider handlers:',
+                'csharpCodeLensProvider.makeCSharpCodeLensProvider handlers: %s',
                 JSON.stringify(handlers, undefined, 2)
             )
 

--- a/src/shared/codelens/localLambdaRunner.ts
+++ b/src/shared/codelens/localLambdaRunner.ts
@@ -551,7 +551,7 @@ export async function waitForDebugPort(
         // this function always attempts once no matter the timeoutDuration
         await tcpPortUsed.waitUntilUsed(debugPort, SAM_LOCAL_PORT_CHECK_RETRY_INTERVAL_MILLIS, remainingTime)
     } catch (err) {
-        getLogger().warn(`Timed out after ${remainingTime} ms waiting for port ${debugPort} to open`, err as Error)
+        getLogger().warn(`Timed out after ${remainingTime} ms waiting for port ${debugPort} to open: %O`, err as Error)
 
         channelLogger.warn(
             'AWS.samcli.local.invoke.port.not.open',
@@ -615,7 +615,7 @@ async function showDebugConsole(): Promise<void> {
         await vscode.commands.executeCommand('workbench.debug.action.toggleRepl')
     } catch (err) {
         // in case the vs code command changes or misbehaves, swallow error
-        getLogger().verbose('Unable to switch to the Debug Console', err as Error)
+        getLogger().verbose('Unable to switch to the Debug Console: %O', err as Error)
     }
 }
 

--- a/src/shared/codelens/pythonCodeLensProvider.ts
+++ b/src/shared/codelens/pythonCodeLensProvider.ts
@@ -105,7 +105,7 @@ const makeLambdaDebugFile = async (params: {
     const debugHandlerFunctionName = 'lambda_handler'
     // TODO: Sanitize handlerFilePrefix, handlerFunctionName, debugHandlerFunctionName
     try {
-        logger.debug('pythonCodeLensProvider.makeLambdaDebugFile params:', JSON.stringify(params, undefined, 2))
+        logger.debug('pythonCodeLensProvider.makeLambdaDebugFile params: %s', JSON.stringify(params, undefined, 2))
         const template = `
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
@@ -127,7 +127,7 @@ def ${debugHandlerFunctionName}(event, context):
 `
 
         const outFilePath = path.join(params.outputDir, `${debugHandlerFileName}.py`)
-        logger.debug('pythonCodeLensProvider.makeLambdaDebugFile outFilePath:', outFilePath)
+        logger.debug('pythonCodeLensProvider.makeLambdaDebugFile outFilePath: %s', outFilePath)
         await writeFile(outFilePath, template)
 
         return {
@@ -135,7 +135,7 @@ def ${debugHandlerFunctionName}(event, context):
             debugHandlerName: `${debugHandlerFileName}.${debugHandlerFunctionName}`,
         }
     } catch (err) {
-        logger.error('makeLambdaDebugFile failed:', err as Error)
+        logger.error('makeLambdaDebugFile failed: %O', err as Error)
         throw err
     }
 }
@@ -371,7 +371,7 @@ export async function waitForPythonDebugAdapter(debugPort: number, timeout: Time
                 }
             }
         } catch (err) {
-            logger.verbose('Error while testing', err as Error)
+            logger.verbose('Error while testing: %O', err as Error)
         } finally {
             await tester.disconnect()
         }
@@ -435,7 +435,7 @@ export async function makePythonCodeLensProvider(
 
             const handlers: LambdaHandlerCandidate[] = await getLambdaHandlerCandidates(document.uri)
             logger.debug(
-                'pythonCodeLensProvider.makePythonCodeLensProvider handlers:',
+                'pythonCodeLensProvider.makePythonCodeLensProvider handlers: %s',
                 JSON.stringify(handlers, undefined, 2)
             )
 

--- a/src/shared/codelens/pythonDebugAdapterHeartbeat.ts
+++ b/src/shared/codelens/pythonDebugAdapterHeartbeat.ts
@@ -32,7 +32,7 @@ export class PythonDebugAdapterHeartbeat {
             })
             this.socket.once('error', (err: Error) => {
                 clearTimeout(timeout)
-                this.logger.verbose('Error while connecting', err)
+                this.logger.verbose('Error while connecting: %O', err)
                 resolve(false)
             })
 
@@ -52,13 +52,13 @@ export class PythonDebugAdapterHeartbeat {
 
             this.socket.on('data', data => {
                 clearTimeout(timeout)
-                this.logger.verbose('Data received from Debug Adapter', data.toString())
+                this.logger.verbose('Data received from Debug Adapter: %s', data.toString())
                 resolve(true)
             })
 
             this.socket.once('error', (err: Error) => {
                 clearTimeout(timeout)
-                this.logger.verbose('Error writing to Debug Adapter', err)
+                this.logger.verbose('Error writing to Debug Adapter: %O', err)
                 resolve(false)
             })
 

--- a/src/shared/credentials/accountId.ts
+++ b/src/shared/credentials/accountId.ts
@@ -21,7 +21,7 @@ export async function getAccountId(credentials: AWS.Credentials, region: string)
 
         return response.Account
     } catch (err) {
-        getLogger().error('Error getting AccountId', err as Error)
+        getLogger().error('Error getting AccountId: %O', err as Error)
 
         return undefined
     }

--- a/src/shared/logger/consoleLogTransport.ts
+++ b/src/shared/logger/consoleLogTransport.ts
@@ -5,9 +5,12 @@
 
 import * as Transport from 'winston-transport'
 
+const MESSAGE = Symbol.for('message')
+
 interface LogEntry {
     level: string
     message: string
+    [MESSAGE]: string
 }
 
 /**
@@ -21,7 +24,7 @@ export class ConsoleLogTransport extends Transport {
 
     public log(info: LogEntry, next: () => void): void {
         setImmediate(() => {
-            console.log(info.message)
+            console.log(info[MESSAGE])
         })
 
         next()

--- a/src/shared/logger/loggableType.ts
+++ b/src/shared/logger/loggableType.ts
@@ -7,7 +7,3 @@
  * Loggable types: Error, string
  */
 export type Loggable = Error | string
-
-export function isLoggableError(loggable: Loggable): boolean {
-    return loggable instanceof Error
-}

--- a/src/shared/logger/logger.ts
+++ b/src/shared/logger/logger.ts
@@ -3,16 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Loggable } from './loggableType'
-
 let toolkitLogger: Logger | undefined
 
 export interface Logger {
-    debug(...message: Loggable[]): void
-    verbose(...message: Loggable[]): void
-    info(...message: Loggable[]): void
-    warn(...message: Loggable[]): void
-    error(...message: Loggable[]): void
+    debug(message: string, ...meta: any[]): void
+    debug(error: Error): void
+    verbose(message: string, ...meta: any[]): void
+    verbose(error: Error): void
+    info(message: string, ...meta: any[]): void
+    info(error: Error): void
+    warn(message: string, ...meta: any[]): void
+    warn(error: Error): void
+    error(message: string, ...meta: any[]): void
+    error(error: Error): void
 }
 
 export type LogLevel = keyof Logger

--- a/src/shared/logger/outputChannelTransport.ts
+++ b/src/shared/logger/outputChannelTransport.ts
@@ -6,9 +6,12 @@
 import * as vscode from 'vscode'
 import * as Transport from 'winston-transport'
 
+export const MESSAGE = Symbol.for('message')
+
 interface LogEntry {
     level: string
     message: string
+    [MESSAGE]: string
 }
 
 export class OutputChannelTransport extends Transport {
@@ -26,7 +29,7 @@ export class OutputChannelTransport extends Transport {
 
     public log(info: LogEntry, next: () => void): void {
         setImmediate(() => {
-            this.outputChannel.appendLine(info.message)
+            this.outputChannel.appendLine(info[MESSAGE])
         })
 
         next()

--- a/src/shared/regions/endpoints.ts
+++ b/src/shared/regions/endpoints.ts
@@ -78,8 +78,8 @@ export function loadEndpoints(json: string): Endpoints | undefined {
         }
     } catch (err) {
         const logger = getLogger()
-        logger.error('Failed to load endpoints manifest', err as Error)
-        logger.verbose('endpoints payload was:', json)
+        logger.error('Failed to load endpoints manifest: %O', err as Error)
+        logger.verbose('endpoints payload was: %s', json)
 
         return undefined
     }

--- a/src/shared/resourcefetcher/compositeResourceFetcher.ts
+++ b/src/shared/resourcefetcher/compositeResourceFetcher.ts
@@ -29,7 +29,7 @@ export class CompositeResourceFetcher implements ResourceFetcher {
                 }
             }
         } catch (err) {
-            this.logger.error('Error loading resource from resource fetchers', err as Error)
+            this.logger.error('Error loading resource from resource fetchers: %O', err as Error)
 
             return undefined
         }
@@ -39,7 +39,7 @@ export class CompositeResourceFetcher implements ResourceFetcher {
         try {
             return await fetcher.get()
         } catch (err) {
-            this.logger.error('Error loading resource from resource fetcher', err as Error)
+            this.logger.error('Error loading resource from resource fetcher: %O', err as Error)
 
             return undefined
         }

--- a/src/shared/resourcefetcher/fileResourceFetcher.ts
+++ b/src/shared/resourcefetcher/fileResourceFetcher.ts
@@ -21,7 +21,7 @@ export class FileResourceFetcher implements ResourceFetcher {
 
             return (await fs.readFile(this.filepath)).toString()
         } catch (err) {
-            this.logger.error(`Error loading resource from ${this.filepath}`, err as Error)
+            this.logger.error(`Error loading resource from ${this.filepath}: %O`, err as Error)
 
             return undefined
         }

--- a/src/shared/resourcefetcher/httpResourceFetcher.ts
+++ b/src/shared/resourcefetcher/httpResourceFetcher.ts
@@ -26,7 +26,7 @@ export class HttpResourceFetcher implements ResourceFetcher {
 
             return contents
         } catch (err) {
-            this.logger.error(`Error loading resource from ${this.url}`, err as Error)
+            this.logger.error(`Error loading resource from ${this.url}: %O`, err as Error)
 
             return undefined
         }

--- a/src/shared/telemetry/activation.ts
+++ b/src/shared/telemetry/activation.ts
@@ -141,6 +141,6 @@ export async function handleTelemetryNoticeResponse(
             vscode.commands.executeCommand('workbench.action.openSettings')
         }
     } catch (err) {
-        getLogger().error('Error while handling reponse from telemetry notice', err as Error)
+        getLogger().error('Error while handling response from telemetry notice: %O', err as Error)
     }
 }

--- a/src/shared/utilities/disposableFiles.ts
+++ b/src/shared/utilities/disposableFiles.ts
@@ -52,7 +52,7 @@ export class DisposableFiles implements vscode.Disposable {
                     }
                 })
             } catch (err) {
-                logger.error('Error during DisposableFiles dispose: ', err as Error)
+                logger.error('Error during DisposableFiles dispose: %O', err as Error)
             } finally {
                 this._disposed = true
             }

--- a/src/shared/utilities/textUtilities.ts
+++ b/src/shared/utilities/textUtilities.ts
@@ -11,7 +11,7 @@ export function removeAnsi(text: string): string {
     try {
         return stripAnsi(text)
     } catch (err) {
-        getLogger().error('Unexpected error while removing Ansi from text', err as Error)
+        getLogger().error('Unexpected error while removing Ansi from text: %O', err as Error)
 
         // Fall back to original text so callers aren't impacted
         return text

--- a/src/shared/utilities/vsCodeUtils.ts
+++ b/src/shared/utilities/vsCodeUtils.ts
@@ -5,7 +5,8 @@
 
 import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
-import { getLogger, Loggable, LogLevel } from '../logger'
+import { getLogger, LogLevel } from '../logger'
+import { Loggable } from '../logger/loggableType'
 
 // TODO: Consider NLS initialization/configuration here & have packages to import localize from here
 export const localize = nls.loadMessageBundle()
@@ -73,7 +74,7 @@ export function getChannelLogger(channel: vscode.OutputChannel): ChannelLogger {
         channel.appendLine(prettyMessage)
         // TODO: Log in english if/when we get multi lang support
         // Log pretty message then Error objects (so logger might show stack traces)
-        logger[level](...[prettyMessage, ...errors])
+        logger[level](prettyMessage, ...errors)
     }
 
     return Object.freeze({

--- a/src/shared/utilities/workspaceUtils.ts
+++ b/src/shared/utilities/workspaceUtils.ts
@@ -62,7 +62,7 @@ export async function addFolderToWorkspace(folder: NewWorkspaceFolder): Promise<
             }
         })
     } catch (err) {
-        logger.error(`Unexpected error adding folder ${folder.uri.fsPath} to workspace`, err as Error)
+        logger.error(`Unexpected error adding folder ${folder.uri.fsPath} to workspace: %O`, err as Error)
 
         return false
     } finally {

--- a/src/stepFunctions/commands/executeStateMachine.ts
+++ b/src/stepFunctions/commands/executeStateMachine.ts
@@ -115,7 +115,7 @@ function createMessageReceivedFunc({
                 } catch (e) {
                     executeResult = 'Failed'
                     const error = e as Error
-                    logger.error('Error starting execution for Step Functions State Machine', error)
+                    logger.error('Error starting execution for Step Functions State Machine: %O', error)
                     outputChannel.appendLine(
                         localize(
                             'AWS.message.error.stepFunctions.executeStateMachine.failed_to_start',

--- a/src/stepFunctions/commands/publishStateMachine.ts
+++ b/src/stepFunctions/commands/publishStateMachine.ts
@@ -109,7 +109,7 @@ async function createStateMachine(
                 wizardResponse.name
             )
         )
-        logger.error(`Failed to create state machine '${wizardResponse.name}'.`, err as Error)
+        logger.error(`Failed to create state machine '${wizardResponse.name}'. %O`, err as Error)
         outputChannel.appendLine('')
     }
 }
@@ -154,7 +154,7 @@ async function updateStateMachine(
                 wizardResponse.stateMachineArn
             )
         )
-        logger.error(`Failed to update '${wizardResponse.stateMachineArn}'.`, err as Error)
+        logger.error(`Failed to update '${wizardResponse.stateMachineArn}'. %O`, err as Error)
         outputChannel.appendLine('')
     }
 }

--- a/src/stepFunctions/utils.ts
+++ b/src/stepFunctions/utils.ts
@@ -147,7 +147,7 @@ async function httpsGetRequestWrapper(url: string): Promise<string> {
         request.get(url, function(error, response) {
             logger.verbose(`Step Functions finished getting content from ${url}`)
             if (error) {
-                logger.verbose(`Step Functions was unable to get content from ${url}`, error as Error)
+                logger.verbose(`Step Functions was unable to get content from ${url}: %O`, error as Error)
                 reject(error)
             } else {
                 resolve(response.body as string)

--- a/src/test/shared/logger/outputChannelLogger.test.ts
+++ b/src/test/shared/logger/outputChannelLogger.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OutputChannelTransport } from '../../../shared/logger/outputChannelTransport'
+import { OutputChannelTransport, MESSAGE } from '../../../shared/logger/outputChannelTransport'
 import { MockOutputChannel } from '../../mockOutputChannel'
 
 describe('OutputChannelTransport', async () => {
@@ -32,6 +32,7 @@ describe('OutputChannelTransport', async () => {
             {
                 level: 'info',
                 message: loggedMessage,
+                [MESSAGE]: loggedMessage,
             },
             async () => {
                 // Test will timeout if expected text is not encountered

--- a/src/test/shared/logger/winstonToolkitLogger.test.ts
+++ b/src/test/shared/logger/winstonToolkitLogger.test.ts
@@ -102,15 +102,6 @@ describe('WinstonToolkitLogger', () => {
             )
         })
 
-        it('logs multiple inputs', async () => {
-            testLogger = new WinstonToolkitLogger('info')
-            testLogger.logToFile(tempLogPath)
-
-            testLogger.info('The', 'quick', 'brown', 'fox')
-
-            assert.ok(await isTextInLogFile(tempLogPath, 'The quick brown fox'), 'Expected error message to be logged')
-        })
-
         it('supports updating the log type', async () => {
             const nonLoggedVerboseEntry = 'verbose entry should not be logged'
             const loggedVerboseEntry = 'verbose entry should be logged'
@@ -193,18 +184,6 @@ describe('WinstonToolkitLogger', () => {
             testLogger.error(errorMessage)
 
             assert.ok((await waitForMessage).includes(errorMessage), 'Expected error message to be logged')
-        })
-
-        it('logs multiple inputs', async () => {
-            testLogger = new WinstonToolkitLogger('info')
-            testLogger.logToOutputChannel(outputChannel)
-            const expectedText = 'The quick brown fox'
-
-            const waitForMessage = waitForLoggedTextByContents(expectedText)
-
-            testLogger.info('The', 'quick', 'brown', 'fox')
-
-            assert.ok((await waitForMessage).includes('The quick brown fox'), 'Expected error message to be logged')
         })
 
         it('supports updating the log type', async () => {

--- a/src/test/shared/sam/cli/testSamCliProcessInvoker.ts
+++ b/src/test/shared/sam/cli/testSamCliProcessInvoker.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert'
 import { SpawnOptions } from 'child_process'
 
-import { isLoggableError } from '../../../../shared/logger/loggableType'
+import { isError } from 'lodash'
 import {
     makeRequiredSamCliProcessInvokeOptions,
     SamCliProcessInvokeOptions,
@@ -103,7 +103,7 @@ export async function assertLogContainsBadExitInformation(
 
     const logText = logger
         .getLoggedEntries()
-        .filter(x => !isLoggableError(x))
+        .filter(x => !isError(x))
         .join('\n')
     expectedTexts.forEach(expectedText => {
         assert.ok(logText.includes(expectedText.text), expectedText.verifyMessage)

--- a/src/test/shared/utilities/vsCodeUtils.test.ts
+++ b/src/test/shared/utilities/vsCodeUtils.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert'
 import { Loggable, LogLevel } from '../../../shared/logger'
-import { isLoggableError } from '../../../shared/logger/loggableType'
+import { isError } from 'lodash'
 import {
     ChannelLogger,
     getChannelLogger,
@@ -99,8 +99,8 @@ describe('getChannelLogger', function() {
 
                     it('writes to the logger', async () => {
                         const actualLogEntries = logger.getLoggedEntries(logLevel)
-                        const loggedErrors = actualLogEntries.filter(isLoggableError)
-                        const loggedText = actualLogEntries.filter(x => !isLoggableError(x))
+                        const loggedErrors = actualLogEntries.filter(isError)
+                        const loggedText = actualLogEntries.filter(x => !isError(x))
 
                         assert.strictEqual(loggedText.length, 1, 'Expected to log only one string')
                         assert.strictEqual(


### PR DESCRIPTION
## Description

This makes it easier to deeply log objects or control formatting
https://github.com/winstonjs/logform#splat

Winston will delegate to Node's util.format for formatting
https://nodejs.org/dist/latest/docs/api/util.html#util_util_format_format_args

e.g.

```typescript
log.info('My full object %O', myObject) // all properties
log.info('My full object %j', myObject) // as JSON
```

`[util.inspect.custom]` can be implemented to override the default formatting
https://nodejs.org/dist/latest/docs/api/util.html#util_custom_inspection_functions_on_objects

The only consequence to this is that stuff like:
`log.error('messsage', error)`

Needs to be converted to:
`log.error('message: %O', error)`

This seems like a small tradeoff compared to the benefits
Especially since the former format isn't a standard winston format

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

## Motivation and Context

This makes it easier to deeply log objects and removes the custom log method signatures.

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
