### PR TITLE
Cancel download code bindings operation when user picks Cancel in the collision prompt

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -179,6 +179,7 @@
     "AWS.message.error.schemas.viewSchema.could_not_open": "Could not fetch and display schema {0} contents",
     "AWS.message.error.schemas.downloadCodeBindings.failed_to_download": "Unable to download schema code",
     "AWS.message.error.schemas.downloadCodeBindings.failed_to_generate": "Unable to generate schema code",
+    "AWS.message.error.schemas.downloadCodeBindings.cancelled:": "Download code bindings cancelled",
     "AWS.message.error.schemas.downloadCodeBindings.invalid_code_generation_status": "Invalid Code generation status {0}",
     "AWS.message.error.schemas.downloadCodeBindings.timout": "Failed to download code for schema {0} before timeout. Please try again later",
     "AWS.message.info.schemas.downloadCodeBindings.start": "Downloading code for schema {0}...",

--- a/src/eventSchemas/commands/downloadSchemaItemCode.ts
+++ b/src/eventSchemas/commands/downloadSchemaItemCode.ts
@@ -373,6 +373,12 @@ export class CodeExtractor {
             responseYes,
             responseNo
         )
+
+        if (!userResponse)
+            throw new UserNotifiedError(
+                localize('AWS.message.error.schemas.downloadCodeBindings.cancelled', 'Download code bindings cancelled')
+            )
+
         return userResponse === responseYes
     }
 


### PR DESCRIPTION



## Description
We recently introduced a feature to let users pick whether or not they would like to override conflicting files during schemas download code bindings. Upon collision, there would a modal displayed with No, Cancel and Yes buttons. Currently both No and Cancel button acts in a a same way and proceeds download by not overriding files.  This commit aims at to fix the Cancel button behavior by cancelling the download code bindings operation.


## Related Issue(s)
https://github.com/aws/aws-toolkit-vscode/pull/1089

## Testing
Added new unit tests.
Locally did end to end testing in my laptop.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
