### PR TITLE
Code-type codelenses now prompt for a runtime

### DIFF
--- a/src/lambda/models/samLambdaRuntime.ts
+++ b/src/lambda/models/samLambdaRuntime.ts
@@ -120,7 +120,7 @@ function getRuntimesForFamily(family: RuntimeFamily): Set<Runtime> | undefined {
  * currRuntime: Runtime to set a "Selected Previously" mark to;
  * runtimeFamily: a RuntimeFamily that will define the list of runtimes to show (default: samLambdaCreatableRuntimes)
  */
-export function promptForRuntime(params: {
+export function createRuntimeQuickPick(params: {
     buttons?: vscode.QuickInputButton[]
     currRuntime?: Runtime
     runtimeFamily?: RuntimeFamily

--- a/src/lambda/models/samLambdaRuntime.ts
+++ b/src/lambda/models/samLambdaRuntime.ts
@@ -18,6 +18,8 @@ export enum RuntimeFamily {
     DotNetCore,
 }
 
+// TODO: Consolidate all of the runtime constructs into a single <Runtime, Set<Runtime>> map
+//       We should be able to eliminate a fair amount of redundancy with that.
 export const nodeJsRuntimes: Set<Runtime> = Set<Runtime>(['nodejs12.x', 'nodejs10.x', 'nodejs8.10'])
 export const pythonRuntimes: Set<Runtime> = Set<Runtime>(['python3.8', 'python3.7', 'python3.6', 'python2.7'])
 export const dotNetRuntimes: Set<Runtime> = Set<Runtime>(['dotnetcore2.1'])
@@ -116,9 +118,10 @@ function getRuntimesForFamily(family: RuntimeFamily): Set<Runtime> | undefined {
 
 /**
  * Creates a quick pick for a Runtime with the following parameters (all optional)
- * @param params buttons: array of buttons to add to the quick pick;
- * currRuntime: Runtime to set a "Selected Previously" mark to;
- * runtimeFamily: a RuntimeFamily that will define the list of runtimes to show (default: samLambdaCreatableRuntimes)
+ * @param {Object} params Optional parameters for creating a QuickPick for runtimes:
+ * @param {vscode.QuickInputButton[]} params.buttons Array of buttons to add to the quick pick;
+ * @param {Runtime} params.currRuntime Runtime to set a "Selected Previously" mark to;
+ * @param {RuntimeFamily} params.runtimeFamily RuntimeFamily that will define the list of runtimes to show (default: samLambdaCreatableRuntimes)
  */
 export function createRuntimeQuickPick(params: {
     buttons?: vscode.QuickInputButton[]

--- a/src/lambda/wizards/samInitWizard.ts
+++ b/src/lambda/wizards/samInitWizard.ts
@@ -27,7 +27,7 @@ import {
     WizardStep,
     WorkspaceFolderQuickPickItem,
 } from '../../shared/wizards/multiStepWizard'
-import { samLambdaCreatableRuntimes, promptForRuntime } from '../models/samLambdaRuntime'
+import { createRuntimeQuickPick, samLambdaCreatableRuntimes } from '../models/samLambdaRuntime'
 import {
     eventBridgeStarterAppTemplate,
     getSamTemplateWizardOption,
@@ -66,7 +66,7 @@ export class DefaultCreateNewSamAppWizardContext extends WizardContext implement
     }
 
     public async promptUserForRuntime(currRuntime?: Runtime): Promise<Runtime | undefined> {
-        const quickPick = promptForRuntime({
+        const quickPick = createRuntimeQuickPick({
             buttons: [this.helpButton],
             currRuntime,
         })

--- a/src/shared/sam/debugger/awsSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfiguration.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode'
 import * as path from 'path'
-import { getDefaultRuntime, RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
+import { Runtime } from 'aws-sdk/clients/lambda'
 import { getNormalizedRelativePath } from '../../utilities/pathUtils'
 import {
     AwsSamDebuggerConfiguration,
@@ -155,14 +155,10 @@ export function createCodeAwsSamDebugConfig(
     folder: vscode.WorkspaceFolder | undefined,
     lambdaHandler: string,
     projectRoot: string,
-    runtimeFamily?: RuntimeFamily
+    runtime: Runtime
 ): AwsSamDebuggerConfiguration {
     const workspaceRelativePath = folder ? getNormalizedRelativePath(folder.uri.fsPath, projectRoot) : projectRoot
     const parentDir = path.basename(path.dirname(projectRoot))
-    const runtime = runtimeFamily ? getDefaultRuntime(runtimeFamily) : undefined
-    if (!runtime) {
-        throw new Error('Invalid or missing runtime family')
-    }
 
     return {
         type: AWS_SAM_DEBUG_TYPE,

--- a/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
@@ -7,7 +7,7 @@ import * as path from 'path'
 import * as vscode from 'vscode'
 import { Runtime } from 'aws-sdk/clients/lambda'
 import { getExistingConfiguration } from '../../../../lambda/config/templates'
-import { getDefaultRuntime, RuntimeFamily, promptForRuntime } from '../../../../lambda/models/samLambdaRuntime'
+import { createRuntimeQuickPick, getDefaultRuntime, RuntimeFamily } from '../../../../lambda/models/samLambdaRuntime'
 import { CloudFormationTemplateRegistry } from '../../../cloudformation/templateRegistry'
 import { LaunchConfiguration } from '../../../debug/launchConfiguration'
 import * as picker from '../../../ui/picker'
@@ -95,7 +95,7 @@ export async function addSamDebugConfiguration(
             preloadedConfig
         )
     } else if (type === CODE_TARGET_TYPE) {
-        const quickPick = promptForRuntime({
+        const quickPick = createRuntimeQuickPick({
             runtimeFamily,
         })
 

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -967,7 +967,7 @@ it('ensureRelativePaths', () => {
         undefined,
         'testName1',
         '/test1/project',
-        lambdaModel.RuntimeFamily.NodeJS
+        lambdaModel.getDefaultRuntime(lambdaModel.RuntimeFamily.NodeJS) ?? ''
     )
     assert.strictEqual((codeConfig.invokeTarget as CodeTargetProperties).projectRoot, '/test1/project')
     ensureRelativePaths(workspace, codeConfig)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Codelenses in source now prompt the user on which runtime to use for the created debug config instead of assuming the newest.

CONSIDERATION: now that we're creating a quick pick, should we also use a quick pick instead of the modal that pops up when using a template codelens with a legacy configuration?

## Motivation and Context

Results of a bug bash

## Testing
Tested manually with all three runtime families.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
