### PR TITLE
Upgrade @types/vscode to 1.42.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -473,9 +473,9 @@
             }
         },
         "@types/vscode": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.40.0.tgz",
-            "integrity": "sha512-5kEIxL3qVRkwhlMerxO7XuMffa+0LBl+iG2TcRa0NsdoeSFLkt/9hJ02jsi/Kvc6y8OVF2N2P2IHP5S4lWf/5w==",
+            "version": "1.42.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.42.0.tgz",
+            "integrity": "sha512-ds6TceMsh77Fs0Mq0Vap6Y72JbGWB8Bay4DrnJlf5d9ui2RSe1wis13oQm+XhguOeH1HUfLGzaDAoupTUtgabw==",
             "dev": true
         },
         "@types/xml2js": {
@@ -4383,7 +4383,7 @@
                     "dependencies": {
                         "minimist": {
                             "version": "1.2.0",
-                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                            "resolved": false,
                             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                             "dev": true,
                             "optional": true

--- a/package.json
+++ b/package.json
@@ -877,7 +877,7 @@
         "@types/sinon": "^7.0.13",
         "@types/tcp-port-used": "^1.0.0",
         "@types/uuid": "^3.4.4",
-        "@types/vscode": "^1.31.0",
+        "@types/vscode": "1.42.0",
         "@types/xml2js": "^0.4.3",
         "@typescript-eslint/eslint-plugin": "^2.27.0",
         "@typescript-eslint/eslint-plugin-tslint": "^2.27.0",

--- a/src/cdk/explorer/awsCdkExplorer.ts
+++ b/src/cdk/explorer/awsCdkExplorer.ts
@@ -47,6 +47,6 @@ export class AwsCdkExplorer implements vscode.TreeDataProvider<AWSTreeNodeBase>,
     }
 
     public refresh(node?: AWSTreeNodeBase) {
-        this.onDidChangeTreeDataEventEmitter.fire()
+        this.onDidChangeTreeDataEventEmitter.fire(undefined)
     }
 }

--- a/src/cdk/explorer/detectCdkProjects.ts
+++ b/src/cdk/explorer/detectCdkProjects.ts
@@ -10,7 +10,7 @@ import { getLogger } from '../../shared/logger'
 import { CdkAppLocation } from './cdkProject'
 
 export async function detectCdkProjects(
-    workspaceFolders: vscode.WorkspaceFolder[] | undefined = vscode.workspace.workspaceFolders
+    workspaceFolders: ReadonlyArray<vscode.WorkspaceFolder> | undefined = vscode.workspace.workspaceFolders
 ): Promise<CdkAppLocation[]> {
     if (!workspaceFolders) {
         return []

--- a/src/eventSchemas/wizards/schemaCodeDownloadWizard.ts
+++ b/src/eventSchemas/wizards/schemaCodeDownloadWizard.ts
@@ -27,7 +27,7 @@ import { SchemaItemNode } from '../explorer/schemaItemNode'
 
 export interface SchemaCodeDownloadWizardContext {
     readonly schemaLangs: Set<codeLang.SchemaCodeLangs>
-    readonly workspaceFolders: vscode.WorkspaceFolder[] | undefined
+    readonly workspaceFolders: ReadonlyArray<vscode.WorkspaceFolder> | undefined
 
     promptUserForVersion(currSchemaVersion?: string): Promise<string | undefined>
 

--- a/src/lambda/wizards/samInitWizard.ts
+++ b/src/lambda/wizards/samInitWizard.ts
@@ -38,7 +38,7 @@ import {
 
 export interface CreateNewSamAppWizardContext {
     readonly lambdaRuntimes: Set<Runtime>
-    readonly workspaceFolders: vscode.WorkspaceFolder[] | undefined
+    readonly workspaceFolders: ReadonlyArray<vscode.WorkspaceFolder> | undefined
 
     promptUserForRuntime(currRuntime?: Runtime): Promise<Runtime | undefined>
     promptUserForTemplate(currRuntime: Runtime, currTemplate?: SamTemplate): Promise<SamTemplate | undefined>

--- a/src/shared/wizards/multiStepWizard.ts
+++ b/src/shared/wizards/multiStepWizard.ts
@@ -49,7 +49,7 @@ export class WorkspaceFolderQuickPickItem implements FolderQuickPickItem {
 
 export class WizardContext {
     public readonly showOpenDialog = vscode.window.showOpenDialog
-    public get workspaceFolders(): vscode.WorkspaceFolder[] | undefined {
+    public get workspaceFolders(): ReadonlyArray<vscode.WorkspaceFolder> | undefined {
         return vscode.workspace.workspaceFolders
     }
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This matches our minimum supported vscode version

## Motivation and Context

Our types should match our min supported vscode version. I noticed the discrepancy when I was trying to use the codicons but the constructor was only declared public in `1.42.0`.

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests pass

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
