### PR TITLE
Configuration codelenses in source files don't draw if a config exists

### DIFF
--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -19,7 +19,7 @@ import { ExtContext } from '../extensions'
 import { recordLambdaInvokeLocal, Result, Runtime } from '../telemetry/telemetry'
 import { nodeJsRuntimes, RuntimeFamily } from '../../lambda/models/samLambdaRuntime'
 import { CODE_TARGET_TYPE } from '../sam/debugger/awsSamDebugConfiguration'
-import { LaunchConfiguration, getExistingSamCodeConfigPaths } from '../debug/launchConfiguration'
+import { getReferencedHandlerPaths, LaunchConfiguration } from '../debug/launchConfiguration'
 
 export type Language = 'python' | 'javascript' | 'csharp'
 
@@ -48,7 +48,7 @@ export async function makeCodeLenses({
     }
 
     const lenses: vscode.CodeLens[] = []
-    const existingConfigs = getExistingSamCodeConfigPaths(new LaunchConfiguration(document.uri))
+    const existingConfigs = getReferencedHandlerPaths(new LaunchConfiguration(document.uri))
     for (const handler of handlers) {
         // handler.range is a RangeOrCharOffset union type. Extract vscode.Range.
         const range =

--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as path from 'path'
 import * as vscode from 'vscode'
 
 import { CloudFormation } from '../cloudformation/cloudformation'
@@ -18,6 +19,7 @@ import { ExtContext } from '../extensions'
 import { recordLambdaInvokeLocal, Result, Runtime } from '../telemetry/telemetry'
 import { nodeJsRuntimes, RuntimeFamily } from '../../lambda/models/samLambdaRuntime'
 import { CODE_TARGET_TYPE } from '../sam/debugger/awsSamDebugConfiguration'
+import { LaunchConfiguration, getExistingSamCodeConfigPaths } from '../debug/launchConfiguration'
 
 export type Language = 'python' | 'javascript' | 'csharp'
 
@@ -46,6 +48,7 @@ export async function makeCodeLenses({
     }
 
     const lenses: vscode.CodeLens[] = []
+    const existingConfigs = getExistingSamCodeConfigPaths(new LaunchConfiguration(document.uri))
     for (const handler of handlers) {
         // handler.range is a RangeOrCharOffset union type. Extract vscode.Range.
         const range =
@@ -63,7 +66,9 @@ export async function makeCodeLenses({
                 rootUri: handler.manifestUri,
                 runtimeFamily,
             }
-            lenses.push(makeAddCodeSamDebugCodeLens(baseParams))
+            if (!existingConfigs.has(path.join(path.dirname(baseParams.rootUri.fsPath), baseParams.handlerName))) {
+                lenses.push(makeAddCodeSamDebugCodeLens(baseParams))
+            }
         } catch (err) {
             getLogger().error(
                 `Could not generate 'configure' code lens for handler '${handler.handlerName}'`,

--- a/src/shared/codelens/samTemplateCodeLensProvider.ts
+++ b/src/shared/codelens/samTemplateCodeLensProvider.ts
@@ -26,7 +26,7 @@ export class SamTemplateCodeLensProvider implements vscode.CodeLensProvider {
             return []
         }
 
-        const existingDebuggedResources = getExistingSamTemplateResourcesForUri(document.uri, launchConfig)
+        const existingDebuggedResources = getExistingSamTemplateResourcesForUri(launchConfig)
 
         return _(functionResources)
             .reject(functionResource => existingDebuggedResources.has(functionResource.name))

--- a/src/shared/codelens/samTemplateCodeLensProvider.ts
+++ b/src/shared/codelens/samTemplateCodeLensProvider.ts
@@ -6,7 +6,7 @@
 import * as _ from 'lodash'
 import * as vscode from 'vscode'
 import { TemplateFunctionResource, TemplateSymbolResolver } from '../cloudformation/templateSymbolResolver'
-import { getExistingSamTemplateResourcesForUri, LaunchConfiguration } from '../debug/launchConfiguration'
+import { getReferencedTemplateResources, LaunchConfiguration } from '../debug/launchConfiguration'
 import { TEMPLATE_TARGET_TYPE } from '../sam/debugger/awsSamDebugConfiguration'
 import { AddSamDebugConfigurationInput } from '../sam/debugger/commands/addSamDebugConfiguration'
 import { localize } from '../utilities/vsCodeUtils'
@@ -26,7 +26,7 @@ export class SamTemplateCodeLensProvider implements vscode.CodeLensProvider {
             return []
         }
 
-        const existingDebuggedResources = getExistingSamTemplateResourcesForUri(launchConfig)
+        const existingDebuggedResources = getReferencedTemplateResources(launchConfig)
 
         return _(functionResources)
             .reject(functionResource => existingDebuggedResources.has(functionResource.name))

--- a/src/shared/debug/launchConfiguration.ts
+++ b/src/shared/debug/launchConfiguration.ts
@@ -40,7 +40,7 @@ export class LaunchConfiguration {
      * Creates a Launch Configuration scoped to the given resource.
      */
     public constructor(
-        public scopedResource: vscode.Uri,
+        public readonly scopedResource: vscode.Uri,
         private readonly configSource: DebugConfigurationSource = new DefaultDebugConfigSource(scopedResource),
         private readonly samValidator: AwsSamDebugConfigurationValidator = new DefaultAwsSamDebugConfigurationValidator(
             CloudFormationTemplateRegistry.getRegistry(),

--- a/src/shared/debug/launchConfiguration.ts
+++ b/src/shared/debug/launchConfiguration.ts
@@ -4,17 +4,24 @@
  */
 
 import * as _ from 'lodash'
+import * as path from 'path'
 import * as vscode from 'vscode'
+import { CloudFormationTemplateRegistry } from '../cloudformation/templateRegistry'
 import {
     AwsSamDebuggerConfiguration,
-    isAwsSamDebugConfiguration,
+    CodeTargetProperties,
     ensureRelativePaths,
+    isAwsSamDebugConfiguration,
+    isCodeTargetProperties,
+    isTemplateTargetProperties,
+    TemplateTargetProperties,
 } from '../sam/debugger/awsSamDebugConfiguration'
 import {
     AwsSamDebugConfigurationValidator,
     DefaultAwsSamDebugConfigurationValidator,
 } from '../sam/debugger/awsSamDebugConfigurationValidator'
-import { CloudFormationTemplateRegistry } from '../cloudformation/templateRegistry'
+import * as pathutils from '../utilities/pathUtils'
+import { tryGetAbsolutePath } from '../utilities/workspaceUtils'
 
 /**
  * Reads and writes DebugConfigurations.
@@ -28,6 +35,7 @@ export interface DebugConfigurationSource {
  * Wraps read and write operations on launch.json.
  */
 export class LaunchConfiguration {
+    public readonly workspaceFolder: vscode.WorkspaceFolder | undefined
     /**
      * Creates a Launch Configuration scoped to the given resource.
      */
@@ -38,7 +46,9 @@ export class LaunchConfiguration {
             CloudFormationTemplateRegistry.getRegistry(),
             vscode.workspace.getWorkspaceFolder(resource)
         )
-    ) {}
+    ) {
+        this.workspaceFolder = vscode.workspace.getWorkspaceFolder(resource)
+    }
 
     public getDebugConfigurations(): vscode.DebugConfiguration[] {
         return _(this.configSource.getDebugConfigurations())
@@ -83,4 +93,61 @@ class DefaultDebugConfigSource implements DebugConfigurationSource {
     public async setDebugConfigurations(value: vscode.DebugConfiguration[]): Promise<void> {
         await this.launch.update('configurations', value)
     }
+}
+
+function getExistingSamTemplateTargets(launchConfig: LaunchConfiguration): TemplateTargetProperties[] {
+    return _(launchConfig.getSamDebugConfigurations())
+        .map(samConfig => samConfig.invokeTarget)
+        .filter(isTemplateTargetProperties)
+        .value()
+}
+
+function getExistingSamCodeTargets(launchConfig: LaunchConfiguration): CodeTargetProperties[] {
+    return _(launchConfig.getSamDebugConfigurations())
+        .map(samConfig => samConfig.invokeTarget)
+        .filter(isCodeTargetProperties)
+        .value()
+}
+
+/**
+ * Returns a Set containing the samTemplateResources from the launch.json file that are also in the provided template file.
+ * @param templateUri Template URI to get resources from
+ * @param launchConfig Launch config to check
+ */
+export function getExistingSamTemplateResourcesForUri(
+    templateUri: vscode.Uri,
+    launchConfig: LaunchConfiguration
+): Set<string> {
+    const existingSamTemplateTargets = getExistingSamTemplateTargets(launchConfig)
+    const folder = vscode.workspace.getWorkspaceFolder(templateUri)
+
+    return _(existingSamTemplateTargets)
+        .filter(target => pathutils.areEqual(folder?.uri.fsPath, target.samTemplatePath, templateUri.fsPath))
+        .map(target => target.samTemplateResource)
+        .thru(array => new Set(array))
+        .value()
+}
+
+/**
+ * Returns a Set containing the full path for all `code`-type `aws-sam` debug configs in a launch.json file.
+ * The full path represents `path.join(workspaceFolder, projectRoot, lambdaHandler)`
+ * (without workspaceFolder if the projectRoot is relative)
+ * @param launchConfig Launch config to check
+ */
+export function getExistingSamCodeConfigPaths(launchConfig: LaunchConfiguration): Set<string> {
+    const existingSamCodeTargets = getExistingSamCodeTargets(launchConfig)
+
+    return _(existingSamCodeTargets)
+        .map(target => {
+            if (path.isAbsolute(target.projectRoot)) {
+                return path.join(target.projectRoot, target.lambdaHandler)
+            }
+            return path.join(
+                tryGetAbsolutePath(launchConfig.workspaceFolder, ''),
+                target.projectRoot,
+                target.lambdaHandler
+            )
+        })
+        .thru(array => new Set(array))
+        .value()
 }

--- a/src/shared/debug/launchConfiguration.ts
+++ b/src/shared/debug/launchConfiguration.ts
@@ -95,14 +95,14 @@ class DefaultDebugConfigSource implements DebugConfigurationSource {
     }
 }
 
-function getExistingSamTemplateTargets(launchConfig: LaunchConfiguration): TemplateTargetProperties[] {
+function getSamTemplateTargets(launchConfig: LaunchConfiguration): TemplateTargetProperties[] {
     return _(launchConfig.getSamDebugConfigurations())
         .map(samConfig => samConfig.invokeTarget)
         .filter(isTemplateTargetProperties)
         .value()
 }
 
-function getExistingSamCodeTargets(launchConfig: LaunchConfiguration): CodeTargetProperties[] {
+function getSamCodeTargets(launchConfig: LaunchConfiguration): CodeTargetProperties[] {
     return _(launchConfig.getSamDebugConfigurations())
         .map(samConfig => samConfig.invokeTarget)
         .filter(isCodeTargetProperties)
@@ -113,8 +113,8 @@ function getExistingSamCodeTargets(launchConfig: LaunchConfiguration): CodeTarge
  * Returns a Set containing the samTemplateResources from the launch.json file that the launch config is scoped to.
  * @param launchConfig Launch config to check
  */
-export function getExistingSamTemplateResourcesForUri(launchConfig: LaunchConfiguration): Set<string> {
-    const existingSamTemplateTargets = getExistingSamTemplateTargets(launchConfig)
+export function getReferencedTemplateResources(launchConfig: LaunchConfiguration): Set<string> {
+    const existingSamTemplateTargets = getSamTemplateTargets(launchConfig)
     const folder = launchConfig.workspaceFolder
 
     return _(existingSamTemplateTargets)
@@ -132,8 +132,8 @@ export function getExistingSamTemplateResourcesForUri(launchConfig: LaunchConfig
  * (without workspaceFolder if the projectRoot is relative).
  * @param launchConfig Launch config to check
  */
-export function getExistingSamCodeConfigPaths(launchConfig: LaunchConfiguration): Set<string> {
-    const existingSamCodeTargets = getExistingSamCodeTargets(launchConfig)
+export function getReferencedHandlerPaths(launchConfig: LaunchConfiguration): Set<string> {
+    const existingSamCodeTargets = getSamCodeTargets(launchConfig)
 
     return _(existingSamCodeTargets)
         .map(target => {

--- a/src/test/shared/codelens/samTemplateCodeLensProvider.test.ts
+++ b/src/test/shared/codelens/samTemplateCodeLensProvider.test.ts
@@ -65,6 +65,12 @@ describe('SamTemplateCodeLensProvider', async () => {
         mockLaunchConfig = mock()
 
         when(mockDocument.uri).thenReturn(templateUri)
+        when(mockLaunchConfig.scopedResource).thenReturn(templateUri)
+        when(mockLaunchConfig.workspaceFolder).thenReturn({
+            uri: templateUri,
+            name: 'notAWorkspaceFolder',
+            index: 1,
+        })
         when(mockLaunchConfig.getSamDebugConfigurations()).thenReturn(debugConfigurations)
     })
 

--- a/src/test/shared/debug/launchConfiguration.test.ts
+++ b/src/test/shared/debug/launchConfiguration.test.ts
@@ -4,11 +4,18 @@
  */
 
 import * as assert from 'assert'
+import * as path from 'path'
 import { deepEqual, instance, mock, verify, when } from 'ts-mockito'
 import * as vscode from 'vscode'
-import { DebugConfigurationSource, LaunchConfiguration } from '../../../shared/debug/launchConfiguration'
+import {
+    DebugConfigurationSource,
+    LaunchConfiguration,
+    getExistingSamTemplateResourcesForUri,
+    getExistingSamCodeConfigPaths,
+} from '../../../shared/debug/launchConfiguration'
 import { AwsSamDebuggerConfiguration } from '../../../shared/sam/debugger/awsSamDebugConfiguration'
 import { AwsSamDebugConfigurationValidator } from '../../../shared/sam/debugger/awsSamDebugConfigurationValidator'
+import * as pathutils from '../../../shared/utilities/pathUtils'
 
 const samDebugConfiguration: AwsSamDebuggerConfiguration = {
     type: 'aws-sam',
@@ -21,16 +28,17 @@ const samDebugConfiguration: AwsSamDebuggerConfiguration = {
     },
 }
 
+function createMockSamDebugConfig(addons?: Partial<AwsSamDebuggerConfiguration>): AwsSamDebuggerConfiguration {
+    return {
+        ...samDebugConfiguration,
+        ...addons,
+    }
+}
+
 const debugConfigurations: vscode.DebugConfiguration[] = [
-    samDebugConfiguration,
-    {
-        ...samDebugConfiguration,
-        type: 'not-aws-sam',
-    },
-    {
-        ...samDebugConfiguration,
-        request: 'invalid-request',
-    },
+    createMockSamDebugConfig(),
+    createMockSamDebugConfig({ type: 'not-aws-sam' }),
+    createMockSamDebugConfig({ request: 'invalid-request' }),
 ]
 
 const templateUri = vscode.Uri.file('/template.yaml')
@@ -77,3 +85,146 @@ describe('LaunchConfiguration', () => {
         verify(mockConfigSource.setDebugConfigurations(deepEqual(expected))).once()
     })
 })
+
+describe('getExistingSamTemplateResourcesForUri', () => {
+    it('includes resources that are in the given template', () => {
+        const mockLaunchConfig = instance(createMockLaunchConfig())
+
+        const resultSet = getExistingSamTemplateResourcesForUri(mockLaunchConfig)
+        const workspaceFolder = mockLaunchConfig.workspaceFolder!.uri.fsPath
+
+        // relative and absolute path of the correct template.yaml file
+        assert.strictEqual(resultSet.has('absolutePathGoodTemplate'), true)
+        assert.strictEqual(resultSet.has('relativePathGoodTemplate'), true)
+        // default case: absolute pathed to root dir
+        assert.strictEqual(resultSet.has('resource'), false)
+        // relative and absolute paths to incorrect template.yaml file in correct dir
+        assert.strictEqual(resultSet.has('relativePathBadTemplate'), false)
+        assert.strictEqual(resultSet.has('absolutePathBadTemplate'), false)
+        // code type handlers, filtered out
+        assert.strictEqual(
+            resultSet.has(pathutils.normalize(path.resolve(workspaceFolder, 'inProject', 'relativeRoot'))),
+            false
+        )
+        assert.strictEqual(
+            resultSet.has(pathutils.normalize(path.resolve(workspaceFolder, 'inProject', 'absoluteRoot'))),
+            false
+        )
+        assert.strictEqual(
+            resultSet.has(pathutils.normalize(path.resolve(workspaceFolder, 'notInProject', 'relativeRoot'))),
+            false
+        )
+        assert.strictEqual(
+            resultSet.has(pathutils.normalize(path.resolve(workspaceFolder, 'notInProject', 'absoluteRoot'))),
+            false
+        )
+    })
+})
+
+describe('getExistingSamCodeConfigPaths', () => {
+    it('includes all resources as absolute paths to root dir + handlers', () => {
+        const mockLaunchConfig = instance(createMockLaunchConfig())
+
+        const resultSet = getExistingSamCodeConfigPaths(mockLaunchConfig)
+        const workspaceFolder = mockLaunchConfig.workspaceFolder!.uri.fsPath
+
+        //template type handlers, these are all false as we throw all of these out
+        assert.strictEqual(resultSet.has('resource'), false)
+        assert.strictEqual(resultSet.has('relativePathGoodTemplate'), false)
+        assert.strictEqual(resultSet.has('relativePathBadTemplate'), false)
+        assert.strictEqual(resultSet.has('absolutePathGoodTemplate'), false)
+        assert.strictEqual(resultSet.has('absolutePathBadTemplate'), false)
+        // code type handlers, these are all true as we keep all code-type handlers
+        assert.strictEqual(
+            resultSet.has(pathutils.normalize(path.resolve(workspaceFolder, 'inProject', 'relativeRoot'))),
+            true
+        )
+        assert.strictEqual(
+            resultSet.has(pathutils.normalize(path.resolve(workspaceFolder, 'inProject', 'absoluteRoot'))),
+            true
+        )
+        assert.strictEqual(
+            resultSet.has(pathutils.normalize(path.resolve(workspaceFolder, 'notInProject', 'differentRelativeRoot'))),
+            true
+        )
+        assert.strictEqual(
+            resultSet.has(pathutils.normalize(path.resolve(workspaceFolder, 'notInProject', 'differentAbsoluteRoot'))),
+            true
+        )
+    })
+})
+
+function createMockLaunchConfig(): LaunchConfiguration {
+    const workspaceFolder = path.resolve('absolutely', 'this', 'is', 'the', 'right', 'path')
+
+    // init mockLaunchConfig
+    const mockLaunchConfig: LaunchConfiguration = mock()
+    when(mockLaunchConfig.workspaceFolder).thenReturn({
+        uri: vscode.Uri.file(workspaceFolder),
+        name: 'mockAroundTheClock',
+        index: 1,
+    })
+    when(mockLaunchConfig.scopedResource).thenReturn(vscode.Uri.file(path.join(workspaceFolder, 'template.yaml')))
+    when(mockLaunchConfig.getSamDebugConfigurations()).thenReturn([
+        // default: template target with not-in-workspace, absolute-pathed samTemplatePath
+        createMockSamDebugConfig(),
+        createMockSamDebugConfig({
+            invokeTarget: {
+                target: 'template',
+                samTemplatePath: 'template.yaml',
+                samTemplateResource: 'relativePathGoodTemplate',
+            },
+        }),
+        createMockSamDebugConfig({
+            invokeTarget: {
+                target: 'template',
+                samTemplatePath: 'template2.yaml',
+                samTemplateResource: 'relativePathBadTemplate',
+            },
+        }),
+        createMockSamDebugConfig({
+            invokeTarget: {
+                target: 'template',
+                samTemplatePath: pathutils.normalize(path.resolve(workspaceFolder, 'template.yaml')),
+                samTemplateResource: 'absolutePathGoodTemplate',
+            },
+        }),
+        createMockSamDebugConfig({
+            invokeTarget: {
+                target: 'template',
+                samTemplatePath: pathutils.normalize(path.resolve(workspaceFolder, 'template2.yaml')),
+                samTemplateResource: 'absolutePathBadTemplate',
+            },
+        }),
+        createMockSamDebugConfig({
+            invokeTarget: {
+                target: 'code',
+                lambdaHandler: 'relativeRoot',
+                projectRoot: 'inProject',
+            },
+        }),
+        createMockSamDebugConfig({
+            invokeTarget: {
+                target: 'code',
+                lambdaHandler: 'differentRelativeRoot',
+                projectRoot: 'notInProject',
+            },
+        }),
+        createMockSamDebugConfig({
+            invokeTarget: {
+                target: 'code',
+                lambdaHandler: 'absoluteRoot',
+                projectRoot: pathutils.normalize(path.resolve(workspaceFolder, 'inProject')),
+            },
+        }),
+        createMockSamDebugConfig({
+            invokeTarget: {
+                target: 'code',
+                lambdaHandler: 'differentAbsoluteRoot',
+                projectRoot: pathutils.normalize(path.resolve(workspaceFolder, 'notInProject')),
+            },
+        }),
+    ])
+
+    return mockLaunchConfig
+}

--- a/src/test/shared/debug/launchConfiguration.test.ts
+++ b/src/test/shared/debug/launchConfiguration.test.ts
@@ -10,8 +10,8 @@ import * as vscode from 'vscode'
 import {
     DebugConfigurationSource,
     LaunchConfiguration,
-    getExistingSamTemplateResourcesForUri,
-    getExistingSamCodeConfigPaths,
+    getReferencedTemplateResources,
+    getReferencedHandlerPaths,
 } from '../../../shared/debug/launchConfiguration'
 import { AwsSamDebuggerConfiguration } from '../../../shared/sam/debugger/awsSamDebugConfiguration'
 import { AwsSamDebugConfigurationValidator } from '../../../shared/sam/debugger/awsSamDebugConfigurationValidator'
@@ -86,11 +86,11 @@ describe('LaunchConfiguration', () => {
     })
 })
 
-describe('getExistingSamTemplateResourcesForUri', () => {
+describe('getReferencedTemplateResources', () => {
     it('includes resources that are in the given template', () => {
         const mockLaunchConfig = instance(createMockLaunchConfig())
 
-        const resultSet = getExistingSamTemplateResourcesForUri(mockLaunchConfig)
+        const resultSet = getReferencedTemplateResources(mockLaunchConfig)
         const workspaceFolder = mockLaunchConfig.workspaceFolder!.uri.fsPath
 
         // relative and absolute path of the correct template.yaml file
@@ -121,11 +121,11 @@ describe('getExistingSamTemplateResourcesForUri', () => {
     })
 })
 
-describe('getExistingSamCodeConfigPaths', () => {
+describe('getReferencedHandlerPaths', () => {
     it('includes all resources as absolute paths to root dir + handlers', () => {
         const mockLaunchConfig = instance(createMockLaunchConfig())
 
-        const resultSet = getExistingSamCodeConfigPaths(mockLaunchConfig)
+        const resultSet = getReferencedHandlerPaths(mockLaunchConfig)
         const workspaceFolder = mockLaunchConfig.workspaceFolder!.uri.fsPath
 
         //template type handlers, these are all false as we throw all of these out


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

"Add Debug Configuration" codelenses in source files used to draw at all times if they met the criteria for codelenses. This change mimics the template.yaml approach which hides the codelenses if a configuration already exists for the file in question.

## Motivation and Context

Gave users mixed feedback since templates and source files worked differently.

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
