### PR TITLE
localLambdaRunner.test.ts: avoid ExtensionDisposableFiles.initialize()

### DIFF
--- a/src/test/fakeExtensionContext.ts
+++ b/src/test/fakeExtensionContext.ts
@@ -4,6 +4,7 @@
  */
 
 import { ExtensionContext, Memento } from 'vscode'
+import { ExtensionDisposableFiles } from '../shared/utilities/disposableFiles'
 
 export interface FakeMementoStorage {
     [key: string]: any
@@ -42,6 +43,22 @@ export class FakeExtensionContext implements ExtensionContext {
 
     public asAbsolutePath(relativePath: string): string {
         return relativePath
+    }
+
+    /**
+     * Creates a fake `vscode.ExtensionContext` for use in tests.
+     *
+     *  Disposes any existing `ExtensionDisposableFiles` and creates a new one
+     *  with the new `ExtContext`.
+     */
+    public static async getNew(): Promise<FakeExtensionContext> {
+        const ctx = new FakeExtensionContext()
+        try {
+            ExtensionDisposableFiles.getInstance().dispose()
+        } catch {
+            await ExtensionDisposableFiles.initialize(ctx)
+        }
+        return ctx
     }
 }
 

--- a/src/test/shared/codelens/localLambdaRunner.test.ts
+++ b/src/test/shared/codelens/localLambdaRunner.test.ts
@@ -12,7 +12,6 @@ import { DebugConfiguration } from '../../../lambda/local/debugConfiguration'
 import * as localLambdaRunner from '../../../shared/codelens/localLambdaRunner'
 import * as fsUtils from '../../../shared/filesystemUtilities'
 import { ChildProcessResult } from '../../../shared/utilities/childProcess'
-import { ExtensionDisposableFiles } from '../../../shared/utilities/disposableFiles'
 import { FakeExtensionContext } from '../../fakeExtensionContext'
 import { FakeChannelLogger } from '../fakeChannelLogger'
 import { assertRejects } from '../utilities/assertUtils'
@@ -20,7 +19,7 @@ import { assertRejects } from '../utilities/assertUtils'
 describe('localLambdaRunner', async () => {
     let tempDir: string
     before(async () => {
-        await ExtensionDisposableFiles.initialize(new FakeExtensionContext())
+        await FakeExtensionContext.getNew()
     })
 
     beforeEach(async () => {


### PR DESCRIPTION
Use FakeExtensionContext.getNew() instead, which forces re-initialization of ExtensionDisposableFiles and avoids an exception if it was already initialized.

ref: https://github.com/aws/aws-toolkit-vscode/pull/1097/files#r435476880

Other tests may call ExtensionDisposableFiles.initialize(), which causes an error (all tests run in the same process):

    Error: ExtensionDisposableFiles already initialized
        at Function.<anonymous> (dist/src/shared/utilities/disposableFiles.js:9:4556)
        at Generator.next (<anonymous>)
        at /codebuild/output/src753373494/src/github.com/aws/aws-toolkit-vscode/dist/src/shared/utilities/disposableFiles.js:9:1746
        at new Promise (<anonymous>)
        at __awaiter (dist/src/shared/utilities/disposableFiles.js:9:662)
        at Function.initialize (dist/src/shared/utilities/disposableFiles.js:9:4311)
        at /codebuild/output/src753373494/src/github.com/aws/aws-toolkit-vscode/src/test/shared/codelens/localLambdaRunner.test.ts:23:40
        at Generator.next (<anonymous>)
        at /codebuild/output/src753373494/src/github.com/aws/aws-toolkit-vscode/dist/src/test/shared/codelens/localLambdaRunner.test.js:12:71
        at new Promise (<anonymous>)
        at __awaiter (dist/src/test/shared/codelens/localLambdaRunner.test.js:8:12)
        at Context.<anonymous> (src/test/shared/codelens/localLambdaRunner.test.ts:22:23)
        at processImmediate (internal/timers.js:439:21)
        at process.topLevelDomainCallback (domain.js:131:23)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
