### PR TITLE
Add Toolkit Initialization metric

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
     "requires": true,
     "dependencies": {
         "@aws-toolkits/telemetry": {
-            "version": "0.0.20",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-0.0.20.tgz",
-            "integrity": "sha512-hFIOsXcFaoaNFv3qKH8H70n8R+kFyOJWlgN05aFe7wf7PhkEFALZyVGQjQzDbsSbjPZL2Yk3lGKoM47o+XIG/A==",
+            "version": "0.0.30",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-0.0.30.tgz",
+            "integrity": "sha512-F07BHqPWgB5Q1gZbIJup3v8j3d07ke4Gchhiu2M64KGgBy/fZNOypHRygjyzsgWfXM92nAXUvZm3cGvGz/HNKQ==",
             "dev": true,
             "requires": {
                 "ajv": "^6.10.2",

--- a/package.json
+++ b/package.json
@@ -858,7 +858,7 @@
         "createRelease": "ts-node ./build-scripts/createRelease.ts"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "0.0.20",
+        "@aws-toolkits/telemetry": "0.0.30",
         "@types/adm-zip": "^0.4.32",
         "@types/async-lock": "^1.1.0",
         "@types/cross-spawn": "^6.0.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,6 +50,7 @@ import {
     recordAwsHelpQuickstart,
     recordAwsReportPluginIssue,
     recordAwsShowExtensionSource,
+    recordToolkitInit,
 } from './shared/telemetry/telemetry'
 import { ExtensionDisposableFiles } from './shared/utilities/disposableFiles'
 import { getChannelLogger } from './shared/utilities/vsCodeUtils'
@@ -58,6 +59,8 @@ import { activate as activateStepFunctions } from './stepFunctions/activation'
 let localize: nls.LocalizeFunc
 
 export async function activate(context: vscode.ExtensionContext) {
+    const activationStartedOn = Date.now()
+
     localize = nls.loadMessageBundle()
 
     ext.context = context
@@ -198,6 +201,8 @@ export async function activate(context: vscode.ExtensionContext) {
         const channelLogger = getChannelLogger(toolkitOutputChannel)
         channelLogger.error('AWS.channel.aws.toolkit.activation.error', 'Error Activating AWS Toolkit', error as Error)
         throw error
+    } finally {
+        recordToolkitInitialization(activationStartedOn)
     }
 }
 
@@ -260,6 +265,19 @@ function makeEndpointsProvider(): EndpointsProvider {
     })
 
     return provider
+}
+
+function recordToolkitInitialization(activationStartedOn: number) {
+    try {
+        const activationFinishedOn = Date.now()
+        const duration = Math.abs(activationFinishedOn - activationStartedOn)
+
+        recordToolkitInit({
+            duration: duration,
+        })
+    } catch (err) {
+        getLogger().error(err)
+    }
 }
 
 // Unique extension entrypoint names, so that they can be obtained from the webpack bundle

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,7 +35,7 @@ import {
     showQuickStartWebview,
     toastNewUser,
 } from './shared/extensionUtilities'
-import { getLogger } from './shared/logger'
+import { getLogger, Logger } from './shared/logger'
 import { activate as activateLogger } from './shared/logger/activation'
 import { DefaultRegionProvider } from './shared/regions/defaultRegionProvider'
 import { EndpointsProvider } from './shared/regions/endpointsProvider'
@@ -197,12 +197,12 @@ export async function activate(context: vscode.ExtensionContext) {
         toastNewUser(context)
 
         await loginWithMostRecentCredentials(toolkitSettings, loginManager)
+
+        recordToolkitInitialization(activationStartedOn, getLogger())
     } catch (error) {
         const channelLogger = getChannelLogger(toolkitOutputChannel)
         channelLogger.error('AWS.channel.aws.toolkit.activation.error', 'Error Activating AWS Toolkit', error as Error)
         throw error
-    } finally {
-        recordToolkitInitialization(activationStartedOn)
     }
 }
 
@@ -267,7 +267,7 @@ function makeEndpointsProvider(): EndpointsProvider {
     return provider
 }
 
-function recordToolkitInitialization(activationStartedOn: number) {
+function recordToolkitInitialization(activationStartedOn: number, logger?: Logger) {
     try {
         const activationFinishedOn = Date.now()
         const duration = Math.abs(activationFinishedOn - activationStartedOn)
@@ -276,7 +276,7 @@ function recordToolkitInitialization(activationStartedOn: number) {
             duration: duration,
         })
     } catch (err) {
-        getLogger().error(err)
+        logger?.error(err)
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -270,7 +270,7 @@ function makeEndpointsProvider(): EndpointsProvider {
 function recordToolkitInitialization(activationStartedOn: number, logger?: Logger) {
     try {
         const activationFinishedOn = Date.now()
-        const duration = Math.abs(activationFinishedOn - activationStartedOn)
+        const duration = activationFinishedOn - activationStartedOn
 
         recordToolkitInit({
             duration: duration,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Emit a metric indicating how long the toolkit takes to activate. This helps us find out the current performance, and long term try to drive it down below 250ms (per guidance from the VS Code team)

Here is a sample of the metrics that are emitted:
![image](https://user-images.githubusercontent.com/39839589/83926457-b4b82780-a73e-11ea-8615-74512f0dfc2d.png)


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
