### PR TITLE
SAM debugconfig: fix placement of .vsdbg

### DIFF
--- a/src/shared/sam/debugger/csharpSamDebug.ts
+++ b/src/shared/sam/debugger/csharpSamDebug.ts
@@ -33,10 +33,10 @@ export async function makeCsharpConfig(config: SamLaunchRequestArgs): Promise<Sa
         throw Error('invalid state: config.baseBuildDir was not set')
     }
     config.codeRoot = getCodeRoot(config.workspaceFolder, config)!
-
     config.samTemplatePath = await makeInputTemplate(config)
-    // XXX: reassignment...
+    // TODO: avoid the reassignment
     // TODO: walk the tree to find .sln, .csproj ?
+    const originalCodeRoot = config.codeRoot
     config.codeRoot = getSamProjectDirPathForFile(config.samTemplatePath)
 
     config = {
@@ -48,7 +48,7 @@ export async function makeCsharpConfig(config: SamLaunchRequestArgs): Promise<Sa
     }
 
     if (!config.noDebug) {
-        config = await makeCoreCLRDebugConfiguration(config, config.codeRoot)
+        config = await makeCoreCLRDebugConfiguration(config, originalCodeRoot)
     }
 
     return config
@@ -152,7 +152,7 @@ export async function makeCoreCLRDebugConfiguration(
     }
     config.debugPort = config.debugPort ?? (await getStartPort())
     const pipeArgs = ['-c', `docker exec -i $(docker ps -q -f publish=${config.debugPort}) \${debuggerCommand}`]
-    config.debuggerPath = pathutil.normalize(getDebuggerPath(config.codeRoot))
+    config.debuggerPath = pathutil.normalize(getDebuggerPath(codeUri))
     await ensureDebuggerPathExists(config.debuggerPath)
 
     if (os.platform() === 'win32') {

--- a/src/test/shared/sam/cli/samCliBuild.test.ts
+++ b/src/test/shared/sam/cli/samCliBuild.test.ts
@@ -59,10 +59,17 @@ describe('SamCliBuildInvocation', async () => {
         await del([tempFolder], { force: true })
     })
 
-    it('Passes build command to sam cli', async () => {
+    it('invokes `sam build` with args', async () => {
         const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker((args: any[]) => {
-            assert.ok(args.length > 0, 'Expected args to be present')
-            assert.strictEqual(args[0], 'build', 'Expected first arg to be the build command')
+            assert.ok(args.length >= 2, 'Expected args to be present')
+            assert.strictEqual(args[0], 'build')
+            assert.strictEqual(args[3], '--template')
+            assert.strictEqual(args[5], '--base-dir')
+
+            // `extraArgs` are appended to the end.
+            assert.strictEqual(args[7], '--debug')
+            assert.strictEqual(args[8], '--build-dir')
+            assert.strictEqual(args[9], 'my/build/dir/')
         })
 
         await new SamCliBuildInvocation({
@@ -70,6 +77,7 @@ describe('SamCliBuildInvocation', async () => {
             baseDir: nonRelevantArg,
             templatePath: placeholderTemplateFile,
             invoker: processInvoker,
+            extraArgs: ['--debug', '--build-dir', 'my/build/dir/'],
         }).execute()
     })
 

--- a/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
+++ b/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
@@ -41,12 +41,20 @@ describe('SamCliLocalInvokeInvocation', async () => {
         await del([tempFolder], { force: true })
     })
 
-    it('Passes local invoke command to sam cli', async () => {
+    it('invokes `sam local` with args', async () => {
         const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
             (invokeArgs: SamLocalInvokeCommandArgs) => {
                 assert.ok(invokeArgs.args.length >= 2, 'Expected args to be present')
-                assert.strictEqual(invokeArgs.args[0], 'local', 'Expected first arg to be local')
-                assert.strictEqual(invokeArgs.args[1], 'invoke', 'Expected second arg to be invoke')
+                assert.strictEqual(invokeArgs.args[0], 'local')
+                assert.strictEqual(invokeArgs.args[1], 'invoke')
+                assert.strictEqual(invokeArgs.args[3], '--template')
+                assert.strictEqual(invokeArgs.args[5], '--event')
+                assert.strictEqual(invokeArgs.args[7], '--env-vars')
+
+                // `extraArgs` are appended to the end.
+                assert.strictEqual(invokeArgs.args[9], '--debug')
+                assert.strictEqual(invokeArgs.args[10], '--build-dir')
+                assert.strictEqual(invokeArgs.args[11], 'my/build/dir/')
             }
         )
 
@@ -56,6 +64,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
             eventPath: placeholderEventFile,
             environmentVariablePath: nonRelevantArg,
             invoker: taskInvoker,
+            extraArgs: ['--debug', '--build-dir', 'my/build/dir/'],
         }).execute()
     })
 

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -572,6 +572,7 @@ describe('AwsSamDebugConfigurationProvider', async () => {
                 folder,
                 input
             ))! as DotNetCoreDebugConfiguration
+            const codeRoot = `${appDir}${input.invokeTarget.projectRoot}`
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
             const expected: SamLaunchRequestArgs = {
                 request: 'attach', // Input "direct-invoke", output "attach".
@@ -603,24 +604,24 @@ describe('AwsSamDebugConfigurationProvider', async () => {
                 //
                 // Csharp-related fields
                 //
-                debuggerPath: expectedCodeRoot + '/.vsdbg', // Normalized to absolute path.
+                debuggerPath: codeRoot + '/.vsdbg', // Normalized to absolute path.
                 processId: '1',
                 pipeTransport: {
                     debuggerPath: '/tmp/lambci_debug_files/vsdbg',
                     // tslint:disable-next-line: no-invalid-template-strings
                     pipeArgs: ['-c', 'docker exec -i $(docker ps -q -f publish=5858) ${debuggerCommand}'],
-                    pipeCwd: expectedCodeRoot,
+                    pipeCwd: codeRoot,
                     pipeProgram: 'sh',
                 },
                 sourceFileMap: {
-                    '/var/task': expectedCodeRoot,
+                    '/var/task': codeRoot,
                 },
                 windows: {
                     pipeTransport: {
                         debuggerPath: '/tmp/lambci_debug_files/vsdbg',
                         // tslint:disable-next-line: no-invalid-template-strings
                         pipeArgs: ['-c', 'docker exec -i $(docker ps -q -f publish=5858) ${debuggerCommand}'],
-                        pipeCwd: expectedCodeRoot,
+                        pipeCwd: codeRoot,
                         pipeProgram: 'powershell',
                     },
                 },
@@ -710,6 +711,7 @@ describe('AwsSamDebugConfigurationProvider', async () => {
                 folder,
                 input
             ))! as DotNetCoreDebugConfiguration
+            const codeRoot = `${appDir}/src/HelloWorld`
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
             const expected: SamLaunchRequestArgs = {
                 request: 'attach', // Input "direct-invoke", output "attach".
@@ -738,24 +740,24 @@ describe('AwsSamDebugConfigurationProvider', async () => {
                 //
                 // Csharp-related fields
                 //
-                debuggerPath: expectedCodeRoot + '/.vsdbg', // Normalized to absolute path.
+                debuggerPath: codeRoot + '/.vsdbg', // Normalized to absolute path.
                 processId: '1',
                 pipeTransport: {
                     debuggerPath: '/tmp/lambci_debug_files/vsdbg',
                     // tslint:disable-next-line: no-invalid-template-strings
                     pipeArgs: ['-c', 'docker exec -i $(docker ps -q -f publish=5858) ${debuggerCommand}'],
-                    pipeCwd: expectedCodeRoot,
+                    pipeCwd: codeRoot,
                     pipeProgram: 'sh',
                 },
                 sourceFileMap: {
-                    '/var/task': expectedCodeRoot,
+                    '/var/task': codeRoot,
                 },
                 windows: {
                     pipeTransport: {
                         debuggerPath: '/tmp/lambci_debug_files/vsdbg',
                         // tslint:disable-next-line: no-invalid-template-strings
                         pipeArgs: ['-c', 'docker exec -i $(docker ps -q -f publish=5858) ${debuggerCommand}'],
-                        pipeCwd: expectedCodeRoot,
+                        pipeCwd: codeRoot,
                         pipeProgram: 'powershell',
                     },
                 },


### PR DESCRIPTION
- fix placement of `.vsdbg` (dotnet debugger)
- add some explicit test coverage of `sam.localArguments` `sam.buildArguments` (see d0963c9)



## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
