### PR TITLE
SAM debugconfig: default to stopOnEntry=false

### DIFF
--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -75,6 +75,8 @@ export async function makeTypescriptConfig(config: SamLaunchRequestArgs): Promis
         localRoot: config.codeRoot,
         remoteRoot: '/var/task',
         protocol: 'inspector',
+        // Stop at first user breakpoint, not the runtime bootstrap file.
+        stopOnEntry: config.stopOnEntry === undefined ? false : !!config.stopOnEntry,
         skipFiles: ['/var/runtime/node_modules/**/*.js', '<node_internals>/**/*.js'],
     }
 

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -386,6 +386,7 @@ describe('SamDebugConfigurationProvider', async () => {
                 protocol: 'inspector',
                 remoteRoot: '/var/task',
                 skipFiles: ['/var/runtime/node_modules/**/*.js', '<node_internals>/**/*.js'],
+                stopOnEntry: false,
             }
 
             assertEqualLaunchConfigs(actual, expected, appDir)
@@ -503,6 +504,7 @@ describe('SamDebugConfigurationProvider', async () => {
                 protocol: 'inspector',
                 remoteRoot: '/var/task',
                 skipFiles: ['/var/runtime/node_modules/**/*.js', '<node_internals>/**/*.js'],
+                stopOnEntry: false,
             }
 
             assertEqualLaunchConfigs(actual, expected, appDir)
@@ -1126,6 +1128,7 @@ Globals:
                 runtime: 'nodejs12.x',
                 runtimeFamily: lambdaModel.RuntimeFamily.NodeJS,
                 skipFiles: ['/var/runtime/node_modules/**/*.js', '<node_internals>/**/*.js'],
+                stopOnEntry: false,
             }
 
             assertEqualLaunchConfigs(actual, expected, appDir)


### PR DESCRIPTION
Before: debugging stops at line 1 of the runtime bootstrap file; user must explicitly "Continue" to proceed with debugging.

After: debugging does not stop until a user breakpoint is hit.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
