### PR TITLE
SAM debugconfig: look for workspace folder

### DIFF
--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -216,6 +216,8 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         if (token?.isCancellationRequested) {
             return undefined
         }
+        folder =
+            folder ?? (vscode.workspace.workspaceFolders?.length ? vscode.workspace.workspaceFolders[0] : undefined)
         if (!folder) {
             getLogger().error(`SAM debug: no workspace folder`)
             vscode.window.showErrorMessage(


### PR DESCRIPTION
### Problem:
> [ERROR]: SAM debug: no workspace folder

### Analysis:
If vscode workspace file exists (example: `.vscode/Untitled.code-workspace`) then:
- vscode adds configs to it instead of `.vscode/launch.json`.
- `folder` is undefined when VSCode invokes `resolveDebugConfiguration()`.
- Workspace folders are available via `vscode.workspace.workspaceFolders[x]`.

### Solution:
- If `folder` is undefined and `vscode.workspace.workspaceFolders.length === 1`,  then use `vscode.workspace.workspaceFolders[0]`.
- NB: If `vscode.workspace.workspaceFolders.length > 1`, VSCode appears to  choose one, and thus `folder` is _not_ undefined when  `resolveDebugConfiguration()` is invoked.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
