### PR TITLE
Gsweet/remove default sentiment

### DIFF
--- a/media/js/submitFeedbackVue.js
+++ b/media/js/submitFeedbackVue.js
@@ -5,9 +5,9 @@ console.log('Loaded!')
         el: '#app',
         data: {
             comment: '',
-            sentiment: 'Positive',
+            sentiment: '',
             isSubmitting: false,
-            error: ''
+            error: '',
         },
         mounted() {
             this.$nextTick(function() {
@@ -32,9 +32,9 @@ console.log('Loaded!')
                 vscode.postMessage({
                     command: 'submitFeedback',
                     comment: this.comment,
-                    sentiment: this.sentiment
+                    sentiment: this.sentiment,
                 })
-            }
-        }
+            },
+        },
     })
 })()

--- a/src/feedback/templates/feedbackTemplates.ts
+++ b/src/feedback/templates/feedbackTemplates.ts
@@ -30,7 +30,7 @@ export class FeedbackTemplates {
         <a href="https://github.com/aws/aws-toolkit-vscode/issues/new/choose">Talk to us on GitHub instead!</a></p>
 
         <input v-if="isSubmitting" type="submit" value="Submitting..." disabled>
-        <input v-else type="submit" @click="submitFeedback" :disabled="comment.length === 0 || comment.length > 2000" value="Submit">
+        <input v-else type="submit" @click="submitFeedback" :disabled="comment.length === 0 || comment.length > 2000  || sentiment === ''" value="Submit">
 
         <div id="error" v-if="error !== ''">
             <strong>{{ error }}</strong>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Removed the default for quick feedback (was 'Positive').  Now user must select happy or sad face before submitting.

## Motivation and Context

Default was Positive.  It was possible users did not know/forgot to change sentiment.  Now its mandatory for the user to choose.


## Testing
All tests pass.
Verified correct sentiments sent to SIM.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
