### PR TITLE
samCliLocalInvoke.ts: fix environment spec

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -316,7 +316,7 @@
     "AWS.samcli.error.notFound.brief": "Failed to get SAM CLI location",
     "AWS.samcli.error.invalid_schema_support_version": "Installed SAM executable does not support templates that require Event Schema selection. Required minimum version {0}, but found {1}",
     "AWS.samcli.local.invoke.ended": "Local invoke of SAM Application has ended.",
-    "AWS.samcli.local.invoke.error": "Error encountered running local SAM Application",
+    "AWS.samcli.local.invoke.error": "Error running local SAM Application: {0}",
     "AWS.samcli.local.invoke.port.not.open": "The debug port doesn't appear to be open. The debugger might not succeed when attaching to your SAM Application.",
     "AWS.samcli.local.invoke.runtime.unsupported": "Unsupported {0} runtime: {1}",
     "AWS.samcli.local.invoke.debugger.install": "Installing .NET Core Debugger to {0}...",

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -96,7 +96,7 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
                 onError: (error: Error): void => {
                     this.channelLogger.error(
                         'AWS.samcli.local.invoke.error',
-                        'Error encountered running local SAM Application',
+                        'Error running local SAM Application: {0}',
                         error
                     )
                     debuggerPromiseClosed = true

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -217,7 +217,10 @@ export class SamCliLocalInvokeInvocation {
 
         await this.args.invoker.invoke({
             options: {
-                env: this.args.environmentVariables,
+                env: {
+                    ...process.env,
+                    ...this.args.environmentVariables,
+                },
             },
             command: 'sam',
             args: invokeArgs,

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -154,6 +154,7 @@ export async function invokeLambdaFunction(
     if (!config.noDebug) {
         // Needed at least for dotnet case; harmless for others.
         samCliArgs.environmentVariables = {
+            ...samCliArgs.environmentVariables,
             SAM_BUILD_MODE: 'debug',
         }
     }

--- a/src/shared/utilities/childProcess.ts
+++ b/src/shared/utilities/childProcess.ts
@@ -73,6 +73,12 @@ export class ChildProcess {
         }
 
         getLogger().info(`Running command: ${this.process} ${this.args.join(' ')}`)
+
+        // Async.
+        // See also crossSpawn.spawnSync().
+        // Arguments are forwarded[1] to node `child_process` module, see its documentation[2].
+        // [1] https://github.com/moxystudio/node-cross-spawn/blob/master/index.js
+        // [2] https://nodejs.org/api/child_process.html
         this.childProcess = crossSpawn(this.process, this.args, this.options)
 
         this.childProcess.stdout?.on('data', (data: { toString(): string }) => {


### PR DESCRIPTION
Problem: ENOENT error during the "sam invoke" step when attempting to
debug, which causes SAM debug to fail:

> ```
> Building SAM Application...
> Build complete.
> Starting the SAM Application locally (see Terminal for output)
> Running command: sam local invoke awsToolkitSamLocalResource --template /tmp/aws-toolkit-vscode/vsctk7JaaJI/output/template.yaml --event /tmp/aws-toolkit-vscode/vsctk7JaaJI/event.json --env-vars /tmp/aws-toolkit-vscode/vsctk7JaaJI/env-vars.json -d 5883
> Error running local SAM Application: spawn sam ENOENT
> Waiting for SAM Application to start before attaching debugger...
> Local invoke of SAM Application has ended.
> ```

Solution: When setting env vars one must also copy the current environment, else it is discarded.


- ref https://github.com/aws/aws-toolkit-vscode/pull/1145

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
