### PR TITLE
Add fakes for tracking and "clicking" buttons shown in messages

### DIFF
--- a/src/shared/vscode/window.ts
+++ b/src/shared/vscode/window.ts
@@ -103,52 +103,16 @@ class DefaultWindow implements Window {
         return vscode.window.showInputBox(options, token)
     }
 
-    public showInformationMessage(message: string, ...items: string[]): Thenable<string | undefined>
-    public showInformationMessage(
-        message: string,
-        options: vscode.MessageOptions,
-        ...items: string[]
-    ): Thenable<string | undefined>
-    public showInformationMessage<T extends vscode.MessageItem>(message: string, ...items: T[]): Thenable<T | undefined>
-    public showInformationMessage<T extends vscode.MessageItem>(
-        message: string,
-        options: vscode.MessageOptions,
-        ...items: T[]
-    ): Thenable<T | undefined>
     public showInformationMessage(...args: any[]): Thenable<any | undefined> {
         // @ts-ignore
         return vscode.window.showInformationMessage(...args)
     }
 
-    public showWarningMessage(message: string, ...items: string[]): Thenable<string | undefined>
-    public showWarningMessage(
-        message: string,
-        options: vscode.MessageOptions,
-        ...items: string[]
-    ): Thenable<string | undefined>
-    public showWarningMessage<T extends vscode.MessageItem>(message: string, ...items: T[]): Thenable<T | undefined>
-    public showWarningMessage<T extends vscode.MessageItem>(
-        message: string,
-        options: vscode.MessageOptions,
-        ...items: T[]
-    ): Thenable<T | undefined>
     public showWarningMessage(...args: any[]): Thenable<any | undefined> {
         // @ts-ignore
         return vscode.window.showWarningMessage(...args)
     }
 
-    public showErrorMessage(message: string, ...items: string[]): Thenable<string | undefined>
-    public showErrorMessage(
-        message: string,
-        options: vscode.MessageOptions,
-        ...items: string[]
-    ): Thenable<string | undefined>
-    public showErrorMessage<T extends vscode.MessageItem>(message: string, ...items: T[]): Thenable<T | undefined>
-    public showErrorMessage<T extends vscode.MessageItem>(
-        message: string,
-        options: vscode.MessageOptions,
-        ...items: T[]
-    ): Thenable<T | undefined>
     public showErrorMessage(...args: any[]): Thenable<any | undefined> {
         // @ts-ignore
         return vscode.window.showErrorMessage(...args)

--- a/src/shared/vscode/window.ts
+++ b/src/shared/vscode/window.ts
@@ -23,16 +23,45 @@ export interface Window {
      * See {@link module:vscode.window.showInformationMessage}.
      */
     showInformationMessage(message: string, ...items: string[]): Thenable<string | undefined>
+    showInformationMessage(
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: string[]
+    ): Thenable<string | undefined>
+    showInformationMessage<T extends vscode.MessageItem>(message: string, ...items: T[]): Thenable<T | undefined>
+    showInformationMessage<T extends vscode.MessageItem>(
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: T[]
+    ): Thenable<T | undefined>
 
     /**
      * See {@link module:vscode.window.showWarningMessage}.
      */
     showWarningMessage(message: string, ...items: string[]): Thenable<string | undefined>
+    showWarningMessage(
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: string[]
+    ): Thenable<string | undefined>
+    showWarningMessage<T extends vscode.MessageItem>(message: string, ...items: T[]): Thenable<T | undefined>
+    showWarningMessage<T extends vscode.MessageItem>(
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: T[]
+    ): Thenable<T | undefined>
 
     /**
      * See {@link module:vscode.window.showErrorMessage}.
      */
     showErrorMessage(message: string, ...items: string[]): Thenable<string | undefined>
+    showErrorMessage(message: string, options: vscode.MessageOptions, ...items: string[]): Thenable<string | undefined>
+    showErrorMessage<T extends vscode.MessageItem>(message: string, ...items: T[]): Thenable<T | undefined>
+    showErrorMessage<T extends vscode.MessageItem>(
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: T[]
+    ): Thenable<T | undefined>
 
     /**
      * See {@link module:vscode.window.withProgress}.
@@ -74,16 +103,55 @@ class DefaultWindow implements Window {
         return vscode.window.showInputBox(options, token)
     }
 
-    public showInformationMessage(message: string, ...items: string[]): Thenable<string | undefined> {
-        return vscode.window.showInformationMessage(message, ...items)
+    public showInformationMessage(message: string, ...items: string[]): Thenable<string | undefined>
+    public showInformationMessage(
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: string[]
+    ): Thenable<string | undefined>
+    public showInformationMessage<T extends vscode.MessageItem>(message: string, ...items: T[]): Thenable<T | undefined>
+    public showInformationMessage<T extends vscode.MessageItem>(
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: T[]
+    ): Thenable<T | undefined>
+    public showInformationMessage(...args: any[]): Thenable<any | undefined> {
+        // @ts-ignore
+        return vscode.window.showInformationMessage(...args)
     }
 
-    public showWarningMessage(message: string, ...items: string[]): Thenable<string | undefined> {
-        return vscode.window.showWarningMessage(message, ...items)
+    public showWarningMessage(message: string, ...items: string[]): Thenable<string | undefined>
+    public showWarningMessage(
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: string[]
+    ): Thenable<string | undefined>
+    public showWarningMessage<T extends vscode.MessageItem>(message: string, ...items: T[]): Thenable<T | undefined>
+    public showWarningMessage<T extends vscode.MessageItem>(
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: T[]
+    ): Thenable<T | undefined>
+    public showWarningMessage(...args: any[]): Thenable<any | undefined> {
+        // @ts-ignore
+        return vscode.window.showWarningMessage(...args)
     }
 
-    public showErrorMessage(message: string, ...items: string[]): Thenable<string | undefined> {
-        return vscode.window.showErrorMessage(message, ...items)
+    public showErrorMessage(message: string, ...items: string[]): Thenable<string | undefined>
+    public showErrorMessage(
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: string[]
+    ): Thenable<string | undefined>
+    public showErrorMessage<T extends vscode.MessageItem>(message: string, ...items: T[]): Thenable<T | undefined>
+    public showErrorMessage<T extends vscode.MessageItem>(
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: T[]
+    ): Thenable<T | undefined>
+    public showErrorMessage(...args: any[]): Thenable<any | undefined> {
+        // @ts-ignore
+        return vscode.window.showErrorMessage(...args)
     }
 
     public withProgress<R>(

--- a/src/test/lambda/commands/deleteLambda.test.ts
+++ b/src/test/lambda/commands/deleteLambda.test.ts
@@ -59,7 +59,7 @@ describe('deleteLambda', async () => {
             expectedRefreshCallCount: 1,
             onAssertOutputChannel(outputChannel: MockOutputChannel) {
                 const expectedMessagePart = String(errorToThrowDuringDelete)
-                assert(!outputChannel.isHidden, 'output channel should not be hidden after error')
+                assert(outputChannel.isShown, 'output channel should be shown after error')
                 assert(
                     outputChannel.value && outputChannel.value.indexOf(expectedMessagePart) > 0,
                     `output channel should contain "${expectedMessagePart}"`

--- a/src/test/mockOutputChannel.ts
+++ b/src/test/mockOutputChannel.ts
@@ -6,9 +6,9 @@
 import * as vscode from 'vscode'
 
 export class MockOutputChannel implements vscode.OutputChannel {
-    public value: string = ''
-    public isHidden: boolean = false
-    public preserveFocus: boolean = false
+    private _value: string = ''
+    private _isShown: boolean = false
+    private _isFocused: boolean = false
 
     public readonly name = 'Mock channel'
 
@@ -19,7 +19,7 @@ export class MockOutputChannel implements vscode.OutputChannel {
     }
 
     public append(value: string): void {
-        this.value += value
+        this._value += value
         this.onDidAppendTextEmitter.fire(value)
     }
 
@@ -28,15 +28,27 @@ export class MockOutputChannel implements vscode.OutputChannel {
     }
 
     public clear(): void {
-        this.value = ''
+        this._value = ''
     }
 
     public dispose(): void {
-        this.value = ''
+        this._value = ''
     }
 
     public hide(): void {
-        this.isHidden = true
+        this._isShown = false
+    }
+
+    public get value(): string {
+        return this._value
+    }
+
+    public get isShown(): boolean {
+        return this._isShown
+    }
+
+    public get isFocused(): boolean {
+        return this._isFocused
     }
 
     /**
@@ -44,11 +56,14 @@ export class MockOutputChannel implements vscode.OutputChannel {
      * show(preserveFocus?: boolean) is really what we should consider.
      */
     public show(columnOrPreserveFocus?: vscode.ViewColumn | boolean, preserveFocus?: boolean): void {
+        this._isShown = true
+
         if (typeof columnOrPreserveFocus === 'boolean') {
-            this.preserveFocus = columnOrPreserveFocus
+            this._isFocused = !columnOrPreserveFocus
         } else if (typeof columnOrPreserveFocus !== 'undefined') {
             throw new TypeError('1st argument must be a boolean if provided. ViewColumn is deprecated')
+        } else {
+            this._isFocused = true
         }
-        this.isHidden = false
     }
 }

--- a/src/test/shared/vscode/fakeWindow.ts
+++ b/src/test/shared/vscode/fakeWindow.ts
@@ -55,46 +55,14 @@ export class FakeWindow implements Window {
         return this._inputBox.show(options)
     }
 
-    public showInformationMessage(message: string, ...items: string[]): Thenable<string | undefined>
-    public showInformationMessage(
-        message: string,
-        options: MessageOptions,
-        ...items: string[]
-    ): Thenable<string | undefined>
-    public showInformationMessage<T extends vscode.MessageItem>(message: string, ...items: T[]): Thenable<T | undefined>
-    public showInformationMessage<T extends vscode.MessageItem>(
-        message: string,
-        options: MessageOptions,
-        ...items: T[]
-    ): Thenable<T | undefined>
     public showInformationMessage(message: string, ...args: any[]): Thenable<any | undefined> {
         return this._message.showInformation(message, ...args)
     }
 
-    public showWarningMessage(message: string, ...items: string[]): Thenable<string | undefined>
-    public showWarningMessage(
-        message: string,
-        options: MessageOptions,
-        ...items: string[]
-    ): Thenable<string | undefined>
-    public showWarningMessage<T extends vscode.MessageItem>(message: string, ...items: T[]): Thenable<T | undefined>
-    public showWarningMessage<T extends vscode.MessageItem>(
-        message: string,
-        options: MessageOptions,
-        ...items: T[]
-    ): Thenable<T | undefined>
     public showWarningMessage(message: string, ...args: any[]): Thenable<any | undefined> {
         return this._message.showWarning(message, ...args)
     }
 
-    public showErrorMessage(message: string, ...items: string[]): Thenable<string | undefined>
-    public showErrorMessage(message: string, options: MessageOptions, ...items: string[]): Thenable<string | undefined>
-    public showErrorMessage<T extends vscode.MessageItem>(message: string, ...items: T[]): Thenable<T | undefined>
-    public showErrorMessage<T extends vscode.MessageItem>(
-        message: string,
-        options: MessageOptions,
-        ...items: T[]
-    ): Thenable<T | undefined>
     public showErrorMessage(message: string, ...args: any[]): Thenable<any | undefined> {
         return this._message.showError(message, ...args)
     }
@@ -255,18 +223,6 @@ class DefaultFakeMessage implements FakeMessage {
      *
      * @returns the selected item, or undefined if no selection is made.
      */
-    public async showInformation(message: string, ...items: string[]): Promise<string | undefined>
-    public async showInformation(
-        message: string,
-        options: MessageOptions,
-        ...items: string[]
-    ): Promise<string | undefined>
-    public async showInformation<T extends vscode.MessageItem>(message: string, ...items: T[]): Promise<T | undefined>
-    public async showInformation<T extends vscode.MessageItem>(
-        message: string,
-        options: MessageOptions,
-        ...items: T[]
-    ): Promise<T | undefined>
     public async showInformation(message: string, ...rest: any[]): Promise<any | undefined> {
         this.information = message
         return DefaultFakeMessage.extractSelectedItem(this.informationSelection, rest)
@@ -277,14 +233,6 @@ class DefaultFakeMessage implements FakeMessage {
      *
      * @returns the selected item, or undefined if no selection is made.
      */
-    public async showWarning(message: string, ...items: string[]): Promise<string | undefined>
-    public async showWarning(message: string, options: MessageOptions, ...items: string[]): Promise<string | undefined>
-    public async showWarning<T extends vscode.MessageItem>(message: string, ...items: T[]): Promise<T | undefined>
-    public async showWarning<T extends vscode.MessageItem>(
-        message: string,
-        options: MessageOptions,
-        ...items: T[]
-    ): Promise<T | undefined>
     public async showWarning(message: string, ...rest: any[]): Promise<any | undefined> {
         this.warning = message
         return DefaultFakeMessage.extractSelectedItem(this.warningSelection, rest)
@@ -295,14 +243,6 @@ class DefaultFakeMessage implements FakeMessage {
      *
      * @returns the selected item, or undefined if no selection is made.
      */
-    public async showError(message: string, ...items: string[]): Promise<string | undefined>
-    public async showError(message: string, options: MessageOptions, ...items: string[]): Promise<string | undefined>
-    public async showError<T extends vscode.MessageItem>(message: string, ...items: T[]): Promise<T | undefined>
-    public async showError<T extends vscode.MessageItem>(
-        message: string,
-        options: MessageOptions,
-        ...items: T[]
-    ): Promise<T | undefined>
     public async showError(message: string, ...rest: any[]): Promise<any | undefined> {
         this.error = message
         return DefaultFakeMessage.extractSelectedItem(this.errorSelection, rest)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add fakes for tracking and "clicking" buttons shown in messages

<!--- Describe your changes in detail -->

## Motivation and Context

This lets us verify that the correct buttons are shown and the correct action is taken on click.

e.g.

```typescript
// Simulate Cancel being clicked
const window = new FakeWindow({ message: { warningSelection: 'Cancel' } })
await deleteFileCommand(window)

// Verify delete wasn't performed
verify(s3.deleteObject(anything())).never()
```

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)

* Update S3 UI with new commands other improvements #1153
* Implement more APIs for S3 client wrapper #1155
* Add S3 delete commands and tweak others #1156 

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
