### PR TITLE
build: introduce "packageAlpha" task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ telemetryCache
 quickStart.html
 .gitcommit
 media/libs/
+package.json.bk
 
 # Auto generated definitions
 src/**/*.gen.ts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,22 @@ When you launch the extension or run tests from Visual Studio Code, it will auto
 
 If you prefer, you can build from the command line:
 
--   To build one time: `npm run compile`
--   To build and watch for file changes: `npm run watch`
+-   To build one time:
+    ```
+    npm run compile
+    ```
+-   To build and watch for file changes:
+    ```
+    npm run watch
+    ```
+-   To build a release artifact:
+    ```
+    npm run package
+    ```
+-   To build an "alpha" artifact (useful for letting others test a particular build):
+    ```
+    npm run packageAlpha
+    ```
 
 #### If you run out of memory while building
 

--- a/build-scripts/packageAlpha.ts
+++ b/build-scripts/packageAlpha.ts
@@ -1,0 +1,32 @@
+/*!
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//
+// Creates an artifact that can be given to users for testing alpha builds:
+//
+//     aws-toolkit-vscode-1.99.0-SNAPSHOT.vsix
+//
+// The script works like this:
+// 1. temporarily change `version` in package.json
+// 2. invoke `vsce package`
+// 3. restore the original package.json
+//
+
+import * as child_process from 'child_process'
+import * as fs from 'fs-extra'
+
+const packageJsonFile = './package.json'
+// Create a backup so that we can restore the original later.
+fs.copyFileSync(packageJsonFile, `${packageJsonFile}.bk`)
+
+const packageJson = JSON.parse(fs.readFileSync('./package.json', { encoding: 'UTF-8' }).toString())
+packageJson.version = '1.99.0-SNAPSHOT'
+
+fs.writeFileSync(packageJsonFile, JSON.stringify(packageJson, undefined, '  '))
+
+child_process.execSync(`vsce package`)
+
+// Restore the original package.json.
+fs.copyFileSync(`${packageJsonFile}.bk`, packageJsonFile)

--- a/package.json
+++ b/package.json
@@ -851,6 +851,7 @@
         "lint": "eslint -c .eslintrc.js --ext .ts .",
         "lintfix": "eslint -c .eslintrc.js --fix --ext .ts .",
         "package": "vsce package",
+        "packageAlpha": "sed -i .bk 's/\\(    \"version\":\\) .*/\\1 \"1.99.0-SNAPSHOT\",/' package.json && vsce package && mv package.json.bk package.json",
         "install-plugin": "vsce package -o aws-toolkit-vscode-test.vsix && code --install-extension aws-toolkit-vscode-test.vsix",
         "generateTelemetry": "node node_modules/@aws-toolkits/telemetry/lib/generateTelemetry.js --extraInput=src/shared/telemetry/vscodeTelemetry.json --output=src/shared/telemetry/telemetry.gen.ts",
         "generateConfigurationAttributes": "ts-node ./build-scripts/generateConfigurationAttributes.ts",

--- a/package.json
+++ b/package.json
@@ -851,7 +851,7 @@
         "lint": "eslint -c .eslintrc.js --ext .ts .",
         "lintfix": "eslint -c .eslintrc.js --fix --ext .ts .",
         "package": "vsce package",
-        "packageAlpha": "sed -i .bk 's/\\(    \"version\":\\) .*/\\1 \"1.99.0-SNAPSHOT\",/' package.json && vsce package && mv package.json.bk package.json",
+        "packageAlpha": "ts-node ./build-scripts/packageAlpha.ts",
         "install-plugin": "vsce package -o aws-toolkit-vscode-test.vsix && code --install-extension aws-toolkit-vscode-test.vsix",
         "generateTelemetry": "node node_modules/@aws-toolkits/telemetry/lib/generateTelemetry.js --extraInput=src/shared/telemetry/vscodeTelemetry.json --output=src/shared/telemetry/telemetry.gen.ts",
         "generateConfigurationAttributes": "ts-node ./build-scripts/generateConfigurationAttributes.ts",

--- a/package.nls.json
+++ b/package.nls.json
@@ -3,6 +3,7 @@
     "AWS.title.createCredentialProfile": "Create a new AWS credential profile",
     "AWS.title.creatingCredentialProfile": "Saving new credential profile {0}",
     "AWS.title.selectCredentialProfile": "Select an AWS credential profile",
+    "AWS.startup.toastIfAlpha": "AWS Toolkit PREVIEW. (To get the latest STABLE version, uninstall this version.)",
     "AWS.cdk.explorerTitle": "AWS CDK Explorer (Preview)",
     "Aws.cdk.explorerNode.noApps": "[No CDK Apps found in Workspaces]",
     "Aws.cdk.explorerNode.app.noConstructTree": "[Unable to load construct tree for this App. Run `cdk synth`]",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,7 @@ import {
     aboutToolkit,
     getToolkitEnvironmentDetails,
     showQuickStartWebview,
-    toastNewUser,
+    showWelcomeMessage,
 } from './shared/extensionUtilities'
 import { getLogger, Logger } from './shared/logger'
 import { activate as activateLogger } from './shared/logger/activation'
@@ -194,7 +194,7 @@ export async function activate(context: vscode.ExtensionContext) {
             await activateStepFunctions(context, awsContext, toolkitOutputChannel)
         })
 
-        toastNewUser(context)
+        showWelcomeMessage(context)
 
         await loginWithMostRecentCredentials(toolkitSettings, loginManager)
 

--- a/src/shared/extensionUtilities.ts
+++ b/src/shared/extensionUtilities.ts
@@ -12,6 +12,7 @@ import { ext } from '../shared/extensionGlobals'
 import { mostRecentVersionKey, pluginVersion } from './constants'
 import { readFileAsString } from './filesystemUtilities'
 import { getLogger } from './logger'
+import { VSCODE_EXTENSION_ID, EXTENSION_ALPHA_VERSION } from './extensions'
 
 const localize = nls.loadMessageBundle()
 
@@ -156,9 +157,9 @@ export function setMostRecentVersion(context: vscode.ExtensionContext): void {
 }
 
 /**
- * Publishes a toast with a link to the welcome page
+ * Shows a message with a link to the quickstart page.
  */
-async function promptQuickStart(): Promise<void> {
+async function showQuickstartPrompt(): Promise<void> {
     const view = localize('AWS.command.quickStart', 'View Quick Start')
     const prompt = await vscode.window.showInformationMessage(
         localize(
@@ -174,18 +175,33 @@ async function promptQuickStart(): Promise<void> {
 }
 
 /**
- * Checks if a user is new to this version
- * If so, pops a toast with a link to a quick start page
+ * Shows a "new version" or "alpha version" message.
+ *
+ * - If extension version is "alpha", shows a warning message.
+ * - If extension version was not previously run on this machine, shows a toast
+ *   with a link to the quickstart page.
+ * - Otherwise does nothing.
  *
  * @param context VS Code Extension Context
  */
-export function toastNewUser(context: vscode.ExtensionContext): void {
+export function showWelcomeMessage(context: vscode.ExtensionContext): void {
+    const version = vscode.extensions.getExtension(VSCODE_EXTENSION_ID.awstoolkit)?.packageJSON.version
+    if (version === EXTENSION_ALPHA_VERSION) {
+        vscode.window.showWarningMessage(
+            localize(
+                'AWS.startup.toastIfAlpha',
+                'AWS Toolkit PREVIEW. (To get the latest STABLE version, uninstall this version.)'
+            )
+        )
+        return
+    }
+
     try {
         if (isDifferentVersion(context)) {
             setMostRecentVersion(context)
             // the welcome toast should be nonblocking.
             // tslint:disable-next-line: no-floating-promises
-            promptQuickStart()
+            showQuickstartPrompt()
         }
     } catch (err) {
         // swallow error and don't block extension load

--- a/src/shared/extensions.ts
+++ b/src/shared/extensions.ts
@@ -7,3 +7,8 @@ export const VSCODE_EXTENSION_ID = {
     awstoolkit: 'amazonwebservices.aws-toolkit-vscode',
     python: 'ms-python.python',
 }
+
+/**
+ * Version of the .vsix produced by the `packageAlpha` script.
+ */
+export const EXTENSION_ALPHA_VERSION = '1.99.0-SNAPSHOT'


### PR DESCRIPTION
- `npm run packageAlpha` creates an artifact that can be delivered to  users for testing alpha builds. It creates artifact: `aws-toolkit-vscode-1.99.0-SNAPSHOT.vsix`
- Show a warning message on startup if the extension version is   alpha.

<img width="571" alt="Screen Shot 2020-06-16 at 4 32 04 PM" src="https://user-images.githubusercontent.com/55561878/84839200-536f3e80-aff1-11ea-872b-74655d7c516a.png">




## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
