### PR TITLE
Use CloudFront for endpoints.json instead of S3

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -9,7 +9,7 @@ export const profileSettingKey: string = 'profile'
 export const mostRecentVersionKey: string = 'awsToolkitMostRecentVersion'
 
 export const hostedFilesBaseUrl: string = 'https://d3rrggjwfhwld2.cloudfront.net/'
-export const endpointsFileUrl: string = 'https://aws-toolkit-endpoints.s3.amazonaws.com/endpoints.json'
+export const endpointsFileUrl: string = 'https://idetoolkits.amazonwebservices.com/endpoints.json'
 export const aboutCredentialsFileUrl: string = 'https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html'
 export const samAboutInstallUrl: string = 'https://aws.amazon.com/serverless/sam/'
 // tslint:disable-next-line:max-line-length


### PR DESCRIPTION
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
