### PR TITLE
SAM: support SAM CLI version 1.x

### DIFF
--- a/.changes/next-release/Feature-6930a1df-1673-4ffb-8a98-38720d102fe9.json
+++ b/.changes/next-release/Feature-6930a1df-1673-4ffb-8a98-38720d102fe9.json
@@ -1,0 +1,4 @@
+{
+    "type": "Feature",
+    "description": "support SAM CLI version 1.x"
+}

--- a/src/lambda/local/debugConfiguration.ts
+++ b/src/lambda/local/debugConfiguration.ts
@@ -43,7 +43,7 @@ export interface PythonDebugConfiguration extends DebugConfiguration {
 
 export interface DotNetCoreDebugConfiguration extends DebugConfiguration {
     type: 'coreclr'
-    processId: string
+    processName: string
     pipeTransport: PipeTransport
     windows: {
         pipeTransport: PipeTransport
@@ -80,7 +80,9 @@ export function makeCoreCLRDebugConfiguration({
         name: 'SamLocalDebug',
         type: 'coreclr',
         request: 'attach',
-        processId: '1',
+        // Since SAM CLI 1.0 we cannot assume PID=1. So use processName=dotnet
+        // instead of processId=1.
+        processName: 'dotnet',
         pipeTransport: {
             pipeProgram: 'sh',
             pipeArgs,

--- a/src/shared/sam/cli/samCliValidator.ts
+++ b/src/shared/sam/cli/samCliValidator.ts
@@ -10,7 +10,7 @@ import { SamCliInfoInvocation, SamCliInfoResponse } from './samCliInfo'
 import { SamCliProcessInvoker } from './samCliInvokerUtils'
 
 export const MINIMUM_SAM_CLI_VERSION_INCLUSIVE = '0.38.0'
-export const MAXIMUM_SAM_CLI_VERSION_EXCLUSIVE = '0.60.0'
+export const MAXIMUM_SAM_CLI_VERSION_EXCLUSIVE = '2.0.0'
 
 // Errors
 export class InvalidSamCliError extends Error {


### PR DESCRIPTION

## Testing:

- For each of SAM CLI 0.45.0, SAM CLI 1.0.0
  - For each of nodejs12.x, python3.7, dotnet2.1
    - Set the `aws.samcli.location` to point to new/old sam binary.
    - Verify that `Run Locally` works
    - Verify that `Debug Locally` works.

With sam 0.45.0, the Toolkit pulls these Docker images:

    Fetching lambci/lambda:dotnetcore2.1 Docker container image
    Fetching lambci/lambda:nodejs12.x Docker container image
    Fetching lambci/lambda:python3.7 Docker container image

With sam 1.0.0, the Toolkit pulls these Docker images:

    Fetching amazon/aws-sam-cli-emulation-image-dotnetcore2.1:latest Docker container image
    Fetching amazon/aws-sam-cli-emulation-image-nodejs10.x:latest Docker container image
    Fetching amazon/aws-sam-cli-emulation-image-nodejs12.x:latest Docker container image
    Fetching amazon/aws-sam-cli-emulation-image-python3.7:latest Docker container image

Per https://github.com/awslabs/aws-sam-cli/pull/2066/ , the new docker images are named like:

    amazon/aws-sam-cli-build-image-<runtime>
    amazon/aws-sam-cli-emulation-image-<runtime>

## Notes:

- Elected not to include `justMyCode:false` in the dotnet config.
- In a test of nodejs12.x, saw this error (transient, went away after retry):
  ```
  docker.errors.ImageNotFound: 404 Client Error: Not Found ("No such image: amazon/aws-sam-cli-emulation-image-nodejs12.x:latest")
  ```
- ref https://github.com/aws/aws-toolkit-jetbrains/pull/1886
- ref e1e6e5f814ce251ef2eefa1ac958fb2e92dd9c20
- ref 60a2eab4d1ada8e52f2ed4b52305c5e69aad7f3e


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
