### PR TITLE
Create reusable fakes/stubs for VSCode UI components (#1074) (#1152)

### DIFF
--- a/src/shared/utilities/promiseUtilities.ts
+++ b/src/shared/utilities/promiseUtilities.ts
@@ -45,3 +45,10 @@ export class PromiseSharer {
         })
     }
 }
+
+/**
+ * Copied from src/vs/base/common/async.ts
+ */
+export function isThenable<T>(obj: any): obj is Promise<T> {
+    return obj && typeof (<Promise<any>>obj).then === 'function'
+}

--- a/src/shared/vscode/commands.ts
+++ b/src/shared/vscode/commands.ts
@@ -1,0 +1,29 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @ts-ignore
+import * as vscode from 'vscode'
+
+/**
+ * Components associated with {@link module:vscode.commands}.
+ */
+export interface Commands {
+    /**
+     * See {@link module:vscode.commands.executeCommand}.
+     */
+    execute<T>(command: string, ...rest: any[]): Thenable<T | undefined>
+}
+
+export namespace Commands {
+    export function vscode(): Commands {
+        return new DefaultCommands()
+    }
+}
+
+class DefaultCommands implements Commands {
+    public execute<T>(command: string, ...rest: any[]): Thenable<T | undefined> {
+        return vscode.commands.executeCommand(command, ...rest)
+    }
+}

--- a/src/shared/vscode/env.ts
+++ b/src/shared/vscode/env.ts
@@ -1,0 +1,33 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @ts-ignore
+import * as vscode from 'vscode'
+
+/**
+ * Components associated with {@link module:vscode.env}.
+ */
+export interface Env {
+    clipboard: Clipboard
+}
+
+export namespace Env {
+    export function vscode(): Env {
+        return new DefaultEnv()
+    }
+}
+
+export interface Clipboard {
+    /**
+     * See {@link module:vscode.Clipboard.writeText}.
+     */
+    writeText(message: string): Thenable<void>
+}
+
+class DefaultEnv implements Env {
+    public get clipboard(): Clipboard {
+        return vscode.env.clipboard
+    }
+}

--- a/src/shared/vscode/window.ts
+++ b/src/shared/vscode/window.ts
@@ -1,0 +1,138 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+
+/**
+ * Components associated with {@link module:vscode.window}.
+ */
+export interface Window {
+    /**
+     * See {@link module:vscode.window.setStatusBarMessage}.
+     */
+    setStatusBarMessage(message: string, hideAfterTimeout: number): vscode.Disposable
+
+    /**
+     * See {@link module:vscode.window.showInputBox}.
+     */
+    showInputBox(options?: vscode.InputBoxOptions, token?: vscode.CancellationToken): Thenable<string | undefined>
+
+    /**
+     * See {@link module:vscode.window.showInformationMessage}.
+     */
+    showInformationMessage(message: string, ...items: string[]): Thenable<string | undefined>
+    showInformationMessage(
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: string[]
+    ): Thenable<string | undefined>
+    showInformationMessage<T extends vscode.MessageItem>(message: string, ...items: T[]): Thenable<T | undefined>
+    showInformationMessage<T extends vscode.MessageItem>(
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: T[]
+    ): Thenable<T | undefined>
+
+    /**
+     * See {@link module:vscode.window.showWarningMessage}.
+     */
+    showWarningMessage(message: string, ...items: string[]): Thenable<string | undefined>
+    showWarningMessage(
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: string[]
+    ): Thenable<string | undefined>
+    showWarningMessage<T extends vscode.MessageItem>(message: string, ...items: T[]): Thenable<T | undefined>
+    showWarningMessage<T extends vscode.MessageItem>(
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: T[]
+    ): Thenable<T | undefined>
+
+    /**
+     * See {@link module:vscode.window.showErrorMessage}.
+     */
+    showErrorMessage(message: string, ...items: string[]): Thenable<string | undefined>
+    showErrorMessage(message: string, options: vscode.MessageOptions, ...items: string[]): Thenable<string | undefined>
+    showErrorMessage<T extends vscode.MessageItem>(message: string, ...items: T[]): Thenable<T | undefined>
+    showErrorMessage<T extends vscode.MessageItem>(
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: T[]
+    ): Thenable<T | undefined>
+
+    /**
+     * See {@link module:vscode.window.withProgress}.
+     */
+    withProgress<R>(
+        options: vscode.ProgressOptions,
+        task: (
+            progress: vscode.Progress<{ message?: string; increment?: number }>,
+            token: vscode.CancellationToken
+        ) => Thenable<R>
+    ): Thenable<R>
+
+    /**
+     * See {@link module:vscode.window.showOpenDialog}.
+     */
+    showOpenDialog(options: vscode.OpenDialogOptions): Thenable<vscode.Uri[] | undefined>
+
+    /**
+     * See {@link module:vscode.window.showSaveDialog}.
+     */
+    showSaveDialog(options: vscode.SaveDialogOptions): Thenable<vscode.Uri | undefined>
+}
+
+export namespace Window {
+    export function vscode(): Window {
+        return new DefaultWindow()
+    }
+}
+
+class DefaultWindow implements Window {
+    public setStatusBarMessage(message: string, hideAfterTimeout: number): vscode.Disposable {
+        return vscode.window.setStatusBarMessage(message, hideAfterTimeout)
+    }
+
+    public showInputBox(
+        options?: vscode.InputBoxOptions,
+        token?: vscode.CancellationToken
+    ): Thenable<string | undefined> {
+        return vscode.window.showInputBox(options, token)
+    }
+
+    public showInformationMessage(...args: any[]): Thenable<any | undefined> {
+        // @ts-ignore
+        return vscode.window.showInformationMessage(...args)
+    }
+
+    public showWarningMessage(...args: any[]): Thenable<any | undefined> {
+        // @ts-ignore
+        return vscode.window.showWarningMessage(...args)
+    }
+
+    public showErrorMessage(...args: any[]): Thenable<any | undefined> {
+        // @ts-ignore
+        return vscode.window.showErrorMessage(...args)
+    }
+
+    public withProgress<R>(
+        options: vscode.ProgressOptions,
+        task: (
+            progress: vscode.Progress<{ message?: string; increment?: number }>,
+            token: vscode.CancellationToken
+        ) => Thenable<R>
+    ): Thenable<R> {
+        return vscode.window.withProgress(options, task)
+    }
+
+    public showOpenDialog(options: vscode.OpenDialogOptions): Thenable<vscode.Uri[] | undefined> {
+        return vscode.window.showOpenDialog(options)
+    }
+
+    public showSaveDialog(options: vscode.SaveDialogOptions): Thenable<vscode.Uri | undefined> {
+        return vscode.window.showSaveDialog(options)
+    }
+}

--- a/src/shared/vscode/workspace.ts
+++ b/src/shared/vscode/workspace.ts
@@ -1,0 +1,35 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+
+/**
+ * Components associated with {@link module:vscode.workspace}.
+ */
+export interface Workspace {
+    /**
+     * See {@link module:vscode.workspace.getConfiguration}.
+     */
+    getConfiguration(section?: string, resource?: vscode.Uri | null): WorkspaceConfiguration
+}
+
+export namespace Workspace {
+    export function vscode(): Workspace {
+        return new DefaultWorkspace()
+    }
+}
+
+export interface WorkspaceConfiguration {
+    /**
+     * See {@link module:vscode.WorkspaceConfiguration.get}.
+     */
+    get<T>(key: string): T | undefined
+}
+
+class DefaultWorkspace implements Workspace {
+    public getConfiguration(section?: string, resource?: vscode.Uri | null): WorkspaceConfiguration {
+        return vscode.workspace.getConfiguration(section, resource)
+    }
+}

--- a/src/test/shared/vscode/fakeCommands.ts
+++ b/src/test/shared/vscode/fakeCommands.ts
@@ -1,0 +1,42 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Commands } from '../../../shared/vscode/commands'
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface FakeCommandsOptions {}
+
+export class FakeCommands implements Commands {
+    private _command: string | undefined
+    private _args: any[] | undefined
+
+    /**
+     * The command that was executed, in any.
+     */
+    public get command(): string | undefined {
+        return this._command
+    }
+
+    /**
+     * The arguments to the command that was executed, if any.
+     */
+    public get args(): any[] | undefined {
+        return this._args
+    }
+
+    public constructor({}: FakeCommandsOptions = {}) {}
+
+    /**
+     * Records the command that was executed, along with its arguments.
+     *
+     * @returns an empty Promise.
+     */
+    public async execute<T>(command: string, ...rest: any[]): Promise<T | undefined> {
+        this._command = command
+        this._args = rest
+
+        return undefined
+    }
+}

--- a/src/test/shared/vscode/fakeEnv.ts
+++ b/src/test/shared/vscode/fakeEnv.ts
@@ -1,0 +1,47 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Env, Clipboard } from '../../../shared/vscode/env'
+
+export interface FakeEnvOptions {
+    clipboard?: ClipboardOptions
+}
+
+export class FakeEnv implements Env {
+    private readonly _clipboard: DefaultFakeClipboard
+
+    public get clipboard(): FakeClipboard {
+        return this._clipboard
+    }
+
+    public constructor({ clipboard }: FakeEnvOptions = {}) {
+        this._clipboard = new DefaultFakeClipboard(clipboard)
+    }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ClipboardOptions {}
+
+export interface FakeClipboard extends Clipboard {
+    /**
+     * The text that was written, if any.
+     */
+    readonly text: string | undefined
+}
+
+class DefaultFakeClipboard implements FakeClipboard {
+    public text: string | undefined
+
+    /**
+     * Records the text that was written.
+     *
+     * @returns an empty Promise.
+     */
+    public async writeText(text: string): Promise<void> {
+        this.text = text
+    }
+
+    public constructor({}: ClipboardOptions = {}) {}
+}

--- a/src/test/shared/vscode/fakeWindow.ts
+++ b/src/test/shared/vscode/fakeWindow.ts
@@ -1,0 +1,395 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import * as _ from 'lodash'
+import { isThenable } from '../../../shared/utilities/promiseUtilities'
+import { Window } from '../../../shared/vscode/window'
+import { inspect } from 'util'
+
+export interface FakeWindowOptions {
+    statusBar?: StatusBarOptions
+    inputBox?: InputBoxOptions
+    message?: MessageOptions
+    progress?: ProgressOptions
+    dialog?: DialogOptions
+}
+
+export class FakeWindow implements Window {
+    private readonly _statusBar: DefaultFakeStatusBar
+    private readonly _inputBox: DefaultFakeInputBox
+    private readonly _message: DefaultFakeMessage
+    private readonly _progress: DefaultFakeProgress
+    private readonly _dialog: DefaultFakeDialog
+
+    public get statusBar(): FakeStatusBar {
+        return this._statusBar
+    }
+
+    public get inputBox(): FakeInputBox {
+        return this._inputBox
+    }
+
+    public get message(): FakeMessage {
+        return this._message
+    }
+
+    public get progress(): FakeProgress {
+        return this._progress
+    }
+
+    public get dialog(): FakeDialog {
+        return this._dialog
+    }
+
+    public setStatusBarMessage(message: string, hideAfterTimeout: number): vscode.Disposable {
+        return this._statusBar.setMessage(message)
+    }
+
+    public showInputBox(
+        options?: vscode.InputBoxOptions,
+        token?: vscode.CancellationToken
+    ): Thenable<string | undefined> {
+        return this._inputBox.show(options)
+    }
+
+    public showInformationMessage(message: string, ...args: any[]): Thenable<any | undefined> {
+        return this._message.showInformation(message, ...args)
+    }
+
+    public showWarningMessage(message: string, ...args: any[]): Thenable<any | undefined> {
+        return this._message.showWarning(message, ...args)
+    }
+
+    public showErrorMessage(message: string, ...args: any[]): Thenable<any | undefined> {
+        return this._message.showError(message, ...args)
+    }
+
+    public withProgress<R>(
+        options: vscode.ProgressOptions,
+        task: (
+            progress: vscode.Progress<{ message?: string; increment?: number }>,
+            token: vscode.CancellationToken
+        ) => Thenable<R>
+    ): Thenable<R> {
+        return this._progress.show(options, task)
+    }
+
+    public showOpenDialog(options: vscode.OpenDialogOptions): Thenable<vscode.Uri[] | undefined> {
+        return this._dialog.showOpen(options)
+    }
+
+    public showSaveDialog(options: vscode.SaveDialogOptions): Thenable<vscode.Uri | undefined> {
+        return this._dialog.showSave(options)
+    }
+
+    public constructor({ statusBar, inputBox, message, progress, dialog }: FakeWindowOptions = {}) {
+        this._statusBar = new DefaultFakeStatusBar(statusBar)
+        this._inputBox = new DefaultFakeInputBox(inputBox)
+        this._message = new DefaultFakeMessage(message)
+        this._progress = new DefaultFakeProgress(progress)
+        this._dialog = new DefaultFakeDialog(dialog)
+    }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface StatusBarOptions {}
+
+export interface FakeStatusBar {
+    /**
+     * The message that was set, if any.
+     */
+    readonly message: string | undefined
+}
+
+class DefaultFakeStatusBar implements FakeStatusBar {
+    public message: string | undefined
+
+    /**
+     * Records the message that was set.
+     *
+     * @returns a no-op Disposable
+     */
+    public setMessage(message: string): vscode.Disposable {
+        this.message = message
+        return new vscode.Disposable(() => undefined)
+    }
+
+    public constructor({}: StatusBarOptions = {}) {}
+}
+
+export interface InputBoxOptions {
+    /**
+     * The input to respond with, if any.
+     */
+    input?: string | undefined
+}
+
+export interface FakeInputBox {
+    /**
+     * The options shown, if any.
+     */
+    readonly options: vscode.InputBoxOptions | undefined
+
+    /**
+     * The message returned from the validateInput function, if any.
+     */
+    readonly errorMessage: string | undefined
+}
+
+class DefaultFakeInputBox implements FakeInputBox {
+    private readonly input: string | undefined
+
+    public errorMessage: string | undefined
+    public options: vscode.InputBoxOptions | undefined
+
+    /**
+     * Passes the {@link input} to the {@link vscode.InputBoxOptions.validateInput} and records the {@link errorMessage}, if any.
+     * If validation fails, acts as though the user cancelled after the failure (by returning an empty Promise).
+     *
+     * @returns a Promise of the {@link input} if validation succeeds or no validation was set,
+     * otherwise returns an empty Promise.
+     */
+    public async show(options?: vscode.InputBoxOptions): Promise<string | undefined> {
+        this.options = options
+        if (this.input !== undefined && options?.validateInput) {
+            const result = options.validateInput(this.input)
+            if (isThenable<string | undefined>(result)) {
+                this.errorMessage = await result
+            } else {
+                this.errorMessage = result as string | undefined
+            }
+
+            if (this.errorMessage) {
+                return Promise.resolve(undefined)
+            }
+        }
+
+        return Promise.resolve(this.input)
+    }
+
+    public constructor({ input }: InputBoxOptions = {}) {
+        this.input = input
+    }
+}
+
+export interface MessageOptions {
+    /**
+     * The information message selection to choose, if any.
+     */
+    informationSelection?: string | undefined
+
+    /**
+     * The warning message selection to choose, if any.
+     */
+    warningSelection?: string | undefined
+
+    /**
+     * The error message selection to choose, if any.
+     */
+    errorSelection?: string | undefined
+}
+
+export interface FakeMessage {
+    /**
+     * The information message that was shown, if any.
+     */
+    readonly information: string | undefined
+
+    /**
+     * The warning message that was shown, if any.
+     */
+    readonly warning: string | undefined
+
+    /**
+     * The error message that was shown, if any.
+     */
+    readonly error: string | undefined
+}
+
+class DefaultFakeMessage implements FakeMessage {
+    private readonly informationSelection: string | undefined
+    private readonly warningSelection: string | undefined
+    private readonly errorSelection: string | undefined
+
+    public information: string | undefined
+    public warning: string | undefined
+    public error: string | undefined
+
+    /**
+     * Records the information message that was shown and selects the given informationSelection, if any.
+     *
+     * @returns the selected item, or undefined if no selection is made.
+     */
+    public async showInformation(message: string, ...rest: any[]): Promise<any | undefined> {
+        this.information = message
+        return DefaultFakeMessage.extractSelectedItem(this.informationSelection, rest)
+    }
+
+    /**
+     * Records the warning message that was shown and selects the given warningSelection if any.
+     *
+     * @returns the selected item, or undefined if no selection is made.
+     */
+    public async showWarning(message: string, ...rest: any[]): Promise<any | undefined> {
+        this.warning = message
+        return DefaultFakeMessage.extractSelectedItem(this.warningSelection, rest)
+    }
+
+    /**
+     * Records the error message that was shown and selects the given errorSelection, if any.
+     *
+     * @returns the selected item, or undefined if no selection is made.
+     */
+    public async showError(message: string, ...rest: any[]): Promise<any | undefined> {
+        this.error = message
+        return DefaultFakeMessage.extractSelectedItem(this.errorSelection, rest)
+    }
+
+    public constructor({ informationSelection, warningSelection, errorSelection }: MessageOptions = {}) {
+        this.informationSelection = informationSelection
+        this.warningSelection = warningSelection
+        this.errorSelection = errorSelection
+    }
+
+    private static extractSelectedItem(
+        selection: string | undefined,
+        args: any[]
+    ): string | vscode.MessageItem | undefined {
+        const items = this.getItems(args)
+        if (!items || !selection) {
+            return undefined
+        }
+
+        const selectedItem = items.find(item => this.getTitle(item) === selection)
+        if (!selectedItem) {
+            throw new Error(`Cannot select '${selection}' from the shown items: ${inspect(items)}`)
+        }
+        return selectedItem
+    }
+
+    private static getItems(args: any[]): (string | vscode.MessageItem)[] | undefined {
+        const items: (string | vscode.MessageItem)[] = _(args)
+            .takeRightWhile(item => _(item).isString() || DefaultFakeMessage.isMessageItem(item))
+            .value()
+
+        return _(items).isEmpty() ? undefined : items
+    }
+
+    private static getTitle(item: string | vscode.MessageItem): string {
+        return _.isString(item) ? item : item.title
+    }
+
+    private static isMessageItem(item: any): item is vscode.MessageItem {
+        return item && item.title
+    }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ProgressOptions {}
+
+export interface FakeProgress {
+    /**
+     * The progress that was reported, if any.
+     */
+    readonly reported: { message?: string; increment?: number }[]
+
+    /**
+     * The options that were shown, if any.
+     */
+    readonly options: vscode.ProgressOptions | undefined
+}
+
+class DefaultFakeProgress implements FakeProgress {
+    public reported: { message?: string; increment?: number }[] = []
+    public options: vscode.ProgressOptions | undefined
+
+    /**
+     * Records the options and progress that were reported, if any.
+     *
+     * @returns the output of the task.
+     */
+    public async show<R>(
+        options: vscode.ProgressOptions,
+        task: (
+            progress: vscode.Progress<{ message?: string; increment?: number }>,
+            token: vscode.CancellationToken
+        ) => Thenable<R>
+    ): Promise<R> {
+        this.options = options
+
+        const reporter: vscode.Progress<{ message?: string; increment?: number }> = {
+            report: item => {
+                this.reported.push(item)
+            },
+        }
+
+        const token: vscode.CancellationToken = {
+            isCancellationRequested: false,
+            onCancellationRequested: new vscode.EventEmitter().event,
+        }
+
+        return task(reporter, token)
+    }
+
+    public constructor({}: ProgressOptions = {}) {}
+}
+
+export interface DialogOptions {
+    /**
+     * The file to select in the open dialog, if any.
+     */
+    openSelections?: vscode.Uri[] | undefined
+
+    /**
+     * The file to select in the save dialog, if any.
+     */
+    saveSelection?: vscode.Uri | undefined
+}
+
+export interface FakeDialog {
+    /**
+     * The open options that were shown, if any.
+     */
+    readonly openOptions: vscode.OpenDialogOptions | undefined
+
+    /**
+     * The save options that were shown, if any.
+     */
+    readonly saveOptions: vscode.SaveDialogOptions | undefined
+}
+
+class DefaultFakeDialog implements FakeDialog {
+    private readonly openSelections: vscode.Uri[] | undefined
+    private readonly saveSelection: vscode.Uri | undefined
+
+    public openOptions: vscode.OpenDialogOptions | undefined
+    public saveOptions: vscode.SaveDialogOptions | undefined
+
+    /**
+     * Selects the file(s) specified in the {@link openSelections}, if any.
+     *
+     * @returns a Promise of the {@link openSelections}.
+     */
+    public async showOpen(options: vscode.OpenDialogOptions): Promise<vscode.Uri[] | undefined> {
+        this.openOptions = options
+        return Promise.resolve(this.openSelections)
+    }
+
+    /**
+     * Selects the file specified in the {@link saveSelection}, if any.
+     *
+     * @returns a Promise of the {@link saveSelection}.
+     */
+    public async showSave(options: vscode.SaveDialogOptions): Promise<vscode.Uri | undefined> {
+        this.saveOptions = options
+        return Promise.resolve(this.saveSelection)
+    }
+
+    public constructor({ openSelections, saveSelection }: DialogOptions = {}) {
+        this.openSelections = openSelections
+        this.saveSelection = saveSelection
+    }
+}

--- a/src/test/shared/vscode/fakeWorkspace.ts
+++ b/src/test/shared/vscode/fakeWorkspace.ts
@@ -1,0 +1,71 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { Workspace, WorkspaceConfiguration } from '../../../shared/vscode/workspace'
+
+export interface FakeWorkspaceOptions {
+    section?: string
+    configuration?: ConfigurationOptions
+}
+
+export class FakeWorkspace implements Workspace {
+    private readonly _section: string | undefined
+    private readonly _configuration: DefaultFakeConfiguration
+
+    public get configuration(): FakeConfiguration {
+        return this._configuration
+    }
+
+    public getConfiguration(section?: string, resource?: vscode.Uri | null): WorkspaceConfiguration {
+        if (section === this._section) {
+            return this._configuration
+        }
+
+        return new DefaultFakeConfiguration()
+    }
+
+    public constructor({ section, configuration }: FakeWorkspaceOptions = {}) {
+        this._section = section
+        this._configuration = new DefaultFakeConfiguration(configuration)
+    }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ConfigurationOptions {
+    /**
+     * The configuration key to
+     */
+    key?: string
+
+    /**
+     * The configuration value to respond with, if any.
+     */
+    value?: any
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface FakeConfiguration {}
+
+class DefaultFakeConfiguration implements WorkspaceConfiguration, FakeConfiguration {
+    private readonly key: string | undefined
+    private readonly value: any | undefined
+
+    /**
+     * @returns the {@link value}.
+     */
+    public get<T>(key: string): T | undefined {
+        if (key === this.key) {
+            return this.value as T | undefined
+        }
+
+        return undefined
+    }
+
+    public constructor({ key, value }: ConfigurationOptions = {}) {
+        this.key = key
+        this.value = value
+    }
+}

--- a/src/test/utilities/mockito.ts
+++ b/src/test/utilities/mockito.ts
@@ -1,0 +1,34 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as mockito from 'ts-mockito'
+import { Mocker } from 'ts-mockito/lib/Mock'
+
+// Workaround https://github.com/NagRock/ts-mockito/issues/163
+export function mock<T>(): T {
+    const mocker = new Mocker(undefined)
+    mocker['excludedPropertyNames'] += 'then'
+
+    return mocker.getMock()
+}
+
+export const spy = mockito.spy
+export const verify = mockito.verify
+export const when = mockito.when
+export const instance = mockito.instance
+export const capture = mockito.capture
+export const reset = mockito.reset
+export const resetCalls = mockito.resetCalls
+export const anyOfClass = mockito.anyOfClass
+export const anyFunction = mockito.anyFunction
+export const anyNumber = mockito.anyNumber
+export const anyString = mockito.anyString
+export const anything = mockito.anything
+export const between = mockito.between
+export const deepEqual = mockito.deepEqual
+export const notNull = mockito.notNull
+export const strictEqual = mockito.strictEqual
+export const match = mockito.match
+export const objectContaining = mockito.objectContaining


### PR DESCRIPTION
## Description

This is a cherry-pick of #1074 and #1152 (already reviewed, no changes).

<!--- Describe your changes in detail -->

## Motivation and Context

See #1074 and #1152

## Related Issue(s)


## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
