### PR TITLE
SAM: respect the 'aws.samcli.location' user setting

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -301,7 +301,7 @@
     "AWS.samcli.deploy.stackName.error.length": "A stack name must not be longer than 128 characters",
     "AWS.samcli.deploy.statusbar.message": "$(cloud-upload) Deploying SAM Application to {0}...",
     "AWS.samcli.deploy.template.prompt": "Which SAM Template would you like to deploy to AWS?",
-    "AWS.samcli.configured.location": "Configured SAM CLI Location: {0}",
+    "AWS.samcli.configured.location": "SAM CLI Location: {0}",
     "AWS.samcli.error.notFound": "Unable to find the SAM CLI, which is required to create new Serverless Applications and debug them locally. If you have already installed the SAM CLI, update your User Settings by locating it.",
     "AWS.samcli.error.notFound.brief": "Could not get SAM CLI location",
     "AWS.samcli.error.invalid_schema_support_version": "Installed SAM executable does not support templates that require Event Schema selection. Required minimum version {0}, but found {1}",

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -77,11 +77,11 @@ export async function activate(activateArguments: {
         )
     )
 
-    await detectSamCli(false)
+    await detectSamCli({ showMessage: false })
     activateArguments.extensionContext.subscriptions.push(
         vscode.workspace.onDidChangeConfiguration(configurationChangeEvent => {
             if (configurationChangeEvent.affectsConfiguration('aws.samcli.location')) {
-                detectSamCli(false)
+                detectSamCli({ showMessage: undefined })
             }
         })
     )
@@ -99,7 +99,10 @@ async function registerServerlessCommands(params: {
         vscode.commands.registerCommand(
             'aws.samcli.detect',
             async () =>
-                await PromiseSharer.getExistingPromiseOrCreate('samcli.detect', async () => await detectSamCli(true))
+                await PromiseSharer.getExistingPromiseOrCreate(
+                    'samcli.detect',
+                    async () => await detectSamCli({ showMessage: true })
+                )
         ),
         vscode.commands.registerCommand('aws.lambda.createNewSamApp', async () => {
             await createNewSamApplication(params.channelLogger, params.awsContext, params.regionProvider)

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -78,6 +78,13 @@ export async function activate(activateArguments: {
     )
 
     await detectSamCli(false)
+    activateArguments.extensionContext.subscriptions.push(
+        vscode.workspace.onDidChangeConfiguration(configurationChangeEvent => {
+            if (configurationChangeEvent.affectsConfiguration('aws.samcli.location')) {
+                detectSamCli(false)
+            }
+        })
+    )
 
     await resumeCreateNewSamApp()
 }

--- a/src/shared/sam/cli/samCliConfiguration.ts
+++ b/src/shared/sam/cli/samCliConfiguration.ts
@@ -27,7 +27,7 @@ export class DefaultSamCliConfiguration implements SamCliConfiguration {
     }
 
     public getSamCliLocation(): string | undefined {
-        return this._configuration.readSetting(DefaultSamCliConfiguration.CONFIGURATION_KEY_SAMCLI_LOCATION)
+        return this._configuration.readSetting<string>(DefaultSamCliConfiguration.CONFIGURATION_KEY_SAMCLI_LOCATION)
     }
 
     public async setSamCliLocation(location: string | undefined): Promise<void> {

--- a/src/shared/sam/cli/samCliConfiguration.ts
+++ b/src/shared/sam/cli/samCliConfiguration.ts
@@ -26,10 +26,12 @@ export class DefaultSamCliConfiguration implements SamCliConfiguration {
         this._samCliLocationProvider = samCliLocationProvider
     }
 
+    /** Gets the current SAM CLI location from the VSCode settings store. */
     public getSamCliLocation(): string | undefined {
         return this._configuration.readSetting<string>(DefaultSamCliConfiguration.CONFIGURATION_KEY_SAMCLI_LOCATION)
     }
 
+    /** Sets the SAM CLI location in the VSCode settings store. */
     public async setSamCliLocation(location: string | undefined): Promise<void> {
         await this._configuration.writeSetting(
             DefaultSamCliConfiguration.CONFIGURATION_KEY_SAMCLI_LOCATION,
@@ -38,6 +40,10 @@ export class DefaultSamCliConfiguration implements SamCliConfiguration {
         )
     }
 
+    /**
+     * Initializes this SamCliConfiguration object from the VSCode user settings,
+     * or tries to auto-detect `sam` in the environment.
+     */
     public async initialize(): Promise<void> {
         const configLocation: string | undefined = this.getSamCliLocation()
         if (!!configLocation) {

--- a/src/shared/sam/cli/samCliDetection.ts
+++ b/src/shared/sam/cli/samCliDetection.ts
@@ -16,34 +16,41 @@ const localize = nls.loadMessageBundle()
 const lock = new AsyncLock()
 
 const learnMore = localize('AWS.samcli.userChoice.visit.install.url', 'Get SAM CLI')
-
 const browseToSamCli = localize('AWS.samcli.userChoice.browse', 'Locate SAM CLI...')
-
 const settingsUpdated = localize('AWS.samcli.detect.settings.updated', 'Settings updated.')
-
 const settingsNotUpdated = localize('AWS.samcli.detect.settings.not.updated', 'No settings changes necessary.')
 
-export async function detectSamCli(showMessageIfDetected: boolean): Promise<void> {
+/** Most-recent resolved SAM CLI location. */
+let currentsamCliLocation: string | undefined = undefined
+
+/**
+ *
+ * @param opt.showMessage true: always show message, false: never show
+ * message, undefined: show message only if the new setting differs from
+ * the old setting.
+ */
+export async function detectSamCli(opt: { showMessage: boolean | undefined }): Promise<void> {
     await lock.acquire('detect SAM CLI', async () => {
         const samCliConfig = new DefaultSamCliConfiguration(
             new DefaultSettingsConfiguration(extensionSettingsPrefix),
             new DefaultSamCliLocationProvider()
         )
 
-        const initialSamCliLocation = samCliConfig.getSamCliLocation()
-
+        const valueBeforeInit = samCliConfig.getSamCliLocation()
         await samCliConfig.initialize()
+        const valueAfterInit = samCliConfig.getSamCliLocation()
+        const isAutoDetected = valueBeforeInit !== valueAfterInit
+        const isUserSettingChanged = currentsamCliLocation !== valueAfterInit
+        currentsamCliLocation = valueAfterInit
 
-        const currentsamCliLocation = samCliConfig.getSamCliLocation()
-
-        if (showMessageIfDetected) {
-            if (!currentsamCliLocation) {
+        if (opt.showMessage !== false) {
+            if (!valueAfterInit) {
                 notifyUserSamCliNotDetected(samCliConfig)
-            } else {
-                const message: string =
-                    initialSamCliLocation === currentsamCliLocation
-                        ? getSettingsNotUpdatedMessage(initialSamCliLocation)
-                        : getSettingsUpdatedMessage(currentsamCliLocation)
+            } else if (isUserSettingChanged || opt.showMessage === true) {
+                const message =
+                    !isAutoDetected && !isUserSettingChanged
+                        ? getSettingsNotUpdatedMessage(valueBeforeInit ?? '?')
+                        : getSettingsUpdatedMessage(currentsamCliLocation ?? '?')
 
                 vscode.window.showInformationMessage(message)
             }
@@ -86,13 +93,13 @@ function notifyUserSamCliNotDetected(samCliConfig: SamCliConfiguration): void {
 }
 
 function getSettingsUpdatedMessage(location: string): string {
-    const configuredLocation = localize('AWS.samcli.configured.location', 'Configured SAM CLI Location: {0}', location)
+    const configuredLocation = localize('AWS.samcli.configured.location', 'SAM CLI Location: {0}', location)
 
     return `${settingsUpdated} ${configuredLocation}`
 }
 
 function getSettingsNotUpdatedMessage(location: string): string {
-    const configuredLocation = localize('AWS.samcli.configured.location', 'Configured SAM CLI Location: {0}', location)
+    const configuredLocation = localize('AWS.samcli.configured.location', 'SAM CLI Location: {0}', location)
 
     return `${settingsNotUpdated} ${configuredLocation}`
 }

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -12,6 +12,7 @@ import { ChildProcess } from '../../utilities/childProcess'
 import { removeAnsi } from '../../utilities/textUtilities'
 import { Timeout } from '../../utilities/timeoutUtils'
 import { ChannelLogger } from '../../utilities/vsCodeUtils'
+import { DefaultSamCliProcessInvokerContext, SamCliProcessInvokerContext } from './samCliInvoker'
 
 const localize = nls.loadMessageBundle()
 
@@ -189,6 +190,7 @@ export class SamCliLocalInvokeInvocation {
     private readonly dockerNetwork?: string
     private readonly skipPullImage: boolean
     private readonly debuggerPath?: string
+    private readonly invokerContext: SamCliProcessInvokerContext
 
     /**
      * @see SamCliLocalInvokeInvocationArguments for parameter info
@@ -204,11 +206,14 @@ export class SamCliLocalInvokeInvocation {
         this.dockerNetwork = params.dockerNetwork
         this.skipPullImage = skipPullImage
         this.debuggerPath = params.debuggerPath
+        // Enterprise!
+        this.invokerContext = new DefaultSamCliProcessInvokerContext()
     }
 
     public async execute(timeout?: Timeout): Promise<void> {
         await this.validate()
 
+        const samCommand = this.invokerContext.cliConfig.getSamCliLocation() ?? 'sam'
         const args = [
             'local',
             'invoke',
@@ -227,7 +232,7 @@ export class SamCliLocalInvokeInvocation {
         this.addArgumentIf(args, !!this.debuggerPath, '--debugger-path', this.debuggerPath!)
 
         await this.invoker.invoke({
-            command: 'sam',
+            command: samCommand,
             args,
             isDebug: !!this.debugPort,
             timeout,

--- a/src/shared/sam/cli/samCliLocator.ts
+++ b/src/shared/sam/cli/samCliLocator.ts
@@ -77,10 +77,14 @@ abstract class BaseSamCliLocator {
         return undefined
     }
 
+    /**
+     * Searches for `getExecutableFilenames()` in `$PATH` and returns the first
+     * path found on the filesystem, if any.
+     */
     private async getSystemPathLocation(): Promise<string | undefined> {
         const envVars = process.env as EnvironmentVariables
 
-        if (!!envVars.PATH) {
+        if (envVars.PATH) {
             const systemPaths: string[] = envVars.PATH.split(path.delimiter).filter(folder => !!folder)
 
             return await this.findFileInFolders(this.getExecutableFilenames(), systemPaths)

--- a/src/test/shared/sam/cli/samCliConfiguration.test.ts
+++ b/src/test/shared/sam/cli/samCliConfiguration.test.ts
@@ -65,6 +65,7 @@ describe('SamCliConfiguration', () => {
 
         await samCliConfig.initialize()
 
+        assert.strictEqual(samCliConfig.getSamCliLocation(), fakeCliLocation)
         assert.strictEqual(timesCalled, 1)
     })
 


### PR DESCRIPTION
The `aws.samcli.location` vscode setting has been exposed since 60a2eab4d1ad but it was not used in `SamCliLocalInvokeInvocation`.

- use the value in `SamCliLocalInvokeInvocation`
- handle `onDidChangeConfiguration` when the setting is changed at runtime
- TODO: use `SamCliProcessInvoker` instead? (why doesn't `samCliConfiguration.ts` use it already, as the other `samCliX` modules do?)


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
