### PR TITLE
SAM CLI upgrade and associated fixes

### DIFF
--- a/.changes/next-release/Breaking Change-f8934213-b3a8-4b65-bcc3-0d97b5097169.json
+++ b/.changes/next-release/Breaking Change-f8934213-b3a8-4b65-bcc3-0d97b5097169.json
@@ -1,0 +1,4 @@
+{
+    "type": "Breaking Change",
+    "description": "Bumped minimum (inclusive) supported SAM CLI version from 0.38.0 to 0.47.0."
+}

--- a/.changes/next-release/Feature-3427d93a-a8da-41e2-9d90-fae3ed0b3526.json
+++ b/.changes/next-release/Feature-3427d93a-a8da-41e2-9d90-fae3ed0b3526.json
@@ -1,0 +1,4 @@
+{
+    "type": "Feature",
+    "description": "Added `dotnetcore3.1` app creation and local run support. Local debug is not currently supported."
+}

--- a/package.nls.json
+++ b/package.nls.json
@@ -308,7 +308,7 @@
     "AWS.samcli.local.invoke.error": "Error encountered running local SAM Application",
     "AWS.samcli.local.invoke.port.not.open": "The debug port doesn't appear to be open. The debugger might not succeed when attaching to your SAM Application.",
     "AWS.samcli.local.invoke.runtime.unsupported": "Unsupported {0} runtime: {1}",
-    "AWS.samcli.local.invoke.debugger.install": "Installing .NET Core Debugger to {0}...",
+    "AWS.samcli.local.invoke.debugger.install": "Installing .NET Core Debugger to {0} using Docker image {1}...",
     "AWS.samcli.local.invoke.debugger.install.failed": "Error installing .NET Core Debugger: {0}",
     "AWS.samcli.local.invoke.debugger.timeout": "The SAM process did not make the debugger available within the time limit",
     "AWS.samcli.notification.not.found": "Unable to find SAM CLI. It is required in order to work with Serverless Applications locally.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -241,6 +241,7 @@
     "AWS.message.toolkitInfo": "OS:  {0} {1} {2}\nVisual Studio Code Version:  {3}\nAWS Toolkit Version:  {4}\n",
     "AWS.output.building.sam.application": "Building SAM Application...",
     "AWS.output.building.sam.application.complete": "Build complete.",
+    "AWS.output.sam.local.no.net.3.1.debug": "NOTE! The `dotnetcore3.1` runtime does not support SAM debugging. This function will be run locally without debug.",
     "AWS.output.sam.local.attaching": "Attaching debugger to SAM Application...",
     "AWS.output.sam.local.attach.success": "Debugger attached",
     "AWS.output.sam.local.attach.failure": "Unable to attach Debugger. Check the Terminal tab for output. If it took longer than expected to successfully start, you may still attach to it.",

--- a/src/lambda/models/samLambdaRuntime.ts
+++ b/src/lambda/models/samLambdaRuntime.ts
@@ -8,7 +8,7 @@ import { Map, Set } from 'immutable'
 
 export const nodeJsRuntimes: Set<Runtime> = Set<Runtime>(['nodejs8.10', 'nodejs10.x', 'nodejs12.x'])
 export const pythonRuntimes: Set<Runtime> = Set<Runtime>(['python3.8', 'python3.7', 'python3.6', 'python2.7'])
-export const dotNetRuntimes: Set<Runtime> = Set<Runtime>(['dotnetcore2.1'])
+export const dotNetRuntimes: Set<Runtime> = Set<Runtime>(['dotnetcore2.1', 'dotnetcore3.1'])
 
 export const samLambdaRuntimes: Set<Runtime> = Set.union([nodeJsRuntimes, pythonRuntimes, dotNetRuntimes])
 

--- a/src/shared/codelens/csharpCodeLensProvider.ts
+++ b/src/shared/codelens/csharpCodeLensProvider.ts
@@ -6,6 +6,9 @@
 import * as path from 'path'
 import * as semver from 'semver'
 import * as vscode from 'vscode'
+import * as nls from 'vscode-nls'
+
+const localize = nls.loadMessageBundle()
 
 import { access } from 'fs-extra'
 import { getHandlerConfig } from '../../lambda/config/templates'
@@ -153,6 +156,17 @@ async function onLocalInvokeCommand(
     })
     let invokeResult: Result = 'Succeeded'
     const lambdaRuntime = CloudFormation.getRuntime(resource)
+
+    // TODO: Remove this line to enable dotnetcore3.1 debugging when it becomes available
+    if (lambdaRuntime === 'dotnetcore3.1' && lambdaLocalInvokeParams.isDebug) {
+        vscode.window.showInformationMessage(
+            localize(
+                'AWS.output.sam.local.no.net.3.1.debug',
+                'NOTE! The dotnetcore3.1 runtime is not currently supported for SAM debugging. The following run will be executed without debugging.'
+            )
+        )
+        lambdaLocalInvokeParams.isDebug = false
+    }
 
     try {
         // Switch over to the output channel so the user has feedback that we're getting things ready

--- a/src/shared/codelens/csharpCodeLensProvider.ts
+++ b/src/shared/codelens/csharpCodeLensProvider.ts
@@ -4,7 +4,6 @@
  */
 
 import * as path from 'path'
-import * as semver from 'semver'
 import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 
@@ -43,7 +42,7 @@ import {
     makeInputTemplate,
     waitForDebugPort,
 } from './localLambdaRunner'
-import { getSamCliContext } from '../sam/cli/samCliContext'
+import { getSamCliContext, getSamCliDockerImageNameWithRuntime } from '../sam/cli/samCliContext'
 
 export const CSHARP_LANGUAGE = 'csharp'
 export const CSHARP_ALLFILES: vscode.DocumentFilter[] = [
@@ -483,10 +482,7 @@ async function _installDebugger(
         const samCliVersionValidatorResult = await samCliContext.validator.getVersionValidatorResult()
         const samCliVersion = samCliVersionValidatorResult.version
 
-        const imageStr =
-            !samCliVersion || semver.gte(samCliVersion, '1.0.0')
-                ? `amazon/aws-sam-cli-emulation-image-${lambdaRuntime}`
-                : `lambci/lambda:${lambdaRuntime}`
+        const imageStr = getSamCliDockerImageNameWithRuntime(samCliVersion, lambdaRuntime)
 
         channelLogger.info(
             'AWS.samcli.local.invoke.debugger.install',

--- a/src/shared/codelens/csharpCodeLensProvider.ts
+++ b/src/shared/codelens/csharpCodeLensProvider.ts
@@ -162,7 +162,7 @@ async function onLocalInvokeCommand(
         vscode.window.showInformationMessage(
             localize(
                 'AWS.output.sam.local.no.net.3.1.debug',
-                'NOTE! The dotnetcore3.1 runtime is not currently supported for SAM debugging. The following run will be executed without debugging.'
+                'NOTE! The `dotnetcore3.1` runtime does not support SAM debugging. This function will be run locally without debug.'
             )
         )
         lambdaLocalInvokeParams.isDebug = false

--- a/src/shared/codelens/csharpCodeLensProvider.ts
+++ b/src/shared/codelens/csharpCodeLensProvider.ts
@@ -42,7 +42,7 @@ import {
     makeInputTemplate,
     waitForDebugPort,
 } from './localLambdaRunner'
-import { getSamCliContext, getSamCliDockerImageNameWithRuntime } from '../sam/cli/samCliContext'
+import { getSamCliContext, getSamCliDockerImageName } from '../sam/cli/samCliContext'
 
 export const CSHARP_LANGUAGE = 'csharp'
 export const CSHARP_ALLFILES: vscode.DocumentFilter[] = [
@@ -482,7 +482,7 @@ async function _installDebugger(
         const samCliVersionValidatorResult = await samCliContext.validator.getVersionValidatorResult()
         const samCliVersion = samCliVersionValidatorResult.version
 
-        const imageStr = getSamCliDockerImageNameWithRuntime(samCliVersion, lambdaRuntime)
+        const imageStr = getSamCliDockerImageName(samCliVersion, lambdaRuntime)
 
         channelLogger.info(
             'AWS.samcli.local.invoke.debugger.install',

--- a/src/shared/sam/cli/samCliContext.ts
+++ b/src/shared/sam/cli/samCliContext.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as semver from 'semver'
 import { SettingsConfiguration } from '../../settingsConfiguration'
 import { DefaultSamCliConfiguration } from './samCliConfiguration'
 import { DefaultSamCliProcessInvoker, SamCliProcessInvokerContext } from './samCliInvoker'
@@ -10,6 +11,7 @@ import { SamCliProcessInvoker } from './samCliInvokerUtils'
 import { DefaultSamCliLocationProvider } from './samCliLocator'
 import { throwAndNotifyIfInvalid } from './samCliValidationUtils'
 import { DefaultSamCliValidator, DefaultSamCliValidatorContext, SamCliValidator } from './samCliValidator'
+import { getLogger } from '../../logger'
 
 export interface SamCliContext {
     validator: SamCliValidator
@@ -51,6 +53,26 @@ export async function getSamCliVersion(context: SamCliContext): Promise<string> 
     throwAndNotifyIfInvalid(result)
 
     return result.versionValidation!.version!
+}
+
+/**
+ * Returns the correct Docker image name based on SAM CLI version.
+ * Anything not greater than 1.0.0, undefined, or non-parseable will use `amazon/aws-sam-cli-emulation-image-${lambdaRuntime}`
+ * Else, use `lambci/lambda:${lambdaRuntime}`
+ * @param samCliVersion Version to evaluate
+ * @param lambdaRuntime Runtime name to append to Docker image
+ */
+export function getSamCliDockerImageNameWithRuntime(samCliVersion: string | undefined, lambdaRuntime: string): string {
+    const amazonImage = `amazon/aws-sam-cli-emulation-image-${lambdaRuntime}`
+    const legacyImage = `lambci/lambda:${lambdaRuntime}`
+    try {
+        return !samCliVersion || semver.gte(samCliVersion, '1.0.0') ? amazonImage : legacyImage
+    } catch (e) {
+        const err = e as Error
+        getLogger().error('Could not parse SAM CLI version:', samCliVersion, err.message)
+
+        return amazonImage
+    }
 }
 
 function makeSamCliContext(): SamCliContext {

--- a/src/shared/sam/cli/samCliContext.ts
+++ b/src/shared/sam/cli/samCliContext.ts
@@ -62,7 +62,7 @@ export async function getSamCliVersion(context: SamCliContext): Promise<string> 
  * @param samCliVersion Version to evaluate
  * @param lambdaRuntime Runtime name to append to Docker image
  */
-export function getSamCliDockerImageNameWithRuntime(samCliVersion: string | undefined, lambdaRuntime: string): string {
+export function getSamCliDockerImageName(samCliVersion: string | undefined, lambdaRuntime: string): string {
     const amazonImage = `amazon/aws-sam-cli-emulation-image-${lambdaRuntime}`
     const legacyImage = `lambci/lambda:${lambdaRuntime}`
     try {

--- a/src/shared/sam/cli/samCliValidator.ts
+++ b/src/shared/sam/cli/samCliValidator.ts
@@ -9,7 +9,7 @@ import { SamCliConfiguration } from './samCliConfiguration'
 import { SamCliInfoInvocation, SamCliInfoResponse } from './samCliInfo'
 import { SamCliProcessInvoker } from './samCliInvokerUtils'
 
-export const MINIMUM_SAM_CLI_VERSION_INCLUSIVE = '0.38.0'
+export const MINIMUM_SAM_CLI_VERSION_INCLUSIVE = '0.47.0'
 export const MAXIMUM_SAM_CLI_VERSION_EXCLUSIVE = '2.0.0'
 
 // Errors

--- a/src/shared/sam/cli/samCliValidator.ts
+++ b/src/shared/sam/cli/samCliValidator.ts
@@ -81,7 +81,6 @@ export class DefaultSamCliValidator implements SamCliValidator {
         return result
     }
 
-    // This method is public for testing purposes
     public async getVersionValidatorResult(): Promise<SamCliVersionValidatorResult> {
         const samCliId: string = await this.context.getSamCliExecutableId()
         if (!this.isSamCliVersionCached(samCliId)) {

--- a/src/shared/sam/cli/samCliValidator.ts
+++ b/src/shared/sam/cli/samCliValidator.ts
@@ -51,6 +51,7 @@ export interface SamCliValidatorResult {
 
 export interface SamCliValidator {
     detectValidSamCli(): Promise<SamCliValidatorResult>
+    getVersionValidatorResult(): Promise<SamCliVersionValidatorResult>
 }
 
 export interface SamCliValidatorContext {

--- a/src/test/lambda/commands/deploySamApplication.test.ts
+++ b/src/test/lambda/commands/deploySamApplication.test.ts
@@ -22,6 +22,7 @@ import {
     SamCliValidator,
     SamCliValidatorResult,
     SamCliVersionValidation,
+    SamCliVersionValidatorResult,
 } from '../../../shared/sam/cli/samCliValidator'
 import { ChildProcessResult } from '../../../shared/utilities/childProcess'
 import { getTestLogger } from '../../globalSetup.test'
@@ -37,6 +38,9 @@ describe('deploySamApplication', async () => {
 
     const badValidator: SamCliValidator = {
         detectValidSamCli: async (): Promise<SamCliValidatorResult> => badValidatorResult,
+        getVersionValidatorResult: async (): Promise<SamCliVersionValidatorResult> => {
+            return { validation: SamCliVersionValidation.VersionNotParseable }
+        },
     }
 
     // Bad Invoker
@@ -59,6 +63,9 @@ describe('deploySamApplication', async () => {
 
     const goodValidator: SamCliValidator = {
         detectValidSamCli: async (): Promise<SamCliValidatorResult> => goodValidatorResult,
+        getVersionValidatorResult: async (): Promise<SamCliVersionValidatorResult> => {
+            return { validation: SamCliVersionValidation.Valid }
+        },
     }
 
     // Good Invoker

--- a/src/test/shared/sam/cli/defaultValidatingSamCliProcessInvoker.test.ts
+++ b/src/test/shared/sam/cli/defaultValidatingSamCliProcessInvoker.test.ts
@@ -17,6 +17,7 @@ import {
     SamCliValidator,
     SamCliValidatorResult,
     SamCliVersionValidation,
+    SamCliVersionValidatorResult,
 } from '../../../../shared/sam/cli/samCliValidator'
 import { ChildProcessResult } from '../../../../shared/utilities/childProcess'
 import { assertThrowsError } from '../../utilities/assertUtils'
@@ -64,6 +65,9 @@ describe('DefaultValidatingSamCliProcessInvoker', async () => {
                         },
                     }
                 },
+                getVersionValidatorResult: async (): Promise<SamCliVersionValidatorResult> => {
+                    return { validation: test.versionValidation }
+                },
             }
 
             const invoker = new DefaultValidatingSamCliProcessInvoker({
@@ -95,6 +99,9 @@ describe('DefaultValidatingSamCliProcessInvoker', async () => {
                     samCliFound: false,
                 }
             },
+            getVersionValidatorResult: async (): Promise<SamCliVersionValidatorResult> => {
+                return { validation: SamCliVersionValidation.VersionNotParseable }
+            },
         }
 
         const invoker = new DefaultValidatingSamCliProcessInvoker({
@@ -118,6 +125,9 @@ describe('DefaultValidatingSamCliProcessInvoker', async () => {
                     samCliFound: true,
                     versionValidation: undefined,
                 }
+            },
+            getVersionValidatorResult: async (): Promise<SamCliVersionValidatorResult> => {
+                return { validation: SamCliVersionValidation.VersionNotParseable }
             },
         }
 
@@ -147,6 +157,9 @@ describe('DefaultValidatingSamCliProcessInvoker', async () => {
                         validation: SamCliVersionValidation.Valid,
                     },
                 }
+            },
+            getVersionValidatorResult: async (): Promise<SamCliVersionValidatorResult> => {
+                return { validation: SamCliVersionValidation.Valid }
             },
         }
 

--- a/src/test/shared/sam/cli/samCliContext.test.ts
+++ b/src/test/shared/sam/cli/samCliContext.test.ts
@@ -4,18 +4,18 @@
  */
 
 import * as assert from 'assert'
-import { getSamCliDockerImageNameWithRuntime } from '../../../../shared/sam/cli/samCliContext'
+import { getSamCliDockerImageName } from '../../../../shared/sam/cli/samCliContext'
 
-describe('getSamCliDockerImageNameWithRuntime', () => {
+describe('getSamCliDockerImageName', () => {
     it('returns the correct values', () => {
         const runtime = 'funtime'
         const amazonImage = `amazon/aws-sam-cli-emulation-image-${runtime}`
         const legacyImage = `lambci/lambda:${runtime}`
 
-        assert.strictEqual(getSamCliDockerImageNameWithRuntime('0.0.0', runtime), legacyImage)
-        assert.strictEqual(getSamCliDockerImageNameWithRuntime('1.0.0', runtime), amazonImage)
-        assert.strictEqual(getSamCliDockerImageNameWithRuntime('999.999.9999', runtime), amazonImage)
-        assert.strictEqual(getSamCliDockerImageNameWithRuntime(undefined, runtime), amazonImage)
-        assert.strictEqual(getSamCliDockerImageNameWithRuntime('1.0.0rc', runtime), amazonImage)
+        assert.strictEqual(getSamCliDockerImageName('0.0.0', runtime), legacyImage)
+        assert.strictEqual(getSamCliDockerImageName('1.0.0', runtime), amazonImage)
+        assert.strictEqual(getSamCliDockerImageName('999.999.9999', runtime), amazonImage)
+        assert.strictEqual(getSamCliDockerImageName(undefined, runtime), amazonImage)
+        assert.strictEqual(getSamCliDockerImageName('1.0.0rc', runtime), amazonImage)
     })
 })

--- a/src/test/shared/sam/cli/samCliContext.test.ts
+++ b/src/test/shared/sam/cli/samCliContext.test.ts
@@ -1,0 +1,21 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { getSamCliDockerImageNameWithRuntime } from '../../../../shared/sam/cli/samCliContext'
+
+describe('getSamCliDockerImageNameWithRuntime', () => {
+    it('returns the correct values', () => {
+        const runtime = 'funtime'
+        const amazonImage = `amazon/aws-sam-cli-emulation-image-${runtime}`
+        const legacyImage = `lambci/lambda:${runtime}`
+
+        assert.strictEqual(getSamCliDockerImageNameWithRuntime('0.0.0', runtime), legacyImage)
+        assert.strictEqual(getSamCliDockerImageNameWithRuntime('1.0.0', runtime), amazonImage)
+        assert.strictEqual(getSamCliDockerImageNameWithRuntime('999.999.9999', runtime), amazonImage)
+        assert.strictEqual(getSamCliDockerImageNameWithRuntime(undefined, runtime), amazonImage)
+        assert.strictEqual(getSamCliDockerImageNameWithRuntime('1.0.0rc', runtime), amazonImage)
+    })
+})

--- a/src/test/shared/sam/cli/samCliInit.test.ts
+++ b/src/test/shared/sam/cli/samCliInit.test.ts
@@ -18,6 +18,7 @@ import {
     SamCliValidator,
     SamCliValidatorResult,
     SamCliVersionValidation,
+    SamCliVersionValidatorResult,
 } from '../../../../shared/sam/cli/samCliValidator'
 import { ChildProcessResult } from '../../../../shared/utilities/childProcess'
 import { getTestLogger } from '../../../globalSetup.test'
@@ -64,6 +65,10 @@ describe('runSamCliInit', async () => {
                     validation: SamCliVersionValidation.Valid,
                 },
             }
+        }
+
+        public async getVersionValidatorResult(): Promise<SamCliVersionValidatorResult> {
+            return { validation: SamCliVersionValidation.VersionNotParseable }
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Assorted SAM CLI fixes:
* Minimum version bump: 0.38.0 -> 0.47.0 (for dotnetcore3.1 compatibility)
  * Only "Run Locally" is available for dotnetcore3.1 functions. "Debug Locally" will automatically convert to a "Run Locally" on execution.
* We manually select the correct Docker image for the SAM CLI version when installing VSDBG.

## Motivation and Context

The dotnetcore3.1 runtime has been available in SAM for a while (but without debugging capabilities). This is a past-due update as we move to newer SAM CLI versions.

SAM CLI 1.0.0 and up use an Amazon-owned Docker image from Dockerhub, `amazon/aws-sam-cli-emulation-image-<runtime>` instead of the community-owned version, `lambci/lambda:<runtime>`. Prior to debugging a .NET Lambda function, we need to pull down the container that the SAM CLI will use and download/unzip a version of the VSDBG debugger that is compatible with the container we will be using. 

Additional optimizations that are TBD include validating whether or not an existing VSDBG is correct for current SAM Docker image.

## Related Issue(s)

Followup to https://github.com/aws/aws-toolkit-vscode/pull/1169
Fix for https://github.com/aws/aws-toolkit-vscode/issues/1180

## Testing

Manual test of the prerelease SAM CLI: removed all local Docker images and initiated a debug of a `dotnetcore2.1` function and verified that only one image was downloaded. Of note: I had to swap the test from a SemVer comparison to a direct string match (since the current version, `1.0.0rc1` is not SemVer-compliant.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
