### PR TITLE
Temporarily reducing VS Code version to 1.46.0 due to issues with 1.47.0

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -1,5 +1,9 @@
 version: 0.2
 
+env:
+    variables:
+        VSCODE_TEST_VERSION: '1.46.0' # TODO: Remove when we resolve debugger issues with integration tests
+
 phases:
     install:
         runtime-versions:

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -2,33 +2,33 @@ version: 0.2
 env:
     variables:
         AWS_TOOLKIT_TEST_NO_COLOR: '1'
-        VSCODE_TEST_VERSION: '1.46.0' # TODO: Remove when we resolve debugger issues with integration tests
+        VSCODE_TEST_VERSION: '1.46.0' # TODO: Remove when we resolve debugger issues with Windows tests
 phases:
     install:
-        commands: if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
-            choco install -y --no-progress codecov
-            }
-            }
+        commands:
+            - |
+                if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
+                    choco install -y --no-progress codecov
+                }
 
     pre_build:
         commands:
             - npm install
 
-    build:
-        commands:
-            - npm run testCompile
-            - npm run lint
-            - $env:TEST_REPORT_DIR="$env:CODEBUILD_SRC_DIR/.test_reports"; npm run test
-            - |
-                if(-Not($Env:CODEBUILD_BUILD_SUCCEEDING -eq "0" -Or $Env:CODE_COV_TOKEN -eq $null)) {
-                  $env:VCS_COMMIT_ID=$Env:CODEBUILD_RESOLVED_SOURCE_VERSION;
-                  $env:CI_BUILD_URL=[uri]::EscapeUriString($Env:CODEBUILD_BUILD_URL);
-                  $env:CI_BUILD_ID=$Env:CODEBUILD_BUILD_ID;
-                  codecov -t $Env:CODE_COV_TOKEN `
-                    --flag unittest `
-                    -f "build/reports/jacoco/coverageReport/coverageReport.xml" `
-                    -c $Env:CODEBUILD_RESOLVED_SOURCE_VERSION
-                }
+    build: command.0
+        - npm run testCompile
+        - npm run lint
+        - $env:TEST_REPORT_DIR="$env:CODEBUILD_SRC_DIR/.test_reports"; npm run test
+        - |
+        if(-Not($Env:CODEBUILD_BUILD_SUCCEEDING -eq "0" -Or $Env:CODE_COV_TOKEN -eq $null)) {
+        $env:VCS_COMMIT_ID=$Env:CODEBUILD_RESOLVED_SOURCE_VERSION;
+        $env:CI_BUILD_URL=[uri]::EscapeUriString($Env:CODEBUILD_BUILD_URL);
+        $env:CI_BUILD_ID=$Env:CODEBUILD_BUILD_ID;
+        codecov -t $Env:CODE_COV_TOKEN `
+        --flag unittest `
+        -f "build/reports/jacoco/coverageReport/coverageReport.xml" `
+        -c $Env:CODEBUILD_RESOLVED_SOURCE_VERSION
+        }
 
 reports:
     unit-test:

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -10,26 +10,25 @@ phases:
                 if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
                     choco install -y --no-progress codecov
                 }
-
     pre_build:
         commands:
             - npm install
 
-    build: command.0
-        - npm run testCompile
-        - npm run lint
-        - $env:TEST_REPORT_DIR="$env:CODEBUILD_SRC_DIR/.test_reports"; npm run test
-        - |
-        if(-Not($Env:CODEBUILD_BUILD_SUCCEEDING -eq "0" -Or $Env:CODE_COV_TOKEN -eq $null)) {
-        $env:VCS_COMMIT_ID=$Env:CODEBUILD_RESOLVED_SOURCE_VERSION;
-        $env:CI_BUILD_URL=[uri]::EscapeUriString($Env:CODEBUILD_BUILD_URL);
-        $env:CI_BUILD_ID=$Env:CODEBUILD_BUILD_ID;
-        codecov -t $Env:CODE_COV_TOKEN `
-        --flag unittest `
-        -f "build/reports/jacoco/coverageReport/coverageReport.xml" `
-        -c $Env:CODEBUILD_RESOLVED_SOURCE_VERSION
-        }
-
+    build:
+        commands:
+            - npm run testCompile
+            - npm run lint
+            - $env:TEST_REPORT_DIR="$env:CODEBUILD_SRC_DIR/.test_reports"; npm run test
+            - |
+                if(-Not($Env:CODEBUILD_BUILD_SUCCEEDING -eq "0" -Or $Env:CODE_COV_TOKEN -eq $null)) {
+                  $env:VCS_COMMIT_ID=$Env:CODEBUILD_RESOLVED_SOURCE_VERSION;
+                  $env:CI_BUILD_URL=[uri]::EscapeUriString($Env:CODEBUILD_BUILD_URL);
+                  $env:CI_BUILD_ID=$Env:CODEBUILD_BUILD_ID;
+                  codecov -t $Env:CODE_COV_TOKEN `
+                    --flag unittest `
+                    -f "build/reports/jacoco/coverageReport/coverageReport.xml" `
+                    -c $Env:CODEBUILD_RESOLVED_SOURCE_VERSION
+                }
 reports:
     unit-test:
         files:

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -5,11 +5,10 @@ env:
         VSCODE_TEST_VERSION: '1.46.0' # TODO: Remove when we resolve debugger issues with integration tests
 phases:
     install:
-        commands:
-            - |
-                if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
-                    choco install -y --no-progress codecov
-                }
+        commands: if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
+            choco install -y --no-progress codecov
+            }
+            }
 
     pre_build:
         commands:
@@ -17,7 +16,6 @@ phases:
 
     build:
         commands:
-            - export VSCODE_TEST_VERSION 1.46.0
             - npm run testCompile
             - npm run lint
             - $env:TEST_REPORT_DIR="$env:CODEBUILD_SRC_DIR/.test_reports"; npm run test

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -2,13 +2,14 @@ version: 0.2
 env:
     variables:
         AWS_TOOLKIT_TEST_NO_COLOR: '1'
+        VSCODE_TEST_VERSION: '1.46.0' # TODO: Remove when we resolve debugger issues with integration tests
 phases:
     install:
         commands:
             - |
-              if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
-                  choco install -y --no-progress codecov
-              }
+                if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
+                    choco install -y --no-progress codecov
+                }
 
     pre_build:
         commands:
@@ -16,6 +17,7 @@ phases:
 
     build:
         commands:
+            - export VSCODE_TEST_VERSION 1.46.0
             - npm run testCompile
             - npm run lint
             - $env:TEST_REPORT_DIR="$env:CODEBUILD_SRC_DIR/.test_reports"; npm run test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently having issues with running our CI Integration tests and Windows unit tests against VS Code 1.47.0 in AWS CodeBuild.
* The Integration tests might be an issue with our code waiting for a port to open on the new debugger. Will require more research.
* Windows unit tests are running into an error with `getmac.exe`. This error is not encountered when using 1.46.0 and our code does not utilize `getmac.exe`. Cut an issue to VS Code (https://github.com/microsoft/vscode/issues/102428) to determine whether or not this is a regression.

Can confirm that the tests run successfully against 1.47.0 on my local Windows 10 machine; so far, this appears to be an issue with the CI hosts only.

## Motivation and Context

We want some degree of integration and Windows test coverage on new PRs in our repo.

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing
Pushing as a draft to ensure that this resolves the issue.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
