### PR TITLE
Activate extension shortly after VSCode startup

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -47,6 +47,7 @@ phases:
         commands:
             - export AWS_TOOLKIT_TEST_USER_DIR=/tmp/
             - export AWS_TOOLKIT_TEST_NO_COLOR=1
+            - export NO_COVERAGE=true
             - npm install --unsafe-perm
             - xvfb-run npm run integrationTest
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "preview": false,
     "qna": "https://github.com/aws/aws-toolkit-vscode/issues",
     "activationEvents": [
+        "onStartupFinished",
         "onCommand:aws.login",
         "onCommand:aws.credential.profile.create",
         "onCommand:aws.logout",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Reintroducing of #1188 with fix for integ tests mentioned in #1192 

Disable coverage during integration tests

<!--- Describe your changes in detail -->

## Motivation and Context

Nothing is currently done with the coverage reports (if they even work)
and this breaks a bunch integration tests in weird circumstances (#1192)

e.g. it causes global context to be unavailable to tests for some reason if activation comes from the plugin itself rather than from the test

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)

#1188
#1192 
<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x]My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
