### PR TITLE
telemetry: do not record passive aws_setCredentials, SAM_detect

### DIFF
--- a/src/credentials/activation.ts
+++ b/src/credentials/activation.ts
@@ -44,14 +44,14 @@ export async function loginWithMostRecentCredentials(
             credentialType: SharedCredentialsProvider.getCredentialsType(),
             credentialTypeId: previousCredentialsId,
         }
-        await loginManager.login(loginCredentialsId)
+        await loginManager.login(true, loginCredentialsId)
     } else if (
         providerMap &&
         profileNames.length === 1 &&
         (await manager.getCredentialsProvider(providerMap[profileNames[0]]))!.canAutoConnect()
     ) {
         // Auto-connect if there is exactly one profile.
-        await loginManager.login(providerMap[profileNames[0]])
+        await loginManager.login(true, providerMap[profileNames[0]])
         // Toast.
         vscode.window.showInformationMessage(`Connected to AWS as "${profileNames[0]}"`)
     } else {

--- a/src/credentials/activation.ts
+++ b/src/credentials/activation.ts
@@ -44,14 +44,14 @@ export async function loginWithMostRecentCredentials(
             credentialType: SharedCredentialsProvider.getCredentialsType(),
             credentialTypeId: previousCredentialsId,
         }
-        await loginManager.login(true, loginCredentialsId)
+        await loginManager.login({ passive: true, providerId: loginCredentialsId })
     } else if (
         providerMap &&
         profileNames.length === 1 &&
         (await manager.getCredentialsProvider(providerMap[profileNames[0]]))!.canAutoConnect()
     ) {
         // Auto-connect if there is exactly one profile.
-        await loginManager.login(true, providerMap[profileNames[0]])
+        await loginManager.login({ passive: true, providerId: providerMap[profileNames[0]] })
         // Toast.
         vscode.window.showInformationMessage(`Connected to AWS as "${profileNames[0]}"`)
     } else {

--- a/src/credentials/loginManager.ts
+++ b/src/credentials/loginManager.ts
@@ -26,8 +26,11 @@ export class LoginManager {
     /**
      * Establishes a Credentials for the Toolkit to use. Essentially the Toolkit becomes "logged in".
      * If an error occurs while trying to set up and verify these credentials, the Toolkit is "logged out".
+     *
+     * @param credentialsProviderId
+     * @param passive  If true, this was _not_ a user-initiated action.
      */
-    public async login(credentialsProviderId: CredentialsProviderId): Promise<void> {
+    public async login(passive: boolean, credentialsProviderId: CredentialsProviderId): Promise<void> {
         let loginResult: Result = 'Succeeded'
         try {
             const provider = await CredentialsProviderManager.getInstance().getCredentialsProvider(
@@ -70,7 +73,9 @@ export class LoginManager {
 
             this.notifyUserInvalidCredentials(credentialsProviderId)
         } finally {
-            recordAwsSetCredentials({ result: loginResult })
+            if (!passive) {
+                recordAwsSetCredentials({ result: loginResult })
+            }
         }
     }
 

--- a/src/credentials/loginManager.ts
+++ b/src/credentials/loginManager.ts
@@ -21,7 +21,10 @@ export class LoginManager {
     private readonly defaultCredentialsRegion = 'us-east-1'
     private readonly credentialsStore: CredentialsStore = new CredentialsStore()
 
-    public constructor(private readonly awsContext: AwsContext) {}
+    public constructor(
+        private readonly awsContext: AwsContext,
+        public readonly recordAwsSetCredentialsFn: typeof recordAwsSetCredentials = recordAwsSetCredentials
+    ) {}
 
     /**
      * Establishes a Credentials for the Toolkit to use. Essentially the Toolkit becomes "logged in".
@@ -74,7 +77,7 @@ export class LoginManager {
             this.notifyUserInvalidCredentials(credentialsProviderId)
         } finally {
             if (!passive) {
-                recordAwsSetCredentials({ result: loginResult })
+                this.recordAwsSetCredentialsFn({ result: loginResult })
             }
         }
     }

--- a/src/shared/defaultAwsContextCommands.ts
+++ b/src/shared/defaultAwsContextCommands.ts
@@ -60,7 +60,7 @@ export class DefaultAWSContextCommands {
             return
         }
 
-        await this.loginManager.login(fromString(profileName))
+        await this.loginManager.login(false, fromString(profileName))
     }
 
     public async onCommandCreateCredentialsProfile(): Promise<void> {
@@ -71,7 +71,7 @@ export class DefaultAWSContextCommands {
             const profileName: string | undefined = await this.promptAndCreateNewCredentialsFile()
 
             if (profileName) {
-                await this.loginManager.login(fromString(profileName))
+                await this.loginManager.login(false, fromString(profileName))
             }
         } else {
             // Get the editor set up and turn things over to the user

--- a/src/shared/defaultAwsContextCommands.ts
+++ b/src/shared/defaultAwsContextCommands.ts
@@ -60,7 +60,7 @@ export class DefaultAWSContextCommands {
             return
         }
 
-        await this.loginManager.login(false, fromString(profileName))
+        await this.loginManager.login({ passive: false, providerId: fromString(profileName) })
     }
 
     public async onCommandCreateCredentialsProfile(): Promise<void> {
@@ -71,7 +71,7 @@ export class DefaultAWSContextCommands {
             const profileName: string | undefined = await this.promptAndCreateNewCredentialsFile()
 
             if (profileName) {
-                await this.loginManager.login(false, fromString(profileName))
+                await this.loginManager.login({ passive: false, providerId: fromString(profileName) })
             }
         } else {
             // Get the editor set up and turn things over to the user

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -77,11 +77,11 @@ export async function activate(activateArguments: {
         )
     )
 
-    await detectSamCli({ showMessage: false })
+    await detectSamCli({ passive: true, showMessage: false })
     activateArguments.extensionContext.subscriptions.push(
         vscode.workspace.onDidChangeConfiguration(configurationChangeEvent => {
             if (configurationChangeEvent.affectsConfiguration('aws.samcli.location')) {
-                detectSamCli({ showMessage: undefined })
+                detectSamCli({ passive: true, showMessage: undefined })
             }
         })
     )
@@ -101,7 +101,7 @@ async function registerServerlessCommands(params: {
             async () =>
                 await PromiseSharer.getExistingPromiseOrCreate(
                     'samcli.detect',
-                    async () => await detectSamCli({ showMessage: true })
+                    async () => await detectSamCli({ passive: false, showMessage: true })
                 )
         ),
         vscode.commands.registerCommand('aws.lambda.createNewSamApp', async () => {

--- a/src/shared/sam/cli/samCliDetection.ts
+++ b/src/shared/sam/cli/samCliDetection.ts
@@ -25,12 +25,12 @@ let currentsamCliLocation: string | undefined = undefined
 
 /**
  *
- * @param opt.passive  If true, this was _not_ a user-initiated action.
- * @param opt.showMessage true: always show message, false: never show
+ * @param args.passive  If true, this was _not_ a user-initiated action.
+ * @param args.showMessage true: always show message, false: never show
  * message, undefined: show message only if the new setting differs from
  * the old setting.
  */
-export async function detectSamCli(opt: { passive: boolean; showMessage: boolean | undefined }): Promise<void> {
+export async function detectSamCli(args: { passive: boolean; showMessage: boolean | undefined }): Promise<void> {
     await lock.acquire('detect SAM CLI', async () => {
         const samCliConfig = new DefaultSamCliConfiguration(
             new DefaultSettingsConfiguration(extensionSettingsPrefix),
@@ -44,10 +44,10 @@ export async function detectSamCli(opt: { passive: boolean; showMessage: boolean
         const isUserSettingChanged = currentsamCliLocation !== valueAfterInit
         currentsamCliLocation = valueAfterInit
 
-        if (opt.showMessage !== false) {
+        if (args.showMessage !== false) {
             if (!valueAfterInit) {
                 notifyUserSamCliNotDetected(samCliConfig)
-            } else if (isUserSettingChanged || opt.showMessage === true) {
+            } else if (isUserSettingChanged || args.showMessage === true) {
                 const message =
                     !isAutoDetected && !isUserSettingChanged
                         ? getSettingsNotUpdatedMessage(valueBeforeInit ?? '?')
@@ -57,7 +57,7 @@ export async function detectSamCli(opt: { passive: boolean; showMessage: boolean
             }
         }
 
-        if (!opt.passive) {
+        if (!args.passive) {
             recordSamDetect({ result: currentsamCliLocation === undefined ? 'Failed' : 'Succeeded' })
         }
     })

--- a/src/shared/sam/cli/samCliDetection.ts
+++ b/src/shared/sam/cli/samCliDetection.ts
@@ -25,11 +25,12 @@ let currentsamCliLocation: string | undefined = undefined
 
 /**
  *
+ * @param opt.passive  If true, this was _not_ a user-initiated action.
  * @param opt.showMessage true: always show message, false: never show
  * message, undefined: show message only if the new setting differs from
  * the old setting.
  */
-export async function detectSamCli(opt: { showMessage: boolean | undefined }): Promise<void> {
+export async function detectSamCli(opt: { passive: boolean; showMessage: boolean | undefined }): Promise<void> {
     await lock.acquire('detect SAM CLI', async () => {
         const samCliConfig = new DefaultSamCliConfiguration(
             new DefaultSettingsConfiguration(extensionSettingsPrefix),
@@ -56,7 +57,9 @@ export async function detectSamCli(opt: { showMessage: boolean | undefined }): P
             }
         }
 
-        recordSamDetect({ result: currentsamCliLocation === undefined ? 'Failed' : 'Succeeded' })
+        if (!opt.passive) {
+            recordSamDetect({ result: currentsamCliLocation === undefined ? 'Failed' : 'Succeeded' })
+        }
     })
 }
 

--- a/src/test/shared/credentials/loginManager.test.ts
+++ b/src/test/shared/credentials/loginManager.test.ts
@@ -56,14 +56,14 @@ describe('LoginManager', async () => {
     it('logs in with credentials (happy path)', async () => {
         const setCredentialsStub = sandbox.stub(awsContext, 'setCredentials')
 
-        await loginManager.login(sampleCredentialsProviderId)
+        await loginManager.login(false, sampleCredentialsProviderId)
         assert.strictEqual(setCredentialsStub.callCount, 1, 'Expected awsContext setCredentials to be called once')
     })
 
     it('logs out (happy path)', async () => {
         const setCredentialsStub = sandbox.stub(awsContext, 'setCredentials')
 
-        await loginManager.login(sampleCredentialsProviderId)
+        await loginManager.login(false, sampleCredentialsProviderId)
         await loginManager.logout()
         assert.strictEqual(setCredentialsStub.callCount, 2, 'Expected awsContext setCredentials to be called twice')
     })
@@ -76,7 +76,7 @@ describe('LoginManager', async () => {
             assert.strictEqual(credentials, undefined)
         })
 
-        await loginManager.login(sampleCredentialsProviderId)
+        await loginManager.login(true, sampleCredentialsProviderId)
         assert.strictEqual(setCredentialsStub.callCount, 1, 'Expected awsContext setCredentials to be called once')
     })
 
@@ -88,7 +88,7 @@ describe('LoginManager', async () => {
             assert.strictEqual(credentials, undefined)
         })
 
-        await loginManager.login(sampleCredentialsProviderId)
+        await loginManager.login(false, sampleCredentialsProviderId)
         assert.strictEqual(setCredentialsStub.callCount, 1, 'Expected awsContext setCredentials to be called once')
     })
 
@@ -100,7 +100,7 @@ describe('LoginManager', async () => {
             assert.strictEqual(credentials, undefined)
         })
 
-        await loginManager.login(sampleCredentialsProviderId)
+        await loginManager.login(false, sampleCredentialsProviderId)
         assert.strictEqual(setCredentialsStub.callCount, 1, 'Expected awsContext setCredentials to be called once')
     })
 })

--- a/src/test/shared/credentials/loginManager.test.ts
+++ b/src/test/shared/credentials/loginManager.test.ts
@@ -55,10 +55,26 @@ describe('LoginManager', async () => {
         sandbox.restore()
     })
 
+    it('passive login does NOT send telemetry', async () => {
+        const setCredentialsStub = sandbox.stub(awsContext, 'setCredentials')
+        await loginManager.login({ passive: true, providerId: sampleCredentialsProviderId })
+
+        assert.strictEqual(setCredentialsStub.callCount, 1)
+        assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, false)
+    })
+
+    it('non-passive login sends telemetry', async () => {
+        const setCredentialsStub = sandbox.stub(awsContext, 'setCredentials')
+        await loginManager.login({ passive: false, providerId: sampleCredentialsProviderId })
+
+        assert.strictEqual(setCredentialsStub.callCount, 1)
+        assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, true)
+    })
+
     it('logs in with credentials (happy path)', async () => {
         const setCredentialsStub = sandbox.stub(awsContext, 'setCredentials')
 
-        await loginManager.login(false, sampleCredentialsProviderId)
+        await loginManager.login({ passive: false, providerId: sampleCredentialsProviderId })
         assert.strictEqual(setCredentialsStub.callCount, 1, 'Expected awsContext setCredentials to be called once')
         assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, true)
     })
@@ -66,7 +82,7 @@ describe('LoginManager', async () => {
     it('logs out (happy path)', async () => {
         const setCredentialsStub = sandbox.stub(awsContext, 'setCredentials')
 
-        await loginManager.login(false, sampleCredentialsProviderId)
+        await loginManager.login({ passive: false, providerId: sampleCredentialsProviderId })
         await loginManager.logout()
         assert.strictEqual(setCredentialsStub.callCount, 2, 'Expected awsContext setCredentials to be called twice')
         assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, true)
@@ -80,7 +96,7 @@ describe('LoginManager', async () => {
             assert.strictEqual(credentials, undefined)
         })
 
-        await loginManager.login(true, sampleCredentialsProviderId)
+        await loginManager.login({ passive: true, providerId: sampleCredentialsProviderId })
         assert.strictEqual(setCredentialsStub.callCount, 1, 'Expected awsContext setCredentials to be called once')
         assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, false)
     })
@@ -93,7 +109,7 @@ describe('LoginManager', async () => {
             assert.strictEqual(credentials, undefined)
         })
 
-        await loginManager.login(false, sampleCredentialsProviderId)
+        await loginManager.login({ passive: false, providerId: sampleCredentialsProviderId })
         assert.strictEqual(setCredentialsStub.callCount, 1, 'Expected awsContext setCredentials to be called once')
         assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, true)
     })
@@ -106,7 +122,7 @@ describe('LoginManager', async () => {
             assert.strictEqual(credentials, undefined)
         })
 
-        await loginManager.login(false, sampleCredentialsProviderId)
+        await loginManager.login({ passive: false, providerId: sampleCredentialsProviderId })
         assert.strictEqual(setCredentialsStub.callCount, 1, 'Expected awsContext setCredentials to be called once')
         assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, true)
     })

--- a/src/test/shared/credentials/loginManager.test.ts
+++ b/src/test/shared/credentials/loginManager.test.ts
@@ -30,11 +30,13 @@ describe('LoginManager', async () => {
     let credentialsProvider: CredentialsProvider
     let getAccountIdStub: sinon.SinonStub<[AWS.Credentials, string], Promise<string | undefined>>
     let getCredentialsProviderStub: sinon.SinonStub<[CredentialsProviderId], Promise<CredentialsProvider | undefined>>
+    let recordAwsSetCredentialsSpy: any
 
     beforeEach(async () => {
         sandbox = sinon.createSandbox()
+        recordAwsSetCredentialsSpy = sandbox.spy()
 
-        loginManager = new LoginManager(awsContext)
+        loginManager = new LoginManager(awsContext, recordAwsSetCredentialsSpy)
         credentialsProvider = {
             getCredentials: sandbox.stub().resolves(sampleCredentials),
             getCredentialsProviderId: sandbox.stub().returns(sampleCredentialsProviderId),
@@ -58,6 +60,7 @@ describe('LoginManager', async () => {
 
         await loginManager.login(false, sampleCredentialsProviderId)
         assert.strictEqual(setCredentialsStub.callCount, 1, 'Expected awsContext setCredentials to be called once')
+        assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, true)
     })
 
     it('logs out (happy path)', async () => {
@@ -66,6 +69,7 @@ describe('LoginManager', async () => {
         await loginManager.login(false, sampleCredentialsProviderId)
         await loginManager.logout()
         assert.strictEqual(setCredentialsStub.callCount, 2, 'Expected awsContext setCredentials to be called twice')
+        assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, true)
     })
 
     it('logs out if credentials could not be retrieved', async () => {
@@ -78,6 +82,7 @@ describe('LoginManager', async () => {
 
         await loginManager.login(true, sampleCredentialsProviderId)
         assert.strictEqual(setCredentialsStub.callCount, 1, 'Expected awsContext setCredentials to be called once')
+        assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, false)
     })
 
     it('logs out if an account Id could not be determined', async () => {
@@ -90,6 +95,7 @@ describe('LoginManager', async () => {
 
         await loginManager.login(false, sampleCredentialsProviderId)
         assert.strictEqual(setCredentialsStub.callCount, 1, 'Expected awsContext setCredentials to be called once')
+        assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, true)
     })
 
     it('logs out if getting an account Id throws an Error', async () => {
@@ -102,5 +108,6 @@ describe('LoginManager', async () => {
 
         await loginManager.login(false, sampleCredentialsProviderId)
         assert.strictEqual(setCredentialsStub.callCount, 1, 'Expected awsContext setCredentials to be called once')
+        assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, true)
     })
 })


### PR DESCRIPTION
The aws_setCredentials, SAM_detect events should not be recorded unless the user actually initiated them.

## Test cases

- when user invokes `AWS: Detect SAM CLI`, telemetry is recorded (`recordSamDetect` is called)
  - `recordSamDetect` is not called on startup 
- when user invokes `AWS: Sign out` followed by `AWS: Connect to AWS`, telemetry is recorded (`recordAwsSetCredentials` is called)
  - `recordAwsSetCredentials` is not called on startup

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
