### PR TITLE
Fixing a flaky test

### DIFF
--- a/src/test/cloudWatchLogs/commands/viewLogStream.test.ts
+++ b/src/test/cloudWatchLogs/commands/viewLogStream.test.ts
@@ -66,7 +66,7 @@ describe('viewLogStreamWizard', async () => {
 
 describe('convertDescribeLogStreamsToQuickPickItems', () => {
     it('converts things correctly', () => {
-        const time = new Date().getSeconds()
+        const time = new Date().getTime()
         const results = convertDescribeLogStreamsToQuickPickItems({
             logStreams: [
                 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Due to a stunning lack of caffeine, I didn't realize that `new Date().getSeconds()` returned the current amount of seconds in the current timestamp after the minutes have been calculated, rather than seconds from epoch; this meant that there was a 1/60 chance that there would be 0 seconds, which JS interprets as falsy. Changed to a proper date calculation (`new Date().getTime()`)

## Motivation and Context

Broken test

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing

Test passes.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
