### PR TITLE
Fixing flaky test

### DIFF
--- a/src/stepFunctions/activation.ts
+++ b/src/stepFunctions/activation.ts
@@ -40,7 +40,10 @@ async function registerStepFunctionCommands(
     extensionContext.subscriptions.push(
         vscode.commands.registerCommand('aws.previewStateMachine', async () => {
             try {
-                return await visualizationManager.visualizeStateMachine(extensionContext.globalState)
+                return await visualizationManager.visualizeStateMachine(
+                    extensionContext.globalState,
+                    vscode.window.activeTextEditor
+                )
             } finally {
                 telemetry.recordStepfunctionsPreviewstatemachine()
             }

--- a/src/stepFunctions/commands/visualizeStateMachine/aslVisualizationManager.ts
+++ b/src/stepFunctions/commands/visualizeStateMachine/aslVisualizationManager.ts
@@ -24,11 +24,7 @@ export class AslVisualizationManager {
 
     public async visualizeStateMachine(
         globalStorage: vscode.Memento,
-        params: {
-            activeTextEditor: vscode.TextEditor | undefined
-        } = {
-            activeTextEditor: vscode.window.activeTextEditor,
-        }
+        activeTextEditor: vscode.TextEditor | undefined
     ): Promise<vscode.WebviewPanel | undefined> {
         const logger: Logger = getLogger()
         const cache = new StateMachineGraphCache()
@@ -39,12 +35,12 @@ export class AslVisualizationManager {
          * Ensure tests are written for this use case as well.
          */
 
-        if (!params.activeTextEditor) {
+        if (!activeTextEditor) {
             logger.error('Could not get active text editor for state machine render.')
             throw new Error('Could not get active text editor for state machine render.')
         }
 
-        const textDocument: vscode.TextDocument = params.activeTextEditor.document
+        const textDocument: vscode.TextDocument = activeTextEditor.document
 
         // Attempt to retrieve existing visualization if it exists.
         const existingVisualization = this.getExistingVisualization(textDocument.uri)

--- a/src/stepFunctions/commands/visualizeStateMachine/aslVisualizationManager.ts
+++ b/src/stepFunctions/commands/visualizeStateMachine/aslVisualizationManager.ts
@@ -22,7 +22,10 @@ export class AslVisualizationManager {
         return this.managedVisualizations
     }
 
-    public async visualizeStateMachine(globalStorage: vscode.Memento): Promise<vscode.WebviewPanel | undefined> {
+    public async visualizeStateMachine(
+        globalStorage: vscode.Memento,
+        activeTextEditor: vscode.TextEditor | undefined = vscode.window.activeTextEditor
+    ): Promise<vscode.WebviewPanel | undefined> {
         const logger: Logger = getLogger()
         const cache = new StateMachineGraphCache()
 
@@ -31,7 +34,6 @@ export class AslVisualizationManager {
          * specifc subset of file types ( .json only, custom .states extension, etc...)
          * Ensure tests are written for this use case as well.
          */
-        const activeTextEditor: vscode.TextEditor | undefined = vscode.window.activeTextEditor
 
         if (!activeTextEditor) {
             logger.error('Could not get active text editor for state machine render.')

--- a/src/stepFunctions/commands/visualizeStateMachine/aslVisualizationManager.ts
+++ b/src/stepFunctions/commands/visualizeStateMachine/aslVisualizationManager.ts
@@ -24,7 +24,11 @@ export class AslVisualizationManager {
 
     public async visualizeStateMachine(
         globalStorage: vscode.Memento,
-        activeTextEditor: vscode.TextEditor | undefined = vscode.window.activeTextEditor
+        params: {
+            activeTextEditor: vscode.TextEditor | undefined
+        } = {
+            activeTextEditor: vscode.window.activeTextEditor,
+        }
     ): Promise<vscode.WebviewPanel | undefined> {
         const logger: Logger = getLogger()
         const cache = new StateMachineGraphCache()
@@ -35,12 +39,12 @@ export class AslVisualizationManager {
          * Ensure tests are written for this use case as well.
          */
 
-        if (!activeTextEditor) {
+        if (!params.activeTextEditor) {
             logger.error('Could not get active text editor for state machine render.')
             throw new Error('Could not get active text editor for state machine render.')
         }
 
-        const textDocument: vscode.TextDocument = activeTextEditor.document
+        const textDocument: vscode.TextDocument = params.activeTextEditor.document
 
         // Attempt to retrieve existing visualization if it exists.
         const existingVisualization = this.getExistingVisualization(textDocument.uri)

--- a/src/test/stepFunctions/commands/visualizeStateMachine.test.ts
+++ b/src/test/stepFunctions/commands/visualizeStateMachine.test.ts
@@ -294,7 +294,7 @@ describe('StepFunctions VisualizeStateMachine', async () => {
 
         // Preview with no active text editor
         const error = await assertThrowsError(async () => {
-            await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage, { activeTextEditor: undefined })
+            await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage, undefined)
         }, 'Expected an error to be thrown')
 
         assert.strictEqual(error.message, 'Could not get active text editor for state machine render.')
@@ -306,7 +306,7 @@ describe('StepFunctions VisualizeStateMachine', async () => {
 
         // Preview Doc1
         mockVsCode.showTextDocument(mockTextDocumentOne)
-        await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage)
+        await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage, vscode.window.activeTextEditor)
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 1)
 
         const managedVisualizations = aslVisualizationManager.getManagedVisualizations()
@@ -318,11 +318,11 @@ describe('StepFunctions VisualizeStateMachine', async () => {
 
         // Preview Doc1
         mockVsCode.showTextDocument(mockTextDocumentOne)
-        await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage)
+        await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage, vscode.window.activeTextEditor)
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 1)
 
         // Preview Doc1 Again
-        await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage)
+        await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage, vscode.window.activeTextEditor)
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 1)
 
         const managedVisualizations = aslVisualizationManager.getManagedVisualizations()
@@ -334,12 +334,12 @@ describe('StepFunctions VisualizeStateMachine', async () => {
 
         // Preview Doc1
         mockVsCode.showTextDocument(mockTextDocumentOne)
-        await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage)
+        await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage, vscode.window.activeTextEditor)
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 1)
 
         // Preview Doc2
         mockVsCode.showTextDocument(mockTextDocumentTwo)
-        await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage)
+        await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage, vscode.window.activeTextEditor)
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 2)
 
         const managedVisualizations = aslVisualizationManager.getManagedVisualizations()
@@ -352,22 +352,22 @@ describe('StepFunctions VisualizeStateMachine', async () => {
 
         // Preview Doc1
         mockVsCode.showTextDocument(mockTextDocumentOne)
-        await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage)
+        await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage, vscode.window.activeTextEditor)
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 1)
 
         // Preview Doc2
         mockVsCode.showTextDocument(mockTextDocumentTwo)
-        await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage)
+        await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage, vscode.window.activeTextEditor)
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 2)
 
         // Preview Doc1 Again
         mockVsCode.showTextDocument(mockTextDocumentOne)
-        await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage)
+        await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage, vscode.window.activeTextEditor)
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 2)
 
         // Preview Doc2 Again
         mockVsCode.showTextDocument(mockTextDocumentTwo)
-        await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage)
+        await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage, vscode.window.activeTextEditor)
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 2)
 
         const managedVisualizations = aslVisualizationManager.getManagedVisualizations()
@@ -380,7 +380,10 @@ describe('StepFunctions VisualizeStateMachine', async () => {
 
         // Preview Doc1
         mockVsCode.showTextDocument(mockTextDocumentOne)
-        let panel = await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage)
+        let panel = await aslVisualizationManager.visualizeStateMachine(
+            mockGlobalStorage,
+            vscode.window.activeTextEditor
+        )
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 1)
 
         // Dispose of visualization panel
@@ -396,12 +399,15 @@ describe('StepFunctions VisualizeStateMachine', async () => {
 
         // Preview Doc1
         mockVsCode.showTextDocument(mockTextDocumentOne)
-        let panel = await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage)
+        let panel = await aslVisualizationManager.visualizeStateMachine(
+            mockGlobalStorage,
+            vscode.window.activeTextEditor
+        )
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 1)
 
         // Preview Doc2
         mockVsCode.showTextDocument(mockTextDocumentTwo)
-        await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage)
+        await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage, vscode.window.activeTextEditor)
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 2)
 
         // Dispose of first visualization panel

--- a/src/test/stepFunctions/commands/visualizeStateMachine.test.ts
+++ b/src/test/stepFunctions/commands/visualizeStateMachine.test.ts
@@ -294,7 +294,7 @@ describe('StepFunctions VisualizeStateMachine', async () => {
 
         // Preview with no active text editor
         const error = await assertThrowsError(async () => {
-            await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage, undefined)
+            await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage, { activeTextEditor: undefined })
         }, 'Expected an error to be thrown')
 
         assert.strictEqual(error.message, 'Could not get active text editor for state machine render.')

--- a/src/test/stepFunctions/commands/visualizeStateMachine.test.ts
+++ b/src/test/stepFunctions/commands/visualizeStateMachine.test.ts
@@ -294,7 +294,7 @@ describe('StepFunctions VisualizeStateMachine', async () => {
 
         // Preview with no active text editor
         const error = await assertThrowsError(async () => {
-            await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage)
+            await aslVisualizationManager.visualizeStateMachine(mockGlobalStorage, undefined)
         }, 'Expected an error to be thrown')
 
         assert.strictEqual(error.message, 'Could not get active text editor for state machine render.')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Deflaking a test

## Motivation and Context

There's no guarantee that extension tests don't open text editors (some actively open webviews, for instance). This is a relatively simple defensive change to ensure that we pass in an expected value.

Alternately, we can look to stub out `vscode.window.activeTextEditor`.

## Related Issue(s)

https://github.com/aws/aws-toolkit-vscode/issues/1201

## Testing
Tests pass, SFN viewer works.
## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
