### PR TITLE
Added createLocalDocument command to SSM Document support

### DIFF
--- a/.changes/next-release/Feature-1d2c5bab-06bd-4c5e-a795-f18c7fb34912.json
+++ b/.changes/next-release/Feature-1d2c5bab-06bd-4c5e-a795-f18c7fb34912.json
@@ -1,4 +1,4 @@
 {
     "type": "Feature",
-    "description": "New Systems Manager (SSM) Document capabilities: Language Support (auto-completion, validation) for authoring SSM Document files."
+    "description": "New Systems Manager (SSM) Document capabilities: Language Support (auto-completion, validation) for authoring SSM Document files. SSM Document can be created locally from templates."
 }

--- a/src/ssmDocument/activation.ts
+++ b/src/ssmDocument/activation.ts
@@ -8,10 +8,11 @@ import { activate as activateDecor } from './ssm/ssmDecoration'
 import { activate as activateSSMLanguageServer } from './ssm/ssmClient'
 import { AwsContext } from '../shared/awsContext'
 
-/* Please ignore this for now. This will be included in a future CR
 import { createSsmDocumentFromTemplate } from './commands/createDocumentFromTemplate'
-import { openDocumentItem } from './commands/openDocumentItem'
 import * as telemetry from '../shared/telemetry/telemetry'
+
+/* Please ignore this for now. This will be included in a future CR
+import { openDocumentItem } from './commands/openDocumentItem'
 import { DocumentItemNode } from './explorer/documentItemNode'
 */
 
@@ -22,12 +23,11 @@ export async function activate(
     awsContext: AwsContext,
     outputChannel: vscode.OutputChannel
 ): Promise<void> {
-    //await registerSsmDocumentCommands(extensionContext, awsContext, outputChannel)
+    await registerSsmDocumentCommands(extensionContext, awsContext, outputChannel)
     await activateSSMLanguageServer(extensionContext)
     activateDecor(extensionContext)
 }
 
-/* Please ignore this for now. This will be included in a future CR
 async function registerSsmDocumentCommands(
     extensionContext: vscode.ExtensionContext,
     awsContext: AwsContext,
@@ -36,16 +36,17 @@ async function registerSsmDocumentCommands(
     extensionContext.subscriptions.push(
         vscode.commands.registerCommand('aws.ssmDocument.createLocalDocument', async () => {
             try {
-                await createSsmDocumentFromTemplate(extensionContext)
+                await createSsmDocumentFromTemplate()
             } finally {
-                telemetry.recordSsmDocumentCreateSsmDocumentFromTemplate()
+                telemetry.recordSsmCreateDocument()
             }
         })
     )
+    /* Please ignore this for now. This will be included in a future CR
     extensionContext.subscriptions.push(
         vscode.commands.registerCommand('aws.ssmDocument.openLocalDocument', async (node: DocumentItemNode) => {
             await openDocumentItem(node, awsContext)
         })
     )
+    */
 }
-*/

--- a/src/ssmDocument/commands/createDocumentFromTemplate.ts
+++ b/src/ssmDocument/commands/createDocumentFromTemplate.ts
@@ -16,7 +16,6 @@ import { getDocumentTemplate } from 'aws-ssm-document-language-service'
 
 export interface SsmDocumentTemplateQuickPickItem extends vscode.QuickPickItem {
     label: string
-    description: string
     filename: string
     language: string
     docType: string
@@ -24,33 +23,9 @@ export interface SsmDocumentTemplateQuickPickItem extends vscode.QuickPickItem {
 
 const SSMDOCUMENT_TEMPLATES: SsmDocumentTemplateQuickPickItem[] = [
     {
-        label: localize('AWS.ssmDocument.template.command22Json.label', 'Command Document (schemaVersion 2.2, JSON)'),
-        description: localize(
-            'AWS.ssmDocument.template.command22Json.description',
-            'An Example of a command document using schemaVersion 2.2 in JSON'
-        ),
-        filename: 'example22.command.ssm.json',
-        language: 'ssm-json',
-        docType: 'command',
-    },
-    {
-        label: localize('AWS.ssmDocument.template.command22Yaml.label', 'Command Document (schemaVersion 2.2, YAML)'),
-        description: localize(
-            'AWS.ssmDocument.template.command22Yaml.description',
-            'An Example of a command document using schemaVersion 2.2 in YAML'
-        ),
-        filename: 'example22.command.ssm.yaml',
-        language: 'ssm-yaml',
-        docType: 'command',
-    },
-    {
         label: localize(
             'AWS.ssmDocument.template.automationJson.label',
             'Automation Document (schemaVersion 0.3, JSON)'
-        ),
-        description: localize(
-            'AWS.ssmDocument.template.automationJson.description',
-            'An Example of a automation document using schemaVersion 0.3 in JSON'
         ),
         filename: 'example.automation.ssm.json',
         language: 'ssm-json',
@@ -61,13 +36,21 @@ const SSMDOCUMENT_TEMPLATES: SsmDocumentTemplateQuickPickItem[] = [
             'AWS.ssmDocument.template.automationYaml.label',
             'Automation Document (schemaVersion 0.3, YAML)'
         ),
-        description: localize(
-            'AWS.ssmDocument.template.automationYaml.description',
-            'An Example of a automation document using schemaVersion 0.3 in YAML'
-        ),
         filename: 'example.automation.ssm.yaml',
         language: 'ssm-yaml',
         docType: 'automation',
+    },
+    {
+        label: localize('AWS.ssmDocument.template.command22Json.label', 'Command Document (schemaVersion 2.2, JSON)'),
+        filename: 'example22.command.ssm.json',
+        language: 'ssm-json',
+        docType: 'command',
+    },
+    {
+        label: localize('AWS.ssmDocument.template.command22Yaml.label', 'Command Document (schemaVersion 2.2, YAML)'),
+        filename: 'example22.command.ssm.yaml',
+        language: 'ssm-yaml',
+        docType: 'command',
     },
 ]
 

--- a/src/ssmDocument/commands/createDocumentFromTemplate.ts
+++ b/src/ssmDocument/commands/createDocumentFromTemplate.ts
@@ -1,0 +1,119 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as nls from 'vscode-nls'
+const localize = nls.loadMessageBundle()
+
+import * as vscode from 'vscode'
+import * as YAML from 'yaml'
+import { getLogger, Logger } from '../../shared/logger'
+import * as picker from '../../shared/ui/picker'
+import { openAndSaveDocument } from '../util/util'
+
+import { getDocumentTemplate } from 'aws-ssm-document-language-service'
+
+export interface SsmDocumentTemplateQuickPickItem {
+    label: string
+    description: string
+    filename: string
+    language: string
+    docType: string
+}
+
+const SSMDOCUMENT_TEMPLATES: SsmDocumentTemplateQuickPickItem[] = [
+    {
+        label: localize('AWS.ssmDocument.template.command22Json.label', 'JSON Command Document 2.2'),
+        description: localize(
+            'AWS.ssmDocument.template.command22Json.description',
+            'An Example of a command document using schemaVersion 2.2 in JSON'
+        ),
+        filename: 'example22.command.ssm.json',
+        language: 'ssm-json',
+        docType: 'command',
+    },
+    {
+        label: localize('AWS.ssmDocument.template.automationJson.label', 'JSON Automation Document 0.3'),
+        description: localize(
+            'AWS.ssmDocument.template.automationJson.description',
+            'An Example of a automation document using schemaVersion 0.3 in JSON'
+        ),
+        filename: 'example.automation.ssm.json',
+        language: 'ssm-json',
+        docType: 'automation',
+    },
+    {
+        label: localize('AWS.ssmDocument.template.command22Yaml.label', 'YAML Command Document 2.2'),
+        description: localize(
+            'AWS.ssmDocument.template.command22Yaml.description',
+            'An Example of a command document using schemaVersion 2.2 in YAML'
+        ),
+        filename: 'example22.command.ssm.yaml',
+        language: 'ssm-yaml',
+        docType: 'command',
+    },
+    {
+        label: localize('AWS.ssmDocument.template.automationYaml.label', 'YAML Automation Document 0.3'),
+        description: localize(
+            'AWS.ssmDocument.template.automationYaml.description',
+            'An Example of a automation document using schemaVersion 0.3 in YAML'
+        ),
+        filename: 'example.automation.ssm.yaml',
+        language: 'ssm-yaml',
+        docType: 'automation',
+    },
+]
+
+export async function createSsmDocumentFromTemplate(): Promise<void> {
+    const logger: Logger = getLogger()
+
+    const quickPick = picker.createQuickPick<SsmDocumentTemplateQuickPickItem>({
+        options: {
+            ignoreFocusOut: true,
+            title: localize('AWS.message.prompt.selectSsmDocumentTemplate.placeholder', 'Select a document templete'),
+        },
+        buttons: [vscode.QuickInputButtons.Back],
+        items: SSMDOCUMENT_TEMPLATES,
+    })
+
+    const choices = await picker.promptUser({
+        picker: quickPick,
+        onDidTriggerButton: (_, resolve) => {
+            resolve(undefined)
+        },
+    })
+
+    const selection = picker.verifySinglePickerOutput(choices)
+
+    // User pressed escape and didn't select a template
+    if (selection === undefined) {
+        return
+    }
+
+    try {
+        logger.debug(`User selected the ${selection.label} template.`)
+        const textDocument: vscode.TextDocument = await openTextDocumentFromSelection(selection)
+        vscode.window.showTextDocument(textDocument)
+    } catch (err) {
+        logger.error(err as Error)
+        vscode.window.showErrorMessage(
+            localize(
+                'AWS.message.error.ssmDocument.openTextDocumentFromSelection',
+                'There was an error creating the SSM Document from the template, check log for details.'
+            )
+        )
+    }
+}
+
+async function openTextDocumentFromSelection(item: SsmDocumentTemplateQuickPickItem): Promise<vscode.TextDocument> {
+    const template: object = getDocumentTemplate(item.docType)
+    let content: string
+    if (item.language === 'ssm-yaml') {
+        content = YAML.stringify(template)
+    } else {
+        content = JSON.stringify(template, undefined, '\t')
+    }
+
+    return await openAndSaveDocument(content, item.filename, item.language)
+}

--- a/src/ssmDocument/commands/createDocumentFromTemplate.ts
+++ b/src/ssmDocument/commands/createDocumentFromTemplate.ts
@@ -14,7 +14,7 @@ import { openAndSaveDocument } from '../util/util'
 
 import { getDocumentTemplate } from 'aws-ssm-document-language-service'
 
-export interface SsmDocumentTemplateQuickPickItem {
+export interface SsmDocumentTemplateQuickPickItem extends vscode.QuickPickItem {
     label: string
     description: string
     filename: string
@@ -24,7 +24,7 @@ export interface SsmDocumentTemplateQuickPickItem {
 
 const SSMDOCUMENT_TEMPLATES: SsmDocumentTemplateQuickPickItem[] = [
     {
-        label: localize('AWS.ssmDocument.template.command22Json.label', 'JSON Command Document 2.2'),
+        label: localize('AWS.ssmDocument.template.command22Json.label', 'Command Document (schemaVersion 2.2, JSON)'),
         description: localize(
             'AWS.ssmDocument.template.command22Json.description',
             'An Example of a command document using schemaVersion 2.2 in JSON'
@@ -34,17 +34,7 @@ const SSMDOCUMENT_TEMPLATES: SsmDocumentTemplateQuickPickItem[] = [
         docType: 'command',
     },
     {
-        label: localize('AWS.ssmDocument.template.automationJson.label', 'JSON Automation Document 0.3'),
-        description: localize(
-            'AWS.ssmDocument.template.automationJson.description',
-            'An Example of a automation document using schemaVersion 0.3 in JSON'
-        ),
-        filename: 'example.automation.ssm.json',
-        language: 'ssm-json',
-        docType: 'automation',
-    },
-    {
-        label: localize('AWS.ssmDocument.template.command22Yaml.label', 'YAML Command Document 2.2'),
+        label: localize('AWS.ssmDocument.template.command22Yaml.label', 'Command Document (schemaVersion 2.2, YAML)'),
         description: localize(
             'AWS.ssmDocument.template.command22Yaml.description',
             'An Example of a command document using schemaVersion 2.2 in YAML'
@@ -54,7 +44,23 @@ const SSMDOCUMENT_TEMPLATES: SsmDocumentTemplateQuickPickItem[] = [
         docType: 'command',
     },
     {
-        label: localize('AWS.ssmDocument.template.automationYaml.label', 'YAML Automation Document 0.3'),
+        label: localize(
+            'AWS.ssmDocument.template.automationJson.label',
+            'Automation Document (schemaVersion 0.3, JSON)'
+        ),
+        description: localize(
+            'AWS.ssmDocument.template.automationJson.description',
+            'An Example of a automation document using schemaVersion 0.3 in JSON'
+        ),
+        filename: 'example.automation.ssm.json',
+        language: 'ssm-json',
+        docType: 'automation',
+    },
+    {
+        label: localize(
+            'AWS.ssmDocument.template.automationYaml.label',
+            'Automation Document (schemaVersion 0.3, YAML)'
+        ),
         description: localize(
             'AWS.ssmDocument.template.automationYaml.description',
             'An Example of a automation document using schemaVersion 0.3 in YAML'
@@ -65,9 +71,7 @@ const SSMDOCUMENT_TEMPLATES: SsmDocumentTemplateQuickPickItem[] = [
     },
 ]
 
-export async function createSsmDocumentFromTemplate(): Promise<void> {
-    const logger: Logger = getLogger()
-
+export async function promptUserForTemplate(): Promise<SsmDocumentTemplateQuickPickItem | undefined> {
     const quickPick = picker.createQuickPick<SsmDocumentTemplateQuickPickItem>({
         options: {
             ignoreFocusOut: true,
@@ -84,7 +88,13 @@ export async function createSsmDocumentFromTemplate(): Promise<void> {
         },
     })
 
-    const selection = picker.verifySinglePickerOutput(choices)
+    return picker.verifySinglePickerOutput(choices)
+}
+
+export async function createSsmDocumentFromTemplate(): Promise<void> {
+    const logger: Logger = getLogger()
+
+    const selection = await promptUserForTemplate()
 
     // User pressed escape and didn't select a template
     if (selection === undefined) {

--- a/src/ssmDocument/util/util.ts
+++ b/src/ssmDocument/util/util.ts
@@ -1,0 +1,29 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as path from 'path'
+import * as vscode from 'vscode'
+import * as fs from 'fs-extra'
+
+export async function openAndSaveDocument(
+    content: string,
+    filename: string,
+    language: string
+): Promise<vscode.TextDocument> {
+    const wsPath = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.fsPath : '/'
+    let filePath = path.join(wsPath, filename)
+    const fileInfo = await vscode.window.showSaveDialog({ defaultUri: vscode.Uri.file(filePath) })
+
+    if (fileInfo) {
+        filePath = fileInfo.fsPath
+        fs.writeFileSync(filePath, content)
+        const openPath = vscode.Uri.file(filePath)
+
+        return await vscode.workspace.openTextDocument(openPath)
+    }
+
+    // The user didn't save the file, so just open an untitiled file
+    return await vscode.workspace.openTextDocument({ content: content, language: language })
+}

--- a/src/test/ssmDocument/commands/createDocumentFromTemplate.test.ts
+++ b/src/test/ssmDocument/commands/createDocumentFromTemplate.test.ts
@@ -1,0 +1,55 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import * as sinon from 'sinon'
+import * as picker from '../../../shared/ui/picker'
+import {
+    createSsmDocumentFromTemplate,
+    SsmDocumentTemplateQuickPickItem,
+} from '../../../ssmDocument/commands/createDocumentFromTemplate'
+import * as openAndSaveDocument from '../../../ssmDocument/util/util'
+
+import * as YAML from 'yaml'
+
+describe('createDocumentFromTemplate', async () => {
+    let sandbox: sinon.SinonSandbox
+    beforeEach(() => {
+        sandbox = sinon.createSandbox()
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    const fakeContent = `{
+        "schemaVersion": "2.2",
+        "mainSteps": []
+    }`
+
+    const fakeSelectionResult: SsmDocumentTemplateQuickPickItem = {
+        label: 'test template',
+        description: 'an example to test creating from template',
+        filename: 'test.command.ssm.json',
+        language: 'ssm-json',
+        docType: 'command',
+    }
+
+    const fakeSelection: SsmDocumentTemplateQuickPickItem[] = []
+    fakeSelection.push(fakeSelectionResult)
+
+    it('open and save document based on selected template', async () => {
+        sandbox.stub(picker, 'promptUser').returns(Promise.resolve(fakeSelection))
+        sandbox.stub(picker, 'verifySinglePickerOutput').returns(fakeSelectionResult)
+        sandbox.stub(JSON, 'stringify').returns(fakeContent)
+        sandbox.stub(YAML, 'stringify').returns(fakeContent)
+
+        const openAndSaveStub = sandbox.stub(openAndSaveDocument, 'openAndSaveDocument')
+        await createSsmDocumentFromTemplate()
+        assert.strictEqual(openAndSaveStub.getCall(0).args[0], fakeContent)
+        assert.strictEqual(openAndSaveStub.getCall(0).args[1], fakeSelectionResult.filename)
+        assert.strictEqual(openAndSaveStub.getCall(0).args[2], fakeSelectionResult.language)
+    })
+})

--- a/src/test/ssmDocument/commands/createDocumentFromTemplate.test.ts
+++ b/src/test/ssmDocument/commands/createDocumentFromTemplate.test.ts
@@ -9,6 +9,7 @@ import * as picker from '../../../shared/ui/picker'
 import {
     createSsmDocumentFromTemplate,
     SsmDocumentTemplateQuickPickItem,
+    promptUserForTemplate,
 } from '../../../ssmDocument/commands/createDocumentFromTemplate'
 import * as openAndSaveDocument from '../../../ssmDocument/util/util'
 
@@ -18,6 +19,8 @@ describe('createDocumentFromTemplate', async () => {
     let sandbox: sinon.SinonSandbox
     beforeEach(() => {
         sandbox = sinon.createSandbox()
+        sandbox.stub(picker, 'promptUser').returns(Promise.resolve(fakeSelection))
+        sandbox.stub(picker, 'verifySinglePickerOutput').returns(fakeSelectionResult)
     })
 
     afterEach(() => {
@@ -40,9 +43,12 @@ describe('createDocumentFromTemplate', async () => {
     const fakeSelection: SsmDocumentTemplateQuickPickItem[] = []
     fakeSelection.push(fakeSelectionResult)
 
+    it('prompt users for templates', async () => {
+        const res = await promptUserForTemplate()
+        assert.strictEqual(res, fakeSelectionResult)
+    })
+
     it('open and save document based on selected template', async () => {
-        sandbox.stub(picker, 'promptUser').returns(Promise.resolve(fakeSelection))
-        sandbox.stub(picker, 'verifySinglePickerOutput').returns(fakeSelectionResult)
         sandbox.stub(JSON, 'stringify').returns(fakeContent)
         sandbox.stub(YAML, 'stringify').returns(fakeContent)
 

--- a/src/test/ssmDocument/commands/createDocumentFromTemplate.test.ts
+++ b/src/test/ssmDocument/commands/createDocumentFromTemplate.test.ts
@@ -34,7 +34,6 @@ describe('createDocumentFromTemplate', async () => {
 
     const fakeSelectionResult: SsmDocumentTemplateQuickPickItem = {
         label: 'test template',
-        description: 'an example to test creating from template',
         filename: 'test.command.ssm.json',
         language: 'ssm-json',
         docType: 'command',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This PR adds creating a SSM Document locally command. This PR follows PR https://github.com/aws/aws-toolkit-vscode/pull/1186
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This command can help users create a SSM Document from templates base on the document type and document format, so that they don't have to start editing a SSM Document from scratch.
## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I included tests in `src/tests/ssmDocument/createDocumentFromTemplates.test.ts`. 
## Screenshots (if appropriate)
<img width="1053" alt="Screen Shot 2020-07-24 at 10 53 46 AM" src="https://user-images.githubusercontent.com/14162779/88410561-28200200-cd9c-11ea-93b0-23388284b94a.png">
<img width="1176" alt="Screen Shot 2020-07-24 at 3 59 58 PM" src="https://user-images.githubusercontent.com/14162779/88434927-d5a80b00-cdc6-11ea-8ed8-e50ffc20826a.png">

<img width="1204" alt="saveFile" src="https://user-images.githubusercontent.com/14162779/88410633-41c14980-cd9c-11ea-92ee-5c711a84a511.png">
<img width="907" alt="openedFile" src="https://user-images.githubusercontent.com/14162779/88410639-44bc3a00-cd9c-11ea-97ff-ed602f3b05f0.png">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
