### PR TITLE
SAM debug: show error on missing launch.json

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -1,5 +1,6 @@
 {
     "AWS.title": "AWS",
+    "AWS.gotoRunPanel": "Run panel",
     "AWS.title.createCredentialProfile": "Create a new AWS credential profile",
     "AWS.title.creatingCredentialProfile": "Saving new credential profile {0}",
     "AWS.title.selectCredentialProfile": "Select an AWS credential profile",
@@ -268,7 +269,7 @@
     "AWS.sam.debugger.invalidRequest": "Debug Configuration has an unsupported request type. Supported types: {0}",
     "AWS.sam.debugger.invalidTarget": "Debug Configuration has an unsupported target type. Supported types: {0}",
     "AWS.sam.debugger.invalidRuntime": "AWS SAM debug: unknown runtime: {0}",
-    "AWS.sam.debugger.noLaunchJson": "AWS SAM: To debug a Lambda locally, first create a launch.json from the VS Code \"Run\" panel",
+    "AWS.sam.debugger.noLaunchJson": "AWS SAM: To debug a Lambda locally, create a launch.json from the Run panel, then select a configuration.",
     "AWS.sam.debugger.noTemplates": "No SAM templates found in workspace",
     "AWS.sam.debugger.noWorkspace": "AWS SAM debug: choose a workspace, then try again",
     "AWS.sam.debugger.failedLaunch": "AWS SAM failed to launch. Try creating launch.json",

--- a/package.nls.json
+++ b/package.nls.json
@@ -268,6 +268,7 @@
     "AWS.sam.debugger.invalidRequest": "Debug Configuration has an unsupported request type. Supported types: {0}",
     "AWS.sam.debugger.invalidTarget": "Debug Configuration has an unsupported target type. Supported types: {0}",
     "AWS.sam.debugger.invalidRuntime": "AWS SAM debug: unknown runtime: {0}",
+    "AWS.sam.debugger.noLaunchJson": "AWS SAM: To debug a Lambda locally, first create a launch.json from the VS Code \"Run\" panel",
     "AWS.sam.debugger.noTemplates": "No SAM templates found in workspace",
     "AWS.sam.debugger.noWorkspace": "AWS SAM debug: choose a workspace, then try again",
     "AWS.sam.debugger.failedLaunch": "AWS SAM failed to launch. Try creating launch.json",

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -265,7 +265,10 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
                     ),
                     localize('AWS.gotoRunPanel', 'Run panel')
                 )
-                .then(async ok => {
+                .then(async result => {
+                    if (!result) {
+                        return
+                    }
                     await vscode.commands.executeCommand('workbench.view.debug')
                 })
             return undefined

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -257,33 +257,13 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         )
 
         if (!hasLaunchJson) {
-            // Try to generate a default config dynamically.
-            const configs: AwsSamDebuggerConfiguration[] | undefined = await this.provideDebugConfigurations(
-                folder,
-                token
-            )
-
-            if (!configs || configs.length === 0) {
-                getLogger().error(
-                    `SAM debug: failed to generate config (found CFN templates: ${cftRegistry.registeredTemplates.length})`
+            vscode.window.showErrorMessage(
+                localize(
+                    'AWS.sam.debugger.noLaunchJson',
+                    'AWS SAM: To debug a Lambda locally, first create a launch.json from the VS Code "Run" panel'
                 )
-                if (cftRegistry.registeredTemplates.length > 0) {
-                    vscode.window.showErrorMessage(
-                        localize('AWS.sam.debugger.noTemplates', 'No SAM templates found in workspace')
-                    )
-                } else {
-                    vscode.window.showErrorMessage(
-                        localize('AWS.sam.debugger.failedLaunch', 'AWS SAM failed to launch. Try creating launch.json')
-                    )
-                }
-                return undefined
-            }
-
-            config = {
-                ...config,
-                ...configs[0],
-            }
-            getLogger().verbose(`SAM debug: generated config (no launch.json): ${JSON.stringify(config)}`)
+            )
+            return undefined
         } else {
             const rv = configValidator.validate(config)
             if (!rv.isValid) {

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -257,12 +257,17 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         )
 
         if (!hasLaunchJson) {
-            vscode.window.showErrorMessage(
-                localize(
-                    'AWS.sam.debugger.noLaunchJson',
-                    'AWS SAM: To debug a Lambda locally, first create a launch.json from the VS Code "Run" panel'
+            vscode.window
+                .showErrorMessage(
+                    localize(
+                        'AWS.sam.debugger.noLaunchJson',
+                        'AWS SAM: To debug a Lambda locally, create a launch.json from the Run panel, then select a configuration.'
+                    ),
+                    localize('AWS.gotoRunPanel', 'Run panel')
                 )
-            )
+                .then(async ok => {
+                    await vscode.commands.executeCommand('workbench.view.debug')
+                })
             return undefined
         } else {
             const rv = configValidator.validate(config)

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -209,6 +209,12 @@ describe('SamDebugConfigurationProvider', async () => {
             // No workspace folder:
             assert.deepStrictEqual(await debugConfigProvider.makeConfig(undefined, config.config), undefined)
 
+            // No launch.json (vscode will pass an empty config.request):
+            assert.deepStrictEqual(
+                await debugConfigProvider.makeConfig(undefined, { ...config.config, request: '' }),
+                undefined
+            )
+
             // Unknown runtime:
             config.config.lambda = {
                 runtime: 'happy-runtime-42',


### PR DESCRIPTION
We currently haven't implemented enough magic (or UI, alternatively) to guess/decide a launchable config if the user doesn't actually have a launch.json.  So for now, just show an error with guidance.

## Screenshot

<img width="588" alt="Screen Shot 2020-07-27 at 5 32 37 PM" src="https://user-images.githubusercontent.com/55561878/88605734-aea04200-d02f-11ea-8a77-c567ff981ae4.png">


## Test case

1. Delete all `launch.json` files in the workspace
2. Visit `template.yaml`
3. Hit F5. VSCode presents a menu of possible debuggers, which includes `AWS SAM: Debug Lambda Function Locally`
4. Select `AWS SAM: Debug Lambda Function Locally`
5. Because there is no `launch.json`, the Lambda runtime, handler name, etc., must be guessed, or we must prompt the user each time. But we currently haven't implemented that. 
    - With this commit, we show an error.
    - Before this commit, we auto-generated configs from the workspace and chose the first one.
        - **Future:** we could show a menu and let the user select one of these configs. But they will also need to choose a runtime for cases where we don't know if it's e.g. a python3.6 or python3.7 project...

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
