### PR TITLE
added explorer nodes and ssmDocument clients

### DIFF
--- a/.changes/next-release/Feature-1d2c5bab-06bd-4c5e-a795-f18c7fb34912.json
+++ b/.changes/next-release/Feature-1d2c5bab-06bd-4c5e-a795-f18c7fb34912.json
@@ -1,4 +1,4 @@
 {
     "type": "Feature",
-    "description": "New Systems Manager (SSM) Document capabilities: Language Support (auto-completion, validation) for authoring SSM Document files. SSM Document can be created locally from templates."
+    "description": "New Systems Manager (SSM) Document capabilities: Language Support (auto-completion, validation) for authoring SSM Document files. SSM Document can be created locally from templates. SSM Document are shown in the AWS Explorer."
 }

--- a/src/awsexplorer/regionNode.ts
+++ b/src/awsexplorer/regionNode.ts
@@ -13,6 +13,7 @@ import { Region } from '../shared/regions/endpoints'
 import { RegionProvider } from '../shared/regions/regionProvider'
 import { AWSTreeNodeBase } from '../shared/treeview/nodes/awsTreeNodeBase'
 import { StepFunctionsNode } from '../stepFunctions/explorer/stepFunctionsNodes'
+import { SsmDocumentNode } from '../ssmDocument/explorer/ssmDocumentNode'
 
 /**
  * An AWS Explorer node representing a region.
@@ -51,6 +52,7 @@ export class RegionNode extends AWSTreeNodeBase {
             { serviceId: 'lambda', createFn: () => new LambdaNode(this.regionCode) },
             { serviceId: 'schemas', createFn: () => new SchemasNode(this.regionCode) },
             { serviceId: 'states', createFn: () => new StepFunctionsNode(this.regionCode) },
+            { serviceId: 'ssm', createFn: () => new SsmDocumentNode(this.regionCode) },
         ]
 
         for (const serviceCandidate of serviceCandidates) {

--- a/src/shared/clients/defaultSsmDocumentClient.ts
+++ b/src/shared/clients/defaultSsmDocumentClient.ts
@@ -1,0 +1,84 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SSM } from 'aws-sdk'
+
+import { ext } from '../extensionGlobals'
+import '../utilities/asyncIteratorShim'
+import { SsmDocumentClient } from './ssmDocumentClient'
+
+export class DefaultSsmDocumentClient implements SsmDocumentClient {
+    public constructor(public readonly regionCode: string) {}
+
+    public async *listDocuments(
+        request: SSM.Types.ListDocumentsRequest = {}
+    ): AsyncIterableIterator<SSM.DocumentIdentifier> {
+        const client = await this.createSdkClient()
+
+        do {
+            const response: SSM.Types.ListDocumentsResult = await client.listDocuments(request).promise()
+
+            if (response.DocumentIdentifiers) {
+                yield* response.DocumentIdentifiers
+            }
+
+            request.NextToken = response.NextToken
+        } while (request.NextToken)
+    }
+
+    public async *listDocumentVersions(documentName: string): AsyncIterableIterator<SSM.Types.DocumentVersionInfo> {
+        const client = await this.createSdkClient()
+
+        const request: SSM.Types.ListDocumentVersionsRequest = {
+            Name: documentName,
+        }
+
+        do {
+            const response: SSM.Types.ListDocumentVersionsResult = await client.listDocumentVersions(request).promise()
+
+            if (response.DocumentVersions) {
+                yield* response.DocumentVersions
+            }
+
+            request.NextToken = response.NextToken
+        } while (request.NextToken)
+    }
+
+    public async getDocument(
+        documentName: string,
+        documentVersion?: string,
+        documentFormat?: string
+    ): Promise<SSM.Types.GetDocumentResult> {
+        const client = await this.createSdkClient()
+
+        const request: SSM.Types.GetDocumentRequest = {
+            Name: documentName,
+            DocumentVersion: documentVersion,
+            DocumentFormat: documentFormat,
+        }
+
+        return await client.getDocument(request).promise()
+    }
+
+    public async createDocument(request: SSM.Types.CreateDocumentRequest): Promise<SSM.Types.CreateDocumentResult> {
+        const client = await this.createSdkClient()
+
+        return await client.createDocument(request).promise()
+    }
+
+    public async updateDocument(request: SSM.Types.UpdateDocumentRequest): Promise<SSM.Types.UpdateDocumentResult> {
+        const client = await this.createSdkClient()
+
+        return await client.updateDocument(request).promise()
+    }
+
+    private async createSdkClient(): Promise<SSM> {
+        return await ext.sdkClientBuilder.createAndConfigureServiceClient(
+            options => new SSM(options),
+            undefined,
+            this.regionCode
+        )
+    }
+}

--- a/src/shared/clients/defaultToolkitClientBuilder.ts
+++ b/src/shared/clients/defaultToolkitClientBuilder.ts
@@ -14,12 +14,14 @@ import { DefaultLambdaClient } from './defaultLambdaClient'
 import { DefaultSchemaClient } from './defaultSchemaClient'
 import { DefaultStepFunctionsClient } from './defaultStepFunctionsClient'
 import { DefaultStsClient } from './defaultStsClient'
+import { DefaultSsmDocumentClient } from './defaultSsmDocumentClient'
 import { EcsClient } from './ecsClient'
 import { IamClient } from './iamClient'
 import { LambdaClient } from './lambdaClient'
 import { SchemaClient } from './schemaClient'
 import { StepFunctionsClient } from './stepFunctionsClient'
 import { StsClient } from './stsClient'
+import { SsmDocumentClient } from './ssmDocumentClient'
 import { ToolkitClientBuilder } from './toolkitClientBuilder'
 
 export class DefaultToolkitClientBuilder implements ToolkitClientBuilder {
@@ -53,5 +55,9 @@ export class DefaultToolkitClientBuilder implements ToolkitClientBuilder {
 
     public createStsClient(regionCode: string, credentials?: ServiceConfigurationOptions): StsClient {
         return new DefaultStsClient(regionCode, credentials)
+    }
+
+    public createSsmClient(regionCode: string): SsmDocumentClient {
+        return new DefaultSsmDocumentClient(regionCode)
     }
 }

--- a/src/shared/clients/ssmDocumentClient.ts
+++ b/src/shared/clients/ssmDocumentClient.ts
@@ -1,0 +1,20 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SSM } from 'aws-sdk'
+
+export interface SsmDocumentClient {
+    readonly regionCode: string
+
+    listDocuments(request: SSM.Types.ListDocumentsRequest): AsyncIterableIterator<SSM.Types.DocumentIdentifier>
+    listDocumentVersions(documentName: string): AsyncIterableIterator<SSM.Types.DocumentVersionInfo>
+    getDocument(
+        documentName: string,
+        documentVersion?: string,
+        documentFormat?: string
+    ): Promise<SSM.Types.GetDocumentResult>
+    createDocument(request: SSM.Types.CreateDocumentRequest): Promise<SSM.Types.CreateDocumentResult>
+    updateDocument(request: SSM.Types.UpdateDocumentRequest): Promise<SSM.Types.UpdateDocumentResult>
+}

--- a/src/shared/clients/toolkitClientBuilder.ts
+++ b/src/shared/clients/toolkitClientBuilder.ts
@@ -12,6 +12,7 @@ import { LambdaClient } from './lambdaClient'
 import { SchemaClient } from './schemaClient'
 import { StepFunctionsClient } from './stepFunctionsClient'
 import { StsClient } from './stsClient'
+import { SsmDocumentClient } from './ssmDocumentClient'
 
 export interface ToolkitClientBuilder {
     createCloudFormationClient(regionCode: string): CloudFormationClient
@@ -29,4 +30,6 @@ export interface ToolkitClientBuilder {
     createStsClient(regionCode: string, credentials?: ServiceConfigurationOptions): StsClient
 
     createIamClient(regionCode: string): IamClient
+
+    createSsmClient(regionCode: string): SsmDocumentClient
 }

--- a/src/ssmDocument/explorer/documentItemNode.ts
+++ b/src/ssmDocument/explorer/documentItemNode.ts
@@ -19,7 +19,7 @@ export class DocumentItemNode extends AWSTreeNodeBase {
 
     public update(documentItem: SSM.Types.DocumentIdentifier): void {
         this.documentItem = documentItem
-        this.label = this.documentItem.Name || ''
+        this.label = this.documentName
     }
 
     public get documentName(): string {
@@ -34,6 +34,10 @@ export class DocumentItemNode extends AWSTreeNodeBase {
         documentVersion?: string,
         documentFormat?: string
     ): Promise<SSM.Types.GetDocumentResult> {
+        if (!this.documentName || !this.documentName.length) {
+            return Promise.resolve({})
+        }
+
         return await this.client.getDocument(
             this.documentName,
             documentVersion || this.documentItem.DocumentVersion,

--- a/src/ssmDocument/explorer/documentItemNode.ts
+++ b/src/ssmDocument/explorer/documentItemNode.ts
@@ -1,0 +1,47 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SSM } from 'aws-sdk'
+
+import { SsmDocumentClient } from '../../shared/clients/ssmDocumentClient'
+import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
+
+import { toArrayAsync } from '../../shared/utilities/collectionUtils'
+
+export class DocumentItemNode extends AWSTreeNodeBase {
+    public constructor(private documentItem: SSM.Types.DocumentIdentifier, public readonly client: SsmDocumentClient) {
+        super('')
+        this.update(documentItem)
+        this.contextValue = 'awsDocumentItemNode'
+    }
+
+    public update(documentItem: SSM.Types.DocumentIdentifier): void {
+        this.documentItem = documentItem
+        this.label = this.documentItem.Name || ''
+    }
+
+    public get documentName(): string {
+        return this.documentItem.Name || ''
+    }
+
+    public get documentOwner(): string {
+        return this.documentItem.Owner || ''
+    }
+
+    public async getDocumentContent(
+        documentVersion?: string,
+        documentFormat?: string
+    ): Promise<SSM.Types.GetDocumentResult> {
+        return await this.client.getDocument(
+            this.documentName,
+            documentVersion || this.documentItem.DocumentVersion,
+            documentFormat || this.documentItem.DocumentFormat
+        )
+    }
+
+    public async listSchemaVersion(): Promise<SSM.Types.DocumentVersionInfo[]> {
+        return await toArrayAsync(this.client.listDocumentVersions(this.documentName))
+    }
+}

--- a/src/ssmDocument/explorer/documentTypeNode.ts
+++ b/src/ssmDocument/explorer/documentTypeNode.ts
@@ -17,7 +17,10 @@ import { PlaceholderNode } from '../../shared/treeview/nodes/placeholderNode'
 import { makeChildrenNodes } from '../../shared/treeview/treeNodeUtilities'
 import { toArrayAsync, updateInPlace } from '../../shared/utilities/collectionUtils'
 import { DocumentItemNode } from './documentItemNode'
-import { amazonRegistryName, userRegistryName, sharedRegistryName } from './registryItemNode'
+
+export const amazonRegistryName = localize('AWS.explorerNode.registry.name.amazon', 'Owned by Amazon')
+export const userRegistryName = localize('AWS.explorerNode.registry.name.self', 'Owned by me')
+export const sharedRegistryName = localize('AWS.explorerNode.registry.name.shared', 'Shared with me')
 
 export class DocumentTypeNode extends AWSTreeNodeBase {
     private readonly documentNodes: Map<string, DocumentItemNode>

--- a/src/ssmDocument/explorer/documentTypeNode.ts
+++ b/src/ssmDocument/explorer/documentTypeNode.ts
@@ -1,0 +1,110 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as nls from 'vscode-nls'
+const localize = nls.loadMessageBundle()
+
+import { SSM } from 'aws-sdk'
+import * as vscode from 'vscode'
+
+import { SsmDocumentClient } from '../../shared/clients/ssmDocumentClient'
+import { ext } from '../../shared/extensionGlobals'
+import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
+import { ErrorNode } from '../../shared/treeview/nodes/errorNode'
+import { PlaceholderNode } from '../../shared/treeview/nodes/placeholderNode'
+import { makeChildrenNodes } from '../../shared/treeview/treeNodeUtilities'
+import { toArrayAsync, updateInPlace } from '../../shared/utilities/collectionUtils'
+import { DocumentItemNode } from './documentItemNode'
+
+export class DocumentTypeNode extends AWSTreeNodeBase {
+    private readonly documentNodes: Map<string, DocumentItemNode>
+
+    public constructor(
+        public readonly regionCode: string,
+        public documentType: string,
+        public readonly registryName: string
+    ) {
+        super('', vscode.TreeItemCollapsibleState.Collapsed)
+
+        this.setLabel()
+
+        this.documentNodes = new Map<string, DocumentItemNode>()
+    }
+
+    private setLabel() {
+        this.label = `${this.documentType}`
+    }
+
+    public update(documentType: string): void {
+        this.documentType = documentType
+        this.setLabel()
+    }
+
+    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+        return await makeChildrenNodes({
+            getChildNodes: async () => {
+                await this.updateChildren()
+
+                return [...this.documentNodes.values()]
+            },
+            getErrorNode: async (error: Error) =>
+                new ErrorNode(
+                    this,
+                    error,
+                    localize('AWS.explorerNode.documentType.error', 'Error loading documentType ssm document items')
+                ),
+            getNoChildrenPlaceholderNode: async () =>
+                new PlaceholderNode(
+                    this,
+                    localize('AWS.explorerNode.documentType.noSsmDocument', `[No document found]`)
+                ),
+            sort: (nodeA: DocumentItemNode, nodeB: DocumentItemNode) =>
+                nodeA.documentName.localeCompare(nodeB.documentName),
+        })
+    }
+
+    public async updateChildren(): Promise<void> {
+        const client: SsmDocumentClient = ext.toolkitClientBuilder.createSsmClient(this.regionCode)
+        const documents = new Map<string, SSM.Types.DocumentIdentifier>()
+
+        let request: SSM.ListDocumentsRequest = {
+            Filters: [
+                {
+                    Key: 'DocumentType',
+                    Values: [this.documentType],
+                },
+            ],
+        }
+
+        if (this.registryName === 'Owned by me') {
+            request.Filters?.push({
+                Key: 'Owner',
+                Values: ['Self'],
+            })
+        } else if (this.registryName === 'Shared with me') {
+            request.Filters?.push({
+                Key: 'Owner',
+                Values: ['Private'],
+            })
+        } else if (this.registryName === 'Owned by Amazon') {
+            request.Filters?.push({
+                Key: 'Owner',
+                Values: ['Amazon'],
+            })
+        }
+
+        const docs = await toArrayAsync(client.listDocuments(request))
+        docs.forEach(doc => {
+            documents.set(doc.Name!, doc)
+        })
+
+        updateInPlace(
+            this.documentNodes,
+            documents.keys(),
+            key => this.documentNodes.get(key)!.update(documents.get(key)!),
+            key => new DocumentItemNode(documents.get(key)!, client)
+        )
+    }
+}

--- a/src/ssmDocument/explorer/registryItemNode.ts
+++ b/src/ssmDocument/explorer/registryItemNode.ts
@@ -17,6 +17,12 @@ import { DocumentTypeNode } from './documentTypeNode'
 
 import { supportedDocumentTypes } from 'aws-ssm-document-language-service'
 
+export const amazonRegistryName = localize('AWS.explorerNode.registry.name.amazon', 'Owned by Amazon')
+export const userRegistryName = localize('AWS.explorerNode.registry.name.self', 'Owned by me')
+export const sharedRegistryName = localize('AWS.explorerNode.registry.name.shared', 'Shared with me')
+
+export const viewOnlyString = localize('AWS.explorer.registry.viewOnly', ' [View Only]')
+
 export class RegistryItemNode extends AWSTreeNodeBase {
     private readonly documentTypeNodes: Map<string, DocumentTypeNode>
 
@@ -29,7 +35,7 @@ export class RegistryItemNode extends AWSTreeNodeBase {
     }
 
     private setLabel() {
-        const viewOnly: string = this.registryName === 'Owned by me' ? '' : ' [View Only]'
+        const viewOnly: string = this.registryName === userRegistryName ? '' : viewOnlyString
         this.label = `${this.registryName}${viewOnly}`
         this.iconPath = ''
     }
@@ -63,6 +69,7 @@ export class RegistryItemNode extends AWSTreeNodeBase {
     }
 
     public async updateChildren(): Promise<void> {
+        // supportedDocumentTypes = ['automation', 'command']
         const documentTypes = supportedDocumentTypes.map((type: string) => {
             return type[0].toUpperCase() + type.slice(1)
         })

--- a/src/ssmDocument/explorer/registryItemNode.ts
+++ b/src/ssmDocument/explorer/registryItemNode.ts
@@ -13,13 +13,9 @@ import { ErrorNode } from '../../shared/treeview/nodes/errorNode'
 import { PlaceholderNode } from '../../shared/treeview/nodes/placeholderNode'
 import { makeChildrenNodes } from '../../shared/treeview/treeNodeUtilities'
 import { updateInPlace } from '../../shared/utilities/collectionUtils'
-import { DocumentTypeNode } from './documentTypeNode'
+import { DocumentTypeNode, userRegistryName } from './documentTypeNode'
 
 import { supportedDocumentTypes } from 'aws-ssm-document-language-service'
-
-export const amazonRegistryName = localize('AWS.explorerNode.registry.name.amazon', 'Owned by Amazon')
-export const userRegistryName = localize('AWS.explorerNode.registry.name.self', 'Owned by me')
-export const sharedRegistryName = localize('AWS.explorerNode.registry.name.shared', 'Shared with me')
 
 export const viewOnlyString = localize('AWS.explorer.registry.viewOnly', ' [View Only]')
 

--- a/src/ssmDocument/explorer/registryItemNode.ts
+++ b/src/ssmDocument/explorer/registryItemNode.ts
@@ -1,0 +1,77 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as nls from 'vscode-nls'
+const localize = nls.loadMessageBundle()
+
+import * as vscode from 'vscode'
+
+import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
+import { ErrorNode } from '../../shared/treeview/nodes/errorNode'
+import { PlaceholderNode } from '../../shared/treeview/nodes/placeholderNode'
+import { makeChildrenNodes } from '../../shared/treeview/treeNodeUtilities'
+import { updateInPlace } from '../../shared/utilities/collectionUtils'
+import { DocumentTypeNode } from './documentTypeNode'
+
+import { supportedDocumentTypes } from 'aws-ssm-document-language-service'
+
+export class RegistryItemNode extends AWSTreeNodeBase {
+    private readonly documentTypeNodes: Map<string, DocumentTypeNode>
+
+    public constructor(public readonly regionCode: string, public registryName: string) {
+        super('', vscode.TreeItemCollapsibleState.Collapsed)
+
+        this.setLabel()
+
+        this.documentTypeNodes = new Map<string, DocumentTypeNode>()
+    }
+
+    private setLabel() {
+        const viewOnly: string = this.registryName === 'Owned by me' ? '' : ' [View Only]'
+        this.label = `${this.registryName}${viewOnly}`
+        this.iconPath = ''
+    }
+
+    public update(registryName: string): void {
+        this.registryName = registryName
+        this.setLabel()
+    }
+
+    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+        return await makeChildrenNodes({
+            getChildNodes: async () => {
+                await this.updateChildren()
+
+                return [...this.documentTypeNodes.values()]
+            },
+            getErrorNode: async (error: Error) =>
+                new ErrorNode(
+                    this,
+                    error,
+                    localize('AWS.explorerNode.registry.error', 'Error loading registry ssm documentType items')
+                ),
+            getNoChildrenPlaceholderNode: async () =>
+                new PlaceholderNode(
+                    this,
+                    localize('AWS.explorerNode.registry.noSsmDocument', `[No documentType found]`)
+                ),
+            sort: (nodeA: DocumentTypeNode, nodeB: DocumentTypeNode) =>
+                nodeA.documentType.localeCompare(nodeB.documentType),
+        })
+    }
+
+    public async updateChildren(): Promise<void> {
+        const documentTypes = supportedDocumentTypes.map((type: string) => {
+            return type[0].toUpperCase() + type.slice(1)
+        })
+
+        updateInPlace(
+            this.documentTypeNodes,
+            documentTypes,
+            key => this.documentTypeNodes.get(key)!.update(key),
+            key => new DocumentTypeNode(this.regionCode, key, this.registryName)
+        )
+    }
+}

--- a/src/ssmDocument/explorer/ssmDocumentNode.ts
+++ b/src/ssmDocument/explorer/ssmDocumentNode.ts
@@ -1,0 +1,67 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as nls from 'vscode-nls'
+const localize = nls.loadMessageBundle()
+
+import * as vscode from 'vscode'
+
+import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
+import { ErrorNode } from '../../shared/treeview/nodes/errorNode'
+import { PlaceholderNode } from '../../shared/treeview/nodes/placeholderNode'
+import { makeChildrenNodes } from '../../shared/treeview/treeNodeUtilities'
+import { updateInPlace } from '../../shared/utilities/collectionUtils'
+import { RegistryItemNode } from './registryItemNode'
+
+import { SSM } from 'aws-sdk'
+
+export class SsmDocumentNode extends AWSTreeNodeBase {
+    private readonly registryNodes: Map<string, RegistryItemNode>
+
+    public constructor(public readonly regionCode: string) {
+        super('SSM Document', vscode.TreeItemCollapsibleState.Collapsed)
+        this.registryNodes = new Map<string, RegistryItemNode>()
+        this.contextValue = 'awsSsmDocumentNode'
+    }
+
+    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+        return await makeChildrenNodes({
+            getChildNodes: async () => {
+                await this.updateChildren()
+
+                return [...this.registryNodes.values()]
+            },
+            getErrorNode: async (error: Error) =>
+                new ErrorNode(
+                    this,
+                    error,
+                    localize('AWS.explorerNode.ssmDocument.error', 'Error loading SSM Document resources')
+                ),
+            getNoChildrenPlaceholderNode: async () =>
+                new PlaceholderNode(
+                    this,
+                    localize('AWS.explorerNode.ssmDocument.noRegistry', '[No SSM Document Registries]')
+                ),
+            sort: (nodeA: RegistryItemNode, nodeB: RegistryItemNode) =>
+                nodeA.registryName.localeCompare(nodeB.registryName),
+        })
+    }
+
+    public async updateChildren(): Promise<void> {
+        const registries = new Map<string, SSM.Types.DocumentIdentifier[]>()
+        registries.set('Owned by Amazon', [])
+        registries.set('Owned by me', [])
+        registries.set('Shared with me', [])
+
+        console.log(registries)
+
+        updateInPlace(
+            this.registryNodes,
+            registries.keys(),
+            key => this.registryNodes.get(key)!.update(key),
+            key => new RegistryItemNode(this.regionCode, key)
+        )
+    }
+}

--- a/src/ssmDocument/explorer/ssmDocumentNode.ts
+++ b/src/ssmDocument/explorer/ssmDocumentNode.ts
@@ -13,7 +13,8 @@ import { ErrorNode } from '../../shared/treeview/nodes/errorNode'
 import { PlaceholderNode } from '../../shared/treeview/nodes/placeholderNode'
 import { makeChildrenNodes } from '../../shared/treeview/treeNodeUtilities'
 import { updateInPlace } from '../../shared/utilities/collectionUtils'
-import { RegistryItemNode, amazonRegistryName, userRegistryName, sharedRegistryName } from './registryItemNode'
+import { amazonRegistryName, userRegistryName, sharedRegistryName } from './documentTypeNode'
+import { RegistryItemNode } from './registryItemNode'
 
 export class SsmDocumentNode extends AWSTreeNodeBase {
     private readonly registryNodes: Map<string, RegistryItemNode>

--- a/src/ssmDocument/explorer/ssmDocumentNode.ts
+++ b/src/ssmDocument/explorer/ssmDocumentNode.ts
@@ -15,8 +15,6 @@ import { makeChildrenNodes } from '../../shared/treeview/treeNodeUtilities'
 import { updateInPlace } from '../../shared/utilities/collectionUtils'
 import { RegistryItemNode, amazonRegistryName, userRegistryName, sharedRegistryName } from './registryItemNode'
 
-import { SSM } from 'aws-sdk'
-
 export class SsmDocumentNode extends AWSTreeNodeBase {
     private readonly registryNodes: Map<string, RegistryItemNode>
     private readonly childRegistryNames = [amazonRegistryName, userRegistryName, sharedRegistryName]

--- a/src/ssmDocument/explorer/ssmDocumentNode.ts
+++ b/src/ssmDocument/explorer/ssmDocumentNode.ts
@@ -13,12 +13,13 @@ import { ErrorNode } from '../../shared/treeview/nodes/errorNode'
 import { PlaceholderNode } from '../../shared/treeview/nodes/placeholderNode'
 import { makeChildrenNodes } from '../../shared/treeview/treeNodeUtilities'
 import { updateInPlace } from '../../shared/utilities/collectionUtils'
-import { RegistryItemNode } from './registryItemNode'
+import { RegistryItemNode, amazonRegistryName, userRegistryName, sharedRegistryName } from './registryItemNode'
 
 import { SSM } from 'aws-sdk'
 
 export class SsmDocumentNode extends AWSTreeNodeBase {
     private readonly registryNodes: Map<string, RegistryItemNode>
+    private readonly childRegistryNames = [amazonRegistryName, userRegistryName, sharedRegistryName]
 
     public constructor(public readonly regionCode: string) {
         super('SSM Document', vscode.TreeItemCollapsibleState.Collapsed)
@@ -51,15 +52,13 @@ export class SsmDocumentNode extends AWSTreeNodeBase {
 
     public async updateChildren(): Promise<void> {
         const registries = new Map<string, SSM.Types.DocumentIdentifier[]>()
-        registries.set('Owned by Amazon', [])
-        registries.set('Owned by me', [])
-        registries.set('Shared with me', [])
-
-        console.log(registries)
+        registries.set(amazonRegistryName, [])
+        registries.set(userRegistryName, [])
+        registries.set(sharedRegistryName, [])
 
         updateInPlace(
             this.registryNodes,
-            registries.keys(),
+            this.childRegistryNames,
             key => this.registryNodes.get(key)!.update(key),
             key => new RegistryItemNode(this.regionCode, key)
         )

--- a/src/ssmDocument/explorer/ssmDocumentNode.ts
+++ b/src/ssmDocument/explorer/ssmDocumentNode.ts
@@ -51,11 +51,6 @@ export class SsmDocumentNode extends AWSTreeNodeBase {
     }
 
     public async updateChildren(): Promise<void> {
-        const registries = new Map<string, SSM.Types.DocumentIdentifier[]>()
-        registries.set(amazonRegistryName, [])
-        registries.set(userRegistryName, [])
-        registries.set(sharedRegistryName, [])
-
         updateInPlace(
             this.registryNodes,
             this.childRegistryNames,

--- a/src/test/ssmDocument/explorer/documentItemNode.test.ts
+++ b/src/test/ssmDocument/explorer/documentItemNode.test.ts
@@ -1,0 +1,41 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { SSM } from 'aws-sdk'
+import * as sinon from 'sinon'
+import { DocumentItemNode } from '../../../ssmDocument/explorer/documentItemNode'
+import { MockSsmDocumentClient } from '../../shared/clients/mockClients'
+
+describe('DocumentItemNode', async () => {
+    let sandbox: sinon.SinonSandbox
+    let testNode: DocumentItemNode
+    const testDoc: SSM.DocumentIdentifier = {
+        Name: 'testDoc',
+        Owner: 'Amazon',
+    }
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox()
+        testNode = new DocumentItemNode(testDoc, new MockSsmDocumentClient())
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    it('initializes name, owner, context value', async () => {
+        assert.strictEqual(testNode.label, testDoc.Name)
+        assert.strictEqual(testNode.documentName, testDoc.Name)
+        assert.strictEqual(testNode.documentOwner, testDoc.Owner)
+        assert.strictEqual(testNode.contextValue, 'awsDocumentItemNode')
+    })
+
+    it('has no children', async () => {
+        const childNode = await testNode.getChildren()
+        assert(childNode !== undefined)
+        assert.strictEqual(childNode.length, 0)
+    })
+})

--- a/src/test/ssmDocument/explorer/documentTypeNode.test.ts
+++ b/src/test/ssmDocument/explorer/documentTypeNode.test.ts
@@ -1,0 +1,84 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { SSM } from 'aws-sdk'
+import * as sinon from 'sinon'
+import { DocumentTypeNode } from '../../../ssmDocument/explorer/documentTypeNode'
+import { ext } from '../../../shared/extensionGlobals'
+import { ToolkitClientBuilder } from '../../../shared/clients/toolkitClientBuilder'
+import { assertNodeListOnlyContainsErrorNode } from '../../utilities/explorerNodeAssertions'
+import { asyncGenerator } from '../../utilities/collectionUtils'
+
+describe('RegistryItemNode', () => {
+    let sandbox: sinon.SinonSandbox
+
+    const fakeRegion = 'testRegion'
+    const documentTypes = ['Automation', 'Command']
+    const registryNames = ['Owned by me', 'Owned by Amazon', 'Shared with me']
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox()
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    it('handles error', async () => {
+        const testNode: DocumentTypeNode = new DocumentTypeNode(fakeRegion, 'Command', 'Owned by me')
+        sandbox.stub(testNode, 'updateChildren').callsFake(() => {
+            throw new Error('Update child error')
+        })
+        const childNodes = await testNode.getChildren()
+
+        assertNodeListOnlyContainsErrorNode(childNodes)
+    })
+
+    it('puts documents into right registry', async () => {
+        documentTypes.forEach(async docType => {
+            registryNames.forEach(async registry => {
+                const testNode: DocumentTypeNode = new DocumentTypeNode(fakeRegion, docType, registry)
+                let owner: string
+                if (registry === 'Owned by Amazon') {
+                    owner = 'Amazon'
+                } else if (registry === 'Owned by me') {
+                    owner = '123456789012'
+                } else {
+                    owner = '987654321012'
+                }
+
+                initializeClientBuilders(owner, docType)
+                const childNode = await testNode.getChildren()
+                const expectedNodeNames = [`${owner}doc`]
+
+                assert.strictEqual(childNode.length, expectedNodeNames.length)
+                childNode.forEach((node, index) => {
+                    assert.strictEqual(node.label, expectedNodeNames[index])
+                })
+            })
+        })
+    })
+
+    function initializeClientBuilders(owner: string, documentType: string): void {
+        const ssmDocumentClient = {
+            listDocuments: sandbox.stub().callsFake(() => {
+                return asyncGenerator<SSM.DocumentIdentifier>([
+                    {
+                        Name: `${owner}doc`,
+                        Owner: `${owner}`,
+                        DocumentType: `${documentType}`,
+                    },
+                ])
+            }),
+        }
+
+        const clientBuilder = {
+            createSsmClient: sandbox.stub().returns(ssmDocumentClient),
+        }
+
+        ext.toolkitClientBuilder = (clientBuilder as any) as ToolkitClientBuilder
+    }
+})

--- a/src/test/ssmDocument/explorer/registryItemNode.test.ts
+++ b/src/test/ssmDocument/explorer/registryItemNode.test.ts
@@ -1,0 +1,55 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import * as sinon from 'sinon'
+import { RegistryItemNode } from '../../../ssmDocument/explorer/registryItemNode'
+import { assertNodeListOnlyContainsErrorNode } from '../../utilities/explorerNodeAssertions'
+
+describe('RegistryItemNode', () => {
+    let sandbox: sinon.SinonSandbox
+
+    const fakeRegion = 'testRegion'
+    const names = ['Owned by Amazon', 'Owned by me', 'Shared with me']
+    const expectedChildNodeNames = ['Automation', 'Command']
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox()
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    it('initialized name and [View Only] correctly', async () => {
+        const testAmazonNode: RegistryItemNode = new RegistryItemNode(fakeRegion, names[0])
+        const testMyNode: RegistryItemNode = new RegistryItemNode(fakeRegion, names[1])
+        const testSharedNode: RegistryItemNode = new RegistryItemNode(fakeRegion, names[2])
+
+        assert.strictEqual(testAmazonNode.label, `${names[0]} [View Only]`)
+        assert.strictEqual(testMyNode.label, `${names[1]}`)
+        assert.strictEqual(testSharedNode.label, `${names[2]} [View Only]`)
+    })
+
+    it('has correct child nodes', async () => {
+        const testNode: RegistryItemNode = new RegistryItemNode(fakeRegion, names[0])
+        const childNodes = await testNode.getChildren()
+
+        assert.strictEqual(childNodes.length, expectedChildNodeNames.length)
+        childNodes.forEach((child, index) => {
+            assert.strictEqual(child.label, expectedChildNodeNames[index])
+        })
+    })
+
+    it('handles error', async () => {
+        const testNode: RegistryItemNode = new RegistryItemNode(fakeRegion, names[0])
+        sandbox.stub(testNode, 'updateChildren').callsFake(() => {
+            throw new Error('Update child error')
+        })
+        const childNodes = await testNode.getChildren()
+
+        assertNodeListOnlyContainsErrorNode(childNodes)
+    })
+})

--- a/src/test/ssmDocument/explorer/registryItemNode.test.ts
+++ b/src/test/ssmDocument/explorer/registryItemNode.test.ts
@@ -6,12 +6,11 @@
 import * as assert from 'assert'
 import * as sinon from 'sinon'
 import {
-    RegistryItemNode,
     amazonRegistryName,
     userRegistryName,
     sharedRegistryName,
-    viewOnlyString,
-} from '../../../ssmDocument/explorer/registryItemNode'
+} from '../../../ssmDocument/explorer/documentTypeNode'
+import { RegistryItemNode, viewOnlyString } from '../../../ssmDocument/explorer/registryItemNode'
 import { assertNodeListOnlyContainsErrorNode } from '../../utilities/explorerNodeAssertions'
 
 describe('RegistryItemNode', () => {

--- a/src/test/ssmDocument/explorer/registryItemNode.test.ts
+++ b/src/test/ssmDocument/explorer/registryItemNode.test.ts
@@ -5,15 +5,22 @@
 
 import * as assert from 'assert'
 import * as sinon from 'sinon'
-import { RegistryItemNode } from '../../../ssmDocument/explorer/registryItemNode'
+import {
+    RegistryItemNode,
+    amazonRegistryName,
+    userRegistryName,
+    sharedRegistryName,
+    viewOnlyString,
+} from '../../../ssmDocument/explorer/registryItemNode'
 import { assertNodeListOnlyContainsErrorNode } from '../../utilities/explorerNodeAssertions'
 
 describe('RegistryItemNode', () => {
     let sandbox: sinon.SinonSandbox
 
     const fakeRegion = 'testRegion'
-    const names = ['Owned by Amazon', 'Owned by me', 'Shared with me']
-    const expectedChildNodeNames = ['Automation', 'Command']
+    const expectedAutomationNodeName = 'Automation'
+    const expectedCommandNodeName = 'Command'
+    const expectedChildNodeNames = [expectedAutomationNodeName, expectedCommandNodeName]
 
     beforeEach(() => {
         sandbox = sinon.createSandbox()
@@ -24,17 +31,17 @@ describe('RegistryItemNode', () => {
     })
 
     it('initialized name and [View Only] correctly', async () => {
-        const testAmazonNode: RegistryItemNode = new RegistryItemNode(fakeRegion, names[0])
-        const testMyNode: RegistryItemNode = new RegistryItemNode(fakeRegion, names[1])
-        const testSharedNode: RegistryItemNode = new RegistryItemNode(fakeRegion, names[2])
+        const testAmazonNode: RegistryItemNode = new RegistryItemNode(fakeRegion, amazonRegistryName)
+        const testMyNode: RegistryItemNode = new RegistryItemNode(fakeRegion, userRegistryName)
+        const testSharedNode: RegistryItemNode = new RegistryItemNode(fakeRegion, sharedRegistryName)
 
-        assert.strictEqual(testAmazonNode.label, `${names[0]} [View Only]`)
-        assert.strictEqual(testMyNode.label, `${names[1]}`)
-        assert.strictEqual(testSharedNode.label, `${names[2]} [View Only]`)
+        assert.strictEqual(testAmazonNode.label, `${amazonRegistryName}${viewOnlyString}`)
+        assert.strictEqual(testMyNode.label, `${userRegistryName}`)
+        assert.strictEqual(testSharedNode.label, `${sharedRegistryName}${viewOnlyString}`)
     })
 
     it('has correct child nodes', async () => {
-        const testNode: RegistryItemNode = new RegistryItemNode(fakeRegion, names[0])
+        const testNode: RegistryItemNode = new RegistryItemNode(fakeRegion, amazonRegistryName)
         const childNodes = await testNode.getChildren()
 
         assert.strictEqual(childNodes.length, expectedChildNodeNames.length)
@@ -44,7 +51,7 @@ describe('RegistryItemNode', () => {
     })
 
     it('handles error', async () => {
-        const testNode: RegistryItemNode = new RegistryItemNode(fakeRegion, names[0])
+        const testNode: RegistryItemNode = new RegistryItemNode(fakeRegion, amazonRegistryName)
         sandbox.stub(testNode, 'updateChildren').callsFake(() => {
             throw new Error('Update child error')
         })

--- a/src/test/ssmDocument/explorer/ssmDocumentNode.test.ts
+++ b/src/test/ssmDocument/explorer/ssmDocumentNode.test.ts
@@ -1,0 +1,94 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { SSM } from 'aws-sdk'
+import * as sinon from 'sinon'
+import { SsmDocumentNode } from '../../../ssmDocument/explorer/ssmDocumentNode'
+import { RegistryItemNode } from '../../../ssmDocument/explorer/registryItemNode'
+import { ToolkitClientBuilder } from '../../../shared/clients/toolkitClientBuilder'
+import { ext } from '../../../shared/extensionGlobals'
+import { assertNodeListOnlyContainsErrorNode } from '../../utilities/explorerNodeAssertions'
+import { asyncGenerator } from '../../utilities/collectionUtils'
+import { DEFAULT_TEST_ACCOUNT_ID, DEFAULT_TEST_REGION_CODE } from '../../utilities/fakeAwsContext'
+
+describe('SsmDocumentNode', () => {
+    let sandbox: sinon.SinonSandbox
+    let testNode: SsmDocumentNode
+    let docs: SSM.DocumentIdentifier[]
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox()
+
+        docs = [
+            {
+                Name: 'AWS-testDoc1',
+                Owner: 'Amazon',
+            },
+            {
+                Name: 'AWS-testDoc2',
+                Owner: 'Amazon',
+            },
+            {
+                Name: 'MyDoc1',
+                Owner: DEFAULT_TEST_ACCOUNT_ID,
+            },
+            {
+                Name: 'SharedDoc1',
+                Owner: '987654321012',
+            },
+            {
+                Name: 'AWS-testDoc3',
+                Owner: 'Amazon',
+            },
+        ] as SSM.DocumentIdentifier[]
+
+        initializeClientBuilders()
+        testNode = new SsmDocumentNode(DEFAULT_TEST_REGION_CODE)
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    it('always has 3 nodes: Owned by Amazon, Owned by me, Shared with me, if any child exists', async () => {
+        const childNodes = await testNode.getChildren()
+        const expectedChildNodeNames: string[] = [
+            'Owned by Amazon [View Only]',
+            'Owned by me',
+            'Shared with me [View Only]',
+        ]
+
+        assert.strictEqual(childNodes.length, expectedChildNodeNames.length, 'Unexpected child node length')
+
+        childNodes.forEach((node, index) => {
+            assert.ok(node instanceof RegistryItemNode, 'Expected child node to be RegistryItemNode')
+            assert.strictEqual(node.label, expectedChildNodeNames[index])
+        })
+    })
+
+    it('handles error', async () => {
+        sandbox.stub(testNode, 'updateChildren').callsFake(() => {
+            throw new Error('Update children error')
+        })
+
+        const childNodes = await testNode.getChildren()
+        assertNodeListOnlyContainsErrorNode(childNodes)
+    })
+
+    function initializeClientBuilders(): void {
+        const ssmDocumentClient = {
+            listDocuments: sandbox.stub().callsFake(() => {
+                return asyncGenerator<SSM.DocumentIdentifier>(docs)
+            }),
+        }
+
+        const clientBuilder = {
+            createSsmClient: sandbox.stub().returns(ssmDocumentClient),
+        }
+
+        ext.toolkitClientBuilder = (clientBuilder as any) as ToolkitClientBuilder
+    }
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added SSM Document Explorer nodes and ssmDocument clients that calls AWS SSM API's to retrieve document info.
The explorer nodes have 4 levels. 
1. SSM Document
2. Registry by document owner 
3. Registry by document type
4. document item
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This allows users to view SSM Documents in VS Code. The open document command will come later.
## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There are tests for each level of the explorer nodes. The tests are created based on the eventSchemas explorer test cases. 

## Screenshots (if appropriate)
<img width="331" alt="Screen Shot 2020-07-28 at 12 44 15 PM" src="https://user-images.githubusercontent.com/14162779/88701759-14dca180-d0d0-11ea-9803-729384e644b2.png">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
