### PR TITLE
CI: do not pin to VSCode 1.46.0

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -1,9 +1,5 @@
 version: 0.2
 
-env:
-    variables:
-        VSCODE_TEST_VERSION: '1.46.0' # TODO: Remove when we resolve debugger issues with integration tests
-
 phases:
     install:
         runtime-versions:

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -10,6 +10,7 @@ phases:
 
     build:
         commands:
+            - export AWS_TOOLKIT_TEST_USER_DIR=/tmp/
             - export AWS_TOOLKIT_TEST_NO_COLOR=1
             - npm run testCompile
             - npm run lint

--- a/buildspec/packageTestVsix.yml
+++ b/buildspec/packageTestVsix.yml
@@ -17,6 +17,7 @@ phases:
 
     build:
         commands:
+            - export AWS_TOOLKIT_TEST_USER_DIR=/tmp/
             - npm run generateNonCodeFiles
             - cp ./extension-readme.md ./README.md
             - npm run package

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -2,7 +2,6 @@ version: 0.2
 env:
     variables:
         AWS_TOOLKIT_TEST_NO_COLOR: '1'
-        VSCODE_TEST_VERSION: '1.46.0' # TODO: Remove when we resolve debugger issues with Windows tests
 phases:
     install:
         commands:

--- a/test-scripts/launchTestUtilities.ts
+++ b/test-scripts/launchTestUtilities.ts
@@ -15,6 +15,8 @@ const MINIMUM = 'minimum'
 /**
  * Downloads and unzips a copy of VS Code to run tests against.
  *
+ * Prints the result of `code --version`.
+ *
  * Test suites can set up an experimental instance of VS Code however they want.
  * This method provides the common use-case, pulling down the latest version (aka 'stable').
  * The VS Code version under test can be altered by setting the environment variable
@@ -28,28 +30,34 @@ export async function setupVSCodeTestInstance(): Promise<string> {
         vsCodeVersion = getMinVsCodeVersion()
     }
 
-    console.log(`About to set up test instance of VS Code, version ${vsCodeVersion}...`)
+    console.log(`Setting up VS Code test instance, version: ${vsCodeVersion}`)
     const vsCodeExecutablePath = await downloadAndUnzipVSCode(vsCodeVersion)
     console.log(`VS Code test instance location: ${vsCodeExecutablePath}`)
+
+    await invokeVSCodeCli(vsCodeExecutablePath, ['--version'])
 
     return vsCodeExecutablePath
 }
 
-export async function installVSCodeExtension(vsCodeExecutablePath: string, extensionIdentifier: string): Promise<void> {
-    console.log(`Installing VS Code Extension: ${extensionIdentifier}`)
+export async function invokeVSCodeCli(vsCodeExecutablePath: string, args: string[]): Promise<Buffer> {
     const vsCodeCliPath = resolveCliPathFromVSCodeExecutablePath(vsCodeExecutablePath)
 
-    const cmdArgs = ['--install-extension', extensionIdentifier]
+    let cmdArgs = [...args]
+
+    // Workaround: set --user-data-dir to avoid this error in CI:
+    // "You are trying to start Visual Studio Code as a super user …"
     if (process.env.AWS_TOOLKIT_TEST_USER_DIR) {
         cmdArgs.push('--user-data-dir', process.env.AWS_TOOLKIT_TEST_USER_DIR)
     }
+
+    console.log(`Invoking vscode CLI command:\n    "${vsCodeCliPath}" ${JSON.stringify(cmdArgs)}`)
     const spawnResult = child_process.spawnSync(vsCodeCliPath, cmdArgs, {
         encoding: 'utf-8',
         stdio: 'inherit',
     })
 
     if (spawnResult.status !== 0) {
-        throw new Error(`Installing VS Code extension ${extensionIdentifier} had exit code ${spawnResult.status}`)
+        throw new Error(`VS Code CLI command failed (exit-code: ${spawnResult.status}): ${vsCodeCliPath} ${cmdArgs}`)
     }
 
     if (spawnResult.error) {
@@ -59,6 +67,16 @@ export async function installVSCodeExtension(vsCodeExecutablePath: string, exten
     if (spawnResult.stdout) {
         console.log(spawnResult.stdout)
     }
+
+    return spawnResult.stdout
+}
+
+export async function installVSCodeExtension(vsCodeExecutablePath: string, extensionIdentifier: string): Promise<void> {
+    console.log(`Installing VS Code Extension: ${extensionIdentifier}`)
+
+    const cmdArgs = ['--install-extension', extensionIdentifier]
+
+    await invokeVSCodeCli(vsCodeExecutablePath, cmdArgs)
 }
 
 function getMinVsCodeVersion(): string {


### PR DESCRIPTION
- do not pin to VSCode `1.46.0`. It doesn't seem to help, since Windows CI still fails.
  - Reverts cda7451080b2
- print exact version (and git hash) of the vscode test instance. Example:
   ```
    $ ./node_modules/.bin/ts-node ./test-scripts/launchTestUtilities.ts
    Seting up VS Code test instance, version: stable
    Found .vscode-test/vscode-1.47.3. Skipping download.
    VS Code test instance location: /Volumes/workplace/aws-toolkit-vscode/.vscode-test/vscode-1.47.3/Visual Studio Code.app/Contents/MacOS/Electron
    Invoking vscode CLI command:
        /Volumes/workplace/aws-toolkit-vscode/.vscode-test/vscode-1.47.3/Visual Studio Code.app/Contents/Resources/app/bin/code --version
    1.47.3
    91899dcef7b8110878ea59626991a18c8a6a1b3e
    x64
   ```


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
