### PR TITLE
CI: restore Windows CI;  use "--verbose --log debug"

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -1,5 +1,11 @@
 version: 0.2
 
+env:
+    variables:
+        AWS_TOOLKIT_TEST_USER_DIR: '/tmp/'
+        AWS_TOOLKIT_TEST_NO_COLOR: '1'
+        NO_COVERAGE: 'true'
+
 phases:
     install:
         runtime-versions:
@@ -41,9 +47,6 @@ phases:
 
     build:
         commands:
-            - export AWS_TOOLKIT_TEST_USER_DIR=/tmp/
-            - export AWS_TOOLKIT_TEST_NO_COLOR=1
-            - export NO_COVERAGE=true
             - npm install --unsafe-perm
             - xvfb-run npm run integrationTest
 

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -1,4 +1,10 @@
 version: 0.2
+
+env:
+    variables:
+        AWS_TOOLKIT_TEST_USER_DIR: '/tmp/'
+        AWS_TOOLKIT_TEST_NO_COLOR: '1'
+
 phases:
     install:
         runtime-versions:
@@ -10,8 +16,6 @@ phases:
 
     build:
         commands:
-            - export AWS_TOOLKIT_TEST_USER_DIR=/tmp/
-            - export AWS_TOOLKIT_TEST_NO_COLOR=1
             - npm run testCompile
             - npm run lint
             - xvfb-run npm test --silent

--- a/buildspec/packageTestVsix.yml
+++ b/buildspec/packageTestVsix.yml
@@ -2,6 +2,7 @@ version: 0.2
 
 env:
     variables:
+        AWS_TOOLKIT_TEST_USER_DIR: '/tmp/'
         # needed or else webpack will cause it to run out of memory
         NODE_OPTIONS: '--max-old-space-size=8192'
 
@@ -17,7 +18,6 @@ phases:
 
     build:
         commands:
-            - export AWS_TOOLKIT_TEST_USER_DIR=/tmp/
             - npm run generateNonCodeFiles
             - cp ./extension-readme.md ./README.md
             - npm run package

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -9,6 +9,13 @@ phases:
                 if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
                     choco install -y --no-progress codecov
                 }
+            # Install getmac to avoid spurious "Command failed: getmac.exe"
+            # error in the build logs. https://github.com/microsoft/vscode/issues/102428
+            - |
+                &python --version
+                &pip --version
+                &pip install getmac
+                &getmac --version
     pre_build:
         commands:
             - npm install

--- a/test-scripts/launchTestUtilities.ts
+++ b/test-scripts/launchTestUtilities.ts
@@ -75,10 +75,7 @@ export async function invokeVSCodeCli(vsCodeExecutablePath: string, args: string
 
 export async function installVSCodeExtension(vsCodeExecutablePath: string, extensionIdentifier: string): Promise<void> {
     console.log(`Installing VS Code Extension: ${extensionIdentifier}`)
-
-    const cmdArgs = ['--install-extension', extensionIdentifier]
-
-    await invokeVSCodeCli(vsCodeExecutablePath, cmdArgs)
+    await invokeVSCodeCli(vsCodeExecutablePath, ['--install-extension', extensionIdentifier])
 }
 
 function getMinVsCodeVersion(): string {

--- a/test-scripts/launchTestUtilities.ts
+++ b/test-scripts/launchTestUtilities.ts
@@ -24,9 +24,7 @@ const MINIMUM = 'minimum'
  */
 export async function setupVSCodeTestInstance(): Promise<string> {
     let vsCodeVersion = process.env[ENVVAR_VSCODE_TEST_VERSION]
-    if (process.platform === 'win32') {
-        vsCodeVersion = getMinVsCodeVersion()
-    } else if (!vsCodeVersion) {
+    if (!vsCodeVersion) {
         vsCodeVersion = STABLE
     } else if (vsCodeVersion === MINIMUM) {
         vsCodeVersion = getMinVsCodeVersion()

--- a/test-scripts/test.ts
+++ b/test-scripts/test.ts
@@ -23,6 +23,8 @@ import { env } from 'process'
             vscodeExecutablePath: vsCodeExecutablePath,
             extensionDevelopmentPath: cwd,
             extensionTestsPath: testEntrypoint,
+            // TODO: remove this after some bake-time on master branch (ETA: 2020-12-15).
+            launchArgs: ['--verbose', '--log', 'debug'],
         })
 
         console.log(`Finished running Main test suite with result code: ${result}`)


### PR DESCRIPTION
- use `env` directive instead of shell-specific commands to set env vars
- ~~also report `--status` after installing the vscode test-instance~~
  - `[main 2020-07-30T18:56:35.684Z] Warning: The --status argument can only be used if Code is already running. Please run it again after Code has started.`
- (temporary commit): invoke tests with `--verbose --log debug`
- Revert "CI: temporarily force "minimum" VSCode on Windows #1224" 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
