### PR TITLE
CI: temporarily force "minimum" VSCode on Windows

### DIFF
--- a/test-scripts/launchTestUtilities.ts
+++ b/test-scripts/launchTestUtilities.ts
@@ -24,7 +24,9 @@ const MINIMUM = 'minimum'
  */
 export async function setupVSCodeTestInstance(): Promise<string> {
     let vsCodeVersion = process.env[ENVVAR_VSCODE_TEST_VERSION]
-    if (!vsCodeVersion) {
+    if (process.platform === 'win32') {
+        vsCodeVersion = getMinVsCodeVersion()
+    } else if (!vsCodeVersion) {
         vsCodeVersion = STABLE
     } else if (vsCodeVersion === MINIMUM) {
         vsCodeVersion = getMinVsCodeVersion()


### PR DESCRIPTION
This allows the release pipeline to proceed, until we debug the CI issue with the "stable" and "insiders" vscode versions on Windows CI.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
