### PR TITLE
Fix test error trying to access uri of undefined document

### DIFF
--- a/src/test/ssmDocument/commands/createDocumentFromTemplate.test.ts
+++ b/src/test/ssmDocument/commands/createDocumentFromTemplate.test.ts
@@ -12,6 +12,7 @@ import {
     promptUserForTemplate,
 } from '../../../ssmDocument/commands/createDocumentFromTemplate'
 import * as openAndSaveDocument from '../../../ssmDocument/util/util'
+import * as vscode from 'vscode'
 
 import * as YAML from 'yaml'
 
@@ -21,6 +22,7 @@ describe('createDocumentFromTemplate', async () => {
         sandbox = sinon.createSandbox()
         sandbox.stub(picker, 'promptUser').returns(Promise.resolve(fakeSelection))
         sandbox.stub(picker, 'verifySinglePickerOutput').returns(fakeSelectionResult)
+        sandbox.stub(vscode.window, 'showTextDocument')
     })
 
     afterEach(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In a test, a stub function (openAndSaveDocument) causing an undefined object to get passed to a showTextDocument call within createSsmDocumentFromTemplate. Fixing this to remove errors that are generated during test runs.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
