### PR TITLE
SAM: search for SAM CLI in ~/.linuxbrew

### DIFF
--- a/src/shared/sam/cli/samCliLocator.ts
+++ b/src/shared/sam/cli/samCliLocator.ts
@@ -139,6 +139,9 @@ class UnixSamCliLocator extends BaseSamCliLocator {
     private static readonly LOCATION_PATHS: string[] = [
         '/usr/local/bin',
         '/usr/bin',
+        // WEIRD BUT TRUE: brew installs to /home/linuxbrew/.linuxbrew if
+        // possible, else to ~/.linuxbrew.  https://docs.brew.sh/Homebrew-on-Linux
+        '/home/linuxbrew/.linuxbrew/bin',
         `${process.env.HOME}/.linuxbrew/bin`,
     ]
 

--- a/src/shared/sam/cli/samCliLocator.ts
+++ b/src/shared/sam/cli/samCliLocator.ts
@@ -136,7 +136,11 @@ class WindowsSamCliLocator extends BaseSamCliLocator {
 }
 
 class UnixSamCliLocator extends BaseSamCliLocator {
-    private static readonly LOCATION_PATHS: string[] = ['/usr/local/bin', '/usr/bin']
+    private static readonly LOCATION_PATHS: string[] = [
+        '/usr/local/bin',
+        '/usr/bin',
+        `${process.env.HOME}/.linuxbrew/bin`,
+    ]
 
     private static readonly EXECUTABLE_FILENAMES: string[] = ['sam']
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

One of SAM CLI's recommended install methods is to use linuxbrew. If linuxbrew is not in $PATH for some reason, Toolkit can work around that by searching the default linuxbrew location.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
