### PR TITLE
Ungate CloudWatch Logs functionality

### DIFF
--- a/.changes/next-release/Feature-97c6535a-a446-4f56-beaa-da5ee8d4a5f9.json
+++ b/.changes/next-release/Feature-97c6535a-a446-4f56-beaa-da5ee8d4a5f9.json
@@ -1,0 +1,4 @@
+{
+    "type": "Feature",
+    "description": "Adding CloudWatch Logs functionality"
+}

--- a/.changes/next-release/Feature-97c6535a-a446-4f56-beaa-da5ee8d4a5f9.json
+++ b/.changes/next-release/Feature-97c6535a-a446-4f56-beaa-da5ee8d4a5f9.json
@@ -1,4 +1,4 @@
 {
     "type": "Feature",
-    "description": "Adding CloudWatch Logs functionality"
+    "description": "CloudWatch Logs functionality"
 }

--- a/src/awsexplorer/regionNode.ts
+++ b/src/awsexplorer/regionNode.ts
@@ -8,7 +8,6 @@ import { SchemasNode } from '../eventSchemas/explorer/schemasNode'
 import { CloudFormationNode } from '../lambda/explorer/cloudFormationNodes'
 import { CloudWatchLogsNode } from '../cloudWatchLogs/explorer/cloudWatchLogsNode'
 import { LambdaNode } from '../lambda/explorer/lambdaNodes'
-import { ActiveFeatureKeys, FeatureToggle } from '../shared/featureToggle'
 import { S3Node } from '../s3/explorer/s3Nodes'
 import { DefaultS3Client } from '../shared/clients/defaultS3Client'
 import { Region } from '../shared/regions/endpoints'
@@ -45,11 +44,7 @@ export class RegionNode extends AWSTreeNodeBase {
         //  This interface exists so we can add additional nodes to the array (otherwise Typescript types the array to what's already in the array at creation)
         const serviceCandidates = [
             { serviceId: 'cloudformation', createFn: () => new CloudFormationNode(this.regionCode) },
-            // Feature Toggle for CloudWatch Logs
-            // REMOVE_WHEN_CLOUDWATCH_LOGS_READY
-            ...(FeatureToggle.getFeatureToggle().isFeatureActive(ActiveFeatureKeys.CloudWatchLogs)
-                ? [{ serviceId: 'logs', createFn: () => new CloudWatchLogsNode(this.regionCode) }]
-                : []),
+            { serviceId: 'logs', createFn: () => new CloudWatchLogsNode(this.regionCode) },
             { serviceId: 'lambda', createFn: () => new LambdaNode(this.regionCode) },
             {
                 serviceId: 's3',

--- a/src/shared/featureToggle.ts
+++ b/src/shared/featureToggle.ts
@@ -14,9 +14,7 @@ import { SettingsConfiguration, DefaultSettingsConfiguration } from './settingsC
  * You cannot have more active features than FeatureToggle.maxFeatures (default: 5)
  * Any features that are flagged in the code but not added here will always return false.
  */
-export enum ActiveFeatureKeys {
-    CloudWatchLogs = 'CloudWatchLogs',
-}
+export enum ActiveFeatureKeys {}
 
 /**
  * This class handles feature access for unreleased or gated features.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ungates Cloudwatch Logs functionality by removing the requirement to have a feature flag set.

## Motivation and Context
Makes feature generally available

## Related Issue(s)
Contingent on https://github.com/aws/aws-toolkit-vscode/pull/1200

## Testing
Confirmed that the feature appears without a feature flag present

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
