### PR TITLE
SAM: change config to "machine" scope; handle failed config write

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
                 },
                 "aws.samcli.location": {
                     "type": "string",
+                    "scope": "machine",
                     "default": "",
                     "markdownDescription": "%AWS.configuration.description.samcli.location%"
                 },

--- a/src/shared/sam/cli/samCliConfiguration.ts
+++ b/src/shared/sam/cli/samCliConfiguration.ts
@@ -36,7 +36,7 @@ export class DefaultSamCliConfiguration implements SamCliConfiguration {
         await this._configuration.writeSetting(
             DefaultSamCliConfiguration.CONFIGURATION_KEY_SAMCLI_LOCATION,
             location,
-            vscode.ConfigurationTarget.Workspace
+            vscode.ConfigurationTarget.Global
         )
     }
 
@@ -56,11 +56,7 @@ export class DefaultSamCliConfiguration implements SamCliConfiguration {
         // Avoid setting the value redundantly (could cause a loop because we
         // listen to the `onDidChangeConfiguration` event).
         if (detectedLocation && configLocation !== detectedLocation) {
-            // Exception if no workspace is open:
-            // "Unable to write to Workspace Settings because no workspace is opened."
-            if (vscode.workspace.name !== undefined) {
-                await this.setSamCliLocation(detectedLocation)
-            }
+            await this.setSamCliLocation(detectedLocation)
         }
     }
 }

--- a/src/shared/sam/cli/samCliConfiguration.ts
+++ b/src/shared/sam/cli/samCliConfiguration.ts
@@ -36,7 +36,7 @@ export class DefaultSamCliConfiguration implements SamCliConfiguration {
         await this._configuration.writeSetting(
             DefaultSamCliConfiguration.CONFIGURATION_KEY_SAMCLI_LOCATION,
             location,
-            vscode.ConfigurationTarget.Global
+            vscode.ConfigurationTarget.Workspace
         )
     }
 
@@ -55,8 +55,12 @@ export class DefaultSamCliConfiguration implements SamCliConfiguration {
         const detectedLocation = (await this._samCliLocationProvider.getLocation()) ?? ''
         // Avoid setting the value redundantly (could cause a loop because we
         // listen to the `onDidChangeConfiguration` event).
-        if (configLocation !== detectedLocation) {
-            await this.setSamCliLocation(detectedLocation)
+        if (detectedLocation && configLocation !== detectedLocation) {
+            // Exception if no workspace is open:
+            // "Unable to write to Workspace Settings because no workspace is opened."
+            if (vscode.workspace.name !== undefined) {
+                await this.setSamCliLocation(detectedLocation)
+            }
         }
     }
 }

--- a/src/shared/settingsConfiguration.ts
+++ b/src/shared/settingsConfiguration.ts
@@ -4,6 +4,7 @@
  */
 
 import * as vscode from 'vscode'
+import { getLogger } from './logger'
 
 /**
  * Wraps the VSCode configuration API and provides Toolkit-related
@@ -14,7 +15,20 @@ export interface SettingsConfiguration {
     readSetting<T>(settingKey: string, defaultValue: T): T
 
     // array values are serialized as a comma-delimited string
-    writeSetting<T>(settingKey: string, value: T | undefined, target: vscode.ConfigurationTarget): Promise<void>
+    /**
+     * Sets a config value.
+     *
+     * Writing to the (VSCode) config store may fail if the user does not have
+     * write permissions, or if some requirement is not met.  For example, the
+     * `vscode.ConfigurationTarget.Workspace` scope requires a workspace.
+     *
+     * @param settingKey  Config key name
+     * @param value  Config value
+     * @param target  Config _scope_
+     *
+     * @returns true on success, else false
+     */
+    writeSetting<T>(settingKey: string, value: T | undefined, target: vscode.ConfigurationTarget): Promise<boolean>
 }
 
 // default configuration settings handler for production release
@@ -22,8 +36,7 @@ export class DefaultSettingsConfiguration implements SettingsConfiguration {
     public constructor(public readonly extensionSettingsPrefix: string) {}
 
     public readSetting<T>(settingKey: string, defaultValue?: T): T | undefined {
-        // tslint:disable-next-line:no-null-keyword
-        const settings = vscode.workspace.getConfiguration(this.extensionSettingsPrefix, null)
+        const settings = vscode.workspace.getConfiguration(this.extensionSettingsPrefix)
 
         if (!settings) {
             return defaultValue
@@ -33,10 +46,14 @@ export class DefaultSettingsConfiguration implements SettingsConfiguration {
         return val ?? defaultValue
     }
 
-    public async writeSetting<T>(settingKey: string, value: T, target: vscode.ConfigurationTarget): Promise<void> {
-        // tslint:disable-next-line:no-null-keyword
-        const settings = vscode.workspace.getConfiguration(this.extensionSettingsPrefix, null)
-
-        await settings.update(settingKey, value, target)
+    public async writeSetting<T>(settingKey: string, value: T, target: vscode.ConfigurationTarget): Promise<boolean> {
+        try {
+            const settings = vscode.workspace.getConfiguration(this.extensionSettingsPrefix)
+            await settings.update(settingKey, value, target)
+            return true
+        } catch (e) {
+            getLogger().error('failed to set config: %O=%O, error: %O', settingKey, value, e)
+            return false
+        }
     }
 }

--- a/src/shared/settingsConfiguration.ts
+++ b/src/shared/settingsConfiguration.ts
@@ -5,8 +5,10 @@
 
 import * as vscode from 'vscode'
 
-// defines helper methods for interacting with VSCode's configuration
-// persistence mechanisms, allowing us to test with mocks.
+/**
+ * Wraps the VSCode configuration API and provides Toolkit-related
+ * configuration functions.
+ */
 export interface SettingsConfiguration {
     readSetting<T>(settingKey: string): T | undefined
     readSetting<T>(settingKey: string, defaultValue: T): T

--- a/src/test/utilities/testSettingsConfiguration.ts
+++ b/src/test/utilities/testSettingsConfiguration.ts
@@ -15,7 +15,8 @@ export class TestSettingsConfiguration implements SettingsConfiguration {
         return this._data[settingKey] as T
     }
 
-    public async writeSetting<T>(settingKey: string, value: T, target?: any): Promise<void> {
+    public async writeSetting<T>(settingKey: string, value: T, target?: any): Promise<boolean> {
         this._data[settingKey] = value
+        return true
     }
 }


### PR DESCRIPTION
Using `Global` scope for the `aws.samcli.location` config entry is untenable because:

- Multiple running VSCode instances may change it, and then all  instances respond to the `onDidChangeConfiguration` event, which may  cause hysterisis (on/off loop).
- _Remote_ VSCode instances share `Global` config with local running  VSCode instances.  Thus machine-dependent settings must not be  `Global`, because the config value on a remote VSCode may conflict  with local instance(s).

`Workspace` is a reasonable scope for `aws.samcli.location` because it is usually auto-detected (setting it manually is usually only  for debugging/experimentation)

## Note

- From the vscode settings UI one can see that there is a concept of machine-specific configuration: `~/.vscode-server/data/Machine/settings.json` . But this is not exposed in the vscode API.
  - **Update:** However, we can set `scope=machine` in the `package.json` declaration. See https://github.com/aws/aws-toolkit-vscode/pull/1241/commits/3f6b1f316c9de1dcbd5c3d49cd230be6effcbde0
- We could greatly simplify the code, and avoid most of these problems, by simply _not_ updating the user's config. If the user's configured SAM CLI is invalid, do auto-detection just-in-time.
  - Done in PR: https://github.com/aws/aws-toolkit-vscode/pull/1242

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
