### PR TITLE
TelemetryService: avoid race after shutdown()

### DIFF
--- a/src/shared/telemetry/defaultTelemetryService.ts
+++ b/src/shared/telemetry/defaultTelemetryService.ts
@@ -147,7 +147,11 @@ export class DefaultTelemetryService implements TelemetryService {
             // this is async so that we don't have pseudo-concurrent invocations of the callback
             async () => {
                 await this.flushRecords()
-                this._timer!.refresh()
+                // Race: _timer may be undefined after shutdown() (this async
+                // closure may be pending on the event-loop, despite clearTimeout()).
+                if (this._timer !== undefined) {
+                    this._timer!.refresh()
+                }
             },
             this._flushPeriod
         )


### PR DESCRIPTION
_timer may be undefined if shutdown() was called, despite clearTimeout(), because the `async` closure scheduled by the previous timer tick may be pending.

    TypeError: Cannot read property 'refresh' of undefined
        at DefaultTelemetryService.<anonymous> (/Volumes/workplace/aws-toolkit-vscode/src/shared/telemetry/defaultTelemetryService.ts:150:30)
        at Generator.next (<anonymous>)
        at fulfilled (/Volumes/workplace/aws-toolkit-vscode/dist/src/shared/telemetry/defaultTelemetryService.js:9:58)
        {stack: 'TypeError: Cannot read property 'refresh' of …ed/telemetry/defaultTelemetryService.js:9:58)', message: 'Cannot read property 'refresh' of undefined'}

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
