### PR TITLE
build: update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1515,6 +1515,12 @@
             "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
             "dev": true
         },
+        "builtin-modules": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+            "dev": true
+        },
         "builtin-status-codes": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
@@ -9370,6 +9376,50 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
             "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
             "dev": true
+        },
+        "tslint": {
+            "version": "6.1.3",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
+            "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.3.0",
+                "commander": "^2.12.1",
+                "diff": "^4.0.1",
+                "glob": "^7.1.1",
+                "js-yaml": "^3.13.1",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.3",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.13.0",
+                "tsutils": "^2.29.0"
+            },
+            "dependencies": {
+                "diff": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+                    "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+                    "dev": true
+                },
+                "tslib": {
+                    "version": "1.13.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+                    "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+                    "dev": true
+                },
+                "tsutils": {
+                    "version": "2.29.0",
+                    "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+                    "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^1.8.1"
+                    }
+                }
+            }
         },
         "tsutils": {
             "version": "3.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1374,12 +1374,6 @@
                 }
             }
         },
-        "bluebird": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
-            "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
-            "dev": true
-        },
         "bn.js": {
             "version": "4.11.8",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
@@ -3589,12 +3583,6 @@
             "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
             "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
         },
-        "figgy-pudding": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-            "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
-            "dev": true
-        },
         "figures": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -5645,12 +5633,6 @@
             "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
             "dev": true
         },
-        "is-wsl": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-            "dev": true
-        },
         "is2": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.1.tgz",
@@ -6410,24 +6392,6 @@
                 }
             }
         },
-        "mississippi": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-            "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
-            "dev": true,
-            "requires": {
-                "concat-stream": "^1.5.0",
-                "duplexify": "^3.4.2",
-                "end-of-stream": "^1.1.0",
-                "flush-write-stream": "^1.0.0",
-                "from2": "^2.1.0",
-                "parallel-transform": "^1.1.0",
-                "pump": "^3.0.0",
-                "pumpify": "^1.3.3",
-                "stream-each": "^1.1.0",
-                "through2": "^2.0.0"
-            }
-        },
         "mixin-deep": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -6738,20 +6702,6 @@
             "version": "2.24.0",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
             "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
-        },
-        "move-concurrently": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
-            "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
-            "dev": true,
-            "requires": {
-                "aproba": "^1.1.1",
-                "copy-concurrently": "^1.0.0",
-                "fs-write-stream-atomic": "^1.0.8",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.3"
-            }
         },
         "mri": {
             "version": "1.1.4",
@@ -8416,12 +8366,6 @@
             "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
             "dev": true
         },
-        "serialize-javascript": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-            "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-            "dev": true
-        },
         "set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -8899,9 +8843,9 @@
             }
         },
         "stream-shift": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-            "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+            "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
             "dev": true
         },
         "string-width": {
@@ -9129,25 +9073,6 @@
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
                     "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-                }
-            }
-        },
-        "terser": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-4.4.0.tgz",
-            "integrity": "sha512-oDG16n2WKm27JO8h4y/w3iqBGAOSCtq7k8dRmrn4Wf9NouL0b2WpMHGChFGZq4nFAQy1FsNJrVQHfurXOSTmOA==",
-            "dev": true,
-            "requires": {
-                "commander": "^2.20.0",
-                "source-map": "~0.6.1",
-                "source-map-support": "~0.5.12"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "2.20.3",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-                    "dev": true
                 }
             }
         },
@@ -10296,6 +10221,52 @@
                         "ssri": "^6.0.1",
                         "unique-filename": "^1.1.1",
                         "y18n": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "bluebird": {
+                            "version": "3.7.2",
+                            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+                            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+                            "dev": true
+                        },
+                        "figgy-pudding": {
+                            "version": "3.5.2",
+                            "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+                            "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
+                            "dev": true
+                        },
+                        "mississippi": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+                            "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+                            "dev": true,
+                            "requires": {
+                                "concat-stream": "^1.5.0",
+                                "duplexify": "^3.4.2",
+                                "end-of-stream": "^1.1.0",
+                                "flush-write-stream": "^1.0.0",
+                                "from2": "^2.1.0",
+                                "parallel-transform": "^1.1.0",
+                                "pump": "^3.0.0",
+                                "pumpify": "^1.3.3",
+                                "stream-each": "^1.1.0",
+                                "through2": "^2.0.0"
+                            }
+                        },
+                        "move-concurrently": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+                            "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+                            "dev": true,
+                            "requires": {
+                                "aproba": "^1.1.1",
+                                "copy-concurrently": "^1.0.0",
+                                "fs-write-stream-atomic": "^1.0.8",
+                                "mkdirp": "^0.5.1",
+                                "rimraf": "^2.5.4",
+                                "run-queue": "^1.0.3"
+                            }
+                        }
                     }
                 },
                 "extend-shallow": {
@@ -10363,9 +10334,9 @@
                     }
                 },
                 "graceful-fs": {
-                    "version": "4.2.3",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-                    "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+                    "version": "4.2.4",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
                     "dev": true
                 },
                 "is-number": {
@@ -10470,9 +10441,9 @@
                     }
                 },
                 "p-limit": {
-                    "version": "2.2.2",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-                    "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
                     "dev": true,
                     "requires": {
                         "p-try": "^2.0.0"
@@ -10524,23 +10495,68 @@
                     "dev": true,
                     "requires": {
                         "figgy-pudding": "^3.5.1"
+                    },
+                    "dependencies": {
+                        "figgy-pudding": {
+                            "version": "3.5.2",
+                            "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+                            "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
+                            "dev": true
+                        }
                     }
                 },
                 "terser-webpack-plugin": {
-                    "version": "1.4.3",
-                    "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
-                    "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+                    "version": "1.4.5",
+                    "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+                    "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
                     "dev": true,
                     "requires": {
                         "cacache": "^12.0.2",
                         "find-cache-dir": "^2.1.0",
                         "is-wsl": "^1.1.0",
                         "schema-utils": "^1.0.0",
-                        "serialize-javascript": "^2.1.2",
+                        "serialize-javascript": "^4.0.0",
                         "source-map": "^0.6.1",
                         "terser": "^4.1.2",
                         "webpack-sources": "^1.4.0",
                         "worker-farm": "^1.7.0"
+                    },
+                    "dependencies": {
+                        "is-wsl": {
+                            "version": "1.1.0",
+                            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+                            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+                            "dev": true
+                        },
+                        "serialize-javascript": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+                            "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+                            "dev": true,
+                            "requires": {
+                                "randombytes": "^2.1.0"
+                            }
+                        },
+                        "terser": {
+                            "version": "4.8.0",
+                            "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+                            "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+                            "dev": true,
+                            "requires": {
+                                "commander": "^2.20.0",
+                                "source-map": "~0.6.1",
+                                "source-map-support": "~0.5.12"
+                            }
+                        },
+                        "worker-farm": {
+                            "version": "1.7.0",
+                            "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+                            "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
+                            "dev": true,
+                            "requires": {
+                                "errno": "~0.1.7"
+                            }
+                        }
                     }
                 },
                 "to-regex-range": {
@@ -10803,15 +10819,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
             "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-        },
-        "worker-farm": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
-            "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
-            "dev": true,
-            "requires": {
-                "errno": "~0.1.7"
-            }
         },
         "wrap-ansi": {
             "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -1080,6 +1080,7 @@
         "ts-loader": "^6.2.0",
         "ts-mockito": "^2.5.0",
         "ts-node": "^8.5.2",
+        "tslint": "^6.1.3",
         "vsce": "^1.69.0",
         "vscode-nls-dev": "^3.3.1",
         "vscode-test": "^1.4.0",


### PR DESCRIPTION
- another round of dependency updates to bump `serialize-javascript`
- add "tslint" peer dependency for eslint-plugin-tslint
  ```
  $ npm install --save-dev 'tslint@^6.0.0'
  ```
  ...silences this message from `npm audit`:
  ```
  npm WARN @typescript-eslint/eslint-plugin-tslint@2.27.0 requires a peer of tslint@^5.0.0 || ^6.0.0 but none is installed. You must install peer dependencies yourself.
  ```
  - see also: https://github.com/typescript-eslint/typescript-eslint/blob/6f397df42cbcf05c10f304c9bbfdae4803aa0ce2/packages/eslint-plugin-tslint/package.json#L44

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
