### PR TITLE
stepFunctions visualization: do not fail if directory exists

### DIFF
--- a/src/stepFunctions/utils.ts
+++ b/src/stepFunctions/utils.ts
@@ -120,12 +120,18 @@ export class StateMachineGraphCache {
         const storageFolder = this.dirPath
 
         try {
-            if (!(await this.fileExists(storageFolder))) {
-                this.logger.debug('Folder for graphing script and styling doesnt exist. Creating it.')
-
-                await this.makeDir(storageFolder)
+            this.logger.debug('stepFunctions: creating directory: %O', storageFolder)
+            await this.makeDir(storageFolder)
+        } catch (err) {
+            this.logger.verbose(err as Error)
+            // EEXIST failure is non-fatal. This function is called as part of
+            // a Promise.all() group of tasks wanting to create the same directory.
+            if (err.code && err.code !== 'EEXIST') {
+                throw err
             }
+        }
 
+        try {
             await this.writeFile(destinationPath, data, 'utf8')
         } catch (err) {
             /*
@@ -133,7 +139,6 @@ export class StateMachineGraphCache {
              * but there was an error trying to write them to this extensions globalStorage location.
              */
             this.logger.error(err as Error)
-
             throw err
         }
     }

--- a/src/test/stepFunctions/utils.test.ts
+++ b/src/test/stepFunctions/utils.test.ts
@@ -5,16 +5,27 @@
 
 import * as assert from 'assert'
 import { IAM } from 'aws-sdk'
+import * as del from 'del'
 import * as sinon from 'sinon'
-import { isStepFunctionsRole, StateMachineGraphCache, isDocumentValid } from '../../stepFunctions/utils'
 import * as vscode from 'vscode'
+import { makeTemporaryToolkitFolder } from '../../shared/filesystemUtilities'
+import { isDocumentValid, isStepFunctionsRole, StateMachineGraphCache } from '../../stepFunctions/utils'
 
 const REQUEST_BODY = 'request body string'
 const ASSET_URL = 'https://something'
 const FILE_PATH = '/some/path'
 const STORAGE_KEY = 'KEY'
+let tempFolder = ''
 
 describe('StateMachineGraphCache', () => {
+    before(async function() {
+        tempFolder = await makeTemporaryToolkitFolder()
+    })
+
+    after(async () => {
+        await del([tempFolder], { force: true })
+    })
+
     describe('updateCachedFile', () => {
         it('downloads a file when it is not in cache and stores it', async () => {
             const globalStorage = {
@@ -38,7 +49,7 @@ describe('StateMachineGraphCache', () => {
                 writeFile,
                 cssFilePath: '',
                 jsFilePath: '',
-                dirPath: '',
+                dirPath: tempFolder,
             })
 
             await cache.updateCachedFile({
@@ -74,7 +85,7 @@ describe('StateMachineGraphCache', () => {
                 writeFile,
                 cssFilePath: '',
                 jsFilePath: '',
-                dirPath: '',
+                dirPath: tempFolder,
             })
 
             await cache.updateCachedFile({


### PR DESCRIPTION
`updateCache()` uses `Promise.all()` to call multiple tasks in parallel which eventually call `writeToLocalStorage()`, targeting the same directory.

fixes https://github.com/aws/aws-toolkit-vscode/issues/1230

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
