### PR TITLE
test: set fake Uri to something actually valid

### DIFF
--- a/src/test/stepFunctions/commands/visualizeStateMachine.test.ts
+++ b/src/test/stepFunctions/commands/visualizeStateMachine.test.ts
@@ -24,11 +24,11 @@ const mockGlobalStorage: vscode.Memento = {
 }
 
 const mockUriOne: vscode.Uri = {
-    authority: 'MockAuthorityOne',
+    authority: 'amazon.com',
     fragment: 'MockFragmentOne',
     fsPath: 'MockFSPathOne',
     query: 'MockQueryOne',
-    path: 'MockPathOne',
+    path: '/MockPathOne',
     scheme: 'MockSchemeOne',
     with: () => {
         return mockUriOne
@@ -59,11 +59,11 @@ const mockTextDocumentOne: vscode.TextDocument = {
 }
 
 const mockUriTwo: vscode.Uri = {
-    authority: 'MockAuthorityTwo',
+    authority: 'amazon.org',
     fragment: 'MockFragmentTwo',
     fsPath: 'MockFSPathTwo',
     query: 'MockQueryTwo',
-    path: 'MockPathTwo',
+    path: '/MockPathTwo',
     scheme: 'MockSchemeTwo',
     with: sinon.spy(),
     toJSON: sinon.spy(),
@@ -92,11 +92,11 @@ const mockTextDocumentTwo: vscode.TextDocument = {
 }
 
 const mockUriThree: vscode.Uri = {
-    authority: 'MockAuthorityYaml',
+    authority: 'amazon.de',
     fragment: 'MockFragmentYaml',
     fsPath: 'MockFSPathYaml',
     query: 'MockQueryYaml',
-    path: 'MockPathYaml',
+    path: '/MockPathYaml',
     scheme: 'MockSchemeYaml',
     with: sinon.spy(),
     toJSON: sinon.spy(),


### PR DESCRIPTION
VSCode "insiders" build has improved Uri validation, thus these tests were failing:

      1) StepFunctions VisualizeStateMachine
           Test AslVisualization on setup all properties are correct:
         Error: [UriError]: If a URI contains an authority component, then the path component must either be empty or begin with a slash ("/") character
          at c:\codebuild\tmp\output\src868706983\src\github.com\aws\aws-toolkit-vscode\.vscode-test\vscode-insiders\resources\app\out\vs\workbench\services\extensions\node\extensionHostProcess.js:154:26
          at new u (c:\codebuild\tmp\output\src868706983\src\github.com\aws\aws-toolkit-vscode\.vscode-test\vscode-insiders\resources\app\out\vs\workbench\services\extensions\node\extensionHostProcess.js:154:340)
          at new h (c:\codebuild\tmp\output\src868706983\src\github.com\aws\aws-toolkit-vscode\.vscode-test\vscode-insiders\resources\app\out\vs\workbench\services\extensions\node\extensionHostProcess.js:156:1)
          at Function.from (c:\codebuild\tmp\output\src868706983\src\github.com\aws\aws-toolkit-vscode\.vscode-test\vscode-insiders\resources\app\out\vs\workbench\services\extensions\node\extensionHostProcess.js:155:462)
          at c:\codebuild\tmp\output\src868706983\src\github.com\aws\aws-toolkit-vscode\.vscode-test\vscode-insiders\resources\app\out\vs\workbench\services\extensions\node\extensionHostProcess.js:819:951
          at Array.map (<anonymous>)
          at c:\codebuild\tmp\output\src868706983\src\github.com\aws\aws-toolkit-vscode\.vscode-test\vscode-insiders\resources\app\out\vs\workbench\services\extensions\node\extensionHostProcess.js:819:938
          at F.createNewWebview (c:\codebuild\tmp\output\src868706983\src\github.com\aws\aws-toolkit-vscode\.vscode-test\vscode-insiders\resources\app\out\vs\workbench\services\extensions\node\extensionHostProcess.js:819:962)
          at F.createWebviewPanel (c:\codebuild\tmp\output\src868706983\src\github.com\aws\aws-toolkit-vscode\.vscode-test\vscode-insiders\resources\app\out\vs\workbench\services\extensions\node\extensionHostProcess.js:818:757)
          at Object.createWebviewPanel (c:\codebuild\tmp\output\src868706983\src\github.com\aws\aws-toolkit-vscode\.vscode-test\vscode-insiders\resources\app\out\vs\workbench\services\extensions\node\extensionHostProcess.js:968:497)
          at MockAslVisualization.createVisualizationWebviewPanel (c:\codebuild\tmp\output\src868706983\src\github.com\aws\aws-toolkit-vscode\dist\src\stepFunctions\commands\visualizeStateMachine\aslVisualization.js:9:11998)
          at MockAslVisualization.setupWebviewPanel (c:\codebuild\tmp\output\src868706983\src\github.com\aws\aws-toolkit-vscode\dist\src\stepFunctions\commands\visualizeStateMachine\aslVisualization.js:9:6837)
          at new AslVisualization (c:\codebuild\tmp\output\src868706983\src\github.com\aws\aws-toolkit-vscode\dist\src\stepFunctions\commands\visualizeStateMachine\aslVisualization.js:9:3136)
          at new MockAslVisualization (c:\codebuild\tmp\output\src868706983\src\github.com\aws\aws-toolkit-vscode\src\test\stepFunctions\commands\visualizeStateMachine.test.ts:468:1)
          at Context.<anonymous> (c:\codebuild\tmp\output\src868706983\src\github.com\aws\aws-toolkit-vscode\src\test\stepFunctions\commands\visualizeStateMachine.test.ts:270:21)
          at processImmediate (internal/timers.js:439:21)
          at process.topLevelDomainCallback (domain.js:130:23)

fix https://github.com/aws/aws-toolkit-vscode/issues/1261

<!--- Provide a general summary of your changes in the Title above -->



## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
