### PR TITLE
CI: reduce noise from apt/pip/docker

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -14,9 +14,9 @@ phases:
         commands:
             # Install required keys and repos for .NET Core 2.1
             - '>/dev/null apt-get -qq update'
-            - wget -q https://packages.microsoft.com/keys/microsoft.asc -O- | apt-key add -
-            - wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-            - dpkg -i packages-microsoft-prod.deb
+            - '>/dev/null wget -q https://packages.microsoft.com/keys/microsoft.asc -O- | apt-key add -'
+            - '>/dev/null wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb'
+            - '>/dev/null dpkg -i packages-microsoft-prod.deb'
             - '>/dev/null add-apt-repository universe'
             - '>/dev/null apt-get -qq install -y apt-transport-https'
             - '>/dev/null apt-get -qq update'
@@ -25,9 +25,9 @@ phases:
             # Install other needed dependencies
             - '>/dev/null apt-get -qq install -y python2.7 python-pip python3.6 python3.7 python3.8 python3-pip python3-distutils docker'
             - '>/dev/null apt-get -qq install -y libgtk-3-dev libxss1 xvfb libnss3-dev libasound2 libasound2-plugins libsecret-1-0'
-            - pip3 install --user aws-sam-cli
-            - pip3 install --upgrade awscli
-            - pip3 install pylint
+            - '>/dev/null pip3 install --user aws-sam-cli'
+            - '>/dev/null pip3 install --upgrade awscli'
+            - '>/dev/null pip3 install pylint'
 
     pre_build:
         commands:
@@ -37,13 +37,13 @@ phases:
             - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay&
             - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
             # Pull SAM related images to avoid delays/timeouts during 'sam local invoke' calls within tests
-            - docker pull lambci/lambda:nodejs8.10
-            - docker pull lambci/lambda:nodejs10.x
-            - docker pull lambci/lambda:nodejs12.x
-            - docker pull lambci/lambda:python2.7
-            - docker pull lambci/lambda:python3.6
-            - docker pull lambci/lambda:python3.7
-            - docker pull lambci/lambda:python3.8
+            - docker pull -q lambci/lambda:nodejs8.10
+            - docker pull -q lambci/lambda:nodejs10.x
+            - docker pull -q lambci/lambda:nodejs12.x
+            - docker pull -q lambci/lambda:python2.7
+            - docker pull -q lambci/lambda:python3.6
+            - docker pull -q lambci/lambda:python3.7
+            - docker pull -q lambci/lambda:python3.8
 
     build:
         commands:

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -13,18 +13,18 @@ phases:
 
         commands:
             # Install required keys and repos for .NET Core 2.1
-            - apt-get update
+            - apt-get -qq update
             - wget -q https://packages.microsoft.com/keys/microsoft.asc -O- | apt-key add -
             - wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
             - dpkg -i packages-microsoft-prod.deb
             - add-apt-repository universe
-            - apt-get install -y apt-transport-https
-            - apt-get update
+            - apt-get -qq install -y apt-transport-https
+            - apt-get -qq update
             # Install .NET Core 2.1
-            - apt-get install -y dotnet-sdk-2.1
+            - apt-get -qq install -y dotnet-sdk-2.1
             # Install other needed dependencies
-            - apt-get install -y python2.7 python-pip python3.6 python3.7 python3.8 python3-pip python3-distutils docker
-            - apt-get install -y libgtk-3-dev libxss1 xvfb libnss3-dev libasound2 libasound2-plugins libsecret-1-0
+            - apt-get -qq install -y python2.7 python-pip python3.6 python3.7 python3.8 python3-pip python3-distutils docker
+            - apt-get -qq install -y libgtk-3-dev libxss1 xvfb libnss3-dev libasound2 libasound2-plugins libsecret-1-0
             - pip3 install --user aws-sam-cli
             - pip3 install --upgrade awscli
             - pip3 install pylint

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -13,18 +13,18 @@ phases:
 
         commands:
             # Install required keys and repos for .NET Core 2.1
-            - apt-get -qq update
+            - '>/dev/null apt-get -qq update'
             - wget -q https://packages.microsoft.com/keys/microsoft.asc -O- | apt-key add -
             - wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
             - dpkg -i packages-microsoft-prod.deb
-            - add-apt-repository universe
-            - apt-get -qq install -y apt-transport-https
-            - apt-get -qq update
+            - '>/dev/null add-apt-repository universe'
+            - '>/dev/null apt-get -qq install -y apt-transport-https'
+            - '>/dev/null apt-get -qq update'
             # Install .NET Core 2.1
-            - apt-get -qq install -y dotnet-sdk-2.1
+            - '>/dev/null apt-get -qq install -y dotnet-sdk-2.1'
             # Install other needed dependencies
-            - apt-get -qq install -y python2.7 python-pip python3.6 python3.7 python3.8 python3-pip python3-distutils docker
-            - apt-get -qq install -y libgtk-3-dev libxss1 xvfb libnss3-dev libasound2 libasound2-plugins libsecret-1-0
+            - '>/dev/null apt-get -qq install -y python2.7 python-pip python3.6 python3.7 python3.8 python3-pip python3-distutils docker'
+            - '>/dev/null apt-get -qq install -y libgtk-3-dev libxss1 xvfb libnss3-dev libasound2 libasound2-plugins libsecret-1-0'
             - pip3 install --user aws-sam-cli
             - pip3 install --upgrade awscli
             - pip3 install pylint

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -14,7 +14,7 @@ phases:
         commands:
             # Install required keys and repos for .NET Core 2.1
             - '>/dev/null apt-get -qq update'
-            - '>/dev/null wget -q https://packages.microsoft.com/keys/microsoft.asc -O- | apt-key add -'
+            - wget -q https://packages.microsoft.com/keys/microsoft.asc -O- | apt-key add -
             - '>/dev/null wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb'
             - '>/dev/null dpkg -i packages-microsoft-prod.deb'
             - '>/dev/null add-apt-repository universe'


### PR DESCRIPTION
This change avoids 100s of non-error messages in the CI build log. Errors/warnings are still shown, and CodeBuild shows "Running command ..." headers, so we still have visibility should anything fail or hang.

Now the log for the INSTALL and PRE_BUILD steps looks like:

```
[Container] 2020/08/27 20:50:48 Entering phase INSTALL
[Container] 2020/08/27 20:50:48 Running command >/dev/null apt-get -qq update
[Container] 2020/08/27 20:50:56 Running command wget -q https://packages.microsoft.com/keys/microsoft.asc -O- | apt-key add -
Warning: apt-key output should not be parsed (stdout is not a terminal)
OK
[Container] 2020/08/27 20:50:57 Running command >/dev/null wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
[Container] 2020/08/27 20:50:57 Running command >/dev/null dpkg -i packages-microsoft-prod.deb
[Container] 2020/08/27 20:50:59 Running command >/dev/null add-apt-repository universe
[Container] 2020/08/27 20:51:01 Running command >/dev/null apt-get -qq install -y apt-transport-https
[Container] 2020/08/27 20:51:03 Running command >/dev/null apt-get -qq update
[Container] 2020/08/27 20:51:05 Running command >/dev/null apt-get -qq install -y dotnet-sdk-2.1
[Container] 2020/08/27 20:51:49 Running command >/dev/null apt-get -qq install -y python2.7 python-pip python3.6 python3.7 python3.8 python3-pip python3-distutils docker
[Container] 2020/08/27 20:52:20 Running command >/dev/null apt-get -qq install -y libgtk-3-dev libxss1 xvfb libnss3-dev libasound2 libasound2-plugins libsecret-1-0
[Container] 2020/08/27 20:52:35 Running command >/dev/null pip3 install --user aws-sam-cli
ERROR: awscli 1.18.117 has requirement botocore==1.17.40, but you'll have botocore 1.16.26 which is incompatible.
WARNING: You are using pip version 19.3.1; however, version 20.2.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
[Container] 2020/08/27 20:52:44 Running command >/dev/null pip3 install --upgrade awscli
ERROR: boto3 1.13.26 has requirement botocore<1.17.0,>=1.16.26, but you'll have botocore 1.17.50 which is incompatible.
WARNING: You are using pip version 19.3.1; however, version 20.2.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
[Container] 2020/08/27 20:52:49 Running command >/dev/null pip3 install pylint
WARNING: You are using pip version 19.3.1; however, version 20.2.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
[Container] 2020/08/27 20:52:55 Phase complete: INSTALL State: SUCCEEDED

...

[Container] 2020/08/27 20:52:52 Entering phase PRE_BUILD
[Container] 2020/08/27 20:52:52 Running command docker pull -q lambci/lambda:nodejs8.10
docker.io/lambci/lambda:nodejs8.10
[Container] 2020/08/27 20:53:08 Running command docker pull -q lambci/lambda:nodejs10.x
docker.io/lambci/lambda:nodejs10.x
[Container] 2020/08/27 20:53:15 Running command docker pull -q lambci/lambda:nodejs12.x
docker.io/lambci/lambda:nodejs12.x
[Container] 2020/08/27 20:53:20 Running command docker pull -q lambci/lambda:python2.7
docker.io/lambci/lambda:python2.7
```

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
