### PR TITLE
UI: rework webviews style/layout

### DIFF
--- a/media/css/submitFeedback.css
+++ b/media/css/submitFeedback.css
@@ -6,20 +6,37 @@ input[type='submit'] {
     cursor: pointer;
 }
 
+select {
+    background-color: var(--vscode-settings-selection-background);
+    color: var(--vscode-settings-textInputForeground);
+    width: 80%;
+}
+
 input[type='submit']:hover {
     background-color: var(--vscode-button-hoverBackground);
+    color: var(--vscode-settings-textInputForeground);
 }
 
 input[type='submit']:disabled {
+    color: var(--vscode-settings-textInputForeground);
     cursor: default;
     opacity: 0.5;
 }
 
+input[type='text'] {
+    font-family: Menlo, Consolas, monospace;
+    background-color: var(--vscode-settings-textInputBackground);
+    color: var(--vscode-settings-textInputForeground);
+    width: 80%;
+}
+
 textarea {
+    font-family: Menlo, Consolas, monospace;
     background-color: var(--vscode-settings-textInputBackground);
     color: var(--vscode-settings-textInputForeground);
     border: 1px solid var(--vscode-settings-textInputBorder);
-    resize: none;
+    resize: vertical;
+    width: 80%;
 }
 
 body.vscode-dark textarea {

--- a/src/apigateway/commands/invokeRemoteRestApi.ts
+++ b/src/apigateway/commands/invokeRemoteRestApi.ts
@@ -76,6 +76,7 @@ export async function invokeRemoteRestApi(params: { outputChannel: vscode.Output
 
         const loadScripts = ExtensionUtilities.getScriptsForHtml(['invokeRemoteRestApiVue.js'], view.webview)
         const loadLibs = ExtensionUtilities.getLibrariesForHtml(['vue.min.js'], view.webview)
+        const loadStylesheets = ExtensionUtilities.getCssForHtml(['submitFeedback.css'], view.webview)
 
         // something is wrong if the paths aren't defined...
         const sortResources = (a: [string, Resource], b: [string, Resource]) => a[1].path!.localeCompare(b[1].path!)
@@ -89,6 +90,7 @@ export async function invokeRemoteRestApi(params: { outputChannel: vscode.Output
                 Resources: new Map([...resources].sort(sortResources)),
                 Scripts: loadScripts,
                 Libraries: loadLibs,
+                Stylesheets: loadStylesheets,
             }),
         })
 

--- a/src/apigateway/templates/apigTemplates.ts
+++ b/src/apigateway/templates/apigTemplates.ts
@@ -8,7 +8,6 @@ export const APIG_REMOTE_INVOKE_TEMPLATE = `
         Invoke methods on <%= ApiName %> (<%= ApiId %>)
     </h1>
     <pre><%= ApiArn %></pre>
-    <br />
     <div id="app">
         <h3>
             Select a resource:
@@ -43,7 +42,7 @@ export const APIG_REMOTE_INVOKE_TEMPLATE = `
         <br />
         <br />
         <textarea
-            rows="20"
+            rows="8"
             cols="90"
             v-model="jsonInput"
         ></textarea>
@@ -62,5 +61,8 @@ export const APIG_REMOTE_INVOKE_TEMPLATE = `
     <% }); %>
     <% Scripts.forEach(function(scr) { %>
         <script src="<%= scr %>"></script>
+    <% }); %>
+    <% Stylesheets.forEach(function(s) { %>
+        <link rel="stylesheet" type="text/css" href="<%= s %>">
     <% }); %>
     `

--- a/src/feedback/templates/feedbackTemplates.ts
+++ b/src/feedback/templates/feedbackTemplates.ts
@@ -42,8 +42,8 @@ export class FeedbackTemplates {
     <% Scripts.forEach(function(scr) { %>
         <script src="<%= scr %>"></script>
     <% }); %>
-    <% Stylesheets.forEach(function(scr) { %>
-        <link rel="stylesheet" type="text/css" href="<%= scr %>">
+    <% Stylesheets.forEach(function(s) { %>
+        <link rel="stylesheet" type="text/css" href="<%= s %>">
     <% }); %>
     `
 }


### PR DESCRIPTION
WIP. Low-effort improvements to webview styling, mainly to (1) match vscode style somewhat, (2) have some uniformity/consistency  to our webviews.

- Try to keep the "Submit" button above-the-fold.
- CSS was designed to use inheritance, let's use it.
- Add some uniformity to widths (80%).
- Attempt to match VSCode style.
- Use monospace for code inputs.

## TODO

- [ ] move common css to a `common.css` thing
- [ ] rethink placement of the "Submit" buttons so that they are always above-the-fold
- [ ] condense the forms some more (example: "Select a method" could be to the left of the dropdown, instead of above it, to save vertical space)


## Screenshot

<img width="1325" alt="webviewstyle" src="https://user-images.githubusercontent.com/55561878/91626690-562dce80-e966-11ea-9a72-c21f6486925b.png">



## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
