### PR TITLE
Use version 1.4.1 of amazon-states-language-service

### DIFF
--- a/.changes/next-release/Bug Fix-96a0f7d4-b5b1-495b-b8b1-6efd814e0fe3.json
+++ b/.changes/next-release/Bug Fix-96a0f7d4-b5b1-495b-b8b1-6efd814e0fe3.json
@@ -1,0 +1,4 @@
+{
+    "type": "Bug Fix",
+    "description": "Fix ASL validation bug marking states as unreachable when defined before a Choice state"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -707,9 +707,9 @@
             "dev": true
         },
         "amazon-states-language-service": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.4.0.tgz",
-            "integrity": "sha512-h+VWviSSGFClqYhoVAsA3cVU3YTJWU1kkZfuwP+uaFFu2GbyQVmY2NEqdPqCHVMUY3o+fW32F9+MDoN5OFwuww==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.4.1.tgz",
+            "integrity": "sha512-LEkmDXlWT6f3K/z+DhHIRbFsXvepX7WGQawY6uALM/bwAZjDzoZ7J1om6Om56spNWDNOjGfHSeR7TdDXMpLinw==",
             "requires": {
                 "vscode-json-languageservice": "3.4.9",
                 "vscode-languageserver": "^6.1.1",
@@ -9456,7 +9456,7 @@
         },
         "tunnel": {
             "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+            "resolved": "http://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
             "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
             "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -1149,7 +1149,7 @@
     },
     "dependencies": {
         "adm-zip": "^0.4.13",
-        "amazon-states-language-service": "^1.4.0",
+        "amazon-states-language-service": "^1.4.1",
         "async-lock": "^1.1.3",
         "aws-sdk": "^2.581.0",
         "bytes": "^3.1.0",


### PR DESCRIPTION
## Description

Upgrade version of amazon-states-language-service from `1.4.0` -> `1.4.1`.

Consumes bug fix for state validation where a state referenced in a Choice state was marked as unreachable when defined before the Choice state (https://github.com/aws/amazon-states-language-service/pull/54).

## Motivation and Context

Fixes false validation errors for state reachability.

## Related Issue(s)

Fixes https://github.com/aws/aws-toolkit-vscode/issues/1117

## Testing

Manually tested extension using the definition referenced in https://github.com/aws/aws-toolkit-vscode/issues/1117#issuecomment-685996951

## Screenshots (if appropriate)

N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
