### PR TITLE
Gating Lambda features

### DIFF
--- a/.changes/next-release/Feature-5da32220-237a-4ec7-9b84-b6952f2e5bae.json
+++ b/.changes/next-release/Feature-5da32220-237a-4ec7-9b84-b6952f2e5bae.json
@@ -1,4 +1,0 @@
-{
-    "type": "Feature",
-    "description": "Lambda functions can be updated with code from ZIP files and directories containing built or unbuilt code"
-}

--- a/.changes/next-release/Feature-c56b7fa8-7102-4006-afd1-5458cb70c0ef.json
+++ b/.changes/next-release/Feature-c56b7fa8-7102-4006-afd1-5458cb70c0ef.json
@@ -1,4 +1,0 @@
-{
-    "type": "Feature",
-    "description": "NodeJS and Python Lambda functions can be imported from an AWS account into a local workspace"
-}

--- a/package.json
+++ b/package.json
@@ -650,12 +650,12 @@
                 },
                 {
                     "command": "aws.importLambda",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeImportable)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeImportable)$/ && aws-toolkit-vscode:LambdaImport",
                     "group": "0@2"
                 },
                 {
                     "command": "aws.uploadLambda",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeImportable)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeImportable)$/ && aws-toolkit-vscode:LambdaUpload",
                     "group": "1@1"
                 },
                 {

--- a/src/lambda/activation.ts
+++ b/src/lambda/activation.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode'
 import { ext } from '../shared/extensionGlobals'
+import { ActiveFeatureKeys, FeatureToggle } from '../shared/featureToggle'
 import { deleteLambda } from './commands/deleteLambda'
 import { invokeLambda } from './commands/invokeLambda'
 import { uploadLambdaCommand } from './commands/uploadLambda'
@@ -36,13 +37,27 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
                     functionNode: node,
                     outputChannel,
                 })
-        ),
-        vscode.commands.registerCommand(
-            'aws.importLambda',
-            async (node: LambdaFunctionNode) => await importLambdaCommand(node)
-        ),
-        vscode.commands.registerCommand('aws.uploadLambda', async (node: LambdaFunctionNode) => {
-            await uploadLambdaCommand(node)
-        })
+        )
     )
+
+    if (FeatureToggle.getFeatureToggle().isFeatureActive(ActiveFeatureKeys.LambdaImport)) {
+        vscode.commands.executeCommand('setContext', 'aws-toolkit-vscode:LambdaImport', true)
+
+        extensionContext.subscriptions.push(
+            vscode.commands.registerCommand(
+                'aws.importLambda',
+                async (node: LambdaFunctionNode) => await importLambdaCommand(node)
+            )
+        )
+    }
+
+    if (FeatureToggle.getFeatureToggle().isFeatureActive(ActiveFeatureKeys.LambdaUpload)) {
+        vscode.commands.executeCommand('setContext', 'aws-toolkit-vscode:LambdaUpload', true)
+
+        extensionContext.subscriptions.push(
+            vscode.commands.registerCommand('aws.uploadLambda', async (node: LambdaFunctionNode) => {
+                await uploadLambdaCommand(node)
+            })
+        )
+    }
 }

--- a/src/shared/featureToggle.ts
+++ b/src/shared/featureToggle.ts
@@ -14,7 +14,10 @@ import { SettingsConfiguration, DefaultSettingsConfiguration } from './settingsC
  * You cannot have more active features than FeatureToggle.maxFeatures (default: 5)
  * Any features that are flagged in the code but not added here will always return false.
  */
-export enum ActiveFeatureKeys {}
+export enum ActiveFeatureKeys {
+    LambdaUpload = 'LambdaUpload',
+    LambdaImport = 'LambdaImport',
+}
 
 /**
  * This class handles feature access for unreleased or gated features.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

A bit too eager on adding the Lambda upload/import functionalities to the `master` branch. This gates these features so they're hidden from the general public. Enterprising users can try these features by adding the following lines to VS Code's `settings.json` file and restarting the IDE:

```
{
...
    "aws.experimentalFeatureFlags": [
        "LambdaImport",
        "LambdaUpload"
    ],
}
```
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
