### PR TITLE
Wiring up skipNewImageCheck

### DIFF
--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -190,6 +190,7 @@ export async function invokeLambdaFunction(
         useContainer: config.sam?.containerBuild || false,
         extraArgs: config.sam?.buildArguments,
         parameterOverrides: config.parameterOverrides,
+        skipPullImage: config.sam?.skipNewImageCheck,
     }
     if (!config.noDebug) {
         // Needed at least for dotnet case; harmless for others.
@@ -233,6 +234,7 @@ export async function invokeLambdaFunction(
         debuggerPath: config.debuggerPath,
         extraArgs: config.sam?.localArguments,
         parameterOverrides: config.parameterOverrides,
+        skipPullImage: config.sam?.skipNewImageCheck,
     }
 
     delete config.invokeTarget // Must not be used beyond this point.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The `skipNewImageCheck` parameter for SAM debug configs now functions

## Motivation and Context

Resolving an oversight. Debated internally on whether or not we should change this to `skipPullImage` to be in line with the SAM CLI's `--skip-pull-image` verbiage but pulled back for two reasons:
* `skipNewImageCheck` is more descriptive
* We have a similar issue with `--use-container` and `containerBuild`. Moving one but not the other would be confusing to users, and moving both would require users to potentially migrate.

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing

Manual testing

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
