### PR TITLE
Show a message and not fail to activate if we can't start the template registry

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -11,7 +11,7 @@
     "Aws.cdk.explorerNode.app.noStacks": "[No stacks in this App]",
     "AWS.channel.aws.toolkit": "AWS Toolkit",
     "AWS.channel.aws.toolkit.activation.error": "Error Activating AWS Toolkit",
-    "AWS.codelens.failToInitialize": "Failed to activate template registry. CodeLenses will appear on SAM template files.",
+    "AWS.codelens.failToInitialize": "Failed to activate template registry. CodeLenses will not appear on SAM template files.",
     "AWS.codelens.lambda.invoke": "Run Locally",
     "AWS.codelens.lambda.invoke.debug": "Debug Locally",
     "AWS.configuration.title": "AWS Configuration",

--- a/package.nls.json
+++ b/package.nls.json
@@ -11,6 +11,7 @@
     "Aws.cdk.explorerNode.app.noStacks": "[No stacks in this App]",
     "AWS.channel.aws.toolkit": "AWS Toolkit",
     "AWS.channel.aws.toolkit.activation.error": "Error Activating AWS Toolkit",
+    "AWS.codelens.failToInitialize": "Unable to activate the template registry, SAM CodeLense's will not work",
     "AWS.codelens.lambda.invoke": "Run Locally",
     "AWS.codelens.lambda.invoke.debug": "Debug Locally",
     "AWS.configuration.title": "AWS Configuration",

--- a/package.nls.json
+++ b/package.nls.json
@@ -11,7 +11,7 @@
     "Aws.cdk.explorerNode.app.noStacks": "[No stacks in this App]",
     "AWS.channel.aws.toolkit": "AWS Toolkit",
     "AWS.channel.aws.toolkit.activation.error": "Error Activating AWS Toolkit",
-    "AWS.codelens.failToInitialize": "Unable to activate the template registry, SAM CodeLense's will not work",
+    "AWS.codelens.failToInitialize": "Failed to activate template registry. CodeLenses will appear on SAM template files.",
     "AWS.codelens.lambda.invoke": "Run Locally",
     "AWS.codelens.lambda.invoke.debug": "Debug Locally",
     "AWS.configuration.title": "AWS Configuration",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -219,9 +219,10 @@ export async function activate(context: vscode.ExtensionContext) {
         await loginWithMostRecentCredentials(toolkitSettings, loginManager)
 
         recordToolkitInitialization(activationStartedOn, getLogger())
-    } catch (e) {
-        getLogger().error(localize('AWS.channel.aws.toolkit.activation.error', 'Error Activating AWS Toolkit'), e)
-        throw e
+    } catch (error) {
+        const channelLogger = getChannelLogger(toolkitOutputChannel)
+        channelLogger.error('AWS.channel.aws.toolkit.activation.error', 'Error Activating AWS Toolkit', error as Error)
+        throw error
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -219,10 +219,9 @@ export async function activate(context: vscode.ExtensionContext) {
         await loginWithMostRecentCredentials(toolkitSettings, loginManager)
 
         recordToolkitInitialization(activationStartedOn, getLogger())
-    } catch (error) {
-        const channelLogger = getChannelLogger(toolkitOutputChannel)
-        channelLogger.error('AWS.channel.aws.toolkit.activation.error', 'Error Activating AWS Toolkit', error as Error)
-        throw error
+    } catch (e) {
+        getLogger().error(localize('AWS.channel.aws.toolkit.activation.error', 'Error Activating AWS Toolkit'), e)
+        throw e
     }
 }
 

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -28,7 +28,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
         await vscode.window.showErrorMessage(
             localize(
                 'AWS.codelens.failToInitialize',
-                'Failed to activate template registry. CodeLenses will appear on SAM template files.'
+                'Failed to activate template registry. CodeLenses will not appear on SAM template files.'
             )
         )
         getLogger().error('Activating the template registry failed', e)

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -25,7 +25,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
         await manager.addTemplateGlob(TEMPLATE_FILE_GLOB_PATTERN)
         extensionContext.subscriptions.push(manager)
     } catch (e) {
-        await vscode.window.showErrorMessage(
+        vscode.window.showErrorMessage(
             localize(
                 'AWS.codelens.failToInitialize',
                 'Failed to activate template registry. CodeLenses will not appear on SAM template files.'

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -25,12 +25,12 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
         await manager.addTemplateGlob(TEMPLATE_FILE_GLOB_PATTERN)
         extensionContext.subscriptions.push(manager)
     } catch (e) {
-        getLogger().error(
+        await vscode.window.showErrorMessage(
             localize(
                 'AWS.codelens.failToInitialize',
                 "Unable to activate the template registry, SAM CodeLense's will not work"
-            ),
-            e
+            )
         )
+        getLogger().error('Activating the template registry failed', e)
     }
 }

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -28,7 +28,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
         await vscode.window.showErrorMessage(
             localize(
                 'AWS.codelens.failToInitialize',
-                "Unable to activate the template registry, SAM CodeLense's will not work"
+                'Failed to activate template registry. CodeLenses will appear on SAM template files.'
             )
         )
         getLogger().error('Activating the template registry failed', e)

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -4,6 +4,8 @@
  */
 
 import * as vscode from 'vscode'
+import { getLogger } from '../logger'
+import { localize } from '../utilities/vsCodeUtils'
 
 import { CloudFormationTemplateRegistry } from './templateRegistry'
 import { CloudFormationTemplateRegistryManager } from './templateRegistryManager'
@@ -17,8 +19,18 @@ export const TEMPLATE_FILE_GLOB_PATTERN = '**/template.{yaml,yml}'
  * @param extensionContext VS Code extension context
  */
 export async function activate(extensionContext: vscode.ExtensionContext): Promise<void> {
-    const registry = CloudFormationTemplateRegistry.getRegistry()
-    const manager = new CloudFormationTemplateRegistryManager(registry)
-    await manager.addTemplateGlob(TEMPLATE_FILE_GLOB_PATTERN)
-    extensionContext.subscriptions.push(manager)
+    try {
+        const registry = CloudFormationTemplateRegistry.getRegistry()
+        const manager = new CloudFormationTemplateRegistryManager(registry)
+        await manager.addTemplateGlob(TEMPLATE_FILE_GLOB_PATTERN)
+        extensionContext.subscriptions.push(manager)
+    } catch (e) {
+        getLogger().error(
+            localize(
+                'AWS.codelens.failToInitialize',
+                "Unable to activate the template registry, SAM CodeLense's will not work"
+            ),
+            e
+        )
+    }
 }

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -31,6 +31,6 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
                 'Failed to activate template registry. CodeLenses will not appear on SAM template files.'
             )
         )
-        getLogger().error('Activating the template registry failed', e)
+        getLogger().error('Failed to activate template registry', e)
     }
 }


### PR DESCRIPTION
On the theme of working towards figuring out what is wrong and fixing #1286 , fix the toolkit activating when using a readonly (444) or folder we have no permissions to (000) as a workspace. 

This seems like a reasonable proxy for read and write issues to a workspace.

## Screenshots
<img width="504" alt="Screen Shot 2020-09-21 at 3 05 22 PM" src="https://user-images.githubusercontent.com/11964782/93826389-f6041280-fc1b-11ea-840a-6cb722d4659d.png">


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
