### PR TITLE
CI/travis: avoid webpack OOM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
 
 script:
     - npm install
-    - npm run vscode:prepublish
+    - NODE_OPTIONS='--max-old-space-size=8192' npm run vscode:prepublish
     - npm test
 
 after_success:


### PR DESCRIPTION
Example https://travis-ci.org/github/aws/aws-toolkit-vscode/jobs/729674803 :

    FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
    ...
    ERROR in extension.js from Terser
    ...
    npm ERR! aws-toolkit-vscode@1.14.0-SNAPSHOT vscode:prepublish: `npm run clean && npm run lint && webpack --mode production && npm run buildScripts`
    npm ERR! Exit status 2

<!--- Provide a general summary of your changes in the Title above -->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
