### PR TITLE
test/integ: wait for previous sessions

### DIFF
--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -141,7 +141,7 @@ describe('SAM Integration Tests', async function() {
     after(async function() {
         tryRemoveFolder(testSuiteRoot)
         // Print a summary of session that were seen by `onDidStartDebugSession`.
-        const sessionReport = sessionLog.map(x => `    {x}`).join('\n')
+        const sessionReport = sessionLog.map(x => `    ${x}`).join('\n')
         console.log(`DebugSessions seen in this run:${sessionReport}`)
     })
 

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -20,6 +20,7 @@ import { AddSamDebugConfigurationInput } from '../shared/sam/debugger/commands/a
 import { findParentProjectFile } from '../shared/utilities/workspaceUtils'
 import { activateExtension, getCodeLenses, getTestWorkspaceFolder, sleep } from './integrationTestsUtilities'
 import { setTestTimeout } from './globalSetup.test'
+import { waitUntil } from '../shared/utilities/timeoutUtils'
 
 const projectFolder = getTestWorkspaceFolder()
 
@@ -263,6 +264,13 @@ describe('SAM Integration Tests', async function() {
 
                 it('invokes and attaches on debug request (F5)', async function() {
                     setTestTimeout(this.test?.fullTitle(), 60000)
+                    // Allow previous sessions to go away.
+                    await waitUntil(
+                        async function() {
+                            return vscode.debug.activeDebugSession === undefined
+                        },
+                        { timeout: 10000, interval: 300 }
+                    )
                     assert.strictEqual(
                         vscode.debug.activeDebugSession,
                         undefined,

--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -77,3 +77,28 @@ export class Timeout {
         }
     }
 }
+
+/**
+ * Invokes `fn()` until it returns a truthy value.
+ *
+ * @param fn  Function whose result is checked
+ * @param opt.timeout  Timeout in ms (default: 5000)
+ * @param opt.interval  Interval in ms between fn() checks (default: 500)
+ *
+ * @returns Result of `fn()`, or `undefined` if timeout was reached.
+ */
+export async function waitUntil<T>(
+    fn: () => Promise<T>,
+    opt: { timeout: number; interval: number } = { timeout: 5000, interval: 500 }
+): Promise<T | undefined> {
+    for (let i = 0; true; i++) {
+        const result: T = await fn()
+        if (result) {
+            return result
+        }
+        if (i * opt.interval >= opt.timeout) {
+            return undefined
+        }
+        await new Promise(r => setTimeout(r, opt.interval))
+    }
+}

--- a/src/test/testRunner.ts
+++ b/src/test/testRunner.ts
@@ -127,9 +127,9 @@ class CoverageRunner {
             // On Windows, extension is loaded pre-test hooks and this mean we lose
             // our chance to hook the Require call. In order to instrument the code
             // we have to decache the JS file so on next load it gets instrumented.
-            // This doesn"t impact tests, but is a concern if we had some integration
-            // tests that relied on VSCode accessing our module since there could be
-            // some shared global state that we lose.
+            // This breaks tests that depend on global state, e.g. any test
+            // that depends on implicit VSCode features (launch.json processing,
+            // LSP symbols, ...).
             decache(fullPath)
         })
 

--- a/test-scripts/launchTestUtilities.ts
+++ b/test-scripts/launchTestUtilities.ts
@@ -33,8 +33,7 @@ export async function setupVSCodeTestInstance(): Promise<string> {
     console.log(`Setting up VS Code test instance, version: ${vsCodeVersion}`)
     const vsCodeExecutablePath = await downloadAndUnzipVSCode(vsCodeVersion)
     console.log(`VS Code test instance location: ${vsCodeExecutablePath}`)
-
-    await invokeVSCodeCli(vsCodeExecutablePath, ['--version'])
+    console.log(await invokeVSCodeCli(vsCodeExecutablePath, ['--version']))
 
     return vsCodeExecutablePath
 }
@@ -64,16 +63,12 @@ export async function invokeVSCodeCli(vsCodeExecutablePath: string, args: string
         throw spawnResult.error
     }
 
-    if (spawnResult.stdout) {
-        console.log(spawnResult.stdout)
-    }
-
     return spawnResult.stdout
 }
 
 export async function installVSCodeExtension(vsCodeExecutablePath: string, extensionIdentifier: string): Promise<void> {
     console.log(`Installing VS Code Extension: ${extensionIdentifier}`)
-    await invokeVSCodeCli(vsCodeExecutablePath, ['--install-extension', extensionIdentifier])
+    console.log(await invokeVSCodeCli(vsCodeExecutablePath, ['--install-extension', extensionIdentifier]))
 }
 
 /**


### PR DESCRIPTION
The test only waits for 1 debug session, but the top-level, user-initiated, `aws-sam` session internally starts a platform-specific session. The "stop debugging" action only stops the foreground session.

Other changes:

- `waitUntil` was cherry-picked from `feature/apigateway`
- change `invokeVSCodeCli()` to let the caller decide if/when to print output
- ~~Restore coverage for integ tests by avoiding `decache()`~~
  - Edit: after removing `decache()`, coverage reports aren't generated. So the need for `decache()` is not Windows-only after all?
    ```
    ==> Searching for coverage reports in:
        + .coverage
    --> No coverage report found.
    ```

Test failure before this PR:

```
     4 failing
      1) SAM Integration Tests
           SAM Application Runtime: python2.7
             Starting with a newly created python2.7 SAM Application...
               invokes and attaches on debug request (F5):
         AssertionError [ERR_ASSERTION]: unexpected debug session in progress: {
      "_debugServiceProxy": {},
      "_id": "a331d28b-da4f-42ed-ab87-d1db6d63566d",
      "_type": "pwa-node",
      "_name": "SamLocalDebug: Child Process [7627]",
      "_configuration": {
        "type": "pwa-node",
        "name": "Child Process [7627]",
        "request": "attach",
        "__pendingTargetId": "7627"
      }
    }
          at Context.<anonymous> (src/integrationTest/sam.test.ts:266:28)
          at Generator.next (<anonymous>)
          at /codebuild/output/src829586781/src/github.com/aws/aws-toolkit-vscode/dist/src/integrationTest/sam.test.js:12:71
          at new Promise (<anonymous>)
          at __awaiter (dist/src/integrationTest/sam.test.js:8:12)
          at Context.<anonymous> (dist/src/integrationTest/sam.test.js:275:40)
          at runMicrotasks (<anonymous>)
          at processTicksAndRejections (internal/process/task_queues.js:94:5)

      2) SAM Integration Tests
           SAM Application Runtime: python3.6
             Starting with a newly created python3.6 SAM Application...
               invokes and attaches on debug request (F5):
         AssertionError [ERR_ASSERTION]: unexpected debug session in progress: {
      "_debugServiceProxy": {},
      "_id": "a331d28b-da4f-42ed-ab87-d1db6d63566d",
      "_type": "pwa-node",
      "_name": "SamLocalDebug: Child Process [7627]",
      "_configuration": {
        "type": "pwa-node",
        "name": "Child Process [7627]",
        "request": "attach",
        "__pendingTargetId": "7627"
      }
    }
          at Context.<anonymous> (src/integrationTest/sam.test.ts:266:28)
          at Generator.next (<anonymous>)
          at /codebuild/output/src829586781/src/github.com/aws/aws-toolkit-vscode/dist/src/integrationTest/sam.test.js:12:71
          at new Promise (<anonymous>)
          at __awaiter (dist/src/integrationTest/sam.test.js:8:12)
          at Context.<anonymous> (dist/src/integrationTest/sam.test.js:275:40)
          at runMicrotasks (<anonymous>)
          at processTicksAndRejections (internal/process/task_queues.js:94:5)

      3) SAM Integration Tests
           SAM Application Runtime: python3.7
             Starting with a newly created python3.7 SAM Application...
               invokes and attaches on debug request (F5):
         AssertionError [ERR_ASSERTION]: unexpected debug session in progress: {
      "_debugServiceProxy": {},
      "_id": "a331d28b-da4f-42ed-ab87-d1db6d63566d",
      "_type": "pwa-node",
      "_name": "SamLocalDebug: Child Process [7627]",
      "_configuration": {
        "type": "pwa-node",
        "name": "Child Process [7627]",
        "request": "attach",
        "__pendingTargetId": "7627"
      }
    }
          at Context.<anonymous> (src/integrationTest/sam.test.ts:266:28)
          at Generator.next (<anonymous>)
          at /codebuild/output/src829586781/src/github.com/aws/aws-toolkit-vscode/dist/src/integrationTest/sam.test.js:12:71
          at new Promise (<anonymous>)
          at __awaiter (dist/src/integrationTest/sam.test.js:8:12)
          at Context.<anonymous> (dist/src/integrationTest/sam.test.js:275:40)
          at runMicrotasks (<anonymous>)
          at processTicksAndRejections (internal/process/task_queues.js:94:5)

      4) SAM Integration Tests
           SAM Application Runtime: python3.8
             Starting with a newly created python3.8 SAM Application...
               invokes and attaches on debug request (F5):
         AssertionError [ERR_ASSERTION]: unexpected debug session in progress: {
      "_debugServiceProxy": {},
      "_id": "a331d28b-da4f-42ed-ab87-d1db6d63566d",
      "_type": "pwa-node",
      "_name": "SamLocalDebug: Child Process [7627]",
      "_configuration": {
        "type": "pwa-node",
        "name": "Child Process [7627]",
        "request": "attach",
        "__pendingTargetId": "7627"
      }
    }
          at Context.<anonymous> (src/integrationTest/sam.test.ts:266:28)
          at Generator.next (<anonymous>)
          at /codebuild/output/src829586781/src/github.com/aws/aws-toolkit-vscode/dist/src/integrationTest/sam.test.js:12:71
          at new Promise (<anonymous>)
          at __awaiter (dist/src/integrationTest/sam.test.js:8:12)
          at Context.<anonymous> (dist/src/integrationTest/sam.test.js:275:40)
          at runMicrotasks (<anonymous>)
          at processTicksAndRejections (internal/process/task_queues.js:94:5)
```