### PR TITLE
Add missing separator to group delete actions away from less destructive operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -710,7 +710,7 @@
                 {
                     "command": "aws.deleteCloudFormation",
                     "when": "view == aws.explorer && viewItem == awsCloudFormationNode",
-                    "group": "2@5"
+                    "group": "3@5"
                 },
                 {
                     "command": "aws.searchSchema",
@@ -824,7 +824,7 @@
                 },
                 {
                     "command": "aws.ssmDocument.deleteDocument",
-                    "group": "2@2",
+                    "group": "3@2",
                     "when": "view == aws.explorer && viewItem == awsDocumentItemNodeWriteable"
                 }
             ]


### PR DESCRIPTION

## Description

This change brings these two context menus in alignment with the rest of the AWS Explorer.

![image](https://user-images.githubusercontent.com/39839589/94872171-c1a10b00-0400-11eb-931c-cac6e8f1809d.png)

![image](https://user-images.githubusercontent.com/39839589/94872177-c49bfb80-0400-11eb-9d16-7a76e73a53b2.png)


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
