### PR TITLE
CI: getmac.exe workaround is no longer needed

### DIFF
--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -11,13 +11,6 @@ phases:
                 if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
                     choco install -y --no-progress codecov
                 }
-            # Install getmac to avoid spurious "Command failed: getmac.exe"
-            # error in the build logs. https://github.com/microsoft/vscode/issues/102428
-            - |
-                &python --version
-                &pip --version
-                &pip install getmac
-                &getmac --version
 
     pre_build:
         commands:


### PR DESCRIPTION
This workaround was only to avoid spurious/noise errors in the CI log:

    Unable to retrieve mac address (Error: Command failed: getmac.exe
    'getmac.exe' is not recognized as an internal or external command,

VSCode 1.50 removes its dependency on getmac.exe so we can remove the workaround.

ref: c0bdf1f5c122
ref: https://github.com/microsoft/vscode/issues/102428

## Testing

- Compare `Windows Unit Tests [insiders]` log to `Windows Unit Tests [stable]`. The Insiders log does _not_ have the getmac.exe message.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
