### PR TITLE
S3: fix argument order when creating DefaultS3Client

### DIFF
--- a/src/shared/clients/defaultToolkitClientBuilder.ts
+++ b/src/shared/clients/defaultToolkitClientBuilder.ts
@@ -70,7 +70,7 @@ export class DefaultToolkitClientBuilder implements ToolkitClientBuilder {
     }
 
     public createS3Client(regionCode: string): S3Client {
-        return new DefaultS3Client(regionCode, this.regionProvider.getPartitionId(regionCode) ?? DEFAULT_PARTITION)
+        return new DefaultS3Client(this.regionProvider.getPartitionId(regionCode) ?? DEFAULT_PARTITION, regionCode)
     }
 
     public createSsmClient(regionCode: string): SsmDocumentClient {


### PR DESCRIPTION
- The order was swapped in c5abd330735f.
- The bug was not noticed because 65da599ddfab was merged meanwhile, and the swapped order was not noticed when fixing the merge-conflict.
  - The tests passed because they create `DefaultS3Client` directly (with the correct arg-order) instead of using `ToolkitClientBuilder`.

## Testing

- AWS Explorer: expand the S3 and observe that buckets are listed. Expand an S3 bucket and observe that its contents are listed.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
