### PR TITLE
SAM debug: preserve user-given config name

### DIFF
--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -337,7 +337,11 @@ describe('SAM Integration Tests', async function() {
                                             // It's a coprocess, ignore it.
                                             return
                                         }
-                                        const failMsg = validateSamDebugSession(endedSession, scenario.runtime)
+                                        const failMsg = validateSamDebugSession(
+                                            endedSession,
+                                            testConfig.name,
+                                            scenario.runtime
+                                        )
                                         if (failMsg) {
                                             reject(new Error(failMsg))
                                         }
@@ -379,12 +383,14 @@ describe('SAM Integration Tests', async function() {
          */
         function validateSamDebugSession(
             debugSession: vscode.DebugSession,
+            expectedName: string,
             expectedRuntime: string
         ): string | undefined {
             const runtime = (debugSession.configuration as any).runtime
-            if (runtime !== expectedRuntime) {
+            const name = (debugSession.configuration as any).name
+            if (name !== name || runtime !== expectedRuntime) {
                 const failMsg =
-                    `Unexpected DebugSession (expected runtime=${expectedRuntime}):` +
+                    `Unexpected DebugSession (expected name="${expectedName}" runtime="${expectedRuntime}"):` +
                     `\n${JSON.stringify(debugSession)}`
                 return failMsg
             }

--- a/src/shared/sam/debugger/csharpSamDebug.ts
+++ b/src/shared/sam/debugger/csharpSamDebug.ts
@@ -45,7 +45,6 @@ export async function makeCsharpConfig(config: SamLaunchRequestArgs): Promise<Sa
         type: 'coreclr',
         request: config.noDebug ? 'launch' : 'attach',
         runtimeFamily: RuntimeFamily.DotNetCore,
-        name: 'SamLocalDebug',
     }
 
     if (!config.noDebug) {
@@ -221,7 +220,6 @@ export async function makeCoreCLRDebugConfiguration(
 
     return {
         ...config,
-        name: 'SamLocalDebug',
         runtimeFamily: RuntimeFamily.DotNetCore,
         request: 'attach',
         // Since SAM CLI 1.0 we cannot assume PID=1. So use processName=dotnet

--- a/src/shared/sam/debugger/pythonSamDebug.ts
+++ b/src/shared/sam/debugger/pythonSamDebug.ts
@@ -162,7 +162,6 @@ export async function makePythonDebugConfig(config: SamLaunchRequestArgs): Promi
         request: config.noDebug ? 'launch' : 'attach',
         runtimeFamily: RuntimeFamily.Python,
         outFilePath: pathutil.normalize(outFilePath ?? '') ?? undefined,
-        name: 'SamLocalDebug',
 
         //
         // Python-specific fields.

--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -69,7 +69,6 @@ export async function makeTypescriptConfig(config: SamLaunchRequestArgs): Promis
         type: 'node',
         request: config.noDebug ? 'launch' : 'attach',
         runtimeFamily: RuntimeFamily.NodeJS,
-        name: 'SamLocalDebug',
         preLaunchTask: undefined,
         address: 'localhost',
         port: config.debugPort ?? -1,

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -402,8 +402,7 @@ describe('SamDebugConfigurationProvider', async () => {
                     //projectRoot: 'root as in beer'
                 },
             })
-            // TODO: why not respect caller-chosen name?
-            assert.strictEqual(resolved!.name, 'SamLocalDebug')
+            assert.strictEqual(resolved!.name, name)
         })
 
         it('target=code: javascript', async () => {
@@ -461,7 +460,7 @@ describe('SamDebugConfigurationProvider', async () => {
                     ...input.lambda,
                 },
                 localRoot: pathutil.normalize(path.join(appDir, 'src')), // Normalized to absolute path.
-                name: 'SamLocalDebug',
+                name: input.name,
                 templatePath: pathutil.normalize(path.join(actual.baseBuildDir ?? '?', 'input/input-template.yaml')),
 
                 //
@@ -581,7 +580,7 @@ describe('SamDebugConfigurationProvider', async () => {
                     ...input.lambda,
                 },
                 localRoot: appDir,
-                name: 'SamLocalDebug',
+                name: input.name,
                 templatePath: pathutil.normalize(
                     path.join(path.dirname(templatePath.fsPath), 'app___vsctk___template.yaml')
                 ),
@@ -688,7 +687,7 @@ describe('SamDebugConfigurationProvider', async () => {
                     memoryMb: undefined,
                     timeoutSec: undefined,
                 },
-                name: 'SamLocalDebug',
+                name: input.name,
                 templatePath: expectedCodeRoot + '/input-template.yaml',
 
                 //
@@ -826,7 +825,7 @@ describe('SamDebugConfigurationProvider', async () => {
                 lambda: {
                     ...input.lambda,
                 },
-                name: 'SamLocalDebug',
+                name: input.name,
                 templatePath: pathutil.normalize(
                     path.join(path.dirname(templatePath.fsPath), 'app___vsctk___template.yaml')
                 ),
@@ -993,7 +992,7 @@ Outputs:
                     memoryMb: undefined,
                     timeoutSec: undefined,
                 },
-                name: 'SamLocalDebug',
+                name: input.name,
                 templatePath: pathutil.normalize(path.join(actual.baseBuildDir ?? '?', 'input/input-template.yaml')),
                 port: actual.debugPort,
                 redirectOutput: false,
@@ -1108,7 +1107,7 @@ Outputs:
                     memoryMb: undefined,
                     timeoutSec: undefined,
                 },
-                name: 'SamLocalDebug',
+                name: input.name,
                 templatePath: pathutil.normalize(
                     path.join(path.dirname(templatePath.fsPath), 'app___vsctk___template.yaml')
                 ),
@@ -1214,7 +1213,7 @@ Outputs:
                 path.join(testutil.getProjectDir(), 'testFixtures/workspaceFolder/js-manifest-in-root/')
             )
             const folder = testutil.getWorkspaceFolder(appDir)
-            const c = {
+            const input = {
                 type: AWS_SAM_DEBUG_TYPE,
                 name: 'test-extraneous-env',
                 request: DIRECT_INVOKE_TYPE,
@@ -1241,7 +1240,7 @@ Outputs:
                 tempFile.fsPath
             )
             await registry.addTemplateToRegistry(tempFile)
-            const actual = (await debugConfigProvider.makeConfig(folder, c))!
+            const actual = (await debugConfigProvider.makeConfig(folder, input))!
             const tempDir = path.dirname(actual.codeRoot)
 
             const expected: SamLaunchRequestArgs = {
@@ -1273,7 +1272,7 @@ Outputs:
                     timeoutSec: 12345, // From template.yaml.
                 },
                 localRoot: pathutil.normalize(path.join(tempDir, 'codeuri')), // Normalized to absolute path.
-                name: 'SamLocalDebug',
+                name: input.name,
                 templatePath: pathutil.normalize(
                     path.join(path.dirname(tempFile.fsPath), 'app___vsctk___template.yaml')
                 ),
@@ -1356,7 +1355,7 @@ Resources:
                     region: 'us-weast-9',
                 },
             }
-            const c = {
+            const input = {
                 type: AWS_SAM_DEBUG_TYPE,
                 name: 'test-extraneous-env',
                 request: DIRECT_INVOKE_TYPE,
@@ -1384,7 +1383,7 @@ Resources:
                 tempFile.fsPath
             )
             await registry.addTemplateToRegistry(tempFile)
-            const actual = (await debugConfigProviderMockCredentials.makeConfig(folder, c))!
+            const actual = (await debugConfigProviderMockCredentials.makeConfig(folder, input))!
             const tempDir = path.dirname(actual.codeRoot)
 
             const expected: SamLaunchRequestArgs = {
@@ -1417,7 +1416,7 @@ Resources:
                     timeoutSec: 12345, // From template.yaml.
                 },
                 localRoot: pathutil.normalize(path.join(tempDir, 'codeuri')), // Normalized to absolute path.
-                name: 'SamLocalDebug',
+                name: input.name,
                 templatePath: pathutil.normalize(path.join(actual.baseBuildDir ?? '?', 'input/input-template.yaml')),
 
                 //


### PR DESCRIPTION
The "SamLocalDebug" name is left-over from the old logic, before the Toolkit supported VSCode launch-configs.

This change has these effects:
- The user-given name will appear in logs/output/messaging.
- Integration tests can assert the name, which serves as an extra guard  to check "overlapping" `DebugSession` events.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
