### PR TITLE
CI/integ: fix failing dotnetcore2.1 package install

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -10,6 +10,8 @@ phases:
     install:
         runtime-versions:
             nodejs: 10
+            docker: 19
+            dotnet: 3.1
 
         commands:
             # Install required keys and repos for .NET Core 2.1
@@ -20,10 +22,8 @@ phases:
             - '>/dev/null add-apt-repository universe'
             - '>/dev/null apt-get -qq install -y apt-transport-https'
             - '>/dev/null apt-get -qq update'
-            # Install .NET Core 2.1
-            - '>/dev/null apt-get -qq install -y dotnet-sdk-2.1'
             # Install other needed dependencies
-            - '>/dev/null apt-get -qq install -y jq python2.7 python-pip python3.6 python3.7 python3.8 python3-pip python3-distutils docker'
+            - '>/dev/null apt-get -qq install -y jq python2.7 python-pip python3.6 python3.7 python3.8 python3-pip python3-distutils'
             - '>/dev/null apt-get -qq install -y libgtk-3-dev libxss1 xvfb libnss3-dev libasound2 libasound2-plugins libsecret-1-0'
             - '>/dev/null pip3 install --user aws-sam-cli'
             - '>/dev/null pip3 install --upgrade awscli'

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -14,11 +14,7 @@ phases:
             dotnet: 3.1
 
         commands:
-            # Install required keys and repos for .NET Core 2.1
             - '>/dev/null apt-get -qq update'
-            - wget -q https://packages.microsoft.com/keys/microsoft.asc -O- | apt-key add -
-            - '>/dev/null wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb'
-            - '>/dev/null dpkg -i packages-microsoft-prod.deb'
             - '>/dev/null add-apt-repository universe'
             - '>/dev/null apt-get -qq install -y apt-transport-https'
             - '>/dev/null apt-get -qq update'

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -14,7 +14,6 @@ phases:
             dotnet: 3.1
 
         commands:
-            - '>/dev/null apt-get -qq update'
             - '>/dev/null add-apt-repository universe'
             - '>/dev/null apt-get -qq install -y apt-transport-https'
             - '>/dev/null apt-get -qq update'


### PR DESCRIPTION
problem: CI environment fails to install "dotnet-sdk-2.1"

    [Container] 2020/10/13 17:44:33 Running command >/dev/null apt-get -qq install -y dotnet-sdk-2.1
    E: Unable to correct problems, you have held broken packages.

solution: install dotnet via AWS codebuild "runtime-versions" directive instead of apt-get. 

fixes https://github.com/aws/aws-toolkit-vscode/issues/1349


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
