### PR TITLE
SAM debugconfig: `payload.json` field should allow any object

### DIFF
--- a/package.json
+++ b/package.json
@@ -290,13 +290,6 @@
                                         "properties": {
                                             "json": {
                                                 "description": "%AWS.configuration.description.awssam.debug.event.json%",
-                                                "additionalProperties": {
-                                                    "type": [
-                                                        "string",
-                                                        "number",
-                                                        "boolean"
-                                                    ]
-                                                },
                                                 "type": "object"
                                             },
                                             "path": {


### PR DESCRIPTION
The `additionalProperties` specification is too restrictive: instead it should be omitted entirely.

ref https://github.com/aws/aws-toolkit-vscode/issues/1344

Test cases:

1. Editing the following launch.json in VSCode does _not_ show   warnings/errors (i.e. it is "valid"):
   ```
    {
        "configurations": [
            {
                "type": "aws-sam",
                "request": "direct-invoke",
                "name": "sam-samples:HelloWorldFunction",
                "invokeTarget": {
                    "target": "template",
                    "templatePath": "sam-samples/template.yaml",
                    "logicalId": "HelloWorldFunction"
                },
                "lambda": {
                    "payload": {
                        "json": {
                            "foo": {
                                "a": 1,
                                "b": {
                                    "bb": []
                                }
                            },
                            "bar": 42
                        }
                    },
                    "environmentVariables": {}
                }
            }
        ]
    }
   ```
2. Changing the "json" item to `"json": 42` is correctly flagged as an error.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
