### PR TITLE
Adding icons for SAM actions

### DIFF
--- a/.changes/next-release/Feature-58dd3336-fb6b-4876-90d5-baf1bf9fad52.json
+++ b/.changes/next-release/Feature-58dd3336-fb6b-4876-90d5-baf1bf9fad52.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "\"Deploy SAM Application\" action is available on region nodes in the AWS Explorer"
+}

--- a/.changes/next-release/Feature-7d6f8be9-8646-4c81-9e1f-287e683c06d4.json
+++ b/.changes/next-release/Feature-7d6f8be9-8646-4c81-9e1f-287e683c06d4.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "\"Create new SAM Application\" action is available from the context menu of Lambda nodes in the AWS Explorer"
+}

--- a/package.json
+++ b/package.json
@@ -816,6 +816,16 @@
                     "group": "inline@2"
                 },
                 {
+                    "command": "aws.lambda.createNewSamApp",
+                    "when": "view == aws.explorer && viewItem == awsLambdaNode",
+                    "group": "inline@1"
+                },
+                {
+                    "command": "aws.deploySamApplication",
+                    "when": "view == aws.explorer && viewItem == awsLambdaNode",
+                    "group": "inline@2"
+                },
+                {
                     "command": "aws.invokeLambda",
                     "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeImportable|awsCloudFormationFunctionNode)$/",
                     "group": "0@1"
@@ -976,7 +986,8 @@
             {
                 "command": "aws.lambda.createNewSamApp",
                 "title": "%AWS.command.createNewSamApp%",
-                "category": "AWS"
+                "category": "AWS",
+                "icon": "$(add)"
             },
             {
                 "command": "aws.login",
@@ -1090,7 +1101,8 @@
             {
                 "command": "aws.deploySamApplication",
                 "title": "%AWS.command.deploySamApplication%",
-                "category": "AWS"
+                "category": "AWS",
+                "icon": "$(cloud-upload)"
             },
             {
                 "command": "aws.submitFeedback",

--- a/package.json
+++ b/package.json
@@ -818,7 +818,7 @@
                 {
                     "command": "aws.lambda.createNewSamApp",
                     "when": "view == aws.explorer && viewItem == awsLambdaNode",
-                    "group": "inline@1"
+                    "group": "0@1"
                 },
                 {
                     "command": "aws.deploySamApplication",
@@ -986,8 +986,7 @@
             {
                 "command": "aws.lambda.createNewSamApp",
                 "title": "%AWS.command.createNewSamApp%",
-                "category": "AWS",
-                "icon": "$(add)"
+                "category": "AWS"
             },
             {
                 "command": "aws.login",

--- a/package.json
+++ b/package.json
@@ -822,8 +822,8 @@
                 },
                 {
                     "command": "aws.deploySamApplication",
-                    "when": "view == aws.explorer && viewItem == awsLambdaNode",
-                    "group": "inline@2"
+                    "when": "view == aws.explorer && viewItem == awsRegionNode",
+                    "group": "inline@1"
                 },
                 {
                     "command": "aws.invokeLambda",

--- a/src/lambda/explorer/lambdaNodes.ts
+++ b/src/lambda/explorer/lambdaNodes.ts
@@ -32,6 +32,7 @@ export class LambdaNode extends AWSTreeNodeBase {
     public constructor(private readonly regionCode: string) {
         super('Lambda', vscode.TreeItemCollapsibleState.Collapsed)
         this.functionNodes = new Map<string, LambdaFunctionNode>()
+        this.contextValue = 'awsLambdaNode'
     }
 
     public async getChildren(): Promise<AWSTreeNodeBase[]> {

--- a/src/lambda/wizards/samDeployWizard.ts
+++ b/src/lambda/wizards/samDeployWizard.ts
@@ -446,7 +446,7 @@ export class SamDeployWizard extends MultiStepWizard<SamDeployWizardResponse> {
                 case ParameterPromptResult.Cancel:
                     return undefined
                 case ParameterPromptResult.Continue:
-                    return this.skipOrReturnRegion(this.S3_BUCKET)
+                    return this.skipOrPromptRegion(this.S3_BUCKET)
             }
         }
 
@@ -458,7 +458,7 @@ export class SamDeployWizard extends MultiStepWizard<SamDeployWizardResponse> {
         if (parameters.size < 1) {
             this.response.parameterOverrides = new Map<string, string>()
 
-            return this.skipOrReturnRegion(this.S3_BUCKET)
+            return this.skipOrPromptRegion(this.S3_BUCKET)
         }
 
         const requiredParameterNames = new Set<string>(
@@ -491,7 +491,7 @@ export class SamDeployWizard extends MultiStepWizard<SamDeployWizardResponse> {
 
         this.response.parameterOverrides = overriddenParameters
 
-        return this.skipOrReturnRegion(this.S3_BUCKET)
+        return this.skipOrPromptRegion(this.S3_BUCKET)
     }
 
     private readonly REGION: WizardStep = async () => {
@@ -505,7 +505,7 @@ export class SamDeployWizard extends MultiStepWizard<SamDeployWizardResponse> {
     private readonly S3_BUCKET: WizardStep = async () => {
         this.response.s3Bucket = await this.context.promptUserForS3Bucket(this.response.region, this.response.s3Bucket)
 
-        return this.response.s3Bucket ? this.STACK_NAME : this.skipOrReturnRegion(this.TEMPLATE)
+        return this.response.s3Bucket ? this.STACK_NAME : this.skipOrPromptRegion(this.TEMPLATE)
     }
 
     private readonly STACK_NAME: WizardStep = async () => {
@@ -517,7 +517,7 @@ export class SamDeployWizard extends MultiStepWizard<SamDeployWizardResponse> {
         return this.response.stackName ? undefined : this.S3_BUCKET
     }
 
-    private skipOrReturnRegion(skipToStep: WizardStep | undefined): WizardStep | undefined {
+    private skipOrPromptRegion(skipToStep: WizardStep | undefined): WizardStep | undefined {
         return this.regionNode ? skipToStep : this.REGION
     }
 }

--- a/src/lambda/wizards/samDeployWizard.ts
+++ b/src/lambda/wizards/samDeployWizard.ts
@@ -25,6 +25,7 @@ import { configureParameterOverrides } from '../config/configureParameterOverrid
 import { getOverriddenParameters, getParameters } from '../utilities/parameterUtils'
 import { CloudFormationTemplateRegistry } from '../../shared/cloudformation/templateRegistry'
 import { ext } from '../../shared/extensionGlobals'
+import { RegionNode } from '../../awsexplorer/regionNode'
 
 export interface SamDeployWizardResponse {
     parameterOverrides: Map<string, string>
@@ -402,8 +403,11 @@ export class DefaultSamDeployWizardContext implements SamDeployWizardContext {
 export class SamDeployWizard extends MultiStepWizard<SamDeployWizardResponse> {
     private readonly response: Partial<SamDeployWizardResponse> = {}
 
-    public constructor(private readonly context: SamDeployWizardContext) {
+    public constructor(private readonly context: SamDeployWizardContext, private readonly regionNode?: RegionNode) {
         super()
+        if (regionNode) {
+            this.response.region = regionNode.regionCode
+        }
     }
 
     protected get startStep() {
@@ -442,7 +446,7 @@ export class SamDeployWizard extends MultiStepWizard<SamDeployWizardResponse> {
                 case ParameterPromptResult.Cancel:
                     return undefined
                 case ParameterPromptResult.Continue:
-                    return this.REGION
+                    return this.skipOrReturnRegion(this.S3_BUCKET)
             }
         }
 
@@ -454,7 +458,7 @@ export class SamDeployWizard extends MultiStepWizard<SamDeployWizardResponse> {
         if (parameters.size < 1) {
             this.response.parameterOverrides = new Map<string, string>()
 
-            return this.REGION
+            return this.skipOrReturnRegion(this.S3_BUCKET)
         }
 
         const requiredParameterNames = new Set<string>(
@@ -487,7 +491,7 @@ export class SamDeployWizard extends MultiStepWizard<SamDeployWizardResponse> {
 
         this.response.parameterOverrides = overriddenParameters
 
-        return this.REGION
+        return this.skipOrReturnRegion(this.S3_BUCKET)
     }
 
     private readonly REGION: WizardStep = async () => {
@@ -501,7 +505,7 @@ export class SamDeployWizard extends MultiStepWizard<SamDeployWizardResponse> {
     private readonly S3_BUCKET: WizardStep = async () => {
         this.response.s3Bucket = await this.context.promptUserForS3Bucket(this.response.region, this.response.s3Bucket)
 
-        return this.response.s3Bucket ? this.STACK_NAME : this.REGION
+        return this.response.s3Bucket ? this.STACK_NAME : this.skipOrReturnRegion(this.TEMPLATE)
     }
 
     private readonly STACK_NAME: WizardStep = async () => {
@@ -511,6 +515,10 @@ export class SamDeployWizard extends MultiStepWizard<SamDeployWizardResponse> {
         })
 
         return this.response.stackName ? undefined : this.S3_BUCKET
+    }
+
+    private skipOrReturnRegion(skipToStep: WizardStep | undefined): WizardStep | undefined {
+        return this.regionNode ? skipToStep : this.REGION
     }
 }
 

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -92,11 +92,11 @@ async function registerServerlessCommands(ctx: ExtContext): Promise<void> {
         }),
         vscode.commands.registerCommand('aws.configureLambda', configureLocalLambda),
         vscode.commands.registerCommand('aws.addSamDebugConfiguration', addSamDebugConfiguration),
-        vscode.commands.registerCommand('aws.deploySamApplication', async () => {
+        vscode.commands.registerCommand('aws.deploySamApplication', async regionNode => {
             const samDeployWizardContext = new DefaultSamDeployWizardContext(ctx.regionProvider, ctx.awsContext)
             const samDeployWizard: SamDeployWizardResponseProvider = {
                 getSamDeployWizardResponse: async (): Promise<SamDeployWizardResponse | undefined> => {
-                    const wizard = new SamDeployWizard(samDeployWizardContext)
+                    const wizard = new SamDeployWizard(samDeployWizardContext, regionNode)
 
                     return wizard.run()
                 },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding a right-click option for `Create new SAM Application` to the top-level Lambda nodes and an action icon for `Deploy SAM Application` to the top-level region nodes.
* Also: Deploying via region node icon now skips the region selection step and uses the region node's region.

Considerations:
* Should we change the names of these to emphasize that this is acting on local, non-Lambda resources? E.g. `Create new local SAM Application`?
* Is this the right iconography?
* Thinking we can add icons for individual Lambda upload/import commands later, shouldn't be conflicting with these because those will be tied to the individual Lambdas rather than the root note.

## Motivation and Context

UX studies have identified that this is a good way to surface this functionality to users even though the actions aren't explicitly tied to Lambdas or remote resources.

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/29374703/96754937-d8df7280-1386-11eb-9ac5-13e1637b12ae.png)

![image](https://user-images.githubusercontent.com/29374703/96754929-d54beb80-1386-11eb-95cc-b79ff93cbaac.png)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
