### PR TITLE
SAM debug: use debugpy instead of ptvsd

### DIFF
--- a/resources/debugger/py_debug_wrapper.py
+++ b/resources/debugger/py_debug_wrapper.py
@@ -11,4 +11,4 @@ if __name__ == '__main__':
     sys.stdout.flush()
 
     # pretend like we invoked the debugger like: python -m <debugger_name>
-    runpy.run_module('ptvsd', run_name='__main__')
+    runpy.run_module('debugpy', run_name='__main__')

--- a/src/shared/sam/debugger/pythonSamDebug.ts
+++ b/src/shared/sam/debugger/pythonSamDebug.ts
@@ -32,7 +32,7 @@ export async function getSamProjectDirPathForFile(filepath: string): Promise<str
     return path.dirname(filepath)
 }
 
-// Add create debugging manifest/requirements.txt containing ptvsd
+// Add create debugging manifest/requirements.txt containing debugpy
 async function makePythonDebugManifest(params: {
     isImageLambda: boolean
     samProjectCodeRoot: string
@@ -40,15 +40,15 @@ async function makePythonDebugManifest(params: {
 }): Promise<string | undefined> {
     let manifestText = ''
     const manfestPath = path.join(params.samProjectCodeRoot, 'requirements.txt')
-    // TODO: figure out how to get ptvsd in the container without hacking the user's requirements
+    // TODO: figure out how to get debugpy in the container without hacking the user's requirements
     const debugManifestPath = params.isImageLambda ? manfestPath : path.join(params.outputDir, 'debug-requirements.txt')
     if (await fileExists(manfestPath)) {
         manifestText = await readFileAsString(manfestPath)
     }
     getLogger().debug(`pythonCodeLensProvider.makePythonDebugManifest params: ${JSON.stringify(params, undefined, 2)}`)
-    // TODO: Make this logic more robust. What if other module names include ptvsd?
-    if (!manifestText.includes('ptvsd')) {
-        manifestText += `${os.EOL}ptvsd>4.2,<5`
+    // TODO: Make this logic more robust. What if other module names include debugpy?
+    if (!manifestText.includes('debugpy')) {
+        manifestText += `${os.EOL}debugpy>=1.0,<2`
         await writeFile(debugManifestPath, manifestText)
 
         return debugManifestPath
@@ -81,7 +81,7 @@ export async function makePythonDebugConfig(config: SamLaunchRequestArgs): Promi
     if (!config.noDebug) {
         config.debuggerPath = ext.context.asAbsolutePath(join('resources', 'debugger'))
         const isImageLambda = isImageLambdaConfig(config)
-        const debugArgs = `/tmp/lambci_debug_files/py_debug_wrapper.py --host 0.0.0.0 --port ${config.debugPort} --wait`
+        const debugArgs = `/tmp/lambci_debug_files/py_debug_wrapper.py --listen 0.0.0.0:${config.debugPort} --wait-for-client`
         if (isImageLambda) {
             const params = getPythonExeAndBootstrap(config.runtime)
             config.debugArgs = [`${params.python} ${debugArgs} ${params.boostrap}`]

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -931,9 +931,9 @@ Outputs:
                     path: '/hello',
                     httpMethod: 'post',
                     headers: {
-                        'user-agent': 'mozilla 42'
+                        'user-agent': 'mozilla 42',
                     },
-                    querystring: 'foo&bar=baz'
+                    querystring: 'foo&bar=baz',
                 },
                 lambda: {
                     // For target=template these are written to env-vars.json,
@@ -977,7 +977,7 @@ Outputs:
                 handlerName: 'src/subfolder/app.handlerTwoFoldersDeep',
                 invokeTarget: { ...input.invokeTarget },
                 api: {
-                    ...input.api as APIGatewayProperties,
+                    ...(input.api as APIGatewayProperties),
                 },
                 lambda: {
                     ...input.lambda,
@@ -1641,7 +1641,7 @@ Outputs:
                 eventPayloadFile: `${actual.baseBuildDir}/event.json`,
                 codeRoot: pathutil.normalize(path.join(appDir, 'hello_world')),
                 debugArgs: [
-                    `/tmp/lambci_debug_files/py_debug_wrapper.py --host 0.0.0.0 --port ${actual.debugPort} --wait`,
+                    `/tmp/lambci_debug_files/py_debug_wrapper.py --listen 0.0.0.0:${actual.debugPort} --wait-for-client`,
                 ],
                 apiPort: undefined,
                 debugPort: actual.debugPort,
@@ -1792,7 +1792,7 @@ Outputs:
                 eventPayloadFile: `${actual.baseBuildDir}/event.json`,
                 codeRoot: pathutil.normalize(path.join(appDir, 'python3.7-plain-sam-app/hello_world')),
                 debugArgs: [
-                    `/tmp/lambci_debug_files/py_debug_wrapper.py --host 0.0.0.0 --port ${actual.debugPort} --wait`,
+                    `/tmp/lambci_debug_files/py_debug_wrapper.py --listen 0.0.0.0:${actual.debugPort} --wait-for-client`,
                 ],
                 apiPort: undefined,
                 debugPort: actual.debugPort,
@@ -1958,9 +1958,9 @@ Outputs:
                     path: '/hello',
                     httpMethod: 'put',
                     headers: {
-                        'accept-language': 'es-CA'
+                        'accept-language': 'es-CA',
                     },
-                    querystring: 'name1=value1&foo&bar'
+                    querystring: 'name1=value1&foo&bar',
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'python3.7-plain-sam-app/template.yaml'))
@@ -1986,14 +1986,14 @@ Outputs:
                 eventPayloadFile: `${actual.baseBuildDir}/event.json`,
                 codeRoot: pathutil.normalize(path.join(appDir, 'python3.7-plain-sam-app/hello_world')),
                 debugArgs: [
-                    `/tmp/lambci_debug_files/py_debug_wrapper.py --host 0.0.0.0 --port ${actual.debugPort} --wait`,
+                    `/tmp/lambci_debug_files/py_debug_wrapper.py --listen 0.0.0.0:${actual.debugPort} --wait-for-client`,
                 ],
                 apiPort: actual.apiPort,
                 debugPort: actual.debugPort,
                 documentUri: vscode.Uri.file(''), // TODO: remove or test.
                 invokeTarget: { ...input.invokeTarget },
                 api: {
-                    ...input.api as APIGatewayProperties,
+                    ...(input.api as APIGatewayProperties),
                 },
                 lambda: {
                     environmentVariables: {},
@@ -2146,7 +2146,7 @@ Outputs:
                 eventPayloadFile: `${actual.baseBuildDir}/event.json`,
                 codeRoot: pathutil.normalize(path.join(appDir, 'python3.7-image-sam-app/hello_world')),
                 debugArgs: [
-                    `/var/lang/bin/python3.7 /tmp/lambci_debug_files/py_debug_wrapper.py --host 0.0.0.0 --port ${actual.debugPort} --wait /var/runtime/bootstrap`,
+                    `/var/lang/bin/python3.7 /tmp/lambci_debug_files/py_debug_wrapper.py --listen 0.0.0.0:${actual.debugPort} --wait-for-client /var/runtime/bootstrap`,
                 ],
                 apiPort: undefined,
                 debugPort: actual.debugPort,


### PR DESCRIPTION
Depends on https://github.com/aws/aws-toolkit-vscode/pull/1361 and resolves https://github.com/aws/aws-toolkit-vscode/issues/1272

ptvsd is considered deprecated and debugpy is the replacement

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
