### PR TITLE
Fix creating buckets in us-east-1

### DIFF
--- a/.changes/next-release/Bug Fix-c1c64d50-c466-48fd-90bc-d5d7e9324f9c.json
+++ b/.changes/next-release/Bug Fix-c1c64d50-c466-48fd-90bc-d5d7e9324f9c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix creating S3 buckets in us-east-1"
+}

--- a/src/shared/clients/defaultS3Client.ts
+++ b/src/shared/clients/defaultS3Client.ts
@@ -62,7 +62,10 @@ export class DefaultS3Client implements S3Client {
             await s3
                 .createBucket({
                     Bucket: request.bucketName,
-                    CreateBucketConfiguration: { LocationConstraint: this.regionCode },
+                    // Passing us-east-1 for LocationConstraint breaks creating bucket. To make a bucket in us-east-1, you need to
+                    // not pass a region, so check for this case.
+                    CreateBucketConfiguration:
+                        this.regionCode == 'us-east-1' ? undefined : { LocationConstraint: this.regionCode },
                 })
                 .promise()
         } catch (e) {

--- a/src/test/shared/clients/defaultS3Client.test.ts
+++ b/src/test/shared/clients/defaultS3Client.test.ts
@@ -158,6 +158,23 @@ describe('DefaultS3Client', () => {
             })
         })
 
+        it('removes the region code for us-east-1', async () => {
+            when(
+                mockS3.createBucket(
+                    deepEqual({
+                        Bucket: bucketName,
+                        CreateBucketConfiguration: undefined,
+                    })
+                )
+            ).thenReturn(success())
+
+            const response = await createClient({ regionCode: 'us-east-1' }).createBucket({ bucketName })
+
+            assert.deepStrictEqual(response, {
+                bucket: new DefaultBucket({ partitionId: partition, region: 'us-east-1', name: bucketName }),
+            })
+        })
+
         it('throws an Error on failure', async () => {
             when(mockS3.createBucket(anything())).thenReturn(failure())
 


### PR DESCRIPTION
Fix creating S3 buckets in us-east-1 by plucking logic from the Java SDK

## Related Issue(s)

#1367

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
