### PR TITLE
build: packageDebug.ts: do not minify the "debug" VSIX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,11 @@ quickStart*.html
 README.quickstart.vscode.md
 .gitcommit
 media/libs/
-package.json.bk
 resources/debugger/__pycache__
+
+# Temporary backup files from packageDebug.ts
+package.json.bk
+webpack.config.js.bk
 
 # Auto generated definitions
 src/**/*.gen.ts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Then clone the repository and install npm dependencies:
 
 When you launch the extension or run tests from Visual Studio Code, it will automatically build the extension and watch for changes.
 
-If you prefer, you can build from the command line:
+Alternatively, these NPM tasks are defined:
 
 -   To build one time:
     ```
@@ -40,13 +40,13 @@ If you prefer, you can build from the command line:
     ```
     npm run watch
     ```
--   To build a release artifact:
+-   To build a release VSIX artifact:
     ```
     npm run package
     ```
--   To build an "alpha" artifact (useful for letting others test a particular build):
+-   To build a "debug" VSIX artifact (faster, does not minify the webpack result):
     ```
-    npm run packageAlpha
+    npm run packageDebug
     ```
 
 #### If you run out of memory while building

--- a/package.json
+++ b/package.json
@@ -1379,7 +1379,7 @@
         "lint": "eslint -c .eslintrc.js --ext .ts .",
         "lintfix": "eslint -c .eslintrc.js --fix --ext .ts .",
         "package": "vsce package",
-        "packageAlpha": "ts-node ./build-scripts/packageAlpha.ts",
+        "packageDebug": "ts-node ./build-scripts/packageDebug.ts",
         "install-plugin": "vsce package -o aws-toolkit-vscode-test.vsix && code --install-extension aws-toolkit-vscode-test.vsix",
         "generateTelemetry": "node node_modules/@aws-toolkits/telemetry/lib/generateTelemetry.js --extraInput=src/shared/telemetry/vscodeTelemetry.json --output=src/shared/telemetry/telemetry.gen.ts",
         "generateConfigurationAttributes": "ts-node ./build-scripts/generateConfigurationAttributes.ts",

--- a/src/shared/extensions.ts
+++ b/src/shared/extensions.ts
@@ -32,6 +32,6 @@ export interface ExtContext {
 }
 
 /**
- * Version of the .vsix produced by the `packageAlpha` script.
+ * Version of the .vsix produced by the `packageDebug` script.
  */
 export const EXTENSION_ALPHA_VERSION = '1.99.0-SNAPSHOT'


### PR DESCRIPTION
- Rename `packageAlpha.ts` to `packageDebug.ts`
- Do not minify the webpack result; useful for debugging and inspection.

<!--- Provide a general summary of your changes in the Title above -->
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
