### PR TITLE
Adding user-configurable limit to CloudWatch Logs calls

### DIFF
--- a/.changes/next-release/Feature-a468d30b-6593-44ea-9ab3-2d4bb93ec1e8.json
+++ b/.changes/next-release/Feature-a468d30b-6593-44ea-9ab3-2d4bb93ec1e8.json
@@ -1,4 +1,4 @@
 {
 	"type": "Feature",
-	"description": "Add support for configuring max amount of CloudWatch Logs entries pulled per service call"
+	"description": "The amount of CloudWatch Logs entries retrieved per request is now configurable."
 }

--- a/.changes/next-release/Feature-a468d30b-6593-44ea-9ab3-2d4bb93ec1e8.json
+++ b/.changes/next-release/Feature-a468d30b-6593-44ea-9ab3-2d4bb93ec1e8.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Add support for configuring max amount of CloudWatch Logs entries pulled per service call"
+}

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
                 },
                 "aws.cloudWatchLogs.limit": {
                     "type": "number",
-                    "default": 1000,
+                    "default": 10000,
                     "description": "%aws.cloudWatchLogs.limit.desc%",
                     "maximum": 10000
                 }

--- a/package.json
+++ b/package.json
@@ -155,6 +155,12 @@
                     "type": "number",
                     "default": 5000,
                     "description": "%AWS.ssmDocument.ssm.maxItemsComputed.desc%"
+                },
+                "aws.cloudWatchLogs.limit": {
+                    "type": "number",
+                    "default": 1000,
+                    "description": "%aws.cloudWatchLogs.limit.desc%",
+                    "maximum": 10000
                 }
             }
         },

--- a/package.nls.json
+++ b/package.nls.json
@@ -390,6 +390,7 @@
     "aws.cloudWatchLogs.codeLens.loadOlder": "Load older events...",
     "aws.cloudWatchLogs.codeLens.loadNewer": "Load newer events...",
     "aws.cloudWatchLogs.invalidEditor": "Not a Cloudwatch Log stream: {0}",
+    "aws.cloudWatchLogs.limit.desc": "The amount of log entries pulled per request from CloudWatch Logs (max 10000)",
     "AWS.samcli.detect.settings.updated": "Settings updated.",
     "AWS.samcli.detect.settings.not.updated": "No settings changes necessary.",
     "AWS.samcli.deploy.general.error": "An error occurred while deploying a SAM Application. {0}",

--- a/package.nls.json
+++ b/package.nls.json
@@ -390,7 +390,7 @@
     "aws.cloudWatchLogs.codeLens.loadOlder": "Load older events...",
     "aws.cloudWatchLogs.codeLens.loadNewer": "Load newer events...",
     "aws.cloudWatchLogs.invalidEditor": "Not a Cloudwatch Log stream: {0}",
-    "aws.cloudWatchLogs.limit.desc": "The amount of log entries pulled per request from CloudWatch Logs (max 10000)",
+    "aws.cloudWatchLogs.limit.desc": "Maximum amount of log entries pulled per request from CloudWatch Logs (max 10000)",
     "AWS.samcli.detect.settings.updated": "Settings updated.",
     "AWS.samcli.detect.settings.not.updated": "No settings changes necessary.",
     "AWS.samcli.deploy.general.error": "An error occurred while deploying a SAM Application. {0}",

--- a/src/cloudWatchLogs/commands/addLogEvents.ts
+++ b/src/cloudWatchLogs/commands/addLogEvents.ts
@@ -5,8 +5,9 @@
 
 import * as vscode from 'vscode'
 import * as AsyncLock from 'async-lock'
-import { LogStreamRegistry } from '../registry/logStreamRegistry'
 import { getLogger } from '../../shared/logger/logger'
+import { SettingsConfiguration } from '../../shared/settingsConfiguration'
+import { LogStreamRegistry } from '../registry/logStreamRegistry'
 
 // TODO: Cut a PR to the async-lock package?...as of now, maxPending = 0 is theoretically ideal, but also falsy (which sets maxPending = 1000):
 // https://github.com/rogierschouten/async-lock/blob/78cb0c2441650d7bdc148548f99542ccc9c93fd7/lib/index.js#L19
@@ -16,7 +17,8 @@ export async function addLogEvents(
     document: vscode.TextDocument,
     registry: LogStreamRegistry,
     headOrTail: 'head' | 'tail',
-    onDidChangeCodeLensEvent?: vscode.EventEmitter<void>
+    onDidChangeCodeLensEvent: vscode.EventEmitter<void>,
+    configuration: SettingsConfiguration
 ): Promise<void> {
     const uri = document.uri
     const lockName = `${headOrTail === 'head' ? 'logStreamHeadLock' : 'logStreamTailLock'}:${uri.path}`
@@ -34,7 +36,7 @@ export async function addLogEvents(
             if (onDidChangeCodeLensEvent) {
                 onDidChangeCodeLensEvent.fire()
             }
-            await registry.updateLog(uri, headOrTail)
+            await registry.updateLog(uri, headOrTail, configuration)
             getLogger().debug('Update done, releasing lock...')
         })
     } catch (e) {

--- a/src/cloudWatchLogs/commands/viewLogStream.ts
+++ b/src/cloudWatchLogs/commands/viewLogStream.ts
@@ -62,7 +62,11 @@ export class DefaultSelectLogStreamWizardContext implements SelectLogStreamWizar
             orderBy: 'LastEventTime',
             descending: true,
         }
-        const qp = picker.createQuickPick({})
+        const qp = picker.createQuickPick({
+            options: {
+                title: localize('aws.cloudWatchLogs.viewLogStream.workflow.prompt', 'Select a log stream'),
+            },
+        })
         const populator = new IteratorTransformer(
             () =>
                 getPaginatedAwsCallIter({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -187,7 +187,7 @@ export async function activate(context: vscode.ExtensionContext) {
             })
         )
 
-        await activateCloudWatchLogs(context)
+        await activateCloudWatchLogs(context, toolkitSettings)
 
         await activateCloudFormationTemplateRegistry(context)
 

--- a/src/test/cloudWatchLogs/commands/addLogEvents.test.ts
+++ b/src/test/cloudWatchLogs/commands/addLogEvents.test.ts
@@ -3,20 +3,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { CloudWatchLogs } from 'aws-sdk'
 import * as lolex from 'lolex'
 import * as sinon from 'sinon'
 import * as vscode from 'vscode'
 import { addLogEvents } from '../../../cloudWatchLogs/commands/addLogEvents'
 import { LogStreamRegistry } from '../../../cloudWatchLogs/registry/logStreamRegistry'
-import { CloudWatchLogs } from 'aws-sdk'
 import { CLOUDWATCH_LOGS_SCHEME } from '../../../shared/constants'
+import { TestSettingsConfiguration } from '../../utilities/testSettingsConfiguration'
 
 describe('addLogEvents', async () => {
     let sandbox: sinon.SinonSandbox
     let clock: lolex.InstalledClock
+    const config = new TestSettingsConfiguration()
 
     before(() => {
         clock = lolex.install()
+        config.writeSetting('cloudWatchLogs.limit', 1000)
     })
 
     beforeEach(() => {
@@ -64,7 +67,7 @@ describe('addLogEvents', async () => {
 
         const fakeEvent = sandbox.createStubInstance(vscode.EventEmitter)
 
-        await addLogEvents(document, fakeRegistry, 'head', fakeEvent)
+        await addLogEvents(document, fakeRegistry, 'head', fakeEvent, config)
 
         sandbox.assert.calledTwice(setBusyStatus)
         sandbox.assert.calledWith(setBusyStatus.firstCall, uri, true)
@@ -120,11 +123,11 @@ describe('addLogEvents', async () => {
 
         const fakeEvent = sandbox.createStubInstance(vscode.EventEmitter)
 
-        addLogEvents(document, fakeRegistry, 'head', fakeEvent)
+        addLogEvents(document, fakeRegistry, 'head', fakeEvent, config)
 
-        addLogEvents(document, fakeRegistry, 'head', fakeEvent)
+        addLogEvents(document, fakeRegistry, 'head', fakeEvent, config)
 
-        addLogEvents(document, fakeRegistry, 'head', fakeEvent)
+        addLogEvents(document, fakeRegistry, 'head', fakeEvent, config)
 
         new Promise(resolve => {
             clock.setTimeout(() => {

--- a/src/test/cloudWatchLogs/document/logStreamDocumentProvider.test.ts
+++ b/src/test/cloudWatchLogs/document/logStreamDocumentProvider.test.ts
@@ -7,11 +7,15 @@ import * as assert from 'assert'
 import * as vscode from 'vscode'
 import { LogStreamDocumentProvider } from '../../../cloudWatchLogs/document/logStreamDocumentProvider'
 import { LogStreamRegistry, CloudWatchLogStreamData } from '../../../cloudWatchLogs/registry/logStreamRegistry'
+import { TestSettingsConfiguration } from '../../utilities/testSettingsConfiguration'
 
 describe('LogStreamDocumentProvider', () => {
     let registry: LogStreamRegistry
     let map: Map<string, CloudWatchLogStreamData>
     let provider: LogStreamDocumentProvider
+
+    const config = new TestSettingsConfiguration()
+    config.writeSetting('cloudWatchLogs.limit', 1000)
 
     const registeredUri = vscode.Uri.parse('has:This')
     // TODO: Make this less flaky when we add manual timestamp controls.
@@ -28,7 +32,7 @@ describe('LogStreamDocumentProvider', () => {
     beforeEach(() => {
         map = new Map<string, CloudWatchLogStreamData>()
         map.set(registeredUri.path, stream)
-        registry = new LogStreamRegistry(map)
+        registry = new LogStreamRegistry(config, map)
         provider = new LogStreamDocumentProvider(registry)
     })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Lets user set a limit for log entries returned per query

## Motivation and Context
Performance issues

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
