### PR TITLE
build: packageDebug.ts: cleanup *.bk files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,6 @@ README.quickstart.vscode.md
 media/libs/
 resources/debugger/__pycache__
 
-# Temporary backup files from packageDebug.ts
-package.json.bk
-webpack.config.js.bk
-
 # Auto generated definitions
 src/**/*.gen.ts
 # Telemetry definition for testing adding telemetry

--- a/build-scripts/packageDebug.ts
+++ b/build-scripts/packageDebug.ts
@@ -40,4 +40,6 @@ try {
     // Restore the original files.
     fs.copyFileSync(`${packageJsonFile}.bk`, packageJsonFile)
     fs.copyFileSync(`${webpackConfigJsFile}.bk`, webpackConfigJsFile)
+    fs.unlinkSync(`${packageJsonFile}.bk`)
+    fs.unlinkSync(`${webpackConfigJsFile}.bk`)
 }


### PR DESCRIPTION
- If `fs.copyFileSync('foo.bk', 'foo')` succeeds then it is very   unlikely that we need the 'foo.bk' file.
- Rename `packageAlpha.ts` to `packageDebug.ts` (forgotten in 979a92f8da57).

<!--- Provide a general summary of your changes in the Title above -->


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
