### PR TITLE
Minor refactor of MultiStepWizard to clarify state transitions

### DIFF
--- a/src/cloudWatchLogs/commands/viewLogStream.ts
+++ b/src/cloudWatchLogs/commands/viewLogStream.ts
@@ -9,7 +9,7 @@ const localize = nls.loadMessageBundle()
 import * as vscode from 'vscode'
 import * as moment from 'moment'
 import * as picker from '../../shared/ui/picker'
-import { MultiStepWizard, WizardStep } from '../../shared/wizards/multiStepWizard'
+import { MultiStepWizard, WIZARD_REPROMPT, WIZARD_TERMINATE, WizardStep } from '../../shared/wizards/multiStepWizard'
 import { LogGroupNode } from '../explorer/logGroupNode'
 import { CloudWatchLogs } from 'aws-sdk'
 import { ext } from '../../shared/extensionGlobals'
@@ -153,11 +153,11 @@ export class SelectLogStreamWizard extends MultiStepWizard<SelectLogStreamRespon
 
         // retry on error
         if (returnVal === picker.IteratingQuickPickController.ERROR_ITEM.label) {
-            return this.SELECT_STREAM
+            return WIZARD_REPROMPT
         }
 
         this.response.logStreamName = returnVal
 
-        return undefined
+        return WIZARD_TERMINATE
     }
 }

--- a/src/cloudWatchLogs/commands/viewLogStream.ts
+++ b/src/cloudWatchLogs/commands/viewLogStream.ts
@@ -9,7 +9,7 @@ const localize = nls.loadMessageBundle()
 import * as vscode from 'vscode'
 import * as moment from 'moment'
 import * as picker from '../../shared/ui/picker'
-import { MultiStepWizard, WIZARD_REPROMPT, WIZARD_TERMINATE, WizardStep } from '../../shared/wizards/multiStepWizard'
+import { MultiStepWizard, WIZARD_RETRY, WIZARD_TERMINATE, WizardStep } from '../../shared/wizards/multiStepWizard'
 import { LogGroupNode } from '../explorer/logGroupNode'
 import { CloudWatchLogs } from 'aws-sdk'
 import { ext } from '../../shared/extensionGlobals'
@@ -153,7 +153,7 @@ export class SelectLogStreamWizard extends MultiStepWizard<SelectLogStreamRespon
 
         // retry on error
         if (returnVal === picker.IteratingQuickPickController.ERROR_ITEM.label) {
-            return WIZARD_REPROMPT
+            return WIZARD_RETRY
         }
 
         this.response.logStreamName = returnVal

--- a/src/eventSchemas/wizards/schemaCodeDownloadWizard.ts
+++ b/src/eventSchemas/wizards/schemaCodeDownloadWizard.ts
@@ -12,7 +12,15 @@ import * as vscode from 'vscode'
 import { eventBridgeSchemasDocUrl } from '../../shared/constants'
 import { createHelpButton } from '../../shared/ui/buttons'
 import * as picker from '../../shared/ui/picker'
-import { MultiStepWizard, promptUserForLocation, WizardContext, WizardStep } from '../../shared/wizards/multiStepWizard'
+import {
+    MultiStepWizard,
+    promptUserForLocation,
+    WIZARD_GOBACK,
+    WIZARD_TERMINATE,
+    WizardContext,
+    wizardContinue,
+    WizardStep,
+} from '../../shared/wizards/multiStepWizard'
 
 import * as codeLang from '../models/schemaCodeLangs'
 
@@ -165,18 +173,18 @@ export class SchemaCodeDownloadWizard extends MultiStepWizard<SchemaCodeDownload
     private readonly SCHEMA_VERSION: WizardStep = async () => {
         this.schemaVersion = await this.context.promptUserForVersion(this.schemaVersion)
 
-        return this.schemaVersion ? this.LANGUAGE : undefined
+        return this.schemaVersion ? wizardContinue(this.LANGUAGE) : WIZARD_TERMINATE
     }
 
     private readonly LANGUAGE: WizardStep = async () => {
         this.language = await this.context.promptUserForLanguage(this.language)
 
-        return this.language ? this.LOCATION : this.SCHEMA_VERSION
+        return this.language ? wizardContinue(this.LOCATION) : WIZARD_GOBACK
     }
 
     private readonly LOCATION: WizardStep = async () => {
         this.location = await this.context.promptUserForLocation()
 
-        return this.location ? undefined : this.LANGUAGE
+        return this.location ? WIZARD_TERMINATE : WIZARD_GOBACK
     }
 }

--- a/src/lambda/wizards/samDeployWizard.ts
+++ b/src/lambda/wizards/samDeployWizard.ts
@@ -20,7 +20,13 @@ import { createHelpButton } from '../../shared/ui/buttons'
 import * as input from '../../shared/ui/input'
 import * as picker from '../../shared/ui/picker'
 import { difference, filter } from '../../shared/utilities/collectionUtils'
-import { MultiStepWizard, WizardStep } from '../../shared/wizards/multiStepWizard'
+import {
+    MultiStepWizard,
+    WIZARD_GOBACK,
+    WIZARD_TERMINATE,
+    wizardContinue,
+    WizardStep,
+} from '../../shared/wizards/multiStepWizard'
 import { configureParameterOverrides } from '../config/configureParameterOverrides'
 import { getOverriddenParameters, getParameters } from '../utilities/parameterUtils'
 import { CloudFormationTemplateRegistry } from '../../shared/cloudformation/templateRegistry'
@@ -437,28 +443,25 @@ export class SamDeployWizard extends MultiStepWizard<SamDeployWizardResponse> {
     private readonly TEMPLATE: WizardStep = async () => {
         this.response.template = await this.context.promptUserForSamTemplate(this.response.template)
 
-        return this.response.template ? this.PARAMETER_OVERRIDES : undefined
-    }
+        if (!this.response.template) {
+            return WIZARD_TERMINATE
+        }
 
-    private readonly PARAMETER_OVERRIDES: WizardStep = async () => {
+        // also ask user to setup CFN parameters if they haven't already done so
         const getNextStep = (result: ParameterPromptResult) => {
             switch (result) {
                 case ParameterPromptResult.Cancel:
-                    return undefined
+                    return WIZARD_TERMINATE
                 case ParameterPromptResult.Continue:
-                    return this.skipOrPromptRegion(this.S3_BUCKET)
+                    return wizardContinue(this.skipOrPromptRegion(this.S3_BUCKET))
             }
-        }
-
-        if (!this.response.template) {
-            throw new Error('Unexpected state: TEMPLATE step is complete, but no template was selected')
         }
 
         const parameters = await this.context.getParameters(this.response.template)
         if (parameters.size < 1) {
             this.response.parameterOverrides = new Map<string, string>()
 
-            return this.skipOrPromptRegion(this.S3_BUCKET)
+            return wizardContinue(this.skipOrPromptRegion(this.S3_BUCKET))
         }
 
         const requiredParameterNames = new Set<string>(
@@ -491,21 +494,19 @@ export class SamDeployWizard extends MultiStepWizard<SamDeployWizardResponse> {
 
         this.response.parameterOverrides = overriddenParameters
 
-        return this.skipOrPromptRegion(this.S3_BUCKET)
+        return wizardContinue(this.skipOrPromptRegion(this.S3_BUCKET))
     }
 
     private readonly REGION: WizardStep = async () => {
         this.response.region = await this.context.promptUserForRegion(this.response.region)
 
-        // The PARAMETER_OVERRIDES step is part of the TEMPLATE step from the user's perspective,
-        // so we go back to the TEMPLATE step instead of PARAMETER_OVERRIDES.
-        return this.response.region ? this.S3_BUCKET : this.TEMPLATE
+        return this.response.region ? wizardContinue(this.S3_BUCKET) : WIZARD_GOBACK
     }
 
     private readonly S3_BUCKET: WizardStep = async () => {
         this.response.s3Bucket = await this.context.promptUserForS3Bucket(this.response.region, this.response.s3Bucket)
 
-        return this.response.s3Bucket ? this.STACK_NAME : this.skipOrPromptRegion(this.TEMPLATE)
+        return this.response.s3Bucket ? wizardContinue(this.STACK_NAME) : WIZARD_GOBACK
     }
 
     private readonly STACK_NAME: WizardStep = async () => {
@@ -514,10 +515,10 @@ export class SamDeployWizard extends MultiStepWizard<SamDeployWizardResponse> {
             validateInput: validateStackName,
         })
 
-        return this.response.stackName ? undefined : this.S3_BUCKET
+        return this.response.stackName ? WIZARD_TERMINATE : WIZARD_GOBACK
     }
 
-    private skipOrPromptRegion(skipToStep: WizardStep | undefined): WizardStep | undefined {
+    private skipOrPromptRegion(skipToStep: WizardStep): WizardStep {
         return this.regionNode ? skipToStep : this.REGION
     }
 }

--- a/src/lambda/wizards/samInitWizard.ts
+++ b/src/lambda/wizards/samInitWizard.ts
@@ -21,7 +21,7 @@ import {
     MultiStepWizard,
     promptUserForLocation,
     WIZARD_GOBACK,
-    WIZARD_REPROMPT,
+    WIZARD_RETRY,
     WIZARD_TERMINATE,
     WizardContext,
     wizardContinue,
@@ -384,7 +384,7 @@ export class CreateNewSamAppWizard extends MultiStepWizard<CreateNewSamAppWizard
         this.template = await this.context.promptUserForTemplate(this.runtime!)
 
         if (this.template === repromptUserForTemplate) {
-            return WIZARD_REPROMPT
+            return WIZARD_RETRY
         }
         if (this.template === eventBridgeStarterAppTemplate) {
             return wizardContinue(this.REGION)

--- a/src/shared/wizards/multiStepWizard.ts
+++ b/src/shared/wizards/multiStepWizard.ts
@@ -10,6 +10,7 @@ import * as os from 'os'
 import * as vscode from 'vscode'
 
 import * as picker from '../../shared/ui/picker'
+import { getLogger } from '../logger/logger'
 
 export interface WizardStep {
     (): Thenable<Transition>
@@ -61,6 +62,7 @@ export abstract class MultiStepWizard<TResult> {
             const step = steps[steps.length - 1]
             // non-terminal if we still have steps
             if (step === undefined) {
+                getLogger().warn('encountered an undefined step, terminating wizard')
                 break
             }
             const result = await step()

--- a/src/ssmDocument/wizards/publishDocumentWizard.ts
+++ b/src/ssmDocument/wizards/publishDocumentWizard.ts
@@ -12,7 +12,14 @@ import { ext } from '../../shared/extensionGlobals'
 import * as input from '../../shared/ui/input'
 import * as picker from '../../shared/ui/picker'
 import { toArrayAsync } from '../../shared/utilities/collectionUtils'
-import { MultiStepWizard, WizardContext, WizardStep } from '../../shared/wizards/multiStepWizard'
+import {
+    MultiStepWizard,
+    WIZARD_GOBACK,
+    WIZARD_TERMINATE,
+    WizardContext,
+    wizardContinue,
+    WizardStep,
+} from '../../shared/wizards/multiStepWizard'
 import { validateDocumentName } from '../util/validateDocumentName'
 const localize = nls.loadMessageBundle()
 
@@ -86,15 +93,15 @@ export class PublishSSMDocumentWizard extends MultiStepWizard<PublishSSMDocument
 
         switch (this.publishAction) {
             case PublishSSMDocumentAction.QuickCreate: {
-                return this.NEW_SSM_DOCUMENT_NAME
+                return wizardContinue(this.NEW_SSM_DOCUMENT_NAME)
             }
 
             case PublishSSMDocumentAction.QuickUpdate: {
-                return this.EXISTING_SSM_DOCUMENT_NAME
+                return wizardContinue(this.EXISTING_SSM_DOCUMENT_NAME)
             }
 
             default: {
-                return undefined
+                return WIZARD_TERMINATE
             }
         }
     }
@@ -102,13 +109,13 @@ export class PublishSSMDocumentWizard extends MultiStepWizard<PublishSSMDocument
     private readonly NEW_SSM_DOCUMENT_TYPE: WizardStep = async () => {
         this.documentType = await this.context.promptUserForDocumentType()
 
-        return this.documentType ? undefined : this.PUBLISH_ACTION
+        return this.documentType ? WIZARD_TERMINATE : WIZARD_GOBACK
     }
 
     private readonly NEW_SSM_DOCUMENT_NAME: WizardStep = async () => {
         this.name = await this.context.promptUserForDocumentName()
 
-        return this.name ? this.NEW_SSM_DOCUMENT_TYPE : this.PUBLISH_ACTION
+        return this.name ? wizardContinue(this.NEW_SSM_DOCUMENT_TYPE) : WIZARD_GOBACK
     }
 
     private readonly EXISTING_SSM_DOCUMENT_NAME: WizardStep = async () => {
@@ -116,7 +123,7 @@ export class PublishSSMDocumentWizard extends MultiStepWizard<PublishSSMDocument
         await this.context.loadSSMDocument(this.documentType)
         this.name = await this.context.promptUserForDocumentToUpdate()
 
-        return this.name ? undefined : this.PUBLISH_ACTION
+        return this.name ? WIZARD_TERMINATE : WIZARD_GOBACK
     }
 }
 

--- a/src/stepFunctions/wizards/publishStateMachineWizard.ts
+++ b/src/stepFunctions/wizards/publishStateMachineWizard.ts
@@ -19,7 +19,14 @@ import { createHelpButton } from '../../shared/ui/buttons'
 import * as input from '../../shared/ui/input'
 import * as picker from '../../shared/ui/picker'
 import { toArrayAsync } from '../../shared/utilities/collectionUtils'
-import { MultiStepWizard, WizardContext, WizardStep } from '../../shared/wizards/multiStepWizard'
+import {
+    MultiStepWizard,
+    WIZARD_GOBACK,
+    WIZARD_TERMINATE,
+    WizardContext,
+    wizardContinue,
+    WizardStep,
+} from '../../shared/wizards/multiStepWizard'
 import { isStepFunctionsRole } from '../utils'
 const localize = nls.loadMessageBundle()
 
@@ -337,13 +344,13 @@ export class PublishStateMachineWizard extends MultiStepWizard<PublishStateMachi
 
         switch (this.publishAction) {
             case PublishStateMachineAction.QuickCreate:
-                return this.ROLE_ARN
+                return wizardContinue(this.ROLE_ARN)
 
             case PublishStateMachineAction.QuickUpdate:
-                return this.EXISTING_STATE_MACHINE_ARN
+                return wizardContinue(this.EXISTING_STATE_MACHINE_ARN)
 
             default:
-                return undefined
+                return WIZARD_TERMINATE
         }
     }
 
@@ -351,19 +358,19 @@ export class PublishStateMachineWizard extends MultiStepWizard<PublishStateMachi
         await this.context.loadIamRoles()
         this.roleArn = await this.context.promptUserForIamRole(this.roleArn)
 
-        return this.roleArn ? this.NEW_STATE_MACHINE_NAME : this.PUBLISH_ACTION
+        return this.roleArn ? wizardContinue(this.NEW_STATE_MACHINE_NAME) : WIZARD_GOBACK
     }
 
     private readonly NEW_STATE_MACHINE_NAME: WizardStep = async () => {
         this.name = await this.context.promptUserForStateMachineName()
 
-        return this.name ? undefined : this.ROLE_ARN
+        return this.name ? WIZARD_TERMINATE : WIZARD_GOBACK
     }
 
     private readonly EXISTING_STATE_MACHINE_ARN: WizardStep = async () => {
         await this.context.loadStateMachines()
         this.stateMachineArn = await this.context.promptUserForStateMachineToUpdate()
 
-        return this.stateMachineArn ? undefined : this.PUBLISH_ACTION
+        return this.stateMachineArn ? WIZARD_TERMINATE : WIZARD_GOBACK
     }
 }

--- a/src/test/shared/wizards/multiStepWizard.test.ts
+++ b/src/test/shared/wizards/multiStepWizard.test.ts
@@ -1,0 +1,114 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    MultiStepWizard,
+    WIZARD_REPROMPT,
+    WIZARD_TERMINATE,
+    WizardStep,
+    wizardContinue,
+    WIZARD_GOBACK,
+} from '../../../shared/wizards/multiStepWizard'
+import * as sinon from 'sinon'
+import assert = require('assert')
+
+class MockMultiStepWizard extends MultiStepWizard<undefined> {
+    public constructor() {
+        super()
+    }
+
+    public get startStep(): WizardStep {
+        return async () => {
+            return WIZARD_TERMINATE
+        }
+    }
+
+    protected getResult(): undefined {
+        return undefined
+    }
+}
+
+describe('run', () => {
+    const mockWizard = new MockMultiStepWizard()
+    let sandbox: sinon.SinonSandbox
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox()
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    describe('terminate', () => {
+        it('works when there are no more steps', async () => {
+            const stub = sinon.stub()
+            stub.returns(WIZARD_TERMINATE)
+            sandbox.stub(mockWizard, 'startStep').value(stub)
+
+            await mockWizard.run()
+
+            assert.strictEqual(stub.callCount, 1)
+        })
+    })
+
+    describe('re-prompt', () => {
+        it('repeats current step', async () => {
+            const stub = sinon.stub()
+            stub.onFirstCall().returns(WIZARD_REPROMPT)
+            stub.onSecondCall().returns(WIZARD_TERMINATE)
+            sandbox.stub(mockWizard, 'startStep').value(stub)
+
+            await mockWizard.run()
+
+            assert.strictEqual(stub.callCount, 2)
+        })
+    })
+
+    describe('go back', () => {
+        it('goes back', async () => {
+            const step1 = sinon.stub()
+            const step2 = sinon.stub()
+            step1.returns(wizardContinue(step2))
+            step2.onFirstCall().returns(WIZARD_GOBACK)
+            step2.onSecondCall().returns(WIZARD_TERMINATE)
+            sandbox.stub(mockWizard, 'startStep').value(step1)
+            await mockWizard.run()
+
+            sinon.assert.callOrder(step1, step2, step1, step2)
+        })
+
+        it('handles branches', async () => {
+            const step1 = sinon.stub()
+            const branch1 = sinon.stub()
+            const branch2 = sinon.stub()
+            const step3 = sinon.stub()
+            step1.onFirstCall().returns(wizardContinue(branch1))
+            step1.onSecondCall().returns(wizardContinue(branch2))
+            branch1.returns(WIZARD_GOBACK)
+            branch2.returns(wizardContinue(step3))
+            step3.onFirstCall().returns(WIZARD_GOBACK)
+            step3.onSecondCall().returns(WIZARD_TERMINATE)
+            sandbox.stub(mockWizard, 'startStep').value(step1)
+            await mockWizard.run()
+
+            // step1 -> branch1 -> step1 -> branch2 -> step3 -> branch2 -> step3 -> terminate
+            sinon.assert.callOrder(step1, branch1, step1, branch2, step3, branch2, step3)
+        })
+    })
+
+    describe('continue', () => {
+        it('continues', async () => {
+            const step1 = sinon.stub()
+            const step2 = sinon.stub()
+            step1.returns(wizardContinue(step2))
+            step2.returns(WIZARD_TERMINATE)
+            sandbox.stub(mockWizard, 'startStep').value(step1)
+            await mockWizard.run()
+
+            sinon.assert.callOrder(step1, step2)
+        })
+    })
+})


### PR DESCRIPTION
The current wizard system expects each step to specify both the next step, as well as the behavior of the "back" button arrow. This is okay for simple flows, but starts to become difficult to follow once you start throwing in conditional behavior and need to figure out which step to actually return.

This attempts to improve readability by moving from explicitly specifying the desired "previous" state to an intent, and moving the onus for handling this onto the homegrown wizard framework instead. This ~unfortunately~ also prevents wizards from intentionally/accidentally jumping around with regards to step ordering

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
