### PR TITLE
Handle temporary files better

### DIFF
--- a/src/eventSchemas/commands/downloadSchemaItemCode.ts
+++ b/src/eventSchemas/commands/downloadSchemaItemCode.ts
@@ -4,14 +4,13 @@
  */
 
 import * as nls from 'vscode-nls'
-import * as del from 'del'
 const localize = nls.loadMessageBundle()
 import { Schemas } from 'aws-sdk'
 import fs = require('fs')
 import path = require('path')
 import * as vscode from 'vscode'
 import { SchemaClient } from '../../shared/clients/schemaClient'
-import { makeTemporaryToolkitFolder } from '../../shared/filesystemUtilities'
+import { makeTemporaryToolkitFolder, tryRemoveFolder } from '../../shared/filesystemUtilities'
 import * as localizedText from '../../shared/localizedText'
 import { getLogger, Logger } from '../../shared/logger'
 import { recordSchemasDownload, Result } from '../../shared/telemetry/telemetry'
@@ -284,7 +283,7 @@ export class CodeExtractor {
         zipContents: ArrayBuffer,
         request: SchemaCodeDownloadRequestDetails
     ): Promise<string | void> {
-        let codeZipDir = ''
+        let codeZipDir: string | undefined
         try {
             const fileName = `${request.schemaName}.${request.schemaVersion}.${request.language}.zip`
 
@@ -317,9 +316,7 @@ export class CodeExtractor {
 
             return undefined
         } finally {
-            if (codeZipDir) {
-                await del(codeZipDir, { force: true })
-            }
+            tryRemoveFolder(codeZipDir)
         }
     }
 

--- a/src/eventSchemas/commands/downloadSchemaItemCode.ts
+++ b/src/eventSchemas/commands/downloadSchemaItemCode.ts
@@ -14,7 +14,6 @@ import { makeTemporaryToolkitFolder } from '../../shared/filesystemUtilities'
 import * as localizedText from '../../shared/localizedText'
 import { getLogger, Logger } from '../../shared/logger'
 import { recordSchemasDownload, Result } from '../../shared/telemetry/telemetry'
-import { ExtensionDisposableFiles } from '../../shared/utilities/disposableFiles'
 import { SchemaItemNode } from '../explorer/schemaItemNode'
 import { getLanguageDetails } from '../models/schemaCodeLangs'
 
@@ -286,7 +285,7 @@ export class CodeExtractor {
     ): Promise<string | void> {
         const fileName = `${request.schemaName}.${request.schemaVersion}.${request.language}.zip`
 
-        const codeZipDir = await this.getDisposableTempFolder()
+        const codeZipDir = await makeTemporaryToolkitFolder()
 
         const codeZipFile = path.join(codeZipDir, fileName)
         const destinationDirectory = request.destinationDirectory.fsPath
@@ -314,13 +313,6 @@ export class CodeExtractor {
         }
 
         return undefined
-    }
-
-    public async getDisposableTempFolder(): Promise<string> {
-        const tempFolder = await makeTemporaryToolkitFolder()
-        ExtensionDisposableFiles.getInstance().addFolder(tempFolder)
-
-        return tempFolder
     }
 
     // Check if downloaded code hierarchy has collisions with the destination directory and display them in output channel

--- a/src/lambda/activation.ts
+++ b/src/lambda/activation.ts
@@ -11,6 +11,7 @@ import { invokeLambda } from './commands/invokeLambda'
 import { uploadLambdaCommand } from './commands/uploadLambda'
 import { LambdaFunctionNode } from './explorer/lambdaFunctionNode'
 import { importLambdaCommand } from './commands/importLambda'
+import * as del from 'del'
 
 /**
  * Activates Lambda components.
@@ -37,7 +38,16 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
                     functionNode: node,
                     outputChannel,
                 })
-        )
+        ),
+        // Capture debug finished events, and delete the base build dir if it exists
+        vscode.debug.onDidTerminateDebugSession(async session => {
+            // if it has a base build dir, then we remove it. We can't find out the type easily since
+            // 'type' is just 'python'/'nodejs' etc, but we can tell it's a run config we care about if
+            // it has a baseBuildDirectory.
+            if (session.configuration?.baseBuildDir !== undefined) {
+                await del(session.configuration.baseBuildDir, { force: true })
+            }
+        })
     )
 
     if (FeatureToggle.getFeatureToggle().isFeatureActive(ActiveFeatureKeys.LambdaImport)) {

--- a/src/lambda/activation.ts
+++ b/src/lambda/activation.ts
@@ -11,7 +11,7 @@ import { invokeLambda } from './commands/invokeLambda'
 import { uploadLambdaCommand } from './commands/uploadLambda'
 import { LambdaFunctionNode } from './explorer/lambdaFunctionNode'
 import { importLambdaCommand } from './commands/importLambda'
-import * as del from 'del'
+import { tryRemoveFolder } from '../shared/filesystemUtilities'
 
 /**
  * Activates Lambda components.
@@ -45,7 +45,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
             // 'type' is just 'python'/'nodejs' etc, but we can tell it's a run config we care about if
             // it has a baseBuildDirectory.
             if (session.configuration?.baseBuildDir !== undefined) {
-                await del(session.configuration.baseBuildDir, { force: true })
+                await tryRemoveFolder(session.configuration.baseBuildDir)
             }
         })
     )

--- a/src/lambda/commands/deploySamApplication.ts
+++ b/src/lambda/commands/deploySamApplication.ts
@@ -3,14 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as del from 'del'
 import * as path from 'path'
 import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 
 import { asEnvironmentVariables } from '../../credentials/credentialsUtilities'
 import { AwsContext, NoActiveCredentialError } from '../../shared/awsContext'
-import { makeTemporaryToolkitFolder } from '../../shared/filesystemUtilities'
+import { makeTemporaryToolkitFolder, tryRemoveFolder } from '../../shared/filesystemUtilities'
 import { getLogger } from '../../shared/logger'
 import { SamCliBuildInvocation } from '../../shared/sam/cli/samCliBuild'
 import { getSamCliContext, SamCliContext } from '../../shared/sam/cli/samCliContext'
@@ -64,7 +63,7 @@ export async function deploySamApplication(
     }
 ): Promise<void> {
     let deployResult: Result = 'Succeeded'
-    let deployFolder = ''
+    let deployFolder: string | undefined
     try {
         const credentials = await awsContext.getCredentials()
         if (!credentials) {
@@ -112,9 +111,7 @@ export async function deploySamApplication(
         deployResult = 'Failed'
         outputDeployError(err as Error, channelLogger)
     } finally {
-        if (deployFolder) {
-            await del(deployFolder, { force: true })
-        }
+        await tryRemoveFolder(deployFolder)
         recordSamDeploy({ result: deployResult })
     }
 }

--- a/src/lambda/commands/importLambda.ts
+++ b/src/lambda/commands/importLambda.ts
@@ -132,7 +132,7 @@ async function downloadAndUnzipLambda(
     let tempDir = ''
     try {
         tempDir = await makeTemporaryToolkitFolder()
-        const downloadLocation = path.join(tempFolder, 'function.zip')
+        const downloadLocation = path.join(tempDir, 'function.zip')
 
         const response = await lambda.getFunction(functionArn)
         const codeLocation = response.Code?.Location!

--- a/src/lambda/commands/importLambda.ts
+++ b/src/lambda/commands/importLambda.ts
@@ -4,7 +4,6 @@
  */
 
 import * as AdmZip from 'adm-zip'
-import * as del from 'del'
 import * as fs from 'fs-extra'
 import * as _ from 'lodash'
 import * as path from 'path'
@@ -13,7 +12,7 @@ import { LambdaFunctionNode } from '../explorer/lambdaFunctionNode'
 import { showConfirmationMessage } from '../../s3/util/messages'
 import { LaunchConfiguration, getReferencedHandlerPaths } from '../../shared/debug/launchConfiguration'
 import { ext } from '../../shared/extensionGlobals'
-import { makeTemporaryToolkitFolder, fileExists } from '../../shared/filesystemUtilities'
+import { makeTemporaryToolkitFolder, fileExists, tryRemoveFolder } from '../../shared/filesystemUtilities'
 import { getLogger } from '../../shared/logger'
 import { HttpResourceFetcher } from '../../shared/resourcefetcher/httpResourceFetcher'
 import { createCodeAwsSamDebugConfig } from '../../shared/sam/debugger/awsSamDebugConfiguration'
@@ -129,7 +128,7 @@ async function downloadAndUnzipLambda(
     lambda = ext.toolkitClientBuilder.createLambdaClient(functionNode.regionCode)
 ): Promise<void> {
     const functionArn = functionNode.configuration.FunctionArn!
-    let tempDir = ''
+    let tempDir: string | undefined
     try {
         tempDir = await makeTemporaryToolkitFolder()
         const downloadLocation = path.join(tempDir, 'function.zip')
@@ -172,9 +171,7 @@ async function downloadAndUnzipLambda(
 
         throw new ImportError()
     } finally {
-        if (tempDir) {
-            await del(tempDir, { force: true })
-        }
+        tryRemoveFolder(tempDir)
     }
 }
 

--- a/src/lambda/commands/importLambda.ts
+++ b/src/lambda/commands/importLambda.ts
@@ -131,7 +131,6 @@ async function downloadAndUnzipLambda(
     const functionArn = functionNode.configuration.FunctionArn!
     try {
         const tempFolder = await makeTemporaryToolkitFolder()
-        ExtensionDisposableFiles.getInstance().addFolder(tempFolder)
         const downloadLocation = path.join(tempFolder, 'function.zip')
 
         const response = await lambda.getFunction(functionArn)

--- a/src/lambda/commands/uploadLambda.ts
+++ b/src/lambda/commands/uploadLambda.ts
@@ -217,7 +217,6 @@ async function runUploadLambdaWithSamBuild(
                 const invoker = getSamCliContext().invoker
 
                 const tempDir = await makeTemporaryToolkitFolder()
-                ExtensionDisposableFiles.getInstance().addFolder(tempDir)
                 const templatePath = path.join(tempDir, 'template.yaml')
                 const resourceName = 'tempResource'
 

--- a/src/lambda/commands/uploadLambda.ts
+++ b/src/lambda/commands/uploadLambda.ts
@@ -9,12 +9,11 @@ import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
 import * as AdmZip from 'adm-zip'
-import * as del from 'del'
 import * as fs from 'fs'
 import * as path from 'path'
 import { showConfirmationMessage } from '../../s3/util/messages'
 import { ext } from '../../shared/extensionGlobals'
-import { fileExists, makeTemporaryToolkitFolder } from '../../shared/filesystemUtilities'
+import { fileExists, makeTemporaryToolkitFolder, tryRemoveFolder } from '../../shared/filesystemUtilities'
 import * as localizedText from '../../shared/localizedText'
 import { getLogger } from '../../shared/logger'
 import { SamCliBuildInvocation } from '../../shared/sam/cli/samCliBuild'
@@ -213,7 +212,7 @@ async function runUploadLambdaWithSamBuild(
             cancellable: false,
         },
         async progress => {
-            let tempDir = ''
+            let tempDir: string | undefined
             try {
                 const invoker = getSamCliContext().invoker
 
@@ -262,9 +261,7 @@ async function runUploadLambdaWithSamBuild(
 
                 return 'Failed'
             } finally {
-                if (tempDir) {
-                    await del(tempDir, { force: true })
-                }
+                await tryRemoveFolder(tempDir)
             }
         }
     )

--- a/src/shared/filesystemUtilities.ts
+++ b/src/shared/filesystemUtilities.ts
@@ -64,7 +64,10 @@ export const makeTemporaryToolkitFolder = async (...relativePathParts: string[])
         await mkdir(tmpPathParent, { recursive: true })
     }
 
-    return mkdtemp(tmpPath)
+    const p = await mkdtemp(tmpPath)
+    // normalize comes from build, but it might not be needed?
+    // TODO see if we need normalize for some platforms
+    return pathutils.normalize(p)
 }
 
 /**

--- a/src/shared/filesystemUtilities.ts
+++ b/src/shared/filesystemUtilities.ts
@@ -66,7 +66,7 @@ export async function tryRemoveFolder(folder?: string) {
         }
         await del(folder, { force: true })
     } catch (err) {
-        getLogger().warn(err as Error)
+        getLogger().warn(`tryRemoveFolder: failed to delete directory '%s': %O`, folder, err as Error)
     }
 }
 

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -78,7 +78,6 @@ export interface SamLaunchRequestArgs extends AwsSamDebuggerConfiguration {
      *  - provider-specific heuristic (last resort)
      */
     codeRoot: string
-    outFilePath?: string
 
     /** Path to (generated) directory used as a working/staging area for SAM. */
     baseBuildDir?: string

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -64,13 +64,6 @@ const SAM_LOCAL_PORT_CHECK_RETRY_TIMEOUT_MILLIS_DEFAULT: number = 30000
 const MAX_DEBUGGER_RETRIES_DEFAULT: number = 30
 const ATTACH_DEBUGGER_RETRY_DELAY_MILLIS: number = 200
 
-export const makeBuildDir = async (): Promise<string> => {
-    const buildDir = await makeTemporaryToolkitFolder()
-    ExtensionDisposableFiles.getInstance().addFolder(buildDir)
-
-    return pathutil.normalize(buildDir)
-}
-
 export function getRelativeFunctionHandler(params: {
     handlerName: string
     runtime: string
@@ -467,7 +460,7 @@ function messageUserWaitingToAttach(channelLogger: ChannelLogger) {
  * @param config
  */
 export async function makeConfig(config: SamLaunchRequestArgs): Promise<void> {
-    config.baseBuildDir = await makeBuildDir()
+    config.baseBuildDir = await makeTemporaryToolkitFolder()
     config.eventPayloadFile = path.join(config.baseBuildDir!, 'event.json')
     config.envFile = path.join(config.baseBuildDir!, 'env-vars.json')
 

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -454,8 +454,7 @@ function messageUserWaitingToAttach(channelLogger: ChannelLogger) {
  * @param config
  */
 export async function makeConfig(config: SamLaunchRequestArgs): Promise<void> {
-    // TODO this normalize has been here for Windows, but is it needed? It might mess things up, it does some
-    // messing with drive letter etc
+    // TODO is this normalize actually needed for any platform?
     config.baseBuildDir = pathutils.normalize(await makeTemporaryToolkitFolder())
     config.eventPayloadFile = path.join(config.baseBuildDir!, 'event.json')
     config.envFile = path.join(config.baseBuildDir!, 'env-vars.json')

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -11,6 +11,7 @@ import { getTemplate, getTemplateResource } from '../../lambda/local/debugConfig
 import { getFamily, RuntimeFamily } from '../../lambda/models/samLambdaRuntime'
 import { ExtContext } from '../extensions'
 import { makeTemporaryToolkitFolder } from '../filesystemUtilities'
+import * as pathutils from '../../shared/utilities/pathUtils'
 import { getLogger } from '../logger'
 import { SettingsConfiguration } from '../settingsConfiguration'
 import { recordLambdaInvokeLocal, Result, Runtime, recordSamAttachDebugger } from '../telemetry/telemetry'
@@ -241,13 +242,6 @@ export async function invokeLambdaFunction(
             runtime: config.runtime as Runtime,
             debug: !config.noDebug,
         })
-        if (config.outFilePath) {
-            try {
-                await unlink(config.outFilePath)
-            } catch (err) {
-                getLogger().warn(err as Error)
-            }
-        }
     }
 
     if (!config.noDebug) {
@@ -460,7 +454,9 @@ function messageUserWaitingToAttach(channelLogger: ChannelLogger) {
  * @param config
  */
 export async function makeConfig(config: SamLaunchRequestArgs): Promise<void> {
-    config.baseBuildDir = await makeTemporaryToolkitFolder()
+    // TODO this normalize has been here for Windows, but is it needed? It might mess things up, it does some
+    // messing with drive letter etc
+    config.baseBuildDir = pathutils.normalize(await makeTemporaryToolkitFolder())
     config.eventPayloadFile = path.join(config.baseBuildDir!, 'event.json')
     config.envFile = path.join(config.baseBuildDir!, 'env-vars.json')
 

--- a/src/test/eventSchemas/commands/downloadSchemaItemCode.test.ts
+++ b/src/test/eventSchemas/commands/downloadSchemaItemCode.test.ts
@@ -336,7 +336,6 @@ describe('SchemaCodeDownload', () => {
         tempFolder = await makeTemporaryToolkitFolder()
         sandbox = sinon.createSandbox()
         destinationDirectory = vscode.Uri.file(tempFolder)
-        sandbox.stub(extractor, 'getDisposableTempFolder').returns(Promise.resolve(tempFolder))
 
         request = {
             registryName: testRegistryName,
@@ -515,7 +514,6 @@ describe('CodeExtractor', () => {
         beforeEach(async () => {
             sandbox = sinon.createSandbox()
             destinationDirectoryUri = vscode.Uri.file(destinationDirectory)
-            sandbox.stub(codeExtractor, 'getDisposableTempFolder').returns(Promise.resolve(destinationDirectory))
 
             request = {
                 registryName: testRegistryName,

--- a/src/test/lambda/local/util.ts
+++ b/src/test/lambda/local/util.ts
@@ -4,29 +4,8 @@
  */
 
 import { writeFile } from 'fs-extra'
-import * as os from 'os'
-import * as path from 'path'
-import { Uri, WorkspaceFolder } from 'vscode'
+import { EOL } from 'os'
 import { CloudFormation } from '../../../shared/cloudformation/cloudformation'
-import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
-
-export async function createWorkspaceFolder(
-    prefix: string
-): Promise<{
-    workspacePath: string
-    workspaceFolder: WorkspaceFolder
-}> {
-    const workspacePath = await makeTemporaryToolkitFolder(prefix)
-
-    return {
-        workspacePath,
-        workspaceFolder: {
-            uri: Uri.file(workspacePath),
-            name: path.basename(workspacePath),
-            index: 0,
-        },
-    }
-}
 
 export async function saveTemplate(templatePath: string, runtime: string, ...functionNames: string[]) {
     const functionResources = functionNames
@@ -47,7 +26,7 @@ export async function saveTemplate(templatePath: string, runtime: string, ...fun
                         Path: /hello
                         Method: get`
         )
-        .join(os.EOL)
+        .join(EOL)
 
     const templateContent = `AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31

--- a/src/test/shared/codelens/localLambdaRunner.test.ts
+++ b/src/test/shared/codelens/localLambdaRunner.test.ts
@@ -270,17 +270,6 @@ describe('localLambdaRunner', async () => {
         })
     })
 
-    describe('makeBuildDir', () => {
-        it('creates a temp directory', async () => {
-            const dir = await localLambdaRunner.makeBuildDir()
-            assert.ok(dir)
-            assert.strictEqual(await fsUtils.fileExists(dir), true)
-            const fsDir = await readdir(dir)
-            assert.strictEqual(fsDir.length, 0)
-            await del(dir, { force: true })
-        })
-    })
-
     describe('executeSamBuild', () => {
         const failedChildProcess: ChildProcessResult = {
             exitCode: 1,

--- a/src/test/shared/codelens/localLambdaRunner.test.ts
+++ b/src/test/shared/codelens/localLambdaRunner.test.ts
@@ -5,7 +5,6 @@
 
 import * as assert from 'assert'
 import * as del from 'del'
-import { readdir } from 'fs-extra'
 import * as vscode from 'vscode'
 import * as fsUtils from '../../../shared/filesystemUtilities'
 import { SamCliBuildInvocation, SamCliBuildInvocationArguments } from '../../../shared/sam/cli/samCliBuild'


### PR DESCRIPTION
- Delete temporary files when we are done using them instead of at deactivation time. Deactivation does not seem to be reliable in some environments and can cause buildup on long running sessions.
- We still will try to delete at deactivation time as before as well if something is missed

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
