### PR TITLE
Moving workspace folder addition in import Lambda flow

### DIFF
--- a/src/lambda/commands/importLambda.ts
+++ b/src/lambda/commands/importLambda.ts
@@ -76,15 +76,6 @@ async function runImportLambda(functionNode: LambdaFunctionNode, window = Window
         }
     }
 
-    if (
-        workspaceFolders.filter(val => {
-            return selectedUri === val.uri
-        }).length === 0
-    ) {
-        await addFolderToWorkspace({ uri: selectedUri! }, true)
-    }
-    const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(importLocation))!
-
     return await window.withProgress<telemetry.Result>(
         {
             location: vscode.ProgressLocation.Notification,
@@ -101,6 +92,16 @@ async function runImportLambda(functionNode: LambdaFunctionNode, window = Window
             try {
                 await downloadAndUnzipLambda(progress, functionNode, importLocation)
                 await openLambdaFile(lambdaLocation)
+
+                if (
+                    workspaceFolders.filter(val => {
+                        return selectedUri === val.uri
+                    }).length === 0
+                ) {
+                    await addFolderToWorkspace({ uri: selectedUri! }, true)
+                }
+                const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(importLocation))!
+
                 await addLaunchConfigEntry(lambdaLocation, functionNode, workspaceFolder)
 
                 return 'Succeeded'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Lambda Import workflow now adds workspace folders later in the workflow. This does not affect functionality.

## Motivation and Context

Found a weird bug with adding workspace folders to VS Code: if a user has an instance of VS Code open that is open to a folder, but the folder is not part of a workspace, and the user attempts to add a workspace folder via extension command, it appears that the extension host restarts, failing the command mid-flight. This does not happen if nothing is open in VS Code (instead, the whole IDE restarts) or if a workspace is in place (works as intended). This helps to mitigate this issue: the user may see an issue with a launch config being added, but should have their Lambda downloaded and unzipped correctly.

As a side note, a deeper dive here did find some issues with the Lambda pulling, but this should be fixed by https://github.com/aws/aws-toolkit-vscode/pull/1379

## Related Issue(s)

Affected by https://github.com/microsoft/vscode/issues/109991

## Testing

Manual testing: Lambda downloads and unzips reliably and is found in the workspace after the folder is added (extension still restarts though)

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
