### PR TITLE
Added more step numbers

### DIFF
--- a/src/cloudWatchLogs/commands/viewLogStream.ts
+++ b/src/cloudWatchLogs/commands/viewLogStream.ts
@@ -51,6 +51,7 @@ export interface SelectLogStreamWizardContext {
 }
 
 export class DefaultSelectLogStreamWizardContext implements SelectLogStreamWizardContext {
+    private readonly totalSteps = 1
     public constructor(private readonly regionCode: string, private readonly logGroupName: string) {}
 
     public async pickLogStream(): Promise<string | undefined> {
@@ -65,6 +66,8 @@ export class DefaultSelectLogStreamWizardContext implements SelectLogStreamWizar
         const qp = picker.createQuickPick({
             options: {
                 title: localize('aws.cloudWatchLogs.viewLogStream.workflow.prompt', 'Select a log stream'),
+                step: 1,
+                totalSteps: this.totalSteps,
             },
         })
         const populator = new IteratorTransformer(

--- a/src/eventSchemas/wizards/schemaCodeDownloadWizard.ts
+++ b/src/eventSchemas/wizards/schemaCodeDownloadWizard.ts
@@ -42,6 +42,7 @@ export interface SchemaCodeDownloadWizardContext {
 export class DefaultSchemaCodeDownloadWizardContext extends WizardContext implements SchemaCodeDownloadWizardContext {
     public readonly schemaLangs = codeLang.schemaCodeLangs
     private readonly helpButton = createHelpButton(localize('AWS.command.help', 'View Toolkit Documentation'))
+    private readonly totalSteps = 3
     public constructor(private readonly node: SchemaItemNode) {
         super()
         this.node = node
@@ -58,6 +59,8 @@ export class DefaultSchemaCodeDownloadWizardContext extends WizardContext implem
                     'Select a code binding language'
                 ),
                 value: currLanguage ? currLanguage : '',
+                step: 2,
+                totalSteps: this.totalSteps,
             },
             buttons: [this.helpButton, vscode.QuickInputButtons.Back],
             items: this.schemaLangs.toArray().map(language => ({
@@ -95,6 +98,8 @@ export class DefaultSchemaCodeDownloadWizardContext extends WizardContext implem
                     this.node.schemaName
                 ),
                 value: currSchemaVersion ? currSchemaVersion : '',
+                step: 1,
+                totalSteps: this.totalSteps,
             },
             buttons: [this.helpButton, vscode.QuickInputButtons.Back],
             items: versions!.map(schemaVersion => ({
@@ -135,6 +140,8 @@ export class DefaultSchemaCodeDownloadWizardContext extends WizardContext implem
                     'Select a workspace folder to download code bindings'
                 ),
             },
+            step: 3,
+            totalSteps: this.totalSteps,
         })
     }
 }

--- a/src/lambda/commands/importLambda.ts
+++ b/src/lambda/commands/importLambda.ts
@@ -25,9 +25,6 @@ import { Window } from '../../shared/vscode/window'
 import { promptUserForLocation, WizardContext } from '../../shared/wizards/multiStepWizard'
 import { getLambdaDetails } from '../utils'
 
-// TODO: Move off of deprecated `request` to `got`?
-// const pipeline = promisify(Stream.pipeline)
-
 export async function importLambdaCommand(functionNode: LambdaFunctionNode) {
     const result = await runImportLambda(functionNode)
 
@@ -47,7 +44,7 @@ async function runImportLambda(functionNode: LambdaFunctionNode, window = Window
         )
         return 'Cancelled'
     }
-    const selectedUri = await promptUserForLocation(new WizardContext())
+    const selectedUri = await promptUserForLocation(new WizardContext(), { step: 1, totalSteps: 1 })
     if (!selectedUri) {
         return 'Cancelled'
     }

--- a/src/lambda/commands/uploadLambda.ts
+++ b/src/lambda/commands/uploadLambda.ts
@@ -59,10 +59,22 @@ async function selectUploadTypeAndRunUpload(functionNode: LambdaFunctionNode): P
             canPickMany: false,
             ignoreFocusOut: true,
             title: localize('AWS.lambda.upload.title', 'Select Upload Type'),
+            step: 1,
+            totalSteps: 1,
         },
         items: [uploadZipItem, uploadDirItem],
+        buttons: [vscode.QuickInputButtons.Back],
     })
-    const response = verifySinglePickerOutput(await promptUser({ picker: picker }))
+    const response = verifySinglePickerOutput(
+        await promptUser({
+            picker: picker,
+            onDidTriggerButton: (button, resolve, reject) => {
+                if (button === vscode.QuickInputButtons.Back) {
+                    resolve(undefined)
+                }
+            },
+        })
+    )
 
     if (!response) {
         return 'Cancelled'
@@ -87,7 +99,7 @@ async function runUploadDirectory(
     const parentDir = await selectFolderForUpload()
 
     if (!parentDir) {
-        return 'Cancelled'
+        return await selectUploadTypeAndRunUpload(functionNode)
     }
 
     const zipDirItem: vscode.QuickPickItem = {
@@ -111,13 +123,25 @@ async function runUploadDirectory(
             canPickMany: false,
             ignoreFocusOut: true,
             title: localize('AWS.lambda.upload.buildDirectory.title', 'Build directory?'),
+            step: 2,
+            totalSteps: 2,
         },
         items: [zipDirItem, buildDirItem],
+        buttons: [vscode.QuickInputButtons.Back],
     })
-    const response = verifySinglePickerOutput(await promptUser({ picker: picker }))
+    const response = verifySinglePickerOutput(
+        await promptUser({
+            picker: picker,
+            onDidTriggerButton: (button, resolve, reject) => {
+                if (button === vscode.QuickInputButtons.Back) {
+                    resolve(undefined)
+                }
+            },
+        })
+    )
 
     if (!response) {
-        return 'Cancelled'
+        return await selectUploadTypeAndRunUpload(functionNode)
     }
 
     if (!(await confirmLambdaDeployment(functionNode))) {

--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -141,6 +141,8 @@ export async function pickAddSamDebugConfiguration(
                 'AWS.pickDebugConfig.prompt',
                 'Create a Debug Configuration from a CloudFormation Template'
             ),
+            step: 1,
+            totalSteps: 1,
         },
         items: [
             ...templateItems,
@@ -161,7 +163,7 @@ export async function pickAddSamDebugConfiguration(
         return undefined
     }
     if (val.label === noTemplate) {
-        await addSamDebugConfiguration(codeConfig, CODE_TARGET_TYPE)
+        await addSamDebugConfiguration(codeConfig, CODE_TARGET_TYPE, { step: 2, totalSteps: 2 })
     } else {
         const templateItem = templateItemsMap.get(val.label)
         if (!templateItem) {

--- a/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
@@ -39,7 +39,8 @@ export interface AddSamDebugConfigurationInput {
  */
 export async function addSamDebugConfiguration(
     { resourceName, rootUri, runtimeFamily }: AddSamDebugConfigurationInput,
-    type: typeof CODE_TARGET_TYPE | typeof TEMPLATE_TARGET_TYPE | typeof API_TARGET_TYPE
+    type: typeof CODE_TARGET_TYPE | typeof TEMPLATE_TARGET_TYPE | typeof API_TARGET_TYPE,
+    step?: { step: number; totalSteps: number }
 ): Promise<void> {
     // tslint:disable-next-line: no-floating-promises
     emitCommandTelemetry()
@@ -100,6 +101,8 @@ export async function addSamDebugConfiguration(
     } else if (type === CODE_TARGET_TYPE) {
         const quickPick = createRuntimeQuickPick({
             runtimeFamily,
+            step: step?.step,
+            totalSteps: step?.totalSteps,
         })
 
         const choices = await picker.promptUser({

--- a/src/stepFunctions/wizards/publishStateMachineWizard.ts
+++ b/src/stepFunctions/wizards/publishStateMachineWizard.ts
@@ -81,6 +81,9 @@ export class DefaultPublishStateMachineWizardContext extends WizardContext imple
     private readonly iamClient: IamClient
     private readonly stepFunctionsClient: StepFunctionsClient
 
+    private readonly totalSteps = 2
+    private additionalSteps: number = 0
+
     public constructor(private readonly defaultRegion: string) {
         super()
         this.stepFunctionsClient = ext.toolkitClientBuilder.createStepFunctionsClient(this.defaultRegion)
@@ -90,6 +93,7 @@ export class DefaultPublishStateMachineWizardContext extends WizardContext imple
     public async promptUserForPublishAction(
         currPublishAction: PublishStateMachineAction | undefined
     ): Promise<PublishStateMachineAction | undefined> {
+        this.additionalSteps = 0
         const publishItems: PublishActionQuickPickItem[] = [
             {
                 label: localize('AWS.stepFunctions.publishWizard.publishAction.quickCreate.label', 'Quick Create'),
@@ -123,6 +127,8 @@ export class DefaultPublishStateMachineWizardContext extends WizardContext imple
                     'Publish to AWS Step Functions ({0})',
                     this.defaultRegion
                 ),
+                step: 1,
+                totalSteps: this.totalSteps,
             },
             buttons: [this.helpButton, vscode.QuickInputButtons.Back],
             items: publishItems,
@@ -148,6 +154,8 @@ export class DefaultPublishStateMachineWizardContext extends WizardContext imple
             options: {
                 title: localize('AWS.stepFunctions.publishWizard.stateMachineName.title', 'Name your state machine'),
                 ignoreFocusOut: true,
+                step: 3,
+                totalSteps: this.totalSteps + this.additionalSteps,
             },
             buttons: [this.helpButton, vscode.QuickInputButtons.Back],
         })
@@ -181,6 +189,7 @@ export class DefaultPublishStateMachineWizardContext extends WizardContext imple
     }
 
     public async promptUserForIamRole(currRoleArn?: string): Promise<string | undefined> {
+        this.additionalSteps = 1
         let roles: AwsResourceQuickPickItem[]
         if (!this.iamRoles || this.iamRoles.length === 0) {
             roles = [
@@ -215,6 +224,8 @@ export class DefaultPublishStateMachineWizardContext extends WizardContext imple
                     this.defaultRegion
                 ),
                 value: currRoleArn ? currRoleArn : '',
+                step: 2,
+                totalSteps: this.totalSteps + this.additionalSteps,
             },
             buttons: [this.helpButton, vscode.QuickInputButtons.Back],
             items: roles,
@@ -275,6 +286,8 @@ export class DefaultPublishStateMachineWizardContext extends WizardContext imple
                     'Select state machine to update ({0})',
                     this.defaultRegion
                 ),
+                step: 2,
+                totalSteps: this.totalSteps,
             },
             buttons: [this.helpButton, vscode.QuickInputButtons.Back],
             items: stateMachines,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
More step numbers, added to the following workflows:
View Log Stream
Import Lambda
Upload Lambda
Create Launch Config

Also added back buttons to the Upload Lambda flow. Should we migrate this to a wizard as well?

TODO:
* Revert changes to 1-step workflows (including view log stream/import lambda)? Are they necessary?
* OR add steps to all 1-step workflows? Change spurred by current issues with adding to the S3 workflows, since those use `showInputBox` rather than `createInputBox`; `showInputBox` has an easier (and much more mockable) workflow but does not allow step numbers.

Whatever we do, we should try and make it uniform.

## Motivation and Context

UX review

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
