### PR TITLE
Fix showing templates from .aws-sam in sam deploy 

### DIFF
--- a/.changes/next-release/Bug Fix-1b137e40-7d80-480d-95a4-318dfbc9d2f3.json
+++ b/.changes/next-release/Bug Fix-1b137e40-7d80-480d-95a4-318dfbc9d2f3.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix showing templates from .aws-sam in Sam Deploy (#1380)"
+}

--- a/src/integrationTest/cloudformation/templateRegistryManager.test.ts
+++ b/src/integrationTest/cloudformation/templateRegistryManager.test.ts
@@ -59,7 +59,7 @@ describe('CloudFormation Template Registry Manager', async () => {
         await registryHasTargetNumberOfFiles(registry, 2)
     })
 
-    it('Ignores templates matching banned patterns', async () => {
+    it('Ignores templates matching excluded patterns', async () => {
         await manager.addTemplateGlob('**/test.{yaml,yml}')
         await manager.addExcludedPattern(/.*nested.*/)
 

--- a/src/integrationTest/cloudformation/templateRegistryManager.test.ts
+++ b/src/integrationTest/cloudformation/templateRegistryManager.test.ts
@@ -59,6 +59,16 @@ describe('CloudFormation Template Registry Manager', async () => {
         await registryHasTargetNumberOfFiles(registry, 2)
     })
 
+    it('Ignores templates matching banned patterns', async () => {
+        await manager.addTemplateGlob('**/test.{yaml,yml}')
+        await manager.addBannedPattern(/.*nested.*/)
+
+        await strToYamlFile(makeSampleSamTemplateYaml(false), path.join(testDir, 'test.yml'))
+        await strToYamlFile(makeSampleSamTemplateYaml(true), path.join(testDirNested, 'test.yaml'))
+
+        await registryHasTargetNumberOfFiles(registry, 1)
+    })
+
     it('can handle changed files', async () => {
         const filepath = path.join(testDir, 'changeMe.yml')
         await strToYamlFile(makeSampleSamTemplateYaml(false), filepath)

--- a/src/integrationTest/cloudformation/templateRegistryManager.test.ts
+++ b/src/integrationTest/cloudformation/templateRegistryManager.test.ts
@@ -61,7 +61,7 @@ describe('CloudFormation Template Registry Manager', async () => {
 
     it('Ignores templates matching banned patterns', async () => {
         await manager.addTemplateGlob('**/test.{yaml,yml}')
-        await manager.addBannedPattern(/.*nested.*/)
+        await manager.addExcludedPattern(/.*nested.*/)
 
         await strToYamlFile(makeSampleSamTemplateYaml(false), path.join(testDir, 'test.yml'))
         await strToYamlFile(makeSampleSamTemplateYaml(true), path.join(testDirNested, 'test.yaml'))

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -18,7 +18,7 @@ export const TEMPLATE_FILE_GLOB_PATTERN = '**/template.{yaml,yml}'
  * a '/' or '\' followed by any number of characters or end of a string (so it
  * matches both /.aws-sam or /.aws-sam/<any number of characters>)
  */
-export const TEMPLATE_FILE_BANNED_PATTERN = /.*[/\\]\.aws-sam([/\\].*|$)/
+export const TEMPLATE_FILE_EXCLUDE_PATTERN = /.*[/\\]\.aws-sam([/\\].*|$)/
 
 /**
  * Creates a CloudFormationTemplateRegistry which retains the state of CloudFormation templates in a workspace.
@@ -30,7 +30,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
     try {
         const registry = CloudFormationTemplateRegistry.getRegistry()
         const manager = new CloudFormationTemplateRegistryManager(registry)
-        await manager.addBannedPattern(TEMPLATE_FILE_BANNED_PATTERN)
+        await manager.addExcludedPattern(TEMPLATE_FILE_EXCLUDE_PATTERN)
         await manager.addTemplateGlob(TEMPLATE_FILE_GLOB_PATTERN)
         extensionContext.subscriptions.push(manager)
     } catch (e) {

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -13,6 +13,14 @@ import { CloudFormationTemplateRegistryManager } from './templateRegistryManager
 export const TEMPLATE_FILE_GLOB_PATTERN = '**/template.{yaml,yml}'
 
 /**
+ * Match any file path that contains a .aws-sam folder. The way this works is:
+ * match anything that starts  with a '/' or '\', then '.aws-sam', then either
+ * a '/' or '\' followed by any number of characters or end of a string (so it
+ * matches both /.aws-sam or /.aws-sam/<any number of characters>)
+ */
+export const TEMPLATE_FILE_BANNED_PATTERN = /.*[/\\]\.aws-sam([/\\].*|$)/
+
+/**
  * Creates a CloudFormationTemplateRegistry which retains the state of CloudFormation templates in a workspace.
  * This also assigns a FileSystemWatcher which will update the registry on any change to tracked templates.
  *
@@ -22,6 +30,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
     try {
         const registry = CloudFormationTemplateRegistry.getRegistry()
         const manager = new CloudFormationTemplateRegistryManager(registry)
+        await manager.addBannedPattern(TEMPLATE_FILE_BANNED_PATTERN)
         await manager.addTemplateGlob(TEMPLATE_FILE_GLOB_PATTERN)
         extensionContext.subscriptions.push(manager)
     } catch (e) {

--- a/src/shared/cloudformation/templateRegistry.ts
+++ b/src/shared/cloudformation/templateRegistry.ts
@@ -32,22 +32,6 @@ export class CloudFormationTemplateRegistry {
     }
 
     /**
-     * Adds multiple templates to the registry.
-     * Invalid templates will have a message logged but otherwise will not report a failure.
-     * @param templateUris Array of vscode.Uris containing templates to remove
-     */
-    public async addTemplatesToRegistry(templateUris: vscode.Uri[]) {
-        for (const templateUri of templateUris) {
-            try {
-                await this.addTemplateToRegistry(templateUri)
-            } catch (e) {
-                const err = e as Error
-                getLogger().verbose(`Template ${templateUri} is malformed: ${err.message}`)
-            }
-        }
-    }
-
-    /**
      * Adds template to registry. Wipes any existing template in its place with newly-parsed copy of the data.
      * @param templateUri vscode.Uri containing the template to load in
      */
@@ -61,7 +45,7 @@ export class CloudFormationTemplateRegistry {
             if (!quiet) {
                 throw e
             }
-            getLogger().verbose(`CloudFormationTemplateRegistry: invalid CFN template: ${e}`)
+            getLogger().verbose(`Template ${templateUri} is malformed: ${e}`)
         }
     }
 

--- a/src/shared/cloudformation/templateRegistryManager.ts
+++ b/src/shared/cloudformation/templateRegistryManager.ts
@@ -61,13 +61,13 @@ export class CloudFormationTemplateRegistryManager implements vscode.Disposable 
         }
     }
 
-    private async addTemplateToRegistry(templateUri: vscode.Uri): Promise<void> {
+    private async addTemplateToRegistry(templateUri: vscode.Uri, quiet?: boolean): Promise<void> {
         const banned = this.bannedFilePatterns.find(pattern => templateUri.fsPath.match(pattern))
         if (banned) {
             getLogger().verbose(`Manager did not add template ${templateUri.fsPath} matching banned pattern ${banned}`)
             return
         }
-        await this.registry.addTemplateToRegistry(templateUri)
+        await this.registry.addTemplateToRegistry(templateUri, quiet)
     }
 
     /**
@@ -79,7 +79,7 @@ export class CloudFormationTemplateRegistryManager implements vscode.Disposable 
         for (const glob of this.globs) {
             const templateUris = await vscode.workspace.findFiles(glob)
             for (const template of templateUris) {
-                await this.addTemplateToRegistry(template)
+                await this.addTemplateToRegistry(template, true)
             }
         }
     }
@@ -105,11 +105,11 @@ export class CloudFormationTemplateRegistryManager implements vscode.Disposable 
             watcher,
             watcher.onDidChange(async uri => {
                 getLogger().verbose(`Manager detected a change to template file: ${uri.fsPath}`)
-                this.addTemplateToRegistry(uri)
+                await this.addTemplateToRegistry(uri)
             }),
             watcher.onDidCreate(async uri => {
                 getLogger().verbose(`Manager detected a new template file: ${uri.fsPath}`)
-                this.addTemplateToRegistry(uri)
+                await this.addTemplateToRegistry(uri)
             }),
             watcher.onDidDelete(async uri => {
                 getLogger().verbose(`Manager detected a deleted template file: ${uri.fsPath}`)

--- a/src/shared/cloudformation/templateRegistryManager.ts
+++ b/src/shared/cloudformation/templateRegistryManager.ts
@@ -11,7 +11,7 @@ export class CloudFormationTemplateRegistryManager implements vscode.Disposable 
     private readonly disposables: vscode.Disposable[] = []
     private _isDisposed: boolean = false
     private readonly globs: vscode.GlobPattern[] = []
-    private readonly bannedFilePatterns: RegExp[] = []
+    private readonly excludedFilePatterns: RegExp[] = []
 
     public constructor(private readonly registry: CloudFormationTemplateRegistry) {
         this.disposables.push(
@@ -42,11 +42,11 @@ export class CloudFormationTemplateRegistryManager implements vscode.Disposable 
     /**
      * Adds a regex pattern to ignore paths containing the pattern
      */
-    public async addBannedPattern(pattern: RegExp): Promise<void> {
+    public async addExcludedPattern(pattern: RegExp): Promise<void> {
         if (this._isDisposed) {
             throw new Error('Manager has already been disposed!')
         }
-        this.bannedFilePatterns.push(pattern)
+        this.excludedFilePatterns.push(pattern)
 
         await this.rebuildRegistry()
     }
@@ -62,7 +62,7 @@ export class CloudFormationTemplateRegistryManager implements vscode.Disposable 
     }
 
     private async addTemplateToRegistry(templateUri: vscode.Uri, quiet?: boolean): Promise<void> {
-        const banned = this.bannedFilePatterns.find(pattern => templateUri.fsPath.match(pattern))
+        const banned = this.excludedFilePatterns.find(pattern => templateUri.fsPath.match(pattern))
         if (banned) {
             getLogger().verbose(`Manager did not add template ${templateUri.fsPath} matching banned pattern ${banned}`)
             return

--- a/src/shared/cloudformation/templateRegistryManager.ts
+++ b/src/shared/cloudformation/templateRegistryManager.ts
@@ -71,7 +71,7 @@ export class CloudFormationTemplateRegistryManager implements vscode.Disposable 
     }
 
     /**
-     * Clears and rebuilds registry using existing glob
+     * Rebuilds registry using current glob and exclusion patterns.
      * All functionality is currently internal to class, but can be made public if we want a manual "refresh" button
      */
     private async rebuildRegistry(): Promise<void> {

--- a/src/shared/cloudformation/templateRegistryManager.ts
+++ b/src/shared/cloudformation/templateRegistryManager.ts
@@ -62,9 +62,9 @@ export class CloudFormationTemplateRegistryManager implements vscode.Disposable 
     }
 
     private async addTemplateToRegistry(templateUri: vscode.Uri, quiet?: boolean): Promise<void> {
-        const banned = this.excludedFilePatterns.find(pattern => templateUri.fsPath.match(pattern))
-        if (banned) {
-            getLogger().verbose(`Manager did not add template ${templateUri.fsPath} matching banned pattern ${banned}`)
+        const excluded = this.excludedFilePatterns.find(pattern => templateUri.fsPath.match(pattern))
+        if (excluded) {
+            getLogger().verbose(`Manager did not add template ${templateUri.fsPath} matching excluded pattern ${excluded}`)
             return
         }
         await this.registry.addTemplateToRegistry(templateUri, quiet)

--- a/src/test/shared/cloudformation/templateRegistry.test.ts
+++ b/src/test/shared/cloudformation/templateRegistry.test.ts
@@ -60,38 +60,6 @@ describe('CloudFormation Template Registry', async () => {
             })
         })
 
-        describe('addTemplatesToRegistry', async () => {
-            it("adds data from multiple templates to the registry and can receive the templates' data", async () => {
-                const filename = vscode.Uri.file(path.join(tempFolder, 'template.yaml'))
-                await strToYamlFile(goodYaml1, filename.fsPath)
-                const filename2 = vscode.Uri.file(path.join(tempFolder, 'template2.yaml'))
-                await strToYamlFile(goodYaml2, filename2.fsPath)
-                await testRegistry.addTemplatesToRegistry([filename, filename2])
-
-                assert.strictEqual(testRegistry.registeredTemplates.length, 2)
-
-                const data = testRegistry.getRegisteredTemplate(filename.fsPath)
-                const data2 = testRegistry.getRegisteredTemplate(filename2.fsPath)
-
-                assertValidTestTemplate(data, filename.fsPath)
-                assertValidTestTemplate(data2, filename2.fsPath)
-            })
-
-            it('swallows errors if a template is not parseable while still parsing valid YAML', async () => {
-                const filename = vscode.Uri.file(path.join(tempFolder, 'template.yaml'))
-                await strToYamlFile(goodYaml1, filename.fsPath)
-                const badFilename = vscode.Uri.file(path.join(tempFolder, 'template2.yaml'))
-                await strToYamlFile(badYaml, badFilename.fsPath)
-                await testRegistry.addTemplatesToRegistry([filename, badFilename])
-
-                assert.strictEqual(testRegistry.registeredTemplates.length, 1)
-
-                const data = testRegistry.getRegisteredTemplate(filename.fsPath)
-
-                assertValidTestTemplate(data, filename.fsPath)
-            })
-        })
-
         // other get cases are tested in the add section
         describe('registeredTemplates', async () => {
             it('returns an empty array if the registry has no registered templates', () => {

--- a/src/test/shared/cloudformation/templateRegistry.test.ts
+++ b/src/test/shared/cloudformation/templateRegistry.test.ts
@@ -22,7 +22,6 @@ import { CloudFormation } from '../../../shared/cloudformation/cloudformation'
 
 describe('CloudFormation Template Registry', async () => {
     const goodYaml1 = makeSampleSamTemplateYaml(false)
-    const goodYaml2 = makeSampleSamTemplateYaml(true)
 
     describe('CloudFormationTemplateRegistry', async () => {
         let testRegistry: CloudFormationTemplateRegistry


### PR DESCRIPTION
- Add banned file patterns, we will log and not add it to the registry
- Code cleanup `addTemplatesToRegistry` was redundant, the base function already had an unused quiet option. Use it in the one place `addTemplatesToRegistry` was used
 
## Related issues
#1380

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
