### PR TITLE
templateRegistry.ts: fix getResourcesForHandler() on empty input

### DIFF
--- a/src/shared/cloudformation/templateRegistry.ts
+++ b/src/shared/cloudformation/templateRegistry.ts
@@ -140,16 +140,18 @@ export function getResourcesForHandler(
     unfilteredTemplates: TemplateDatum[] = CloudFormationTemplateRegistry.getRegistry().registeredTemplates
 ): { templateDatum: TemplateDatum; name: string; resourceData: CloudFormation.Resource }[] {
     // TODO: Array.flat and Array.flatMap not introduced until >= Node11.x -- migrate when VS Code updates Node ver
-    return unfilteredTemplates
-        .map(templateDatum => {
-            return getResourcesForHandlerFromTemplateDatum(filepath, handler, templateDatum).map(resource => {
-                return {
-                    ...resource,
-                    templateDatum,
-                }
-            })
+    const o = unfilteredTemplates.map(templateDatum => {
+        return getResourcesForHandlerFromTemplateDatum(filepath, handler, templateDatum).map(resource => {
+            return {
+                ...resource,
+                templateDatum,
+            }
         })
-        .reduce((acc, cur) => [...acc, ...cur])
+    })
+    if (o.length === 0) {
+        return []
+    }
+    return o.reduce((acc, cur) => [...acc, ...cur])
 }
 
 /**

--- a/src/test/shared/cloudformation/templateRegistry.test.ts
+++ b/src/test/shared/cloudformation/templateRegistry.test.ts
@@ -221,6 +221,14 @@ describe('CloudFormation Template Registry', async () => {
     }
 
     describe('getResourcesForHandler', () => {
+        it('handles empty input', () => {
+            // Empty `unfilteredTemplates` input:
+            assert.deepStrictEqual(
+                getResourcesForHandler(path.join(rootPath, nestedPath, 'index.js'), 'handler', []),
+                []
+            )
+        })
+
         it('returns an array containing resources that contain references to the handler in question', () => {
             const val = getResourcesForHandler(path.join(rootPath, nestedPath, 'index.js'), 'handler', [
                 nonParentTemplate,


### PR DESCRIPTION
fix "TypeError: Reduce of empty array with no initial value"


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
