### PR TITLE
logger: introduce logLevelEnabled(), setLogLevel()

### DIFF
--- a/src/integrationTest/globalSetup.test.ts
+++ b/src/integrationTest/globalSetup.test.ts
@@ -9,7 +9,8 @@
 import * as assert from 'assert'
 import { VSCODE_EXTENSION_ID } from '../shared/extensions'
 import { activateExtension } from './integrationTestsUtilities'
-import { setMaxLogging } from '../shared/logger/logger'
+import { getLogger } from '../shared/logger'
+import { WinstonToolkitLogger } from '../shared/logger/winstonToolkitLogger'
 
 // ASSUMPTION: Tests are not run concurrently
 
@@ -37,7 +38,7 @@ export function setTestTimeout(testName: string | undefined, ms: number) {
         throw Error(`timeout set by previous test was not cleared: "${timeout.name}"`)
     }
     timeout.name = testName
-    timeout.id = setTimeout(function() {
+    timeout.id = setTimeout(function () {
         const name = timeout.name
         clearTestTimeout()
         assert.fail(`Exceeded timeout of ${(ms / 1000).toFixed(1)} seconds: "${name}"`)
@@ -49,15 +50,19 @@ before(async () => {
     console.log('globalSetup: before()')
     // Needed for getLogger().
     await activateExtension(VSCODE_EXTENSION_ID.awstoolkit)
+
     // Log as much as possible, useful for debugging integration tests.
-    setMaxLogging()
+    getLogger().setLogLevel('debug')
+    if (getLogger() instanceof WinstonToolkitLogger) {
+        ;(getLogger() as WinstonToolkitLogger).logToConsole()
+    }
 })
 // After all tests end, once only:
 after(async () => {
     console.log('globalSetup: after()')
 })
 
-afterEach(function() {
+afterEach(function () {
     clearTestTimeout()
 })
 

--- a/src/shared/logger/logger.ts
+++ b/src/shared/logger/logger.ts
@@ -18,9 +18,38 @@ export interface Logger {
     warn(error: Error): void
     error(message: string, ...meta: any[]): void
     error(error: Error): void
+    /** Returns true if the given log level is being logged.  */
+    logLevelEnabled(logLevel: LogLevel): boolean
 }
 
-export type LogLevel = keyof Logger
+/**
+ * Log levels ordered for comparison.
+ *
+ * See https://github.com/winstonjs/winston#logging-levels :
+ * > RFC5424: severity of levels is numerically ascending from most important
+ * > to least important.
+ */
+const logLevels = new Map<LogLevel, number>([
+    ['error', 1],
+    ['warn', 2],
+    ['info', 3],
+    ['verbose', 4],
+    ['debug', 5],
+])
+
+export type LogLevel = 'error' | 'warn' | 'info' | 'verbose' | 'debug'
+
+/**
+ * Compares log levels.
+ *
+ * @returns
+ * - Zero if the log levels are equal
+ * - Negative if `l1` is less than `l2`
+ * - Positive if `l1` is greater than `l2`
+ */
+export function compareLogLevel(l1: LogLevel, l2: LogLevel): number {
+    return logLevels.get(l1)! - logLevels.get(l2)!
+}
 
 /**
  * Gets the logger if it has been initialized

--- a/src/shared/logger/logger.ts
+++ b/src/shared/logger/logger.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { WinstonToolkitLogger } from './winstonToolkitLogger'
-
 let toolkitLogger: Logger | undefined
 
 export interface Logger {
@@ -18,6 +16,7 @@ export interface Logger {
     warn(error: Error): void
     error(message: string, ...meta: any[]): void
     error(error: Error): void
+    setLogLevel(logLevel: LogLevel): void
     /** Returns true if the given log level is being logged.  */
     logLevelEnabled(logLevel: LogLevel): boolean
 }
@@ -71,14 +70,4 @@ export function getLogger(): Logger {
  */
 export function setLogger(logger: Logger | undefined) {
     toolkitLogger = logger
-}
-
-export function setMaxLogging() {
-    if (getLogger() instanceof WinstonToolkitLogger) {
-        const logger = getLogger() as WinstonToolkitLogger
-        logger.setLogLevel('debug')
-        logger.logToConsole()
-    } else {
-        throw Error('getLogger() is not a WinstonToolkitLogger')
-    }
 }

--- a/src/shared/logger/winstonToolkitLogger.ts
+++ b/src/shared/logger/winstonToolkitLogger.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode'
 import * as winston from 'winston'
 import { ConsoleLogTransport } from './consoleLogTransport'
-import { Logger, LogLevel } from './logger'
+import { Logger, LogLevel, compareLogLevel } from './logger'
 import { OutputChannelTransport } from './outputChannelTransport'
 import { isError } from 'util'
 
@@ -35,6 +35,11 @@ export class WinstonToolkitLogger implements Logger, vscode.Disposable {
         this.logger.log(this.logger.level, `Setting log level to: ${logLevel}`)
         this.logger.level = logLevel
         this.logger.log(this.logger.level, `Log level is now: ${this.logger.level}`)
+    }
+
+    public logLevelEnabled(logLevel: LogLevel): boolean {
+        const currentLevel = this.logger.level as LogLevel
+        return compareLogLevel(currentLevel, logLevel) >= 0
     }
 
     public logToFile(logPath: string): void {

--- a/src/test/shared/logger/winstonToolkitLogger.test.ts
+++ b/src/test/shared/logger/winstonToolkitLogger.test.ts
@@ -24,6 +24,29 @@ describe('WinstonToolkitLogger', () => {
         }
     })
 
+    it('logLevelEnabled()', () => {
+        const logger = new WinstonToolkitLogger('info')
+        assert.strictEqual(true, logger.logLevelEnabled('error'))
+        assert.strictEqual(true, logger.logLevelEnabled('warn'))
+        assert.strictEqual(true, logger.logLevelEnabled('info'))
+        assert.strictEqual(false, logger.logLevelEnabled('verbose'))
+        assert.strictEqual(false, logger.logLevelEnabled('debug'))
+
+        logger.setLogLevel('error')
+        assert.strictEqual(true, logger.logLevelEnabled('error'))
+        assert.strictEqual(false, logger.logLevelEnabled('warn'))
+        assert.strictEqual(false, logger.logLevelEnabled('info'))
+        assert.strictEqual(false, logger.logLevelEnabled('verbose'))
+        assert.strictEqual(false, logger.logLevelEnabled('debug'))
+
+        logger.setLogLevel('debug')
+        assert.strictEqual(true, logger.logLevelEnabled('error'))
+        assert.strictEqual(true, logger.logLevelEnabled('warn'))
+        assert.strictEqual(true, logger.logLevelEnabled('info'))
+        assert.strictEqual(true, logger.logLevelEnabled('verbose'))
+        assert.strictEqual(true, logger.logLevelEnabled('debug'))
+    })
+
     it('creates an object', () => {
         assert.notStrictEqual(new WinstonToolkitLogger('info'), undefined)
     })

--- a/src/test/testLogger.ts
+++ b/src/test/testLogger.ts
@@ -52,6 +52,10 @@ export class TestLogger implements Logger {
         })
     }
 
+    public setLogLevel(logLevel: LogLevel) {
+        this.logLevel = logLevel
+    }
+
     public logLevelEnabled(logLevel: LogLevel): boolean {
         const currentLevel = this.logLevel as LogLevel
         return compareLogLevel(currentLevel, logLevel) >= 0

--- a/src/test/testLogger.ts
+++ b/src/test/testLogger.ts
@@ -4,6 +4,7 @@
  */
 
 import { Loggable, Logger, LogLevel } from '../shared/logger'
+import { compareLogLevel } from '../shared/logger/logger'
 
 /**
  * In-memory Logger implementation suitable for use by tests.
@@ -13,6 +14,8 @@ export class TestLogger implements Logger {
         logLevel: LogLevel
         entry: Loggable
     }[] = []
+
+    public constructor(private logLevel: LogLevel = 'debug') {}
 
     public debug(...message: Loggable[]): void {
         this.addLoggedEntries('debug', message)
@@ -47,5 +50,10 @@ export class TestLogger implements Logger {
                 entry,
             })
         })
+    }
+
+    public logLevelEnabled(logLevel: LogLevel): boolean {
+        const currentLevel = this.logLevel as LogLevel
+        return compareLogLevel(currentLevel, logLevel) >= 0
     }
 }


### PR DESCRIPTION
- `logger: introduce logLevelEnabled()`
  - Sometimes it is useful to enable certain behaviors based on the current log-level.
  - Examples:
    - When invoking `sam` CLI, if the current log-level is 'debug' then it
      could make sense to use `sam --debug …`
    - Other third-party components like debuggers have verbosity levels that
      are useful to include in the Toolkit's own logs. (Else the debugger
     logs get lost or must be configured some other way.)
- `logger: introduce setLogLevel()`
  - Avoids circular import detected by webpack:
     ```
    ERROR in Circular dependency detected:
    src/shared/logger/logger.ts -> src/shared/logger/winstonToolkitLogger.ts -> src/shared/logger/logger.ts
    ERROR in Circular dependency detected:
    src/shared/logger/winstonToolkitLogger.ts -> src/shared/logger/logger.ts -> src/shared/logger/winstonToolkitLogger.ts
     ```

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
