### PR TITLE
Emit 'sam build' output to the user output channel

### DIFF
--- a/src/shared/sam/cli/samCliBuild.ts
+++ b/src/shared/sam/cli/samCliBuild.ts
@@ -106,13 +106,11 @@ export class SamCliBuildInvocation {
             ...this.args.environmentVariables,
         }
 
-        const childProcessResult = await this.args.invoker.invoke(
-            {
-                spawnOptions: { env },
-                arguments: invokeArgs,
-            },
-            getChannelLogger(ext.outputChannel)
-        )
+        const childProcessResult = await this.args.invoker.invoke({
+            spawnOptions: { env },
+            arguments: invokeArgs,
+            channelLogger: getChannelLogger(ext.outputChannel),
+        })
 
         logAndThrowIfUnexpectedExitCode(childProcessResult, 0)
 

--- a/src/shared/sam/cli/samCliBuild.ts
+++ b/src/shared/sam/cli/samCliBuild.ts
@@ -8,6 +8,8 @@ import { getLogger, Logger } from '../../logger'
 import { logAndThrowIfUnexpectedExitCode, SamCliProcessInvoker } from './samCliInvokerUtils'
 import { DefaultSamCliProcessInvoker } from './samCliInvoker'
 import { pushIf } from '../../utilities/collectionUtils'
+import { ext } from '../../extensionGlobals'
+import { getChannelLogger } from '../../utilities/vsCodeUtils'
 
 export interface SamCliBuildInvocationArguments {
     /**
@@ -104,10 +106,13 @@ export class SamCliBuildInvocation {
             ...this.args.environmentVariables,
         }
 
-        const childProcessResult = await this.args.invoker.invoke({
-            spawnOptions: { env },
-            arguments: invokeArgs,
-        })
+        const childProcessResult = await this.args.invoker.invoke(
+            {
+                spawnOptions: { env },
+                arguments: invokeArgs,
+            },
+            getChannelLogger(ext.outputChannel)
+        )
 
         logAndThrowIfUnexpectedExitCode(childProcessResult, 0)
 

--- a/src/shared/sam/cli/samCliInvoker.ts
+++ b/src/shared/sam/cli/samCliInvoker.ts
@@ -14,7 +14,6 @@ import {
     SamCliProcessInvoker,
 } from './samCliInvokerUtils'
 import { DefaultSamCliLocationProvider } from './samCliLocator'
-import { ChannelLogger } from '../../utilities/vsCodeUtils'
 
 export interface SamCliProcessInvokerContext {
     cliConfig: SamCliConfiguration
@@ -40,10 +39,7 @@ export function resolveSamCliProcessInvokerContext(
 export class DefaultSamCliProcessInvoker implements SamCliProcessInvoker {
     public constructor(private readonly context: SamCliProcessInvokerContext = resolveSamCliProcessInvokerContext()) {}
 
-    public async invoke(
-        options?: SamCliProcessInvokeOptions,
-        channelLogger?: ChannelLogger
-    ): Promise<ChildProcessResult> {
+    public async invoke(options?: SamCliProcessInvokeOptions): Promise<ChildProcessResult> {
         const invokeOptions = makeRequiredSamCliProcessInvokeOptions(options)
         const logger = getLogger()
 
@@ -61,15 +57,15 @@ export class DefaultSamCliProcessInvoker implements SamCliProcessInvoker {
             ...invokeOptions.arguments
         )
 
-        channelLogger?.info('AWS.running.command', 'Running command: {0}', `${childProcess}`)
+        options?.channelLogger?.info('AWS.running.command', 'Running command: {0}', `${childProcess}`)
         logger.verbose(`running: ${childProcess}`)
         return await childProcess.run(
             (text: string) => {
-                channelLogger?.emitMessage(text)
+                options?.channelLogger?.emitMessage(text)
                 logger.verbose(`stdout: ${text}`)
             },
             (text: string) => {
-                channelLogger?.emitMessage(text)
+                options?.channelLogger?.emitMessage(text)
                 logger.verbose(`stderr: ${text}`)
             }
         )

--- a/src/shared/sam/cli/samCliInvokerUtils.ts
+++ b/src/shared/sam/cli/samCliInvokerUtils.ts
@@ -6,6 +6,7 @@
 import { SpawnOptions } from 'child_process'
 import { getLogger } from '../../logger'
 import { ChildProcessResult } from '../../utilities/childProcess'
+import { ChannelLogger } from '../../utilities/vsCodeUtils'
 
 export interface SamCliProcessInvokeOptions {
     spawnOptions?: SpawnOptions
@@ -24,7 +25,7 @@ export function makeRequiredSamCliProcessInvokeOptions(
 }
 
 export interface SamCliProcessInvoker {
-    invoke(options?: SamCliProcessInvokeOptions): Promise<ChildProcessResult>
+    invoke(options?: SamCliProcessInvokeOptions, channelLogger?: ChannelLogger): Promise<ChildProcessResult>
 }
 
 export function logAndThrowIfUnexpectedExitCode(processResult: ChildProcessResult, expectedExitCode: number): void {

--- a/src/shared/sam/cli/samCliInvokerUtils.ts
+++ b/src/shared/sam/cli/samCliInvokerUtils.ts
@@ -27,7 +27,7 @@ export function makeRequiredSamCliProcessInvokeOptions(
 }
 
 export interface SamCliProcessInvoker {
-    invoke(options?: SamCliProcessInvokeOptions, channelLogger?: ChannelLogger): Promise<ChildProcessResult>
+    invoke(options?: SamCliProcessInvokeOptions): Promise<ChildProcessResult>
 }
 
 export function logAndThrowIfUnexpectedExitCode(processResult: ChildProcessResult, expectedExitCode: number): void {

--- a/src/shared/sam/cli/samCliInvokerUtils.ts
+++ b/src/shared/sam/cli/samCliInvokerUtils.ts
@@ -11,11 +11,13 @@ import { ChannelLogger } from '../../utilities/vsCodeUtils'
 export interface SamCliProcessInvokeOptions {
     spawnOptions?: SpawnOptions
     arguments?: string[]
+    /** Optionally log stdout and stderr to the specified logger */
+    channelLogger?: ChannelLogger
 }
 
 export function makeRequiredSamCliProcessInvokeOptions(
     options?: SamCliProcessInvokeOptions
-): Required<SamCliProcessInvokeOptions> {
+): Required<Omit<SamCliProcessInvokeOptions, 'channelLogger'>> {
     options = options || {}
 
     return {

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -5,12 +5,10 @@
 
 import * as child_process from 'child_process'
 import { pushIf } from '../../utilities/collectionUtils'
-import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 import { fileExists } from '../../filesystemUtilities'
 import { getLogger, Logger } from '../../logger'
 import { ChildProcess } from '../../utilities/childProcess'
-import { removeAnsi } from '../../utilities/textUtilities'
 import { Timeout } from '../../utilities/timeoutUtils'
 import { ChannelLogger } from '../../utilities/vsCodeUtils'
 import { DefaultSamCliProcessInvokerContext, SamCliProcessInvokerContext } from './samCliInvoker'
@@ -59,13 +57,13 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
 
             await childProcess.start({
                 onStdout: (text: string): void => {
-                    this.emitMessage(text)
+                    this.channelLogger.emitMessage(text)
                     // If we have a timeout (as we do on debug) refresh the timeout as we receive text
                     params.timeout?.refresh()
                     this.logger.verbose(`stdout: ${text}`)
                 },
                 onStderr: (text: string): void => {
-                    this.emitMessage(text)
+                    this.channelLogger.emitMessage(text)
                     // If we have a timeout (as we do on debug) refresh the timeout as we receive text
                     params.timeout?.refresh()
                     this.logger.verbose(`stderr: ${text}`)
@@ -134,13 +132,6 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
                 throw err
             }
         })
-    }
-
-    private emitMessage(text: string): void {
-        // From VS Code API: If no debug session is active, output sent to the debug console is not shown.
-        // We send text to output channel and debug console to ensure no text is lost.
-        this.channelLogger.channel.append(removeAnsi(text))
-        vscode.debug.activeDebugConsole.append(text)
     }
 }
 

--- a/src/shared/utilities/childProcess.ts
+++ b/src/shared/utilities/childProcess.ts
@@ -65,8 +65,8 @@ export class ChildProcess {
      * Calls `start()` with default listeners that resolve()/reject() on process end.
      */
     public async run(
-        stdoutListener?: (text: string) => void,
-        stderrListener?: (text: string) => void
+        onStdout?: (text: string) => void,
+        onStderr?: (text: string) => void
     ): Promise<ChildProcessResult> {
         return await new Promise<ChildProcessResult>(async (resolve, reject) => {
             await this.start({
@@ -82,8 +82,8 @@ export class ChildProcess {
                         resolve(this.processResult)
                     }
                 },
-                onStderr: stderrListener,
-                onStdout: stdoutListener,
+                onStderr: onStderr,
+                onStdout: onStdout,
             }).catch(reject)
             if (!this.childProcess) {
                 reject('child process not started')

--- a/src/shared/utilities/childProcess.ts
+++ b/src/shared/utilities/childProcess.ts
@@ -64,7 +64,10 @@ export class ChildProcess {
     /**
      * Calls `start()` with default listeners that resolve()/reject() on process end.
      */
-    public async run(): Promise<ChildProcessResult> {
+    public async run(
+        stdoutListener?: (text: string) => void,
+        stderrListener?: (text: string) => void
+    ): Promise<ChildProcessResult> {
         return await new Promise<ChildProcessResult>(async (resolve, reject) => {
             await this.start({
                 collect: true,
@@ -79,6 +82,8 @@ export class ChildProcess {
                         resolve(this.processResult)
                     }
                 },
+                onStderr: stderrListener,
+                onStdout: stdoutListener,
             }).catch(reject)
             if (!this.childProcess) {
                 reject('child process not started')

--- a/src/test/shared/fakeChannelLogger.ts
+++ b/src/test/shared/fakeChannelLogger.ts
@@ -36,4 +36,6 @@ export class FakeChannelLogger implements ChannelLogger {
     public verbose(nlsKey: string, nlsTemplate: string, ...templateTokens: Loggable[]): void {
         this.loggedVerboseKeys.add(nlsKey)
     }
+
+    public emitMessage(message: string): void {}
 }


### PR DESCRIPTION
AWS Toolkit:
```
Preparing to debug 'app.lambda_handler' locally...
Building SAM Application...
Running command: (not started) [/usr/local/bin/sam build --build-dir /tmp/aws-toolkit-vscode/vsctkSnup4p/output --template /Users/richali/tmp/saminit/py/app___vsctk___template.yaml --use-container]
Starting Build inside a container
Building codeuri: hello_world/ runtime: python3.8 metadata: {} functions: ['HelloWorldFunction']

Fetching amazon/aws-sam-cli-build-image-python3.8 Docker container image......
Mounting /Users/richali/tmp/saminit/py/hello_world as /tmp/samcli/source:ro,delegated inside runtime container

Build Succeeded

Built Artifacts  : private/tmp/aws-toolkit-vscode/vsctkSnup4p/output
Built Template   : private/tmp/aws-toolkit-vscode/vsctkSnup4p/output/template.yaml

Commands you can use next
=========================
[*] Invoke Function: sam local invoke -t private/tmp/aws-toolkit-vscode/vsctkSnup4p/output/template.yaml
[*] Deploy: sam deploy --guided --template-file private/tmp/aws-toolkit-vscode/vsctkSnup4p/output/template.yaml
    
Running PythonPipBuilder:ResolveDependencies
Running PythonPipBuilder:CopySource
Build complete.
Starting the SAM Application locally (see Terminal for output)
```

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
