### PR TITLE
SAM CLI: specify --debug if log-level is "debug"

### DIFF
--- a/src/shared/sam/cli/samCliBuild.ts
+++ b/src/shared/sam/cli/samCliBuild.ts
@@ -86,7 +86,14 @@ export class SamCliBuildInvocation {
     public async execute(): Promise<number> {
         await this.validate()
 
-        const invokeArgs: string[] = ['build', '--build-dir', this.args.buildDir, '--template', this.args.templatePath]
+        const invokeArgs: string[] = [
+            'build',
+            ...(getLogger().logLevelEnabled('debug') ? ['--debug'] : []),
+            '--build-dir',
+            this.args.buildDir,
+            '--template',
+            this.args.templatePath,
+        ]
 
         pushIf(invokeArgs, !!this.args.baseDir, '--base-dir', this.args.baseDir!)
         pushIf(invokeArgs, !!this.args.dockerNetwork, '--docker-network', this.args.dockerNetwork!)

--- a/src/shared/sam/cli/samCliDeploy.ts
+++ b/src/shared/sam/cli/samCliDeploy.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { getLogger } from '../../logger/logger'
 import { map } from '../../utilities/collectionUtils'
 import { logAndThrowIfUnexpectedExitCode, SamCliProcessInvoker } from './samCliInvokerUtils'
 
@@ -20,6 +21,7 @@ export async function runSamCliDeploy(
 ): Promise<void> {
     const args = [
         'deploy',
+        ...(getLogger().logLevelEnabled('debug') ? ['--debug'] : []),
         '--template-file',
         deployArguments.templateFile,
         '--stack-name',

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -218,6 +218,7 @@ export class SamCliLocalInvokeInvocation {
         const invokeArgs = [
             'local',
             'invoke',
+            ...(getLogger().logLevelEnabled('debug') ? ['--debug'] : []),
             this.args.templateResourceName,
             '--template',
             this.args.templatePath,

--- a/src/shared/sam/cli/samCliStartApi.ts
+++ b/src/shared/sam/cli/samCliStartApi.ts
@@ -4,6 +4,7 @@
  */
 
 import { fileExists } from '../../filesystemUtilities'
+import { getLogger } from '../../logger'
 import { pushIf } from '../../utilities/collectionUtils'
 
 export interface SamCliStartApiArguments {
@@ -57,6 +58,7 @@ export async function buildSamCliStartApiArguments(args: SamCliStartApiArguments
     const invokeArgs = [
         'local',
         'start-api',
+        ...(getLogger().logLevelEnabled('debug') ? ['--debug'] : []),
         '--template',
         args.templatePath,
         '--env-vars',

--- a/src/test/shared/sam/cli/samCliBuild.test.ts
+++ b/src/test/shared/sam/cli/samCliBuild.test.ts
@@ -62,13 +62,14 @@ describe('SamCliBuildInvocation', async () => {
         const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker((args: any[]) => {
             assert.ok(args.length >= 2, 'Expected args to be present')
             assert.strictEqual(args[0], 'build')
-            assert.strictEqual(args[3], '--template')
-            assert.strictEqual(args[5], '--base-dir')
+            // --debug is present because tests run with "debug" log-level. #1403
+            assert.strictEqual(args[1], '--debug')
+            assert.strictEqual(args[4], '--template')
+            assert.strictEqual(args[6], '--base-dir')
 
             // `extraArgs` are appended to the end.
-            assert.strictEqual(args[7], '--parameter-overrides')
-            assert.strictEqual(args[8], 'math=math')
-            assert.strictEqual(args[9], '--debug')
+            assert.strictEqual(args[8], '--parameter-overrides')
+            assert.strictEqual(args[9], 'math=math')
             assert.strictEqual(args[10], '--build-dir')
             assert.strictEqual(args[11], 'my/build/dir/')
         })
@@ -78,7 +79,7 @@ describe('SamCliBuildInvocation', async () => {
             baseDir: nonRelevantArg,
             templatePath: placeholderTemplateFile,
             invoker: processInvoker,
-            extraArgs: ['--debug', '--build-dir', 'my/build/dir/'],
+            extraArgs: ['--build-dir', 'my/build/dir/'],
             parameterOverrides: ['math=math'],
         }).execute()
     })

--- a/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
+++ b/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
@@ -46,12 +46,13 @@ describe('SamCliLocalInvokeInvocation', async () => {
                 assert.ok(invokeArgs.args.length >= 2, 'Expected args to be present')
                 assert.strictEqual(invokeArgs.args[0], 'local')
                 assert.strictEqual(invokeArgs.args[1], 'invoke')
-                assert.strictEqual(invokeArgs.args[3], '--template')
-                assert.strictEqual(invokeArgs.args[5], '--event')
-                assert.strictEqual(invokeArgs.args[7], '--env-vars')
+                // --debug is present because tests run with "debug" log-level. #1403
+                assert.strictEqual(invokeArgs.args[2], '--debug')
+                assert.strictEqual(invokeArgs.args[4], '--template')
+                assert.strictEqual(invokeArgs.args[6], '--event')
+                assert.strictEqual(invokeArgs.args[8], '--env-vars')
 
                 // `extraArgs` are appended to the end.
-                assert.strictEqual(invokeArgs.args[9], '--debug')
                 assert.strictEqual(invokeArgs.args[10], '--build-dir')
                 assert.strictEqual(invokeArgs.args[11], 'my/build/dir/')
             }
@@ -63,7 +64,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
             eventPath: placeholderEventFile,
             environmentVariablePath: nonRelevantArg,
             invoker: taskInvoker,
-            extraArgs: ['--debug', '--build-dir', 'my/build/dir/'],
+            extraArgs: ['--build-dir', 'my/build/dir/'],
         }).execute()
     })
 

--- a/src/test/shared/sam/cli/samCliStartApi.test.ts
+++ b/src/test/shared/sam/cli/samCliStartApi.test.ts
@@ -32,17 +32,18 @@ describe('SamCliStartApi', async () => {
         const invokeArgs = await buildSamCliStartApiArguments({
             templatePath: placeholderTemplateFile,
             environmentVariablePath: nonRelevantArg,
-            extraArgs: ['--debug', '--build-dir', 'my/build/dir/'],
+            extraArgs: ['--build-dir', 'my/build/dir/'],
         })
 
         assert.ok(invokeArgs.length >= 2, 'Expected args to be present')
         assert.strictEqual(invokeArgs[0], 'local')
         assert.strictEqual(invokeArgs[1], 'start-api')
-        assert.strictEqual(invokeArgs[2], '--template')
-        assert.strictEqual(invokeArgs[4], '--env-vars')
+        // --debug is present because tests run with "debug" log-level. #1403
+        assert.strictEqual(invokeArgs[2], '--debug')
+        assert.strictEqual(invokeArgs[3], '--template')
+        assert.strictEqual(invokeArgs[5], '--env-vars')
 
         // `extraArgs` are appended to the end.
-        assert.strictEqual(invokeArgs[6], '--debug')
         assert.strictEqual(invokeArgs[7], '--build-dir')
         assert.strictEqual(invokeArgs[8], 'my/build/dir/')
     })


### PR DESCRIPTION
Show SAM CLI `--debug` messages if current Toolkit log-level is "debug".

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
