### PR TITLE
Ensure a region node is indeed a region node

### DIFF
--- a/src/lambda/wizards/samDeployWizard.ts
+++ b/src/lambda/wizards/samDeployWizard.ts
@@ -535,7 +535,7 @@ export class SamDeployWizard extends MultiStepWizard<SamDeployWizardResponse> {
     }
 
     private skipOrPromptRegion(skipToStep: WizardStep): WizardStep {
-        return this.regionNode ? skipToStep : this.REGION
+        return this.regionNode && this.regionNode.hasOwnProperty('regionCode') ? skipToStep : this.REGION
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ensures that the region node is a region node by checking for a `regionCode` property. This prevents the deploy workflow from skipping the region selection, which would mean that a user can't select an S3 bucket.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
