### PR TITLE
Cloud Watch Logs -> Cloudwatch Logs in settings UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
                     "default": 5000,
                     "description": "%AWS.ssmDocument.ssm.maxItemsComputed.desc%"
                 },
-                "aws.cloudWatchLogs.limit": {
+                "aws.cloudwatchLogs.limit": {
                     "type": "number",
                     "default": 10000,
                     "description": "%aws.cloudWatchLogs.limit.desc%",


### PR DESCRIPTION
VS Code uses Start Casing when parsing configuration keys for their Settings UI. This converts "Cloud Watch Logs" to "Cloudwatch Logs".

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
