### PR TITLE
Fixup excessive codelens filesystem access

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -14,6 +14,7 @@
     "AWS.channel.aws.toolkit": "AWS Toolkit",
     "AWS.channel.aws.toolkit.activation.error": "Error Activating AWS Toolkit",
     "AWS.codelens.failToInitialize": "Failed to activate template registry. CodeLenses will not appear on SAM template files.",
+    "AWS.codelens.failToInitializeCode": "Failed to activate Lambda handler CodeLesns's",
     "AWS.codelens.lambda.invoke": "Run Locally",
     "AWS.codelens.lambda.invoke.debug": "Debug Locally",
     "AWS.configuration.title": "AWS Configuration",

--- a/src/integrationTest/cloudformation/templateRegistry.test.ts
+++ b/src/integrationTest/cloudformation/templateRegistry.test.ts
@@ -42,13 +42,13 @@ describe('CloudFormation Template Registry', async () => {
         await strToYamlFile(makeSampleSamTemplateYaml(true), path.join(testDir, 'test.yaml'))
         await strToYamlFile(makeSampleSamTemplateYaml(false), path.join(testDirNested, 'test.yml'))
 
-        await registry.addTemplateGlob('**/test.{yaml,yml}')
+        await registry.addWatchPattern('**/test.{yaml,yml}')
 
         await registryHasTargetNumberOfFiles(registry, 2)
     })
 
     it('adds dynamically-added template files with yaml and yml extensions at various nesting levels', async () => {
-        await registry.addTemplateGlob('**/test.{yaml,yml}')
+        await registry.addWatchPattern('**/test.{yaml,yml}')
 
         await strToYamlFile(makeSampleSamTemplateYaml(false), path.join(testDir, 'test.yml'))
         await strToYamlFile(makeSampleSamTemplateYaml(true), path.join(testDirNested, 'test.yaml'))
@@ -57,7 +57,7 @@ describe('CloudFormation Template Registry', async () => {
     })
 
     it('Ignores templates matching excluded patterns', async () => {
-        await registry.addTemplateGlob('**/test.{yaml,yml}')
+        await registry.addWatchPattern('**/test.{yaml,yml}')
         await registry.addExcludedPattern(/.*nested.*/)
 
         await strToYamlFile(makeSampleSamTemplateYaml(false), path.join(testDir, 'test.yml'))
@@ -70,7 +70,7 @@ describe('CloudFormation Template Registry', async () => {
         const filepath = path.join(testDir, 'changeMe.yml')
         await strToYamlFile(makeSampleSamTemplateYaml(false), filepath)
 
-        await registry.addTemplateGlob('**/changeMe.yml')
+        await registry.addWatchPattern('**/changeMe.yml')
 
         await registryHasTargetNumberOfFiles(registry, 1)
 
@@ -82,7 +82,7 @@ describe('CloudFormation Template Registry', async () => {
     })
 
     it('can handle deleted files', async () => {
-        await registry.addTemplateGlob('**/deleteMe.yml')
+        await registry.addWatchPattern('**/deleteMe.yml')
 
         // Specifically creating the file after the watcher is added
         // Otherwise, it seems the file is deleted before the file watcher realizes the file exists
@@ -99,7 +99,7 @@ describe('CloudFormation Template Registry', async () => {
 })
 
 async function registryHasTargetNumberOfFiles(registry: CloudFormationTemplateRegistry, target: number) {
-    while (registry.registeredTemplates.length !== target) {
+    while (registry.registeredItems.length !== target) {
         await new Promise(resolve => setTimeout(resolve, 20))
     }
 }
@@ -112,9 +112,9 @@ async function queryRegistryForFileWithGlobalsKeyStatus(
     let foundMatch = false
     while (!foundMatch) {
         await new Promise(resolve => setTimeout(resolve, 20))
-        const obj = registry.getRegisteredTemplate(filepath)
+        const obj = registry.getRegisteredItem(filepath)
         if (obj) {
-            foundMatch = Object.keys(obj.template).includes('Globals') === hasGlobals
+            foundMatch = Object.keys(obj.item).includes('Globals') === hasGlobals
         }
     }
 }

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -120,7 +120,7 @@ function runtimeNeedsWorkaround(lang: Language) {
     return vscode.version.startsWith('1.42') || lang === 'csharp' || lang === 'python'
 }
 
-describe('SAM Integration Tests', async function() {
+describe('SAM Integration Tests', async function () {
     const samApplicationName = 'testProject'
     /**
      * Breadcrumbs from each process, printed at end of all scenarios to give
@@ -129,7 +129,7 @@ describe('SAM Integration Tests', async function() {
     const sessionLog: string[] = []
     let testSuiteRoot: string
 
-    before(async function() {
+    before(async function () {
         await activateExtensions()
         await configureAwsToolkitExtension()
         await configurePythonExtension()
@@ -139,7 +139,7 @@ describe('SAM Integration Tests', async function() {
         mkdirpSync(testSuiteRoot)
     })
 
-    after(async function() {
+    after(async function () {
         tryRemoveFolder(testSuiteRoot)
         // Print a summary of session that were seen by `onDidStartDebugSession`.
         const sessionReport = sessionLog.map(x => `    ${x}`).join('\n')
@@ -149,16 +149,16 @@ describe('SAM Integration Tests', async function() {
     for (let scenarioIndex = 0; scenarioIndex < scenarios.length; scenarioIndex++) {
         const scenario = scenarios[scenarioIndex]
 
-        describe(`SAM Application Runtime: ${scenario.runtime}`, async function() {
+        describe(`SAM Application Runtime: ${scenario.runtime}`, async function () {
             let runtimeTestRoot: string
 
-            before(async function() {
+            before(async function () {
                 runtimeTestRoot = path.join(testSuiteRoot, scenario.runtime)
                 console.log('runtimeTestRoot: ', runtimeTestRoot)
                 mkdirpSync(runtimeTestRoot)
             })
 
-            after(async function() {
+            after(async function () {
                 tryRemoveFolder(runtimeTestRoot)
             })
 
@@ -169,19 +169,19 @@ describe('SAM Integration Tests', async function() {
             /**
              * This suite cleans up at the end of each test.
              */
-            describe('Starting from scratch', async function() {
+            describe('Starting from scratch', async function () {
                 let testDir: string
 
-                beforeEach(async function() {
+                beforeEach(async function () {
                     testDir = await mkdtemp(path.join(runtimeTestRoot, 'test-'))
                     log(`testDir: ${testDir}`)
                 })
 
-                afterEach(async function() {
+                afterEach(async function () {
                     tryRemoveFolder(testDir)
                 })
 
-                it('creates a new SAM Application (happy path)', async function() {
+                it('creates a new SAM Application (happy path)', async function () {
                     await createSamApplication(testDir)
 
                     // Check for readme file
@@ -194,7 +194,7 @@ describe('SAM Integration Tests', async function() {
              * This suite makes a sam app that all tests operate on.
              * Cleanup happens at the end of the suite.
              */
-            describe(`Starting with a newly created ${scenario.runtime} SAM Application...`, async function() {
+            describe(`Starting with a newly created ${scenario.runtime} SAM Application...`, async function () {
                 let testDisposables: vscode.Disposable[]
 
                 let testDir: string
@@ -202,7 +202,7 @@ describe('SAM Integration Tests', async function() {
                 let appPath: string
                 let cfnTemplatePath: string
 
-                before(async function() {
+                before(async function () {
                     testDir = await mkdtemp(path.join(runtimeTestRoot, 'samapp-'))
                     log(`testDir: ${testDir}`)
 
@@ -212,46 +212,46 @@ describe('SAM Integration Tests', async function() {
                     samAppCodeUri = await openSamAppFile(appPath)
                 })
 
-                beforeEach(async function() {
+                beforeEach(async function () {
                     testDisposables = []
                     await closeAllEditors()
                 })
 
-                afterEach(async function() {
+                afterEach(async function () {
                     // tslint:disable-next-line: no-unsafe-any
                     testDisposables.forEach(d => d.dispose())
                     await stopDebugger()
                 })
 
-                after(async function() {
+                after(async function () {
                     tryRemoveFolder(testDir)
                 })
 
-                it('the SAM Template contains the expected runtime', async function() {
+                it('the SAM Template contains the expected runtime', async function () {
                     const fileContents = readFileSync(cfnTemplatePath).toString()
                     assert.ok(fileContents.includes(`Runtime: ${scenario.runtime}`))
                 })
 
-                it('produces an error when creating a SAM Application to the same location', async function() {
+                it('produces an error when creating a SAM Application to the same location', async function () {
                     const err = await assertThrowsError(async () => await createSamApplication(testDir))
                     assert(err.message.includes('directory already exists'))
                 })
 
-                it('produces an Add Debug Configuration codelens', async function() {
+                it('produces an Add Debug Configuration codelens', async function () {
                     setTestTimeout(this.test?.fullTitle(), 60000)
                     const codeLens = await getAddConfigCodeLens(samAppCodeUri)
                     assert.ok(codeLens)
 
-                    let manifestFile: string
+                    let manifestFile: RegExp
                     switch (scenario.language) {
                         case 'javascript':
-                            manifestFile = 'package.json'
+                            manifestFile = /^package\.json$/
                             break
                         case 'python':
-                            manifestFile = 'requirements.txt'
+                            manifestFile = /^requirements\.txt$/
                             break
                         case 'csharp':
-                            manifestFile = '*.csproj'
+                            manifestFile = /^.*\.csproj$/
                             break
                         default:
                             assert.fail('invalid scenario language')
@@ -262,11 +262,11 @@ describe('SAM Integration Tests', async function() {
                     assertCodeLensReferencesHasSameRoot(codeLens, projectRoot!)
                 })
 
-                it('invokes and attaches on debug request (F5)', async function() {
+                it('invokes and attaches on debug request (F5)', async function () {
                     setTestTimeout(this.test?.fullTitle(), 60000)
                     // Allow previous sessions to go away.
                     await waitUntil(
-                        async function() {
+                        async function () {
                             return vscode.debug.activeDebugSession === undefined
                         },
                         { timeout: 100, interval: 300 }

--- a/src/integrationTest/shared/utilities/workspaceUtils.test.ts
+++ b/src/integrationTest/shared/utilities/workspaceUtils.test.ts
@@ -87,7 +87,7 @@ describe('findParentProjectFile', async () => {
             for (const file of test.filesToUse) {
                 await writeFile(file.fsPath, '')
             }
-            const projectFile = await findParentProjectFile(sourceCodeUri, '*.csproj')
+            const projectFile = await findParentProjectFile(sourceCodeUri, /^.*\.csproj$/)
             if (test.expectedResult) {
                 // doesn't do a deepStrictEqual because VS Code sets a hidden field to `undefined` when returning instead of `null` (when it's created)
                 // for all intents and purposes, if this matches, it's good enough for us.

--- a/src/integrationTest/shared/utilities/workspaceUtils.test.ts
+++ b/src/integrationTest/shared/utilities/workspaceUtils.test.ts
@@ -4,21 +4,25 @@
  */
 
 import * as assert from 'assert'
-import { writeFile, mkdir, mkdirp, remove } from 'fs-extra'
+import { writeFile, mkdirp, remove } from 'fs-extra'
 import * as path from 'path'
+import { ext } from '../../../shared/extensionGlobals'
 import * as vscode from 'vscode'
 import { findParentProjectFile, getWorkspaceRelativePath } from '../../../shared/utilities/workspaceUtils'
 import { getTestWorkspaceFolder } from '../../integrationTestsUtilities'
+import { CodelensRootRegistry } from '../../../shared/sam/codelensRootRegistry'
 
 describe('findParentProjectFile', async () => {
     const workspaceDir = getTestWorkspaceFolder()
     let filesToDelete: vscode.Uri[]
 
+    // Save the global registry and restore it after the test
+    let globalRegistry: CodelensRootRegistry
+
     const sourceCodeUri = vscode.Uri.file(path.join(workspaceDir, 'someproject', 'src', 'Program.cs'))
     const projectInSameFolderUri = vscode.Uri.file(path.join(workspaceDir, 'someproject', 'src', 'App.csproj'))
     const projectInParentFolderUri = vscode.Uri.file(path.join(workspaceDir, 'someproject', 'App.csproj'))
     const projectInParentParentFolderUri = vscode.Uri.file(path.join(workspaceDir, 'App.csproj'))
-    const projectInParentButOutOfWorkspace = vscode.Uri.file(path.join(workspaceDir, '..', 'App.csproj'))
     const projectOutOfParentChainUri = vscode.Uri.file(path.join(workspaceDir, 'someotherproject', 'App.csproj'))
 
     const testScenarios = [
@@ -57,21 +61,22 @@ describe('findParentProjectFile', async () => {
             filesToUse: [projectOutOfParentChainUri],
             expectedResult: undefined,
         },
-        {
-            scenario: 'returns undefined when the project file is in the parent chain but out of the workspace folder',
-            filesToUse: [projectInParentButOutOfWorkspace],
-            expectedResult: undefined,
-        },
     ]
 
     before(async () => {
         await mkdirp(path.join(workspaceDir, 'someproject', 'src'))
-        await mkdir(path.join(workspaceDir, 'someotherproject'))
+        await mkdirp(path.join(workspaceDir, 'someotherproject'))
+        globalRegistry = ext.codelensRootRegistry
     })
 
     after(async () => {
         remove(path.join(workspaceDir, 'someproject'))
         remove(path.join(workspaceDir, 'someotherproject'))
+        ext.codelensRootRegistry = globalRegistry
+    })
+
+    beforeEach(() => {
+        ext.codelensRootRegistry = new CodelensRootRegistry()
     })
 
     afterEach(async () => {
@@ -79,6 +84,7 @@ describe('findParentProjectFile', async () => {
             remove(file.fsPath)
         }
         filesToDelete = []
+        ext.codelensRootRegistry.dispose()
     })
 
     testScenarios.forEach(test => {
@@ -86,12 +92,15 @@ describe('findParentProjectFile', async () => {
             filesToDelete = test.filesToUse
             for (const file of test.filesToUse) {
                 await writeFile(file.fsPath, '')
+                // Add it to the registry. The registry is async and we are not
+                // testing the registry in this test, so manually use it
+                await ext.codelensRootRegistry.addItemToRegistry(file)
             }
             const projectFile = await findParentProjectFile(sourceCodeUri, /^.*\.csproj$/)
             if (test.expectedResult) {
                 // doesn't do a deepStrictEqual because VS Code sets a hidden field to `undefined` when returning instead of `null` (when it's created)
                 // for all intents and purposes, if this matches, it's good enough for us.
-                assert.strictEqual(projectFile!.fsPath, test.expectedResult!.fsPath)
+                assert.strictEqual(projectFile?.fsPath, test.expectedResult?.fsPath)
             } else {
                 assert.strictEqual(projectFile, test.expectedResult)
             }

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -206,7 +206,7 @@ export async function createNewSamApplication(
         // Race condition where SAM app is created but template doesn't register in time.
         // Poll for 5 seconds, otherwise direct user to codelens.
         const isTemplateRegistered = await waitUntil(async () => {
-            return ext.templateRegistry.getRegisteredTemplate(uri.fsPath)
+            return ext.templateRegistry.getRegisteredItem(uri.fsPath)
         })
 
         if (isTemplateRegistered) {

--- a/src/lambda/local/debugConfiguration.ts
+++ b/src/lambda/local/debugConfiguration.ts
@@ -156,7 +156,7 @@ export function getTemplate(
     }
     const templateInvoke = config.invokeTarget as TemplateTargetProperties
     const fullPath = tryGetAbsolutePath(folder, templateInvoke.templatePath)
-    const cfnTemplate = ext.templateRegistry.getRegisteredTemplate(fullPath)?.template
+    const cfnTemplate = ext.templateRegistry.getRegisteredItem(fullPath)?.item
     return cfnTemplate
 }
 

--- a/src/lambda/wizards/samDeployWizard.ts
+++ b/src/lambda/wizards/samDeployWizard.ts
@@ -619,7 +619,7 @@ function validateStackName(value: string): string | undefined {
 }
 
 async function getTemplateChoices(...workspaceFolders: vscode.Uri[]): Promise<SamTemplateQuickPickItem[]> {
-    const templateUris = ext.templateRegistry.registeredTemplates.map(o => vscode.Uri.file(o.path))
+    const templateUris = ext.templateRegistry.registeredItems.map(o => vscode.Uri.file(o.path))
     const uriToLabel: Map<vscode.Uri, string> = new Map<vscode.Uri, string>()
     const labelCounts: Map<string, number> = new Map()
 

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -42,8 +42,8 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
         )
         getLogger().error('Failed to activate template registry', e)
         // This prevents us from breaking for any reason later if it fails to load. Since
-        // Noop watcher is always empty, we will get back empty strings with no issues.
-        ext.templateRegistry = (new NoopWatcher() as any) as CloudFormationTemplateRegistry
+        // Noop watcher is always empty, we will get back empty arrays with no issues.
+        ext.templateRegistry = (new NoopWatcher() as unknown) as CloudFormationTemplateRegistry
     }
     // If setting it up worked, add it to subscriptions so it is cleaned up at exit
     extensionContext.subscriptions.push(ext.templateRegistry)

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -30,7 +30,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
     try {
         const registry = new CloudFormationTemplateRegistry()
         await registry.addExcludedPattern(TEMPLATE_FILE_EXCLUDE_PATTERN)
-        await registry.addTemplateGlob(TEMPLATE_FILE_GLOB_PATTERN)
+        await registry.addWatchPattern(TEMPLATE_FILE_GLOB_PATTERN)
         extensionContext.subscriptions.push(registry)
         ext.templateRegistry = registry
     } catch (e) {

--- a/src/shared/cloudformation/templateRegistry.ts
+++ b/src/shared/cloudformation/templateRegistry.ts
@@ -10,15 +10,15 @@ import { isInDirectory } from '../filesystemUtilities'
 import { dotNetRuntimes } from '../../lambda/models/samLambdaRuntime'
 import { getLambdaDetails } from '../../lambda/utils'
 import { ext } from '../extensionGlobals'
-import { WorkspaceFileRegistry, WorkspaceItem } from '../fileRegistry'
+import { WatchedFiles, WatchedItem } from '../watchedFiles'
 
 export interface TemplateDatum {
     path: string
     template: CloudFormation.Template
 }
 
-export class CloudFormationTemplateRegistry extends WorkspaceFileRegistry<CloudFormation.Template> {
-    protected registryName: string = 'CloudFormationTemplateRegistry'
+export class CloudFormationTemplateRegistry extends WatchedFiles<CloudFormation.Template> {
+    protected name: string = 'CloudFormationTemplateRegistry'
     protected async load(path: string): Promise<CloudFormation.Template> {
         return await CloudFormation.load(path)
     }
@@ -34,8 +34,8 @@ export class CloudFormationTemplateRegistry extends WorkspaceFileRegistry<CloudF
 export function getResourcesForHandler(
     filepath: string,
     handler: string,
-    unfilteredTemplates: WorkspaceItem<CloudFormation.Template>[] = ext.templateRegistry.registeredItems
-): { templateDatum: WorkspaceItem<CloudFormation.Template>; name: string; resourceData: CloudFormation.Resource }[] {
+    unfilteredTemplates: WatchedItem<CloudFormation.Template>[] = ext.templateRegistry.registeredItems
+): { templateDatum: WatchedItem<CloudFormation.Template>; name: string; resourceData: CloudFormation.Resource }[] {
     // TODO: Array.flat and Array.flatMap not introduced until >= Node11.x -- migrate when VS Code updates Node ver
     const o = unfilteredTemplates.map(templateDatum => {
         return getResourcesForHandlerFromTemplateDatum(filepath, handler, templateDatum).map(resource => {
@@ -60,7 +60,7 @@ export function getResourcesForHandler(
 export function getResourcesForHandlerFromTemplateDatum(
     filepath: string,
     handler: string,
-    templateDatum: WorkspaceItem<CloudFormation.Template>
+    templateDatum: WatchedItem<CloudFormation.Template>
 ): { name: string; resourceData: CloudFormation.Resource }[] {
     const matchingResources: { name: string; resourceData: CloudFormation.Resource }[] = []
     const templateDirname = path.dirname(templateDatum.path)

--- a/src/shared/cloudformation/templateRegistry.ts
+++ b/src/shared/cloudformation/templateRegistry.ts
@@ -18,6 +18,7 @@ export interface TemplateDatum {
 }
 
 export class CloudFormationTemplateRegistry extends WorkspaceFileRegistry<CloudFormation.Template> {
+    protected registryName: string = 'CloudFormationTemplateRegistry'
     protected async load(path: string): Promise<CloudFormation.Template> {
         return await CloudFormation.load(path)
     }

--- a/src/shared/cloudformation/templateRegistry.ts
+++ b/src/shared/cloudformation/templateRegistry.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as vscode from 'vscode'
-import { getLogger } from '../logger/logger'
 import { CloudFormation } from './cloudformation'
 import * as pathutils from '../utilities/pathUtils'
 import * as path from 'path'
@@ -12,189 +10,16 @@ import { isInDirectory } from '../filesystemUtilities'
 import { dotNetRuntimes } from '../../lambda/models/samLambdaRuntime'
 import { getLambdaDetails } from '../../lambda/utils'
 import { ext } from '../extensionGlobals'
+import { WorkspaceFileRegistry, WorkspaceItem } from '../fileRegistry'
 
 export interface TemplateDatum {
     path: string
     template: CloudFormation.Template
 }
 
-export class CloudFormationTemplateRegistry implements vscode.Disposable {
-    private readonly disposables: vscode.Disposable[] = []
-    private _isDisposed: boolean = false
-    private readonly globs: vscode.GlobPattern[] = []
-    private readonly excludedFilePatterns: RegExp[] = []
-    private readonly templateRegistryData: Map<string, CloudFormation.Template> = new Map<
-        string,
-        CloudFormation.Template
-    >()
-
-    public constructor() {
-        this.disposables.push(
-            vscode.workspace.onDidChangeWorkspaceFolders(async () => {
-                await this.rebuildRegistry()
-            })
-        )
-    }
-
-    /**
-     * Adds a glob pattern to use for lookups and resets the registry to use it.
-     * Added templates cannot be removed without restarting the extension.
-     * Throws an error if this manager has already been disposed.
-     * @param glob vscode.GlobPattern to be used for lookups
-     */
-    public async addTemplateGlob(glob: vscode.GlobPattern): Promise<void> {
-        if (this._isDisposed) {
-            throw new Error('Manager has already been disposed!')
-        }
-        this.globs.push(glob)
-
-        const watcher = vscode.workspace.createFileSystemWatcher(glob)
-        this.addWatcher(watcher)
-
-        await this.rebuildRegistry()
-    }
-
-    /**
-     * Adds a regex pattern to ignore paths containing the pattern
-     */
-    public async addExcludedPattern(pattern: RegExp): Promise<void> {
-        if (this._isDisposed) {
-            throw new Error('Manager has already been disposed!')
-        }
-        this.excludedFilePatterns.push(pattern)
-
-        await this.rebuildRegistry()
-    }
-
-    /**
-     * Adds template to registry. Wipes any existing template in its place with newly-parsed copy of the data.
-     * @param templateUri vscode.Uri containing the template to load in
-     */
-    public async addTemplateToRegistry(templateUri: vscode.Uri, quiet?: boolean): Promise<void> {
-        const excluded = this.excludedFilePatterns.find(pattern => templateUri.fsPath.match(pattern))
-        if (excluded) {
-            getLogger().verbose(
-                `Manager did not add template ${templateUri.fsPath} matching excluded pattern ${excluded}`
-            )
-            return
-        }
-        const pathAsString = pathutils.normalize(templateUri.fsPath)
-        this.assertAbsolute(pathAsString)
-        try {
-            const template = await CloudFormation.load(pathAsString)
-            this.templateRegistryData.set(pathAsString, template)
-        } catch (e) {
-            if (!quiet) {
-                throw e
-            }
-            getLogger().verbose(`Template ${templateUri} is malformed: ${e}`)
-        }
-    }
-
-    /**
-     * Get a specific template's data
-     * @param path Path to template of interest
-     */
-    public getRegisteredTemplate(path: string): TemplateDatum | undefined {
-        const normalizedPath = pathutils.normalize(path)
-        this.assertAbsolute(normalizedPath)
-        const template = this.templateRegistryData.get(normalizedPath)
-        if (template) {
-            return {
-                path: normalizedPath,
-                template: template,
-            }
-        }
-    }
-
-    /**
-     * Returns the registry's data as an array of TemplateData objects
-     */
-    public get registeredTemplates(): TemplateDatum[] {
-        const arr: TemplateDatum[] = []
-
-        for (const templatePath of this.templateRegistryData.keys()) {
-            const template = this.getRegisteredTemplate(templatePath)
-            if (template) {
-                arr.push(template)
-            }
-        }
-
-        return arr
-    }
-
-    /**
-     * Removes a template from the registry.
-     * @param templateUri vscode.Uri containing template to remove
-     */
-    public removeTemplateFromRegistry(templateUri: vscode.Uri): void {
-        const pathAsString = pathutils.normalize(templateUri.fsPath)
-        this.assertAbsolute(pathAsString)
-        this.templateRegistryData.delete(pathAsString)
-    }
-
-    /**
-     * Disposes CloudFormationTemplateRegistryManager and marks as disposed.
-     */
-    public dispose(): void {
-        if (!this._isDisposed) {
-            while (this.disposables.length > 0) {
-                const disposable = this.disposables.pop()
-                if (disposable) {
-                    disposable.dispose()
-                }
-            }
-            this._isDisposed = true
-        }
-    }
-
-    /**
-     * Rebuilds registry using current glob and exclusion patterns.
-     * All functionality is currently internal to class, but can be made public if we want a manual "refresh" button
-     */
-    private async rebuildRegistry(): Promise<void> {
-        this.reset()
-        for (const glob of this.globs) {
-            const templateUris = await vscode.workspace.findFiles(glob)
-            for (const template of templateUris) {
-                await this.addTemplateToRegistry(template, true)
-            }
-        }
-    }
-
-    /**
-     * Removes all templates from the registry.
-     */
-    public reset() {
-        this.templateRegistryData.clear()
-    }
-
-    /**
-     * Sets watcher functionality and adds to this.disposables
-     * @param watcher vscode.FileSystemWatcher
-     */
-    private addWatcher(watcher: vscode.FileSystemWatcher): void {
-        this.disposables.push(
-            watcher,
-            watcher.onDidChange(async uri => {
-                getLogger().verbose(`Manager detected a change to template file: ${uri.fsPath}`)
-                await this.addTemplateToRegistry(uri)
-            }),
-            watcher.onDidCreate(async uri => {
-                getLogger().verbose(`Manager detected a new template file: ${uri.fsPath}`)
-                await this.addTemplateToRegistry(uri)
-            }),
-            watcher.onDidDelete(async uri => {
-                getLogger().verbose(`Manager detected a deleted template file: ${uri.fsPath}`)
-                this.removeTemplateFromRegistry(uri)
-            })
-        )
-    }
-
-    private assertAbsolute(p: string) {
-        if (!path.isAbsolute(p)) {
-            throw Error(`CloudFormationTemplateRegistry: path is relative: ${p}`)
-        }
+export class CloudFormationTemplateRegistry extends WorkspaceFileRegistry<CloudFormation.Template> {
+    protected async load(path: string): Promise<CloudFormation.Template> {
+        return await CloudFormation.load(path)
     }
 }
 
@@ -208,8 +33,8 @@ export class CloudFormationTemplateRegistry implements vscode.Disposable {
 export function getResourcesForHandler(
     filepath: string,
     handler: string,
-    unfilteredTemplates: TemplateDatum[] = ext.templateRegistry.registeredTemplates
-): { templateDatum: TemplateDatum; name: string; resourceData: CloudFormation.Resource }[] {
+    unfilteredTemplates: WorkspaceItem<CloudFormation.Template>[] = ext.templateRegistry.registeredItems
+): { templateDatum: WorkspaceItem<CloudFormation.Template>; name: string; resourceData: CloudFormation.Resource }[] {
     // TODO: Array.flat and Array.flatMap not introduced until >= Node11.x -- migrate when VS Code updates Node ver
     const o = unfilteredTemplates.map(templateDatum => {
         return getResourcesForHandlerFromTemplateDatum(filepath, handler, templateDatum).map(resource => {
@@ -234,7 +59,7 @@ export function getResourcesForHandler(
 export function getResourcesForHandlerFromTemplateDatum(
     filepath: string,
     handler: string,
-    templateDatum: TemplateDatum
+    templateDatum: WorkspaceItem<CloudFormation.Template>
 ): { name: string; resourceData: CloudFormation.Resource }[] {
     const matchingResources: { name: string; resourceData: CloudFormation.Resource }[] = []
     const templateDirname = path.dirname(templateDatum.path)
@@ -244,7 +69,7 @@ export function getResourcesForHandlerFromTemplateDatum(
     }
 
     // no resources
-    const resources = templateDatum.template.Resources
+    const resources = templateDatum.item.Resources
     if (!resources) {
         return []
     }
@@ -259,15 +84,15 @@ export function getResourcesForHandlerFromTemplateDatum(
             // parse template values that could potentially be refs
             const registeredRuntime = CloudFormation.getStringForProperty(
                 resource.Properties?.Runtime,
-                templateDatum.template
+                templateDatum.item
             )
             const registeredCodeUri = CloudFormation.getStringForProperty(
                 resource.Properties?.CodeUri,
-                templateDatum.template
+                templateDatum.item
             )
             const registeredHandler = CloudFormation.getStringForProperty(
                 resource.Properties?.Handler,
-                templateDatum.template
+                templateDatum.item
             )
 
             if (registeredRuntime && registeredHandler && registeredCodeUri) {

--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -218,10 +218,7 @@ export async function makePythonCodeLensProvider(): Promise<vscode.CodeLensProvi
             }
 
             const handlers: LambdaHandlerCandidate[] = await pythonCodelens.getLambdaHandlerCandidates(document.uri)
-            logger.debug(
-                'pythonCodeLensProvider.makePythonCodeLensProvider handlers: %s',
-                JSON.stringify(handlers, undefined, 2)
-            )
+            logger.debug('pythonCodeLensProvider.makePythonCodeLensProvider handlers: %O', handlers)
 
             return makeCodeLenses({
                 document,
@@ -242,7 +239,7 @@ export async function makeCSharpCodeLensProvider(): Promise<vscode.CodeLensProvi
             token: vscode.CancellationToken
         ): Promise<vscode.CodeLens[]> => {
             const handlers: LambdaHandlerCandidate[] = await csharpCodelens.getLambdaHandlerCandidates(document)
-            logger.debug('makeCSharpCodeLensProvider handlers: %s', JSON.stringify(handlers, undefined, 2))
+            logger.debug('makeCSharpCodeLensProvider handlers: %O', handlers)
 
             return makeCodeLenses({
                 document,
@@ -263,7 +260,7 @@ export function makeTypescriptCodeLensProvider(): vscode.CodeLensProvider {
             token: vscode.CancellationToken
         ): Promise<vscode.CodeLens[]> => {
             const handlers = await tsCodelens.getLambdaHandlerCandidates(document)
-            logger.debug('makeTypescriptCodeLensProvider handlers:', JSON.stringify(handlers, undefined, 2))
+            logger.debug('makeTypescriptCodeLensProvider handlers: %O', handlers)
 
             return makeCodeLenses({
                 document,

--- a/src/shared/codelens/csharpCodeLensProvider.ts
+++ b/src/shared/codelens/csharpCodeLensProvider.ts
@@ -15,6 +15,7 @@ export const CSHARP_ALLFILES: vscode.DocumentFilter[] = [
         language: CSHARP_LANGUAGE,
     },
 ]
+export const CSHARP_BASE_PATTERN = '**/*.csproj'
 
 const REGEXP_RESERVED_WORD_PUBLIC = /\bpublic\b/
 
@@ -168,13 +169,7 @@ export function isValidMethodSignature(symbol: vscode.DocumentSymbol): boolean {
         // remove generics from parameter string so we can do a predictable split on comma
         const strippedStr = stripGenericsFromParams(parametersArr[0])
         const individualParams = strippedStr.split(',')
-        if (
-            individualParams.length === 1 ||
-            individualParams[1]
-                .valueOf()
-                .trimLeft()
-                .startsWith(lambdaContextType)
-        ) {
+        if (individualParams.length === 1 || individualParams[1].valueOf().trimLeft().startsWith(lambdaContextType)) {
             return true
         }
     }

--- a/src/shared/codelens/csharpCodeLensProvider.ts
+++ b/src/shared/codelens/csharpCodeLensProvider.ts
@@ -34,7 +34,7 @@ export async function getLambdaHandlerCandidates(document: vscode.TextDocument):
 
     // TODO : Perform an XPATH parse on the project file
     // If Project/PropertyGroup/AssemblyName exists, use that. Otherwise use the file name.
-    const assemblyUri = await findParentProjectFile(document.uri, '*.csproj')
+    const assemblyUri = await findParentProjectFile(document.uri, /^.*\.csproj$/)
     if (!assemblyUri) {
         return []
     }

--- a/src/shared/codelens/pythonCodeLensProvider.ts
+++ b/src/shared/codelens/pythonCodeLensProvider.ts
@@ -19,7 +19,7 @@ export const PYTHON_ALLFILES: vscode.DocumentFilter[] = [
 export const PYTHON_BASE_PATTERN = '**/requirements.txt'
 
 export async function getLambdaHandlerCandidates(uri: vscode.Uri): Promise<LambdaHandlerCandidate[]> {
-    const requirementsFile = await findParentProjectFile(uri, 'requirements.txt')
+    const requirementsFile = await findParentProjectFile(uri, /^requirements\.txt$/)
     if (!requirementsFile) {
         return []
     }

--- a/src/shared/codelens/pythonCodeLensProvider.ts
+++ b/src/shared/codelens/pythonCodeLensProvider.ts
@@ -16,6 +16,8 @@ export const PYTHON_ALLFILES: vscode.DocumentFilter[] = [
     },
 ]
 
+export const PYTHON_BASE_PATTERN = '**/requirements.txt'
+
 export async function getLambdaHandlerCandidates(uri: vscode.Uri): Promise<LambdaHandlerCandidate[]> {
     const requirementsFile = await findParentProjectFile(uri, 'requirements.txt')
     if (!requirementsFile) {

--- a/src/shared/codelens/typescriptCodeLensProvider.ts
+++ b/src/shared/codelens/typescriptCodeLensProvider.ts
@@ -10,6 +10,17 @@ import { TypescriptLambdaHandlerSearch } from '../typescriptLambdaHandlerSearch'
 import { normalizeSeparator } from '../utilities/pathUtils'
 import { findParentProjectFile } from '../utilities/workspaceUtils'
 
+export const JAVASCRIPT_LANGUAGE = 'javascript'
+
+export const JAVASCRIPT_ALL_FILES: vscode.DocumentFilter[] = [
+    {
+        language: JAVASCRIPT_LANGUAGE,
+        scheme: 'file',
+    },
+]
+
+export const JAVASCRIPT_BASE_PATTERN = '**/package.json'
+
 export async function getLambdaHandlerCandidates(document: vscode.TextDocument): Promise<LambdaHandlerCandidate[]> {
     const packageJsonFile = await findParentProjectFile(document.uri, 'package.json')
 

--- a/src/shared/codelens/typescriptCodeLensProvider.ts
+++ b/src/shared/codelens/typescriptCodeLensProvider.ts
@@ -22,7 +22,7 @@ export const JAVASCRIPT_ALL_FILES: vscode.DocumentFilter[] = [
 export const JAVASCRIPT_BASE_PATTERN = '**/package.json'
 
 export async function getLambdaHandlerCandidates(document: vscode.TextDocument): Promise<LambdaHandlerCandidate[]> {
-    const packageJsonFile = await findParentProjectFile(document.uri, 'package.json')
+    const packageJsonFile = await findParentProjectFile(document.uri, /^package\.json$/)
 
     if (!packageJsonFile) {
         return []

--- a/src/shared/extensionGlobals.ts
+++ b/src/shared/extensionGlobals.ts
@@ -8,7 +8,7 @@ import { AWSClientBuilder } from './awsClientBuilder'
 import { AWSContextCommands } from './awsContextCommands'
 import { ToolkitClientBuilder } from './clients/toolkitClientBuilder'
 import { CloudFormationTemplateRegistry } from './cloudformation/templateRegistry'
-import { CodelensRootRegistry } from './sam/rootRegistry'
+import { CodelensRootRegistry } from './sam/codelensRootRegistry'
 import { TelemetryService } from './telemetry/telemetryService'
 
 /**

--- a/src/shared/extensionGlobals.ts
+++ b/src/shared/extensionGlobals.ts
@@ -8,6 +8,7 @@ import { AWSClientBuilder } from './awsClientBuilder'
 import { AWSContextCommands } from './awsContextCommands'
 import { ToolkitClientBuilder } from './clients/toolkitClientBuilder'
 import { CloudFormationTemplateRegistry } from './cloudformation/templateRegistry'
+import { WorkspaceFileRegistry } from './fileRegistry'
 import { TelemetryService } from './telemetry/telemetryService'
 
 /**
@@ -22,6 +23,7 @@ export namespace ext {
     export let toolkitClientBuilder: ToolkitClientBuilder
     export let telemetry: TelemetryService
     export let templateRegistry: CloudFormationTemplateRegistry
+    export let codelensRootRegistry: WorkspaceFileRegistry<string>
 
     export namespace iconPaths {
         export const dark: IconPaths = makeIconPathsObject()

--- a/src/shared/extensionGlobals.ts
+++ b/src/shared/extensionGlobals.ts
@@ -8,7 +8,7 @@ import { AWSClientBuilder } from './awsClientBuilder'
 import { AWSContextCommands } from './awsContextCommands'
 import { ToolkitClientBuilder } from './clients/toolkitClientBuilder'
 import { CloudFormationTemplateRegistry } from './cloudformation/templateRegistry'
-import { WorkspaceFileRegistry } from './fileRegistry'
+import { CodelensRootRegistry } from './sam/rootRegistry'
 import { TelemetryService } from './telemetry/telemetryService'
 
 /**
@@ -23,7 +23,7 @@ export namespace ext {
     export let toolkitClientBuilder: ToolkitClientBuilder
     export let telemetry: TelemetryService
     export let templateRegistry: CloudFormationTemplateRegistry
-    export let codelensRootRegistry: WorkspaceFileRegistry<string>
+    export let codelensRootRegistry: CodelensRootRegistry
 
     export namespace iconPaths {
         export const dark: IconPaths = makeIconPathsObject()

--- a/src/shared/fileRegistry.ts
+++ b/src/shared/fileRegistry.ts
@@ -1,0 +1,199 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { getLogger } from './logger/logger'
+import * as pathutils from './utilities/pathUtils'
+import * as path from 'path'
+
+export interface WorkspaceItem<T> {
+    path: string
+    item: T
+}
+
+/**
+ * WorkspaceFileRegistry lets us index files in the current registry. It is used
+ * for CFN templates among other things
+ */
+export abstract class WorkspaceFileRegistry<T> implements vscode.Disposable {
+    private readonly disposables: vscode.Disposable[] = []
+    private _isDisposed: boolean = false
+    private readonly globs: vscode.GlobPattern[] = []
+    private readonly excludedFilePatterns: RegExp[] = []
+    private readonly templateRegistryData: Map<string, T> = new Map<string, T>()
+
+    /**
+     * Load in filesystem items or throw
+     * @param path A string with the absolute path to the detected file
+     */
+    protected abstract load(path: string): Promise<T>
+
+    public constructor() {
+        this.disposables.push(
+            vscode.workspace.onDidChangeWorkspaceFolders(async () => {
+                await this.rebuildRegistry()
+            })
+        )
+    }
+
+    /**
+     * Adds a glob pattern to use for lookups and resets the registry to use it.
+     * Throws an error if this manager has already been disposed.
+     * @param glob vscode.GlobPattern to be used for lookups
+     */
+    public async addWatchPattern(glob: vscode.GlobPattern): Promise<void> {
+        if (this._isDisposed) {
+            throw new Error('Manager has already been disposed!')
+        }
+        this.globs.push(glob)
+
+        const watcher = vscode.workspace.createFileSystemWatcher(glob)
+        this.addWatcher(watcher)
+
+        await this.rebuildRegistry()
+    }
+
+    /**
+     * Adds a regex pattern to ignore paths containing the pattern
+     */
+    public async addExcludedPattern(pattern: RegExp): Promise<void> {
+        if (this._isDisposed) {
+            throw new Error('Manager has already been disposed!')
+        }
+        this.excludedFilePatterns.push(pattern)
+
+        await this.rebuildRegistry()
+    }
+
+    /**
+     * Adds an item to registry. Wipes any existing item in its place with new copy of the data
+     * @param uri vscode.Uri containing the item to load in
+     */
+    public async addItemToRegistry(uri: vscode.Uri, quiet?: boolean): Promise<void> {
+        const excluded = this.excludedFilePatterns.find(pattern => uri.fsPath.match(pattern))
+        if (excluded) {
+            getLogger().verbose(`Manager did not add template ${uri.fsPath} matching excluded pattern ${excluded}`)
+            return
+        }
+        const pathAsString = pathutils.normalize(uri.fsPath)
+        this.assertAbsolute(pathAsString)
+        try {
+            const template = await this.load(pathAsString)
+            this.templateRegistryData.set(pathAsString, template)
+        } catch (e) {
+            if (!quiet) {
+                throw e
+            }
+            getLogger().verbose(`Template ${uri} is malformed: ${e}`)
+        }
+    }
+
+    /**
+     * Get a specific template's data
+     * @param path Path to template of interest
+     */
+    public getRegisteredTemplate(path: string): WorkspaceItem<T> | undefined {
+        const normalizedPath = pathutils.normalize(path)
+        this.assertAbsolute(normalizedPath)
+        const item = this.templateRegistryData.get(normalizedPath)
+        if (!item) {
+            return undefined
+        }
+        return {
+            path: normalizedPath,
+            item: item,
+        }
+    }
+
+    /**
+     * Returns the registry's data as an array of T objects
+     */
+    public get registeredItems(): WorkspaceItem<T>[] {
+        const arr: WorkspaceItem<T>[] = []
+
+        for (const templatePath of this.templateRegistryData.keys()) {
+            const template = this.getRegisteredTemplate(templatePath)
+            if (template) {
+                arr.push(template)
+            }
+        }
+
+        return arr
+    }
+
+    /**
+     * Removes a template from the registry.
+     * @param templateUri vscode.Uri containing template to remove
+     */
+    public removeTemplateFromRegistry(templateUri: vscode.Uri): void {
+        const pathAsString = pathutils.normalize(templateUri.fsPath)
+        this.assertAbsolute(pathAsString)
+        this.templateRegistryData.delete(pathAsString)
+    }
+
+    /**
+     * Disposes CloudFormationTemplateRegistryManager and marks as disposed.
+     */
+    public dispose(): void {
+        if (!this._isDisposed) {
+            while (this.disposables.length > 0) {
+                const disposable = this.disposables.pop()
+                if (disposable) {
+                    disposable.dispose()
+                }
+            }
+            this._isDisposed = true
+        }
+    }
+
+    /**
+     * Rebuilds registry using current glob and exclusion patterns.
+     * All functionality is currently internal to class, but can be made public if we want a manual "refresh" button
+     */
+    private async rebuildRegistry(): Promise<void> {
+        this.reset()
+        for (const glob of this.globs) {
+            const templateUris = await vscode.workspace.findFiles(glob)
+            for (const template of templateUris) {
+                await this.addItemToRegistry(template, true)
+            }
+        }
+    }
+
+    /**
+     * Removes all templates from the registry.
+     */
+    public reset() {
+        this.templateRegistryData.clear()
+    }
+
+    /**
+     * Sets watcher functionality and adds to this.disposables
+     * @param watcher vscode.FileSystemWatcher
+     */
+    private addWatcher(watcher: vscode.FileSystemWatcher): void {
+        this.disposables.push(
+            watcher,
+            watcher.onDidChange(async uri => {
+                getLogger().verbose(`Manager detected a change to template file: ${uri.fsPath}`)
+                await this.addItemToRegistry(uri)
+            }),
+            watcher.onDidCreate(async uri => {
+                getLogger().verbose(`Manager detected a new file: ${uri.fsPath}`)
+                await this.addItemToRegistry(uri)
+            }),
+            watcher.onDidDelete(async uri => {
+                getLogger().verbose(`Manager detected a deleted template file: ${uri.fsPath}`)
+                this.removeTemplateFromRegistry(uri)
+            })
+        )
+    }
+
+    private assertAbsolute(p: string) {
+        if (!path.isAbsolute(p)) {
+            throw Error(`FileRegistry: path is relative: ${p}`)
+        }
+    }
+}

--- a/src/shared/fileRegistry.ts
+++ b/src/shared/fileRegistry.ts
@@ -177,7 +177,7 @@ export abstract class WorkspaceFileRegistry<T> implements vscode.Disposable {
         this.disposables.push(
             watcher,
             watcher.onDidChange(async uri => {
-                getLogger().verbose(`Manager detected a change to template file: ${uri.fsPath}`)
+                getLogger().verbose(`Manager detected a change to tracked file: ${uri.fsPath}`)
                 await this.addItemToRegistry(uri)
             }),
             watcher.onDidCreate(async uri => {

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -172,9 +172,11 @@ async function activateCodeLensProviders(
         ext.codelensRootRegistry = registry
     } catch (e) {
         vscode.window.showErrorMessage(
-            localize('AWS.codelens.failToInitializeCode', "Failed to activate Lambda handler CodeLesns's")
+            localize('AWS.codelens.failToInitializeCode', 'Failed to activate Lambda handler CodeLenses')
         )
-        getLogger().error('Failed to activate template registry', e)
+        getLogger().error('Failed to activate codelens registry', e)
+        // This prevents us from breaking for any reason later if it fails to load. Since
+        // Noop watcher is always empty, we will get back empty arrays with no issues.
         ext.codelensRootRegistry = (new NoopWatcher() as unknown) as CodelensRootRegistry
     }
     context.extensionContext.subscriptions.push(ext.codelensRootRegistry)

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -32,6 +32,7 @@ import { detectSamCli } from './cli/samCliDetection'
 import { SamDebugConfigProvider } from './debugger/awsSamDebugger'
 import { addSamDebugConfiguration } from './debugger/commands/addSamDebugConfiguration'
 import { AWS_SAM_DEBUG_TYPE } from './debugger/awsSamDebugConfiguration'
+import { WorkspaceFileRegistry } from '../fileRegistry'
 
 const STATE_NAME_SUPPRESS_YAML_PROMPT = 'aws.sam.suppressYamlPrompt'
 
@@ -113,6 +114,12 @@ async function registerServerlessCommands(ctx: ExtContext): Promise<void> {
     // TODO : Register CodeLens commands from here instead of in xxxCodeLensProvider.ts::initialize
 }
 
+class RootRegistry extends WorkspaceFileRegistry<string> {
+    protected async load(path: string): Promise<string> {
+        return path
+    }
+}
+
 async function activateCodeLensProviders(
     context: ExtContext,
     configuration: SettingsConfiguration,
@@ -164,6 +171,11 @@ async function activateCodeLensProviders(
             await codelensUtils.makeCSharpCodeLensProvider()
         )
     )
+
+    const registry = new RootRegistry()
+    await registry.addWatchPattern('')
+    context.extensionContext.subscriptions.push(registry)
+    ext.codelensRootRegistry = registry
 
     return disposables
 }

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -33,7 +33,7 @@ import { detectSamCli } from './cli/samCliDetection'
 import { SamDebugConfigProvider } from './debugger/awsSamDebugger'
 import { addSamDebugConfiguration } from './debugger/commands/addSamDebugConfiguration'
 import { AWS_SAM_DEBUG_TYPE } from './debugger/awsSamDebugConfiguration'
-import { CodelensRootRegistry } from './rootRegistry'
+import { CodelensRootRegistry } from './codelensRootRegistry'
 
 const STATE_NAME_SUPPRESS_YAML_PROMPT = 'aws.sam.suppressYamlPrompt'
 

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -6,6 +6,7 @@
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
+import * as path from 'path'
 import * as vscode from 'vscode'
 import { createNewSamApplication, resumeCreateNewSamApp } from '../../lambda/commands/createNewSamApp'
 import { deploySamApplication, SamDeployWizardResponseProvider } from '../../lambda/commands/deploySamApplication'
@@ -115,8 +116,8 @@ async function registerServerlessCommands(ctx: ExtContext): Promise<void> {
 }
 
 class RootRegistry extends WorkspaceFileRegistry<string> {
-    protected async load(path: string): Promise<string> {
-        return path
+    protected async load(p: string): Promise<string> {
+        return path.basename(p)
     }
 }
 
@@ -173,7 +174,9 @@ async function activateCodeLensProviders(
     )
 
     const registry = new RootRegistry()
-    await registry.addWatchPattern('')
+    await registry.addWatchPattern('**/requirements.txt')
+    await registry.addWatchPattern('**/package.json')
+    await registry.addWatchPattern('**/*.csproj')
     context.extensionContext.subscriptions.push(registry)
     ext.codelensRootRegistry = registry
 

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -34,6 +34,7 @@ import { SamDebugConfigProvider } from './debugger/awsSamDebugger'
 import { addSamDebugConfiguration } from './debugger/commands/addSamDebugConfiguration'
 import { AWS_SAM_DEBUG_TYPE } from './debugger/awsSamDebugConfiguration'
 import { CodelensRootRegistry } from './codelensRootRegistry'
+import { NoopWatcher } from '../watchedFiles'
 
 const STATE_NAME_SUPPRESS_YAML_PROMPT = 'aws.sam.suppressYamlPrompt'
 
@@ -168,18 +169,15 @@ async function activateCodeLensProviders(
         await registry.addWatchPattern(jsLensProvider.JAVASCRIPT_BASE_PATTERN)
         await registry.addWatchPattern(csLensProvider.CSHARP_BASE_PATTERN)
 
-        context.extensionContext.subscriptions.push(registry)
-
         ext.codelensRootRegistry = registry
     } catch (e) {
         vscode.window.showErrorMessage(
-            localize(
-                'AWS.codelens.failToInitialize',
-                'Failed to activate template registry. CodeLenses will not appear on SAM template files.'
-            )
+            localize('AWS.codelens.failToInitializeCode', "Failed to activate Lambda handler CodeLesns's")
         )
         getLogger().error('Failed to activate template registry', e)
+        ext.codelensRootRegistry = (new NoopWatcher() as unknown) as CodelensRootRegistry
     }
+    context.extensionContext.subscriptions.push(ext.codelensRootRegistry)
 
     return disposables
 }

--- a/src/shared/sam/codelensRootRegistry.ts
+++ b/src/shared/sam/codelensRootRegistry.ts
@@ -16,6 +16,7 @@ import { WorkspaceFileRegistry } from '../fileRegistry'
  * is valid for each codelense
  */
 export class CodelensRootRegistry extends WorkspaceFileRegistry<string> {
+    protected registryName: string = 'CodelensRootRegistry'
     protected async load(p: string): Promise<string> {
         return path.basename(p)
     }

--- a/src/shared/sam/codelensRootRegistry.ts
+++ b/src/shared/sam/codelensRootRegistry.ts
@@ -4,7 +4,7 @@
  */
 
 import * as path from 'path'
-import { WorkspaceFileRegistry } from '../fileRegistry'
+import { WatchedFiles } from '../watchedFiles'
 
 /**
  * CodelensRootRegistry stores the locations of files that we consider as candidates for
@@ -15,8 +15,8 @@ import { WorkspaceFileRegistry } from '../fileRegistry'
  * The type it stores it the basename of the path, so we can figure out if the candidate
  * is valid for each codelense
  */
-export class CodelensRootRegistry extends WorkspaceFileRegistry<string> {
-    protected registryName: string = 'CodelensRootRegistry'
+export class CodelensRootRegistry extends WatchedFiles<string> {
+    protected name: string = 'CodelensRootRegistry'
     protected async load(p: string): Promise<string> {
         return path.basename(p)
     }

--- a/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
@@ -64,7 +64,7 @@ export class DefaultAwsSamDebugConfigurationValidator implements AwsSamDebugConf
                 const fullpath = tryGetAbsolutePath(this.workspaceFolder, config.invokeTarget.templatePath)
                 // Normalize to absolute path for use in the runner.
                 config.invokeTarget.templatePath = fullpath
-                cfnTemplate = ext.templateRegistry.getRegisteredTemplate(fullpath)?.template
+                cfnTemplate = ext.templateRegistry.getRegisteredItem(fullpath)?.item
             }
             rv = this.validateTemplateConfig(config, config.invokeTarget.templatePath, cfnTemplate)
         } else if (config.invokeTarget.target === CODE_TARGET_TYPE) {

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -169,22 +169,22 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         const configs: AwsSamDebuggerConfiguration[] = []
         if (folder) {
             const folderPath = folder.uri.fsPath
-            const templates = ext.templateRegistry.registeredTemplates
+            const templates = ext.templateRegistry.registeredItems
 
             for (const templateDatum of templates) {
                 if (isInDirectory(folderPath, templateDatum.path)) {
-                    if (!templateDatum.template.Resources) {
+                    if (!templateDatum.item.Resources) {
                         getLogger().error(`provideDebugConfigurations: invalid template: ${templateDatum.path}`)
                         continue
                     }
-                    for (const resourceKey of Object.keys(templateDatum.template.Resources)) {
-                        const resource = templateDatum.template.Resources[resourceKey]
+                    for (const resourceKey of Object.keys(templateDatum.item.Resources)) {
+                        const resource = templateDatum.item.Resources[resourceKey]
                         if (resource) {
                             const runtimeName = resource.Properties?.Runtime
                             configs.push(
                                 createTemplateAwsSamDebugConfig(
                                     folder,
-                                    CloudFormation.getStringForProperty(runtimeName, templateDatum.template),
+                                    CloudFormation.getStringForProperty(runtimeName, templateDatum.item),
                                     resourceKey,
                                     templateDatum.path
                                 )
@@ -199,10 +199,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
                                         configs.push(
                                             createApiAwsSamDebugConfig(
                                                 folder,
-                                                CloudFormation.getStringForProperty(
-                                                    runtimeName,
-                                                    templateDatum.template
-                                                ),
+                                                CloudFormation.getStringForProperty(runtimeName, templateDatum.item),
                                                 resourceKey,
                                                 templateDatum.path,
                                                 {

--- a/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
@@ -54,14 +54,11 @@ export async function addSamDebugConfiguration(
         let preloadedConfig = undefined
 
         if (workspaceFolder) {
-            const templateDatum = ext.templateRegistry.getRegisteredTemplate(rootUri.fsPath)
+            const templateDatum = ext.templateRegistry.getRegisteredItem(rootUri.fsPath)
             if (templateDatum) {
-                const resource = templateDatum.template.Resources![resourceName]
+                const resource = templateDatum.item.Resources![resourceName]
                 if (resource && resource.Properties) {
-                    const handler = CloudFormation.getStringForProperty(
-                        resource.Properties.Handler,
-                        templateDatum.template
-                    )
+                    const handler = CloudFormation.getStringForProperty(resource.Properties.Handler, templateDatum.item)
                     const existingConfig = await getExistingConfiguration(workspaceFolder, handler ?? '', rootUri)
                     if (existingConfig) {
                         const responseMigrate: string = localize(

--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -29,7 +29,7 @@ export async function invokeTypescriptLambda(
 }
 
 export async function getSamProjectDirPathForFile(filepath: string): Promise<string> {
-    const packageJsonPath = await findParentProjectFile(vscode.Uri.parse(filepath), 'package.json')
+    const packageJsonPath = await findParentProjectFile(vscode.Uri.parse(filepath), /^package\.json$/)
     if (!packageJsonPath) {
         throw new Error(`Cannot find package.json for: ${filepath}`)
     }

--- a/src/shared/sam/rootRegistry.ts
+++ b/src/shared/sam/rootRegistry.ts
@@ -1,0 +1,22 @@
+/*!
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as path from 'path'
+import { WorkspaceFileRegistry } from '../fileRegistry'
+
+/**
+ * CodelensRootRegistry stores the locations of files that we consider as candidates for
+ * the root of a potential Lambda handler. For example, any requirements.txt could be
+ * in the root of a Python Lambda handler. We store these and update them as they are
+ * updated so we do not have to rescan the file system.
+ *
+ * The type it stores it the basename of the path, so we can figure out if the candidate
+ * is valid for each codelense
+ */
+export class CodelensRootRegistry extends WorkspaceFileRegistry<string> {
+    protected async load(p: string): Promise<string> {
+        return path.basename(p)
+    }
+}

--- a/src/shared/utilities/pathUtils.ts
+++ b/src/shared/utilities/pathUtils.ts
@@ -48,11 +48,11 @@ export function normalizeSeparator(p: string) {
     return normalized
 }
 
-export function dirnameWithTrailingSlash(path: string): string {
+export function normalizedDirnameWithTrailingSlash(path: string): string {
     const dir = normalize(path)
     let dirname = _path.dirname(dir)
-    if (!dirname.endsWith(_path.sep)) {
-        dirname += _path.sep
+    if (!dirname.endsWith('/')) {
+        dirname += '/'
     }
 
     return dirname

--- a/src/shared/utilities/pathUtils.ts
+++ b/src/shared/utilities/pathUtils.ts
@@ -49,7 +49,7 @@ export function normalizeSeparator(p: string) {
 }
 
 export function dirnameWithTrailingSlash(path: string): string {
-    let dir = normalize(path)
+    const dir = normalize(path)
     let dirname = _path.dirname(dir)
     if (!dirname.endsWith(_path.sep)) {
         dirname += _path.sep

--- a/src/shared/utilities/pathUtils.ts
+++ b/src/shared/utilities/pathUtils.ts
@@ -49,7 +49,8 @@ export function normalizeSeparator(p: string) {
 }
 
 export function dirnameWithTrailingSlash(path: string): string {
-    let dirname = _path.dirname(path)
+    let dir = normalize(path)
+    let dirname = _path.dirname(dir)
     if (!dirname.endsWith(_path.sep)) {
         dirname += _path.sep
     }

--- a/src/shared/utilities/workspaceUtils.ts
+++ b/src/shared/utilities/workspaceUtils.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 import { getLogger } from '../logger'
 import { isInDirectory } from '../filesystemUtilities'
-import { dirnameWithTrailingSlash } from './pathUtils'
+import { normalizedDirnameWithTrailingSlash, normalize } from './pathUtils'
 import { ext } from '../extensionGlobals'
 
 /**
@@ -105,9 +105,9 @@ export async function findParentProjectFile(
     // Use the project file "closest" in the parent chain to sourceCodeUri
     const parentProjectFiles = workspaceProjectFiles
         .filter(uri => {
-            const dirname = dirnameWithTrailingSlash(uri)
+            const dirname = normalizedDirnameWithTrailingSlash(uri)
 
-            return sourceCodeUri.fsPath.startsWith(dirname)
+            return normalize(sourceCodeUri.fsPath).startsWith(dirname)
         })
         .sort((a, b) => {
             if (isInDirectory(path.parse(a).dir, path.parse(b).dir)) {

--- a/src/shared/utilities/workspaceUtils.ts
+++ b/src/shared/utilities/workspaceUtils.ts
@@ -103,7 +103,7 @@ export async function findParentProjectFile(
         .map(item => item.path)
 
     // Use the project file "closest" in the parent chain to sourceCodeUri
-    let parentProjectFiles = workspaceProjectFiles
+    const parentProjectFiles = workspaceProjectFiles
         .filter(uri => {
             const dirname = dirnameWithTrailingSlash(uri)
 

--- a/src/shared/utilities/workspaceUtils.ts
+++ b/src/shared/utilities/workspaceUtils.ts
@@ -91,7 +91,7 @@ export async function addFolderToWorkspace(
  */
 export async function findParentProjectFile(
     sourceCodeUri: vscode.Uri,
-    projectFile: string
+    projectFile: RegExp
 ): Promise<vscode.Uri | undefined> {
     const workspaceFolder = vscode.workspace.getWorkspaceFolder(sourceCodeUri)
     if (!workspaceFolder) {

--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -9,6 +9,7 @@
 import * as assert from 'assert'
 import { appendFileSync, mkdirpSync, remove } from 'fs-extra'
 import { join } from 'path'
+import { CodelensRootRegistry } from '../shared/sam/codelensRootRegistry'
 import { CloudFormationTemplateRegistry } from '../shared/cloudformation/templateRegistry'
 import { ext } from '../shared/extensionGlobals'
 import { getLogger } from '../shared/logger'
@@ -44,6 +45,7 @@ before(async () => {
     const service = new DefaultTelemetryService(mockContext, mockAws, mockPublisher)
     ext.telemetry = service
     ext.templateRegistry = new CloudFormationTemplateRegistry()
+    ext.codelensRootRegistry = new CodelensRootRegistry()
 })
 
 beforeEach(async function () {

--- a/src/test/lambda/commands/createNewSamApp.test.ts
+++ b/src/test/lambda/commands/createNewSamApp.test.ts
@@ -62,7 +62,7 @@ describe('addInitialLaunchConfiguration', function () {
 
         testutil.toFile(makeSampleSamTemplateYaml(true), tempTemplate.fsPath)
 
-        await ext.templateRegistry.addTemplateToRegistry(tempTemplate)
+        await ext.templateRegistry.addItemToRegistry(tempTemplate)
         const launchConfigs = await addInitialLaunchConfiguration(
             fakeContext,
             fakeWorkspaceFolder,
@@ -96,7 +96,7 @@ describe('addInitialLaunchConfiguration', function () {
 
         testutil.toFile(makeSampleSamTemplateYaml(true), tempTemplate.fsPath)
 
-        await ext.templateRegistry.addTemplateToRegistry(tempTemplate)
+        await ext.templateRegistry.addItemToRegistry(tempTemplate)
         const launchConfigs = await addInitialLaunchConfiguration(
             fakeContext,
             fakeWorkspaceFolder,

--- a/src/test/lambda/config/templates.test.ts
+++ b/src/test/lambda/config/templates.test.ts
@@ -797,7 +797,7 @@ describe('getExistingConfiguration', async () => {
     it('returns undefined if the legacy config file is not valid JSON', async () => {
         await writeFile(tempTemplateFile.fsPath, makeSampleSamTemplateYaml(true, { handler: matchedHandler }), 'utf8')
         await writeFile(tempConfigFile, makeSampleSamTemplateYaml(true, { handler: matchedHandler }), 'utf8')
-        await ext.templateRegistry.addTemplateToRegistry(tempTemplateFile)
+        await ext.templateRegistry.addItemToRegistry(tempTemplateFile)
         const val = await getExistingConfiguration(fakeWorkspaceFolder, matchedHandler, tempTemplateFile)
         assert.strictEqual(val, undefined)
     })
@@ -818,7 +818,7 @@ describe('getExistingConfiguration', async () => {
             },
         }
         await writeFile(tempConfigFile, JSON.stringify(configData), 'utf8')
-        await ext.templateRegistry.addTemplateToRegistry(tempTemplateFile)
+        await ext.templateRegistry.addItemToRegistry(tempTemplateFile)
         const val = await getExistingConfiguration(fakeWorkspaceFolder, matchedHandler, tempTemplateFile)
         assert.ok(val)
         if (val) {

--- a/src/test/shared/cloudformation/templateRegistry.test.ts
+++ b/src/test/shared/cloudformation/templateRegistry.test.ts
@@ -12,13 +12,13 @@ import {
     CloudFormationTemplateRegistry,
     getResourcesForHandler,
     getResourcesForHandlerFromTemplateDatum,
-    TemplateDatum,
 } from '../../../shared/cloudformation/templateRegistry'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 import { assertThrowsError } from '../utilities/assertUtils'
 import { badYaml, makeSampleSamTemplateYaml, strToYamlFile } from './cloudformationTestUtils'
 import { assertEqualPaths } from '../../testUtil'
 import { CloudFormation } from '../../../shared/cloudformation/cloudformation'
+import { WorkspaceItem } from '../../../shared/fileRegistry'
 
 describe('CloudFormation Template Registry', async () => {
     const goodYaml1 = makeSampleSamTemplateYaml(false)
@@ -36,15 +36,15 @@ describe('CloudFormation Template Registry', async () => {
             await fs.remove(tempFolder)
         })
 
-        describe('addTemplateToRegistry', async () => {
+        describe('addItemToRegistry', async () => {
             it("adds data from a template to the registry and can receive the template's data", async () => {
                 const filename = vscode.Uri.file(path.join(tempFolder, 'template.yaml'))
                 await strToYamlFile(goodYaml1, filename.fsPath)
-                await testRegistry.addTemplateToRegistry(filename)
+                await testRegistry.addItemToRegistry(filename)
 
-                assert.strictEqual(testRegistry.registeredTemplates.length, 1)
+                assert.strictEqual(testRegistry.registeredItems.length, 1)
 
-                const data = testRegistry.getRegisteredTemplate(filename.fsPath)
+                const data = testRegistry.getRegisteredItem(filename.fsPath)
 
                 assertValidTestTemplate(data, filename.fsPath)
             })
@@ -54,30 +54,30 @@ describe('CloudFormation Template Registry', async () => {
                 await strToYamlFile(badYaml, filename.fsPath)
 
                 await assertThrowsError(
-                    async () => await testRegistry.addTemplateToRegistry(vscode.Uri.file(filename.fsPath))
+                    async () => await testRegistry.addItemToRegistry(vscode.Uri.file(filename.fsPath))
                 )
             })
         })
 
         // other get cases are tested in the add section
-        describe('registeredTemplates', async () => {
+        describe('registeredItems', async () => {
             it('returns an empty array if the registry has no registered templates', () => {
-                assert.strictEqual(testRegistry.registeredTemplates.length, 0)
+                assert.strictEqual(testRegistry.registeredItems.length, 0)
             })
         })
 
         // other get cases are tested in the add section
-        describe('getRegisteredTemplate', async () => {
+        describe('getRegisteredItem', async () => {
             it('returns undefined if the registry has no registered templates', () => {
-                assert.strictEqual(testRegistry.getRegisteredTemplate('/template.yaml'), undefined)
+                assert.strictEqual(testRegistry.getRegisteredItem('/template.yaml'), undefined)
             })
 
             it('returns undefined if the registry does not contain the template in question', async () => {
                 const filename = vscode.Uri.file(path.join(tempFolder, 'template.yaml'))
                 await strToYamlFile(goodYaml1, filename.fsPath)
-                await testRegistry.addTemplateToRegistry(vscode.Uri.file(filename.fsPath))
+                await testRegistry.addItemToRegistry(vscode.Uri.file(filename.fsPath))
 
-                assert.strictEqual(testRegistry.getRegisteredTemplate('/not-the-template.yaml'), undefined)
+                assert.strictEqual(testRegistry.getRegisteredItem('/not-the-template.yaml'), undefined)
             })
         })
 
@@ -85,21 +85,21 @@ describe('CloudFormation Template Registry', async () => {
             it('removes an added template', async () => {
                 const filename = vscode.Uri.file(path.join(tempFolder, 'template.yaml'))
                 await strToYamlFile(goodYaml1, filename.fsPath)
-                await testRegistry.addTemplateToRegistry(vscode.Uri.file(filename.fsPath))
-                assert.strictEqual(testRegistry.registeredTemplates.length, 1)
+                await testRegistry.addItemToRegistry(vscode.Uri.file(filename.fsPath))
+                assert.strictEqual(testRegistry.registeredItems.length, 1)
 
-                testRegistry.removeTemplateFromRegistry(vscode.Uri.file(filename.fsPath))
-                assert.strictEqual(testRegistry.registeredTemplates.length, 0)
+                testRegistry.removeItemFromRegistry(vscode.Uri.file(filename.fsPath))
+                assert.strictEqual(testRegistry.registeredItems.length, 0)
             })
 
             it('does not affect the registry if a nonexistant template is removed', async () => {
                 const filename = vscode.Uri.file(path.join(tempFolder, 'template.yaml'))
                 await strToYamlFile(goodYaml1, filename.fsPath)
-                await testRegistry.addTemplateToRegistry(vscode.Uri.file(filename.fsPath))
-                assert.strictEqual(testRegistry.registeredTemplates.length, 1)
+                await testRegistry.addItemToRegistry(vscode.Uri.file(filename.fsPath))
+                assert.strictEqual(testRegistry.registeredItems.length, 1)
 
-                testRegistry.removeTemplateFromRegistry(vscode.Uri.file(path.join(tempFolder, 'wrong-template.yaml')))
-                assert.strictEqual(testRegistry.registeredTemplates.length, 1)
+                testRegistry.removeItemFromRegistry(vscode.Uri.file(path.join(tempFolder, 'wrong-template.yaml')))
+                assert.strictEqual(testRegistry.registeredItems.length, 1)
             })
         })
     })
@@ -121,11 +121,11 @@ describe('CloudFormation Template Registry', async () => {
     }
     const nonParentTemplate = {
         path: path.join(otherPath, 'template.yaml'),
-        template: {},
+        item: {},
     }
     const workingTemplate = {
         path: path.join(rootPath, 'template.yaml'),
-        template: {
+        item: {
             Resources: {
                 resource1: matchingResource,
             },
@@ -133,7 +133,7 @@ describe('CloudFormation Template Registry', async () => {
     }
     const noResourceTemplate = {
         path: path.join(rootPath, 'template.yaml'),
-        template: {
+        item: {
             Resources: {},
         },
     }
@@ -150,7 +150,7 @@ describe('CloudFormation Template Registry', async () => {
     }
     const dotNetTemplate = {
         path: path.join(rootPath, 'template.yaml'),
-        template: {
+        item: {
             Resources: {
                 resource1: compiledResource,
             },
@@ -158,7 +158,7 @@ describe('CloudFormation Template Registry', async () => {
     }
     const multiResourceTemplate = {
         path: path.join(rootPath, 'template.yaml'),
-        template: {
+        item: {
             Resources: {
                 resource1: matchingResource,
                 resource2: {
@@ -173,7 +173,7 @@ describe('CloudFormation Template Registry', async () => {
     }
     const badRuntimeTemplate = {
         path: path.join(rootPath, 'template.yaml'),
-        template: {
+        item: {
             Resources: {
                 badResource: {
                     ...matchingResource,
@@ -330,10 +330,10 @@ describe('CloudFormation Template Registry', async () => {
     })
 })
 
-function assertValidTestTemplate(data: TemplateDatum | undefined, filename: string): void {
+function assertValidTestTemplate(data: WorkspaceItem<CloudFormation.Template> | undefined, filename: string): void {
     assert.ok(data)
     if (data) {
         assertEqualPaths(data.path, filename)
-        assert.ok(data.template.Resources?.TestResource)
+        assert.ok(data.item.Resources?.TestResource)
     }
 }

--- a/src/test/shared/cloudformation/templateRegistry.test.ts
+++ b/src/test/shared/cloudformation/templateRegistry.test.ts
@@ -18,8 +18,9 @@ import { assertThrowsError } from '../utilities/assertUtils'
 import { badYaml, makeSampleSamTemplateYaml, strToYamlFile } from './cloudformationTestUtils'
 import { assertEqualPaths } from '../../testUtil'
 import { CloudFormation } from '../../../shared/cloudformation/cloudformation'
-import { WorkspaceItem } from '../../../shared/fileRegistry'
+import { WatchedItem } from '../../../shared/watchedFiles'
 
+// TODO almost all of these tests should be moved to test WatchedFiles instead
 describe('CloudFormation Template Registry', async () => {
     const goodYaml1 = makeSampleSamTemplateYaml(false)
 
@@ -88,7 +89,7 @@ describe('CloudFormation Template Registry', async () => {
                 await testRegistry.addItemToRegistry(vscode.Uri.file(filename.fsPath))
                 assert.strictEqual(testRegistry.registeredItems.length, 1)
 
-                testRegistry.removeItemFromRegistry(vscode.Uri.file(filename.fsPath))
+                testRegistry.remove(vscode.Uri.file(filename.fsPath))
                 assert.strictEqual(testRegistry.registeredItems.length, 0)
             })
 
@@ -98,7 +99,7 @@ describe('CloudFormation Template Registry', async () => {
                 await testRegistry.addItemToRegistry(vscode.Uri.file(filename.fsPath))
                 assert.strictEqual(testRegistry.registeredItems.length, 1)
 
-                testRegistry.removeItemFromRegistry(vscode.Uri.file(path.join(tempFolder, 'wrong-template.yaml')))
+                testRegistry.remove(vscode.Uri.file(path.join(tempFolder, 'wrong-template.yaml')))
                 assert.strictEqual(testRegistry.registeredItems.length, 1)
             })
         })
@@ -330,7 +331,7 @@ describe('CloudFormation Template Registry', async () => {
     })
 })
 
-function assertValidTestTemplate(data: WorkspaceItem<CloudFormation.Template> | undefined, filename: string): void {
+function assertValidTestTemplate(data: WatchedItem<CloudFormation.Template> | undefined, filename: string): void {
     assert.ok(data)
     if (data) {
         assertEqualPaths(data.path, filename)

--- a/src/test/shared/debug/launchConfiguration.test.ts
+++ b/src/test/shared/debug/launchConfiguration.test.ts
@@ -105,7 +105,7 @@ describe('LaunchConfiguration', () => {
     const templateUriCsharp = vscode.Uri.file(path.join(workspace.uri.fsPath, 'csharp2.1-plain-sam-app/template.yaml'))
 
     beforeEach(async () => {
-        await ext.templateRegistry.addTemplateGlob(TEMPLATE_FILE_GLOB_PATTERN)
+        await ext.templateRegistry.addWatchPattern(TEMPLATE_FILE_GLOB_PATTERN)
 
         // TODO: remove mocks in favor of testing src/testFixtures/ data.
         mockConfigSource = mock()

--- a/src/test/shared/sam/debugger/awsSamDebugConfigurationValidator.test.ts
+++ b/src/test/shared/sam/debugger/awsSamDebugConfigurationValidator.test.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode'
 import { instance, mock, when } from 'ts-mockito'
 
 import { CloudFormation } from '../../../../shared/cloudformation/cloudformation'
-import { CloudFormationTemplateRegistry, TemplateDatum } from '../../../../shared/cloudformation/templateRegistry'
+import { CloudFormationTemplateRegistry } from '../../../../shared/cloudformation/templateRegistry'
 import {
     AwsSamDebuggerConfiguration,
     TemplateTargetProperties,
@@ -16,6 +16,7 @@ import {
 import { DefaultAwsSamDebugConfigurationValidator } from '../../../../shared/sam/debugger/awsSamDebugConfigurationValidator'
 import { createBaseTemplate } from '../../cloudformation/cloudformationTestUtils'
 import { ext } from '../../../../shared/extensionGlobals'
+import { WorkspaceItem } from '../../../../shared/fileRegistry'
 
 function createTemplateConfig(): AwsSamDebuggerConfiguration {
     return {
@@ -60,10 +61,10 @@ function createApiConfig(): AwsSamDebuggerConfiguration {
     }
 }
 
-function createTemplateData(): TemplateDatum {
+function createTemplateData(): WorkspaceItem<CloudFormation.Template> {
     return {
         path: '/',
-        template: createBaseTemplate(),
+        item: createBaseTemplate(),
     }
 }
 
@@ -89,7 +90,7 @@ describe('DefaultAwsSamDebugConfigurationValidator', () => {
     })
 
     beforeEach(() => {
-        when(mockRegistry.getRegisteredTemplate('/')).thenReturn(templateData)
+        when(mockRegistry.getRegisteredItem('/')).thenReturn(templateData)
 
         ext.templateRegistry = mockRegistry
 
@@ -112,7 +113,7 @@ describe('DefaultAwsSamDebugConfigurationValidator', () => {
 
     it("returns invalid when resolving template debug configurations with a template that isn't in the registry", () => {
         const mockEmptyRegistry: CloudFormationTemplateRegistry = mock()
-        when(mockEmptyRegistry.getRegisteredTemplate('/')).thenReturn(undefined)
+        when(mockEmptyRegistry.getRegisteredItem('/')).thenReturn(undefined)
 
         validator = new DefaultAwsSamDebugConfigurationValidator(instance(mockFolder))
 
@@ -137,8 +138,7 @@ describe('DefaultAwsSamDebugConfigurationValidator', () => {
     })
 
     it('returns undefined when resolving template debug configurations with a resource that has an invalid runtime in template', () => {
-        const properties = templateData.template.Resources?.TestResource
-            ?.Properties as CloudFormation.ResourceProperties
+        const properties = templateData.item.Resources?.TestResource?.Properties as CloudFormation.ResourceProperties
         properties.Runtime = 'invalid'
 
         const result = validator.validate(templateConfig)

--- a/src/test/shared/sam/debugger/awsSamDebugConfigurationValidator.test.ts
+++ b/src/test/shared/sam/debugger/awsSamDebugConfigurationValidator.test.ts
@@ -16,7 +16,7 @@ import {
 import { DefaultAwsSamDebugConfigurationValidator } from '../../../../shared/sam/debugger/awsSamDebugConfigurationValidator'
 import { createBaseTemplate } from '../../cloudformation/cloudformationTestUtils'
 import { ext } from '../../../../shared/extensionGlobals'
-import { WorkspaceItem } from '../../../../shared/fileRegistry'
+import { WatchedItem } from '../../../../shared/watchedFiles'
 
 function createTemplateConfig(): AwsSamDebuggerConfiguration {
     return {
@@ -61,7 +61,7 @@ function createApiConfig(): AwsSamDebuggerConfiguration {
     }
 }
 
-function createTemplateData(): WorkspaceItem<CloudFormation.Template> {
+function createTemplateData(): WatchedItem<CloudFormation.Template> {
     return {
         path: '/',
         item: createBaseTemplate(),

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -138,7 +138,7 @@ describe('SamDebugConfigurationProvider', async () => {
 
             // Malformed template.yaml:
             testutil.toFile('bogus', tempFile.fsPath)
-            await ext.templateRegistry.addTemplateToRegistry(tempFile)
+            await ext.templateRegistry.addItemToRegistry(tempFile)
             assert.deepStrictEqual(await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder), [])
         })
 
@@ -146,14 +146,14 @@ describe('SamDebugConfigurationProvider', async () => {
             const bigYamlStr = `${makeSampleSamTemplateYaml(true)}\nTestResource2:\n .   Type: AWS::Serverless::Api`
 
             testutil.toFile(bigYamlStr, tempFile.fsPath)
-            await ext.templateRegistry.addTemplateToRegistry(tempFile)
+            await ext.templateRegistry.addItemToRegistry(tempFile)
             const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
             assert.strictEqual(provided!.length, 1)
         })
 
         it('returns one item if a template with one resource is in the workspace', async () => {
             testutil.toFile(makeSampleSamTemplateYaml(true), tempFile.fsPath)
-            await ext.templateRegistry.addTemplateToRegistry(tempFile)
+            await ext.templateRegistry.addItemToRegistry(tempFile)
             const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
             assert.notStrictEqual(provided, undefined)
             assert.strictEqual(provided!.length, 1)
@@ -169,7 +169,7 @@ describe('SamDebugConfigurationProvider', async () => {
                 resourceName: resources[0],
             })}\n${makeSampleYamlResource({ resourceName: resources[1] })}`
             testutil.toFile(bigYamlStr, tempFile.fsPath)
-            await ext.templateRegistry.addTemplateToRegistry(tempFile)
+            await ext.templateRegistry.addItemToRegistry(tempFile)
             const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
             assert.notStrictEqual(provided, undefined)
             if (provided) {
@@ -195,9 +195,9 @@ describe('SamDebugConfigurationProvider', async () => {
             testutil.toFile(makeSampleSamTemplateYaml(true, { resourceName: resources[1] }), nestedYaml.fsPath)
             testutil.toFile(makeSampleSamTemplateYaml(true, { resourceName: badResourceName }), similarNameYaml.fsPath)
 
-            await ext.templateRegistry.addTemplateToRegistry(tempFile)
-            await ext.templateRegistry.addTemplateToRegistry(nestedYaml)
-            await ext.templateRegistry.addTemplateToRegistry(similarNameYaml)
+            await ext.templateRegistry.addItemToRegistry(tempFile)
+            await ext.templateRegistry.addItemToRegistry(nestedYaml)
+            await ext.templateRegistry.addItemToRegistry(similarNameYaml)
 
             const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
             assert.notStrictEqual(provided, undefined)
@@ -220,7 +220,7 @@ describe('SamDebugConfigurationProvider', async () => {
             console.log(bigYamlStr)
 
             testutil.toFile(bigYamlStr, tempFile.fsPath)
-            await ext.templateRegistry.addTemplateToRegistry(tempFile)
+            await ext.templateRegistry.addItemToRegistry(tempFile)
             const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
             assert.strictEqual(provided!.length, 2)
             assert.strictEqual(provided![1].invokeTarget.target, API_TARGET_TYPE)
@@ -236,7 +236,7 @@ describe('SamDebugConfigurationProvider', async () => {
             console.log(bigYamlStr)
 
             testutil.toFile(bigYamlStr, tempFile.fsPath)
-            await ext.templateRegistry.addTemplateToRegistry(tempFile)
+            await ext.templateRegistry.addItemToRegistry(tempFile)
             const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
             assert.strictEqual(provided!.length, 1)
         })
@@ -363,7 +363,7 @@ describe('SamDebugConfigurationProvider', async () => {
                 makeSampleSamTemplateYaml(true, { resourceName, runtime: 'moreLikeRanOutOfTime' }),
                 tempFile.fsPath
             )
-            await ext.templateRegistry.addTemplateToRegistry(tempFile)
+            await ext.templateRegistry.addItemToRegistry(tempFile)
             const resolved = await debugConfigProvider.makeConfig(undefined, {
                 type: AWS_SAM_DEBUG_TYPE,
                 name: 'whats in a name',
@@ -390,7 +390,7 @@ describe('SamDebugConfigurationProvider', async () => {
         it('supports workspace-relative template path ("./foo.yaml")', async () => {
             testutil.toFile(makeSampleSamTemplateYaml(true, { runtime: 'nodejs12.x' }), tempFile.fsPath)
             // Register with *full* path.
-            await ext.templateRegistry.addTemplateToRegistry(tempFile)
+            await ext.templateRegistry.addItemToRegistry(tempFile)
             // Simulates launch.json:
             //     "invokeTarget": {
             //         "target": "./test.yaml",
@@ -563,7 +563,7 @@ describe('SamDebugConfigurationProvider', async () => {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await ext.templateRegistry.addTemplateToRegistry(templatePath)
+            await ext.templateRegistry.addItemToRegistry(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
 
             const expected: SamLaunchRequestArgs = {
@@ -808,7 +808,7 @@ describe('SamDebugConfigurationProvider', async () => {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await ext.templateRegistry.addTemplateToRegistry(templatePath)
+            await ext.templateRegistry.addItemToRegistry(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))! as DotNetCoreDebugConfiguration
             const codeRoot = `${appDir}/src/HelloWorld`
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
@@ -1088,7 +1088,7 @@ Outputs:
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'python3.7-plain-sam-app/template.yaml'))
-            await ext.templateRegistry.addTemplateToRegistry(templatePath)
+            await ext.templateRegistry.addItemToRegistry(templatePath)
 
             // Invoke with noDebug=false (the default).
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
@@ -1270,7 +1270,7 @@ Outputs:
                 }),
                 tempFile.fsPath
             )
-            await ext.templateRegistry.addTemplateToRegistry(tempFile)
+            await ext.templateRegistry.addItemToRegistry(tempFile)
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
             const tempDir = path.dirname(actual.codeRoot)
 
@@ -1413,7 +1413,7 @@ Resources:
                 }),
                 tempFile.fsPath
             )
-            await ext.templateRegistry.addTemplateToRegistry(tempFile)
+            await ext.templateRegistry.addItemToRegistry(tempFile)
             const actual = (await debugConfigProviderMockCredentials.makeConfig(folder, input))!
             const tempDir = path.dirname(actual.codeRoot)
 
@@ -1522,7 +1522,7 @@ async function getConfig(
     const appDir = pathutil.normalize(path.join(testutil.getProjectDir(), rootFolder))
     const folder = testutil.getWorkspaceFolder(appDir)
     const templateFile = pathutil.normalize(path.join(appDir, 'template.yaml'))
-    await registry.addTemplateToRegistry(vscode.Uri.file(templateFile))
+    await registry.addItemToRegistry(vscode.Uri.file(templateFile))
 
     // Generate config(s) from a sample project.
     const configs = await debugConfigProvider.provideDebugConfigurations(folder)
@@ -1571,7 +1571,7 @@ async function createAndRegisterYaml(
     registry: CloudFormationTemplateRegistry
 ) {
     testutil.toFile(makeSampleSamTemplateYaml(true, subValues), file.fsPath)
-    await registry.addTemplateToRegistry(file)
+    await registry.addItemToRegistry(file)
 }
 
 describe('createTemplateAwsSamDebugConfig', () => {
@@ -1737,13 +1737,13 @@ describe('debugConfiguration', () => {
 
         // Template with relative path:
         testutil.toFile(makeSampleSamTemplateYaml(true, { codeUri: relativePath }), tempFile.fsPath)
-        await ext.templateRegistry.addTemplateToRegistry(tempFile)
+        await ext.templateRegistry.addItemToRegistry(tempFile)
         assert.strictEqual(debugConfiguration.getCodeRoot(folder, config), fullPath)
         assert.strictEqual(debugConfiguration.getHandlerName(folder, config), 'handler')
 
         // Template with absolute path:
         testutil.toFile(makeSampleSamTemplateYaml(true, { codeUri: fullPath }), tempFile.fsPath)
-        await ext.templateRegistry.addTemplateToRegistry(tempFile)
+        await ext.templateRegistry.addItemToRegistry(tempFile)
         assert.strictEqual(debugConfiguration.getCodeRoot(folder, config), fullPath)
 
         // Template with refs that don't override:
@@ -1762,7 +1762,7 @@ describe('debugConfiguration', () => {
             },
         })
         testutil.toFile(makeSampleSamTemplateYaml(true, { codeUri: fullPath }, paramStr), tempFileRefs.fsPath)
-        await ext.templateRegistry.addTemplateToRegistry(tempFileRefs)
+        await ext.templateRegistry.addItemToRegistry(tempFileRefs)
         assert.strictEqual(debugConfiguration.getCodeRoot(folder, fileRefsConfig), fullPath)
         assert.strictEqual(debugConfiguration.getHandlerName(folder, fileRefsConfig), 'handler')
 
@@ -1789,7 +1789,7 @@ describe('debugConfiguration', () => {
             ),
             tempFileDefaultRefs.fsPath
         )
-        await ext.templateRegistry.addTemplateToRegistry(tempFileDefaultRefs)
+        await ext.templateRegistry.addItemToRegistry(tempFileDefaultRefs)
         assert.strictEqual(debugConfiguration.getCodeRoot(folder, fileDefaultRefsConfig), fullPath)
         assert.strictEqual(debugConfiguration.getHandlerName(folder, fileDefaultRefsConfig), 'thisWillOverride')
 
@@ -1811,7 +1811,7 @@ describe('debugConfiguration', () => {
             makeSampleSamTemplateYaml(true, { codeUri: fullPath, handler: '!Ref override' }, paramStrNoDefaultOverride),
             tempFileOverrideRef.fsPath
         )
-        await ext.templateRegistry.addTemplateToRegistry(tempFileOverrideRef)
+        await ext.templateRegistry.addItemToRegistry(tempFileOverrideRef)
         assert.strictEqual(debugConfiguration.getCodeRoot(folder, fileOverrideRefConfig), fullPath)
         assert.strictEqual(debugConfiguration.getHandlerName(folder, fileOverrideRefConfig), 'override')
     })

--- a/src/test/shared/utilities/pathUtils.test.ts
+++ b/src/test/shared/utilities/pathUtils.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert'
 import * as os from 'os'
 import * as path from 'path'
 import {
-    dirnameWithTrailingSlash,
+    normalizedDirnameWithTrailingSlash,
     getNormalizedRelativePath,
     normalizeSeparator,
     normalize,
@@ -24,10 +24,10 @@ describe('pathUtils', async () => {
         assert.strictEqual(relativePath, expectedRelativePath.replace(path.sep, path.posix.sep))
     })
 
-    it('dirnameWithTrailingSlash()', async () => {
-        const expectedResult = path.join('src', 'processors') + path.sep
+    it('normalizedDirnameWithTrailingSlash()', async () => {
+        const expectedResult = path.join('src', 'processors') + '/'
         const input = path.join(expectedResult, 'app.js')
-        const actualResult = dirnameWithTrailingSlash(input)
+        const actualResult = normalizedDirnameWithTrailingSlash(input)
         assert.strictEqual(actualResult, expectedResult, 'Expected path to contain trailing slash')
     })
 

--- a/src/test/shared/utilities/pathUtils.test.ts
+++ b/src/test/shared/utilities/pathUtils.test.ts
@@ -25,7 +25,7 @@ describe('pathUtils', async () => {
     })
 
     it('normalizedDirnameWithTrailingSlash()', async () => {
-        const expectedResult = path.join('src', 'processors') + '/'
+        const expectedResult = 'src/processors/'
         const input = path.join(expectedResult, 'app.js')
         const actualResult = normalizedDirnameWithTrailingSlash(input)
         assert.strictEqual(actualResult, expectedResult, 'Expected path to contain trailing slash')


### PR DESCRIPTION
- Due to the way the codelens's were implemented, it does a search through the whole workspace everytime something is typed into a compatible file:
 ```
 await vscode.workspace.findFiles(
        new vscode.RelativePattern(workspaceFolder, path.join('**', projectFile))
    )
```
This spins off a `rg` process and is a waste of resources
- Replace this with a registry for files we are interested in modeled after the cfn template registry
- Move the cfn template registry to be based off of the generic one
## Opening the PR in draft for names/functionality feedback

## todo
Make the two WorkspaceFileRegistry's able to fail and not break the plugin later

## Related issues
#1248

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
