### PR TITLE
Contributing guide mentions git secrets requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ Before you start, install the following dependencies.
     -   NPM version: 6.4.1 or higher
 -   [Typescript](https://www.typescriptlang.org/)
 -   [Git](https://git-scm.com/downloads)
+-   [AWS `git secrets`](https://github.com/awslabs/git-secrets)
 
 Then clone the repository and install npm dependencies:
 
@@ -133,7 +134,6 @@ We appreciate contributions via pull requests! Before sending a pull request, en
 1. You are working against the latest source on the _master_ branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
-4. You have installed the [AWS `git secrets`](https://github.com/awslabs/git-secrets) hook, which will ensure you aren't accidentally commiting AWS access or secret keys. This is enforced on commit.
 
 To send us a pull request, please:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,7 @@ We appreciate contributions via pull requests! Before sending a pull request, en
 1. You are working against the latest source on the _master_ branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
+4. You have installed the [AWS `git secrets`](https://github.com/awslabs/git-secrets) hook, which will ensure you aren't accidentally commiting AWS access or secret keys. This is enforced on commit.
 
 To send us a pull request, please:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Mentioning that commits now require the [AWS `git secrets`](https://github.com/awslabs/git-secrets) hook, which is called on commit. This helps ensure that any contributors to the repo will not accidentally post their AWS credentials by exiting out of the commit if anything resembling credentials is included.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
