### PR TITLE
CI: disable codecov annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -23,3 +23,6 @@ coverage:
         changes: no
 
 comment: off
+
+github_checks:
+    annotations: false


### PR DESCRIPTION
- They are too noisy, makes PR review difficult.
- We don't get credit for coverage from our integ tests, because of  a tooling bug, which makes it very difficult to reach 100% coverage.

https://docs.codecov.io/docs/github-checks-beta#disabling-github-checks-patch-annotations-via-yaml

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
