### PR TITLE
StepFunctions: Add YAML option to ASL template creation

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -319,6 +319,8 @@
     "AWS.message.prompt.credentials.definition.help": "Would you like some information related to defining credentials?",
     "AWS.message.prompt.credentials.definition.tryAgain": "The credentials do not appear to be valid. Check the AWS Toolkit Logs for details. Would you like to try again?",
     "AWS.message.prompt.selectLocalLambda.placeholder": "Select a lambda function",
+    "AWS.message.prompt.selectStateMachineTemplate.placeholder": "Select a starter template",
+    "AWS.message.prompt.selectStateMachineTemplateFormat.placeholder": "Select template format",
     "AWS.message.prompt.quickStart.toastMessage": "You are now using AWS Toolkit version {0}",
     "AWS.message.prompt.region.hide.title": "Select a region to hide from the AWS Explorer",
     "AWS.message.prompt.region.show.title": "Select a region to show in the AWS Explorer",

--- a/src/stepFunctions/commands/createStateMachineFromTemplate.ts
+++ b/src/stepFunctions/commands/createStateMachineFromTemplate.ts
@@ -5,130 +5,61 @@
 
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
+import { safeDump, safeLoad } from 'js-yaml'
 
 import * as path from 'path'
 import * as vscode from 'vscode'
 import { readFileAsString } from '../../shared/filesystemUtilities'
 import { getLogger, Logger } from '../../shared/logger'
-import * as picker from '../../shared/ui/picker'
-
-interface StateMachineTemplateQuickPickItem {
-    label: string
-    description: string
-    fileName: string
-}
-
-const STARTER_TEMPLATES: StateMachineTemplateQuickPickItem[] = [
-    {
-        label: localize('AWS.stepfunctions.template.helloWorld.label', 'Hello world'),
-        description: localize(
-            'AWS.stepfunctions.template.helloWorld.description',
-            'A basic example using a Pass state.'
-        ),
-        fileName: 'HelloWorld.asl.json',
-    },
-    {
-        label: localize('AWS.stepfunctions.template.retryFailure.label', 'Retry failure'),
-        description: localize(
-            'AWS.stepfunctions.template.retryFailure.description',
-            'An example of a Task state using a retry policy to handle Lambda failures.'
-        ),
-        fileName: 'RetryFailure.asl.json',
-    },
-    {
-        label: localize('AWS.stepfunctions.template.waitState.label', 'Wait state'),
-        description: localize(
-            'AWS.stepfunctions.template.waitState.description',
-            'Delays the state machine from continuing for a specified time.'
-        ),
-        fileName: 'WaitState.asl.json',
-    },
-    {
-        label: localize('AWS.stepfunctions.template.parallel.label', 'Parallel'),
-        description: localize(
-            'AWS.stepfunctions.template.parallel.description',
-            'Used to create parallel branches of execution in your state machine.'
-        ),
-        fileName: 'Parallel.asl.json',
-    },
-    {
-        label: localize('AWS.stepfunctions.template.mapState.label', 'Map state'),
-        description: localize(
-            'AWS.stepfunctions.template.mapState.description',
-            'Use a Map state to dynamically process data in an array.'
-        ),
-        fileName: 'MapState.asl.json',
-    },
-    {
-        label: localize('AWS.stepfunctions.template.catchFailure.label', 'Catch failure'),
-        description: localize(
-            'AWS.stepfunctions.template.catchFailure.description',
-            'An example of a Task state using Catchers to handle Lambda failures.'
-        ),
-        fileName: 'CatchFailure.asl.json',
-    },
-    {
-        label: localize('AWS.stepfunctions.template.choiceState.label', 'Choice state'),
-        description: localize(
-            'AWS.stepfunctions.template.choiceState.description',
-            'Adds branching logic to a state machine.'
-        ),
-        fileName: 'ChoiceState.asl.json',
-    },
-]
+import CreateStateMachineWizard, {
+    StateMachineTemplateQuickPickItem,
+    TemplateFormats,
+} from '../wizards/createStateMachineWizard'
 
 export async function createStateMachineFromTemplate(context: vscode.ExtensionContext) {
     const logger: Logger = getLogger()
 
-    const quickPick = picker.createQuickPick<StateMachineTemplateQuickPickItem>({
-        options: {
-            ignoreFocusOut: true,
-            title: localize('AWS.message.prompt.selectStateMachineTemplate.placeholder', 'Select a starter template'),
-            step: 1,
-            totalSteps: 1,
-        },
-        buttons: [vscode.QuickInputButtons.Back],
-        items: STARTER_TEMPLATES,
-    })
+    const wizardResponse = await new CreateStateMachineWizard().run()
 
-    const choices = await picker.promptUser({
-        picker: quickPick,
-        onDidTriggerButton: (_, resolve) => {
-            resolve(undefined)
-        },
-    })
-
-    const selection = picker.verifySinglePickerOutput(choices)
-
-    // User pressed escape
-    if (selection === undefined) {
-        return
-    }
-
-    try {
-        logger.debug(`User selected the ${selection.label} template.`)
-
-        const textDocumentFromSelection = await getTextDocumentForSelectedItem(selection, context.extensionPath)
-
-        vscode.window.showTextDocument(textDocumentFromSelection)
-    } catch (err) {
-        logger.error(err as Error)
-        vscode.window.showErrorMessage(
-            localize(
-                'AWS.message.error.stepfunctions.getTextDocumentForSelectedItem',
-                'There was an error creating the State Machine Template, check log for details.'
+    if (wizardResponse && wizardResponse.template && wizardResponse.templateFormat) {
+        try {
+            logger.debug(
+                `User selected the ${wizardResponse.template.label} template of ${wizardResponse.templateFormat} format`
             )
-        )
+
+            const textDocumentFromSelection = await getTextDocumentForSelectedItem(
+                wizardResponse.template,
+                context.extensionPath,
+                wizardResponse.templateFormat
+            )
+
+            vscode.window.showTextDocument(textDocumentFromSelection)
+        } catch (err) {
+            logger.error(err as Error)
+            vscode.window.showErrorMessage(
+                localize(
+                    'AWS.message.error.stepfunctions.getTextDocumentForSelectedItem',
+                    'There was an error creating the State Machine Template, check log for details.'
+                )
+            )
+        }
     }
 }
 
 async function getTextDocumentForSelectedItem(
     item: StateMachineTemplateQuickPickItem,
-    extensionPath: string
+    extensionPath: string,
+    format: string
 ): Promise<vscode.TextDocument> {
+    let content = await readFileAsString(path.join(extensionPath, 'templates', item.fileName))
+
+    if (format === TemplateFormats.YAML) {
+        content = safeDump(safeLoad(content))
+    }
+
     const options = {
-        content: await readFileAsString(path.join(extensionPath, 'templates', item.fileName)),
-        language: 'asl',
+        content,
+        language: format === TemplateFormats.YAML ? 'asl-yaml' : 'asl',
     }
 
     return await vscode.workspace.openTextDocument(options)

--- a/src/stepFunctions/commands/createStateMachineFromTemplate.ts
+++ b/src/stepFunctions/commands/createStateMachineFromTemplate.ts
@@ -54,6 +54,7 @@ async function getTextDocumentForSelectedItem(
     let content = await readFileAsString(path.join(extensionPath, 'templates', item.fileName))
 
     if (format === TemplateFormats.YAML) {
+        // Convert JSON string to YAML string
         content = safeDump(safeLoad(content))
     }
 

--- a/src/stepFunctions/wizards/createStateMachineWizard.ts
+++ b/src/stepFunctions/wizards/createStateMachineWizard.ts
@@ -1,0 +1,182 @@
+/*!
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as nls from 'vscode-nls'
+const localize = nls.loadMessageBundle()
+
+import * as vscode from 'vscode'
+import * as picker from '../../shared/ui/picker'
+
+import {
+    MultiStepWizard,
+    WIZARD_GOBACK,
+    WIZARD_TERMINATE,
+    wizardContinue,
+    WizardStep,
+} from '../../shared/wizards/multiStepWizard'
+
+export interface StateMachineTemplateQuickPickItem {
+    label: string
+    description: string
+    fileName: string
+}
+
+export const STARTER_TEMPLATES: StateMachineTemplateQuickPickItem[] = [
+    {
+        label: localize('AWS.stepfunctions.template.helloWorld.label', 'Hello world'),
+        description: localize(
+            'AWS.stepfunctions.template.helloWorld.description',
+            'A basic example using a Pass state.'
+        ),
+        fileName: 'HelloWorld.asl.json',
+    },
+    {
+        label: localize('AWS.stepfunctions.template.retryFailure.label', 'Retry failure'),
+        description: localize(
+            'AWS.stepfunctions.template.retryFailure.description',
+            'An example of a Task state using a retry policy to handle Lambda failures.'
+        ),
+        fileName: 'RetryFailure.asl.json',
+    },
+    {
+        label: localize('AWS.stepfunctions.template.waitState.label', 'Wait state'),
+        description: localize(
+            'AWS.stepfunctions.template.waitState.description',
+            'Delays the state machine from continuing for a specified time.'
+        ),
+        fileName: 'WaitState.asl.json',
+    },
+    {
+        label: localize('AWS.stepfunctions.template.parallel.label', 'Parallel'),
+        description: localize(
+            'AWS.stepfunctions.template.parallel.description',
+            'Used to create parallel branches of execution in your state machine.'
+        ),
+        fileName: 'Parallel.asl.json',
+    },
+    {
+        label: localize('AWS.stepfunctions.template.mapState.label', 'Map state'),
+        description: localize(
+            'AWS.stepfunctions.template.mapState.description',
+            'Use a Map state to dynamically process data in an array.'
+        ),
+        fileName: 'MapState.asl.json',
+    },
+    {
+        label: localize('AWS.stepfunctions.template.catchFailure.label', 'Catch failure'),
+        description: localize(
+            'AWS.stepfunctions.template.catchFailure.description',
+            'An example of a Task state using Catchers to handle Lambda failures.'
+        ),
+        fileName: 'CatchFailure.asl.json',
+    },
+    {
+        label: localize('AWS.stepfunctions.template.choiceState.label', 'Choice state'),
+        description: localize(
+            'AWS.stepfunctions.template.choiceState.description',
+            'Adds branching logic to a state machine.'
+        ),
+        fileName: 'ChoiceState.asl.json',
+    },
+]
+
+export enum TemplateFormats {
+    YAML = 'YAML',
+    JSON = 'JSON',
+}
+
+const TEMPLATE_FORMATS = [{ label: TemplateFormats.JSON }, { label: TemplateFormats.YAML }]
+
+interface CreateStateMachineWizardResponse {
+    template: StateMachineTemplateQuickPickItem
+    templateFormat: TemplateFormats
+}
+
+export default class CreateStateMachineWizard extends MultiStepWizard<CreateStateMachineWizardResponse> {
+    private template?: StateMachineTemplateQuickPickItem
+    private templateFormat?: TemplateFormats
+    private promptUser: typeof picker.promptUser
+
+    public constructor(promptUser?: typeof picker.promptUser) {
+        super()
+
+        this.promptUser = promptUser || picker.promptUser.bind(picker)
+    }
+
+    protected get startStep() {
+        return this.CREATE_TEMPLATE_ACTION
+    }
+
+    private readonly CREATE_TEMPLATE_ACTION: WizardStep = async () => {
+        const quickPick = picker.createQuickPick<StateMachineTemplateQuickPickItem>({
+            options: {
+                ignoreFocusOut: true,
+                title: localize(
+                    'AWS.message.prompt.selectStateMachineTemplate.placeholder',
+                    'Select a starter template'
+                ),
+                step: 1,
+                totalSteps: 2,
+            },
+            buttons: [vscode.QuickInputButtons.Back],
+            items: STARTER_TEMPLATES,
+        })
+
+        const choices = await this.promptUser({
+            picker: quickPick,
+            onDidTriggerButton: (button, resolve) => {
+                if (button === vscode.QuickInputButtons.Back) {
+                    resolve(undefined)
+                }
+            },
+        })
+
+        console.log(choices)
+
+        this.template = picker.verifySinglePickerOutput<StateMachineTemplateQuickPickItem>(choices)
+
+        return this.template ? wizardContinue(this.TEMPLATE_FORMAT_ACTION) : WIZARD_GOBACK
+    }
+
+    private readonly TEMPLATE_FORMAT_ACTION: WizardStep = async () => {
+        const quickPick = picker.createQuickPick({
+            options: {
+                ignoreFocusOut: true,
+                title: localize(
+                    'AWS.message.prompt.selectStateMachineTemplateFormat.placeholder',
+                    'Select template format'
+                ),
+                step: 2,
+                totalSteps: 2,
+            },
+            buttons: [vscode.QuickInputButtons.Back],
+            items: TEMPLATE_FORMATS,
+        })
+
+        const choices = await this.promptUser({
+            picker: quickPick,
+            onDidTriggerButton: (button, resolve) => {
+                if (button === vscode.QuickInputButtons.Back) {
+                    resolve(undefined)
+                }
+            },
+        })
+
+        this.templateFormat = picker.verifySinglePickerOutput<{ label: TemplateFormats }>(choices)?.label
+
+        return this.templateFormat ? WIZARD_TERMINATE : WIZARD_GOBACK
+    }
+
+    protected getResult() {
+        return (
+            (this.template &&
+                this.templateFormat && {
+                    template: this.template,
+                    templateFormat: this.templateFormat,
+                }) ||
+            undefined
+        )
+    }
+}

--- a/src/test/stepFunctions/wizards/createStateMachineWizard.test.ts
+++ b/src/test/stepFunctions/wizards/createStateMachineWizard.test.ts
@@ -1,0 +1,29 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as assert from 'assert'
+import CreateStateMachineWizard, {
+    STARTER_TEMPLATES,
+    TemplateFormats,
+} from '../../../stepFunctions/wizards/createStateMachineWizard'
+
+describe('CreateStateMachineWizard', async () => {
+    it('exits when cancelled', async () => {
+        const mockUserPrompt: any = () => Promise.resolve(undefined)
+        const wizard = new CreateStateMachineWizard(mockUserPrompt)
+        const result = await wizard.run()
+
+        assert.ok(!result)
+    })
+
+    it('returns format and template type when completed', async () => {
+        const promptRsults = [[STARTER_TEMPLATES[0]], [{ label: TemplateFormats.YAML }]]
+
+        const mockUserPrompt: any = (options: any) => Promise.resolve(promptRsults.shift())
+        const wizard = new CreateStateMachineWizard(mockUserPrompt)
+        const result = await wizard.run()
+
+        assert.deepStrictEqual(result, { template: STARTER_TEMPLATES[0], templateFormat: TemplateFormats.YAML })
+    })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I added multiple step wizard to allow customer choose format (YAML/JSON) when they use "AWS: Create New State Machine" command.

## Motivation and Context
We want to unable users to use templates of Step Functions state machines in YAML

## Testing
Tested it manually.

## Screenshots
<img width="1015" alt="Screen Shot 2020-12-09 at 2 17 26 PM" src="https://user-images.githubusercontent.com/6964729/101695385-5b9cb980-3a29-11eb-95e0-1c3442eb7c94.png">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
