### PR TITLE
SAM debug: remove "max retries" user setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,11 +101,6 @@
                     "default": "",
                     "markdownDescription": "%AWS.configuration.description.samcli.location%"
                 },
-                "aws.samcli.debug.attach.retry.maximum": {
-                    "type": "number",
-                    "default": 30,
-                    "description": "%AWS.configuration.description.samcli.debug.attach.retry.maximum%"
-                },
                 "aws.samcli.debug.attach.timeout.millis": {
                     "type": "number",
                     "default": 30000,

--- a/package.nls.json
+++ b/package.nls.json
@@ -23,7 +23,6 @@
     "AWS.configuration.description.logLevel": "The AWS Toolkit's log level (changes reflected on restart)",
     "AWS.configuration.description.onDefaultRegionMissing": "Action to take when a Profile's default region is hidden in the Explorer. Possible values:\n* `add` - shows region in the explorer\n* `ignore` - does nothing with the region\n* `prompt` - (default) asks the user what they would like to do.",
     "AWS.configuration.description.s3.maxItemsPerPage": "Controls how many S3 items are listed before showing a node to `Load More...`.\nThis corresponds to the `MaxKeys` requested in a single call to S3. [Learn More](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html#AmazonS3-ListObjectsV2-response-MaxKeys)",
-    "AWS.configuration.description.samcli.debug.attach.retry.maximum": "If the Toolkit is unable to attach a debugger, this is the number of times to retry before giving up.",
     "AWS.configuration.description.samcli.debug.attach.timeout": "Maximum time (in milliseconds) to wait for SAM output while starting a Local Lambda session",
     "AWS.configuration.description.samcli.location": "Location of SAM CLI. SAM CLI is used to create, build, package, and deploy Serverless Applications. [Learn More](https://aws.amazon.com/serverless/sam/)",
     "AWS.configuration.description.telemetry": "Enable AWS Toolkit to send usage data to AWS.",

--- a/src/test/shared/codelens/localLambdaRunner.test.ts
+++ b/src/test/shared/codelens/localLambdaRunner.test.ts
@@ -60,7 +60,6 @@ describe('localLambdaRunner', async () => {
             await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 channelLogger,
-                maxRetries: 0,
                 onStartDebugging: startDebuggingReturnsTrue,
                 onWillRetry,
             })
@@ -72,7 +71,6 @@ describe('localLambdaRunner', async () => {
             await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 channelLogger,
-                maxRetries: 0,
                 onStartDebugging: startDebuggingReturnsTrue,
                 onWillRetry,
             })
@@ -87,7 +85,6 @@ describe('localLambdaRunner', async () => {
             await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 channelLogger,
-                maxRetries: 0,
                 onStartDebugging: startDebuggingReturnsTrue,
                 onWillRetry,
                 onRecordAttachDebuggerMetric: (attachResult: boolean | undefined, attempts: number) => {
@@ -101,7 +98,6 @@ describe('localLambdaRunner', async () => {
             const results = await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 channelLogger,
-                maxRetries: 0,
                 onStartDebugging: startDebuggingReturnsTrue,
                 onWillRetry,
             })
@@ -109,23 +105,10 @@ describe('localLambdaRunner', async () => {
             assert.ok(results.success, 'Expected attach results to be successful')
         })
 
-        it('Failure to attach has no retries', async () => {
-            await localLambdaRunner.attachDebugger({
-                debugConfig: ({} as any) as SamLaunchRequestArgs,
-                channelLogger,
-                maxRetries: 0,
-                onStartDebugging: startDebuggingReturnsFalse,
-                onWillRetry,
-            })
-
-            assert.strictEqual(actualRetries, 0, 'Did not expect any retries when attaching debugger fails')
-        })
-
         it('Failure to attach logs that the debugger did not attach', async () => {
             await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 channelLogger,
-                maxRetries: 0,
                 onStartDebugging: startDebuggingReturnsFalse,
                 onWillRetry,
             })
@@ -140,7 +123,6 @@ describe('localLambdaRunner', async () => {
             await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 channelLogger,
-                maxRetries: 0,
                 onStartDebugging: startDebuggingReturnsFalse,
                 onWillRetry,
                 onRecordAttachDebuggerMetric: (attachResult: boolean | undefined, attempts: number) => {
@@ -153,7 +135,6 @@ describe('localLambdaRunner', async () => {
             const results = await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 channelLogger,
-                maxRetries: 0,
                 onStartDebugging: startDebuggingReturnsFalse,
                 onWillRetry,
             })
@@ -161,27 +142,10 @@ describe('localLambdaRunner', async () => {
             assert.strictEqual(results.success, false, 'Expected attach results to fail')
         })
 
-        it('Attempts to retry when startDebugging returns undefined', async () => {
-            const maxRetries: number = 3
-
-            await localLambdaRunner.attachDebugger({
-                debugConfig: ({} as any) as SamLaunchRequestArgs,
-                channelLogger,
-                maxRetries: maxRetries,
-                onStartDebugging: startDebuggingReturnsFalse,
-                onWillRetry,
-            })
-
-            assert.strictEqual(actualRetries, maxRetries, 'Unexpected Retry count')
-        })
-
         it('Logs about exceeding the retry limit', async () => {
-            const maxRetries: number = 3
-
             await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 channelLogger,
-                maxRetries,
                 onStartDebugging: startDebuggingReturnsFalse,
                 onWillRetry,
             })
@@ -196,10 +160,9 @@ describe('localLambdaRunner', async () => {
             await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 channelLogger,
-                maxRetries: 2,
                 onStartDebugging: startDebuggingReturnsFalse,
                 onRecordAttachDebuggerMetric: (attachResult: boolean | undefined, attempts: number): void => {
-                    assert.strictEqual(actualRetries, 2, 'Metrics should only be recorded once')
+                    assert.strictEqual(actualRetries, 4, 'Metrics should only be recorded once')
                     assert.notStrictEqual(attachResult, undefined, 'attachResult should not be undefined')
                 },
                 onWillRetry,
@@ -207,16 +170,14 @@ describe('localLambdaRunner', async () => {
         })
 
         it('Returns true if attach succeeds during retries', async () => {
-            const maxRetries: number = 5
             const results = await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 channelLogger,
-                maxRetries,
                 onStartDebugging: async (
                     folder: vscode.WorkspaceFolder | undefined,
                     nameOrConfiguration: string | vscode.DebugConfiguration
                 ): Promise<boolean> => {
-                    const retVal = actualRetries === maxRetries - 2 ? true : undefined
+                    const retVal = actualRetries === 3 ? true : undefined
 
                     return retVal!
                 },
@@ -227,11 +188,9 @@ describe('localLambdaRunner', async () => {
         })
 
         it('Returns false if retry count exceeded', async () => {
-            const maxRetries: number = 3
             const results = await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 channelLogger,
-                maxRetries,
                 onStartDebugging: startDebuggingReturnsFalse,
                 onWillRetry,
             })


### PR DESCRIPTION
This setting is stored as 30 for all users, which is way too high. Retrying more than a few times is very bad user experience. Until recently, the retry logic didn't work, so users have never actually encountered a need for this setting. Expecting them to
configure it will just be confusing, and there is little reason for it to be configurable anyway.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
