### PR TITLE
SAM debug: fix payload JSON validation

### DIFF
--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -630,7 +630,7 @@ export async function makeJsonFiles(config: SamLaunchRequestArgs): Promise<void>
     if (payloadPath) {
         const fullpath = tryGetAbsolutePath(config.workspaceFolder, payloadPath)
         try {
-            JSON.parse(await readFile(payloadPath, { encoding: 'utf-8' }))
+            JSON.parse(await readFile(fullpath, { encoding: 'utf-8' }))
         } catch (e) {
             throw Error(`Invalid JSON in payload file: ${payloadPath}`)
         }

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -1603,6 +1603,8 @@ Outputs:
             const appDir = pathutil.normalize(
                 path.join(testutil.getProjectDir(), 'testFixtures/workspaceFolder/python3.7-plain-sam-app')
             )
+            const relPayloadPath = `events/event.json`
+            const absPayloadPath = `${appDir}/${relPayloadPath}`
             const folder = testutil.getWorkspaceFolder(appDir)
             const input = {
                 type: AWS_SAM_DEBUG_TYPE,
@@ -1616,7 +1618,7 @@ Outputs:
                 lambda: {
                     runtime: 'python3.7',
                     payload: {
-                        path: `${appDir}/events/event.json`,
+                        path: relPayloadPath,
                     },
                 },
             }
@@ -1685,7 +1687,7 @@ Outputs:
             assertFileText(expected.envFile, '{"awsToolkitSamLocalResource":{}}')
             assert.strictEqual(
                 readFileSync(actual.eventPayloadFile, 'utf-8'),
-                readFileSync(input.lambda.payload.path, 'utf-8')
+                readFileSync(absPayloadPath, 'utf-8')
             )
             assertFileText(
                 expected.templatePath,


### PR DESCRIPTION
Problem: the validation tries to load JSON from a relative path, but the process CWD is "/", so the file is not found.

Solution: pass the absolute path.

--
regression by 5f05a50d8a291
ref #1439


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
