### PR TITLE
Updates version of amazon-states-language-service

### DIFF
--- a/.changes/next-release/Feature-85fc3d12-13de-40ca-aa7d-0f008bc84e0e.json
+++ b/.changes/next-release/Feature-85fc3d12-13de-40ca-aa7d-0f008bc84e0e.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Adds Amazon States Language (YAML) format to the ASL Language Server. Adds option to choose YAML format when creating new Step Functions state machine from a template."
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -680,9 +680,9 @@
             "dev": true
         },
         "amazon-states-language-service": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.6.1.tgz",
-            "integrity": "sha512-BffxFNGj17EAxKtiArrweNkEc2zJ8PB3J6OQVwhoRv6NHYKRFo9SE8xrhqu20LpxCLfaFQ005pTuOoqbDxqsEQ==",
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.6.3.tgz",
+            "integrity": "sha512-hu7MlVIBxuTUZJOtOlDVNolyuuIdwhWM1hJZRmttBoYgh/pCU6a8pQWm4wYV7lxMb8ETDZA/LjPw4Hvy3vDiAw==",
             "requires": {
                 "@types/prettier": "^2.1.1",
                 "js-yaml": "^3.14.0",

--- a/package.json
+++ b/package.json
@@ -1401,8 +1401,8 @@
                     "Amazon States Language (YAML)"
                 ],
                 "extensions": [
-                    ".asl.yml",
-                    ".asl.yaml"
+                    ".asl.yaml",
+                    ".asl.yml"
                 ]
             },
             {
@@ -1553,7 +1553,7 @@
     },
     "dependencies": {
         "adm-zip": "^0.4.13",
-        "amazon-states-language-service": "^1.6.1",
+        "amazon-states-language-service": "^1.6.3",
         "async-lock": "^1.1.3",
         "aws-sdk": "^2.581.0",
         "aws-ssm-document-language-service": "^1.0.0",


### PR DESCRIPTION
Bumps up the version of the amazon-states-language-service. The new one contains various bug fixes for YAML support in ASL.

I flipped the order of file extension in package.json to `asl.yaml` having priority over `asl.yml` - templates, by default will have preferable `asl.yaml` extension. 

## Description

<!--- Describe your changes in detail -->

## Motivation and Context
YAML Support in VS Code for Amazon States Language

## Related Issue(s)

<!--- What is the related issue you are trying to fix? -->

## Testing
Tested manually by creating various state machines from templates and from scratch. 
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
