### PR TITLE
test: remove verbose VSCode logging

### DIFF
--- a/test-scripts/test.ts
+++ b/test-scripts/test.ts
@@ -30,8 +30,8 @@ async function setupVSCode(): Promise<string> {
             vscodeExecutablePath: vsCodeExecutablePath,
             extensionDevelopmentPath: rootDir,
             extensionTestsPath: testEntrypoint,
-            // TODO: remove "--verbose --log ..." after some bake-time on master branch (ETA: 2020-12-15).
-            launchArgs: ['--verbose', '--log', 'debug', testWorkspace],
+            // For verbose VSCode logs, add "--verbose --log debug". c2165cf48e62c
+            launchArgs: [testWorkspace],
         })
 
         console.log(`Finished running Main test suite with result code: ${result}`)


### PR DESCRIPTION
This was a temporary change, not needed since CI has been relatively stable.

reverts c2165cf48e62

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
