### PR TITLE
Fix deployment for image based lambdas in sam cli 1.14+

### DIFF
--- a/src/lambda/commands/deploySamApplication.ts
+++ b/src/lambda/commands/deploySamApplication.ts
@@ -217,6 +217,7 @@ async function deployOperation(params: {
                 region: params.deployParameters.region,
                 stackName: params.deployParameters.destinationStackName,
                 s3Bucket: params.deployParameters.packageBucketName,
+                ecrRepo: params.deployParameters.ecrRepo,
             },
             params.invoker
         )

--- a/src/shared/sam/cli/samCliDeploy.ts
+++ b/src/shared/sam/cli/samCliDeploy.ts
@@ -14,6 +14,7 @@ export interface SamCliDeployParameters {
     region: string
     stackName: string
     s3Bucket: string
+    ecrRepo?: string
 }
 
 export async function runSamCliDeploy(
@@ -36,6 +37,11 @@ export async function runSamCliDeploy(
         '--s3-bucket',
         deployArguments.s3Bucket,
     ]
+
+    if (deployArguments.ecrRepo) {
+        args.push('--image-repository', deployArguments.ecrRepo)
+    }
+
     if (deployArguments.parameterOverrides.size > 0) {
         const overrides = [...map(deployArguments.parameterOverrides.entries(), ([key, value]) => `${key}=${value}`)]
         args.push('--parameter-overrides', ...overrides)


### PR DESCRIPTION
https://github.com/aws/aws-toolkit-jetbrains/pull/2295

* 1.14.0 made the sam deploy option `--image-repository` required for image based lambdas
* Tested on 1.13.1 and 1.15.0

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
