### PR TITLE
Use CodeArtifact for AWS CodeBuild CI jobs

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -32,7 +32,12 @@ phases:
             # Should only affect tests run through IDEs team-hosted CodeBuild.
             - |
                 if [ $CODEARTIFACT_DOMAIN ] && [ $CODEARTIFACT_REPO ] && [ $ACCOUNT_ID ]; then
-                  aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO"
+                  aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO" > /dev/null 2>&1
+                  if [$? -eq 0 ]; then
+                    echo "Connected to CodeArtifact"
+                  else
+                    echo "CodeArtifact connection failed. Falling back to npm"
+                  fi
                 fi
             # make sure that SAM is in the path, is not automatically done on CodeBuild
             - USER_BASE_PATH=$(python -m site --user-base) && export PATH=$PATH:$USER_BASE_PATH/bin

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -28,6 +28,12 @@ phases:
 
     pre_build:
         commands:
+            # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
+            # Should only affect tests run through IDEs team-hosted CodeBuild.
+            - |
+                if [ $CODEARTIFACT_DOMAIN ] && [ $CODEARTIFACT_REPO ] && [ $ACCOUNT_ID ]; then
+                  aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO"
+                fi
             # make sure that SAM is in the path, is not automatically done on CodeBuild
             - USER_BASE_PATH=$(python -m site --user-base) && export PATH=$PATH:$USER_BASE_PATH/bin
             # start Docker
@@ -36,7 +42,7 @@ phases:
 
     build:
         commands:
-            - npm install --unsafe-perm
+            - npm ci --unsafe-perm
             - xvfb-run npm run integrationTest
 
 reports:

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -31,13 +31,12 @@ phases:
             # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
             # Should only affect tests run through IDEs team-hosted CodeBuild.
             - |
-                if [ $TOOLKITS_CODEARTIFACT_DOMAIN ] && [ $TOOLKITS_CODEARTIFACT_REPO ] && [ $ACCOUNT_ID ]; then
-                  aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO" > /dev/null 2>&1
-                  if [ $? -eq 0 ]; then
-                    echo "Connected to CodeArtifact"
-                  else
-                    echo "CodeArtifact connection failed. Falling back to npm"
-                  fi
+                if [ "$TOOLKITS_CODEARTIFACT_DOMAIN" ] && [ "$TOOLKITS_CODEARTIFACT_REPO" ] && [ "$ACCOUNT_ID" ]; then
+                    if aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO" > /dev/null 2>&1; then
+                        echo "Connected to CodeArtifact"
+                    else
+                        echo "CodeArtifact connection failed. Falling back to npm"
+                    fi
                 fi
             # make sure that SAM is in the path, is not automatically done on CodeBuild
             - USER_BASE_PATH=$(python -m site --user-base) && export PATH=$PATH:$USER_BASE_PATH/bin

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -33,7 +33,7 @@ phases:
             - |
                 if [ $CODEARTIFACT_DOMAIN ] && [ $CODEARTIFACT_REPO ] && [ $ACCOUNT_ID ]; then
                   aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO" > /dev/null 2>&1
-                  if [$? -eq 0 ]; then
+                  if [ $? -eq 0 ]; then
                     echo "Connected to CodeArtifact"
                   else
                     echo "CodeArtifact connection failed. Falling back to npm"

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -31,8 +31,8 @@ phases:
             # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
             # Should only affect tests run through IDEs team-hosted CodeBuild.
             - |
-                if [ $CODEARTIFACT_DOMAIN ] && [ $CODEARTIFACT_REPO ] && [ $ACCOUNT_ID ]; then
-                  aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO" > /dev/null 2>&1
+                if [ $TOOLKITS_CODEARTIFACT_DOMAIN ] && [ $TOOLKITS_CODEARTIFACT_REPO ] && [ $ACCOUNT_ID ]; then
+                  aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO" > /dev/null 2>&1
                   if [ $? -eq 0 ]; then
                     echo "Connected to CodeArtifact"
                   else

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -16,7 +16,12 @@ phases:
             # Should only affect tests run through IDEs team-hosted CodeBuild.
             - |
                 if [ $CODEARTIFACT_DOMAIN ] && [ $CODEARTIFACT_REPO ] && [ $ACCOUNT_ID ]; then
-                  aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO"
+                  aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO" > /dev/null 2>&1
+                  if [$? -eq 0 ]; then
+                    echo "Connected to CodeArtifact"
+                  else
+                    echo "CodeArtifact connection failed. Falling back to npm"
+                  fi
                 fi
             - npm ci --unsafe-perm
 

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -15,8 +15,8 @@ phases:
             # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
             # Should only affect tests run through IDEs team-hosted CodeBuild.
             - |
-                if [ $CODEARTIFACT_DOMAIN ] && [ $CODEARTIFACT_REPO ] && [ $ACCOUNT_ID ]; then
-                  aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO" > /dev/null 2>&1
+                if [ $TOOLKITS_CODEARTIFACT_DOMAIN ] && [ $TOOLKITS_CODEARTIFACT_REPO ] && [ $ACCOUNT_ID ]; then
+                  aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO" > /dev/null 2>&1
                   if [ $? -eq 0 ]; then
                     echo "Connected to CodeArtifact"
                   else

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -15,13 +15,12 @@ phases:
             # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
             # Should only affect tests run through IDEs team-hosted CodeBuild.
             - |
-                if [ $TOOLKITS_CODEARTIFACT_DOMAIN ] && [ $TOOLKITS_CODEARTIFACT_REPO ] && [ $ACCOUNT_ID ]; then
-                  aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO" > /dev/null 2>&1
-                  if [ $? -eq 0 ]; then
-                    echo "Connected to CodeArtifact"
-                  else
-                    echo "CodeArtifact connection failed. Falling back to npm"
-                  fi
+                if [ "$TOOLKITS_CODEARTIFACT_DOMAIN" ] && [ "$TOOLKITS_CODEARTIFACT_REPO" ] && [ "$ACCOUNT_ID" ]; then
+                    if aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO" > /dev/null 2>&1; then
+                        echo "Connected to CodeArtifact"
+                    else
+                        echo "CodeArtifact connection failed. Falling back to npm"
+                    fi
                 fi
             - npm ci --unsafe-perm
 

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -17,7 +17,7 @@ phases:
             - |
                 if [ $CODEARTIFACT_DOMAIN ] && [ $CODEARTIFACT_REPO ] && [ $ACCOUNT_ID ]; then
                   aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO" > /dev/null 2>&1
-                  if [$? -eq 0 ]; then
+                  if [ $? -eq 0 ]; then
                     echo "Connected to CodeArtifact"
                   else
                     echo "CodeArtifact connection failed. Falling back to npm"

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -12,7 +12,13 @@ phases:
 
     pre_build:
         commands:
-            - npm install --unsafe-perm
+            # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
+            # Should only affect tests run through IDEs team-hosted CodeBuild.
+            - |
+                if [ $CODEARTIFACT_DOMAIN ] && [ $CODEARTIFACT_REPO ] && [ $ACCOUNT_ID ]; then
+                  aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO"
+                fi
+            - npm ci --unsafe-perm
 
     build:
         commands:

--- a/buildspec/packageTestVsix.yml
+++ b/buildspec/packageTestVsix.yml
@@ -16,8 +16,8 @@ phases:
             # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
             # Should only affect tests run through IDEs team-hosted CodeBuild.
             - |
-                if [ $CODEARTIFACT_DOMAIN ] && [ $CODEARTIFACT_REPO ] && [ $ACCOUNT_ID ]; then
-                  aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO" > /dev/null 2>&1
+                if [ $TOOLKITS_CODEARTIFACT_DOMAIN ] && [ $TOOLKITS_CODEARTIFACT_REPO ] && [ $ACCOUNT_ID ]; then
+                  aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO" > /dev/null 2>&1
                   if [ $? -eq 0 ]; then
                     echo "Connected to CodeArtifact"
                   else

--- a/buildspec/packageTestVsix.yml
+++ b/buildspec/packageTestVsix.yml
@@ -16,13 +16,12 @@ phases:
             # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
             # Should only affect tests run through IDEs team-hosted CodeBuild.
             - |
-                if [ $TOOLKITS_CODEARTIFACT_DOMAIN ] && [ $TOOLKITS_CODEARTIFACT_REPO ] && [ $ACCOUNT_ID ]; then
-                  aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO" > /dev/null 2>&1
-                  if [ $? -eq 0 ]; then
-                    echo "Connected to CodeArtifact"
-                  else
-                    echo "CodeArtifact connection failed. Falling back to npm"
-                  fi
+                if [ "$TOOLKITS_CODEARTIFACT_DOMAIN" ] && [ "$TOOLKITS_CODEARTIFACT_REPO" ] && [ "$ACCOUNT_ID" ]; then
+                    if aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO" > /dev/null 2>&1; then
+                        echo "Connected to CodeArtifact"
+                    else
+                        echo "CodeArtifact connection failed. Falling back to npm"
+                    fi
                 fi
             # --unsafe-perm is needed because we run as root
             - npm ci --unsafe-perm

--- a/buildspec/packageTestVsix.yml
+++ b/buildspec/packageTestVsix.yml
@@ -13,8 +13,14 @@ phases:
 
     pre_build:
         commands:
+            # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
+            # Should only affect tests run through IDEs team-hosted CodeBuild.
+            - |
+                if [ $CODEARTIFACT_DOMAIN ] && [ $CODEARTIFACT_REPO ] && [ $ACCOUNT_ID ]; then
+                  aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO"
+                fi
             # --unsafe-perm is needed because we run as root
-            - npm install --unsafe-perm
+            - npm ci --unsafe-perm
 
     build:
         commands:

--- a/buildspec/packageTestVsix.yml
+++ b/buildspec/packageTestVsix.yml
@@ -18,7 +18,7 @@ phases:
             - |
                 if [ $CODEARTIFACT_DOMAIN ] && [ $CODEARTIFACT_REPO ] && [ $ACCOUNT_ID ]; then
                   aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO" > /dev/null 2>&1
-                  if [$? -eq 0 ]; then
+                  if [ $? -eq 0 ]; then
                     echo "Connected to CodeArtifact"
                   else
                     echo "CodeArtifact connection failed. Falling back to npm"

--- a/buildspec/packageTestVsix.yml
+++ b/buildspec/packageTestVsix.yml
@@ -17,7 +17,12 @@ phases:
             # Should only affect tests run through IDEs team-hosted CodeBuild.
             - |
                 if [ $CODEARTIFACT_DOMAIN ] && [ $CODEARTIFACT_REPO ] && [ $ACCOUNT_ID ]; then
-                  aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO"
+                  aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO" > /dev/null 2>&1
+                  if [$? -eq 0 ]; then
+                    echo "Connected to CodeArtifact"
+                  else
+                    echo "CodeArtifact connection failed. Falling back to npm"
+                  fi
                 fi
             # --unsafe-perm is needed because we run as root
             - npm ci --unsafe-perm

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -16,10 +16,16 @@ phases:
         commands:
             # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
             # Should only affect tests run through IDEs team-hosted CodeBuild.
-            - |
-                if ($Env:CODEARTIFACT_DOMAIN -and $Env:CODEARTIFACT_REPO -and $Env:ACCOUNT_ID) {
-                  aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO"
-                }
+            # UNCOMMENT THE FOLLOWING WHEN VS CODE CAN BUILD IN WIN_SERVER_CORE_2019_BASE: https://github.com/microsoft/vscode/issues/77499
+            # - |
+            #     if ($Env:CODEARTIFACT_DOMAIN -and $Env:CODEARTIFACT_REPO -and $Env:ACCOUNT_ID) {
+            #       aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO"
+            #         if ($?) {
+            #             echo "Connected to CodeArtifact"
+            #         } else {
+            #             echo "CodeArtifact connection failed. Falling back to npm"
+            #         }
+            #     }
             - npm ci
 
     build:

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -18,15 +18,15 @@ phases:
             # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
             # Should only affect tests run through IDEs team-hosted CodeBuild.
             # UNCOMMENT THE FOLLOWING WHEN VS CODE CAN BUILD IN WIN_SERVER_CORE_2019_BASE: https://github.com/microsoft/vscode/issues/77499
-            - |
-                if ($Env:CODEARTIFACT_DOMAIN -and $Env:CODEARTIFACT_REPO -and $Env:ACCOUNT_ID) {
-                  aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO"
-                    if ($?) {
-                        echo "Connected to CodeArtifact"
-                    } else {
-                        echo "CodeArtifact connection failed. Falling back to npm"
-                    }
-                }
+            # - |
+            #     if ($Env:CODEARTIFACT_DOMAIN -and $Env:CODEARTIFACT_REPO -and $Env:ACCOUNT_ID) {
+            #       aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO"
+            #         if ($?) {
+            #             echo "Connected to CodeArtifact"
+            #         } else {
+            #             echo "CodeArtifact connection failed. Falling back to npm"
+            #         }
+            #     }
             - npm ci
 
     build:

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -17,9 +17,9 @@ phases:
             # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
             # Should only affect tests run through IDEs team-hosted CodeBuild.
             - |
-                if [ $CODEARTIFACT_DOMAIN ] && [ $CODEARTIFACT_REPO ] && [ $ACCOUNT_ID ]; then
+                if ($Env:CODEARTIFACT_DOMAIN -and $Env:CODEARTIFACT_REPO -and $Env:ACCOUNT_ID) {
                   aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO"
-                fi
+                }
             - npm ci
 
     build:

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -14,7 +14,13 @@ phases:
 
     pre_build:
         commands:
-            - npm install
+            # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
+            # Should only affect tests run through IDEs team-hosted CodeBuild.
+            - |
+                if [ $CODEARTIFACT_DOMAIN ] && [ $CODEARTIFACT_REPO ] && [ $ACCOUNT_ID ]; then
+                  aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO"
+                fi
+            - npm ci
 
     build:
         commands:

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -19,8 +19,8 @@ phases:
             # Should only affect tests run through IDEs team-hosted CodeBuild.
             # UNCOMMENT THE FOLLOWING WHEN VS CODE CAN BUILD IN WIN_SERVER_CORE_2019_BASE: https://github.com/microsoft/vscode/issues/77499
             # - |
-            #     if ($Env:CODEARTIFACT_DOMAIN -and $Env:CODEARTIFACT_REPO -and $Env:ACCOUNT_ID) {
-            #       aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO"
+            #     if ($Env:TOOLKITS_CODEARTIFACT_DOMAIN -and $Env:TOOLKITS_CODEARTIFACT_REPO -and $Env:ACCOUNT_ID) {
+            #       aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO"
             #         if ($?) {
             #             echo "Connected to CodeArtifact"
             #         } else {

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -11,21 +11,22 @@ phases:
                 if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
                     choco install -y --no-progress codecov
                 }
+            - choco install vcredist140
 
     pre_build:
         commands:
             # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
             # Should only affect tests run through IDEs team-hosted CodeBuild.
             # UNCOMMENT THE FOLLOWING WHEN VS CODE CAN BUILD IN WIN_SERVER_CORE_2019_BASE: https://github.com/microsoft/vscode/issues/77499
-            # - |
-            #     if ($Env:CODEARTIFACT_DOMAIN -and $Env:CODEARTIFACT_REPO -and $Env:ACCOUNT_ID) {
-            #       aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO"
-            #         if ($?) {
-            #             echo "Connected to CodeArtifact"
-            #         } else {
-            #             echo "CodeArtifact connection failed. Falling back to npm"
-            #         }
-            #     }
+            - |
+                if ($Env:CODEARTIFACT_DOMAIN -and $Env:CODEARTIFACT_REPO -and $Env:ACCOUNT_ID) {
+                  aws codeartifact login --tool npm --domain "$CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$CODEARTIFACT_REPO"
+                    if ($?) {
+                        echo "Connected to CodeArtifact"
+                    } else {
+                        echo "CodeArtifact connection failed. Falling back to npm"
+                    }
+                }
             - npm ci
 
     build:

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -11,7 +11,6 @@ phases:
                 if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
                     choco install -y --no-progress codecov
                 }
-            - choco install vcredist140
 
     pre_build:
         commands:


### PR DESCRIPTION
* ~~Doing some additional testing, want to ensure that the buildscripts don't attempt to use CodeArtifact if env vars aren't present (I have confirmed that a CodePipeline tracking the child branch does use CodeArtifact correctly).~~ Confirmed
  * ~~Our main CI and Github Actions/Travis accounts are currently not wired up for CodeArtifact and should skip the CodeArtifact `pre-build` step. Tests run against this PR should confirm this.~~ Confirmed
* ~~We may need to roll back Windows CodeArtifact usage. This is because we can't update our Windows builds to the newer CodeBuild image (required by CodeBuild): https://github.com/microsoft/vscode/issues/77499~~ Rolled back

## Description

This change implements [CodeArtifact](https://aws.amazon.com/codeartifact/) as a cache for NPM for CI jobs run by AWS CodeBuild. This gives us insurance that we can build and deploy VS Code even if NPM goes down.

Additionally, moved to `npm ci` for install to ensure only the packages in the `package-lock` are built.

## Motivation and Context

We don't want to be in a place where we need a fix that we can't deploy due to issues with CI.

## Testing

Tested against a private AWS account. Deploying these changes to a CodePipeline tracking the child branch resulted in a CodeArtifact repo being populated with the appropriate packages.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
