### PR TITLE
Reorganize group names for context menus

### DIFF
--- a/package.json
+++ b/package.json
@@ -800,27 +800,32 @@
                 {
                     "command": "aws.quickStart",
                     "when": "view == aws.explorer",
-                    "group": "y_quickStart@1"
+                    "group": "4_quickStart@1"
                 },
                 {
                     "command": "aws.help",
                     "when": "view == aws.explorer",
-                    "group": "z_externalLinks@1"
+                    "group": "5_externalLinks@1"
                 },
                 {
                     "command": "aws.github",
                     "when": "view == aws.explorer",
-                    "group": "z_externalLinks@2"
+                    "group": "5_externalLinks@2"
                 },
                 {
                     "command": "aws.createIssueOnGitHub",
                     "when": "view == aws.explorer",
-                    "group": "z_externalLinks@3"
+                    "group": "5_externalLinks@3"
                 },
                 {
                     "command": "aws.submitFeedback",
                     "when": "view == aws.explorer",
-                    "group": "z_externalLinks@4"
+                    "group": "5_externalLinks@4"
+                },
+                {
+                    "command": "aws.aboutToolkit",
+                    "when": "view == aws.explorer",
+                    "group": "z_about@1"
                 },
                 {
                     "command": "aws.refreshCdkExplorer",
@@ -830,17 +835,12 @@
                 {
                     "command": "aws.cdk.help",
                     "when": "view == aws.cdk.explorer",
-                    "group": "z_externalLinks@2"
+                    "group": "1_externalLinks@1"
                 },
                 {
                     "command": "aws.cdk.provideFeedback",
                     "when": "view == aws.cdk.explorer",
-                    "group": "z_externalLinks@3"
-                },
-                {
-                    "command": "aws.aboutToolkit",
-                    "when": "view == aws.explorer",
-                    "group": "zz_about@1"
+                    "group": "1_externalLinks@2"
                 }
             ],
             "view/item/context": [

--- a/package.json
+++ b/package.json
@@ -835,12 +835,12 @@
                 {
                     "command": "aws.cdk.help",
                     "when": "view == aws.cdk.explorer",
-                    "group": "1_externalLinks@1"
+                    "group": "z_externalLinks@1"
                 },
                 {
                     "command": "aws.cdk.provideFeedback",
                     "when": "view == aws.cdk.explorer",
-                    "group": "1_externalLinks@2"
+                    "group": "z_externalLinks@2"
                 }
             ],
             "view/item/context": [

--- a/package.json
+++ b/package.json
@@ -805,22 +805,22 @@
                 {
                     "command": "aws.help",
                     "when": "view == aws.explorer",
-                    "group": "5_externalLinks@1"
+                    "group": "y_externalLinks@1"
                 },
                 {
                     "command": "aws.github",
                     "when": "view == aws.explorer",
-                    "group": "5_externalLinks@2"
+                    "group": "y_externalLinks@2"
                 },
                 {
                     "command": "aws.createIssueOnGitHub",
                     "when": "view == aws.explorer",
-                    "group": "5_externalLinks@3"
+                    "group": "y_externalLinks@3"
                 },
                 {
                     "command": "aws.submitFeedback",
                     "when": "view == aws.explorer",
-                    "group": "5_externalLinks@4"
+                    "group": "y_externalLinks@4"
                 },
                 {
                     "command": "aws.aboutToolkit",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Without changing the text or order, renamed some of the group names in package.json for organization and logical flow.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
An example in the CDK menu had a group with entries of 2 and 3, but not 1.  

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
