### PR TITLE
Fixing BeforeEach and AfterEach for DefaultSamDeployWizardContext firing before each test

### DIFF
--- a/src/test/lambda/wizards/samDeployWizard.test.ts
+++ b/src/test/lambda/wizards/samDeployWizard.test.ts
@@ -644,11 +644,12 @@ describe('SamDeployWizard', async () => {
 })
 
 describe('DefaultSamDeployWizardContext', async () => {
-    const context = new DefaultSamDeployWizardContext(await FakeExtensionContext.getFakeExtContext())
+    let context: DefaultSamDeployWizardContext
     let sandbox: sinon.SinonSandbox
 
-    beforeEach(() => {
+    beforeEach(async () => {
         sandbox = sinon.createSandbox()
+        context = new DefaultSamDeployWizardContext(await FakeExtensionContext.getFakeExtContext())
     })
 
     afterEach(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Tests were failing with:
```
  1) "after each" hook for "displays region nodes with user-friendly region names":
     TypeError: Cannot read property 'restore' of undefined
      at Context.<anonymous> (src/test/lambda/wizards/samDeployWizard.test.ts:655:17)
```

For some reason, the `beforeEach` and `afterEach` blocks for `DefaultSamDeployWizardContext` were firing before and after every test in the codebase. Unsure why this fixes it, but it does (validated through breakpoints in code)

Additionally, this makes the heading for `DefaultSamDeployWizardContext` show up in the test output as it should (it didn't before)

## Motivation and Context
Tests work as they should

## Related Issue(s)
https://github.com/aws/aws-toolkit-vscode/issues/1458

## Testing
Local tests, breakpoints on `DefaultSamDeployWizardContext`'s `beforeEach` and `afterEach` hooks no longer fire on every test

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
