### PR TITLE
"Create SAM app": default to a more intuitive name

### DIFF
--- a/.changes/next-release/Feature-298a87ca-c8dc-4522-a990-529eb66b7f55.json
+++ b/.changes/next-release/Feature-298a87ca-c8dc-4522-a990-529eb66b7f55.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "\"Create new SAM Application\" command suggests a more-intuitive name"
+}

--- a/src/lambda/wizards/samInitWizard.ts
+++ b/src/lambda/wizards/samInitWizard.ts
@@ -37,6 +37,7 @@ import {
 } from '../models/samTemplates'
 import * as semver from 'semver'
 import { MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_IMAGE_SUPPORT } from '../../shared/sam/cli/samCliValidator'
+import * as fsutil from '../../shared/filesystemUtilities'
 
 const localize = nls.loadMessageBundle()
 
@@ -456,8 +457,11 @@ export class CreateNewSamAppWizard extends MultiStepWizard<CreateNewSamAppWizard
     }
 
     private readonly NAME: WizardStep = async () => {
+        // Default to a name like "lambda-python3.8-1".
+        const defaultName = this.location ? fsutil.getNonexistentFilename(
+            this.location.path, `lambda-${this.runtime}`, '', 99) : ''
         this.name = await this.context.promptUserForName(
-            this.name ?? (this.location ? path.basename(this.location.path) : '')
+            this.name ?? defaultName
         )
 
         return this.name ? WIZARD_TERMINATE : WIZARD_GOBACK

--- a/src/lambda/wizards/samInitWizard.ts
+++ b/src/lambda/wizards/samInitWizard.ts
@@ -458,7 +458,7 @@ export class CreateNewSamAppWizard extends MultiStepWizard<CreateNewSamAppWizard
 
     private readonly NAME: WizardStep = async () => {
         // Default to a name like "lambda-python3.8-1".
-        const defaultName = fsutil.getNonexistentFilename(this.location!.path, `lambda-${this.runtime}`, '', 99)
+        const defaultName = fsutil.getNonexistentFilename(this.location!.fsPath, `lambda-${this.runtime}`, '', 99)
         this.name = await this.context.promptUserForName(this.name ?? defaultName)
 
         return this.name ? WIZARD_TERMINATE : WIZARD_GOBACK

--- a/src/lambda/wizards/samInitWizard.ts
+++ b/src/lambda/wizards/samInitWizard.ts
@@ -458,11 +458,8 @@ export class CreateNewSamAppWizard extends MultiStepWizard<CreateNewSamAppWizard
 
     private readonly NAME: WizardStep = async () => {
         // Default to a name like "lambda-python3.8-1".
-        const defaultName = this.location ? fsutil.getNonexistentFilename(
-            this.location.path, `lambda-${this.runtime}`, '', 99) : ''
-        this.name = await this.context.promptUserForName(
-            this.name ?? defaultName
-        )
+        const defaultName = fsutil.getNonexistentFilename(this.location!.path, `lambda-${this.runtime}`, '', 99)
+        this.name = await this.context.promptUserForName(this.name ?? defaultName)
 
         return this.name ? WIZARD_TERMINATE : WIZARD_GOBACK
     }

--- a/src/shared/filesystemUtilities.ts
+++ b/src/shared/filesystemUtilities.ts
@@ -130,7 +130,7 @@ export function isInDirectory(d: string, p: string): boolean {
  * @param suffix  Filename suffix, typically an extension (".txt"), may be empty
  * @param max  Stop searching if all permutations up to this number exist
  */
-export function getNonexistentFilename(dir: string, name: string, suffix: string, max: number = 999): string {
+export function getNonexistentFilename(dir: string, name: string, suffix: string, max: number = 99): string {
     if (!name) {
         throw new Error(`name is empty`)
     }

--- a/src/test/lambda/wizards/samInitWizard.test.ts
+++ b/src/test/lambda/wizards/samInitWizard.test.ts
@@ -22,6 +22,7 @@ import {
 } from '../../../lambda/wizards/samInitWizard'
 import { RuntimePackageType } from '../../../lambda/models/samLambdaRuntime'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
+import { assertEqualPaths } from '../../testUtil'
 
 function isMultiDimensionalArray(array: any[] | any[][] | undefined): boolean {
     if (!array) {
@@ -397,7 +398,7 @@ describe('CreateNewSamAppWizard', async () => {
             describe('location', async () => {
                 it('uses user response as schema', async () => {
                     assert.ok(args)
-                    assert.strictEqual(args!.location.fsPath, locationPath)
+                    assertEqualPaths(args!.location.fsPath, locationPath)
                 })
 
                 it('backtracks when cancelled', async () => {
@@ -416,7 +417,7 @@ describe('CreateNewSamAppWizard', async () => {
 
                     assert.ok(args)
                     assert.strictEqual(args!.schemaName, 'AWSBatchJobStateChange')
-                    assert.strictEqual(args!.location.fsPath, locationPath)
+                    assertEqualPaths(args!.location.fsPath, locationPath)
                 })
             })
         })
@@ -438,7 +439,7 @@ describe('CreateNewSamAppWizard', async () => {
             const args = await wizard.run()
 
             assert.ok(args)
-            assert.strictEqual(args!.location.fsPath, dir)
+            assertEqualPaths(args!.location.fsPath, dir)
         })
 
         it('backtracks when cancelled', async () => {
@@ -457,7 +458,7 @@ describe('CreateNewSamAppWizard', async () => {
 
             assert.ok(args)
             assert.strictEqual(args!.template, eventBridgeHelloWorldTemplate)
-            assert.strictEqual(args!.location.fsPath, dir)
+            assertEqualPaths(args!.location.fsPath, dir)
         })
 
         it("contains a 'browse' option", async () => {
@@ -476,7 +477,7 @@ describe('CreateNewSamAppWizard', async () => {
             const args = await wizard.run()
 
             assert.ok(args)
-            assert.strictEqual(args!.location.fsPath, dir)
+            assertEqualPaths(args!.location.fsPath, dir)
         })
 
         it('contains an option for each workspace folder', async () => {
@@ -501,7 +502,7 @@ describe('CreateNewSamAppWizard', async () => {
             const args = await wizard.run()
 
             assert.ok(args)
-            assert.strictEqual(args!.location.fsPath, workspaceFolderPaths[0])
+            assertEqualPaths(args!.location.fsPath, workspaceFolderPaths[0])
         })
     })
 
@@ -539,7 +540,7 @@ describe('CreateNewSamAppWizard', async () => {
             const args = await wizard.run()
 
             assert.ok(args)
-            assert.strictEqual(args!.location.fsPath, dir2)
+            assertEqualPaths(args!.location.fsPath, dir2)
             assert.strictEqual(args!.name, 'myName')
         })
     })

--- a/src/test/lambda/wizards/samInitWizard.test.ts
+++ b/src/test/lambda/wizards/samInitWizard.test.ts
@@ -7,6 +7,7 @@ import * as assert from 'assert'
 import { Runtime } from 'aws-sdk/clients/lambda'
 import { Set } from 'immutable'
 import * as path from 'path'
+import * as fs from 'fs'
 import * as vscode from 'vscode'
 import {
     eventBridgeHelloWorldTemplate,
@@ -20,6 +21,7 @@ import {
     CreateNewSamAppWizardResponse,
 } from '../../../lambda/wizards/samInitWizard'
 import { RuntimePackageType } from '../../../lambda/models/samLambdaRuntime'
+import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 
 function isMultiDimensionalArray(array: any[] | any[][] | undefined): boolean {
     if (!array) {
@@ -203,13 +205,22 @@ class MockCreateNewSamAppWizardContext implements CreateNewSamAppWizardContext {
 }
 
 describe('CreateNewSamAppWizard', async () => {
+    let dir: string
+    let dir2: string
+    before(async () => {
+        dir = await makeTemporaryToolkitFolder()
+        dir2 = await makeTemporaryToolkitFolder()
+    })
+    after(async () => {
+        fs.rmdirSync(dir)
+    })
     describe('runtime', async () => {
         it('uses user response as runtime', async () => {
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
                 Set<Runtime>(['nodejs8.10']),
                 'myName',
-                [vscode.Uri.file(path.join('my', 'workspace', 'folder'))],
+                [vscode.Uri.file(dir)],
                 Set<SamTemplate>([helloWorldTemplate]),
                 [],
                 [],
@@ -227,7 +238,7 @@ describe('CreateNewSamAppWizard', async () => {
                 [],
                 Set<Runtime>(),
                 'myName',
-                [vscode.Uri.file(path.join('my', 'workspace', 'folder'))],
+                [vscode.Uri.file(dir)],
                 [],
                 [],
                 [],
@@ -242,12 +253,11 @@ describe('CreateNewSamAppWizard', async () => {
 
     describe('template', async () => {
         it('uses user response as template', async () => {
-            const locationPath = path.join('my', 'quick', 'pick', 'result')
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
                 Set<Runtime>(['nodejs8.10']),
                 'myName',
-                [vscode.Uri.file(locationPath)],
+                [vscode.Uri.file(dir)],
                 Set<SamTemplate>([helloWorldTemplate]),
                 [],
                 [],
@@ -261,12 +271,11 @@ describe('CreateNewSamAppWizard', async () => {
         })
 
         it('backtracks when cancelled', async () => {
-            const locationPath = path.join('my', 'quick', 'pick', 'result')
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
                 [Set<Runtime>(['python3.6']), Set<Runtime>(['nodejs8.10'])],
                 'myName',
-                [vscode.Uri.file(locationPath)],
+                [vscode.Uri.file(dir)],
                 [undefined, Set<SamTemplate>([helloWorldTemplate])],
                 [],
                 [],
@@ -281,7 +290,13 @@ describe('CreateNewSamAppWizard', async () => {
         })
 
         describe('eventBridge-schema-app template', async () => {
-            const locationPath = path.join('my', 'quick', 'pick', 'result')
+            let locationPath: string
+            before(async () => {
+                locationPath = await makeTemporaryToolkitFolder()
+            })
+            after(async () => {
+                fs.rmdirSync(locationPath)
+            })
             let context: CreateNewSamAppWizardContext
             let wizard: CreateNewSamAppWizard
             let args: CreateNewSamAppWizardResponse | undefined
@@ -382,7 +397,7 @@ describe('CreateNewSamAppWizard', async () => {
             describe('location', async () => {
                 it('uses user response as schema', async () => {
                     assert.ok(args)
-                    assert.strictEqual(args!.location.fsPath, `${path.sep}${locationPath}`)
+                    assert.strictEqual(args!.location.fsPath, locationPath)
                 })
 
                 it('backtracks when cancelled', async () => {
@@ -401,7 +416,7 @@ describe('CreateNewSamAppWizard', async () => {
 
                     assert.ok(args)
                     assert.strictEqual(args!.schemaName, 'AWSBatchJobStateChange')
-                    assert.strictEqual(args!.location.fsPath, `${path.sep}${locationPath}`)
+                    assert.strictEqual(args!.location.fsPath, locationPath)
                 })
             })
         })
@@ -409,12 +424,11 @@ describe('CreateNewSamAppWizard', async () => {
 
     describe('location', async () => {
         it('uses user response as location', async () => {
-            const locationPath = path.join('my', 'quick', 'pick', 'result')
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
                 Set<Runtime>(['nodejs8.10']),
                 'myName',
-                [vscode.Uri.file(locationPath)],
+                [vscode.Uri.file(dir)],
                 Set<SamTemplate>([helloWorldTemplate]),
                 [],
                 [],
@@ -424,16 +438,15 @@ describe('CreateNewSamAppWizard', async () => {
             const args = await wizard.run()
 
             assert.ok(args)
-            assert.strictEqual(args!.location.fsPath, `${path.sep}${locationPath}`)
+            assert.strictEqual(args!.location.fsPath, dir)
         })
 
         it('backtracks when cancelled', async () => {
-            const locationPath = path.join('my', 'quick', 'pick', 'result')
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
                 [Set<Runtime>(['python3.6']), Set<Runtime>(['nodejs8.10'])],
                 'myName',
-                [undefined, [vscode.Uri.file(locationPath)]],
+                [undefined, [vscode.Uri.file(dir)]],
                 [Set<SamTemplate>([helloWorldTemplate]), Set<SamTemplate>([eventBridgeHelloWorldTemplate])],
                 [],
                 [],
@@ -444,18 +457,16 @@ describe('CreateNewSamAppWizard', async () => {
 
             assert.ok(args)
             assert.strictEqual(args!.template, eventBridgeHelloWorldTemplate)
-            assert.strictEqual(args!.location.fsPath, `${path.sep}${locationPath}`)
+            assert.strictEqual(args!.location.fsPath, dir)
         })
 
         it("contains a 'browse' option", async () => {
             const name = 'myInputBoxResult'
-            const locationPath = path.join('my', 'quick', 'pick', 'result')
-
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
                 Set<Runtime>(['nodejs8.10']),
                 name,
-                [vscode.Uri.file(locationPath)],
+                [vscode.Uri.file(dir)],
                 Set<SamTemplate>([helloWorldTemplate]),
                 [],
                 [],
@@ -465,11 +476,11 @@ describe('CreateNewSamAppWizard', async () => {
             const args = await wizard.run()
 
             assert.ok(args)
-            assert.strictEqual(args!.location.fsPath, `${path.sep}${locationPath}`)
+            assert.strictEqual(args!.location.fsPath, dir)
         })
 
         it('contains an option for each workspace folder', async () => {
-            const workspaceFolderPaths = [path.join('workspace', 'folder', '1'), path.join('workspace', 'folder', '2')]
+            const workspaceFolderPaths = [dir, dir2]
 
             let index = 0
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
@@ -490,7 +501,7 @@ describe('CreateNewSamAppWizard', async () => {
             const args = await wizard.run()
 
             assert.ok(args)
-            assert.strictEqual(args!.location.fsPath, `${path.sep}${workspaceFolderPaths[0]}`)
+            assert.strictEqual(args!.location.fsPath, workspaceFolderPaths[0])
         })
     })
 
@@ -500,7 +511,7 @@ describe('CreateNewSamAppWizard', async () => {
                 [],
                 Set<Runtime>(['nodejs8.10']),
                 'myName',
-                [vscode.Uri.file(path.join('my', 'quick', 'pick', 'result'))],
+                [vscode.Uri.file(dir)],
                 Set<SamTemplate>([helloWorldTemplate]),
                 [],
                 [],
@@ -518,10 +529,7 @@ describe('CreateNewSamAppWizard', async () => {
                 [],
                 Set<Runtime>(['nodejs8.10']),
                 ['', 'myName'],
-                [
-                    [vscode.Uri.file(path.join('my', 'quick', 'pick', 'result', '1'))],
-                    [vscode.Uri.file(path.join('my', 'quick', 'pick', 'result', '2'))],
-                ],
+                [[vscode.Uri.file(dir)], [vscode.Uri.file(dir2)]],
                 Set<SamTemplate>([helloWorldTemplate]),
                 [],
                 [],
@@ -531,7 +539,7 @@ describe('CreateNewSamAppWizard', async () => {
             const args = await wizard.run()
 
             assert.ok(args)
-            assert.strictEqual(args!.location.fsPath, `${path.sep}${path.join('my', 'quick', 'pick', 'result', '2')}`)
+            assert.strictEqual(args!.location.fsPath, dir2)
             assert.strictEqual(args!.name, 'myName')
         })
     })

--- a/src/test/shared/filesystemUtilities.test.ts
+++ b/src/test/shared/filesystemUtilities.test.ts
@@ -54,7 +54,7 @@ describe('filesystemUtilities', () => {
             await writeFile(path.join(dir, 'foo.txt'), '', 'utf8')
             await writeFile(path.join(dir, 'foo-1.txt'), '', 'utf8')
             // Looks like "foo-75446d5d.txt".
-            assert.ok(/foo-[a-fA-F0-9]{8}/.test(getNonexistentFilename(dir, 'foo', '.txt', 1)))
+            assert.ok(/^foo-[a-fA-F0-9]{8}.txt$/.test(getNonexistentFilename(dir, 'foo', '.txt', 1)))
         })
     })
 

--- a/src/test/shared/filesystemUtilities.test.ts
+++ b/src/test/shared/filesystemUtilities.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert'
 import * as os from 'os'
 import { writeFile, remove } from 'fs-extra'
 import * as path from 'path'
-import { fileExists, isInDirectory, makeTemporaryToolkitFolder, tempDirPath } from '../../shared/filesystemUtilities'
+import { fileExists, getNonexistentFilename, isInDirectory, makeTemporaryToolkitFolder, tempDirPath } from '../../shared/filesystemUtilities'
 
 describe('filesystemUtilities', () => {
     const targetFilename = 'findThisFile12345.txt'
@@ -30,8 +30,35 @@ describe('filesystemUtilities', () => {
             await remove(folder)
         }
     })
+    
+    describe('getNonexistentFilename()', () => {
+        it('failure modes', async () => {
+            assert.throws(() => {
+                getNonexistentFilename('/bogus/directory/', 'foo', '.txt', 99)
+            })
+            assert.throws(() => {
+                getNonexistentFilename('', 'foo', '.txt', 99)
+            })
+        })
+        it('returns a filename that does not exist in the directory', async () => {
+            const dir = tempFolder
+            await writeFile(path.join(dir, 'foo.txt'), '', 'utf8')
+            await writeFile(path.join(dir, 'foo-0.txt'), '', 'utf8')
+            await writeFile(path.join(dir, 'foo-1.txt'), '', 'utf8')
+            await writeFile(path.join(dir, 'foo-2.txt'), '', 'utf8')
+            assert.strictEqual(getNonexistentFilename(dir, 'foo', '.txt', 99), 'foo-3.txt')
+            assert.strictEqual(getNonexistentFilename(dir, 'foo', '', 99), 'foo')
+        })
+        it('returns "foo-RANDOM.txt" if max is reached', async () => {
+            const dir = tempFolder
+            await writeFile(path.join(dir, 'foo.txt'), '', 'utf8')
+            await writeFile(path.join(dir, 'foo-1.txt'), '', 'utf8')
+            // Looks like "foo-75446d5d.txt".
+            assert.ok(/foo-[a-fA-F0-9]{8}/.test(getNonexistentFilename(dir, 'foo', '.txt', 1)))
+        })
+    })
 
-    describe('makeTemporaryToolkitFolder', () => {
+    describe('makeTemporaryToolkitFolder()', () => {
         it(`makes temp dirs as children to filesystemUtilities.tempDirPath ('${tempDirPath}')`, async () => {
             const parentFolder = path.dirname(tempFolder)
 


### PR DESCRIPTION
Problem:
Before this commit the "AWS: Create new SAM application" command
defaults the application folder name based on the parent folder:
https://github.com/aws/aws-toolkit-vscode/blob/44dad848fbed20e3b081dfa4cad6f41e00e05a0c/src/lambda/wizards/samInitWizard.ts#L445
In cloud9 this always is `environment`, which is not helpful.

Solution:
Default to a name like "lambda-python3.8", and append a number if such
a name already exists in the workspace.

<img width="750" alt="Screen Shot 2021-01-15 at 3 28 13 PM" src="https://user-images.githubusercontent.com/55561878/104788573-65f85480-5747-11eb-8bd9-05b0371e0861.png">


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
