### PR TITLE
ACCOUNT_ID => TOOLKITS_ACCOUNT_ID

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -31,8 +31,8 @@ phases:
             # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
             # Should only affect tests run through IDEs team-hosted CodeBuild.
             - |
-                if [ "$TOOLKITS_CODEARTIFACT_DOMAIN" ] && [ "$TOOLKITS_CODEARTIFACT_REPO" ] && [ "$ACCOUNT_ID" ]; then
-                    if aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO" > /dev/null 2>&1; then
+                if [ "$TOOLKITS_CODEARTIFACT_DOMAIN" ] && [ "$TOOLKITS_CODEARTIFACT_REPO" ] && [ "TOOLKITS_$ACCOUNT_ID" ]; then
+                    if aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$TOOLKITS_ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO" > /dev/null 2>&1; then
                         echo "Connected to CodeArtifact"
                     else
                         echo "CodeArtifact connection failed. Falling back to npm"

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -15,8 +15,8 @@ phases:
             # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
             # Should only affect tests run through IDEs team-hosted CodeBuild.
             - |
-                if [ "$TOOLKITS_CODEARTIFACT_DOMAIN" ] && [ "$TOOLKITS_CODEARTIFACT_REPO" ] && [ "$ACCOUNT_ID" ]; then
-                    if aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO" > /dev/null 2>&1; then
+                if [ "$TOOLKITS_CODEARTIFACT_DOMAIN" ] && [ "$TOOLKITS_CODEARTIFACT_REPO" ] && [ "$TOOLKITS_ACCOUNT_ID" ]; then
+                    if aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$TOOLKITS_ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO" > /dev/null 2>&1; then
                         echo "Connected to CodeArtifact"
                     else
                         echo "CodeArtifact connection failed. Falling back to npm"

--- a/buildspec/packageTestVsix.yml
+++ b/buildspec/packageTestVsix.yml
@@ -16,8 +16,8 @@ phases:
             # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
             # Should only affect tests run through IDEs team-hosted CodeBuild.
             - |
-                if [ "$TOOLKITS_CODEARTIFACT_DOMAIN" ] && [ "$TOOLKITS_CODEARTIFACT_REPO" ] && [ "$ACCOUNT_ID" ]; then
-                    if aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO" > /dev/null 2>&1; then
+                if [ "$TOOLKITS_CODEARTIFACT_DOMAIN" ] && [ "$TOOLKITS_CODEARTIFACT_REPO" ] && [ "$TOOLKITS_ACCOUNT_ID" ]; then
+                    if aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$TOOLKITS_ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO" > /dev/null 2>&1; then
                         echo "Connected to CodeArtifact"
                     else
                         echo "CodeArtifact connection failed. Falling back to npm"

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -18,8 +18,8 @@ phases:
             # Should only affect tests run through IDEs team-hosted CodeBuild.
             # UNCOMMENT THE FOLLOWING WHEN VS CODE CAN BUILD IN WIN_SERVER_CORE_2019_BASE: https://github.com/microsoft/vscode/issues/77499
             # - |
-            #     if ($Env:TOOLKITS_CODEARTIFACT_DOMAIN -and $Env:TOOLKITS_CODEARTIFACT_REPO -and $Env:ACCOUNT_ID) {
-            #       aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO"
+            #     if ($Env:TOOLKITS_CODEARTIFACT_DOMAIN -and $Env:TOOLKITS_CODEARTIFACT_REPO -and $Env:TOOLKITS_ACCOUNT_ID) {
+            #       aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$TOOLKITS_ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO"
             #         if ($?) {
             #             echo "Connected to CodeArtifact"
             #         } else {


### PR DESCRIPTION
Decided to rename `ACCOUNT_ID` in our buildspecs.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
