### PR TITLE
API Gateway nodes include their IDs

### DIFF
--- a/.changes/next-release/Feature-8729574b-6dd2-4ab4-88bb-a5f13b710e0b.json
+++ b/.changes/next-release/Feature-8729574b-6dd2-4ab4-88bb-a5f13b710e0b.json
@@ -1,4 +1,4 @@
 {
 	"type": "Feature",
-	"description": "API Gateway nodes include their ID in the label"
+	"description": "List API Gateway names with their ID (so Toolkit can list APIs with identical names)"
 }

--- a/.changes/next-release/Feature-8729574b-6dd2-4ab4-88bb-a5f13b710e0b.json
+++ b/.changes/next-release/Feature-8729574b-6dd2-4ab4-88bb-a5f13b710e0b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "API Gateway nodes include their ID in the label"
+}

--- a/src/apigateway/explorer/apiGatewayNodes.ts
+++ b/src/apigateway/explorer/apiGatewayNodes.ts
@@ -46,7 +46,7 @@ export class ApiGatewayNode extends AWSTreeNodeBase {
                     this,
                     localize('AWS.explorerNode.apigateway.noApis', '[No API Gateway REST APIs found]')
                 ),
-            sort: (nodeA: RestApiNode, nodeB: RestApiNode) => nodeA.name.localeCompare(nodeB.name),
+            sort: (nodeA: RestApiNode, nodeB: RestApiNode) => nodeA.label!.localeCompare(nodeB.label!),
         })
     }
 
@@ -54,7 +54,7 @@ export class ApiGatewayNode extends AWSTreeNodeBase {
         const client: ApiGatewayClient = ext.toolkitClientBuilder.createApiGatewayClient(this.regionCode)
         const apis: Map<string, RestApi> = toMap(
             await toArrayAsync(client.listApis()),
-            configuration => configuration.name
+            configuration => `${configuration.name} (${configuration.id})`
         )
 
         updateInPlace(

--- a/src/apigateway/explorer/apiNodes.ts
+++ b/src/apigateway/explorer/apiNodes.ts
@@ -21,7 +21,7 @@ export class RestApiNode extends AWSTreeNodeBase implements AWSResourceNode {
 
     public update(api: RestApi): void {
         this.api = api
-        this.label = this.api.name || ''
+        this.label = `${this.api.name} (${this.api.id})` || ''
         this.tooltip = this.api.description
     }
 

--- a/src/test/apigateway/explorer/apiGatewayNodes.test.ts
+++ b/src/test/apigateway/explorer/apiGatewayNodes.test.ts
@@ -18,19 +18,34 @@ import { RestApiNode } from '../../../apigateway/explorer/apiNodes'
 
 const FAKE_PARTITION_ID = 'aws'
 const FAKE_REGION_CODE = 'someregioncode'
-const UNSORTED_TEXT = ['zebra', 'Antelope', 'aardvark', 'elephant']
-const SORTED_TEXT = ['aardvark', 'Antelope', 'elephant', 'zebra']
+const UNSORTED_TEXT = [
+    { name: 'zebra', id: "it's zee not zed" },
+    { name: 'zebra', id: "it's actually zed" },
+    { name: 'Antelope', id: 'anti-antelope' },
+    { name: 'aardvark', id: 'a-a-r-d-vark' },
+    { name: 'elephant', id: 'trunk capacity' },
+]
+const SORTED_TEXT = [
+    'aardvark (a-a-r-d-vark)',
+    'Antelope (anti-antelope)',
+    'elephant (trunk capacity)',
+    "zebra (it's actually zed)",
+    "zebra (it's zee not zed)",
+]
 
 describe('ApiGatewayNode', () => {
     let sandbox: sinon.SinonSandbox
     let testNode: ApiGatewayNode
 
-    let apiNames: string[]
+    let apiNames: { name: string; id: string }[]
 
     beforeEach(() => {
         sandbox = sinon.createSandbox()
 
-        apiNames = ['api1', 'api2']
+        apiNames = [
+            { name: 'api1', id: '11111' },
+            { name: 'api2', id: '22222' },
+        ]
 
         initializeClientBuilders()
 
@@ -79,9 +94,10 @@ describe('ApiGatewayNode', () => {
         const apiGatewayClient = {
             listApis: sandbox.stub().callsFake(() => {
                 return asyncGenerator<RestApi>(
-                    apiNames.map<RestApi>(name => {
+                    apiNames.map<RestApi>(({ name, id }) => {
                         return {
-                            name: name,
+                            name,
+                            id,
                         }
                     })
                 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Names for API Gateway nodes are not guaranteed unique. This change adds the ID to the node labels in parenthesis, similar to how it's shown in the console's breadcrumbs

## Motivation and Context

If multiple APIs had the same name, all APIs for the region would not be viewable

## Related Issue(s)

https://github.com/aws/aws-toolkit-vscode/issues/1468

## Testing
Tests pass

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
