### PR TITLE
CI: fix python2.7 setup

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -14,12 +14,18 @@ phases:
             dotnet: 3.1
 
         commands:
+            # For Python2.x on Ubuntu 20.4:
+            - add-apt-repository universe
             - '>/dev/null add-apt-repository universe'
             - '>/dev/null apt-get -qq install -y apt-transport-https'
             - '>/dev/null apt-get -qq update'
             # Install other needed dependencies
-            - '>/dev/null apt-get -qq install -y jq python2.7 python-pip python3.6 python3.7 python3.8 python3-pip python3-distutils'
+            - '>/dev/null apt-get -qq install -y jq python2.7 python3.6 python3.7 python3.8 python3-pip python3-distutils'
             - '>/dev/null apt-get -qq install -y libgtk-3-dev libxss1 xvfb libnss3-dev libasound2 libasound2-plugins libsecret-1-0'
+            # For Python2.x on Ubuntu 20.4:
+            - curl https://bootstrap.pypa.io/2.7/get-pip.py --output get-pip.py
+            # For Python2.x on Ubuntu 20.4:
+            - python2 get-pip.py
             - '>/dev/null pip3 install --upgrade aws-sam-cli'
             - '>/dev/null pip3 install --upgrade awscli'
             - '>/dev/null pip3 install pylint'

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -14,18 +14,12 @@ phases:
             dotnet: 3.1
 
         commands:
-            # For Python2.x on Ubuntu 20.4:
-            - add-apt-repository universe
             - '>/dev/null add-apt-repository universe'
             - '>/dev/null apt-get -qq install -y apt-transport-https'
             - '>/dev/null apt-get -qq update'
             # Install other needed dependencies
-            - '>/dev/null apt-get -qq install -y jq python2.7 python3.6 python3.7 python3.8 python3-pip python3-distutils'
+            - '>/dev/null apt-get -qq install -y jq python2.7 python-pip python3.6 python3.7 python3.8 python3-pip python3-distutils'
             - '>/dev/null apt-get -qq install -y libgtk-3-dev libxss1 xvfb libnss3-dev libasound2 libasound2-plugins libsecret-1-0'
-            # For Python2.x on Ubuntu 20.4:
-            - curl https://bootstrap.pypa.io/2.7/get-pip.py --output get-pip.py
-            # For Python2.x on Ubuntu 20.4:
-            - python2 get-pip.py
             - '>/dev/null pip3 install --upgrade aws-sam-cli'
             - '>/dev/null pip3 install --upgrade awscli'
             - '>/dev/null pip3 install pylint'

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -6,6 +6,7 @@
 import * as assert from 'assert'
 import { Runtime } from 'aws-sdk/clients/lambda'
 import { mkdirpSync, mkdtemp, removeSync } from 'fs-extra'
+import * as fs from 'fs-extra'
 import * as path from 'path'
 import * as vscode from 'vscode'
 import { getDependencyManager } from '../../src/lambda/models/samLambdaRuntime'
@@ -299,6 +300,20 @@ describe('SAM Integration Tests', async function () {
                 let appPath: string
                 let cfnTemplatePath: string
 
+                /**
+                 * TEMPORARY hack for python2.7
+                 * see https://github.com/aws/aws-toolkit-vscode/pull/1478
+                 */
+                function fixPython27Dockerfile(dir: string) {
+                    const dockerfile = path.join(dir, samApplicationName, 'hello_world/Dockerfile')
+                    const text = fs.readFileSync(dockerfile, { encoding: 'utf-8' })
+                    const text2 = text.replace(
+                        'https://bootstrap.pypa.io/get-pip.py',
+                        'https://bootstrap.pypa.io/2.7/get-pip.py'
+                    )
+                    fs.writeFileSync(dockerfile, text2, { encoding: 'utf-8' })
+                }
+
                 before(async function () {
                     testDir = await mkdtemp(path.join(runtimeTestRoot, 'samapp-'))
                     log(`testDir: ${testDir}`)
@@ -307,6 +322,9 @@ describe('SAM Integration Tests', async function () {
                     appPath = path.join(testDir, samApplicationName, scenario.path)
                     cfnTemplatePath = path.join(testDir, samApplicationName, 'template.yaml')
                     assert.ok(await fileExists(cfnTemplatePath), `Expected SAM template to exist at ${cfnTemplatePath}`)
+                    if (scenario.baseImage && scenario.runtime === 'python2.7') {
+                        fixPython27Dockerfile(testDir)
+                    }
                     samAppCodeUri = await openSamAppFile(appPath)
                 })
 


### PR DESCRIPTION
- Pip2 and Python27 are no longer available (end-of-life) in the  standard repo in the CodeBuild 5.0 image, so add workarounds to  install them.
  - Python 2.7 is in the `Universe` repository.
  - Pip2 is not, install it with their install script.

ref https://github.com/aws/aws-toolkit-jetbrains/pull/2366

## Notes

- TODO: revert this PR after https://github.com/aws/aws-sam-cli-app-templates/pull/82 is merged.
    - `sam` [clones HEAD of the "aws-sam-cli-app-templates" repo](https://github.com/aws/aws-sam-cli/blob/23d244927c245eae874efbc21957bdfc143a8e61/samcli/commands/init/init_templates.py#L27)
  
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
