### PR TITLE
Add Golang as EventBridge Schema Code Generation support language

### DIFF
--- a/.changes/next-release/Feature-db9d1116-847c-4bcf-ba8a-f6fa54bdd19b.json
+++ b/.changes/next-release/Feature-db9d1116-847c-4bcf-ba8a-f6fa54bdd19b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Add Golang as EventBridge Schema Code Generation support language"
+}

--- a/src/eventSchemas/models/schemaCodeLangs.ts
+++ b/src/eventSchemas/models/schemaCodeLangs.ts
@@ -9,9 +9,10 @@ import { Set as ImmutableSet } from 'immutable'
 export const JAVA = 'Java 8+'
 export const PYTHON = 'Python 3.6+'
 export const TYPESCRIPT = 'Typescript 3+'
-export type SchemaCodeLangs = 'Java 8+' | 'Python 3.6+' | 'Typescript 3+'
+export const GOLANG = 'Go 1+'
+export type SchemaCodeLangs = 'Java 8+' | 'Python 3.6+' | 'Typescript 3+' | 'Go 1+'
 
-export const schemaCodeLangs: ImmutableSet<SchemaCodeLangs> = ImmutableSet([JAVA, PYTHON, TYPESCRIPT])
+export const schemaCodeLangs: ImmutableSet<SchemaCodeLangs> = ImmutableSet([JAVA, PYTHON, TYPESCRIPT, GOLANG])
 
 const javaDetail = {
     apiValue: 'Java8',
@@ -28,6 +29,11 @@ const typescriptDetail = {
     extension: '.ts',
 }
 
+const goDetail = {
+    apiValue: 'Go1',
+    extension: '.go',
+}
+
 export function getLanguageDetails(
     language: SchemaCodeLangs
 ): {
@@ -41,6 +47,8 @@ export function getLanguageDetails(
             return pythonDetail
         case TYPESCRIPT:
             return typescriptDetail
+        case GOLANG:
+            return goDetail
         default:
             throw new Error(`Language ${language} is not supported as Schema Code Language`)
     }


### PR DESCRIPTION
Add Golang as EventBridge Schema Code Generation support language

## Description

Add Golang as new selection when customer wanna generate code iwth schema

## Motivation and Context

The EventBridge Schema Registry allows you to discover, create, and manage OpenAPI or JSONSchema Draft4 specification schemas for events on EventBridge. You can find schemas for existing AWS services, create and upload custom schemas, or generate a schema based on events on an event bus. For all schemas in EventBridge you can generate and download code bindings to help quickly build applications that use those events. You can also export AWS registry and your discovered schemas in OpenAPI 3 format to JSONSchema format.

In 2021, we decide to add new programming language support for code binding, Golang

## Related Issue(s)

No

## Testing

Run extension test with VS code and verify Golang is a choice codebinding

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
