### PR TITLE
Schemas: fix code generation on download failure

### DIFF
--- a/.changes/next-release/Bug Fix-55703bad-99e5-4cd8-ba13-8f913f7c044d.json
+++ b/.changes/next-release/Bug Fix-55703bad-99e5-4cd8-ba13-8f913f7c044d.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "When download operation fails, detemine if code generation was not previously kicked of using the error name"
+}

--- a/.changes/next-release/Bug Fix-55703bad-99e5-4cd8-ba13-8f913f7c044d.json
+++ b/.changes/next-release/Bug Fix-55703bad-99e5-4cd8-ba13-8f913f7c044d.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "When download operation fails, detemine if code generation was not previously kicked of using the error name"
+	"description": "Schemas: download failure would not trigger code generation under certain conditions"
 }

--- a/src/eventSchemas/commands/downloadSchemaItemCode.ts
+++ b/src/eventSchemas/commands/downloadSchemaItemCode.ts
@@ -136,7 +136,7 @@ export class SchemaCodeDownloader {
             zipContents = await this.downloader.download(request)
         } catch (err) {
             const error = err as Error
-            if (error.stack && error.stack.includes('NotFoundException')) {
+            if (error.name == 'ResourceNotFound') {
                 //If the code generation wasn't previously kicked off, do so
                 vscode.window.showInformationMessage(
                     localize(

--- a/src/test/eventSchemas/commands/downloadSchemaItemCode.test.ts
+++ b/src/test/eventSchemas/commands/downloadSchemaItemCode.test.ts
@@ -387,7 +387,7 @@ describe('SchemaCodeDownload', () => {
             assert.strictEqual(response, fileContent, `${expectedFilePath} :file content do not match`)
         })
 
-        it('should return error if downloading code fails with anything other than NotFoundException', async () => {
+        it('should return error if downloading code fails with anything other than ResourceNotFound', async () => {
             const customError = new Error('Custom error')
             const codeDownloaderStub = sandbox.stub(downloader, 'download').returns(Promise.reject(customError))
 
@@ -399,7 +399,7 @@ describe('SchemaCodeDownload', () => {
             assert.strictEqual(customError, error, 'Should throw Custom error')
         })
 
-        it('should generate code if download fails with NotFoundException and place it into requested directory', async () => {
+        it('should generate code if download fails with ResourceNotFound and place it into requested directory', async () => {
             sandbox.stub(poller, 'pollForCompletion').returns(Promise.resolve('CREATE_COMPLETE'))
             const codeDownloaderStub = sandbox.stub(downloader, 'download')
             const codeGeneratorResponse: Schemas.PutCodeBindingResponse = {
@@ -408,7 +408,7 @@ describe('SchemaCodeDownload', () => {
             sandbox.stub(generator, 'generate').returns(Promise.resolve(codeGeneratorResponse))
 
             const customError = new Error('Resource Not Found Exception')
-            customError.stack = 'This should trigger the code in catch block - NotFoundException'
+            customError.name = 'ResourceNotFound'
 
             codeDownloaderStub.onCall(0).returns(Promise.reject(customError)) // should fail on first call
             codeDownloaderStub.onCall(1).returns(Promise.resolve(arrayBuffer)) // should succeed on second


### PR DESCRIPTION
…eviously kicked of using the error name

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context
Just found a bug that download code bindings for custom schemas (all schemas other than `aws.schemas` registry) fails with an error.  The way that code generation logic works, we try to download code bindings ( this automatically works for aws.schemas as they are pre-generated), if it fails with NotFound exception then we generate the code bindings. Previously we would use stack parameter from the Error interface to determine the error type, which seems to be not returned anymore. Instead there is a new parameter `name` which contains the error type. 

## Testing
I did an end-to end testing by selecting a custom schema in my account, download its code bindings for 3 different languages and verified that all are successful.   

## Checklist

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
