### PR TITLE
Source-based codelenses can generate template run configs for image-based Lambdas.

### DIFF
--- a/src/shared/cloudformation/templateRegistry.ts
+++ b/src/shared/cloudformation/templateRegistry.ts
@@ -148,7 +148,7 @@ export function getResourcesForHandlerFromTemplateDatum(
                     resource.Metadata?.Dockerfile,
                     templateDatum.item
                 )
-                if (registeredPackageType && registeredDockerContext && registeredDockerFile) {
+                if (registeredPackageType === 'Image' && registeredDockerContext && registeredDockerFile) {
                     // path must be inside dockerDir
                     const dockerDir = path.join(templateDirname, registeredDockerContext)
                     if (isInDirectory(dockerDir, filepath)) {

--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode'
 import { RuntimeFamily } from '../../lambda/models/samLambdaRuntime'
+import { CloudFormation } from '../cloudformation/cloudformation'
 import { getResourcesForHandler } from '../cloudformation/templateRegistry'
 import { LambdaHandlerCandidate } from '../lambdaHandlerSearch'
 import { getLogger } from '../logger'
@@ -57,9 +58,11 @@ export async function makeCodeLenses({
 
             if (associatedResources.length > 0) {
                 for (const resource of associatedResources) {
+                    const isImage = CloudFormation.isImageLambdaResource(resource.resourceData.Properties)
                     templateConfigs.push({
                         resourceName: resource.name,
                         rootUri: vscode.Uri.file(resource.templateDatum.path),
+                        runtimeFamily: isImage ? runtimeFamily : undefined,
                     })
                     const events = resource.resourceData.Properties?.Events
                     if (events) {
@@ -71,6 +74,7 @@ export async function makeCodeLenses({
                                     resourceName: resource.name,
                                     rootUri: vscode.Uri.file(resource.templateDatum.path),
                                     apiEvent: { name: key, event: value },
+                                    runtimeFamily: isImage ? runtimeFamily : undefined,
                                 })
                             }
                         }

--- a/src/shared/sam/debugger/awsSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfiguration.ts
@@ -213,6 +213,14 @@ export function createApiAwsSamDebugConfig(
     const workspaceRelativePath = folder ? getNormalizedRelativePath(folder.uri.fsPath, templatePath) : templatePath
     const templateParentDir = path.basename(path.dirname(templatePath))
 
+    const withRuntime = runtimeName
+        ? {
+              lambda: {
+                  runtime: runtimeName,
+              },
+          }
+        : undefined
+
     return {
         type: AWS_SAM_DEBUG_TYPE,
         request: DIRECT_INVOKE_TYPE,
@@ -229,5 +237,6 @@ export function createApiAwsSamDebugConfig(
             httpMethod: (preloadedConfig?.httpMethod as APIGatewayProperties['httpMethod']) ?? 'get',
             payload: preloadedConfig?.payload ?? { json: {} },
         },
+        ...withRuntime,
     }
 }

--- a/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
@@ -51,7 +51,8 @@ export async function addSamDebugConfiguration(
     let runtimeName = runtimeFamily ? getDefaultRuntime(runtimeFamily) : undefined
     let addRuntimeNameToConfig = false
 
-    if (type === TEMPLATE_TARGET_TYPE) {
+    // both of these config types use templates
+    if (type === TEMPLATE_TARGET_TYPE || type === API_TARGET_TYPE) {
         let preloadedConfig = undefined
 
         if (workspaceFolder) {
@@ -63,36 +64,42 @@ export async function addSamDebugConfiguration(
                 }
 
                 if (CloudFormation.isZipLambdaResource(resource.Properties)) {
-                    const handler = CloudFormation.getStringForProperty(resource.Properties.Handler, templateDatum.item)
-                    const existingConfig = await getExistingConfiguration(workspaceFolder, handler ?? '', rootUri)
-                    if (existingConfig) {
-                        const responseMigrate: string = localize(
-                            'AWS.sam.debugger.useExistingConfig.migrate',
-                            'Create based on the legacy config'
+                    if (type === TEMPLATE_TARGET_TYPE) {
+                        const handler = CloudFormation.getStringForProperty(
+                            resource.Properties.Handler,
+                            templateDatum.item
                         )
-                        const responseNew: string = localize(
-                            'AWS.sam.debugger.useExistingConfig.doNotMigrate',
-                            'Create new config only'
-                        )
-                        const prompt = await vscode.window.showInformationMessage(
-                            localize(
-                                'AWS.sam.debugger.useExistingConfig',
-                                'AWS Toolkit detected an existing legacy configuration for this function. Create the debug config based on the legacy config?'
-                            ),
-                            { modal: true },
-                            responseMigrate,
-                            responseNew
-                        )
-                        if (!prompt) {
-                            // User selected "Cancel". Abandon config creation
-                            return
-                        } else if (prompt === responseMigrate) {
-                            preloadedConfig = existingConfig
+                        const existingConfig = await getExistingConfiguration(workspaceFolder, handler ?? '', rootUri)
+                        if (existingConfig) {
+                            const responseMigrate: string = localize(
+                                'AWS.sam.debugger.useExistingConfig.migrate',
+                                'Create based on the legacy config'
+                            )
+                            const responseNew: string = localize(
+                                'AWS.sam.debugger.useExistingConfig.doNotMigrate',
+                                'Create new config only'
+                            )
+                            const prompt = await vscode.window.showInformationMessage(
+                                localize(
+                                    'AWS.sam.debugger.useExistingConfig',
+                                    'AWS Toolkit detected an existing legacy configuration for this function. Create the debug config based on the legacy config?'
+                                ),
+                                { modal: true },
+                                responseMigrate,
+                                responseNew
+                            )
+                            if (!prompt) {
+                                // User selected "Cancel". Abandon config creation
+                                return
+                            } else if (prompt === responseMigrate) {
+                                preloadedConfig = existingConfig
+                            }
                         }
                     }
-                } else if (CloudFormation.isImageLambdaResource(resource.Properties) && runtimeFamily === undefined) {
+                } else if (CloudFormation.isImageLambdaResource(resource.Properties)) {
                     const quickPick = createRuntimeQuickPick({
                         showImageRuntimes: false,
+                        runtimeFamily,
                     })
 
                     const choices = await picker.promptUser({
@@ -113,14 +120,32 @@ export async function addSamDebugConfiguration(
                 }
             }
         }
-        samDebugConfig = createTemplateAwsSamDebugConfig(
-            workspaceFolder,
-            runtimeName,
-            addRuntimeNameToConfig,
-            resourceName,
-            rootUri.fsPath,
-            preloadedConfig
-        )
+
+        if (type === TEMPLATE_TARGET_TYPE) {
+            samDebugConfig = createTemplateAwsSamDebugConfig(
+                workspaceFolder,
+                runtimeName,
+                addRuntimeNameToConfig,
+                resourceName,
+                rootUri.fsPath,
+                preloadedConfig
+            )
+        } else {
+            // If the event has no properties, the default will be used
+            const apiConfig = {
+                path: apiEvent?.event.Properties?.Path,
+                httpMethod: apiEvent?.event.Properties?.Method,
+                payload: apiEvent?.event.Properties?.Payload,
+            }
+
+            samDebugConfig = createApiAwsSamDebugConfig(
+                workspaceFolder,
+                runtimeName,
+                resourceName,
+                rootUri.fsPath,
+                apiConfig
+            )
+        }
     } else if (type === CODE_TARGET_TYPE) {
         const quickPick = createRuntimeQuickPick({
             showImageRuntimes: false,
@@ -151,21 +176,6 @@ export async function addSamDebugConfiguration(
             // User backed out of runtime selection. Abandon config creation.
             return
         }
-    } else if (type === API_TARGET_TYPE) {
-        // If the event has no properties, the default will be used
-        const preloadedConfig = {
-            path: apiEvent?.event.Properties?.Path,
-            httpMethod: apiEvent?.event.Properties?.Method,
-            payload: apiEvent?.event.Properties?.Payload,
-        }
-
-        samDebugConfig = createApiAwsSamDebugConfig(
-            workspaceFolder,
-            runtimeName,
-            resourceName,
-            rootUri.fsPath,
-            preloadedConfig
-        )
     } else {
         throw new Error('Unrecognized debug target type')
     }

--- a/src/test/shared/cloudformation/templateRegistry.test.ts
+++ b/src/test/shared/cloudformation/templateRegistry.test.ts
@@ -16,7 +16,7 @@ import {
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 import { assertThrowsError } from '../utilities/assertUtils'
 import { badYaml, makeSampleSamTemplateYaml, strToYamlFile } from './cloudformationTestUtils'
-import { assertEqualPaths } from '../../testUtil'
+import { assertEqualPaths, toFile } from '../../testUtil'
 import { CloudFormation } from '../../../shared/cloudformation/cloudformation'
 import { WatchedItem } from '../../../shared/watchedFiles'
 import { writeFile } from 'fs-extra'
@@ -350,8 +350,6 @@ describe('CloudFormation Template Registry', async () => {
             tempFolder = await makeTemporaryToolkitFolder()
             helloPath = path.join(tempFolder, 'hello-world')
             nestedPath = path.join(helloPath, 'nested')
-            await fs.mkdirp(nestedPath)
-            await fs.mkdirp(helloPath)
         })
 
         afterEach(async () => {
@@ -378,8 +376,8 @@ describe('CloudFormation Template Registry', async () => {
         }
 
         it('checks for an exact handler match to a relative path in a Dockerfile for image functions', async () => {
-            await writeFile(path.join(helloPath, 'Dockerfile'), 'CMD: ["index.handler"]', 'utf8')
-            await writeFile(path.join(nestedPath, 'Dockerfile'), 'CMD: ["index.handler"]', 'utf8')
+            toFile('CMD: ["index.handler"]', path.join(helloPath, 'Dockerfile'))
+            toFile('CMD: ["index.handler"]', path.join(nestedPath, 'Dockerfile'))
 
             const helloWorldResource = {
                 ...resource,
@@ -448,16 +446,8 @@ describe('CloudFormation Template Registry', async () => {
         })
 
         it('checks for an exact handler match for C# files in a Dockerfile for image functions', async () => {
-            await writeFile(
-                path.join(helloPath, 'Dockerfile'),
-                'CMD: ["HelloWorld::HelloWorld.Function::FunctionHandler"]',
-                'utf8'
-            )
-            await writeFile(
-                path.join(nestedPath, 'Dockerfile'),
-                'CMD: ["HelloWorld::HelloWorld.Function::FunctionHandler"]',
-                'utf8'
-            )
+            toFile('CMD: ["HelloWorld::HelloWorld.Function::FunctionHandler"]', path.join(helloPath, 'Dockerfile'))
+            toFile('CMD: ["HelloWorld::HelloWorld.Function::FunctionHandler"]', path.join(nestedPath, 'Dockerfile'))
 
             const helloWorldResource = {
                 ...resource,

--- a/src/test/shared/cloudformation/templateRegistry.test.ts
+++ b/src/test/shared/cloudformation/templateRegistry.test.ts
@@ -19,7 +19,6 @@ import { badYaml, makeSampleSamTemplateYaml, strToYamlFile } from './cloudformat
 import { assertEqualPaths, toFile } from '../../testUtil'
 import { CloudFormation } from '../../../shared/cloudformation/cloudformation'
 import { WatchedItem } from '../../../shared/watchedFiles'
-import { writeFile } from 'fs-extra'
 
 // TODO almost all of these tests should be moved to test WatchedFiles instead
 describe('CloudFormation Template Registry', async () => {

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -2966,6 +2966,7 @@ describe('createTemplateAwsSamDebugConfig', () => {
 describe('createApiAwsSamDebugConfig', () => {
     const name = 'my body is a template'
     const templatePath = path.join('two', 'roads', 'diverged', 'in', 'a', 'yellow', 'wood')
+    const runtime = 'timeToRun'
 
     it('creates a API-type SAM debugger configuration with minimal configurations', () => {
         const config = createApiAwsSamDebugConfig(undefined, undefined, name, templatePath)
@@ -2989,13 +2990,13 @@ describe('createApiAwsSamDebugConfig', () => {
     })
 
     it('creates a API-type SAM debugger configuration with additional params', () => {
-        const config = createApiAwsSamDebugConfig(undefined, undefined, name, templatePath, {
+        const config = createApiAwsSamDebugConfig(undefined, runtime, name, templatePath, {
             payload: { json: { key: 'value' } },
             httpMethod: 'OPTIONS',
             path: '/api',
         })
         assert.deepStrictEqual(config, {
-            name: `API yellow:${name}`,
+            name: `API yellow:${name} (${runtime})`,
             type: AWS_SAM_DEBUG_TYPE,
             request: DIRECT_INVOKE_TYPE,
             invokeTarget: {
@@ -3009,6 +3010,9 @@ describe('createApiAwsSamDebugConfig', () => {
                 payload: {
                     json: { key: 'value' },
                 },
+            },
+            lambda: {
+                runtime,
             },
         })
     })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Codelenses in source files can generate template run configs for image-based Lambdas.
* If the template resource is an image, looks through the linked Dockerfile for a match on the handler.
  * The handler is relative to the Dockerfile location, unless it's C# (in which case it's absolute).
  * Looks for a direct match in quotes. (targeting things like `CMD ["app.handler"]`. 

## Motivation and Context
Gives a bit better support to active development of image-based Lambdas.

## Related Issue(s)

## Testing
Local tests and added tests pass.
* Generated handlers match those from initial SAM app creation (aside from the name).
  * Actually works a bit better than the in-template API codelenses; those don't pick up paths.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
