### PR TITLE
runtimes: dotnet 5.0

### DIFF
--- a/.changes/next-release/Feature-2c4a26e6-46c9-4d6a-b94d-9b7b591d0fb7.json
+++ b/.changes/next-release/Feature-2c4a26e6-46c9-4d6a-b94d-9b7b591d0fb7.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Support for SAM CLI 1.16: SAM create/run dotnet5.0"
+}

--- a/.changes/next-release/Feature-cbc68594-0491-470d-91b8-83ff87a3170c.json
+++ b/.changes/next-release/Feature-cbc68594-0491-470d-91b8-83ff87a3170c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Improved validation when searching for SAM CLI #1465"
+}

--- a/src/lambda/models/samLambdaRuntime.ts
+++ b/src/lambda/models/samLambdaRuntime.ts
@@ -65,8 +65,7 @@ export const samLambdaCreatableRuntimes: ImmutableSet<Runtime> = isCloud9()
 const dotnet50 = 'dotnet5.0'
 export const samImageLambdaRuntimes = ImmutableSet<Runtime>([
     ...samLambdaCreatableRuntimes,
-    // TODO enable to allow dotnet 5 support
-    // dotnet50,
+    dotnet50,
     // SAM also supports ruby, go, java, but toolkit does not support
 ])
 

--- a/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode'
 import * as fs from 'fs'
-import { samZipLambdaRuntimes } from '../../../lambda/models/samLambdaRuntime'
+import { samImageLambdaRuntimes, samZipLambdaRuntimes } from '../../../lambda/models/samLambdaRuntime'
 import { CloudFormation } from '../../cloudformation/cloudformation'
 import { localize } from '../../utilities/vsCodeUtils'
 import {
@@ -171,13 +171,13 @@ export class DefaultAwsSamDebugConfigurationValidator implements AwsSamDebugConf
                 }
             }
             // can't infer the runtime for image-based lambdas
-            if (!config.lambda?.runtime || !samZipLambdaRuntimes.has(config.lambda.runtime)) {
+            if (!config.lambda?.runtime || !samImageLambdaRuntimes.has(config.lambda.runtime)) {
                 return {
                     isValid: false,
                     message: localize(
                         'AWS.sam.debugger.missingRuntimeForImage',
                         'Run configurations for Image-based Lambdas require a valid Lambda runtime value, expected one of [{0}]',
-                        Array.from(samZipLambdaRuntimes).join(', ')
+                        Array.from(samImageLambdaRuntimes).join(', ')
                     ),
                 }
             }


### PR DESCRIPTION
- Support SAM CLI 1.16, which includes dotnet5.0 template support
- Not gated on SAM CLI version.
    - Gating is planned for a future release, but the current behavior is reasonable: if `sam` is an older version which doesn't support the dotnet5.0 template, Toolkit focuses the VSCode Output window and shows this error message:
      `Error: Invalid value for '-i' / '--base-image': invalid choice: amazon/dotnet5.0-base. (choose from amazon/nodejs12.x-base, amazon/nodejs10.x-base, amazon/python3.8-base, ...)`

## Testing

- dotnet5: 
    - tested with https://github.com/aws/aws-sam-cli/commit/8b7d51ac890d44e447850f8565ce43eb66065a56
    - sam init works
    - sam run/debug works
   
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
