### PR TITLE
Check SAM template global values if defaults are missing

### DIFF
--- a/.changes/next-release/Feature-0c29042c-cae4-4e59-82ca-6d2c091f5c1f.json
+++ b/.changes/next-release/Feature-0c29042c-cae4-4e59-82ca-6d2c091f5c1f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "SAM templates handle Global values correctly when Resource-level fields are missing."
+}

--- a/src/lambda/local/debugConfiguration.ts
+++ b/src/lambda/local/debugConfiguration.ts
@@ -115,9 +115,10 @@ export function getCodeRoot(
             // Image lambda or ZIP lambda?
             const isImageLambda = CloudFormation.isImageLambdaResource(templateResource.Properties)
             const uri = isImageLambda
-                ? CloudFormation.getStringForProperty(templateResource?.Metadata?.DockerContext, template)
+                ? CloudFormation.getStringForProperty(templateResource?.Metadata, 'DockerContext', template)
                 : CloudFormation.getStringForProperty(
-                      (templateResource.Properties as CloudFormation.ZipResourceProperties)?.CodeUri,
+                      templateResource.Properties as CloudFormation.ZipResourceProperties,
+                      'CodeUri',
                       template
                   )
             return uri !== undefined ? pathutil.normalize(path.resolve(templateDir ?? '', uri)) : undefined

--- a/src/shared/cloudformation/templateRegistry.ts
+++ b/src/shared/cloudformation/templateRegistry.ts
@@ -86,29 +86,35 @@ export function getResourcesForHandlerFromTemplateDatum(
         ) {
             // parse template values that could potentially be refs
             const registeredRuntime = CloudFormation.getStringForProperty(
-                resource.Properties?.Runtime,
+                resource.Properties,
+                'Runtime',
                 templateDatum.item
             )
             const registeredCodeUri = CloudFormation.getStringForProperty(
-                resource.Properties?.CodeUri,
+                resource.Properties,
+                'CodeUri',
                 templateDatum.item
             )
             const registeredHandler = CloudFormation.getStringForProperty(
-                resource.Properties?.Handler,
+                resource.Properties,
+                'Handler',
                 templateDatum.item
             )
 
             // properties for image type templates
             const registeredPackageType = CloudFormation.getStringForProperty(
-                resource.Properties?.PackageType,
+                resource.Properties,
+                'PackageType',
                 templateDatum.item
             )
             const registeredDockerContext = CloudFormation.getStringForProperty(
-                resource.Metadata?.DockerContext,
+                resource.Metadata,
+                'DockerContext',
                 templateDatum.item
             )
             const registeredDockerFile = CloudFormation.getStringForProperty(
-                resource.Metadata?.Dockerfile,
+                resource.Metadata,
+                'Dockerfile',
                 templateDatum.item
             )
 

--- a/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
@@ -185,7 +185,8 @@ export class DefaultAwsSamDebugConfigurationValidator implements AwsSamDebugConf
             // TODO: Decide what to do with this re: refs.
             // As of now, this has to be directly declared without a ref, despite the fact that SAM will handle a ref.
             // Should we just pass validation off to SAM and ignore validation at this point, or should we directly process the value (like the handler)?
-            if (!resource?.Properties?.Runtime || !samZipLambdaRuntimes.has(resource?.Properties?.Runtime as string)) {
+            const runtime = CloudFormation.getStringForProperty(resource?.Properties, 'Runtime', cfnTemplate)
+            if (!runtime || !samZipLambdaRuntimes.has(runtime)) {
                 return {
                     isValid: false,
                     message: localize(
@@ -198,7 +199,7 @@ export class DefaultAwsSamDebugConfigurationValidator implements AwsSamDebugConf
             }
         }
 
-        const templateEnv = resource?.Properties.Environment
+        const templateEnv = resource?.Properties?.Environment
         if (templateEnv?.Variables) {
             const templateEnvVars = Object.keys(templateEnv.Variables)
             const missingVars: string[] = []

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -198,12 +198,16 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
                         if (resource) {
                             // we do not know enough to populate the runtime field for Image-based Lambdas
                             const runtimeName = CloudFormation.isZipLambdaResource(resource?.Properties)
-                                ? resource?.Properties?.Runtime
+                                ? CloudFormation.getStringForProperty(
+                                      resource?.Properties,
+                                      'Runtime',
+                                      templateDatum.item
+                                  ) ?? ''
                                 : ''
                             configs.push(
                                 createTemplateAwsSamDebugConfig(
                                     folder,
-                                    CloudFormation.getStringForProperty(runtimeName, templateDatum.item),
+                                    runtimeName,
                                     false,
                                     resourceKey,
                                     templateDatum.path
@@ -219,7 +223,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
                                         configs.push(
                                             createApiAwsSamDebugConfig(
                                                 folder,
-                                                CloudFormation.getStringForProperty(runtimeName, templateDatum.item),
+                                                runtimeName,
                                                 resourceKey,
                                                 templateDatum.path,
                                                 {
@@ -346,17 +350,17 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         const runtime: string | undefined =
             config.lambda?.runtime ??
             (template && isZip
-                ? CloudFormation.getStringForProperty(templateResource?.Properties?.Runtime, template)
+                ? CloudFormation.getStringForProperty(templateResource?.Properties, 'Runtime', template)
                 : undefined) ??
             getDefaultRuntime(getRuntimeFamily(editor?.document?.languageId ?? 'unknown'))
 
         const lambdaMemory =
             (template
-                ? CloudFormation.getNumberForProperty(templateResource?.Properties?.MemorySize, template)
+                ? CloudFormation.getNumberForProperty(templateResource?.Properties, 'MemorySize', template)
                 : undefined) ?? config.lambda?.memoryMb
         const lambdaTimeout =
             (template
-                ? CloudFormation.getNumberForProperty(templateResource?.Properties?.Timeout, template)
+                ? CloudFormation.getNumberForProperty(templateResource?.Properties, 'Timeout', template)
                 : undefined) ?? config.lambda?.timeoutSec
 
         // TODO: Remove this when min sam version is > 1.13.0

--- a/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
@@ -66,7 +66,8 @@ export async function addSamDebugConfiguration(
                 if (CloudFormation.isZipLambdaResource(resource.Properties)) {
                     if (type === TEMPLATE_TARGET_TYPE) {
                         const handler = CloudFormation.getStringForProperty(
-                            resource.Properties.Handler,
+                            resource.Properties,
+                            'Handler',
                             templateDatum.item
                         )
                         const existingConfig = await getExistingConfiguration(workspaceFolder, handler ?? '', rootUri)

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -803,7 +803,7 @@ describe('SamDebugConfigurationProvider', async () => {
                     ...input.lambda,
                     environmentVariables: {},
                     memoryMb: undefined,
-                    timeoutSec: undefined,
+                    timeoutSec: 3,
                 },
                 localRoot: appDir,
                 name: input.name,
@@ -1209,7 +1209,7 @@ Outputs:
                         'test-envvar-1': 'test value 1',
                     },
                     memoryMb: 42,
-                    timeoutSec: 717,
+                    timeoutSec: 10,
                     payload: {
                         json: {
                             'test-payload-key-1': 'test payload value 1',
@@ -1409,7 +1409,7 @@ Outputs:
                         'test-envvar-1': 'test value 1',
                     },
                     memoryMb: 42,
-                    timeoutSec: 717,
+                    timeoutSec: 10,
                     payload: {
                         json: {
                             'test-payload-key-1': 'test payload value 1',
@@ -1807,7 +1807,7 @@ Outputs:
                 lambda: {
                     environmentVariables: {},
                     memoryMb: undefined,
-                    timeoutSec: undefined,
+                    timeoutSec: 3,
                 },
                 name: input.name,
                 templatePath: pathutil.normalize(
@@ -2005,7 +2005,7 @@ Outputs:
                 lambda: {
                     environmentVariables: {},
                     memoryMb: undefined,
-                    timeoutSec: undefined,
+                    timeoutSec: 3,
                 },
                 name: input.name,
                 templatePath: pathutil.normalize(
@@ -2163,7 +2163,7 @@ Outputs:
                 lambda: {
                     environmentVariables: {},
                     memoryMb: undefined,
-                    timeoutSec: undefined,
+                    timeoutSec: 3,
                     runtime: 'python3.7',
                 },
                 name: input.name,
@@ -2459,7 +2459,7 @@ Outputs:
                 lambda: {
                     environmentVariables: {},
                     memoryMb: undefined,
-                    timeoutSec: undefined,
+                    timeoutSec: 3,
                 },
                 sam: {
                     containerBuild: true,
@@ -3089,7 +3089,7 @@ describe('debugConfiguration', () => {
         }
 
         // Template with relative path:
-        testutil.toFile(makeSampleSamTemplateYaml(true, { codeUri: relativePath }), tempFile.fsPath)
+        testutil.toFile(makeSampleSamTemplateYaml(true, { codeUri: relativePath, handler: 'handler' }), tempFile.fsPath)
         await ext.templateRegistry.addItemToRegistry(tempFile)
         assert.strictEqual(debugConfiguration.getCodeRoot(folder, config), fullPath)
         assert.strictEqual(debugConfiguration.getHandlerName(folder, config), 'handler')
@@ -3114,7 +3114,10 @@ describe('debugConfiguration', () => {
                 Default: 'notDoingAnything',
             },
         })
-        testutil.toFile(makeSampleSamTemplateYaml(true, { codeUri: fullPath }, paramStr), tempFileRefs.fsPath)
+        testutil.toFile(
+            makeSampleSamTemplateYaml(true, { codeUri: fullPath, handler: 'handler' }, paramStr),
+            tempFileRefs.fsPath
+        )
         await ext.templateRegistry.addItemToRegistry(tempFileRefs)
         assert.strictEqual(debugConfiguration.getCodeRoot(folder, fileRefsConfig), fullPath)
         assert.strictEqual(debugConfiguration.getHandlerName(folder, fileRefsConfig), 'handler')

--- a/src/test/templates/sam/samTemplateGenerator.test.ts
+++ b/src/test/templates/sam/samTemplateGenerator.test.ts
@@ -111,14 +111,14 @@ describe('SamTemplateGenerator', () => {
 
         const template: CloudFormation.Template = await CloudFormation.load(templateFilename)
         assert.ok(template.Globals, 'Expected loaded template to have a Globals section')
-        const globals = template.Globals!
+        const globals = template.Globals
         assert.notStrictEqual(Object.keys(globals).length, 0, 'Expected Template Globals to be not empty')
 
         const functionKey = 'Function'
         const timeoutKey = 'Timeout'
         assert.ok(globals[functionKey], 'Expected Globals to contain Function')
-        assert.ok(globals[functionKey][timeoutKey], 'Expected Globals.Function to contain Timeout')
-        assert.strictEqual(globals[functionKey][timeoutKey], 5, 'Unexpected Globals.Function.Timeout value')
+        assert.ok(globals[functionKey]![timeoutKey], 'Expected Globals.Function to contain Timeout')
+        assert.strictEqual(globals[functionKey]![timeoutKey], 5, 'Unexpected Globals.Function.Timeout value')
     })
 
     it('errs if resource name is missing', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fields in the `Globals` field of a SAM template are now checked when handling SAM template operations.
* Any fields set directly in a Function resource will take priority over a Globals value.
* These fields can include Refs.
* Technically handles all [currently-accepted Globals fields](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-specification-template-anatomy-globals.html#sam-specification-template-anatomy-globals-supported-resources-and-properties), although we may not be handling these directly in the toolkit (they should be passed to execution, however)

## Motivation and Context

SAM accepts values in `Globals` which we didn't account for.

## Related Issue(s)

https://github.com/aws/aws-toolkit-vscode/issues/1211
https://github.com/aws/aws-toolkit-vscode/issues/1395

## Testing
Testing a SAM template with Globals fields for runtime and handler work as expected; they are used when a resource doesn't have one of the fields, and are overridden by the resource's fields if present.

Will do some additional stress-testing.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
