### PR TITLE
cloud9: don't show telemetry popup

### DIFF
--- a/src/shared/telemetry/activation.ts
+++ b/src/shared/telemetry/activation.ts
@@ -60,7 +60,7 @@ export async function activate(activateArguments: {
     applyTelemetryEnabledState(ext.telemetry, activateArguments.toolkitSettings)
 
     // Prompt user about telemetry if they haven't been
-    if (!hasUserSeenTelemetryNotice(activateArguments.extensionContext)) {
+    if (!isCloud9() && !hasUserSeenTelemetryNotice(activateArguments.extensionContext)) {
         showTelemetryNotice(activateArguments.extensionContext)
     }
 


### PR DESCRIPTION
Not needed in cloud9.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
