### PR TITLE
runtimes: remove nodejs8

### DIFF
--- a/.changes/next-release/Breaking Change-711c2a47-7b8f-4554-b409-6d2fe567e0d8.json
+++ b/.changes/next-release/Breaking Change-711c2a47-7b8f-4554-b409-6d2fe567e0d8.json
@@ -1,0 +1,4 @@
+{
+	"type": "Breaking Change",
+	"description": "SAM debug: remove nodejs8.10 support"
+}

--- a/src/lambda/models/samLambdaRuntime.ts
+++ b/src/lambda/models/samLambdaRuntime.ts
@@ -27,7 +27,6 @@ export const nodeJsRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>([
     'nodejs14.x',
     'nodejs12.x',
     'nodejs10.x',
-    'nodejs8.10',
 ])
 export const pythonRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>([
     'python3.8',
@@ -48,23 +47,20 @@ export const samZipLambdaRuntimes: ImmutableSet<Runtime> = ImmutableSet.union([
     dotNetRuntimes,
 ])
 
-// cloud9 supports a subset of runtimes for debugging, so we limit specifically to that.
+// Cloud9 supports a subset of runtimes for debugging.
 // * .NET is not supported
-// * Node8 is deprecated (and shouldn't be creatable via UI)
 // * Python2.7 + 3.6 are not supported for debugging by IKP3db
 // for some reason, ImmutableSet does not like `ImmutableSet.union().filter()`; initialize union set here.
 const cloud9SupportedBaseRuntimes: ImmutableSet<Runtime> = ImmutableSet.union([nodeJsRuntimes, pythonRuntimes])
 const cloud9SupportedCreateRuntimes = cloud9SupportedBaseRuntimes.filter(
-    (runtime: string) => !['nodejs8.10', 'python3.6', 'python2.7'].includes(runtime)
+    (runtime: string) => !['python3.6', 'python2.7'].includes(runtime)
 )
 // only interpreted languages are importable as compiled languages won't provide a useful artifact for editing.
 export const samLambdaImportableRuntimes: ImmutableSet<Runtime> = ImmutableSet.union([nodeJsRuntimes, pythonRuntimes])
 
 export const samLambdaCreatableRuntimes: ImmutableSet<Runtime> = isCloud9()
     ? cloud9SupportedCreateRuntimes
-    : // Filter out node8 until local debugging is no longer supported, and
-      // it can be removed from samLambdaRuntimes
-      samZipLambdaRuntimes.filter((runtime: string) => runtime !== 'nodejs8.10')
+    : samZipLambdaRuntimes
 
 // Image runtimes are not a direct subset of valid ZIP lambda types
 const dotnet50 = 'dotnet5.0'

--- a/src/test/lambda/models/samLambdaRuntime.test.ts
+++ b/src/test/lambda/models/samLambdaRuntime.test.ts
@@ -18,9 +18,9 @@ describe('compareSamLambdaRuntime', async () => {
         lowerRuntime: Runtime
         higherRuntime: Runtime
     }[] = [
-        { lowerRuntime: 'nodejs8.10', higherRuntime: 'nodejs10.x' },
-        { lowerRuntime: 'nodejs8.10', higherRuntime: 'nodejs12.x' },
+        { lowerRuntime: 'nodejs12.x', higherRuntime: 'nodejs14.x' },
         { lowerRuntime: 'nodejs10.x', higherRuntime: 'nodejs12.x' },
+        { lowerRuntime: 'nodejs10.x', higherRuntime: 'nodejs14.x' },
         { lowerRuntime: 'nodejs10.x', higherRuntime: 'nodejs10.x (Image)' },
         { lowerRuntime: 'nodejs10.x (Image)', higherRuntime: 'nodejs12.x' },
     ]

--- a/src/test/lambda/wizards/samInitWizard.test.ts
+++ b/src/test/lambda/wizards/samInitWizard.test.ts
@@ -219,7 +219,7 @@ describe('CreateNewSamAppWizard', async () => {
         it('uses user response as runtime', async () => {
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
-                Set<Runtime>(['nodejs8.10']),
+                Set<Runtime>(['nodejs10.x']),
                 'myName',
                 [vscode.Uri.file(dir)],
                 Set<SamTemplate>([helloWorldTemplate]),
@@ -231,7 +231,7 @@ describe('CreateNewSamAppWizard', async () => {
             const args = await wizard.run()
 
             assert.ok(args)
-            assert.strictEqual(args!.runtime, 'nodejs8.10')
+            assert.strictEqual(args!.runtime, 'nodejs10.x')
         })
 
         it('exits when cancelled', async () => {
@@ -256,7 +256,7 @@ describe('CreateNewSamAppWizard', async () => {
         it('uses user response as template', async () => {
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
-                Set<Runtime>(['nodejs8.10']),
+                Set<Runtime>(['nodejs10.x']),
                 'myName',
                 [vscode.Uri.file(dir)],
                 Set<SamTemplate>([helloWorldTemplate]),
@@ -274,7 +274,7 @@ describe('CreateNewSamAppWizard', async () => {
         it('backtracks when cancelled', async () => {
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
-                [Set<Runtime>(['python3.6']), Set<Runtime>(['nodejs8.10'])],
+                [Set<Runtime>(['python3.6']), Set<Runtime>(['nodejs10.x'])],
                 'myName',
                 [vscode.Uri.file(dir)],
                 [undefined, Set<SamTemplate>([helloWorldTemplate])],
@@ -286,7 +286,7 @@ describe('CreateNewSamAppWizard', async () => {
             const args = await wizard.run()
 
             assert.ok(args)
-            assert.strictEqual(args!.runtime, 'nodejs8.10')
+            assert.strictEqual(args!.runtime, 'nodejs10.x')
             assert.strictEqual(args!.template, helloWorldTemplate)
         })
 
@@ -305,7 +305,7 @@ describe('CreateNewSamAppWizard', async () => {
             beforeEach(async () => {
                 context = new MockCreateNewSamAppWizardContext(
                     [],
-                    Set<Runtime>(['nodejs8.10']),
+                    Set<Runtime>(['nodejs10.x']),
                     'myName',
                     [vscode.Uri.file(locationPath)],
                     Set<SamTemplate>([eventBridgeStarterAppTemplate]),
@@ -326,7 +326,7 @@ describe('CreateNewSamAppWizard', async () => {
                 it('backtracks when cancelled', async () => {
                     context = new MockCreateNewSamAppWizardContext(
                         [],
-                        [Set<Runtime>(['python3.6']), Set<Runtime>(['nodejs8.10'])],
+                        [Set<Runtime>(['python3.6']), Set<Runtime>(['nodejs10.x'])],
                         'myName',
                         [vscode.Uri.file(locationPath)],
                         Set<SamTemplate>([eventBridgeStarterAppTemplate]),
@@ -352,7 +352,7 @@ describe('CreateNewSamAppWizard', async () => {
                 it('backtracks when cancelled', async () => {
                     context = new MockCreateNewSamAppWizardContext(
                         [],
-                        [Set<Runtime>(['python3.6']), Set<Runtime>(['nodejs8.10'])],
+                        [Set<Runtime>(['python3.6']), Set<Runtime>(['nodejs10.x'])],
                         'myName',
                         [vscode.Uri.file(locationPath)],
                         Set<SamTemplate>([eventBridgeStarterAppTemplate]),
@@ -378,7 +378,7 @@ describe('CreateNewSamAppWizard', async () => {
                 it('backtracks when cancelled', async () => {
                     context = new MockCreateNewSamAppWizardContext(
                         [],
-                        [Set<Runtime>(['python3.6']), Set<Runtime>(['nodejs8.10'])],
+                        [Set<Runtime>(['python3.6']), Set<Runtime>(['nodejs10.x'])],
                         'myName',
                         [vscode.Uri.file(locationPath)],
                         Set<SamTemplate>([eventBridgeStarterAppTemplate]),
@@ -404,7 +404,7 @@ describe('CreateNewSamAppWizard', async () => {
                 it('backtracks when cancelled', async () => {
                     context = new MockCreateNewSamAppWizardContext(
                         [],
-                        [Set<Runtime>(['python3.6']), Set<Runtime>(['nodejs8.10'])],
+                        [Set<Runtime>(['python3.6']), Set<Runtime>(['nodejs10.x'])],
                         'myName',
                         [undefined, [vscode.Uri.file(locationPath)]],
                         Set<SamTemplate>([eventBridgeStarterAppTemplate]),
@@ -427,7 +427,7 @@ describe('CreateNewSamAppWizard', async () => {
         it('uses user response as location', async () => {
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
-                Set<Runtime>(['nodejs8.10']),
+                Set<Runtime>(['nodejs10.x']),
                 'myName',
                 [vscode.Uri.file(dir)],
                 Set<SamTemplate>([helloWorldTemplate]),
@@ -445,7 +445,7 @@ describe('CreateNewSamAppWizard', async () => {
         it('backtracks when cancelled', async () => {
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
-                [Set<Runtime>(['python3.6']), Set<Runtime>(['nodejs8.10'])],
+                [Set<Runtime>(['python3.6']), Set<Runtime>(['nodejs10.x'])],
                 'myName',
                 [undefined, [vscode.Uri.file(dir)]],
                 [Set<SamTemplate>([helloWorldTemplate]), Set<SamTemplate>([eventBridgeHelloWorldTemplate])],
@@ -465,7 +465,7 @@ describe('CreateNewSamAppWizard', async () => {
             const name = 'myInputBoxResult'
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
-                Set<Runtime>(['nodejs8.10']),
+                Set<Runtime>(['nodejs10.x']),
                 name,
                 [vscode.Uri.file(dir)],
                 Set<SamTemplate>([helloWorldTemplate]),
@@ -490,7 +490,7 @@ describe('CreateNewSamAppWizard', async () => {
                     name: path.basename(p),
                     index: index++,
                 })),
-                Set<Runtime>(['nodejs8.10']),
+                Set<Runtime>(['nodejs10.x']),
                 'myName',
                 [],
                 Set<SamTemplate>([helloWorldTemplate]),
@@ -510,7 +510,7 @@ describe('CreateNewSamAppWizard', async () => {
         it('uses user response as name', async () => {
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
-                Set<Runtime>(['nodejs8.10']),
+                Set<Runtime>(['nodejs10.x']),
                 'myName',
                 [vscode.Uri.file(dir)],
                 Set<SamTemplate>([helloWorldTemplate]),
@@ -528,7 +528,7 @@ describe('CreateNewSamAppWizard', async () => {
         it('backtracks when cancelled', async () => {
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
-                Set<Runtime>(['nodejs8.10']),
+                Set<Runtime>(['nodejs10.x']),
                 ['', 'myName'],
                 [[vscode.Uri.file(dir)], [vscode.Uri.file(dir2)]],
                 Set<SamTemplate>([helloWorldTemplate]),

--- a/src/test/shared/sam/cli/samCliInit.test.ts
+++ b/src/test/shared/sam/cli/samCliInit.test.ts
@@ -53,7 +53,7 @@ describe('runSamCliInit', async () => {
     const sampleSamInitArgs: SamCliInitArgs = {
         name: 'qwerty',
         location: '/some/path/to/code.js',
-        runtime: 'nodejs8.10',
+        runtime: 'nodejs10.x',
         template: helloWorldTemplate,
         dependencyManager: sampleDependencyManager,
     }


### PR DESCRIPTION
nodejs8 is EOL and not supported by Lambda since 1 year.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
