### PR TITLE
Revert "CI: workaround invalid yarn key"

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -15,7 +15,7 @@ phases:
 
         commands:
             # WORKAROUND for out-of-date yarn key. https://github.com/yarnpkg/yarn/issues/7866
-            - '>/dev/null apt-get install dirmngr && apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com'
+            - 'curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -'
             - '>/dev/null add-apt-repository universe'
             - '>/dev/null apt-get -qq install -y apt-transport-https'
             - '>/dev/null apt-get -qq update'


### PR DESCRIPTION
This reverts commit a52644096ba9e3a4815ef98debed04053893f23f.

The `dirmngr` approach fails in codepipeline. Since this is a temporary change anyway, try the `curl` approach to unblock the pipeline.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
