### PR TITLE
sam init telemetry improvements

### DIFF
--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -85,7 +85,12 @@ export async function resumeCreateNewSamApp(
             return
         }
 
-        await addInitialLaunchConfiguration(extContext, folder, uri, samInitState?.runtime)
+        await addInitialLaunchConfiguration(
+            extContext,
+            folder,
+            uri,
+            samInitState?.isImage ? samInitState?.runtime : undefined
+        )
         await vscode.window.showTextDocument(uri)
     } finally {
         activationReloadState.clearSamInitState()

--- a/src/shared/activationReloadState.ts
+++ b/src/shared/activationReloadState.ts
@@ -28,7 +28,7 @@ export class ActivationReloadState {
             ? {
                   path: activationPath,
                   runtime: this.extensionContext.globalState.get<string>(SAM_INIT_RUNTIME_KEY),
-                  isImage: this.extensionContext.globalState.get<boolean>(SAM_INIT_IMAGE_BOOLEAN_KEY) ?? false,
+                  isImage: this.extensionContext.globalState.get<boolean>(SAM_INIT_IMAGE_BOOLEAN_KEY),
               }
             : undefined
     }

--- a/src/shared/activationReloadState.ts
+++ b/src/shared/activationReloadState.ts
@@ -8,11 +8,13 @@ import { ext } from './extensionGlobals'
 import { Runtime } from 'aws-sdk/clients/lambda'
 
 export const ACTIVATION_LAUNCH_PATH_KEY = 'ACTIVATION_LAUNCH_PATH_KEY'
-export const SAM_INIT_IMAGE_RUNTIME_KEY = 'SAM_INIT_IMAGE_RUNTIME_KEY'
+export const SAM_INIT_RUNTIME_KEY = 'SAM_INIT_RUNTIME_KEY'
+export const SAM_INIT_IMAGE_BOOLEAN_KEY = 'SAM_INIT_IMAGE_BOOLEAN_KEY'
 
 export interface SamInitState {
     path: string | undefined
-    imageRuntime: Runtime | undefined
+    runtime: Runtime | undefined
+    isImage: boolean | undefined
 }
 
 /**
@@ -25,19 +27,22 @@ export class ActivationReloadState {
         return activationPath
             ? {
                   path: activationPath,
-                  imageRuntime: this.extensionContext.globalState.get<string>(SAM_INIT_IMAGE_RUNTIME_KEY),
+                  runtime: this.extensionContext.globalState.get<string>(SAM_INIT_RUNTIME_KEY),
+                  isImage: this.extensionContext.globalState.get<boolean>(SAM_INIT_IMAGE_BOOLEAN_KEY) ?? false,
               }
             : undefined
     }
 
     public setSamInitState(state: SamInitState): void {
         this.extensionContext.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, state.path)
-        this.extensionContext.globalState.update(SAM_INIT_IMAGE_RUNTIME_KEY, state.imageRuntime)
+        this.extensionContext.globalState.update(SAM_INIT_RUNTIME_KEY, state.runtime)
+        this.extensionContext.globalState.update(SAM_INIT_IMAGE_BOOLEAN_KEY, state.isImage)
     }
 
     public clearSamInitState(): void {
         this.extensionContext.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, undefined)
-        this.extensionContext.globalState.update(SAM_INIT_IMAGE_RUNTIME_KEY, undefined)
+        this.extensionContext.globalState.update(SAM_INIT_RUNTIME_KEY, undefined)
+        this.extensionContext.globalState.update(SAM_INIT_IMAGE_BOOLEAN_KEY, undefined)
     }
 
     protected get extensionContext(): vscode.ExtensionContext {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes to `sam init` telemetry
* Removing potential PII source (`name` metadata)
* Telemetry event is emitted on `sam init` resumption

## Motivation and Context

OpEx

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
