### PR TITLE
Better error message for missing runtimes

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -391,7 +391,7 @@
     "AWS.sam.debugger.noLaunchJson": "AWS SAM: To debug a Lambda locally, create a launch.json from the Run panel, then select a configuration.",
     "AWS.sam.debugger.noTemplates": "No SAM templates found in workspace",
     "AWS.sam.debugger.noWorkspace": "AWS SAM debug: choose a workspace, then try again",
-    "AWS.sam.debugger.failedLaunch.missingRuntime": "Toolkit could not assume a runtime for config: {0}. Add a \"lambda.runtime\" field to your launch configuration.",
+    "AWS.sam.debugger.failedLaunch.missingRuntime": "Toolkit could not infer a runtime for config: {0}. Add a \"lambda.runtime\" field to your launch configuration.",
     "AWS.sam.debugger.missingTemplate": "Cannot find template file (must be workspace-relative, or absolute): {0}",
     "AWS.sam.debugger.missingResource": "Cannot find template resource \"{0}\" in template file: {1}",
     "AWS.sam.debugger.missingField": "Missing required field \"{0}\" in debug config",

--- a/package.nls.json
+++ b/package.nls.json
@@ -391,7 +391,7 @@
     "AWS.sam.debugger.noLaunchJson": "AWS SAM: To debug a Lambda locally, create a launch.json from the Run panel, then select a configuration.",
     "AWS.sam.debugger.noTemplates": "No SAM templates found in workspace",
     "AWS.sam.debugger.noWorkspace": "AWS SAM debug: choose a workspace, then try again",
-    "AWS.sam.debugger.failedLaunch": "AWS SAM failed to launch. Try creating launch.json",
+    "AWS.sam.debugger.failedLaunch.missingRuntime": "Toolkit could not assume a runtime for config: {0}. Add a \"lambda.runtime\" field to your launch configuration.",
     "AWS.sam.debugger.missingTemplate": "Cannot find template file (must be workspace-relative, or absolute): {0}",
     "AWS.sam.debugger.missingResource": "Cannot find template resource \"{0}\" in template file: {1}",
     "AWS.sam.debugger.missingField": "Missing required field \"{0}\" in debug config",

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -383,7 +383,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
             vscode.window.showErrorMessage(
                 localize(
                     'AWS.sam.debugger.failedLaunch.missingRuntime',
-                    'Toolkit could not assume a runtime for config: {0}. Add a "lambda.runtime" field to your launch configuration.',
+                    'Toolkit could not infer a runtime for config: {0}. Add a "lambda.runtime" field to your launch configuration.',
                     config.name
                 )
             )

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -379,9 +379,13 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         }
 
         if (!runtime) {
-            getLogger().error(`SAM debug: failed to launch config: ${config})`)
+            getLogger().error(`SAM debug: failed to launch config (missing runtime): ${config})`)
             vscode.window.showErrorMessage(
-                localize('AWS.sam.debugger.failedLaunch', 'AWS SAM failed to launch. Try creating launch.json')
+                localize(
+                    'AWS.sam.debugger.failedLaunch.missingRuntime',
+                    'Toolkit could not assume a runtime for config: {0}. Add a "lambda.runtime" field to your launch configuration.',
+                    config.name
+                )
             )
             return undefined
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Rewording an extremely vague error message when a runtime is not inferrable by the SAM runner. This is increasingly necessary with image-type Lambdas, as the toolkit cannot infer the runtime from a Dockerfile.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
