### PR TITLE
Force Cloud9 behavior with "aws-debug.forceCloud9" setting

### DIFF
--- a/src/shared/extensionUtilities.ts
+++ b/src/shared/extensionUtilities.ts
@@ -12,6 +12,7 @@ import { ext } from '../shared/extensionGlobals'
 import { readFileAsString } from './filesystemUtilities'
 import { getLogger } from './logger'
 import { VSCODE_EXTENSION_ID, EXTENSION_ALPHA_VERSION } from './extensions'
+import { DefaultSettingsConfiguration } from './settingsConfiguration'
 
 const localize = nls.loadMessageBundle()
 
@@ -85,7 +86,9 @@ export function getIdeProperties(): IdeProperties {
  * Returns whether or not this is Cloud9
  */
 export function isCloud9(): boolean {
-    return getIdeType() === IDE.cloud9
+    const settings = new DefaultSettingsConfiguration('aws-debug')
+
+    return getIdeType() === IDE.cloud9 || !!settings.readSetting<boolean>('forceCloud9', false)
 }
 
 export class ExtensionUtilities {

--- a/src/shared/extensionUtilities.ts
+++ b/src/shared/extensionUtilities.ts
@@ -86,7 +86,7 @@ export function getIdeProperties(): IdeProperties {
  * Returns whether or not this is Cloud9
  */
 export function isCloud9(): boolean {
-    const settings = new DefaultSettingsConfiguration('aws-debug')
+    const settings = new DefaultSettingsConfiguration('aws')
 
     return getIdeType() === IDE.cloud9 || !!settings.readSetting<boolean>('forceCloud9', false)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Force any `isCloud9()` statements to `true` by adding the following setting to any VS Code settings:
```
{
...
    "aws.forceCloud9": true,
...
}
```
Potentially override the `getIdeType()` call as well? 

## Motivation and Context
Lets us test expected Cloud9 functionalities quickly in VS Code

## Testing

See screenshot

## Screenshots (if appropriate)
(note fewer menu options)
![image](https://user-images.githubusercontent.com/29374703/109048770-4f211800-768c-11eb-88ea-2355399d3067.png)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
