### PR TITLE
Correct handling of import failures

### DIFF
--- a/.changes/next-release/Bug Fix-73f417d5-8b4f-4fb4-9e7f-7fb94e110fe1.json
+++ b/.changes/next-release/Bug Fix-73f417d5-8b4f-4fb4-9e7f-7fb94e110fe1.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Toolkit correctly handles failures when importing Lambdas for supported language families that have not been added explicitly as importable"
+}

--- a/src/lambda/commands/importLambda.ts
+++ b/src/lambda/commands/importLambda.ts
@@ -86,11 +86,30 @@ async function runImportLambda(functionNode: LambdaFunctionNode, window = Window
             ),
         },
         async progress => {
-            const lambdaLocation = path.join(importLocation, getLambdaDetails(functionNode.configuration).fileName)
-            try {
-                await downloadAndUnzipLambda(progress, functionNode, importLocation)
-                await openLambdaFile(lambdaLocation)
+            let lambdaLocation: string
 
+            try {
+                lambdaLocation = path.join(importLocation, getLambdaDetails(functionNode.configuration).fileName)
+                await downloadAndUnzipLambda(progress, functionNode, importLocation)
+            } catch (e) {
+                // initial download failed or runtime is unsupported.
+                // show error and return a failure
+                const err = e as Error
+                getLogger().error(err)
+                window.showErrorMessage(
+                    localize(
+                        'AWS.lambda.import.importError',
+                        'Error importing Lambda function {0}: {1}',
+                        functionNode.configuration.FunctionArn!,
+                        err.message
+                    )
+                )
+
+                return 'Failed'
+            }
+
+            try {
+                await openLambdaFile(lambdaLocation)
                 if (
                     workspaceFolders.filter(val => {
                         return selectedUri === val.uri
@@ -104,11 +123,6 @@ async function runImportLambda(functionNode: LambdaFunctionNode, window = Window
 
                 return 'Succeeded'
             } catch (e) {
-                if (e instanceof ImportError) {
-                    // failed the download/unzip step. Non-functional, definite failure
-                    return 'Failed'
-                }
-
                 // failed to open handler file or add launch config.
                 // not a failure since the function is downloaded to a workspace directory.
                 return 'Succeeded'
@@ -159,7 +173,7 @@ async function downloadAndUnzipLambda(
                         if (err) {
                             // err unzipping
                             zipErr = err
-                            resolve(undefined)
+                            resolve(false)
                         } else {
                             progress.report({ increment: 10 })
                             resolve(true)
@@ -168,7 +182,7 @@ async function downloadAndUnzipLambda(
                 } catch (err) {
                     // err loading zip into AdmZip, prior to attempting an unzip
                     zipErr = err
-                    resolve(undefined)
+                    resolve(false)
                 }
             })
         })
@@ -177,17 +191,6 @@ async function downloadAndUnzipLambda(
             throw zipErr
         }
     } catch (e) {
-        const err = e as Error
-        getLogger().error(err)
-        window.showErrorMessage(
-            localize(
-                'AWS.lambda.import.importError',
-                'Error importing Lambda function {0}: {1}',
-                functionArn,
-                err.message
-            )
-        )
-
         throw new ImportError()
     } finally {
         tryRemoveFolder(tempDir)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If a language was not specifically flagged as not-importable but was imported, an uncaught error would be thrown causing the user to unknowingly crash out of the import process. This handles this specific error as a failure and will now log appropriately.

## Motivation and Context

No surprises, if something doesn't work we should be clear that it doesn't work
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
