### PR TITLE
auth: Set the `stsRegionalEndpoints` flag on the client config

### DIFF
--- a/src/shared/clients/defaultStsClient.ts
+++ b/src/shared/clients/defaultStsClient.ts
@@ -16,15 +16,16 @@ export class DefaultStsClient implements StsClient {
 
     public async getCallerIdentity(): Promise<STS.GetCallerIdentityResponse> {
         const sdkClient = await this.createSdkClient()
-
         const response = await sdkClient.getCallerIdentity().promise()
-
         return response
     }
 
     private async createSdkClient(): Promise<STS> {
         return await ext.sdkClientBuilder.createAndConfigureServiceClient(
-            options => new STS(options),
+            options => {
+                options.stsRegionalEndpoints = 'regional'
+                return new STS(options)
+            },
             this.credentials,
             this.regionCode
         )


### PR DESCRIPTION
Problem:
Toolkit fails with "Error: Could not determine Account Id for credentials".

Solution:
Set the `stsRegionalEndpoints` flag on the client config:
https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#stsRegionalEndpoints-property

fixes https://github.com/aws/aws-toolkit-vscode/issues/1183


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
