### PR TITLE
waitUntil(): ensure timeout, check undefined explicitly

### DIFF
--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -87,7 +87,7 @@ export class Timeout {
  *
  * @returns Result of `fn()`, or `undefined` if timeout was reached.
  */
- export async function waitUntil<T>(
+export async function waitUntil<T>(
     fn: () => Promise<T>,
     opt: { timeout: number; interval: number } = { timeout: 5000, interval: 500 }
 ): Promise<T | undefined> {

--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -94,6 +94,7 @@ export async function waitUntil<T>(
     for (let i = 0; true; i++) {
         const start: number = Date.now()
         const result: T = await Promise.race([fn(), new Promise<T>(r => setTimeout(r, opt.timeout))])
+        // Ensures that we never overrun the timeout
         opt.timeout -= (Date.now() - start)
 
         if (result != undefined) {

--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -87,18 +87,22 @@ export class Timeout {
  *
  * @returns Result of `fn()`, or `undefined` if timeout was reached.
  */
-export async function waitUntil<T>(
+ export async function waitUntil<T>(
     fn: () => Promise<T>,
     opt: { timeout: number; interval: number } = { timeout: 5000, interval: 500 }
 ): Promise<T | undefined> {
     for (let i = 0; true; i++) {
-        const result: T = await fn()
-        if (result) {
+        const start: number = Date.now()
+        const result: T = await Promise.race([fn(), new Promise<T>(r => setTimeout(r, opt.timeout))])
+        opt.timeout -= (Date.now() - start)
+
+        if (result != undefined) {
             return result
         }
         if (i * opt.interval >= opt.timeout) {
             return undefined
         }
+
         await new Promise(r => setTimeout(r, opt.interval))
     }
 }

--- a/src/test/shared/utilities/childProcess.test.ts
+++ b/src/test/shared/utilities/childProcess.test.ts
@@ -145,7 +145,7 @@ describe('ChildProcess', async () => {
             const childProcess = new ChildProcess(batchFile)
 
             const result = await childProcess.run()
-
+            
             assert.notStrictEqual(result.exitCode, 0)
             assert.notStrictEqual(result.error, undefined)
         })
@@ -311,7 +311,7 @@ describe('ChildProcess', async () => {
                 childProcess.stop()
                 await waitUntil(
                     async () => {
-                        return childProcess.stopped === true
+                        return (childProcess.stopped === true) ? true : undefined
                     },
                     { timeout: 1000, interval: 100 }
                 )
@@ -330,7 +330,7 @@ describe('ChildProcess', async () => {
                 childProcess.stop()
                 await waitUntil(
                     async () => {
-                        return childProcess.stopped === true
+                        return (childProcess.stopped === true) ? true : undefined
                     },
                     { timeout: 1000, interval: 100 }
                 )
@@ -355,7 +355,7 @@ describe('ChildProcess', async () => {
                 childProcess.stop()
                 await waitUntil(
                     async () => {
-                        return childProcess.stopped === true
+                        return (childProcess.stopped === true) ? true : undefined
                     },
                     { timeout: 1000, interval: 100 }
                 )
@@ -374,7 +374,7 @@ describe('ChildProcess', async () => {
                 childProcess.stop()
                 await waitUntil(
                     async () => {
-                        return childProcess.stopped === true
+                        return (childProcess.stopped === true) ? true : undefined
                     },
                     { timeout: 1000, interval: 100 }
                 )

--- a/src/test/shared/utilities/childProcess.test.ts
+++ b/src/test/shared/utilities/childProcess.test.ts
@@ -145,7 +145,7 @@ describe('ChildProcess', async () => {
             const childProcess = new ChildProcess(batchFile)
 
             const result = await childProcess.run()
-            
+
             assert.notStrictEqual(result.exitCode, 0)
             assert.notStrictEqual(result.error, undefined)
         })

--- a/src/test/shared/utilities/timeoutUtils.test.ts
+++ b/src/test/shared/utilities/timeoutUtils.test.ts
@@ -106,6 +106,7 @@ describe('timeoutUtils', async () => {
     describe('waitUntil', async () => {
         const testSettings = {callCounter: 0, callGoal: 0, functionDelay: 10}
 
+        // Test function, increments a counter every time it is called
         async function testFunction(): Promise<number | undefined> {
             if (++testSettings.callCounter == testSettings.callGoal) {
                 return testSettings.callCounter
@@ -114,6 +115,7 @@ describe('timeoutUtils', async () => {
             }
         }
 
+        // Simple wrapper that waits until calling testFunction
         async function slowTestFunction(): Promise<number | undefined> {
             await new Promise(r => setTimeout(r, testSettings.functionDelay))
             return testFunction()

--- a/src/test/shared/utilities/timeoutUtils.test.ts
+++ b/src/test/shared/utilities/timeoutUtils.test.ts
@@ -146,6 +146,17 @@ describe('timeoutUtils', async () => {
             assert.strictEqual(returnValue, undefined)
         })
 
+        it('returns true/false values correctly', async () => {
+            assert.strictEqual(true, await timeoutUtils.waitUntil(async () => true, { timeout: 30, interval: 10 }))
+            assert.strictEqual(false, await timeoutUtils.waitUntil(async () => false, { timeout: 30, interval: 10 }))
+        })
+
+        it('timeout when function takes longer than timeout parameter', async () => {
+            testSettings.functionDelay = 100
+            const returnValue: number | undefined = await timeoutUtils.waitUntil(slowTestFunction, { timeout: 50, interval: 10 })
+            assert.strictEqual(returnValue, undefined)
+        })
+
         it('timeout from slow function calls', async () => {
             testSettings.callGoal = 10
             const returnValue: number | undefined = await timeoutUtils.waitUntil(slowTestFunction, { timeout: 50, interval: 10 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

A few changes have been done:

- Improved waitUntil in timeoutUtilities.ts by explicitly checking for undefined values and enforcing the timeout constraint, as mentioned in the comments of #1315
- Explicitly checking for undefined return values in waitUntil broke some test cases for childProcess.ts that relied on false return values, this was fixed by returning undefined in the test function for false values
- Test cases were added for waitUntil, again as mentioned in #1315

Previous comments mentioned an optional "attempts" parameter for waitUntil to prevent a function from being called for longer than the timeout period. Instead of this, waitUntil now records how long the function takes to execute. Now waitUntil will always terminate within the timeout period.

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
