### PR TITLE
Added error handlers for ChildProcess to fix ENOTCONN bug

### DIFF
--- a/src/shared/utilities/childProcess.ts
+++ b/src/shared/utilities/childProcess.ts
@@ -72,14 +72,14 @@ export class ChildProcess {
             await this.start({
                 collect: true,
                 onClose: () => {
-                    resolve(this.processResult)
+                    resolve(this.processResult as ChildProcessResult)
                 },
                 onExit: () => {
                     const didClose = !!this.processResult
                     // Race: 'close' may happen after 'exit'. Do not resolve
                     // before 'close' (the streams may have pending data).
                     if (!didClose) {
-                        resolve(this.processResult)
+                        resolve(this.processResult as ChildProcessResult)
                     }
                 },
                 onStderr: onStderr,
@@ -104,6 +104,23 @@ export class ChildProcess {
         // [2] https://nodejs.org/api/child_process.html
         this.childProcess = crossSpawn.spawn(this.command, this.args, this.options)
 
+        function errorHandler(process: ChildProcess, params: ChildProcessStartArguments, error: Error): void {
+            process.processError = error
+            if (params.onError) {
+                params.onError(error)
+            }
+        }
+
+        // Emitted whenever:
+        //  1. Process could not be spawned, or
+        //  2. Process could not be killed, or
+        //  3. Sending a message to the child process failed.
+        // https://nodejs.org/api/child_process.html#child_process_class_childprocess
+        // We also register error event handlers on the output/error streams in case a lower level library fails
+        this.childProcess.on('error', (err) => { errorHandler(this, params, err) })
+        this.childProcess.stdout?.on('error', (err) => { errorHandler(this, params, err) })
+        this.childProcess.stderr?.on('error', (err) => { errorHandler(this, params, err) })
+
         this.childProcess.stdout?.on('data', (data: { toString(): string }) => {
             if (params.collect) {
                 this.stdoutChunks.push(data.toString())
@@ -121,18 +138,6 @@ export class ChildProcess {
 
             if (params.onStderr) {
                 params.onStderr(data.toString())
-            }
-        })
-
-        // Emitted whenever:
-        //  1. Process could not be spawned, or
-        //  2. Process could not be killed, or
-        //  3. Sending a message to the child process failed.
-        // https://nodejs.org/api/child_process.html#child_process_class_childprocess
-        this.childProcess.on('error', error => {
-            this.processError = error
-            if (params.onError) {
-                params.onError(error)
             }
         })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Added error handlers to the ChildProcess start method to fix ENOTCONN errors on macOS (#1525)
Errors were propagating through the error and output streams of the child process and were not being handled correctly.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
