### PR TITLE
waitUntil(): fix false positives

### DIFF
--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -374,9 +374,9 @@ describe('SAM Integration Tests', async function () {
                     // Allow previous sessions to go away.
                     await waitUntil(
                         async function () {
-                            return vscode.debug.activeDebugSession === undefined
+                            return (vscode.debug.activeDebugSession === undefined) ? true : undefined
                         },
-                        { timeout: 100, interval: 300 }
+                        { timeout: 1000, interval: 100 }
                     )
                     // FIXME: This assert is disabled to unblock CI.
                     // assert.strictEqual(

--- a/src/lambda/commands/importLambda.ts
+++ b/src/lambda/commands/importLambda.ts
@@ -167,13 +167,13 @@ async function downloadAndUnzipLambda(
         // keep attempting the unzip until the zip is fully built or fail after 5 seconds
         let zipErr: Error | undefined
         const val = await waitUntil(async () => {
-            return await new Promise<boolean>(resolve => {
+            return await new Promise<boolean | undefined>(resolve => {
                 try {
                     new AdmZip(downloadLocation).extractAllToAsync(importLocation, true, err => {
                         if (err) {
                             // err unzipping
                             zipErr = err
-                            resolve(false)
+                            resolve(undefined)
                         } else {
                             progress.report({ increment: 10 })
                             resolve(true)
@@ -182,7 +182,7 @@ async function downloadAndUnzipLambda(
                 } catch (err) {
                     // err loading zip into AdmZip, prior to attempting an unzip
                     zipErr = err
-                    resolve(false)
+                    resolve(undefined)
                 }
             })
         })

--- a/src/shared/utilities/childProcess.ts
+++ b/src/shared/utilities/childProcess.ts
@@ -211,7 +211,7 @@ export class ChildProcess {
             if (force === true) {
                 waitUntil(
                     async () => {
-                        return this.stopped
+                        return (this.stopped === true) ? true : undefined
                     },
                     { timeout: 3000, interval: 200 }
                 )

--- a/src/test/shared/utilities/timeoutUtils.test.ts
+++ b/src/test/shared/utilities/timeoutUtils.test.ts
@@ -108,8 +108,8 @@ describe('timeoutUtils', async () => {
 
         // Test function, increments a counter every time it is called
         async function testFunction(): Promise<number | undefined> {
-            if (++testSettings.callCounter == testSettings.callGoal) {
-                return testSettings.callCounter
+            if (++testSettings.callCounter >= testSettings.callGoal) {
+                return testSettings.callGoal
             } else {
                 return undefined
             }

--- a/src/test/shared/utilities/timeoutUtils.test.ts
+++ b/src/test/shared/utilities/timeoutUtils.test.ts
@@ -136,7 +136,7 @@ describe('timeoutUtils', async () => {
 
         it('returns value after multiple function calls', async () => {
             testSettings.callGoal = 4
-            const returnValue: number | undefined = await timeoutUtils.waitUntil(testFunction, { timeout: 200, interval: 10 })
+            const returnValue: number | undefined = await timeoutUtils.waitUntil(testFunction, { timeout: 10000, interval: 10 })
             assert.strictEqual(returnValue, testSettings.callGoal)
         })
 
@@ -147,8 +147,8 @@ describe('timeoutUtils', async () => {
         })
 
         it('returns true/false values correctly', async () => {
-            assert.strictEqual(true, await timeoutUtils.waitUntil(async () => true, { timeout: 100, interval: 10 }))
-            assert.strictEqual(false, await timeoutUtils.waitUntil(async () => false, { timeout: 100, interval: 10 }))
+            assert.strictEqual(true, await timeoutUtils.waitUntil(async () => true, { timeout: 10000, interval: 10 }))
+            assert.strictEqual(false, await timeoutUtils.waitUntil(async () => false, { timeout: 10000, interval: 10 }))
         })
 
         it('timeout when function takes longer than timeout parameter', async () => {
@@ -166,7 +166,7 @@ describe('timeoutUtils', async () => {
         it('returns value with after multiple calls and function delay ', async () => {
             testSettings.callGoal = 3
             testSettings.functionDelay = 5
-            const returnValue: number | undefined = await timeoutUtils.waitUntil(slowTestFunction, { timeout: 200, interval: 5 })
+            const returnValue: number | undefined = await timeoutUtils.waitUntil(slowTestFunction, { timeout: 10000, interval: 5 })
             assert.strictEqual(returnValue, testSettings.callGoal)
         })
     })

--- a/src/test/shared/utilities/timeoutUtils.test.ts
+++ b/src/test/shared/utilities/timeoutUtils.test.ts
@@ -136,7 +136,7 @@ describe('timeoutUtils', async () => {
 
         it('returns value after multiple function calls', async () => {
             testSettings.callGoal = 4
-            const returnValue: number | undefined = await timeoutUtils.waitUntil(testFunction, { timeout: 60, interval: 10 })
+            const returnValue: number | undefined = await timeoutUtils.waitUntil(testFunction, { timeout: 200, interval: 10 })
             assert.strictEqual(returnValue, testSettings.callGoal)
         })
 
@@ -147,8 +147,8 @@ describe('timeoutUtils', async () => {
         })
 
         it('returns true/false values correctly', async () => {
-            assert.strictEqual(true, await timeoutUtils.waitUntil(async () => true, { timeout: 30, interval: 10 }))
-            assert.strictEqual(false, await timeoutUtils.waitUntil(async () => false, { timeout: 30, interval: 10 }))
+            assert.strictEqual(true, await timeoutUtils.waitUntil(async () => true, { timeout: 100, interval: 10 }))
+            assert.strictEqual(false, await timeoutUtils.waitUntil(async () => false, { timeout: 100, interval: 10 }))
         })
 
         it('timeout when function takes longer than timeout parameter', async () => {
@@ -166,7 +166,7 @@ describe('timeoutUtils', async () => {
         it('returns value with after multiple calls and function delay ', async () => {
             testSettings.callGoal = 3
             testSettings.functionDelay = 5
-            const returnValue: number | undefined = await timeoutUtils.waitUntil(slowTestFunction, { timeout: 60, interval: 5 })
+            const returnValue: number | undefined = await timeoutUtils.waitUntil(slowTestFunction, { timeout: 200, interval: 5 })
             assert.strictEqual(returnValue, testSettings.callGoal)
         })
     })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Tests were sometimes failing erroneously due to the timeout time being too low.
A use of waitUntil was also changed to not use false return values.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
