### PR TITLE
childProcess.ts: don't handle stream errors in older vscode

### DIFF
--- a/src/shared/utilities/childProcess.ts
+++ b/src/shared/utilities/childProcess.ts
@@ -122,7 +122,8 @@ export class ChildProcess {
         this.childProcess.on('error', err => {
             errorHandler(this, params, err)
         })
-        if (semver.gte(vscode.version, '1.54')) {
+        if (semver.gte(vscode.version, '1.54.0')) {
+            // #1539
             this.childProcess.stdout?.on('error', err => {
                 errorHandler(this, params, err)
             })


### PR DESCRIPTION
The childProcess issue fixed by #1539 started in vscode 1.54

ref https://github.com/aws/aws-toolkit-vscode/pull/1539


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
