### PR TITLE
test/integ: fix integ tests on vscode 1.42

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "url": "https://github.com/aws/aws-toolkit-vscode"
     },
     "engines": {
-        "vscode": "^1.50.0"
+        "vscode": "^1.54.0"
     },
     "icon": "resources/aws-icon-256x256.png",
     "bugs": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "url": "https://github.com/aws/aws-toolkit-vscode"
     },
     "engines": {
-        "vscode": "^1.42.0"
+        "vscode": "^1.50.0"
     },
     "icon": "resources/aws-icon-256x256.png",
     "bugs": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "url": "https://github.com/aws/aws-toolkit-vscode"
     },
     "engines": {
-        "vscode": "^1.54.0"
+        "vscode": "^1.52.0"
     },
     "icon": "resources/aws-icon-256x256.png",
     "bugs": {

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -337,10 +337,6 @@ describe('SAM Integration Tests', async function () {
                 })
 
                 it('produces an Add Debug Configuration codelens', async function () {
-                    if (vscode.version.startsWith('1.42')) {
-                        this.skip()
-                    }
-
                     setTestTimeout(this.test?.fullTitle(), 60000)
                     const codeLens = await getAddConfigCodeLens(samAppCodeUri)
                     assert.ok(codeLens)
@@ -366,10 +362,6 @@ describe('SAM Integration Tests', async function () {
                 })
 
                 it('invokes and attaches on debug request (F5)', async function () {
-                    if (vscode.version.startsWith('1.42')) {
-                        this.skip()
-                    }
-
                     setTestTimeout(this.test?.fullTitle(), 90000)
                     // Allow previous sessions to go away.
                     const noDebugSession: boolean | undefined = await waitUntil(

--- a/src/integrationTest/shared/codelens/samTemplateCodeLensProvider.test.ts
+++ b/src/integrationTest/shared/codelens/samTemplateCodeLensProvider.test.ts
@@ -28,10 +28,6 @@ describe('SamTemplateCodeLensProvider', async function () {
     })
 
     it('provides a CodeLens for a file with a new resource', async function () {
-        if (vscode.version.startsWith('1.42')) {
-            this.skip()
-        }
-
         const codeLenses = await codeLensProvider.provideCodeLenses(
             document,
             instance(mockCancellationToken),


### PR DESCRIPTION
WIP

results

- NO: 1.42
- NO: 1.50
- OK: 1.52

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
