### PR TITLE
Lambda UX: bug fix - clear form prior to loading new config

### DIFF
--- a/media/css/samInvokeForm.css
+++ b/media/css/samInvokeForm.css
@@ -74,7 +74,7 @@ textarea {
     font-weight: bold;
 }
 
-#invoke-button {
+.form-buttons {
     margin-left: 20px;
 }
 

--- a/src/lambda/vue/samInvokeVue.ts
+++ b/src/lambda/vue/samInvokeVue.ts
@@ -111,6 +111,7 @@ export const Component = Vue.extend({
                     this.launchConfig.invokeTarget.templatePath = event.data.template
                     break
                 case 'loadSamLaunchConfig':
+                    this.clearForm()
                     this.launchConfig = newLaunchConfig(event.data.launchConfig)
                     if (event.data.launchConfig.lambda?.payload) {
                         this.payload.value = JSON.stringify(event.data.launchConfig.lambda.payload.json, undefined, 4)
@@ -206,7 +207,6 @@ export const Component = Vue.extend({
             this.formatDataAndExecute('saveLaunchConfig')
         },
         loadConfig() {
-            this.resetJsonErrors()
             vscode.postMessage({
                 command: 'loadSamLaunchConfig',
             })
@@ -298,6 +298,18 @@ export const Component = Vue.extend({
                     },
                 },
             })
+        },
+        clearForm() {
+            this.launchConfig = newLaunchConfig()
+            this.containerBuildStr = ''
+            this.skipNewImageCheckStr = ''
+            this.payload = {value: '', errorMsg: ''}
+            this.apiPayload = {value: '', errorMsg: ''}
+            this.environmentVariables = {value: '', errorMsg: ''}
+            this.parameters = {value: '', errorMsg: ''}
+            this.headers = {value: '', errorMsg: ''}
+            this.stageVariables = {value: '', errorMsg: ''}
+            this.showAllFields = false
         }
     },
     // `createElement` is inferred, but `render` needs return type
@@ -511,8 +523,9 @@ export const Component = Vue.extend({
             <div class="json-parse-error" v-if="payload.errorMsg">Error parsing JSON: {{payload.errorMsg}}</div>
         </div>
         <div class="invoke-button-container">
-            <button v-on:click.prevent="save">Save Debug Configuration</button>
-            <button id="invoke-button" v-on:click.prevent="launch">Invoke Debug Configuration</button>
+            <button class="form-buttons" v-on:click.prevent="clearForm">Clear Form</button>
+            <button class="form-buttons" v-on:click.prevent="save">Save Debug Configuration</button>
+            <button class="form-buttons" v-on:click.prevent="launch">Invoke Debug Configuration</button>
         </div>
     </form>
 </template>

--- a/src/lambda/vue/samInvokeVue.ts
+++ b/src/lambda/vue/samInvokeVue.ts
@@ -523,7 +523,6 @@ export const Component = Vue.extend({
             <div class="json-parse-error" v-if="payload.errorMsg">Error parsing JSON: {{payload.errorMsg}}</div>
         </div>
         <div class="invoke-button-container">
-            <button class="form-buttons" v-on:click.prevent="clearForm">Clear Form</button>
             <button class="form-buttons" v-on:click.prevent="save">Save Debug Configuration</button>
             <button class="form-buttons" v-on:click.prevent="launch">Invoke Debug Configuration</button>
         </div>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

This fixes a bug that occurred when attempting to load a config when data had already been entered or a different config was already loaded.  The `clearForm` method will run immediately before loading a config into the form.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
