### PR TITLE
Replace arrow functions in mocha test calls with traditional functions

### DIFF
--- a/src/integrationTest/cloudformation/templateRegistry.test.ts
+++ b/src/integrationTest/cloudformation/templateRegistry.test.ts
@@ -14,31 +14,31 @@ import { getTestWorkspaceFolder } from '../integrationTestsUtilities'
  * Note: these tests are pretty shallow right now. They do not test the following:
  * * Adding/removing workspace folders
  */
-describe('CloudFormation Template Registry', async () => {
+describe('CloudFormation Template Registry', async function() {
     let registry: CloudFormationTemplateRegistry
     let workspaceDir: string
     let testDir: string
     let testDirNested: string
     let dir: number = 0
 
-    before(async () => {
+    before(async function() {
         workspaceDir = getTestWorkspaceFolder()
     })
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         testDir = path.join(workspaceDir, dir.toString())
         testDirNested = path.join(testDir, 'nested')
         await fs.mkdirp(testDirNested)
         registry = new CloudFormationTemplateRegistry()
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         registry.dispose()
         await fs.remove(testDir)
         dir++
     })
 
-    it('adds initial template files with yaml and yml extensions at various nesting levels', async () => {
+    it('adds initial template files with yaml and yml extensions at various nesting levels', async function() {
         await strToYamlFile(makeSampleSamTemplateYaml(true), path.join(testDir, 'test.yaml'))
         await strToYamlFile(makeSampleSamTemplateYaml(false), path.join(testDirNested, 'test.yml'))
 
@@ -47,7 +47,7 @@ describe('CloudFormation Template Registry', async () => {
         await registryHasTargetNumberOfFiles(registry, 2)
     })
 
-    it('adds dynamically-added template files with yaml and yml extensions at various nesting levels', async () => {
+    it('adds dynamically-added template files with yaml and yml extensions at various nesting levels', async function() {
         await registry.addWatchPattern('**/test.{yaml,yml}')
 
         await strToYamlFile(makeSampleSamTemplateYaml(false), path.join(testDir, 'test.yml'))
@@ -56,7 +56,7 @@ describe('CloudFormation Template Registry', async () => {
         await registryHasTargetNumberOfFiles(registry, 2)
     })
 
-    it('Ignores templates matching excluded patterns', async () => {
+    it('Ignores templates matching excluded patterns', async function() {
         await registry.addWatchPattern('**/test.{yaml,yml}')
         await registry.addExcludedPattern(/.*nested.*/)
 
@@ -66,7 +66,7 @@ describe('CloudFormation Template Registry', async () => {
         await registryHasTargetNumberOfFiles(registry, 1)
     })
 
-    it('can handle changed files', async () => {
+    it('can handle changed files', async function() {
         const filepath = path.join(testDir, 'changeMe.yml')
         await strToYamlFile(makeSampleSamTemplateYaml(false), filepath)
 
@@ -81,7 +81,7 @@ describe('CloudFormation Template Registry', async () => {
         await queryRegistryForFileWithGlobalsKeyStatus(registry, filepath, true)
     })
 
-    it('can handle deleted files', async () => {
+    it('can handle deleted files', async function() {
         await registry.addWatchPattern('**/deleteMe.yml')
 
         // Specifically creating the file after the watcher is added

--- a/src/integrationTest/codelens.js.test.ts
+++ b/src/integrationTest/codelens.js.test.ts
@@ -14,13 +14,13 @@ const CODELENS_TEST_TIMEOUT_MILLIS = 10000
 
 const workspaceFolder = getTestWorkspaceFolder()
 
-describe('SAM Local CodeLenses (JS)', async () => {
+describe('SAM Local CodeLenses (JS)', async function() {
     // TODO : Extend this test suite out to work for different projects with different file configurations
     before(async function () {
         this.timeout(ACTIVATE_EXTENSION_TIMEOUT_MILLIS)
     })
 
-    it('appear when manifest in subfolder and app is beside manifest', async () => {
+    it('appear when manifest in subfolder and app is beside manifest', async function() {
         const appRoot = join(workspaceFolder, 'js-plain-sam-app')
         const appCodePath = join(appRoot, 'src', 'app.js')
         const expectedHandlerName = 'app.handlerBesidePackageJson'
@@ -31,7 +31,7 @@ describe('SAM Local CodeLenses (JS)', async () => {
         assertAddDebugConfigCodeLensExists(codeLenses, expectedHandlerName, dirname(appCodePath))
     }).timeout(CODELENS_TEST_TIMEOUT_MILLIS)
 
-    it('appear when manifest in root', async () => {
+    it('appear when manifest in root', async function() {
         const appRoot = join(workspaceFolder, 'js-manifest-in-root')
         const appCodePath = join(appRoot, 'src', 'subfolder', 'app.js')
         const expectedHandlerName = 'src/subfolder/app.handlerTwoFoldersDeep'
@@ -42,7 +42,7 @@ describe('SAM Local CodeLenses (JS)', async () => {
         assertAddDebugConfigCodeLensExists(codeLenses, expectedHandlerName, join(dirname(appCodePath), '..', '..'))
     }).timeout(CODELENS_TEST_TIMEOUT_MILLIS)
 
-    it('appear when manifest in subfolder and app in subfolder to manifest', async () => {
+    it('appear when manifest in subfolder and app in subfolder to manifest', async function() {
         const appRoot = join(workspaceFolder, 'js-manifest-in-subfolder')
         const appCodePath = join(appRoot, 'src', 'subfolder', 'app.js')
         const expectedHandlerName = 'subfolder/app.handlerInManifestSubfolder'
@@ -53,7 +53,7 @@ describe('SAM Local CodeLenses (JS)', async () => {
         assertAddDebugConfigCodeLensExists(codeLenses, expectedHandlerName, join(dirname(appCodePath), '..'))
     }).timeout(CODELENS_TEST_TIMEOUT_MILLIS)
 
-    it('appear when project is a few folders deep in the workspace', async () => {
+    it('appear when project is a few folders deep in the workspace', async function() {
         const appRoot = join(workspaceFolder, 'deeper-projects', 'js-plain-sam-app')
         const appCodePath = join(appRoot, 'src', 'app.js')
         const expectedHandlerName = 'app.projectDeepInWorkspace'

--- a/src/integrationTest/globalSetup.test.ts
+++ b/src/integrationTest/globalSetup.test.ts
@@ -46,7 +46,7 @@ export function setTestTimeout(testName: string | undefined, ms: number) {
 }
 
 // Before all tests begin, once only:
-before(async () => {
+before(async function() {
     console.log('globalSetup: before()')
     // Needed for getLogger().
     await activateExtension(VSCODE_EXTENSION_ID.awstoolkit)
@@ -58,7 +58,7 @@ before(async () => {
     }
 })
 // After all tests end, once only:
-after(async () => {
+after(async function() {
     console.log('globalSetup: after()')
 })
 

--- a/src/integrationTest/shared/codelens/samTemplateCodeLensProvider.test.ts
+++ b/src/integrationTest/shared/codelens/samTemplateCodeLensProvider.test.ts
@@ -12,14 +12,14 @@ import { LaunchConfiguration } from '../../../shared/debug/launchConfiguration'
 import { API_TARGET_TYPE, TEMPLATE_TARGET_TYPE } from '../../../shared/sam/debugger/awsSamDebugConfiguration'
 import * as workspaceUtils from '../../../shared/utilities/workspaceUtils'
 
-describe('SamTemplateCodeLensProvider', async () => {
+describe('SamTemplateCodeLensProvider', async function() {
     let codeLensProvider: SamTemplateCodeLensProvider = new SamTemplateCodeLensProvider()
     let document: vscode.TextDocument
     let launchConfig: LaunchConfiguration
     let templateUri: vscode.Uri
     let mockCancellationToken: vscode.CancellationToken
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         codeLensProvider = new SamTemplateCodeLensProvider()
         document = (await workspaceUtils.openTextDocument('python3.7-plain-sam-app/template.yaml'))!
         templateUri = document.uri
@@ -27,7 +27,7 @@ describe('SamTemplateCodeLensProvider', async () => {
         mockCancellationToken = mock()
     })
 
-    it('provides a CodeLens for a file with a new resource', async () => {
+    it('provides a CodeLens for a file with a new resource', async function() {
         const codeLenses = await codeLensProvider.provideCodeLenses(
             document,
             instance(mockCancellationToken),
@@ -62,7 +62,7 @@ describe('SamTemplateCodeLensProvider', async () => {
         assert.deepStrictEqual(codeLenses, expectedCodeLens)
     })
 
-    it('provides no code lenses for a file with no resources', async () => {
+    it('provides no code lenses for a file with no resources', async function() {
         const mockSymbolResolver: TemplateSymbolResolver = mock()
         when(mockSymbolResolver.getResourcesOfKind('function', anything())).thenResolve([])
 

--- a/src/integrationTest/shared/utilities/workspaceUtils.test.ts
+++ b/src/integrationTest/shared/utilities/workspaceUtils.test.ts
@@ -12,7 +12,7 @@ import { findParentProjectFile, getWorkspaceRelativePath } from '../../../shared
 import { getTestWorkspaceFolder } from '../../integrationTestsUtilities'
 import { CodelensRootRegistry } from '../../../shared/sam/codelensRootRegistry'
 
-describe('findParentProjectFile', async () => {
+describe('findParentProjectFile', async function() {
     const workspaceDir = getTestWorkspaceFolder()
     let filesToDelete: vscode.Uri[]
 
@@ -63,23 +63,23 @@ describe('findParentProjectFile', async () => {
         },
     ]
 
-    before(async () => {
+    before(async function() {
         await mkdirp(path.join(workspaceDir, 'someproject', 'src'))
         await mkdirp(path.join(workspaceDir, 'someotherproject'))
         globalRegistry = ext.codelensRootRegistry
     })
 
-    after(async () => {
+    after(async function() {
         remove(path.join(workspaceDir, 'someproject'))
         remove(path.join(workspaceDir, 'someotherproject'))
         ext.codelensRootRegistry = globalRegistry
     })
 
-    beforeEach(() => {
+    beforeEach(function() {
         ext.codelensRootRegistry = new CodelensRootRegistry()
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         for (const file of filesToDelete) {
             remove(file.fsPath)
         }
@@ -108,12 +108,12 @@ describe('findParentProjectFile', async () => {
     })
 })
 
-describe('getWorkspaceRelativePath', () => {
+describe('getWorkspaceRelativePath', function() {
     const parentPath = path.join('/', 'level1', 'level2')
     const nestedPath = path.join(parentPath, 'level3')
     const childPath = path.join(nestedPath, 'level4')
 
-    it('returns a path relative to the first parent path it sees', () => {
+    it('returns a path relative to the first parent path it sees', function() {
         const relativePath = getWorkspaceRelativePath(childPath, {
             workspaceFolders: [
                 {
@@ -132,12 +132,12 @@ describe('getWorkspaceRelativePath', () => {
         assert.strictEqual(relativePath, 'level4')
     })
 
-    it('returns undefined if no workspace folders exist', () => {
+    it('returns undefined if no workspace folders exist', function() {
         const relativePath = getWorkspaceRelativePath(childPath, { workspaceFolders: undefined })
         assert.strictEqual(relativePath, undefined)
     })
 
-    it('returns undefined if no paths are parents', () => {
+    it('returns undefined if no paths are parents', function() {
         const relativePath = getWorkspaceRelativePath(childPath, {
             workspaceFolders: [
                 {

--- a/src/integrationTest/stepFunctions/visualizeStateMachine.test.ts
+++ b/src/integrationTest/stepFunctions/visualizeStateMachine.test.ts
@@ -95,26 +95,26 @@ async function waitUntilWebviewIsVisible(webviewPanel: vscode.WebviewPanel | und
     })
 }
 
-describe('visualizeStateMachine', async () => {
+describe('visualizeStateMachine', async function() {
     before(async function() {
         this.timeout(600000)
     })
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         // Make a temp folder for all these tests
         tempFolder = await makeTemporaryToolkitFolder()
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         await fs.remove(tempFolder)
     })
 
-    after(async () => {
+    after(async function() {
         // Test suite cleans up after itself
         await vscode.commands.executeCommand('workbench.action.closeAllEditors')
     })
 
-    it('opens up a webview when there is an active text editor', async () => {
+    it('opens up a webview when there is an active text editor', async function() {
         const stateMachineFileText = '{}'
         const fileName = 'mysamplestatemachine.json'
         await openATextEditorWithText(stateMachineFileText, fileName)
@@ -124,7 +124,7 @@ describe('visualizeStateMachine', async () => {
         assert.ok(result)
     }).timeout(15000) // Give the first test that calls aws.previewStateMachine a chance to download the visualizer
 
-    it('correctly displays content when given a sample state machine', async () => {
+    it('correctly displays content when given a sample state machine', async function() {
         const fileName = 'mysamplestatemachine.json'
         const textEditor = await openATextEditorWithText(sampleStateMachine, fileName)
 
@@ -147,7 +147,7 @@ describe('visualizeStateMachine', async () => {
         }
     })
 
-    it('correctly displays content when given a sample state machine in yaml', async () => {
+    it('correctly displays content when given a sample state machine in yaml', async function() {
         const fileName = 'mysamplestatemachine.asl.yaml'
         const textEditor = await openATextEditorWithText(samleStateMachineYaml, fileName)
 
@@ -170,7 +170,7 @@ describe('visualizeStateMachine', async () => {
         }
     })
 
-    it('update webview is triggered when user saves correct text editor', async () => {
+    it('update webview is triggered when user saves correct text editor', async function() {
         const stateMachineFileText = '{}'
         const fileName = 'mysamplestatemachine.json'
         const textEditor = await openATextEditorWithText(stateMachineFileText, fileName)
@@ -204,7 +204,7 @@ describe('visualizeStateMachine', async () => {
         }
     })
 
-    it('throws an error if no active text editor is open', async () => {
+    it('throws an error if no active text editor is open', async function() {
         // Make sure nothing is open from previous tests.
         await vscode.commands.executeCommand('workbench.action.closeAllEditors')
 
@@ -213,7 +213,7 @@ describe('visualizeStateMachine', async () => {
         )
     })
 
-    it('doesnt update the graph if a seperate file is opened or modified', async () => {
+    it('doesnt update the graph if a seperate file is opened or modified', async function() {
         const stateMachineFileText = '{}'
         const stateMachineDefinitionFile = 'mystatemachine.json'
         await openATextEditorWithText(stateMachineFileText, stateMachineDefinitionFile)

--- a/src/test/apigateway/commands/copyUrl.test.ts
+++ b/src/test/apigateway/commands/copyUrl.test.ts
@@ -6,8 +6,8 @@
 import * as assert from 'assert'
 import { buildDefaultApiInvokeUrl } from '../../../apigateway/commands/copyUrl'
 
-describe('buildDefaultApiInvokeUrl', () => {
-    it('builds a url', async () => {
+describe('buildDefaultApiInvokeUrl', function() {
+    it('builds a url', async function() {
         const expected = 'https://1234567ab.execute-api.us-east-1.amazonaws.com/stagename'
 
         assert.deepStrictEqual(

--- a/src/test/apigateway/commands/invokeRemoteRestApi.test.ts
+++ b/src/test/apigateway/commands/invokeRemoteRestApi.test.ts
@@ -7,9 +7,9 @@ import * as assert from 'assert'
 import { listValidMethods } from '../../../apigateway/commands/invokeRemoteRestApi'
 import { Resource } from 'aws-sdk/clients/apigateway'
 
-describe('listValidMethods', () => {
+describe('listValidMethods', function() {
     const allMethods = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT']
-    it('returns all methods if "ANY" is a method', async () => {
+    it('returns all methods if "ANY" is a method', async function() {
         const resources = new Map<string, Resource>()
         const resource: Resource = {
             resourceMethods: {
@@ -22,7 +22,7 @@ describe('listValidMethods', () => {
 
         assert.deepStrictEqual(actual, allMethods)
     })
-    it('returns dedupe-d all methods if "ANY" declared with another method', async () => {
+    it('returns dedupe-d all methods if "ANY" declared with another method', async function() {
         const resources = new Map<string, Resource>()
         const resource: Resource = {
             resourceMethods: {
@@ -36,7 +36,7 @@ describe('listValidMethods', () => {
 
         assert.deepStrictEqual(actual, allMethods)
     })
-    it('returns get if declares get', async () => {
+    it('returns get if declares get', async function() {
         const resources = new Map<string, Resource>()
         const resource: Resource = {
             resourceMethods: {
@@ -49,7 +49,7 @@ describe('listValidMethods', () => {
 
         assert.deepStrictEqual(actual, ['GET'])
     })
-    it('returns nothing if no methods', async () => {
+    it('returns nothing if no methods', async function() {
         const resources = new Map<string, Resource>()
         const resource: Resource = {}
         resources.set('resource', resource)

--- a/src/test/apigateway/explorer/apiGatewayNodes.test.ts
+++ b/src/test/apigateway/explorer/apiGatewayNodes.test.ts
@@ -33,13 +33,13 @@ const SORTED_TEXT = [
     "zebra (it's zee not zed)",
 ]
 
-describe('ApiGatewayNode', () => {
+describe('ApiGatewayNode', function() {
     let sandbox: sinon.SinonSandbox
     let testNode: ApiGatewayNode
 
     let apiNames: { name: string; id: string }[]
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
 
         apiNames = [
@@ -52,11 +52,11 @@ describe('ApiGatewayNode', () => {
         testNode = new ApiGatewayNode(FAKE_PARTITION_ID, FAKE_REGION_CODE)
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    it('returns placeholder node if no children are present', async () => {
+    it('returns placeholder node if no children are present', async function() {
         apiNames = []
 
         const childNodes = await testNode.getChildren()
@@ -64,7 +64,7 @@ describe('ApiGatewayNode', () => {
         assertNodeListOnlyContainsPlaceholderNode(childNodes)
     })
 
-    it('has RestApi child nodes', async () => {
+    it('has RestApi child nodes', async function() {
         const childNodes = await testNode.getChildren()
 
         assert.strictEqual(childNodes.length, apiNames.length, 'Unexpected child count')
@@ -72,7 +72,7 @@ describe('ApiGatewayNode', () => {
         childNodes.forEach(node => assert.ok(node instanceof RestApiNode, 'Expected child node to be RestApiNode'))
     })
 
-    it('sorts child nodes', async () => {
+    it('sorts child nodes', async function() {
         apiNames = UNSORTED_TEXT
 
         const childNodes = await testNode.getChildren()
@@ -81,7 +81,7 @@ describe('ApiGatewayNode', () => {
         assert.deepStrictEqual(actualChildOrder, SORTED_TEXT, 'Unexpected child sort order')
     })
 
-    it('has an error node for a child if an error happens during loading', async () => {
+    it('has an error node for a child if an error happens during loading', async function() {
         sandbox.stub(testNode, 'updateChildren').callsFake(() => {
             throw new Error('Update Children error!')
         })

--- a/src/test/awsExplorer/awsExplorer.test.ts
+++ b/src/test/awsExplorer/awsExplorer.test.ts
@@ -17,10 +17,10 @@ import {
     makeFakeAwsContextWithPlaceholderIds,
 } from '../utilities/fakeAwsContext'
 
-describe('AwsExplorer', () => {
+describe('AwsExplorer', function() {
     let sandbox: sinon.SinonSandbox
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
         // contingency for current Node impl: requires a client built from ext.toolkitClientBuilder.
         const clientBuilder = {
@@ -30,11 +30,11 @@ describe('AwsExplorer', () => {
         ext.toolkitClientBuilder = (clientBuilder as any) as ToolkitClientBuilder
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    it('displays region nodes with user-friendly region names', async () => {
+    it('displays region nodes with user-friendly region names', async function() {
         const awsContext = makeFakeAwsContextWithPlaceholderIds(({} as any) as AWS.Credentials)
         const regionProvider = new FakeRegionProvider()
 
@@ -54,7 +54,7 @@ describe('AwsExplorer', () => {
         assert.strictEqual(regionNode.regionName, DEFAULT_TEST_REGION_NAME)
     })
 
-    it('refreshes when the Region Provider is updated', async () => {
+    it('refreshes when the Region Provider is updated', async function() {
         const awsContext = makeFakeAwsContextWithPlaceholderIds(({} as any) as AWS.Credentials)
         const regionProvider = new FakeRegionProvider()
 

--- a/src/test/awsExplorer/childNodeCache.test.ts
+++ b/src/test/awsExplorer/childNodeCache.test.ts
@@ -24,12 +24,12 @@ class FakeNode extends AWSTreeNodeBase implements LoadMoreNode {
     public clearChildren(): void {}
 }
 
-describe('ChildNodeCache', () => {
+describe('ChildNodeCache', function() {
     const continuationToken = 'continuationToken'
     const fakeNode = new FakeNode('fakeNode')
     const anotherFakeNode = new FakeNode('anotherFakeNode')
 
-    it('starts empty, with no continuation token, and is pristine', () => {
+    it('starts empty, with no continuation token, and is pristine', function() {
         const cache = new ChildNodeCache()
 
         assert.deepStrictEqual(cache.children, [])
@@ -37,7 +37,7 @@ describe('ChildNodeCache', () => {
         assert.strictEqual(cache.isPristine, true)
     })
 
-    it('appends initial items and updates continuation token and pristine state', () => {
+    it('appends initial items and updates continuation token and pristine state', function() {
         const cache = new ChildNodeCache()
         cache.appendPage({ newChildren: [fakeNode, anotherFakeNode], newContinuationToken: continuationToken })
 
@@ -46,7 +46,7 @@ describe('ChildNodeCache', () => {
         assert.strictEqual(cache.isPristine, false)
     })
 
-    it('appends additional items', () => {
+    it('appends additional items', function() {
         const newFakeNode = new FakeNode('newFakeNode')
 
         const cache = new ChildNodeCache()

--- a/src/test/awsExplorer/childNodeLoader.test.ts
+++ b/src/test/awsExplorer/childNodeLoader.test.ts
@@ -27,7 +27,7 @@ class FakeLoadMore implements LoadMoreNode {
     public clearChildren(): void {}
 }
 
-describe('ChildNodeLoader', () => {
+describe('ChildNodeLoader', function() {
     const fakeNode = new FakeNode()
     const fakeLoadMore = new FakeLoadMore()
 
@@ -57,8 +57,8 @@ describe('ChildNodeLoader', () => {
         })
     }
 
-    describe('first call to getChildren', () => {
-        it('loads and returns initial children', async () => {
+    describe('first call to getChildren', function() {
+        it('loads and returns initial children', async function() {
             const loader = childLoader()
 
             const [firstNode, ...otherNodes] = await loader.getChildren()
@@ -67,7 +67,7 @@ describe('ChildNodeLoader', () => {
             assert.strictEqual(otherNodes.length, 0)
         })
 
-        it('loads and returns initial children with more results', async () => {
+        it('loads and returns initial children with more results', async function() {
             const loader = continuedChildLoader('token')
 
             const [firstNode, moreResultsNode, ...otherNodes] = await loader.getChildren()
@@ -78,8 +78,8 @@ describe('ChildNodeLoader', () => {
         })
     })
 
-    describe('subsequent calls to getChildren', () => {
-        it('returns existing children', async () => {
+    describe('subsequent calls to getChildren', function() {
+        it('returns existing children', async function() {
             const loader = childLoader()
 
             await loader.getChildren()
@@ -90,8 +90,8 @@ describe('ChildNodeLoader', () => {
         })
     })
 
-    describe('loadMoreChildren', () => {
-        it('loads and appends next page of children', async () => {
+    describe('loadMoreChildren', function() {
+        it('loads and appends next page of children', async function() {
             const loader = continuedChildLoader('token')
 
             await loader.getChildren()
@@ -104,7 +104,7 @@ describe('ChildNodeLoader', () => {
             assert.strictEqual(otherNodes.length, 0)
         })
 
-        it('has no effect if all children already loaded', async () => {
+        it('has no effect if all children already loaded', async function() {
             const loader = childLoader()
 
             await loader.getChildren()
@@ -116,7 +116,7 @@ describe('ChildNodeLoader', () => {
             assert.strictEqual(otherNodes.length, 0)
         })
 
-        it('queues up concurrent calls', async () => {
+        it('queues up concurrent calls', async function() {
             const loader = delayedChildLoader('token')
 
             const firstCall = loader.getChildren()
@@ -135,8 +135,8 @@ describe('ChildNodeLoader', () => {
         })
     })
 
-    describe('clearChildren', () => {
-        it('resets cache', async () => {
+    describe('clearChildren', function() {
+        it('resets cache', async function() {
             const loader = childLoader()
 
             await loader.getChildren()

--- a/src/test/awsExplorer/commands/copyArn.test.ts
+++ b/src/test/awsExplorer/commands/copyArn.test.ts
@@ -9,16 +9,16 @@ import { AWSResourceNode } from '../../../shared/treeview/nodes/awsResourceNode'
 import { FakeEnv } from '../../shared/vscode/fakeEnv'
 import { FakeWindow } from '../../shared/vscode/fakeWindow'
 
-describe('copyArnCommand', () => {
+describe('copyArnCommand', function() {
     let window: FakeWindow
     let env: FakeEnv
 
-    beforeEach(() => {
+    beforeEach(function() {
         window = new FakeWindow()
         env = new FakeEnv()
     })
 
-    it('copies arn to clipboard and shows status bar confirmation', async () => {
+    it('copies arn to clipboard and shows status bar confirmation', async function() {
         const node: AWSResourceNode = {
             arn: 'arn',
             name: 'name',
@@ -30,7 +30,7 @@ describe('copyArnCommand', () => {
         assert.strictEqual(window.message.error, undefined)
     })
 
-    it('shows error message on failure', async () => {
+    it('shows error message on failure', async function() {
         await copyArnCommand(new NoArnNode(), window, env)
 
         assert.strictEqual(env.clipboard.text, undefined)

--- a/src/test/awsExplorer/commands/copyName.test.ts
+++ b/src/test/awsExplorer/commands/copyName.test.ts
@@ -9,8 +9,8 @@ import { AWSResourceNode } from '../../../shared/treeview/nodes/awsResourceNode'
 import { FakeEnv } from '../../shared/vscode/fakeEnv'
 import { FakeWindow } from '../../shared/vscode/fakeWindow'
 
-describe('copyNameCommand', () => {
-    it('copies name to clipboard and shows status bar confirmation', async () => {
+describe('copyNameCommand', function() {
+    it('copies name to clipboard and shows status bar confirmation', async function() {
         const node: AWSResourceNode = {
             arn: 'arn',
             name: 'name',

--- a/src/test/awsExplorer/commands/loadMoreChildren.test.ts
+++ b/src/test/awsExplorer/commands/loadMoreChildren.test.ts
@@ -11,16 +11,16 @@ import { LoadMoreNode } from '../../../shared/treeview/nodes/loadMoreNode'
 import { FakeWindow } from '../../shared/vscode/fakeWindow'
 import { verify, instance, mock, when } from '../../utilities/mockito'
 
-describe('loadMoreChildrenCommand', () => {
+describe('loadMoreChildrenCommand', function() {
     let mockNode: AWSTreeNodeBase & LoadMoreNode
     let mockAwsExplorer: AwsExplorer
 
-    beforeEach(() => {
+    beforeEach(function() {
         mockNode = mock()
         mockAwsExplorer = mock()
     })
 
-    it('loads more children and refreshes the node', async () => {
+    it('loads more children and refreshes the node', async function() {
         when(mockNode.isLoadingMoreChildren()).thenReturn(false)
 
         const window = new FakeWindow()
@@ -33,7 +33,7 @@ describe('loadMoreChildrenCommand', () => {
         assert.strictEqual(window.message.error, undefined)
     })
 
-    it('ignores invocation when load more is already in progress', async () => {
+    it('ignores invocation when load more is already in progress', async function() {
         when(mockNode.isLoadingMoreChildren()).thenReturn(true)
 
         const window = new FakeWindow()
@@ -45,7 +45,7 @@ describe('loadMoreChildrenCommand', () => {
         assert.strictEqual(window.message.error, undefined)
     })
 
-    it('shows an error message and refreshes the node on failure', async () => {
+    it('shows an error message and refreshes the node on failure', async function() {
         when(mockNode.isLoadingMoreChildren()).thenReturn(false)
         when(mockNode.loadMoreChildren()).thenThrow(new Error('Expected failure'))
 

--- a/src/test/awsExplorer/regionNode.test.ts
+++ b/src/test/awsExplorer/regionNode.test.ts
@@ -11,11 +11,11 @@ import { SchemasNode } from '../../eventSchemas/explorer/schemasNode'
 import { DEFAULT_TEST_REGION_CODE, DEFAULT_TEST_REGION_NAME, FakeRegionProvider } from '../utilities/fakeAwsContext'
 import { ToolkitClientBuilder } from '../../shared/clients/toolkitClientBuilder'
 
-describe('RegionNode', () => {
+describe('RegionNode', function() {
     let sandbox: sinon.SinonSandbox
     let testNode: RegionNode
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
         console.log('initializing...')
 
@@ -29,24 +29,24 @@ describe('RegionNode', () => {
         testNode = new RegionNode({ id: regionCode, name: regionName }, new FakeRegionProvider())
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.reset()
     })
 
     const regionCode = DEFAULT_TEST_REGION_CODE
     const regionName = DEFAULT_TEST_REGION_NAME
 
-    it('initializes name and tooltip', async () => {
+    it('initializes name and tooltip', async function() {
         assert.strictEqual(testNode.label, regionName)
         assert.strictEqual(testNode.tooltip, `${regionName} [${regionCode}]`)
     })
 
-    it('contains children', async () => {
+    it('contains children', async function() {
         const childNodes = await testNode.getChildren()
         assert.ok(childNodes.length > 0, 'Expected region node to have child nodes')
     })
 
-    it('does not have child nodes for services not available in a region', async () => {
+    it('does not have child nodes for services not available in a region', async function() {
         const regionProvider = new FakeRegionProvider()
         regionProvider.servicesNotInRegion.push('schemas')
         const regionNode = new RegionNode({ id: regionCode, name: regionName }, regionProvider)

--- a/src/test/cdk/detectCdkProjects.test.ts
+++ b/src/test/cdk/detectCdkProjects.test.ts
@@ -13,11 +13,11 @@ import { saveCdkJson } from './utilities/treeTestUtils'
 import { createTestWorkspaceFolder } from '../testUtil'
 import { FakeExtensionContext } from '../fakeExtensionContext'
 
-describe('detectCdkProjects', () => {
+describe('detectCdkProjects', function() {
     const workspacePaths: string[] = []
     const workspaceFolders: vscode.WorkspaceFolder[] = []
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         await FakeExtensionContext.getFakeExtContext()
         const workspaceFolder = await createTestWorkspaceFolder('vsctk-cdk')
 
@@ -25,7 +25,7 @@ describe('detectCdkProjects', () => {
         workspaceFolders.push(workspaceFolder)
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         for (const path of workspacePaths) {
             await fs.remove(path)
         }
@@ -34,28 +34,28 @@ describe('detectCdkProjects', () => {
         workspaceFolders.length = 0
     })
 
-    it('detects no projects when workspaceFolders is undefined', async () => {
+    it('detects no projects when workspaceFolders is undefined', async function() {
         const actual = await detectCdkProjects(undefined)
 
         assert.ok(actual)
         assert.strictEqual(actual.length, 0)
     })
 
-    it('detects no projects when workspaceFolders is empty', async () => {
+    it('detects no projects when workspaceFolders is empty', async function() {
         const actual = await detectCdkProjects([])
 
         assert.ok(actual)
         assert.strictEqual(actual.length, 0)
     })
 
-    it('detects no projects when cdk.json does not exist', async () => {
+    it('detects no projects when cdk.json does not exist', async function() {
         const actual = await detectCdkProjects(workspaceFolders)
 
         assert.ok(actual)
         assert.strictEqual(actual.length, 0)
     })
 
-    it('detects CDK project when cdk.json exists', async () => {
+    it('detects CDK project when cdk.json exists', async function() {
         const cdkJsonPath = path.join(workspaceFolders[0].uri.fsPath, 'cdk.json')
         await saveCdkJson(cdkJsonPath)
         const actual = await detectCdkProjects(workspaceFolders)
@@ -69,7 +69,7 @@ describe('detectCdkProjects', () => {
         assert.strictEqual(project.treePath, path.join(cdkJsonPath, '..', 'cdk.out', 'tree.json'))
     })
 
-    it('detects CDK projects in multi-folder workspace', async () => {
+    it('detects CDK projects in multi-folder workspace', async function() {
         assert.strictEqual(workspacePaths.length, 1)
 
         workspacePaths.push(await makeTemporaryToolkitFolder('vsctk2'))

--- a/src/test/cdk/explorer/appNode.test.ts
+++ b/src/test/cdk/explorer/appNode.test.ts
@@ -16,20 +16,20 @@ import { clearTestIconPaths, IconPath, setupTestIconPaths } from '../utilities/i
 import * as treeUtils from '../utilities/treeTestUtils'
 
 let sandbox: sinon.SinonSandbox
-describe('AppNode', () => {
-    before(async () => {
+describe('AppNode', function() {
+    before(async function() {
         setupTestIconPaths()
     })
 
-    after(async () => {
+    after(async function() {
         clearTestIconPaths()
     })
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
@@ -38,14 +38,14 @@ describe('AppNode', () => {
     const cdkJsonPath = path.join(workspaceFolderPath, workspaceFolderName, 'cdk.json')
     const treePath = path.join(cdkJsonPath, '..', 'cdk.out', 'tree.json')
 
-    it('initializes label and tooltip', async () => {
+    it('initializes label and tooltip', async function() {
         const testNode = getTestNode()
 
         assert.strictEqual(testNode.label, path.relative(path.dirname(workspaceFolderPath), path.dirname(cdkJsonPath)))
         assert.strictEqual(testNode.tooltip, `${cdkJsonPath}`)
     })
 
-    it('initializes icon paths', async () => {
+    it('initializes icon paths', async function() {
         const testNode = getTestNode()
 
         const iconPath = testNode.iconPath as IconPath
@@ -54,7 +54,7 @@ describe('AppNode', () => {
         assert.strictEqual(iconPath.light.path, cdk.iconPaths.light.cdk, 'Unexpected light icon path')
     })
 
-    it('returns placeholder node when app contains no stacks', async () => {
+    it('returns placeholder node when app contains no stacks', async function() {
         const testNode = getTestNode()
         const mockApp: app.CdkApp = { metadata: treeUtils.getTreeWithNoStack(), location: testNode.app }
         sandbox.stub(app, 'getApp').resolves(mockApp)
@@ -65,7 +65,7 @@ describe('AppNode', () => {
         assert.strictEqual(childNodes[0] instanceof PlaceholderNode, true)
     })
 
-    it('returns construct node when app has stacks', async () => {
+    it('returns construct node when app has stacks', async function() {
         const testNode = getTestNode()
         const mockApp: app.CdkApp = { metadata: treeUtils.getTree(), location: testNode.app }
         sandbox.stub(app, 'getApp').resolves(mockApp)
@@ -76,7 +76,7 @@ describe('AppNode', () => {
         assert.strictEqual(childNodes[0] instanceof ConstructNode, true)
     })
 
-    it('returns placeholder node when tree.json cannot be loaded', async () => {
+    it('returns placeholder node when tree.json cannot be loaded', async function() {
         const testNode = getTestNode()
         sandbox.stub(app, 'getApp').throws()
 

--- a/src/test/cdk/explorer/awsCdkExplorer.test.ts
+++ b/src/test/cdk/explorer/awsCdkExplorer.test.ts
@@ -14,15 +14,15 @@ import * as app from '../../../cdk/explorer/nodes/appNode'
 import { CdkErrorNode } from '../../../cdk/explorer/nodes/errorNode'
 
 let sandbox: sinon.SinonSandbox
-beforeEach(() => {
+beforeEach(function() {
     sandbox = sinon.createSandbox()
 })
 
-afterEach(() => {
+afterEach(function() {
     sandbox.restore()
 })
-describe('AwsCdkExplorer', () => {
-    it('Displays Error node indicating that no CDK projects were found in empty workspace', async () => {
+describe('AwsCdkExplorer', function() {
+    it('Displays Error node indicating that no CDK projects were found in empty workspace', async function() {
         const awsCdkExplorer = new AwsCdkExplorer()
 
         const treeNodesPromise = awsCdkExplorer.getChildren()
@@ -33,7 +33,7 @@ describe('AwsCdkExplorer', () => {
         assert.strictEqual(treeNodes[0] instanceof CdkErrorNode, true)
     })
 
-    it('Displays a project node when workspaces are detected', async () => {
+    it('Displays a project node when workspaces are detected', async function() {
         const stubUri = sandbox.createStubInstance(vscode.Uri)
         const workspaceFolder: vscode.WorkspaceFolder = { uri: stubUri, index: 0, name: 'testworkspace' }
 

--- a/src/test/cdk/explorer/constructNode.test.ts
+++ b/src/test/cdk/explorer/constructNode.test.ts
@@ -14,12 +14,12 @@ import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
 import { clearTestIconPaths, IconPath, setupTestIconPaths } from '../utilities/iconPathUtils'
 import * as treeUtils from '../utilities/treeTestUtils'
 
-describe('ConstructNode', () => {
-    before(async () => {
+describe('ConstructNode', function() {
+    before(async function() {
         setupTestIconPaths()
     })
 
-    after(async () => {
+    after(async function() {
         clearTestIconPaths()
     })
 
@@ -27,7 +27,7 @@ describe('ConstructNode', () => {
     const constructTreePath = 'Path/To/MyConstruct'
     const cdkJsonPath = path.join('the', 'road', 'to', 'cdk.json')
 
-    it('initializes label and tooltip', async () => {
+    it('initializes label and tooltip', async function() {
         const testNode = generateTestNode(label)
         assert.strictEqual(testNode.label, label)
         assert.strictEqual(testNode.collapsibleState, vscode.TreeItemCollapsibleState.Collapsed)
@@ -39,7 +39,7 @@ describe('ConstructNode', () => {
         assert.strictEqual(testNode.id, `${cdkJsonPath}/${label}`)
     })
 
-    it('initializes icon paths for CloudFormation resources', async () => {
+    it('initializes icon paths for CloudFormation resources', async function() {
         const treeEntity: ConstructTreeEntity = {
             id: label,
             path: constructTreePath,
@@ -60,7 +60,7 @@ describe('ConstructNode', () => {
         assert.strictEqual(iconPath.light.path, cdk.iconPaths.light.cloudFormation, 'Unexpected light icon path')
     })
 
-    it('initializes icon paths for CDK constructs', async () => {
+    it('initializes icon paths for CDK constructs', async function() {
         const testNode = new ConstructNode(
             new FakeParentNode(cdkJsonPath),
             label,
@@ -73,7 +73,7 @@ describe('ConstructNode', () => {
         assert.strictEqual(iconPath.light.path, cdk.iconPaths.light.cdk, 'Unexpected light icon path')
     })
 
-    it('returns no child nodes if construct does not have any', async () => {
+    it('returns no child nodes if construct does not have any', async function() {
         const testNode = new ConstructNode(
             new FakeParentNode(cdkJsonPath),
             label,
@@ -85,7 +85,7 @@ describe('ConstructNode', () => {
         assert.strictEqual(childNodes.length, 0, 'Unexpected child nodes')
     })
 
-    it('child node has no collapsible state if it has no children or attributes', async () => {
+    it('child node has no collapsible state if it has no children or attributes', async function() {
         const treeEntity: ConstructTreeEntity = {
             id: label,
             path: constructTreePath,
@@ -103,7 +103,7 @@ describe('ConstructNode', () => {
         assert.strictEqual(childNodes[0].collapsibleState, vscode.TreeItemCollapsibleState.None)
     })
 
-    it('child node is collapsed if construct has child with attributes', async () => {
+    it('child node is collapsed if construct has child with attributes', async function() {
         const childWithAttributes = treeUtils.generateTreeChildResource()
         childWithAttributes.Resource.attributes = treeUtils.generateAttributes()
 
@@ -125,7 +125,7 @@ describe('ConstructNode', () => {
         assert.strictEqual(childNodes[0].collapsibleState, vscode.TreeItemCollapsibleState.Collapsed)
     })
 
-    it('returns child node of PropertyNode when construct has props', async () => {
+    it('returns child node of PropertyNode when construct has props', async function() {
         const treeEntity: ConstructTreeEntity = {
             id: label,
             path: constructTreePath,
@@ -144,7 +144,7 @@ describe('ConstructNode', () => {
         assert.strictEqual(childNodes[0] instanceof PropertyNode, true, 'Expected child node to be a PropertyNode')
     })
 
-    it('returns child nodes of PropertyNode and ConstructNode when construct has props and children', async () => {
+    it('returns child nodes of PropertyNode and ConstructNode when construct has props and children', async function() {
         const treeWithChildrenAndProps: ConstructTreeEntity = {
             id: label,
             path: constructTreePath,
@@ -164,7 +164,7 @@ describe('ConstructNode', () => {
         assert.strictEqual(childNodes[1] instanceof ConstructNode, true, 'Expected child node to be a ConstructNode')
     })
 
-    it('returns child node if a construct has grandchildren', async () => {
+    it('returns child node if a construct has grandchildren', async function() {
         const testNode = new ConstructNode(
             new FakeParentNode(cdkJsonPath),
             label,

--- a/src/test/cdk/explorer/errorNode.test.ts
+++ b/src/test/cdk/explorer/errorNode.test.ts
@@ -7,11 +7,11 @@ import * as assert from 'assert'
 import * as vscode from 'vscode'
 import { CdkErrorNode } from '../../../cdk/explorer/nodes/errorNode'
 
-describe('CdkErrorNode', () => {
+describe('CdkErrorNode', function() {
     const label = '[no projects]'
     const tooltip = 'we will integrate this with the CLI to create an app!'
 
-    it('initializes label and tooltip', async () => {
+    it('initializes label and tooltip', async function() {
         const testNode = new CdkErrorNode(label, tooltip)
 
         assert.strictEqual(testNode.label, label)
@@ -19,7 +19,7 @@ describe('CdkErrorNode', () => {
         assert.strictEqual(testNode.collapsibleState, vscode.TreeItemCollapsibleState.None)
     })
 
-    it('has no children', async () => {
+    it('has no children', async function() {
         const testNode = new CdkErrorNode(label, tooltip)
 
         const childNodes = await testNode.getChildren()

--- a/src/test/cdk/explorer/propertyNode.test.ts
+++ b/src/test/cdk/explorer/propertyNode.test.ts
@@ -9,23 +9,23 @@ import { PropertyNode } from '../../../cdk/explorer/nodes/propertyNode'
 import { ext } from '../../../shared/extensionGlobals'
 import { clearTestIconPaths, IconPath, setupTestIconPaths } from '../../shared/utilities/iconPathUtils'
 
-describe('PropertyNode', () => {
-    before(async () => {
+describe('PropertyNode', function() {
+    before(async function() {
         setupTestIconPaths()
     })
 
-    after(async () => {
+    after(async function() {
         clearTestIconPaths()
     })
 
     const label = 'myProperty'
 
-    it('initializes label', async () => {
+    it('initializes label', async function() {
         const testNode = new PropertyNode(label, vscode.TreeItemCollapsibleState.Collapsed)
         assert.strictEqual(testNode.label, label)
     })
 
-    it('initializes icon paths for properties', async () => {
+    it('initializes icon paths for properties', async function() {
         const testNode = new PropertyNode(label, vscode.TreeItemCollapsibleState.Collapsed)
 
         const iconPath = testNode.iconPath as IconPath
@@ -34,7 +34,7 @@ describe('PropertyNode', () => {
         assert.strictEqual(iconPath.light.path, ext.iconPaths.light.settings, 'Unexpected light icon path')
     })
 
-    it('returns no children when property does not have nested values', async () => {
+    it('returns no children when property does not have nested values', async function() {
         const testNode = new PropertyNode(label, vscode.TreeItemCollapsibleState.Collapsed)
 
         const childNodes = await testNode.getChildren()
@@ -42,7 +42,7 @@ describe('PropertyNode', () => {
         assert.strictEqual(childNodes.length, 0, 'Expected no child nodes for a property with non-nested properties')
     })
 
-    it('returns single child when property has a string value', async () => {
+    it('returns single child when property has a string value', async function() {
         const value = 'string value'
         const children: { [key: string]: any } = { key: value }
         const testNode = new PropertyNode(label, vscode.TreeItemCollapsibleState.Collapsed, children)
@@ -53,7 +53,7 @@ describe('PropertyNode', () => {
         assert.strictEqual(childNodes[0].label, `key: ${value}`)
     })
 
-    it('returns single child when property has a boolean value', async () => {
+    it('returns single child when property has a boolean value', async function() {
         const children: { [key: string]: any } = { key: true }
         const testNode = new PropertyNode(label, vscode.TreeItemCollapsibleState.Collapsed, children)
 
@@ -63,7 +63,7 @@ describe('PropertyNode', () => {
         assert.strictEqual(childNodes[0].label, 'key: true')
     })
 
-    it('returns single child when property has an int value', async () => {
+    it('returns single child when property has an int value', async function() {
         const value = 100
         const children: { [key: string]: any } = { key: value }
         const testNode = new PropertyNode(label, vscode.TreeItemCollapsibleState.Collapsed, children)
@@ -74,7 +74,7 @@ describe('PropertyNode', () => {
         assert.strictEqual(childNodes[0].label, `key: ${value}`, 'Unexpected label on PropertyNode')
     })
 
-    it('returns a nested property node with a property node for each value in the array', async () => {
+    it('returns a nested property node with a property node for each value in the array', async function() {
         const values = ['one', 'two', 'three']
         const children: { [key: string]: any } = { key: values }
 
@@ -88,7 +88,7 @@ describe('PropertyNode', () => {
         assert.strictEqual(childPropertyNodes.length, 3, 'Expected each value in nested array to have a child node')
     })
 
-    it('returns a nested property node with nested object as child property nodes', async () => {
+    it('returns a nested property node with nested object as child property nodes', async function() {
         const nestedObject = {
             evenMoreNested: 'nestedValue',
         }

--- a/src/test/cdk/tree/treeInspector.test.ts
+++ b/src/test/cdk/tree/treeInspector.test.ts
@@ -8,11 +8,11 @@ import * as treeInspector from '../../../cdk/explorer/tree/treeInspector'
 import { CfnResourceKeys, ConstructProps, ConstructTreeEntity } from '../../../cdk/explorer/tree/types'
 import * as treeUtils from '../utilities/treeTestUtils'
 
-describe('TreeInspector', () => {
+describe('TreeInspector', function() {
     const testLabel = 'my label'
     const treePath = 'my-project/cdk.out/tree.json'
 
-    it('returns label when construct is not named Resource', async () => {
+    it('returns label when construct is not named Resource', async function() {
         const construct = treeUtils.generateConstructTreeEntity(testLabel, treePath)
 
         const label = treeInspector.getDisplayLabel(construct)
@@ -20,7 +20,7 @@ describe('TreeInspector', () => {
         assert.strictEqual(label, construct.id, 'Unexpected label')
     })
 
-    it('includes type when construct is named Resource and type exists', async () => {
+    it('includes type when construct is named Resource and type exists', async function() {
         const id = 'Resource'
         const type = 'AWS::S3::Bucket'
         const attributes = { 'aws:cdk:cloudformation:type': type }
@@ -32,7 +32,7 @@ describe('TreeInspector', () => {
         assert.strictEqual(label, `${id} (${type})`)
     })
 
-    it('returns unchanged label when construct is named Resource and no type information exists', async () => {
+    it('returns unchanged label when construct is named Resource and no type information exists', async function() {
         const id = 'Resource'
 
         const construct: ConstructTreeEntity = { id, path: treePath }
@@ -42,7 +42,7 @@ describe('TreeInspector', () => {
         assert.strictEqual(label, id)
     })
 
-    it('returns default if no type information exists', async () => {
+    it('returns default if no type information exists', async function() {
         const construct = treeUtils.generateConstructTreeEntity(testLabel, treePath)
 
         const type = treeInspector.getTypeAttributeOrDefault(construct, '')
@@ -50,7 +50,7 @@ describe('TreeInspector', () => {
         assert.strictEqual(type, '')
     })
 
-    it('returns type when type information exists', async () => {
+    it('returns type when type information exists', async function() {
         const testType = 'AWS:SQS::Queue'
         const construct: ConstructTreeEntity = {
             id: testLabel,
@@ -63,7 +63,7 @@ describe('TreeInspector', () => {
         assert.strictEqual(type, testType)
     })
 
-    it('includes construct in tree', async () => {
+    it('includes construct in tree', async function() {
         const construct = treeUtils.generateConstructTreeEntity(testLabel, treePath)
 
         const includeConstruct = treeInspector.includeConstructInTree(construct)
@@ -71,7 +71,7 @@ describe('TreeInspector', () => {
         assert.strictEqual(includeConstruct, true, 'expected construct to be included in the tree')
     })
 
-    it('excludes the `Tree` construct that the CDK adds by default', async () => {
+    it('excludes the `Tree` construct that the CDK adds by default', async function() {
         const construct: ConstructTreeEntity = { id: 'Tree', path: 'Tree' }
 
         const includeConstruct = treeInspector.includeConstructInTree(construct)
@@ -79,7 +79,7 @@ describe('TreeInspector', () => {
         assert.strictEqual(includeConstruct, false, 'Tree construct should be excluded from the tree')
     })
 
-    it('returns properties when a construct has attributes', async () => {
+    it('returns properties when a construct has attributes', async function() {
         const attributes = treeUtils.generateAttributes()
         const expectedProps: ConstructProps = attributes[CfnResourceKeys.PROPS]
         const construct: ConstructTreeEntity = {
@@ -93,7 +93,7 @@ describe('TreeInspector', () => {
         assert.deepStrictEqual(props, expectedProps)
     })
 
-    it('returns undefined when construct does not have attributes', async () => {
+    it('returns undefined when construct does not have attributes', async function() {
         const construct: ConstructTreeEntity = {
             id: 'no',
             path: 'attributes',
@@ -104,7 +104,7 @@ describe('TreeInspector', () => {
         assert.strictEqual(props, undefined)
     })
 
-    it('returns undefined when construct does not have CloudFormation properties', async () => {
+    it('returns undefined when construct does not have CloudFormation properties', async function() {
         const construct: ConstructTreeEntity = {
             id: 'no-cloudformation',
             path: 'attributes',

--- a/src/test/cloudWatchLogs/commands/addLogEvents.test.ts
+++ b/src/test/cloudWatchLogs/commands/addLogEvents.test.ts
@@ -12,30 +12,30 @@ import { LogStreamRegistry } from '../../../cloudWatchLogs/registry/logStreamReg
 import { CLOUDWATCH_LOGS_SCHEME } from '../../../shared/constants'
 import { TestSettingsConfiguration } from '../../utilities/testSettingsConfiguration'
 
-describe('addLogEvents', async () => {
+describe('addLogEvents', async function() {
     let sandbox: sinon.SinonSandbox
     let clock: sinon.SinonFakeTimers
     const config = new TestSettingsConfiguration()
 
-    before(() => {
+    before(function() {
         clock = FakeTimers.install()
         config.writeSetting('cloudWatchLogs.limit', 1000)
     })
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
     })
 
-    afterEach(() => {
+    afterEach(function() {
         clock.reset()
         sandbox.restore()
     })
 
-    after(() => {
+    after(function() {
         clock.uninstall()
     })
 
-    it('runs updateLog and sets busy status correctly', async () => {
+    it('runs updateLog and sets busy status correctly', async function() {
         const uri = vscode.Uri.parse(`${CLOUDWATCH_LOGS_SCHEME}:group:stream:region`)
         const setBusyStatus = sandbox.stub<[vscode.Uri, boolean], void>()
         const updateLog = sandbox.stub<
@@ -78,7 +78,7 @@ describe('addLogEvents', async () => {
         sandbox.assert.calledWith(updateLog.firstCall, uri, 'head')
     })
 
-    it('async-locks to prevent more than one execution at a time', async () => {
+    it('async-locks to prevent more than one execution at a time', async function() {
         const uri = vscode.Uri.parse(`${CLOUDWATCH_LOGS_SCHEME}:group:stream:region`)
         const setBusyStatus = sandbox.stub<[vscode.Uri, boolean], void>()
         const updateLog = sandbox.stub<

--- a/src/test/cloudWatchLogs/commands/copyLogStreamName.test.ts
+++ b/src/test/cloudWatchLogs/commands/copyLogStreamName.test.ts
@@ -8,16 +8,16 @@ import * as vscode from 'vscode'
 import { copyLogStreamName } from '../../../cloudWatchLogs/commands/copyLogStreamName'
 import { CLOUDWATCH_LOGS_SCHEME } from '../../../shared/constants'
 
-describe('copyLogStreamName', async () => {
-    beforeEach(async () => {
+describe('copyLogStreamName', async function() {
+    beforeEach(async function() {
         await vscode.env.clipboard.writeText('')
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         await vscode.env.clipboard.writeText('')
     })
 
-    it('copies stream names from valid URIs and does not copy anything new if the URI is invalid', async () => {
+    it('copies stream names from valid URIs and does not copy anything new if the URI is invalid', async function() {
         const streamName = 'stream'
         await copyLogStreamName(vscode.Uri.parse(`${CLOUDWATCH_LOGS_SCHEME}:group:${streamName}:account`))
 

--- a/src/test/cloudWatchLogs/commands/saveCurrentLogStreamContent.test.ts
+++ b/src/test/cloudWatchLogs/commands/saveCurrentLogStreamContent.test.ts
@@ -14,13 +14,13 @@ import { CLOUDWATCH_LOGS_SCHEME } from '../../../shared/constants'
 import { fileExists, makeTemporaryToolkitFolder, readFileAsString } from '../../../shared/filesystemUtilities'
 import { FakeWindow } from '../../shared/vscode/fakeWindow'
 
-describe('saveCurrentLogStreamContent', async () => {
+describe('saveCurrentLogStreamContent', async function() {
     const logContent = 'shutdown is imminent'
     let filename: string
     let fakeRegistry: LogStreamRegistry
     let tempDir: string
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         tempDir = await makeTemporaryToolkitFolder()
         filename = path.join(tempDir, 'bobLoblawsLawB.log')
         fakeRegistry = ({
@@ -30,11 +30,11 @@ describe('saveCurrentLogStreamContent', async () => {
         } as any) as LogStreamRegistry
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         await fs.remove(tempDir)
     })
 
-    it('saves log content to a file', async () => {
+    it('saves log content to a file', async function() {
         await saveCurrentLogStreamContent(
             vscode.Uri.parse(`${CLOUDWATCH_LOGS_SCHEME}:g:s:r`),
             fakeRegistry,
@@ -49,7 +49,7 @@ describe('saveCurrentLogStreamContent', async () => {
         assert.strictEqual(await readFileAsString(filename), logContent)
     })
 
-    it('does not do anything if the URI is invalid', async () => {
+    it('does not do anything if the URI is invalid', async function() {
         await saveCurrentLogStreamContent(
             vscode.Uri.parse(`notCloudWatch:hahahaha`),
             fakeRegistry,

--- a/src/test/cloudWatchLogs/commands/viewLogStream.test.ts
+++ b/src/test/cloudWatchLogs/commands/viewLogStream.test.ts
@@ -36,8 +36,8 @@ class MockSelectLogStreamWizardContext implements SelectLogStreamWizardContext {
     }
 }
 
-describe('viewLogStreamWizard', async () => {
-    it('exits when cancelled', async () => {
+describe('viewLogStreamWizard', async function() {
+    it('exits when cancelled', async function() {
         const wizard = new SelectLogStreamWizard(
             new LogGroupNode(new FakeParentNode('asdf'), 'region', {}),
             new MockSelectLogStreamWizardContext([undefined])
@@ -47,7 +47,7 @@ describe('viewLogStreamWizard', async () => {
         assert.ok(!result)
     })
 
-    it('returns the selected log stream name', async () => {
+    it('returns the selected log stream name', async function() {
         const streamName = 'stream/name'
         const region = 'us-weast-99'
         const groupName = 'grouper'
@@ -64,8 +64,8 @@ describe('viewLogStreamWizard', async () => {
     })
 })
 
-describe('convertDescribeLogStreamsToQuickPickItems', () => {
-    it('converts things correctly', () => {
+describe('convertDescribeLogStreamsToQuickPickItems', function() {
+    it('converts things correctly', function() {
         const time = new Date().getTime()
         const results = convertDescribeLogStreamsToQuickPickItems({
             logStreams: [

--- a/src/test/cloudWatchLogs/document/logStreamDocumentProvider.test.ts
+++ b/src/test/cloudWatchLogs/document/logStreamDocumentProvider.test.ts
@@ -9,7 +9,7 @@ import { LogStreamDocumentProvider } from '../../../cloudWatchLogs/document/logS
 import { LogStreamRegistry, CloudWatchLogStreamData } from '../../../cloudWatchLogs/registry/logStreamRegistry'
 import { TestSettingsConfiguration } from '../../utilities/testSettingsConfiguration'
 
-describe('LogStreamDocumentProvider', () => {
+describe('LogStreamDocumentProvider', function() {
     let registry: LogStreamRegistry
     let map: Map<string, CloudWatchLogStreamData>
     let provider: LogStreamDocumentProvider
@@ -29,14 +29,14 @@ describe('LogStreamDocumentProvider', () => {
         busy: false,
     }
 
-    beforeEach(() => {
+    beforeEach(function() {
         map = new Map<string, CloudWatchLogStreamData>()
         map.set(registeredUri.path, stream)
         registry = new LogStreamRegistry(config, map)
         provider = new LogStreamDocumentProvider(registry)
     })
 
-    it('provides content if it exists and a blank string if it does not', () => {
+    it('provides content if it exists and a blank string if it does not', function() {
         assert.strictEqual(
             provider.provideTextDocumentContent(registeredUri),
             `                             \t${message}\n`

--- a/src/test/cloudWatchLogs/explorer/cloudWatchLogsNode.test.ts
+++ b/src/test/cloudWatchLogs/explorer/cloudWatchLogsNode.test.ts
@@ -20,14 +20,14 @@ const FAKE_REGION_CODE = 'someregioncode'
 const UNSORTED_TEXT = ['zebra', 'Antelope', 'aardvark', 'elephant']
 const SORTED_TEXT = ['aardvark', 'Antelope', 'elephant', 'zebra']
 
-describe('CloudWatchLogsNode', () => {
+describe('CloudWatchLogsNode', function() {
     let sandbox: sinon.SinonSandbox
     let testNode: CloudWatchLogsNode
 
     // Mocked Lambda Client returns Log Groups for anything listed in logGroupNames
     let logGroupNames: string[]
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
 
         logGroupNames = ['group1', 'group2']
@@ -37,11 +37,11 @@ describe('CloudWatchLogsNode', () => {
         testNode = new CloudWatchLogsNode(FAKE_REGION_CODE)
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    it('returns placeholder node if no children are present', async () => {
+    it('returns placeholder node if no children are present', async function() {
         logGroupNames = []
 
         const childNodes = await testNode.getChildren()
@@ -49,7 +49,7 @@ describe('CloudWatchLogsNode', () => {
         assertNodeListOnlyContainsPlaceholderNode(childNodes)
     })
 
-    it('has LogGroupNode child nodes', async () => {
+    it('has LogGroupNode child nodes', async function() {
         const childNodes = await testNode.getChildren()
 
         assert.strictEqual(childNodes.length, logGroupNames.length, 'Unexpected child count')
@@ -57,7 +57,7 @@ describe('CloudWatchLogsNode', () => {
         childNodes.forEach(node => assert.ok(node instanceof LogGroupNode, 'Expected child node to be LogGroupNode'))
     })
 
-    it('has child nodes with CloudWatch Log contextValue', async () => {
+    it('has child nodes with CloudWatch Log contextValue', async function() {
         const childNodes = await testNode.getChildren()
 
         childNodes.forEach(node =>
@@ -69,7 +69,7 @@ describe('CloudWatchLogsNode', () => {
         )
     })
 
-    it('sorts child nodes', async () => {
+    it('sorts child nodes', async function() {
         logGroupNames = UNSORTED_TEXT
 
         const childNodes = await testNode.getChildren()
@@ -78,7 +78,7 @@ describe('CloudWatchLogsNode', () => {
         assert.deepStrictEqual(actualChildOrder, SORTED_TEXT, 'Unexpected child sort order')
     })
 
-    it('has an error node for a child if an error happens during loading', async () => {
+    it('has an error node for a child if an error happens during loading', async function() {
         sandbox.stub(testNode, 'updateChildren').callsFake(() => {
             throw new Error('Update Children error!')
         })

--- a/src/test/cloudWatchLogs/explorer/logGroupNode.test.ts
+++ b/src/test/cloudWatchLogs/explorer/logGroupNode.test.ts
@@ -11,12 +11,12 @@ import { ext } from '../../../shared/extensionGlobals'
 import { TestAWSTreeNode } from '../../shared/treeview/nodes/testAWSTreeNode'
 import { clearTestIconPaths, IconPath, setupTestIconPaths } from '../../shared/utilities/iconPathUtils'
 
-describe('LogGroupNode', () => {
+describe('LogGroupNode', function() {
     const parentNode = new TestAWSTreeNode('test node')
     let testNode: LogGroupNode
     let fakeLogGroup: CloudWatchLogs.LogGroup
 
-    before(async () => {
+    before(async function() {
         setupTestIconPaths()
         fakeLogGroup = {
             logGroupName: "it'sBig/it'sHeavy/it'sWood",
@@ -26,42 +26,42 @@ describe('LogGroupNode', () => {
         testNode = new LogGroupNode(parentNode, 'someregioncode', fakeLogGroup)
     })
 
-    after(async () => {
+    after(async function() {
         clearTestIconPaths()
     })
 
-    it('instantiates without issue', async () => {
+    it('instantiates without issue', async function() {
         assert.ok(testNode)
     })
 
-    it('initializes the parent node', async () => {
+    it('initializes the parent node', async function() {
         assert.strictEqual(testNode.parent, parentNode, 'unexpected parent node')
     })
 
-    it('initializes the region code', async () => {
+    it('initializes the region code', async function() {
         assert.strictEqual(testNode.regionCode, 'someregioncode')
     })
 
-    it('initializes the label', async () => {
+    it('initializes the label', async function() {
         assert.strictEqual(testNode.label, fakeLogGroup.logGroupName)
     })
 
-    it('initializes the functionName', async () => {
+    it('initializes the functionName', async function() {
         assert.strictEqual(testNode.name, fakeLogGroup.logGroupName)
     })
 
-    it('initializes the tooltip', async () => {
+    it('initializes the tooltip', async function() {
         assert.strictEqual(testNode.tooltip, `${fakeLogGroup.logGroupName}${os.EOL}${fakeLogGroup.arn}`)
     })
 
-    it('initializes the icon', async () => {
+    it('initializes the icon', async function() {
         const iconPath = testNode.iconPath as IconPath
 
         assert.strictEqual(iconPath.dark.path, ext.iconPaths.dark.cloudWatchLogGroup, 'Unexpected dark icon path')
         assert.strictEqual(iconPath.light.path, ext.iconPaths.light.cloudWatchLogGroup, 'Unexpected light icon path')
     })
 
-    it('has no children', async () => {
+    it('has no children', async function() {
         const childNodes = await testNode.getChildren()
         assert.ok(childNodes)
         assert.strictEqual(childNodes.length, 0, 'Expected node to have no children')

--- a/src/test/cloudWatchLogs/registry/logStreamRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logStreamRegistry.test.ts
@@ -11,7 +11,7 @@ import { CloudWatchLogStreamData, LogStreamRegistry } from '../../../cloudWatchL
 import { CLOUDWATCH_LOGS_SCHEME, INSIGHTS_TIMESTAMP_FORMAT } from '../../../shared/constants'
 import { TestSettingsConfiguration } from '../../utilities/testSettingsConfiguration'
 
-describe('LogStreamRegistry', async () => {
+describe('LogStreamRegistry', async function() {
     let registry: LogStreamRegistry
     let map: Map<string, CloudWatchLogStreamData>
 
@@ -74,7 +74,7 @@ describe('LogStreamRegistry', async () => {
     const missingRegisteredUri = vscode.Uri.parse(`${CLOUDWATCH_LOGS_SCHEME}:Not:Here:Dude`)
     const newLineUri = vscode.Uri.parse(`${CLOUDWATCH_LOGS_SCHEME}:ANOTHER:LINE:PIEEEECCCEEEEEE`)
 
-    beforeEach(() => {
+    beforeEach(function() {
         map = new Map<string, CloudWatchLogStreamData>()
         map.set(registeredUri.path, stream)
         map.set(shorterRegisteredUri.path, simplerStream)
@@ -82,14 +82,14 @@ describe('LogStreamRegistry', async () => {
         registry = new LogStreamRegistry(config, map)
     })
 
-    describe('hasLog', () => {
-        it('correctly returns whether or not the log is registered', () => {
+    describe('hasLog', function() {
+        it('correctly returns whether or not the log is registered', function() {
             assert.strictEqual(registry.hasLog(registeredUri), true)
             assert.strictEqual(registry.hasLog(missingRegisteredUri), false)
         })
     })
 
-    describe('registerLog', async () => {
+    describe('registerLog', async function() {
         it("registers logs and doesn't overwrite existing logs", async () => {
             await registry.registerLog(missingRegisteredUri, getLogEventsFromUriComponentsFn)
             const blankPostRegister = registry.getLogContent(missingRegisteredUri)
@@ -101,8 +101,8 @@ describe('LogStreamRegistry', async () => {
         })
     })
 
-    describe('getLogContent', () => {
-        it('gets unformatted log content', () => {
+    describe('getLogContent', function() {
+        it('gets unformatted log content', function() {
             const text = registry.getLogContent(registeredUri)
 
             assert.strictEqual(
@@ -111,7 +111,7 @@ describe('LogStreamRegistry', async () => {
             )
         })
 
-        it('gets log content formatted to show timestamps', () => {
+        it('gets log content formatted to show timestamps', function() {
             const text = registry.getLogContent(registeredUri, { timestamps: true })
 
             assert.strictEqual(
@@ -124,7 +124,7 @@ describe('LogStreamRegistry', async () => {
             )
         })
 
-        it('indents log entries with newlines of all flavors if timestamps are shown but otherwise does not act on them', () => {
+        it('indents log entries with newlines of all flavors if timestamps are shown but otherwise does not act on them', function() {
             const timestampText = registry.getLogContent(newLineUri, { timestamps: true })
             const noTimestampText = registry.getLogContent(newLineUri)
 
@@ -138,7 +138,7 @@ describe('LogStreamRegistry', async () => {
         })
     })
 
-    describe('updateLog', async () => {
+    describe('updateLog', async function() {
         it("adds content to existing streams at both head and tail ends and doesn't do anything if the log isn't registered", async () => {
             await registry.updateLog(shorterRegisteredUri, 'tail', config, getLogEventsFromUriComponentsFn)
             const initialWithTail = registry.getLogContent(shorterRegisteredUri)
@@ -153,14 +153,14 @@ describe('LogStreamRegistry', async () => {
         })
     })
 
-    describe('deregisterLog', () => {
-        it('deletes a log', () => {
+    describe('deregisterLog', function() {
+        it('deletes a log', function() {
             assert.strictEqual(registry.hasLog(registeredUri), true)
             registry.deregisterLog(registeredUri)
             assert.strictEqual(registry.hasLog(registeredUri), false)
         })
 
-        it('does not error if the log does not exist in the registry', () => {
+        it('does not error if the log does not exist in the registry', function() {
             assert.strictEqual(registry.hasLog(missingRegisteredUri), false)
             registry.deregisterLog(missingRegisteredUri)
             assert.strictEqual(registry.hasLog(missingRegisteredUri), false)

--- a/src/test/cloudWatchLogs/utils.test.ts
+++ b/src/test/cloudWatchLogs/utils.test.ts
@@ -18,18 +18,18 @@ const goodUri = vscode.Uri.parse(
     `${CLOUDWATCH_LOGS_SCHEME}:${goodComponents.groupName}:${goodComponents.streamName}:${goodComponents.regionName}`
 )
 
-describe('convertUriToLogGroupInfo', async () => {
-    it('converts a valid URI to components', () => {
+describe('convertUriToLogGroupInfo', async function() {
+    it('converts a valid URI to components', function() {
         assert.deepStrictEqual(parseCloudWatchLogsUri(goodUri), goodComponents)
     })
 
-    it('does not convert URIs with an invalid scheme', async () => {
+    it('does not convert URIs with an invalid scheme', async function() {
         await assertThrowsError(async () => {
             parseCloudWatchLogsUri(vscode.Uri.parse('wrong:scheme'))
         })
     })
 
-    it('does not convert URIs with more or less than three elements', async () => {
+    it('does not convert URIs with more or less than three elements', async function() {
         await assertThrowsError(async () => {
             parseCloudWatchLogsUri(vscode.Uri.parse(`${CLOUDWATCH_LOGS_SCHEME}:elementOne:elementTwo`))
         })
@@ -42,8 +42,8 @@ describe('convertUriToLogGroupInfo', async () => {
     })
 })
 
-describe('convertLogGroupInfoToUri', () => {
-    it('converts components to a valid URI', () => {
+describe('convertLogGroupInfoToUri', function() {
+    it('converts components to a valid URI', function() {
         assert.deepStrictEqual(
             convertLogGroupInfoToUri(goodComponents.groupName, goodComponents.streamName, goodComponents.regionName),
             goodUri

--- a/src/test/credentials/awsCredentialsStatusBarItem.test.ts
+++ b/src/test/credentials/awsCredentialsStatusBarItem.test.ts
@@ -7,16 +7,16 @@ import * as assert from 'assert'
 import * as vscode from 'vscode'
 import { updateCredentialsStatusBarItem } from '../../credentials/awsCredentialsStatusBarItem'
 
-describe('updateCredentialsStatusBarItem', async () => {
+describe('updateCredentialsStatusBarItem', async function() {
     let statusBarItem: vscode.StatusBarItem
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         statusBarItem = ({
             text: '',
         } as any) as vscode.StatusBarItem
     })
 
-    it('updates text with credentials id', async () => {
+    it('updates text with credentials id', async function() {
         const credentialId = 'qwerty'
 
         updateCredentialsStatusBarItem(statusBarItem, credentialId)
@@ -26,7 +26,7 @@ describe('updateCredentialsStatusBarItem', async () => {
         )
     })
 
-    it('updates text with placeholder when there is no credentials id', async () => {
+    it('updates text with placeholder when there is no credentials id', async function() {
         updateCredentialsStatusBarItem(statusBarItem, undefined)
         assert.ok(
             statusBarItem.text.includes('(not connected)'),

--- a/src/test/credentials/provider/credentialsProviderFactory.test.ts
+++ b/src/test/credentials/provider/credentialsProviderFactory.test.ts
@@ -8,7 +8,7 @@ import { CredentialsProvider } from '../../../credentials/providers/credentialsP
 import { BaseCredentialsProviderFactory } from '../../../credentials/providers/credentialsProviderFactory'
 import { CredentialsProviderId } from '../../../credentials/providers/credentialsProviderId'
 
-describe('BaseCredentialsProviderFactory', async () => {
+describe('BaseCredentialsProviderFactory', async function() {
     /**
      * This class exposes abstract class functionality for the purpose of testing it.
      */
@@ -38,30 +38,30 @@ describe('BaseCredentialsProviderFactory', async () => {
 
     let sut: TestCredentialsProviderFactory
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         sut = new TestCredentialsProviderFactory()
     })
 
-    it('can add a provider', async () => {
+    it('can add a provider', async function() {
         sut.addProvider(makeSampleCredentialsProvider('provider1'))
         assert.strictEqual(sut.getProviders().length, 1)
     })
 
-    it('can remove a provider', async () => {
+    it('can remove a provider', async function() {
         const provider = makeSampleCredentialsProvider('provider1')
         sut.getProviders().push(provider)
         sut.removeProvider(provider)
         assert.strictEqual(sut.getProviders().length, 0)
     })
 
-    it('can reset providers', async () => {
+    it('can reset providers', async function() {
         const provider = makeSampleCredentialsProvider('provider1')
         sut.getProviders().push(provider)
         sut.resetProviders()
         assert.strictEqual(sut.getProviders().length, 0)
     })
 
-    it('can list providers', async () => {
+    it('can list providers', async function() {
         const provider = makeSampleCredentialsProvider('provider1')
         const provider2 = makeSampleCredentialsProvider('provider2')
         sut.getProviders().push(provider)
@@ -73,7 +73,7 @@ describe('BaseCredentialsProviderFactory', async () => {
         assert.notStrictEqual(providers.indexOf(provider2), -1, 'Expected provider 2 to be in listed providers')
     })
 
-    it('returns a requested provider', async () => {
+    it('returns a requested provider', async function() {
         const provider = makeSampleCredentialsProvider('provider1')
         sut.getProviders().push(provider)
 
@@ -81,7 +81,7 @@ describe('BaseCredentialsProviderFactory', async () => {
         assert.notStrictEqual(retrievedProvider, undefined)
     })
 
-    it('returns undefined when requesting a provider it does not have', async () => {
+    it('returns undefined when requesting a provider it does not have', async function() {
         const provider = makeSampleCredentialsProvider('provider1')
         sut.getProviders().push(provider)
 

--- a/src/test/credentials/provider/credentialsProviderId.test.ts
+++ b/src/test/credentials/provider/credentialsProviderId.test.ts
@@ -7,37 +7,37 @@ import * as assert from 'assert'
 import { asString, fromString, isEqual } from '../../../credentials/providers/credentialsProviderId'
 import { assertThrowsError } from '../../shared/utilities/assertUtils'
 
-describe('CredentialsProviderId', async () => {
-    describe('fromString', async () => {
-        it('produces CredentialsProviderId from a string', async () => {
+describe('CredentialsProviderId', async function() {
+    describe('fromString', async function() {
+        it('produces CredentialsProviderId from a string', async function() {
             const id = fromString('profile:default')
 
             assert.strictEqual(id.credentialType, 'profile')
             assert.strictEqual(id.credentialTypeId, 'default')
         })
 
-        it('supports cases where the separator is in the credentialTypeId', async () => {
+        it('supports cases where the separator is in the credentialTypeId', async function() {
             const id = fromString('profile:default:foo')
 
             assert.strictEqual(id.credentialType, 'profile')
             assert.strictEqual(id.credentialTypeId, 'default:foo')
         })
 
-        it('errs on unexpected format - not enough separators', async () => {
+        it('errs on unexpected format - not enough separators', async function() {
             await assertThrowsError(async () => {
                 fromString('default')
             })
         })
 
-        it('errs on unexpected format - different separator', async () => {
+        it('errs on unexpected format - different separator', async function() {
             await assertThrowsError(async () => {
                 fromString('profile$default')
             })
         })
     })
 
-    describe('asString', async () => {
-        it('converts a CredentialsProviderId to a string', async () => {
+    describe('asString', async function() {
+        it('converts a CredentialsProviderId to a string', async function() {
             const id = asString({
                 credentialType: 'profile',
                 credentialTypeId: 'default',
@@ -47,8 +47,8 @@ describe('CredentialsProviderId', async () => {
         })
     })
 
-    describe('isEqual', async () => {
-        it('detects matches', async () => {
+    describe('isEqual', async function() {
+        it('detects matches', async function() {
             assert.strictEqual(
                 isEqual(
                     {
@@ -64,7 +64,7 @@ describe('CredentialsProviderId', async () => {
             )
         })
 
-        it('detects non-matches in credentialType', async () => {
+        it('detects non-matches in credentialType', async function() {
             assert.strictEqual(
                 isEqual(
                     {
@@ -80,7 +80,7 @@ describe('CredentialsProviderId', async () => {
             )
         })
 
-        it('detects non-matches in credentialTypeId', async () => {
+        it('detects non-matches in credentialTypeId', async function() {
             assert.strictEqual(
                 isEqual(
                     {

--- a/src/test/credentials/provider/credentialsProviderManager.test.ts
+++ b/src/test/credentials/provider/credentialsProviderManager.test.ts
@@ -49,14 +49,14 @@ class TestCredentialsProviderFactory implements CredentialsProviderFactory {
     public async refresh(): Promise<void> {}
 }
 
-describe('CredentialsProviderManager', async () => {
+describe('CredentialsProviderManager', async function() {
     let sut: CredentialsProviderManager
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         sut = new CredentialsProviderManager()
     })
 
-    it('getCredentialProviderNames()', async () => {
+    it('getCredentialProviderNames()', async function() {
         const factoryA = new TestCredentialsProviderFactory('credentialTypeA', ['one'])
         const factoryB = new TestCredentialsProviderFactory('credentialTypeB', ['two', 'three'])
         sut.addProviderFactory(factoryA)
@@ -79,8 +79,8 @@ describe('CredentialsProviderManager', async () => {
         assert.deepStrictEqual(expectedCredentials, await sut.getCredentialProviderNames())
     })
 
-    describe('getAllCredentialsProviders', async () => {
-        it('returns all providers', async () => {
+    describe('getAllCredentialsProviders', async function() {
+        it('returns all providers', async function() {
             const factoryA = new TestCredentialsProviderFactory('credentialTypeA', ['one'])
             const factoryB = new TestCredentialsProviderFactory('credentialTypeB', ['two', 'three'])
 
@@ -120,8 +120,8 @@ describe('CredentialsProviderManager', async () => {
         })
     })
 
-    describe('getCredentialsProvider', async () => {
-        it('returns a provider', async () => {
+    describe('getCredentialsProvider', async function() {
+        it('returns a provider', async function() {
             const factoryA = new TestCredentialsProviderFactory('profile', ['default'])
             const expectedCredentialsProviderId: CredentialsProviderId = {
                 credentialType: 'profile',
@@ -140,7 +140,7 @@ describe('CredentialsProviderManager', async () => {
             )
         })
 
-        it('returns undefined when there is a factory but the factory does not contain a provider', async () => {
+        it('returns undefined when there is a factory but the factory does not contain a provider', async function() {
             const factoryA = new TestCredentialsProviderFactory('profile', ['default2'])
 
             sut.addProviderFactory(factoryA)
@@ -153,7 +153,7 @@ describe('CredentialsProviderManager', async () => {
             assert.strictEqual(provider, undefined, 'Manager was not supposed to return a provider')
         })
 
-        it('returns undefined when there is not a factory for the given credentialsType', async () => {
+        it('returns undefined when there is not a factory for the given credentialsType', async function() {
             const factoryA = new TestCredentialsProviderFactory('ec2', ['instance'])
 
             sut.addProviderFactory(factoryA)

--- a/src/test/credentials/provider/sharedCredentialsProvider.test.ts
+++ b/src/test/credentials/provider/sharedCredentialsProvider.test.ts
@@ -10,8 +10,8 @@ import { assertThrowsError } from '../../shared/utilities/assertUtils'
 
 const MISSING_PROPERTIES_FRAGMENT = 'missing properties'
 
-describe('SharedCredentialsProvider', async () => {
-    it('constructor fails if profile does not exist', async () => {
+describe('SharedCredentialsProvider', async function() {
+    it('constructor fails if profile does not exist', async function() {
         await assertThrowsError(async () => {
             // @ts-ignore - sut is unused, we expect the constructor to throw
             const sut = new SharedCredentialsProvider(
@@ -21,7 +21,7 @@ describe('SharedCredentialsProvider', async () => {
         })
     })
 
-    it('produces a CredentialsProviderId', async () => {
+    it('produces a CredentialsProviderId', async function() {
         const sut = new SharedCredentialsProvider(
             'default',
             new Map<string, Profile>([['default', { aws_access_key_id: 'x', aws_secret_access_key: 'y' }]])
@@ -33,7 +33,7 @@ describe('SharedCredentialsProvider', async () => {
         })
     })
 
-    it('gets profile properties', async () => {
+    it('gets profile properties', async function() {
         const sut = new SharedCredentialsProvider(
             'default',
             new Map<string, Profile>([
@@ -45,7 +45,7 @@ describe('SharedCredentialsProvider', async () => {
         assert.strictEqual(sut.canAutoConnect(), true)
     })
 
-    it('profile properties may be undefined', async () => {
+    it('profile properties may be undefined', async function() {
         const sut = new SharedCredentialsProvider(
             'default',
             new Map<string, Profile>([['default', { aws_access_key_id: 'x', aws_secret_access_key: 'y' }]])
@@ -54,7 +54,7 @@ describe('SharedCredentialsProvider', async () => {
         assert.strictEqual(sut.getDefaultRegion(), undefined)
     })
 
-    it('validation identifies a source_profile reference that does not exist', async () => {
+    it('validation identifies a source_profile reference that does not exist', async function() {
         const sut = new SharedCredentialsProvider(
             'default',
             new Map<string, Profile>([['default', { role_arn: 'x', source_profile: 'fakeprofile' }]])
@@ -64,7 +64,7 @@ describe('SharedCredentialsProvider', async () => {
         assertSubstringsInText(sut.validate(), 'not found')
     })
 
-    it('validation identifies a source_profile reference cycle', async () => {
+    it('validation identifies a source_profile reference cycle', async function() {
         const sut = new SharedCredentialsProvider(
             'profileA',
             new Map<string, Profile>([
@@ -78,7 +78,7 @@ describe('SharedCredentialsProvider', async () => {
         assertSubstringsInText(sut.validate(), 'Cycle detected', 'profileA', 'profileB', 'profileC')
     })
 
-    it('validation identifies when access key id is missing a corresponding secret key', async () => {
+    it('validation identifies when access key id is missing a corresponding secret key', async function() {
         const sut = new SharedCredentialsProvider(
             'default',
             new Map<string, Profile>([['default', { aws_access_key_id: 'x' }]])
@@ -88,7 +88,7 @@ describe('SharedCredentialsProvider', async () => {
         assertSubstringsInText(sut.validate(), MISSING_PROPERTIES_FRAGMENT, 'aws_secret_access_key')
     })
 
-    it('validation identifies when session_token is missing a corresponding access key id', async () => {
+    it('validation identifies when session_token is missing a corresponding access key id', async function() {
         const sut = new SharedCredentialsProvider(
             'default',
             new Map<string, Profile>([['default', { aws_secret_access_key: 'y', aws_session_token: 'z' }]])
@@ -98,7 +98,7 @@ describe('SharedCredentialsProvider', async () => {
         assertSubstringsInText(sut.validate(), MISSING_PROPERTIES_FRAGMENT, 'aws_access_key_id')
     })
 
-    it('validation identifies when session_token is missing a corresponding secret key', async () => {
+    it('validation identifies when session_token is missing a corresponding secret key', async function() {
         const sut = new SharedCredentialsProvider(
             'default',
             new Map<string, Profile>([['default', { aws_access_key_id: 'x', aws_session_token: 'z' }]])
@@ -108,7 +108,7 @@ describe('SharedCredentialsProvider', async () => {
         assertSubstringsInText(sut.validate(), MISSING_PROPERTIES_FRAGMENT, 'aws_secret_access_key')
     })
 
-    it('validation identifies when the profile contains no supported properties', async () => {
+    it('validation identifies when the profile contains no supported properties', async function() {
         const sut = new SharedCredentialsProvider(
             'default',
             new Map<string, Profile>([['default', { hello: 'world' }]])
@@ -118,7 +118,7 @@ describe('SharedCredentialsProvider', async () => {
         assertSubstringsInText(sut.validate(), 'not supported')
     })
 
-    it('validates a valid profile with an access key', async () => {
+    it('validates a valid profile with an access key', async function() {
         const sut = new SharedCredentialsProvider(
             'default',
             new Map<string, Profile>([['default', { aws_access_key_id: 'x', aws_secret_access_key: 'y' }]])
@@ -127,7 +127,7 @@ describe('SharedCredentialsProvider', async () => {
         assert.strictEqual(sut.validate(), undefined)
     })
 
-    it('validates a valid profile with a session token', async () => {
+    it('validates a valid profile with a session token', async function() {
         const sut = new SharedCredentialsProvider(
             'default',
             new Map<string, Profile>([
@@ -138,7 +138,7 @@ describe('SharedCredentialsProvider', async () => {
         assert.strictEqual(sut.validate(), undefined)
     })
 
-    it('validates a valid profile with credential_process', async () => {
+    it('validates a valid profile with credential_process', async function() {
         const sut = new SharedCredentialsProvider(
             'default',
             new Map<string, Profile>([['default', { credential_process: 'x' }]])
@@ -147,7 +147,7 @@ describe('SharedCredentialsProvider', async () => {
         assert.strictEqual(sut.validate(), undefined)
     })
 
-    it('validates a valid profile with role_arn', async () => {
+    it('validates a valid profile with role_arn', async function() {
         const sut = new SharedCredentialsProvider(
             'default',
             new Map<string, Profile>([['default', { role_arn: 'x' }]])
@@ -156,7 +156,7 @@ describe('SharedCredentialsProvider', async () => {
         assert.strictEqual(sut.validate(), undefined)
     })
 
-    it('validates a valid profile with role_arn and source_profile', async () => {
+    it('validates a valid profile with role_arn and source_profile', async function() {
         const sut = new SharedCredentialsProvider(
             'default',
             new Map<string, Profile>([
@@ -168,7 +168,7 @@ describe('SharedCredentialsProvider', async () => {
         assert.strictEqual(sut.validate(), undefined)
     })
 
-    it('getCredentials throws when the profile is not valid', async () => {
+    it('getCredentials throws when the profile is not valid', async function() {
         const sut = new SharedCredentialsProvider(
             'default',
             new Map<string, Profile>([['default', { aws_access_key_id: 'x' }]])

--- a/src/test/credentials/provider/sharedCredentialsProviderFactory.test.ts
+++ b/src/test/credentials/provider/sharedCredentialsProviderFactory.test.ts
@@ -11,7 +11,7 @@ import { SharedCredentialsProviderFactory } from '../../../credentials/providers
 import * as sharedCredentials from '../../../credentials/sharedCredentials'
 import { Profile } from '../../../shared/credentials/credentialsFile'
 
-describe('SharedCredentialsProviderFactory', async () => {
+describe('SharedCredentialsProviderFactory', async function() {
     let sandbox: sinon.SinonSandbox
     let loadSharedCredentialsProfilesStub: sinon.SinonStub<[], Promise<Map<string, Profile>>>
 
@@ -32,7 +32,7 @@ describe('SharedCredentialsProviderFactory', async () => {
     const validProfileName2 = 'alt'
     const invalidProfileName = 'gary'
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         sandbox = sinon.createSandbox()
 
         sharedCredentialsLastModifiedMillis = 1
@@ -51,11 +51,11 @@ describe('SharedCredentialsProviderFactory', async () => {
             .callsFake(async () => sharedCredentialProfiles)
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         sandbox.restore()
     })
 
-    it('produces credential providers from shared credentials profiles', async () => {
+    it('produces credential providers from shared credentials profiles', async function() {
         const sut = new SharedCredentialsProviderFactory()
 
         await sut.refresh()
@@ -84,7 +84,7 @@ describe('SharedCredentialsProviderFactory', async () => {
         )
     })
 
-    it('does not load providers for invalid profiles', async () => {
+    it('does not load providers for invalid profiles', async function() {
         sharedCredentialProfiles.set(invalidProfileName, inValidProfile)
 
         const sut = new SharedCredentialsProviderFactory()
@@ -103,7 +103,7 @@ describe('SharedCredentialsProviderFactory', async () => {
         )
     })
 
-    it('refresh does not reload from file if the file has not changed', async () => {
+    it('refresh does not reload from file if the file has not changed', async function() {
         const sut = new SharedCredentialsProviderFactory()
 
         // First load
@@ -118,7 +118,7 @@ describe('SharedCredentialsProviderFactory', async () => {
         )
     })
 
-    it('refresh reloads from file if the file has changed', async () => {
+    it('refresh reloads from file if the file has changed', async function() {
         const sut = new SharedCredentialsProviderFactory()
 
         // First load

--- a/src/test/credentials/sharedCredentials.test.ts
+++ b/src/test/credentials/sharedCredentials.test.ts
@@ -10,27 +10,27 @@ import { getConfigFilename, getCredentialsFilename } from '../../credentials/sha
 import { EnvironmentVariables } from '../../shared/environmentVariables'
 import { makeTemporaryToolkitFolder } from '../../shared/filesystemUtilities'
 
-describe('sharedCredentials', () => {
+describe('sharedCredentials', function() {
     let tempFolder: string
 
-    before(async () => {
+    before(async function() {
         // Make a temp folder for all these tests
         // Stick some temp credentials files in there to load from
         tempFolder = await makeTemporaryToolkitFolder()
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         const env = process.env as EnvironmentVariables
         delete env.AWS_SHARED_CREDENTIALS_FILE
         delete env.AWS_CONFIG_FILE
     })
 
-    after(async () => {
+    after(async function() {
         await fs.remove(tempFolder)
     })
 
-    describe('getCredentialsFilename', () => {
-        it('uses the default credentials path if AWS_SHARED_CREDENTIALS_FILE is not set', async () => {
+    describe('getCredentialsFilename', function() {
+        it('uses the default credentials path if AWS_SHARED_CREDENTIALS_FILE is not set', async function() {
             const env = process.env as EnvironmentVariables
             env.AWS_SHARED_CREDENTIALS_FILE = ''
 
@@ -38,7 +38,7 @@ describe('sharedCredentials', () => {
             assert.strictEqual(filename.length > 0, true)
         })
 
-        it('gets AWS_SHARED_CREDENTIALS_FILE if set', async () => {
+        it('gets AWS_SHARED_CREDENTIALS_FILE if set', async function() {
             const expectedFilename = path.join(tempFolder, 'credentials-custom-name-test')
             const env = process.env as EnvironmentVariables
             env.AWS_SHARED_CREDENTIALS_FILE = expectedFilename
@@ -48,8 +48,8 @@ describe('sharedCredentials', () => {
         })
     })
 
-    describe('getConfigFilename', () => {
-        it('uses the default config path if AWS_CONFIG_FILE is not set', async () => {
+    describe('getConfigFilename', function() {
+        it('uses the default config path if AWS_CONFIG_FILE is not set', async function() {
             const env = process.env as EnvironmentVariables
             env.AWS_CONFIG_FILE = ''
 
@@ -57,7 +57,7 @@ describe('sharedCredentials', () => {
             assert.strictEqual(filename.length > 0, true)
         })
 
-        it('gets AWS_CONFIG_FILE if set', async () => {
+        it('gets AWS_CONFIG_FILE if set', async function() {
             const expectedFilename = path.join(tempFolder, 'config-custom-name-test')
             const env = process.env as EnvironmentVariables
             env.AWS_CONFIG_FILE = expectedFilename

--- a/src/test/ecr/commands/copyRepositoryUri.test.ts
+++ b/src/test/ecr/commands/copyRepositoryUri.test.ts
@@ -11,8 +11,8 @@ import { EcrNode } from '../../../ecr/explorer/ecrNode'
 import { EcrClient, EcrRepository } from '../../../shared/clients/ecrClient'
 import { copyRepositoryUri } from '../../../ecr/commands/copyRepositoryUri'
 
-describe('copyUriCommand', () => {
-    it('Copies URI to clipboard and shows in the status bar', async () => {
+describe('copyUriCommand', function() {
+    it('Copies URI to clipboard and shows in the status bar', async function() {
         const node = new EcrRepositoryNode(
             {} as EcrNode,
             {} as EcrClient,

--- a/src/test/ecr/commands/copyTagUri.test.ts
+++ b/src/test/ecr/commands/copyTagUri.test.ts
@@ -11,8 +11,8 @@ import { EcrClient, EcrRepository } from '../../../shared/clients/ecrClient'
 import { EcrTagNode } from '../../../ecr/explorer/ecrTagNode'
 import { copyTagUri } from '../../../ecr/commands/copyTagUri'
 
-describe('copyTagUriCommand', () => {
-    it('Copies URI to clipboard and shows in the status bar', async () => {
+describe('copyTagUriCommand', function() {
+    it('Copies URI to clipboard and shows in the status bar', async function() {
         const parentNode = {} as EcrRepositoryNode
         const node = new EcrTagNode(
             parentNode,

--- a/src/test/ecr/commands/createRepository.test.ts
+++ b/src/test/ecr/commands/createRepository.test.ts
@@ -12,21 +12,21 @@ import { createRepository } from '../../../ecr/commands/createRepository'
 import { MockEcrClient } from '../../shared/clients/mockClients'
 import { FakeCommands } from '../../shared/vscode/fakeCommands'
 
-describe('createRepositoryCommand', () => {
+describe('createRepositoryCommand', function() {
     const ecr: EcrClient = new MockEcrClient({})
     let node: EcrNode
     let sandbox: sinon.SinonSandbox
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
         node = new EcrNode(ecr)
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    it('prompts for repo name, creates repo, shows success, and refreshes node', async () => {
+    it('prompts for repo name, creates repo, shows success, and refreshes node', async function() {
         const repoName = 'amazingecrrepo'
 
         const stub = sandbox.stub(ecr, 'createRepository').callsFake(async name => {
@@ -47,7 +47,7 @@ describe('createRepositoryCommand', () => {
         assert.deepStrictEqual(commands.args, [node])
     })
 
-    it('does nothing when prompt is cancelled', async () => {
+    it('does nothing when prompt is cancelled', async function() {
         const spy = sandbox.spy(ecr, 'createRepository')
 
         await createRepository(node, new FakeWindow(), new FakeCommands())
@@ -55,7 +55,7 @@ describe('createRepositoryCommand', () => {
         assert.ok(spy.notCalled)
     })
 
-    it('Shows an error message and refreshes node when repository creation fails', async () => {
+    it('Shows an error message and refreshes node when repository creation fails', async function() {
         sandbox.stub(ecr, 'createRepository').callsFake(async () => {
             throw Error('Network busted')
         })
@@ -70,7 +70,7 @@ describe('createRepositoryCommand', () => {
         assert.deepStrictEqual(commands.args, [node])
     })
 
-    it('Warns when repository name is invalid', async () => {
+    it('Warns when repository name is invalid', async function() {
         const window = new FakeWindow({ inputBox: { input: '404' } })
 
         await createRepository(node, window, new FakeCommands())

--- a/src/test/ecr/commands/deleteRepository.test.ts
+++ b/src/test/ecr/commands/deleteRepository.test.ts
@@ -13,23 +13,23 @@ import { FakeCommands } from '../../shared/vscode/fakeCommands'
 import { EcrRepositoryNode } from '../../../ecr/explorer/ecrRepositoryNode'
 import { deleteRepository } from '../../../ecr/commands/deleteRepository'
 
-describe('deleteRepositoryCommand', () => {
+describe('deleteRepositoryCommand', function() {
     const repositoryName = 'reponame'
     const parentNode: EcrNode = {} as EcrNode
     const ecr: EcrClient = new MockEcrClient({})
     let node: EcrRepositoryNode
     let sandbox: sinon.SinonSandbox
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
         node = new EcrRepositoryNode(parentNode, ecr, { repositoryName: repositoryName } as EcrRepository)
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    it('Confirms deletion, deletes repository, shows progress bar, and refreshes parent node', async () => {
+    it('Confirms deletion, deletes repository, shows progress bar, and refreshes parent node', async function() {
         const window = new FakeWindow({ inputBox: { input: repositoryName } })
         const commands = new FakeCommands()
         const stub = sandbox.stub(ecr, 'deleteRepository').callsFake(async name => {
@@ -49,7 +49,7 @@ describe('deleteRepositoryCommand', () => {
         assert.deepStrictEqual(commands.args, [parentNode])
     })
 
-    it('Does nothing when deletion is cancelled', async () => {
+    it('Does nothing when deletion is cancelled', async function() {
         const spy = sandbox.spy(ecr, 'deleteRepository')
 
         await deleteRepository(node, new FakeWindow(), new FakeCommands())
@@ -57,7 +57,7 @@ describe('deleteRepositoryCommand', () => {
         assert.ok(spy.notCalled)
     })
 
-    it('shows an error message and refreshes node when repository deletion fails', async () => {
+    it('shows an error message and refreshes node when repository deletion fails', async function() {
         sandbox.stub(ecr, 'deleteRepository').callsFake(async () => {
             throw Error('Network busted')
         })
@@ -72,7 +72,7 @@ describe('deleteRepositoryCommand', () => {
         assert.deepStrictEqual(commands.args, [parentNode])
     })
 
-    it('Warns when confirmation is invalid', async () => {
+    it('Warns when confirmation is invalid', async function() {
         const window = new FakeWindow({ inputBox: { input: 'something other than the repo name' } })
         const commands = new FakeCommands()
 

--- a/src/test/ecr/commands/deleteTag.test.ts
+++ b/src/test/ecr/commands/deleteTag.test.ts
@@ -13,7 +13,7 @@ import { EcrClient, EcrRepository } from '../../../shared/clients/ecrClient'
 import { MockEcrClient } from '../../shared/clients/mockClients'
 import { deleteTag } from '../../../ecr/commands/deleteTag'
 
-describe('deleteTag', () => {
+describe('deleteTag', function() {
     const repositoryName = 'reponame'
     const tagName = 'tag'
     const parentNode = {} as EcrRepositoryNode
@@ -21,16 +21,16 @@ describe('deleteTag', () => {
     let node: EcrTagNode
     let sandbox: sinon.SinonSandbox
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
         node = new EcrTagNode(parentNode, ecr, { repositoryName: repositoryName } as EcrRepository, tagName)
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    it('confirms deletion, deletes file, shows status bar confirmation, and refreshes parent node', async () => {
+    it('confirms deletion, deletes file, shows status bar confirmation, and refreshes parent node', async function() {
         const window = new FakeWindow({ message: { warningSelection: 'Delete' } })
         const commands = new FakeCommands()
         const stub = sandbox.stub(ecr, 'deleteTag').callsFake(async (name, tag) => {
@@ -50,7 +50,7 @@ describe('deleteTag', () => {
         assert.deepStrictEqual(commands.args, [parentNode])
     })
 
-    it('does nothing when deletion is cancelled', async () => {
+    it('does nothing when deletion is cancelled', async function() {
         const window = new FakeWindow({ message: { warningSelection: 'Cancel' } })
         const commands = new FakeCommands()
         const spy = sandbox.spy(ecr, 'deleteTag')
@@ -64,7 +64,7 @@ describe('deleteTag', () => {
         assert.strictEqual(commands.command, undefined)
     })
 
-    it('shows an error message and refreshes node when file deletion fails', async () => {
+    it('shows an error message and refreshes node when file deletion fails', async function() {
         sandbox.stub(ecr, 'deleteTag').callsFake(async () => {
             throw new Error('network broke')
         })

--- a/src/test/ecr/explorer/EcrNode.test.ts
+++ b/src/test/ecr/explorer/EcrNode.test.ts
@@ -13,20 +13,20 @@ import { PlaceholderNode } from '../../../shared/treeview/nodes/placeholderNode'
 import { ErrorNode } from '../../../shared/treeview/nodes/errorNode'
 import { EcrTagNode } from '../../../ecr/explorer/ecrTagNode'
 
-describe('EcrNode', () => {
+describe('EcrNode', function() {
     let ecr: EcrClient
     let sandbox: sinon.SinonSandbox
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
         ecr = new MockEcrClient({})
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    it('Gets children and sorts them by repository name', async () => {
+    it('Gets children and sorts them by repository name', async function() {
         const firstRepo: EcrRepository = { repositoryName: 'name', repositoryArn: 'arn', repositoryUri: 'uri' }
         const secondRepo: EcrRepository = { repositoryName: 'uri', repositoryArn: 'arn', repositoryUri: 'uri' }
         sinon.stub(ecr, 'describeRepositories').callsFake(async function* () {
@@ -46,7 +46,7 @@ describe('EcrNode', () => {
         assert.strictEqual(otherNodes.length, 0)
     })
 
-    it('Shows empty node on no children', async () => {
+    it('Shows empty node on no children', async function() {
         const stub = sinon.stub(ecr, 'describeRepositories').callsFake(async function* () {})
 
         const [firstNode, ...otherNodes] = await new EcrNode(ecr).getChildren()
@@ -57,7 +57,7 @@ describe('EcrNode', () => {
         assert.ok(stub.calledOnce)
     })
 
-    it('Shows error node when getting children fails', async () => {
+    it('Shows error node when getting children fails', async function() {
         const stub = sinon.stub(ecr, 'describeRepositories').callsFake(async function* () {
             throw Error('network super busted')
             // at least one yield is required for async generator even if it is unreachable
@@ -73,21 +73,21 @@ describe('EcrNode', () => {
     })
 })
 
-describe('EcrRepositoryNode', () => {
+describe('EcrRepositoryNode', function() {
     const repository: EcrRepository = { repositoryName: 'name', repositoryUri: 'uri', repositoryArn: 'arn' }
     let ecr: EcrClient
     let sandbox: sinon.SinonSandbox
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
         ecr = new MockEcrClient({})
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    it('Gets children and sorts them by tag name', async () => {
+    it('Gets children and sorts them by tag name', async function() {
         sinon.stub(ecr, 'describeTags').callsFake(async function* () {
             yield 'ztag'
             yield 'atag'
@@ -111,7 +111,7 @@ describe('EcrRepositoryNode', () => {
         assert.strictEqual(otherNodes.length, 0)
     })
 
-    it('Shows empty node on no children', async () => {
+    it('Shows empty node on no children', async function() {
         const stub = sinon.stub(ecr, 'describeTags').callsFake(async function* () {})
 
         const [firstNode, ...otherNodes] = await new EcrRepositoryNode({} as EcrNode, ecr, repository).getChildren()
@@ -122,7 +122,7 @@ describe('EcrRepositoryNode', () => {
         assert.ok(stub.calledOnce)
     })
 
-    it('Shows error node when getting children fails', async () => {
+    it('Shows error node when getting children fails', async function() {
         const stub = sinon.stub(ecr, 'describeTags').callsFake(async function* () {
             throw Error('network super busted')
             // at least one yield is required for async generator even if it is unreachable

--- a/src/test/ecr/utils.test.ts
+++ b/src/test/ecr/utils.test.ts
@@ -6,13 +6,13 @@
 import * as assert from 'assert'
 import { validateRepositoryName } from '../../ecr/utils'
 
-describe('createRepositoryCommand', () => {
-    it('Validates repository name starts with a lowercase letter', () => {
+describe('createRepositoryCommand', function() {
+    it('Validates repository name starts with a lowercase letter', function() {
         const message = validateRepositoryName('404')
         assert.strictEqual(message, 'Repository name must start with a lowercase letter')
     })
 
-    it('Validates repository name does not contain uppercase characters', () => {
+    it('Validates repository name does not contain uppercase characters', function() {
         const message = validateRepositoryName('abcDEF')
         assert.strictEqual(
             message,
@@ -20,13 +20,13 @@ describe('createRepositoryCommand', () => {
         )
     })
 
-    it('Validates repository name against large regex the service uses', () => {
+    it('Validates repository name against large regex the service uses', function() {
         ;['abc--a', 'abc//a', 'abc__a', 'abc-', 'abc/', 'abc_'].forEach(item =>
             assert.strictEqual(validateRepositoryName(item), 'Invalid repository name')
         )
     })
 
-    it('Allows lowercase names with slashes, underscores, and dashes', () => {
+    it('Allows lowercase names with slashes, underscores, and dashes', function() {
         const message = validateRepositoryName('abc1/def2/hij3_klmno-p5')
         assert.strictEqual(message, undefined)
     })

--- a/src/test/eventSchemas/commands/downloadSchemaItemCode.test.ts
+++ b/src/test/eventSchemas/commands/downloadSchemaItemCode.test.ts
@@ -27,12 +27,12 @@ import { MockSchemaClient } from '../../shared/clients/mockClients'
 import admZip = require('adm-zip')
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 
-describe('CodeDownloader', () => {
+describe('CodeDownloader', function() {
     let tempFolder: string
     let sandbox: sinon.SinonSandbox
     let destinationDirectory: vscode.Uri
     let request: SchemaCodeDownloadRequestDetails
-    beforeEach(async () => {
+    beforeEach(async function() {
         tempFolder = await makeTemporaryToolkitFolder()
         sandbox = sinon.createSandbox()
         destinationDirectory = vscode.Uri.file(tempFolder)
@@ -47,7 +47,7 @@ describe('CodeDownloader', () => {
         }
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         sandbox.restore()
         await fs.remove(tempFolder)
     })
@@ -59,8 +59,8 @@ describe('CodeDownloader', () => {
     const schemaClient = new MockSchemaClient()
     const codeDownloader = new CodeDownloader(schemaClient)
 
-    describe('codeDownloader', async () => {
-        it('should return an error if the response body is not Buffer', async () => {
+    describe('codeDownloader', async function() {
+        it('should return an error if the response body is not Buffer', async function() {
             const erroMessage = 'Response body should be Buffer type'
             const response: Schemas.GetCodeBindingSourceResponse = {
                 Body: 'Invalied body',
@@ -72,7 +72,7 @@ describe('CodeDownloader', () => {
             assert.strictEqual(error.message, erroMessage, 'Should fail for same error')
         })
 
-        it('should return arrayBuffer for valid Body type', async () => {
+        it('should return arrayBuffer for valid Body type', async function() {
             const myBuffer = Buffer.from('TEST STRING')
             const response: Schemas.GetCodeBindingSourceResponse = {
                 Body: myBuffer,
@@ -104,12 +104,12 @@ describe('CodeDownloader', () => {
     })
 })
 
-describe('CodeGenerator', () => {
+describe('CodeGenerator', function() {
     let tempFolder: string
     let sandbox: sinon.SinonSandbox
     let destinationDirectory: vscode.Uri
     let request: SchemaCodeDownloadRequestDetails
-    beforeEach(async () => {
+    beforeEach(async function() {
         tempFolder = await makeTemporaryToolkitFolder()
         sandbox = sinon.createSandbox()
         destinationDirectory = vscode.Uri.file(tempFolder)
@@ -124,7 +124,7 @@ describe('CodeGenerator', () => {
         }
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         sandbox.restore()
         await fs.remove(tempFolder)
     })
@@ -143,8 +143,8 @@ describe('CodeGenerator', () => {
     const schemaClient = new MockSchemaClient()
     const codeGenerator = new CodeGenerator(schemaClient)
 
-    describe('codeGenerator', async () => {
-        it('should return the current status of code generation', async () => {
+    describe('codeGenerator', async function() {
+        it('should return the current status of code generation', async function() {
             const response: Schemas.PutCodeBindingResponse = {
                 Status: CodeGenerationStatus.CREATE_IN_PROGRESS,
             }
@@ -160,7 +160,7 @@ describe('CodeGenerator', () => {
 
         // If code bindings were not generated, but putCodeBinding was already called, ConflictException occurs
         // Return CREATE_IN_PROGRESS and keep polling in this case
-        it('should return valid code generation status if it gets ConflictException', async () => {
+        it('should return valid code generation status if it gets ConflictException', async function() {
             const response: Schemas.PutCodeBindingResponse = {
                 Status: CodeGenerationStatus.CREATE_IN_PROGRESS,
             }
@@ -177,12 +177,12 @@ describe('CodeGenerator', () => {
         })
     })
 })
-describe('CodeGeneratorStatusPoller', () => {
+describe('CodeGeneratorStatusPoller', function() {
     let tempFolder: string
     let sandbox: sinon.SinonSandbox
     let destinationDirectory: vscode.Uri
     let request: SchemaCodeDownloadRequestDetails
-    beforeEach(async () => {
+    beforeEach(async function() {
         tempFolder = await makeTemporaryToolkitFolder()
         sandbox = sinon.createSandbox()
         destinationDirectory = vscode.Uri.file(tempFolder)
@@ -197,7 +197,7 @@ describe('CodeGeneratorStatusPoller', () => {
         }
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         sandbox.restore()
         await fs.remove(tempFolder)
     })
@@ -219,8 +219,8 @@ describe('CodeGeneratorStatusPoller', () => {
     const schemaClient = new MockSchemaClient()
     const statuspoller = new CodeGenerationStatusPoller(schemaClient)
 
-    describe('getCurrentStatus', async () => {
-        it('should return the current status of code generation', async () => {
+    describe('getCurrentStatus', async function() {
+        it('should return the current status of code generation', async function() {
             const firstStatus: Schemas.DescribeCodeBindingResponse = {
                 Status: CodeGenerationStatus.CREATE_IN_PROGRESS,
             }
@@ -240,8 +240,8 @@ describe('CodeGeneratorStatusPoller', () => {
         })
     })
 
-    describe('codeGeneratorStatusPoller', async () => {
-        it('fails if code generation status is invalid without retry', async () => {
+    describe('codeGeneratorStatusPoller', async function() {
+        it('fails if code generation status is invalid without retry', async function() {
             const schemaResponse: Schemas.DescribeCodeBindingResponse = {
                 Status: CodeGenerationStatus.CREATE_FAILED,
             }
@@ -263,7 +263,7 @@ describe('CodeGeneratorStatusPoller', () => {
             )
         })
 
-        it('times out after max attempts if status is still in progress', async () => {
+        it('times out after max attempts if status is still in progress', async function() {
             const schemaResponse: Schemas.DescribeCodeBindingResponse = {
                 Status: CodeGenerationStatus.CREATE_IN_PROGRESS,
             }
@@ -288,7 +288,7 @@ describe('CodeGeneratorStatusPoller', () => {
             )
         })
 
-        it('succeeds when code is previously generated without retry', async () => {
+        it('succeeds when code is previously generated without retry', async function() {
             const schemaResponse: Schemas.DescribeCodeBindingResponse = {
                 Status: CodeGenerationStatus.CREATE_COMPLETE,
             }
@@ -306,7 +306,7 @@ describe('CodeGeneratorStatusPoller', () => {
             assert.strictEqual(status, schemaResponse.Status, 'status should match')
         })
 
-        it('succeeds once the code generation status is complete within maxRetry attempts', async () => {
+        it('succeeds once the code generation status is complete within maxRetry attempts', async function() {
             const statusPoll = sandbox.stub(statuspoller, 'getCurrentStatus')
             statusPoll.onCall(0).returns(Promise.resolve(CodeGenerationStatus.CREATE_IN_PROGRESS))
             statusPoll.onCall(1).returns(Promise.resolve(CodeGenerationStatus.CREATE_COMPLETE)) // After maxAttempts
@@ -322,7 +322,7 @@ describe('CodeGeneratorStatusPoller', () => {
     })
 })
 
-describe('SchemaCodeDownload', () => {
+describe('SchemaCodeDownload', function() {
     let tempFolder: string
     let sandbox: sinon.SinonSandbox
     let destinationDirectory: vscode.Uri
@@ -330,7 +330,7 @@ describe('SchemaCodeDownload', () => {
 
     let arrayBuffer: Buffer
     let fileName: string
-    beforeEach(async () => {
+    beforeEach(async function() {
         tempFolder = await makeTemporaryToolkitFolder()
         sandbox = sinon.createSandbox()
         destinationDirectory = vscode.Uri.file(tempFolder)
@@ -350,7 +350,7 @@ describe('SchemaCodeDownload', () => {
         arrayBuffer = zip.toBuffer()
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         sandbox.restore()
         await fs.remove(tempFolder)
     })
@@ -370,8 +370,8 @@ describe('SchemaCodeDownload', () => {
 
     const schemaCodeDownloader = new SchemaCodeDownloader(downloader, generator, poller, extractor)
 
-    describe('downloadCode', async () => {
-        it('should download pre-generated code and place it into requested directory ', async () => {
+    describe('downloadCode', async function() {
+        it('should download pre-generated code and place it into requested directory ', async function() {
             const codeDownloaderStub = sandbox.stub(downloader, 'download').returns(Promise.resolve(arrayBuffer))
 
             await schemaCodeDownloader.downloadCode(request)
@@ -387,7 +387,7 @@ describe('SchemaCodeDownload', () => {
             assert.strictEqual(response, fileContent, `${expectedFilePath} :file content do not match`)
         })
 
-        it('should return error if downloading code fails with anything other than ResourceNotFound', async () => {
+        it('should return error if downloading code fails with anything other than ResourceNotFound', async function() {
             const customError = new Error('Custom error')
             const codeDownloaderStub = sandbox.stub(downloader, 'download').returns(Promise.reject(customError))
 
@@ -399,7 +399,7 @@ describe('SchemaCodeDownload', () => {
             assert.strictEqual(customError, error, 'Should throw Custom error')
         })
 
-        it('should generate code if download fails with ResourceNotFound and place it into requested directory', async () => {
+        it('should generate code if download fails with ResourceNotFound and place it into requested directory', async function() {
             sandbox.stub(poller, 'pollForCompletion').returns(Promise.resolve('CREATE_COMPLETE'))
             const codeDownloaderStub = sandbox.stub(downloader, 'download')
             const codeGeneratorResponse: Schemas.PutCodeBindingResponse = {
@@ -425,7 +425,7 @@ describe('SchemaCodeDownload', () => {
             assert.strictEqual(response, fileContent, 'Extracted file content do not match with expected')
         })
 
-        it('should return coreCodeFilePath', async () => {
+        it('should return coreCodeFilePath', async function() {
             const expectedFilePath = path.join(request.destinationDirectory.fsPath, fileName)
             sandbox.stub(downloader, 'download').returns(Promise.resolve(arrayBuffer))
             sandbox.stub(extractor, 'extractAndPlace').returns(Promise.resolve(expectedFilePath))
@@ -440,16 +440,16 @@ describe('SchemaCodeDownload', () => {
     })
 })
 
-describe('CodeExtractor', () => {
+describe('CodeExtractor', function() {
     let destinationDirectory: string
     let sandbox: sinon.SinonSandbox
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         destinationDirectory = await makeTemporaryToolkitFolder()
         sandbox = sinon.createSandbox()
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         await fs.remove(destinationDirectory)
         sandbox.restore()
     })
@@ -457,8 +457,8 @@ describe('CodeExtractor', () => {
     const outputChannel = new MockOutputChannel()
     const codeExtractor = new CodeExtractor(outputChannel)
 
-    describe('checkFileCollisions', () => {
-        it('should return true when zipFile directoryFile contents clash ', async () => {
+    describe('checkFileCollisions', function() {
+        it('should return true when zipFile directoryFile contents clash ', async function() {
             const fileName = 'test.txt'
             const zipName = path.join(destinationDirectory, 'test.zip')
 
@@ -479,7 +479,7 @@ describe('CodeExtractor', () => {
             assert(outputChannel.value.includes(expectedMessage), `channel missing msg: ${expectedMessage}`)
         })
 
-        it('should return false if no collision present', async () => {
+        it('should return false if no collision present', async function() {
             const fileName1 = 'test.txt'
             const zipName = path.join(destinationDirectory, 'test.zip')
 
@@ -499,7 +499,7 @@ describe('CodeExtractor', () => {
             )
         })
     })
-    describe('extractAndPlace', () => {
+    describe('extractAndPlace', function() {
         const testSchemaName = 'aws.batch.testSchema'
         const testRegistryName = 'testRegistry'
         const language = 'Java8'
@@ -509,7 +509,7 @@ describe('CodeExtractor', () => {
         let destinationDirectoryUri: vscode.Uri
         let request: SchemaCodeDownloadRequestDetails
 
-        beforeEach(async () => {
+        beforeEach(async function() {
             sandbox = sinon.createSandbox()
             destinationDirectoryUri = vscode.Uri.file(destinationDirectory)
 
@@ -523,12 +523,12 @@ describe('CodeExtractor', () => {
             }
         })
 
-        afterEach(async () => {
+        afterEach(async function() {
             sandbox.restore()
             await fs.remove(destinationDirectory)
         })
 
-        it('should extract files if no collision present', async () => {
+        it('should extract files if no collision present', async function() {
             const fileName1 = 'test.text'
             const zipName1 = path.join(destinationDirectory, 'test.zip')
 
@@ -558,7 +558,7 @@ describe('CodeExtractor', () => {
             assert.strictEqual(file2Content, 'Second file content', `${file2Path} : file content do not match`)
         })
 
-        it('should not override file content if user picks No when collision occurs', async () => {
+        it('should not override file content if user picks No when collision occurs', async function() {
             sandbox.stub(codeExtractor, 'confirmOverwriteCollisions').returns(Promise.resolve(false))
 
             const fileName1 = 'test.txt'
@@ -583,7 +583,7 @@ describe('CodeExtractor', () => {
             assert.strictEqual(file1Content, expectedFileContent, `${file1Path} :File content should not be overriden`)
         })
 
-        it('should override file content if user picks Yes when collision occurs', async () => {
+        it('should override file content if user picks Yes when collision occurs', async function() {
             sandbox.stub(codeExtractor, 'confirmOverwriteCollisions').returns(Promise.resolve(true))
 
             const fileName1 = 'test.txt'
@@ -609,7 +609,7 @@ describe('CodeExtractor', () => {
             assert.strictEqual(file1Content, overridenFileContent, `${file1Path} :File content should be overriden`)
         })
 
-        it('should throw error if user picks Cancel when collision occurs', async () => {
+        it('should throw error if user picks Cancel when collision occurs', async function() {
             const error = new Error('Download code bindings cancelled')
             sandbox.stub(codeExtractor, 'confirmOverwriteCollisions').returns(Promise.reject(error))
 
@@ -636,7 +636,7 @@ describe('CodeExtractor', () => {
             assert.strictEqual(file1Content, expectedFileContent, `${file1Path} :File content should not be overriden`)
         })
 
-        it('should return coreCodeFilePath if it exists inside zip content', async () => {
+        it('should return coreCodeFilePath if it exists inside zip content', async function() {
             //grab the title from schemaName
             const title = testSchemaName.split('.').pop()
             const fileName = title!.concat('.java')
@@ -652,8 +652,8 @@ describe('CodeExtractor', () => {
         })
     })
 
-    describe('getCoreCodeFilePath', () => {
-        it('shoul return file path if it exists in zipFile', async () => {
+    describe('getCoreCodeFilePath', function() {
+        it('shoul return file path if it exists in zipFile', async function() {
             const coreFile = 'test.java'
             const zipName = path.join(destinationDirectory, 'test.zip')
             createZipFileInTempDirectory(coreFile, 'First file content', zipName)
@@ -663,7 +663,7 @@ describe('CodeExtractor', () => {
             assert.strictEqual(coreCodeFilePath, coreFile, 'Core file path should match')
         })
 
-        it('should return undefined if file does not exist in zipFile', async () => {
+        it('should return undefined if file does not exist in zipFile', async function() {
             const fileName = 'test.java'
             const zipName = path.join(destinationDirectory, 'test.zip')
             createZipFileInTempDirectory(fileName, 'First file content', zipName)

--- a/src/test/eventSchemas/commands/searchSchemas.test.ts
+++ b/src/test/eventSchemas/commands/searchSchemas.test.ts
@@ -26,13 +26,13 @@ import { asyncGenerator } from '../../utilities/collectionUtils'
 
 import * as vscode from 'vscode'
 
-describe('Search Schemas', () => {
+describe('Search Schemas', function() {
     let sandbox: sinon.SinonSandbox
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
@@ -67,8 +67,8 @@ describe('Search Schemas', () => {
         SchemaVersions: [versionSummary1],
     }
 
-    describe('getSearchListForSingleRegistry', () => {
-        it('should return summaries', async () => {
+    describe('getSearchListForSingleRegistry', function() {
+        it('should return summaries', async function() {
             const searchSummaryList = [searchSummary1, searchSummary2]
 
             sandbox
@@ -101,7 +101,7 @@ describe('Search Schemas', () => {
             assert.strictEqual(results[1].RegistryName, TEST_REGISTRY, 'summary should belong to requested registry')
         })
 
-        it('should display an error message when search api call fails', async () => {
+        it('should display an error message when search api call fails', async function() {
             const searchSummaryList = [searchSummary1, searchSummary2]
 
             const vscodeSpy = sandbox.spy(vscode.window, 'showErrorMessage')
@@ -121,8 +121,8 @@ describe('Search Schemas', () => {
         })
     })
 
-    describe('getSearchResults', () => {
-        it('should display error message for failed registries and return summaries for successful ones', async () => {
+    describe('getSearchResults', function() {
+        it('should display error message for failed registries and return summaries for successful ones', async function() {
             const vscodeSpy = sandbox.spy(vscode.window, 'showErrorMessage')
             const displayMessage = `Unable to search registry ${FAIL_REGISTRY}`
             const displayMessage2 = `Unable to search registry ${FAIL_REGISTRY2}`
@@ -174,9 +174,9 @@ describe('Search Schemas', () => {
         })
     })
 
-    describe('createMessageReceivedFunc', () => {
+    describe('createMessageReceivedFunc', function() {
         let postMessageSpy: sinon.SinonSpy<[any], Thenable<boolean>>
-        beforeEach(() => {
+        beforeEach(function() {
             postMessageSpy = sandbox.spy(onPostMessage)
         })
 
@@ -193,7 +193,7 @@ describe('Search Schemas', () => {
             Content: AWS_EVENT_SCHEMA_RAW,
         }
 
-        it('shows schema content for latest matching schema version by default', async () => {
+        it('shows schema content for latest matching schema version by default', async function() {
             const versionedSummary = {
                 RegistryName: TEST_REGISTRY,
                 Title: getPageHeader(singleRegistryName),
@@ -245,7 +245,7 @@ describe('Search Schemas', () => {
             )
         })
 
-        it('shows schema content for user selected version', async () => {
+        it('shows schema content for user selected version', async function() {
             const versionedSummary = {
                 RegistryName: TEST_REGISTRY,
                 Title: getPageHeader(multipleRegistryNames),
@@ -287,7 +287,7 @@ describe('Search Schemas', () => {
             )
         })
 
-        it('shows schema list when user makes a search', async () => {
+        it('shows schema list when user makes a search', async function() {
             const fakeMessage: CommandMessage = { command: 'searchSchemas', keyword: 'searchText' }
 
             const expectResults1 = {
@@ -331,7 +331,7 @@ describe('Search Schemas', () => {
             )
         })
 
-        it('throws an error for an invalid command message', async () => {
+        it('throws an error for an invalid command message', async function() {
             const fakeMessage: CommandMessage = { command: 'invalidCommand' }
             const errorMessage = `Search webview command ${fakeMessage.command} is invalid`
             const returnedFunc = createMessageReceivedFunc({
@@ -356,8 +356,8 @@ describe('Search Schemas', () => {
         }
     })
 
-    describe('getRegistryNameList', () => {
-        it('should return list with single registry name for registryItemNode', async () => {
+    describe('getRegistryNameList', function() {
+        it('should return list with single registry name for registryItemNode', async function() {
             const fakeRegistryNew = {
                 RegistryName: TEST_REGISTRY,
                 RegistryArn: 'arn:aws:schemas:us-west-2:19930409:registry/testRegistry',
@@ -369,7 +369,7 @@ describe('Search Schemas', () => {
             assert.deepStrictEqual(result, [TEST_REGISTRY], 'should have a single registry name in it')
         })
 
-        it('should return list with multiple registry names for schemasNode', async () => {
+        it('should return list with multiple registry names for schemasNode', async function() {
             const schemasNode = new SchemasNode(fakeRegion)
             const registrySummary1 = { RegistryArn: 'arn:aws:registry/' + TEST_REGISTRY, RegistryName: TEST_REGISTRY }
             const registrySummary2 = { RegistryArn: 'arn:aws:registry/' + TEST_REGISTRY2, RegistryName: TEST_REGISTRY2 }
@@ -380,7 +380,7 @@ describe('Search Schemas', () => {
             assert.deepStrictEqual(result, [TEST_REGISTRY, TEST_REGISTRY2], 'should have two registry names in it')
         })
 
-        it('should return an empty list and display error message if schemas service not available in the region', async () => {
+        it('should return an empty list and display error message if schemas service not available in the region', async function() {
             const vscodeSpy = sandbox.spy(vscode.window, 'showErrorMessage')
             const displayMessage = 'Error loading Schemas resources'
 

--- a/src/test/eventSchemas/commands/viewSchemaItem.test.ts
+++ b/src/test/eventSchemas/commands/viewSchemaItem.test.ts
@@ -54,25 +54,25 @@ const AWS_EVENT_SCHEMA_PRETTY = `{
   }
 }`
 
-describe('viewSchemaItem', async () => {
+describe('viewSchemaItem', async function() {
     let sandbox: sinon.SinonSandbox
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    describe('schemaFormatter', () => {
-        it('can pretty print schema content', () => {
+    describe('schemaFormatter', function() {
+        it('can pretty print schema content', function() {
             const formattedSchema = schemaFormatter(AWS_EVENT_SCHEMA_RAW, SCHEMA_TAB_SIZE)
             assert.strictEqual(formattedSchema, AWS_EVENT_SCHEMA_PRETTY, 'Schema content not pretty printed')
         })
     })
 
-    describe('showSchemaContent', async () => {
-        it('inserts pretty schema content into an editor', async () => {
+    describe('showSchemaContent', async function() {
+        it('inserts pretty schema content into an editor', async function() {
             const insertStub = stubTextEditInsert()
             await showSchemaContent(AWS_EVENT_SCHEMA_RAW, SCHEMA_TAB_SIZE)
 
@@ -88,7 +88,7 @@ describe('viewSchemaItem', async () => {
     }
     const expectedSchema = JSON.stringify(JSON.parse(AWS_EVENT_SCHEMA_RAW), undefined, getTabSizeSetting())
 
-    it('prettifies schema content and inserts into the editor ', async () => {
+    it('prettifies schema content and inserts into the editor ', async function() {
         const schemaNode = generateSchemaItemNode()
         const insertStub = stubTextEditInsert()
 

--- a/src/test/eventSchemas/explorer/registryItemNode.test.ts
+++ b/src/test/eventSchemas/explorer/registryItemNode.test.ts
@@ -19,11 +19,11 @@ import { MockSchemaClient, MockToolkitClientBuilder } from '../../shared/clients
 import { clearTestIconPaths, IconPath, setupTestIconPaths } from '../../shared/utilities/iconPathUtils'
 import { asyncGenerator } from '../../utilities/collectionUtils'
 
-describe('RegistryItemNode', () => {
+describe('RegistryItemNode', function() {
     const fakeRegion = 'testRegion'
     let fakeRegistry: Schemas.RegistrySummary
 
-    before(async () => {
+    before(async function() {
         setupTestIconPaths()
         fakeRegistry = {
             RegistryName: 'myRegistry',
@@ -31,7 +31,7 @@ describe('RegistryItemNode', () => {
         }
     })
 
-    after(async () => {
+    after(async function() {
         clearTestIconPaths()
     })
 
@@ -42,14 +42,14 @@ describe('RegistryItemNode', () => {
     }
 
     // Validates we tagged the node correctly.
-    it('initializes name and tooltip', async () => {
+    it('initializes name and tooltip', async function() {
         const testNode: RegistryItemNode = generateTestNode()
 
         assert.strictEqual(testNode.label, `${fakeRegistry.RegistryName}`)
         assert.strictEqual(testNode.tooltip, `${fakeRegistry.RegistryName}${os.EOL}${fakeRegistry.RegistryArn}`)
     })
 
-    it('initializes icon', async () => {
+    it('initializes icon', async function() {
         const testNode: RegistryItemNode = generateTestNode()
 
         const iconPath = testNode.iconPath as IconPath
@@ -58,7 +58,7 @@ describe('RegistryItemNode', () => {
         assert.strictEqual(iconPath.light.path, ext.iconPaths.light.registry, 'Unexpected light icon path')
     })
 
-    it('returns placeholder node if no children are present', async () => {
+    it('returns placeholder node if no children are present', async function() {
         const schemaClient = ({
             regionCode: 'code',
 
@@ -76,7 +76,7 @@ describe('RegistryItemNode', () => {
         assert.strictEqual(childNodes[0] instanceof PlaceholderNode, true)
     })
 
-    it('returns schemas that belong to Registry', async () => {
+    it('returns schemas that belong to Registry', async function() {
         class TestMockSchemaClient extends MockSchemaClient {
             public constructor(
                 public readonly schemaItemArray: Schemas.SchemaSummary[] = [],
@@ -135,7 +135,7 @@ describe('RegistryItemNode', () => {
     }
 })
 
-describe('DefaultRegistryNode', () => {
+describe('DefaultRegistryNode', function() {
     const fakeRegion: string = 'testRegion'
 
     class SchemaMockToolkitClientBuilder extends MockToolkitClientBuilder {
@@ -160,7 +160,7 @@ describe('DefaultRegistryNode', () => {
         }
     }
 
-    it('Sorts Registries', async () => {
+    it('Sorts Registries', async function() {
         const inputRegistryNames: string[] = ['zebra', 'Antelope', 'aardvark', 'elephant']
         const schemaClient = new RegistryNamesMockSchemaClient(inputRegistryNames)
         ext.toolkitClientBuilder = new SchemaMockToolkitClientBuilder(schemaClient)
@@ -192,7 +192,7 @@ describe('DefaultRegistryNode', () => {
         assertChildNodeRegistryName(children[3], 'zebra')
     })
 
-    it('returns placeholder node if no children are present', async () => {
+    it('returns placeholder node if no children are present', async function() {
         const inputRegistryNames: string[] = []
         const schemaClient = new RegistryNamesMockSchemaClient(inputRegistryNames)
         ext.toolkitClientBuilder = new SchemaMockToolkitClientBuilder(schemaClient)
@@ -203,7 +203,7 @@ describe('DefaultRegistryNode', () => {
         assertNodeListOnlyContainsPlaceholderNode(childNodes)
     })
 
-    it('handles error', async () => {
+    it('handles error', async function() {
         //typo in the name of the method
         class ThrowErrorDefaultSchemaRegistrynNode extends SchemasNode {
             public constructor() {

--- a/src/test/eventSchemas/explorer/schemaItemNode.test.ts
+++ b/src/test/eventSchemas/explorer/schemaItemNode.test.ts
@@ -16,11 +16,11 @@ import { MockSchemaClient, MockToolkitClientBuilder } from '../../shared/clients
 import { clearTestIconPaths, IconPath, setupTestIconPaths } from '../../shared/utilities/iconPathUtils'
 import { asyncGenerator } from '../../utilities/collectionUtils'
 
-describe('SchemaItemNode', () => {
+describe('SchemaItemNode', function() {
     let fakeSchemaItem: Schemas.SchemaSummary
     const fakeRegistryName = 'testRegistry'
 
-    before(async () => {
+    before(async function() {
         setupTestIconPaths()
         fakeSchemaItem = {
             SchemaName: 'testSchemaName',
@@ -28,19 +28,19 @@ describe('SchemaItemNode', () => {
         }
     })
 
-    after(async () => {
+    after(async function() {
         clearTestIconPaths()
     })
 
     // Validates we tagged the node correctly
-    it('initializes name and tooltip', async () => {
+    it('initializes name and tooltip', async function() {
         const testNode = generateTestNode()
 
         assert.strictEqual(testNode.label, fakeSchemaItem.SchemaName)
         assert.strictEqual(testNode.tooltip, `${fakeSchemaItem.SchemaName}${os.EOL}${fakeSchemaItem.SchemaArn}`)
     })
 
-    it('initializes icon', async () => {
+    it('initializes icon', async function() {
         const testNode = generateTestNode()
 
         const iconPath = testNode.iconPath as IconPath
@@ -51,14 +51,14 @@ describe('SchemaItemNode', () => {
 
     // Validates we don't yield some unexpected value that our command triggers
     // don't recognize
-    it('returns expected context value', async () => {
+    it('returns expected context value', async function() {
         const testNode = generateTestNode()
 
         assert.strictEqual(testNode.contextValue, 'awsSchemaItemNode')
     })
 
     // Validates schemaItem nodes are leaves
-    it('has no children', async () => {
+    it('has no children', async function() {
         const testNode = generateTestNode()
 
         const childNodes = await testNode.getChildren()
@@ -71,11 +71,11 @@ describe('SchemaItemNode', () => {
     }
 })
 
-describe('RegistryItemNode', () => {
+describe('RegistryItemNode', function() {
     const fakeRegion = 'testRegistry'
     let fakeRegistry: Schemas.RegistrySummary
 
-    before(async () => {
+    before(async function() {
         fakeRegistry = {
             RegistryName: 'testRegistry',
             RegistryArn: 'arn:aws:schemas:us-west-2:19930409:registry/testRegistry',
@@ -116,7 +116,7 @@ describe('RegistryItemNode', () => {
         }
     }
 
-    it('Sorts Schema Items By Name', async () => {
+    it('Sorts Schema Items By Name', async function() {
         const inputSchemaNames: string[] = ['zebra', 'Antelope', 'aardvark', 'elephant']
         const schemaClient = new SchemaNamesMockSchemaClient(inputSchemaNames)
         ext.toolkitClientBuilder = new TestMockToolkitClientBuilder(schemaClient)
@@ -152,7 +152,7 @@ describe('RegistryItemNode', () => {
         assertChildNodeSchemaName(children[3], 'zebra')
     })
 
-    it('handles error', async () => {
+    it('handles error', async function() {
         const testNode = new ThrowErrorRegistryItemNode(fakeRegion, fakeRegistry)
 
         const childNodes = await testNode.getChildren()

--- a/src/test/eventSchemas/explorer/schemasNode.test.ts
+++ b/src/test/eventSchemas/explorer/schemasNode.test.ts
@@ -20,14 +20,14 @@ const FAKE_REGION_CODE = 'someregioncode'
 const UNSORTED_TEXT = ['zebra', 'Antelope', 'aardvark', 'elephant']
 const SORTED_TEXT = ['aardvark', 'Antelope', 'elephant', 'zebra']
 
-describe('SchemasNode', () => {
+describe('SchemasNode', function() {
     let sandbox: sinon.SinonSandbox
     let testNode: SchemasNode
 
     // Mocked Lambda Client returns Lambda Functions for anything listed in lambdaFunctionNames
     let registryNames: string[]
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
 
         registryNames = ['registry1', 'registry2']
@@ -37,11 +37,11 @@ describe('SchemasNode', () => {
         testNode = new SchemasNode(FAKE_REGION_CODE)
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    it('returns placeholder node if no children are present', async () => {
+    it('returns placeholder node if no children are present', async function() {
         registryNames = []
 
         const childNodes = await testNode.getChildren()
@@ -49,7 +49,7 @@ describe('SchemasNode', () => {
         assertNodeListOnlyContainsPlaceholderNode(childNodes)
     })
 
-    it('has RegistryItemNode child nodes', async () => {
+    it('has RegistryItemNode child nodes', async function() {
         const childNodes = await testNode.getChildren()
 
         assert.strictEqual(childNodes.length, registryNames.length, 'Unexpected child count')
@@ -59,7 +59,7 @@ describe('SchemasNode', () => {
         )
     })
 
-    it('sorts child nodes', async () => {
+    it('sorts child nodes', async function() {
         registryNames = UNSORTED_TEXT
 
         const childNodes = await testNode.getChildren()
@@ -68,7 +68,7 @@ describe('SchemasNode', () => {
         assert.deepStrictEqual(actualChildOrder, SORTED_TEXT, 'Unexpected child sort order')
     })
 
-    it('has an error node for a child if an error happens during loading', async () => {
+    it('has an error node for a child if an error happens during loading', async function() {
         sandbox.stub(testNode, 'updateChildren').callsFake(() => {
             throw new Error('Update Children error!')
         })

--- a/src/test/eventSchemas/model/schemaCodeGenUtils.test.ts
+++ b/src/test/eventSchemas/model/schemaCodeGenUtils.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert'
 import { IdentifierFormatter, SchemaCodeGenUtils } from '../../../eventSchemas/models/schemaCodeGenUtils'
 
-describe('SchemaCodeGenUtils', async () => {
+describe('SchemaCodeGenUtils', async function() {
     const testScenarios = [
         {
             scenario: 'builds the "aws event" package name',
@@ -55,7 +55,7 @@ describe('SchemaCodeGenUtils', async () => {
         },
     ]
 
-    describe('buildSchemaPackageName', async () => {
+    describe('buildSchemaPackageName', async function() {
         testScenarios.forEach(test => {
             it(test.scenario, async () => {
                 const codeGen = new SchemaCodeGenUtils()
@@ -66,13 +66,13 @@ describe('SchemaCodeGenUtils', async () => {
     })
 })
 
-describe('IdentifierFormatter', async () => {
-    describe('toValidIdentifier', async () => {
-        it('replaces invalid identifier characters with underscore', async () => {
+describe('IdentifierFormatter', async function() {
+    describe('toValidIdentifier', async function() {
+        it('replaces invalid identifier characters with underscore', async function() {
             assert.strictEqual(IdentifierFormatter.toValidIdentifier('Review.created?today'), 'Review_created_today')
         })
 
-        it('replaces package seperator @ with dot', async () => {
+        it('replaces package seperator @ with dot', async function() {
             assert.strictEqual(IdentifierFormatter.toValidIdentifier('Review@created'), 'Review.created')
         })
     })

--- a/src/test/eventSchemas/model/schemaCodeLangs.test.ts
+++ b/src/test/eventSchemas/model/schemaCodeLangs.test.ts
@@ -12,8 +12,8 @@ import {
 import { samZipLambdaRuntimes } from '../../../lambda/models/samLambdaRuntime'
 import { assertThrowsError } from '../../../test/shared/utilities/assertUtils'
 
-describe('getLanguageDetails', () => {
-    it('should successfully return details for supported languages', () => {
+describe('getLanguageDetails', function() {
+    it('should successfully return details for supported languages', function() {
         for (const language of schemaCodeLangs.values()) {
             const result = getLanguageDetails(language)
             assert.ok(
@@ -24,8 +24,8 @@ describe('getLanguageDetails', () => {
     })
 })
 
-describe('getApiValueForSchemasDownload', () => {
-    it('should return api value for runtimes supported by eventBridge application', async () => {
+describe('getApiValueForSchemasDownload', function() {
+    it('should return api value for runtimes supported by eventBridge application', async function() {
         for (const runtime of samZipLambdaRuntimes.values()) {
             switch (runtime) {
                 case 'python3.6':

--- a/src/test/eventSchemas/providers/schemasDataProvider.test.ts
+++ b/src/test/eventSchemas/providers/schemasDataProvider.test.ts
@@ -13,12 +13,12 @@ import {
 import { MockSchemaClient } from '../../shared/clients/mockClients'
 import { asyncGenerator } from '../../utilities/collectionUtils'
 
-describe('schemasDataProvider', () => {
+describe('schemasDataProvider', function() {
     let sandbox: sinon.SinonSandbox
     let dataProviderObject: SchemasDataProvider
     let cacheData: Cache
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         sandbox = sinon.createSandbox()
         const regionDataWithCredentials: credentialsRegionDataListMap = {
             credentials: testCredentials,
@@ -36,7 +36,7 @@ describe('schemasDataProvider', () => {
         clientStubSchema.onCall(1).returns(asyncGenerator([schemaSummary]))
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
@@ -54,15 +54,15 @@ describe('schemasDataProvider', () => {
     const testCredentials = ({} as any) as AWS.Credentials
     const testCredentials2 = ({} as any) as AWS.Credentials
 
-    describe('getRegistries', () => {
-        it('should return registries for given region', async () => {
+    describe('getRegistries', function() {
+        it('should return registries for given region', async function() {
             const registryNames = await dataProviderObject.getRegistries(TEST_REGION, schemaClient, testCredentials)
             assert.ok(registryNames!.length === 2, 'unexpected number of registries returned')
             assert.strictEqual(registryNames![0], TEST_REGISTRY, 'TEST_REGISTRY name should match')
             assert.strictEqual(registryNames![1], TEST_REGISTRY2, 'TEST_REGISTRY2 name should match')
         })
 
-        it('should retain results when it is queried with same credentials ', async () => {
+        it('should retain results when it is queried with same credentials ', async function() {
             await dataProviderObject.getRegistries(TEST_REGION, schemaClient, testCredentials)
             await dataProviderObject.getRegistries(TEST_REGION2, schemaClient, testCredentials)
 
@@ -102,7 +102,7 @@ describe('schemasDataProvider', () => {
             )
         })
 
-        it('should retain results when it is queried with different credentials ', async () => {
+        it('should retain results when it is queried with different credentials ', async function() {
             await dataProviderObject.getRegistries(TEST_REGION, schemaClient, testCredentials)
             await dataProviderObject.getRegistries(TEST_REGION, schemaClient, testCredentials2)
 
@@ -128,7 +128,7 @@ describe('schemasDataProvider', () => {
             )
         })
 
-        it('should return undefined when error occurs', async () => {
+        it('should return undefined when error occurs', async function() {
             sandbox.restore()
             sandbox.stub(schemaClient, 'listRegistries').throws(new Error('Custom error'))
             const result = await dataProviderObject.getRegistries(TEST_REGION, schemaClient, testCredentials)
@@ -141,8 +141,8 @@ describe('schemasDataProvider', () => {
         })
     })
 
-    describe('getSchemas', () => {
-        it('should return schemas for given region', async () => {
+    describe('getSchemas', function() {
+        it('should return schemas for given region', async function() {
             const schemas = await dataProviderObject.getSchemas(
                 TEST_REGION,
                 TEST_REGISTRY,
@@ -155,7 +155,7 @@ describe('schemasDataProvider', () => {
             assert.strictEqual(schemas![1], schemaSummary2, 'schemaSummary2 should match')
         })
 
-        it('should retain results when it is queried with same credentials ', async () => {
+        it('should retain results when it is queried with same credentials ', async function() {
             await dataProviderObject.getSchemas(TEST_REGION, TEST_REGISTRY, schemaClient, testCredentials)
             await dataProviderObject.getSchemas(TEST_REGION, TEST_REGISTRY2, schemaClient, testCredentials)
 
@@ -192,7 +192,7 @@ describe('schemasDataProvider', () => {
             )
         })
 
-        it('should retain results when it is queried with different credentials ', async () => {
+        it('should retain results when it is queried with different credentials ', async function() {
             await dataProviderObject.getSchemas(TEST_REGION, TEST_REGISTRY, schemaClient, testCredentials)
             await dataProviderObject.getSchemas(TEST_REGION, TEST_REGISTRY, schemaClient, testCredentials2)
 
@@ -218,7 +218,7 @@ describe('schemasDataProvider', () => {
             )
         })
 
-        it('should return undefined when error occurs ', async () => {
+        it('should return undefined when error occurs ', async function() {
             sandbox.restore()
             sandbox.stub(schemaClient, 'listSchemas').throws(new Error('Custom error'))
             const result = await dataProviderObject.getSchemas(

--- a/src/test/eventSchemas/templates/schemasAppTemplateUtils.test.ts
+++ b/src/test/eventSchemas/templates/schemasAppTemplateUtils.test.ts
@@ -35,16 +35,16 @@ const CUSTOMER_UPLOADED_SCHEMA_MULTIPLE_TYPES_EXPECTED_PACKAGE_NAME =
 
 const schemaClient = new MockSchemaClient()
 
-describe('Build template parameters for AwsEventSchema', async () => {
+describe('Build template parameters for AwsEventSchema', async function() {
     let sandbox: sinon.SinonSandbox
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
-    it('should build correct template parameters for aws event schema', async () => {
+    it('should build correct template parameters for aws event schema', async function() {
         const schemaResponse: Schemas.DescribeSchemaResponse = {
             Content: AWS_EVENT_SCHEMA_CONTENT,
             SchemaVersion: SCHEMA_VERSION,
@@ -85,16 +85,16 @@ describe('Build template parameters for AwsEventSchema', async () => {
     })
 })
 
-describe('Build template parameters for PartnerSchema', async () => {
+describe('Build template parameters for PartnerSchema', async function() {
     let sandbox: sinon.SinonSandbox
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
-    it('should build correct template parameters for partner schema', async () => {
+    it('should build correct template parameters for partner schema', async function() {
         const schemaResponse: Schemas.DescribeSchemaResponse = {
             Content: PARTNER_SCHEMA_CONTENT,
             SchemaVersion: SCHEMA_VERSION,
@@ -135,17 +135,17 @@ describe('Build template parameters for PartnerSchema', async () => {
     })
 })
 
-describe('Build template parameters for CustomerUploadedSchema', async () => {
+describe('Build template parameters for CustomerUploadedSchema', async function() {
     let sandbox: sinon.SinonSandbox
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    it('should build correct template parameters for customer uploaded schema with single type', async () => {
+    it('should build correct template parameters for customer uploaded schema with single type', async function() {
         const schemaResponse: Schemas.DescribeSchemaResponse = {
             Content: CUSTOMER_UPLOADED_SCHEMA,
             SchemaVersion: SCHEMA_VERSION,
@@ -182,16 +182,16 @@ describe('Build template parameters for CustomerUploadedSchema', async () => {
     })
 })
 
-describe('Build template parameters for CustomerUploadedSchemaMultipleTypes', async () => {
+describe('Build template parameters for CustomerUploadedSchemaMultipleTypes', async function() {
     let sandbox: sinon.SinonSandbox
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
-    it('should  build correct template parameters for customer uploaded schema with multiple types', async () => {
+    it('should  build correct template parameters for customer uploaded schema with multiple types', async function() {
         const schemaResponse: Schemas.DescribeSchemaResponse = {
             Content: CUSTOMER_UPLOADED_SCHEMA_MULTIPLE_TYPES,
             SchemaVersion: SCHEMA_VERSION,

--- a/src/test/eventSchemas/wizards/schemaCodeDownloadWizard.test.ts
+++ b/src/test/eventSchemas/wizards/schemaCodeDownloadWizard.test.ts
@@ -132,9 +132,9 @@ class MockSchemaCodeDownloadWizardContext implements SchemaCodeDownloadWizardCon
     }
 }
 
-describe('SchemaCodeDownloadWizard', async () => {
-    describe('version', async () => {
-        it('uses user response as schemaVersion', async () => {
+describe('SchemaCodeDownloadWizard', async function() {
+    describe('version', async function() {
+        it('uses user response as schemaVersion', async function() {
             const context: SchemaCodeDownloadWizardContext = new MockSchemaCodeDownloadWizardContext(
                 [],
                 Set<SchemaCodeLangs>([JAVA]),
@@ -149,7 +149,7 @@ describe('SchemaCodeDownloadWizard', async () => {
             assert.strictEqual(args!.schemaVersion, 'schemaVersion3')
         })
 
-        it('exits when cancelled', async () => {
+        it('exits when cancelled', async function() {
             const context: SchemaCodeDownloadWizardContext = new MockSchemaCodeDownloadWizardContext(
                 [],
                 Set<SchemaCodeLangs>([JAVA]),
@@ -163,8 +163,8 @@ describe('SchemaCodeDownloadWizard', async () => {
         })
     })
 
-    describe('language', async () => {
-        it('uses user response as language', async () => {
+    describe('language', async function() {
+        it('uses user response as language', async function() {
             const context: SchemaCodeDownloadWizardContext = new MockSchemaCodeDownloadWizardContext(
                 [],
                 Set<SchemaCodeLangs>([JAVA]),
@@ -178,7 +178,7 @@ describe('SchemaCodeDownloadWizard', async () => {
             assert.strictEqual(args!.language, JAVA)
         })
 
-        it('backtracks when cancelled', async () => {
+        it('backtracks when cancelled', async function() {
             const context: SchemaCodeDownloadWizardContext = new MockSchemaCodeDownloadWizardContext(
                 [],
                 Set(),
@@ -192,8 +192,8 @@ describe('SchemaCodeDownloadWizard', async () => {
         })
     })
 
-    describe('location', async () => {
-        it('uses user response as location', async () => {
+    describe('location', async function() {
+        it('uses user response as location', async function() {
             const locationPath = path.join('my', 'quick', 'pick', 'result')
             const context: SchemaCodeDownloadWizardContext = new MockSchemaCodeDownloadWizardContext(
                 [],
@@ -208,7 +208,7 @@ describe('SchemaCodeDownloadWizard', async () => {
             assert.strictEqual(args!.location.fsPath, `${path.sep}${locationPath}`)
         })
 
-        it('backtracks when cancelled', async () => {
+        it('backtracks when cancelled', async function() {
             const locationPath = path.join('my', 'quick', 'pick', 'result')
             const context: SchemaCodeDownloadWizardContext = new MockSchemaCodeDownloadWizardContext(
                 [],
@@ -241,7 +241,7 @@ describe('SchemaCodeDownloadWizard', async () => {
             assert.strictEqual(args!.location.fsPath, `${path.sep}${locationPath}`)
         })
 
-        it('contains an option for each workspace folder', async () => {
+        it('contains an option for each workspace folder', async function() {
             const workspaceFolderPaths = [path.join('workspace', 'folder', '1'), path.join('workspace', 'folder', '2')]
 
             let index = 0

--- a/src/test/feedback/commands/submitFeedbackListener.test.ts
+++ b/src/test/feedback/commands/submitFeedbackListener.test.ts
@@ -11,18 +11,18 @@ const COMMENT = 'comment'
 const SENTIMENT = 'Positive'
 const message = { command: 'submitFeedback', comment: COMMENT, sentiment: SENTIMENT }
 
-describe('submitFeedbackListener', () => {
+describe('submitFeedbackListener', function() {
     let mockPanel: FeedbackPanel
     let mockWindow: Window
     let mockTelemetry: TelemetryService
 
-    beforeEach(() => {
+    beforeEach(function() {
         mockPanel = mock()
         mockWindow = mock()
         mockTelemetry = mock()
     })
 
-    it('submits feedback, disposes, and shows message on success', async () => {
+    it('submits feedback, disposes, and shows message on success', async function() {
         const listener = submitFeedbackListener(instance(mockPanel), instance(mockWindow), instance(mockTelemetry))
         await listener(message)
 
@@ -31,7 +31,7 @@ describe('submitFeedbackListener', () => {
         verify(mockWindow.showInformationMessage('Thanks for the feedback!')).once()
     })
 
-    it('submits feedback and posts failure message on failure', async () => {
+    it('submits feedback and posts failure message on failure', async function() {
         const error = 'Expected failure'
 
         when(mockTelemetry.postFeedback(anything())).thenThrow(new Error(error))

--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -27,7 +27,7 @@ const testLogOutput = join(testReportDir, 'testLog.log')
 // Expectation: Tests are not run concurrently
 let testLogger: TestLogger | undefined
 
-before(async () => {
+before(async function() {
     // Clean up and set up test logs
     try {
         await remove(testLogOutput)

--- a/src/test/lambda/commands/createNewSamApp.test.ts
+++ b/src/test/lambda/commands/createNewSamApp.test.ts
@@ -29,7 +29,7 @@ describe('addInitialLaunchConfiguration', function () {
     let fakeWorkspaceFolder: vscode.WorkspaceFolder
     let fakeContext: ExtContext
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         mockLaunchConfiguration = mock()
         fakeContext = await FakeExtensionContext.getFakeExtContext()
         tempFolder = await makeTemporaryToolkitFolder()
@@ -55,12 +55,12 @@ describe('addInitialLaunchConfiguration', function () {
         ])
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         await fs.remove(tempFolder)
         ext.templateRegistry.reset()
     })
 
-    it('produces and returns initial launch configurations', async () => {
+    it('produces and returns initial launch configurations', async function() {
         when(mockLaunchConfiguration.addDebugConfigurations(anything())).thenResolve()
 
         testutil.toFile(makeSampleSamTemplateYaml(true), tempTemplate.fsPath)
@@ -98,7 +98,7 @@ describe('addInitialLaunchConfiguration', function () {
         assert.strictEqual(matchingConfigs!.length, 1)
     })
 
-    it('produces and returns initial launch configurations with runtime', async () => {
+    it('produces and returns initial launch configurations with runtime', async function() {
         when(mockLaunchConfiguration.addDebugConfigurations(anything())).thenResolve()
 
         testutil.toFile(makeSampleSamTemplateYaml(true), tempTemplate.fsPath)
@@ -138,7 +138,7 @@ describe('addInitialLaunchConfiguration', function () {
         assert.strictEqual(matchingConfigs!.length, 1)
     })
 
-    it('returns a blank array if it does not match any launch configs', async () => {
+    it('returns a blank array if it does not match any launch configs', async function() {
         when(mockLaunchConfiguration.addDebugConfigurations(anything())).thenResolve()
 
         testutil.toFile(makeSampleSamTemplateYaml(true), tempTemplate.fsPath)

--- a/src/test/lambda/commands/deleteLambda.test.ts
+++ b/src/test/lambda/commands/deleteLambda.test.ts
@@ -8,8 +8,8 @@ import { deleteLambda } from '../../../lambda/commands/deleteLambda'
 import { MockOutputChannel } from '../../mockOutputChannel'
 import { MockLambdaClient } from '../../shared/clients/mockClients'
 
-describe('deleteLambda', async () => {
-    it('should do nothing if function name is not provided', async () => {
+describe('deleteLambda', async function() {
+    it('should do nothing if function name is not provided', async function() {
         await assertLambdaDeleteWorksWhen({
             // test variables
             functionName: '',
@@ -21,7 +21,7 @@ describe('deleteLambda', async () => {
         })
     })
 
-    it('should delete lambda when confirmed', async () => {
+    it('should delete lambda when confirmed', async function() {
         await assertLambdaDeleteWorksWhen({
             // test variables
             functionName: 'myFunctionName',
@@ -33,7 +33,7 @@ describe('deleteLambda', async () => {
         })
     })
 
-    it('should not delete lambda when cancelled', async () => {
+    it('should not delete lambda when cancelled', async function() {
         await assertLambdaDeleteWorksWhen({
             // test variables
             functionName: 'myFunctionName',
@@ -45,7 +45,7 @@ describe('deleteLambda', async () => {
         })
     })
 
-    it('should handles errors gracefully', async () => {
+    it('should handles errors gracefully', async function() {
         const errorToThrowDuringDelete = new SyntaxError('Fake error inserted to test error handling')
 
         await assertLambdaDeleteWorksWhen({

--- a/src/test/lambda/commands/deploySamApplication.test.ts
+++ b/src/test/lambda/commands/deploySamApplication.test.ts
@@ -24,7 +24,7 @@ import { ChildProcessResult } from '../../../shared/utilities/childProcess'
 import { assertLogsContain, getTestLogger } from '../../globalSetup.test'
 import { FakeChildProcessResult, TestSamCliProcessInvoker } from '../../shared/sam/cli/testSamCliProcessInvoker'
 
-describe('deploySamApplication', async () => {
+describe('deploySamApplication', async function() {
     // Bad Validator
 
     const badValidatorResult: SamCliValidatorResult = {
@@ -119,7 +119,7 @@ describe('deploySamApplication', async () => {
     }
 
     let tempToolkitFolder: string
-    beforeEach(async () => {
+    beforeEach(async function() {
         tempToolkitFolder = await makeTemporaryToolkitFolder()
         const templatePath = path.join(tempToolkitFolder, 'template.yaml')
         writeFile(templatePath)
@@ -141,11 +141,11 @@ describe('deploySamApplication', async () => {
         runningDeployProcess = undefined
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         await fs.remove(tempToolkitFolder)
     })
 
-    it('deploys with the happy path', async () => {
+    it('deploys with the happy path', async function() {
         await deploySamApplication(
             {
                 samCliContext: goodSamCliContext(),
@@ -161,7 +161,7 @@ describe('deploySamApplication', async () => {
         assert.strictEqual(invokerCalledCount, 3, 'Unexpected sam cli invoke count')
     })
 
-    it('informs user of error when user is not logged in', async () => {
+    it('informs user of error when user is not logged in', async function() {
         testCredentials = undefined
 
         await deploySamApplication(
@@ -178,7 +178,7 @@ describe('deploySamApplication', async () => {
         assertGeneralErrorLogged()
     })
 
-    it('informs user of error when sam cli is invalid', async () => {
+    it('informs user of error when sam cli is invalid', async function() {
         await deploySamApplication(
             {
                 samCliContext: invalidSamCliContext,
@@ -193,7 +193,7 @@ describe('deploySamApplication', async () => {
         assertGeneralErrorLogged()
     })
 
-    it('exits if the wizard is cancelled', async () => {
+    it('exits if the wizard is cancelled', async function() {
         samDeployWizardResponse = undefined
 
         await deploySamApplication(
@@ -210,7 +210,7 @@ describe('deploySamApplication', async () => {
         assert.strictEqual(invokerCalledCount, 0, 'Did not expect sam cli to get invoked')
     })
 
-    it('continues deploying with initial template if invoking sam build fails', async () => {
+    it('continues deploying with initial template if invoking sam build fails', async function() {
         goodSamCliProcessInvoker = new TestSamCliProcessInvoker(
             (spawnOptions, args: any[]): ChildProcessResult => {
                 invokerCalledCount++
@@ -240,7 +240,7 @@ describe('deploySamApplication', async () => {
         assertErrorLogsSwallowed('broken build', false)
     })
 
-    it('informs user of error if invoking sam package fails', async () => {
+    it('informs user of error if invoking sam package fails', async function() {
         goodSamCliProcessInvoker = new TestSamCliProcessInvoker(
             (spawnOptions, args: any[]): ChildProcessResult => {
                 invokerCalledCount++
@@ -271,7 +271,7 @@ describe('deploySamApplication', async () => {
         assertGeneralErrorLogged()
     })
 
-    it('informs user of error if invoking sam deploy fails', async () => {
+    it('informs user of error if invoking sam deploy fails', async function() {
         goodSamCliProcessInvoker = new TestSamCliProcessInvoker(
             (spawnOptions, args: any[]): ChildProcessResult => {
                 invokerCalledCount++

--- a/src/test/lambda/commands/importLambda.test.ts
+++ b/src/test/lambda/commands/importLambda.test.ts
@@ -6,9 +6,9 @@
 import { openLambdaFile } from '../../../lambda/commands/importLambda'
 import { assertThrowsError } from '../../shared/utilities/assertUtils'
 
-describe('importLambda', async () => {
-    describe('openLambdaFile', async () => {
-        it('throws if a file does not exist', async () => {
+describe('importLambda', async function() {
+    describe('openLambdaFile', async function() {
+        it('throws if a file does not exist', async function() {
             await assertThrowsError(async () => openLambdaFile('/asdfasdfasfdasdfasdf.js'))
         })
     })

--- a/src/test/lambda/config/samParameterCompletionItemProvider.test.ts
+++ b/src/test/lambda/config/samParameterCompletionItemProvider.test.ts
@@ -93,8 +93,8 @@ class MockSamParameterCompletionItemProviderContext implements SamParameterCompl
     }
 }
 
-describe('SamParameterCompletionItemProvider', async () => {
-    it('recovers gracefully if document is not in a workspace', async () => {
+describe('SamParameterCompletionItemProvider', async function() {
+    it('recovers gracefully if document is not in a workspace', async function() {
         const warnArgs: (Error | string)[][] = []
         const provider = new SamParameterCompletionItemProvider(
             new MockSamParameterCompletionItemProviderContext({
@@ -126,7 +126,7 @@ describe('SamParameterCompletionItemProvider', async () => {
         )
     })
 
-    it('does not provide suggestions if document symbols could not be loaded', async () => {
+    it('does not provide suggestions if document symbols could not be loaded', async function() {
         const provider = new SamParameterCompletionItemProvider(
             new MockSamParameterCompletionItemProviderContext({
                 executeCommand: async () => undefined,
@@ -148,7 +148,7 @@ describe('SamParameterCompletionItemProvider', async () => {
         assert.strictEqual(actualItems.length, 0)
     })
 
-    it('does not provide suggestions if no matching template is found', async () => {
+    it('does not provide suggestions if no matching template is found', async function() {
         const provider = new SamParameterCompletionItemProvider(
             new MockSamParameterCompletionItemProviderContext({
                 executeCommand: async <T>() => ([] as any) as T,
@@ -170,7 +170,7 @@ describe('SamParameterCompletionItemProvider', async () => {
         assert.strictEqual(actualItems.length, 0)
     })
 
-    it('suggests all parameter names if user has not started typing the parameter name', async () => {
+    it('suggests all parameter names if user has not started typing the parameter name', async function() {
         const templatesSymbol = createTemplatesSymbol({
             includeOverrides: true,
             parameterName: 'myParamName',
@@ -212,7 +212,7 @@ describe('SamParameterCompletionItemProvider', async () => {
         assert.strictEqual(actualItems[1].insertText, 'MyParamName2')
     })
 
-    it('suggests only matching parameter names if user has started typing the parameter name', async () => {
+    it('suggests only matching parameter names if user has started typing the parameter name', async function() {
         const templatesSymbol = createTemplatesSymbol({
             includeOverrides: true,
             parameterName: 'myParamName',
@@ -257,7 +257,7 @@ describe('SamParameterCompletionItemProvider', async () => {
         assert.strictEqual(actualItems[1].insertText, 'MyParamName2')
     })
 
-    it('recovers gracefully if templates.json is empty or invalid', async () => {
+    it('recovers gracefully if templates.json is empty or invalid', async function() {
         const provider = new SamParameterCompletionItemProvider(
             new MockSamParameterCompletionItemProviderContext({
                 executeCommand: async <T>() => undefined,
@@ -276,7 +276,7 @@ describe('SamParameterCompletionItemProvider', async () => {
         assert.strictEqual(actualItems.length, 0)
     })
 
-    it('recovers gracefully if cursor is not within the `templates` property', async () => {
+    it('recovers gracefully if cursor is not within the `templates` property', async function() {
         const templatesSymbol = createTemplatesSymbol({
             includeOverrides: true,
             parameterName: 'myParamName',
@@ -319,7 +319,7 @@ describe('SamParameterCompletionItemProvider', async () => {
         assert.strictEqual(actualItems.length, 0)
     })
 
-    it('recovers gracefully if `parameterOverrides` is not defined for this template', async () => {
+    it('recovers gracefully if `parameterOverrides` is not defined for this template', async function() {
         const templatesSymbol = createTemplatesSymbol({})
         const provider = new SamParameterCompletionItemProvider(
             new MockSamParameterCompletionItemProviderContext({
@@ -358,7 +358,7 @@ describe('SamParameterCompletionItemProvider', async () => {
         assert.strictEqual(actualItems.length, 0)
     })
 
-    it('recovers gracefully if cursor is not within the `parameterOverrides` property', async () => {
+    it('recovers gracefully if cursor is not within the `parameterOverrides` property', async function() {
         const templatesSymbol = createTemplatesSymbol({
             includeOverrides: true,
             parameterName: 'myParamName',
@@ -401,7 +401,7 @@ describe('SamParameterCompletionItemProvider', async () => {
         assert.strictEqual(actualItems.length, 0)
     })
 
-    it('recovers gracefully if cursor is not within a property name within `parameterOverrides`', async () => {
+    it('recovers gracefully if cursor is not within a property name within `parameterOverrides`', async function() {
         const templatesSymbol = createTemplatesSymbol({
             includeOverrides: true,
             parameterName: 'myParamName',

--- a/src/test/lambda/config/templates.test.ts
+++ b/src/test/lambda/config/templates.test.ts
@@ -34,9 +34,9 @@ class MockLoadTemplatesConfigContext {
     }
 }
 
-describe('templates', async () => {
-    describe('load', async () => {
-        it('loads a valid file without parameter overrides', async () => {
+describe('templates', async function() {
+    describe('load', async function() {
+        it('loads a valid file without parameter overrides', async function() {
             const rawJson = `{
                 "templates": {
                     "relative/path/to/template.yaml": {
@@ -59,7 +59,7 @@ describe('templates', async () => {
             assert.strictEqual(Object.getOwnPropertyNames(template).length, 0)
         })
 
-        it('loads a valid file with parameter overrides', async () => {
+        it('loads a valid file with parameter overrides', async function() {
             const rawJson = `{
                 "templates": {
                     "relative/path/to/template.yaml": {
@@ -97,7 +97,7 @@ describe('templates', async () => {
             assert.strictEqual(myParam2!.value, 'myValue2')
         })
 
-        it('returns minimal config on missing file', async () => {
+        it('returns minimal config on missing file', async function() {
             const context = new MockLoadTemplatesConfigContext({
                 fileExists: async pathLike => false,
             })
@@ -109,7 +109,7 @@ describe('templates', async () => {
             assert.strictEqual(Object.getOwnPropertyNames(config.templates).length, 0)
         })
 
-        it('throws on error loading file', async () => {
+        it('throws on error loading file', async function() {
             const context = new MockLoadTemplatesConfigContext({
                 readFile: async pathLike => {
                     throw new Error('oh no')
@@ -128,7 +128,7 @@ describe('templates', async () => {
             assert.fail()
         })
 
-        it('gracefully handles invalid JSON', async () => {
+        it('gracefully handles invalid JSON', async function() {
             const context = new MockLoadTemplatesConfigContext({
                 readFile: async pathLike => '{',
             })
@@ -148,7 +148,7 @@ describe('templates', async () => {
             assert.fail()
         })
 
-        it('supports JSON comments', async () => {
+        it('supports JSON comments', async function() {
             const rawJson = `{
                 "templates": {
                     // A single-comment.
@@ -175,7 +175,7 @@ describe('templates', async () => {
             assert.strictEqual(Object.getOwnPropertyNames(template).length, 0)
         })
 
-        it('reads the correct path', async () => {
+        it('reads the correct path', async function() {
             const readArgs: string[] = []
             const context = new MockLoadTemplatesConfigContext({
                 readFile: async pathLike => {
@@ -191,7 +191,7 @@ describe('templates', async () => {
             assert.strictEqual(readArgs[0], path.join('my', 'path', '.aws', 'templates.json'))
         })
 
-        it('saves dirty documents before loading', async () => {
+        it('saves dirty documents before loading', async function() {
             const saveArgs: string[] = []
             let read: boolean = false
             let readBeforeSave: boolean = false
@@ -220,15 +220,15 @@ describe('templates', async () => {
     })
 })
 
-describe('getTemplatesConfigPath', async () => {
-    it('returns expected path', async () => {
+describe('getTemplatesConfigPath', async function() {
+    it('returns expected path', async function() {
         const configPath = getTemplatesConfigPath(path.join('my', 'workspace'))
 
         assert.strictEqual(configPath, path.join('my', 'workspace', '.aws', 'templates.json'))
     })
 })
 
-describe('TemplatesConfigPopulator', async () => {
+describe('TemplatesConfigPopulator', async function() {
     const testModificationOptions = {
         formattingOptions: {
             tabSize: 4,
@@ -236,7 +236,7 @@ describe('TemplatesConfigPopulator', async () => {
         },
     }
 
-    it('handles ModificationOptions', async () => {
+    it('handles ModificationOptions', async function() {
         const inputJson: string = '{}'
 
         const expectedJson: string = String.raw`{
@@ -258,8 +258,8 @@ describe('TemplatesConfigPopulator', async () => {
         assert.strictEqual(JSON.stringify(results.json), JSON.stringify(expectedJson))
     })
 
-    describe('ensureTemplateSectionExists', async () => {
-        it('handles clean data', async () => {
+    describe('ensureTemplateSectionExists', async function() {
+        it('handles clean data', async function() {
             const inputJson: string = String.raw`{
     "templates": {
         "someprocessor": {}
@@ -274,7 +274,7 @@ describe('TemplatesConfigPopulator', async () => {
             assert.strictEqual(JSON.stringify(results.json), JSON.stringify(inputJson))
         })
 
-        it('handles missing templates section', async () => {
+        it('handles missing templates section', async function() {
             const inputJson: string = '{}'
 
             const expectedJson: string = String.raw`{
@@ -291,7 +291,7 @@ describe('TemplatesConfigPopulator', async () => {
             assert.strictEqual(JSON.stringify(results.json), JSON.stringify(expectedJson))
         })
 
-        it('handles missing template section', async () => {
+        it('handles missing template section', async function() {
             const inputJson: string = String.raw`{
     "templates": {}
 }`
@@ -310,7 +310,7 @@ describe('TemplatesConfigPopulator', async () => {
             assert.strictEqual(JSON.stringify(results.json), JSON.stringify(expectedJson))
         })
 
-        it('errs with invalid templates type', async () => {
+        it('errs with invalid templates type', async function() {
             const inputJson: string = `{
             "templates": 1234
         }`
@@ -330,8 +330,8 @@ describe('TemplatesConfigPopulator', async () => {
         })
     })
 
-    describe('ensureTemplateHandlerSectionExists', async () => {
-        it('handles clean data', async () => {
+    describe('ensureTemplateHandlerSectionExists', async function() {
+        it('handles clean data', async function() {
             const inputJson: string = String.raw`{
     "templates": {
         "someprocessor": {
@@ -353,7 +353,7 @@ describe('TemplatesConfigPopulator', async () => {
             assert.strictEqual(JSON.stringify(results.json), JSON.stringify(inputJson))
         })
 
-        it('errs with invalid template type', async () => {
+        it('errs with invalid template type', async function() {
             const inputJson: string = String.raw`{
             "templates": {
                 "someprocessor": true
@@ -375,7 +375,7 @@ describe('TemplatesConfigPopulator', async () => {
             )
         })
 
-        it('errs with invalid handlers type', async () => {
+        it('errs with invalid handlers type', async function() {
             const inputJson: string = String.raw`{
             "templates": {
                 "someprocessor": {
@@ -398,7 +398,7 @@ describe('TemplatesConfigPopulator', async () => {
             )
         })
 
-        it('errs with invalid handler type', async () => {
+        it('errs with invalid handler type', async function() {
             const inputJson: string = String.raw`{
             "templates": {
                 "someprocessor": {
@@ -423,7 +423,7 @@ describe('TemplatesConfigPopulator', async () => {
             )
         })
 
-        it('handles missing handlers section', async () => {
+        it('handles missing handlers section', async function() {
             const inputJson: string = String.raw`{
     "templates": {
         "someprocessor": {
@@ -452,7 +452,7 @@ describe('TemplatesConfigPopulator', async () => {
             assert.strictEqual(JSON.stringify(results.json), JSON.stringify(expectedJson))
         })
 
-        it('handles missing handler section', async () => {
+        it('handles missing handler section', async function() {
             const inputJson: string = String.raw`{
     "templates": {
         "someprocessor": {
@@ -483,8 +483,8 @@ describe('TemplatesConfigPopulator', async () => {
         })
     })
 
-    describe('ensureTemplateHandlerPropertiesExist', async () => {
-        it('handles clean data', async () => {
+    describe('ensureTemplateHandlerPropertiesExist', async function() {
+        it('handles clean data', async function() {
             const inputJson: string = `{
     "templates": {
         "someprocessor": {
@@ -506,7 +506,7 @@ describe('TemplatesConfigPopulator', async () => {
             assert.strictEqual(JSON.stringify(results.json), JSON.stringify(inputJson))
         })
 
-        it('errs with invalid handler type', async () => {
+        it('errs with invalid handler type', async function() {
             const inputJson: string = String.raw`{
             "templates": {
                 "someprocessor": {
@@ -531,7 +531,7 @@ describe('TemplatesConfigPopulator', async () => {
             )
         })
 
-        it('errs with invalid event type', async () => {
+        it('errs with invalid event type', async function() {
             const inputJson: string = String.raw`{
             "templates": {
                 "someprocessor": {
@@ -558,7 +558,7 @@ describe('TemplatesConfigPopulator', async () => {
             )
         })
 
-        it('handles missing everything', async () => {
+        it('handles missing everything', async function() {
             const inputJson: string = String.raw`{
     "templates": {
         "someprocessor": {
@@ -591,7 +591,7 @@ describe('TemplatesConfigPopulator', async () => {
             assert.strictEqual(JSON.stringify(results.json), JSON.stringify(expectedJson))
         })
 
-        it('handles missing event', async () => {
+        it('handles missing event', async function() {
             const inputJson: string = String.raw`{
     "templates": {
         "someprocessor": {
@@ -625,7 +625,7 @@ describe('TemplatesConfigPopulator', async () => {
             assert.strictEqual(JSON.stringify(results.json), JSON.stringify(expectedJson))
         })
 
-        it('handles missing envvars', async () => {
+        it('handles missing envvars', async function() {
             const inputJson: string = String.raw`{
     "templates": {
         "someprocessor": {
@@ -660,8 +660,8 @@ describe('TemplatesConfigPopulator', async () => {
         })
     })
 
-    describe('ensureTemplateParameterOverrideExists', async () => {
-        it('creates parameterOverrides section if it does not already exist', async () => {
+    describe('ensureTemplateParameterOverrideExists', async function() {
+        it('creates parameterOverrides section if it does not already exist', async function() {
             const inputJson: string = String.raw`{
     "templates": {
         "someprocessor": {
@@ -686,7 +686,7 @@ describe('TemplatesConfigPopulator', async () => {
             assert.strictEqual(isDirty, true, 'Expected results to be dirty')
         })
 
-        it('adds new override if it does not already exist', async () => {
+        it('adds new override if it does not already exist', async function() {
             const inputJson: string = String.raw`{
     "templates": {
         "someprocessor": {
@@ -713,7 +713,7 @@ describe('TemplatesConfigPopulator', async () => {
             assert.strictEqual(isDirty, true, 'Expected results to be dirty')
         })
 
-        it('does not overwrite existing overrides', async () => {
+        it('does not overwrite existing overrides', async function() {
             const inputJson: string = String.raw`{
     "templates": {
         "someprocessor": {
@@ -732,7 +732,7 @@ describe('TemplatesConfigPopulator', async () => {
             assert.strictEqual(isDirty, false, 'Expected results to be clean')
         })
 
-        it('throws if parameterOverrides exists, but is not an object or null', async () => {
+        it('throws if parameterOverrides exists, but is not an object or null', async function() {
             const inputJson: string = String.raw`{
     "templates": {
         "someprocessor": {
@@ -745,7 +745,7 @@ describe('TemplatesConfigPopulator', async () => {
             assert.throws(() => populator.ensureTemplateParameterOverrideExists('someprocessor', 'myParam'))
         })
 
-        it('throws if override value exists, but is not a string or null', async () => {
+        it('throws if override value exists, but is not a string or null', async function() {
             const inputJson: string = String.raw`{
     "templates": {
         "someprocessor": {
@@ -762,7 +762,7 @@ describe('TemplatesConfigPopulator', async () => {
     })
 })
 
-describe('getExistingConfiguration', async () => {
+describe('getExistingConfiguration', async function() {
     let tempFolder: string
     let tempTemplateFile: vscode.Uri
     let tempConfigFile: string
@@ -770,7 +770,7 @@ describe('getExistingConfiguration', async () => {
     let tempConfigFolder: string
     const matchedHandler = "it'sTheSameHandler"
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         tempFolder = await makeTemporaryToolkitFolder()
         tempTemplateFile = vscode.Uri.file(path.join(tempFolder, 'test.yaml'))
         fakeWorkspaceFolder = {
@@ -783,7 +783,7 @@ describe('getExistingConfiguration', async () => {
         tempConfigFile = path.join(tempConfigFolder, 'templates.json')
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         await remove(tempFolder)
         ext.templateRegistry.reset()
     })
@@ -793,7 +793,7 @@ describe('getExistingConfiguration', async () => {
         assert.strictEqual(val, undefined)
     })
 
-    it('returns undefined if the legacy config file is not valid JSON', async () => {
+    it('returns undefined if the legacy config file is not valid JSON', async function() {
         await writeFile(tempTemplateFile.fsPath, makeSampleSamTemplateYaml(true, { handler: matchedHandler }), 'utf8')
         await writeFile(tempConfigFile, makeSampleSamTemplateYaml(true, { handler: matchedHandler }), 'utf8')
         await ext.templateRegistry.addItemToRegistry(tempTemplateFile)
@@ -801,7 +801,7 @@ describe('getExistingConfiguration', async () => {
         assert.strictEqual(val, undefined)
     })
 
-    it('returns data from the legacy config file', async () => {
+    it('returns data from the legacy config file', async function() {
         await writeFile(tempTemplateFile.fsPath, makeSampleSamTemplateYaml(true, { handler: matchedHandler }), 'utf8')
         const configData = {
             templates: {

--- a/src/test/lambda/explorer/cloudFormationNodes.test.ts
+++ b/src/test/lambda/explorer/cloudFormationNodes.test.ts
@@ -28,7 +28,7 @@ const FAKE_REGION_CODE = 'someregioncode'
 const UNSORTED_TEXT = ['zebra', 'Antelope', 'aardvark', 'elephant']
 const SORTED_TEXT = ['aardvark', 'Antelope', 'elephant', 'zebra']
 
-describe('CloudFormationStackNode', () => {
+describe('CloudFormationStackNode', function() {
     let fakeStackSummary: CloudFormation.StackSummary
     let sandbox: sinon.SinonSandbox
     let testNode: CloudFormationStackNode
@@ -39,7 +39,7 @@ describe('CloudFormationStackNode', () => {
     // Mocked CloudFormation Client returns Lambda Function Stack Resources for anything listed in cloudFormationStacklambdaFunctionNames
     let cloudFormationStacklambdaFunctionNames: string[]
 
-    before(async () => {
+    before(async function() {
         setupTestIconPaths()
         fakeStackSummary = {
             CreationTime: new Date(),
@@ -49,7 +49,7 @@ describe('CloudFormationStackNode', () => {
         }
     })
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
 
         lambdaFunctionNames = ['function1', 'function2']
@@ -60,27 +60,27 @@ describe('CloudFormationStackNode', () => {
         testNode = generateTestNode()
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    after(async () => {
+    after(async function() {
         clearTestIconPaths()
     })
 
-    it('initializes name and tooltip', async () => {
+    it('initializes name and tooltip', async function() {
         assert.strictEqual(testNode.label, `${fakeStackSummary.StackName} [${fakeStackSummary.StackStatus}]`)
         assert.strictEqual(testNode.tooltip, `${fakeStackSummary.StackName}${os.EOL}${fakeStackSummary.StackId}`)
     })
 
-    it('initializes icon', async () => {
+    it('initializes icon', async function() {
         const iconPath = testNode.iconPath as IconPath
 
         assert.strictEqual(iconPath.dark.path, ext.iconPaths.dark.cloudFormation, 'Unexpected dark icon path')
         assert.strictEqual(iconPath.light.path, ext.iconPaths.light.cloudFormation, 'Unexpected light icon path')
     })
 
-    it('returns placeholder node if no children are present', async () => {
+    it('returns placeholder node if no children are present', async function() {
         lambdaFunctionNames = []
         cloudFormationStacklambdaFunctionNames = []
 
@@ -89,7 +89,7 @@ describe('CloudFormationStackNode', () => {
         assertNodeListOnlyContainsPlaceholderNode(childNodes)
     })
 
-    it('has LambdaFunctionNode child nodes', async () => {
+    it('has LambdaFunctionNode child nodes', async function() {
         const childNodes = await testNode.getChildren()
 
         assert.strictEqual(childNodes.length, cloudFormationStacklambdaFunctionNames.length, 'Unexpected child count')
@@ -99,7 +99,7 @@ describe('CloudFormationStackNode', () => {
         )
     })
 
-    it('has child nodes with CloudFormation contextValue', async () => {
+    it('has child nodes with CloudFormation contextValue', async function() {
         const childNodes = await testNode.getChildren()
 
         childNodes.forEach(node =>
@@ -111,7 +111,7 @@ describe('CloudFormationStackNode', () => {
         )
     })
 
-    it('only includes functions which are in a CloudFormation stack', async () => {
+    it('only includes functions which are in a CloudFormation stack', async function() {
         lambdaFunctionNames = ['lambda1', 'lambda2', 'lambda3']
         cloudFormationStacklambdaFunctionNames = ['lambda1', 'lambda3']
 
@@ -129,7 +129,7 @@ describe('CloudFormationStackNode', () => {
         )
     })
 
-    it('sorts child nodes', async () => {
+    it('sorts child nodes', async function() {
         lambdaFunctionNames = UNSORTED_TEXT
         cloudFormationStacklambdaFunctionNames = UNSORTED_TEXT
 
@@ -139,7 +139,7 @@ describe('CloudFormationStackNode', () => {
         assert.deepStrictEqual(actualChildOrder, SORTED_TEXT, 'Unexpected child sort order')
     })
 
-    it('has an error node for a child if an error happens during loading', async () => {
+    it('has an error node for a child if an error happens during loading', async function() {
         const lambdaClient = {
             listFunctions: sandbox.stub().callsFake(() => {
                 throw new Error('loading failure')
@@ -204,17 +204,17 @@ describe('CloudFormationStackNode', () => {
     }
 })
 
-describe('CloudFormationNode', () => {
+describe('CloudFormationNode', function() {
     let sandbox: sinon.SinonSandbox
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    it('has CloudFormationStackNode child nodes', async () => {
+    it('has CloudFormationStackNode child nodes', async function() {
         const inputStackNames: string[] = ['stack123']
 
         const cloudFormationClient = makeCloudFormationClient(inputStackNames)
@@ -234,7 +234,7 @@ describe('CloudFormationNode', () => {
         )
     })
 
-    it('has sorted child nodes', async () => {
+    it('has sorted child nodes', async function() {
         const inputStackNames = UNSORTED_TEXT
         const expectedChildOrder = SORTED_TEXT
 
@@ -255,7 +255,7 @@ describe('CloudFormationNode', () => {
         assert.deepStrictEqual(actualChildOrder, expectedChildOrder, 'Unexpected child sort order')
     })
 
-    it('returns placeholder node if no children are present', async () => {
+    it('returns placeholder node if no children are present', async function() {
         const cloudFormationClient = makeCloudFormationClient([])
 
         const clientBuilder = {
@@ -271,7 +271,7 @@ describe('CloudFormationNode', () => {
         assertNodeListOnlyContainsPlaceholderNode(children)
     })
 
-    it('has an error node for a child if an error happens during loading', async () => {
+    it('has an error node for a child if an error happens during loading', async function() {
         const testNode = new CloudFormationNode(FAKE_REGION_CODE)
         sandbox.stub(testNode, 'updateChildren').callsFake(() => {
             throw new Error('Update Children error!')

--- a/src/test/lambda/explorer/lambdaFunctionNode.test.ts
+++ b/src/test/lambda/explorer/lambdaFunctionNode.test.ts
@@ -11,12 +11,12 @@ import { ext } from '../../../shared/extensionGlobals'
 import { TestAWSTreeNode } from '../../shared/treeview/nodes/testAWSTreeNode'
 import { clearTestIconPaths, IconPath, setupTestIconPaths } from '../../shared/utilities/iconPathUtils'
 
-describe('LambdaFunctionNode', () => {
+describe('LambdaFunctionNode', function() {
     const parentNode = new TestAWSTreeNode('test node')
     let testNode: LambdaFunctionNode
     let fakeFunctionConfig: Lambda.FunctionConfiguration
 
-    before(async () => {
+    before(async function() {
         setupTestIconPaths()
         fakeFunctionConfig = {
             FunctionName: 'testFunctionName',
@@ -26,45 +26,45 @@ describe('LambdaFunctionNode', () => {
         testNode = new LambdaFunctionNode(parentNode, 'someregioncode', fakeFunctionConfig)
     })
 
-    after(async () => {
+    after(async function() {
         clearTestIconPaths()
     })
 
-    it('instantiates without issue', async () => {
+    it('instantiates without issue', async function() {
         assert.ok(testNode)
     })
 
-    it('initializes the parent node', async () => {
+    it('initializes the parent node', async function() {
         assert.strictEqual(testNode.parent, parentNode, 'unexpected parent node')
     })
 
-    it('initializes the region code', async () => {
+    it('initializes the region code', async function() {
         assert.strictEqual(testNode.regionCode, 'someregioncode')
     })
 
-    it('initializes the label', async () => {
+    it('initializes the label', async function() {
         assert.strictEqual(testNode.label, fakeFunctionConfig.FunctionName)
     })
 
-    it('initializes the functionName', async () => {
+    it('initializes the functionName', async function() {
         assert.strictEqual(testNode.functionName, fakeFunctionConfig.FunctionName)
     })
 
-    it('initializes the tooltip', async () => {
+    it('initializes the tooltip', async function() {
         assert.strictEqual(
             testNode.tooltip,
             `${fakeFunctionConfig.FunctionName}${os.EOL}${fakeFunctionConfig.FunctionArn}`
         )
     })
 
-    it('initializes the icon', async () => {
+    it('initializes the icon', async function() {
         const iconPath = testNode.iconPath as IconPath
 
         assert.strictEqual(iconPath.dark.path, ext.iconPaths.dark.lambda, 'Unexpected dark icon path')
         assert.strictEqual(iconPath.light.path, ext.iconPaths.light.lambda, 'Unexpected light icon path')
     })
 
-    it('has no children', async () => {
+    it('has no children', async function() {
         const childNodes = await testNode.getChildren()
         assert.ok(childNodes)
         assert.strictEqual(childNodes.length, 0, 'Expected node to have no children')

--- a/src/test/lambda/explorer/lambdaNodes.test.ts
+++ b/src/test/lambda/explorer/lambdaNodes.test.ts
@@ -20,14 +20,14 @@ const FAKE_REGION_CODE = 'someregioncode'
 const UNSORTED_TEXT = ['zebra', 'Antelope', 'aardvark', 'elephant']
 const SORTED_TEXT = ['aardvark', 'Antelope', 'elephant', 'zebra']
 
-describe('LambdaNode', () => {
+describe('LambdaNode', function() {
     let sandbox: sinon.SinonSandbox
     let testNode: LambdaNode
 
     // Mocked Lambda Client returns Lambda Functions for anything listed in lambdaFunctionNames
     let lambdaFunctionNames: string[]
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
 
         lambdaFunctionNames = ['function1', 'function2']
@@ -37,11 +37,11 @@ describe('LambdaNode', () => {
         testNode = new LambdaNode(FAKE_REGION_CODE)
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    it('returns placeholder node if no children are present', async () => {
+    it('returns placeholder node if no children are present', async function() {
         lambdaFunctionNames = []
 
         const childNodes = await testNode.getChildren()
@@ -49,7 +49,7 @@ describe('LambdaNode', () => {
         assertNodeListOnlyContainsPlaceholderNode(childNodes)
     })
 
-    it('has LambdaFunctionNode child nodes', async () => {
+    it('has LambdaFunctionNode child nodes', async function() {
         const childNodes = await testNode.getChildren()
 
         assert.strictEqual(childNodes.length, lambdaFunctionNames.length, 'Unexpected child count')
@@ -59,7 +59,7 @@ describe('LambdaNode', () => {
         )
     })
 
-    it('has child nodes with Lambda Function contextValue', async () => {
+    it('has child nodes with Lambda Function contextValue', async function() {
         const childNodes = await testNode.getChildren()
 
         childNodes.forEach(node =>
@@ -71,7 +71,7 @@ describe('LambdaNode', () => {
         )
     })
 
-    it('sorts child nodes', async () => {
+    it('sorts child nodes', async function() {
         lambdaFunctionNames = UNSORTED_TEXT
 
         const childNodes = await testNode.getChildren()
@@ -80,7 +80,7 @@ describe('LambdaNode', () => {
         assert.deepStrictEqual(actualChildOrder, SORTED_TEXT, 'Unexpected child sort order')
     })
 
-    it('has an error node for a child if an error happens during loading', async () => {
+    it('has an error node for a child if an error happens during loading', async function() {
         sandbox.stub(testNode, 'updateChildren').callsFake(() => {
             throw new Error('Update Children error!')
         })

--- a/src/test/lambda/local/debugConfiguration.test.ts
+++ b/src/test/lambda/local/debugConfiguration.test.ts
@@ -19,11 +19,11 @@ import { CloudFormationTemplateRegistry } from '../../../shared/cloudformation/t
 import { isImageLambdaConfig } from '../../../lambda/local/debugConfiguration'
 import { ext } from '../../../shared/extensionGlobals'
 
-describe('makeCoreCLRDebugConfiguration', async () => {
+describe('makeCoreCLRDebugConfiguration', async function() {
     let tempFolder: string
     let fakeWorkspaceFolder: vscode.WorkspaceFolder
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         tempFolder = await makeTemporaryToolkitFolder()
         fakeWorkspaceFolder = {
             uri: vscode.Uri.file(tempFolder),
@@ -32,7 +32,7 @@ describe('makeCoreCLRDebugConfiguration', async () => {
         }
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         await fs.remove(tempFolder)
     })
 
@@ -74,9 +74,9 @@ describe('makeCoreCLRDebugConfiguration', async () => {
         return makeCoreCLRDebugConfiguration(fakeLaunchConfig, codeUri)
     }
 
-    describe('windows', async () => {
+    describe('windows', async function() {
         if (os.platform() === 'win32') {
-            it('massages drive letters to uppercase', async () => {
+            it('massages drive letters to uppercase', async function() {
                 const config = await makeConfig({})
                 assert.strictEqual(
                     config.windows.pipeTransport.pipeCwd.substring(0, 1),
@@ -85,12 +85,12 @@ describe('makeCoreCLRDebugConfiguration', async () => {
             })
         }
 
-        it('uses powershell', async () => {
+        it('uses powershell', async function() {
             const config = await makeConfig({})
             assert.strictEqual(config.windows.pipeTransport.pipeProgram, 'powershell')
         })
 
-        it('uses the specified port', async () => {
+        it('uses the specified port', async function() {
             const config = await makeConfig({})
             assert.strictEqual(
                 config.windows.pipeTransport.pipeArgs.some(arg => arg.includes(config.debugPort!!.toString())),
@@ -98,14 +98,14 @@ describe('makeCoreCLRDebugConfiguration', async () => {
             )
         })
     })
-    describe('*nix', async () => {
-        it('uses the default shell', async () => {
+    describe('*nix', async function() {
+        it('uses the default shell', async function() {
             const config = await makeConfig({})
 
             assert.strictEqual(config.pipeTransport.pipeProgram, 'sh')
         })
 
-        it('uses the specified port', async () => {
+        it('uses the specified port', async function() {
             const config = await makeConfig({})
 
             assert.strictEqual(
@@ -116,14 +116,14 @@ describe('makeCoreCLRDebugConfiguration', async () => {
     })
 })
 
-describe('isImageLambdaConfig', async () => {
+describe('isImageLambdaConfig', async function() {
     let tempFolder: string
     let fakeWorkspaceFolder: vscode.WorkspaceFolder
 
     let registry: CloudFormationTemplateRegistry
     let appDir: string
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         tempFolder = await makeTemporaryToolkitFolder()
         fakeWorkspaceFolder = {
             uri: vscode.Uri.file(tempFolder),
@@ -134,7 +134,7 @@ describe('isImageLambdaConfig', async () => {
         appDir = pathutil.normalize(path.join(testutil.getProjectDir(), 'testFixtures/workspaceFolder/'))
     })
 
-    it('true for Image-backed template', async () => {
+    it('true for Image-backed template', async function() {
         const templatePath = vscode.Uri.file(path.join(appDir, 'python3.7-image-sam-app/template.yaml'))
         await registry.addItemToRegistry(templatePath)
 
@@ -163,7 +163,7 @@ describe('isImageLambdaConfig', async () => {
         assert.strictEqual(isImageLambdaConfig(input), true)
     })
 
-    it('false for ZIP-backed template', async () => {
+    it('false for ZIP-backed template', async function() {
         const templatePath = vscode.Uri.file(path.join(appDir, 'python3.7-plain-sam-app/template.yaml'))
         await registry.addItemToRegistry(templatePath)
 
@@ -192,7 +192,7 @@ describe('isImageLambdaConfig', async () => {
         assert.strictEqual(isImageLambdaConfig(input), false)
     })
 
-    it('false for code-type', async () => {
+    it('false for code-type', async function() {
         const input = {
             name: 'fake-launch-config',
             workspaceFolder: fakeWorkspaceFolder,

--- a/src/test/lambda/models/samLambdaRuntime.test.ts
+++ b/src/test/lambda/models/samLambdaRuntime.test.ts
@@ -13,7 +13,7 @@ import {
     RuntimeFamily,
 } from '../../../lambda/models/samLambdaRuntime'
 
-describe('compareSamLambdaRuntime', async () => {
+describe('compareSamLambdaRuntime', async function() {
     const scenarios: {
         lowerRuntime: Runtime
         higherRuntime: Runtime
@@ -36,8 +36,8 @@ describe('compareSamLambdaRuntime', async () => {
     })
 })
 
-describe('getDependencyManager', async () => {
-    it('all runtimes are handled', async () => {
+describe('getDependencyManager', async function() {
+    it('all runtimes are handled', async function() {
         samZipLambdaRuntimes.forEach(runtime => {
             // Checking that call does not throw
             getDependencyManager(runtime)
@@ -45,11 +45,11 @@ describe('getDependencyManager', async () => {
     })
 })
 
-describe('getFamily', async () => {
-    it('unknown runtime name', async () => {
+describe('getFamily', async function() {
+    it('unknown runtime name', async function() {
         assert.strictEqual(getFamily('foo'), RuntimeFamily.Unknown)
     })
-    it('handles all known runtimes', async () => {
+    it('handles all known runtimes', async function() {
         samZipLambdaRuntimes.forEach(runtime => {
             assert.notStrictEqual(getFamily(runtime), RuntimeFamily.Unknown)
         })

--- a/src/test/lambda/models/samTemplates.test.ts
+++ b/src/test/lambda/models/samTemplates.test.ts
@@ -30,8 +30,8 @@ const validTemplateOptions: Set<SamTemplate> = Set<SamTemplate>([
 
 const defaultTemplateOptions: Set<SamTemplate> = Set<SamTemplate>([helloWorldTemplate, stepFunctionsSampleApp])
 
-describe('getSamTemplateWizardOption', () => {
-    it('should successfully return available templates for specific runtime', () => {
+describe('getSamTemplateWizardOption', function() {
+    it('should successfully return available templates for specific runtime', function() {
         for (const runtime of samZipLambdaRuntimes.values()) {
             const result = getSamTemplateWizardOption(runtime, 'Zip', CLI_VERSION_STEP_FUNCTIONS_TEMPLATE)
             switch (runtime) {
@@ -55,7 +55,7 @@ describe('getSamTemplateWizardOption', () => {
         }
     })
 
-    it('should not return Step Functions templates for a SAM CLI version that does not support them', () => {
+    it('should not return Step Functions templates for a SAM CLI version that does not support them', function() {
         for (const runtime of samZipLambdaRuntimes.values()) {
             const result = getSamTemplateWizardOption(runtime, 'Zip', '0.40.0')
             assert(!result.contains(stepFunctionsSampleApp))
@@ -63,23 +63,23 @@ describe('getSamTemplateWizardOption', () => {
     })
 })
 
-describe('getSamCliTemplateParameter', () => {
-    it('should successfully return template values used by sam cli', () => {
+describe('getSamCliTemplateParameter', function() {
+    it('should successfully return template values used by sam cli', function() {
         for (const template of validTemplateOptions.values()) {
             const result = getSamCliTemplateParameter(template)
             assert.ok(result, `Template name on the wizard : ${template}, sam cli parameter value : ${result}`)
         }
     })
 
-    it('should return error if the template option is not valid', async () => {
+    it('should return error if the template option is not valid', async function() {
         const errorMessage = `${repromptUserForTemplate} is not valid sam template`
         const error = await assertThrowsError(async () => getSamCliTemplateParameter(repromptUserForTemplate))
         assert.strictEqual(error.message, errorMessage, 'Should fail for same error')
     })
 })
 
-describe('getTemplateDescription', async () => {
-    it('all templates are handled', async () => {
+describe('getTemplateDescription', async function() {
+    it('all templates are handled', async function() {
         validTemplateOptions.forEach(template => {
             // Checking that call does not throw
             getTemplateDescription(template)

--- a/src/test/lambda/utilities/parameterUtils.test.ts
+++ b/src/test/lambda/utilities/parameterUtils.test.ts
@@ -15,9 +15,9 @@ import {
 } from '../../../lambda/utilities/parameterUtils'
 import { getNormalizedRelativePath } from '../../../shared/utilities/pathUtils'
 
-describe('parameterUtils', async () => {
-    describe('getParameters', async () => {
-        it('returns an empty map if template has no parameters section', async () => {
+describe('parameterUtils', async function() {
+    describe('getParameters', async function() {
+        it('returns an empty map if template has no parameters section', async function() {
             const context: GetParametersContext = {
                 loadTemplate: async () => ({}),
             }
@@ -26,7 +26,7 @@ describe('parameterUtils', async () => {
             assert.strictEqual(actual.size, 0)
         })
 
-        it('returns an empty map if parameters section is empty', async () => {
+        it('returns an empty map if parameters section is empty', async function() {
             const context: GetParametersContext = {
                 loadTemplate: async () => ({
                     Parameters: {},
@@ -37,7 +37,7 @@ describe('parameterUtils', async () => {
             assert.strictEqual(actual.size, 0)
         })
 
-        it('sets `required` to true if default is undefined', async () => {
+        it('sets `required` to true if default is undefined', async function() {
             const context: GetParametersContext = {
                 loadTemplate: async () => ({
                     Parameters: {
@@ -56,7 +56,7 @@ describe('parameterUtils', async () => {
             assert.strictEqual(parameter!.required, true)
         })
 
-        it('sets `required` to false if default is defined, but falsy', async () => {
+        it('sets `required` to false if default is defined, but falsy', async function() {
             const context: GetParametersContext = {
                 loadTemplate: async () => ({
                     Parameters: {
@@ -76,7 +76,7 @@ describe('parameterUtils', async () => {
             assert.strictEqual(parameter!.required, false)
         })
 
-        it('sets `required` to false if default is defined and truthy', async () => {
+        it('sets `required` to false if default is defined and truthy', async function() {
             const context: GetParametersContext = {
                 loadTemplate: async () => ({
                     Parameters: {
@@ -97,8 +97,8 @@ describe('parameterUtils', async () => {
         })
     })
 
-    describe('getParameterNames', async () => {
-        it('returns an empty array if no parameters were found', async () => {
+    describe('getParameterNames', async function() {
+        it('returns an empty array if no parameters were found', async function() {
             const context: GetParametersContext = {
                 loadTemplate: async () => ({}),
             }
@@ -107,7 +107,7 @@ describe('parameterUtils', async () => {
             assert.strictEqual(actual.length, 0)
         })
 
-        it('returns the names of each parameter', async () => {
+        it('returns the names of each parameter', async function() {
             const context: GetParametersContext = {
                 loadTemplate: async () => ({
                     Parameters: {
@@ -128,12 +128,12 @@ describe('parameterUtils', async () => {
         })
     })
 
-    describe('getOverriddenParameters', async () => {
+    describe('getOverriddenParameters', async function() {
         const workspaceFolderUri = vscode.Uri.file(path.join('my', 'workspace', 'folder'))
         const templateUri = vscode.Uri.file(path.join(workspaceFolderUri.fsPath, 'some', 'template.yaml'))
         const templateId = getNormalizedRelativePath(workspaceFolderUri.fsPath, templateUri.fsPath)
 
-        it('throws if template is not in the workspace', async () => {
+        it('throws if template is not in the workspace', async function() {
             const context: GetOverriddenParametersContext = {
                 getWorkspaceFolder: uri => undefined,
                 loadTemplatesConfig: async () => ({
@@ -152,7 +152,7 @@ describe('parameterUtils', async () => {
             assert.fail('expected exception, but none occurred')
         })
 
-        it('returns undefined if no config is found for this template', async () => {
+        it('returns undefined if no config is found for this template', async function() {
             const context: GetOverriddenParametersContext = {
                 getWorkspaceFolder: () => ({
                     uri: workspaceFolderUri,
@@ -166,7 +166,7 @@ describe('parameterUtils', async () => {
             assert.strictEqual(actual, undefined)
         })
 
-        it('returns undefined if config for this template does not contain `parameterOverrides`', async () => {
+        it('returns undefined if config for this template does not contain `parameterOverrides`', async function() {
             const context: GetOverriddenParametersContext = {
                 getWorkspaceFolder: () => ({
                     uri: workspaceFolderUri,
@@ -182,7 +182,7 @@ describe('parameterUtils', async () => {
             assert.strictEqual(actual, undefined)
         })
 
-        it('returns an empty map if this template contains an empty `parameterOverrides`', async () => {
+        it('returns an empty map if this template contains an empty `parameterOverrides`', async function() {
             const context: GetOverriddenParametersContext = {
                 getWorkspaceFolder: () => ({
                     uri: vscode.Uri.file(workspaceFolderUri.fsPath),
@@ -201,7 +201,7 @@ describe('parameterUtils', async () => {
             assert.strictEqual(actual!.size, 0)
         })
 
-        it('returns a map of parameter names to their overridden values', async () => {
+        it('returns a map of parameter names to their overridden values', async function() {
             const context: GetOverriddenParametersContext = {
                 getWorkspaceFolder: () => ({
                     uri: workspaceFolderUri,

--- a/src/test/lambda/utils.test.ts
+++ b/src/test/lambda/utils.test.ts
@@ -7,9 +7,9 @@ import * as assert from 'assert'
 import { getLambdaDetails } from '../../lambda/utils'
 import { assertThrowsError } from '../shared/utilities/assertUtils'
 
-describe('lambda utils', async () => {
-    describe('getLambdaDetails', () => {
-        it('returns valid filenames and function names', () => {
+describe('lambda utils', async function() {
+    describe('getLambdaDetails', function() {
+        it('returns valid filenames and function names', function() {
             const jsNonNestedParsedName = getLambdaDetails({
                 Runtime: 'nodejs12.x',
                 Handler: 'app.lambda_handler',
@@ -36,7 +36,7 @@ describe('lambda utils', async () => {
             assert(PyNestedParsedName.functionName, 'lambda_handler')
         })
 
-        it('throws if the handler is not a supported runtime', async () => {
+        it('throws if the handler is not a supported runtime', async function() {
             // unsupported runtime for import
             await assertThrowsError(async () =>
                 getLambdaDetails({

--- a/src/test/lambda/wizards/samDeployWizard.test.ts
+++ b/src/test/lambda/wizards/samDeployWizard.test.ts
@@ -166,17 +166,17 @@ function normalizePath(...paths: string[]): string {
     return vscode.Uri.file(path.join(...paths)).fsPath
 }
 
-describe('SamDeployWizard', async () => {
+describe('SamDeployWizard', async function() {
     const extContext = await FakeExtensionContext.getFakeExtContext()
-    describe('TEMPLATE', async () => {
-        it('fails gracefully when no templates are found', async () => {
+    describe('TEMPLATE', async function() {
+        it('fails gracefully when no templates are found', async function() {
             const wizard = new SamDeployWizard(new MockSamDeployWizardContext(extContext, [[]], [undefined], [], []))
             const result = await wizard.run()
 
             assert.ok(!result)
         })
 
-        it('exits wizard when cancelled', async () => {
+        it('exits wizard when cancelled', async function() {
             const workspaceFolderPath = normalizePath('my', 'workspace', 'folder')
             const wizard = new SamDeployWizard(
                 new MockSamDeployWizardContext(
@@ -192,7 +192,7 @@ describe('SamDeployWizard', async () => {
             assert.ok(!result)
         })
 
-        it('uses user response as template', async () => {
+        it('uses user response as template', async function() {
             const workspaceFolderPath = normalizePath('my', 'workspace', 'folder')
             const templatePath = normalizePath(workspaceFolderPath, 'template.yaml')
             const wizard = new SamDeployWizard(
@@ -214,7 +214,7 @@ describe('SamDeployWizard', async () => {
         })
     })
 
-    describe('PARAMETER_OVERRIDES', async () => {
+    describe('PARAMETER_OVERRIDES', async function() {
         async function makeFakeContext({
             getParameters,
             getOverriddenParameters,
@@ -253,8 +253,8 @@ describe('SamDeployWizard', async () => {
             }
         }
 
-        describe('SAM template has no parameters', async () => {
-            it('skips configuring overrides and continues wizard', async () => {
+        describe('SAM template has no parameters', async function() {
+            it('skips configuring overrides and continues wizard', async function() {
                 const context = await makeFakeContext({
                     getParameters: async () => new Map<string, { required: boolean }>([]),
                     getOverriddenParameters: async () => {
@@ -273,8 +273,8 @@ describe('SamDeployWizard', async () => {
             })
         })
 
-        describe('SAM template has only optional parameters', async () => {
-            it('skips configuring overrides and continues wizard if parameterOverrides is defined', async () => {
+        describe('SAM template has only optional parameters', async function() {
+            it('skips configuring overrides and continues wizard if parameterOverrides is defined', async function() {
                 const context = await makeFakeContext({
                     getParameters: async () =>
                         new Map<string, { required: boolean }>([['myParam', { required: false }]]),
@@ -291,7 +291,7 @@ describe('SamDeployWizard', async () => {
                 assert.strictEqual(result!.parameterOverrides.size, 0)
             })
 
-            it('skips configuring overrides and continues wizard if parameterOverrides is undefined and user declines prompt', async () => {
+            it('skips configuring overrides and continues wizard if parameterOverrides is undefined and user declines prompt', async function() {
                 const context = await makeFakeContext({
                     getParameters: async () =>
                         new Map<string, { required: boolean }>([['myParam', { required: false }]]),
@@ -306,7 +306,7 @@ describe('SamDeployWizard', async () => {
                 assert.strictEqual(result!.parameterOverrides.size, 0)
             })
 
-            it('configures overrides and cancels wizard if parameterOverrides is undefined and user accepts prompt', async () => {
+            it('configures overrides and cancels wizard if parameterOverrides is undefined and user accepts prompt', async function() {
                 const configureParameterOverridesArgs: {
                     templateUri: vscode.Uri
                     missingParameters?: Set<string> | undefined
@@ -332,8 +332,8 @@ describe('SamDeployWizard', async () => {
             })
         })
 
-        describe('SAM template has required parameters', async () => {
-            it('configures overrides and cancels wizard if overrides are not defined', async () => {
+        describe('SAM template has required parameters', async function() {
+            it('configures overrides and cancels wizard if overrides are not defined', async function() {
                 const configureParameterOverridesArgs: {
                     templateUri: vscode.Uri
                     missingParameters?: Set<string> | undefined
@@ -359,7 +359,7 @@ describe('SamDeployWizard', async () => {
                 assert.strictEqual(configureParameterOverridesArgs[0].missingParameters!.has('myParam'), true)
             })
 
-            it('configures overrides and cancels wizard if there are missing overrides', async () => {
+            it('configures overrides and cancels wizard if there are missing overrides', async function() {
                 const configureParameterOverridesArgs: {
                     templateUri: vscode.Uri
                     missingParameters?: Set<string> | undefined
@@ -385,7 +385,7 @@ describe('SamDeployWizard', async () => {
                 assert.strictEqual(configureParameterOverridesArgs[0].missingParameters!.has('myParam'), true)
             })
 
-            it('stores existing overrides and continues without configuring overrides if there are no missing overrides', async () => {
+            it('stores existing overrides and continues without configuring overrides if there are no missing overrides', async function() {
                 const configureParameterOverridesArgs: {
                     templateUri: vscode.Uri
                     missingParameters?: Set<string> | undefined
@@ -414,8 +414,8 @@ describe('SamDeployWizard', async () => {
         })
     })
 
-    describe('REGION', async () => {
-        it('uses user response for region', async () => {
+    describe('REGION', async function() {
+        it('uses user response for region', async function() {
             const workspaceFolderPath = normalizePath('my', 'workspace', 'folder', '1')
             const templatePath = normalizePath(workspaceFolderPath, 'template.yaml')
             const region = 'us-east-1'
@@ -438,7 +438,7 @@ describe('SamDeployWizard', async () => {
             assert.strictEqual(result!.region, region)
         })
 
-        it('goes back when cancelled', async () => {
+        it('goes back when cancelled', async function() {
             const workspaceFolderPath1 = normalizePath('my', 'workspace', 'folder', '1')
             const workspaceFolderPath2 = normalizePath('my', 'workspace', 'folder', '2')
             const templatePath1 = normalizePath(workspaceFolderPath1, 'template.yaml')
@@ -470,8 +470,8 @@ describe('SamDeployWizard', async () => {
         })
     })
 
-    describe('S3_BUCKET', async () => {
-        it('goes back when cancelled', async () => {
+    describe('S3_BUCKET', async function() {
+        it('goes back when cancelled', async function() {
             const workspaceFolderPath1 = normalizePath('my', 'workspace', 'folder', '1')
             const workspaceFolderPath2 = normalizePath('my', 'workspace', 'folder', '2')
             const templatePath1 = normalizePath(workspaceFolderPath1, 'template.yaml')
@@ -504,7 +504,7 @@ describe('SamDeployWizard', async () => {
             assert.strictEqual(result!.region, region2)
         })
 
-        it('uses user response as s3Bucket', async () => {
+        it('uses user response as s3Bucket', async function() {
             const workspaceFolderPath = normalizePath('my', 'workspace', 'folder')
             const templatePath = normalizePath(workspaceFolderPath, 'template.yaml')
             const wizard = new SamDeployWizard(
@@ -526,8 +526,8 @@ describe('SamDeployWizard', async () => {
         })
     })
 
-    describe('ECR_REPO', async () => {
-        it('goes back when cancelled', async () => {
+    describe('ECR_REPO', async function() {
+        it('goes back when cancelled', async function() {
             const workspaceFolderPath = normalizePath('my', 'workspace', 'folder')
             const templatePath = normalizePath(workspaceFolderPath, 'template.yaml')
 
@@ -551,7 +551,7 @@ describe('SamDeployWizard', async () => {
             assert.strictEqual(result?.ecrRepo?.repositoryUri, 'uri')
         })
 
-        it('uses user response as repo', async () => {
+        it('uses user response as repo', async function() {
             const workspaceFolderPath = normalizePath('my', 'workspace', 'folder')
             const templatePath = normalizePath(workspaceFolderPath, 'template.yaml')
             const wizard = new SamDeployWizard(
@@ -574,8 +574,8 @@ describe('SamDeployWizard', async () => {
         })
     })
 
-    describe('STACK_NAME', async () => {
-        it('goes back when cancelled', async () => {
+    describe('STACK_NAME', async function() {
+        it('goes back when cancelled', async function() {
             const workspaceFolderPath = normalizePath('my', 'workspace', 'folder')
             const templatePath = normalizePath(workspaceFolderPath, 'template.yaml')
             const wizard = new SamDeployWizard(
@@ -596,7 +596,7 @@ describe('SamDeployWizard', async () => {
             assert.strictEqual(result!.s3Bucket, 'mys3bucketname2')
         })
 
-        it('uses user response as stackName', async () => {
+        it('uses user response as stackName', async function() {
             const workspaceFolderPath = normalizePath('my', 'workspace', 'folder')
             const templatePath = normalizePath(workspaceFolderPath, 'template.yaml')
             const wizard = new SamDeployWizard(
@@ -617,7 +617,7 @@ describe('SamDeployWizard', async () => {
             assert.strictEqual(result!.stackName, 'myStackName')
         })
 
-        describe('validation', async () => {
+        describe('validation', async function() {
             async function assertValidationFails(stackName: string | undefined): Promise<void> {
                 const workspaceFolderPath = normalizePath('my', 'workspace', 'folder')
                 const templatePath = normalizePath(workspaceFolderPath, 'template.yaml')
@@ -642,18 +642,18 @@ describe('SamDeployWizard', async () => {
                 assert.fail(`Expected validation for stack name '${stackName}' to fail, but it passed.`)
             }
 
-            it('validates that stackName does not contain invalid charcters', async () => {
+            it('validates that stackName does not contain invalid charcters', async function() {
                 await assertValidationFails('ab_c')
                 await assertValidationFails('ab$c')
                 await assertValidationFails('ab.c')
             })
 
-            it('validates that stackName begins with an alphabetic character', async () => {
+            it('validates that stackName begins with an alphabetic character', async function() {
                 await assertValidationFails('1abc')
                 await assertValidationFails('-abc')
             })
 
-            it('validates that stackName is not longer than 128 characters', async () => {
+            it('validates that stackName is not longer than 128 characters', async function() {
                 const parts = []
                 for (let i = 0; i < 129; i++) {
                     parts.push('a')
@@ -665,21 +665,21 @@ describe('SamDeployWizard', async () => {
     })
 })
 
-describe('DefaultSamDeployWizardContext', async () => {
+describe('DefaultSamDeployWizardContext', async function() {
     let context: DefaultSamDeployWizardContext
     let sandbox: sinon.SinonSandbox
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         sandbox = sinon.createSandbox()
         context = new DefaultSamDeployWizardContext(await FakeExtensionContext.getFakeExtContext())
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    describe('promptUserForS3Bucket', async () => {
-        it('returns an s3 bucket name', async () => {
+    describe('promptUserForS3Bucket', async function() {
+        it('returns an s3 bucket name', async function() {
             const bucketName = 'strictlyForBuckets'
             sandbox
                 .stub(picker, 'promptUser')
@@ -689,13 +689,13 @@ describe('DefaultSamDeployWizardContext', async () => {
             assert.strictEqual(output, bucketName)
         })
 
-        it('returns undefined on receiving undefined from the picker (back button)', async () => {
+        it('returns undefined on receiving undefined from the picker (back button)', async function() {
             sandbox.stub(picker, 'promptUser').onFirstCall().returns(Promise.resolve(undefined))
             const output = await context.promptUserForS3Bucket(1, 'us-weast-1')
             assert.strictEqual(output, undefined)
         })
 
-        it('returns undefined if the user selects a no items/error message', async () => {
+        it('returns undefined if the user selects a no items/error message', async function() {
             const messages = {
                 noBuckets: "NO! We're out of bear claws",
                 bucketError: 'One box of one dozen, starving, crazed weasels',
@@ -714,8 +714,8 @@ describe('DefaultSamDeployWizardContext', async () => {
         })
     })
 
-    describe('promptUserForEcrRepo', async () => {
-        it('returns an ECR Repo', async () => {
+    describe('promptUserForEcrRepo', async function() {
+        it('returns an ECR Repo', async function() {
             const repoName = 'repo'
             sandbox
                 .stub(picker, 'promptUser')
@@ -725,15 +725,15 @@ describe('DefaultSamDeployWizardContext', async () => {
             assert.notStrictEqual(output, { repositoryUri: 'uri' })
         })
 
-        it('returns undefined on receiving undefined from the picker (back button)', async () => {
+        it('returns undefined on receiving undefined from the picker (back button)', async function() {
             sandbox.stub(picker, 'promptUser').onFirstCall().returns(Promise.resolve(undefined))
             const output = await context.promptUserForEcrRepo(1, 'us-weast-1')
             assert.strictEqual(output, undefined)
         })
     })
 
-    describe('promptUserForNewS3Bucket', async () => {
-        it('returns an S3 bucket name', async () => {
+    describe('promptUserForNewS3Bucket', async function() {
+        it('returns an S3 bucket name', async function() {
             const bucketName = 'shinyNewBucket'
             sandbox
                 .stub(input, 'promptUser')
@@ -743,7 +743,7 @@ describe('DefaultSamDeployWizardContext', async () => {
             assert.strictEqual(output, bucketName) 
         })
 
-        it('retunrs undefined if nothing is entered', async () => {
+        it('retunrs undefined if nothing is entered', async function() {
             sandbox
             .stub(input, 'promptUser')
             .onFirstCall()

--- a/src/test/lambda/wizards/samInitWizard.test.ts
+++ b/src/test/lambda/wizards/samInitWizard.test.ts
@@ -205,18 +205,18 @@ class MockCreateNewSamAppWizardContext implements CreateNewSamAppWizardContext {
     }
 }
 
-describe('CreateNewSamAppWizard', async () => {
+describe('CreateNewSamAppWizard', async function() {
     let dir: string
     let dir2: string
-    before(async () => {
+    before(async function() {
         dir = await makeTemporaryToolkitFolder()
         dir2 = await makeTemporaryToolkitFolder()
     })
-    after(async () => {
+    after(async function() {
         fs.rmdirSync(dir)
     })
-    describe('runtime', async () => {
-        it('uses user response as runtime', async () => {
+    describe('runtime', async function() {
+        it('uses user response as runtime', async function() {
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
                 Set<Runtime>(['nodejs10.x']),
@@ -234,7 +234,7 @@ describe('CreateNewSamAppWizard', async () => {
             assert.strictEqual(args!.runtime, 'nodejs10.x')
         })
 
-        it('exits when cancelled', async () => {
+        it('exits when cancelled', async function() {
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
                 Set<Runtime>(),
@@ -252,8 +252,8 @@ describe('CreateNewSamAppWizard', async () => {
         })
     })
 
-    describe('template', async () => {
-        it('uses user response as template', async () => {
+    describe('template', async function() {
+        it('uses user response as template', async function() {
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
                 Set<Runtime>(['nodejs10.x']),
@@ -271,7 +271,7 @@ describe('CreateNewSamAppWizard', async () => {
             assert.strictEqual(args!.template, helloWorldTemplate)
         })
 
-        it('backtracks when cancelled', async () => {
+        it('backtracks when cancelled', async function() {
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
                 [Set<Runtime>(['python3.6']), Set<Runtime>(['nodejs10.x'])],
@@ -290,19 +290,19 @@ describe('CreateNewSamAppWizard', async () => {
             assert.strictEqual(args!.template, helloWorldTemplate)
         })
 
-        describe('eventBridge-schema-app template', async () => {
+        describe('eventBridge-schema-app template', async function() {
             let locationPath: string
-            before(async () => {
+            before(async function() {
                 locationPath = await makeTemporaryToolkitFolder()
             })
-            after(async () => {
+            after(async function() {
                 fs.rmdirSync(locationPath)
             })
             let context: CreateNewSamAppWizardContext
             let wizard: CreateNewSamAppWizard
             let args: CreateNewSamAppWizardResponse | undefined
 
-            beforeEach(async () => {
+            beforeEach(async function() {
                 context = new MockCreateNewSamAppWizardContext(
                     [],
                     Set<Runtime>(['nodejs10.x']),
@@ -317,13 +317,13 @@ describe('CreateNewSamAppWizard', async () => {
                 args = await wizard.run()
             })
 
-            describe('region', async () => {
-                it('uses user response as region', async () => {
+            describe('region', async function() {
+                it('uses user response as region', async function() {
                     assert.ok(args)
                     assert.strictEqual(args!.region, 'us-west-2')
                 })
 
-                it('backtracks when cancelled', async () => {
+                it('backtracks when cancelled', async function() {
                     context = new MockCreateNewSamAppWizardContext(
                         [],
                         [Set<Runtime>(['python3.6']), Set<Runtime>(['nodejs10.x'])],
@@ -343,13 +343,13 @@ describe('CreateNewSamAppWizard', async () => {
                 })
             })
 
-            describe('registry', async () => {
-                it('uses user response as registry', async () => {
+            describe('registry', async function() {
+                it('uses user response as registry', async function() {
                     assert.ok(args)
                     assert.strictEqual(args!.registryName, 'aws.events')
                 })
 
-                it('backtracks when cancelled', async () => {
+                it('backtracks when cancelled', async function() {
                     context = new MockCreateNewSamAppWizardContext(
                         [],
                         [Set<Runtime>(['python3.6']), Set<Runtime>(['nodejs10.x'])],
@@ -369,13 +369,13 @@ describe('CreateNewSamAppWizard', async () => {
                 })
             })
 
-            describe('schema', async () => {
-                it('uses user response as schema', async () => {
+            describe('schema', async function() {
+                it('uses user response as schema', async function() {
                     assert.ok(args)
                     assert.strictEqual(args!.schemaName, 'AWSAPICallViaCloudTrail')
                 })
 
-                it('backtracks when cancelled', async () => {
+                it('backtracks when cancelled', async function() {
                     context = new MockCreateNewSamAppWizardContext(
                         [],
                         [Set<Runtime>(['python3.6']), Set<Runtime>(['nodejs10.x'])],
@@ -395,13 +395,13 @@ describe('CreateNewSamAppWizard', async () => {
                 })
             })
 
-            describe('location', async () => {
-                it('uses user response as schema', async () => {
+            describe('location', async function() {
+                it('uses user response as schema', async function() {
                     assert.ok(args)
                     assertEqualPaths(args!.location.fsPath, locationPath)
                 })
 
-                it('backtracks when cancelled', async () => {
+                it('backtracks when cancelled', async function() {
                     context = new MockCreateNewSamAppWizardContext(
                         [],
                         [Set<Runtime>(['python3.6']), Set<Runtime>(['nodejs10.x'])],
@@ -423,8 +423,8 @@ describe('CreateNewSamAppWizard', async () => {
         })
     })
 
-    describe('location', async () => {
-        it('uses user response as location', async () => {
+    describe('location', async function() {
+        it('uses user response as location', async function() {
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
                 Set<Runtime>(['nodejs10.x']),
@@ -442,7 +442,7 @@ describe('CreateNewSamAppWizard', async () => {
             assertEqualPaths(args!.location.fsPath, dir)
         })
 
-        it('backtracks when cancelled', async () => {
+        it('backtracks when cancelled', async function() {
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
                 [Set<Runtime>(['python3.6']), Set<Runtime>(['nodejs10.x'])],
@@ -480,7 +480,7 @@ describe('CreateNewSamAppWizard', async () => {
             assertEqualPaths(args!.location.fsPath, dir)
         })
 
-        it('contains an option for each workspace folder', async () => {
+        it('contains an option for each workspace folder', async function() {
             const workspaceFolderPaths = [dir, dir2]
 
             let index = 0
@@ -506,8 +506,8 @@ describe('CreateNewSamAppWizard', async () => {
         })
     })
 
-    describe('name', async () => {
-        it('uses user response as name', async () => {
+    describe('name', async function() {
+        it('uses user response as name', async function() {
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
                 Set<Runtime>(['nodejs10.x']),
@@ -525,7 +525,7 @@ describe('CreateNewSamAppWizard', async () => {
             assert.strictEqual(args!.name, 'myName')
         })
 
-        it('backtracks when cancelled', async () => {
+        it('backtracks when cancelled', async function() {
             const context: CreateNewSamAppWizardContext = new MockCreateNewSamAppWizardContext(
                 [],
                 Set<Runtime>(['nodejs10.x']),

--- a/src/test/s3/commands/copyPath.test.ts
+++ b/src/test/s3/commands/copyPath.test.ts
@@ -10,8 +10,8 @@ import { S3Client } from '../../../shared/clients/s3Client'
 import { FakeEnv } from '../../shared/vscode/fakeEnv'
 import { FakeWindow } from '../../shared/vscode/fakeWindow'
 
-describe('copyPathCommand', () => {
-    it('copies path to clipboard and shows status bar confirmation', async () => {
+describe('copyPathCommand', function() {
+    it('copies path to clipboard and shows status bar confirmation', async function() {
         const node = createS3FolderNode()
 
         const window = new FakeWindow()

--- a/src/test/s3/commands/createBucket.test.ts
+++ b/src/test/s3/commands/createBucket.test.ts
@@ -11,17 +11,17 @@ import { FakeCommands } from '../../shared/vscode/fakeCommands'
 import { FakeWindow } from '../../shared/vscode/fakeWindow'
 import { anything, mock, instance, when, deepEqual, verify } from '../../utilities/mockito'
 
-describe('createBucketCommand', () => {
+describe('createBucketCommand', function() {
     const bucketName = 'buc.ket-n4.m3'
     let s3: S3Client
     let node: S3Node
 
-    beforeEach(() => {
+    beforeEach(function() {
         s3 = mock()
         node = new S3Node(instance(s3))
     })
 
-    it('prompts for bucket name, creates bucket, shows success, and refreshes node', async () => {
+    it('prompts for bucket name, creates bucket, shows success, and refreshes node', async function() {
         when(s3.createBucket(deepEqual({ bucketName }))).thenResolve({
             bucket: { name: bucketName, region: 'region', arn: 'arn' },
         })
@@ -39,13 +39,13 @@ describe('createBucketCommand', () => {
         assert.deepStrictEqual(commands.args, [node])
     })
 
-    it('does nothing when prompt is cancelled', async () => {
+    it('does nothing when prompt is cancelled', async function() {
         await createBucketCommand(node, new FakeWindow(), new FakeCommands())
 
         verify(s3.createFolder(anything())).never()
     })
 
-    it('shows an error message and refreshes node when bucket creation fails', async () => {
+    it('shows an error message and refreshes node when bucket creation fails', async function() {
         when(s3.createBucket(anything())).thenReject(new Error('Expected failure'))
 
         const window = new FakeWindow({ inputBox: { input: bucketName } })
@@ -58,7 +58,7 @@ describe('createBucketCommand', () => {
         assert.deepStrictEqual(commands.args, [node])
     })
 
-    it('warns when bucket name is invalid', async () => {
+    it('warns when bucket name is invalid', async function() {
         const window = new FakeWindow({ inputBox: { input: 'gg' } })
         const commands = new FakeCommands()
         await createBucketCommand(node, window, commands)

--- a/src/test/s3/commands/createFolder.test.ts
+++ b/src/test/s3/commands/createFolder.test.ts
@@ -12,7 +12,7 @@ import { FakeCommands } from '../../shared/vscode/fakeCommands'
 import { FakeWindow } from '../../shared/vscode/fakeWindow'
 import { anything, mock, instance, when, deepEqual, verify } from '../../utilities/mockito'
 
-describe('createFolderCommand', () => {
+describe('createFolderCommand', function() {
     const invalidFolderNames: { folderName: string; error: string }[] = [
         { folderName: 'contains/delimiter', error: `Folder name must not contain '/'` },
         { folderName: '', error: 'Folder name must not be empty' },
@@ -25,7 +25,7 @@ describe('createFolderCommand', () => {
     let s3: S3Client
     let node: S3BucketNode
 
-    beforeEach(() => {
+    beforeEach(function() {
         s3 = mock()
         node = new S3BucketNode(
             { name: bucketName, region: 'region', arn: 'arn' },
@@ -34,7 +34,7 @@ describe('createFolderCommand', () => {
         )
     })
 
-    it('prompts for folder name, creates folder, shows success, and refreshes node', async () => {
+    it('prompts for folder name, creates folder, shows success, and refreshes node', async function() {
         when(s3.createFolder(deepEqual({ path: folderPath, bucketName }))).thenResolve({
             folder: { name: folderName, path: folderPath, arn: 'arn' },
         })
@@ -52,13 +52,13 @@ describe('createFolderCommand', () => {
         assert.deepStrictEqual(commands.args, [node])
     })
 
-    it('does nothing when prompt is cancelled', async () => {
+    it('does nothing when prompt is cancelled', async function() {
         await createFolderCommand(node, new FakeWindow(), new FakeCommands())
 
         verify(s3.createFolder(anything())).never()
     })
 
-    it('shows an error message and refreshes node when folder creation fails', async () => {
+    it('shows an error message and refreshes node when folder creation fails', async function() {
         when(s3.createFolder(anything())).thenReject(new Error('Expected failure'))
 
         const window = new FakeWindow({ inputBox: { input: folderName } })

--- a/src/test/s3/commands/deleteBucket.test.ts
+++ b/src/test/s3/commands/deleteBucket.test.ts
@@ -13,20 +13,20 @@ import { FakeCommands } from '../../shared/vscode/fakeCommands'
 import { FakeWindow } from '../../shared/vscode/fakeWindow'
 import { anything, mock, instance, when, deepEqual, verify } from '../../utilities/mockito'
 
-describe('deleteBucketCommand', () => {
+describe('deleteBucketCommand', function() {
     const bucketName = 'bucket-name'
 
     let s3: S3Client
     let parentNode: S3Node
     let node: S3BucketNode
 
-    beforeEach(() => {
+    beforeEach(function() {
         s3 = mock()
         parentNode = new S3Node(instance(s3))
         node = new S3BucketNode({ name: bucketName, region: 'region', arn: 'arn' }, parentNode, instance(s3))
     })
 
-    it('confirms deletion, deletes bucket, shows progress bar, and refreshes parent node', async () => {
+    it('confirms deletion, deletes bucket, shows progress bar, and refreshes parent node', async function() {
         const window = new FakeWindow({ inputBox: { input: bucketName } })
         const commands = new FakeCommands()
         await deleteBucketCommand(node, window, commands)
@@ -43,7 +43,7 @@ describe('deleteBucketCommand', () => {
         assert.deepStrictEqual(commands.args, [parentNode])
     })
 
-    it('does nothing when deletion is cancelled', async () => {
+    it('does nothing when deletion is cancelled', async function() {
         const window = new FakeWindow()
         const commands = new FakeCommands()
         await deleteBucketCommand(node, window, commands)
@@ -54,7 +54,7 @@ describe('deleteBucketCommand', () => {
         assert.strictEqual(commands.command, undefined)
     })
 
-    it('shows an error message and refreshes node when bucket deletion fails', async () => {
+    it('shows an error message and refreshes node when bucket deletion fails', async function() {
         when(s3.deleteBucket(anything())).thenReject(new Error('Expected failure'))
 
         const window = new FakeWindow({ inputBox: { input: bucketName } })
@@ -67,7 +67,7 @@ describe('deleteBucketCommand', () => {
         assert.deepStrictEqual(commands.args, [parentNode])
     })
 
-    it('warns when confirmation is invalid', async () => {
+    it('warns when confirmation is invalid', async function() {
         const window = new FakeWindow({ inputBox: { input: 'something other than the bucket name' } })
         const commands = new FakeCommands()
         await deleteBucketCommand(node, window, commands)

--- a/src/test/s3/commands/deleteFile.test.ts
+++ b/src/test/s3/commands/deleteFile.test.ts
@@ -13,7 +13,7 @@ import { FakeCommands } from '../../shared/vscode/fakeCommands'
 import { FakeWindow } from '../../shared/vscode/fakeWindow'
 import { anything, mock, instance, when, deepEqual, verify } from '../../utilities/mockito'
 
-describe('deleteFileCommand', () => {
+describe('deleteFileCommand', function() {
     const key = 'foo/bar.jpg'
     const name = 'bar.jpg'
     const bucketName = 'bucket-name'
@@ -23,13 +23,13 @@ describe('deleteFileCommand', () => {
     let parentNode: S3BucketNode
     let node: S3FileNode
 
-    beforeEach(() => {
+    beforeEach(function() {
         s3 = mock()
         parentNode = new S3BucketNode(bucket, {} as S3Node, instance(s3))
         node = new S3FileNode(bucket, { name, key, arn: 'arn' }, parentNode, instance(s3))
     })
 
-    it('confirms deletion, deletes file, shows status bar confirmation, and refreshes parent node', async () => {
+    it('confirms deletion, deletes file, shows status bar confirmation, and refreshes parent node', async function() {
         const window = new FakeWindow({ message: { warningSelection: 'Delete' } })
         const commands = new FakeCommands()
         await deleteFileCommand(node, window, commands)
@@ -42,7 +42,7 @@ describe('deleteFileCommand', () => {
         assert.deepStrictEqual(commands.args, [parentNode])
     })
 
-    it('does nothing when deletion is cancelled', async () => {
+    it('does nothing when deletion is cancelled', async function() {
         const window = new FakeWindow({ message: { warningSelection: 'Cancel' } })
         const commands = new FakeCommands()
         await deleteFileCommand(node, window, commands)
@@ -53,7 +53,7 @@ describe('deleteFileCommand', () => {
         assert.strictEqual(commands.command, undefined)
     })
 
-    it('shows an error message and refreshes node when file deletion fails', async () => {
+    it('shows an error message and refreshes node when file deletion fails', async function() {
         when(s3.deleteObject(anything())).thenReject(new Error('Expected failure'))
 
         const window = new FakeWindow({ message: { warningSelection: 'Delete' } })

--- a/src/test/s3/commands/downloadFileAs.test.ts
+++ b/src/test/s3/commands/downloadFileAs.test.ts
@@ -14,7 +14,7 @@ import { MockOutputChannel } from '../../mockOutputChannel'
 import { FakeWindow } from '../../shared/vscode/fakeWindow'
 import { anything, mock, instance, when, capture, verify } from '../../utilities/mockito'
 
-describe('downloadFileAsCommand', () => {
+describe('downloadFileAsCommand', function() {
     const bucketName = 'bucket-name'
     const key = 'path/to/file.jpg'
     const fileName = 'file.jpg'
@@ -26,7 +26,7 @@ describe('downloadFileAsCommand', () => {
     let bucketNode: S3BucketNode
     let node: S3FileNode
 
-    beforeEach(() => {
+    beforeEach(function() {
         s3 = mock()
 
         const bucket: Bucket = { name: bucketName, region: 'region', arn: 'arn' }
@@ -39,7 +39,7 @@ describe('downloadFileAsCommand', () => {
         )
     })
 
-    it('prompts for save location, downloads file with progress, and shows output channel', async () => {
+    it('prompts for save location, downloads file with progress, and shows output channel', async function() {
         when(s3.downloadFile(anything())).thenResolve()
 
         const window = new FakeWindow({ dialog: { saveSelection: saveLocation } })
@@ -71,13 +71,13 @@ describe('downloadFileAsCommand', () => {
         assert.strictEqual(outputChannel.isFocused, false)
     })
 
-    it('does nothing when prompt is cancelled', async () => {
+    it('does nothing when prompt is cancelled', async function() {
         await downloadFileAsCommand(node, new FakeWindow())
 
         verify(s3.downloadFile(anything())).never()
     })
 
-    it('shows an error message when download fails', async () => {
+    it('shows an error message when download fails', async function() {
         when(s3.downloadFile(anything())).thenReject(new Error('Expected failure'))
 
         const window = new FakeWindow({ dialog: { saveSelection: saveLocation } })

--- a/src/test/s3/commands/uploadFile.test.ts
+++ b/src/test/s3/commands/uploadFile.test.ts
@@ -14,7 +14,7 @@ import { FakeCommands } from '../../shared/vscode/fakeCommands'
 import { FakeWindow } from '../../shared/vscode/fakeWindow'
 import { anything, mock, instance, when, capture, verify } from '../../utilities/mockito'
 
-describe('uploadFileCommand', () => {
+describe('uploadFileCommand', function() {
     const bucketName = 'bucket-name'
     const key = 'file.jpg'
     const sizeBytes = 16
@@ -24,7 +24,7 @@ describe('uploadFileCommand', () => {
     let s3: S3Client
     let node: S3BucketNode
 
-    beforeEach(() => {
+    beforeEach(function() {
         s3 = mock()
         node = new S3BucketNode(
             { name: bucketName, region: 'region', arn: 'arn' },
@@ -33,7 +33,7 @@ describe('uploadFileCommand', () => {
         )
     })
 
-    it('prompts for file location, uploads file with progress, shows output channel, and refreshes node', async () => {
+    it('prompts for file location, uploads file with progress, shows output channel, and refreshes node', async function() {
         when(s3.uploadFile(anything())).thenResolve()
 
         const window = new FakeWindow({ dialog: { openSelections: [fileLocation] } })
@@ -67,13 +67,13 @@ describe('uploadFileCommand', () => {
         assert.deepStrictEqual(commands.args, [node])
     })
 
-    it('does nothing when prompt is cancelled', async () => {
+    it('does nothing when prompt is cancelled', async function() {
         await uploadFileCommand(node, statFile, new FakeWindow(), new FakeCommands())
 
         verify(s3.uploadFile(anything())).never()
     })
 
-    it('shows an error message when upload fails', async () => {
+    it('shows an error message when upload fails', async function() {
         when(s3.uploadFile(anything())).thenReject(new Error('Expected failure'))
 
         const window = new FakeWindow({ dialog: { openSelections: [fileLocation] } })

--- a/src/test/s3/explorer/s3BucketNode.test.ts
+++ b/src/test/s3/explorer/s3BucketNode.test.ts
@@ -15,7 +15,7 @@ import { LoadMoreNode } from '../../../shared/treeview/nodes/loadMoreNode'
 import { deepEqual, instance, mock, when } from '../../utilities/mockito'
 import { FakeWorkspace } from '../../shared/vscode/fakeWorkspace'
 
-describe('S3BucketNode', () => {
+describe('S3BucketNode', function() {
     const name = 'bucket-name'
     const continuationToken = 'continuationToken'
     const bucket: Bucket = { name, region: 'region', arn: 'arn' }
@@ -46,12 +46,12 @@ describe('S3BucketNode', () => {
         assertBucketNode((node as MoreResultsNode).parent)
     }
 
-    beforeEach(() => {
+    beforeEach(function() {
         s3 = mock()
     })
 
-    describe('getChildren', () => {
-        it('gets children', async () => {
+    describe('getChildren', function() {
+        it('gets children', async function() {
             when(s3.listFiles(deepEqual({ bucketName: name, continuationToken: undefined, maxResults }))).thenResolve({
                 folders: [folder],
                 files: [file],
@@ -70,7 +70,7 @@ describe('S3BucketNode', () => {
             assert.strictEqual(otherNodes.length, 0)
         })
 
-        it('gets children with node for loading more results', async () => {
+        it('gets children with node for loading more results', async function() {
             when(s3.listFiles(deepEqual({ bucketName: name, continuationToken: undefined, maxResults }))).thenResolve({
                 folders: [folder],
                 files: [file],

--- a/src/test/s3/explorer/s3FileNode.test.ts
+++ b/src/test/s3/explorer/s3FileNode.test.ts
@@ -9,7 +9,7 @@ import { S3BucketNode } from '../../../s3/explorer/s3BucketNode'
 import { S3_DATE_FORMAT, S3FileNode } from '../../../s3/explorer/s3FileNode'
 import { S3Client } from '../../../shared/clients/s3Client'
 
-describe('S3FileNode', () => {
+describe('S3FileNode', function() {
     const arn = 'arn'
     const name = 'file.jpg'
     const key = 'path/to/file.jpg'
@@ -18,7 +18,7 @@ describe('S3FileNode', () => {
     const now = new Date(2020, 6, 4)
     const lastModifiedReadable = moment(lastModified).format(S3_DATE_FORMAT)
 
-    it('creates an S3 File Node', async () => {
+    it('creates an S3 File Node', async function() {
         const node = new S3FileNode(
             { name: 'bucket-name', region: 'region', arn: 'arn' },
             { name, key, arn, sizeBytes, lastModified },

--- a/src/test/s3/explorer/s3FolderNode.test.ts
+++ b/src/test/s3/explorer/s3FolderNode.test.ts
@@ -13,7 +13,7 @@ import { LoadMoreNode } from '../../../shared/treeview/nodes/loadMoreNode'
 import { deepEqual, instance, mock, when } from '../../utilities/mockito'
 import { FakeWorkspace } from '../../shared/vscode/fakeWorkspace'
 
-describe('S3FolderNode', () => {
+describe('S3FolderNode', function() {
     const bucketName = 'bucket-name'
     const path = 'folder/path'
     const continuationToken = 'continuationToken'
@@ -46,12 +46,12 @@ describe('S3FolderNode', () => {
         assertFolderNode((node as MoreResultsNode).parent, folder)
     }
 
-    beforeEach(() => {
+    beforeEach(function() {
         s3 = mock()
     })
 
-    describe('getChildren', () => {
-        it('gets children', async () => {
+    describe('getChildren', function() {
+        it('gets children', async function() {
             when(
                 s3.listFiles(deepEqual({ bucketName, folderPath: path, continuationToken: undefined, maxResults }))
             ).thenResolve({
@@ -68,7 +68,7 @@ describe('S3FolderNode', () => {
             assert.strictEqual(otherNodes.length, 0)
         })
 
-        it('gets children with node for loading more results', async () => {
+        it('gets children with node for loading more results', async function() {
             when(
                 s3.listFiles(deepEqual({ bucketName, folderPath: path, continuationToken: undefined, maxResults }))
             ).thenResolve({

--- a/src/test/s3/explorer/s3Nodes.test.ts
+++ b/src/test/s3/explorer/s3Nodes.test.ts
@@ -10,7 +10,7 @@ import { S3Client, Bucket } from '../../../shared/clients/s3Client'
 import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
 import { instance, mock, when } from '../../utilities/mockito'
 
-describe('S3Node', () => {
+describe('S3Node', function() {
     const firstBucket: Bucket = { name: 'first-bucket-name', region: 'firstRegion', arn: 'firstArn' }
     const secondBucket: Bucket = { name: 'second-bucket-name', region: 'secondRegion', arn: 'secondArn' }
 
@@ -21,11 +21,11 @@ describe('S3Node', () => {
         assert.deepStrictEqual((node as S3BucketNode).bucket, expectedBucket)
     }
 
-    beforeEach(() => {
+    beforeEach(function() {
         s3 = mock()
     })
 
-    it('gets children', async () => {
+    it('gets children', async function() {
         when(s3.listBuckets()).thenResolve({
             buckets: [firstBucket, secondBucket],
         })

--- a/src/test/s3/util/progressReporter.test.ts
+++ b/src/test/s3/util/progressReporter.test.ts
@@ -8,14 +8,14 @@ import * as vscode from 'vscode'
 import { progressReporter } from '../../../s3/progressReporter'
 import { deepEqual, mock, verify, anyNumber, instance } from '../../utilities/mockito'
 
-describe('progressReporter', () => {
+describe('progressReporter', function() {
     let progress: vscode.Progress<{ message?: string; increment?: number }>
 
-    beforeEach(() => {
+    beforeEach(function() {
         progress = mock()
     })
 
-    it('reports incremental percentage when total is provided', () => {
+    it('reports incremental percentage when total is provided', function() {
         const reporter = progressReporter({ progress: instance(progress), totalBytes: 16, minIntervalMillis: 0 })
 
         reporter(4)
@@ -25,7 +25,7 @@ describe('progressReporter', () => {
         verify(progress.report(deepEqual({ increment: 50 }))).once()
     })
 
-    it('throttles progress updates when update frequency exceeds throttle interval', () => {
+    it('throttles progress updates when update frequency exceeds throttle interval', function() {
         const reporter = progressReporter({
             progress: instance(progress),
             totalBytes: 16,
@@ -55,7 +55,7 @@ describe('progressReporter', () => {
         ).once()
     })
 
-    it('reports no incremental percentage when total is not provided', () => {
+    it('reports no incremental percentage when total is not provided', function() {
         const reporter = progressReporter({ progress: instance(progress), minIntervalMillis: 0 })
 
         reporter(4)
@@ -63,21 +63,21 @@ describe('progressReporter', () => {
         verify(progress.report(anyNumber())).never()
     })
 
-    it('throws an error if total bytes is not an integer', () => {
+    it('throws an error if total bytes is not an integer', function() {
         assert.throws(
             () => progressReporter({ progress: instance(progress), totalBytes: 1.5, minIntervalMillis: 0 }),
             /must be an integer/
         )
     })
 
-    it('throws an error if total bytes is negative', () => {
+    it('throws an error if total bytes is negative', function() {
         assert.throws(
             () => progressReporter({ progress: instance(progress), totalBytes: -5, minIntervalMillis: 0 }),
             /cannot be negative/
         )
     })
 
-    it('throws an error if updated with bytes less than loaded bytes', () => {
+    it('throws an error if updated with bytes less than loaded bytes', function() {
         const reporter = progressReporter({ progress: instance(progress), totalBytes: 16, minIntervalMillis: 0 })
 
         reporter(4)
@@ -85,19 +85,19 @@ describe('progressReporter', () => {
         assert.throws(() => reporter(2), /cannot be less than loadedBytes/)
     })
 
-    it('throws an error if updated with non integer bytes', () => {
+    it('throws an error if updated with non integer bytes', function() {
         const reporter = progressReporter({ progress: instance(progress), totalBytes: 5, minIntervalMillis: 0 })
 
         assert.throws(() => reporter(1.5), /must be an integer/)
     })
 
-    it('throws an error if updated with negative bytes', () => {
+    it('throws an error if updated with negative bytes', function() {
         const reporter = progressReporter({ progress: instance(progress), totalBytes: 5, minIntervalMillis: 0 })
 
         assert.throws(() => reporter(-5), /cannot be negative/)
     })
 
-    it('throws an error if updated with bytes greater than total bytes', () => {
+    it('throws an error if updated with bytes greater than total bytes', function() {
         const reporter = progressReporter({ progress: instance(progress), totalBytes: 2, minIntervalMillis: 0 })
 
         assert.throws(() => reporter(5), /cannot be greater than totalBytes/)

--- a/src/test/s3/util/util.test.ts
+++ b/src/test/s3/util/util.test.ts
@@ -6,19 +6,19 @@
 import * as assert from 'assert'
 import { readablePath } from '../../../s3/util'
 
-describe('messages', () => {
-    describe('readablePath', () => {
+describe('messages', function() {
+    describe('readablePath', function() {
         const bucketName = 'bucket-name'
         const bucketPath = ''
         const objectPath = 'path/to/object'
 
-        it('creates a readable path for an S3 bucket', () => {
+        it('creates a readable path for an S3 bucket', function() {
             const path = readablePath({ bucket: { name: bucketName }, path: bucketPath })
 
             assert.strictEqual(path, 's3://bucket-name')
         })
 
-        it('creates a readable path for an object in an S3 bucket', () => {
+        it('creates a readable path for an object in an S3 bucket', function() {
             const path = readablePath({ bucket: { name: bucketName }, path: objectPath })
 
             assert.strictEqual(path, 's3://bucket-name/path/to/object')

--- a/src/test/s3/util/validateBucketName.test.ts
+++ b/src/test/s3/util/validateBucketName.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert'
 import { validateBucketName } from '../../../s3/util'
 
-describe('validateBucketName', () => {
+describe('validateBucketName', function() {
     const invalidErrors: { bucketNames: string[]; error: string }[] = [
         { bucketNames: ['a', 'aa', 'a'.repeat(64)], error: 'Bucket name must be between 3 and 63 characters long' },
         { bucketNames: ['-bucket'], error: 'Bucket name must start with a lowercase letter or number' },
@@ -22,7 +22,7 @@ describe('validateBucketName', () => {
         { bucketNames: ['127.0.0.1'], error: 'Bucket name must not resemble an IP address' },
     ]
 
-    it('returns undefined for a valid bucket name', () => {
+    it('returns undefined for a valid bucket name', function() {
         assert.strictEqual(validateBucketName('v.4.l1d.buc.ket-n4.m3'), undefined)
     })
 

--- a/src/test/shared/activationReloadState.test.ts
+++ b/src/test/shared/activationReloadState.test.ts
@@ -25,17 +25,17 @@ class TestActivationReloadState extends ActivationReloadState {
     }
 }
 
-describe('ActivationReloadState', async () => {
+describe('ActivationReloadState', async function() {
     let extensionContext: FakeExtensionContext
     let activationReloadState: ActivationReloadState
 
-    beforeEach(() => {
+    beforeEach(function() {
         extensionContext = new FakeExtensionContext()
         activationReloadState = new TestActivationReloadState(extensionContext)
     })
 
-    describe('setSamInitState', async () => {
-        it('without runtime', async () => {
+    describe('setSamInitState', async function() {
+        it('without runtime', async function() {
             activationReloadState.setSamInitState({
                 path: 'somepath',
                 runtime: undefined,
@@ -59,7 +59,7 @@ describe('ActivationReloadState', async () => {
             )
         })
 
-        it('with runtime', async () => {
+        it('with runtime', async function() {
             activationReloadState.setSamInitState({
                 path: 'somepath',
                 runtime: 'someruntime',
@@ -83,7 +83,7 @@ describe('ActivationReloadState', async () => {
             )
         })
 
-        it('with image', async () => {
+        it('with image', async function() {
             activationReloadState.setSamInitState({
                 path: 'somepath',
                 runtime: 'someruntime',
@@ -108,8 +108,8 @@ describe('ActivationReloadState', async () => {
         })
     })
 
-    describe('getSamInitState', async () => {
-        it('path defined, without runtime', async () => {
+    describe('getSamInitState', async function() {
+        it('path defined, without runtime', async function() {
             await extensionContext.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, 'getsomepath')
             await extensionContext.globalState.update(SAM_INIT_RUNTIME_KEY, undefined)
 
@@ -130,7 +130,7 @@ describe('ActivationReloadState', async () => {
             )
         })
 
-        it('path defined, with runtime', async () => {
+        it('path defined, with runtime', async function() {
             await extensionContext.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, 'getsomepath')
             await extensionContext.globalState.update(SAM_INIT_RUNTIME_KEY, 'getsomeruntime')
 
@@ -151,7 +151,7 @@ describe('ActivationReloadState', async () => {
             )
         })
 
-        it('path defined, with runtime and isImage', async () => {
+        it('path defined, with runtime and isImage', async function() {
             await extensionContext.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, 'getsomepath')
             await extensionContext.globalState.update(SAM_INIT_RUNTIME_KEY, 'getsomeruntime')
             await extensionContext.globalState.update(SAM_INIT_IMAGE_BOOLEAN_KEY, true)
@@ -173,7 +173,7 @@ describe('ActivationReloadState', async () => {
             )
         })
 
-        it('path undefined', async () => {
+        it('path undefined', async function() {
             await extensionContext.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, undefined)
 
             assert.strictEqual(
@@ -184,7 +184,7 @@ describe('ActivationReloadState', async () => {
         })
     })
 
-    it('clearLaunchPath', async () => {
+    it('clearLaunchPath', async function() {
         activationReloadState.setSamInitState({
             path: 'somepath',
             runtime: 'someruntime',

--- a/src/test/shared/clients/defaultEcsClient.test.ts
+++ b/src/test/shared/clients/defaultEcsClient.test.ts
@@ -8,15 +8,15 @@ import { AWSError, ECS } from 'aws-sdk'
 import { DefaultEcsClient } from '../../../shared/clients/defaultEcsClient'
 import { assertThrowsError } from '../utilities/assertUtils'
 
-describe('defaultEcsClient', async () => {
+describe('defaultEcsClient', async function() {
     let testClient: TestEcsClient
 
-    before(() => {
+    before(function() {
         testClient = new TestEcsClient()
     })
 
-    describe('listClusters', async () => {
-        it('lists clusters from a single page', async () => {
+    describe('listClusters', async function() {
+        it('lists clusters from a single page', async function() {
             const targetArr = ['cluster1', 'cluster2', 'cluster3']
             testClient.listClustersResponses = [
                 {
@@ -31,7 +31,7 @@ describe('defaultEcsClient', async () => {
             assert.deepStrictEqual(targetArr, arr)
         })
 
-        it('lists clusters from multiple pages', async () => {
+        it('lists clusters from multiple pages', async function() {
             const targetArr1 = ['cluster1', 'cluster2', 'cluster3']
             const targetArr2 = ['cluster4', 'cluster5', 'cluster6']
             const targetArr3 = ['cluster7', 'cluster8', 'cluster9']
@@ -56,7 +56,7 @@ describe('defaultEcsClient', async () => {
             assert.deepStrictEqual(targetArr1.concat(targetArr2).concat(targetArr3), arr)
         })
 
-        it('handles errors', async () => {
+        it('handles errors', async function() {
             testClient.listClustersResponses = new Error() as AWSError
             await assertThrowsError(async () => {
                 const iterator = testClient.listClusters()
@@ -68,8 +68,8 @@ describe('defaultEcsClient', async () => {
         })
     })
 
-    describe('listServices', async () => {
-        it('lists services from a single page', async () => {
+    describe('listServices', async function() {
+        it('lists services from a single page', async function() {
             const targetArr = ['service1', 'service2', 'service3']
             testClient.listServicesResponses = [
                 {
@@ -84,7 +84,7 @@ describe('defaultEcsClient', async () => {
             assert.deepStrictEqual(targetArr, arr)
         })
 
-        it('lists services from multiple pages', async () => {
+        it('lists services from multiple pages', async function() {
             const targetArr1 = ['service1', 'service2', 'service3']
             const targetArr2 = ['service4', 'service5', 'service6']
             const targetArr3 = ['service7', 'service8', 'service9']
@@ -109,7 +109,7 @@ describe('defaultEcsClient', async () => {
             assert.deepStrictEqual(targetArr1.concat(targetArr2).concat(targetArr3), arr)
         })
 
-        it('handles errors', async () => {
+        it('handles errors', async function() {
             testClient.listServicesResponses = new Error() as AWSError
             await assertThrowsError(async () => {
                 const iterator = testClient.listServices('ourcluster')
@@ -121,8 +121,8 @@ describe('defaultEcsClient', async () => {
         })
     })
 
-    describe('ListTaskDefinitionFamilies', async () => {
-        it('lists task definition families from a single page', async () => {
+    describe('ListTaskDefinitionFamilies', async function() {
+        it('lists task definition families from a single page', async function() {
             const targetArr = ['fam1', 'fam2', 'fam3']
             testClient.listTaskDefinitionFamiliesResponses = [
                 {
@@ -137,7 +137,7 @@ describe('defaultEcsClient', async () => {
             assert.deepStrictEqual(targetArr, arr)
         })
 
-        it('lists task definition families from multiple pages', async () => {
+        it('lists task definition families from multiple pages', async function() {
             const targetArr1 = ['fam1', 'fam2', 'fam3']
             const targetArr2 = ['fam4', 'fam5', 'fam6']
             const targetArr3 = ['fam7', 'fam8', 'fam9']
@@ -162,7 +162,7 @@ describe('defaultEcsClient', async () => {
             assert.deepStrictEqual(targetArr1.concat(targetArr2).concat(targetArr3), arr)
         })
 
-        it('handles errors', async () => {
+        it('handles errors', async function() {
             testClient.listTaskDefinitionFamiliesResponses = new Error() as AWSError
             await assertThrowsError(async () => {
                 const iterator = testClient.listTaskDefinitionFamilies()

--- a/src/test/shared/clients/defaultS3Client.test.ts
+++ b/src/test/shared/clients/defaultS3Client.test.ts
@@ -32,7 +32,7 @@ class FakeAwsError extends Error {
     }
 }
 
-describe('DefaultS3Client', () => {
+describe('DefaultS3Client', function() {
     const partition = 'aws'
     const region = 'us-west-2'
     const bucketName = 'bucketName'
@@ -108,7 +108,7 @@ describe('DefaultS3Client', () => {
         }
     }
 
-    beforeEach(() => {
+    beforeEach(function() {
         mockS3 = mock()
     })
 
@@ -140,8 +140,8 @@ describe('DefaultS3Client', () => {
         return new DefaultS3Client(partitionId, regionCode, () => Promise.resolve(instance(mockS3)), fileStreams)
     }
 
-    describe('createBucket', () => {
-        it('creates a bucket', async () => {
+    describe('createBucket', function() {
+        it('creates a bucket', async function() {
             when(
                 mockS3.createBucket(
                     deepEqual({
@@ -158,7 +158,7 @@ describe('DefaultS3Client', () => {
             })
         })
 
-        it('removes the region code for us-east-1', async () => {
+        it('removes the region code for us-east-1', async function() {
             when(
                 mockS3.createBucket(
                     deepEqual({
@@ -175,14 +175,14 @@ describe('DefaultS3Client', () => {
             })
         })
 
-        it('throws an Error on failure', async () => {
+        it('throws an Error on failure', async function() {
             when(mockS3.createBucket(anything())).thenReturn(failure())
 
             await assert.rejects(createClient().createBucket({ bucketName }), error)
         })
     })
 
-    describe('deleteBucket', () => {
+    describe('deleteBucket', function() {
         const {
             firstPageRequest: firstList,
             secondPageRequest: secondList,
@@ -192,7 +192,7 @@ describe('DefaultS3Client', () => {
         const anyListResponse = secondListResponse
         const { firstRequest: firstDelete, secondRequest: secondDelete } = new DeleteObjectsFixtures()
 
-        it('empties a bucket and deletes it', async () => {
+        it('empties a bucket and deletes it', async function() {
             when(mockS3.listObjectVersions(deepEqual(firstList))).thenReturn(success(firstListResponse))
             when(mockS3.deleteObjects(deepEqual(firstDelete))).thenReturn(success({}))
 
@@ -208,7 +208,7 @@ describe('DefaultS3Client', () => {
             verify(mockS3.deleteBucket(anything())).once()
         })
 
-        it('throws an Error on listObjectVersions failure', async () => {
+        it('throws an Error on listObjectVersions failure', async function() {
             when(mockS3.listObjectVersions(anything())).thenReturn(failure())
 
             await assert.rejects(createClient().deleteBucket({ bucketName }), error)
@@ -217,7 +217,7 @@ describe('DefaultS3Client', () => {
             verify(mockS3.deleteBucket(anything())).never()
         })
 
-        it('throws an Error on deleteObjects failure', async () => {
+        it('throws an Error on deleteObjects failure', async function() {
             when(mockS3.listObjectVersions(anything())).thenReturn(success(anyListResponse))
             when(mockS3.deleteObjects(anything())).thenReturn(failure())
 
@@ -226,7 +226,7 @@ describe('DefaultS3Client', () => {
             verify(mockS3.deleteBucket(anything())).never()
         })
 
-        it('throws an Error on deleteBucket failure', async () => {
+        it('throws an Error on deleteBucket failure', async function() {
             when(mockS3.listObjectVersions(anything())).thenReturn(success(anyListResponse))
             when(mockS3.deleteObjects(anything())).thenReturn(success({}))
             when(mockS3.deleteBucket(anything())).thenReturn(failure())
@@ -235,8 +235,8 @@ describe('DefaultS3Client', () => {
         })
     })
 
-    describe('createFolder', () => {
-        it('creates a folder', async () => {
+    describe('createFolder', function() {
+        it('creates a folder', async function() {
             when(mockS3.upload(deepEqual({ Bucket: bucketName, Key: folderPath, Body: '' }))).thenReturn(success())
 
             const response = await createClient().createFolder({ bucketName, path: folderPath })
@@ -246,15 +246,15 @@ describe('DefaultS3Client', () => {
             })
         })
 
-        it('throws an Error on failure', async () => {
+        it('throws an Error on failure', async function() {
             when(mockS3.upload(anything())).thenReturn(failure())
 
             await assert.rejects(createClient().createFolder({ bucketName, path: folderPath }), error)
         })
     })
 
-    describe('downloadFile', () => {
-        it('downloads a file', async () => {
+    describe('downloadFile', function() {
+        it('downloads a file', async function() {
             when(mockS3.getObject(deepEqual({ Bucket: bucketName, Key: fileKey }))).thenReturn(success())
 
             const fileStreams = new FakeFileStreams({ readData: fileData })
@@ -272,7 +272,7 @@ describe('DefaultS3Client', () => {
             assert.ok(progressCaptor.progress > 0)
         })
 
-        it('throws an Error on failure', async () => {
+        it('throws an Error on failure', async function() {
             when(mockS3.getObject(anything())).thenReturn(failure())
 
             await assert.rejects(
@@ -286,8 +286,8 @@ describe('DefaultS3Client', () => {
         })
     })
 
-    describe('uploadFile', () => {
-        it('uploads a file', async () => {
+    describe('uploadFile', function() {
+        it('uploads a file', async function() {
             const mockManagedUpload: ManagedUpload = mock()
             when(mockManagedUpload.promise()).thenReturn(
                 Promise.resolve({ Location: '', ETag: '', Bucket: '', Key: '' })
@@ -320,7 +320,7 @@ describe('DefaultS3Client', () => {
             assert.strictEqual(progressCaptor.progress, 3)
         })
 
-        it('throws an Error on failure', async () => {
+        it('throws an Error on failure', async function() {
             when(mockS3.upload(anything())).thenReturn(failure())
 
             await assert.rejects(
@@ -334,8 +334,8 @@ describe('DefaultS3Client', () => {
         })
     })
 
-    describe('listBuckets', () => {
-        it('lists a bucket', async () => {
+    describe('listBuckets', function() {
+        it('lists a bucket', async function() {
             when(mockS3.listBuckets()).thenReturn(
                 success({ Buckets: [{ Name: bucketName }, { Name: outOfRegionBucketName }] })
             )
@@ -358,7 +358,7 @@ describe('DefaultS3Client', () => {
             })
         })
 
-        it('Filters buckets with no name', async () => {
+        it('Filters buckets with no name', async function() {
             when(mockS3.listBuckets()).thenReturn(
                 success({ Buckets: [{ Name: undefined }, { Name: outOfRegionBucketName }] })
             )
@@ -385,7 +385,7 @@ describe('DefaultS3Client', () => {
             })
         })
 
-        it('throws an Error on listBuckets failure', async () => {
+        it('throws an Error on listBuckets failure', async function() {
             when(mockS3.listBuckets()).thenReturn(failure())
 
             await assert.rejects(createClient().listBuckets(), error)
@@ -393,7 +393,7 @@ describe('DefaultS3Client', () => {
             verify(mockS3.headBucket(anything())).never()
         })
 
-        it('returns region from exception on headBucket failure', async () => {
+        it('returns region from exception on headBucket failure', async function() {
             when(mockS3.listBuckets()).thenReturn(success({ Buckets: [{ Name: bucketName }] }))
             when(mockS3.headBucket(anything())).thenReturn(failure())
 
@@ -410,8 +410,8 @@ describe('DefaultS3Client', () => {
         })
     })
 
-    describe('listFiles', () => {
-        it('lists files and folders', async () => {
+    describe('listFiles', function() {
+        it('lists files and folders', async function() {
             when(
                 mockS3.listObjectsV2(
                     deepEqual({
@@ -453,14 +453,14 @@ describe('DefaultS3Client', () => {
             })
         })
 
-        it('throws an Error on listFiles failure', async () => {
+        it('throws an Error on listFiles failure', async function() {
             when(mockS3.listObjectsV2(anything())).thenReturn(failure())
 
             await assert.rejects(createClient().listFiles({ bucketName, folderPath, continuationToken }), error)
         })
     })
 
-    describe('listObjectVersions', () => {
+    describe('listObjectVersions', function() {
         const {
             firstPageRequest,
             secondPageRequest,
@@ -468,7 +468,7 @@ describe('DefaultS3Client', () => {
             secondPageResponse,
         } = new ListObjectVersionsFixtures()
 
-        it('lists objects and their versions with a continuation token for the next page of results', async () => {
+        it('lists objects and their versions with a continuation token for the next page of results', async function() {
             when(mockS3.listObjectVersions(deepEqual(firstPageRequest))).thenReturn(success(firstPageResponse))
 
             const response = await createClient().listObjectVersions({ bucketName })
@@ -482,13 +482,13 @@ describe('DefaultS3Client', () => {
             })
         })
 
-        it('throws an Error on listObjectVersions failure', async () => {
+        it('throws an Error on listObjectVersions failure', async function() {
             when(mockS3.listObjectVersions(anything())).thenReturn(failure())
 
             await assert.rejects(createClient().listObjectVersions({ bucketName }), error)
         })
 
-        it('returns pages from listObjectVersionsIterable', async () => {
+        it('returns pages from listObjectVersionsIterable', async function() {
             when(mockS3.listObjectVersions(deepEqual(firstPageRequest))).thenReturn(success(firstPageResponse))
             when(mockS3.listObjectVersions(deepEqual(secondPageRequest))).thenReturn(success(secondPageResponse))
 
@@ -508,7 +508,7 @@ describe('DefaultS3Client', () => {
             assert.deepStrictEqual(otherPages, [])
         })
 
-        it('throws an Error on listObjectVersionsIterable iterate failure', async () => {
+        it('throws an Error on listObjectVersionsIterable iterate failure', async function() {
             when(mockS3.listObjectVersions(anything())).thenReturn(failure())
 
             const iterable = createClient().listObjectVersionsIterable({ bucketName })
@@ -516,8 +516,8 @@ describe('DefaultS3Client', () => {
         })
     })
 
-    describe('deleteObject', () => {
-        it('deletes an object', async () => {
+    describe('deleteObject', function() {
+        it('deletes an object', async function() {
             when(mockS3.deleteObject(deepEqual({ Bucket: bucketName, Key: fileKey }))).thenReturn(success({}))
 
             await createClient().deleteObject({ bucketName, key: fileKey })
@@ -525,15 +525,15 @@ describe('DefaultS3Client', () => {
             verify(mockS3.deleteObject(anything())).once()
         })
 
-        it('throws an Error on failure', async () => {
+        it('throws an Error on failure', async function() {
             when(mockS3.deleteObject(anything())).thenReturn(failure())
 
             await assert.rejects(createClient().deleteObject({ bucketName, key: fileKey }), error)
         })
     })
 
-    describe('deleteObjects', () => {
-        it('deletes objects', async () => {
+    describe('deleteObjects', function() {
+        it('deletes objects', async function() {
             when(
                 mockS3.deleteObjects(
                     deepEqual({
@@ -565,7 +565,7 @@ describe('DefaultS3Client', () => {
             assert.deepStrictEqual(response, { errors: [] })
         })
 
-        it('returns a list of errors on partial failure', async () => {
+        it('returns a list of errors on partial failure', async function() {
             const error: S3.Error = {
                 Key: folderPath,
                 VersionId: folderVersionId,
@@ -584,7 +584,7 @@ describe('DefaultS3Client', () => {
             assert.deepStrictEqual(response, { errors: [error] })
         })
 
-        it('throws an Error on failure', async () => {
+        it('throws an Error on failure', async function() {
             when(mockS3.deleteObjects(anything())).thenReturn(failure())
 
             await assert.rejects(createClient().deleteObjects({ bucketName, objects: [{ key: fileKey }] }), error)
@@ -592,8 +592,8 @@ describe('DefaultS3Client', () => {
     })
 })
 
-describe('DefaultBucket', () => {
-    it('properly constructs an instance', () => {
+describe('DefaultBucket', function() {
+    it('properly constructs an instance', function() {
         const bucket = new DefaultBucket({ partitionId: 'partitionId', region: 'region', name: 'name' })
         assert.strictEqual(bucket.name, 'name')
         assert.strictEqual(bucket.region, 'region')
@@ -601,8 +601,8 @@ describe('DefaultBucket', () => {
     })
 })
 
-describe('DefaultFolder', () => {
-    it('properly constructs an instance', () => {
+describe('DefaultFolder', function() {
+    it('properly constructs an instance', function() {
         const folder = new DefaultFolder({
             partitionId: 'partitionId',
             bucketName: 'bucketName',
@@ -614,8 +614,8 @@ describe('DefaultFolder', () => {
     })
 })
 
-describe('DefaultFile', () => {
-    it('properly constructs an instance', () => {
+describe('DefaultFile', function() {
+    it('properly constructs an instance', function() {
         const file = new DefaultFile({
             partitionId: 'partitionId',
             bucketName: 'bucketName',

--- a/src/test/shared/cloudformation/cloudformation.test.ts
+++ b/src/test/shared/cloudformation/cloudformation.test.ts
@@ -20,23 +20,23 @@ import {
     strToYamlFile,
 } from './cloudformationTestUtils'
 
-describe('CloudFormation', () => {
+describe('CloudFormation', function() {
     let tempFolder: string
     let filename: string
 
-    before(async () => {
+    before(async function() {
         // Make a temp folder for all these tests
         // Stick some temp credentials files in there to load from
         tempFolder = await makeTemporaryToolkitFolder()
         filename = path.join(tempFolder, 'temp.yaml')
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         await fs.remove(filename)
     })
 
-    describe('load', async () => {
-        it('can successfully load a file', async () => {
+    describe('load', async function() {
+        it('can successfully load a file', async function() {
             const yamlStr = makeSampleSamTemplateYaml(true)
 
             await strToYamlFile(yamlStr, filename)
@@ -44,7 +44,7 @@ describe('CloudFormation', () => {
             assert.deepStrictEqual(loadedTemplate, createBaseTemplate())
         })
 
-        it('can successfully load a file without globals', async () => {
+        it('can successfully load a file without globals', async function() {
             const yamlStr = makeSampleSamTemplateYaml(false)
 
             await strToYamlFile(yamlStr, filename)
@@ -56,7 +56,7 @@ describe('CloudFormation', () => {
             assert.deepStrictEqual(loadedTemplate, expectedTemplate)
         })
 
-        it('can successfully load a file with parameters', async () => {
+        it('can successfully load a file with parameters', async function() {
             const yamlStr: string = `Parameters:
     MyParam1:
         Type: String
@@ -87,7 +87,7 @@ describe('CloudFormation', () => {
             assert.deepStrictEqual(loadedTemplate, expectedTemplate)
         })
 
-        it('Does not load YAML with missing fields', async () => {
+        it('Does not load YAML with missing fields', async function() {
             // handler is missing
             const badYamlStr: string = `Resources:
                                             TestResource:
@@ -103,7 +103,7 @@ describe('CloudFormation', () => {
             await assertRejects(async () => await CloudFormation.load(filename))
         })
 
-        it('only loads valid YAML', async () => {
+        it('only loads valid YAML', async function() {
             // same as above, minus the handler
             const badYamlStr: string = `Resources:
                                             TestResource:
@@ -119,7 +119,7 @@ describe('CloudFormation', () => {
             await assertRejects(async () => await CloudFormation.load(filename))
         })
 
-        it('Loads YAML with references', async () => {
+        it('Loads YAML with references', async function() {
             // This one is valid, "!Ref" is valid!
             const validYamlStr: string = `Resources:
                                             TestResource:
@@ -136,7 +136,7 @@ describe('CloudFormation', () => {
             await CloudFormation.load(filename)
         })
 
-        it('Loads YAML without a CodeUri', async () => {
+        it('Loads YAML without a CodeUri', async function() {
             // This one is valid, "!Ref" is valid!
             const validYamlStr: string = `Resources:
                                             TestResource:
@@ -154,13 +154,13 @@ describe('CloudFormation', () => {
         })
     })
 
-    describe('save', async () => {
-        it('can successfully save a file', async () => {
+    describe('save', async function() {
+        it('can successfully save a file', async function() {
             await CloudFormation.save(createBaseTemplate(), filename)
             assert.strictEqual(await SystemUtilities.fileExists(filename), true)
         })
 
-        it('can successfully save a file to YAML and load the file as a CloudFormation.Template', async () => {
+        it('can successfully save a file to YAML and load the file as a CloudFormation.Template', async function() {
             const baseTemplate = createBaseTemplate()
             await CloudFormation.save(baseTemplate, filename)
             assert.strictEqual(await SystemUtilities.fileExists(filename), true)
@@ -169,12 +169,12 @@ describe('CloudFormation', () => {
         })
     })
 
-    describe('validateTemplate', async () => {
-        it('can successfully validate a valid template', () => {
+    describe('validateTemplate', async function() {
+        it('can successfully validate a valid template', function() {
             assert.doesNotThrow(() => CloudFormation.validateTemplate(createBaseTemplate()))
         })
 
-        it('can detect an invalid template', () => {
+        it('can detect an invalid template', function() {
             const badTemplate = createBaseTemplate()
             delete (badTemplate.Resources!.TestResource as any)!.Type
             assert.throws(
@@ -185,12 +185,12 @@ describe('CloudFormation', () => {
         })
     })
 
-    describe('validateResource', async () => {
-        it('can successfully validate a valid resource', () => {
+    describe('validateResource', async function() {
+        it('can successfully validate a valid resource', function() {
             assert.doesNotThrow(() => CloudFormation.validateResource(createBaseResource(), createBaseTemplate()))
         })
 
-        it('can detect an invalid resource', () => {
+        it('can detect an invalid resource', function() {
             const badResource = createBaseResource()
             delete (badResource.Properties as any)!.Handler
             assert.throws(
@@ -200,7 +200,7 @@ describe('CloudFormation', () => {
             )
         })
 
-        it('can detect invalid Image resources', () => {
+        it('can detect invalid Image resources', function() {
             const badResource = createBaseImageResource()
             assert.ok(CloudFormation.isImageLambdaResource(badResource.Properties))
 
@@ -252,7 +252,7 @@ describe('CloudFormation', () => {
         return path.join(path.dirname(__filename), 'yaml', templateFileName)
     }
 
-    describe('getResourceFromTemplate', async () => {
+    describe('getResourceFromTemplate', async function() {
         for (const scenario of templateWithExistingHandlerScenarios) {
             it(`should retrieve resource for ${scenario.title}`, async () => {
                 const templatePath = makeTemplatePath(scenario.templateFileName)
@@ -288,7 +288,7 @@ describe('CloudFormation', () => {
         }
     })
 
-    describe('getResourceFromTemplateResources', async () => {
+    describe('getResourceFromTemplateResources', async function() {
         for (const scenario of templateWithExistingHandlerScenarios) {
             it(`should retrieve resource for ${scenario.title}`, async () => {
                 const templatePath = makeTemplatePath(scenario.templateFileName)
@@ -326,7 +326,7 @@ describe('CloudFormation', () => {
         }
     })
 
-    describe('Ref handlers', () => {
+    describe('Ref handlers', function() {
         const newTemplate: () => CloudFormation.Template = () => {
             return {
                 Globals: {
@@ -369,8 +369,8 @@ describe('CloudFormation', () => {
             }
         }
 
-        describe('getStringForProperty', () => {
-            it('returns a string', () => {
+        describe('getStringForProperty', function() {
+            it('returns a string', function() {
                 const template = newTemplate()
                 assert.strictEqual(
                     CloudFormation.getStringForProperty(template.Resources!.resource?.Properties, 'Handler', template),
@@ -378,7 +378,7 @@ describe('CloudFormation', () => {
                 )
             })
 
-            it('returns a string from a ref with a default value', () => {
+            it('returns a string from a ref with a default value', function() {
                 const property: CloudFormation.Ref = {
                     Ref: 'strParamVal',
                 }
@@ -390,7 +390,7 @@ describe('CloudFormation', () => {
                 )
             })
 
-            it('returns undefined if the ref does not have a default value', () => {
+            it('returns undefined if the ref does not have a default value', function() {
                 const property: CloudFormation.Ref = {
                     Ref: 'strParamNoVal',
                 }
@@ -402,7 +402,7 @@ describe('CloudFormation', () => {
                 )
             })
 
-            it('returns undefined if a number is provided', () => {
+            it('returns undefined if a number is provided', function() {
                 const property: number = 1
                 const template = newTemplate()
                 template.Resources!.resource!.Properties!.MemorySize = property
@@ -416,7 +416,7 @@ describe('CloudFormation', () => {
                 )
             })
 
-            it('returns undefined if a ref to a number is provided', () => {
+            it('returns undefined if a ref to a number is provided', function() {
                 const property: CloudFormation.Ref = {
                     Ref: 'numParamVal',
                 }
@@ -432,12 +432,12 @@ describe('CloudFormation', () => {
                 )
             })
 
-            it('returns undefined if undefined is provided', () => {
+            it('returns undefined if undefined is provided', function() {
                 const template = newTemplate()
                 assert.strictEqual(CloudFormation.getStringForProperty(undefined, 'dont-matter', template), undefined)
             })
 
-            it('returns a global value', () => {
+            it('returns a global value', function() {
                 const template = newTemplate()
                 assert.strictEqual(
                     CloudFormation.getStringForProperty(template.Resources!.resource?.Properties, 'Runtime', template),
@@ -445,7 +445,7 @@ describe('CloudFormation', () => {
                 )
             })
 
-            it('returns a global Ref value', () => {
+            it('returns a global Ref value', function() {
                 const template = newTemplate()
                 assert.strictEqual(
                     CloudFormation.getStringForProperty(
@@ -457,7 +457,7 @@ describe('CloudFormation', () => {
                 )
             })
 
-            it('returns undefined for a global number value', () => {
+            it('returns undefined for a global number value', function() {
                 const template = newTemplate()
                 assert.strictEqual(
                     CloudFormation.getStringForProperty(template.Resources!.resource?.Properties, 'Timeout', template),
@@ -465,7 +465,7 @@ describe('CloudFormation', () => {
                 )
             })
 
-            it('returns undefined for a global Ref number value', () => {
+            it('returns undefined for a global Ref number value', function() {
                 const template = newTemplate()
                 assert.strictEqual(
                     CloudFormation.getStringForProperty(
@@ -478,8 +478,8 @@ describe('CloudFormation', () => {
             })
         })
 
-        describe('getNumberForProperty', () => {
-            it('returns a number', () => {
+        describe('getNumberForProperty', function() {
+            it('returns a number', function() {
                 const property: number = 1
                 const template = newTemplate()
                 template.Resources!.resource!.Properties!.MemorySize = property
@@ -493,7 +493,7 @@ describe('CloudFormation', () => {
                 )
             })
 
-            it('returns a number from a ref with a default value', () => {
+            it('returns a number from a ref with a default value', function() {
                 const property: CloudFormation.Ref = {
                     Ref: 'numParamVal',
                 }
@@ -509,7 +509,7 @@ describe('CloudFormation', () => {
                 )
             })
 
-            it('returns undefined if the ref does not have a default value', () => {
+            it('returns undefined if the ref does not have a default value', function() {
                 const property: CloudFormation.Ref = {
                     Ref: 'numParamNoVal',
                 }
@@ -525,7 +525,7 @@ describe('CloudFormation', () => {
                 )
             })
 
-            it('returns undefined is a string', () => {
+            it('returns undefined is a string', function() {
                 const template = newTemplate()
                 assert.strictEqual(
                     CloudFormation.getNumberForProperty(template.Resources!.resource!.Properties, 'Handler', template),
@@ -533,7 +533,7 @@ describe('CloudFormation', () => {
                 )
             })
 
-            it('returns undefined if a ref to a string is provided', () => {
+            it('returns undefined if a ref to a string is provided', function() {
                 const property: CloudFormation.Ref = {
                     Ref: 'strParamVal',
                 }
@@ -545,12 +545,12 @@ describe('CloudFormation', () => {
                 )
             })
 
-            it('returns undefined if undefined is provided', () => {
+            it('returns undefined if undefined is provided', function() {
                 const template = newTemplate()
                 assert.strictEqual(CloudFormation.getNumberForProperty(undefined, 'dont-matter', template), undefined)
             })
 
-            it('returns a global value', () => {
+            it('returns a global value', function() {
                 const template = newTemplate()
                 assert.strictEqual(
                     CloudFormation.getNumberForProperty(template.Resources!.resource?.Properties, 'Timeout', template),
@@ -558,7 +558,7 @@ describe('CloudFormation', () => {
                 )
             })
 
-            it('returns a global Ref value', () => {
+            it('returns a global Ref value', function() {
                 const template = newTemplate()
                 assert.strictEqual(
                     CloudFormation.getNumberForProperty(
@@ -570,7 +570,7 @@ describe('CloudFormation', () => {
                 )
             })
 
-            it('returns undefined for a global string value', () => {
+            it('returns undefined for a global string value', function() {
                 const template = newTemplate()
                 assert.strictEqual(
                     CloudFormation.getNumberForProperty(template.Resources!.resource?.Properties, 'Runtime', template),
@@ -578,7 +578,7 @@ describe('CloudFormation', () => {
                 )
             })
 
-            it('returns undefined for a global Ref string value', () => {
+            it('returns undefined for a global Ref string value', function() {
                 const template = newTemplate()
                 assert.strictEqual(
                     CloudFormation.getNumberForProperty(
@@ -591,14 +591,14 @@ describe('CloudFormation', () => {
             })
         })
 
-        describe('resolvePropertyWithOverrides', () => {
-            it('returns a string', () => {
+        describe('resolvePropertyWithOverrides', function() {
+            it('returns a string', function() {
                 const property: string = 'good'
                 const template = newTemplate()
                 assert.strictEqual(CloudFormation.resolvePropertyWithOverrides(property, template), property)
             })
 
-            it('returns a string from a ref with a default value', () => {
+            it('returns a string from a ref with a default value', function() {
                 const property: CloudFormation.Ref = {
                     Ref: 'strParamVal',
                 }
@@ -606,13 +606,13 @@ describe('CloudFormation', () => {
                 assert.strictEqual(CloudFormation.resolvePropertyWithOverrides(property, template), 'asdf')
             })
 
-            it('returns a number', () => {
+            it('returns a number', function() {
                 const property: number = 1
                 const template = newTemplate()
                 assert.strictEqual(CloudFormation.resolvePropertyWithOverrides(property, template), 1)
             })
 
-            it('returns a number from a ref with a default value', () => {
+            it('returns a number from a ref with a default value', function() {
                 const property: CloudFormation.Ref = {
                     Ref: 'numParamVal',
                 }
@@ -620,12 +620,12 @@ describe('CloudFormation', () => {
                 assert.strictEqual(CloudFormation.resolvePropertyWithOverrides(property, template), 999)
             })
 
-            it('returns undefined if undefined is provided', () => {
+            it('returns undefined if undefined is provided', function() {
                 const template = newTemplate()
                 assert.strictEqual(CloudFormation.resolvePropertyWithOverrides(undefined, template), undefined)
             })
 
-            it('returns undefined if the ref does not have a default value and no overrides are present', () => {
+            it('returns undefined if the ref does not have a default value and no overrides are present', function() {
                 const property: CloudFormation.Ref = {
                     Ref: 'strParamNoVal',
                 }
@@ -633,7 +633,7 @@ describe('CloudFormation', () => {
                 assert.strictEqual(CloudFormation.resolvePropertyWithOverrides(property, template), undefined)
             })
 
-            it('returns the override value if no default value provided', () => {
+            it('returns the override value if no default value provided', function() {
                 const property: CloudFormation.Ref = {
                     Ref: 'strParamNoVal',
                 }
@@ -647,7 +647,7 @@ describe('CloudFormation', () => {
                 )
             })
 
-            it('returns the override value even if default value provided', () => {
+            it('returns the override value even if default value provided', function() {
                 const property: CloudFormation.Ref = {
                     Ref: 'strParamVal',
                 }

--- a/src/test/shared/cloudformation/templateRegistry.test.ts
+++ b/src/test/shared/cloudformation/templateRegistry.test.ts
@@ -21,23 +21,23 @@ import { CloudFormation } from '../../../shared/cloudformation/cloudformation'
 import { WatchedItem } from '../../../shared/watchedFiles'
 
 // TODO almost all of these tests should be moved to test WatchedFiles instead
-describe('CloudFormation Template Registry', async () => {
+describe('CloudFormation Template Registry', async function() {
     const goodYaml1 = makeSampleSamTemplateYaml(false)
 
-    describe('CloudFormationTemplateRegistry', async () => {
+    describe('CloudFormationTemplateRegistry', async function() {
         let testRegistry: CloudFormationTemplateRegistry
         let tempFolder: string
 
-        beforeEach(async () => {
+        beforeEach(async function() {
             tempFolder = await makeTemporaryToolkitFolder()
             testRegistry = new CloudFormationTemplateRegistry()
         })
 
-        afterEach(async () => {
+        afterEach(async function() {
             await fs.remove(tempFolder)
         })
 
-        describe('addItemToRegistry', async () => {
+        describe('addItemToRegistry', async function() {
             it("adds data from a template to the registry and can receive the template's data", async () => {
                 const filename = vscode.Uri.file(path.join(tempFolder, 'template.yaml'))
                 await strToYamlFile(goodYaml1, filename.fsPath)
@@ -50,7 +50,7 @@ describe('CloudFormation Template Registry', async () => {
                 assertValidTestTemplate(data, filename.fsPath)
             })
 
-            it('throws an error if the file to add is not a CF template', async () => {
+            it('throws an error if the file to add is not a CF template', async function() {
                 const filename = vscode.Uri.file(path.join(tempFolder, 'template.yaml'))
                 await strToYamlFile(badYaml, filename.fsPath)
 
@@ -61,15 +61,15 @@ describe('CloudFormation Template Registry', async () => {
         })
 
         // other get cases are tested in the add section
-        describe('registeredItems', async () => {
-            it('returns an empty array if the registry has no registered templates', () => {
+        describe('registeredItems', async function() {
+            it('returns an empty array if the registry has no registered templates', function() {
                 assert.strictEqual(testRegistry.registeredItems.length, 0)
             })
         })
 
         // other get cases are tested in the add section
-        describe('getRegisteredItem', async () => {
-            it('Returns the item from the VSCode URI', async () => {
+        describe('getRegisteredItem', async function() {
+            it('Returns the item from the VSCode URI', async function() {
                 const filename = vscode.Uri.file(path.join(tempFolder, 'template.yaml'))
                 await strToYamlFile(goodYaml1, filename.fsPath)
                 await testRegistry.addItemToRegistry(filename)
@@ -79,11 +79,11 @@ describe('CloudFormation Template Registry', async () => {
                 assertValidTestTemplate(data, filename.fsPath)
             })
 
-            it('returns undefined if the registry has no registered templates', () => {
+            it('returns undefined if the registry has no registered templates', function() {
                 assert.strictEqual(testRegistry.getRegisteredItem('/template.yaml'), undefined)
             })
 
-            it('returns undefined if the registry does not contain the template in question', async () => {
+            it('returns undefined if the registry does not contain the template in question', async function() {
                 const filename = vscode.Uri.file(path.join(tempFolder, 'template.yaml'))
                 await strToYamlFile(goodYaml1, filename.fsPath)
                 await testRegistry.addItemToRegistry(vscode.Uri.file(filename.fsPath))
@@ -92,8 +92,8 @@ describe('CloudFormation Template Registry', async () => {
             })
         })
 
-        describe('removeTemplateFromRegistry', async () => {
-            it('removes an added template', async () => {
+        describe('removeTemplateFromRegistry', async function() {
+            it('removes an added template', async function() {
                 const filename = vscode.Uri.file(path.join(tempFolder, 'template.yaml'))
                 await strToYamlFile(goodYaml1, filename.fsPath)
                 await testRegistry.addItemToRegistry(vscode.Uri.file(filename.fsPath))
@@ -103,7 +103,7 @@ describe('CloudFormation Template Registry', async () => {
                 assert.strictEqual(testRegistry.registeredItems.length, 0)
             })
 
-            it('does not affect the registry if a nonexistant template is removed', async () => {
+            it('does not affect the registry if a nonexistant template is removed', async function() {
                 const filename = vscode.Uri.file(path.join(tempFolder, 'template.yaml'))
                 await strToYamlFile(goodYaml1, filename.fsPath)
                 await testRegistry.addItemToRegistry(vscode.Uri.file(filename.fsPath))
@@ -198,8 +198,8 @@ describe('CloudFormation Template Registry', async () => {
         },
     }
 
-    describe('getResourcesForHandler', () => {
-        it('handles empty input', () => {
+    describe('getResourcesForHandler', function() {
+        it('handles empty input', function() {
             // Empty `unfilteredTemplates` input:
             assert.deepStrictEqual(
                 getResourcesForHandler(path.join(rootPath, nestedPath, 'index.js'), 'handler', []),
@@ -207,7 +207,7 @@ describe('CloudFormation Template Registry', async () => {
             )
         })
 
-        it('returns an array containing resources that contain references to the handler in question', () => {
+        it('returns an array containing resources that contain references to the handler in question', function() {
             const val = getResourcesForHandler(path.join(rootPath, nestedPath, 'index.js'), 'handler', [
                 nonParentTemplate,
                 workingTemplate,
@@ -248,8 +248,8 @@ describe('CloudFormation Template Registry', async () => {
         })
     })
 
-    describe('getResourcesForHandlerFromTemplateDatum', () => {
-        it('returns an empty array if the given template is not a parent of the handler file in question', () => {
+    describe('getResourcesForHandlerFromTemplateDatum', function() {
+        it('returns an empty array if the given template is not a parent of the handler file in question', function() {
             const val = getResourcesForHandlerFromTemplateDatum(
                 path.join(rootPath, 'index.js'),
                 'handler',
@@ -259,7 +259,7 @@ describe('CloudFormation Template Registry', async () => {
             assert.deepStrictEqual(val, [])
         })
 
-        it('returns an empty array if the template has no resources', () => {
+        it('returns an empty array if the template has no resources', function() {
             const val = getResourcesForHandlerFromTemplateDatum(
                 path.join(rootPath, nestedPath, 'index.js'),
                 'handler',
@@ -269,7 +269,7 @@ describe('CloudFormation Template Registry', async () => {
             assert.deepStrictEqual(val, [])
         })
 
-        it('returns a template resource if it has a matching handler', () => {
+        it('returns a template resource if it has a matching handler', function() {
             const val = getResourcesForHandlerFromTemplateDatum(
                 path.join(rootPath, nestedPath, 'index.js'),
                 'handler',
@@ -284,7 +284,7 @@ describe('CloudFormation Template Registry', async () => {
             ])
         })
 
-        it('ignores path handling if using a compiled language', () => {
+        it('ignores path handling if using a compiled language', function() {
             const val = getResourcesForHandlerFromTemplateDatum(
                 path.join(rootPath, nestedPath, 'index.cs'),
                 'Asdf::Asdf.Function::FunctionHandler',
@@ -299,7 +299,7 @@ describe('CloudFormation Template Registry', async () => {
             ])
         })
 
-        it('returns all template resources if it has multiple matching handlers', () => {
+        it('returns all template resources if it has multiple matching handlers', function() {
             const val = getResourcesForHandlerFromTemplateDatum(
                 path.join(rootPath, nestedPath, 'index.js'),
                 'handler',
@@ -324,7 +324,7 @@ describe('CloudFormation Template Registry', async () => {
             ])
         })
 
-        it('does not break if the resource has a non-parseable runtime', () => {
+        it('does not break if the resource has a non-parseable runtime', function() {
             const val = getResourcesForHandlerFromTemplateDatum(
                 path.join(rootPath, nestedPath, 'index.js'),
                 'handler',
@@ -340,18 +340,18 @@ describe('CloudFormation Template Registry', async () => {
         })
     })
 
-    describe('getResourcesForHandlerFromTemplateDatum (image tests)', async () => {
+    describe('getResourcesForHandlerFromTemplateDatum (image tests)', async function() {
         let tempFolder: string
         let helloPath: string
         let nestedPath: string
 
-        beforeEach(async () => {
+        beforeEach(async function() {
             tempFolder = await makeTemporaryToolkitFolder()
             helloPath = path.join(tempFolder, 'hello-world')
             nestedPath = path.join(helloPath, 'nested')
         })
 
-        afterEach(async () => {
+        afterEach(async function() {
             await fs.remove(tempFolder)
         })
 
@@ -374,7 +374,7 @@ describe('CloudFormation Template Registry', async () => {
             },
         }
 
-        it('checks for an exact handler match to a relative path in a Dockerfile for image functions', async () => {
+        it('checks for an exact handler match to a relative path in a Dockerfile for image functions', async function() {
             toFile('CMD: ["index.handler"]', path.join(helloPath, 'Dockerfile'))
             toFile('CMD: ["index.handler"]', path.join(nestedPath, 'Dockerfile'))
 
@@ -444,7 +444,7 @@ describe('CloudFormation Template Registry', async () => {
             )
         })
 
-        it('checks for an exact handler match for C# files in a Dockerfile for image functions', async () => {
+        it('checks for an exact handler match for C# files in a Dockerfile for image functions', async function() {
             toFile('CMD: ["HelloWorld::HelloWorld.Function::FunctionHandler"]', path.join(helloPath, 'Dockerfile'))
             toFile('CMD: ["HelloWorld::HelloWorld.Function::FunctionHandler"]', path.join(nestedPath, 'Dockerfile'))
 

--- a/src/test/shared/cloudformation/templateSymbolResolver.test.ts
+++ b/src/test/shared/cloudformation/templateSymbolResolver.test.ts
@@ -54,14 +54,14 @@ function symbol(name: string, kind: vscode.SymbolKind, children: vscode.Document
     return newSymbol
 }
 
-describe('TemplateSymbolResolver', () => {
+describe('TemplateSymbolResolver', function() {
     let mockDocument: vscode.TextDocument
     let document: vscode.TextDocument
 
     let mockSymbolProvider: TemplateSymbolProvider
     let symbolProvider: TemplateSymbolProvider
 
-    beforeEach(() => {
+    beforeEach(function() {
         mockDocument = mock()
         document = instance(mockDocument)
 
@@ -74,7 +74,7 @@ describe('TemplateSymbolResolver', () => {
         when(mockSymbolProvider.getText(looksLikeFunctionType, document)).thenReturn('Type: NotActuallyAFunction')
     })
 
-    it('gets function resources', async () => {
+    it('gets function resources', async function() {
         const symbolResolver = new TemplateSymbolResolver(document, symbolProvider)
         const functionResources = await symbolResolver.getResourcesOfKind('function', false)
 

--- a/src/test/shared/codelens/codeLensUtils.test.ts
+++ b/src/test/shared/codelens/codeLensUtils.test.ts
@@ -12,19 +12,19 @@ import * as Picker from '../../../shared/ui/picker'
 import { API_TARGET_TYPE, CODE_TARGET_TYPE, TEMPLATE_TARGET_TYPE } from '../../../shared/sam/debugger/awsSamDebugConfiguration'
 import * as AddSamDebugConfiguration from '../../../shared/sam/debugger/commands/addSamDebugConfiguration'
 
-describe('codeLensUtils', () => {
-    describe('pickAddSamDebugConfiguration', () => {
+describe('codeLensUtils', function() {
+    describe('pickAddSamDebugConfiguration', function() {
         let sandbox: sinon.SinonSandbox
 
-        beforeEach(() => {
+        beforeEach(function() {
             sandbox = sinon.createSandbox()
         })
 
-        afterEach(() => {
+        afterEach(function() {
             sandbox.restore()
         })
 
-        it('should use CODE_TARGET_TYPE with no templateConfigs', () => {
+        it('should use CODE_TARGET_TYPE with no templateConfigs', function() {
             const addSamStub = sandbox.stub(AddSamDebugConfiguration, 'addSamDebugConfiguration')
             const codeConfig: AddSamDebugConfiguration.AddSamDebugConfigurationInput = {resourceName: 'codeResource', rootUri: vscode.Uri.file('path')} 
             const templateConfigs: AddSamDebugConfiguration.AddSamDebugConfigurationInput[] = []
@@ -34,7 +34,7 @@ describe('codeLensUtils', () => {
             assert.strictEqual(addSamStub.calledOnceWith(codeConfig, CODE_TARGET_TYPE), true)
         })
     
-        it('should use CODE_TARGET_TYPE when no template option is chosen', async () => {
+        it('should use CODE_TARGET_TYPE when no template option is chosen', async function() {
             sandbox.stub(Picker, 'promptUser').resolves(undefined)
             sandbox.stub(Picker, 'verifySinglePickerOutput').returns({label: 'No Template'})
             const addSamStub = sandbox.stub(AddSamDebugConfiguration, 'addSamDebugConfiguration').resolves()
@@ -46,7 +46,7 @@ describe('codeLensUtils', () => {
             assert.strictEqual(addSamStub.calledOnceWith(codeConfig, CODE_TARGET_TYPE), true)
         })
 
-        it('should use API_TARGET_TYPE when API template option is chosen', async () => {
+        it('should use API_TARGET_TYPE when API template option is chosen', async function() {
             sandbox.stub(Picker, 'promptUser').resolves(undefined)
             sandbox.stub(Picker, 'verifySinglePickerOutput').returns({label: `${path.sep}path:templateWithApi (API Event: eventName)`})
             const addSamStub = sandbox.stub(AddSamDebugConfiguration, 'addSamDebugConfiguration').resolves()
@@ -58,7 +58,7 @@ describe('codeLensUtils', () => {
             assert.strictEqual(addSamStub.args[0][1], API_TARGET_TYPE)
         })
 
-        it('should use TEMPLATE_TARGET_TYPE when non API template option is chosen', async () => {
+        it('should use TEMPLATE_TARGET_TYPE when non API template option is chosen', async function() {
             sandbox.stub(Picker, 'promptUser').resolves(undefined)
             sandbox.stub(Picker, 'verifySinglePickerOutput').returns({label: `${path.sep}path:templateNoApi`})
             const addSamStub = sandbox.stub(AddSamDebugConfiguration, 'addSamDebugConfiguration').resolves()

--- a/src/test/shared/codelens/csharpCodeLensProvider.test.ts
+++ b/src/test/shared/codelens/csharpCodeLensProvider.test.ts
@@ -22,19 +22,19 @@ import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 
 const fakeRange = new vscode.Range(0, 0, 0, 0)
 
-describe('getLambdaHandlerComponents', async () => {
+describe('getLambdaHandlerComponents', async function() {
     let tempFolder: string
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         // Make a temp folder for all these tests
         tempFolder = await makeTemporaryToolkitFolder()
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         await fs.remove(tempFolder)
     })
 
-    it('Detects a public function symbol', async () => {
+    it('Detects a public function symbol', async function() {
         const programFile = path.join(tempFolder, 'program.cs')
         await writeFile(programFile, sampleDotNetSamProgram.getFunctionText())
 
@@ -54,7 +54,7 @@ describe('getLambdaHandlerComponents', async () => {
     })
 })
 
-describe('isPublicClassSymbol', async () => {
+describe('isPublicClassSymbol', async function() {
     const sampleClassSymbol: vscode.DocumentSymbol = new vscode.DocumentSymbol(
         'HelloWorld.Function',
         '',
@@ -63,7 +63,7 @@ describe('isPublicClassSymbol', async () => {
         fakeRange
     )
 
-    it('returns true for a public class', async () => {
+    it('returns true for a public class', async function() {
         const doc = {
             getText: (range?: vscode.Range): string => {
                 return 'public class Function {}'
@@ -74,7 +74,7 @@ describe('isPublicClassSymbol', async () => {
         assert.strictEqual(isPublic, true, 'Expected symbol to be a public class')
     })
 
-    it('returns false when symbol is not of type Class', async () => {
+    it('returns false when symbol is not of type Class', async function() {
         const symbol = new vscode.DocumentSymbol(
             sampleClassSymbol.name,
             sampleClassSymbol.detail,
@@ -93,7 +93,7 @@ describe('isPublicClassSymbol', async () => {
         assert.strictEqual(isPublic, false, 'Expected symbol not to be a public class')
     })
 
-    it('returns false when class is not public', async () => {
+    it('returns false when class is not public', async function() {
         const doc = {
             getText: (range?: vscode.Range): string => 'private class ',
         }
@@ -103,7 +103,7 @@ describe('isPublicClassSymbol', async () => {
     })
 })
 
-describe('isPublicMethodSymbol', async () => {
+describe('isPublicMethodSymbol', async function() {
     const validPublicMethodTests = [
         {
             scenario: 'signature all on one line',
@@ -167,7 +167,7 @@ describe('isPublicMethodSymbol', async () => {
         })
     })
 
-    it('returns false for a symbol that is not a method', async () => {
+    it('returns false for a symbol that is not a method', async function() {
         const symbol = new vscode.DocumentSymbol(
             'FunctionHandler(APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)',
             '',
@@ -186,7 +186,7 @@ describe('isPublicMethodSymbol', async () => {
         assert.strictEqual(isPublic, false, 'Expected symbol not to be a public method')
     })
 
-    it('returns false when the method is not public', async () => {
+    it('returns false when the method is not public', async function() {
         const handler = generateFunctionHandler('FunctionHandler', 'APIGatewayProxyResponse', 'ILambdaContext')
         const symbol = new vscode.DocumentSymbol(handler, '', vscode.SymbolKind.Method, fakeRange, fakeRange)
         const doc = {
@@ -203,7 +203,7 @@ describe('isPublicMethodSymbol', async () => {
         assert.strictEqual(isPublic, false, 'Expected symbol not to be a public method')
     })
 
-    it('returns false when a private method name contains the word public in it', async () => {
+    it('returns false when a private method name contains the word public in it', async function() {
         const symbol = new vscode.DocumentSymbol('notpublicmethod', '', vscode.SymbolKind.Method, fakeRange, fakeRange)
 
         const doc = {
@@ -220,7 +220,7 @@ describe('isPublicMethodSymbol', async () => {
         assert.strictEqual(isPublic, false, 'Expected symbol not to be a public method')
     })
 
-    it('returns false when the second parameter is not an ILambdaContext', async () => {
+    it('returns false when the second parameter is not an ILambdaContext', async function() {
         const symbol: vscode.DocumentSymbol = new vscode.DocumentSymbol(
             'FunctionHandler(APIGatewayProxyRequest apigProxyEvent, string context)',
             '',
@@ -296,8 +296,8 @@ describe('isPublicMethodSymbol', async () => {
     }
 })
 
-describe('generateDotNetLambdaHandler', async () => {
-    it('produces a handler name', async () => {
+describe('generateDotNetLambdaHandler', async function() {
+    it('produces a handler name', async function() {
         const components: DotNetLambdaHandlerComponents = {
             assembly: 'myAssembly',
             namespace: 'myNamespace',

--- a/src/test/shared/codelens/localLambdaRunner.test.ts
+++ b/src/test/shared/codelens/localLambdaRunner.test.ts
@@ -15,24 +15,24 @@ import { assertRejects } from '../utilities/assertUtils'
 import { SamLaunchRequestArgs } from '../../../shared/sam/debugger/awsSamDebugger'
 import { assertLogsContain } from '../../globalSetup.test'
 
-describe('localLambdaRunner', async () => {
+describe('localLambdaRunner', async function() {
     let tempDir: string
-    before(async () => {
+    before(async function() {
         await FakeExtensionContext.getNew()
     })
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         tempDir = await fsUtils.makeTemporaryToolkitFolder()
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         await fs.remove(tempDir)
     })
 
-    describe('attachDebugger', async () => {
+    describe('attachDebugger', async function() {
         let actualRetries: number = 0
 
-        beforeEach(async () => {
+        beforeEach(async function() {
             actualRetries = 0
         })
 
@@ -54,7 +54,7 @@ describe('localLambdaRunner', async () => {
             return Promise.resolve(false)
         }
 
-        it('Successful attach has no retries', async () => {
+        it('Successful attach has no retries', async function() {
             await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 onStartDebugging: startDebuggingReturnsTrue,
@@ -64,7 +64,7 @@ describe('localLambdaRunner', async () => {
             assert.strictEqual(actualRetries, 0, 'Did not expect any retries when attaching debugger succeeds')
         })
 
-        it('Successful attach logs that the debugger attached', async () => {
+        it('Successful attach logs that the debugger attached', async function() {
             await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 onStartDebugging: startDebuggingReturnsTrue,
@@ -75,7 +75,7 @@ describe('localLambdaRunner', async () => {
             assertLogsContain('Debugger attached', false, 'info')
         })
 
-        it('Successful attach records a success metric', async () => {
+        it('Successful attach records a success metric', async function() {
             await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 onStartDebugging: startDebuggingReturnsTrue,
@@ -87,7 +87,7 @@ describe('localLambdaRunner', async () => {
             })
         })
 
-        it('Successful attach returns success', async () => {
+        it('Successful attach returns success', async function() {
             const results = await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 onStartDebugging: startDebuggingReturnsTrue,
@@ -97,7 +97,7 @@ describe('localLambdaRunner', async () => {
             assert.ok(results.success, 'Expected attach results to be successful')
         })
 
-        it('Failure to attach logs that the debugger did not attach', async () => {
+        it('Failure to attach logs that the debugger did not attach', async function() {
             await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 onStartDebugging: startDebuggingReturnsFalse,
@@ -108,7 +108,7 @@ describe('localLambdaRunner', async () => {
             assertLogsContain('Unable to attach Debugger', false, 'error')
         })
 
-        it('Failure to attach records a fail metric', async () => {
+        it('Failure to attach records a fail metric', async function() {
             await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 onStartDebugging: startDebuggingReturnsFalse,
@@ -119,7 +119,7 @@ describe('localLambdaRunner', async () => {
             })
         })
 
-        it('Failure to attach returns failure', async () => {
+        it('Failure to attach returns failure', async function() {
             const results = await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 onStartDebugging: startDebuggingReturnsFalse,
@@ -129,7 +129,7 @@ describe('localLambdaRunner', async () => {
             assert.strictEqual(results.success, false, 'Expected attach results to fail')
         })
 
-        it('Logs about exceeding the retry limit', async () => {
+        it('Logs about exceeding the retry limit', async function() {
             await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 onStartDebugging: startDebuggingReturnsFalse,
@@ -140,7 +140,7 @@ describe('localLambdaRunner', async () => {
             assertLogsContain('Retry limit reached', false, 'error')
         })
 
-        it('Does not log metrics when startDebugging returns false', async () => {
+        it('Does not log metrics when startDebugging returns false', async function() {
             await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 onStartDebugging: startDebuggingReturnsFalse,
@@ -152,7 +152,7 @@ describe('localLambdaRunner', async () => {
             })
         })
 
-        it('Returns true if attach succeeds during retries', async () => {
+        it('Returns true if attach succeeds during retries', async function() {
             const results = await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 onStartDebugging: async (
@@ -169,7 +169,7 @@ describe('localLambdaRunner', async () => {
             assert.ok(results.success, 'Expected attach results to succeed')
         })
 
-        it('Returns false if retry count exceeded', async () => {
+        it('Returns false if retry count exceeded', async function() {
             const results = await localLambdaRunner.attachDebugger({
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 onStartDebugging: startDebuggingReturnsFalse,
@@ -180,7 +180,7 @@ describe('localLambdaRunner', async () => {
         })
     })
 
-    describe('executeSamBuild', () => {
+    describe('executeSamBuild', function() {
         const failedChildProcess: ChildProcessResult = {
             exitCode: 1,
             error: new Error('you are already dead'),
@@ -212,12 +212,12 @@ describe('localLambdaRunner', async () => {
             }
         }
 
-        it('fails when the child process returns a nonzero exit code', async () => {
+        it('fails when the child process returns a nonzero exit code', async function() {
             const samArgs = generateSamBuildParams(false)
             await assertRejects(async () => await new SamCliBuildInvocation(samArgs).execute())
         })
 
-        it('succeeds when the child process returns with an exit code of 0', async () => {
+        it('succeeds when the child process returns with an exit code of 0', async function() {
             const samArgs = generateSamBuildParams(true)
             assert.strictEqual(await new SamCliBuildInvocation(samArgs).execute(), 0)
         })

--- a/src/test/shared/codelens/pythonCodeLensProvider.test.ts
+++ b/src/test/shared/codelens/pythonCodeLensProvider.test.ts
@@ -6,8 +6,8 @@
 import * as assert from 'assert'
 import { getLocalRootVariants } from '../../../shared/utilities/pathUtils'
 
-describe('pythonCodeLensProvider', async () => {
-    describe('getLocalRootVariants', async () => {
+describe('pythonCodeLensProvider', async function() {
+    describe('getLocalRootVariants', async function() {
         if (process.platform === 'win32') {
             const testScenarios = [
                 {
@@ -34,14 +34,14 @@ describe('pythonCodeLensProvider', async () => {
                 })
             })
 
-            it('Returns the same string for network location - windows', async () => {
+            it('Returns the same string for network location - windows', async function() {
                 const variants = getLocalRootVariants('//share/src/code.js')
                 assert.ok(variants)
                 assert.strictEqual(variants.length, 1, 'Only expected one variant')
                 assert.strictEqual(variants[0], '//share/src/code.js', 'Unexpected variant text')
             })
 
-            it('Returns the same string for weird input - windows', async () => {
+            it('Returns the same string for weird input - windows', async function() {
                 const variants = getLocalRootVariants('src/code.js')
                 assert.ok(variants)
                 assert.strictEqual(variants.length, 1, 'Only expected one variant')

--- a/src/test/shared/credentials/accountId.test.ts
+++ b/src/test/shared/credentials/accountId.test.ts
@@ -10,7 +10,7 @@ import { ToolkitClientBuilder } from '../../../shared/clients/toolkitClientBuild
 import { getAccountId } from '../../../shared/credentials/accountId'
 import { ext } from '../../../shared/extensionGlobals'
 
-describe('getAccountId', () => {
+describe('getAccountId', function() {
     let sandbox: sinon.SinonSandbox
 
     const credentials: AWS.Credentials = ({} as any) as AWS.Credentials
@@ -29,7 +29,7 @@ describe('getAccountId', () => {
     }
     let createStsClientStub: sinon.SinonStub<[], StsClient>
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         sandbox = sinon.createSandbox()
 
         createStsClientStub = sandbox.stub(clientBuilder, 'createStsClient').returns(stsClient)
@@ -37,11 +37,11 @@ describe('getAccountId', () => {
         ext.toolkitClientBuilder = (clientBuilder as any) as ToolkitClientBuilder
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         sandbox.restore()
     })
 
-    it('returns an account id (happy path)', async () => {
+    it('returns an account id (happy path)', async function() {
         const mockResponse: AWS.STS.GetCallerIdentityResponse = {
             Account: 'some valid account id',
         }
@@ -53,7 +53,7 @@ describe('getAccountId', () => {
         assert.strictEqual(accountId, mockResponse.Account)
     })
 
-    it('returns undefined if getCallerIdentity returns an undefined account', async () => {
+    it('returns undefined if getCallerIdentity returns an undefined account', async function() {
         const mockResponse: AWS.STS.GetCallerIdentityResponse = {
             Account: undefined,
         }
@@ -65,7 +65,7 @@ describe('getAccountId', () => {
         assert.strictEqual(accountId, undefined)
     })
 
-    it('returns undefined if getCallerIdentity throws', async () => {
+    it('returns undefined if getCallerIdentity throws', async function() {
         sandbox.stub(stsClient, 'getCallerIdentity').callsFake(() => {
             throw new Error('Simulating service error')
         })
@@ -75,7 +75,7 @@ describe('getAccountId', () => {
         assert.strictEqual(accountId, undefined)
     })
 
-    it('returns undefined if STS is not defined and toolkitClientBuilder cannot create an STS client', async () => {
+    it('returns undefined if STS is not defined and toolkitClientBuilder cannot create an STS client', async function() {
         createStsClientStub.restore()
         sandbox.stub(clientBuilder, 'createStsClient').callsFake(() => {
             throw new Error('Simulating STS Client not creating')

--- a/src/test/shared/credentials/credentialsProfileMru.test.ts
+++ b/src/test/shared/credentials/credentialsProfileMru.test.ts
@@ -7,8 +7,8 @@ import * as assert from 'assert'
 import { CredentialsProfileMru } from '../../../shared/credentials/credentialsProfileMru'
 import { FakeExtensionContext } from '../../fakeExtensionContext'
 
-describe('CredentialsProfileMru', () => {
-    it('lists no profile when none exist', async () => {
+describe('CredentialsProfileMru', function() {
+    it('lists no profile when none exist', async function() {
         const credentialsMru = new CredentialsProfileMru(new FakeExtensionContext())
 
         const mru = credentialsMru.getMruList()
@@ -17,7 +17,7 @@ describe('CredentialsProfileMru', () => {
         assert.strictEqual(mru.length, 0)
     })
 
-    it('lists single profile when only one exists', async () => {
+    it('lists single profile when only one exists', async function() {
         const credentialsMru = new CredentialsProfileMru(new FakeExtensionContext())
 
         await credentialsMru.setMostRecentlyUsedProfile('apples')
@@ -29,7 +29,7 @@ describe('CredentialsProfileMru', () => {
         assert.strictEqual(mru[0], 'apples')
     })
 
-    it('lists multiple profiles when multiple exist', async () => {
+    it('lists multiple profiles when multiple exist', async function() {
         const credentialsMru = new CredentialsProfileMru(new FakeExtensionContext())
 
         await credentialsMru.setMostRecentlyUsedProfile('dogs')
@@ -43,7 +43,7 @@ describe('CredentialsProfileMru', () => {
         assert.strictEqual(mru[1], 'dogs')
     })
 
-    it('does not list duplicate profiles', async () => {
+    it('does not list duplicate profiles', async function() {
         const credentialsMru = new CredentialsProfileMru(new FakeExtensionContext())
 
         await credentialsMru.setMostRecentlyUsedProfile('bbq')
@@ -60,7 +60,7 @@ describe('CredentialsProfileMru', () => {
         assert.strictEqual(mru[2], 'dill')
     })
 
-    it('does not list more than MAX_CRENDTIAL_MRU_SIZE profiles', async () => {
+    it('does not list more than MAX_CRENDTIAL_MRU_SIZE profiles', async function() {
         const credentialsMru = new CredentialsProfileMru(new FakeExtensionContext())
 
         for (let i = 0; i < CredentialsProfileMru.MAX_CREDENTIAL_MRU_SIZE + 1; i++) {

--- a/src/test/shared/credentials/credentialsStore.test.ts
+++ b/src/test/shared/credentials/credentialsStore.test.ts
@@ -9,7 +9,7 @@ import { CredentialsStore } from '../../../credentials/credentialsStore'
 import { CredentialsProvider } from '../../../credentials/providers/credentialsProvider'
 import { CredentialsProviderId } from '../../../credentials/providers/credentialsProviderId'
 
-describe('CredentialsStore', async () => {
+describe('CredentialsStore', async function() {
     let sandbox: sinon.SinonSandbox
     let sut: CredentialsStore
     const sampleCredentials = ({} as any) as AWS.Credentials
@@ -18,12 +18,12 @@ describe('CredentialsStore', async () => {
         credentialTypeId: 'someId',
     }
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         sandbox = sinon.createSandbox()
         sut = new CredentialsStore()
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         sandbox.restore()
     })
 
@@ -34,11 +34,11 @@ describe('CredentialsStore', async () => {
         } as any) as CredentialsProvider
     }
 
-    it('getCredentials returns undefined when credentials are not loaded', async () => {
+    it('getCredentials returns undefined when credentials are not loaded', async function() {
         assert.strictEqual(await sut.getCredentials(sampleCredentialsProviderId), undefined)
     })
 
-    it('upsertCredentials creates when credentials are not loaded', async () => {
+    it('upsertCredentials creates when credentials are not loaded', async function() {
         const provider = makeSampleCredentialsProvider(1)
         const loadedCredentials = await sut.upsertCredentials(sampleCredentialsProviderId, provider)
 
@@ -46,7 +46,7 @@ describe('CredentialsStore', async () => {
         assert.strictEqual(loadedCredentials.credentialsHashCode, provider.getHashCode())
     })
 
-    it('upsertCredentials does not call create method once credentials are loaded', async () => {
+    it('upsertCredentials does not call create method once credentials are loaded', async function() {
         const provider = makeSampleCredentialsProvider()
         const getCredentialsStub = sandbox
             .stub(provider, 'getCredentials')
@@ -63,7 +63,7 @@ describe('CredentialsStore', async () => {
         assert.strictEqual(loadedCredentials2.credentials, sampleCredentials)
     })
 
-    it('getCredentials returns stored credentials', async () => {
+    it('getCredentials returns stored credentials', async function() {
         const provider = makeSampleCredentialsProvider(2)
         await sut.upsertCredentials(sampleCredentialsProviderId, provider)
         const loadedCredentials = await sut.getCredentials(sampleCredentialsProviderId)
@@ -72,7 +72,7 @@ describe('CredentialsStore', async () => {
         assert.strictEqual(loadedCredentials?.credentialsHashCode, provider.getHashCode())
     })
 
-    it('invalidate removes the credentials from storage', async () => {
+    it('invalidate removes the credentials from storage', async function() {
         await sut.upsertCredentials(sampleCredentialsProviderId, makeSampleCredentialsProvider())
         sut.invalidateCredentials(sampleCredentialsProviderId)
         const loadedCredentials = await sut.getCredentials(sampleCredentialsProviderId)

--- a/src/test/shared/credentials/defaultCredentialSelectionDataProvider.test.ts
+++ b/src/test/shared/credentials/defaultCredentialSelectionDataProvider.test.ts
@@ -13,9 +13,9 @@ import {
 } from '../../../shared/credentials/defaultCredentialSelectionDataProvider'
 import { MultiStepInputFlowController } from '../../../shared/multiStepInputFlowController'
 
-describe('defaultCredentialSelectionDataProvider', () => {
-    describe('credentialProfileSelector', () => {
-        it('stops on selection of existing profile name', async () => {
+describe('defaultCredentialSelectionDataProvider', function() {
+    describe('credentialProfileSelector', function() {
+        it('stops on selection of existing profile name', async function() {
             // need to find a better mock solution
             class MockCredentialSelectionDataProvider implements CredentialSelectionDataProvider {
                 public constructor(public readonly existingProfileNames: string[]) {}
@@ -63,8 +63,8 @@ describe('defaultCredentialSelectionDataProvider', () => {
         })
     })
 
-    describe('promptToDefineCredentialsProfile', () => {
-        it('populates prompt with profiles from from data provider', async () => {
+    describe('promptToDefineCredentialsProfile', function() {
+        it('populates prompt with profiles from from data provider', async function() {
             const sampleProfileName: string = 'demoProfile'
             const sampleAccessKey: string = 'ABCD1234'
             const sampleSecretKey: string = '!@#$!@#$'

--- a/src/test/shared/credentials/loginManager.test.ts
+++ b/src/test/shared/credentials/loginManager.test.ts
@@ -13,7 +13,7 @@ import { AwsContext } from '../../../shared/awsContext'
 import * as accountId from '../../../shared/credentials/accountId'
 import { CredentialsStore } from '../../../credentials/credentialsStore'
 
-describe('LoginManager', async () => {
+describe('LoginManager', async function() {
     let sandbox: sinon.SinonSandbox
 
     const awsContext = ({
@@ -35,7 +35,7 @@ describe('LoginManager', async () => {
     let getCredentialsProviderStub: sinon.SinonStub<[CredentialsProviderId], Promise<CredentialsProvider | undefined>>
     let recordAwsSetCredentialsSpy: any
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         sandbox = sinon.createSandbox()
         recordAwsSetCredentialsSpy = sandbox.spy()
 
@@ -54,11 +54,11 @@ describe('LoginManager', async () => {
         getCredentialsProviderStub.resolves(credentialsProvider)
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         sandbox.restore()
     })
 
-    it('passive login does NOT send telemetry', async () => {
+    it('passive login does NOT send telemetry', async function() {
         const setCredentialsStub = sandbox.stub(awsContext, 'setCredentials')
         await loginManager.login({ passive: true, providerId: sampleCredentialsProviderId })
 
@@ -66,7 +66,7 @@ describe('LoginManager', async () => {
         assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, false)
     })
 
-    it('non-passive login sends telemetry', async () => {
+    it('non-passive login sends telemetry', async function() {
         const setCredentialsStub = sandbox.stub(awsContext, 'setCredentials')
         await loginManager.login({ passive: false, providerId: sampleCredentialsProviderId })
 
@@ -74,7 +74,7 @@ describe('LoginManager', async () => {
         assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, true)
     })
 
-    it('logs in with credentials (happy path)', async () => {
+    it('logs in with credentials (happy path)', async function() {
         const setCredentialsStub = sandbox.stub(awsContext, 'setCredentials')
 
         await loginManager.login({ passive: false, providerId: sampleCredentialsProviderId })
@@ -82,7 +82,7 @@ describe('LoginManager', async () => {
         assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, true)
     })
 
-    it('logs out (happy path)', async () => {
+    it('logs out (happy path)', async function() {
         const setCredentialsStub = sandbox.stub(awsContext, 'setCredentials')
 
         await loginManager.login({ passive: false, providerId: sampleCredentialsProviderId })
@@ -91,7 +91,7 @@ describe('LoginManager', async () => {
         assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, true)
     })
 
-    it('logs out if credentials could not be retrieved', async () => {
+    it('logs out if credentials could not be retrieved', async function() {
         getCredentialsProviderStub.reset()
         getCredentialsProviderStub.resolves(undefined)
         const setCredentialsStub = sandbox.stub(awsContext, 'setCredentials').callsFake(async credentials => {
@@ -104,7 +104,7 @@ describe('LoginManager', async () => {
         assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, false)
     })
 
-    it('logs out if an account Id could not be determined', async () => {
+    it('logs out if an account Id could not be determined', async function() {
         getAccountIdStub.reset()
         getAccountIdStub.resolves(undefined)
         const setCredentialsStub = sandbox.stub(awsContext, 'setCredentials').callsFake(async credentials => {
@@ -117,7 +117,7 @@ describe('LoginManager', async () => {
         assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, true)
     })
 
-    it('logs out if getting an account Id throws an Error', async () => {
+    it('logs out if getting an account Id throws an Error', async function() {
         getAccountIdStub.reset()
         getAccountIdStub.throws('Simulating getAccountId throwing an Error')
         const setCredentialsStub = sandbox.stub(awsContext, 'setCredentials').callsFake(async credentials => {

--- a/src/test/shared/credentials/userCredentialsUtils.test.ts
+++ b/src/test/shared/credentials/userCredentialsUtils.test.ts
@@ -12,27 +12,27 @@ import { UserCredentialsUtils } from '../../../shared/credentials/userCredential
 import { EnvironmentVariables } from '../../../shared/environmentVariables'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 
-describe('UserCredentialsUtils', () => {
+describe('UserCredentialsUtils', function() {
     let tempFolder: string
 
-    before(async () => {
+    before(async function() {
         // Make a temp folder for all these tests
         // Stick some temp credentials files in there to load from
         tempFolder = await makeTemporaryToolkitFolder()
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         const env = process.env as EnvironmentVariables
         delete env.AWS_SHARED_CREDENTIALS_FILE
         delete env.AWS_CONFIG_FILE
     })
 
-    after(async () => {
+    after(async function() {
         await fs.remove(tempFolder)
     })
 
-    describe('findExistingCredentialsFilenames', () => {
-        it('returns both filenames if both files exist', async () => {
+    describe('findExistingCredentialsFilenames', function() {
+        it('returns both filenames if both files exist', async function() {
             const credentialsFilename = path.join(tempFolder, 'credentials-both-exist-test')
             const configFilename = path.join(tempFolder, 'config-both-exist-test')
 
@@ -48,7 +48,7 @@ describe('UserCredentialsUtils', () => {
             assert.strictEqual(foundFiles.length, 2)
         })
 
-        it('returns credentials file if it exists and config file does not exist', async () => {
+        it('returns credentials file if it exists and config file does not exist', async function() {
             const credentialsFilename = path.join(tempFolder, 'credentials-exist-test')
             const configFilename = path.join(tempFolder, 'config-not-exist-test')
 
@@ -64,7 +64,7 @@ describe('UserCredentialsUtils', () => {
             assert.strictEqual(foundFiles[0], credentialsFilename)
         })
 
-        it('returns config file if it exists and credentials file does not exist', async () => {
+        it('returns config file if it exists and credentials file does not exist', async function() {
             const credentialsFilename = path.join(tempFolder, 'credentials-not-exist-test')
             const configFilename = path.join(tempFolder, 'config-exist-test')
 
@@ -80,7 +80,7 @@ describe('UserCredentialsUtils', () => {
             assert.strictEqual(foundFiles[0], configFilename)
         })
 
-        it('returns empty result if neither file exists', async () => {
+        it('returns empty result if neither file exists', async function() {
             const credentialsFilename = path.join(tempFolder, 'credentials-not-exist-test')
             const configFilename = path.join(tempFolder, 'config-not-exist-test')
 
@@ -94,8 +94,8 @@ describe('UserCredentialsUtils', () => {
         })
     })
 
-    describe('generateCredentialsFile', () => {
-        it('generates a valid credentials file', async () => {
+    describe('generateCredentialsFile', function() {
+        it('generates a valid credentials file', async function() {
             const credentialsFilename = path.join(tempFolder, 'credentials-generation-test')
             const profileName = 'someRandomProfileName'
 

--- a/src/test/shared/debug/launchConfiguration.test.ts
+++ b/src/test/shared/debug/launchConfiguration.test.ts
@@ -89,7 +89,7 @@ const debugConfigurations: vscode.DebugConfiguration[] = [
 
 const templateUri = vscode.Uri.file('/template.yaml')
 
-describe('LaunchConfiguration', () => {
+describe('LaunchConfiguration', function() {
     let mockConfigSource: DebugConfigurationSource
     let mockSamValidator: AwsSamDebugConfigurationValidator
 
@@ -104,7 +104,7 @@ describe('LaunchConfiguration', () => {
     )
     const templateUriCsharp = vscode.Uri.file(path.join(workspace.uri.fsPath, 'csharp2.1-plain-sam-app/template.yaml'))
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         await ext.templateRegistry.addWatchPattern(TEMPLATE_FILE_GLOB_PATTERN)
 
         // TODO: remove mocks in favor of testing src/testFixtures/ data.
@@ -114,11 +114,11 @@ describe('LaunchConfiguration', () => {
         when(mockSamValidator.validate(deepEqual(samDebugConfiguration))).thenReturn({ isValid: true })
     })
 
-    afterEach(() => {
+    afterEach(function() {
         ext.templateRegistry.reset()
     })
 
-    it('getConfigsMappedToTemplates(type=api)', async () => {
+    it('getConfigsMappedToTemplates(type=api)', async function() {
         const actual = getConfigsMappedToTemplates(new LaunchConfiguration(templateUriJsPlainApp), 'api')
         assert.deepStrictEqual(actual.size, 0)
 
@@ -135,7 +135,7 @@ describe('LaunchConfiguration', () => {
         assert.deepStrictEqual((actual3[0].invokeTarget as any).logicalId, 'HelloWorldFunction')
     })
 
-    it('getConfigsMappedToTemplates(type=undefined) returns target=template + target=api resources', async () => {
+    it('getConfigsMappedToTemplates(type=undefined) returns target=template + target=api resources', async function() {
         const actual = Array.from(
             getConfigsMappedToTemplates(new LaunchConfiguration(templateUriJsPlainApp), undefined)
         )
@@ -155,13 +155,13 @@ describe('LaunchConfiguration', () => {
         assert.deepStrictEqual((actual3[0].invokeTarget as any).logicalId, 'HelloWorldFunction')
     })
 
-    it('gets debug configurations', () => {
+    it('gets debug configurations', function() {
         const launchConfig = new LaunchConfiguration(templateUriJsPlainApp)
         const expected = testLaunchJsonData['configurations']
         assertEqualLaunchJsons(launchConfig.getDebugConfigurations(), expected, workspace.uri, false)
     })
 
-    it('gets aws-sam debug configurations', () => {
+    it('gets aws-sam debug configurations', function() {
         const launchConfig = new LaunchConfiguration(templateUriJsPlainApp)
         const expected = (testLaunchJsonData['configurations'] as any[]).filter(
             o => o.type === 'aws-sam' && o.request === 'direct-invoke'
@@ -170,7 +170,7 @@ describe('LaunchConfiguration', () => {
         assertEqualLaunchJsons(actual, expected, workspace.uri, true)
     })
 
-    it('adds single debug configuration', async () => {
+    it('adds single debug configuration', async function() {
         const launchConfig = new LaunchConfiguration(
             templateUri,
             instance(mockConfigSource),
@@ -182,7 +182,7 @@ describe('LaunchConfiguration', () => {
         verify(mockConfigSource.setDebugConfigurations(deepEqual(expected))).once()
     })
 
-    it('adds multiple debug configurations', async () => {
+    it('adds multiple debug configurations', async function() {
         const launchConfig = new LaunchConfiguration(
             templateUri,
             instance(mockConfigSource),
@@ -195,8 +195,8 @@ describe('LaunchConfiguration', () => {
     })
 })
 
-describe('getReferencedHandlerPaths', () => {
-    it('includes all resources as absolute paths to root dir + handlers', () => {
+describe('getReferencedHandlerPaths', function() {
+    it('includes all resources as absolute paths to root dir + handlers', function() {
         const mockLaunchConfig = instance(createMockLaunchConfig())
 
         const resultSet = getReferencedHandlerPaths(mockLaunchConfig)

--- a/src/test/shared/defaultAwsClientBuilder.test.ts
+++ b/src/test/shared/defaultAwsClientBuilder.test.ts
@@ -10,15 +10,15 @@ import { version } from 'vscode'
 import { DefaultAWSClientBuilder } from '../../shared/awsClientBuilder'
 import { FakeAwsContext } from '../utilities/fakeAwsContext'
 
-describe('DefaultAwsClientBuilder', () => {
-    describe('createAndConfigureSdkClient', () => {
+describe('DefaultAwsClientBuilder', function() {
+    describe('createAndConfigureSdkClient', function() {
         class FakeService extends Service {
             public constructor(config?: ServiceConfigurationOptions) {
                 super(config)
             }
         }
 
-        it('includes custom user-agent if no options are specified', async () => {
+        it('includes custom user-agent if no options are specified', async function() {
             const builder = new DefaultAWSClientBuilder(new FakeAwsContext())
             const service = await builder.createAndConfigureServiceClient(opts => new FakeService(opts))
 
@@ -29,7 +29,7 @@ describe('DefaultAwsClientBuilder', () => {
             )
         })
 
-        it('includes custom user-agent if not specified in options', async () => {
+        it('includes custom user-agent if not specified in options', async function() {
             const builder = new DefaultAWSClientBuilder(new FakeAwsContext())
             const service = await builder.createAndConfigureServiceClient(opts => new FakeService(opts), {})
 
@@ -37,7 +37,7 @@ describe('DefaultAwsClientBuilder', () => {
             assert.notStrictEqual(service.config.customUserAgent, undefined)
         })
 
-        it('does not override custom user-agent if specified in options', async () => {
+        it('does not override custom user-agent if specified in options', async function() {
             const builder = new DefaultAWSClientBuilder(new FakeAwsContext())
             const service = await builder.createAndConfigureServiceClient(opts => new FakeService(opts), {
                 customUserAgent: 'CUSTOM USER AGENT',

--- a/src/test/shared/defaultAwsContext.test.ts
+++ b/src/test/shared/defaultAwsContext.test.ts
@@ -10,13 +10,13 @@ import { regionSettingKey } from '../../shared/constants'
 import { DefaultAwsContext } from '../../shared/defaultAwsContext'
 import { FakeExtensionContext, FakeMementoStorage } from '../fakeExtensionContext'
 
-describe('DefaultAwsContext', () => {
+describe('DefaultAwsContext', function() {
     const testRegion1Value: string = 're-gion-1'
     const testRegion2Value: string = 're-gion-2'
     const testRegion3Value: string = 're-gion-3'
     const testAccountIdValue: string = '123456789012'
 
-    it('instantiates with no credentials', async () => {
+    it('instantiates with no credentials', async function() {
         const testContext = new DefaultAwsContext(new FakeExtensionContext())
 
         assert.strictEqual(testContext.getCredentialProfileName(), undefined)
@@ -24,7 +24,7 @@ describe('DefaultAwsContext', () => {
         assert.strictEqual(await testContext.getCredentials(), undefined)
     })
 
-    it('sets credentials and gets credentialsId', async () => {
+    it('sets credentials and gets credentialsId', async function() {
         const awsCredentials = makeSampleAwsContextCredentials()
 
         const testContext = new DefaultAwsContext(new FakeExtensionContext())
@@ -33,14 +33,14 @@ describe('DefaultAwsContext', () => {
         assert.strictEqual(testContext.getCredentialProfileName(), awsCredentials.credentialsId)
     })
 
-    it('sets undefined credentials and gets credentialsId', async () => {
+    it('sets undefined credentials and gets credentialsId', async function() {
         const testContext = new DefaultAwsContext(new FakeExtensionContext())
 
         await testContext.setCredentials(undefined)
         assert.strictEqual(testContext.getCredentialProfileName(), undefined)
     })
 
-    it('sets credentials and gets accountId', async () => {
+    it('sets credentials and gets accountId', async function() {
         const awsCredentials = makeSampleAwsContextCredentials()
 
         const testContext = new DefaultAwsContext(new FakeExtensionContext())
@@ -49,14 +49,14 @@ describe('DefaultAwsContext', () => {
         assert.strictEqual(testContext.getCredentialAccountId(), awsCredentials.accountId)
     })
 
-    it('sets undefined credentials and gets accountId', async () => {
+    it('sets undefined credentials and gets accountId', async function() {
         const testContext = new DefaultAwsContext(new FakeExtensionContext())
 
         await testContext.setCredentials(undefined)
         assert.strictEqual(testContext.getCredentialAccountId(), undefined)
     })
 
-    it('sets credentials and gets credentials', async () => {
+    it('sets credentials and gets credentials', async function() {
         const awsCredentials = makeSampleAwsContextCredentials()
 
         const testContext = new DefaultAwsContext(new FakeExtensionContext())
@@ -65,14 +65,14 @@ describe('DefaultAwsContext', () => {
         assert.strictEqual(await testContext.getCredentials(), awsCredentials.credentials)
     })
 
-    it('sets undefined credentials and gets credentials', async () => {
+    it('sets undefined credentials and gets credentials', async function() {
         const testContext = new DefaultAwsContext(new FakeExtensionContext())
 
         await testContext.setCredentials(undefined)
         assert.strictEqual(await testContext.getCredentials(), undefined)
     })
 
-    it('gets single region from config on startup', async () => {
+    it('gets single region from config on startup', async function() {
         const fakeMementoStorage: FakeMementoStorage = {}
         fakeMementoStorage[regionSettingKey] = [testRegion1Value]
 
@@ -86,7 +86,7 @@ describe('DefaultAwsContext', () => {
         assert.strictEqual(regions[0], testRegion1Value)
     })
 
-    it('gets multiple regions from config on startup', async () => {
+    it('gets multiple regions from config on startup', async function() {
         const fakeMementoStorage: FakeMementoStorage = {}
         fakeMementoStorage[regionSettingKey] = [testRegion1Value, testRegion2Value]
 
@@ -101,7 +101,7 @@ describe('DefaultAwsContext', () => {
         assert.strictEqual(regions[1], testRegion2Value)
     })
 
-    it('updates globalState on single region change', async () => {
+    it('updates globalState on single region change', async function() {
         const extensionContext = new FakeExtensionContext()
         const testContext = new DefaultAwsContext(extensionContext)
         await testContext.addExplorerRegion(testRegion1Value)
@@ -112,7 +112,7 @@ describe('DefaultAwsContext', () => {
         assert.strictEqual(persistedRegions![0], testRegion1Value)
     })
 
-    it('updates globalState on multiple region change', async () => {
+    it('updates globalState on multiple region change', async function() {
         const extensionContext = new FakeExtensionContext()
         const testContext = new DefaultAwsContext(extensionContext)
         await testContext.addExplorerRegion(testRegion1Value, testRegion2Value)
@@ -124,7 +124,7 @@ describe('DefaultAwsContext', () => {
         assert.strictEqual(persistedRegions![1], testRegion2Value)
     })
 
-    it('updates globalState on region removal', async () => {
+    it('updates globalState on region removal', async function() {
         const extensionContext = new FakeExtensionContext()
         const testContext = new DefaultAwsContext(extensionContext)
         await testContext.addExplorerRegion(testRegion1Value, testRegion2Value, testRegion3Value)
@@ -137,7 +137,7 @@ describe('DefaultAwsContext', () => {
         assert.strictEqual(persistedRegions![1], testRegion3Value)
     })
 
-    it('fires event on credentials change', async () => {
+    it('fires event on credentials change', async function() {
         const testContext = new DefaultAwsContext(new FakeExtensionContext())
 
         const awsCredentials = makeSampleAwsContextCredentials()

--- a/src/test/shared/extensionUtilities.test.ts
+++ b/src/test/shared/extensionUtilities.test.ts
@@ -19,8 +19,8 @@ import * as filesystemUtilities from '../../shared/filesystemUtilities'
 import { FakeExtensionContext } from '../fakeExtensionContext'
 import { assertRejects } from './utilities/assertUtils'
 
-describe('extensionUtilities', () => {
-    describe('safeGet', () => {
+describe('extensionUtilities', function() {
+    describe('safeGet', function() {
         class Blah {
             public someProp?: string
 
@@ -29,7 +29,7 @@ describe('extensionUtilities', () => {
             }
         }
 
-        it('can access sub-property', () => {
+        it('can access sub-property', function() {
             assert.strictEqual(
                 safeGet(new Blah('hello!'), x => x.someProp),
                 'hello!'
@@ -45,16 +45,16 @@ describe('extensionUtilities', () => {
         })
     })
 
-    describe('createQuickStartWebview', async () => {
+    describe('createQuickStartWebview', async function() {
         const context = new FakeExtensionContext()
         let tempDir: string | undefined
 
-        beforeEach(async () => {
+        beforeEach(async function() {
             tempDir = await filesystemUtilities.makeTemporaryToolkitFolder()
             context.extensionPath = tempDir
         })
 
-        afterEach(async () => {
+        afterEach(async function() {
             if (tempDir) {
                 await remove(tempDir)
             }
@@ -66,7 +66,7 @@ describe('extensionUtilities', () => {
             })
         })
 
-        it('returns a webview with unaltered text if a valid file is passed without tokens', async () => {
+        it('returns a webview with unaltered text if a valid file is passed without tokens', async function() {
             const filetext = 'this temp page does not have any tokens'
             const filepath = 'tokenless'
             await writeFile(path.join(context.extensionPath, filepath), filetext)
@@ -77,7 +77,7 @@ describe('extensionUtilities', () => {
             assert.strictEqual(forcedWebview.webview.html, filetext)
         })
 
-        it('returns a webview with tokens replaced', async () => {
+        it('returns a webview with tokens replaced', async function() {
             const token = '!!EXTENSIONROOT!!'
             const basetext = 'this temp page has tokens: '
             const filetext = basetext + token
@@ -93,8 +93,8 @@ describe('extensionUtilities', () => {
         })
     })
 
-    describe('isDifferentVersion', () => {
-        it('returns false if the version exists and matches the existing version exactly', () => {
+    describe('isDifferentVersion', function() {
+        it('returns false if the version exists and matches the existing version exactly', function() {
             const goodVersion = '1.2.3'
             const extContext = new FakeExtensionContext()
             extContext.globalState.update(mostRecentVersionKey, goodVersion)
@@ -118,8 +118,8 @@ describe('extensionUtilities', () => {
         })
     })
 
-    describe('setMostRecentVersion', () => {
-        it('sets the most recent version', () => {
+    describe('setMostRecentVersion', function() {
+        it('sets the most recent version', function() {
             const extContext = new FakeExtensionContext()
             setMostRecentVersion(extContext)
 

--- a/src/test/shared/featureToggle.test.ts
+++ b/src/test/shared/featureToggle.test.ts
@@ -7,9 +7,9 @@ import * as assert from 'assert'
 import { ActiveFeatureKeys, FeatureToggle } from '../../shared/featureToggle'
 import { TestSettingsConfiguration } from '../utilities/testSettingsConfiguration'
 
-describe('FeatureToggle', async () => {
-    describe('isFeatureActive', async () => {
-        it('returns true if feature is declared active and is present in settings.json', async () => {
+describe('FeatureToggle', async function() {
+    describe('isFeatureActive', async function() {
+        it('returns true if feature is declared active and is present in settings.json', async function() {
             // simulate settings.json
             const config = new TestSettingsConfiguration()
             const flag = 'myFlag'
@@ -21,7 +21,7 @@ describe('FeatureToggle', async () => {
             assert.ok(features.isFeatureActive(flag))
         })
 
-        it('returns false for features that are not declared as active feature keys but are present in settings.json', async () => {
+        it('returns false for features that are not declared as active feature keys but are present in settings.json', async function() {
             // simulate settings.json
             const config = new TestSettingsConfiguration()
             const flag = 'myFlag'
@@ -33,7 +33,7 @@ describe('FeatureToggle', async () => {
             assert.strictEqual(features.isFeatureActive(notFlag), false)
         })
 
-        it('returns false for features that are declared as active feature keys but are not active in settings.json', async () => {
+        it('returns false for features that are declared as active feature keys but are not active in settings.json', async function() {
             // simulate settings.json
             const config = new TestSettingsConfiguration()
             const flag = 'myFlag'
@@ -46,7 +46,7 @@ describe('FeatureToggle', async () => {
             assert.strictEqual(features.isFeatureActive(notFlag), false)
         })
 
-        it('throws an error if too many features are registered', () => {
+        it('throws an error if too many features are registered', function() {
             const config = new TestSettingsConfiguration()
             assert.throws(() => new FeatureToggle(config, ['1', '2', '3', '4', '5', '6']))
         })

--- a/src/test/shared/filesystemUtilities.test.ts
+++ b/src/test/shared/filesystemUtilities.test.ts
@@ -9,13 +9,13 @@ import { writeFile, remove } from 'fs-extra'
 import * as path from 'path'
 import { fileExists, getNonexistentFilename, isInDirectory, makeTemporaryToolkitFolder, tempDirPath } from '../../shared/filesystemUtilities'
 
-describe('filesystemUtilities', () => {
+describe('filesystemUtilities', function() {
     const targetFilename = 'findThisFile12345.txt'
     let targetFilePath: string
     let tempFolder: string
     const foldersToCleanUp: string[] = []
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         // Make a temp folder for all these tests
         tempFolder = await makeTemporaryToolkitFolder()
         targetFilePath = path.join(tempFolder, targetFilename)
@@ -25,14 +25,14 @@ describe('filesystemUtilities', () => {
         foldersToCleanUp.push(tempFolder)
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         for (const folder of foldersToCleanUp) {
             await remove(folder)
         }
     })
     
-    describe('getNonexistentFilename()', () => {
-        it('failure modes', async () => {
+    describe('getNonexistentFilename()', function() {
+        it('failure modes', async function() {
             assert.throws(() => {
                 getNonexistentFilename('/bogus/directory/', 'foo', '.txt', 99)
             })
@@ -40,7 +40,7 @@ describe('filesystemUtilities', () => {
                 getNonexistentFilename('', 'foo', '.txt', 99)
             })
         })
-        it('returns a filename that does not exist in the directory', async () => {
+        it('returns a filename that does not exist in the directory', async function() {
             const dir = tempFolder
             await writeFile(path.join(dir, 'foo.txt'), '', 'utf8')
             await writeFile(path.join(dir, 'foo-0.txt'), '', 'utf8')
@@ -49,7 +49,7 @@ describe('filesystemUtilities', () => {
             assert.strictEqual(getNonexistentFilename(dir, 'foo', '.txt', 99), 'foo-3.txt')
             assert.strictEqual(getNonexistentFilename(dir, 'foo', '', 99), 'foo')
         })
-        it('returns "foo-RANDOM.txt" if max is reached', async () => {
+        it('returns "foo-RANDOM.txt" if max is reached', async function() {
             const dir = tempFolder
             await writeFile(path.join(dir, 'foo.txt'), '', 'utf8')
             await writeFile(path.join(dir, 'foo-1.txt'), '', 'utf8')
@@ -58,7 +58,7 @@ describe('filesystemUtilities', () => {
         })
     })
 
-    describe('makeTemporaryToolkitFolder()', () => {
+    describe('makeTemporaryToolkitFolder()', function() {
         it(`makes temp dirs as children to filesystemUtilities.tempDirPath ('${tempDirPath}')`, async () => {
             const parentFolder = path.dirname(tempFolder)
 
@@ -69,11 +69,11 @@ describe('filesystemUtilities', () => {
             )
         })
 
-        it('creates a folder', async () => {
+        it('creates a folder', async function() {
             assert.ok(await fileExists(tempFolder), `expected folder to exist: ${tempFolder}`)
         })
 
-        it('makes nested temp dirs', async () => {
+        it('makes nested temp dirs', async function() {
             const nestedTempDirPath = await makeTemporaryToolkitFolder('nestedSubfolder', 'moreNestedSubfolder')
 
             foldersToCleanUp.push(nestedTempDirPath)
@@ -88,7 +88,7 @@ describe('filesystemUtilities', () => {
         })
     })
 
-    it('isInDirectory()', () => {
+    it('isInDirectory()', function() {
         const basePath = path.join('this', 'is', 'the', 'way')
         const extendedPath = path.join(basePath, 'forward')
         const filename = 'yadayadayada.log'

--- a/src/test/shared/logger/activation.test.ts
+++ b/src/test/shared/logger/activation.test.ts
@@ -11,16 +11,16 @@ import { Logger } from '../../../shared/logger'
 import { makeLogger } from '../../../shared/logger/activation'
 import { WinstonToolkitLogger } from '../../../shared/logger/winstonToolkitLogger'
 
-describe('makeLogger', () => {
+describe('makeLogger', function() {
     let tempFolder: string
     let testLogger: Logger | undefined
 
-    before(async () => {
+    before(async function() {
         tempFolder = await makeTemporaryToolkitFolder()
         testLogger = makeLogger({ staticLogLevel: 'debug', logPaths: [join(tempFolder, 'log.txt')] })
     })
 
-    after(async () => {
+    after(async function() {
         if (testLogger && testLogger instanceof WinstonToolkitLogger) {
             testLogger.dispose()
         }
@@ -29,7 +29,7 @@ describe('makeLogger', () => {
         await fs.remove(tempFolder)
     })
 
-    it('creates a logger object', () => {
+    it('creates a logger object', function() {
         assert.notStrictEqual(testLogger, undefined)
         assert.ok(testLogger instanceof WinstonToolkitLogger)
     })

--- a/src/test/shared/logger/winstonToolkitLogger.test.ts
+++ b/src/test/shared/logger/winstonToolkitLogger.test.ts
@@ -11,20 +11,20 @@ import { WinstonToolkitLogger } from '../../../shared/logger/winstonToolkitLogge
 import { MockOutputChannel } from '../../mockOutputChannel'
 import { assertThrowsError } from '../utilities/assertUtils'
 
-describe('WinstonToolkitLogger', () => {
+describe('WinstonToolkitLogger', function() {
     let tempFolder: string
 
-    before(async () => {
+    before(async function() {
         tempFolder = await filesystemUtilities.makeTemporaryToolkitFolder()
     })
 
-    after(async () => {
+    after(async function() {
         if (await filesystemUtilities.fileExists(tempFolder)) {
             await fs.remove(tempFolder)
         }
     })
 
-    it('logLevelEnabled()', () => {
+    it('logLevelEnabled()', function() {
         const logger = new WinstonToolkitLogger('info')
         assert.strictEqual(true, logger.logLevelEnabled('error'))
         assert.strictEqual(true, logger.logLevelEnabled('warn'))
@@ -47,11 +47,11 @@ describe('WinstonToolkitLogger', () => {
         assert.strictEqual(true, logger.logLevelEnabled('debug'))
     })
 
-    it('creates an object', () => {
+    it('creates an object', function() {
         assert.notStrictEqual(new WinstonToolkitLogger('info'), undefined)
     })
 
-    it('throws when logging to a disposed object', async () => {
+    it('throws when logging to a disposed object', async function() {
         const logger = new WinstonToolkitLogger('info')
         logger.dispose()
 
@@ -91,23 +91,23 @@ describe('WinstonToolkitLogger', () => {
         },
     ]
 
-    describe('logs to a file', async () => {
+    describe('logs to a file', async function() {
         let tempLogPath: string
         let tempFileCounter = 0
         let testLogger: WinstonToolkitLogger | undefined
 
-        beforeEach(async () => {
+        beforeEach(async function() {
             tempLogPath = path.join(tempFolder, `temp-${++tempFileCounter}.log`)
         })
 
-        afterEach(async () => {
+        afterEach(async function() {
             if (testLogger) {
                 testLogger.dispose()
                 testLogger = undefined
             }
         })
 
-        it('does not log a lower level', async () => {
+        it('does not log a lower level', async function() {
             const debugMessage = 'debug message'
             const errorMessage = 'error message'
 
@@ -125,7 +125,7 @@ describe('WinstonToolkitLogger', () => {
             )
         })
 
-        it('supports updating the log type', async () => {
+        it('supports updating the log type', async function() {
             const nonLoggedVerboseEntry = 'verbose entry should not be logged'
             const loggedVerboseEntry = 'verbose entry should be logged'
 
@@ -179,22 +179,22 @@ describe('WinstonToolkitLogger', () => {
         }
     })
 
-    describe('logs to an OutputChannel', async () => {
+    describe('logs to an OutputChannel', async function() {
         let testLogger: WinstonToolkitLogger | undefined
         let outputChannel: MockOutputChannel
 
-        beforeEach(async () => {
+        beforeEach(async function() {
             outputChannel = new MockOutputChannel()
         })
 
-        afterEach(async () => {
+        afterEach(async function() {
             if (testLogger) {
                 testLogger.dispose()
                 testLogger = undefined
             }
         })
 
-        it('does not log a lower level', async () => {
+        it('does not log a lower level', async function() {
             const debugMessage = 'debug message'
             const errorMessage = 'error message'
 
@@ -209,7 +209,7 @@ describe('WinstonToolkitLogger', () => {
             assert.ok((await waitForMessage).includes(errorMessage), 'Expected error message to be logged')
         })
 
-        it('supports updating the log type', async () => {
+        it('supports updating the log type', async function() {
             const nonLoggedVerboseEntry = 'verbose entry should not be logged'
             const loggedVerboseEntry = 'verbose entry should be logged'
 

--- a/src/test/shared/regions/defaultRegionProvider.test.ts
+++ b/src/test/shared/regions/defaultRegionProvider.test.ts
@@ -43,14 +43,14 @@ const sampleEndpoints = {
     ],
 }
 
-describe('DefaultRegionProvider', async () => {
+describe('DefaultRegionProvider', async function() {
     const resourceFetcher: ResourceFetcher = {
         get: async () => {
             return JSON.stringify(sampleEndpoints)
         },
     }
 
-    describe('isServiceInRegion', async () => {
+    describe('isServiceInRegion', async function() {
         let sandbox: sinon.SinonSandbox
 
         let endpoints: Endpoints
@@ -59,7 +59,7 @@ describe('DefaultRegionProvider', async () => {
         const regionCode = 'someRegion'
         const serviceId = 'someService'
 
-        beforeEach(() => {
+        beforeEach(function() {
             sandbox = sinon.createSandbox()
 
             endpoints = {
@@ -93,17 +93,17 @@ describe('DefaultRegionProvider', async () => {
             sandbox.stub(endpointsProvider, 'getEndpoints').returns(endpoints)
         })
 
-        afterEach(() => {
+        afterEach(function() {
             sandbox.restore()
         })
 
-        it('indicates when a service is in a region', async () => {
+        it('indicates when a service is in a region', async function() {
             const regionProvider = new DefaultRegionProvider(endpointsProvider)
 
             assert.ok(regionProvider.isServiceInRegion(serviceId, regionCode), 'Expected service to be in region')
         })
 
-        it('indicates when a service is not in a region', async () => {
+        it('indicates when a service is not in a region', async function() {
             const regionProvider = new DefaultRegionProvider(endpointsProvider)
 
             assert.ok(
@@ -113,68 +113,68 @@ describe('DefaultRegionProvider', async () => {
         })
     })
 
-    describe('getDnsSuffixForRegion', async () => {
+    describe('getDnsSuffixForRegion', async function() {
         let endpointsProvider: EndpointsProvider
         let regionProvider: DefaultRegionProvider
 
-        beforeEach(async () => {
+        beforeEach(async function() {
             endpointsProvider = new EndpointsProvider(resourceFetcher, resourceFetcher)
             await endpointsProvider.load()
 
             regionProvider = new DefaultRegionProvider(endpointsProvider)
         })
 
-        it('gets DNS suffix for a known region', async () => {
+        it('gets DNS suffix for a known region', async function() {
             const partitionId = regionProvider.getDnsSuffixForRegion('region1')
             assert.strictEqual(partitionId, 'totallyLegit.tld')
         })
 
-        it('returns undefined for an unknown region', async () => {
+        it('returns undefined for an unknown region', async function() {
             const partitionId = regionProvider.getDnsSuffixForRegion('foo')
             assert.strictEqual(partitionId, undefined)
         })
     })
 
-    describe('getPartitionId', async () => {
+    describe('getPartitionId', async function() {
         let endpointsProvider: EndpointsProvider
         let regionProvider: DefaultRegionProvider
 
-        beforeEach(async () => {
+        beforeEach(async function() {
             endpointsProvider = new EndpointsProvider(resourceFetcher, resourceFetcher)
             await endpointsProvider.load()
 
             regionProvider = new DefaultRegionProvider(endpointsProvider)
         })
 
-        it('gets partition for a known region', async () => {
+        it('gets partition for a known region', async function() {
             const partitionId = regionProvider.getPartitionId('awscnregion1')
             assert.strictEqual(partitionId, 'aws-cn')
         })
 
-        it('returns undefined for an unknown region', async () => {
+        it('returns undefined for an unknown region', async function() {
             const partitionId = regionProvider.getPartitionId('foo')
             assert.strictEqual(partitionId, undefined)
         })
     })
 
-    describe('getRegions', async () => {
+    describe('getRegions', async function() {
         let endpointsProvider: EndpointsProvider
         let regionProvider: DefaultRegionProvider
 
-        beforeEach(async () => {
+        beforeEach(async function() {
             endpointsProvider = new EndpointsProvider(resourceFetcher, resourceFetcher)
             await endpointsProvider.load()
 
             regionProvider = new DefaultRegionProvider(endpointsProvider)
         })
 
-        it('gets regions for a known partition', async () => {
+        it('gets regions for a known partition', async function() {
             const regions = regionProvider.getRegions('aws')
             assert.ok(regions)
             assert.strictEqual(regions.length, 3, 'Unexpected amount of regions returned')
         })
 
-        it('returns empty array for an unknown partition', async () => {
+        it('returns empty array for an unknown partition', async function() {
             const regions = regionProvider.getRegions('foo')
             assert.ok(regions)
             assert.strictEqual(regions.length, 0, 'Unexpected regions returned')

--- a/src/test/shared/regions/endpoints.test.ts
+++ b/src/test/shared/regions/endpoints.test.ts
@@ -56,20 +56,20 @@ const sampleEndpoints = {
     ],
 }
 
-describe('loadEndpoints', async () => {
+describe('loadEndpoints', async function() {
     const json = JSON.stringify(sampleEndpoints)
 
-    it('returns undefined for malformed json', async () => {
+    it('returns undefined for malformed json', async function() {
         const endpoints = loadEndpoints('{ foo: ')
         assert.strictEqual(endpoints, undefined)
     })
 
-    it('returns an object for well-formed json', async () => {
+    it('returns an object for well-formed json', async function() {
         const endpoints = loadEndpoints(json)
         assert.ok(endpoints)
     })
 
-    it('loads partitions', async () => {
+    it('loads partitions', async function() {
         const endpoints = loadEndpoints(json)!
         assert.strictEqual(endpoints.partitions.length, 3, 'Unexpected amount of partitions loaded')
         const partition = endpoints.partitions[0]
@@ -77,7 +77,7 @@ describe('loadEndpoints', async () => {
         assert.strictEqual(partition.name, 'Standard')
     })
 
-    it('loads regions', async () => {
+    it('loads regions', async function() {
         const endpoints = loadEndpoints(json)!
         const partition = endpoints.partitions[0]
         const regions = partition.regions
@@ -87,7 +87,7 @@ describe('loadEndpoints', async () => {
         assert.strictEqual(region.name, 'aws region two')
     })
 
-    it('loads services', async () => {
+    it('loads services', async function() {
         const endpoints = loadEndpoints(json)!
         const partition = endpoints.partitions[2]
         const services = partition.services

--- a/src/test/shared/regions/endpointsProvider.test.ts
+++ b/src/test/shared/regions/endpointsProvider.test.ts
@@ -9,7 +9,7 @@ import * as assert from 'assert'
 import { EndpointsProvider } from '../../../shared/regions/endpointsProvider'
 import { ResourceFetcher } from '../../../shared/resourcefetcher/resourcefetcher'
 
-describe('EndpointsProvider', async () => {
+describe('EndpointsProvider', async function() {
     const data1 = '{}'
     const data2 = JSON.stringify({
         partitions: [
@@ -32,21 +32,21 @@ describe('EndpointsProvider', async () => {
         get: async () => undefined,
     }
 
-    it('loads from local fetcher', async () => {
+    it('loads from local fetcher', async function() {
         const provider = new EndpointsProvider(fetcher1, undefinedFetcher)
         await provider.load()
 
         assert.strictEqual(provider.getEndpoints()?.partitions.length, 0)
     })
 
-    it('loads from remote fetcher', async () => {
+    it('loads from remote fetcher', async function() {
         const provider = new EndpointsProvider(undefinedFetcher, fetcher2)
         await provider.load()
 
         assert.strictEqual(provider.getEndpoints()?.partitions.length, 1)
     })
 
-    it('raises events after each fetcher', async () => {
+    it('raises events after each fetcher', async function() {
         let timesCalled = 0
         const provider = new EndpointsProvider(fetcher1, fetcher2)
         provider.onEndpointsUpdated(e => {
@@ -57,7 +57,7 @@ describe('EndpointsProvider', async () => {
         assert.strictEqual(timesCalled, 2, 'Expected event to be raised twice')
     })
 
-    it('does not raise an event if local fetcher returns nothing', async () => {
+    it('does not raise an event if local fetcher returns nothing', async function() {
         let timesCalled = 0
         const provider = new EndpointsProvider(undefinedFetcher, fetcher2)
         provider.onEndpointsUpdated(e => {
@@ -68,7 +68,7 @@ describe('EndpointsProvider', async () => {
         assert.strictEqual(timesCalled, 1, 'Expected event to be raised once')
     })
 
-    it('does not raise an event if remote fetcher returns nothing', async () => {
+    it('does not raise an event if remote fetcher returns nothing', async function() {
         let timesCalled = 0
         const provider = new EndpointsProvider(fetcher1, undefinedFetcher)
         provider.onEndpointsUpdated(e => {

--- a/src/test/shared/regions/regionUtilities.test.ts
+++ b/src/test/shared/regions/regionUtilities.test.ts
@@ -12,7 +12,7 @@ import { Region } from '../../../shared/regions/endpoints'
 import { RegionProvider } from '../../../shared/regions/regionProvider'
 import { getRegionsForActiveCredentials } from '../../../shared/regions/regionUtilities'
 
-describe('getRegionsForActiveCredentials', async () => {
+describe('getRegionsForActiveCredentials', async function() {
     let sandbox: sinon.SinonSandbox
     let awsContext: AwsContext
     let regionProvider: RegionProvider
@@ -33,7 +33,7 @@ describe('getRegionsForActiveCredentials', async () => {
         },
     ]
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
 
         fnGetCredentialDefaultRegion = sandbox.stub()
@@ -54,25 +54,25 @@ describe('getRegionsForActiveCredentials', async () => {
         } as any) as RegionProvider
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    it('returns regions in the same partition', async () => {
+    it('returns regions in the same partition', async function() {
         fnGetCredentialDefaultRegion.returns(samplePartitionRegions[0].id)
 
         const regions = getRegionsForActiveCredentials(awsContext, regionProvider)
         assert.deepStrictEqual(regions, samplePartitionRegions)
     })
 
-    it('defaults to the standard partition if no default region is found', async () => {
+    it('defaults to the standard partition if no default region is found', async function() {
         fnGetCredentialDefaultRegion.returns(undefined)
 
         getRegionsForActiveCredentials(awsContext, regionProvider)
         assert.ok(fnGetPartitionId.alwaysCalledWith('us-east-1'), 'expected default region to be used')
     })
 
-    it('defaults to the standard partition if default region is not recognized', async () => {
+    it('defaults to the standard partition if default region is not recognized', async function() {
         fnGetCredentialDefaultRegion.returns('foo')
 
         fnGetPartitionId.reset()

--- a/src/test/shared/resourceFetcher/compositeResourceFetcher.test.ts
+++ b/src/test/shared/resourceFetcher/compositeResourceFetcher.test.ts
@@ -6,10 +6,10 @@
 import * as assert from 'assert'
 import { CompositeResourceFetcher } from '../../../shared/resourcefetcher/compositeResourceFetcher'
 
-describe('CompositeResourceFetcher', async () => {
+describe('CompositeResourceFetcher', async function() {
     const expectedContents = 'Hello World!\n12345'
 
-    it('loads from a resource fetcher', async () => {
+    it('loads from a resource fetcher', async function() {
         const fetcher = {
             get: async () => expectedContents,
         }
@@ -20,7 +20,7 @@ describe('CompositeResourceFetcher', async () => {
         assert.strictEqual(contents, expectedContents)
     })
 
-    it('loads from the first resource fetcher to return contents', async () => {
+    it('loads from the first resource fetcher to return contents', async function() {
         const fetcher1 = {
             get: async () => undefined,
         }
@@ -41,7 +41,7 @@ describe('CompositeResourceFetcher', async () => {
         assert.strictEqual(contents, expectedContents)
     })
 
-    it('tries to load from the next resource fetcher when one raises an error', async () => {
+    it('tries to load from the next resource fetcher when one raises an error', async function() {
         const fetcher1 = {
             get: async () => {
                 assert.fail('Error, load from the next fetcher')
@@ -58,7 +58,7 @@ describe('CompositeResourceFetcher', async () => {
         assert.strictEqual(contents, expectedContents)
     })
 
-    it('returns undefined if no resource fetcher returns contents', async () => {
+    it('returns undefined if no resource fetcher returns contents', async function() {
         let timesCalled = 0
         const fetcher = {
             get: async () => {

--- a/src/test/shared/resourceFetcher/fileResourceFetcher.test.ts
+++ b/src/test/shared/resourceFetcher/fileResourceFetcher.test.ts
@@ -9,18 +9,18 @@ import { join } from 'path'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 import { FileResourceFetcher } from '../../../shared/resourcefetcher/fileResourceFetcher'
 
-describe('FileResourceFetcher', async () => {
+describe('FileResourceFetcher', async function() {
     let tempFolder: string
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         tempFolder = await makeTemporaryToolkitFolder()
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         await fs.remove(tempFolder)
     })
 
-    it('loads the contents of a file', async () => {
+    it('loads the contents of a file', async function() {
         const testFile = join(tempFolder, 'file.txt')
         const expectedContents = 'Hello World!\n12345'
 
@@ -33,7 +33,7 @@ describe('FileResourceFetcher', async () => {
         assert.strictEqual(contents, expectedContents)
     })
 
-    it('returns undefined if the file does not exist', async () => {
+    it('returns undefined if the file does not exist', async function() {
         const sut = new FileResourceFetcher(join(tempFolder, 'somefile'))
 
         const contents = await sut.get()

--- a/src/test/shared/sam/cli/samCliBuild.test.ts
+++ b/src/test/shared/sam/cli/samCliBuild.test.ts
@@ -21,7 +21,7 @@ import {
     TestSamCliProcessInvoker,
 } from './testSamCliProcessInvoker'
 
-describe('SamCliBuildInvocation', async () => {
+describe('SamCliBuildInvocation', async function() {
     class FakeChildProcessResult implements ChildProcessResult {
         public exitCode: number = 0
         public error = undefined
@@ -48,17 +48,17 @@ describe('SamCliBuildInvocation', async () => {
         fileExists: async (filePath: string): Promise<boolean> => true,
     }
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         tempFolder = await makeTemporaryToolkitFolder()
         placeholderTemplateFile = path.join(tempFolder, 'template.yaml')
         await writeFile(placeholderTemplateFile, '')
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         await remove(tempFolder)
     })
 
-    it('invokes `sam build` with args', async () => {
+    it('invokes `sam build` with args', async function() {
         const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker((args: any[]) => {
             assert.ok(args.length >= 2, 'Expected args to be present')
             assert.strictEqual(args[0], 'build')
@@ -84,7 +84,7 @@ describe('SamCliBuildInvocation', async () => {
         }).execute()
     })
 
-    it('Passes Build Dir to sam cli', async () => {
+    it('Passes Build Dir to sam cli', async function() {
         const expectedBuildDir = '/build'
 
         const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker((args: any[]) => {
@@ -99,7 +99,7 @@ describe('SamCliBuildInvocation', async () => {
         }).execute()
     })
 
-    it('Passes Base Dir to sam cli', async () => {
+    it('Passes Base Dir to sam cli', async function() {
         const expectedBaseDir = '/src'
 
         const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker((args: any[]) => {
@@ -114,7 +114,7 @@ describe('SamCliBuildInvocation', async () => {
         }).execute()
     })
 
-    it('Does not pass Base Dir to sam cli', async () => {
+    it('Does not pass Base Dir to sam cli', async function() {
         const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker((args: any[]) => {
             assertArgNotPresent(args, '--base-dir')
         })
@@ -126,7 +126,7 @@ describe('SamCliBuildInvocation', async () => {
         }).execute()
     })
 
-    it('Passes Template to sam cli', async () => {
+    it('Passes Template to sam cli', async function() {
         const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker((args: any[]) => {
             assertArgsContainArgument(args, '--template', placeholderTemplateFile)
         })
@@ -139,7 +139,7 @@ describe('SamCliBuildInvocation', async () => {
         }).execute()
     })
 
-    it('passes --use-container to sam cli if useContainer is true', async () => {
+    it('passes --use-container to sam cli if useContainer is true', async function() {
         const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker((args: any[]) => {
             assert.notStrictEqual(args.indexOf('--use-container'), -1, 'Expected --use-container arg')
         })
@@ -152,7 +152,7 @@ describe('SamCliBuildInvocation', async () => {
         }).execute()
     })
 
-    it('does not pass --use-container to sam cli if useContainer is false', async () => {
+    it('does not pass --use-container to sam cli if useContainer is false', async function() {
         const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker((args: any[]) => {
             assertArgNotPresent(args, '--use-container')
         })
@@ -165,7 +165,7 @@ describe('SamCliBuildInvocation', async () => {
         }).execute()
     })
 
-    it('does not pass --use-container to sam cli if useContainer is undefined', async () => {
+    it('does not pass --use-container to sam cli if useContainer is undefined', async function() {
         const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker((args: any[]) => {
             assertArgNotPresent(args, '--use-container')
         })
@@ -177,7 +177,7 @@ describe('SamCliBuildInvocation', async () => {
         }).execute()
     })
 
-    it('passes --manifest to sam cli if manifestPath is set', async () => {
+    it('passes --manifest to sam cli if manifestPath is set', async function() {
         const expectedArg = 'mypath'
 
         const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker((args: any[]) => {
@@ -192,7 +192,7 @@ describe('SamCliBuildInvocation', async () => {
         }).execute()
     })
 
-    it('does not pass --manifest to sam cli if manifestPath is not set', async () => {
+    it('does not pass --manifest to sam cli if manifestPath is not set', async function() {
         const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker((args: any[]) => {
             assertArgNotPresent(args, '--manifest')
         })
@@ -204,7 +204,7 @@ describe('SamCliBuildInvocation', async () => {
         }).execute()
     })
 
-    it('Passes docker network to sam cli', async () => {
+    it('Passes docker network to sam cli', async function() {
         const expectedDockerNetwork = 'hello-world'
 
         const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker((args: any[]) => {
@@ -219,7 +219,7 @@ describe('SamCliBuildInvocation', async () => {
         }).execute()
     })
 
-    it('Does not pass docker network to sam cli if undefined', async () => {
+    it('Does not pass docker network to sam cli if undefined', async function() {
         const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker((args: any[]) => {
             assertArgNotPresent(args, '--docker-network')
         })
@@ -231,7 +231,7 @@ describe('SamCliBuildInvocation', async () => {
         }).execute()
     })
 
-    it('passes --skip-pull-image to sam cli if skipPullImage is true', async () => {
+    it('passes --skip-pull-image to sam cli if skipPullImage is true', async function() {
         const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker((args: any[]) => {
             assert.notStrictEqual(args.indexOf('--skip-pull-image'), -1, 'Expected --skip-pull-image arg')
         })
@@ -244,7 +244,7 @@ describe('SamCliBuildInvocation', async () => {
         }).execute()
     })
 
-    it('does not pass --skip-pull-image to sam cli if skipPullImageis false', async () => {
+    it('does not pass --skip-pull-image to sam cli if skipPullImageis false', async function() {
         const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker((args: any[]) => {
             assertArgNotPresent(args, '--skip-pull-image')
         })
@@ -257,7 +257,7 @@ describe('SamCliBuildInvocation', async () => {
         }).execute()
     })
 
-    it('does not pass --skip-pull-image to sam cli if skipPullImage is undefined', async () => {
+    it('does not pass --skip-pull-image to sam cli if skipPullImage is undefined', async function() {
         const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker((args: any[]) => {
             assertArgNotPresent(args, '--skip-pull-image')
         })
@@ -269,7 +269,7 @@ describe('SamCliBuildInvocation', async () => {
         }).execute()
     })
 
-    it('throws on unexpected exit code', async () => {
+    it('throws on unexpected exit code', async function() {
         const error = await assertThrowsError(async () => {
             await new SamCliBuildInvocation(
                 {

--- a/src/test/shared/sam/cli/samCliConfiguration.test.ts
+++ b/src/test/shared/sam/cli/samCliConfiguration.test.ts
@@ -11,20 +11,20 @@ import { DefaultSamCliConfiguration, SamCliConfiguration } from '../../../../sha
 import { SamCliLocationProvider } from '../../../../shared/sam/cli/samCliLocator'
 import { TestSettingsConfiguration } from '../../../utilities/testSettingsConfiguration'
 
-describe('SamCliConfiguration', () => {
+describe('SamCliConfiguration', function() {
     let tempFolder: string
     let settingsConfiguration: TestSettingsConfiguration
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         tempFolder = await makeTemporaryToolkitFolder()
         settingsConfiguration = new TestSettingsConfiguration()
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         await fs.remove(tempFolder)
     })
 
-    it('uses config value when referencing file that exists', async () => {
+    it('uses config value when referencing file that exists', async function() {
         const fakeCliLocation = path.join(tempFolder, 'fakeSamCli')
 
         createSampleFile(fakeCliLocation)
@@ -44,7 +44,7 @@ describe('SamCliConfiguration', () => {
         assert.strictEqual(samCliConfig.getSamCliLocation(), fakeCliLocation)
     })
 
-    it('calls location provider when config not set', async () => {
+    it('calls location provider when config not set', async function() {
         let timesCalled: number = 0
 
         const samCliConfig: SamCliConfiguration = new DefaultSamCliConfiguration(settingsConfiguration, {
@@ -60,7 +60,7 @@ describe('SamCliConfiguration', () => {
         assert.strictEqual(timesCalled, 1)
     })
 
-    it('location provider detects a file', async () => {
+    it('location provider detects a file', async function() {
         const fakeCliLocation = path.join(tempFolder, 'fakeSamCli')
 
         const samCliConfig: SamCliConfiguration = new DefaultSamCliConfiguration(settingsConfiguration, {
@@ -74,7 +74,7 @@ describe('SamCliConfiguration', () => {
         assert.strictEqual(samCliConfig.getSamCliLocation(), fakeCliLocation)
     })
 
-    it('location provider does not detect a file', async () => {
+    it('location provider does not detect a file', async function() {
         const samCliConfig: SamCliConfiguration = new DefaultSamCliConfiguration(settingsConfiguration, {
             getLocation: async (): Promise<string | undefined> => {
                 return Promise.resolve(undefined)

--- a/src/test/shared/sam/cli/samCliDeploy.test.ts
+++ b/src/test/shared/sam/cli/samCliDeploy.test.ts
@@ -19,18 +19,18 @@ import {
     BadExitCodeSamCliProcessInvoker,
 } from './testSamCliProcessInvoker'
 
-describe('runSamCliDeploy', async () => {
+describe('runSamCliDeploy', async function() {
     const fakeRegion = 'region'
     const fakeStackName = 'stackName'
     const fakeS3BucketName = 'coolbucket'
     const fakeTemplateFile = 'template'
     let invokeCount: number
 
-    beforeEach(() => {
+    beforeEach(function() {
         invokeCount = 0
     })
 
-    it('does not include --parameter-overrides if there are no overrides', async () => {
+    it('does not include --parameter-overrides if there are no overrides', async function() {
         const invoker = new MockSamCliProcessInvoker(args => {
             invokeCount++
             assertArgNotPresent(args, '--parameter-overrides')
@@ -41,7 +41,7 @@ describe('runSamCliDeploy', async () => {
         assert.strictEqual(invokeCount, 1, 'Unexpected invoke count')
     })
 
-    it('includes overrides as a string of key=value pairs', async () => {
+    it('includes overrides as a string of key=value pairs', async function() {
         const invoker = new MockSamCliProcessInvoker(args => {
             invokeCount++
             assertArgIsPresent(args, '--parameter-overrides')
@@ -65,7 +65,7 @@ describe('runSamCliDeploy', async () => {
         assert.strictEqual(invokeCount, 1, 'Unexpected invoke count')
     })
 
-    it('includes a template, stack name, bucket, and region', async () => {
+    it('includes a template, stack name, bucket, and region', async function() {
         const invoker = new MockSamCliProcessInvoker(args => {
             invokeCount++
             assertArgsContainArgument(args, '--template-file', fakeTemplateFile)
@@ -79,7 +79,7 @@ describe('runSamCliDeploy', async () => {
         assert.strictEqual(invokeCount, 1, 'Unexpected invoke count')
     })
 
-    it('Passes all cloudformation capabilities', async () => {
+    it('Passes all cloudformation capabilities', async function() {
         const invoker = new MockSamCliProcessInvoker(args => {
             invokeCount++
             assertArgIsPresent(args, '--capabilities')
@@ -93,7 +93,7 @@ describe('runSamCliDeploy', async () => {
         assert.strictEqual(invokeCount, 1, 'Unexpected invoke count')
     })
 
-    it('throws on unexpected exit code', async () => {
+    it('throws on unexpected exit code', async function() {
         const badExitCodeProcessInvoker = new BadExitCodeSamCliProcessInvoker({})
 
         const error = await assertThrowsError(async () => {

--- a/src/test/shared/sam/cli/samCliInfo.test.ts
+++ b/src/test/shared/sam/cli/samCliInfo.test.ts
@@ -16,7 +16,7 @@ import {
     TestSamCliProcessInvoker,
 } from './testSamCliProcessInvoker'
 
-describe('SamCliInfoInvocation', async () => {
+describe('SamCliInfoInvocation', async function() {
     const successfulInvoker: TestSamCliProcessInvoker = new TestSamCliProcessInvoker(
         (spawnOptions, args: any[]): ChildProcessResult => {
             return new FakeChildProcessResult({
@@ -30,7 +30,7 @@ describe('SamCliInfoInvocation', async () => {
         }
     }
 
-    it('converts sam info response to SamCliInfoResponse', async () => {
+    it('converts sam info response to SamCliInfoResponse', async function() {
         const response: SamCliInfoResponse | undefined = new TestSamCliInfoCommand({
             invoker: successfulInvoker,
         }).convertOutput('{"version": "1.2.3"}')
@@ -39,7 +39,7 @@ describe('SamCliInfoInvocation', async () => {
         assert.strictEqual(response!.version, '1.2.3')
     })
 
-    it('converts sam info response containing unexpected fields to SamCliInfoResponse', async () => {
+    it('converts sam info response containing unexpected fields to SamCliInfoResponse', async function() {
         const response: SamCliInfoResponse | undefined = new TestSamCliInfoCommand({
             invoker: successfulInvoker,
         }).convertOutput('{"version": "1.2.3", "bananas": "123"}')
@@ -48,7 +48,7 @@ describe('SamCliInfoInvocation', async () => {
         assert.strictEqual(response!.version, '1.2.3')
     })
 
-    it('converts sam info response without version to SamCliInfoResponse', async () => {
+    it('converts sam info response without version to SamCliInfoResponse', async function() {
         const response: SamCliInfoResponse | undefined = new TestSamCliInfoCommand({
             invoker: successfulInvoker,
         }).convertOutput('{}')
@@ -57,7 +57,7 @@ describe('SamCliInfoInvocation', async () => {
         assert.strictEqual(response!.version, undefined)
     })
 
-    it('converts non-response to undefined', async () => {
+    it('converts non-response to undefined', async function() {
         ;['qwerty', '{"version": "1.2.3"} you have no new email messages'].forEach(output => {
             const response: SamCliInfoResponse | undefined = new TestSamCliInfoCommand({
                 invoker: successfulInvoker,
@@ -67,7 +67,7 @@ describe('SamCliInfoInvocation', async () => {
         })
     })
 
-    it('handles successful errorcode and output', async () => {
+    it('handles successful errorcode and output', async function() {
         const samInfo: SamCliInfoInvocation = new SamCliInfoInvocation({ invoker: successfulInvoker })
 
         const response = await samInfo.execute()
@@ -75,7 +75,7 @@ describe('SamCliInfoInvocation', async () => {
         assert.strictEqual(response.version, '1.2.3', 'unexpected sam info version')
     })
 
-    it('handles successful errorcode with strange output', async () => {
+    it('handles successful errorcode with strange output', async function() {
         const invoker: TestSamCliProcessInvoker = new TestSamCliProcessInvoker(
             (spawnOptions, args: any[]): ChildProcessResult => {
                 return new FakeChildProcessResult({
@@ -90,7 +90,7 @@ describe('SamCliInfoInvocation', async () => {
         }, 'Expected a error to be thrown')
     })
 
-    it('throws on unexpected exit code', async () => {
+    it('throws on unexpected exit code', async function() {
         const badExitCodeProcessInvoker = new BadExitCodeSamCliProcessInvoker({})
 
         const error = await assertThrowsError(async () => {

--- a/src/test/shared/sam/cli/samCliInit.test.ts
+++ b/src/test/shared/sam/cli/samCliInit.test.ts
@@ -27,7 +27,7 @@ import {
 import { SchemaTemplateExtraContext } from '../../../../eventSchemas/templates/schemasAppTemplateUtils'
 import { FakeSamCliValidator } from '../../../fakeExtensionContext'
 
-describe('runSamCliInit', async () => {
+describe('runSamCliInit', async function() {
     class FakeChildProcessResult implements ChildProcessResult {
         public exitCode: number = 0
         public error = undefined
@@ -58,8 +58,8 @@ describe('runSamCliInit', async () => {
         dependencyManager: sampleDependencyManager,
     }
 
-    describe('runSamCliInit with HelloWorld template', async () => {
-        it('Passes init command to sam cli', async () => {
+    describe('runSamCliInit with HelloWorld template', async function() {
+        it('Passes init command to sam cli', async function() {
             const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker(
                 (spawnOptions: SpawnOptions, args: any[]) => {
                     assert.ok(args.length > 0, 'Expected args to be present')
@@ -75,7 +75,7 @@ describe('runSamCliInit', async () => {
             await runSamCliInit(sampleSamInitArgs, context)
         })
 
-        it('Passes name to sam cli', async () => {
+        it('Passes name to sam cli', async function() {
             const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker(
                 (spawnOptions: SpawnOptions, args: any[]) => {
                     assertArgsContainArgument(args, '--name', sampleSamInitArgs.name)
@@ -90,7 +90,7 @@ describe('runSamCliInit', async () => {
             await runSamCliInit(sampleSamInitArgs, context)
         })
 
-        it('Passes location to sam cli', async () => {
+        it('Passes location to sam cli', async function() {
             const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker(
                 (spawnOptions: SpawnOptions, args: any[]) => {
                     assert.strictEqual(spawnOptions.cwd, sampleSamInitArgs.location, 'Unexpected cwd')
@@ -105,7 +105,7 @@ describe('runSamCliInit', async () => {
             await runSamCliInit(sampleSamInitArgs, context)
         })
 
-        it('Passes runtime to sam cli', async () => {
+        it('Passes runtime to sam cli', async function() {
             const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker(
                 (spawnOptions: SpawnOptions, args: any[]) => {
                     assertArgsContainArgument(args, '--runtime', sampleSamInitArgs.runtime!)
@@ -120,7 +120,7 @@ describe('runSamCliInit', async () => {
             await runSamCliInit(sampleSamInitArgs, context)
         })
 
-        it('throws on unexpected exit code', async () => {
+        it('throws on unexpected exit code', async function() {
             const badExitCodeProcessInvoker = new BadExitCodeSamCliProcessInvoker({})
             const context: SamCliContext = {
                 validator: defaultFakeValidator,
@@ -139,7 +139,7 @@ describe('runSamCliInit', async () => {
             )
         })
 
-        it('Passes --no-interactive', async () => {
+        it('Passes --no-interactive', async function() {
             const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker(
                 (spawnOptions: SpawnOptions, args: any[]) => {
                     assertArgIsPresent(args, '--no-interactive')
@@ -154,7 +154,7 @@ describe('runSamCliInit', async () => {
             await runSamCliInit(sampleSamInitArgs, context)
         })
 
-        it('Passes --app-template', async () => {
+        it('Passes --app-template', async function() {
             const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker(
                 (spawnOptions: SpawnOptions, args: any[]) => {
                     assertArgsContainArgument(args, '--app-template', getSamCliTemplateParameter(helloWorldTemplate))
@@ -170,7 +170,7 @@ describe('runSamCliInit', async () => {
             await runSamCliInit(sampleSamInitArgs, context)
         })
 
-        it('Passes --dependency-manager', async () => {
+        it('Passes --dependency-manager', async function() {
             const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker(
                 (spawnOptions: SpawnOptions, args: any[]) => {
                     assertArgsContainArgument(args, '--dependency-manager', sampleDependencyManager)
@@ -186,7 +186,7 @@ describe('runSamCliInit', async () => {
         })
     })
 
-    describe('runSamCliInit With EventBridgeStartAppTemplate', async () => {
+    describe('runSamCliInit With EventBridgeStartAppTemplate', async function() {
         const extraContent: SchemaTemplateExtraContext = {
             AWS_Schema_registry: 'testRegistry',
             AWS_Schema_name: 'testSchema',
@@ -205,7 +205,7 @@ describe('runSamCliInit', async () => {
             dependencyManager: sampleDependencyManager,
         }
 
-        it('Passes --extra-context for eventBridgeStarterAppTemplate', async () => {
+        it('Passes --extra-context for eventBridgeStarterAppTemplate', async function() {
             const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker(
                 (spawnOptions: SpawnOptions, args: any[]) => {
                     assertArgsContainArgument(

--- a/src/test/shared/sam/cli/samCliInvokerUtils.test.ts
+++ b/src/test/shared/sam/cli/samCliInvokerUtils.test.ts
@@ -8,8 +8,8 @@ import { getTestLogger } from '../../../globalSetup.test'
 import { assertThrowsError } from '../../utilities/assertUtils'
 import { assertErrorContainsBadExitMessage, assertLogContainsBadExitInformation } from './testSamCliProcessInvoker'
 
-describe('logAndThrowIfUnexpectedExitCode', async () => {
-    it('does not throw on expected exit code', async () => {
+describe('logAndThrowIfUnexpectedExitCode', async function() {
+    it('does not throw on expected exit code', async function() {
         logAndThrowIfUnexpectedExitCode(
             {
                 exitCode: 123,
@@ -21,7 +21,7 @@ describe('logAndThrowIfUnexpectedExitCode', async () => {
         )
     })
 
-    it('throws on unexpected exit code', async () => {
+    it('throws on unexpected exit code', async function() {
         const exitError = new Error('bad result')
         const childProcessResult = {
             exitCode: 123,

--- a/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
+++ b/src/test/shared/sam/cli/samCliLocalInvoke.test.ts
@@ -15,7 +15,7 @@ import {
 import { ChildProcess } from '../../../../shared/utilities/childProcess'
 import { assertArgIsPresent, assertArgNotPresent, assertArgsContainArgument } from './samCliTestUtils'
 
-describe('SamCliLocalInvokeInvocation', async () => {
+describe('SamCliLocalInvokeInvocation', async function() {
     class TestSamLocalInvokeCommand implements SamLocalInvokeCommand {
         public constructor(private readonly onInvoke: ({ ...params }: SamLocalInvokeCommandArgs) => void) {}
 
@@ -30,7 +30,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
     let placeholderEventFile: string
     const nonRelevantArg = 'arg is not of interest to this test'
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         tempFolder = await makeTemporaryToolkitFolder()
         placeholderTemplateFile = path.join(tempFolder, 'template.yaml')
         placeholderEventFile = path.join(tempFolder, 'event.json')
@@ -38,11 +38,11 @@ describe('SamCliLocalInvokeInvocation', async () => {
         await writeFile(placeholderEventFile, '')
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         await remove(tempFolder)
     })
 
-    it('invokes `sam local` with args', async () => {
+    it('invokes `sam local` with args', async function() {
         const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
             (invokeArgs: SamLocalInvokeCommandArgs) => {
                 assert.ok(invokeArgs.args.length >= 2, 'Expected args to be present')
@@ -70,7 +70,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
         }).execute()
     })
 
-    it('Passes template resource name to sam cli', async () => {
+    it('Passes template resource name to sam cli', async function() {
         const expectedResourceName = 'HelloWorldResource'
         const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
             (invokeArgs: SamLocalInvokeCommandArgs) => {
@@ -87,7 +87,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
         }).execute()
     })
 
-    it('Passes template path to sam cli', async () => {
+    it('Passes template path to sam cli', async function() {
         const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
             (invokeArgs: SamLocalInvokeCommandArgs) => {
                 assertArgsContainArgument(invokeArgs.args, '--template', placeholderTemplateFile)
@@ -103,7 +103,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
         }).execute()
     })
 
-    it('Passes event path to sam cli', async () => {
+    it('Passes event path to sam cli', async function() {
         const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
             (invokeArgs: SamLocalInvokeCommandArgs) => {
                 assertArgsContainArgument(invokeArgs.args, '--event', placeholderEventFile)
@@ -119,7 +119,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
         }).execute()
     })
 
-    it('Passes env-vars path to sam cli', async () => {
+    it('Passes env-vars path to sam cli', async function() {
         const expectedEnvVarsPath = 'envvars.json'
         const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
             (invokeArgs: SamLocalInvokeCommandArgs) => {
@@ -136,7 +136,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
         }).execute()
     })
 
-    it('Passes debug port to sam cli', async () => {
+    it('Passes debug port to sam cli', async function() {
         const expectedDebugPort = '1234'
         const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
             (invokeArgs: SamLocalInvokeCommandArgs) => {
@@ -154,7 +154,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
         }).execute()
     })
 
-    it('undefined debug port does not pass to sam cli', async () => {
+    it('undefined debug port does not pass to sam cli', async function() {
         const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
             (invokeArgs: SamLocalInvokeCommandArgs) => {
                 assertArgNotPresent(invokeArgs.args, '-d')
@@ -171,7 +171,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
         }).execute()
     })
 
-    it('Passes docker network to sam cli', async () => {
+    it('Passes docker network to sam cli', async function() {
         const expectedDockerNetwork = 'hello-world'
         const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
             (invokeArgs: SamLocalInvokeCommandArgs) => {
@@ -189,7 +189,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
         }).execute()
     })
 
-    it('Does not pass docker network to sam cli when undefined', async () => {
+    it('Does not pass docker network to sam cli when undefined', async function() {
         const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
             (invokeArgs: SamLocalInvokeCommandArgs) => {
                 assertArgNotPresent(invokeArgs.args, '--docker-network')
@@ -206,7 +206,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
         }).execute()
     })
 
-    it('passes --skip-pull-image to sam cli if skipPullImage is true', async () => {
+    it('passes --skip-pull-image to sam cli if skipPullImage is true', async function() {
         const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
             (invokeArgs: SamLocalInvokeCommandArgs) => {
                 assertArgIsPresent(invokeArgs.args, '--skip-pull-image')
@@ -223,7 +223,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
         }).execute()
     })
 
-    it('does not pass --skip-pull-image to sam cli if skipPullImage is false', async () => {
+    it('does not pass --skip-pull-image to sam cli if skipPullImage is false', async function() {
         const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
             (invokeArgs: SamLocalInvokeCommandArgs) => {
                 assertArgNotPresent(invokeArgs.args, '--skip-pull-image')
@@ -240,7 +240,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
         }).execute()
     })
 
-    it('does not pass --skip-pull-image to sam cli if skipPullImage is undefined', async () => {
+    it('does not pass --skip-pull-image to sam cli if skipPullImage is undefined', async function() {
         const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
             (invokeArgs: SamLocalInvokeCommandArgs) => {
                 assertArgNotPresent(invokeArgs.args, '--skip-pull-image')
@@ -257,7 +257,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
         }).execute()
     })
 
-    it('Passes debuggerPath to sam cli', async () => {
+    it('Passes debuggerPath to sam cli', async function() {
         const expectedDebuggerPath = path.join('foo', 'bar')
 
         const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
@@ -276,7 +276,7 @@ describe('SamCliLocalInvokeInvocation', async () => {
         }).execute()
     })
 
-    it('Does not pass debuggerPath to sam cli when undefined', async () => {
+    it('Does not pass debuggerPath to sam cli when undefined', async function() {
         const taskInvoker: SamLocalInvokeCommand = new TestSamLocalInvokeCommand(
             (invokeArgs: SamLocalInvokeCommandArgs) => {
                 assertArgNotPresent(invokeArgs.args, '--debugger-path')

--- a/src/test/shared/sam/cli/samCliPackage.test.ts
+++ b/src/test/shared/sam/cli/samCliPackage.test.ts
@@ -14,7 +14,7 @@ import {
     BadExitCodeSamCliProcessInvoker,
 } from './testSamCliProcessInvoker'
 
-describe('SamCliPackageInvocation', async () => {
+describe('SamCliPackageInvocation', async function() {
     let invokeCount: number
     const packageParameters: SamCliPackageParameters = {
         sourceTemplateFile: 'template',
@@ -24,11 +24,11 @@ describe('SamCliPackageInvocation', async () => {
         s3Bucket: 'bucket',
     }
 
-    beforeEach(() => {
+    beforeEach(function() {
         invokeCount = 0
     })
 
-    it('includes a template, s3 bucket, output template file, and region', async () => {
+    it('includes a template, s3 bucket, output template file, and region', async function() {
         const invoker = new MockSamCliProcessInvoker(args => {
             invokeCount++
             assertArgsContainArgument(args, '--template-file', 'template')
@@ -43,7 +43,7 @@ describe('SamCliPackageInvocation', async () => {
         assert.strictEqual(invokeCount, 1, 'Unexpected invoke count')
     })
 
-    it('includes a template, s3 bucket, output template file, region, and repo', async () => {
+    it('includes a template, s3 bucket, output template file, region, and repo', async function() {
         const invoker = new MockSamCliProcessInvoker(args => {
             invokeCount++
             assertArgsContainArgument(args, '--template-file', 'template')
@@ -58,7 +58,7 @@ describe('SamCliPackageInvocation', async () => {
         assert.strictEqual(invokeCount, 1, 'Unexpected invoke count')
     })
 
-    it('throws on unexpected exit code', async () => {
+    it('throws on unexpected exit code', async function() {
         const badExitCodeProcessInvoker = new BadExitCodeSamCliProcessInvoker({})
 
         const error = await assertThrowsError(async () => {

--- a/src/test/shared/sam/cli/samCliStartApi.test.ts
+++ b/src/test/shared/sam/cli/samCliStartApi.test.ts
@@ -10,13 +10,13 @@ import { makeTemporaryToolkitFolder } from '../../../../shared/filesystemUtiliti
 import { buildSamCliStartApiArguments } from '../../../../shared/sam/cli/samCliStartApi'
 import { assertArgIsPresent, assertArgNotPresent, assertArgsContainArgument } from './samCliTestUtils'
 
-describe('SamCliStartApi', async () => {
+describe('SamCliStartApi', async function() {
     let tempFolder: string
     let placeholderTemplateFile: string
     let placeholderEventFile: string
     const nonRelevantArg = 'arg is not of interest to this test'
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         tempFolder = await makeTemporaryToolkitFolder()
         placeholderTemplateFile = join(tempFolder, 'template.yaml')
         placeholderEventFile = join(tempFolder, 'event.json')
@@ -24,11 +24,11 @@ describe('SamCliStartApi', async () => {
         await writeFile(placeholderEventFile, '')
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         await remove(tempFolder)
     })
 
-    it('invokes `sam local start-api` with correct args', async () => {
+    it('invokes `sam local start-api` with correct args', async function() {
         const invokeArgs = await buildSamCliStartApiArguments({
             templatePath: placeholderTemplateFile,
             environmentVariablePath: nonRelevantArg,
@@ -48,7 +48,7 @@ describe('SamCliStartApi', async () => {
         assert.strictEqual(invokeArgs[8], 'my/build/dir/')
     })
 
-    it('Passes template path to sam cli', async () => {
+    it('Passes template path to sam cli', async function() {
         const invokeArgs = await buildSamCliStartApiArguments({
             templatePath: placeholderTemplateFile,
             environmentVariablePath: nonRelevantArg,
@@ -57,7 +57,7 @@ describe('SamCliStartApi', async () => {
         assertArgsContainArgument(invokeArgs, '--template', placeholderTemplateFile)
     })
 
-    it('Passes env-vars path to sam cli', async () => {
+    it('Passes env-vars path to sam cli', async function() {
         const expectedEnvVarsPath = 'envvars.json'
         const invokeArgs = await buildSamCliStartApiArguments({
             templatePath: placeholderTemplateFile,
@@ -67,7 +67,7 @@ describe('SamCliStartApi', async () => {
         assertArgsContainArgument(invokeArgs, '--env-vars', expectedEnvVarsPath)
     })
 
-    it('Passes debug port to sam cli', async () => {
+    it('Passes debug port to sam cli', async function() {
         const expectedDebugPort = '1234'
 
         const invokeArgs = await buildSamCliStartApiArguments({
@@ -79,7 +79,7 @@ describe('SamCliStartApi', async () => {
         assertArgsContainArgument(invokeArgs, '--debug-port', expectedDebugPort)
     })
 
-    it('undefined debug port does not pass to sam cli', async () => {
+    it('undefined debug port does not pass to sam cli', async function() {
         const invokeArgs = await buildSamCliStartApiArguments({
             templatePath: placeholderTemplateFile,
             environmentVariablePath: nonRelevantArg,
@@ -89,7 +89,7 @@ describe('SamCliStartApi', async () => {
         assertArgNotPresent(invokeArgs, '--debug-port')
     })
 
-    it('Passes docker network to sam cli', async () => {
+    it('Passes docker network to sam cli', async function() {
         const expectedDockerNetwork = 'hello-world'
 
         const invokeArgs = await buildSamCliStartApiArguments({
@@ -101,7 +101,7 @@ describe('SamCliStartApi', async () => {
         assertArgsContainArgument(invokeArgs, '--docker-network', expectedDockerNetwork)
     })
 
-    it('Does not pass docker network to sam cli when undefined', async () => {
+    it('Does not pass docker network to sam cli when undefined', async function() {
         const invokeArgs = await buildSamCliStartApiArguments({
             templatePath: placeholderTemplateFile,
             environmentVariablePath: nonRelevantArg,
@@ -111,7 +111,7 @@ describe('SamCliStartApi', async () => {
         assertArgNotPresent(invokeArgs, '--docker-network')
     })
 
-    it('passes --skip-pull-image to sam cli if skipPullImage is true', async () => {
+    it('passes --skip-pull-image to sam cli if skipPullImage is true', async function() {
         const invokeArgs = await buildSamCliStartApiArguments({
             templatePath: placeholderTemplateFile,
             environmentVariablePath: nonRelevantArg,
@@ -121,7 +121,7 @@ describe('SamCliStartApi', async () => {
         assertArgIsPresent(invokeArgs, '--skip-pull-image')
     })
 
-    it('does not pass --skip-pull-image to sam cli if skipPullImage is false', async () => {
+    it('does not pass --skip-pull-image to sam cli if skipPullImage is false', async function() {
         const invokeArgs = await buildSamCliStartApiArguments({
             templatePath: placeholderTemplateFile,
             environmentVariablePath: nonRelevantArg,
@@ -131,7 +131,7 @@ describe('SamCliStartApi', async () => {
         assertArgNotPresent(invokeArgs, '--skip-pull-image')
     })
 
-    it('does not pass --skip-pull-image to sam cli if skipPullImage is undefined', async () => {
+    it('does not pass --skip-pull-image to sam cli if skipPullImage is undefined', async function() {
         const invokeArgs = await buildSamCliStartApiArguments({
             templatePath: placeholderTemplateFile,
             environmentVariablePath: nonRelevantArg,
@@ -141,7 +141,7 @@ describe('SamCliStartApi', async () => {
         assertArgNotPresent(invokeArgs, '--skip-pull-image')
     })
 
-    it('Passes debuggerPath to sam cli', async () => {
+    it('Passes debuggerPath to sam cli', async function() {
         const expectedDebuggerPath = join('foo', 'bar')
 
         const invokeArgs = await buildSamCliStartApiArguments({
@@ -153,7 +153,7 @@ describe('SamCliStartApi', async () => {
         assertArgsContainArgument(invokeArgs, '--debugger-path', expectedDebuggerPath)
     })
 
-    it('Does not pass debuggerPath to sam cli when undefined', async () => {
+    it('Does not pass debuggerPath to sam cli when undefined', async function() {
         const invokeArgs = await buildSamCliStartApiArguments({
             templatePath: placeholderTemplateFile,
             environmentVariablePath: nonRelevantArg,

--- a/src/test/shared/sam/cli/samCliValidationNotification.test.ts
+++ b/src/test/shared/sam/cli/samCliValidationNotification.test.ts
@@ -18,7 +18,7 @@ import {
     makeSamCliValidationNotification,
 } from '../../../../shared/sam/cli/samCliValidationNotification'
 
-describe('makeSamCliValidationNotification', async () => {
+describe('makeSamCliValidationNotification', async function() {
     const fakeSamCliValidationNotification: SamCliValidationNotification = {
         show: () => {
             throw new Error('show is unused')
@@ -27,7 +27,7 @@ describe('makeSamCliValidationNotification', async () => {
     const actionLabelUpdateSamCli = 'Get SAM CLI'
     const actionLabelUpdateToolkit = 'Visit Marketplace'
 
-    it('handles SamCliNotFoundError', async () => {
+    it('handles SamCliNotFoundError', async function() {
         makeSamCliValidationNotification(
             new SamCliNotFoundError(),
             (message: string, actions: SamCliValidationNotificationAction[]): SamCliValidationNotification => {
@@ -93,7 +93,7 @@ describe('makeSamCliValidationNotification', async () => {
         })
     })
 
-    it('handles Unexpected input', async () => {
+    it('handles Unexpected input', async function() {
         makeSamCliValidationNotification(
             new InvalidSamCliError('different error'),
             (message: string, actions: SamCliValidationNotificationAction[]): SamCliValidationNotification => {

--- a/src/test/shared/sam/cli/samCliValidator.test.ts
+++ b/src/test/shared/sam/cli/samCliValidator.test.ts
@@ -13,7 +13,7 @@ import {
     SamCliVersionValidation,
 } from '../../../../shared/sam/cli/samCliValidator'
 
-describe('DefaultSamCliValidator', async () => {
+describe('DefaultSamCliValidator', async function() {
     class TestSamCliValidatorContext implements SamCliValidatorContext {
         public samCliVersionId: string = new Date().valueOf().toString()
         public getInfoCallCount: number = 0
@@ -65,7 +65,7 @@ describe('DefaultSamCliValidator', async () => {
         },
     ]
 
-    describe('detectValidSamCli', async () => {
+    describe('detectValidSamCli', async function() {
         samCliVersionTestScenarios.forEach(test => {
             it(`handles case where SAM CLI exists and ${test.situation}`, async () => {
                 const validatorContext = new TestSamCliValidatorContext(test.version)
@@ -86,7 +86,7 @@ describe('DefaultSamCliValidator', async () => {
             })
         })
 
-        it('handles case where SAM CLI is not found', async () => {
+        it('handles case where SAM CLI is not found', async function() {
             const validatorContext = new TestSamCliValidatorContext('')
             validatorContext.mockSamLocation = ''
             const samCliValidator = new DefaultSamCliValidator(validatorContext)
@@ -98,7 +98,7 @@ describe('DefaultSamCliValidator', async () => {
         })
     })
 
-    describe('getVersionValidatorResult', async () => {
+    describe('getVersionValidatorResult', async function() {
         samCliVersionTestScenarios.forEach(test => {
             it(`Validates SAM CLI binary for the case: ${test.situation}`, async () => {
                 const validatorContext = new TestSamCliValidatorContext(test.version)
@@ -116,7 +116,7 @@ describe('DefaultSamCliValidator', async () => {
             })
         })
 
-        it('Uses the cached validation result', async () => {
+        it('Uses the cached validation result', async function() {
             const validatorContext = new TestSamCliValidatorContext(MINIMUM_SAM_CLI_VERSION_INCLUSIVE)
             const samCliValidator = new DefaultSamCliValidator(validatorContext)
 
@@ -126,7 +126,7 @@ describe('DefaultSamCliValidator', async () => {
             assert.strictEqual(validatorContext.getInfoCallCount, 1, 'getInfo called more than once')
         })
 
-        it('Does not use the cached validation result if the SAM CLI timestamp changed', async () => {
+        it('Does not use the cached validation result if the SAM CLI timestamp changed', async function() {
             const validatorContext = new TestSamCliValidatorContext(MINIMUM_SAM_CLI_VERSION_INCLUSIVE)
             const samCliValidator = new DefaultSamCliValidator(validatorContext)
 
@@ -140,7 +140,7 @@ describe('DefaultSamCliValidator', async () => {
         })
     })
 
-    describe('validateSamCliVersion', async () => {
+    describe('validateSamCliVersion', async function() {
         samCliVersionTestScenarios.forEach(test => {
             it(`validates when ${test.situation}`, async () => {
                 const validation: SamCliVersionValidation = DefaultSamCliValidator.validateSamCliVersion(test.version)

--- a/src/test/shared/sam/debugger/awsSamDebugConfigurationValidator.test.ts
+++ b/src/test/shared/sam/debugger/awsSamDebugConfigurationValidator.test.ts
@@ -91,7 +91,7 @@ function createImageTemplateData(): WatchedItem<CloudFormation.Template> {
     }
 }
 
-describe('DefaultAwsSamDebugConfigurationValidator', () => {
+describe('DefaultAwsSamDebugConfigurationValidator', function() {
     const templateConfig = createTemplateConfig()
     const imageTemplateConfig = createImageTemplateConfig()
     const codeConfig = createCodeConfig()
@@ -106,15 +106,15 @@ describe('DefaultAwsSamDebugConfigurationValidator', () => {
 
     let savedRegistry: CloudFormationTemplateRegistry
 
-    before(() => {
+    before(function() {
         savedRegistry = ext.templateRegistry
     })
 
-    after(() => {
+    after(function() {
         ext.templateRegistry = savedRegistry
     })
 
-    beforeEach(() => {
+    beforeEach(function() {
         when(mockRegistry.getRegisteredItem('/')).thenReturn(templateData)
         when(mockRegistry.getRegisteredItem('/image')).thenReturn(imageTemplateData)
 
@@ -123,14 +123,14 @@ describe('DefaultAwsSamDebugConfigurationValidator', () => {
         validator = new DefaultAwsSamDebugConfigurationValidator(instance(mockFolder))
     })
 
-    it('returns invalid when resolving debug configurations with an invalid request type', () => {
+    it('returns invalid when resolving debug configurations with an invalid request type', function() {
         templateConfig.request = 'not-direct-invoke'
 
         const result = validator.validate(templateConfig)
         assert.strictEqual(result.isValid, false)
     })
 
-    it('returns invalid when resolving debug configurations with an invalid target type', () => {
+    it('returns invalid when resolving debug configurations with an invalid target type', function() {
         templateConfig.invokeTarget.target = 'not-valid' as any
 
         const result = validator.validate(templateConfig as any)
@@ -163,7 +163,7 @@ describe('DefaultAwsSamDebugConfigurationValidator', () => {
         assert.strictEqual(result.isValid, false)
     })
 
-    it('returns undefined when resolving template debug configurations with a resource that has an invalid runtime in template', () => {
+    it('returns undefined when resolving template debug configurations with a resource that has an invalid runtime in template', function() {
         const properties = templateData.item.Resources?.TestResource?.Properties as CloudFormation.ZipResourceProperties
         properties.Runtime = 'invalid'
 
@@ -179,7 +179,7 @@ describe('DefaultAwsSamDebugConfigurationValidator', () => {
         assert.strictEqual(result.isValid, false)
     })
 
-    it('API config is invalid when it does not have an API field', () => {
+    it('API config is invalid when it does not have an API field', function() {
         const config = createApiConfig()
         config.api = undefined
 
@@ -196,14 +196,14 @@ describe('DefaultAwsSamDebugConfigurationValidator', () => {
         assert.strictEqual(result.isValid, false)
     })
 
-    it('returns invalid when resolving code debug configurations with invalid runtimes', () => {
+    it('returns invalid when resolving code debug configurations with invalid runtimes', function() {
         codeConfig.lambda = { runtime: 'asd' }
 
         const result = validator.validate(codeConfig)
         assert.strictEqual(result.isValid, false)
     })
 
-    it('returns invalid when Image app does not declare runtime', () => {
+    it('returns invalid when Image app does not declare runtime', function() {
         const lambda = imageTemplateConfig.lambda
 
         delete lambda?.runtime

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -128,7 +128,7 @@ async function assertEqualNoDebugTemplateTarget(
     assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug)
 }
 
-describe('SamDebugConfigurationProvider', async () => {
+describe('SamDebugConfigurationProvider', async function() {
     let debugConfigProvider: SamDebugConfigProvider
     let tempFolder: string
     let tempFolderSimilarName: string | undefined
@@ -139,7 +139,7 @@ describe('SamDebugConfigurationProvider', async () => {
     const resourceName = 'myResource'
     const mockedCredentials = new Credentials('access', 'secret', 'session')
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         fakeContext = await FakeExtensionContext.getFakeExtContext()
         debugConfigProvider = new SamDebugConfigProvider(fakeContext)
         sandbox = sinon.createSandbox()
@@ -150,7 +150,7 @@ describe('SamDebugConfigurationProvider', async () => {
         tempFolderSimilarName = undefined
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         await remove(tempFolder)
         if (tempFolderSimilarName) {
             await remove(tempFolderSimilarName)
@@ -159,8 +159,8 @@ describe('SamDebugConfigurationProvider', async () => {
         sandbox.restore()
     })
 
-    describe('provideDebugConfig', async () => {
-        it('failure modes', async () => {
+    describe('provideDebugConfig', async function() {
+        it('failure modes', async function() {
             // No workspace folder:
             assert.deepStrictEqual(await debugConfigProvider.provideDebugConfigurations(undefined), [])
             // Workspace with no templates:
@@ -172,7 +172,7 @@ describe('SamDebugConfigurationProvider', async () => {
             assert.deepStrictEqual(await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder), [])
         })
 
-        it('Ignores non function type resources', async () => {
+        it('Ignores non function type resources', async function() {
             const bigYamlStr = `${makeSampleSamTemplateYaml(true)}\nTestResource2:\n .   Type: AWS::Serverless::Api`
 
             testutil.toFile(bigYamlStr, tempFile.fsPath)
@@ -181,7 +181,7 @@ describe('SamDebugConfigurationProvider', async () => {
             assert.strictEqual(provided!.length, 1)
         })
 
-        it('returns one item if a template with one resource is in the workspace', async () => {
+        it('returns one item if a template with one resource is in the workspace', async function() {
             testutil.toFile(makeSampleSamTemplateYaml(true), tempFile.fsPath)
             await ext.templateRegistry.addItemToRegistry(tempFile)
             const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
@@ -193,7 +193,7 @@ describe('SamDebugConfigurationProvider', async () => {
             )
         })
 
-        it('returns multiple items if a template with multiple resources is in the workspace', async () => {
+        it('returns multiple items if a template with multiple resources is in the workspace', async function() {
             const resources = ['resource1', 'resource2']
             const bigYamlStr = `${makeSampleSamTemplateYaml(true, {
                 resourceName: resources[0],
@@ -209,7 +209,7 @@ describe('SamDebugConfigurationProvider', async () => {
             }
         })
 
-        it('only detects the specifically targeted workspace folder (and its subfolders)', async () => {
+        it('only detects the specifically targeted workspace folder (and its subfolders)', async function() {
             const resources = ['resource1', 'resource2']
             const badResourceName = 'notIt'
 
@@ -239,7 +239,7 @@ describe('SamDebugConfigurationProvider', async () => {
             }
         })
 
-        it('Returns api function type resources as additional api configurations', async () => {
+        it('Returns api function type resources as additional api configurations', async function() {
             const bigYamlStr = `${makeSampleSamTemplateYaml(true)}
             Events:
                 HelloWorld2:
@@ -258,7 +258,7 @@ describe('SamDebugConfigurationProvider', async () => {
             assert.strictEqual(provided![1].api?.httpMethod, 'get')
         })
 
-        it('Ignores HttpApi events', async () => {
+        it('Ignores HttpApi events', async function() {
             const bigYamlStr = `${makeSampleSamTemplateYaml(true)}
             Events:
                 HelloWorld2:
@@ -272,8 +272,8 @@ describe('SamDebugConfigurationProvider', async () => {
         })
     })
 
-    describe('makeConfig', async () => {
-        it('failure modes', async () => {
+    describe('makeConfig', async function() {
+        it('failure modes', async function() {
             const config = await getConfig(
                 debugConfigProvider,
                 ext.templateRegistry,
@@ -329,7 +329,7 @@ describe('SamDebugConfigurationProvider', async () => {
             )
         })
 
-        it('returns undefined when resolving debug configurations with an invalid request type', async () => {
+        it('returns undefined when resolving debug configurations with an invalid request type', async function() {
             const resolved = await debugConfigProvider.makeConfig(undefined, {
                 type: AWS_SAM_DEBUG_TYPE,
                 name: 'whats in a name',
@@ -343,7 +343,7 @@ describe('SamDebugConfigurationProvider', async () => {
             assert.strictEqual(resolved, undefined)
         })
 
-        it('returns undefined when resolving debug configurations with an invalid target type', async () => {
+        it('returns undefined when resolving debug configurations with an invalid target type', async function() {
             const tgt = 'not-code' as 'code'
             const resolved = await debugConfigProvider.makeConfig(undefined, {
                 type: AWS_SAM_DEBUG_TYPE,
@@ -372,7 +372,7 @@ describe('SamDebugConfigurationProvider', async () => {
             assert.strictEqual(resolved, undefined)
         })
 
-        it('returns undefined when resolving template debug configurations with a resource that has an invalid runtime in template', async () => {
+        it('returns undefined when resolving template debug configurations with a resource that has an invalid runtime in template', async function() {
             await createAndRegisterYaml(
                 { resourceName, runtime: 'moreLikeRanOutOfTime' },
                 tempFile,
@@ -388,7 +388,7 @@ describe('SamDebugConfigurationProvider', async () => {
             assert.strictEqual(resolved, undefined)
         })
 
-        it('returns undefined when resolving template debug configurations with a resource that has an invalid runtime in template', async () => {
+        it('returns undefined when resolving template debug configurations with a resource that has an invalid runtime in template', async function() {
             testutil.toFile(
                 makeSampleSamTemplateYaml(true, { resourceName, runtime: 'moreLikeRanOutOfTime' }),
                 tempFile.fsPath
@@ -407,7 +407,7 @@ describe('SamDebugConfigurationProvider', async () => {
             assert.strictEqual(resolved, undefined)
         })
 
-        it('returns undefined when resolving code debug configurations with invalid runtimes', async () => {
+        it('returns undefined when resolving code debug configurations with invalid runtimes', async function() {
             const resolved = await debugConfigProvider.makeConfig(undefined, {
                 ...createBaseCodeConfig({}),
                 lambda: {
@@ -417,7 +417,7 @@ describe('SamDebugConfigurationProvider', async () => {
             assert.strictEqual(resolved, undefined)
         })
 
-        it('supports workspace-relative template path ("./foo.yaml")', async () => {
+        it('supports workspace-relative template path ("./foo.yaml")', async function() {
             testutil.toFile(makeSampleSamTemplateYaml(true, { runtime: 'nodejs12.x' }), tempFile.fsPath)
             // Register with *full* path.
             await ext.templateRegistry.addItemToRegistry(tempFile)
@@ -444,7 +444,7 @@ describe('SamDebugConfigurationProvider', async () => {
             assert.strictEqual(resolved!.name, name)
         })
 
-        it('target=code: javascript', async () => {
+        it('target=code: javascript', async function() {
             const appDir = pathutil.normalize(
                 path.join(testutil.getProjectDir(), 'testFixtures/workspaceFolder/js-manifest-in-root/')
             )
@@ -597,7 +597,7 @@ describe('SamDebugConfigurationProvider', async () => {
             assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug)
         })
 
-        it('target=template: javascript', async () => {
+        it('target=template: javascript', async function() {
             const appDir = pathutil.normalize(
                 path.join(testutil.getProjectDir(), 'testFixtures/workspaceFolder/js-manifest-in-root')
             )
@@ -752,7 +752,7 @@ describe('SamDebugConfigurationProvider', async () => {
             assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug)
         })
 
-        it('target=template: Image javascript', async () => {
+        it('target=template: Image javascript', async function() {
             const appDir = pathutil.normalize(
                 path.join(testutil.getProjectDir(), 'testFixtures/workspaceFolder/js-image-sam-app')
             )
@@ -915,7 +915,7 @@ Outputs:
             assertEqualNoDebugTemplateTarget(input, expected, folder, debugConfigProvider)
         })
 
-        it('target=api: javascript', async () => {
+        it('target=api: javascript', async function() {
             const appDir = pathutil.normalize(
                 path.join(testutil.getProjectDir(), 'testFixtures/workspaceFolder/js-manifest-in-root')
             )
@@ -1033,7 +1033,7 @@ Outputs:
             assertEqualNoDebugTemplateTarget(input, expected, folder, debugConfigProvider)
         })
 
-        it('target=code: dotnet/csharp', async () => {
+        it('target=code: dotnet/csharp', async function() {
             const appDir = pathutil.normalize(
                 path.join(testutil.getProjectDir(), 'testFixtures/workspaceFolder/csharp2.1-plain-sam-app/')
             )
@@ -1190,7 +1190,7 @@ Outputs:
             assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug)
         })
 
-        it('target=template: dotnet/csharp', async () => {
+        it('target=template: dotnet/csharp', async function() {
             const appDir = pathutil.normalize(
                 path.join(testutil.getProjectDir(), 'testFixtures/workspaceFolder/csharp2.1-plain-sam-app')
             )
@@ -1389,7 +1389,7 @@ Outputs:
             assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug)
         })
 
-        it('target=template: Image dotnet/csharp', async () => {
+        it('target=template: Image dotnet/csharp', async function() {
             const appDir = pathutil.normalize(
                 path.join(testutil.getProjectDir(), 'testFixtures/workspaceFolder/csharp2.1-image-sam-app')
             )
@@ -1605,7 +1605,7 @@ Outputs:
             assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug)
         })
 
-        it('target=code: python 3.7', async () => {
+        it('target=code: python 3.7', async function() {
             const appDir = pathutil.normalize(
                 path.join(testutil.getProjectDir(), 'testFixtures/workspaceFolder/python3.7-plain-sam-app')
             )
@@ -1763,7 +1763,7 @@ Outputs:
             assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug)
         })
 
-        it('target=template: python 3.7 (deep project tree)', async () => {
+        it('target=template: python 3.7 (deep project tree)', async function() {
             // To test a deeper tree, use "testFixtures/workspaceFolder/" as the root.
             const appDir = pathutil.normalize(path.join(testutil.getProjectDir(), 'testFixtures/workspaceFolder/'))
             const folder = testutil.getWorkspaceFolder(appDir)
@@ -1949,7 +1949,7 @@ Outputs:
             assertEqualNoDebugTemplateTarget(input, expected, folder, debugConfigProvider)
         })
 
-        it('target=api: python 3.7 (deep project tree)', async () => {
+        it('target=api: python 3.7 (deep project tree)', async function() {
             // Use "testFixtures/workspaceFolder/" as the project root to test
             // a deeper tree.
             const appDir = pathutil.normalize(path.join(testutil.getProjectDir(), 'testFixtures/workspaceFolder/'))
@@ -2115,7 +2115,7 @@ Outputs:
             assertEqualNoDebugTemplateTarget(input, expected, folder, debugConfigProvider)
         })
 
-        it('target=template: Image python 3.7', async () => {
+        it('target=template: Image python 3.7', async function() {
             // Use "testFixtures/workspaceFolder/" as the project root to test
             // a deeper tree.
             const appDir = pathutil.normalize(path.join(testutil.getProjectDir(), 'testFixtures/workspaceFolder/'))
@@ -2300,7 +2300,7 @@ Outputs:
             assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug)
         })
 
-        it('target=code: ikpdb, python 3.7', async () => {
+        it('target=code: ikpdb, python 3.7', async function() {
             const appDir = pathutil.normalize(
                 path.join(testutil.getProjectDir(), 'testFixtures/workspaceFolder/python3.7-plain-sam-app')
             )
@@ -2413,7 +2413,7 @@ Outputs:
             assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug)
         })
 
-        it('target=template: ikpdb, python 3.7 (deep project tree)', async () => {
+        it('target=template: ikpdb, python 3.7 (deep project tree)', async function() {
             // To test a deeper tree, use "testFixtures/workspaceFolder/" as the root.
             const appDir = pathutil.normalize(path.join(testutil.getProjectDir(), 'testFixtures/workspaceFolder/'))
             const folder = testutil.getWorkspaceFolder(appDir)
@@ -2571,7 +2571,7 @@ Outputs:
             assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug)
         })
 
-        it('debugconfig with extraneous env vars', async () => {
+        it('debugconfig with extraneous env vars', async function() {
             const appDir = pathutil.normalize(
                 path.join(testutil.getProjectDir(), 'testFixtures/workspaceFolder/js-manifest-in-root/')
             )
@@ -2682,7 +2682,7 @@ Resources:
             )
         })
 
-        it('debugconfig with aws section', async () => {
+        it('debugconfig with aws section', async function() {
             const mockCredentialsStore: CredentialsStore = new CredentialsStore()
 
             const credentialsProvider: CredentialsProvider = {
@@ -2807,8 +2807,8 @@ Resources:
     })
 })
 
-describe('ensureRelativePaths', () => {
-    it('ensures paths are relative', () => {
+describe('ensureRelativePaths', function() {
+    it('ensures paths are relative', function() {
         const workspace: vscode.WorkspaceFolder = {
             uri: vscode.Uri.file('/test1/'),
             name: 'test workspace',
@@ -2921,11 +2921,11 @@ async function createAndRegisterYaml(
     await registry.addItemToRegistry(file)
 }
 
-describe('createTemplateAwsSamDebugConfig', () => {
+describe('createTemplateAwsSamDebugConfig', function() {
     const name = 'my body is a template'
     const templatePath = path.join('two', 'roads', 'diverged', 'in', 'a', 'yellow', 'wood')
 
-    it('creates a template-type SAM debugger configuration with minimal configurations', () => {
+    it('creates a template-type SAM debugger configuration with minimal configurations', function() {
         const config = createTemplateAwsSamDebugConfig(undefined, undefined, false, name, templatePath)
         assert.deepStrictEqual(config, {
             name: `yellow:${name}`,
@@ -2943,7 +2943,7 @@ describe('createTemplateAwsSamDebugConfig', () => {
         })
     })
 
-    it('creates a template-type SAM debugger configuration with additional params', () => {
+    it('creates a template-type SAM debugger configuration with additional params', function() {
         const params = {
             eventJson: {
                 payload: 'uneventufl',
@@ -2960,18 +2960,18 @@ describe('createTemplateAwsSamDebugConfig', () => {
         assert.strictEqual(config.sam?.containerBuild, undefined)
     })
 
-    it('creates a template-type SAM debugger configuration with a runtime', () => {
+    it('creates a template-type SAM debugger configuration with a runtime', function() {
         const config = createTemplateAwsSamDebugConfig(undefined, 'runtime', true, name, templatePath, undefined)
         assert.deepStrictEqual(config.lambda?.runtime, 'runtime')
     })
 })
 
-describe('createApiAwsSamDebugConfig', () => {
+describe('createApiAwsSamDebugConfig', function() {
     const name = 'my body is a template'
     const templatePath = path.join('two', 'roads', 'diverged', 'in', 'a', 'yellow', 'wood')
     const runtime = 'timeToRun'
 
-    it('creates a API-type SAM debugger configuration with minimal configurations', () => {
+    it('creates a API-type SAM debugger configuration with minimal configurations', function() {
         const config = createApiAwsSamDebugConfig(undefined, undefined, name, templatePath)
         assert.deepStrictEqual(config, {
             name: `API yellow:${name}`,
@@ -2992,7 +2992,7 @@ describe('createApiAwsSamDebugConfig', () => {
         })
     })
 
-    it('creates a API-type SAM debugger configuration with additional params', () => {
+    it('creates a API-type SAM debugger configuration with additional params', function() {
         const config = createApiAwsSamDebugConfig(undefined, runtime, name, templatePath, {
             payload: { json: { key: 'value' } },
             httpMethod: 'OPTIONS',
@@ -3021,21 +3021,21 @@ describe('createApiAwsSamDebugConfig', () => {
     })
 })
 
-describe('debugConfiguration', () => {
+describe('debugConfiguration', function() {
     let tempFolder: string
     let tempFile: vscode.Uri
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         tempFolder = await makeTemporaryToolkitFolder()
         tempFile = vscode.Uri.file(path.join(tempFolder, 'test.yaml'))
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         await remove(tempFolder)
         ext.templateRegistry.reset()
     })
 
-    it('getCodeRoot(), getHandlerName() with invokeTarget=code', async () => {
+    it('getCodeRoot(), getHandlerName() with invokeTarget=code', async function() {
         const folder = testutil.getWorkspaceFolder(tempFolder)
         const relativePath = 'src'
         const fullPath = pathutil.normalize(path.join(tempFolder, relativePath))
@@ -3065,7 +3065,7 @@ describe('debugConfiguration', () => {
         assert.strictEqual(debugConfiguration.getCodeRoot(folder, config), fullPath)
     })
 
-    it('getCodeRoot(), getHandlerName() with invokeTarget=template', async () => {
+    it('getCodeRoot(), getHandlerName() with invokeTarget=template', async function() {
         const folder = testutil.getWorkspaceFolder(tempFolder)
         const relativePath = 'src'
         const fullPath = pathutil.normalize(path.join(tempFolder, relativePath))

--- a/src/test/shared/settingsConfiguration.test.ts
+++ b/src/test/shared/settingsConfiguration.test.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode'
 import { extensionSettingsPrefix } from '../../shared/constants'
 import { DefaultSettingsConfiguration } from '../../shared/settingsConfiguration'
 
-describe('DefaultSettingsConfiguration', () => {
+describe('DefaultSettingsConfiguration', function() {
     // These tests use an actual extension setting, because vscode.WorkspaceConfiguration fails when
     // you attempt to update one that isn't defined in package.json. We will restore the setting value
     // at the end of the tests.
@@ -17,15 +17,15 @@ describe('DefaultSettingsConfiguration', () => {
 
     let sut: DefaultSettingsConfiguration
 
-    before(async () => {
+    before(async function() {
         originalSettingValue = vscode.workspace.getConfiguration(extensionSettingsPrefix).get(SETTING_KEY)
     })
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         sut = new DefaultSettingsConfiguration(extensionSettingsPrefix)
     })
 
-    after(async () => {
+    after(async function() {
         await vscode.workspace
             .getConfiguration(extensionSettingsPrefix)
             .update(SETTING_KEY, originalSettingValue, vscode.ConfigurationTarget.Global)
@@ -45,10 +45,10 @@ describe('DefaultSettingsConfiguration', () => {
         // Note: we don't test undefined because retrieval returns the package.json configured default value, if there is one
     ]
 
-    describe('readSetting', async () => {
+    describe('readSetting', async function() {
         let settings: vscode.WorkspaceConfiguration
 
-        beforeEach(async () => {
+        beforeEach(async function() {
             settings = vscode.workspace.getConfiguration(extensionSettingsPrefix)
         })
 
@@ -62,7 +62,7 @@ describe('DefaultSettingsConfiguration', () => {
         })
     })
 
-    describe('writeSetting', async () => {
+    describe('writeSetting', async function() {
         scenarios.forEach(scenario => {
             it(scenario.desc, async () => {
                 await sut.writeSetting(SETTING_KEY, scenario.testValue, vscode.ConfigurationTarget.Global)

--- a/src/test/shared/systemUtilities.test.ts
+++ b/src/test/shared/systemUtilities.test.ts
@@ -12,28 +12,28 @@ import { EnvironmentVariables } from '../../shared/environmentVariables'
 import { makeTemporaryToolkitFolder } from '../../shared/filesystemUtilities'
 import { SystemUtilities } from '../../shared/systemUtilities'
 
-describe('SystemUtilities', () => {
+describe('SystemUtilities', function() {
     let tempFolder: string
 
-    before(async () => {
+    before(async function() {
         // Make a temp folder for all these tests
         // Stick some temp credentials files in there to load from
         tempFolder = await makeTemporaryToolkitFolder()
     })
 
-    after(async () => {
+    after(async function() {
         await fs.remove(tempFolder)
     })
 
-    describe('getHomeDirectory', () => {
-        it('gets HOME if set', async () => {
+    describe('getHomeDirectory', function() {
+        it('gets HOME if set', async function() {
             const env = process.env as EnvironmentVariables
 
             env.HOME = 'c:\\qwerty'
             assert.strictEqual(SystemUtilities.getHomeDirectory(), 'c:\\qwerty')
         })
 
-        it('gets USERPROFILE if set and HOME is not set', async () => {
+        it('gets USERPROFILE if set and HOME is not set', async function() {
             const env = process.env as EnvironmentVariables
 
             delete env.HOME
@@ -41,7 +41,7 @@ describe('SystemUtilities', () => {
             assert.strictEqual(SystemUtilities.getHomeDirectory(), 'c:\\profiles\\qwerty')
         })
 
-        it('gets HOMEPATH if set and HOME and USERPROFILE are not set', async () => {
+        it('gets HOMEPATH if set and HOME and USERPROFILE are not set', async function() {
             const env = process.env as EnvironmentVariables
 
             delete env.HOME
@@ -54,7 +54,7 @@ describe('SystemUtilities', () => {
             )
         })
 
-        it('prefixes result with HOMEDRIVE if set', async () => {
+        it('prefixes result with HOMEDRIVE if set', async function() {
             const env = process.env as EnvironmentVariables
 
             delete env.HOME
@@ -64,7 +64,7 @@ describe('SystemUtilities', () => {
             assert.strictEqual(SystemUtilities.getHomeDirectory(), `x:${path.sep}users${path.sep}homepath`)
         })
 
-        it('falls back on os.homedir if no environment variables are set', async () => {
+        it('falls back on os.homedir if no environment variables are set', async function() {
             const env = process.env as EnvironmentVariables
 
             delete env.HOME
@@ -76,8 +76,8 @@ describe('SystemUtilities', () => {
         })
     })
 
-    describe('fileExists', () => {
-        it('returns true if file exists', async () => {
+    describe('fileExists', function() {
+        it('returns true if file exists', async function() {
             const filename: string = path.join(tempFolder, 'existing-file.txt')
 
             fs.writeFileSync(filename, 'hello world', 'utf8')
@@ -85,7 +85,7 @@ describe('SystemUtilities', () => {
             assert.strictEqual(await SystemUtilities.fileExists(filename), true)
         })
 
-        it('returns false if file does not exist', async () => {
+        it('returns false if file does not exist', async function() {
             const filename: string = path.join(tempFolder, 'non-existing-file.txt')
             assert.strictEqual(await SystemUtilities.fileExists(filename), false)
         })

--- a/src/test/shared/telemetry/activation.test.ts
+++ b/src/test/shared/telemetry/activation.test.ts
@@ -23,23 +23,23 @@ import {
 import { DefaultSettingsConfiguration } from '../../../shared/settingsConfiguration'
 import { extensionSettingsPrefix } from '../../../shared/constants'
 
-describe('handleTelemetryNoticeResponse', () => {
+describe('handleTelemetryNoticeResponse', function() {
     let extensionContext: vscode.ExtensionContext
     let sandbox: sinon.SinonSandbox
 
-    before(() => {
+    before(function() {
         sandbox = sinon.createSandbox()
     })
 
-    after(() => {
+    after(function() {
         sandbox.restore()
     })
 
-    beforeEach(() => {
+    beforeEach(function() {
         extensionContext = new FakeExtensionContext()
     })
 
-    it('does nothing when notice is discarded', async () => {
+    it('does nothing when notice is discarded', async function() {
         await handleTelemetryNoticeResponse(undefined, extensionContext)
 
         assert.strictEqual(
@@ -49,7 +49,7 @@ describe('handleTelemetryNoticeResponse', () => {
         )
     })
 
-    it('handles View Settings response', async () => {
+    it('handles View Settings response', async function() {
         const executeCommand = sandbox.stub(vscode.commands, 'executeCommand')
 
         await handleTelemetryNoticeResponse(noticeResponseViewSettings, extensionContext)
@@ -62,7 +62,7 @@ describe('handleTelemetryNoticeResponse', () => {
         )
     })
 
-    it('handles Ok response', async () => {
+    it('handles Ok response', async function() {
         await handleTelemetryNoticeResponse(noticeResponseOk, extensionContext)
 
         assert.strictEqual(
@@ -73,7 +73,7 @@ describe('handleTelemetryNoticeResponse', () => {
     })
 })
 
-describe('Telemetry on activation', () => {
+describe('Telemetry on activation', function() {
     let settings: vscode.WorkspaceConfiguration
     const toolkitSettings = new DefaultSettingsConfiguration(extensionSettingsPrefix)
 
@@ -81,12 +81,12 @@ describe('Telemetry on activation', () => {
     // Restore the initial value after testing is complete.
     let originalTelemetryValue: any
 
-    before(async () => {
+    before(async function() {
         settings = vscode.workspace.getConfiguration(extensionSettingsPrefix)
         originalTelemetryValue = settings.get('telemetry')
     })
 
-    after(async () => {
+    after(async function() {
         await settings.update('telemetry', originalTelemetryValue, vscode.ConfigurationTarget.Global)
     })
 
@@ -137,7 +137,7 @@ describe('Telemetry on activation', () => {
         }, // The 'expectedSanitizedValue' is true based on the package.json configuration declaration
     ]
 
-    describe('isTelemetryEnabled', () => {
+    describe('isTelemetryEnabled', function() {
         scenarios.forEach(scenario => {
             it(scenario.desc, async () => {
                 await settings.update('telemetry', scenario.initialSettingValue, vscode.ConfigurationTarget.Global)
@@ -148,7 +148,7 @@ describe('Telemetry on activation', () => {
         })
     })
 
-    describe('sanitizeTelemetrySetting', () => {
+    describe('sanitizeTelemetrySetting', function() {
         scenarios.forEach(scenario => {
             it(scenario.desc, async () => {
                 await settings.update('telemetry', scenario.initialSettingValue, vscode.ConfigurationTarget.Global)
@@ -161,23 +161,23 @@ describe('Telemetry on activation', () => {
     })
 })
 
-describe('hasUserSeenTelemetryNotice', async () => {
+describe('hasUserSeenTelemetryNotice', async function() {
     let extensionContext: vscode.ExtensionContext
     let sandbox: sinon.SinonSandbox
 
-    before(() => {
+    before(function() {
         sandbox = sinon.createSandbox()
     })
 
-    after(() => {
+    after(function() {
         sandbox.restore()
     })
 
-    beforeEach(() => {
+    beforeEach(function() {
         extensionContext = new FakeExtensionContext()
     })
 
-    it('is affected by setHasUserSeenTelemetryNotice', async () => {
+    it('is affected by setHasUserSeenTelemetryNotice', async function() {
         assert.ok(!hasUserSeenTelemetryNotice(extensionContext))
         await setHasUserSeenTelemetryNotice(extensionContext)
         assert.ok(hasUserSeenTelemetryNotice(extensionContext))
@@ -198,41 +198,41 @@ describe('hasUserSeenTelemetryNotice', async () => {
     })
 })
 
-describe('getComputeRegion', async () => {
+describe('getComputeRegion', async function() {
     const metadataService = new MetadataService()
 
     let sandbox: sinon.SinonSandbox
 
-    before(() => {
+    before(function() {
         sandbox = sinon.createSandbox()
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    it('returns a compute region', async () => {
+    it('returns a compute region', async function() {
         sandbox.stub(metadataService, 'request').callsArgWith(1, undefined, '{"region": "us-weast-1"}')
 
         const val = await getComputeRegion(metadataService, true)
         assert.strictEqual(val, 'us-weast-1')
     })
 
-    it('returns "unknown" if cloud9 and the MetadataService request fails', async () => {
+    it('returns "unknown" if cloud9 and the MetadataService request fails', async function() {
         sandbox.stub(metadataService, 'request').callsArgWith(1, {} as AWSError, 'lol')
 
         const val = await getComputeRegion(metadataService, true)
         assert.strictEqual(val, 'unknown')
     })
 
-    it('returns "unknown" if cloud9 and can not find a region', async () => {
+    it('returns "unknown" if cloud9 and can not find a region', async function() {
         sandbox.stub(metadataService, 'request').callsArgWith(1, undefined, '{"legion": "d\'honneur"}')
 
         const val = await getComputeRegion(metadataService, true)
         assert.strictEqual(val, 'unknown')
     })
 
-    it('returns undefined if not cloud9', async () => {
+    it('returns undefined if not cloud9', async function() {
         sandbox.stub(metadataService, 'request').callsArgWith(1, undefined, 'lol')
 
         const val = await getComputeRegion(metadataService, false)

--- a/src/test/shared/telemetry/defaultTelemetryPublisher.test.ts
+++ b/src/test/shared/telemetry/defaultTelemetryPublisher.test.ts
@@ -26,8 +26,8 @@ class MockTelemetryClient implements TelemetryClient {
     }
 }
 
-describe('DefaultTelemetryPublisher', () => {
-    it('posts feedback', async () => {
+describe('DefaultTelemetryPublisher', function() {
+    it('posts feedback', async function() {
         const client = new MockTelemetryClient()
         const publisher = new DefaultTelemetryPublisher('', '', new AWS.Credentials('', ''), client)
 
@@ -37,7 +37,7 @@ describe('DefaultTelemetryPublisher', () => {
         assert.strictEqual(client.feedback, feedback)
     })
 
-    it('enqueues events', () => {
+    it('enqueues events', function() {
         const publisher = new DefaultTelemetryPublisher('', '', new AWS.Credentials('', ''), new MockTelemetryClient())
         publisher.enqueue(...[{ MetricName: 'name', Value: 1, Unit: 'None', EpochTimestamp: new Date().getTime() }])
         assert.strictEqual(publisher.queue.length, 1)
@@ -45,7 +45,7 @@ describe('DefaultTelemetryPublisher', () => {
         assert.strictEqual(publisher.queue.length, 2)
     })
 
-    it('can flush single event', async () => {
+    it('can flush single event', async function() {
         const publisher = new DefaultTelemetryPublisher('', '', new AWS.Credentials('', ''), new MockTelemetryClient())
         publisher.enqueue(...[{ MetricName: 'name', Value: 1, Unit: 'None', EpochTimestamp: new Date().getTime() }])
 
@@ -55,7 +55,7 @@ describe('DefaultTelemetryPublisher', () => {
         assert.strictEqual(publisher.queue.length, 0)
     })
 
-    it('retains queue on flush failure', async () => {
+    it('retains queue on flush failure', async function() {
         const batch = [{ MetricName: 'name', Value: 1, Unit: 'None', EpochTimestamp: new Date().getTime() }]
         const publisher = new DefaultTelemetryPublisher(
             '',

--- a/src/test/shared/telemetry/defaultTelemetryService.test.ts
+++ b/src/test/shared/telemetry/defaultTelemetryService.test.ts
@@ -28,7 +28,7 @@ let mockAws: FakeAwsContext
 let mockPublisher: FakeTelemetryPublisher
 let service: DefaultTelemetryService
 
-beforeEach(() => {
+beforeEach(function() {
     mockContext = new FakeExtensionContext()
     mockAws = new FakeAwsContext()
     mockPublisher = new FakeTelemetryPublisher()
@@ -36,28 +36,28 @@ beforeEach(() => {
     ext.telemetry = service
 })
 
-afterEach(async () => {
+afterEach(async function() {
     // Remove the persist file as it is saved
     await fs.remove(ext.telemetry.persistFilePath)
     ext.telemetry = originalTelemetryClient
 })
 
-describe('DefaultTelemetryService', () => {
+describe('DefaultTelemetryService', function() {
     const testFlushPeriod = 10
     let clock: sinon.SinonFakeTimers
     let sandbox: sinon.SinonSandbox
 
-    before(() => {
+    before(function() {
         sandbox = sinon.createSandbox()
         clock = FakeTimers.install()
     })
 
-    after(() => {
+    after(function() {
         clock.uninstall()
         sandbox.restore()
     })
 
-    it('posts feedback', async () => {
+    it('posts feedback', async function() {
         service.telemetryEnabled = false
         const feedback = { comment: '', sentiment: '' }
         await service.postFeedback(feedback)
@@ -65,7 +65,7 @@ describe('DefaultTelemetryService', () => {
         assert.strictEqual(mockPublisher.feedback, feedback)
     })
 
-    it('publishes periodically if user has said ok', async () => {
+    it('publishes periodically if user has said ok', async function() {
         service.clearRecords()
         service.telemetryEnabled = true
         service.flushPeriod = testFlushPeriod
@@ -82,7 +82,7 @@ describe('DefaultTelemetryService', () => {
         assert.strictEqual(mockPublisher.enqueueCount, mockPublisher.flushCount)
     })
 
-    it('events automatically inject the active account id into the metadata', async () => {
+    it('events automatically inject the active account id into the metadata', async function() {
         const mockAwsWithIds = makeFakeAwsContextWithPlaceholderIds(({} as any) as AWS.Credentials)
         service = new DefaultTelemetryService(mockContext, mockAwsWithIds, undefined, mockPublisher)
         ext.telemetry = service
@@ -98,7 +98,7 @@ describe('DefaultTelemetryService', () => {
         assertMetadataContainsTestAccount(metricDatum, DEFAULT_TEST_ACCOUNT_ID)
     })
 
-    it('events with `session` namespace do not have an account tied to them', async () => {
+    it('events with `session` namespace do not have an account tied to them', async function() {
         service.clearRecords()
         service.telemetryEnabled = true
         service.flushPeriod = testFlushPeriod
@@ -119,7 +119,7 @@ describe('DefaultTelemetryService', () => {
         assertMetadataContainsTestAccount(shutdownEvent, AccountStatus.NotApplicable)
     })
 
-    it('events created with a bad active account produce metadata mentioning the bad account', async () => {
+    it('events created with a bad active account produce metadata mentioning the bad account', async function() {
         const mockAwsBad = ({
             getCredentialAccountId: () => 'this is bad!',
         } as any) as AwsContext
@@ -143,7 +143,7 @@ describe('DefaultTelemetryService', () => {
         assertMetadataContainsTestAccount(metricDatum, AccountStatus.Invalid)
     })
 
-    it('events created prior to signing in do not have an account attached', async () => {
+    it('events created prior to signing in do not have an account attached', async function() {
         service.clearRecords()
         service.telemetryEnabled = true
         service.flushPeriod = testFlushPeriod
@@ -162,7 +162,7 @@ describe('DefaultTelemetryService', () => {
         assertMetadataContainsTestAccount(metricDatum, AccountStatus.NotSet)
     })
 
-    it('events are never recorded if telemetry has been disabled', async () => {
+    it('events are never recorded if telemetry has been disabled', async function() {
         service.clearRecords()
         service.telemetryEnabled = false
         service.flushPeriod = testFlushPeriod

--- a/src/test/shared/telemetry/telemetryCache.test.ts
+++ b/src/test/shared/telemetry/telemetryCache.test.ts
@@ -6,15 +6,15 @@
 import * as assert from 'assert'
 import { filterTelemetryCacheEvents } from '../../../shared/telemetry/defaultTelemetryService'
 
-describe('Telemetry cache', () => {
-    it('Rejects bad data', () => {
+describe('Telemetry cache', function() {
+    it('Rejects bad data', function() {
         const input = "THis isn't even valid json"
 
         const output = filterTelemetryCacheEvents(input)
         assert.strictEqual(output.length, 0)
     })
 
-    it('Filters out old data', () => {
+    it('Filters out old data', function() {
         const input = JSON.parse(
             '[{"namespace":"session","createTime":"2020-01-07T22:24:13.356Z","data":[{"name":"end","value":4226661,"unit":"Milliseconds","metadata":{}}]}]'
         )
@@ -23,7 +23,7 @@ describe('Telemetry cache', () => {
         assert.strictEqual(output.length, 0)
     })
 
-    it('Extracts good data when there is bad data present', () => {
+    it('Extracts good data when there is bad data present', function() {
         const input = JSON.parse(
             `["this is a string", 
             {"namespace":"session","data":[{"name":"end","value":4226661,"unit":"Milliseconds","metadata":{}}]},
@@ -34,7 +34,7 @@ describe('Telemetry cache', () => {
         assert.strictEqual(output.length, 1)
     })
 
-    it('Extracts good data when there is old data missing EpochTimestamp present', () => {
+    it('Extracts good data when there is old data missing EpochTimestamp present', function() {
         const input = JSON.parse(
             `[
                 {"createTime":"2020-02-07T16:54:58.293Z", "data":[{"MetricName":"session_end","Value":18709,"Unit":"None", "Metadata":[{"Key":"awsAccount","Value":"n/a"}]}]},
@@ -47,7 +47,7 @@ describe('Telemetry cache', () => {
         assert.strictEqual(output.length, 1)
     })
 
-    it('Happy path with passive', () => {
+    it('Happy path with passive', function() {
         const input = JSON.parse(
             '[{"MetricName":"session_end","Value":18709,"Unit":"None", "Passive": true, "EpochTimestamp": "2324324","Metadata":[{"Key":"awsAccount","Value":"n/a"}]}]'
         )
@@ -55,7 +55,7 @@ describe('Telemetry cache', () => {
         assert.strictEqual(output.length, 1)
     })
 
-    it('Happy path', () => {
+    it('Happy path', function() {
         const input = JSON.parse(
             '[{"MetricName":"session_end","Value":18709,"Unit":"None", "EpochTimestamp": "2324324","Metadata":[{"Key":"awsAccount","Value":"n/a"}]}]'
         )

--- a/src/test/shared/treeview/nodes/errorNode.test.ts
+++ b/src/test/shared/treeview/nodes/errorNode.test.ts
@@ -7,13 +7,13 @@ import * as assert from 'assert'
 import { ErrorNode } from '../../../../shared/treeview/nodes/errorNode'
 import { TestAWSTreeNode } from './testAWSTreeNode'
 
-describe('ErrorNode', () => {
+describe('ErrorNode', function() {
     const parentNode = new TestAWSTreeNode('test parent node')
     const error = new Error('error message')
     error.name = 'myMockError'
 
     // Validates we tagged the node correctly
-    it('initializes label and tooltip', async () => {
+    it('initializes label and tooltip', async function() {
         const testNode = new ErrorNode(parentNode, error, 'Error loading resources')
 
         assert.strictEqual(testNode.label, 'Error loading resources')
@@ -21,7 +21,7 @@ describe('ErrorNode', () => {
     })
 
     // Validates function nodes are leaves
-    it('has no children', async () => {
+    it('has no children', async function() {
         const testNode = new ErrorNode(parentNode, error, `Error loading resources (${error.name})`)
 
         const childNodes = await testNode.getChildren()

--- a/src/test/shared/treeview/treeNodeUtilities.test.ts
+++ b/src/test/shared/treeview/treeNodeUtilities.test.ts
@@ -9,12 +9,12 @@ import { PlaceholderNode } from '../../../shared/treeview/nodes/placeholderNode'
 import { makeChildrenNodes } from '../../../shared/treeview/treeNodeUtilities'
 import { TestAWSTreeNode } from './nodes/testAWSTreeNode'
 
-describe('makeChildrenNodes', async () => {
+describe('makeChildrenNodes', async function() {
     const parentNode = new TestAWSTreeNode('parent node')
     const nodeA = new PlaceholderNode(parentNode, 'node A')
     const nodeB = new PlaceholderNode(parentNode, 'node B')
 
-    it('returns child nodes', async () => {
+    it('returns child nodes', async function() {
         const childNodes = await makeChildrenNodes({
             getChildNodes: async () => [nodeA, nodeB],
             getErrorNode: async (error: Error) => makeErrorNode(error),
@@ -25,7 +25,7 @@ describe('makeChildrenNodes', async () => {
         assert.deepStrictEqual(childNodes[1], nodeB, 'Unexpected second child node')
     })
 
-    it('returns an error node if an error is encountered', async () => {
+    it('returns an error node if an error is encountered', async function() {
         const expectedError = new Error('loading error')
         const expectedErrorNode = makeErrorNode(expectedError)
 
@@ -41,7 +41,7 @@ describe('makeChildrenNodes', async () => {
         assert.deepStrictEqual(actualChildNode, expectedErrorNode, 'Child node was not the error node')
     })
 
-    it('returns a placeholder node if there are no child nodes', async () => {
+    it('returns a placeholder node if there are no child nodes', async function() {
         const expectedPlaceholderNode = new PlaceholderNode(parentNode, 'No child nodes found')
         const childNodes = await makeChildrenNodes({
             getChildNodes: async () => [],
@@ -54,7 +54,7 @@ describe('makeChildrenNodes', async () => {
         assert.deepStrictEqual(actualChildNode, expectedPlaceholderNode, 'Child node was not the placeholder node')
     })
 
-    it('returns an empty list if there are no child nodes and no placeholder', async () => {
+    it('returns an empty list if there are no child nodes and no placeholder', async function() {
         const childNodes = await makeChildrenNodes({
             getChildNodes: async () => [],
             getErrorNode: async (error: Error) => makeErrorNode(error),
@@ -63,7 +63,7 @@ describe('makeChildrenNodes', async () => {
         assert.strictEqual(childNodes.length, 0, 'Unexpected child node count')
     })
 
-    it('sorts the child nodes', async () => {
+    it('sorts the child nodes', async function() {
         const childNodes = await makeChildrenNodes({
             getChildNodes: async () => [nodeB, nodeA],
             getErrorNode: async (error: Error) => makeErrorNode(error),
@@ -75,7 +75,7 @@ describe('makeChildrenNodes', async () => {
         assert.deepStrictEqual(childNodes[1], nodeB, 'Unexpected second child node')
     })
 
-    it('does not sort the child nodes if a sort method is not provided', async () => {
+    it('does not sort the child nodes if a sort method is not provided', async function() {
         const childNodes = await makeChildrenNodes({
             getChildNodes: async () => [nodeB, nodeA],
             getErrorNode: async (error: Error) => makeErrorNode(error),

--- a/src/test/shared/ui/buttons.test.ts
+++ b/src/test/shared/ui/buttons.test.ts
@@ -8,23 +8,23 @@ import { ext } from '../../../shared/extensionGlobals'
 import * as buttons from '../../../shared/ui/buttons'
 import { clearTestIconPaths, IconPath, setupTestIconPaths } from '../utilities/iconPathUtils'
 
-describe('UI buttons', () => {
-    before(() => {
+describe('UI buttons', function() {
+    before(function() {
         setupTestIconPaths()
     })
 
-    after(() => {
+    after(function() {
         clearTestIconPaths()
     })
 
-    it('creates a help button without a tooltip', () => {
+    it('creates a help button without a tooltip', function() {
         const help = buttons.createHelpButton()
 
         assert.strictEqual(help.tooltip, undefined)
         assertIconPath(help.iconPath as IconPath)
     })
 
-    it('creates a help button with a tooltip', () => {
+    it('creates a help button with a tooltip', function() {
         const tooltip = 'you must be truly desperate to come to me for help'
         const help = buttons.createHelpButton(tooltip)
 

--- a/src/test/shared/ui/input.test.ts
+++ b/src/test/shared/ui/input.test.ts
@@ -7,17 +7,17 @@ import * as assert from 'assert'
 import * as vscode from 'vscode'
 import * as input from '../../../shared/ui/input'
 
-describe('createInputBox', async () => {
+describe('createInputBox', async function() {
     let testInput: vscode.InputBox | undefined
 
-    afterEach(() => {
+    afterEach(function() {
         if (testInput) {
             testInput.dispose()
             testInput = undefined
         }
     })
 
-    it('Sets buttons', async () => {
+    it('Sets buttons', async function() {
         const buttons: vscode.QuickInputButton[] = [vscode.QuickInputButtons.Back]
 
         testInput = input.createInputBox({
@@ -27,7 +27,7 @@ describe('createInputBox', async () => {
         assert.deepStrictEqual(testInput.buttons, buttons)
     })
 
-    it('Sets Options', async () => {
+    it('Sets Options', async function() {
         const options = {
             title: 'title',
             placeHolder: 'placeholder',
@@ -41,7 +41,7 @@ describe('createInputBox', async () => {
         assertInputBoxOptions(testInput, options)
     })
 
-    it('Sets boolean Options to false values', async () => {
+    it('Sets boolean Options to false values', async function() {
         const options = {
             ignoreFocusOut: false,
         }
@@ -53,7 +53,7 @@ describe('createInputBox', async () => {
         assertInputBoxOptions(testInput, options)
     })
 
-    it('Sets Options to undefined values', async () => {
+    it('Sets Options to undefined values', async function() {
         const options = {}
 
         testInput = input.createInputBox({
@@ -63,7 +63,7 @@ describe('createInputBox', async () => {
         assertInputBoxOptions(testInput, options)
     })
 
-    it('Does not set Options', async () => {
+    it('Does not set Options', async function() {
         testInput = input.createInputBox({})
 
         assertInputBoxOptions(testInput, {})
@@ -99,18 +99,18 @@ describe('createInputBox', async () => {
     }
 })
 
-describe('promptUser', async () => {
+describe('promptUser', async function() {
     let sampleInput: TestInputBox
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         sampleInput = new TestInputBox()
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         sampleInput.dispose()
     })
 
-    it('Accepted value is returned', async () => {
+    it('Accepted value is returned', async function() {
         const promptPromise = input.promptUser({
             inputBox: sampleInput,
         })
@@ -123,7 +123,7 @@ describe('promptUser', async () => {
         assert.strictEqual(promptResult, 'hello world', 'InputBox accepted value was not expected value')
     })
 
-    it('Hide returns undefined', async () => {
+    it('Hide returns undefined', async function() {
         const promptPromise = input.promptUser({
             inputBox: sampleInput,
         })
@@ -135,7 +135,7 @@ describe('promptUser', async () => {
         assert.strictEqual(result, undefined, `Expected calling hide() on prompt to return undefined, got ${result}`)
     })
 
-    it('Button can cancel and return undefined', async () => {
+    it('Button can cancel and return undefined', async function() {
         const buttonOfInterest = vscode.QuickInputButtons.Back
         sampleInput.buttons = [buttonOfInterest]
 
@@ -163,7 +163,7 @@ describe('promptUser', async () => {
         )
     })
 
-    it('Button can return a value', async () => {
+    it('Button can return a value', async function() {
         const buttonOfInterest = vscode.QuickInputButtons.Back
         const expectedValue = 'hello world'
         sampleInput.buttons = [buttonOfInterest]
@@ -190,7 +190,7 @@ describe('promptUser', async () => {
         assert.strictEqual(promptResult, expectedValue, 'InputBox accepted value was not expected value')
     })
 
-    it('Button can do something and leave input box open', async () => {
+    it('Button can do something and leave input box open', async function() {
         const buttonOfInterest = vscode.QuickInputButtons.Back
         sampleInput.buttons = [buttonOfInterest]
         let handledButtonPress: boolean = false

--- a/src/test/shared/ui/picker.test.ts
+++ b/src/test/shared/ui/picker.test.ts
@@ -10,17 +10,17 @@ import * as vscode from 'vscode'
 import * as picker from '../../../shared/ui/picker'
 import { IteratorTransformer } from '../../../shared/utilities/collectionUtils'
 
-describe('createQuickPick', async () => {
+describe('createQuickPick', async function() {
     let testPicker: vscode.QuickPick<vscode.QuickPickItem> | undefined
 
-    afterEach(() => {
+    afterEach(function() {
         if (testPicker) {
             testPicker.dispose()
             testPicker = undefined
         }
     })
 
-    it('Sets items', async () => {
+    it('Sets items', async function() {
         const items: vscode.QuickPickItem[] = [{ label: 'item one' }, { label: 'item two' }, { label: 'item triangle' }]
 
         testPicker = picker.createQuickPick({
@@ -30,7 +30,7 @@ describe('createQuickPick', async () => {
         assert.deepStrictEqual(testPicker.items, items)
     })
 
-    it('Sets item options', async () => {
+    it('Sets item options', async function() {
         const items: vscode.QuickPickItem[] = [
             {
                 label: 'label',
@@ -45,7 +45,7 @@ describe('createQuickPick', async () => {
         assert.deepStrictEqual(testPicker.items, items)
     })
 
-    it('Sets buttons', async () => {
+    it('Sets buttons', async function() {
         const buttons: vscode.QuickInputButton[] = [vscode.QuickInputButtons.Back]
 
         testPicker = picker.createQuickPick({
@@ -55,7 +55,7 @@ describe('createQuickPick', async () => {
         assert.deepStrictEqual(testPicker.buttons, buttons)
     })
 
-    it('Sets Options', async () => {
+    it('Sets Options', async function() {
         const options = {
             title: 'title',
             placeHolder: 'placeholder',
@@ -72,7 +72,7 @@ describe('createQuickPick', async () => {
         assertPickerOptions(testPicker, options)
     })
 
-    it('Sets boolean Options to false values', async () => {
+    it('Sets boolean Options to false values', async function() {
         const options = {
             matchOnDescription: false,
             matchOnDetail: false,
@@ -86,7 +86,7 @@ describe('createQuickPick', async () => {
         assertPickerOptions(testPicker, options)
     })
 
-    it('Sets Options to undefined values', async () => {
+    it('Sets Options to undefined values', async function() {
         const options = {}
 
         testPicker = picker.createQuickPick({
@@ -96,7 +96,7 @@ describe('createQuickPick', async () => {
         assertPickerOptions(testPicker, options)
     })
 
-    it('Does not set Options', async () => {
+    it('Does not set Options', async function() {
         testPicker = picker.createQuickPick({})
 
         assertPickerOptions(testPicker, {})
@@ -156,18 +156,18 @@ describe('createQuickPick', async () => {
     }
 })
 
-describe('promptUser', async () => {
+describe('promptUser', async function() {
     let samplePicker: TestQuickPick<vscode.QuickPickItem>
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         samplePicker = createSamplePicker()
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         samplePicker.dispose()
     })
 
-    it('Accepted value is returned', async () => {
+    it('Accepted value is returned', async function() {
         const selectedItem = [samplePicker.items[0]]
 
         const promptPromise = picker.promptUser({
@@ -181,7 +181,7 @@ describe('promptUser', async () => {
         assertPromptResultEquals(promptResult, selectedItem)
     })
 
-    it('Hide returns undefined', async () => {
+    it('Hide returns undefined', async function() {
         const promptPromise = picker.promptUser({
             picker: samplePicker,
         })
@@ -193,7 +193,7 @@ describe('promptUser', async () => {
         assert.strictEqual(result, undefined, `Expected calling hide() on prompt to return undefined, got ${result}`)
     })
 
-    it('Button can cancel and return undefined', async () => {
+    it('Button can cancel and return undefined', async function() {
         const buttonOfInterest = vscode.QuickInputButtons.Back
         samplePicker.buttons = [buttonOfInterest]
 
@@ -221,7 +221,7 @@ describe('promptUser', async () => {
         )
     })
 
-    it('Button can return a value', async () => {
+    it('Button can return a value', async function() {
         const buttonOfInterest = vscode.QuickInputButtons.Back
         const selectedItem = [samplePicker.items[0]]
         samplePicker.buttons = [buttonOfInterest]
@@ -247,7 +247,7 @@ describe('promptUser', async () => {
         assertPromptResultEquals(promptResult, selectedItem)
     })
 
-    it('Button can do something and leave picker open', async () => {
+    it('Button can do something and leave picker open', async function() {
         const buttonOfInterest = vscode.QuickInputButtons.Back
         samplePicker.buttons = [buttonOfInterest]
         let handledButtonPress: boolean = false
@@ -370,7 +370,7 @@ describe('promptUser', async () => {
     }
 })
 
-describe('IteratingQuickPickController', async () => {
+describe('IteratingQuickPickController', async function() {
     const values = ['a', 'b', 'c']
     const result = [{ label: 'A' }, { label: 'B' }, { label: 'C' }]
     const errMessage = 'ahhhhhhhhh!!!'
@@ -379,20 +379,20 @@ describe('IteratingQuickPickController', async () => {
     let quickPick: vscode.QuickPick<vscode.QuickPickItem>
     let clock: sinon.SinonFakeTimers
 
-    before(() => {
+    before(function() {
         clock = FakeTimers.install()
     })
 
-    after(() => {
+    after(function() {
         clock.uninstall()
     })
 
-    beforeEach(() => {
+    beforeEach(function() {
         clock.reset()
         quickPick = picker.createQuickPick<vscode.QuickPickItem>({})
     })
 
-    afterEach(() => {
+    afterEach(function() {
         quickPick.dispose()
     })
 
@@ -425,7 +425,7 @@ describe('IteratingQuickPickController', async () => {
 
     async function* blankIteratorFn(): AsyncIterator<string> {}
 
-    it('appends a refresh button to the quickPick', () => {
+    it('appends a refresh button to the quickPick', function() {
         new picker.IteratingQuickPickController(
             quickPick,
             new IteratorTransformer<string, vscode.QuickPickItem>(() => iteratorFn(), converter)
@@ -435,7 +435,7 @@ describe('IteratingQuickPickController', async () => {
         assert.strictEqual(quickPick.buttons[0], picker.IteratingQuickPickController.REFRESH_BUTTON)
     })
 
-    it('returns iterated values on start and on reset', async () => {
+    it('returns iterated values on start and on reset', async function() {
         const controller = new picker.IteratingQuickPickController(
             quickPick,
             new IteratorTransformer<string, vscode.QuickPickItem>(() => iteratorFn(), converter)
@@ -480,7 +480,7 @@ describe('IteratingQuickPickController', async () => {
         await clock.nextAsync()
     })
 
-    it('does not return additional values if start is called on a finished iterator', async () => {
+    it('does not return additional values if start is called on a finished iterator', async function() {
         const controller = new picker.IteratingQuickPickController(
             quickPick,
             new IteratorTransformer<string, vscode.QuickPickItem>(() => iteratorFn(), converter)
@@ -512,7 +512,7 @@ describe('IteratingQuickPickController', async () => {
         await clock.nextAsync()
     })
 
-    it('pauses and restarts iteration', async () => {
+    it('pauses and restarts iteration', async function() {
         const controller = new picker.IteratingQuickPickController(
             quickPick,
             new IteratorTransformer<string, vscode.QuickPickItem>(() => iteratorFn(), converter)
@@ -549,7 +549,7 @@ describe('IteratingQuickPickController', async () => {
         await clock.nextAsync()
     })
 
-    it('appends an error item', async () => {
+    it('appends an error item', async function() {
         const controller = new picker.IteratingQuickPickController(
             quickPick,
             new IteratorTransformer<string, vscode.QuickPickItem>(() => errIteratorFn(), converter)
@@ -572,7 +572,7 @@ describe('IteratingQuickPickController', async () => {
         await clock.nextAsync()
     })
 
-    it('appends a no items item', async () => {
+    it('appends a no items item', async function() {
         const controller = new picker.IteratingQuickPickController(
             quickPick,
             new IteratorTransformer<string, vscode.QuickPickItem>(() => blankIteratorFn(), converter)
@@ -589,7 +589,7 @@ describe('IteratingQuickPickController', async () => {
         await clock.nextAsync()
     })
 
-    it('only appends values from the current refresh cycle', async () => {
+    it('only appends values from the current refresh cycle', async function() {
         const controller = new picker.IteratingQuickPickController(
             quickPick,
             new IteratorTransformer<string, vscode.QuickPickItem>(() => iteratorFn(), converter)
@@ -634,7 +634,7 @@ describe('IteratingQuickPickController', async () => {
         await clock.nextAsync()
     })
 
-    describe('iteratingOnDidTriggerButton', async () => {
+    describe('iteratingOnDidTriggerButton', async function() {
         class fakeIteratingQuickPickController extends picker.IteratingQuickPickController<undefined> {
             public constructor(
                 private readonly spy: sinon.SinonSpy,
@@ -662,15 +662,15 @@ describe('IteratingQuickPickController', async () => {
 
         let sandbox: sinon.SinonSandbox
 
-        beforeEach(() => {
+        beforeEach(function() {
             sandbox = sinon.createSandbox()
         })
 
-        afterEach(() => {
+        afterEach(function() {
             sandbox.restore()
         })
 
-        it('triggers a refresh and returns undefined', async () => {
+        it('triggers a refresh and returns undefined', async function() {
             const spy = sandbox.spy()
             const controller = new fakeIteratingQuickPickController(spy)
             const out = await controller.iteratingOnDidTriggerButton(
@@ -682,7 +682,7 @@ describe('IteratingQuickPickController', async () => {
             assert.ok(spy.calledOnce)
         })
 
-        it('returns undefined if no override is provided', async () => {
+        it('returns undefined if no override is provided', async function() {
             const spy = sandbox.spy()
             const controller = new fakeIteratingQuickPickController(spy)
             const out = await controller.iteratingOnDidTriggerButton(
@@ -694,7 +694,7 @@ describe('IteratingQuickPickController', async () => {
             assert.ok(spy.notCalled)
         })
 
-        it('returns a value from the override function', async () => {
+        it('returns a value from the override function', async function() {
             const spy = sandbox.spy()
             const callback = async () => {
                 return items

--- a/src/test/shared/utilities/childProcess.test.ts
+++ b/src/test/shared/utilities/childProcess.test.ts
@@ -11,22 +11,22 @@ import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 import { ChildProcess, ChildProcessResult } from '../../../shared/utilities/childProcess'
 import { waitUntil } from '../../../shared/utilities/timeoutUtils'
 
-describe('ChildProcess', async () => {
+describe('ChildProcess', async function() {
     let tempFolder: string
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         // Make a temp folder for all these tests
         // Stick some temp credentials files in there to load from
         tempFolder = await makeTemporaryToolkitFolder()
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         await fs.remove(tempFolder)
     })
 
-    describe('run', async () => {
+    describe('run', async function() {
         if (process.platform === 'win32') {
-            it('runs and captures stdout - windows', async () => {
+            it('runs and captures stdout - windows', async function() {
                 const batchFile = path.join(tempFolder, 'test-script.bat')
                 writeBatchFile(batchFile)
 
@@ -41,7 +41,7 @@ describe('ChildProcess', async () => {
                 })
             })
 
-            it('runs cmd files containing a space in the filename and folder', async () => {
+            it('runs cmd files containing a space in the filename and folder', async function() {
                 const subfolder: string = path.join(tempFolder, 'sub folder')
                 const command: string = path.join(subfolder, 'test script.cmd')
 
@@ -60,7 +60,7 @@ describe('ChildProcess', async () => {
                 })
             })
 
-            it('errs when starting twice - windows', async () => {
+            it('errs when starting twice - windows', async function() {
                 const batchFile = path.join(tempFolder, 'test-script.bat')
                 writeBatchFile(batchFile)
 
@@ -79,7 +79,7 @@ describe('ChildProcess', async () => {
                 assert.fail('Expected exception, but none was thrown.')
             })
         } else {
-            it('runs and captures stdout - unix', async () => {
+            it('runs and captures stdout - unix', async function() {
                 const scriptFile = path.join(tempFolder, 'test-script.sh')
                 writeShellFile(scriptFile)
 
@@ -94,7 +94,7 @@ describe('ChildProcess', async () => {
                 })
             })
 
-            it('errs when starting twice - unix', async () => {
+            it('errs when starting twice - unix', async function() {
                 const scriptFile = path.join(tempFolder, 'test-script.sh')
                 writeShellFile(scriptFile)
 
@@ -114,7 +114,7 @@ describe('ChildProcess', async () => {
             })
         } // END Linux only tests
 
-        it('runs scripts containing a space in the filename and folder', async () => {
+        it('runs scripts containing a space in the filename and folder', async function() {
             const subfolder: string = path.join(tempFolder, 'sub folder')
             let command: string
 
@@ -139,7 +139,7 @@ describe('ChildProcess', async () => {
             })
         })
 
-        it('reports error for missing executable', async () => {
+        it('reports error for missing executable', async function() {
             const batchFile = path.join(tempFolder, 'nonExistentScript')
 
             const childProcess = new ChildProcess(batchFile)
@@ -173,7 +173,7 @@ describe('ChildProcess', async () => {
         }
     })
 
-    describe('start', async () => {
+    describe('start', async function() {
         async function assertRegularRun(childProcess: ChildProcess): Promise<void> {
             await new Promise<void>(async (resolve, reject) => {
                 await childProcess.start({
@@ -189,7 +189,7 @@ describe('ChildProcess', async () => {
         }
 
         if (process.platform === 'win32') {
-            it('starts and captures stdout - windows', async () => {
+            it('starts and captures stdout - windows', async function() {
                 const batchFile = path.join(tempFolder, 'test-script.bat')
                 writeBatchFile(batchFile)
 
@@ -198,7 +198,7 @@ describe('ChildProcess', async () => {
                 await assertRegularRun(childProcess)
             })
 
-            it('runs cmd files containing a space in the filename and folder', async () => {
+            it('runs cmd files containing a space in the filename and folder', async function() {
                 const subfolder: string = path.join(tempFolder, 'sub folder')
                 const command: string = path.join(subfolder, 'test script.cmd')
 
@@ -211,7 +211,7 @@ describe('ChildProcess', async () => {
                 await assertRegularRun(childProcess)
             })
 
-            it('errs when starting twice - windows', async () => {
+            it('errs when starting twice - windows', async function() {
                 const batchFile = path.join(tempFolder, 'test-script.bat')
                 writeBatchFile(batchFile)
 
@@ -232,7 +232,7 @@ describe('ChildProcess', async () => {
         } // END Windows only tests
 
         if (process.platform !== 'win32') {
-            it('runs and captures stdout - unix', async () => {
+            it('runs and captures stdout - unix', async function() {
                 const scriptFile = path.join(tempFolder, 'test-script.sh')
                 writeShellFile(scriptFile)
 
@@ -241,7 +241,7 @@ describe('ChildProcess', async () => {
                 await assertRegularRun(childProcess)
             })
 
-            it('errs when starting twice - unix', async () => {
+            it('errs when starting twice - unix', async function() {
                 const scriptFile = path.join(tempFolder, 'test-script.sh')
                 writeShellFile(scriptFile)
 
@@ -261,7 +261,7 @@ describe('ChildProcess', async () => {
             })
         } // END Linux only tests
 
-        it('runs scripts containing a space in the filename and folder', async () => {
+        it('runs scripts containing a space in the filename and folder', async function() {
             const subfolder: string = path.join(tempFolder, 'sub folder')
             let command: string
 
@@ -280,7 +280,7 @@ describe('ChildProcess', async () => {
             await assertRegularRun(childProcess)
         })
 
-        it('reports error for missing executable', async () => {
+        it('reports error for missing executable', async function() {
             const batchFile = path.join(tempFolder, 'nonExistentScript')
 
             const childProcess = new ChildProcess(batchFile)
@@ -296,9 +296,9 @@ describe('ChildProcess', async () => {
         })
     })
 
-    describe('stop()', async () => {
+    describe('stop()', async function() {
         if (process.platform === 'win32') {
-            it('detects running processes and successfully stops a running process - Windows', async () => {
+            it('detects running processes and successfully stops a running process - Windows', async function() {
                 const batchFile = path.join(tempFolder, 'test-script.bat')
                 writeBatchFileWithDelays(batchFile)
 
@@ -316,7 +316,7 @@ describe('ChildProcess', async () => {
                 assert.strictEqual(childProcess.stopped, true)
             })
 
-            it('cannot stop() previously stopped processes - Windows', async () => {
+            it('cannot stop() previously stopped processes - Windows', async function() {
                 const batchFile = path.join(tempFolder, 'test-script.bat')
                 writeBatchFileWithDelays(batchFile)
 
@@ -338,7 +338,7 @@ describe('ChildProcess', async () => {
         } // END Windows-only tests
 
         if (process.platform !== 'win32') {
-            it('detects running processes and successfully stops a running process - Unix', async () => {
+            it('detects running processes and successfully stops a running process - Unix', async function() {
                 const scriptFile = path.join(tempFolder, 'test-script.sh')
                 writeShellFileWithDelays(scriptFile)
 
@@ -356,7 +356,7 @@ describe('ChildProcess', async () => {
                 assert.strictEqual(childProcess.stopped, true)
             })
 
-            it('cannot stop() previously stopped processes - Unix', async () => {
+            it('cannot stop() previously stopped processes - Unix', async function() {
                 const scriptFile = path.join(tempFolder, 'test-script.sh')
                 writeShellFileWithDelays(scriptFile)
 

--- a/src/test/shared/utilities/collectionUtils.test.ts
+++ b/src/test/shared/utilities/collectionUtils.test.ts
@@ -29,25 +29,25 @@ import {
 
 import { asyncGenerator } from '../../utilities/collectionUtils'
 
-describe('CollectionUtils', async () => {
+describe('CollectionUtils', async function() {
     let sandbox: sinon.SinonSandbox
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    describe('union', async () => {
-        it('returns an empty set if both inputs are empty', async () => {
+    describe('union', async function() {
+        it('returns an empty set if both inputs are empty', async function() {
             const result = union([], [])
 
             assert.ok(result)
             assert.strictEqual(result.size, 0)
         })
 
-        it('includes all elements from both inputs', async () => {
+        it('includes all elements from both inputs', async function() {
             const result = union(['a', 'b'], ['b', 'c'])
 
             assert.ok(result)
@@ -58,22 +58,22 @@ describe('CollectionUtils', async () => {
         })
     })
 
-    describe('intersection', async () => {
-        it('returns an empty set if both insputs are empty', async () => {
+    describe('intersection', async function() {
+        it('returns an empty set if both insputs are empty', async function() {
             const result = intersection([], [])
 
             assert.ok(result)
             assert.strictEqual(result.size, 0)
         })
 
-        it('returns an empty set if inputs have no elements in common', async () => {
+        it('returns an empty set if inputs have no elements in common', async function() {
             const result = intersection(['a'], ['b'])
 
             assert.ok(result)
             assert.strictEqual(result.size, 0)
         })
 
-        it('returns only elements that are present in both inputs', async () => {
+        it('returns only elements that are present in both inputs', async function() {
             const result = intersection(['a', 'b'], ['b', 'c'])
 
             assert.ok(result)
@@ -82,15 +82,15 @@ describe('CollectionUtils', async () => {
         })
     })
 
-    describe('difference', async () => {
-        it('returns an empty set if the first input is empty', async () => {
+    describe('difference', async function() {
+        it('returns an empty set if the first input is empty', async function() {
             const result = difference([], ['a'])
 
             assert.ok(result)
             assert.strictEqual(result.size, 0)
         })
 
-        it('returns the elements in the first input if the second input is empty', async () => {
+        it('returns the elements in the first input if the second input is empty', async function() {
             const result = difference(['a'], [])
 
             assert.ok(result)
@@ -98,7 +98,7 @@ describe('CollectionUtils', async () => {
             assert.ok(result.has('a'))
         })
 
-        it('does not return elements that are present in the second input', async () => {
+        it('does not return elements that are present in the second input', async function() {
             const result = difference(['a', 'b'], ['b'])
 
             assert.ok(result)
@@ -107,15 +107,15 @@ describe('CollectionUtils', async () => {
         })
     })
 
-    describe('complement', async () => {
-        it('returns an empty set if the second input is empty', async () => {
+    describe('complement', async function() {
+        it('returns an empty set if the second input is empty', async function() {
             const result = complement(['a'], [])
 
             assert.ok(result)
             assert.strictEqual(result.size, 0)
         })
 
-        it('returns the elements in the second input if the first input is empty', async () => {
+        it('returns the elements in the second input if the first input is empty', async function() {
             const result = complement([], ['a'])
 
             assert.ok(result)
@@ -123,7 +123,7 @@ describe('CollectionUtils', async () => {
             assert.ok(result.has('a'))
         })
 
-        it('does not return elements that are present in the first input', async () => {
+        it('does not return elements that are present in the first input', async function() {
             const result = complement(['b'], ['a', 'b'])
 
             assert.ok(result)
@@ -132,15 +132,15 @@ describe('CollectionUtils', async () => {
         })
     })
 
-    describe('toArrayAsync', async () => {
-        it('returns an empty array if input is empty', async () => {
+    describe('toArrayAsync', async function() {
+        it('returns an empty array if input is empty', async function() {
             const result = await toArrayAsync(asyncGenerator([]))
 
             assert.ok(result)
             assert.strictEqual(result.length, 0)
         })
 
-        it('returns each item in input', async () => {
+        it('returns each item in input', async function() {
             const result = await toArrayAsync(asyncGenerator(['a', 'b']))
 
             assert.ok(result)
@@ -150,15 +150,15 @@ describe('CollectionUtils', async () => {
         })
     })
 
-    describe('toMap', async () => {
-        it('returns an empty map if the input is empty', async () => {
+    describe('toMap', async function() {
+        it('returns an empty map if the input is empty', async function() {
             const result = toMap<string, { key: string }>([], item => item.key)
 
             assert.ok(result)
             assert.strictEqual(result.size, 0)
         })
 
-        it('uses selector to choose keys', async () => {
+        it('uses selector to choose keys', async function() {
             const result = toMap<string, { key: string }>([{ key: 'a' }, { key: 'b' }, { key: 'c' }], item => item.key)
 
             assert.ok(result)
@@ -168,7 +168,7 @@ describe('CollectionUtils', async () => {
             assert.ok(result.has('c'))
         })
 
-        it('throws an error on duplicate keys', async () => {
+        it('throws an error on duplicate keys', async function() {
             assert.throws(() =>
                 toMap<string, { key: string }>(
                     [{ key: 'a' }, { key: 'b' }, { key: 'b' }, { key: 'c' }],
@@ -178,15 +178,15 @@ describe('CollectionUtils', async () => {
         })
     })
 
-    describe('toMapAsync', async () => {
-        it('returns an empty map if the input is empty', async () => {
+    describe('toMapAsync', async function() {
+        it('returns an empty map if the input is empty', async function() {
             const result = await toMapAsync<string, { key: string }>(asyncGenerator([]), item => item.key)
 
             assert.ok(result)
             assert.strictEqual(result.size, 0)
         })
 
-        it('uses selector to choose keys', async () => {
+        it('uses selector to choose keys', async function() {
             const result = await toMapAsync(
                 asyncGenerator([{ key: 'a' }, { key: 'b' }, { key: 'c' }]),
                 item => item.key
@@ -199,7 +199,7 @@ describe('CollectionUtils', async () => {
             assert.ok(result.has('c'))
         })
 
-        it('throws an error on duplicate keys', async () => {
+        it('throws an error on duplicate keys', async function() {
             // TODO: Why is assert.rejects not found at runtime?
             async function assertRejects(action: () => Promise<any>) {
                 let threw: boolean = false
@@ -226,8 +226,8 @@ describe('CollectionUtils', async () => {
         })
     })
 
-    describe('updateInPlace', async () => {
-        it('removes items that are present in the original map, but not the input', async () => {
+    describe('updateInPlace', async function() {
+        it('removes items that are present in the original map, but not the input', async function() {
             const map = new Map<string, number>()
             map.set('a', 1)
 
@@ -242,7 +242,7 @@ describe('CollectionUtils', async () => {
             assert.strictEqual(map.size, 0)
         })
 
-        it('updates items that are present in both the original map and the input', async () => {
+        it('updates items that are present in both the original map and the input', async function() {
             const map = new Map<string, number>()
             map.set('a', 1)
             map.set('b', 2)
@@ -262,7 +262,7 @@ describe('CollectionUtils', async () => {
             assert.strictEqual(map.get('b'), 42)
         })
 
-        it('adds items that are present in the input, but not the original map', async () => {
+        it('adds items that are present in the input, but not the original map', async function() {
             const map = new Map<string, number>()
 
             updateInPlace(
@@ -282,20 +282,20 @@ describe('CollectionUtils', async () => {
         })
     })
 
-    describe('first', async () => {
-        it('returns the first item the sequence is not empty', async () => {
+    describe('first', async function() {
+        it('returns the first item the sequence is not empty', async function() {
             const result = await first(asyncGenerator(['first']))
 
             assert.strictEqual(result, 'first')
         })
 
-        it('returns undefined if the sequence is empty', async () => {
+        it('returns undefined if the sequence is empty', async function() {
             const result = await first(asyncGenerator([]))
 
             assert.strictEqual(result, undefined)
         })
 
-        it('lazily iterates the sequence', async () => {
+        it('lazily iterates the sequence', async function() {
             async function* generator(): AsyncIterable<string> {
                 yield 'first'
                 assert.fail('generator iterated too far')
@@ -307,36 +307,36 @@ describe('CollectionUtils', async () => {
         })
     })
 
-    describe('take', async () => {
-        it('returns the first <count> items if sequence contains at least that many items', async () => {
+    describe('take', async function() {
+        it('returns the first <count> items if sequence contains at least that many items', async function() {
             const result = await take(asyncGenerator(['first', 'second', 'third']), 2)
 
             assert.ok(result)
             assert.strictEqual(result.length, 2)
         })
 
-        it('returns the first <sequence.length> items if sequence contains fewer than <count> items', async () => {
+        it('returns the first <sequence.length> items if sequence contains fewer than <count> items', async function() {
             const result = await take(asyncGenerator(['first', 'second']), 3)
 
             assert.ok(result)
             assert.strictEqual(result.length, 2)
         })
 
-        it('returns an empty array if sequence is empty', async () => {
+        it('returns an empty array if sequence is empty', async function() {
             const result = await take(asyncGenerator([]), 1)
 
             assert.ok(result)
             assert.strictEqual(result.length, 0)
         })
 
-        it('returns an empty array if count is 0', async () => {
+        it('returns an empty array if count is 0', async function() {
             const result = await take(asyncGenerator(['first']), 0)
 
             assert.ok(result)
             assert.strictEqual(result.length, 0)
         })
 
-        it('lazily iterates the sequence', async () => {
+        it('lazily iterates the sequence', async function() {
             async function* generator(): AsyncIterable<string> {
                 yield 'first'
                 yield 'second'
@@ -350,8 +350,8 @@ describe('CollectionUtils', async () => {
         })
     })
 
-    describe('filter', async () => {
-        it('returns the original sequence filtered by the predicate', async () => {
+    describe('filter', async function() {
+        it('returns the original sequence filtered by the predicate', async function() {
             const input: Iterable<number> = [1, 2]
             const result = filter(input, i => i % 2 === 0)
 
@@ -361,8 +361,8 @@ describe('CollectionUtils', async () => {
         })
     })
 
-    describe('filterAsync', async () => {
-        it('returns the original sequence filtered by the predicate', async () => {
+    describe('filterAsync', async function() {
+        it('returns the original sequence filtered by the predicate', async function() {
             const result = await toArrayAsync(filterAsync([1, 2], async i => i % 2 === 0))
 
             assert.ok(result)
@@ -371,8 +371,8 @@ describe('CollectionUtils', async () => {
         })
     })
 
-    describe('getPaginatedAwsCallIter', async () => {
-        it('iterates as long as results are present', async () => {
+    describe('getPaginatedAwsCallIter', async function() {
+        it('iterates as long as results are present', async function() {
             const fakeCall = sandbox.stub<
                 [CloudWatchLogs.DescribeLogStreamsRequest],
                 CloudWatchLogs.DescribeLogStreamsResponse
@@ -424,8 +424,8 @@ describe('CollectionUtils', async () => {
         })
     })
 
-    describe('IteratorTransformer', async () => {
-        it('transforms values from the iterator and does not carry state over when creating another iterator', async () => {
+    describe('IteratorTransformer', async function() {
+        it('transforms values from the iterator and does not carry state over when creating another iterator', async function() {
             const values = ['a', 'b', 'c']
             async function* iteratorFn(): AsyncIterator<string> {
                 for (const val of values) {

--- a/src/test/shared/utilities/disposableFiles.test.ts
+++ b/src/test/shared/utilities/disposableFiles.test.ts
@@ -11,20 +11,20 @@ import { fileExists, makeTemporaryToolkitFolder } from '../../../shared/filesyst
 import { DisposableFiles, ExtensionDisposableFiles } from '../../../shared/utilities/disposableFiles'
 import { TestExtensionDisposableFiles } from '../../fakeExtensionContext'
 
-describe('DisposableFiles', async () => {
+describe('DisposableFiles', async function() {
     let tempFolder: string
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         // Make a temp folder for all these tests
         // Stick some temp credentials files in there to load from
         tempFolder = await makeTemporaryToolkitFolder()
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         await remove(tempFolder)
     })
 
-    it('deletes file on dispose', async () => {
+    it('deletes file on dispose', async function() {
         const tempFile = path.join(tempFolder, 'file.txt')
         await writeFile(tempFile, 'hi')
 
@@ -35,7 +35,7 @@ describe('DisposableFiles', async () => {
         assert.strictEqual(await fileExists(tempFile), false)
     })
 
-    it('deletes folder on dispose', async () => {
+    it('deletes folder on dispose', async function() {
         const testTempFolder = path.join(tempFolder, 'qwerty')
         await mkdir(testTempFolder)
 
@@ -46,7 +46,7 @@ describe('DisposableFiles', async () => {
         assert.strictEqual(await fileExists(testTempFolder), false)
     })
 
-    it('deletes folder containing contents on dispose', async () => {
+    it('deletes folder containing contents on dispose', async function() {
         const testTempFolder = path.join(tempFolder, 'qwerty')
         await mkdir(testTempFolder)
         await writeFile(path.join(testTempFolder, 'file1.txt'), 'hi')
@@ -63,7 +63,7 @@ describe('DisposableFiles', async () => {
         assert.strictEqual(await fileExists(testTempFolder), false)
     })
 
-    it('is okay deleting a parent folder before a child folder', async () => {
+    it('is okay deleting a parent folder before a child folder', async function() {
         const testTempFolder = path.join(tempFolder, 'qwerty')
         const subFolder1 = path.join(tempFolder, 'child1')
         const subFolder2 = path.join(subFolder1, 'child2')
@@ -85,21 +85,21 @@ describe('DisposableFiles', async () => {
     })
 })
 
-describe('ExtensionDisposableFiles', async () => {
+describe('ExtensionDisposableFiles', async function() {
     let extensionContext: vscode.ExtensionContext
 
-    beforeEach(() => {
+    beforeEach(function() {
         extensionContext = ({
             subscriptions: [],
         } as any) as vscode.ExtensionContext
         TestExtensionDisposableFiles.clearInstance()
     })
 
-    afterEach(() => {
+    afterEach(function() {
         TestExtensionDisposableFiles.resetOriginalInstance()
     })
 
-    it('getInstance throws error if not initialized', async () => {
+    it('getInstance throws error if not initialized', async function() {
         try {
             ExtensionDisposableFiles.getInstance()
             assert.strictEqual(true, false, 'error expected')
@@ -108,7 +108,7 @@ describe('ExtensionDisposableFiles', async () => {
         }
     })
 
-    it('cannot be initialized twice', async () => {
+    it('cannot be initialized twice', async function() {
         await ExtensionDisposableFiles.initialize(extensionContext)
 
         try {
@@ -119,7 +119,7 @@ describe('ExtensionDisposableFiles', async () => {
         }
     })
 
-    it('creates temp folder on initialization', async () => {
+    it('creates temp folder on initialization', async function() {
         await ExtensionDisposableFiles.initialize(extensionContext)
 
         assert.ok(ExtensionDisposableFiles.getInstance().toolkitTempFolder)

--- a/src/test/shared/utilities/messageUtilities.test.ts
+++ b/src/test/shared/utilities/messageUtilities.test.ts
@@ -8,13 +8,13 @@ import { showConfirmationMessage, showErrorWithLogs, showOutputMessage } from '.
 import { MockOutputChannel } from '../../mockOutputChannel'
 import { FakeWindow } from '../../shared/vscode/fakeWindow'
 
-describe('messages', () => {
-    describe('showConfirmationMessage', () => {
+describe('messages', function() {
+    describe('showConfirmationMessage', function() {
         const prompt = 'prompt'
         const confirm = 'confirm'
         const cancel = 'cancel'
 
-        it('confirms warning message when the user clicks confirm', async () => {
+        it('confirms warning message when the user clicks confirm', async function() {
             const window = new FakeWindow({ message: { warningSelection: confirm } })
 
             const isConfirmed = await showConfirmationMessage({ prompt, confirm, cancel }, window)
@@ -23,7 +23,7 @@ describe('messages', () => {
             assert.strictEqual(isConfirmed, true)
         })
 
-        it('cancels warning message when the user clicks cancel', async () => {
+        it('cancels warning message when the user clicks cancel', async function() {
             const window = new FakeWindow({ message: { warningSelection: cancel } })
 
             const isConfirmed = await showConfirmationMessage({ prompt, confirm, cancel }, window)
@@ -33,8 +33,8 @@ describe('messages', () => {
         })
     })
 
-    describe('showOutputMessage', () => {
-        it('shows and appends line to output channel', () => {
+    describe('showOutputMessage', function() {
+        it('shows and appends line to output channel', function() {
             const outputChannel = new MockOutputChannel()
             showOutputMessage('message', outputChannel)
 
@@ -44,10 +44,10 @@ describe('messages', () => {
         })
     })
 
-    describe('showErrorWithLogs', () => {
+    describe('showErrorWithLogs', function() {
         const message = 'message'
 
-        it('shows error message with a button to view logs', async () => {
+        it('shows error message with a button to view logs', async function() {
             const window = new FakeWindow({ message: { errorSelection: 'View Logs...' } })
             await showErrorWithLogs(message, window)
             assert.strictEqual(window.message.error, message)

--- a/src/test/shared/utilities/pathUtils.test.ts
+++ b/src/test/shared/utilities/pathUtils.test.ts
@@ -15,8 +15,8 @@ import {
     getDriveLetter,
 } from '../../../shared/utilities/pathUtils'
 
-describe('pathUtils', async () => {
-    it('getNormalizedRelativePath()', async () => {
+describe('pathUtils', async function() {
+    it('getNormalizedRelativePath()', async function() {
         const workspaceFolderPath = path.join('my', 'workspace')
         const expectedRelativePath = path.join('processors', 'template.yaml')
         const templatePath = path.join(workspaceFolderPath, expectedRelativePath)
@@ -24,14 +24,14 @@ describe('pathUtils', async () => {
         assert.strictEqual(relativePath, expectedRelativePath.replace(path.sep, path.posix.sep))
     })
 
-    it('normalizedDirnameWithTrailingSlash()', async () => {
+    it('normalizedDirnameWithTrailingSlash()', async function() {
         const expectedResult = 'src/processors/'
         const input = path.join(expectedResult, 'app.js')
         const actualResult = normalizedDirnameWithTrailingSlash(input)
         assert.strictEqual(actualResult, expectedResult, 'Expected path to contain trailing slash')
     })
 
-    it('areEqual()', () => {
+    it('areEqual()', function() {
         const workspaceFolderPath = path.join('/my', 'workspace')
         assert.ok(areEqual(undefined, 'a/b/c', 'a/b/c'))
         assert.ok(areEqual(workspaceFolderPath, '/my/workspace/foo', './foo'))
@@ -48,7 +48,7 @@ describe('pathUtils', async () => {
         }
     })
 
-    it('normalizeSeparator()', () => {
+    it('normalizeSeparator()', function() {
         assert.strictEqual(normalizeSeparator('a/b/c'), 'a/b/c')
         assert.strictEqual(normalizeSeparator('a\\b\\c'), 'a/b/c')
         assert.strictEqual(normalizeSeparator('a\\\\b\\c\\/\\'), 'a/b/c/')
@@ -68,7 +68,7 @@ describe('pathUtils', async () => {
         )
     })
 
-    it('normalize()', () => {
+    it('normalize()', function() {
         assert.strictEqual(normalize('../../FOO/BAR'), '../../FOO/BAR')
         assert.strictEqual(normalize('c:\\foo\\bar.txt'), 'C:/foo/bar.txt')
         assert.strictEqual(normalize('C:\\foo\\bar.txt'), 'C:/foo/bar.txt')

--- a/src/test/shared/utilities/promiseutilities.test.ts
+++ b/src/test/shared/utilities/promiseutilities.test.ts
@@ -7,18 +7,18 @@ import * as assert from 'assert'
 import * as vscode from 'vscode'
 import { PromiseSharer } from '../../../shared/utilities/promiseUtilities'
 
-describe('PromiseSharer', async () => {
+describe('PromiseSharer', async function() {
     let eventEmitter: vscode.EventEmitter<void>
     let event: vscode.Event<void>
     let waitForEventCount = 0
 
-    beforeEach(() => {
+    beforeEach(function() {
         eventEmitter = new vscode.EventEmitter<void>()
         event = eventEmitter.event
         waitForEventCount = 0
     })
 
-    afterEach(() => {
+    afterEach(function() {
         eventEmitter.dispose()
     })
 
@@ -32,7 +32,7 @@ describe('PromiseSharer', async () => {
         })
     }
 
-    it('joins promises', async () => {
+    it('joins promises', async function() {
         let promisesCompleted: number = 0
 
         const p1 = PromiseSharer.getExistingPromiseOrCreate('abc', waitForEvent).then(() => {
@@ -52,7 +52,7 @@ describe('PromiseSharer', async () => {
         assert.strictEqual(promisesCompleted, 3)
     })
 
-    it('does not join different promises', async () => {
+    it('does not join different promises', async function() {
         let promisesCompleted: number = 0
 
         const p1 = PromiseSharer.getExistingPromiseOrCreate('abc', waitForEvent).then(() => {
@@ -74,7 +74,7 @@ describe('PromiseSharer', async () => {
         assert.strictEqual(promisesCompleted, 3)
     })
 
-    it('starts a new promise if previous one completed', async () => {
+    it('starts a new promise if previous one completed', async function() {
         const p1 = PromiseSharer.getExistingPromiseOrCreate('abc', waitForEvent)
         eventEmitter.fire()
         await p1

--- a/src/test/shared/utilities/symbolUtilities.test.ts
+++ b/src/test/shared/utilities/symbolUtilities.test.ts
@@ -18,9 +18,9 @@ function makeSymbol(name: string): vscode.DocumentSymbol {
     )
 }
 
-describe('symbolUtilities', async () => {
-    describe('loadSymbols', async () => {
-        it('returns symbols if available', async () => {
+describe('symbolUtilities', async function() {
+    describe('loadSymbols', async function() {
+        it('returns symbols if available', async function() {
             const context: LoadSymbolsContext = {
                 async executeCommand<T>(command: string, ...args: any[]): Promise<T | undefined> {
                     return ([makeSymbol('MyName')] as unknown) as T
@@ -38,7 +38,7 @@ describe('symbolUtilities', async () => {
             assert.strictEqual(actual![0].name, 'MyName')
         })
 
-        it('does not retry if maxRetries is 0', async () => {
+        it('does not retry if maxRetries is 0', async function() {
             const executeCommandArgs: { command: string; uri: vscode.Uri }[] = []
             const context: LoadSymbolsContext = {
                 async executeCommand<T>(command: string, ...args: any[]): Promise<T | undefined> {
@@ -61,7 +61,7 @@ describe('symbolUtilities', async () => {
             assert.strictEqual(executeCommandArgs[0].uri.fsPath, path.sep)
         })
 
-        it('retries if maxRetries is non-zero', async () => {
+        it('retries if maxRetries is non-zero', async function() {
             const executeReturnValues = [undefined, undefined, [makeSymbol('MyName')]].reverse()
             const executeCommandArgs: { command: string; uri: vscode.Uri }[] = []
             const context: LoadSymbolsContext = {
@@ -89,7 +89,7 @@ describe('symbolUtilities', async () => {
             }
         })
 
-        it('returns undefined if all retries fail', async () => {
+        it('returns undefined if all retries fail', async function() {
             const executeCommandArgs: { command: string; uri: vscode.Uri }[] = []
             const context: LoadSymbolsContext = {
                 async executeCommand<T>(command: string, ...args: any[]): Promise<T | undefined> {
@@ -115,8 +115,8 @@ describe('symbolUtilities', async () => {
         })
     })
 
-    describe('getChildrenRange', async () => {
-        it('returns the range for the child if exactly one child is found', async () => {
+    describe('getChildrenRange', async function() {
+        it('returns the range for the child if exactly one child is found', async function() {
             const symbol = new vscode.DocumentSymbol(
                 'MyParent',
                 'MyParentDetail',
@@ -143,7 +143,7 @@ describe('symbolUtilities', async () => {
             assert.strictEqual(actualRange.end.character, 10)
         })
 
-        it('returns the range for all children if multiple children are found', async () => {
+        it('returns the range for all children if multiple children are found', async function() {
             const symbol = new vscode.DocumentSymbol(
                 'MyParent',
                 'MyParentDetail',
@@ -180,7 +180,7 @@ describe('symbolUtilities', async () => {
             assert.strictEqual(actualRange.end.character, 10)
         })
 
-        it('returns the range for the entire symbol if no children are found', async () => {
+        it('returns the range for the entire symbol if no children are found', async function() {
             const symbol = new vscode.DocumentSymbol(
                 'MyParent',
                 'MyParentDetail',

--- a/src/test/shared/utilities/textUtilities.test.ts
+++ b/src/test/shared/utilities/textUtilities.test.ts
@@ -6,23 +6,23 @@
 import * as assert from 'assert'
 import { getStringHash, removeAnsi } from '../../../shared/utilities/textUtilities'
 
-describe('removeAnsi', async () => {
-    it('removes ansi code from text', async () => {
+describe('removeAnsi', async function() {
+    it('removes ansi code from text', async function() {
         assert.strictEqual(removeAnsi('\u001b[31mHello World'), 'Hello World')
     })
 
-    it('text without ansi code remains as-is', async () => {
+    it('text without ansi code remains as-is', async function() {
         const text = 'Hello World 123!'
         assert.strictEqual(removeAnsi(text), text)
     })
 })
 
-describe('getStringHash', async () => {
-    it('produces a hash', async () => {
+describe('getStringHash', async function() {
+    it('produces a hash', async function() {
         assert.ok(getStringHash('hello'))
     })
 
-    it('produces a different hash for different strings', async () => {
+    it('produces a different hash for different strings', async function() {
         assert.notStrictEqual(getStringHash('hello'), getStringHash('hello '))
     })
 })

--- a/src/test/shared/utilities/timeoutUtils.test.ts
+++ b/src/test/shared/utilities/timeoutUtils.test.ts
@@ -7,19 +7,19 @@ import * as assert from 'assert'
 import * as FakeTimers from '@sinonjs/fake-timers'
 import * as timeoutUtils from '../../../shared/utilities/timeoutUtils'
 
-describe('timeoutUtils', async () => {
+describe('timeoutUtils', async function() {
     let clock: sinon.SinonFakeTimers
 
-    before(() => {
+    before(function() {
         clock = FakeTimers.install()
     })
 
-    after(() => {
+    after(function() {
         clock.uninstall()
     })
 
-    describe('Timeout', async () => {
-        it('returns > 0 if the timer is still active', async () => {
+    describe('Timeout', async function() {
+        it('returns > 0 if the timer is still active', async function() {
             const timerLengthMs = 100
             const longTimer = new timeoutUtils.Timeout(timerLengthMs)
             clock.tick(timerLengthMs / 2)
@@ -28,7 +28,7 @@ describe('timeoutUtils', async () => {
             longTimer.killTimer()
         })
 
-        it('returns 0 if timer is expired', async () => {
+        it('returns 0 if timer is expired', async function() {
             const timerLengthMs = 10
             const shortTimer = new timeoutUtils.Timeout(timerLengthMs)
             clock.tick(timerLengthMs + 1)
@@ -37,14 +37,14 @@ describe('timeoutUtils', async () => {
             }, 10)
         })
 
-        it('returns a Promise if a timer is active', async () => {
+        it('returns a Promise if a timer is active', async function() {
             const longTimer = new timeoutUtils.Timeout(300)
             assert.strictEqual(longTimer.timer instanceof Promise, true)
             // kill the timer to not mess with other tests
             longTimer.killTimer()
         })
 
-        it('timer object rejects if a timer is expired', async () => {
+        it('timer object rejects if a timer is expired', async function() {
             const timerLengthMs = 10
             const shortTimer = new timeoutUtils.Timeout(timerLengthMs)
             clock.tick(timerLengthMs + 1)
@@ -53,7 +53,7 @@ describe('timeoutUtils', async () => {
             })
         })
 
-        it('successfully kills active timers', async () => {
+        it('successfully kills active timers', async function() {
             const longTimer = new timeoutUtils.Timeout(300)
             // make sure this is an active Promise
             assert.strictEqual(longTimer.timer instanceof Promise, true)
@@ -67,7 +67,7 @@ describe('timeoutUtils', async () => {
             }
         })
 
-        it('correctly reports an elapsed time', async () => {
+        it('correctly reports an elapsed time', async function() {
             const checkTimerMs = 50
             const longTimer = new timeoutUtils.Timeout(checkTimerMs * 6)
 
@@ -80,7 +80,7 @@ describe('timeoutUtils', async () => {
             longTimer.killTimer()
         })
 
-        it('Correctly reports elapsed time with refresh', async () => {
+        it('Correctly reports elapsed time with refresh', async function() {
             const longTimer = new timeoutUtils.Timeout(10)
             clock.tick(5)
             longTimer.refresh()
@@ -92,7 +92,7 @@ describe('timeoutUtils', async () => {
             longTimer.killTimer()
         })
 
-        it('Refresh pushes back the start time', async () => {
+        it('Refresh pushes back the start time', async function() {
             const longTimer = new timeoutUtils.Timeout(10)
             clock.tick(5)
             longTimer.refresh()
@@ -103,7 +103,7 @@ describe('timeoutUtils', async () => {
         })
     })
 
-    describe('waitUntil', async () => {
+    describe('waitUntil', async function() {
         const testSettings = {
             callCounter: 0, 
             callGoal: 0, 
@@ -129,7 +129,7 @@ describe('timeoutUtils', async () => {
             return testFunction()
         }
 
-        before(() => {
+        before(function() {
             clock.uninstall()
 
             // Makes a clock that runs clockSpeed times as fast as a normal clock (uses 1ms intervals)
@@ -141,58 +141,58 @@ describe('timeoutUtils', async () => {
             clock = FakeTimers.install()
         })
 
-        after(() => {
+        after(function() {
             clearInterval(fastClock)
         })
 
-        beforeEach(() => {
+        beforeEach(function() {
             testSettings.callCounter = 0
             testSettings.functionDelay = 10
         })
 
-        it('returns value after multiple function calls', async () => {
+        it('returns value after multiple function calls', async function() {
             testSettings.callGoal = 4
             const returnValue: number | undefined = await timeoutUtils.waitUntil(testFunction, { timeout: 10000, interval: 10, truthy: false })
             assert.strictEqual(returnValue, testSettings.callGoal)
         })
 
-        it('timeout before function returns defined value', async () => {
+        it('timeout before function returns defined value', async function() {
             testSettings.callGoal = 7
             const returnValue: number | undefined = await timeoutUtils.waitUntil(testFunction, { timeout: 30, interval: 10, truthy: false })
             assert.strictEqual(returnValue, undefined)
         })
 
-        it('returns true/false values correctly', async () => {
+        it('returns true/false values correctly', async function() {
             assert.strictEqual(true, await timeoutUtils.waitUntil(async () => true, { timeout: 10000, interval: 10, truthy: false }))
             assert.strictEqual(false, await timeoutUtils.waitUntil(async () => false, { timeout: 10000, interval: 10, truthy: false }))
         })
 
-        it('timeout when function takes longer than timeout parameter', async () => {
+        it('timeout when function takes longer than timeout parameter', async function() {
             testSettings.functionDelay = 100
             const returnValue: number | undefined = await timeoutUtils.waitUntil(slowTestFunction, { timeout: 50, interval: 10, truthy: false })
             assert.strictEqual(returnValue, undefined)
         })
 
-        it('timeout from slow function calls', async () => {
+        it('timeout from slow function calls', async function() {
             testSettings.callGoal = 10
             const returnValue: number | undefined = await timeoutUtils.waitUntil(slowTestFunction, { timeout: 50, interval: 10, truthy: false })
             assert.strictEqual(returnValue, undefined)
         })
 
-        it('returns value with after multiple calls and function delay ', async () => {
+        it('returns value with after multiple calls and function delay ', async function() {
             testSettings.callGoal = 3
             testSettings.functionDelay = 5
             const returnValue: number | undefined = await timeoutUtils.waitUntil(slowTestFunction, { timeout: 10000, interval: 5, truthy: false })
             assert.strictEqual(returnValue, testSettings.callGoal)
         })
 
-        it('returns value after setting truthy parameter to true', async () => {
+        it('returns value after setting truthy parameter to true', async function() {
             let counter: number = 0
             const result: boolean | undefined = await timeoutUtils.waitUntil(async () => counter++ == 5, { timeout: 1000, interval: 5, truthy: true })
             assert.strictEqual(result, true)
         })
 
-        it('timeout after setting truthy parameter to true', async () => {
+        it('timeout after setting truthy parameter to true', async function() {
             let counter: number = 0
             const result: boolean | undefined = await timeoutUtils.waitUntil(async () => counter++ == 5, { timeout: 15, interval: 5, truthy: true })
             assert.strictEqual(result, undefined)

--- a/src/test/shared/wizards/multiStepWizard.test.ts
+++ b/src/test/shared/wizards/multiStepWizard.test.ts
@@ -32,25 +32,25 @@ class MockMultiStepWizard extends MultiStepWizard<undefined> {
     }
 }
 
-describe('run', () => {
+describe('run', function() {
     const mockWizard = new MockMultiStepWizard()
     let sandbox: sinon.SinonSandbox
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    it('handles undefined starting step', async () => {
+    it('handles undefined starting step', async function() {
         sandbox.stub(mockWizard, 'startStep').value(undefined)
 
         await mockWizard.run()
     })
 
-    it('handles undefined steps', async () => {
+    it('handles undefined steps', async function() {
         const stub = sinon.stub()
         stub.returns({
             nextState: WizardNextState.CONTINUE,
@@ -61,8 +61,8 @@ describe('run', () => {
         await mockWizard.run()
     })
 
-    describe('terminate', () => {
-        it('works when there are no more steps', async () => {
+    describe('terminate', function() {
+        it('works when there are no more steps', async function() {
             const stub = sinon.stub()
             stub.returns(WIZARD_TERMINATE)
             sandbox.stub(mockWizard, 'startStep').value(stub)
@@ -73,8 +73,8 @@ describe('run', () => {
         })
     })
 
-    describe('retry', () => {
-        it('repeats current step', async () => {
+    describe('retry', function() {
+        it('repeats current step', async function() {
             const stub = sinon.stub()
             stub.onFirstCall().returns(WIZARD_RETRY)
             stub.onSecondCall().returns(WIZARD_TERMINATE)
@@ -86,8 +86,8 @@ describe('run', () => {
         })
     })
 
-    describe('go back', () => {
-        it('goes back', async () => {
+    describe('go back', function() {
+        it('goes back', async function() {
             const step1 = sinon.stub()
             const step2 = sinon.stub()
             step1.returns(wizardContinue(step2))
@@ -99,7 +99,7 @@ describe('run', () => {
             sinon.assert.callOrder(step1, step2, step1, step2)
         })
 
-        it('handles branches', async () => {
+        it('handles branches', async function() {
             const step1 = sinon.stub()
             const branch1 = sinon.stub()
             const branch2 = sinon.stub()
@@ -118,8 +118,8 @@ describe('run', () => {
         })
     })
 
-    describe('continue', () => {
-        it('continues', async () => {
+    describe('continue', function() {
+        it('continues', async function() {
             const step1 = sinon.stub()
             const step2 = sinon.stub()
             step1.returns(wizardContinue(step2))

--- a/src/test/ssmDocument/commands/createDocumentFromTemplate.test.ts
+++ b/src/test/ssmDocument/commands/createDocumentFromTemplate.test.ts
@@ -17,17 +17,17 @@ import * as fsUtilities from '../../../shared/filesystemUtilities'
 import * as YAML from 'yaml'
 import { FakeExtensionContext } from '../../fakeExtensionContext'
 
-describe('createDocumentFromTemplate', async () => {
+describe('createDocumentFromTemplate', async function() {
     let mockContext: vscode.ExtensionContext
     let sandbox: sinon.SinonSandbox
-    before(() => {
+    before(function() {
         mockContext = new FakeExtensionContext()
     })
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
@@ -46,7 +46,7 @@ describe('createDocumentFromTemplate', async () => {
     const fakeSelection: SsmDocumentTemplateQuickPickItem[] = []
     fakeSelection.push(fakeSelectionResult)
 
-    it('open and save document based on selected template', async () => {
+    it('open and save document based on selected template', async function() {
         sandbox.stub(picker, 'promptUser').returns(Promise.resolve(fakeSelection))
         sandbox.stub(picker, 'verifySinglePickerOutput').returns(fakeSelectionResult)
         sandbox.stub(fsUtilities, 'readFileAsString').returns(Promise.resolve(fakeContent))

--- a/src/test/ssmDocument/commands/deleteDocument.test.ts
+++ b/src/test/ssmDocument/commands/deleteDocument.test.ts
@@ -13,7 +13,7 @@ import { FakeWindow } from '../../shared/vscode/fakeWindow'
 import { RegistryItemNode } from '../../../ssmDocument/explorer/registryItemNode'
 import { SSM } from 'aws-sdk'
 
-describe('deleteDocument', async () => {
+describe('deleteDocument', async function() {
     let ssmClient: SsmDocumentClient
     let node: DocumentItemNodeWriteable
     let parentNode: RegistryItemNode
@@ -28,13 +28,13 @@ describe('deleteDocument', async () => {
 
     const fakeRegion: string = 'us-east-1'
 
-    beforeEach(() => {
+    beforeEach(function() {
         ssmClient = mock()
         parentNode = mock()
         node = new DocumentItemNodeWriteable(fakeDoc, ssmClient, fakeRegion, parentNode)
     })
 
-    it('confirms deletion, deletes file, and refreshes parent node', async () => {
+    it('confirms deletion, deletes file, and refreshes parent node', async function() {
         const window = new FakeWindow({ message: { warningSelection: 'Delete' } })
         const commands = new FakeCommands()
         await deleteDocument(node, window, commands)

--- a/src/test/ssmDocument/commands/openDocumentItem.test.ts
+++ b/src/test/ssmDocument/commands/openDocumentItem.test.ts
@@ -16,13 +16,13 @@ import * as picker from '../../../shared/ui/picker'
 import { MockSsmDocumentClient } from '../../shared/clients/mockClients'
 import { FakeAwsContext } from '../../utilities/fakeAwsContext'
 
-describe('openDocumentItem', async () => {
+describe('openDocumentItem', async function() {
     let sandbox: sinon.SinonSandbox
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
@@ -61,7 +61,7 @@ describe('openDocumentItem', async () => {
         description: 'Open document with format JSON',
     }
 
-    it('create DocumentItemNode and openDocumentItem functionality', async () => {
+    it('create DocumentItemNode and openDocumentItem functionality', async function() {
         sandbox.stub(vscode.window, 'showSaveDialog').returns(Promise.resolve(vscode.Uri.file('test')))
         sandbox
             .stub(picker, 'promptUser')

--- a/src/test/ssmDocument/commands/publishDocument.test.ts
+++ b/src/test/ssmDocument/commands/publishDocument.test.ts
@@ -59,7 +59,7 @@ const mockDoc: vscode.TextDocument = {
     validateRange: sinon.spy(),
 }
 
-describe('publishSSMDocument', async () => {
+describe('publishSSMDocument', async function() {
     let sandbox = sinon.createSandbox()
     const fakeAwsContext = new FakeAwsContext()
     const fakeRegionProvider = new FakeRegionProvider()
@@ -79,7 +79,7 @@ describe('publishSSMDocument', async () => {
     let textDocument: vscode.TextDocument
     let apiCalled: string
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         sandbox = sinon.createSandbox()
         apiCalled = ''
         textDocument = { ...mockDoc }
@@ -91,11 +91,11 @@ describe('publishSSMDocument', async () => {
         initializeClientBuilders()
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         sandbox.restore()
     })
 
-    it('tests calling createDocument', async () => {
+    it('tests calling createDocument', async function() {
         const wizardStub = sandbox.stub(PublishSSMDocumentWizard.prototype, 'run').returns(
             Promise.resolve({
                 PublishSsmDocAction: 'Create',
@@ -111,7 +111,7 @@ describe('publishSSMDocument', async () => {
         assert.strictEqual(apiCalled, 'createDocument')
     })
 
-    it('tests calling updateDocument', async () => {
+    it('tests calling updateDocument', async function() {
         const wizardStub = sandbox.stub(PublishSSMDocumentWizard.prototype, 'run').returns(
             Promise.resolve({
                 PublishSsmDocAction: 'Update',
@@ -146,7 +146,7 @@ describe('publishSSMDocument', async () => {
     }
 })
 
-describe('publishDocument', async () => {
+describe('publishDocument', async function() {
     let wizardResponse: PublishSSMDocumentWizardResponse
     let textDocument: vscode.TextDocument
     let result: SSM.CreateDocumentResult | SSM.UpdateDocumentResult
@@ -164,7 +164,7 @@ describe('publishDocument', async () => {
         Name: 'test',
     }
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         sandbox = sinon.createSandbox()
 
         wizardResponse = {
@@ -181,12 +181,12 @@ describe('publishDocument', async () => {
         }
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    describe('createDocument', async () => {
-        it('createDocument API returns successfully', async () => {
+    describe('createDocument', async function() {
+        it('createDocument API returns successfully', async function() {
             client = new MockSsmDocumentClient(
                 undefined,
                 undefined,
@@ -208,7 +208,7 @@ describe('publishDocument', async () => {
             assert(createSpy.calledWith(fakeCreateRequest))
         })
 
-        it('createDocument API failed', async () => {
+        it('createDocument API failed', async function() {
             client = new MockSsmDocumentClient(
                 undefined,
                 undefined,
@@ -234,8 +234,8 @@ describe('publishDocument', async () => {
         })
     })
 
-    describe('updateDocument', async () => {
-        it('updateDocument API returns successfully', async () => {
+    describe('updateDocument', async function() {
+        it('updateDocument API returns successfully', async function() {
             client = new MockSsmDocumentClient(
                 undefined,
                 undefined,
@@ -257,7 +257,7 @@ describe('publishDocument', async () => {
             assert(updateSpy.calledWith(fakeUpdateRequest))
         })
 
-        it('updateDocument API failed', async () => {
+        it('updateDocument API failed', async function() {
             client = new MockSsmDocumentClient(
                 undefined,
                 undefined,

--- a/src/test/ssmDocument/commands/updateDocumentVersion.test.ts
+++ b/src/test/ssmDocument/commands/updateDocumentVersion.test.ts
@@ -16,13 +16,13 @@ import { mock } from '../../utilities/mockito'
 import { SsmDocumentClient } from '../../../shared/clients/ssmDocumentClient'
 import { MockSsmDocumentClient } from '../../shared/clients/mockClients'
 
-describe('openDocumentItem', async () => {
+describe('openDocumentItem', async function() {
     let sandbox: sinon.SinonSandbox
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
@@ -53,7 +53,7 @@ describe('openDocumentItem', async () => {
         description: 'default',
     }
 
-    it('updateDocumentVersion with correct name and version', async () => {
+    it('updateDocumentVersion with correct name and version', async function() {
         sandbox
             .stub(picker, 'promptUser')
             .onFirstCall()

--- a/src/test/ssmDocument/explorer/documentItemNode.test.ts
+++ b/src/test/ssmDocument/explorer/documentItemNode.test.ts
@@ -9,7 +9,7 @@ import * as sinon from 'sinon'
 import { DocumentItemNode } from '../../../ssmDocument/explorer/documentItemNode'
 import { MockSsmDocumentClient } from '../../shared/clients/mockClients'
 
-describe('DocumentItemNode', async () => {
+describe('DocumentItemNode', async function() {
     let sandbox: sinon.SinonSandbox
     let testNode: DocumentItemNode
     const testDoc: SSM.DocumentIdentifier = {
@@ -18,23 +18,23 @@ describe('DocumentItemNode', async () => {
     }
     const fakeRegion = 'us-east-1'
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
         testNode = new DocumentItemNode(testDoc, new MockSsmDocumentClient(), fakeRegion)
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    it('initializes name, owner, context value', async () => {
+    it('initializes name, owner, context value', async function() {
         assert.strictEqual(testNode.label, testDoc.Name)
         assert.strictEqual(testNode.documentName, testDoc.Name)
         assert.strictEqual(testNode.documentOwner, testDoc.Owner)
         assert.strictEqual(testNode.contextValue, 'awsDocumentItemNode')
     })
 
-    it('has no children', async () => {
+    it('has no children', async function() {
         const childNode = await testNode.getChildren()
         assert(childNode !== undefined)
         assert.strictEqual(childNode.length, 0)

--- a/src/test/ssmDocument/explorer/documentTypeNode.test.ts
+++ b/src/test/ssmDocument/explorer/documentTypeNode.test.ts
@@ -9,22 +9,22 @@ import { DocumentTypeNode } from '../../../ssmDocument/explorer/documentTypeNode
 
 import { assertNodeListOnlyContainsErrorNode } from '../../utilities/explorerNodeAssertions'
 
-describe('DocumentTypeNode', () => {
+describe('DocumentTypeNode', function() {
     let sandbox: sinon.SinonSandbox
 
     const fakeRegion = 'testRegion'
     const expectedChildNodeNames = ['Owned by Amazon', 'Owned by me', 'Shared with me']
     const documentType = 'Automation'
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    it('has correct child nodes', async () => {
+    it('has correct child nodes', async function() {
         const testNode: DocumentTypeNode = new DocumentTypeNode(fakeRegion, documentType)
         const childNodes = await testNode.getChildren()
 
@@ -34,7 +34,7 @@ describe('DocumentTypeNode', () => {
         })
     })
 
-    it('handles error', async () => {
+    it('handles error', async function() {
         const testNode: DocumentTypeNode = new DocumentTypeNode(fakeRegion, documentType)
         sandbox.stub(testNode, 'updateChildren').callsFake(() => {
             throw new Error('Update child error')

--- a/src/test/ssmDocument/explorer/registryItemNode.test.ts
+++ b/src/test/ssmDocument/explorer/registryItemNode.test.ts
@@ -12,22 +12,22 @@ import { ToolkitClientBuilder } from '../../../shared/clients/toolkitClientBuild
 import { assertNodeListOnlyContainsErrorNode } from '../../utilities/explorerNodeAssertions'
 import { asyncGenerator } from '../../utilities/collectionUtils'
 
-describe('RegistryItemNode', () => {
+describe('RegistryItemNode', function() {
     let sandbox: sinon.SinonSandbox
 
     const fakeRegion = 'testRegion'
     const documentType = 'Automation'
     const registryNames = ['Owned by me', 'Owned by Amazon', 'Shared with me']
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    it('handles error', async () => {
+    it('handles error', async function() {
         const testNode: RegistryItemNode = new RegistryItemNode(fakeRegion, 'Owned by me', documentType)
         sandbox.stub(testNode, 'updateChildren').callsFake(() => {
             throw new Error('Update child error')
@@ -37,7 +37,7 @@ describe('RegistryItemNode', () => {
         assertNodeListOnlyContainsErrorNode(childNodes)
     })
 
-    it('puts documents into right registry', async () => {
+    it('puts documents into right registry', async function() {
         registryNames.forEach(async registry => {
             const testNode: RegistryItemNode = new RegistryItemNode(fakeRegion, registry, documentType)
             let owner: string

--- a/src/test/ssmDocument/explorer/ssmDocumentNode.test.ts
+++ b/src/test/ssmDocument/explorer/ssmDocumentNode.test.ts
@@ -14,12 +14,12 @@ import { assertNodeListOnlyContainsErrorNode } from '../../utilities/explorerNod
 import { asyncGenerator } from '../../utilities/collectionUtils'
 import { DEFAULT_TEST_ACCOUNT_ID, DEFAULT_TEST_REGION_CODE } from '../../utilities/fakeAwsContext'
 
-describe('SsmDocumentNode', () => {
+describe('SsmDocumentNode', function() {
     let sandbox: sinon.SinonSandbox
     let testNode: SsmDocumentNode
     let docs: SSM.DocumentIdentifier[]
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
 
         docs = [
@@ -49,11 +49,11 @@ describe('SsmDocumentNode', () => {
         testNode = new SsmDocumentNode(DEFAULT_TEST_REGION_CODE)
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    it('always has 1 node: Automation Documents, if any child exists', async () => {
+    it('always has 1 node: Automation Documents, if any child exists', async function() {
         const childNodes = await testNode.getChildren()
         const expectedChildNodeNames: string[] = ['Automation Documents']
 
@@ -65,7 +65,7 @@ describe('SsmDocumentNode', () => {
         })
     })
 
-    it('handles error', async () => {
+    it('handles error', async function() {
         sandbox.stub(testNode, 'updateChildren').callsFake(() => {
             throw new Error('Update children error')
         })

--- a/src/test/ssmDocument/util/validateDocumentName.test.ts
+++ b/src/test/ssmDocument/util/validateDocumentName.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert'
 import { validateDocumentName } from '../../../ssmDocument/util/validateDocumentName'
 
-describe('validateDocumenttName', () => {
+describe('validateDocumenttName', function() {
     const invalidErrors: { documentNames: string[]; error: string }[] = [
         { documentNames: [''], error: 'Document name cannot be empty' },
         {
@@ -22,7 +22,7 @@ describe('validateDocumenttName', () => {
             error: 'Document name length must be between 3 and 128 characters',
         },
     ]
-    it('returns undefined for a valid document name', () => {
+    it('returns undefined for a valid document name', function() {
         assert.strictEqual(validateDocumentName('Aaaaa'), undefined)
     })
 

--- a/src/test/stepFunctions/commands/visualizeStateMachine.test.ts
+++ b/src/test/stepFunctions/commands/visualizeStateMachine.test.ts
@@ -214,7 +214,7 @@ const mockExtensionContext: vscode.ExtensionContext = {
     asAbsolutePath: sinon.spy(),
 }
 
-describe('StepFunctions VisualizeStateMachine', async () => {
+describe('StepFunctions VisualizeStateMachine', async function() {
     let mockVsCode: MockVSCode
 
     const oldWebviewScriptsPath = ext.visualizationResourcePaths.localWebviewScriptsPath
@@ -226,7 +226,7 @@ describe('StepFunctions VisualizeStateMachine', async () => {
     const oldThemeCssPath = ext.visualizationResourcePaths.stateMachineCustomThemeCSS
 
     // Before all
-    before(() => {
+    before(function() {
         mockVsCode = new MockVSCode()
 
         ext.visualizationResourcePaths.localWebviewScriptsPath = mockUriOne
@@ -244,17 +244,17 @@ describe('StepFunctions VisualizeStateMachine', async () => {
     })
 
     // Before each
-    beforeEach(() => {
+    beforeEach(function() {
         aslVisualizationManager = new AslVisualizationManager(mockExtensionContext)
     })
 
     // After each
-    afterEach(() => {
+    afterEach(function() {
         mockVsCode.closeAll()
     })
 
     // After all
-    after(() => {
+    after(function() {
         sandbox.restore()
         ext.visualizationResourcePaths.localWebviewScriptsPath = oldWebviewScriptsPath
         ext.visualizationResourcePaths.webviewBodyScript = oldWebviewBodyPath
@@ -266,7 +266,7 @@ describe('StepFunctions VisualizeStateMachine', async () => {
     })
 
     // Tests
-    it('Test AslVisualization on setup all properties are correct', () => {
+    it('Test AslVisualization on setup all properties are correct', function() {
         const vis = new MockAslVisualization(mockTextDocumentOne)
 
         assert.deepStrictEqual(vis.documentUri, mockTextDocumentOne.uri)
@@ -285,11 +285,11 @@ describe('StepFunctions VisualizeStateMachine', async () => {
         assert.ok(webview.html)
     })
 
-    it('Test AslVisualizationManager on setup managedVisualizations set is empty', () => {
+    it('Test AslVisualizationManager on setup managedVisualizations set is empty', function() {
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 0)
     })
 
-    it('Test AslVisualizationManager managedVisualizations set still empty if no active text editor', async () => {
+    it('Test AslVisualizationManager managedVisualizations set still empty if no active text editor', async function() {
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 0)
 
         // Preview with no active text editor
@@ -301,7 +301,7 @@ describe('StepFunctions VisualizeStateMachine', async () => {
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 0)
     })
 
-    it('Test AslVisualizationManager managedVisualizations set has one AslVis on first preview', async () => {
+    it('Test AslVisualizationManager managedVisualizations set has one AslVis on first preview', async function() {
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 0)
 
         // Preview Doc1
@@ -313,7 +313,7 @@ describe('StepFunctions VisualizeStateMachine', async () => {
         assert.ok(managedVisualizations.get(mockTextDocumentOne.uri.path))
     })
 
-    it('Test AslVisualizationManager managedVisualizations set does not add second Vis on duplicate preview', async () => {
+    it('Test AslVisualizationManager managedVisualizations set does not add second Vis on duplicate preview', async function() {
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 0)
 
         // Preview Doc1
@@ -329,7 +329,7 @@ describe('StepFunctions VisualizeStateMachine', async () => {
         assert.ok(managedVisualizations.get(mockTextDocumentOne.uri.path))
     })
 
-    it('Test AslVisualizationManager managedVisualizations set adds second Vis on different preview', async () => {
+    it('Test AslVisualizationManager managedVisualizations set adds second Vis on different preview', async function() {
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 0)
 
         // Preview Doc1
@@ -347,7 +347,7 @@ describe('StepFunctions VisualizeStateMachine', async () => {
         assert.ok(managedVisualizations.get(mockTextDocumentTwo.uri.path))
     })
 
-    it('Test AslVisualizationManager managedVisualizations set does not add duplicate renders when multiple Vis active', async () => {
+    it('Test AslVisualizationManager managedVisualizations set does not add duplicate renders when multiple Vis active', async function() {
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 0)
 
         // Preview Doc1
@@ -375,7 +375,7 @@ describe('StepFunctions VisualizeStateMachine', async () => {
         assert.ok(managedVisualizations.get(mockTextDocumentTwo.uri.path))
     })
 
-    it('Test AslVisualizationManager managedVisualizations set removes visualization on visualization dispose, single vis', async () => {
+    it('Test AslVisualizationManager managedVisualizations set removes visualization on visualization dispose, single vis', async function() {
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 0)
 
         // Preview Doc1
@@ -394,7 +394,7 @@ describe('StepFunctions VisualizeStateMachine', async () => {
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 0)
     })
 
-    it('Test AslVisualizationManager managedVisualizations set removes correct visualization on visualization dispose, multiple vis', async () => {
+    it('Test AslVisualizationManager managedVisualizations set removes correct visualization on visualization dispose, multiple vis', async function() {
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 0)
 
         // Preview Doc1
@@ -418,7 +418,7 @@ describe('StepFunctions VisualizeStateMachine', async () => {
         assert.strictEqual(aslVisualizationManager.getManagedVisualizations().size, 1)
     })
 
-    it('Test AslVisualisation sendUpdateMessage posts a correct update message for YAML files', async () => {
+    it('Test AslVisualisation sendUpdateMessage posts a correct update message for YAML files', async function() {
         const postMessage = sinon.spy()
         class MockAslVisualizationYaml extends AslVisualization {
             public getWebview(): vscode.Webview | undefined {
@@ -441,7 +441,7 @@ describe('StepFunctions VisualizeStateMachine', async () => {
         assert.deepEqual(postMessage.firstCall.args, [message])
     })
 
-    it('Test AslVisualisation sendUpdateMessage posts a correct update message for ASL files', async () => {
+    it('Test AslVisualisation sendUpdateMessage posts a correct update message for ASL files', async function() {
         const postMessage = sinon.spy()
         class MockAslVisualizationJson extends AslVisualization {
             public getWebview(): vscode.Webview | undefined {

--- a/src/test/stepFunctions/explorer/stepFunctionNodes.test.ts
+++ b/src/test/stepFunctions/explorer/stepFunctionNodes.test.ts
@@ -23,14 +23,14 @@ const FAKE_REGION_CODE = 'someregioncode'
 const UNSORTED_TEXT = ['zebra', 'Antelope', 'aardvark', 'elephant']
 const SORTED_TEXT = ['aardvark', 'Antelope', 'elephant', 'zebra']
 
-describe('StepFunctionsNode', () => {
+describe('StepFunctionsNode', function() {
     let sandbox: sinon.SinonSandbox
     let testNode: StepFunctionsNode
 
     // Mocked Step Functions Client returns State Machines for anything listed in stateMachineNames
     let stateMachineNames: string[]
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox()
 
         stateMachineNames = ['stateMachine1', 'stateMachine2']
@@ -40,11 +40,11 @@ describe('StepFunctionsNode', () => {
         testNode = new StepFunctionsNode(FAKE_REGION_CODE)
     })
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore()
     })
 
-    it('returns placeholder node if no children are present', async () => {
+    it('returns placeholder node if no children are present', async function() {
         stateMachineNames = []
 
         const childNodes = await testNode.getChildren()
@@ -52,7 +52,7 @@ describe('StepFunctionsNode', () => {
         assertNodeListOnlyContainsPlaceholderNode(childNodes)
     })
 
-    it('has StateMachineNode child nodes', async () => {
+    it('has StateMachineNode child nodes', async function() {
         const childNodes = await testNode.getChildren()
 
         assert.strictEqual(childNodes.length, stateMachineNames.length, 'Unexpected child count')
@@ -62,7 +62,7 @@ describe('StepFunctionsNode', () => {
         )
     })
 
-    it('has child nodes with State Machine contextValue', async () => {
+    it('has child nodes with State Machine contextValue', async function() {
         const childNodes = await testNode.getChildren()
 
         childNodes.forEach(node =>
@@ -74,7 +74,7 @@ describe('StepFunctionsNode', () => {
         )
     })
 
-    it('sorts child nodes', async () => {
+    it('sorts child nodes', async function() {
         stateMachineNames = UNSORTED_TEXT
 
         const childNodes = await testNode.getChildren()
@@ -83,7 +83,7 @@ describe('StepFunctionsNode', () => {
         assert.deepStrictEqual(actualChildOrder, SORTED_TEXT, 'Unexpected child sort order')
     })
 
-    it('has an error node for a child if an error happens during loading', async () => {
+    it('has an error node for a child if an error happens during loading', async function() {
         sandbox.stub(testNode, 'updateChildren').callsFake(() => {
             throw new Error('Update Children error!')
         })

--- a/src/test/stepFunctions/utils.test.ts
+++ b/src/test/stepFunctions/utils.test.ts
@@ -17,17 +17,17 @@ const FILE_PATH = '/some/path'
 const STORAGE_KEY = 'KEY'
 let tempFolder = ''
 
-describe('StateMachineGraphCache', () => {
+describe('StateMachineGraphCache', function() {
     before(async function () {
         tempFolder = await makeTemporaryToolkitFolder()
     })
 
-    after(async () => {
+    after(async function() {
         await fs.remove(tempFolder)
     })
 
-    describe('updateCachedFile', () => {
-        it('downloads a file when it is not in cache and stores it', async () => {
+    describe('updateCachedFile', function() {
+        it('downloads a file when it is not in cache and stores it', async function() {
             const globalStorage = {
                 update: sinon.spy(),
                 get: sinon.stub().returns(undefined),
@@ -58,7 +58,7 @@ describe('StateMachineGraphCache', () => {
             assert.ok(writeFile.calledWith(FILE_PATH, REQUEST_BODY))
         })
 
-        it('downloads and stores a file when cached file exists but url has been updated', async () => {
+        it('downloads and stores a file when cached file exists but url has been updated', async function() {
             const globalStorage = {
                 update: sinon.spy(),
                 get: sinon.stub().returns('https://old-url'),
@@ -89,7 +89,7 @@ describe('StateMachineGraphCache', () => {
             assert.ok(writeFile.calledWith(FILE_PATH, REQUEST_BODY))
         })
 
-        it('it does not store data when file exists and url for it is same', async () => {
+        it('it does not store data when file exists and url for it is same', async function() {
             const globalStorage = {
                 update: sinon.spy(),
                 get: sinon.stub().returns(ASSET_URL),
@@ -120,7 +120,7 @@ describe('StateMachineGraphCache', () => {
             assert.ok(writeFile.notCalled)
         })
 
-        it('creates assets directory when it does not exist', async () => {
+        it('creates assets directory when it does not exist', async function() {
             const globalStorage = {
                 update: sinon.spy(),
                 get: sinon.stub().returns(undefined),
@@ -158,7 +158,7 @@ describe('StateMachineGraphCache', () => {
     })
 })
 
-describe('isStepFunctionsRole', () => {
+describe('isStepFunctionsRole', function() {
     const baseIamRole: IAM.Role = {
         Path: '',
         RoleName: '',
@@ -167,7 +167,7 @@ describe('isStepFunctionsRole', () => {
         CreateDate: new Date(),
     }
 
-    it('return true if the Step Functions service principal is in the AssumeRolePolicyDocument', () => {
+    it('return true if the Step Functions service principal is in the AssumeRolePolicyDocument', function() {
         const role: IAM.Role = {
             ...baseIamRole,
             AssumeRolePolicyDocument: JSON.stringify({
@@ -186,7 +186,7 @@ describe('isStepFunctionsRole', () => {
         assert.ok(isStepFunctionsRole(role))
     })
 
-    it('returns false if the role does not have an AssumeRolePolicyDocument', () => {
+    it('returns false if the role does not have an AssumeRolePolicyDocument', function() {
         assert.ok(!isStepFunctionsRole(baseIamRole))
     })
 
@@ -210,8 +210,8 @@ describe('isStepFunctionsRole', () => {
     })
 })
 
-describe('isDocumentValid', async () => {
-    it('returns true for valid ASL', async () => {
+describe('isDocumentValid', async function() {
+    it('returns true for valid ASL', async function() {
         const aslText = `
             {
                 "StartAt": "FirstMatchState",
@@ -230,7 +230,7 @@ describe('isDocumentValid', async () => {
         assert.ok(isValid)
     })
 
-    it('returns true for ASL with invalid arns', async () => {
+    it('returns true for ASL with invalid arns', async function() {
         const aslText = `
             {
                 "StartAt": "FirstMatchState",
@@ -249,7 +249,7 @@ describe('isDocumentValid', async () => {
         assert.ok(isValid)
     })
 
-    it('returns false for invalid ASL', async () => {
+    it('returns false for invalid ASL', async function() {
         const aslText = `
             {
                 "StartAt": "Does not exist",

--- a/src/test/stepFunctions/wizards/createStateMachineWizard.test.ts
+++ b/src/test/stepFunctions/wizards/createStateMachineWizard.test.ts
@@ -8,8 +8,8 @@ import CreateStateMachineWizard, {
     TemplateFormats,
 } from '../../../stepFunctions/wizards/createStateMachineWizard'
 
-describe('CreateStateMachineWizard', async () => {
-    it('exits when cancelled', async () => {
+describe('CreateStateMachineWizard', async function() {
+    it('exits when cancelled', async function() {
         const mockUserPrompt: any = () => Promise.resolve(undefined)
         const wizard = new CreateStateMachineWizard(mockUserPrompt)
         const result = await wizard.run()
@@ -17,7 +17,7 @@ describe('CreateStateMachineWizard', async () => {
         assert.ok(!result)
     })
 
-    it('returns format and template type when completed', async () => {
+    it('returns format and template type when completed', async function() {
         const promptRsults = [[STARTER_TEMPLATES[0]], [{ label: TemplateFormats.YAML }]]
 
         const mockUserPrompt: any = (options: any) => Promise.resolve(promptRsults.shift())

--- a/src/test/stepFunctions/wizards/publishStateMachineWizard.test.ts
+++ b/src/test/stepFunctions/wizards/publishStateMachineWizard.test.ts
@@ -10,9 +10,9 @@ import {
     PublishStateMachineWizardResponse,
 } from '../../../stepFunctions/wizards/publishStateMachineWizard'
 
-describe('PublishStateMachineWizard', async () => {
-    describe('PUBLISH_ACTION', async () => {
-        it('exits when cancelled', async () => {
+describe('PublishStateMachineWizard', async function() {
+    describe('PUBLISH_ACTION', async function() {
+        it('exits when cancelled', async function() {
             const context: PublishStateMachineWizardContext = new MockPublishStateMachineWizardContext()
             const wizard = new PublishStateMachineWizard(context)
             const result: PublishStateMachineWizardResponse | undefined = await wizard.run()
@@ -21,8 +21,8 @@ describe('PublishStateMachineWizard', async () => {
         })
     })
 
-    describe('Quick create', async () => {
-        it('exits gracefully if cancelled', async () => {
+    describe('Quick create', async function() {
+        it('exits gracefully if cancelled', async function() {
             const roleArn: string = 'arn:aws:iam::123456789012:role/myRole'
             const context: PublishStateMachineWizardContext = new MockPublishStateMachineWizardContext(
                 [PublishStateMachineAction.QuickCreate],
@@ -35,7 +35,7 @@ describe('PublishStateMachineWizard', async () => {
             assert.ok(!result)
         })
 
-        it('returns create response when completed', async () => {
+        it('returns create response when completed', async function() {
             const name: string = 'myStateMachine'
             const roleArn: string = 'arn:aws:iam::123456789012:role/myRole'
             const context: PublishStateMachineWizardContext = new MockPublishStateMachineWizardContext(
@@ -52,8 +52,8 @@ describe('PublishStateMachineWizard', async () => {
         })
     })
 
-    describe('Quick update', async () => {
-        it('exits gracefully if cancelled', async () => {
+    describe('Quick update', async function() {
+        it('exits gracefully if cancelled', async function() {
             const context: PublishStateMachineWizardContext = new MockPublishStateMachineWizardContext([
                 PublishStateMachineAction.QuickUpdate,
             ])
@@ -63,7 +63,7 @@ describe('PublishStateMachineWizard', async () => {
             assert.ok(!result)
         })
 
-        it('returns update response when completed', async () => {
+        it('returns update response when completed', async function() {
             const stateMachineArn: string = 'arn:aws:states:us-east-1:123456789012:stateMachine:myStateMachine'
             const context: PublishStateMachineWizardContext = new MockPublishStateMachineWizardContext(
                 [PublishStateMachineAction.QuickUpdate],

--- a/src/test/templates/sam/samTemplateGenerator.test.ts
+++ b/src/test/templates/sam/samTemplateGenerator.test.ts
@@ -11,7 +11,7 @@ import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 import { SystemUtilities } from '../../../shared/systemUtilities'
 import { SamTemplateGenerator } from '../../../shared/templates/sam/samTemplateGenerator'
 
-describe('SamTemplateGenerator', () => {
+describe('SamTemplateGenerator', function() {
     const sampleCodeUriValue: string = 'sampleCodeUri'
     const sampleFunctionHandlerValue: string = 'sampleFunctionHandler'
     const sampleResourceNameValue: string = 'sampleResourceName'
@@ -22,12 +22,12 @@ describe('SamTemplateGenerator', () => {
     let templateFilename: string
     let tempFolder: string
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         tempFolder = await makeTemporaryToolkitFolder()
         templateFilename = path.join(tempFolder, 'template.yml')
     })
 
-    afterEach(async () => {
+    afterEach(async function() {
         await fs.remove(tempFolder)
     })
 
@@ -39,7 +39,7 @@ describe('SamTemplateGenerator', () => {
             .withResourceName(sampleResourceNameValue)
     }
 
-    it('Produces a minimal template', async () => {
+    it('Produces a minimal template', async function() {
         await makeMinimalTemplate().generate(templateFilename)
 
         assert.strictEqual(await SystemUtilities.fileExists(templateFilename), true)
@@ -56,7 +56,7 @@ describe('SamTemplateGenerator', () => {
         assert.strictEqual(resource!.Properties!.Runtime, sampleRuntimeValue)
     })
 
-    it('Produces a template containing MemorySize', async () => {
+    it('Produces a template containing MemorySize', async function() {
         await makeMinimalTemplate().withMemorySize(sampleMemorySize).generate(templateFilename)
 
         assert.strictEqual(await SystemUtilities.fileExists(templateFilename), true)
@@ -70,7 +70,7 @@ describe('SamTemplateGenerator', () => {
         assert.strictEqual(resource!.Properties!.MemorySize, sampleMemorySize)
     })
 
-    it('Produces a template containing Timeout', async () => {
+    it('Produces a template containing Timeout', async function() {
         await makeMinimalTemplate().withTimeout(sampleTimeout).generate(templateFilename)
 
         assert.strictEqual(await SystemUtilities.fileExists(templateFilename), true)
@@ -84,7 +84,7 @@ describe('SamTemplateGenerator', () => {
         assert.strictEqual(resource!.Properties!.Timeout, sampleTimeout)
     })
 
-    it('Produces a template containing Environment', async () => {
+    it('Produces a template containing Environment', async function() {
         await makeMinimalTemplate().withEnvironment(sampleEnvironment).generate(templateFilename)
 
         assert.strictEqual(await SystemUtilities.fileExists(templateFilename), true)
@@ -98,7 +98,7 @@ describe('SamTemplateGenerator', () => {
         assert.deepStrictEqual(resource!.Properties!.Environment, sampleEnvironment)
     })
 
-    it('Produces a template with a Globals section', async () => {
+    it('Produces a template with a Globals section', async function() {
         await makeMinimalTemplate()
             .withGlobals({
                 Function: {
@@ -121,7 +121,7 @@ describe('SamTemplateGenerator', () => {
         assert.strictEqual(globals[functionKey]![timeoutKey], 5, 'Unexpected Globals.Function.Timeout value')
     })
 
-    it('errs if resource name is missing', async () => {
+    it('errs if resource name is missing', async function() {
         const error: Error = await assertThrowsError(async () => {
             await new SamTemplateGenerator()
                 .withCodeUri(sampleCodeUriValue)
@@ -135,7 +135,7 @@ describe('SamTemplateGenerator', () => {
         assert.strictEqual(await SystemUtilities.fileExists(templateFilename), false)
     })
 
-    it('errs if function handler is missing', async () => {
+    it('errs if function handler is missing', async function() {
         const error: Error = await assertThrowsError(async () => {
             await new SamTemplateGenerator()
                 .withCodeUri(sampleCodeUriValue)
@@ -149,7 +149,7 @@ describe('SamTemplateGenerator', () => {
         assert.strictEqual(await SystemUtilities.fileExists(templateFilename), false)
     })
 
-    it('errs if code uri is missing', async () => {
+    it('errs if code uri is missing', async function() {
         const error: Error = await assertThrowsError(async () => {
             await new SamTemplateGenerator()
                 .withFunctionHandler(sampleFunctionHandlerValue)
@@ -163,7 +163,7 @@ describe('SamTemplateGenerator', () => {
         assert.strictEqual(await SystemUtilities.fileExists(templateFilename), false)
     })
 
-    it('errs if runtime is missing', async () => {
+    it('errs if runtime is missing', async function() {
         const error: Error = await assertThrowsError(async () => {
             await new SamTemplateGenerator()
                 .withCodeUri(sampleCodeUriValue)

--- a/src/test/typescriptLambdaHandlerSearch.test.ts
+++ b/src/test/typescriptLambdaHandlerSearch.test.ts
@@ -9,8 +9,8 @@ import { readFileAsString } from '../shared/filesystemUtilities'
 import { RootlessLambdaHandlerCandidate } from '../shared/lambdaHandlerSearch'
 import { TypescriptLambdaHandlerSearch } from '../shared/typescriptLambdaHandlerSearch'
 
-describe('TypescriptLambdaHandlerSearch', () => {
-    it('finds export declared functions in Typescript code', async () => {
+describe('TypescriptLambdaHandlerSearch', function() {
+    it('finds export declared functions in Typescript code', async function() {
         const filename: string = path.join(getSamplesFolder(), 'typescript', 'sampleFunctions.ts')
 
         const expectedHandlerNames: Set<string> = new Set([
@@ -27,7 +27,7 @@ describe('TypescriptLambdaHandlerSearch', () => {
         await testTypescriptLambdaHandlerSearch(filename, expectedHandlerNames)
     })
 
-    it('ignores class declarations in Typescript code', async () => {
+    it('ignores class declarations in Typescript code', async function() {
         const filename: string = path.join(getSamplesFolder(), 'typescript', 'sampleClasses.ts')
 
         const expectedHandlerNames: Set<string> = new Set(['sampleClasses.exportedFunctionWithNoArgs'])
@@ -35,7 +35,7 @@ describe('TypescriptLambdaHandlerSearch', () => {
         await testTypescriptLambdaHandlerSearch(filename, expectedHandlerNames)
     })
 
-    it('ignores interface declarations in Typescript code', async () => {
+    it('ignores interface declarations in Typescript code', async function() {
         const filename: string = path.join(getSamplesFolder(), 'typescript', 'sampleInterfaces.ts')
 
         const expectedHandlerNames: Set<string> = new Set(['sampleInterfaces.exportedFunctionWithNoArgs'])
@@ -43,7 +43,7 @@ describe('TypescriptLambdaHandlerSearch', () => {
         await testTypescriptLambdaHandlerSearch(filename, expectedHandlerNames)
     })
 
-    it('finds module.exports declared functions in javascript code', async () => {
+    it('finds module.exports declared functions in javascript code', async function() {
         const filename: string = path.join(getSamplesFolder(), 'javascript', 'sampleFunctions.js')
 
         const expectedHandlerNames: Set<string> = new Set([
@@ -61,7 +61,7 @@ describe('TypescriptLambdaHandlerSearch', () => {
         await testTypescriptLambdaHandlerSearch(filename, expectedHandlerNames)
     })
 
-    it('ignores class declarations in javascript code', async () => {
+    it('ignores class declarations in javascript code', async function() {
         const filename: string = path.join(getSamplesFolder(), 'javascript', 'sampleClasses.js')
 
         const expectedHandlerNames: Set<string> = new Set(['sampleClasses.exportedFunctionWithNoArgs'])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
All arrow functions of the form `() =>` used in `describe`, `it`, `before`, `beforeEach`, `after`,  and `afterEach` have been replaced with the traditional form `function()`

Code was changed running this command inside the project directory:
`find . -name '*.test.ts' -print0 | xargs -0 sed -i '' -E "/[ ]*(describe\('|it\('|before\(|after\(|beforeEach\(|afterEach\(|context\()/s/\(([a-zA-Z0-9,-_:. ]*)\) => /function(\1) /"`

Note: this command could change (almost) any arrow function to a traditional function if the need arises

<!--- Describe your changes in detail -->

## Motivation and Context
Arrow functions rebind `this` to the caller, which for mocha tests replaces the [mocha context.](https://mochajs.org/#arrow-functions) Our tests currently do not use the mocha context, however, this change future-proofs the code to allow for its usage.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
