### PR TITLE
SSO: clarify SHA1 usage, suppress warning

### DIFF
--- a/src/shared/utilities/textUtilities.ts
+++ b/src/shared/utilities/textUtilities.ts
@@ -30,13 +30,6 @@ export function getStringHash(text: string): string {
     return hash.digest('hex')
 }
 
-
-export function getSHA1StringHash(text: string): string {
-    const shasum = crypto.createHash('sha1')
-    shasum.update(text) //lgtm [js/weak-cryptographic-algorithm]
-    return shasum.digest('hex')
-}
-
 /**
  * Temporary util while Cloud9 does not have codicon support
  */


### PR DESCRIPTION
- Move the hash logic out of textUtilities: it is only for use by SSO.
- Explain the reasoning for SHA1
- Suppress the LGTM warning to avoid false positive.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
