### PR TITLE
CI: temporarily skip integ tests on vscode 1.42

### DIFF
--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -337,6 +337,10 @@ describe('SAM Integration Tests', async function () {
                 })
 
                 it('produces an Add Debug Configuration codelens', async function () {
+                    if (vscode.version.startsWith('1.42')) {
+                        this.skip()
+                    }
+
                     setTestTimeout(this.test?.fullTitle(), 60000)
                     const codeLens = await getAddConfigCodeLens(samAppCodeUri)
                     assert.ok(codeLens)
@@ -370,13 +374,13 @@ describe('SAM Integration Tests', async function () {
                     )
 
                     assert.strictEqual(
-                         noDebugSession,
-                         true,
-                         `unexpected debug session in progress: ${JSON.stringify(
-                             vscode.debug.activeDebugSession,
-                             undefined,
-                             2
-                         )}`
+                        noDebugSession,
+                        true,
+                        `unexpected debug session in progress: ${JSON.stringify(
+                            vscode.debug.activeDebugSession,
+                            undefined,
+                            2
+                        )}`
                     )
 
                     const testConfig = {

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -366,6 +366,10 @@ describe('SAM Integration Tests', async function () {
                 })
 
                 it('invokes and attaches on debug request (F5)', async function () {
+                    if (vscode.version.startsWith('1.42')) {
+                        this.skip()
+                    }
+
                     setTestTimeout(this.test?.fullTitle(), 90000)
                     // Allow previous sessions to go away.
                     const noDebugSession: boolean | undefined = await waitUntil(

--- a/src/integrationTest/shared/codelens/samTemplateCodeLensProvider.test.ts
+++ b/src/integrationTest/shared/codelens/samTemplateCodeLensProvider.test.ts
@@ -12,14 +12,14 @@ import { LaunchConfiguration } from '../../../shared/debug/launchConfiguration'
 import { API_TARGET_TYPE, TEMPLATE_TARGET_TYPE } from '../../../shared/sam/debugger/awsSamDebugConfiguration'
 import * as workspaceUtils from '../../../shared/utilities/workspaceUtils'
 
-describe('SamTemplateCodeLensProvider', async function() {
+describe('SamTemplateCodeLensProvider', async function () {
     let codeLensProvider: SamTemplateCodeLensProvider = new SamTemplateCodeLensProvider()
     let document: vscode.TextDocument
     let launchConfig: LaunchConfiguration
     let templateUri: vscode.Uri
     let mockCancellationToken: vscode.CancellationToken
 
-    beforeEach(async function() {
+    beforeEach(async function () {
         codeLensProvider = new SamTemplateCodeLensProvider()
         document = (await workspaceUtils.openTextDocument('python3.7-plain-sam-app/template.yaml'))!
         templateUri = document.uri
@@ -27,7 +27,11 @@ describe('SamTemplateCodeLensProvider', async function() {
         mockCancellationToken = mock()
     })
 
-    it('provides a CodeLens for a file with a new resource', async function() {
+    it('provides a CodeLens for a file with a new resource', async function () {
+        if (vscode.version.startsWith('1.42')) {
+            this.skip()
+        }
+
         const codeLenses = await codeLensProvider.provideCodeLenses(
             document,
             instance(mockCancellationToken),
@@ -62,7 +66,7 @@ describe('SamTemplateCodeLensProvider', async function() {
         assert.deepStrictEqual(codeLenses, expectedCodeLens)
     })
 
-    it('provides no code lenses for a file with no resources', async function() {
+    it('provides no code lenses for a file with no resources', async function () {
         const mockSymbolResolver: TemplateSymbolResolver = mock()
         when(mockSymbolResolver.getResourcesOfKind('function', anything())).thenResolve([])
 


### PR DESCRIPTION

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
