### PR TITLE
SAM: make output look nicer

### DIFF
--- a/src/shared/logger/winstonToolkitLogger.ts
+++ b/src/shared/logger/winstonToolkitLogger.ts
@@ -94,7 +94,7 @@ export class WinstonToolkitLogger implements Logger, vscode.Disposable {
 
     private writeToLogs(level: LogLevel, message: string | Error, ...meta: any[]): void {
         // Don't write new lines after a log message, makes it look strange
-        if (typeof(message) == "string") {
+        if (typeof message == "string") {
             message = message.toString().trimEnd()
         }
 

--- a/src/shared/logger/winstonToolkitLogger.ts
+++ b/src/shared/logger/winstonToolkitLogger.ts
@@ -94,7 +94,7 @@ export class WinstonToolkitLogger implements Logger, vscode.Disposable {
 
     private writeToLogs(level: LogLevel, message: string | Error, ...meta: any[]): void {
         // Don't write new lines after a log message, makes it look strange
-        if (typeof message == "string") {
+        if (typeof message === "string") {
             message = message.toString().trimEnd()
         }
 

--- a/src/shared/logger/winstonToolkitLogger.ts
+++ b/src/shared/logger/winstonToolkitLogger.ts
@@ -93,6 +93,11 @@ export class WinstonToolkitLogger implements Logger, vscode.Disposable {
     }
 
     private writeToLogs(level: LogLevel, message: string | Error, ...meta: any[]): void {
+        // Don't write new lines after a log message, makes it look strange
+        if (typeof(message) == "string") {
+            message = message.toString().trimEnd()
+        }
+
         if (this.disposed) {
             throw new Error('Cannot write to disposed logger')
         }

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -66,13 +66,13 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
         const runDebugger = new Promise<void>((resolve, reject) => {
             return childProcess.start({
                 onStdout: (text: string): void => {
-                    getLogger('debugConsole').info(text)
+                    getLogger('debugConsole').info(text.trimEnd())
                     // If we have a timeout (as we do on debug) refresh the timeout as we receive text
                     params.timeout?.refresh()
                     this.logger.verbose('SAM: pid %d: stdout: %s', childProcess.pid(), removeAnsi(text))
                 },
                 onStderr: (text: string): void => {
-                    getLogger('debugConsole').error(text)
+                    getLogger('debugConsole').info(text.trimEnd())
                     // If we have a timeout (as we do on debug) refresh the timeout as we receive text
                     params.timeout?.refresh()
                     this.logger.verbose('SAM: pid %d: stderr: %s', childProcess.pid(), removeAnsi(text))

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -66,13 +66,13 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
         const runDebugger = new Promise<void>((resolve, reject) => {
             return childProcess.start({
                 onStdout: (text: string): void => {
-                    getLogger('debugConsole').info(text.trimEnd())
+                    getLogger('debugConsole').info(text)
                     // If we have a timeout (as we do on debug) refresh the timeout as we receive text
                     params.timeout?.refresh()
                     this.logger.verbose('SAM: pid %d: stdout: %s', childProcess.pid(), removeAnsi(text))
                 },
                 onStderr: (text: string): void => {
-                    getLogger('debugConsole').info(text.trimEnd())
+                    getLogger('debugConsole').info(text)
                     // If we have a timeout (as we do on debug) refresh the timeout as we receive text
                     params.timeout?.refresh()
                     this.logger.verbose('SAM: pid %d: stderr: %s', childProcess.pid(), removeAnsi(text))

--- a/src/shared/utilities/childProcess.ts
+++ b/src/shared/utilities/childProcess.ts
@@ -6,7 +6,6 @@
 import * as child_process from 'child_process'
 import * as crossSpawn from 'cross-spawn'
 import * as os from 'os'
-import { map } from 'lodash'
 import { getLogger } from '../logger'
 import { waitUntil } from './timeoutUtils'
 
@@ -136,7 +135,7 @@ export class ChildProcess {
             if (params.onStdout) {
                 const lines: string[] = (this.stdoutBuffer + data.toString()).split(/\r?\n/)
                 this.stdoutBuffer = lines.pop()!
-                map(lines, (line) => params.onStdout!(line + os.EOL))
+                lines.map((line) => params.onStdout!(line + os.EOL))
             }
         })
 
@@ -148,7 +147,7 @@ export class ChildProcess {
             if (params.onStderr) {
                 const lines: string[] = (this.stderrBuffer + data.toString()).split(/\r?\n/)
                 this.stderrBuffer = lines.pop()!
-                map(lines, (line) => params.onStderr!(line + os.EOL)) 
+                lines.map((line) => params.onStderr!(line + os.EOL)) 
             }
         })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`childProcess.ts` was modified to buffer the output/error streams, only sending data to its listeners when newline characters are received (or the stream is closed). `samCliLocalInvoke.ts` logs stderr as `info` instead of `error`. Error messages from the stderr stream still need to be checked for. The logger now also trims new lines from the ends of its inputs.

<!--- Describe your changes in detail -->

## Motivation and Context
The SAM CLI child process previously spammed the output channel with useless newlines and listed normal messages as errors. 

<!--- Why is this change required? What problem does it solve? -->

## Screenshots
Before:
<img width="1101" alt="Screen Shot 2021-03-17 at 5 02 08 PM" src="https://user-images.githubusercontent.com/31319484/111553936-960da500-8742-11eb-87c5-f43b949a6c3f.png">

After:
<img width="1121" alt="Screen Shot 2021-03-17 at 5 00 20 PM" src="https://user-images.githubusercontent.com/31319484/111553943-9b6aef80-8742-11eb-9b77-e2aa48af05fc.png">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
