### PR TITLE
SAM: fixed bug created by adding version telemetry

### DIFF
--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -64,7 +64,6 @@ export async function resumeCreateNewSamApp(
 
     try {
         samInitState = activationReloadState.getSamInitState()
-        samVersion = await getSamCliVersion(getSamCliContext())
 
         const pathToLaunch = samInitState?.path
         if (!pathToLaunch) {
@@ -88,6 +87,8 @@ export async function resumeCreateNewSamApp(
 
             return
         }
+
+        samVersion = await getSamCliVersion(getSamCliContext())
 
         await addInitialLaunchConfiguration(
             extContext,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Users were being told the SAM CLI was not found even though they were not trying to use serverless applications (see #1580). This was because the SAM version was being checked before `pathToLaunch` was checked. Bug originated from this PR: #1554

<!--- Describe your changes in detail -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
