### PR TITLE
fix CI failure "Multiple lambda image application templates found"

### DIFF
--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -64,6 +64,7 @@ export async function resumeCreateNewSamApp(
 
     try {
         samInitState = activationReloadState.getSamInitState()
+        samVersion = await getSamCliVersion(getSamCliContext())
 
         const pathToLaunch = samInitState?.path
         if (!pathToLaunch) {
@@ -87,8 +88,6 @@ export async function resumeCreateNewSamApp(
 
             return
         }
-
-        samVersion = await getSamCliVersion(getSamCliContext())
 
         await addInitialLaunchConfiguration(
             extContext,


### PR DESCRIPTION
WIP

```
  1) SAM Integration Tests
       SAM Application Runtime: python3.8 (Image)
         Starting from scratch
           creates a new SAM Application (happy path):
     Error: Error with child process: Cloning app templates from https://github.com/aws/aws-sam-cli-app-templates
,Error: Multiple lambda image application templates found. This should not be possible, please raise an issue.
      at Object.logAndThrowIfUnexpectedExitCode (src/shared/sam/cli/samCliInvokerUtils.ts:57:11)
```

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
