### PR TITLE
startup: skip telemetry if we aren't resuming

### DIFF
--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -59,17 +59,15 @@ export async function resumeCreateNewSamApp(
 ) {
     let createResult: Result = 'Succeeded'
     let reason: CreateReason = 'complete'
-    let samInitState: SamInitState | undefined
     let samVersion: string | undefined
+    const samInitState: SamInitState | undefined = activationReloadState.getSamInitState()
+
+    const pathToLaunch = samInitState?.path
+    if (!pathToLaunch) {
+        return
+    }
 
     try {
-        samInitState = activationReloadState.getSamInitState()
-
-        const pathToLaunch = samInitState?.path
-        if (!pathToLaunch) {
-            return
-        }
-
         const uri = vscode.Uri.file(pathToLaunch)
         const folder = vscode.workspace.getWorkspaceFolder(uri)
         if (!folder) {
@@ -106,8 +104,8 @@ export async function resumeCreateNewSamApp(
         ext.outputChannel.show(true)
         getLogger('channel').error(
             localize(
-                "AWS.samcli.initWizard.resume.error",
-                "An error occured while resuming SAM Application creation. {0}",
+                'AWS.samcli.initWizard.resume.error',
+                'An error occured while resuming SAM Application creation. {0}',
                 checkLogsMessage
             )
         )
@@ -260,10 +258,11 @@ export async function createNewSamApplication(
 
         // Race condition where SAM app is created but template doesn't register in time.
         // Poll for 5 seconds, otherwise direct user to codelens.
-        const isTemplateRegistered = await waitUntil(
-            async () => ext.templateRegistry.getRegisteredItem(uri),
-            { timeout: 5000, interval: 500, truthy: false }
-        )
+        const isTemplateRegistered = await waitUntil(async () => ext.templateRegistry.getRegisteredItem(uri), {
+            timeout: 5000,
+            interval: 500,
+            truthy: false,
+        })
 
         if (isTemplateRegistered) {
             const newLaunchConfigs = await addInitialLaunchConfiguration(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Checks if previous SAM initialization state exists outside of the try/catch block. The `finally` block was always being executed previously, regardless of whether or not we were resuming SAM app creation.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
