### PR TITLE
telemetry: never emit non-passive metrics at startup

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -241,6 +241,12 @@ export async function activate(context: vscode.ExtensionContext) {
         await loginWithMostRecentCredentials(toolkitSettings, loginManager)
 
         recordToolkitInitialization(activationStartedOn, getLogger())
+
+        for (const metric of ext.telemetry.records) {
+            if (!metric.Passive) {
+                throw Error('non-passive metric emitted at startup')
+            }
+        }
     } catch (error) {
         getLogger('channel').error(
             localize(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,11 +70,9 @@ let localize: nls.LocalizeFunc
 
 export async function activate(context: vscode.ExtensionContext) {
     const activationStartedOn = Date.now()
-
     localize = nls.loadMessageBundle()
+    ext.init(context, extWindow.Window.vscode())
 
-    ext.window = extWindow.Window.vscode()
-    ext.context = context
     const toolkitOutputChannel = vscode.window.createOutputChannel(localize('AWS.channel.aws.toolkit', 'AWS Toolkit'))
     await activateLogger(context, toolkitOutputChannel)
     const remoteInvokeOutputChannel = vscode.window.createOutputChannel(
@@ -260,11 +258,11 @@ export async function activate(context: vscode.ExtensionContext) {
  * special-cases).
  */
 function assertPassiveTelemetry() {
-    const reloading = ext.reloading()
+    const didReload = ext.didReload()
     // These special-case metrics may be non-passive during a VSCode "reload".
     const activeAllowed = ['sam_init']
     for (const metric of ext.telemetry.records) {
-        if (metric.Passive || (reloading && activeAllowed.includes(metric.MetricName))) {
+        if (metric.Passive || (didReload && activeAllowed.includes(metric.MetricName))) {
             continue
         }
         throw Error('non-passive metric emitted at startup')

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -57,24 +57,22 @@ export async function resumeCreateNewSamApp(
     extContext: ExtContext,
     activationReloadState: ActivationReloadState = new ActivationReloadState()
 ) {
+    if (!ext.reloading()) {
+        return
+    }
+
     let createResult: Result = 'Succeeded'
     let reason: CreateReason = 'complete'
     let samVersion: string | undefined
     const samInitState: SamInitState | undefined = activationReloadState.getSamInitState()
-
-    const pathToLaunch = samInitState?.path
-    if (!pathToLaunch) {
-        return
-    }
-
     try {
-        const uri = vscode.Uri.file(pathToLaunch)
+        const uri = vscode.Uri.file(samInitState?.path!)
         const folder = vscode.workspace.getWorkspaceFolder(uri)
         if (!folder) {
             createResult = 'Failed'
             reason = 'error'
-            // This should never happen, as `pathToLaunch` will only be set if `uri` is in
-            // the newly added workspace folder.
+            // Should never happen, because `samInitState.path` is only set if
+            // `uri` is in the newly-added workspace folder.
             vscode.window.showErrorMessage(
                 localize(
                     'AWS.samcli.initWizard.source.error.notInWorkspace',

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -57,7 +57,7 @@ export async function resumeCreateNewSamApp(
     extContext: ExtContext,
     activationReloadState: ActivationReloadState = new ActivationReloadState()
 ) {
-    if (!ext.reloading()) {
+    if (!ext.didReload()) {
         return
     }
 

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -57,10 +57,6 @@ export async function resumeCreateNewSamApp(
     extContext: ExtContext,
     activationReloadState: ActivationReloadState = new ActivationReloadState()
 ) {
-    if (!ext.didReload()) {
-        return
-    }
-
     let createResult: Result = 'Succeeded'
     let reason: CreateReason = 'complete'
     let samVersion: string | undefined

--- a/src/shared/activationReloadState.ts
+++ b/src/shared/activationReloadState.ts
@@ -22,7 +22,7 @@ export interface SamInitState {
  */
 export class ActivationReloadState {
     public getSamInitState(): SamInitState | undefined {
-        return ext.reloading()
+        return ext.didReload()
             ? {
                   path: this.extensionContext.globalState.get<string>(ACTIVATION_LAUNCH_PATH_KEY),
                   runtime: this.extensionContext.globalState.get<string>(SAM_INIT_RUNTIME_KEY),

--- a/src/shared/activationReloadState.ts
+++ b/src/shared/activationReloadState.ts
@@ -22,13 +22,11 @@ export interface SamInitState {
  */
 export class ActivationReloadState {
     public getSamInitState(): SamInitState | undefined {
-        return ext.didReload()
-            ? {
-                  path: this.extensionContext.globalState.get<string>(ACTIVATION_LAUNCH_PATH_KEY),
-                  runtime: this.extensionContext.globalState.get<string>(SAM_INIT_RUNTIME_KEY),
-                  isImage: this.extensionContext.globalState.get<boolean>(SAM_INIT_IMAGE_BOOLEAN_KEY),
-              }
-            : undefined
+        return {
+            path: this.extensionContext.globalState.get<string>(ACTIVATION_LAUNCH_PATH_KEY),
+            runtime: this.extensionContext.globalState.get<string>(SAM_INIT_RUNTIME_KEY),
+            isImage: this.extensionContext.globalState.get<boolean>(SAM_INIT_IMAGE_BOOLEAN_KEY),
+        }
     }
 
     public setSamInitState(state: SamInitState): void {

--- a/src/shared/activationReloadState.ts
+++ b/src/shared/activationReloadState.ts
@@ -22,11 +22,9 @@ export interface SamInitState {
  */
 export class ActivationReloadState {
     public getSamInitState(): SamInitState | undefined {
-        const activationPath = this.extensionContext.globalState.get<string>(ACTIVATION_LAUNCH_PATH_KEY)
-
-        return activationPath
+        return ext.reloading()
             ? {
-                  path: activationPath,
+                  path: this.extensionContext.globalState.get<string>(ACTIVATION_LAUNCH_PATH_KEY),
                   runtime: this.extensionContext.globalState.get<string>(SAM_INIT_RUNTIME_KEY),
                   isImage: this.extensionContext.globalState.get<boolean>(SAM_INIT_IMAGE_BOOLEAN_KEY),
               }

--- a/src/shared/extensionGlobals.ts
+++ b/src/shared/extensionGlobals.ts
@@ -28,13 +28,21 @@ export namespace ext {
     export let templateRegistry: CloudFormationTemplateRegistry
     export let codelensRootRegistry: CodelensRootRegistry
 
+    let _didReload = false
+
+    export function init(context: ExtensionContext, window: Window) {
+        ext.context = context
+        ext.window = window
+        _didReload = !!ext.context.globalState.get<string>(ACTIVATION_LAUNCH_PATH_KEY)
+    }
+
     /**
      * Whether the current session was (likely) a reload forced by VSCode
      * during a workspace folder operation.  Must be checked before
      * `clearSamInitState()` is called.
      */
-    export function reloading(): boolean {
-        return !!ext.context.globalState.get<string>(ACTIVATION_LAUNCH_PATH_KEY)
+    export function didReload(): boolean {
+        return _didReload
     }
 
     export namespace iconPaths {

--- a/src/shared/extensionGlobals.ts
+++ b/src/shared/extensionGlobals.ts
@@ -33,7 +33,7 @@ export namespace ext {
     export function init(context: ExtensionContext, window: Window) {
         ext.context = context
         ext.window = window
-        _didReload = !!ext.context.globalState.get<string>(ACTIVATION_LAUNCH_PATH_KEY)
+        _didReload = !!ext.context.globalState.get<string>('ACTIVATION_LAUNCH_PATH_KEY')
     }
 
     /**

--- a/src/shared/extensionGlobals.ts
+++ b/src/shared/extensionGlobals.ts
@@ -4,6 +4,7 @@
  */
 
 import { ExtensionContext, OutputChannel, Uri } from 'vscode'
+import { ACTIVATION_LAUNCH_PATH_KEY } from './activationReloadState'
 import { AWSClientBuilder } from './awsClientBuilder'
 import { AWSContextCommands } from './awsContextCommands'
 import { ToolkitClientBuilder } from './clients/toolkitClientBuilder'
@@ -26,6 +27,15 @@ export namespace ext {
     export let telemetry: TelemetryService
     export let templateRegistry: CloudFormationTemplateRegistry
     export let codelensRootRegistry: CodelensRootRegistry
+
+    /**
+     * Whether the current session was (likely) a reload forced by VSCode
+     * during a workspace folder operation.  Must be checked before
+     * `clearSamInitState()` is called.
+     */
+    export function reloading(): boolean {
+        return !!ext.context.globalState.get<string>(ACTIVATION_LAUNCH_PATH_KEY)
+    }
 
     export namespace iconPaths {
         export const dark: IconPaths = makeIconPathsObject()

--- a/src/shared/extensionGlobals.ts
+++ b/src/shared/extensionGlobals.ts
@@ -4,7 +4,6 @@
  */
 
 import { ExtensionContext, OutputChannel, Uri } from 'vscode'
-import { ACTIVATION_LAUNCH_PATH_KEY } from './activationReloadState'
 import { AWSClientBuilder } from './awsClientBuilder'
 import { AWSContextCommands } from './awsContextCommands'
 import { ToolkitClientBuilder } from './clients/toolkitClientBuilder'
@@ -38,8 +37,7 @@ export namespace ext {
 
     /**
      * Whether the current session was (likely) a reload forced by VSCode
-     * during a workspace folder operation.  Must be checked before
-     * `clearSamInitState()` is called.
+     * during a workspace folder operation.
      */
     export function didReload(): boolean {
         return _didReload

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -75,7 +75,9 @@ export async function activate(ctx: ExtContext): Promise<void> {
         })
     )
 
-    await resumeCreateNewSamApp(ctx)
+    if (ext.didReload()) {
+        await resumeCreateNewSamApp(ctx)
+    }
 }
 
 async function registerServerlessCommands(ctx: ExtContext): Promise<void> {

--- a/src/shared/telemetry/telemetryService.ts
+++ b/src/shared/telemetry/telemetryService.ts
@@ -10,6 +10,7 @@ import { TelemetryFeedback } from './telemetryFeedback'
 export interface TelemetryService {
     telemetryEnabled: boolean
     persistFilePath: string
+    records: ReadonlyArray<MetricDatum>
 
     start(): Promise<void>
     shutdown(): Promise<void>

--- a/src/test/fake/fakeTelemetryService.ts
+++ b/src/test/fake/fakeTelemetryService.ts
@@ -5,11 +5,14 @@
 
 import { TelemetryPublisher } from '../../shared/telemetry/telemetryPublisher'
 import { TelemetryFeedback } from '../../shared/telemetry/telemetryFeedback'
+import { MetricDatum } from '../../shared/telemetry/clienttelemetry'
 
 export class FakeTelemetryPublisher implements TelemetryPublisher {
+    private readonly _eventQueue: MetricDatum[] = []
+    /** How many times flush() was called. */
     public flushCount = 0
+    /** How many times enqueue() was called. */
     public enqueueCount = 0
-    public enqueuedItems = 0
 
     public feedback?: TelemetryFeedback
 
@@ -21,7 +24,11 @@ export class FakeTelemetryPublisher implements TelemetryPublisher {
 
     public enqueue(...events: any[]) {
         this.enqueueCount++
-        this.enqueuedItems += events.length
+        this._eventQueue.push(...events)
+    }
+
+    public get queue(): MetricDatum[] {
+        return this._eventQueue
     }
 
     public async flush() {

--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -15,9 +15,8 @@ import { ext } from '../shared/extensionGlobals'
 import { getLogger, LogLevel } from '../shared/logger'
 import { setLogger } from '../shared/logger/logger'
 import { DefaultTelemetryService } from '../shared/telemetry/defaultTelemetryService'
-import { TelemetryFeedback } from '../shared/telemetry/telemetryFeedback'
-import { TelemetryPublisher } from '../shared/telemetry/telemetryPublisher'
 import { FakeExtensionContext } from './fakeExtensionContext'
+import * as fakeTelemetry from './fake/fakeTelemetryService'
 import { TestLogger } from './testLogger'
 import { FakeAwsContext } from './utilities/fakeAwsContext'
 
@@ -27,7 +26,7 @@ const testLogOutput = join(testReportDir, 'testLog.log')
 // Expectation: Tests are not run concurrently
 let testLogger: TestLogger | undefined
 
-before(async function() {
+before(async function () {
     // Clean up and set up test logs
     try {
         await remove(testLogOutput)
@@ -36,12 +35,7 @@ before(async function() {
     // Set up global telemetry client
     const mockContext = new FakeExtensionContext()
     const mockAws = new FakeAwsContext()
-    const mockPublisher: TelemetryPublisher = {
-        async init() {},
-        async postFeedback(feedback: TelemetryFeedback): Promise<void> {},
-        enqueue(...events: any[]) {},
-        async flush() {},
-    }
+    const mockPublisher = new fakeTelemetry.FakeTelemetryPublisher()
     const service = new DefaultTelemetryService(mockContext, mockAws, undefined, mockPublisher)
     ext.telemetry = service
     ext.templateRegistry = new CloudFormationTemplateRegistry()

--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -14,6 +14,7 @@ import { CloudFormationTemplateRegistry } from '../shared/cloudformation/templat
 import { ext } from '../shared/extensionGlobals'
 import { getLogger, LogLevel } from '../shared/logger'
 import { setLogger } from '../shared/logger/logger'
+import * as extWindow from '../shared/vscode/window'
 import { DefaultTelemetryService } from '../shared/telemetry/defaultTelemetryService'
 import { FakeExtensionContext } from './fakeExtensionContext'
 import * as fakeTelemetry from './fake/fakeTelemetryService'
@@ -33,10 +34,11 @@ before(async function () {
     } catch (e) {}
     mkdirpSync(testReportDir)
     // Set up global telemetry client
-    const mockContext = new FakeExtensionContext()
-    const mockAws = new FakeAwsContext()
-    const mockPublisher = new fakeTelemetry.FakeTelemetryPublisher()
-    const service = new DefaultTelemetryService(mockContext, mockAws, undefined, mockPublisher)
+    const fakeContext = new FakeExtensionContext()
+    const fakeAws = new FakeAwsContext()
+    const fakeTelemetryPublisher = new fakeTelemetry.FakeTelemetryPublisher()
+    const service = new DefaultTelemetryService(fakeContext, fakeAws, undefined, fakeTelemetryPublisher)
+    ext.init(fakeContext, extWindow.Window.vscode())
     ext.telemetry = service
     ext.templateRegistry = new CloudFormationTemplateRegistry()
     ext.codelensRootRegistry = new CodelensRootRegistry()

--- a/src/test/shared/activationReloadState.test.ts
+++ b/src/test/shared/activationReloadState.test.ts
@@ -6,36 +6,27 @@
 'use strict'
 
 import * as assert from 'assert'
-import * as vscode from 'vscode'
 import {
     ACTIVATION_LAUNCH_PATH_KEY,
     ActivationReloadState,
     SAM_INIT_RUNTIME_KEY,
     SAM_INIT_IMAGE_BOOLEAN_KEY,
 } from '../../shared/activationReloadState'
-import { FakeExtensionContext } from '../fakeExtensionContext'
+import { ext } from '../../shared/extensionGlobals'
 
-class TestActivationReloadState extends ActivationReloadState {
-    public constructor(private readonly context: vscode.ExtensionContext) {
-        super()
-    }
-
-    protected get extensionContext(): vscode.ExtensionContext {
-        return this.context
-    }
-}
-
-describe('ActivationReloadState', async function() {
-    let extensionContext: FakeExtensionContext
+describe('ActivationReloadState', async function () {
     let activationReloadState: ActivationReloadState
 
-    beforeEach(function() {
-        extensionContext = new FakeExtensionContext()
-        activationReloadState = new TestActivationReloadState(extensionContext)
+    beforeEach(function () {
+        activationReloadState = new ActivationReloadState()
     })
 
-    describe('setSamInitState', async function() {
-        it('without runtime', async function() {
+    afterEach(function () {
+        activationReloadState.clearSamInitState()
+    })
+
+    describe('setSamInitState', async function () {
+        it('without runtime', async function () {
             activationReloadState.setSamInitState({
                 path: 'somepath',
                 runtime: undefined,
@@ -43,23 +34,23 @@ describe('ActivationReloadState', async function() {
             })
 
             assert.strictEqual(
-                extensionContext.globalState.get(ACTIVATION_LAUNCH_PATH_KEY),
+                ext.context.globalState.get(ACTIVATION_LAUNCH_PATH_KEY),
                 'somepath',
                 'Unexpected Launch Path value was set'
             )
             assert.strictEqual(
-                extensionContext.globalState.get(SAM_INIT_RUNTIME_KEY),
+                ext.context.globalState.get(SAM_INIT_RUNTIME_KEY),
                 undefined,
                 'Unexpected init runtime key value was set'
             )
             assert.strictEqual(
-                extensionContext.globalState.get(SAM_INIT_IMAGE_BOOLEAN_KEY),
+                ext.context.globalState.get(SAM_INIT_IMAGE_BOOLEAN_KEY),
                 false,
                 'Unexpected init image boolean value was set'
             )
         })
 
-        it('with runtime', async function() {
+        it('with runtime', async function () {
             activationReloadState.setSamInitState({
                 path: 'somepath',
                 runtime: 'someruntime',
@@ -67,23 +58,23 @@ describe('ActivationReloadState', async function() {
             })
 
             assert.strictEqual(
-                extensionContext.globalState.get(ACTIVATION_LAUNCH_PATH_KEY),
+                ext.context.globalState.get(ACTIVATION_LAUNCH_PATH_KEY),
                 'somepath',
                 'Unexpected Launch Path value was set'
             )
             assert.strictEqual(
-                extensionContext.globalState.get(SAM_INIT_RUNTIME_KEY),
+                ext.context.globalState.get(SAM_INIT_RUNTIME_KEY),
                 'someruntime',
                 'Unexpected init runtime value was set'
             )
             assert.strictEqual(
-                extensionContext.globalState.get(SAM_INIT_IMAGE_BOOLEAN_KEY),
+                ext.context.globalState.get(SAM_INIT_IMAGE_BOOLEAN_KEY),
                 false,
                 'Unexpected init image boolean value was set'
             )
         })
 
-        it('with image', async function() {
+        it('with image', async function () {
             activationReloadState.setSamInitState({
                 path: 'somepath',
                 runtime: 'someruntime',
@@ -91,27 +82,27 @@ describe('ActivationReloadState', async function() {
             })
 
             assert.strictEqual(
-                extensionContext.globalState.get(ACTIVATION_LAUNCH_PATH_KEY),
+                ext.context.globalState.get(ACTIVATION_LAUNCH_PATH_KEY),
                 'somepath',
                 'Unexpected Launch Path value was set'
             )
             assert.strictEqual(
-                extensionContext.globalState.get(SAM_INIT_RUNTIME_KEY),
+                ext.context.globalState.get(SAM_INIT_RUNTIME_KEY),
                 'someruntime',
                 'Unexpected init runtime value was set'
             )
             assert.strictEqual(
-                extensionContext.globalState.get(SAM_INIT_IMAGE_BOOLEAN_KEY),
+                ext.context.globalState.get(SAM_INIT_IMAGE_BOOLEAN_KEY),
                 true,
                 'Unexpected init image boolean value was set'
             )
         })
     })
 
-    describe('getSamInitState', async function() {
-        it('path defined, without runtime', async function() {
-            await extensionContext.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, 'getsomepath')
-            await extensionContext.globalState.update(SAM_INIT_RUNTIME_KEY, undefined)
+    describe('getSamInitState', async function () {
+        it('path defined, without runtime', async function () {
+            await ext.context.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, 'getsomepath')
+            await ext.context.globalState.update(SAM_INIT_RUNTIME_KEY, undefined)
 
             assert.strictEqual(
                 activationReloadState.getSamInitState()?.path,
@@ -130,9 +121,9 @@ describe('ActivationReloadState', async function() {
             )
         })
 
-        it('path defined, with runtime', async function() {
-            await extensionContext.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, 'getsomepath')
-            await extensionContext.globalState.update(SAM_INIT_RUNTIME_KEY, 'getsomeruntime')
+        it('path defined, with runtime', async function () {
+            await ext.context.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, 'getsomepath')
+            await ext.context.globalState.update(SAM_INIT_RUNTIME_KEY, 'getsomeruntime')
 
             assert.strictEqual(
                 activationReloadState.getSamInitState()?.path,
@@ -151,10 +142,10 @@ describe('ActivationReloadState', async function() {
             )
         })
 
-        it('path defined, with runtime and isImage', async function() {
-            await extensionContext.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, 'getsomepath')
-            await extensionContext.globalState.update(SAM_INIT_RUNTIME_KEY, 'getsomeruntime')
-            await extensionContext.globalState.update(SAM_INIT_IMAGE_BOOLEAN_KEY, true)
+        it('path defined, with runtime and isImage', async function () {
+            await ext.context.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, 'getsomepath')
+            await ext.context.globalState.update(SAM_INIT_RUNTIME_KEY, 'getsomeruntime')
+            await ext.context.globalState.update(SAM_INIT_IMAGE_BOOLEAN_KEY, true)
 
             assert.strictEqual(
                 activationReloadState.getSamInitState()?.path,
@@ -173,8 +164,8 @@ describe('ActivationReloadState', async function() {
             )
         })
 
-        it('path undefined', async function() {
-            await extensionContext.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, undefined)
+        it('path undefined', async function () {
+            await ext.context.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, undefined)
 
             assert.strictEqual(
                 activationReloadState.getSamInitState(),
@@ -184,7 +175,7 @@ describe('ActivationReloadState', async function() {
         })
     })
 
-    it('clearLaunchPath', async function() {
+    it('clearLaunchPath', async function () {
         activationReloadState.setSamInitState({
             path: 'somepath',
             runtime: 'someruntime',
@@ -193,19 +184,19 @@ describe('ActivationReloadState', async function() {
         activationReloadState.clearSamInitState()
 
         assert.strictEqual(
-            extensionContext.globalState.get(ACTIVATION_LAUNCH_PATH_KEY),
+            ext.context.globalState.get(ACTIVATION_LAUNCH_PATH_KEY),
             undefined,
             'Expected launch path to be cleared (undefined)'
         )
 
         assert.strictEqual(
-            extensionContext.globalState.get(SAM_INIT_RUNTIME_KEY),
+            ext.context.globalState.get(SAM_INIT_RUNTIME_KEY),
             undefined,
             'Expected runtime key to be cleared (undefined)'
         )
 
         assert.strictEqual(
-            extensionContext.globalState.get(SAM_INIT_IMAGE_BOOLEAN_KEY),
+            ext.context.globalState.get(SAM_INIT_IMAGE_BOOLEAN_KEY),
             undefined,
             'Expected isImage key to be cleared (undefined)'
         )

--- a/src/test/shared/activationReloadState.test.ts
+++ b/src/test/shared/activationReloadState.test.ts
@@ -25,6 +25,18 @@ describe('ActivationReloadState', async function () {
         activationReloadState.clearSamInitState()
     })
 
+    it('decides ext.didReload()', async function () {
+        await ext.context.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, undefined)
+        // Force ext to re-initialize.
+        ext.init(ext.context, ext.window)
+        assert.strictEqual(ext.didReload(), false)
+
+        await ext.context.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, '/some/path')
+        // Force ext to re-initialize.
+        ext.init(ext.context, ext.window)
+        assert.strictEqual(ext.didReload(), true)
+    })
+
     describe('setSamInitState', async function () {
         it('without runtime', async function () {
             activationReloadState.setSamInitState({

--- a/src/test/shared/activationReloadState.test.ts
+++ b/src/test/shared/activationReloadState.test.ts
@@ -163,16 +163,6 @@ describe('ActivationReloadState', async function () {
                 'Unexpected init image boolean value was retrieved'
             )
         })
-
-        it('path undefined', async function () {
-            await ext.context.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, undefined)
-
-            assert.strictEqual(
-                activationReloadState.getSamInitState(),
-                undefined,
-                'expected sam init state to be undefined'
-            )
-        })
     })
 
     it('clearLaunchPath', async function () {

--- a/src/test/shared/activationReloadState.test.ts
+++ b/src/test/shared/activationReloadState.test.ts
@@ -15,10 +15,10 @@ import {
 import { ext } from '../../shared/extensionGlobals'
 
 describe('ActivationReloadState', async function () {
-    let activationReloadState: ActivationReloadState
+    const activationReloadState = new ActivationReloadState()
 
     beforeEach(function () {
-        activationReloadState = new ActivationReloadState()
+        activationReloadState.clearSamInitState()
     })
 
     afterEach(function () {


### PR DESCRIPTION


## Description

Assert that non-passive metrics are never emitted at startup (except when "resuming", i.e. `resumeCreateNewSamApp()`).

After reverting e9f6543ae4cc, integration tests fail correctly:

      1) "before all" hook in "{root}":
         Error: non-passive metric emitted at startup
          at Object.<anonymous> (/Volumes/workplace/aws-toolkit-vscode/src/extension.ts:247:23)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
