### PR TITLE
telemetry: do not add user agent to requests

### DIFF
--- a/src/shared/awsClientBuilder.ts
+++ b/src/shared/awsClientBuilder.ts
@@ -12,7 +12,8 @@ export interface AWSClientBuilder {
     createAndConfigureServiceClient<T>(
         awsServiceFactory: (options: ServiceConfigurationOptions) => T,
         awsServiceOpts?: ServiceConfigurationOptions,
-        region?: string
+        region?: string,
+        addUserAgent?: boolean
     ): Promise<T>
 }
 
@@ -28,7 +29,8 @@ export class DefaultAWSClientBuilder implements AWSClientBuilder {
     public async createAndConfigureServiceClient<T>(
         awsServiceFactory: (options: ServiceConfigurationOptions) => T,
         awsServiceOpts?: ServiceConfigurationOptions,
-        region?: string
+        region?: string,
+        addUserAgent: boolean = true
     ): Promise<T> {
         if (!awsServiceOpts) {
             awsServiceOpts = {}
@@ -42,7 +44,7 @@ export class DefaultAWSClientBuilder implements AWSClientBuilder {
             awsServiceOpts.region = region
         }
 
-        if (!awsServiceOpts.customUserAgent) {
+        if (!awsServiceOpts.customUserAgent && addUserAgent) {
             const platformName = env.appName.replace(/\s/g, '-')
             awsServiceOpts.customUserAgent = `AWS-Toolkit-For-VSCode/${pluginVersion} ${platformName}/${version}`
         }

--- a/src/shared/telemetry/defaultTelemetryClient.ts
+++ b/src/shared/telemetry/defaultTelemetryClient.ts
@@ -88,14 +88,19 @@ export class DefaultTelemetryClient implements TelemetryClient {
 
         return new DefaultTelemetryClient(
             clientId,
-            await ext.sdkClientBuilder.createAndConfigureServiceClient(opts => new Service(opts), {
-                // @ts-ignore: apiConfig is internal and not in the TS declaration file
-                apiConfig: apiConfig,
-                region: region,
-                credentials: credentials,
-                correctClockSkew: true,
-                endpoint: DefaultTelemetryClient.DEFAULT_TELEMETRY_ENDPOINT,
-            })
+            await ext.sdkClientBuilder.createAndConfigureServiceClient(
+                opts => new Service(opts),
+                {
+                    // @ts-ignore: apiConfig is internal and not in the TS declaration file
+                    apiConfig: apiConfig,
+                    region: region,
+                    credentials: credentials,
+                    correctClockSkew: true,
+                    endpoint: DefaultTelemetryClient.DEFAULT_TELEMETRY_ENDPOINT,
+                },
+                undefined,
+                false
+            )
         )
     }
 }


### PR DESCRIPTION
JB reference: https://github.com/aws/aws-toolkit-jetbrains/pull/2507

sidenote on change: I would have preferred it to be like JB where we added it explicitly in the constructor of each client (but we have an additional layer that makes it easier), so fall back to "add another argument"

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
