### PR TITLE
SFN: adds publish for YAML state machine

### DIFF
--- a/.changes/next-release/Feature-b6e48e85-7d01-40fd-82b2-be99cf3a6244.json
+++ b/.changes/next-release/Feature-b6e48e85-7d01-40fd-82b2-be99cf3a6244.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Step Functions: adds ability to publish/update state machine from ASL YAML files."
+}

--- a/package.nls.json
+++ b/package.nls.json
@@ -281,6 +281,7 @@
     "AWS.message.info.stepFunctions.executeStateMachine.started": "Execution started",
     "AWS.message.error.stepFunctions.publishStateMachine.createFailure": "Failed to create state machine: {0}",
     "AWS.message.error.stepFunctions.publishStateMachine.updateFailure": "Failed to update state machine: {0}",
+    "AWS.message.error.stepFunctions.publishStateMachine.invalidYAML": "Cannot publish invalid YAML file",
     "AWS.message.info.stepFunctions.publishStateMachine.createSuccess": "Successfully created state machine '{0}'",
     "AWS.message.info.stepFunctions.publishStateMachine.creating": "Creating state machine '{0}' in {1}...",
     "AWS.message.info.stepFunctions.publishStateMachine.updateSuccess": "Successfully updated state machine '{0}'",

--- a/src/stepFunctions/activation.ts
+++ b/src/stepFunctions/activation.ts
@@ -13,6 +13,8 @@ import { createStateMachineFromTemplate } from './commands/createStateMachineFro
 import { publishStateMachine } from './commands/publishStateMachine'
 import { AslVisualizationManager } from './commands/visualizeStateMachine/aslVisualizationManager'
 
+import { ASL_FORMATS, YAML_ASL, JSON_ASL } from './constants/aslFormats'
+
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
@@ -112,7 +114,7 @@ function initializeCodeLens(context: vscode.ExtensionContext) {
             }
             const renderCodeLens = new vscode.CodeLens(topOfDocument, renderCommand)
 
-            if (document.languageId === 'asl') {
+            if (ASL_FORMATS.includes(document.languageId)) {
                 const publishCommand: vscode.Command = {
                     command: 'aws.stepfunctions.publishStateMachine',
                     title: localize('AWS.stepFunctions.publish', 'Publish to Step Functions'),
@@ -126,7 +128,7 @@ function initializeCodeLens(context: vscode.ExtensionContext) {
         }
     }
 
-    const docSelector = [{ language: 'asl' }, { language: 'asl-yaml' }]
+    const docSelector = [{ language: JSON_ASL }, { language: YAML_ASL }]
 
     const codeLensProviderDisposable = vscode.languages.registerCodeLensProvider(
         docSelector,

--- a/src/stepFunctions/asl/aslServer.ts
+++ b/src/stepFunctions/asl/aslServer.ts
@@ -38,6 +38,8 @@ import * as URL from 'url'
 import { getLanguageModelCache } from '../../shared/languageServer/languageModelCache'
 import { formatError, runSafe, runSafeAsync } from '../../shared/languageServer/utils/runner'
 
+import { YAML_ASL, JSON_ASL } from '../constants/aslFormats'
+
 namespace ResultLimitReachedNotification {
     export const type: NotificationType<string, any> = new NotificationType('asl/resultLimitReached')
 }
@@ -212,7 +214,7 @@ connection.onDidChangeConfiguration(change => {
         if (enableFormatter) {
             if (!formatterRegistration) {
                 formatterRegistration = connection.client.register(DocumentRangeFormattingRequest.type, {
-                    documentSelector: [{ language: 'asl' }, { language: 'asl-yaml' }],
+                    documentSelector: [{ language: JSON_ASL }, { language: YAML_ASL }],
                 })
             }
         } else if (formatterRegistration) {
@@ -272,7 +274,7 @@ function triggerValidation(textDocument: TextDocument): void {
 
 // sets language service depending on document language
 function getLanguageService(langId: string): LanguageService {
-    if (langId === 'asl-yaml') {
+    if (langId === YAML_ASL) {
         return aslYamlLanguageService
     } else {
         return aslJsonLanguageService

--- a/src/stepFunctions/asl/client.ts
+++ b/src/stepFunctions/asl/client.ts
@@ -39,6 +39,8 @@ import {
     TransportKind,
 } from 'vscode-languageclient'
 
+import { YAML_ASL, JSON_ASL, ASL_FORMATS } from '../constants/aslFormats'
+
 namespace ResultLimitReachedNotification {
     export const type: NotificationType<string, any> = new NotificationType('asl/resultLimitReached')
 }
@@ -69,10 +71,10 @@ export async function activate(extensionContext: ExtensionContext) {
     }
 
     const documentSelector = [
-        { schema: 'file', language: 'asl' },
-        { schema: 'untitled', language: 'asl' },
-        { schema: 'file', language: 'asl-yaml' },
-        { schema: 'untitled', language: 'asl-yaml' },
+        { schema: 'file', language: JSON_ASL },
+        { schema: 'untitled', language: JSON_ASL },
+        { schema: 'file', language: YAML_ASL },
+        { schema: 'untitled', language: YAML_ASL },
     ]
 
     // Options to control the language client
@@ -85,7 +87,7 @@ export async function activate(extensionContext: ExtensionContext) {
         },
         synchronize: {
             // Synchronize the setting section 'json' to the server
-            configurationSection: ['asl', 'asl-yaml'],
+            configurationSection: ASL_FORMATS,
             fileEvents: workspace.createFileSystemWatcher('**/*.{asl,asl.json,asl.yml,asl.yaml}'),
         },
         middleware: {

--- a/src/stepFunctions/commands/createStateMachineFromTemplate.ts
+++ b/src/stepFunctions/commands/createStateMachineFromTemplate.ts
@@ -16,6 +16,8 @@ import CreateStateMachineWizard, {
     TemplateFormats,
 } from '../wizards/createStateMachineWizard'
 
+import { YAML_ASL, JSON_ASL } from '../constants/aslFormats'
+
 export async function createStateMachineFromTemplate(context: vscode.ExtensionContext) {
     const logger: Logger = getLogger()
 
@@ -60,7 +62,7 @@ async function getTextDocumentForSelectedItem(
 
     const options = {
         content,
-        language: format === TemplateFormats.YAML ? 'asl-yaml' : 'asl',
+        language: format === TemplateFormats.YAML ? YAML_ASL : JSON_ASL,
     }
 
     return await vscode.workspace.openTextDocument(options)

--- a/src/stepFunctions/commands/visualizeStateMachine/aslVisualization.ts
+++ b/src/stepFunctions/commands/visualizeStateMachine/aslVisualization.ts
@@ -13,6 +13,8 @@ import { getLogger, Logger } from '../../../shared/logger'
 import { isDocumentValid } from '../../utils'
 import * as yaml from 'yaml'
 
+import { YAML_ASL } from '../../constants/aslFormats'
+
 const YAML_OPTIONS: yaml.Options = {
     merge: false,
     maxAliasCount: 0,
@@ -62,7 +64,7 @@ export class AslVisualization {
 
     public async sendUpdateMessage(updatedTextDocument: vscode.TextDocument) {
         const logger: Logger = getLogger()
-        const isYaml = updatedTextDocument.languageId === 'asl-yaml'
+        const isYaml = updatedTextDocument.languageId === YAML_ASL
         const text = updatedTextDocument.getText()
         let stateMachineData = text
         let yamlErrors: string[] = []

--- a/src/stepFunctions/constants/aslFormats.ts
+++ b/src/stepFunctions/constants/aslFormats.ts
@@ -1,0 +1,13 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const JSON_ASL = 'asl'
+export const JSON_TYPE = 'json'
+export const YAML_ASL = 'asl-yaml'
+export const YAML_TYPE = 'yaml'
+export const YAML_FORMATS = [YAML_TYPE, YAML_ASL]
+export const JSON_FORMATS = [JSON_TYPE, JSON_ASL]
+export const VALID_SFN_PUBLISH_FORMATS = JSON_FORMATS.concat(YAML_FORMATS)
+export const ASL_FORMATS = [JSON_ASL, YAML_ASL]

--- a/src/stepFunctions/wizards/createStateMachineWizard.ts
+++ b/src/stepFunctions/wizards/createStateMachineWizard.ts
@@ -133,8 +133,6 @@ export default class CreateStateMachineWizard extends MultiStepWizard<CreateStat
             },
         })
 
-        console.log(choices)
-
         this.template = picker.verifySinglePickerOutput<StateMachineTemplateQuickPickItem>(choices)
 
         return this.template ? wizardContinue(this.TEMPLATE_FORMAT_ACTION) : WIZARD_GOBACK

--- a/src/test/stepFunctions/commands/visualizeStateMachine.test.ts
+++ b/src/test/stepFunctions/commands/visualizeStateMachine.test.ts
@@ -14,6 +14,8 @@ import { ext } from '../../../shared/extensionGlobals'
 import { StateMachineGraphCache } from '../../../stepFunctions/utils'
 import { assertThrowsError } from '../../shared/utilities/assertUtils'
 
+import { YAML_ASL, JSON_ASL } from '../../../../src/stepFunctions/constants/aslFormats'
+
 // Top level defintions
 let aslVisualizationManager: AslVisualizationManager
 let sandbox: sinon.SinonSandbox
@@ -125,7 +127,7 @@ const mockTextDocumentYaml: vscode.TextDocument = {
     isClosed: false,
     isDirty: false,
     isUntitled: false,
-    languageId: 'asl-yaml',
+    languageId: YAML_ASL,
     lineCount: 0,
     uri: mockUriThree,
     version: 0,
@@ -147,7 +149,7 @@ const mockTextDocumentJson: vscode.TextDocument = {
     isClosed: false,
     isDirty: false,
     isUntitled: false,
-    languageId: 'asl',
+    languageId: JSON_ASL,
     lineCount: 0,
     uri: mockUriThree,
     version: 0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds ability to publish YAML state machine for Step Functions. 

<!--- Describe your changes in detail -->
When user tries to publish state machine in yaml or asl-yaml format, it will be converted to json and published to Step Functions API. SFN API does not support publish of YAML state machines directly so it needs to be converted to JSON first. 

## Motivation and Context
We want to give users ability to publish their state machines in YAML.

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
#1526 

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
