### PR TITLE
telemetry: do not assert *cached* metrics at startup

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -244,7 +244,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
         recordToolkitInitialization(activationStartedOn, getLogger())
 
-        assertPassiveTelemetry()
+        ext.telemetry.assertPassiveTelemetry(ext.didReload())
     } catch (error) {
         getLogger('channel').error(
             localize(
@@ -254,22 +254,6 @@ export async function activate(context: vscode.ExtensionContext) {
             )
         )
         throw error
-    }
-}
-
-/**
- * Only passive telemetry is allowed during startup (except for some known
- * special-cases).
- */
-function assertPassiveTelemetry() {
-    const didReload = ext.didReload()
-    // These special-case metrics may be non-passive during a VSCode "reload".
-    const activeAllowed = ['sam_init']
-    for (const metric of ext.telemetry.records) {
-        if (metric.Passive || (didReload && activeAllowed.includes(metric.MetricName))) {
-            continue
-        }
-        throw Error('non-passive metric emitted at startup')
     }
 }
 

--- a/src/shared/extensionUtilities.ts
+++ b/src/shared/extensionUtilities.ts
@@ -6,6 +6,7 @@
 import * as _ from 'lodash'
 import * as os from 'os'
 import * as path from 'path'
+import * as semver from 'semver'
 import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 import { ext } from '../shared/extensionGlobals'
@@ -18,11 +19,12 @@ const localize = nls.loadMessageBundle()
 
 const VSCODE_APPNAME = 'Visual Studio Code'
 const CLOUD9_APPNAME = 'AWS Cloud9'
+const TEST_VERSION = 'testPluginVersion'
 
 export const mostRecentVersionKey: string = 'awsToolkitMostRecentVersion'
 // This is a hack to get around webpack messing everything up in unit test mode, it's also a very obvious
 // bad version if something goes wrong while building it
-let pluginVersion = 'testPluginVersion'
+let pluginVersion = TEST_VERSION
 try {
     pluginVersion = PLUGINVERSION
 } catch (e) {}
@@ -122,14 +124,13 @@ export class ExtensionUtilities {
 }
 
 /**
- * A utility function that takes a possibly null value and applies
- * the given function to it, returning the result of the function or null
+ * Applies function `getFn` to `obj` and returns the result, or fails silently.
  *
- * example usage:
+ * Example:
  *
- * function blah(value?: SomeObject) {
- *  nullSafeGet(value, x => x.propertyOfSomeObject)
- * }
+ *     function blah(value?: SomeObject) {
+ *       safeGet(value, x => x.propertyOfSomeObject)
+ *     }
  *
  * @param obj the object to attempt the get function on
  * @param getFn the function to use to determine the mapping value
@@ -230,6 +231,14 @@ export function isDifferentVersion(context: vscode.ExtensionContext, currVersion
  */
 export function setMostRecentVersion(context: vscode.ExtensionContext): void {
     context.globalState.update(mostRecentVersionKey, pluginVersion)
+}
+
+/**
+ * Returns true if the current build is a production build (as opposed to a
+ * prerelease/test/nightly build)
+ */
+export function isReleaseVersion(): boolean {
+    return !semver.prerelease(pluginVersion) && pluginVersion !== TEST_VERSION
 }
 
 /**

--- a/src/shared/telemetry/defaultTelemetryService.ts
+++ b/src/shared/telemetry/defaultTelemetryService.ts
@@ -33,6 +33,14 @@ export class DefaultTelemetryService implements TelemetryService {
     private _timer?: NodeJS.Timer
     private publisher?: TelemetryPublisher
     private readonly _eventQueue: MetricDatum[]
+    /**
+     * Last metric (if any) loaded from cached telemetry from a previous
+     * session.
+     *
+     * We cannot infer this from "session_start" because there can in theory be
+     * multiple "session_start" metrics cached from multiple sessions.
+     */
+    private _endOfCache: MetricDatum | undefined
 
     public constructor(
         private readonly context: ExtensionContext,
@@ -59,6 +67,7 @@ export class DefaultTelemetryService implements TelemetryService {
 
     public async start(): Promise<void> {
         this._eventQueue.push(...DefaultTelemetryService.readEventsFromCache(this.persistFilePath))
+        this._endOfCache = this._eventQueue[this._eventQueue.length - 1]
         recordSessionStart()
         await this.startTimer()
     }
@@ -260,6 +269,32 @@ export class DefaultTelemetryService implements TelemetryService {
             getLogger().error(error)
 
             return []
+        }
+    }
+
+    /**
+     * Only passive telemetry is allowed during startup (except for some known
+     * special-cases).
+     */
+    public assertPassiveTelemetry(didReload: boolean) {
+        // Special case: these may be non-passive during a VSCode "reload". #1592
+        const activeAllowed = ['sam_init']
+        // Metrics from the previous session can be arbitrary: we can't reason
+        // about whether they should be passive/active.
+        let readingCache = true
+
+        // Array for..of is in-order:
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach
+        for (const metric of this._eventQueue) {
+            if (readingCache) {
+                readingCache = metric !== this._endOfCache
+                // Skip cached metrics.
+                continue
+            }
+            if (metric.Passive || (didReload && activeAllowed.includes(metric.MetricName))) {
+                continue
+            }
+            throw Error(`non-passive metric emitted at startup: ${metric.MetricName}`)
         }
     }
 }

--- a/src/shared/telemetry/telemetryService.ts
+++ b/src/shared/telemetry/telemetryService.ts
@@ -17,4 +17,9 @@ export interface TelemetryService {
     postFeedback(feedback: TelemetryFeedback): Promise<void>
     record(event: MetricDatum, awsContext?: AwsContext): void
     clearRecords(): void
+    /**
+     * Only passive telemetry is allowed during startup (except for some known
+     * special-cases).
+     */
+    assertPassiveTelemetry(didReload: boolean): void
 }

--- a/src/test/shared/telemetry/defaultTelemetryService.test.ts
+++ b/src/test/shared/telemetry/defaultTelemetryService.test.ts
@@ -21,7 +21,6 @@ import {
 } from '../../utilities/fakeAwsContext'
 import { FakeTelemetryPublisher } from '../../fake/fakeTelemetryService'
 import ClientTelemetry = require('../../../shared/telemetry/clienttelemetry')
-import { assertThrowsError } from '../utilities/assertUtils'
 
 const originalTelemetryClient: TelemetryService = ext.telemetry
 let mockContext: FakeExtensionContext
@@ -99,7 +98,7 @@ describe('DefaultTelemetryService', function () {
         service.record(fakeMetric(6, false))
 
         // Must throw.
-        assertThrowsError(async () => {
+        assert.throws(() => {
             service.assertPassiveTelemetry(false)
         })
 

--- a/src/test/shared/telemetry/defaultTelemetryService.test.ts
+++ b/src/test/shared/telemetry/defaultTelemetryService.test.ts
@@ -21,6 +21,7 @@ import {
 } from '../../utilities/fakeAwsContext'
 import { FakeTelemetryPublisher } from '../../fake/fakeTelemetryService'
 import ClientTelemetry = require('../../../shared/telemetry/clienttelemetry')
+import { assertThrowsError } from '../utilities/assertUtils'
 
 const originalTelemetryClient: TelemetryService = ext.telemetry
 let mockContext: FakeExtensionContext
@@ -41,6 +42,16 @@ afterEach(async function () {
     await fs.remove(ext.telemetry.persistFilePath)
     ext.telemetry = originalTelemetryClient
 })
+
+function fakeMetric(value: number, passive: boolean) {
+    return {
+        Passive: passive,
+        MetricName: `metric${value}`,
+        Value: value,
+        Unit: 'None',
+        EpochTimestamp: new Date().getTime(),
+    }
+}
 
 describe('DefaultTelemetryService', function () {
     const testFlushPeriod = 10
@@ -63,6 +74,36 @@ describe('DefaultTelemetryService', function () {
         await service.postFeedback(feedback)
 
         assert.strictEqual(mockPublisher.feedback, feedback)
+    })
+
+    it('assertPassiveTelemetry() throws if active, non-cached metric is emitted during startup', async function () {
+        service.clearRecords()
+        service.telemetryEnabled = true
+        service.flushPeriod = testFlushPeriod
+
+        // Simulate cached telemetry by prepopulating records before start().
+        // (Normally readEventsFromCache() does this.)
+        service.record(fakeMetric(1, true))
+        service.record(fakeMetric(2, true))
+        // Active *cached* metric.
+        service.record(fakeMetric(4, false))
+        await service.start()
+
+        // Passive *non-cached* metric.
+        service.record(fakeMetric(5, true))
+
+        // Must *not* throw.
+        service.assertPassiveTelemetry(false)
+
+        // Active *non-cached* metric.
+        service.record(fakeMetric(6, false))
+
+        // Must throw.
+        assertThrowsError(async () => {
+            service.assertPassiveTelemetry(false)
+        })
+
+        await service.shutdown()
     })
 
     it('publishes periodically if user has said ok', async function () {


### PR DESCRIPTION
When asserting passive metrics at startup, we must skip cached telemetry
from the previous session: it can contain arbitrary metrics, we cannot
reason about whether they should be passive or active.

ref #1592


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
