### PR TITLE
telemetry: record CredentialType on login

### DIFF
--- a/src/credentials/providers/credentialsProvider.ts
+++ b/src/credentials/providers/credentialsProvider.ts
@@ -3,10 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { CredentialType } from '../../shared/telemetry/telemetry.gen';
 import { CredentialsProviderId } from './credentialsProviderId'
 
 export interface CredentialsProvider {
     getCredentialsProviderId(): CredentialsProviderId
+    /**
+     * Gets the credential type, mostly for use in telemetry.
+     * 
+     * TODO: use this to build `getCredentialsProviderId()`.
+     */
+    getCredentialsType2(): CredentialType
     getDefaultRegion(): string | undefined
     getHashCode(): string
     getCredentials(): Promise<AWS.Credentials>

--- a/src/credentials/providers/credentialsProviderId.ts
+++ b/src/credentials/providers/credentialsProviderId.ts
@@ -6,7 +6,9 @@
 const CREDENTIALS_PROVIDER_ID_SEPARATOR = ':'
 
 export interface CredentialsProviderId {
+    /** Credential type name, e.g. "profile". */
     readonly credentialType: string
+    /** User-defined profile name, e.g. "default". */
     readonly credentialTypeId: string
 }
 

--- a/src/credentials/providers/sharedCredentialsProvider.ts
+++ b/src/credentials/providers/sharedCredentialsProvider.ts
@@ -15,6 +15,7 @@ import { SsoAccessTokenProvider } from '../sso/ssoAccessTokenProvider'
 import { CredentialsProvider } from './credentialsProvider'
 import { CredentialsProviderId } from './credentialsProviderId'
 import { SsoCredentialProvider } from './ssoCredentialProvider'
+import { CredentialType } from '../../shared/telemetry/telemetry.gen'
 
 const SHARED_CREDENTIAL_PROPERTIES = {
     AWS_ACCESS_KEY_ID: 'aws_access_key_id',
@@ -244,8 +245,19 @@ export class SharedCredentialsProvider implements CredentialsProvider {
         AWS.config.sts.region = this.getDefaultRegion()
     }
 
+    /**
+     * Legacy function that does nothing particularly useful.
+     *
+     * You are probably looking for `getCredentialsType2()`.
+     *
+     * TODO: deprecated / why is this static?!
+     */
     public static getCredentialsType(): string {
         return SharedCredentialsProvider.CREDENTIALS_TYPE
+    }
+
+    public getCredentialsType2(): CredentialType {
+        return this.isSsoProfile() ? 'ssoProfile' : 'staticProfile'
     }
 
     public isSsoProfile(): boolean {

--- a/src/test/shared/credentials/loginManager.test.ts
+++ b/src/test/shared/credentials/loginManager.test.ts
@@ -42,6 +42,7 @@ describe('LoginManager', async function () {
         loginManager = new LoginManager(awsContext, credentialsStore, recordAwsSetCredentialsSpy)
         credentialsProvider = {
             getCredentials: sandbox.stub().resolves(sampleCredentials),
+            getCredentialsType2: sandbox.stub().resolves('staticProfile'),
             getCredentialsProviderId: sandbox.stub().returns(sampleCredentialsProviderId),
             getDefaultRegion: sandbox.stub().returns('someRegion'),
             getHashCode: sandbox.stub().returns('1234'),

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -300,6 +300,7 @@ describe('SamDebugConfigurationProvider', async function () {
 
             const credentialsProvider: CredentialsProvider = {
                 getCredentials: sandbox.stub().resolves(({} as any) as AWS.Credentials),
+                getCredentialsType2: sandbox.stub().resolves('staticProfile'),
                 getCredentialsProviderId: sandbox.stub().returns({
                     credentialType: 'test',
                     credentialTypeId: 'someId',
@@ -2684,6 +2685,7 @@ Resources:
 
             const credentialsProvider: CredentialsProvider = {
                 getCredentials: sandbox.stub().resolves(({} as any) as AWS.Credentials),
+                getCredentialsType2: sandbox.stub().resolves('staticProfile'),
                 getCredentialsProviderId: sandbox.stub().returns({
                     credentialType: 'test',
                     credentialTypeId: 'someId',


### PR DESCRIPTION
Before this, we did not record CredentialType.

The old/existing `SharedCredentialsProvider.getCredentialsType()`
function does nothing very useful, we should migrate away from it.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
