### PR TITLE
childprocess: do not log "sam --info" command

### DIFF
--- a/src/shared/logger/index.ts
+++ b/src/shared/logger/index.ts
@@ -14,3 +14,4 @@ export type Loggable = loggableType.Loggable
 export type Logger = logger.Logger
 export type LogLevel = logger.LogLevel
 export const getLogger = logger.getLogger
+export const getNullLogger = logger.getNullLogger

--- a/src/shared/logger/logger.ts
+++ b/src/shared/logger/logger.ts
@@ -73,6 +73,34 @@ export function getLogger(type?: 'channel' | 'debugConsole' | 'main'): Logger {
     return logger
 }
 
+export class NullLogger implements Logger {
+    public setLogLevel(logLevel: LogLevel) {}
+    public logLevelEnabled(logLevel: LogLevel): boolean {
+        return false
+    }
+    public debug(message: string | Error, ...meta: any[]): number {
+        return 0
+    }
+    public verbose(message: string | Error, ...meta: any[]): number {
+        return 0
+    }
+    public info(message: string | Error, ...meta: any[]): number {
+        return 0
+    }
+    public warn(message: string | Error, ...meta: any[]): number {
+        return 0
+    }
+    public error(message: string | Error, ...meta: any[]): number {
+        return 0
+    }
+    public getLogById(logID: number, file: string): string | undefined {
+        return undefined
+    }
+}
+
+export function getNullLogger(type?: 'channel' | 'debugConsole' | 'main'): Logger {
+    return new NullLogger()
+}
 /**
  * Sets (or clears) the logger that is accessible to code.
  * The Extension is expected to call this only once per log type.

--- a/src/shared/sam/cli/samCliInfo.ts
+++ b/src/shared/sam/cli/samCliInfo.ts
@@ -41,7 +41,11 @@ export class SamCliInfoInvocation {
     }
 
     public async execute(): Promise<SamCliInfoResponse> {
-        const childProcessResult = await this.invoker.invoke({ arguments: ['--info'] })
+        const childProcessResult = await this.invoker.invoke({
+            // "info" command is noisy and uninteresting, don't log it.
+            logging: false,
+            arguments: ['--info'],
+        })
 
         logAndThrowIfUnexpectedExitCode(childProcessResult, 0)
         const response = this.convertOutput(childProcessResult.stdout)

--- a/src/shared/sam/cli/samCliInvokerUtils.ts
+++ b/src/shared/sam/cli/samCliInvokerUtils.ts
@@ -12,6 +12,7 @@ export interface SamCliProcessInvokeOptions {
     arguments?: string[]
     onStdout?: ChildProcessStartArguments['onStdout']
     onStderr?: ChildProcessStartArguments['onStderr']
+    /** Log command invocations (default: true). */
     logging?: boolean
 }
 

--- a/src/shared/sam/cli/samCliInvokerUtils.ts
+++ b/src/shared/sam/cli/samCliInvokerUtils.ts
@@ -12,11 +12,12 @@ export interface SamCliProcessInvokeOptions {
     arguments?: string[]
     onStdout?: ChildProcessStartArguments['onStdout']
     onStderr?: ChildProcessStartArguments['onStderr']
+    logging?: boolean
 }
 
 export function makeRequiredSamCliProcessInvokeOptions(
     options?: SamCliProcessInvokeOptions
-): Required<Omit<SamCliProcessInvokeOptions, 'channelLogger' | 'onStdout' | 'onStderr'>> {
+): Required<Omit<SamCliProcessInvokeOptions, 'channelLogger' | 'onStdout' | 'onStderr' | 'logging'>> {
     options = options || {}
 
     return {

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -56,7 +56,7 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
     ) {}
 
     public async invoke({ options, ...params }: SamLocalInvokeCommandArgs): Promise<ChildProcess> {
-        const childProcess = new ChildProcess(params.command, options, ...params.args)
+        const childProcess = new ChildProcess(true, params.command, options, ...params.args)
         getLogger('channel').info('AWS.running.command', 'Running: {0}', `${childProcess}`)
         // "sam local invoke", "sam local start-api", etc.
         const samCommandName = `sam ${params.args[0]} ${params.args[1]}`
@@ -77,7 +77,7 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
                     params.timeout?.refresh()
                     this.logger.verbose('SAM: pid %d: stderr: %s', childProcess.pid(), removeAnsi(text))
                     if (checkForCues) {
-                        // Look for messages like "Waiting for debugger to attach" before returning back to caller
+                        // Look for messages like "Debugger attached" before returning back to caller
                         if (this.debuggerAttachCues.some(cue => text.includes(cue))) {
                             this.logger.verbose(
                                 `SAM: pid ${childProcess.pid()}: local SAM app is ready for debugger to attach`

--- a/src/shared/sam/debugger/csharpSamDebug.ts
+++ b/src/shared/sam/debugger/csharpSamDebug.ts
@@ -132,7 +132,7 @@ async function _installDebugger({ debuggerPath }: InstallDebuggerArgs): Promise<
             installArgs = ['-v', vsDbgVersion, '-r', vsDbgRuntime, '-l', debuggerPath]
         }
 
-        const childProcess = new ChildProcess(installCommand, {}, ...installArgs)
+        const childProcess = new ChildProcess(true, installCommand, {}, ...installArgs)
 
         const installPromise = new Promise<void>(async (resolve, reject) => {
             await childProcess.start({

--- a/src/test/shared/utilities/childProcess.test.ts
+++ b/src/test/shared/utilities/childProcess.test.ts
@@ -30,7 +30,7 @@ describe('ChildProcess', async function () {
                 const batchFile = path.join(tempFolder, 'test-script.bat')
                 writeBatchFile(batchFile)
 
-                const childProcess = new ChildProcess(batchFile)
+                const childProcess = new ChildProcess(true, batchFile)
 
                 const result = await childProcess.run()
 
@@ -49,7 +49,7 @@ describe('ChildProcess', async function () {
 
                 writeWindowsCommandFile(command)
 
-                const childProcess = new ChildProcess(command)
+                const childProcess = new ChildProcess(true, command)
 
                 const result = await childProcess.run()
 
@@ -64,7 +64,7 @@ describe('ChildProcess', async function () {
                 const batchFile = path.join(tempFolder, 'test-script.bat')
                 writeBatchFile(batchFile)
 
-                const childProcess = new ChildProcess(batchFile)
+                const childProcess = new ChildProcess(true, batchFile)
 
                 // We want to verify that the error is thrown even if the first
                 // invocation is still in progress, so we don't await the promise.
@@ -83,7 +83,7 @@ describe('ChildProcess', async function () {
                 const scriptFile = path.join(tempFolder, 'test-script.sh')
                 writeShellFile(scriptFile)
 
-                const childProcess = new ChildProcess(scriptFile)
+                const childProcess = new ChildProcess(true, scriptFile)
 
                 const result = await childProcess.run()
 
@@ -98,7 +98,7 @@ describe('ChildProcess', async function () {
                 const scriptFile = path.join(tempFolder, 'test-script.sh')
                 writeShellFile(scriptFile)
 
-                const childProcess = new ChildProcess(scriptFile)
+                const childProcess = new ChildProcess(true, scriptFile)
 
                 // We want to verify that the error is thrown even if the first
                 // invocation is still in progress, so we don't await the promise.
@@ -128,7 +128,7 @@ describe('ChildProcess', async function () {
                 writeShellFile(command)
             }
 
-            const childProcess = new ChildProcess(command)
+            const childProcess = new ChildProcess(true, command)
 
             const result = await childProcess.run()
 
@@ -142,7 +142,7 @@ describe('ChildProcess', async function () {
         it('reports error for missing executable', async function () {
             const batchFile = path.join(tempFolder, 'nonExistentScript')
 
-            const childProcess = new ChildProcess(batchFile)
+            const childProcess = new ChildProcess(true, batchFile)
 
             const result = await childProcess.run()
 
@@ -193,7 +193,7 @@ describe('ChildProcess', async function () {
                 const batchFile = path.join(tempFolder, 'test-script.bat')
                 writeBatchFile(batchFile)
 
-                const childProcess = new ChildProcess(batchFile)
+                const childProcess = new ChildProcess(true, batchFile)
 
                 await assertRegularRun(childProcess)
             })
@@ -206,7 +206,7 @@ describe('ChildProcess', async function () {
 
                 writeWindowsCommandFile(command)
 
-                const childProcess = new ChildProcess(command)
+                const childProcess = new ChildProcess(true, command)
 
                 await assertRegularRun(childProcess)
             })
@@ -215,7 +215,7 @@ describe('ChildProcess', async function () {
                 const batchFile = path.join(tempFolder, 'test-script.bat')
                 writeBatchFile(batchFile)
 
-                const childProcess = new ChildProcess(batchFile)
+                const childProcess = new ChildProcess(true, batchFile)
 
                 // We want to verify that the error is thrown even if the first
                 // invocation is still in progress, so we don't await the promise.
@@ -236,7 +236,7 @@ describe('ChildProcess', async function () {
                 const scriptFile = path.join(tempFolder, 'test-script.sh')
                 writeShellFile(scriptFile)
 
-                const childProcess = new ChildProcess(scriptFile)
+                const childProcess = new ChildProcess(true, scriptFile)
 
                 await assertRegularRun(childProcess)
             })
@@ -245,7 +245,7 @@ describe('ChildProcess', async function () {
                 const scriptFile = path.join(tempFolder, 'test-script.sh')
                 writeShellFile(scriptFile)
 
-                const childProcess = new ChildProcess(scriptFile)
+                const childProcess = new ChildProcess(true, scriptFile)
 
                 // We want to verify that the error is thrown even if the first
                 // invocation is still in progress, so we don't await the promise.
@@ -275,7 +275,7 @@ describe('ChildProcess', async function () {
                 writeShellFile(command)
             }
 
-            const childProcess = new ChildProcess(command)
+            const childProcess = new ChildProcess(true, command)
 
             await assertRegularRun(childProcess)
         })
@@ -283,7 +283,7 @@ describe('ChildProcess', async function () {
         it('reports error for missing executable', async function () {
             const batchFile = path.join(tempFolder, 'nonExistentScript')
 
-            const childProcess = new ChildProcess(batchFile)
+            const childProcess = new ChildProcess(true, batchFile)
 
             await new Promise<void>(async (resolve, reject) => {
                 await childProcess.start({
@@ -302,7 +302,7 @@ describe('ChildProcess', async function () {
                 const batchFile = path.join(tempFolder, 'test-script.bat')
                 writeBatchFileWithDelays(batchFile)
 
-                const childProcess = new ChildProcess(batchFile)
+                const childProcess = new ChildProcess(true, batchFile)
 
                 // `await` is intentionally not used, we want to check the process while it runs.
                 childProcess.run()
@@ -317,7 +317,7 @@ describe('ChildProcess', async function () {
                 const batchFile = path.join(tempFolder, 'test-script.bat')
                 writeBatchFileWithDelays(batchFile)
 
-                const childProcess = new ChildProcess(batchFile)
+                const childProcess = new ChildProcess(true, batchFile)
 
                 // `await` is intentionally not used, we want to check the process while it runs.
                 childProcess.run()
@@ -336,7 +336,7 @@ describe('ChildProcess', async function () {
                 const scriptFile = path.join(tempFolder, 'test-script.sh')
                 writeShellFileWithDelays(scriptFile)
 
-                const childProcess = new ChildProcess('sh', {}, scriptFile)
+                const childProcess = new ChildProcess(true, 'sh', {}, scriptFile)
 
                 // `await` is intentionally not used, we want to check the process while it runs.
                 childProcess.run()
@@ -351,7 +351,7 @@ describe('ChildProcess', async function () {
                 const scriptFile = path.join(tempFolder, 'test-script.sh')
                 writeShellFileWithDelays(scriptFile)
 
-                const childProcess = new ChildProcess(scriptFile)
+                const childProcess = new ChildProcess(true, scriptFile)
 
                 // `await` is intentionally not used, we want to check the process while it runs.
                 childProcess.run()


### PR DESCRIPTION
"sam --info" is noisy and not useful in the logs.

before:

    2021-03-31 16:37:03 [VERBOSE]: SAM debug: config: "3/31 API n12-image:HelloWorldFunction (nodejs12.x)"
    2021-03-31 16:37:03 [VERBOSE]: Searching for SAM CLI in: /usr/local/bin/sam
    2021-03-31 16:37:03 [INFO]: Running command: (not started) [/usr/local/bin/sam --info]
    2021-03-31 16:37:03 [INFO]: SAM CLI not configured, using SAM found at: '/usr/local/bin/sam'
    2021-03-31 16:37:03 [VERBOSE]: running: (not started) [/usr/local/bin/sam --info]
    2021-03-31 16:37:04 [VERBOSE]: stdout: {
      "version": "1.20.0"
    }

after:

    2021-03-31 16:49:21 [VERBOSE]: SAM debug: config: "3/31 API n12-image:HelloWorldFunction (nodejs12.x)"
    2021-03-31 16:49:21 [VERBOSE]: Searching for SAM CLI in: /usr/local/bin/sam
    2021-03-31 16:49:22 [INFO]: SAM CLI location: /usr/local/bin/sam

<!--- Provide a general summary of your changes in the Title above -->


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
