### PR TITLE
SAM debug: retry only once

### DIFF
--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -70,7 +70,7 @@ function makeResourceName(config: SamLaunchRequestArgs): string {
 
 const SAM_LOCAL_PORT_CHECK_RETRY_INTERVAL_MILLIS: number = 125
 const SAM_LOCAL_PORT_CHECK_RETRY_TIMEOUT_MILLIS_DEFAULT: number = 30000
-const MAX_DEBUGGER_RETRIES: number = 4
+const MAX_DEBUGGER_RETRIES: number = 1
 const ATTACH_DEBUGGER_RETRY_DELAY_MILLIS: number = 1000
 
 /** "sam local start-api" wrapper from the current debug-session. */

--- a/src/test/shared/codelens/localLambdaRunner.test.ts
+++ b/src/test/shared/codelens/localLambdaRunner.test.ts
@@ -145,7 +145,7 @@ describe('localLambdaRunner', async function () {
                 debugConfig: ({} as any) as SamLaunchRequestArgs,
                 onStartDebugging: startDebuggingReturnsFalse,
                 onRecordAttachDebuggerMetric: (attachResult: boolean | undefined, attempts: number): void => {
-                    assert.strictEqual(actualRetries, 4, 'Metrics should only be recorded once')
+                    assert.strictEqual(actualRetries, 1, 'Metrics should only be recorded once')
                     assert.notStrictEqual(attachResult, undefined, 'attachResult should not be undefined')
                 },
                 onWillRetry,
@@ -159,7 +159,7 @@ describe('localLambdaRunner', async function () {
                     folder: vscode.WorkspaceFolder | undefined,
                     nameOrConfiguration: string | vscode.DebugConfiguration
                 ): Promise<boolean> => {
-                    const retVal = actualRetries === 3 ? true : undefined
+                    const retVal = actualRetries === 0 ? true : undefined
 
                     return retVal!
                 },


### PR DESCRIPTION
Retrying more than once is a bad experience: VSCode will show the
debugger UI again and again, and user must hit the "Stop" button every
time we retry.

TODO: can we listen to the "Stop" button and cancel retries then?

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
