### PR TITLE
test: fix unreliable SSO tests

### DIFF
--- a/src/test/credentials/provider/ssoAccessTokenProvider.test.ts
+++ b/src/test/credentials/provider/ssoAccessTokenProvider.test.ts
@@ -148,7 +148,9 @@ describe('SsoAccessTokenProvider', () => {
             const stubSaveAccessToken = sandbox.stub(cache, 'saveAccessToken').returns()
 
             const startTime = Date.now()
-            const receivedToken = await sut.accessToken()
+            const tokenPromise = sut.accessToken()
+            clock.runAllAsync()
+            const receivedToken = await tokenPromise
             const endTime = Date.now()
 
             const durationInSeconds = (endTime - startTime) / 1000
@@ -191,7 +193,6 @@ describe('SsoAccessTokenProvider', () => {
             stubCreateToken.onFirstCall().returns(({
                 promise: sandbox.stub().throws({ code: 'SlowDownException' }),
             } as any) as SDK.Request<CreateTokenResponse, SDK.AWSError>)
-            clock.nextAsync()
 
             stubCreateToken.onSecondCall().returns(({
                 promise: sandbox.stub().resolves(fakeCreateTokenResponse),
@@ -200,16 +201,18 @@ describe('SsoAccessTokenProvider', () => {
             const stubSaveAccessToken = sandbox.stub(cache, 'saveAccessToken').returns()
 
             const startTime = Date.now()
-            const returnedToken = await sut.accessToken()
+            const tokenPromise = sut.accessToken()
+            clock.runAllAsync()
+            const receivedToken = await tokenPromise
             const endTime = Date.now()
 
             const durationInSeconds = (endTime - startTime) / 1000
 
             //The default backoff delay is 5 seconds, the starting retry interval is 1 second
             assert.strictEqual(durationInSeconds >= 6, true, 'Duration not over 6 seconds')
-            assert.strictEqual(returnedToken.startUrl, validAccessToken.startUrl)
-            assert.strictEqual(returnedToken.region, validAccessToken.region)
-            assert.strictEqual(returnedToken.accessToken, validAccessToken.accessToken)
+            assert.strictEqual(receivedToken.startUrl, validAccessToken.startUrl)
+            assert.strictEqual(receivedToken.region, validAccessToken.region)
+            assert.strictEqual(receivedToken.accessToken, validAccessToken.accessToken)
 
             assert.strictEqual(stubSaveAccessToken.calledOnce, true, 'Access token not saved')
         })

--- a/src/test/credentials/provider/ssoAccessTokenProvider.test.ts
+++ b/src/test/credentials/provider/ssoAccessTokenProvider.test.ts
@@ -13,7 +13,7 @@ import { CreateTokenResponse, StartDeviceAuthorizationResponse } from 'aws-sdk/c
 import { SsoClientRegistration } from '../../../credentials/sso/ssoClientRegistration'
 import { assertThrowsError } from '../../../test/shared/utilities/assertUtils'
 
-describe('SsoAccessTokenProvider', () => {
+describe('SsoAccessTokenProvider', function () {
     const sandbox = sinon.createSandbox()
 
     const ssoRegion = 'fakeRegion'
@@ -65,21 +65,21 @@ describe('SsoAccessTokenProvider', () => {
 
     let clock: sinon.SinonFakeTimers
 
-    before(() => {
+    before(function () {
         clock = FakeTimers.install()
     })
 
-    afterEach(async () => {
+    afterEach(async function () {
         sandbox.restore()
         clock.reset()
     })
 
-    after(() => {
+    after(function () {
         clock.uninstall()
     })
 
-    describe('accessToken', () => {
-        it('returns a cached token', async () => {
+    describe('accessToken', function () {
+        it('returns a cached token', async function () {
             sandbox.stub(cache, 'loadAccessToken').returns(validAccessToken)
 
             const receivedToken = await sut.accessToken()
@@ -87,7 +87,7 @@ describe('SsoAccessTokenProvider', () => {
             assert.strictEqual(receivedToken, validAccessToken)
         })
 
-        it('creates a new access token with a cached client registration', async () => {
+        it('creates a new access token with a cached client registration', async function () {
             setUpStubCache(validRegistation)
             const stubAuthorizeClient = sandbox.stub(sut, 'authorizeClient').resolves(validAuthorization)
 
@@ -107,7 +107,7 @@ describe('SsoAccessTokenProvider', () => {
             assert.strictEqual(stubAuthorizeClient.calledOnce, true)
         })
 
-        it('creates an access token without caches', async () => {
+        it('creates an access token without caches', async function () {
             setUpStubCache()
             const stubRegisterClient = sandbox.stub(sut, 'registerClient').resolves(validRegistation)
             const stubAuthorizeClient = sandbox.stub(sut, 'authorizeClient').resolves(validAuthorization)
@@ -130,7 +130,7 @@ describe('SsoAccessTokenProvider', () => {
             assert.strictEqual(stubSaveAccessToken.calledOnce, true)
         })
 
-        it('creates access token after multiple polls', async () => {
+        it('creates access token after multiple polls', async function () {
             setUpStubCache()
             sandbox.stub(sut, 'registerClient').resolves(validRegistation)
             sandbox.stub(sut, 'authorizeClient').resolves(validAuthorization)
@@ -139,7 +139,6 @@ describe('SsoAccessTokenProvider', () => {
             stubCreateToken.onFirstCall().returns(({
                 promise: sandbox.stub().throws({ code: 'AuthorizationPendingException' }),
             } as any) as SDK.Request<CreateTokenResponse, SDK.AWSError>)
-            clock.nextAsync()
 
             stubCreateToken.onSecondCall().returns(({
                 promise: sandbox.stub().resolves(fakeCreateTokenResponse),
@@ -164,7 +163,7 @@ describe('SsoAccessTokenProvider', () => {
             assert.strictEqual(stubSaveAccessToken.calledOnce, true)
         })
 
-        it('stops polling for unspecified errors during createToken call', async () => {
+        it('stops polling for unspecified errors during createToken call', async function () {
             setUpStubCache(validRegistation)
             sandbox.stub(sut, 'authorizeClient').resolves(validAuthorization)
 
@@ -185,7 +184,7 @@ describe('SsoAccessTokenProvider', () => {
             assert.strictEqual(stubSaveAccessToken.called, false)
         })
 
-        it('adds backoff delay on SlowDownException', async () => {
+        it('adds backoff delay on SlowDownException', async function () {
             setUpStubCache(validRegistation)
             sandbox.stub(sut, 'authorizeClient').resolves(validAuthorization)
 
@@ -218,8 +217,8 @@ describe('SsoAccessTokenProvider', () => {
         })
     })
 
-    describe('authorizeClient', () => {
-        it('removes the client registration cache on InvalidClientException', async () => {
+    describe('authorizeClient', function () {
+        it('removes the client registration cache on InvalidClientException', async function () {
             const errToThrow = new Error() as SDK.AWSError
             errToThrow.code = 'InvalidClientException'
 


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Unreliable SSO tests (#1583) caused by unfulfilled promises.

## Solution
Use `clock.runAllAsync` to make sure the tests do not get stuck waiting for a promise to be fulfilled.
Arrow functions were replaced to stay aligned with #1561 (unrelated to the fix).

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
