### PR TITLE
credentials: fix "Create Credentials Profile" command

### DIFF
--- a/src/shared/defaultAwsContextCommands.ts
+++ b/src/shared/defaultAwsContextCommands.ts
@@ -9,7 +9,7 @@ const localize = nls.loadMessageBundle()
 import { Credentials } from 'aws-sdk'
 import { env, QuickPickItem, Uri, ViewColumn, window } from 'vscode'
 import { LoginManager } from '../credentials/loginManager'
-import { fromString } from '../credentials/providers/credentialsProviderId'
+import { CredentialsProviderId, fromString } from '../credentials/providers/credentialsProviderId'
 import { CredentialsProviderManager } from '../credentials/providers/credentialsProviderManager'
 import { AwsContext } from './awsContext'
 import { AwsContextTreeCollection } from './awsContextTreeCollection'
@@ -74,8 +74,12 @@ export class DefaultAWSContextCommands {
 
             if (profileName) {
                 // TODO: change this once we figure out what profile types we should have
-                const profileNameWithType: string = SharedCredentialsProvider.getCredentialsType() + ':' + profileName
-                await this.loginManager.login({ passive: false, providerId: fromString(profileNameWithType) })
+                const sharedProviderId: CredentialsProviderId = {
+                    credentialType: SharedCredentialsProvider.getCredentialsType(),
+                    credentialTypeId: profileName,
+                }
+
+                await this.loginManager.login({ passive: false, providerId: sharedProviderId })
             }
         }
 

--- a/src/shared/defaultAwsContextCommands.ts
+++ b/src/shared/defaultAwsContextCommands.ts
@@ -28,6 +28,7 @@ import { Region } from './regions/endpoints'
 import { RegionProvider } from './regions/regionProvider'
 import { getRegionsForActiveCredentials } from './regions/regionUtilities'
 import { createQuickPick, promptUser } from './ui/picker'
+import { SharedCredentialsProvider } from '../credentials/providers/sharedCredentialsProvider'
 
 const TITLE_HIDE_REGION = localize(
     'AWS.message.prompt.region.hide.title',
@@ -72,12 +73,13 @@ export class DefaultAWSContextCommands {
             const profileName: string | undefined = await this.promptAndCreateNewCredentialsFile()
 
             if (profileName) {
-                await this.loginManager.login({ passive: false, providerId: fromString(profileName) })
+                // TODO: change this once we figure out what profile types we should have
+                const profileNameWithType: string = SharedCredentialsProvider.getCredentialsType() + ':' + profileName
+                await this.loginManager.login({ passive: false, providerId: fromString(profileNameWithType) })
             }
-        } else {
-            // Get the editor set up and turn things over to the user
-            await this.editCredentials()
         }
+
+        await this.editCredentials()
     }
 
     public async onCommandLogout() {


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
The command 'AWS.command.credential.profile.create' was failing despite valid inputs, caused by old code not being updated to use new structures.

## Solution
Create a new `CredentialsProviderId` using the `SharedCredentialsProvider` type and pass that to the login manager. Consider this fix temporary until a more defined way of assigning credential provider types is established.

Bonus: the credentials file is opened after creating a new profile (it was not doing this behavior previously)

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
