### PR TITLE
fix: Pass container environment variables when invoking SAM API

### DIFF
--- a/src/shared/sam/cli/samCliStartApi.ts
+++ b/src/shared/sam/cli/samCliStartApi.ts
@@ -51,6 +51,8 @@ export interface SamCliStartApiArguments {
     parameterOverrides?: string[]
     /** SAM args specified by user (`sam.localArguments`). */
     extraArgs?: string[]
+    /** Path to the container environment variable file */
+    containerEnvFile?: string
 }
 
 /**
@@ -77,6 +79,7 @@ export async function buildSamCliStartApiArguments(args: SamCliStartApiArguments
     pushIf(invokeArgs, !!args.skipPullImage, '--skip-pull-image')
     pushIf(invokeArgs, !!args.debuggerPath, '--debugger-path', args.debuggerPath!)
     pushIf(invokeArgs, !!args.debugArgs, '--debug-args', ...(args.debugArgs ?? []))
+    pushIf(invokeArgs, !!args.containerEnvFile, '--container-env-vars', args.containerEnvFile)
     pushIf(
         invokeArgs,
         !!args.parameterOverrides && args.parameterOverrides.length > 0,

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -257,6 +257,7 @@ export async function invokeLambdaFunction(
             debugArgs: config.debugArgs,
             skipPullImage: config.sam?.skipNewImageCheck,
             parameterOverrides: config.parameterOverrides,
+            containerEnvFile: config.containerEnvFile,
             extraArgs: config.sam?.localArguments,
         })
 
@@ -321,7 +322,7 @@ export async function invokeLambdaFunction(
 
         // sam local invoke ...
         const command = new SamCliLocalInvokeInvocation(localInvokeArgs)
-        let samVersion: string | undefined 
+        let samVersion: string | undefined
         let invokeResult: telemetry.Result = 'Failed'
 
         try {


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Debugger was not attaching when using image lambdas in `start-api` mode. See #1443

This was because container environment variables were not being given to SAM CLI. SAM should be setting defaults if we fail to give it environment variables, but for some reason it isn't. It's difficult to say what the exact cause is due to so many parameters being exchanged. One possibility is that something we're setting is preventing the defaults from being used.

## Solution
Add a `containerEnvFile` field to `buildSamCliStartApiArguments`.

**Future work:**
There seems to be a ton of duplicate code for invoking local lambdas, which is probably why this bug happened (invoke local had the correct field, API did not). Some refactors surrounding the SAM CLI code should be considered, especially for the argument interfaces and functions creating them.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
