### PR TITLE
SAM: Make 'onWillAttachDebugger' do something useful

### DIFF
--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -362,7 +362,7 @@ export async function invokeLambdaFunction(
             getLogger('channel').info(
                 localize('AWS.output.sam.local.waiting', 'Waiting for SAM application to start...')
             )
-            config.onWillAttachDebugger(config.debugPort!, timer)
+            await config.onWillAttachDebugger(config.debugPort!, timer)
         }
         // HACK: remove non-serializable properties before attaching.
         // TODO: revisit this :)


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
`onWillAttachDebugger` was creating a race condition between debugger attachment and checking for ports. 

## Solution
Use 'await' to make it a blocking call. If this causes tests to fail then we should just rip out the `waitForPort` code (it was never doing anything useful before).

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
