### PR TITLE
test/integ: Remove runtime workaround

### DIFF
--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -413,10 +413,6 @@ describe('SAM Integration Tests', async function () {
                 })
 
                 it('produces an Add Debug Configuration codelens', async function () {
-                    if (vscode.version.startsWith('1.42')) {
-                        this.skip()
-                    }
-
                     setTestTimeout(this.test?.fullTitle(), 60000)
                     const codeLenses = await getAddConfigCodeLens(samAppCodeUri)
                     assert.ok(codeLenses && codeLenses.length === 2)
@@ -444,10 +440,6 @@ describe('SAM Integration Tests', async function () {
                 })
 
                 it('invokes and attaches on debug request (F5)', async function () {
-                    if (vscode.version.startsWith('1.42')) {
-                        this.skip()
-                    }
-
                     setTestTimeout(this.test?.fullTitle(), 90000)
                     // Allow previous sessions to go away.
                     const noDebugSession: boolean | undefined = await waitUntil(

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -196,7 +196,7 @@ function validateSamDebugSession(
 ): string | undefined {
     const runtime = (debugSession.configuration as any).runtime
     const name = (debugSession.configuration as any).name
-    if (name !== name || runtime !== expectedRuntime) {
+    if (name !== expectedName || runtime !== expectedRuntime) {
         const failMsg =
             `Unexpected DebugSession (expected name="${expectedName}" runtime="${expectedRuntime}"):` +
             `\n${JSON.stringify(debugSession)}`
@@ -413,6 +413,10 @@ describe('SAM Integration Tests', async function () {
                 })
 
                 it('produces an Add Debug Configuration codelens', async function () {
+                    if (vscode.version.startsWith('1.42') && scenario.language === 'python') {
+                        this.skip()
+                    }
+
                     setTestTimeout(this.test?.fullTitle(), 60000)
                     const codeLenses = await getAddConfigCodeLens(samAppCodeUri)
                     assert.ok(codeLenses && codeLenses.length === 2)
@@ -440,6 +444,10 @@ describe('SAM Integration Tests', async function () {
                 })
 
                 it('invokes and attaches on debug request (F5)', async function () {
+                    if (vscode.version.startsWith('1.42') && scenario.language === 'python') {
+                        this.skip()
+                    }
+
                     setTestTimeout(this.test?.fullTitle(), 90000)
                     // Allow previous sessions to go away.
                     const noDebugSession: boolean | undefined = await waitUntil(

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -376,7 +376,7 @@ describe('SAM Integration Tests', async function () {
                     // Allow previous sessions to go away.
                     const noDebugSession: boolean | undefined = await waitUntil(
                         async () => vscode.debug.activeDebugSession === undefined,
-                        { timeout: 1000, interval: 100, truthy: true }
+                        { timeout: 10000, interval: 100, truthy: true }
                     )
 
                     assert.strictEqual(

--- a/src/integrationTest/shared/codelens/samTemplateCodeLensProvider.test.ts
+++ b/src/integrationTest/shared/codelens/samTemplateCodeLensProvider.test.ts
@@ -28,10 +28,6 @@ describe('SamTemplateCodeLensProvider', async function () {
     })
 
     it('provides a CodeLens for a file with a new resource', async function () {
-        if (vscode.version.startsWith('1.42')) {
-            this.skip()
-        }
-
         const codeLenses = await codeLensProvider.provideCodeLenses(
             document,
             instance(mockCancellationToken),

--- a/src/integrationTest/shared/codelens/samTemplateCodeLensProvider.test.ts
+++ b/src/integrationTest/shared/codelens/samTemplateCodeLensProvider.test.ts
@@ -28,6 +28,10 @@ describe('SamTemplateCodeLensProvider', async function () {
     })
 
     it('provides a CodeLens for a file with a new resource', async function () {
+        if (vscode.version.startsWith('1.42')) {
+            this.skip()
+        }
+
         const codeLenses = await codeLensProvider.provideCodeLenses(
             document,
             instance(mockCancellationToken),


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Extra code was being used to handle runtimes differently. 

## Solution
Moved the `startDebugger` code and rewrote some of it to manage race conditions better.

~~**Removed the skips for 1.42 to test to see if it works now**~~
Python still fails, seems to have something to do with the DAP for that version.

**Also need to make sure this doesn't negatively affect Java tests too much**
<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
