### PR TITLE
build: "await" all async function calls

### DIFF
--- a/src/amazonq/activation.ts
+++ b/src/amazonq/activation.ts
@@ -57,7 +57,7 @@ export const amazonQWelcomeCommand = Commands.declare(
     { id: 'aws.amazonq.welcome', compositeKey: { 1: 'source' } },
     (context: ExtensionContext, publisher: MessagePublisher<any>) => (_: VsCodeCommandArg, source: string) => {
         telemetry.ui_click.run(() => {
-            focusAmazonQPanel()
+            void focusAmazonQPanel()
             welcome(context, publisher)
             telemetry.record({ elementId: 'toolkit_openedWelcomeToAmazonQPage', source })
         })

--- a/src/amazonq/auth/controller.ts
+++ b/src/amazonq/auth/controller.ts
@@ -26,10 +26,10 @@ export class AuthController {
     }
 
     private handleFullAuth() {
-        showManageCwConnections.execute(placeholder, amazonQChatSource)
+        void showManageCwConnections.execute(placeholder, amazonQChatSource)
     }
 
     private handleReAuth() {
-        reconnect.execute(placeholder, amazonQChatSource, true)
+        void reconnect.execute(placeholder, amazonQChatSource, true)
     }
 }

--- a/src/amazonq/commons/controllers/contentController.ts
+++ b/src/amazonq/commons/controllers/contentController.ts
@@ -4,6 +4,7 @@
  */
 
 import { Position, TextEditor, window } from 'vscode'
+import { getLogger } from '../../../shared/logger'
 
 export class EditorContentController {
     public insertTextAtCursorPosition(
@@ -17,11 +18,16 @@ export class EditorContentController {
                 .edit(editBuilder => {
                     editBuilder.insert(cursorStart, text)
                 })
-                .then(appliedEdits => {
-                    if (appliedEdits) {
-                        trackCodeEdit(editor, cursorStart)
+                .then(
+                    appliedEdits => {
+                        if (appliedEdits) {
+                            trackCodeEdit(editor, cursorStart)
+                        }
+                    },
+                    e => {
+                        getLogger().error('TextEditor.edit failed: %s', (e as Error).message)
                     }
-                })
+                )
         }
     }
 }

--- a/src/amazonq/explorer/amazonQChildrenNodes.ts
+++ b/src/amazonq/explorer/amazonQChildrenNodes.ts
@@ -18,7 +18,7 @@ import { focusAmazonQPanel } from '../../auth/ui/vue/show'
 const localize = nls.loadMessageBundle()
 
 export const learnMoreAmazonQCommand = Commands.declare('aws.amazonq.learnMore', () => () => {
-    vscode.env.openExternal(vscode.Uri.parse(amazonQHelpUrl))
+    void vscode.env.openExternal(vscode.Uri.parse(amazonQHelpUrl))
 })
 
 export const createLearnMoreNode = () =>
@@ -33,7 +33,7 @@ export const switchToAmazonQCommand = Commands.declare('_aws.amazonq.focusView',
         elementId: 'amazonq_switchToQChat',
         passive: false,
     })
-    focusAmazonQPanel()
+    void focusAmazonQPanel()
 })
 
 export const switchToAmazonQNode = () =>
@@ -60,7 +60,7 @@ export const createTransformByQ = () => {
     const prefix = transformByQState.getPrefixTextForButton()
     let status = transformByQState.getPolledJobStatus().toLowerCase()
     if (transformByQState.isRunning()) {
-        vscode.commands.executeCommand('setContext', 'gumby.isTransformAvailable', false)
+        void vscode.commands.executeCommand('setContext', 'gumby.isTransformAvailable', false)
         if (status === '') {
             // job is running but polling has not started yet, so display generic message
             status = CodeWhispererConstants.transformByQStateRunningMessage

--- a/src/amazonq/explorer/amazonQNode.ts
+++ b/src/amazonq/explorer/amazonQNode.ts
@@ -47,10 +47,10 @@ export class AmazonQNode implements TreeNode {
     }
 
     private getDescription(): string {
-        vscode.commands.executeCommand('setContext', 'gumby.isTransformAvailable', false)
+        void vscode.commands.executeCommand('setContext', 'gumby.isTransformAvailable', false)
         if (AuthUtil.instance.isConnectionValid()) {
             if (AuthUtil.instance.isEnterpriseSsoInUse()) {
-                vscode.commands.executeCommand('setContext', 'gumby.isTransformAvailable', true)
+                void vscode.commands.executeCommand('setContext', 'gumby.isTransformAvailable', true)
                 return 'IAM Identity Center Connected'
             } else if (AuthUtil.instance.isBuilderIdInUse()) {
                 return 'AWS Builder ID Connected'
@@ -64,7 +64,7 @@ export class AmazonQNode implements TreeNode {
     }
 
     public getChildren() {
-        vscode.commands.executeCommand('setContext', 'gumby.isTransformAvailable', false)
+        void vscode.commands.executeCommand('setContext', 'gumby.isTransformAvailable', false)
         if (AuthUtil.instance.isConnectionExpired()) {
             return [createReconnect('tree'), createLearnMoreNode()]
         }
@@ -85,7 +85,7 @@ export class AmazonQNode implements TreeNode {
         } else {
             // logged in
             if (AuthUtil.instance.isConnectionValid() && AuthUtil.instance.isEnterpriseSsoInUse()) {
-                vscode.commands.executeCommand('setContext', 'gumby.isTransformAvailable', true)
+                void vscode.commands.executeCommand('setContext', 'gumby.isTransformAvailable', true)
                 return [switchToAmazonQNode(), createTransformByQ(), createOpenReferenceLog('tree')] // transform only available for IdC users
             }
             return [switchToAmazonQNode(), createOpenReferenceLog('tree')]

--- a/src/amazonq/onboardingPage/index.ts
+++ b/src/amazonq/onboardingPage/index.ts
@@ -9,6 +9,7 @@ import path from 'path'
 import { MessagePublisher } from '../messages/messagePublisher'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { focusAmazonQPanel } from '../../auth/ui/vue/show'
+import { getLogger } from '../../shared/logger'
 
 export function welcome(context: vscode.ExtensionContext, cwcWebViewToAppsPublisher: MessagePublisher<any>): void {
     const panel = vscode.window.createWebviewPanel(
@@ -34,12 +35,17 @@ export function welcome(context: vscode.ExtensionContext, cwcWebViewToAppsPublis
                 switch (message.command) {
                     case 'sendToQ':
                         telemetry.record({ elementId: 'amazonq_meet_askq' })
-                        focusAmazonQPanel().then(() => {
-                            cwcWebViewToAppsPublisher.publish({
-                                type: 'onboarding-page-cwc-button-clicked',
-                                command: 'onboarding-page-interaction',
-                            })
-                        })
+                        focusAmazonQPanel().then(
+                            () => {
+                                cwcWebViewToAppsPublisher.publish({
+                                    type: 'onboarding-page-cwc-button-clicked',
+                                    command: 'onboarding-page-interaction',
+                                })
+                            },
+                            e => {
+                                getLogger().error('focusAmazonQPanel failed: %s', (e as Error).message)
+                            }
+                        )
 
                         return
 

--- a/src/amazonq/util/viewBadgeHandler.ts
+++ b/src/amazonq/util/viewBadgeHandler.ts
@@ -7,6 +7,7 @@ import { window, TreeItem, TreeView, ViewBadge } from 'vscode'
 import { getLogger } from '../../shared/logger'
 import globals from '../../shared/extensionGlobals'
 import { getChatAuthState } from '../../codewhisperer/util/authUtil'
+import { GlobalState } from '../../shared/globalState'
 
 let badgeHelperView: TreeView<void> | undefined
 const mementoKey = 'hasAlreadyOpenedAmazonQ'
@@ -43,8 +44,7 @@ export function changeViewBadge(badge?: ViewBadge) {
  * Removes the view badge from the badge helper view and prevents it from showing up ever again
  */
 export function deactivateInitialViewBadge() {
-    const memento = globals.context.globalState
-    memento.update(mementoKey, true)
+    GlobalState.instance.tryUpdate(mementoKey, true)
     changeViewBadge()
 }
 

--- a/src/amazonq/webview/messages/messageDispatcher.ts
+++ b/src/amazonq/webview/messages/messageDispatcher.ts
@@ -7,6 +7,7 @@ import { Webview } from 'vscode'
 import { MessagePublisher } from '../../messages/messagePublisher'
 import { MessageListener } from '../../messages/messageListener'
 import { TabType } from '../ui/storages/tabsStorage'
+import { getLogger } from '../../../shared/logger'
 
 export function dispatchWebViewMessagesToApps(
     webview: Webview,
@@ -23,6 +24,8 @@ export function dispatchWebViewMessagesToApps(
 
 export function dispatchAppsMessagesToWebView(webView: Webview, appsMessageListener: MessageListener<any>) {
     appsMessageListener.onMessage(msg => {
-        webView.postMessage(JSON.stringify(msg))
+        webView.postMessage(JSON.stringify(msg)).then(undefined, e => {
+            getLogger().error('webView.postMessage failed: %s', (e as Error).message)
+        })
     })
 }

--- a/src/amazonq/webview/ui/apps/cwChatConnector.ts
+++ b/src/amazonq/webview/ui/apps/cwChatConnector.ts
@@ -211,7 +211,7 @@ export class Connector {
             },
             messageData.command
         )
-        this.sendTriggerTabIDReceived(
+        await this.sendTriggerTabIDReceived(
             messageData.triggerID,
             triggerTabID !== undefined ? triggerTabID : 'no-available-tabs'
         )

--- a/src/amazonq/webview/ui/apps/featureDevChatConnector.ts
+++ b/src/amazonq/webview/ui/apps/featureDevChatConnector.ts
@@ -194,7 +194,7 @@ export class Connector {
         }
 
         if (messageData.type === 'authNeededException') {
-            this.processAuthNeededException(messageData)
+            await this.processAuthNeededException(messageData)
             return
         }
 

--- a/src/amazonq/webview/ui/connector.ts
+++ b/src/amazonq/webview/ui/connector.ts
@@ -98,17 +98,14 @@ export class Connector {
             if (this.isUIReady) {
                 switch (this.tabsStorage.getTab(tabID)?.type) {
                     case 'featuredev':
-                        this.featureDevChatConnector.requestGenerativeAIAnswer(tabID, payload)
-                        break
+                        return this.featureDevChatConnector.requestGenerativeAIAnswer(tabID, payload)
                     default:
-                        this.cwChatConnector.requestGenerativeAIAnswer(tabID, payload)
-                        break
+                        return this.cwChatConnector.requestGenerativeAIAnswer(tabID, payload)
                 }
             } else {
-                setTimeout(() => {
-                    this.requestGenerativeAIAnswer(tabID, payload)
+                return setTimeout(() => {
+                    return this.requestGenerativeAIAnswer(tabID, payload)
                 }, 2000)
-                return
             }
         })
 

--- a/src/amazonq/webview/ui/followUps/handler.ts
+++ b/src/amazonq/webview/ui/followUps/handler.ts
@@ -60,7 +60,7 @@ export class FollowUpInteractionHandler {
             this.tabsStorage.resetTabTimer(tabID)
 
             if (followUp.type !== undefined && followUp.type === 'init-prompt') {
-                this.connector.requestGenerativeAIAnswer(tabID, {
+                void this.connector.requestGenerativeAIAnswer(tabID, {
                     chatMessage: followUp.prompt,
                 })
                 return

--- a/src/amazonq/webview/ui/messages/handler.ts
+++ b/src/amazonq/webview/ui/messages/handler.ts
@@ -47,7 +47,7 @@ export class TextMessageHandler {
 
         this.tabsStorage.updateTabStatus(tabID, 'busy')
 
-        this.connector
+        void this.connector
             .requestGenerativeAIAnswer(tabID, {
                 chatMessage: chatPrompt.prompt ?? '',
                 chatCommand: chatPrompt.command,

--- a/src/amazonq/webview/ui/quickActions/handler.ts
+++ b/src/amazonq/webview/ui/quickActions/handler.ts
@@ -123,7 +123,7 @@ export class QuickActionHandler {
                     promptInputDisabledState: true,
                 })
 
-                this.connector.requestGenerativeAIAnswer(affectedTabId, {
+                void this.connector.requestGenerativeAIAnswer(affectedTabId, {
                     chatMessage: realPromptText,
                 })
             }

--- a/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -59,10 +59,14 @@ export class FeatureDevController {
         this.contentController = new EditorContentController()
 
         this.chatControllerMessageListeners.processHumanChatMessage.event(data => {
-            this.processUserChatMessage(data)
+            this.processUserChatMessage(data).catch(e => {
+                getLogger().error('processUserChatMessage failed: %s', (e as Error).message)
+            })
         })
         this.chatControllerMessageListeners.processChatItemVotedMessage.event(data => {
-            this.processChatItemVotedMessage(data.tabID, data.messageId, data.vote)
+            this.processChatItemVotedMessage(data.tabID, data.messageId, data.vote).catch(e => {
+                getLogger().error('processChatItemVotedMessage failed: %s', (e as Error).message)
+            })
         })
         this.chatControllerMessageListeners.followUpClicked.event(data => {
             switch (data.followUp.type) {

--- a/src/apigateway/commands/copyUrl.ts
+++ b/src/apigateway/commands/copyUrl.ts
@@ -53,7 +53,7 @@ export async function copyUrlCommand(node: RestApiNode, regionProvider: RegionPr
     }))
 
     if (quickPickItems.length === 0) {
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             localize('AWS.apig.copyUrlNoStages', "Failed to copy URL because '{0}' has no stages", node.name)
         )
         telemetry.apigateway_copyUrl.emit({ result: 'Failed' })

--- a/src/apprunner/activation.ts
+++ b/src/apprunner/activation.ts
@@ -38,7 +38,7 @@ const deployServiceFailed = localize(
 const deleteServiceFailed = localize('aws.apprunner.deleteService.failed', 'Failed to delete App Runner service')
 
 const copyUrl = async (node: AppRunnerServiceNode) => {
-    copyToClipboard(node.url, 'URL')
+    await copyToClipboard(node.url, 'URL')
     telemetry.apprunner_copyServiceUrl.emit({ passive: false })
 }
 const openUrl = async (node: AppRunnerServiceNode) => {
@@ -86,7 +86,7 @@ export async function activate(context: ExtContext): Promise<void> {
                     await command(...args)
                 } catch (err) {
                     getLogger().error(`${tuple[1]}: %s`, err)
-                    showViewLogsMessage(tuple[1])
+                    await showViewLogsMessage(tuple[1])
                 }
             })
         )

--- a/src/apprunner/commands/createServiceFromEcr.ts
+++ b/src/apprunner/commands/createServiceFromEcr.ts
@@ -38,7 +38,7 @@ export async function createFromEcr(
         }
 
         await client.createService(result)
-        vscode.commands.executeCommand('aws.refreshAwsExplorer', true)
+        await vscode.commands.executeCommand('aws.refreshAwsExplorer', true)
         telemetryResult = 'Succeeded'
     } finally {
         telemetry.apprunner_createService.emit({

--- a/src/apprunner/wizards/deploymentButton.ts
+++ b/src/apprunner/wizards/deploymentButton.ts
@@ -40,12 +40,12 @@ async function showDeploymentCostNotification(): Promise<void> {
         const viewPricing = localize('aws.apprunner.createService.priceNotice.view', 'View Pricing')
         const pricingUri = vscode.Uri.parse(apprunnerPricingUrl)
 
-        vscode.window.showInformationMessage(notice, viewPricing, dontShow).then(async button => {
+        await vscode.window.showInformationMessage(notice, viewPricing, dontShow).then(async button => {
             if (button === viewPricing) {
-                openUrl(pricingUri)
+                await openUrl(pricingUri)
                 await showDeploymentCostNotification()
             } else if (button === dontShow) {
-                settings.disablePrompt('apprunnerNotifyPricing')
+                await settings.disablePrompt('apprunnerNotifyPricing')
             }
         })
     }

--- a/src/auth/activation.ts
+++ b/src/auth/activation.ts
@@ -20,18 +20,18 @@ export async function initialize(
     awsContext: AwsContext,
     loginManager: LoginManager
 ): Promise<void> {
-    Auth.instance.onDidChangeActiveConnection(conn => {
+    Auth.instance.onDidChangeActiveConnection(async conn => {
         // This logic needs to be moved to `Auth.useConnection` to correctly record `passive`
         if (conn?.type === 'iam' && conn.state === 'valid') {
-            loginManager.login({ passive: true, providerId: fromString(conn.id) })
+            await loginManager.login({ passive: true, providerId: fromString(conn.id) })
         } else {
-            loginManager.logout()
+            await loginManager.logout()
         }
     })
 
     extensionContext.subscriptions.push(showManageConnections.register(extensionContext))
 
-    showManageConnectionsOnStartup()
+    await showManageConnectionsOnStartup()
 }
 
 /**
@@ -53,5 +53,5 @@ async function showManageConnectionsOnStartup() {
     }
 
     // Show connection management to user
-    showManageConnections.execute(placeholder, 'firstStartup')
+    await showManageConnections.execute(placeholder, 'firstStartup')
 }

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -845,7 +845,9 @@ export class Auth implements AuthService, ConnectionManager {
                 getLogger().info(`auth: automatically connected with "${id}"`)
                 // Removes the setting from the UI
                 if (id === legacyProfile) {
-                    new CredentialsSettings().delete('profile')
+                    new CredentialsSettings().delete('profile').catch(e => {
+                        getLogger().warn('CredentialsSettings.delete("profile") failed: %s', (e as Error).message)
+                    })
                 }
             }
         }

--- a/src/auth/connection.ts
+++ b/src/auth/connection.ts
@@ -15,7 +15,7 @@ import { onceChanged } from '../shared/utilities/functionUtils'
 
 /** Shows an error message unless it is the same as the last one shown. */
 const warnOnce = onceChanged((s: string, url: string) => {
-    showMessageWithUrl(s, url, undefined, 'error')
+    void showMessageWithUrl(s, url, undefined, 'error')
 })
 
 export const scopesCodeCatalyst = ['codecatalyst:read_write']

--- a/src/auth/credentials/utils.ts
+++ b/src/auth/credentials/utils.ts
@@ -17,6 +17,7 @@ import { fromExtensionManifest } from '../../shared/settings'
 import { Profile } from './sharedCredentials'
 import { createInputBox, promptUser } from '../../shared/ui/input'
 import { openUrl } from '../../shared/utilities/vsCodeUtils'
+import { getLogger } from '../../shared/logger'
 
 const credentialsTimeout = 300000 // 5 minutes
 const credentialsProgressDelay = 1000
@@ -44,14 +45,17 @@ export function showLoginFailedMessage(credentialsId: string, errMsg: string): v
         localize('AWS.message.credentials.invalid', 'Credentials "{0}" failed to connect: {1}', credentialsId, errMsg),
         'error',
         buttons
-    ).then((selection: string | undefined) => {
-        if (selection === getHelp) {
-            openUrl(vscode.Uri.parse(authHelpUrl))
-        }
-        if (selection === editCreds) {
-            vscode.commands.executeCommand('aws.credentials.edit')
-        }
-    })
+    )
+        .then((selection: string | undefined) => {
+            if (selection === getHelp) {
+                return openUrl(vscode.Uri.parse(authHelpUrl))
+            } else if (selection === editCreds) {
+                return vscode.commands.executeCommand('aws.credentials.edit')
+            }
+        })
+        .catch(e => {
+            getLogger().error('xxx failed: %s', (e as Error).message)
+        })
 }
 
 export function hasProfileProperty(profile: Profile, propertyName: string): boolean {

--- a/src/auth/credentials/utils.ts
+++ b/src/auth/credentials/utils.ts
@@ -17,7 +17,6 @@ import { fromExtensionManifest } from '../../shared/settings'
 import { Profile } from './sharedCredentials'
 import { createInputBox, promptUser } from '../../shared/ui/input'
 import { openUrl } from '../../shared/utilities/vsCodeUtils'
-import { getLogger } from '../../shared/logger'
 
 const credentialsTimeout = 300000 // 5 minutes
 const credentialsProgressDelay = 1000
@@ -41,21 +40,17 @@ export function showLoginFailedMessage(credentialsId: string, errMsg: string): v
     // TODO: getHelp page for Cloud9.
     const buttons = isCloud9() ? [editCreds] : [editCreds, getHelp]
 
-    showViewLogsMessage(
+    void showViewLogsMessage(
         localize('AWS.message.credentials.invalid', 'Credentials "{0}" failed to connect: {1}', credentialsId, errMsg),
         'error',
         buttons
-    )
-        .then((selection: string | undefined) => {
-            if (selection === getHelp) {
-                return openUrl(vscode.Uri.parse(authHelpUrl))
-            } else if (selection === editCreds) {
-                return vscode.commands.executeCommand('aws.credentials.edit')
-            }
-        })
-        .catch(e => {
-            getLogger().error('xxx failed: %s', (e as Error).message)
-        })
+    ).then((selection: string | undefined) => {
+        if (selection === getHelp) {
+            return openUrl(vscode.Uri.parse(authHelpUrl))
+        } else if (selection === editCreds) {
+            return vscode.commands.executeCommand('aws.credentials.edit')
+        }
+    })
 }
 
 export function hasProfileProperty(profile: Profile, propertyName: string): boolean {
@@ -84,7 +79,7 @@ export async function resolveProviderWithCancel(
     globals.clock.setTimeout(() => {
         timeout = timeout as Timeout // Typescript lost scope of the correct type here
         if (timeout.completed !== true) {
-            showMessageWithCancel(
+            void showMessageWithCancel(
                 localize('AWS.message.credentials.pending', 'Getting credentials for profile: {0}', profile),
                 timeout
             )

--- a/src/auth/deprecated/loginManager.ts
+++ b/src/auth/deprecated/loginManager.ts
@@ -181,7 +181,7 @@ export async function loginWithMostRecentCredentials(
             }
             getLogger().info('autoconnect: connected: %O', asString(creds))
             if (popup) {
-                vscode.window.showInformationMessage(
+                await vscode.window.showInformationMessage(
                     localize(
                         'AWS.message.credentials.connected',
                         'Connected to {0} with {1}',
@@ -329,7 +329,7 @@ function createCredentialsShim(
             }
 
             const credentials = await provider.getCredentials()
-            store.setCredentials(credentials, provider)
+            await store.setCredentials(credentials, provider)
             getLogger().debug(`credentials: refresh succeeded for: ${formatProviderId()}`)
             result = 'Succeeded'
 
@@ -338,13 +338,13 @@ function createCredentialsShim(
             if (error instanceof ToolkitError && error.cancelled) {
                 result = 'Cancelled'
             } else {
-                showViewLogsMessage(`Failed to refresh credentials: ${(error as any)?.message}`)
+                void showViewLogsMessage(`Failed to refresh credentials: ${(error as any)?.message}`)
             }
 
             state.credentials = undefined
             store.invalidateCredentials(providerId)
             globals.awsContext.credentialsShim = undefined
-            globals.awsContext.setCredentials(undefined, true)
+            await globals.awsContext.setCredentials(undefined, true)
 
             throw error
         } finally {

--- a/src/auth/deprecated/loginManager.ts
+++ b/src/auth/deprecated/loginManager.ts
@@ -148,7 +148,9 @@ export class LoginManager {
             await loginWithMostRecentCredentials(new CredentialsSettings(), loginManager)
         } catch (err) {
             getLogger().error('credentials: failed to auto-connect: %s', err)
-            showViewLogsMessage(localize('AWS.credentials.autoconnect.fatal', 'Exception occurred while connecting'))
+            void showViewLogsMessage(
+                localize('AWS.credentials.autoconnect.fatal', 'Exception occurred while connecting')
+            )
         }
         return !!(await awsContext.getCredentials())
     }

--- a/src/auth/secondaryAuth.ts
+++ b/src/auth/secondaryAuth.ts
@@ -124,7 +124,9 @@ export class SecondaryAuth<T extends Connection = Connection> {
         })
 
         // Register listener and handle connection immediately in case we were instantiated late
-        handleConnectionChanged(this.auth.activeConnection)
+        handleConnectionChanged(this.auth.activeConnection).catch(e => {
+            getLogger().error('handleConnectionChanged() failed: %s', (e as Error).message)
+        })
         this.auth.onDidChangeActiveConnection(handleConnectionChanged)
         this.auth.onDidDeleteConnection(async (deletedConnId: Connection['id']) => {
             if (deletedConnId === this.#activeConnection?.id) {

--- a/src/auth/ui/statusBarItem.ts
+++ b/src/auth/ui/statusBarItem.ts
@@ -29,7 +29,7 @@ export async function initializeAwsCredentialsStatusBarItem(
 
     const update = debounce(() => updateItem(statusBarItem, devSettings))
 
-    update()
+    await update()
     context.subscriptions.push(
         statusBarItem,
         onDidChangeConnections(() => update()),

--- a/src/auth/ui/vue/show.ts
+++ b/src/auth/ui/vue/show.ts
@@ -181,7 +181,7 @@ export class AuthWebview extends VueWebview {
     }
 
     async showAmazonQChat(): Promise<void> {
-        focusAmazonQPanel()
+        return focusAmazonQPanel()
     }
 
     async getIdentityCenterRegion(): Promise<Region | undefined> {
@@ -781,7 +781,9 @@ async function showAuthWebview(
         subscriptions = [
             webview.onDidDispose(() => {
                 if (activePanel) {
-                    emitWebviewClosed(activePanel.server)
+                    emitWebviewClosed(activePanel.server).catch(e => {
+                        getLogger().error('emitWebviewClosed failed: %s', (e as Error).message)
+                    })
                 }
                 vscode.Disposable.from(...(subscriptions ?? [])).dispose()
                 activePanel = undefined

--- a/src/auth/ui/vue/show.ts
+++ b/src/auth/ui/vue/show.ts
@@ -169,15 +169,15 @@ export class AuthWebview extends VueWebview {
     }
 
     async showResourceExplorer(): Promise<void> {
-        vscode.commands.executeCommand('aws.explorer.focus')
+        await vscode.commands.executeCommand('aws.explorer.focus')
     }
 
     async showCodeWhispererView(): Promise<void> {
-        vscode.commands.executeCommand('aws.codewhisperer.focus')
+        await vscode.commands.executeCommand('aws.codewhisperer.focus')
     }
 
     async showCodeCatalystNode(): Promise<void> {
-        vscode.commands.executeCommand('aws.codecatalyst.maybeFocus')
+        await vscode.commands.executeCommand('aws.codecatalyst.maybeFocus')
     }
 
     async showAmazonQChat(): Promise<void> {
@@ -410,7 +410,7 @@ export class AuthWebview extends VueWebview {
     }
 
     openFeedbackForm() {
-        submitFeedback.execute(placeholder, 'AWS Toolkit')
+        return submitFeedback.execute(placeholder, 'AWS Toolkit')
     }
 
     // -------------------- Telemetry Stuff --------------------
@@ -614,6 +614,8 @@ export class AuthWebview extends VueWebview {
             featureType,
             result: 'Succeeded',
             attempts: authAttempts,
+        }).catch(e => {
+            getLogger().error('emitAuthAttempt failed: %s', (e as Error).message)
         })
         this.addSuccessfulAuth(id)
     }

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -62,7 +62,7 @@ export async function promptForConnection(auth: Auth, type?: 'iam' | 'sso'): Pro
     if (resp === 'addNewConnection') {
         // TODO: Cannot call function directly due to circular dependency. Refactor to fix this.
         const source: AuthSource = 'addConnectionQuickPick' // enforcing type sanity check
-        vscode.commands.executeCommand(showConnectionsPageCommand, placeholder, source)
+        await vscode.commands.executeCommand(showConnectionsPageCommand, placeholder, source)
         return undefined
     }
 
@@ -235,7 +235,7 @@ export async function showRegionPrompter(
 }
 
 Commands.register('aws.auth.help', async () => {
-    openUrl(vscode.Uri.parse(authHelpUrl))
+    await openUrl(vscode.Uri.parse(authHelpUrl))
     telemetry.aws_help.emit()
 })
 
@@ -558,7 +558,10 @@ export class AuthNode implements TreeNode<Auth> {
 
     public getTreeItem() {
         // Calling this here is robust but `TreeShim` must be instantiated lazily to stop side-effects
-        this.resource.tryAutoConnect()
+        // TODO: this is a race!
+        this.resource.tryAutoConnect().catch(e => {
+            getLogger().error('tryAutoConnect failed: %s', (e as Error).message)
+        })
 
         if (!this.resource.hasConnections) {
             const item = new vscode.TreeItem(`Connect to ${getIdeProperties().company} to Get Started...`)
@@ -725,7 +728,9 @@ export class ExtensionUse {
         }
 
         // Update state, so next time it is not first use
-        state.update(this.isExtensionFirstUseKey, false)
+        state.update(this.isExtensionFirstUseKey, false).then(undefined, e => {
+            getLogger().error('Memento.update failed: %s', (e as Error).message)
+        })
 
         return this.isFirstUseCurrentSession
     }

--- a/src/codecatalyst/devEnv.ts
+++ b/src/codecatalyst/devEnv.ts
@@ -206,7 +206,7 @@ class Message implements vscode.Disposable {
                     this.currentWarningMessageTimeout!.cancel()
                 })
         } else {
-            showMessageWithCancel(
+            void showMessageWithCancel(
                 this.buildInactiveWarningMessage(minutesUserWasInactive, minutesUntilShutdown),
                 this.currentWarningMessageTimeout
             )

--- a/src/ecs/commands.ts
+++ b/src/ecs/commands.ts
@@ -88,7 +88,7 @@ export const runCommandInContainer = Commands.register('aws.ecs.runCommandInCont
 
         const { container, task, command } = await runCommandWizard(obj)
         const timeout = new Timeout(600000)
-        showMessageWithCancel('Running command...', timeout)
+        void showMessageWithCancel('Running command...', timeout)
 
         try {
             const { path, args, dispose } = await container.prepareCommandForTask(command, task)

--- a/src/shared/activationReloadState.ts
+++ b/src/shared/activationReloadState.ts
@@ -36,19 +36,19 @@ export class ActivationReloadState {
     }
 
     public setSamInitState(state: SamInitState): void {
-        this.extensionContext.globalState.update(activationTemplatePathKey, state.template)
-        this.extensionContext.globalState.update(activationLaunchPathKey, state.readme)
-        this.extensionContext.globalState.update(samInitRuntimeKey, state.runtime)
-        this.extensionContext.globalState.update(samInitArchKey, state.architecture)
-        this.extensionContext.globalState.update(samInitImageBooleanKey, state.isImage)
+        void this.extensionContext.globalState.update(activationTemplatePathKey, state.template)
+        void this.extensionContext.globalState.update(activationLaunchPathKey, state.readme)
+        void this.extensionContext.globalState.update(samInitRuntimeKey, state.runtime)
+        void this.extensionContext.globalState.update(samInitArchKey, state.architecture)
+        void this.extensionContext.globalState.update(samInitImageBooleanKey, state.isImage)
     }
 
     public clearSamInitState(): void {
-        this.extensionContext.globalState.update(activationTemplatePathKey, undefined)
-        this.extensionContext.globalState.update(activationLaunchPathKey, undefined)
-        this.extensionContext.globalState.update(samInitRuntimeKey, undefined)
-        this.extensionContext.globalState.update(samInitArchKey, undefined)
-        this.extensionContext.globalState.update(samInitImageBooleanKey, undefined)
+        void this.extensionContext.globalState.update(activationTemplatePathKey, undefined)
+        void this.extensionContext.globalState.update(activationLaunchPathKey, undefined)
+        void this.extensionContext.globalState.update(samInitRuntimeKey, undefined)
+        void this.extensionContext.globalState.update(samInitArchKey, undefined)
+        void this.extensionContext.globalState.update(samInitImageBooleanKey, undefined)
     }
 
     protected get extensionContext(): vscode.ExtensionContext {

--- a/src/shared/awsContextCommands.ts
+++ b/src/shared/awsContextCommands.ts
@@ -135,7 +135,7 @@ export class AwsContextCommands {
             credentialTypeId: resp.name,
         }
 
-        vscode.window.showInformationMessage(
+        await vscode.window.showInformationMessage(
             localize(
                 'AWS.message.prompt.credentials.definition.done',
                 'Created {0} credentials profile: {1}',
@@ -164,9 +164,9 @@ export class AwsContextCommands {
         if (userResponse === localizedText.yes) {
             return true
         } else if (userResponse === localizedText.no) {
-            PromptSettings.instance.disablePrompt('createCredentialsProfile')
+            await PromptSettings.instance.disablePrompt('createCredentialsProfile')
         } else if (userResponse === localizedText.help) {
-            openUrl(vscode.Uri.parse(credentialHelpUrl))
+            await openUrl(vscode.Uri.parse(credentialHelpUrl))
             return await this.promptCredentialsSetup()
         }
 

--- a/src/shared/awsFiletypes.ts
+++ b/src/shared/awsFiletypes.ts
@@ -100,7 +100,7 @@ export function activate(): void {
                 doc.languageId !== 'ini' &&
                 (basename === 'credentials' || basename === 'config')
             ) {
-                vscode.languages.setTextDocumentLanguage(doc, 'ini')
+                await vscode.languages.setTextDocumentLanguage(doc, 'ini')
             }
 
             if (await isSameMetricPending(telemKind, fileExt)) {

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -29,7 +29,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
         extensionContext.subscriptions.push(registry)
         setTemplateRegistryInGlobals(registry)
     } catch (e) {
-        vscode.window.showErrorMessage(
+        await vscode.window.showErrorMessage(
             localize(
                 'AWS.codelens.failToInitialize',
                 'Failed to activate template registry. {0}} will not appear on SAM template files.',

--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -317,7 +317,7 @@ export async function makePythonCodeLensProvider(configuration: SamCliSettings):
                 return []
             }
             // Try to activate the Python Extension before requesting symbols from a python file
-            activateExtension(VSCODE_EXTENSION_ID.python)
+            await activateExtension(VSCODE_EXTENSION_ID.python)
             if (token.isCancellationRequested) {
                 return []
             }

--- a/src/shared/credentials/defaultCredentialSelectionDataProvider.ts
+++ b/src/shared/credentials/defaultCredentialSelectionDataProvider.ts
@@ -253,7 +253,7 @@ export async function credentialProfileSelector(
         ]
         const item = await dataProvider.pickCredentialProfile(input, actions, state)
         if (item.label === actions[0].label) {
-            vscode.commands.executeCommand('aws.credentials.edit')
+            await vscode.commands.executeCommand('aws.credentials.edit')
         } else {
             state.credentialProfile = item
         }

--- a/src/shared/debug/launchConfiguration.ts
+++ b/src/shared/debug/launchConfiguration.ts
@@ -127,11 +127,13 @@ class DefaultDebugConfigSource implements DebugConfigurationSource {
         } catch (e) {
             const helpText = localize('AWS.generic.message.getHelp', 'Get Help...')
             getLogger().error('setDebugConfigurations failed: %O', e as Error)
-            showViewLogsMessage(makeFailedWriteMessage('launch.json'), 'error', [helpText]).then(async buttonText => {
-                if (buttonText === helpText) {
-                    openUrl(vscode.Uri.parse(launchConfigDocUrl))
+            await showViewLogsMessage(makeFailedWriteMessage('launch.json'), 'error', [helpText]).then(
+                async buttonText => {
+                    if (buttonText === helpText) {
+                        await openUrl(vscode.Uri.parse(launchConfigDocUrl))
+                    }
                 }
-            })
+            )
         }
     }
 }

--- a/src/shared/extensionUtilities.ts
+++ b/src/shared/extensionUtilities.ts
@@ -174,7 +174,9 @@ export async function showQuickStartWebview(context: vscode.ExtensionContext): P
         const view = await createQuickStartWebview(context)
         view.reveal()
     } catch {
-        vscode.window.showErrorMessage(localize('AWS.command.quickStart.error', 'Error while loading Quick Start page'))
+        await vscode.window.showErrorMessage(
+            localize('AWS.command.quickStart.error', 'Error while loading Quick Start page')
+        )
     }
 }
 
@@ -261,7 +263,9 @@ export function isDifferentVersion(context: vscode.ExtensionContext, currVersion
  * @param context VS Code Extension Context
  */
 export function setMostRecentVersion(context: vscode.ExtensionContext): void {
-    context.globalState.update(mostRecentVersionKey, extensionVersion)
+    context.globalState.update(mostRecentVersionKey, extensionVersion).then(undefined, e => {
+        getLogger().error('globalState.update() failed: %s', (e as Error).message)
+    })
 }
 
 /**
@@ -280,7 +284,7 @@ async function promptQuickstart(): Promise<void> {
         view
     )
     if (prompt === view) {
-        vscode.commands.executeCommand('aws.quickStart')
+        await vscode.commands.executeCommand('aws.quickStart')
     }
 }
 
@@ -301,7 +305,7 @@ export function showWelcomeMessage(context: vscode.ExtensionContext): void {
     }
     const version = vscode.extensions.getExtension(VSCODE_EXTENSION_ID.awstoolkit)?.packageJSON.version
     if (version === extensionAlphaVersion) {
-        vscode.window.showWarningMessage(
+        void vscode.window.showWarningMessage(
             localize(
                 'AWS.startup.toastIfAlpha',
                 '{0} Toolkit PREVIEW. (To get the latest STABLE version, uninstall this version.)',
@@ -314,7 +318,7 @@ export function showWelcomeMessage(context: vscode.ExtensionContext): void {
         if (isDifferentVersion(context)) {
             setMostRecentVersion(context)
             if (!isCloud9()) {
-                promptQuickstart()
+                void promptQuickstart()
             }
         }
     } catch (err) {
@@ -331,7 +335,7 @@ export async function aboutToolkit(): Promise<void> {
     const copyButtonLabel = localize('AWS.message.prompt.copyButtonLabel', 'Copy')
     const result = await vscode.window.showInformationMessage(toolkitEnvDetails, { modal: true }, copyButtonLabel)
     if (result === copyButtonLabel) {
-        vscode.env.clipboard.writeText(toolkitEnvDetails)
+        void vscode.env.clipboard.writeText(toolkitEnvDetails)
     }
 }
 

--- a/src/shared/extensions/git.ts
+++ b/src/shared/extensions/git.ts
@@ -382,7 +382,7 @@ export class GitExtension {
 
             return { files, dispose: () => tryRemoveFolder(tmpDir), stats: { downloadSize } }
         } catch (err) {
-            tryRemoveFolder(tmpDir)
+            void tryRemoveFolder(tmpDir)
             throw err
         }
     }

--- a/src/shared/extensions/ssh.ts
+++ b/src/shared/extensions/ssh.ts
@@ -64,7 +64,7 @@ exit !$?
             })
 
             if (!result.stdout.includes(runningMessage) && !result.stderr) {
-                vscode.window.showInformationMessage(
+                await vscode.window.showInformationMessage(
                     localize('AWS.ssh.ssh-agent.start', 'The SSH agent has been started.')
                 )
             }
@@ -130,7 +130,10 @@ export async function startVscodeRemote(
     const workspaceUri = `vscode-remote://ssh-remote+${userAt}${hostname}${targetDirectory}`
 
     const settings = new RemoteSshSettings()
-    settings.ensureDefaultExtension(VSCODE_EXTENSION_ID.awstoolkit)
+    settings.ensureDefaultExtension(VSCODE_EXTENSION_ID.awstoolkit).catch(e => {
+        // Non-fatal. Some users intentionally have readonly settings.
+        getLogger().warn('startVscodeRemote: failed to set "defaultExtensions": %s', (e as Error).message)
+    })
 
     if (process.platform === 'win32') {
         await Promise.all([

--- a/src/shared/filesystemUtilities.ts
+++ b/src/shared/filesystemUtilities.ts
@@ -13,6 +13,7 @@ import * as vscode from 'vscode'
 import { getLogger } from './logger'
 import * as pathutils from './utilities/pathUtils'
 import globals from '../shared/extensionGlobals'
+import { GlobalState } from './globalState'
 
 const defaultEncoding: BufferEncoding = 'utf8'
 
@@ -272,9 +273,9 @@ export async function setDefaultDownloadPath(downloadPath: string) {
     try {
         const savePath = await stat(downloadPath)
         if (savePath.isDirectory()) {
-            globals.context.globalState.update('aws.downloadPath', downloadPath)
+            GlobalState.instance.tryUpdate('aws.downloadPath', downloadPath)
         } else {
-            globals.context.globalState.update('aws.downloadPath', path.dirname(downloadPath))
+            GlobalState.instance.tryUpdate('aws.downloadPath', path.dirname(downloadPath))
         }
     } catch (err) {
         getLogger().error('Error while setting "aws.downloadPath"', err as Error)

--- a/src/shared/fs/templateRegistry.ts
+++ b/src/shared/fs/templateRegistry.ts
@@ -108,13 +108,18 @@ export class AsyncCloudFormationTemplateRegistry {
             }
         })
 
-        this.setupPromise.then(() => {
-            if (perf) {
-                perf.done()
+        this.setupPromise.then(
+            () => {
+                if (perf) {
+                    perf.done()
+                }
+                this.isSetup = true
+                cancelSetup.dispose()
+            },
+            e => {
+                getLogger().error('AsyncCloudFormationTemplateRegistry: setupPromise failed: %s', (e as Error).message)
             }
-            this.isSetup = true
-            cancelSetup.dispose()
-        })
+        )
 
         return this.setupPromise
     }

--- a/src/shared/fs/watchedFiles.ts
+++ b/src/shared/fs/watchedFiles.ts
@@ -167,12 +167,12 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
         this.disposables.push(
             vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => {
                 if (isUntitledScheme(event.document.uri)) {
-                    this.addItem(event.document.uri, true, event.document.getText())
+                    return this.addItem(event.document.uri, true, event.document.getText())
                 }
             }),
             vscode.workspace.onDidCloseTextDocument((event: vscode.TextDocument) => {
                 if (isUntitledScheme(event.uri)) {
-                    this.remove(event.uri)
+                    return this.remove(event.uri)
                 }
             })
         )

--- a/src/shared/globalState.ts
+++ b/src/shared/globalState.ts
@@ -1,0 +1,41 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import globals from './extensionGlobals'
+import { getLogger } from './logger/logger'
+
+export class GlobalState implements vscode.Memento {
+    static #instance: GlobalState
+    static get instance(): GlobalState {
+        return (this.#instance ??= new GlobalState())
+    }
+
+    public keys(): readonly string[] {
+        return globals.context.globalState.keys()
+    }
+
+    public get<T>(key: string, defaultValue?: T): T | undefined {
+        return globals.context.globalState.get(key) ?? defaultValue
+    }
+
+    /** Asynchronously updates globalState, or logs an error on failure. */
+    public tryUpdate(key: string, value: any): void {
+        globals.context.globalState.update(key, value).then(
+            undefined, // TODO: log.debug() ?
+            e => {
+                getLogger().error('GlobalState: failed to set "%s": %s', key, (e as Error).message)
+            }
+        )
+    }
+
+    public update(key: string, value: any): Thenable<void> {
+        return globals.context.globalState.update(key, value)
+    }
+
+    public static samAndCfnSchemaDestinationUri() {
+        return vscode.Uri.joinPath(globals.context.globalStorageUri, 'sam.schema.json')
+    }
+}

--- a/src/shared/logger/activation.ts
+++ b/src/shared/logger/activation.ts
@@ -198,7 +198,7 @@ async function createLogWatcher(logFile: vscode.Uri): Promise<vscode.Disposable>
         }
         checking = true
         if (!(await fsCommon.fileExists(logFile))) {
-            vscode.window.showWarningMessage(
+            await vscode.window.showWarningMessage(
                 localize('AWS.log.logFileMove', 'The log file for this session has been moved or deleted.')
             )
             watcher.close()

--- a/src/shared/regions/regionProvider.ts
+++ b/src/shared/regions/regionProvider.ts
@@ -173,7 +173,7 @@ export class RegionProvider {
         load().catch(err => {
             getLogger().error('Failure while loading Endpoints Manifest: %s', err)
 
-            vscode.window.showErrorMessage(
+            return vscode.window.showErrorMessage(
                 `${localize(
                     'AWS.error.endpoint.load.failure',
                     'The {0} Toolkit was unable to load endpoints data.',

--- a/src/shared/remoteSession.ts
+++ b/src/shared/remoteSession.ts
@@ -50,7 +50,7 @@ async function withoutShellIntegration<T>(cb: () => T | Promise<T>): Promise<T> 
         await Settings.instance.update('terminal.integrated.shellIntegration.enabled', false)
         return await cb()
     } finally {
-        Settings.instance.update('terminal.integrated.shellIntegration.enabled', userValue)
+        await Settings.instance.update('terminal.integrated.shellIntegration.enabled', userValue)
     }
 }
 

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -65,7 +65,7 @@ export async function activate(ctx: ExtContext): Promise<void> {
     }
 
     if (config.get('enableCodeLenses', false)) {
-        activateSlowCodeLensesOnce()
+        await activateSlowCodeLensesOnce()
     }
 
     await registerCommands(ctx, config)
@@ -97,7 +97,7 @@ export async function activate(ctx: ExtContext): Promise<void> {
         switch (event.key) {
             case 'location':
                 // This only shows a message (passive=true), does not set anything.
-                sharedDetectSamCli({ passive: true, showMessage: true })
+                await sharedDetectSamCli({ passive: true, showMessage: true })
                 break
             case 'enableCodeLenses':
                 if (config.get(event.key, false) && !didActivateCodeLensProviders) {
@@ -156,7 +156,7 @@ async function registerCommands(ctx: ExtContext, settings: SamCliSettings): Prom
         }),
         Commands.register({ id: 'aws.toggleSamCodeLenses', autoconnect: false }, async () => {
             const toggled = !settings.get('enableCodeLenses', false)
-            settings.update('enableCodeLenses', toggled)
+            await settings.update('enableCodeLenses', toggled)
         })
     )
 }
@@ -180,7 +180,7 @@ async function activateCodeLensRegistry(context: ExtContext) {
         ])
         await registry.rebuild()
     } catch (e) {
-        vscode.window.showErrorMessage(
+        await vscode.window.showErrorMessage(
             localize(
                 'AWS.codelens.failToInitializeCode',
                 'Failed to activate Lambda handler {0}',
@@ -199,7 +199,7 @@ async function samDebugConfigCmd() {
     const activeEditor = vscode.window.activeTextEditor
     if (!activeEditor) {
         getLogger().error(`aws.addSamDebugConfig was called without an active text editor`)
-        vscode.window.showErrorMessage(
+        await vscode.window.showErrorMessage(
             localize('AWS.pickDebugHandler.noEditor', 'Toolkit could not find an active editor')
         )
 
@@ -209,7 +209,7 @@ async function samDebugConfigCmd() {
     const provider = supportedLanguages[document.languageId]
     if (!provider) {
         getLogger().error(`aws.addSamDebugConfig called on a document with an invalid language: ${document.languageId}`)
-        vscode.window.showErrorMessage(
+        await vscode.window.showErrorMessage(
             localize(
                 'AWS.pickDebugHandler.invalidLanguage',
                 'Toolkit cannot detect handlers in language: {0}',
@@ -222,7 +222,7 @@ async function samDebugConfigCmd() {
 
     // TODO: No reason for this to depend on the codelense provider (which scans the whole workspace and creates filewatchers).
     const lenses = (await provider.provideCodeLenses(document, new vscode.CancellationTokenSource().token, true)) ?? []
-    codelensUtils.invokeCodeLensCommandPalette(document, lenses)
+    await codelensUtils.invokeCodeLensCommandPalette(document, lenses)
 }
 
 /**
@@ -312,7 +312,7 @@ async function createYamlExtensionPrompt(): Promise<void> {
         for (const change of event.contentChanges) {
             const changedLine = event.document.lineAt(change.range.start.line)
             if (changedLine.text.includes('AWSTemplateFormatVersion')) {
-                promptInstallYamlPlugin(yamlPromptDisposables)
+                await promptInstallYamlPlugin(yamlPromptDisposables)
                 return
             }
         }

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -333,7 +333,7 @@ async function createYamlExtensionPrompt(): Promise<void> {
         // user opens a template file
         vscode.workspace.onDidOpenTextDocument(
             async (doc: vscode.TextDocument) => {
-                promptInstallYamlPluginFromFilename(doc.fileName, yamlPromptDisposables)
+                void promptInstallYamlPluginFromFilename(doc.fileName, yamlPromptDisposables)
             },
             undefined,
             yamlPromptDisposables
@@ -381,7 +381,7 @@ async function createYamlExtensionPrompt(): Promise<void> {
         })
 
         if (openTemplateYamls.length > 0) {
-            promptInstallYamlPluginFromEditor(openTemplateYamls[0], yamlPromptDisposables)
+            void promptInstallYamlPluginFromEditor(openTemplateYamls[0], yamlPromptDisposables)
         }
     }
 }
@@ -391,7 +391,7 @@ async function promptInstallYamlPluginFromEditor(
     disposables: vscode.Disposable[]
 ): Promise<void> {
     if (editor) {
-        promptInstallYamlPluginFromFilename(editor.document.fileName, disposables)
+        void promptInstallYamlPluginFromFilename(editor.document.fileName, disposables)
     }
 }
 
@@ -402,7 +402,7 @@ async function promptInstallYamlPluginFromEditor(
  */
 async function promptInstallYamlPluginFromFilename(fileName: string, disposables: vscode.Disposable[]): Promise<void> {
     if (fileName.endsWith('template.yaml') || fileName.endsWith('template.yml')) {
-        promptInstallYamlPlugin(disposables)
+        void promptInstallYamlPlugin(disposables)
     }
 }
 
@@ -432,9 +432,9 @@ async function promptInstallYamlPlugin(disposables: vscode.Disposable[]) {
 
     switch (response) {
         case installBtn:
-            showExtensionPage(VSCODE_EXTENSION_ID.yaml)
+            await showExtensionPage(VSCODE_EXTENSION_ID.yaml)
             break
         case permanentlySuppress:
-            settings.disablePrompt('yamlExtPrompt')
+            await settings.disablePrompt('yamlExtPrompt')
     }
 }

--- a/src/shared/sam/cli/samCliDetection.ts
+++ b/src/shared/sam/cli/samCliDetection.ts
@@ -49,7 +49,7 @@ export async function detectSamCli(args: { passive: boolean; showMessage: boolea
         if (notFound) {
             notifyUserSamCliNotDetected(config)
         } else if (args.showMessage === true) {
-            vscode.window.showInformationMessage(getSettingsUpdatedMessage(sam.path ?? '?'))
+            void vscode.window.showInformationMessage(getSettingsUpdatedMessage(sam.path ?? '?'))
         }
     }
 
@@ -60,7 +60,7 @@ export async function detectSamCli(args: { passive: boolean; showMessage: boolea
 
 function notifyUserSamCliNotDetected(SamCliSettings: SamCliSettings): void {
     // inform the user, but don't wait for this to complete
-    vscode.window
+    void vscode.window
         .showErrorMessage(
             localize(
                 'AWS.samcli.error.notFound',
@@ -83,7 +83,7 @@ function notifyUserSamCliNotDetected(SamCliSettings: SamCliSettings): void {
                 if (!!location && location.length === 1) {
                     const path: string = location[0].fsPath
                     await SamCliSettings.update('location', path)
-                    vscode.window.showInformationMessage(getSettingsUpdatedMessage(path))
+                    void vscode.window.showInformationMessage(getSettingsUpdatedMessage(path))
                 }
             }
         })

--- a/src/shared/sam/cli/samCliSettings.ts
+++ b/src/shared/sam/cli/samCliSettings.ts
@@ -93,7 +93,7 @@ export class SamCliSettings extends fromExtensionManifest('aws.samcli', descript
         try {
             return this.get('manuallySelectedBuckets')
         } catch (error) {
-            this.delete('manuallySelectedBuckets')
+            void this.delete('manuallySelectedBuckets')
         }
     }
 

--- a/src/shared/sam/cli/samCliValidationNotification.ts
+++ b/src/shared/sam/cli/samCliValidationNotification.ts
@@ -31,7 +31,7 @@ export interface SamCliValidationNotificationAction {
 const actionGoToSamCli: SamCliValidationNotificationAction = {
     label: () => localize('AWS.samcli.userChoice.visit.install.url', 'Install latest SAM CLI'),
     invoke: async () => {
-        openUrl(samInstallUrl)
+        void openUrl(samInstallUrl)
     },
 }
 
@@ -43,7 +43,7 @@ const actionGoToVsCodeMarketplace: SamCliValidationNotificationAction = {
             getIdeProperties().company
         ),
     invoke: async () => {
-        showExtensionPage(VSCODE_EXTENSION_ID.awstoolkit)
+        void showExtensionPage(VSCODE_EXTENSION_ID.awstoolkit)
     },
 }
 

--- a/src/shared/sam/cli/samCliValidationUtils.ts
+++ b/src/shared/sam/cli/samCliValidationUtils.ts
@@ -38,7 +38,7 @@ export function throwAndNotifyIfInvalid(validationResult: SamCliValidatorResult)
         if (err instanceof InvalidSamCliError) {
             // SAM not found.
             // Calling code does not wait for the notification to complete
-            notifySamCliValidation(err)
+            void notifySamCliValidation(err)
         }
 
         // SAM found but version is invalid or failed to parse.

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -377,11 +377,11 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
             }
         } catch (err) {
             if (err instanceof SamLaunchRequestError) {
-                err.showNotification()
+                void err.showNotification()
             } else if (err instanceof ToolkitError) {
-                new SamLaunchRequestError(err.message, { ...err }).showNotification()
+                void new SamLaunchRequestError(err.message, { ...err }).showNotification()
             } else {
-                SamLaunchRequestError.chain(err, 'Failed to run launch configuration').showNotification()
+                void SamLaunchRequestError.chain(err, 'Failed to run launch configuration').showNotification()
             }
         }
     }
@@ -443,7 +443,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
             if (!rv.isValid) {
                 throw new ToolkitError(`Invalid launch configuration: ${rv.message}`, { code: 'BadLaunchConfig' })
             } else if (rv.message) {
-                vscode.window.showInformationMessage(rv.message)
+                void vscode.window.showInformationMessage(rv.message)
             }
             getLogger().verbose(`SAM debug: config: ${JSON.stringify(config.name)}`)
         }
@@ -460,7 +460,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         const handlerName = await getHandlerName(folder, config)
 
         config.baseBuildDir = resolve(folder.uri.fsPath, config.sam?.buildDir ?? (await makeTemporaryToolkitFolder()))
-        fs.ensureDir(config.baseBuildDir)
+        await fs.ensureDir(config.baseBuildDir)
 
         if (templateInvoke?.templatePath) {
             // Normalize to absolute path.
@@ -521,7 +521,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         if (goRuntimes.includes(runtime) && !config.noDebug) {
             const samCliVersion = await getSamCliVersion(this.ctx.samCliContext())
             if (semver.lt(samCliVersion, minSamCliVersionForGoSupport)) {
-                vscode.window.showWarningMessage(
+                void vscode.window.showWarningMessage(
                     localize(
                         'AWS.output.sam.local.no.go.support',
                         'Debugging go1.x lambdas requires a minimum SAM CLI version of {0}. Function will run locally without debug.',

--- a/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
@@ -45,7 +45,7 @@ export async function addSamDebugConfiguration(
     step?: { step: number; totalSteps: number }
 ): Promise<void> {
     // emit without waiting
-    emitCommandTelemetry()
+    void emitCommandTelemetry()
 
     let samDebugConfig: AwsSamDebuggerConfiguration
     const workspaceFolder = vscode.workspace.getWorkspaceFolder(rootUri)
@@ -168,7 +168,7 @@ export async function addSamDebugConfiguration(
     }
 
     if (openWebview) {
-        vscode.commands.executeCommand('aws.launchConfigForm', samDebugConfig)
+        await vscode.commands.executeCommand('aws.launchConfigForm', samDebugConfig)
     } else {
         const launchConfig = new LaunchConfiguration(rootUri)
         await launchConfig.addDebugConfiguration(samDebugConfig)

--- a/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
@@ -178,7 +178,7 @@ export async function addSamDebugConfiguration(
 }
 
 export async function openLaunchJsonFile(): Promise<void> {
-    vscode.commands.executeCommand(
+    await vscode.commands.executeCommand(
         vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length <= 1
             ? 'workbench.action.debug.configure'
             : 'workbench.action.openWorkspaceSettingsFile'

--- a/src/shared/sam/debugger/csharpSamDebug.ts
+++ b/src/shared/sam/debugger/csharpSamDebug.ts
@@ -80,7 +80,7 @@ export async function invokeCsharpLambda(ctx: ExtContext, config: SamLaunchReque
 
     if (!config.noDebug) {
         if (config.architecture === 'arm64') {
-            vscode.window.showWarningMessage(
+            await vscode.window.showWarningMessage(
                 localize(
                     'AWS.sam.noArm.dotnet.debug',
                     'The vsdbg debugger does not currently support the arm64 architecture. Function will run locally without debug.'

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -413,7 +413,7 @@ async function requestLocalApi(
                 } else if (!notificationShown && obj.attemptCount >= retryLimit) {
                     notificationShown = true
                     getLogger().debug('Local API: showing cancel notification')
-                    showMessageWithCancel('Waiting for local API to start...', timeout)
+                    void showMessageWithCancel('Waiting for local API to start...', timeout)
                 }
 
                 getLogger().debug(`Local API: retry (${obj.attemptCount}): ${uri}: ${obj.error.message}`)

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -352,7 +352,7 @@ export async function runLambdaFunction(
             retryDelayMillis: attachDebuggerRetryDelayMillis,
         })
 
-        showDebugConsole()
+        await showDebugConsole()
     }
 
     try {

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -81,7 +81,11 @@ export class SchemaService {
     }
 
     public async start(): Promise<void> {
-        getDefaultSchemas().then(schemas => (this.schemas = schemas))
+        getDefaultSchemas()
+            .then(schemas => (this.schemas = schemas))
+            .catch(e => {
+                getLogger().error('getDefaultSchemas failed: %s', (e as Error).message)
+            })
         await this.startTimer()
     }
 
@@ -94,7 +98,9 @@ export class SchemaService {
     public registerMapping(mapping: SchemaMapping, flush?: boolean): void {
         this.updateQueue.push(mapping)
         if (flush === true) {
-            this.processUpdates()
+            this.processUpdates().catch(e => {
+                getLogger().error('SchemaService: processUpdates() failed: %s', (e as Error).message)
+            })
         }
     }
 

--- a/src/shared/sshConfig.ts
+++ b/src/shared/sshConfig.ts
@@ -96,9 +96,9 @@ export class SshConfig {
         )
 
         const openConfig = localize('AWS.ssh.openConfig', 'Open config...')
-        vscode.window.showWarningMessage(oldConfig, openConfig).then(resp => {
+        await vscode.window.showWarningMessage(oldConfig, openConfig).then(resp => {
             if (resp === openConfig) {
-                vscode.window.showTextDocument(vscode.Uri.file(getSshConfigPath()))
+                void vscode.window.showTextDocument(vscode.Uri.file(getSshConfigPath()))
             }
         })
 

--- a/src/shared/telemetry/activation.ts
+++ b/src/shared/telemetry/activation.ts
@@ -92,7 +92,7 @@ function showTelemetryNotice(extensionContext: vscode.ExtensionContext) {
     )
 
     // Don't wait for a response
-    vscode.window
+    void vscode.window
         .showInformationMessage(telemetryNoticeText, noticeResponseViewSettings, noticeResponseOk)
         .then(async response => handleTelemetryNoticeResponse(response, extensionContext))
 }
@@ -109,12 +109,12 @@ export async function handleTelemetryNoticeResponse(
             return
         }
 
-        setHasUserSeenTelemetryNotice(extensionContext)
+        await setHasUserSeenTelemetryNotice(extensionContext)
 
         // noticeResponseOk is a no-op
 
         if (response === noticeResponseViewSettings) {
-            openSettings('aws.telemetry')
+            await openSettings('aws.telemetry')
         }
     } catch (err) {
         getLogger().error('Error while handling response from telemetry notice: %O', err as Error)

--- a/src/shared/treeview/nodes/awsTreeNodeBase.ts
+++ b/src/shared/treeview/nodes/awsTreeNodeBase.ts
@@ -21,9 +21,9 @@ export abstract class AWSTreeNodeBase extends TreeItem {
 
     public refresh(): void {
         if (isCloud9()) {
-            commands.executeCommand('aws.refreshAwsExplorer', true)
+            void commands.executeCommand('aws.refreshAwsExplorer', true)
         } else {
-            commands.executeCommand('aws.refreshAwsExplorerNode', this)
+            void commands.executeCommand('aws.refreshAwsExplorerNode', this)
         }
     }
 }

--- a/src/shared/treeview/resource.ts
+++ b/src/shared/treeview/resource.ts
@@ -12,6 +12,7 @@ import { once } from '../utilities/functionUtils'
 import { Commands } from '../vscode/commands2'
 import { TreeNode } from './resourceTreeDataProvider'
 import { createErrorItem, createPlaceholderItem } from './utils'
+import { getLogger } from '../logger'
 
 interface SimpleResourceProvider<T = unknown> {
     readonly paginated?: false
@@ -60,7 +61,9 @@ export class PageLoader<T> {
     public dispose(): void {
         this.pages.length = 0
         this.isDone = true
-        this.iterator?.return?.()
+        this.iterator?.return?.().catch(e => {
+            getLogger().error('PageLoader.dispose() failed: %s', (e as Error).message)
+        })
     }
 
     private async next(): Promise<T[] | undefined> {

--- a/src/shared/treeview/utils.ts
+++ b/src/shared/treeview/utils.ts
@@ -95,7 +95,9 @@ export class TreeShim<T = unknown> extends AWSTreeNodeBase {
 
     public constructor(public readonly node: TreeNode<T>) {
         super('Loading...')
-        this.updateTreeItem()
+        this.updateTreeItem().catch(e => {
+            getLogger().error('TreeShim.updateTreeItem() failed: %s', (e as Error).message)
+        })
 
         this.node.onDidChangeChildren?.(() => {
             this.children = undefined

--- a/src/shared/ui/buttons.ts
+++ b/src/shared/ui/buttons.ts
@@ -52,7 +52,7 @@ export class QuickInputLinkButton implements QuickInputButton<void> {
     }
 
     public onClick(): void {
-        openUrl(this.uri)
+        void openUrl(this.uri)
     }
 }
 

--- a/src/shared/ui/common/region.ts
+++ b/src/shared/ui/common/region.ts
@@ -60,7 +60,9 @@ export function createRegionPrompter(
 
     return prompter.transform(item => {
         getLogger().debug('createRegionPrompter: selected %O', item)
-        globals.context.globalState.update(lastRegionKey, item)
+        globals.context.globalState.update(lastRegionKey, item).then(undefined, e => {
+            getLogger().error('globalState.update() failed: %s', (e as Error).message)
+        })
         return item
     })
 }

--- a/src/shared/ui/common/roles.ts
+++ b/src/shared/ui/common/roles.ts
@@ -74,11 +74,11 @@ function addCreateRoleButton(
             .then(role => [{ label: role.RoleName, data: role }])
             .catch(err => {
                 getLogger().error('role prompter: Failed to create new role: %s', err)
-                showViewLogsMessage(localize('AWS.rolePrompter.createRole.failed', 'Failed to create new role'))
+                void showViewLogsMessage(localize('AWS.rolePrompter.createRole.failed', 'Failed to create new role'))
                 return []
             })
 
-        prompter.loadItems(items)
+        return prompter.loadItems(items)
     }
 
     prompter.quickPick.buttons = [

--- a/src/shared/ui/common/roles.ts
+++ b/src/shared/ui/common/roles.ts
@@ -78,7 +78,9 @@ function addCreateRoleButton(
                 return []
             })
 
-        return prompter.loadItems(items)
+        prompter.loadItems(items).catch(e => {
+            getLogger().error('addCreateRoleButton: loadItems() failed: %s', (e as Error).message)
+        })
     }
 
     prompter.quickPick.buttons = [

--- a/src/shared/ui/common/variablesPrompter.ts
+++ b/src/shared/ui/common/variablesPrompter.ts
@@ -65,26 +65,23 @@ function parseEnvFile(contents: string): { [key: string]: string } {
 export function createVariablesPrompter(
     buttons?: PrompterButtons<string>
 ): QuickPickPrompter<{ [name: string]: string }> {
-    const openDialog = () => {
-        return promisifyThenable(vscode.window.showOpenDialog({ canSelectMany: false }))
-            .then(resp => {
-                if (resp === undefined) {
-                    throw new Error('Closed dialog')
-                }
-
-                return resp[0].fsPath
-            })
-            .then(path => fs.promises.readFile(path))
-            .then(contents => parseEnvFile(contents.toString()))
-            .catch(err => {
-                if (err.message !== 'Closed dialog') {
-                    showViewLogsMessage(
-                        localize('AWS.environmentVariables.prompt.failed', 'Failed to read environment variables')
-                    )
-                }
-
-                return WIZARD_RETRY
-            })
+    const openDialog = async () => {
+        try {
+            const resp = await promisifyThenable(vscode.window.showOpenDialog({ canSelectMany: false }))
+            if (resp === undefined) {
+                throw new Error('Closed dialog')
+            }
+            const path = resp[0].fsPath
+            const contents = await fs.promises.readFile(path)
+            return parseEnvFile(contents.toString())
+        } catch (err) {
+            if ((err as Error).message !== 'Closed dialog') {
+                showViewLogsMessage(
+                    localize('AWS.environmentVariables.prompt.failed', 'Failed to read environment variables')
+                )
+            }
+            return WIZARD_RETRY
+        }
     }
 
     const items: DataQuickPickItem<{ [name: string]: string }>[] = [

--- a/src/shared/ui/picker.ts
+++ b/src/shared/ui/picker.ts
@@ -237,7 +237,9 @@ export class IteratingQuickPickController<TResponse> {
             getLogger().debug('IteratingQuickPickController is already done iterating. Call reset() and start again')
             return
         }
-        this.loadItems()
+        this.loadItems().catch(e => {
+            getLogger().error('IteratingQuickPickController: loadItems failed: %s', (e as Error).message)
+        })
     }
 
     /**

--- a/src/shared/ui/pickerPrompter.ts
+++ b/src/shared/ui/pickerPrompter.ts
@@ -148,7 +148,9 @@ export function createQuickPick<T>(
             ? new FilterBoxQuickPickPrompter<T>(picker, mergedOptions)
             : new QuickPickPrompter<T>(picker, mergedOptions)
 
-    prompter.loadItems(items, false, mergedOptions.recentlyUsed)
+    prompter.loadItems(items, false, mergedOptions.recentlyUsed).catch(e => {
+        getLogger().error('createQuickPick: loadItems failed: %s', (e as Error).message)
+    })
 
     return prompter
 }

--- a/src/shared/utilities/cliUtils.ts
+++ b/src/shared/utilities/cliUtils.ts
@@ -101,7 +101,7 @@ export async function installCli(cli: AwsClis, confirm: boolean): Promise<string
 
         if (selection !== install) {
             if (selection === manualInstall) {
-                openUrl(vscode.Uri.parse(cliToInstall.manualInstallLink))
+                void openUrl(vscode.Uri.parse(cliToInstall.manualInstallLink))
             }
             throw new CancellationError('user')
         }
@@ -140,14 +140,14 @@ export async function installCli(cli: AwsClis, confirm: boolean): Promise<string
 
         result = 'Failed'
 
-        vscode.window
+        void vscode.window
             .showErrorMessage(
                 localize('AWS.cli.failedInstall', 'Installation of the {0} CLI failed.', cliToInstall.name),
                 manualInstall
             )
             .then(button => {
                 if (button === manualInstall) {
-                    openUrl(vscode.Uri.parse(cliToInstall.manualInstallLink))
+                    void openUrl(vscode.Uri.parse(cliToInstall.manualInstallLink))
                 }
             })
 
@@ -156,13 +156,18 @@ export async function installCli(cli: AwsClis, confirm: boolean): Promise<string
         if (tempDir) {
             getLogger().info('Cleaning up installer...')
             // nonblocking: use `then`
-            tryRemoveFolder(tempDir).then(success => {
-                if (success) {
-                    getLogger().info('Removed installer.')
-                } else {
-                    getLogger().warn(`Failed to clean up installer in temp directory: ${tempDir}`)
+            tryRemoveFolder(tempDir).then(
+                success => {
+                    if (success) {
+                        getLogger().info('Removed installer.')
+                    } else {
+                        getLogger().warn(`installCli: failed to clean up temp directory: ${tempDir}`)
+                    }
+                },
+                e => {
+                    getLogger().error('installCli: tryRemoveFolder failed: %s', (e as Error).message)
                 }
-            })
+            )
         }
 
         telemetry.aws_toolInstallation.emit({ result, toolId: cli })

--- a/src/shared/utilities/messages.ts
+++ b/src/shared/utilities/messages.ts
@@ -72,7 +72,7 @@ export async function showMessageWithUrl(
     const p = showMessageWithItems(message, kind, items)
     return p.then<string | undefined>(selection => {
         if (selection === urlItem) {
-            openUrl(uri)
+            void openUrl(uri)
         }
         return selection
     })
@@ -181,7 +181,7 @@ async function showProgressWithTimeout(
                         })
                         return
                     }
-                    vscode.window.withProgress(options, function (progress, token) {
+                    void vscode.window.withProgress(options, function (progress, token) {
                         token.onCancellationRequested(() => timeout.cancel())
                         resolve(progress)
                         return new Promise(timeout.onCompletion)
@@ -290,7 +290,7 @@ export class Messages {
  * @returns prompts message to user on with progress
  */
 export async function showTimedMessage(message: string, duration: number) {
-    vscode.window.withProgress(
+    void vscode.window.withProgress(
         {
             location: vscode.ProgressLocation.Notification,
             title: message,

--- a/src/shared/utilities/messages.ts
+++ b/src/shared/utilities/messages.ts
@@ -200,6 +200,8 @@ async function showProgressWithTimeout(
 /**
  * Shows a Progress message which allows the user to cancel a pending `timeout` task.
  *
+ * Logs on failure; call with `void` if you don't need the result.
+ *
  * @param message Message to display
  * @param timeout Timeout object that will be killed if the user clicks 'Cancel'
  * @param showAfterMs Do not show the progress message until `showAfterMs` milliseconds.

--- a/src/shared/utilities/vsCodeUtils.ts
+++ b/src/shared/utilities/vsCodeUtils.ts
@@ -63,7 +63,7 @@ export async function showExtensionPage(extId: string) {
         const err = e as Error
         getLogger().error('extension.open command failed: %s', err.message)
         const uri = vscode.Uri.parse(`https://marketplace.visualstudio.com/items?itemName=${extId}`)
-        openUrl(uri)
+        void openUrl(uri)
     }
 }
 
@@ -86,9 +86,9 @@ export function showInstallExtensionMsg(
     const items = [installBtn]
 
     const p = vscode.window.showErrorMessage(msg, ...items)
-    p.then<string | undefined>(selection => {
+    void p.then<string | undefined>(selection => {
         if (selection === installBtn) {
-            showExtensionPage(extId)
+            void showExtensionPage(extId)
         }
         return selection
     })
@@ -203,9 +203,9 @@ export function normalizeVSCodeUri(uri: vscode.Uri): string {
 export function reloadWindowPrompt(message: string): void {
     const reload = 'Reload'
 
-    vscode.window.showInformationMessage(message, reload).then(selected => {
+    void vscode.window.showInformationMessage(message, reload).then(selected => {
         if (selected === reload) {
-            vscode.commands.executeCommand('workbench.action.reloadWindow')
+            void vscode.commands.executeCommand('workbench.action.reloadWindow')
         }
     })
 }

--- a/src/shared/vscode/uriHandler.ts
+++ b/src/shared/vscode/uriHandler.ts
@@ -35,7 +35,7 @@ export class UriHandler implements vscode.UriHandler {
         const uriNoQuery = uri.with({ query: '' }).toString()
 
         if (!this.handlers.has(uri.path)) {
-            showViewLogsMessage(localize('AWS.uriHandler.nohandler', 'No handler for URI: {0}', uriNoQuery))
+            void showViewLogsMessage(localize('AWS.uriHandler.nohandler', 'No handler for URI: {0}', uriNoQuery))
             getLogger().warn('UriHandler: no handler for path "%s" in handlers: %O', uri.path, this.handlers)
             return
         }
@@ -55,7 +55,7 @@ export class UriHandler implements vscode.UriHandler {
                 'Failed to parse URI query: {0}',
                 uriNoQuery
             )
-            showViewLogsMessage(failedParsedMessage)
+            void showViewLogsMessage(failedParsedMessage)
             getLogger().error(`UriHandler: query parsing failed for path "${uri.path}": %O`, err)
             return
         }
@@ -69,7 +69,7 @@ export class UriHandler implements vscode.UriHandler {
                 'Failed to handle URI: {0}',
                 uriNoQuery
             )
-            showViewLogsMessage(failedResolvedMessage)
+            void showViewLogsMessage(failedResolvedMessage)
             getLogger().error(`UriHandler: unexpected exception when handling "${uri.path}": %O`, err)
         }
     }

--- a/src/shared/wizards/multiStepWizard.ts
+++ b/src/shared/wizards/multiStepWizard.ts
@@ -212,7 +212,7 @@ export async function promptUserForLocation(
             if (button === vscode.QuickInputButtons.Back) {
                 resolve(undefined)
             } else if (button === additionalParams?.helpButton?.button) {
-                openUrl(vscode.Uri.parse(additionalParams.helpButton.url))
+                void openUrl(vscode.Uri.parse(additionalParams.helpButton.url))
             }
         },
     })

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -285,7 +285,7 @@ describe('SamDebugConfigurationProvider', async function () {
     describe('makeConfig', async function () {
         describe('buildDir', function () {
             it('uses `buildDir` as `baseBuildDir` when provided', async function () {
-                const buildDir = path.resolve('/my', 'build', 'dir')
+                const buildDir = (await testutil.createTestWorkspaceFolder('my-build-dir')).uri.fsPath
                 const folder = testutil.getWorkspaceFolder(testutil.getProjectDir())
                 const launchConfig = await getConfig(
                     debugConfigProvider,
@@ -302,7 +302,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 )
 
                 const actual = await debugConfigProvider.makeConfig(folder, config)
-                assert.strictEqual(actual?.baseBuildDir, buildDir)
+                testutil.assertEqualPaths(actual?.baseBuildDir ?? '', buildDir)
             })
         })
 


### PR DESCRIPTION
## Note

_This is a partial batch of changes. The `no-floating-promises` rule will be enabled in a future PR._

## Problem

- code may forget to call async functions with `await`, which can cause bugs or hide failures.
- Example: https://github.com/aws/aws-toolkit-vscode/pull/1636


## Solution

- Enable the eslint `no-floating-promises` rule. [doc](https://typescript-eslint.io/rules/no-floating-promises/)
    - Will be enabled in a future PR, not this one.
- For cases where we _want_ async behavior, use `.then()` or `void`.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
