### PR TITLE
Delay makes debugger attach more consistently

### DIFF
--- a/src/shared/sam/debugger/javaSamDebug.ts
+++ b/src/shared/sam/debugger/javaSamDebug.ts
@@ -58,6 +58,11 @@ export async function makeJavaConfig(config: SamLaunchRequestArgs): Promise<SamL
 export async function invokeJavaLambda(ctx: ExtContext, config: SamLaunchRequestArgs): Promise<SamLaunchRequestArgs> {
     config.samLocalInvokeCommand = new DefaultSamLocalInvokeCommand([WAIT_FOR_DEBUGGER_MESSAGES.JAVA])
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    config.onWillAttachDebugger = waitForPort
+    config.onWillAttachDebugger = async (port, timeout) => {
+        await new Promise<void>(async resolve => {
+            await waitForPort(port, timeout, true)
+            setTimeout(resolve, 250)
+        })
+    }
     return await invokeLambdaFunction(ctx, config, async () => {})
 }

--- a/src/shared/sam/debugger/javaSamDebug.ts
+++ b/src/shared/sam/debugger/javaSamDebug.ts
@@ -61,7 +61,7 @@ export async function invokeJavaLambda(ctx: ExtContext, config: SamLaunchRequest
     config.onWillAttachDebugger = async (port, timeout) => {
         await new Promise<void>(async resolve => {
             await waitForPort(port, timeout, true)
-            setTimeout(resolve, 250)
+            setTimeout(resolve, 1000)
         })
     }
     return await invokeLambdaFunction(ctx, config, async () => {})


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
The Java debugger didn't attach ~50% of the time on first try. For the most part, it seemed that it attached 100% on the second attempt. This means that we likely need a delay before the debugger starts fully.
## Solution
This introduces a 250 ms wait before attaching. This is a lot more consistent on my machine; will see if it's better for others.
<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
