### PR TITLE
Templates are handled correctly on sam init and in codelenses

### DIFF
--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -51,8 +51,8 @@ import { getIdeProperties, isCloud9 } from '../../shared/extensionUtilities'
 
 type CreateReason = 'unknown' | 'userCancelled' | 'fileNotFound' | 'complete' | 'error'
 
-/** Target file to open after creating a new SAM application */
-export const SAM_INIT_OPEN_TARGET: string = 'README.md'
+export const SAM_INIT_TEMPLATE_FILE: string = 'template.yaml'
+export const SAM_INIT_README_FILE: string = 'README.md'
 
 export async function resumeCreateNewSamApp(
     extContext: ExtContext,
@@ -63,8 +63,9 @@ export async function resumeCreateNewSamApp(
     let samVersion: string | undefined
     const samInitState: SamInitState | undefined = activationReloadState.getSamInitState()
     try {
-        const uri = vscode.Uri.file(samInitState?.path!)
-        const folder = vscode.workspace.getWorkspaceFolder(uri)
+        const templateUri = vscode.Uri.file(samInitState?.template!)
+        const readmeUri = vscode.Uri.file(samInitState?.readme!)
+        const folder = vscode.workspace.getWorkspaceFolder(templateUri)
         if (!folder) {
             createResult = 'Failed'
             reason = 'error'
@@ -74,7 +75,7 @@ export async function resumeCreateNewSamApp(
                 localize(
                     'AWS.samcli.initWizard.source.error.notInWorkspace',
                     "Could not open file '{0}'. If this file exists on disk, try adding it to your workspace.",
-                    uri.fsPath
+                    templateUri.fsPath
                 )
             )
 
@@ -86,10 +87,12 @@ export async function resumeCreateNewSamApp(
         await addInitialLaunchConfiguration(
             extContext,
             folder,
-            uri,
+            templateUri,
             samInitState?.isImage ? samInitState?.runtime : undefined
         )
-        await vscode.window.showTextDocument(uri)
+        isCloud9()
+            ? await vscode.workspace.openTextDocument(readmeUri)
+            : await vscode.commands.executeCommand('markdown.showPreviewToSide', readmeUri)
     } catch (err) {
         createResult = 'Failed'
         reason = 'error'
@@ -197,8 +200,9 @@ export async function createNewSamApplication(
 
         await runSamCliInit(initArguments, samCliContext)
 
-        const uri = await getMainUri(config)
-        if (!uri) {
+        const templateUri = await getProjectUri(config, SAM_INIT_TEMPLATE_FILE)
+        const readmeUri = await getProjectUri(config, SAM_INIT_README_FILE)
+        if (!templateUri || !readmeUri) {
             reason = 'fileNotFound'
 
             return
@@ -235,7 +239,8 @@ export async function createNewSamApplication(
 
         // In case adding the workspace folder triggers a VS Code restart, persist relevant state to be used after reload
         activationReloadState.setSamInitState({
-            path: uri.fsPath,
+            template: templateUri.fsPath,
+            readme: readmeUri.fsPath,
             runtime: createRuntime,
             isImage: config.packageType === 'Image',
         })
@@ -250,7 +255,7 @@ export async function createNewSamApplication(
 
         // Race condition where SAM app is created but template doesn't register in time.
         // Poll for 5 seconds, otherwise direct user to codelens.
-        const isTemplateRegistered = await waitUntil(async () => ext.templateRegistry.getRegisteredItem(uri), {
+        const isTemplateRegistered = await waitUntil(async () => ext.templateRegistry.getRegisteredItem(templateUri), {
             timeout: 5000,
             interval: 500,
             truthy: false,
@@ -259,8 +264,8 @@ export async function createNewSamApplication(
         if (isTemplateRegistered) {
             const newLaunchConfigs = await addInitialLaunchConfiguration(
                 extContext,
-                vscode.workspace.getWorkspaceFolder(uri)!,
-                uri,
+                vscode.workspace.getWorkspaceFolder(templateUri)!,
+                templateUri,
                 createRuntime
             )
             if (newLaunchConfigs && newLaunchConfigs.length > 0) {
@@ -292,8 +297,8 @@ export async function createNewSamApplication(
         activationReloadState.clearSamInitState()
         // TODO: Replace when Cloud9 supports `markdown` commands
         isCloud9()
-            ? await vscode.workspace.openTextDocument(uri)
-            : await vscode.commands.executeCommand('markdown.showPreviewToSide', uri)
+            ? await vscode.workspace.openTextDocument(readmeUri)
+            : await vscode.commands.executeCommand('markdown.showPreviewToSide', readmeUri)
     } catch (err) {
         createResult = 'Failed'
         reason = 'error'
@@ -329,10 +334,11 @@ async function validateSamCli(samCliValidator: SamCliValidator): Promise<void> {
     throwAndNotifyIfInvalid(validationResult)
 }
 
-export async function getMainUri(
-    config: Pick<CreateNewSamAppWizardResponse, 'location' | 'name'>
+export async function getProjectUri(
+    config: Pick<CreateNewSamAppWizardResponse, 'location' | 'name'>,
+    file: string
 ): Promise<vscode.Uri | undefined> {
-    const cfnTemplatePath = path.resolve(config.location.fsPath, config.name, SAM_INIT_OPEN_TARGET)
+    const cfnTemplatePath = path.resolve(config.location.fsPath, config.name, file)
     if (await fileExists(cfnTemplatePath)) {
         return vscode.Uri.file(cfnTemplatePath)
     } else {
@@ -340,7 +346,7 @@ export async function getMainUri(
             localize(
                 'AWS.samcli.initWizard.source.error.notFound',
                 'Project created successfully, but {0} file not found: {1}',
-                SAM_INIT_OPEN_TARGET,
+                file,
                 cfnTemplatePath
             )
         )

--- a/src/shared/activationReloadState.ts
+++ b/src/shared/activationReloadState.ts
@@ -7,12 +7,14 @@ import * as vscode from 'vscode'
 import { ext } from './extensionGlobals'
 import { Runtime } from 'aws-sdk/clients/lambda'
 
+export const ACTIVATION_TEMPLATE_PATH_KEY = 'ACTIVATION_TEMPLATE_PATH_KEY'
 export const ACTIVATION_LAUNCH_PATH_KEY = 'ACTIVATION_LAUNCH_PATH_KEY'
 export const SAM_INIT_RUNTIME_KEY = 'SAM_INIT_RUNTIME_KEY'
 export const SAM_INIT_IMAGE_BOOLEAN_KEY = 'SAM_INIT_IMAGE_BOOLEAN_KEY'
 
 export interface SamInitState {
-    path: string | undefined
+    template: string | undefined
+    readme: string | undefined
     runtime: Runtime | undefined
     isImage: boolean | undefined
 }
@@ -23,19 +25,22 @@ export interface SamInitState {
 export class ActivationReloadState {
     public getSamInitState(): SamInitState | undefined {
         return {
-            path: this.extensionContext.globalState.get<string>(ACTIVATION_LAUNCH_PATH_KEY),
+            template: this.extensionContext.globalState.get<string>(ACTIVATION_TEMPLATE_PATH_KEY),
+            readme: this.extensionContext.globalState.get<string>(ACTIVATION_LAUNCH_PATH_KEY),
             runtime: this.extensionContext.globalState.get<string>(SAM_INIT_RUNTIME_KEY),
             isImage: this.extensionContext.globalState.get<boolean>(SAM_INIT_IMAGE_BOOLEAN_KEY),
         }
     }
 
     public setSamInitState(state: SamInitState): void {
-        this.extensionContext.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, state.path)
+        this.extensionContext.globalState.update(ACTIVATION_TEMPLATE_PATH_KEY, state.template)
+        this.extensionContext.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, state.readme)
         this.extensionContext.globalState.update(SAM_INIT_RUNTIME_KEY, state.runtime)
         this.extensionContext.globalState.update(SAM_INIT_IMAGE_BOOLEAN_KEY, state.isImage)
     }
 
     public clearSamInitState(): void {
+        this.extensionContext.globalState.update(ACTIVATION_TEMPLATE_PATH_KEY, undefined)
         this.extensionContext.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, undefined)
         this.extensionContext.globalState.update(SAM_INIT_RUNTIME_KEY, undefined)
         this.extensionContext.globalState.update(SAM_INIT_IMAGE_BOOLEAN_KEY, undefined)

--- a/src/shared/cloudformation/templateRegistry.ts
+++ b/src/shared/cloudformation/templateRegistry.ts
@@ -8,7 +8,7 @@ import { CloudFormation } from './cloudformation'
 import * as pathutils from '../utilities/pathUtils'
 import * as path from 'path'
 import { isInDirectory } from '../filesystemUtilities'
-import { dotNetRuntimes } from '../../lambda/models/samLambdaRuntime'
+import { dotNetRuntimes, javaRuntimes } from '../../lambda/models/samLambdaRuntime'
 import { getLambdaDetails } from '../../lambda/utils'
 import { ext } from '../extensionGlobals'
 import { WatchedFiles, WatchedItem } from '../watchedFiles'
@@ -122,7 +122,7 @@ export function getResourcesForHandlerFromTemplateDatum(
                 // .NET is currently a special case in that the filepath and handler aren't specific.
                 // For now: check if handler matches and check if the code URI contains the filepath.
                 // TODO: Can we use Omnisharp to help guide us better?
-                if (dotNetRuntimes.includes(registeredRuntime)) {
+                if (dotNetRuntimes.includes(registeredRuntime) || javaRuntimes.includes(registeredRuntime)) {
                     if (
                         handler === registeredHandler &&
                         isInDirectory(

--- a/src/test/lambda/commands/createNewSamApp.test.ts
+++ b/src/test/lambda/commands/createNewSamApp.test.ts
@@ -12,8 +12,8 @@ import * as fs from 'fs-extra'
 import { FakeExtensionContext } from '../../fakeExtensionContext'
 import {
     addInitialLaunchConfiguration,
-    getMainUri,
-    SAM_INIT_OPEN_TARGET,
+    getProjectUri,
+    SAM_INIT_TEMPLATE_FILE,
 } from '../../../lambda/commands/createNewSamApp'
 import { LaunchConfiguration } from '../../../shared/debug/launchConfiguration'
 import { anything, capture, instance, mock, when } from 'ts-mockito'
@@ -41,7 +41,7 @@ describe('createNewSamApp', function () {
         fakeContext = await FakeExtensionContext.getFakeExtContext()
         tempFolder = await makeTemporaryToolkitFolder()
         tempTemplate = vscode.Uri.file(path.join(tempFolder, 'test.yaml'))
-        fakeTarget = path.join(tempFolder, SAM_INIT_OPEN_TARGET)
+        fakeTarget = path.join(tempFolder, SAM_INIT_TEMPLATE_FILE)
         testutil.toFile('target file', fakeTarget)
 
         fakeWorkspaceFolder = {
@@ -71,15 +71,18 @@ describe('createNewSamApp', function () {
         ext.templateRegistry.reset()
     })
 
-    describe('getMainUri', function () {
+    describe('getProjectUri', function () {
         it('returns the target file when it exists', async function () {
-            assert.strictEqual(normalize((await getMainUri(fakeResponse))?.fsPath ?? ''), normalize(fakeTarget))
+            assert.strictEqual(
+                normalize((await getProjectUri(fakeResponse, SAM_INIT_TEMPLATE_FILE))?.fsPath ?? ''),
+                normalize(fakeTarget)
+            )
         })
         it('returns undefined when the target does not exist', async function () {
             const badResponse1 = { location: fakeResponse.location, name: 'notreal' }
             const badResponse2 = { location: vscode.Uri.parse('fake://notreal'), name: 'notafile' }
-            assert.strictEqual((await getMainUri(badResponse1))?.fsPath, undefined)
-            assert.strictEqual((await getMainUri(badResponse2))?.fsPath, undefined)
+            assert.strictEqual((await getProjectUri(badResponse1, SAM_INIT_TEMPLATE_FILE))?.fsPath, undefined)
+            assert.strictEqual((await getProjectUri(badResponse2, SAM_INIT_TEMPLATE_FILE))?.fsPath, undefined)
         })
     })
 
@@ -94,7 +97,7 @@ describe('createNewSamApp', function () {
             const launchConfigs = await addInitialLaunchConfiguration(
                 fakeContext,
                 fakeWorkspaceFolder,
-                (await getMainUri(fakeResponse))!,
+                (await getProjectUri(fakeResponse, SAM_INIT_TEMPLATE_FILE))!,
                 undefined,
                 instance(mockLaunchConfiguration)
             )
@@ -201,7 +204,7 @@ describe('createNewSamApp', function () {
             testutil.toFile(makeSampleSamTemplateYaml(true), tempTemplate.fsPath)
             testutil.toFile(makeSampleSamTemplateYaml(true), otherTemplate1.fsPath)
             testutil.toFile(makeSampleSamTemplateYaml(true), otherTemplate2.fsPath)
-            testutil.toFile('target file', path.join(otherFolder1, SAM_INIT_OPEN_TARGET))
+            testutil.toFile('target file', path.join(otherFolder1, SAM_INIT_TEMPLATE_FILE))
 
             await ext.templateRegistry.addItemToRegistry(tempTemplate)
             await ext.templateRegistry.addItemToRegistry(otherTemplate1)
@@ -210,7 +213,7 @@ describe('createNewSamApp', function () {
             const launchConfigs1 = await addInitialLaunchConfiguration(
                 fakeContext,
                 fakeWorkspaceFolder,
-                (await getMainUri(fakeResponse))!,
+                (await getProjectUri(fakeResponse, SAM_INIT_TEMPLATE_FILE))!,
                 undefined,
                 instance(mockLaunchConfiguration)
             )
@@ -218,7 +221,10 @@ describe('createNewSamApp', function () {
             const launchConfigs2 = await addInitialLaunchConfiguration(
                 fakeContext,
                 fakeWorkspaceFolder,
-                (await getMainUri({ location: fakeWorkspaceFolder.uri, name: 'otherFolder' }))!,
+                (await getProjectUri(
+                    { location: fakeWorkspaceFolder.uri, name: 'otherFolder' },
+                    SAM_INIT_TEMPLATE_FILE
+                ))!,
                 undefined,
                 instance(mockLaunchConfiguration)
             )

--- a/src/test/shared/activationReloadState.test.ts
+++ b/src/test/shared/activationReloadState.test.ts
@@ -11,6 +11,7 @@ import {
     ActivationReloadState,
     SAM_INIT_RUNTIME_KEY,
     SAM_INIT_IMAGE_BOOLEAN_KEY,
+    ACTIVATION_TEMPLATE_PATH_KEY,
 } from '../../shared/activationReloadState'
 import { ext } from '../../shared/extensionGlobals'
 
@@ -40,7 +41,8 @@ describe('ActivationReloadState', async function () {
     describe('setSamInitState', async function () {
         it('without runtime', async function () {
             activationReloadState.setSamInitState({
-                path: 'somepath',
+                template: 'sometemplate',
+                readme: 'somepath',
                 runtime: undefined,
                 isImage: false,
             })
@@ -49,6 +51,11 @@ describe('ActivationReloadState', async function () {
                 ext.context.globalState.get(ACTIVATION_LAUNCH_PATH_KEY),
                 'somepath',
                 'Unexpected Launch Path value was set'
+            )
+            assert.strictEqual(
+                ext.context.globalState.get(ACTIVATION_TEMPLATE_PATH_KEY),
+                'someTemplate',
+                'Unexpected Template Path value was set'
             )
             assert.strictEqual(
                 ext.context.globalState.get(SAM_INIT_RUNTIME_KEY),
@@ -64,7 +71,8 @@ describe('ActivationReloadState', async function () {
 
         it('with runtime', async function () {
             activationReloadState.setSamInitState({
-                path: 'somepath',
+                template: 'sometemplate',
+                readme: 'somepath',
                 runtime: 'someruntime',
                 isImage: false,
             })
@@ -73,6 +81,11 @@ describe('ActivationReloadState', async function () {
                 ext.context.globalState.get(ACTIVATION_LAUNCH_PATH_KEY),
                 'somepath',
                 'Unexpected Launch Path value was set'
+            )
+            assert.strictEqual(
+                ext.context.globalState.get(ACTIVATION_TEMPLATE_PATH_KEY),
+                'someTemplate',
+                'Unexpected Template Path value was set'
             )
             assert.strictEqual(
                 ext.context.globalState.get(SAM_INIT_RUNTIME_KEY),
@@ -88,7 +101,8 @@ describe('ActivationReloadState', async function () {
 
         it('with image', async function () {
             activationReloadState.setSamInitState({
-                path: 'somepath',
+                template: 'sometemplate',
+                readme: 'somepath',
                 runtime: 'someruntime',
                 isImage: true,
             })
@@ -97,6 +111,11 @@ describe('ActivationReloadState', async function () {
                 ext.context.globalState.get(ACTIVATION_LAUNCH_PATH_KEY),
                 'somepath',
                 'Unexpected Launch Path value was set'
+            )
+            assert.strictEqual(
+                ext.context.globalState.get(ACTIVATION_TEMPLATE_PATH_KEY),
+                'someTemplate',
+                'Unexpected Template Path value was set'
             )
             assert.strictEqual(
                 ext.context.globalState.get(SAM_INIT_RUNTIME_KEY),
@@ -114,12 +133,18 @@ describe('ActivationReloadState', async function () {
     describe('getSamInitState', async function () {
         it('path defined, without runtime', async function () {
             await ext.context.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, 'getsomepath')
+            await ext.context.globalState.update(ACTIVATION_TEMPLATE_PATH_KEY, 'gettemplatepath')
             await ext.context.globalState.update(SAM_INIT_RUNTIME_KEY, undefined)
 
             assert.strictEqual(
-                activationReloadState.getSamInitState()?.path,
+                activationReloadState.getSamInitState()?.readme,
                 'getsomepath',
                 'Unexpected Launch Path value was retrieved'
+            )
+            assert.strictEqual(
+                activationReloadState.getSamInitState()?.template,
+                'gettemplatepath',
+                'Unexpected Template Path value was retrieved'
             )
             assert.strictEqual(
                 activationReloadState.getSamInitState()?.runtime,
@@ -135,12 +160,18 @@ describe('ActivationReloadState', async function () {
 
         it('path defined, with runtime', async function () {
             await ext.context.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, 'getsomepath')
+            await ext.context.globalState.update(ACTIVATION_TEMPLATE_PATH_KEY, 'gettemplatepath')
             await ext.context.globalState.update(SAM_INIT_RUNTIME_KEY, 'getsomeruntime')
 
             assert.strictEqual(
-                activationReloadState.getSamInitState()?.path,
+                activationReloadState.getSamInitState()?.readme,
                 'getsomepath',
                 'Unexpected Launch Path value was retrieved'
+            )
+            assert.strictEqual(
+                activationReloadState.getSamInitState()?.template,
+                'gettemplatepath',
+                'Unexpected Template Path value was retrieved'
             )
             assert.strictEqual(
                 activationReloadState.getSamInitState()?.runtime,
@@ -156,13 +187,19 @@ describe('ActivationReloadState', async function () {
 
         it('path defined, with runtime and isImage', async function () {
             await ext.context.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, 'getsomepath')
+            await ext.context.globalState.update(ACTIVATION_TEMPLATE_PATH_KEY, 'gettemplatepath')
             await ext.context.globalState.update(SAM_INIT_RUNTIME_KEY, 'getsomeruntime')
             await ext.context.globalState.update(SAM_INIT_IMAGE_BOOLEAN_KEY, true)
 
             assert.strictEqual(
-                activationReloadState.getSamInitState()?.path,
+                activationReloadState.getSamInitState()?.readme,
                 'getsomepath',
                 'Unexpected Launch Path value was retrieved'
+            )
+            assert.strictEqual(
+                activationReloadState.getSamInitState()?.template,
+                'gettemplatepath',
+                'Unexpected Template Path value was retrieved'
             )
             assert.strictEqual(
                 activationReloadState.getSamInitState()?.runtime,
@@ -179,7 +216,8 @@ describe('ActivationReloadState', async function () {
 
     it('clearLaunchPath', async function () {
         activationReloadState.setSamInitState({
-            path: 'somepath',
+            template: 'sometemplate',
+            readme: 'somepath',
             runtime: 'someruntime',
             isImage: true,
         })
@@ -189,6 +227,12 @@ describe('ActivationReloadState', async function () {
             ext.context.globalState.get(ACTIVATION_LAUNCH_PATH_KEY),
             undefined,
             'Expected launch path to be cleared (undefined)'
+        )
+
+        assert.strictEqual(
+            ext.context.globalState.get(ACTIVATION_TEMPLATE_PATH_KEY),
+            undefined,
+            'Expected template path to be cleared (undefined)'
         )
 
         assert.strictEqual(

--- a/src/test/shared/activationReloadState.test.ts
+++ b/src/test/shared/activationReloadState.test.ts
@@ -54,7 +54,7 @@ describe('ActivationReloadState', async function () {
             )
             assert.strictEqual(
                 ext.context.globalState.get(ACTIVATION_TEMPLATE_PATH_KEY),
-                'someTemplate',
+                'sometemplate',
                 'Unexpected Template Path value was set'
             )
             assert.strictEqual(
@@ -84,7 +84,7 @@ describe('ActivationReloadState', async function () {
             )
             assert.strictEqual(
                 ext.context.globalState.get(ACTIVATION_TEMPLATE_PATH_KEY),
-                'someTemplate',
+                'sometemplate',
                 'Unexpected Template Path value was set'
             )
             assert.strictEqual(
@@ -114,7 +114,7 @@ describe('ActivationReloadState', async function () {
             )
             assert.strictEqual(
                 ext.context.globalState.get(ACTIVATION_TEMPLATE_PATH_KEY),
-                'someTemplate',
+                'sometemplate',
                 'Unexpected Template Path value was set'
             )
             assert.strictEqual(


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Launch configs weren't created on sam init and couldn't be created referencing templates through Java codelenses.

## Solution

Swapping to opening the readme file caused some issues with creating the initial launch config, so we now explicitly look at the template and readme files on creation. This also includes a change to the template registry to connect Java handlers and files to templates to allow codelenses to create template configs (by using the C# implementation)

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
