### PR TITLE
logger: Fix 'getLogById'

### DIFF
--- a/src/shared/logger/activation.ts
+++ b/src/shared/logger/activation.ts
@@ -164,7 +164,7 @@ async function registerLoggerCommands(context: vscode.ExtensionContext): Promise
         vscode.commands.registerCommand(
             'aws.viewLogsAtMessage',
             async (logID: number = -1, logUri: vscode.Uri = LOG_URI) => {
-                const msg: string | undefined = getLogger().getLogById(logID, logUri.toString(true))
+                const msg: string | undefined = getLogger().getLogById(logID, logUri)
                 const editor: vscode.TextEditor | undefined = await openLogUri(logUri)
 
                 if (!msg || !editor) {

--- a/src/shared/logger/logger.ts
+++ b/src/shared/logger/logger.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Uri } from 'vscode'
+
 const toolkitLoggers: {
     main: Logger | undefined
     channel: Logger | undefined
@@ -23,7 +25,7 @@ export interface Logger {
     setLogLevel(logLevel: LogLevel): void
     /** Returns true if the given log level is being logged.  */
     logLevelEnabled(logLevel: LogLevel): boolean
-    getLogById(logID: number, file: string): string | undefined
+    getLogById(logID: number, file: Uri): string | undefined
 }
 
 /**
@@ -93,7 +95,7 @@ export class NullLogger implements Logger {
     public error(message: string | Error, ...meta: any[]): number {
         return 0
     }
-    public getLogById(logID: number, file: string): string | undefined {
+    public getLogById(logID: number, file: Uri): string | undefined {
         return undefined
     }
 }

--- a/src/test/shared/logger/winstonToolkitLogger.test.ts
+++ b/src/test/shared/logger/winstonToolkitLogger.test.ts
@@ -7,6 +7,7 @@ import * as assert from 'assert'
 import * as path from 'path'
 import * as filesystemUtilities from '../../../shared/filesystemUtilities'
 import * as fs from 'fs-extra'
+import * as vscode from 'vscode'
 import { WinstonToolkitLogger } from '../../../shared/logger/winstonToolkitLogger'
 import { MockOutputChannel } from '../../mockOutputChannel'
 import { assertThrowsError } from '../utilities/assertUtils'
@@ -306,7 +307,7 @@ describe('WinstonToolkitLogger', function () {
         it('get info log message', async function () {
             const logID: number = testLogger!.info('test')
             const msg: string | undefined = await waitUntil(
-                async () => testLogger!.getLogById(logID, `file://${tempLogPath}`),
+                async () => testLogger!.getLogById(logID, vscode.Uri.file(tempLogPath)),
                 { timeout: 2000, interval: 10, truthy: false }
             )
             assert.notStrictEqual(msg, undefined)
@@ -315,7 +316,7 @@ describe('WinstonToolkitLogger', function () {
         it('debug log message is undefined', async function () {
             const logID: number = testLogger!.debug('debug test')
             const msg: string | undefined = await waitUntil(
-                async () => testLogger!.getLogById(logID, `file://${tempLogPath}`),
+                async () => testLogger!.getLogById(logID, vscode.Uri.file(tempLogPath)),
                 { timeout: 50, interval: 5, truthy: false }
             )
             assert.strictEqual(msg, undefined)
@@ -330,7 +331,7 @@ describe('WinstonToolkitLogger', function () {
                 testLogger!.debug('debug log')
 
                 const msg: string | undefined = await waitUntil(
-                    async () => testLogger!.getLogById(logID, `file://${tempLogPath}`),
+                    async () => testLogger!.getLogById(logID, vscode.Uri.file(tempLogPath)),
                     { timeout: 400, interval: 10, truthy: false }
                 )
                 assert.notStrictEqual(msg, undefined)
@@ -349,7 +350,7 @@ describe('WinstonToolkitLogger', function () {
             }
 
             const middleMsg: string | undefined = await waitUntil(
-                async () => testLogger!.getLogById(logIDs[Math.floor(logIDs.length / 2)], `file://${tempLogPath}`),
+                async () => testLogger!.getLogById(logIDs[Math.floor(logIDs.length / 2)], vscode.Uri.file(tempLogPath)),
                 { timeout: 2000, interval: 10, truthy: false }
             )
 
@@ -374,7 +375,7 @@ describe('WinstonToolkitLogger', function () {
 
             const middleFile: string = filePaths[Math.floor(filePaths.length / 2)]
             const middleMsg: string | undefined = await waitUntil(
-                async () => testLogger!.getLogById(logIDs[Math.floor(logIDs.length / 2)], `file://${middleFile}`),
+                async () => testLogger!.getLogById(logIDs[Math.floor(logIDs.length / 2)], vscode.Uri.file(middleFile)),
                 { timeout: 2000, interval: 5, truthy: false }
             )
 
@@ -387,7 +388,7 @@ describe('WinstonToolkitLogger', function () {
             const logID: number = testLogger!.error('Test error')
 
             const msg: string | undefined = await waitUntil(
-                async () => testLogger!.getLogById(logID, `channel://${outputChannel.name}`),
+                async () => testLogger!.getLogById(logID, vscode.Uri.parse(`channel://${outputChannel.name}`)),
                 { timeout: 2000, interval: 5, truthy: false }
             )
 
@@ -400,13 +401,13 @@ describe('WinstonToolkitLogger', function () {
             testLogger!.debug('debug log')
 
             assert.throws(
-                () => testLogger!.getLogById(-1, ''),
+                () => testLogger!.getLogById(-1, vscode.Uri.file('')),
                 Error,
                 'Invalid log state, logID=-1 must be in the range [0, 3)!'
             )
 
             assert.throws(
-                () => testLogger!.getLogById(3, ''),
+                () => testLogger!.getLogById(3, vscode.Uri.file('')),
                 Error,
                 'Invalid log state, logID=3 must be in the range [0, 3)!'
             )

--- a/src/test/testLogger.ts
+++ b/src/test/testLogger.ts
@@ -5,6 +5,7 @@
 
 import { Loggable, Logger, LogLevel } from '../shared/logger'
 import { compareLogLevel } from '../shared/logger/logger'
+import { Uri } from 'vscode'
 
 /**
  * In-memory Logger implementation suitable for use by tests.
@@ -55,7 +56,7 @@ export class TestLogger implements Logger {
     }
 
     // No need to actually implement this. Log tracking is tested in winstonToolkitLogger.test.ts
-    public getLogById(logID: number, file: string): string | undefined {
+    public getLogById(logID: number, file: Uri): string | undefined {
         return undefined
     }
 


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
The function `getLogById` would fail to find the recorded log on Windows machines. This was because the file scheme was hardcoded as 'file://', but on Windows local files use the scheme 'file:///'.

## Solution
Require log tracking functions to use `vscode.Uri` instead of a raw string. This way we do not have to worry about parsing for different operating systems.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
