### PR TITLE
integ/tests: Minor improvements for 'sam.test.ts'

### DIFF
--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -451,7 +451,14 @@ describe('SAM Integration Tests', async function () {
                     setTestTimeout(this.test?.fullTitle(), 90000)
                     // Allow previous sessions to go away.
                     const noDebugSession: boolean | undefined = await waitUntil(
-                        async () => vscode.debug.activeDebugSession === undefined,
+                        async () => {
+                            if (vscode.debug.activeDebugSession !== undefined) {
+                                await stopDebugger(undefined)
+                                return false
+                            }
+
+                            return true
+                        },
                         { timeout: 10000, interval: 100, truthy: true }
                     )
 

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -189,8 +189,9 @@ async function getAddConfigCodeLens(documentUri: vscode.Uri): Promise<vscode.Cod
                 }
             } catch (e) {
                 console.log(`sam.test.ts: getAddConfigCodeLens(): failed, retrying:\n${e}`)
-                return undefined
             }
+
+            return undefined
         },
         { timeout: CODELENS_TIMEOUT, interval: CODELENS_RETRY_INTERVAL, truthy: false }
     )


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Integration tests sometimes fail due to active debug sessions. This can happen if a session starts after another one ends, but before the next test begins. The 'getAddDebugConfigCodeLens' also would run indefinitely if it timed-out.

## Solution
* Repeatedly force old debug sessios to close before beginning a new session (***).
* Update 'getAddDebugConfigCodeLens' to use 'waitUntil'
* Add constants for readability

*****This is just so integration tests don't erroneously fail as much. The root cause lies somewhere with the NodeJS tests, since those are the only ones causing this issue. Ideally there should never be a debug session from a previous state.**

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
