### PR TITLE
CDK: search 2 levels of descendants

### DIFF
--- a/.changes/next-release/Feature-4362f78f-c52d-4fab-b215-f744c7b090e0.json
+++ b/.changes/next-release/Feature-4362f78f-c52d-4fab-b215-f744c7b090e0.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "CDK: search for CDK projects up to 2 levels deep (previously 1)"
+}

--- a/.changes/next-release/Feature-d0efaf09-2f4a-4a35-b742-1e13719dcd5b.json
+++ b/.changes/next-release/Feature-d0efaf09-2f4a-4a35-b742-1e13719dcd5b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "CDK: move CDK panel to AWS view #1632"
+}

--- a/src/cdk/explorer/detectCdkProjects.ts
+++ b/src/cdk/explorer/detectCdkProjects.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { access, readdir, stat } from 'fs-extra'
+import { access, fstat, readdir, stat } from 'fs-extra'
+import * as fs from 'fs-extra'
 import * as path from 'path'
 import * as vscode from 'vscode'
 import { getLogger } from '../../shared/logger'
@@ -46,21 +47,29 @@ export async function* detectLocalCdkProjects({
     workspaceUris: vscode.Uri[]
 }): AsyncIterableIterator<vscode.Uri> {
     for (const workspaceFolder of workspaceUris) {
-        for await (const folder of getFolderCandidates(workspaceFolder)) {
+        for await (const folder of getFolderCandidates(workspaceFolder, 2, 0)) {
             yield* detectCdkProjectsInFolder(folder)
         }
     }
 }
 
-async function* getFolderCandidates(uri: vscode.Uri): AsyncIterableIterator<string> {
-    // Search the root and first level of children only.
+/**
+ * Generates names of directory `uri` and its descendant directories up to `maxLevels` levels.
+ */
+async function* getFolderCandidates(uri: vscode.Uri, maxLevels: number, level: number): AsyncIterableIterator<string> {
+    if (!(await stat(uri.fsPath)).isDirectory()) {
+        throw Error(`not a directory: "${uri.fsPath}"`)
+    }
     yield uri.fsPath
 
     const entries = await readdir(uri.fsPath)
     for (const entry of entries.map(p => path.join(uri.fsPath, p))) {
         const stats = await stat(entry)
         if (stats.isDirectory()) {
-            yield entry
+            if (level <= maxLevels) {
+                const dirUri = vscode.Uri.file(entry)
+                yield* getFolderCandidates(dirUri, maxLevels, level + 1)
+            }
         }
     }
 }

--- a/src/cdk/explorer/detectCdkProjects.ts
+++ b/src/cdk/explorer/detectCdkProjects.ts
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { access, fstat, readdir, stat } from 'fs-extra'
-import * as fs from 'fs-extra'
+import { access, readdir, stat } from 'fs-extra'
 import * as path from 'path'
 import * as vscode from 'vscode'
 import { getLogger } from '../../shared/logger'


### PR DESCRIPTION


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem

CDK Explorer does not detect CDK projects that are children-of-children
of the main root folder.



## Solution

Search one level deeper.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
