### PR TITLE
Users can get help after creating a new SAM app

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -526,6 +526,7 @@
     "AWS.generic.filetype.directory": "Directory",
     "AWS.generic.filetype.zipfile": "ZIP Archive",
     "AWS.generic.message.getHelp": "Get Help...",
+    "AWS.generic.message.learnMore": "Learn More",
     "AWS.generic.name": "name",
     "AWS.template.error.showErrorDetails.title": "Error details for",
     "AWS.template.error.showErrorDetails.errorCode": "Error code",

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -45,7 +45,7 @@ import { isTemplateTargetProperties } from '../../shared/sam/debugger/awsSamDebu
 import { TemplateTargetProperties } from '../../shared/sam/debugger/awsSamDebugConfiguration'
 import { openLaunchJsonFile } from '../../shared/sam/debugger/commands/addSamDebugConfiguration'
 import { waitUntil } from '../../shared/utilities/timeoutUtils'
-import { launchConfigDocUrl } from '../../shared/constants'
+import { debugNewSamApp, launchConfigDocUrl } from '../../shared/constants'
 import { Runtime } from 'aws-sdk/clients/lambda'
 import { getIdeProperties, isCloud9 } from '../../shared/extensionUtilities'
 
@@ -395,6 +395,8 @@ export async function addInitialLaunchConfiguration(
 }
 
 async function showCompletionNotification(appName: string, configs: string): Promise<void> {
+    const openJson = localize('AWS.generic.open', 'Open {0}', 'launch.json')
+    const learnMore = localize('AWS.generic.message.learnMore', 'Learn More')
     const action = await vscode.window.showInformationMessage(
         localize(
             'AWS.samcli.initWizard.completionMessage',
@@ -402,10 +404,13 @@ async function showCompletionNotification(appName: string, configs: string): Pro
             appName,
             configs
         ),
-        localize('AWS.generic.open', 'Open {0}', 'launch.json')
+        openJson,
+        learnMore
     )
 
-    if (action) {
+    if (action === openJson) {
         await openLaunchJsonFile()
+    } else if (action === learnMore) {
+        vscode.env.openExternal(vscode.Uri.parse(debugNewSamApp))
     }
 }

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -45,7 +45,7 @@ import { isTemplateTargetProperties } from '../../shared/sam/debugger/awsSamDebu
 import { TemplateTargetProperties } from '../../shared/sam/debugger/awsSamDebugConfiguration'
 import { openLaunchJsonFile } from '../../shared/sam/debugger/commands/addSamDebugConfiguration'
 import { waitUntil } from '../../shared/utilities/timeoutUtils'
-import { debugNewSamApp, launchConfigDocUrl } from '../../shared/constants'
+import { debugNewSamAppUrl, launchConfigDocUrl } from '../../shared/constants'
 import { Runtime } from 'aws-sdk/clients/lambda'
 import { getIdeProperties, isCloud9 } from '../../shared/extensionUtilities'
 
@@ -411,6 +411,6 @@ async function showCompletionNotification(appName: string, configs: string): Pro
     if (action === openJson) {
         await openLaunchJsonFile()
     } else if (action === learnMore) {
-        vscode.env.openExternal(vscode.Uri.parse(debugNewSamApp))
+        vscode.env.openExternal(vscode.Uri.parse(debugNewSamAppUrl))
     }
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -57,6 +57,11 @@ export const ssmDocumentPublishGuideUrl: string =
     'https://docs.aws.amazon.com/systems-manager/latest/userguide/create-ssm-doc.html'
 export const ssmJson: string = 'ssm-json'
 export const ssmYaml: string = 'ssm-yaml'
+
+// URL for post-Create SAM App
+export const debugNewSamApp: string =
+    'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/serverless-apps.html#serverless-apps-debug'
+
 /**
  * Moment format for rendering readable dates.
  *

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -59,8 +59,9 @@ export const ssmJson: string = 'ssm-json'
 export const ssmYaml: string = 'ssm-yaml'
 
 // URL for post-Create SAM App
-export const debugNewSamApp: string =
-    'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/serverless-apps.html#serverless-apps-debug'
+export const debugNewSamAppUrl: string = isCloud9()
+    ? 'https://docs.aws.amazon.com/cloud9/latest/user-guide/serverless-apps-toolkit.html#sam-run-debug'
+    : 'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/serverless-apps.html#serverless-apps-debug'
 
 /**
  * Moment format for rendering readable dates.


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Users who have created a SAM application might not know what to do after they've created it.

## Solution
Offer a user a direct link to the relevant docs on create.
![image](https://user-images.githubusercontent.com/29374703/115458795-0d6ba400-a1db-11eb-8afa-e984cca10799.png)

Links to the following pages: [VS Code](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/serverless-apps.html#serverless-apps-debug) , [Cloud9](https://docs.aws.amazon.com/cloud9/latest/user-guide/serverless-apps-toolkit.html#sam-run-debug)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
