### PR TITLE
SAM: Workaround for Delve bug

### DIFF
--- a/src/lambda/local/debugConfiguration.ts
+++ b/src/lambda/local/debugConfiguration.ts
@@ -77,13 +77,20 @@ export interface DotNetCoreDebugConfiguration extends SamLaunchRequestArgs {
         [key: string]: string
     }
 }
+
+/** Go extension legacy adapter uses this for source mapping when debugging remotely */
+export interface SubstitutePath {
+    from: string
+    to: string
+}
+
 export interface GoDebugConfiguration extends SamLaunchRequestArgs {
     readonly runtimeFamily: RuntimeFamily.Go
     readonly preLaunchTask?: string
     readonly host: 'localhost'
     readonly port: number
-    readonly localRoot: string
-    readonly remoteRoot: string
+    readonly substitutePath: SubstitutePath[]
+    readonly debugAdapter: 'legacy' | 'dlv-dap' // dlv-dap is not supported by us
 }
 
 export interface PipeTransport {

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -3369,7 +3369,6 @@ Resources:
                 lambda: {
                     ...input.lambda,
                 },
-                localRoot: pathutil.normalize(path.join(appDir, 'hello-world')), // Normalized to absolute path.
                 name: input.name,
                 templatePath: pathutil.normalize(path.join(appDir, 'hello-world', 'app___vsctk___template.yaml')),
                 parameterOverrides: undefined,
@@ -3382,9 +3381,10 @@ Resources:
                 processName: 'godelve',
                 port: actual.debugPort,
                 preLaunchTask: undefined,
-                remoteRoot: '/var/task',
                 skipFiles: [],
                 debugArgs: ['-delveAPI=2'],
+                substitutePath: [{ from: '/not/a/real/path', to: '/not/a/real/path' }],
+                debugAdapter: 'legacy',
             }
 
             assertEqualLaunchConfigs(actual, expected)
@@ -3414,40 +3414,6 @@ Resources:
       Timeout: 9000
 `
             )
-
-            //
-            // Test pathMapping
-            //
-            const inputWithPathMapping = {
-                ...input,
-                lambda: {
-                    ...input.lambda,
-                    pathMappings: [
-                        {
-                            localRoot: 'somethingLocal',
-                            remoteRoot: 'somethingRemote',
-                        },
-                        {
-                            localRoot: 'ignoredLocal',
-                            remoteRoot: 'ignoredRemote',
-                        },
-                    ] as PathMapping[],
-                },
-            }
-            const actualWithPathMapping = (await debugConfigProvider.makeConfig(folder, inputWithPathMapping))!
-            const expectedWithPathMapping: SamLaunchRequestArgs = {
-                ...expected,
-                lambda: {
-                    ...expected.lambda,
-                    pathMappings: inputWithPathMapping.lambda.pathMappings,
-                },
-                localRoot: 'somethingLocal',
-                remoteRoot: 'somethingRemote',
-                baseBuildDir: actualWithPathMapping.baseBuildDir,
-                envFile: `${actualWithPathMapping.baseBuildDir}/env-vars.json`,
-                eventPayloadFile: `${actualWithPathMapping.baseBuildDir}/event.json`,
-            }
-            assertEqualLaunchConfigs(actualWithPathMapping, expectedWithPathMapping)
 
             //
             // Test noDebug=true.


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

### This is just a draft for now because I want to try a PR for the Go extension before implementing a workaround here
#### Also the actual workaround is only a couple lines, the rest of the changes are just removing the old source mapping code that didn't do anything

## Problem
Go1.15+ causes a bug in Delve that prevents in from parsing the Go runtime assembly file. Delve returns an empty file string to VSCode's debug adapter, causing an unhandled exception to be thrown. 

## Solution
We can bypass this by preventing the debug adapter from inferring file paths through setting `substitutePath` in the launch configuration. This does not need to actually do anything. We are running Delve in 'exec' mode, meaning there isn't any file paths to convert from local/remote. We also set `debugAdapter` to 'legacy' just in case the Go extension decides to make 'dlv-dap' the default. There appears to still be issues with variables not being resolved correctly, though this is a bug with the Go extension.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
