### PR TITLE
AWS Explorer refreshes after SAM application is deployed

### DIFF
--- a/src/lambda/commands/deploySamApplication.ts
+++ b/src/lambda/commands/deploySamApplication.ts
@@ -111,6 +111,8 @@ export async function deploySamApplication(
         )
 
         await deployApplicationPromise
+        // no need to await, doesn't need to block further execution
+        vscode.commands.executeCommand('aws.refreshAwsExplorer')
 
         // successful deploy: retain S3 bucket for quick future access
         // JSON object of type: { [profile: string]: { [region: string]: bucket } }


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Deploying a SAM application wouldn't show any of the resources in the AWS explorer on a successfuly deployment

## Solution
Refresh the entire explorer on deploy. Opting for this over a single service because CFN/SAM can deploy more than just Lambda.
<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
