### PR TITLE
SAM: Add retries back in for Python only

### DIFF
--- a/.changes/next-release/Bug Fix-adb07031-c137-4311-b1b2-57023233c633.json
+++ b/.changes/next-release/Bug Fix-adb07031-c137-4311-b1b2-57023233c633.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "SAM Python debugging: restore retry to ensure successful attach #1666"
+}

--- a/src/shared/sam/debugger/pythonSamDebug.ts
+++ b/src/shared/sam/debugger/pythonSamDebug.ts
@@ -21,7 +21,7 @@ import * as pathutil from '../../utilities/pathUtils'
 import { getLocalRootVariants } from '../../utilities/pathUtils'
 import { Timeout } from '../../utilities/timeoutUtils'
 import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
-import { invokeLambdaFunction, makeInputTemplate } from '../localLambdaRunner'
+import { invokeLambdaFunction, makeInputTemplate, waitForPort } from '../localLambdaRunner'
 import { SamLaunchRequestArgs } from './awsSamDebugger'
 import { ext } from '../../extensionGlobals'
 import { Runtime } from 'aws-sdk/clients/lambda'
@@ -237,8 +237,9 @@ async function waitForIkpdb(debugPort: number, timeout: Timeout) {
 }
 
 export async function waitForPythonDebugAdapter(debugPort: number, timeout: Timeout) {
+    await waitForPort(debugPort, timeout)
     await new Promise<void>(resolve => {
-        setTimeout(resolve, 1000)
+        setTimeout(resolve, 3000)
     })
 }
 

--- a/src/shared/sam/debugger/pythonSamDebug.ts
+++ b/src/shared/sam/debugger/pythonSamDebug.ts
@@ -216,12 +216,12 @@ export async function invokePythonLambda(
         WAIT_FOR_DEBUGGER_MESSAGES.PYTHON,
         WAIT_FOR_DEBUGGER_MESSAGES.PYTHON_IKPDB,
     ])
-    // Must not used waitForPythonDebugAdapter() for ikpdb: the socket consumes
+    // Must not used waitForPort() for ikpdb: the socket consumes
     // ikpdb's initial message and ikpdb does not have a --wait-for-client
     // mode, then cloud9 never sees the init message and waits forever.
     //
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    config.onWillAttachDebugger = config.useIkpdb ? waitForIkpdb : waitForPythonDebugAdapter
+    config.onWillAttachDebugger = config.useIkpdb ? waitForIkpdb : waitForPort
     const c = (await invokeLambdaFunction(ctx, config, async () => {})) as PythonDebugConfiguration
     return c
 }
@@ -233,13 +233,6 @@ async function waitForIkpdb(debugPort: number, timeout: Timeout) {
     getLogger().info('waitForIkpdb: wait 2 seconds')
     await new Promise<void>(resolve => {
         setTimeout(resolve, 2000)
-    })
-}
-
-export async function waitForPythonDebugAdapter(debugPort: number, timeout: Timeout) {
-    await waitForPort(debugPort, timeout)
-    await new Promise<void>(resolve => {
-        setTimeout(resolve, 3000)
     })
 }
 

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -72,7 +72,6 @@ function makeResourceName(config: SamLaunchRequestArgs): string {
 
 const SAM_LOCAL_PORT_CHECK_RETRY_INTERVAL_MILLIS: number = 125
 const SAM_LOCAL_PORT_CHECK_RETRY_TIMEOUT_MILLIS_DEFAULT: number = 30000
-const MAX_DEBUGGER_RETRIES: number = 1
 const ATTACH_DEBUGGER_RETRY_DELAY_MILLIS: number = 1000
 
 /** "sam local start-api" wrapper from the current debug-session. */
@@ -520,10 +519,18 @@ export async function attachDebugger({
 
     getLogger('channel').info(localize('AWS.output.sam.local.attaching', 'Attaching debugger to SAM application...'))
 
+    // The Python extension will silently fail, so it's ok for us to automatically retry
+    // Users still will not be able to stop debugging without clicking stop a bunch, but
+    // at least it's not modal popups.
+    // TODO: figure out why the Python debug client fails to attach on the first try
+    function maxRetries() {
+        return params.debugConfig.runtimeFamily === RuntimeFamily.Python ? 8 : 1
+    }
+
     do {
         isDebuggerAttached = await onStartDebugging(undefined, params.debugConfig)
         if (!isDebuggerAttached) {
-            if (retries < MAX_DEBUGGER_RETRIES) {
+            if (retries < maxRetries()) {
                 if (onWillRetry) {
                     await onWillRetry()
                 }


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
'debugpy' does not emit a message when it starts, so our cue message only detects when the debug wrapper is executed. Since we do not retry debugger attachment anymore, the process will fail if 'debugpy' has not completely finished initializing. 

## Solution
* Bump the sleep time from 1 second to 3 seconds
* Use `waitForPort` before we sleep. The port being used does not mean that 'debugpy' is ready for connections, but it does mean it has started the server (so slightly better than the cue message).

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
