### PR TITLE
integ/tests: Reduce transient failures

### DIFF
--- a/src/integrationTest/codelens.js.test.ts
+++ b/src/integrationTest/codelens.js.test.ts
@@ -6,11 +6,12 @@
 import * as assert from 'assert'
 import { dirname, join } from 'path'
 import * as vscode from 'vscode'
-import { expectCodeLenses, getTestWorkspaceFolder } from './integrationTestsUtilities'
+import { getAddConfigCodeLens, getTestWorkspaceFolder } from './integrationTestsUtilities'
 import { AddSamDebugConfigurationInput } from '../shared/sam/debugger/commands/addSamDebugConfiguration'
 
 const ACTIVATE_EXTENSION_TIMEOUT_MILLIS = 30000
 const CODELENS_TEST_TIMEOUT_MILLIS = 10000
+const CODELENS_RETRY_INTERVAL = 1000
 
 const workspaceFolder = getTestWorkspaceFolder()
 
@@ -26,7 +27,11 @@ describe('SAM Local CodeLenses (JS)', async function () {
         const expectedHandlerName = 'app.handlerBesidePackageJson'
         const document = await vscode.workspace.openTextDocument(appCodePath)
 
-        const codeLenses = await expectCodeLenses(document.uri)
+        const codeLenses = await getAddConfigCodeLens(
+            document.uri,
+            CODELENS_TEST_TIMEOUT_MILLIS,
+            CODELENS_RETRY_INTERVAL
+        )
 
         assertAddDebugConfigCodeLensExists(codeLenses, expectedHandlerName, dirname(appCodePath))
     }).timeout(CODELENS_TEST_TIMEOUT_MILLIS)
@@ -37,7 +42,11 @@ describe('SAM Local CodeLenses (JS)', async function () {
         const expectedHandlerName = 'src/subfolder/app.handlerTwoFoldersDeep'
         const document = await vscode.workspace.openTextDocument(appCodePath)
 
-        const codeLenses = await expectCodeLenses(document.uri)
+        const codeLenses = await getAddConfigCodeLens(
+            document.uri,
+            CODELENS_TEST_TIMEOUT_MILLIS,
+            CODELENS_RETRY_INTERVAL
+        )
 
         assertAddDebugConfigCodeLensExists(codeLenses, expectedHandlerName, join(dirname(appCodePath), '..', '..'))
     }).timeout(CODELENS_TEST_TIMEOUT_MILLIS)
@@ -48,7 +57,11 @@ describe('SAM Local CodeLenses (JS)', async function () {
         const expectedHandlerName = 'subfolder/app.handlerInManifestSubfolder'
         const document = await vscode.workspace.openTextDocument(appCodePath)
 
-        const codeLenses = await expectCodeLenses(document.uri)
+        const codeLenses = await getAddConfigCodeLens(
+            document.uri,
+            CODELENS_TEST_TIMEOUT_MILLIS,
+            CODELENS_RETRY_INTERVAL
+        )
 
         assertAddDebugConfigCodeLensExists(codeLenses, expectedHandlerName, join(dirname(appCodePath), '..'))
     }).timeout(CODELENS_TEST_TIMEOUT_MILLIS)
@@ -59,16 +72,22 @@ describe('SAM Local CodeLenses (JS)', async function () {
         const expectedHandlerName = 'app.projectDeepInWorkspace'
         const document = await vscode.workspace.openTextDocument(appCodePath)
 
-        const codeLenses = await expectCodeLenses(document.uri)
+        const codeLenses = await getAddConfigCodeLens(
+            document.uri,
+            CODELENS_TEST_TIMEOUT_MILLIS,
+            CODELENS_RETRY_INTERVAL
+        )
 
         assertAddDebugConfigCodeLensExists(codeLenses, expectedHandlerName, dirname(appCodePath))
     })
 
     function assertAddDebugConfigCodeLensExists(
-        codeLenses: vscode.CodeLens[],
+        codeLenses: vscode.CodeLens[] | undefined,
         expectedHandlerName: string,
         manifestPath: string
     ) {
+        assert.ok(codeLenses !== undefined, 'Did not expect undefined when requesting CodeLenses')
+
         const debugCodeLenses = getLocalInvokeCodeLenses(codeLenses).filter(codeLens =>
             hasLocalInvokeArguments(codeLens, expectedHandlerName, manifestPath)
         )

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -228,7 +228,7 @@ async function invokeLambdaHandler(
             debugPort: debugPort,
             debuggerPath: config.debuggerPath,
             debugArgs: config.debugArgs,
-            skipPullImage: config.sam?.skipNewImageCheck,
+            skipPullImage: true, // We already built the image, but `sam local start-api` will try to build it again
             parameterOverrides: config.parameterOverrides,
             containerEnvFile: config.containerEnvFile,
             extraArgs: config.sam?.localArguments,

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -297,7 +297,7 @@ async function invokeLambdaHandler(
             debugArgs: config.debugArgs,
             containerEnvFile: config.containerEnvFile,
             extraArgs: config.sam?.localArguments,
-            skipPullImage: config.sam?.skipNewImageCheck,
+            skipPullImage: true, // We already built the image, but `sam local invoke` will try to build it again
             parameterOverrides: config.parameterOverrides,
             name: config.name,
         }

--- a/test-scripts/test.ts
+++ b/test-scripts/test.ts
@@ -9,9 +9,16 @@ import { VSCODE_EXTENSION_ID } from '../src/shared/extensions'
 import { installVSCodeExtension, setupVSCodeTestInstance } from './launchTestUtilities'
 import { env } from 'process'
 
+/**
+ * Amount of time to wait before executing tests.
+ * This gives time for extensions to initialize, otherwise the first CodeLens test will fail.
+ */
+const START_UP_DELAY = 20000
+
 async function setupVSCode(): Promise<string> {
     const vsCodeExecutablePath = await setupVSCodeTestInstance()
     await installVSCodeExtension(vsCodeExecutablePath, VSCODE_EXTENSION_ID.yaml)
+    await new Promise(r => setTimeout(r, START_UP_DELAY))
     return vsCodeExecutablePath
 }
 


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
A test or two will fail randomly during integration tests (though every other test passes)
The command `sam local start-api` appears to sometimes build the image twice for the 'image' + 'start-api' combo, causing the test to fail due to timeout.

## Solution
* Add a start-up delay before running tests (20 seconds for now)
* Force 'skip-pull-image' when invoking an API lambda.
* Small refactor to `codelens.js.test.ts` (why is this named like that) replacing `expectCodeLenses` with `getAddConfigCodeLens`

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
