### PR TITLE
settings/CDK: remove "Enable CDK" setting

### DIFF
--- a/.changes/next-release/Removal-e6787559-2fbe-4733-bcfa-f019b6ac99dd.json
+++ b/.changes/next-release/Removal-e6787559-2fbe-4733-bcfa-f019b6ac99dd.json
@@ -1,0 +1,4 @@
+{
+	"type": "Removal",
+	"description": "Settings: remove \"Enable CDK Explorer\" option (VSCode has built-in support for showing/hiding panels already)"
+}

--- a/package.json
+++ b/package.json
@@ -552,7 +552,7 @@
                 {
                     "id": "aws.cdk.explorer",
                     "name": "%AWS.cdk.explorerTitle%",
-                    "when": "config.aws.cdk.explorer.enabled"
+                    "when": "config.aws.cdk.explorer.enabled && !isCloud9"
                 }
             ]
         },

--- a/package.json
+++ b/package.json
@@ -109,11 +109,6 @@
                     "default": 30000,
                     "markdownDescription": "%AWS.configuration.description.samcli.debug.attach.timeout%"
                 },
-                "aws.cdk.explorer.enabled": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "%AWS.configuration.description.cdk.explorer.enabled%"
-                },
                 "aws.logLevel": {
                     "type": "string",
                     "default": "info",
@@ -552,7 +547,7 @@
                 {
                     "id": "aws.cdk.explorer",
                     "name": "%AWS.cdk.explorerTitle%",
-                    "when": "config.aws.cdk.explorer.enabled && !isCloud9"
+                    "when": "!isCloud9"
                 }
             ]
         },

--- a/package.nls.json
+++ b/package.nls.json
@@ -18,7 +18,6 @@
     "AWS.codelens.lambda.configEditor": "Edit Debug Configuration (Beta)",
     "AWS.configuration.title": "AWS Configuration",
     "AWS.configuration.profileDescription": "The name of the credential profile to obtain credentials from.",
-    "AWS.configuration.description.cdk.explorer.enabled": "Enable CDK Explorer",
     "AWS.configuration.description.logLevel": "The AWS Toolkit's log level (changes reflected on restart)",
     "AWS.configuration.description.onDefaultRegionMissing": "Action to take when a Profile's default region is hidden in the Explorer. Possible values:\n* `add` - shows region in the explorer\n* `ignore` - does nothing with the region\n* `prompt` - (default) asks the user what they would like to do.",
     "AWS.configuration.description.s3.maxItemsPerPage": "Controls how many S3 items are listed before showing a node to `Load More...`.\nThis corresponds to the `MaxKeys` requested in a single call to S3. [Learn More](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html#AmazonS3-ListObjectsV2-response-MaxKeys)",

--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -53,9 +53,11 @@ export async function activate(activateArguments: {
         activateArguments.regionProvider
     )
 
-    activateArguments.context.subscriptions.push(
-        vscode.window.registerTreeDataProvider(awsExplorer.viewProviderId, awsExplorer)
-    )
+    const view = vscode.window.createTreeView(awsExplorer.viewProviderId, {
+        treeDataProvider: awsExplorer,
+        showCollapseAll: true,
+    })
+    activateArguments.context.subscriptions.push(view)
 
     await registerAwsExplorerCommands(
         activateArguments.context,

--- a/src/cdk/activation.ts
+++ b/src/cdk/activation.ts
@@ -5,18 +5,10 @@
 
 import * as vscode from 'vscode'
 import { cdkDocumentationUrl } from '../shared/constants'
-import {
-    recordCdkAppExpanded,
-    recordCdkExplorerDisabled,
-    recordCdkExplorerEnabled,
-    recordCdkHelp,
-    recordCdkRefreshExplorer,
-} from '../shared/telemetry/telemetry'
+import { recordCdkAppExpanded, recordCdkHelp, recordCdkRefreshExplorer } from '../shared/telemetry/telemetry'
 import { AwsCdkExplorer } from './explorer/awsCdkExplorer'
 import { AppNode } from './explorer/nodes/appNode'
 import { cdk } from './globals'
-
-const EXPLORER_ENABLED_CONFIG_KEY = 'aws.cdk.explorer.enabled'
 
 /**
  * Activate AWS CDK related functionality for the extension.
@@ -34,25 +26,14 @@ export async function activate(activateArguments: { extensionContext: vscode.Ext
     activateArguments.extensionContext.subscriptions.push(view)
 
     // Indicates workspace includes a CDK app and user has expanded the Node
-    const appNodeExpanded = view.onDidExpandElement(e => {
-        if (e.element instanceof AppNode && !e.element.expandMetricRecorded) {
-            e.element.expandMetricRecorded = true
-            recordCdkAppExpanded()
-        }
-    })
-    activateArguments.extensionContext.subscriptions.push(appNodeExpanded)
-
-    // Indicates CDK explorer view was toggled through configuration setting
-    const explorerEnabledToggled = vscode.workspace.onDidChangeConfiguration(e => {
-        if (e.affectsConfiguration(EXPLORER_ENABLED_CONFIG_KEY)) {
-            if (vscode.workspace.getConfiguration().get(EXPLORER_ENABLED_CONFIG_KEY)) {
-                recordCdkExplorerEnabled()
-            } else {
-                recordCdkExplorerDisabled()
+    activateArguments.extensionContext.subscriptions.push(
+        view.onDidExpandElement(e => {
+            if (e.element instanceof AppNode && !e.element.expandMetricRecorded) {
+                e.element.expandMetricRecorded = true
+                recordCdkAppExpanded()
             }
-        }
-    })
-    activateArguments.extensionContext.subscriptions.push(explorerEnabledToggled)
+        })
+    )
 }
 
 function initializeIconPaths(context: vscode.ExtensionContext) {


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem

- CDK: the "Enable CDK" setting is redundant, VSCode already has implicit support for showing/hiding panels
- CDK panel is shown on Cloud9

## Solution

- remove "Enable CDK" setting
- hide CDK on Cloud9

Closes https://github.com/aws/aws-toolkit-vscode/issues/1669

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
