### PR TITLE
CDK: show main-menu items if AWS panel is hidden; search for projects only if CDK is enabled

### DIFF
--- a/.changes/next-release/Feature-5137cbc0-26f1-4f13-9a14-e39394545448.json
+++ b/.changes/next-release/Feature-5137cbc0-26f1-4f13-9a14-e39394545448.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "CDK: menu includes standard items if AWS view is hidden"
+}

--- a/package.json
+++ b/package.json
@@ -801,27 +801,27 @@
                 },
                 {
                     "command": "aws.help",
-                    "when": "view == aws.explorer",
+                    "when": "view == aws.explorer || !aws.explorer.visible && view =~ /^aws/",
                     "group": "y_externalLinks@1"
                 },
                 {
                     "command": "aws.github",
-                    "when": "view == aws.explorer",
+                    "when": "view == aws.explorer || !aws.explorer.visible && view =~ /^aws/",
                     "group": "y_externalLinks@2"
                 },
                 {
                     "command": "aws.createIssueOnGitHub",
-                    "when": "view == aws.explorer",
+                    "when": "view == aws.explorer || !aws.explorer.visible && view =~ /^aws/",
                     "group": "y_externalLinks@3"
                 },
                 {
                     "command": "aws.submitFeedback",
-                    "when": "view == aws.explorer",
+                    "when": "view == aws.explorer || !aws.explorer.visible && view =~ /^aws/",
                     "group": "y_externalLinks@4"
                 },
                 {
                     "command": "aws.aboutToolkit",
-                    "when": "view == aws.explorer",
+                    "when": "view == aws.explorer || !aws.explorer.visible && view =~ /^aws/",
                     "group": "z_about@1"
                 },
                 {
@@ -833,16 +833,6 @@
                     "command": "aws.cdk.help",
                     "when": "view == aws.cdk.explorer",
                     "group": "z_externalLinks@1"
-                },
-                {
-                    "command": "aws.createIssueOnGitHub",
-                    "when": "view == aws.cdk.explorer",
-                    "group": "z_externalLinks@2"
-                },
-                {
-                    "command": "aws.submitFeedback",
-                    "when": "view == aws.cdk.explorer",
-                    "group": "z_externalLinks@3"
                 }
             ],
             "view/item/context": [

--- a/src/cdk/activation.ts
+++ b/src/cdk/activation.ts
@@ -25,6 +25,14 @@ export async function activate(activateArguments: { extensionContext: vscode.Ext
     })
     activateArguments.extensionContext.subscriptions.push(view)
 
+    activateArguments.extensionContext.subscriptions.push(
+        view.onDidChangeVisibility(e => {
+            explorer.visible = e.visible
+            if (e.visible) {
+                explorer.refresh()
+            }
+        })
+    )
     // Indicates workspace includes a CDK app and user has expanded the Node
     activateArguments.extensionContext.subscriptions.push(
         view.onDidExpandElement(e => {

--- a/src/cdk/explorer/awsCdkExplorer.ts
+++ b/src/cdk/explorer/awsCdkExplorer.ts
@@ -18,6 +18,7 @@ import { CdkErrorNode } from './nodes/errorNode'
  */
 export class AwsCdkExplorer implements vscode.TreeDataProvider<AWSTreeNodeBase>, RefreshableAwsTreeProvider {
     public viewProviderId: string = 'aws.cdk.explorer'
+    public visible = false
     private readonly onDidChangeTreeDataEventEmitter: vscode.EventEmitter<AWSTreeNodeBase | undefined>
 
     public get onDidChangeTreeData(): vscode.Event<AWSTreeNodeBase | undefined> {
@@ -33,6 +34,9 @@ export class AwsCdkExplorer implements vscode.TreeDataProvider<AWSTreeNodeBase>,
     }
 
     public async getChildren(element?: AWSTreeNodeBase): Promise<AWSTreeNodeBase[]> {
+        if (!this.visible) {
+            return []
+        }
         if (element) {
             return element.getChildren()
         } else {

--- a/src/test/cdk/explorer/awsCdkExplorer.test.ts
+++ b/src/test/cdk/explorer/awsCdkExplorer.test.ts
@@ -21,19 +21,24 @@ beforeEach(function () {
 afterEach(function () {
     sandbox.restore()
 })
+
 describe('AwsCdkExplorer', function () {
-    it('Displays Error node indicating that no CDK projects were found in empty workspace', async function () {
+    it('does nothing if not visible', async function () {
         const awsCdkExplorer = new AwsCdkExplorer()
+        awsCdkExplorer.visible = false
+        const treeNodes = await awsCdkExplorer.getChildren()
+        assert.strictEqual(treeNodes.length, 0)
+    })
 
-        const treeNodesPromise = awsCdkExplorer.getChildren()
-
-        const treeNodes = await treeNodesPromise
-        assert(treeNodes)
+    it('shows a message if no CDK projects were found', async function () {
+        const awsCdkExplorer = new AwsCdkExplorer()
+        awsCdkExplorer.visible = true
+        const treeNodes = await awsCdkExplorer.getChildren()
         assert.strictEqual(treeNodes.length, 1)
         assert.strictEqual(treeNodes[0] instanceof CdkErrorNode, true)
     })
 
-    it('Displays a project node when workspaces are detected', async function () {
+    it('shows CDK projects', async function () {
         const stubUri = sandbox.createStubInstance(vscode.Uri)
         const workspaceFolder: vscode.WorkspaceFolder = { uri: stubUri, index: 0, name: 'testworkspace' }
 
@@ -48,9 +53,8 @@ describe('AwsCdkExplorer', function () {
         sandbox.stub(app, 'AppNode').returns(stubAppNode)
 
         const awsCdkExplorer = new AwsCdkExplorer()
-        const treeNodesPromise = awsCdkExplorer.getChildren()
-        const treeNodes = await treeNodesPromise
-        assert(treeNodes)
+        awsCdkExplorer.visible = true
+        const treeNodes = await awsCdkExplorer.getChildren()
         assert.strictEqual(treeNodes.length, 1)
         assert.strictEqual(treeNodes[0], stubAppNode)
     })


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem

1. If CDK view is hidden, it's wasteful to search for CDK projects.
1. Any view can be shown/hidden. But the Toolkit "standard" menu items (such as help docs, feedback, etc.) are defined in the AWS view. 

## Solution

1. Skip search if CDK view is not visible; refresh() when set to visible.
1. If the AWS view is hidden, show the "standard" menu items in non-AWS view menus.
    - ref e132be025e90 #1632

<img width="441" alt="aws-cdk-panel-menus" src="https://user-images.githubusercontent.com/55561878/116273585-ba43a500-a736-11eb-96cb-56d4672437a2.png">


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
