### PR TITLE
SAM run/debug: cannot run/debug if project dir has non-alphanumeric chars

### DIFF
--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -743,7 +743,7 @@ export namespace CloudFormation {
      * @param filename Filename
      * @returns  Resource id based on `path`
      */
-    export function getResourceId(s: string) {
+    export function makeResourceId(s: string) {
         return s.replace(/[^A-Za-z0-9]/g, '')
     }
 }

--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -741,7 +741,7 @@ export namespace CloudFormation {
      * > The logical ID must be alphanumeric (A-Za-z0-9) and unique within the template
      *
      * @param filename Filename
-     * @returns  Resource id based on `path`
+     * @returns  Resource id derived from the input.
      */
     export function makeResourceId(s: string) {
         return s.replace(/[^A-Za-z0-9]/g, '')

--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -731,4 +731,19 @@ export namespace CloudFormation {
 
         return undefined
     }
+
+    /**
+     * Removes characters disallowed in CFN/SAM logical resource ids.
+     *
+     * Example: "/a/b/c/foo-Bar!_baz{9)=+" => "abcfooBarbaz9"
+     *
+     * Reference: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html
+     * > The logical ID must be alphanumeric (A-Za-z0-9) and unique within the template
+     *
+     * @param filename Filename
+     * @returns  Resource id based on `path`
+     */
+    export function getResourceId(s: string) {
+        return s.replace(/[^A-Za-z0-9]/g, '')
+    }
 }

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -67,10 +67,9 @@ function getEnvironmentVariables(
  */
 function makeResourceName(config: SamLaunchRequestArgs): string {
     if (config.invokeTarget.target === 'code') {
-        // const projectDir = vscode.Uri.file(config.invokeTarget.projectRoot)
         // CodeUri may be ".", we need a name. #1685
         const fullPath = tryGetAbsolutePath(config.workspaceFolder, config.invokeTarget.projectRoot)
-        const logicalId = CloudFormation.getResourceId(path.parse(fullPath).name)
+        const logicalId = CloudFormation.makeResourceId(path.parse(fullPath).name)
         return logicalId === ''
             ? 'resource1' // projectRoot has only non-alphanumeric chars :(
             : logicalId

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -34,6 +34,7 @@ import { DefaultSamCliConfiguration } from './cli/samCliConfiguration'
 import { extensionSettingsPrefix } from '../constants'
 import { DefaultSamCliLocationProvider } from './cli/samCliLocator'
 import { getSamCliContext, getSamCliVersion } from './cli/samCliContext'
+import { CloudFormation } from '../cloudformation/cloudformation'
 
 const localize = nls.loadMessageBundle()
 
@@ -65,9 +66,17 @@ function getEnvironmentVariables(
  * Decides the resource name for the generated template.yaml.
  */
 function makeResourceName(config: SamLaunchRequestArgs): string {
-    return config.invokeTarget.target === 'code'
-        ? path.parse(config.invokeTarget.projectRoot).name
-        : config.invokeTarget.logicalId
+    if (config.invokeTarget.target === 'code') {
+        // const projectDir = vscode.Uri.file(config.invokeTarget.projectRoot)
+        // CodeUri may be ".", we need a name. #1685
+        const fullPath = tryGetAbsolutePath(config.workspaceFolder, config.invokeTarget.projectRoot)
+        const logicalId = CloudFormation.getResourceId(path.parse(fullPath).name)
+        return logicalId === ''
+            ? 'resource1' // projectRoot has only non-alphanumeric chars :(
+            : logicalId
+    } else {
+        return config.invokeTarget.logicalId
+    }
 }
 
 const SAM_LOCAL_PORT_CHECK_RETRY_INTERVAL_MILLIS: number = 125


### PR DESCRIPTION

## Problem:
Cannot run/debug if project dir has non-alphanumeric chars (such as hyphens).

- For Java compat, ba1cbffc57a3b changed makeResourceName() (which   generates a temporary/intermediate template.yaml) such that it chooses  a resource name based on the project directory name.
  - To avoid having multiple codepaths, we chose to use this logic for    all runtime types.
  - But filesystem (directory) name may have characters that are not    allowed in a SAM/CFN template.yaml resource id (logical id).

## Solution:
- Scrub the name when generating a resource id.
- Expand the path to ensure relative paths like "." have a usable name.

ref https://github.com/aws/aws-toolkit-vscode/issues/1684
ref https://github.com/aws/aws-toolkit-vscode/issues/1685

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
