### PR TITLE
SAM: Stop lambda runner on a fatal error

### DIFF
--- a/.changes/next-release/Feature-0eb750ad-9159-4b82-9f58-f68b3510ff79.json
+++ b/.changes/next-release/Feature-0eb750ad-9159-4b82-9f58-f68b3510ff79.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "SAM run/debug: fail early so that build/invoke errors are more obvious #1689"
+}

--- a/src/shared/sam/debugger/csharpSamDebug.ts
+++ b/src/shared/sam/debugger/csharpSamDebug.ts
@@ -16,7 +16,7 @@ import { RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
 import * as pathutil from '../../../shared/utilities/pathUtils'
 import { ExtContext } from '../../extensions'
 import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
-import { invokeLambdaFunction, makeInputTemplate, waitForPort } from '../localLambdaRunner'
+import { buildAndInvokeLambdaHandler, makeInputTemplate, waitForPort } from '../localLambdaRunner'
 import { SamLaunchRequestArgs } from './awsSamDebugger'
 import { ChildProcess } from '../../utilities/childProcess'
 import { HttpResourceFetcher } from '../../resourcefetcher/httpResourceFetcher'
@@ -68,7 +68,7 @@ export async function invokeCsharpLambda(ctx: ExtContext, config: SamLaunchReque
     config.samLocalInvokeCommand = new DefaultSamLocalInvokeCommand([WAIT_FOR_DEBUGGER_MESSAGES.DOTNET])
     // eslint-disable-next-line @typescript-eslint/unbound-method
     config.onWillAttachDebugger = waitForPort
-    return await invokeLambdaFunction(ctx, config, async () => {
+    return await buildAndInvokeLambdaHandler(ctx, config, async () => {
         if (!config.noDebug) {
             await _installDebugger({
                 debuggerPath: config.debuggerPath!!,

--- a/src/shared/sam/debugger/csharpSamDebug.ts
+++ b/src/shared/sam/debugger/csharpSamDebug.ts
@@ -16,7 +16,7 @@ import { RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
 import * as pathutil from '../../../shared/utilities/pathUtils'
 import { ExtContext } from '../../extensions'
 import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
-import { buildAndInvokeLambdaHandler, makeInputTemplate, waitForPort } from '../localLambdaRunner'
+import { runLambdaFunction, makeInputTemplate, waitForPort } from '../localLambdaRunner'
 import { SamLaunchRequestArgs } from './awsSamDebugger'
 import { ChildProcess } from '../../utilities/childProcess'
 import { HttpResourceFetcher } from '../../resourcefetcher/httpResourceFetcher'
@@ -68,7 +68,7 @@ export async function invokeCsharpLambda(ctx: ExtContext, config: SamLaunchReque
     config.samLocalInvokeCommand = new DefaultSamLocalInvokeCommand([WAIT_FOR_DEBUGGER_MESSAGES.DOTNET])
     // eslint-disable-next-line @typescript-eslint/unbound-method
     config.onWillAttachDebugger = waitForPort
-    return await buildAndInvokeLambdaHandler(ctx, config, async () => {
+    return await runLambdaFunction(ctx, config, async () => {
         if (!config.noDebug) {
             await _installDebugger({
                 debuggerPath: config.debuggerPath!!,

--- a/src/shared/sam/debugger/goSamDebug.ts
+++ b/src/shared/sam/debugger/goSamDebug.ts
@@ -12,7 +12,7 @@ import * as pathutil from '../../../shared/utilities/pathUtils'
 import { ExtContext } from '../../extensions'
 import { findParentProjectFile } from '../../utilities/workspaceUtils'
 import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
-import { buildAndInvokeLambdaHandler, makeInputTemplate } from '../localLambdaRunner'
+import { runLambdaFunction, makeInputTemplate } from '../localLambdaRunner'
 import { SamLaunchRequestArgs } from './awsSamDebugger'
 import { getLogger } from '../../logger'
 import { chmod, ensureDir, writeFile, pathExistsSync, unlinkSync, existsSync } from 'fs-extra'
@@ -42,7 +42,7 @@ export async function invokeGoLambda(ctx: ExtContext, config: GoDebugConfigurati
         return {} as GoDebugConfiguration
     }
 
-    const c = (await buildAndInvokeLambdaHandler(ctx, config, async () => {})) as GoDebugConfiguration
+    const c = (await runLambdaFunction(ctx, config, async () => {})) as GoDebugConfiguration
     return c
 }
 

--- a/src/shared/sam/debugger/goSamDebug.ts
+++ b/src/shared/sam/debugger/goSamDebug.ts
@@ -12,7 +12,7 @@ import * as pathutil from '../../../shared/utilities/pathUtils'
 import { ExtContext } from '../../extensions'
 import { findParentProjectFile } from '../../utilities/workspaceUtils'
 import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
-import { invokeLambdaFunction, makeInputTemplate } from '../localLambdaRunner'
+import { buildAndInvokeLambdaHandler, makeInputTemplate } from '../localLambdaRunner'
 import { SamLaunchRequestArgs } from './awsSamDebugger'
 import { getLogger } from '../../logger'
 import { chmod, ensureDir, writeFile, pathExistsSync, unlinkSync, existsSync } from 'fs-extra'
@@ -35,17 +35,14 @@ export async function invokeGoLambda(ctx: ExtContext, config: GoDebugConfigurati
 
     if (!config.noDebug && !(await installDebugger(config.debuggerPath!))) {
         showErrorWithLogs(
-            localize(
-                'AWS.sam.debugger.godelve.failed',
-                'Failed to install Delve for the lambda container.'
-            )
+            localize('AWS.sam.debugger.godelve.failed', 'Failed to install Delve for the lambda container.')
         )
 
         // Terminates the debug session by sending up a dummy config
         return {} as GoDebugConfiguration
     }
 
-    const c = (await invokeLambdaFunction(ctx, config, async () => {})) as GoDebugConfiguration
+    const c = (await buildAndInvokeLambdaHandler(ctx, config, async () => {})) as GoDebugConfiguration
     return c
 }
 

--- a/src/shared/sam/debugger/javaSamDebug.ts
+++ b/src/shared/sam/debugger/javaSamDebug.ts
@@ -9,7 +9,7 @@ import { RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
 import { ExtContext, VSCODE_EXTENSION_ID } from '../../extensions'
 import { getLogger } from '../../logger'
 import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
-import { invokeLambdaFunction, makeInputTemplate, waitForPort } from '../localLambdaRunner'
+import { buildAndInvokeLambdaHandler, makeInputTemplate, waitForPort } from '../localLambdaRunner'
 import { SamLaunchRequestArgs } from './awsSamDebugger'
 
 export async function activateJavaExtensionIfInstalled() {
@@ -64,5 +64,5 @@ export async function invokeJavaLambda(ctx: ExtContext, config: SamLaunchRequest
             setTimeout(resolve, 1000)
         })
     }
-    return await invokeLambdaFunction(ctx, config, async () => {})
+    return await buildAndInvokeLambdaHandler(ctx, config, async () => {})
 }

--- a/src/shared/sam/debugger/javaSamDebug.ts
+++ b/src/shared/sam/debugger/javaSamDebug.ts
@@ -9,7 +9,7 @@ import { RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
 import { ExtContext, VSCODE_EXTENSION_ID } from '../../extensions'
 import { getLogger } from '../../logger'
 import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
-import { buildAndInvokeLambdaHandler, makeInputTemplate, waitForPort } from '../localLambdaRunner'
+import { runLambdaFunction, makeInputTemplate, waitForPort } from '../localLambdaRunner'
 import { SamLaunchRequestArgs } from './awsSamDebugger'
 
 export async function activateJavaExtensionIfInstalled() {
@@ -64,5 +64,5 @@ export async function invokeJavaLambda(ctx: ExtContext, config: SamLaunchRequest
             setTimeout(resolve, 1000)
         })
     }
-    return await buildAndInvokeLambdaHandler(ctx, config, async () => {})
+    return await runLambdaFunction(ctx, config, async () => {})
 }

--- a/src/shared/sam/debugger/pythonSamDebug.ts
+++ b/src/shared/sam/debugger/pythonSamDebug.ts
@@ -21,7 +21,7 @@ import * as pathutil from '../../utilities/pathUtils'
 import { getLocalRootVariants } from '../../utilities/pathUtils'
 import { Timeout } from '../../utilities/timeoutUtils'
 import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
-import { buildAndInvokeLambdaHandler, makeInputTemplate } from '../localLambdaRunner'
+import { runLambdaFunction, makeInputTemplate } from '../localLambdaRunner'
 import { SamLaunchRequestArgs } from './awsSamDebugger'
 import { ext } from '../../extensionGlobals'
 import { Runtime } from 'aws-sdk/clients/lambda'
@@ -231,7 +231,7 @@ export async function invokePythonLambda(
     //
     // eslint-disable-next-line @typescript-eslint/unbound-method
     config.onWillAttachDebugger = config.useIkpdb ? waitForIkpdb : undefined
-    const c = (await buildAndInvokeLambdaHandler(ctx, config, async () => {})) as PythonDebugConfiguration
+    const c = (await runLambdaFunction(ctx, config, async () => {})) as PythonDebugConfiguration
     return c
 }
 

--- a/src/shared/sam/debugger/pythonSamDebug.ts
+++ b/src/shared/sam/debugger/pythonSamDebug.ts
@@ -21,7 +21,7 @@ import * as pathutil from '../../utilities/pathUtils'
 import { getLocalRootVariants } from '../../utilities/pathUtils'
 import { Timeout } from '../../utilities/timeoutUtils'
 import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
-import { invokeLambdaFunction, makeInputTemplate } from '../localLambdaRunner'
+import { buildAndInvokeLambdaHandler, makeInputTemplate } from '../localLambdaRunner'
 import { SamLaunchRequestArgs } from './awsSamDebugger'
 import { ext } from '../../extensionGlobals'
 import { Runtime } from 'aws-sdk/clients/lambda'
@@ -231,7 +231,7 @@ export async function invokePythonLambda(
     //
     // eslint-disable-next-line @typescript-eslint/unbound-method
     config.onWillAttachDebugger = config.useIkpdb ? waitForIkpdb : undefined
-    const c = (await invokeLambdaFunction(ctx, config, async () => {})) as PythonDebugConfiguration
+    const c = (await buildAndInvokeLambdaHandler(ctx, config, async () => {})) as PythonDebugConfiguration
     return c
 }
 

--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -11,7 +11,7 @@ import * as pathutil from '../../../shared/utilities/pathUtils'
 import { ExtContext } from '../../extensions'
 import { findParentProjectFile } from '../../utilities/workspaceUtils'
 import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
-import { invokeLambdaFunction, makeInputTemplate, waitForPort } from '../localLambdaRunner'
+import { buildAndInvokeLambdaHandler, makeInputTemplate, waitForPort } from '../localLambdaRunner'
 import { SamLaunchRequestArgs } from './awsSamDebugger'
 import { getLogger } from '../../logger'
 
@@ -25,7 +25,7 @@ export async function invokeTypescriptLambda(
     config.samLocalInvokeCommand = new DefaultSamLocalInvokeCommand([WAIT_FOR_DEBUGGER_MESSAGES.NODEJS])
     // eslint-disable-next-line @typescript-eslint/unbound-method
     config.onWillAttachDebugger = waitForPort
-    const c = (await invokeLambdaFunction(ctx, config, async () => {})) as NodejsDebugConfiguration
+    const c = (await buildAndInvokeLambdaHandler(ctx, config, async () => {})) as NodejsDebugConfiguration
     return c
 }
 

--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -11,7 +11,7 @@ import * as pathutil from '../../../shared/utilities/pathUtils'
 import { ExtContext } from '../../extensions'
 import { findParentProjectFile } from '../../utilities/workspaceUtils'
 import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
-import { buildAndInvokeLambdaHandler, makeInputTemplate, waitForPort } from '../localLambdaRunner'
+import { runLambdaFunction, makeInputTemplate, waitForPort } from '../localLambdaRunner'
 import { SamLaunchRequestArgs } from './awsSamDebugger'
 import { getLogger } from '../../logger'
 
@@ -25,7 +25,7 @@ export async function invokeTypescriptLambda(
     config.samLocalInvokeCommand = new DefaultSamLocalInvokeCommand([WAIT_FOR_DEBUGGER_MESSAGES.NODEJS])
     // eslint-disable-next-line @typescript-eslint/unbound-method
     config.onWillAttachDebugger = waitForPort
-    const c = (await buildAndInvokeLambdaHandler(ctx, config, async () => {})) as NodejsDebugConfiguration
+    const c = (await runLambdaFunction(ctx, config, async () => {})) as NodejsDebugConfiguration
     return c
 }
 

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -137,7 +137,7 @@ export async function makeInputTemplate(config: SamLaunchRequestArgs): Promise<s
     return pathutil.normalize(inputTemplatePath)
 }
 
-export async function buildLambdaHandler(
+async function buildLambdaHandler(
     timer: Timeout,
     env: NodeJS.ProcessEnv,
     config: SamLaunchRequestArgs
@@ -199,7 +199,7 @@ export async function buildLambdaHandler(
     }
 }
 
-export async function invokeLambdaHandler(
+async function invokeLambdaHandler(
     timer: Timeout,
     env: NodeJS.ProcessEnv,
     config: SamLaunchRequestArgs
@@ -337,13 +337,13 @@ export async function invokeLambdaHandler(
 }
 
 /**
- * Prepares and invokes a lambda function via `sam local invoke`.
+ * Prepares and invokes a lambda function via `sam local (invoke/api)`.
  *
  * @param ctx
  * @param config
  * @param onAfterBuild  Called after `SamCliBuildInvocation.execute()`
  */
-export async function buildAndInvokeLambdaHandler(
+export async function runLambdaFunction(
     ctx: ExtContext,
     config: SamLaunchRequestArgs,
     onAfterBuild: () => Promise<void>

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -17,7 +17,6 @@ import { DefaultSettingsConfiguration, SettingsConfiguration } from '../settings
 import * as telemetry from '../telemetry/telemetry'
 import { SamTemplateGenerator } from '../templates/sam/samTemplateGenerator'
 import * as pathutil from '../utilities/pathUtils'
-import { normalizeSeparator } from '../utilities/pathUtils'
 import { Timeout } from '../utilities/timeoutUtils'
 import { tryGetAbsolutePath } from '../utilities/workspaceUtils'
 import { SamCliBuildInvocation, SamCliBuildInvocationArguments } from './cli/samCliBuild'
@@ -83,24 +82,8 @@ const SAM_LOCAL_PORT_CHECK_RETRY_TIMEOUT_MILLIS_DEFAULT: number = 30000
 const ATTACH_DEBUGGER_RETRY_DELAY_MILLIS: number = 1000
 
 /** "sam local start-api" wrapper from the current debug-session. */
-let samStartApi: Promise<void>
+let samStartApi: Promise<boolean>
 let samStartApiProc: ChildProcess | undefined
-
-export function getRelativeFunctionHandler(params: {
-    handlerName: string
-    runtime: string
-    handlerRelativePath: string
-}): string {
-    // Make function handler relative to baseDir
-    let relativeFunctionHandler: string
-    if (shouldAppendRelativePathToFunctionHandler(params.runtime)) {
-        relativeFunctionHandler = normalizeSeparator(path.join(params.handlerRelativePath, params.handlerName))
-    } else {
-        relativeFunctionHandler = params.handlerName
-    }
-
-    return relativeFunctionHandler
-}
 
 export async function makeInputTemplate(config: SamLaunchRequestArgs): Promise<string> {
     let newTemplate: SamTemplateGenerator
@@ -154,31 +137,11 @@ export async function makeInputTemplate(config: SamLaunchRequestArgs): Promise<s
     return pathutil.normalize(inputTemplatePath)
 }
 
-/**
- * Prepares and invokes a lambda function via `sam local invoke`.
- *
- * @param ctx
- * @param config
- * @param onAfterBuild  Called after `SamCliBuildInvocation.execute()`
- */
-export async function invokeLambdaFunction(
-    ctx: ExtContext,
-    config: SamLaunchRequestArgs,
-    onAfterBuild: () => Promise<void>
-): Promise<SamLaunchRequestArgs> {
-    // Switch over to the output channel so the user has feedback that we're getting things ready
-    ctx.outputChannel.show(true)
-    if (!config.noDebug) {
-        const msg =
-            (config.invokeTarget.target === 'api' ? `API "${config.api?.path}", ` : '') +
-            `Lambda "${config.handlerName}"`
-        getLogger('channel').info(localize('AWS.output.sam.local.startDebug', 'Preparing to debug locally: {0}', msg))
-    } else {
-        getLogger('channel').info(
-            localize('AWS.output.sam.local.startRun', 'Preparing to run locally: {0}', config.handlerName)
-        )
-    }
-
+export async function buildLambdaHandler(
+    timer: Timeout,
+    env: NodeJS.ProcessEnv,
+    config: SamLaunchRequestArgs
+): Promise<boolean> {
     const processInvoker = new DefaultSamCliProcessInvoker({
         preloadedConfig: new DefaultSamCliConfiguration(
             new DefaultSettingsConfiguration(extensionSettingsPrefix),
@@ -188,10 +151,7 @@ export async function invokeLambdaFunction(
 
     getLogger('channel').info(localize('AWS.output.building.sam.application', 'Building SAM application...'))
     const samBuildOutputFolder = path.join(config.baseBuildDir!, 'output')
-    const envVars = {
-        ...(config.awsCredentials ? asEnvironmentVariables(config.awsCredentials) : {}),
-        ...(config.aws?.region ? { AWS_DEFAULT_REGION: config.aws.region } : {}),
-    }
+
     const samCliArgs: SamCliBuildInvocationArguments = {
         buildDir: samBuildOutputFolder,
         // undefined triggers SAM to use the template's dir as the code root
@@ -199,7 +159,7 @@ export async function invokeLambdaFunction(
         templatePath: config.templatePath!,
         invoker: processInvoker,
         manifestPath: config.manifestPath,
-        environmentVariables: envVars,
+        environmentVariables: env,
         useContainer: config.sam?.containerBuild || false,
         extraArgs: config.sam?.buildArguments,
         skipPullImage: config.sam?.skipNewImageCheck,
@@ -228,22 +188,26 @@ export async function invokeLambdaFunction(
         await remove(config.templatePath)
         config.templatePath = path.join(samBuildOutputFolder, 'template.yaml')
         getLogger('channel').info(localize('AWS.output.building.sam.application.complete', 'Build complete.'))
+        return true
     } catch (err) {
         // build unsuccessful: don't delete temp template and continue using it for invocation
         // will be cleaned up in the last `finally` step
         getLogger('channel').warn(
             localize('AWS.samcli.build.failedBuild', '"sam build" failed: {0}', config.templatePath)
         )
+        return false
     }
+}
 
-    await onAfterBuild()
-
+export async function invokeLambdaHandler(
+    timer: Timeout,
+    env: NodeJS.ProcessEnv,
+    config: SamLaunchRequestArgs
+): Promise<boolean> {
     getLogger('channel').info(localize('AWS.output.starting.sam.app.locally', 'Starting SAM application locally'))
     getLogger().debug(`localLambdaRunner.invokeLambdaFunction: ${config.name}`)
 
-    const timer = createInvokeTimer(ctx.settings)
     const debugPort = !config.noDebug ? config.debugPort?.toString() : undefined
-    const lambdaPackageType = isImageLambdaConfig(config) ? 'Image' : 'Zip'
 
     if (config.invokeTarget.target === 'api') {
         // sam local start-api ...
@@ -259,7 +223,7 @@ export async function invokeLambdaFunction(
             templatePath: config.templatePath,
             dockerNetwork: config.sam?.dockerNetwork,
             environmentVariablePath: config.envFile,
-            environmentVariables: envVars,
+            environmentVariables: env,
             port: config.apiPort?.toString(),
             debugPort: debugPort,
             debuggerPath: config.debuggerPath,
@@ -282,36 +246,42 @@ export async function invokeLambdaFunction(
 
         // We want async behavior so `await` is intentionally not used here, we
         // need to call requestLocalApi() while it is up.
-        samStartApi = config
-            .samLocalInvokeCommand!.invoke({
-                options: {
-                    env: {
-                        ...process.env,
-                        ...envVars,
+        samStartApi = new Promise(resolve => {
+            config
+                .samLocalInvokeCommand!.invoke({
+                    options: {
+                        env: {
+                            ...process.env,
+                            ...env,
+                        },
                     },
-                },
-                command: samCommand,
-                args: samArgs,
-                // "sam local start-api" produces "attach" messages similar to "sam local invoke".
-                waitForCues: true,
-                timeout: timer,
-                name: config.name,
-            })
-            .then(sam => {
-                recordApigwTelemetry('Succeeded')
-                samStartApiProc = sam
-            })
-            .catch(e => {
-                recordApigwTelemetry('Failed')
-                getLogger().warn(e as Error)
-                getLogger('channel').error(
-                    localize(
-                        'AWS.error.during.apig.local',
-                        'Failed to start local API Gateway: {0}',
-                        (e as Error).message
+                    command: samCommand,
+                    args: samArgs,
+                    // "sam local start-api" produces "attach" messages similar to "sam local invoke".
+                    waitForCues: true,
+                    timeout: timer,
+                    name: config.name,
+                })
+                .then(sam => {
+                    recordApigwTelemetry('Succeeded')
+                    samStartApiProc = sam
+                    resolve(true)
+                })
+                .catch(e => {
+                    recordApigwTelemetry('Failed')
+                    getLogger().warn(e as Error)
+                    getLogger('channel').error(
+                        localize(
+                            'AWS.error.during.apig.local',
+                            'Failed to start local API Gateway: {0}',
+                            (e as Error).message
+                        )
                     )
-                )
-            })
+                    resolve(false)
+                })
+        })
+
+        return true
     } else {
         // 'target=code' or 'target=template'
         const localInvokeArgs: SamCliLocalInvokeInvocationArguments = {
@@ -319,7 +289,7 @@ export async function invokeLambdaFunction(
             templatePath: config.templatePath,
             eventPath: config.eventPayloadFile,
             environmentVariablePath: config.envFile,
-            environmentVariables: envVars,
+            environmentVariables: env,
             invoker: config.samLocalInvokeCommand!,
             dockerNetwork: config.sam?.dockerNetwork,
             debugPort: debugPort,
@@ -349,16 +319,63 @@ export async function invokeLambdaFunction(
                     (err as Error).message
                 )
             )
+
+            return false
         } finally {
             await remove(config.templatePath)
             telemetry.recordLambdaInvokeLocal({
-                lambdaPackageType: lambdaPackageType,
+                lambdaPackageType: isImageLambdaConfig(config) ? 'Image' : 'Zip',
                 result: invokeResult,
                 runtime: config.runtime as telemetry.Runtime,
                 debug: !config.noDebug,
                 version: samVersion,
             })
         }
+
+        return true
+    }
+}
+
+/**
+ * Prepares and invokes a lambda function via `sam local invoke`.
+ *
+ * @param ctx
+ * @param config
+ * @param onAfterBuild  Called after `SamCliBuildInvocation.execute()`
+ */
+export async function buildAndInvokeLambdaHandler(
+    ctx: ExtContext,
+    config: SamLaunchRequestArgs,
+    onAfterBuild: () => Promise<void>
+): Promise<SamLaunchRequestArgs> {
+    // Switch over to the output channel so the user has feedback that we're getting things ready
+    ctx.outputChannel.show(true)
+    if (!config.noDebug) {
+        const msg =
+            (config.invokeTarget.target === 'api' ? `API "${config.api?.path}", ` : '') +
+            `Lambda "${config.handlerName}"`
+        getLogger('channel').info(localize('AWS.output.sam.local.startDebug', 'Preparing to debug locally: {0}', msg))
+    } else {
+        getLogger('channel').info(
+            localize('AWS.output.sam.local.startRun', 'Preparing to run locally: {0}', config.handlerName)
+        )
+    }
+
+    const envVars = {
+        ...(config.awsCredentials ? asEnvironmentVariables(config.awsCredentials) : {}),
+        ...(config.aws?.region ? { AWS_DEFAULT_REGION: config.aws.region } : {}),
+    }
+
+    const timer = createInvokeTimer(ctx.settings)
+
+    if (!(await buildLambdaHandler(timer, envVars, config))) {
+        return config
+    }
+
+    await onAfterBuild()
+
+    if (!(await invokeLambdaHandler(timer, envVars, config))) {
+        return config
     }
 
     if (!config.noDebug) {
@@ -367,7 +384,9 @@ export async function invokeLambdaFunction(
             // Send the request to the local API server.
             await requestLocalApi(ctx, config.api!, config.apiPort!, payload)
             // Wait for cue messages ("Starting debugger" etc.) before attach.
-            await samStartApi
+            if (!(await samStartApi)) {
+                return config
+            }
         }
 
         if (config.onWillAttachDebugger) {
@@ -387,7 +406,7 @@ export async function invokeLambdaFunction(
             retryDelayMillis: ATTACH_DEBUGGER_RETRY_DELAY_MILLIS,
             onRecordAttachDebuggerMetric: (attachResult: boolean | undefined, attempts: number): void => {
                 telemetry.recordSamAttachDebugger({
-                    lambdaPackageType: lambdaPackageType,
+                    lambdaPackageType: isImageLambdaConfig(config) ? 'Image' : 'Zip',
                     runtime: config.runtime as telemetry.Runtime,
                     result: attachResult ? 'Succeeded' : 'Failed',
                     attempts: attempts,


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Our lambda runner would keep trying to execute despite key components failing, frustrating users and outputting useless information.

## Solution
* Break up lambda runner into key components (Builder and Invoker functions)
* Return a boolean for the success or failure of each function
* Immediately return as soon as a component fails

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
