### PR TITLE
CI: remove dirmngr + apt-key step

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -14,8 +14,6 @@ phases:
             dotnet: 3.1
 
         commands:
-            # WORKAROUND for out-of-date yarn key. https://github.com/yarnpkg/yarn/issues/7866
-            - '>/dev/null apt-get install dirmngr && apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com'
             - '>/dev/null add-apt-repository universe'
             - 'wget -O- https://apt.corretto.aws/corretto.key | apt-key add - '
             - '>/dev/null add-apt-repository "deb https://apt.corretto.aws stable main"'


### PR DESCRIPTION
## Problem

dirmngr sometimes fails with a "IPC error", which causes CI to fail.

## Solution

Remove it since it was a temporary fix for https://github.com/yarnpkg/yarn/issues/7866

ref a52644096ba9e3a4815ef98debed04053893f23f
ref c8fb4347b7bd7a8b38bda821a1463115607f4db1


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
