### PR TITLE
CI/dependabot: avoid PRs in "staging"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,10 @@
-# Please see the documentation for all configuration options:
+# Documentation for configuration options:
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "daily"
+    - package-ecosystem: 'npm'
+      directory: '/' # Location of package manifests.
+      target-branch: 'master' # Avoid updates to "staging".
+      schedule:
+          interval: 'daily'


### PR DESCRIPTION
## Problem

Dependabot sends PRs to staging repo.

## Solution

Specify "master" branch explicitly.

From https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#target-branch : 

> When you use this option, the settings for this package manager will no longer affect any pull requests raised for security updates.

Hmm..

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
