### PR TITLE
startup: auto-connect when AWS Explorer is shown

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,7 @@ import * as nls from 'vscode-nls'
 import { activate as activateAwsExplorer } from './awsexplorer/activation'
 import { activate as activateCdk } from './cdk/activation'
 import { activate as activateCloudWatchLogs } from './cloudWatchLogs/activation'
-import { initialize as initializeCredentials, loginWithMostRecentCredentials } from './credentials/activation'
+import { initialize as initializeCredentials } from './credentials/activation'
 import { initializeAwsCredentialsStatusBarItem } from './credentials/awsCredentialsStatusBarItem'
 import { LoginManager } from './credentials/loginManager'
 import { CredentialsProviderManager } from './credentials/providers/credentialsProviderManager'
@@ -200,7 +200,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
         await activateAwsExplorer({
             awsContext,
-            context,
             awsContextTrees,
             regionProvider,
             toolkitOutputChannel,
@@ -239,8 +238,6 @@ export async function activate(context: vscode.ExtensionContext) {
         }
 
         showWelcomeMessage(context)
-
-        await loginWithMostRecentCredentials(toolkitSettings, loginManager)
 
         recordToolkitInitialization(activationStartedOn, getLogger())
 


### PR DESCRIPTION
## Problem:
Toolkit eagerly tries to login on startup, regardless of whether it is being used.

## Solution:
Do not attempt auto-login until AWS Explorer is made visible.

ref #1433

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
