### PR TITLE
CDK: reduce log noise

### DIFF
--- a/src/cdk/explorer/detectCdkProjects.ts
+++ b/src/cdk/explorer/detectCdkProjects.ts
@@ -79,7 +79,9 @@ async function* detectCdkProjectsInFolder(folder: string): AsyncIterableIterator
         await access(cdkJsonPath)
         yield vscode.Uri.file(cdkJsonPath)
     } catch (err) {
-        // This is usually because the file doesn't exist, but could also be a permissions issue.
-        getLogger().debug(`Error detecting CDK apps in ${folder}: %O`, err as Error)
+        if (err.code !== 'ENOENT') {
+            // Permissions issue?
+            getLogger().debug(`Error detecting CDK apps in ${folder}: %O`, err as Error)
+        }
     }
 }


### PR DESCRIPTION
## Problem:
`detectCdkProjectsInFolder()` produces log spam for every folder which does *not* have a cdk.json:

    2021-05-03 03:57:44 [DEBUG]: Error detecting CDK apps in /Volumes/workplace/sam-samples: [Error: ENOENT: no such file or directory, access '/Volumes/workplace/sam-samples/cdk.json'] {
      errno: -2,
      code: 'ENOENT',
      syscall: 'access',
      path: '/Volumes/workplace/sam-samples/cdk.json'
    }

This is not useful, we only might be interested in "permissions issue" cases.

## Solution:
Skip ENOENT cases.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
