### PR TITLE
Better direct Lambda upload messaging

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -246,7 +246,7 @@
     "AWS.lambda.upload.buildDirectory.title": "Build directory?",
     "AWS.lambda.upload.prebuiltDir.detail": "AWS Toolkit will upload a ZIP of the selected directory.",
     "AWS.lambda.upload.unbuiltDir.detail": "AWS Toolkit will attempt to build the selected directory using the sam build command.",
-    "AWS.lambda.upload.confirm": "This will immediately publish the selected code as a new version of Lambda: {0}.\n\nAWS Toolkit cannot guarantee that the built code will work.\n\nContinue?",
+    "AWS.lambda.upload.confirm": "This will immediately publish the selected code as the $LATEST version of Lambda: {0}.\n\nContinue?",
     "AWS.lambda.upload.handlerNotFound": "AWS Toolkit can't find a file corresponding to handler: {0} at filepath {1}.\n\nThis directory likely will not work with this function.\n\nProceed with upload anyway?",
     "AWS.lambda.upload.progress.generatingTemplate": "Setting up temporary build files...",
     "AWS.lambda.upload.progress.samBuilding": "Building project via sam build command...",

--- a/src/lambda/commands/uploadLambda.ts
+++ b/src/lambda/commands/uploadLambda.ts
@@ -302,7 +302,7 @@ async function confirmLambdaDeployment(functionNode: LambdaFunctionNode, window 
         {
             prompt: localize(
                 'AWS.lambda.upload.confirm',
-                'This will immediately publish the selected code as a new version of Lambda: {0}.\n\nAWS Toolkit cannot guarantee that the built code will work.\n\nContinue?',
+                'This will immediately publish the selected code as the $LATEST version of Lambda: {0}.\n\nContinue?',
                 functionNode.functionName
             ),
             confirm: localizedText.yes,


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem

Lambda upload message was confusing

## Solution

Removed confusing bits and made it more in-line with the console notifications.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
