### PR TITLE
feat(sam): try auto-connect on "Deploy", "SAM Local Run/Debug"

### DIFF
--- a/src/credentials/activation.ts
+++ b/src/credentials/activation.ts
@@ -7,18 +7,8 @@ import * as vscode from 'vscode'
 import { AwsContext } from '../shared/awsContext'
 import { profileSettingKey } from '../shared/constants'
 import { CredentialsProfileMru } from '../shared/credentials/credentialsProfileMru'
-import { LoginManager } from './loginManager'
-import { asString, CredentialsId, fromString } from './providers/credentials'
-import { CredentialsProviderManager } from './providers/credentialsProviderManager'
-import { SharedCredentialsProvider } from './providers/sharedCredentialsProvider'
-import { getIdeProperties } from '../shared/extensionUtilities'
-
-import * as nls from 'vscode-nls'
-import { isCloud9 } from '../shared/extensionUtilities'
-import { getLogger } from '../shared/logger/logger'
-import { CredentialsSettings } from './credentialsUtilities'
 import { Settings } from '../shared/settings'
-const localize = nls.loadMessageBundle()
+import { CredentialsSettings } from './credentialsUtilities'
 
 export async function initialize(
     extensionContext: vscode.ExtensionContext,
@@ -28,96 +18,6 @@ export async function initialize(
     const credentialSettings = new CredentialsSettings(settings)
     updateMruWhenAwsContextChanges(awsContext, extensionContext)
     updateConfigurationWhenAwsContextChanges(credentialSettings, awsContext, extensionContext)
-}
-
-/**
- * Auto-connects with the last-used credentials, else the "default" profile,
- * else randomly tries the first three profiles (for Cloud9, ECS, or other
- * container-like environments).
- */
-export async function loginWithMostRecentCredentials(
-    settings: CredentialsSettings,
-    loginManager: LoginManager
-): Promise<void> {
-    const defaultName = 'profile:default'
-    const manager = CredentialsProviderManager.getInstance()
-    const previousCredentialsId = settings.get('profile', '')
-
-    async function tryConnect(creds: CredentialsId, popup: boolean): Promise<boolean> {
-        const provider = await manager.getCredentialsProvider(creds)
-        // 'provider' may be undefined if the last-used credentials no longer exists.
-        if (!provider) {
-            getLogger().warn('autoconnect: getCredentialsProvider() lookup failed for profile: %O', asString(creds))
-        } else if (provider.canAutoConnect()) {
-            if (!(await loginManager.login({ passive: true, providerId: creds }))) {
-                getLogger().warn('autoconnect: failed to connect: "%s"', asString(creds))
-                return false
-            }
-            getLogger().info('autoconnect: connected: %O', asString(creds))
-            if (popup) {
-                vscode.window.showInformationMessage(
-                    localize(
-                        'AWS.message.credentials.connected',
-                        'Connected to {0} with {1}',
-                        getIdeProperties().company,
-                        asString(creds)
-                    )
-                )
-            }
-            return true
-        }
-        return false
-    }
-
-    // Auto-connect if there is a recently-used profile.
-    if (previousCredentialsId) {
-        // Migrate from old Toolkits: default to "shared" provider type.
-        const loginCredentialsId = tryMakeCredentialsProviderId(previousCredentialsId) ?? {
-            credentialSource: SharedCredentialsProvider.getProviderType(),
-            credentialTypeId: previousCredentialsId,
-        }
-        if (await tryConnect(loginCredentialsId, false)) {
-            return
-        }
-        getLogger().warn('autoconnect: login failed: "%s"', previousCredentialsId)
-    }
-
-    const providerMap = await manager.getCredentialProviderNames()
-    const profileNames = Object.keys(providerMap)
-    // Look for "default" profile or exactly one (any name).
-    const defaultProfile = profileNames.includes(defaultName)
-        ? defaultName
-        : profileNames.length === 1
-        ? profileNames[0]
-        : undefined
-
-    if (!previousCredentialsId && profileNames.length === 0) {
-        await loginManager.logout(true)
-        getLogger().info('autoconnect: skipped (profileNames=%d)', profileNames.length)
-        return
-    }
-
-    // Try to auto-connect the default profile.
-    if (defaultProfile) {
-        getLogger().info('autoconnect: trying "%s"', defaultProfile)
-        if (await tryConnect(providerMap[defaultProfile], !isCloud9())) {
-            return
-        }
-    }
-
-    // Try to auto-connect up to 3 other profiles (useful for Cloud9, ECS, …).
-    for (let i = 0; i < 4 && i < profileNames.length; i++) {
-        const p = profileNames[i]
-        if (p === defaultName) {
-            continue
-        }
-        getLogger().info('autoconnect: trying "%s"', p)
-        if (await tryConnect(providerMap[p], !isCloud9())) {
-            return
-        }
-    }
-
-    await loginManager.logout(true)
 }
 
 function updateMruWhenAwsContextChanges(awsContext: AwsContext, extensionContext: vscode.ExtensionContext) {
@@ -150,12 +50,4 @@ function updateConfigurationWhenAwsContextChanges(
             }
         })
     )
-}
-
-function tryMakeCredentialsProviderId(credentials: string): CredentialsId | undefined {
-    try {
-        return fromString(credentials)
-    } catch (err) {
-        return undefined
-    }
 }

--- a/src/credentials/loginManager.ts
+++ b/src/credentials/loginManager.ts
@@ -3,20 +3,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as vscode from 'vscode'
+import globals from '../shared/extensionGlobals'
 import { CancellationError } from '../shared/utilities/timeoutUtils'
 import { AwsContext } from '../shared/awsContext'
 import { getAccountId } from '../shared/credentials/accountId'
 import { getLogger } from '../shared/logger'
 import { recordAwsValidateCredentials, recordVscodeActiveRegions, Result } from '../shared/telemetry/telemetry'
 import { CredentialsStore } from './credentialsStore'
-import { notifyUserInvalidCredentials } from './credentialsUtilities'
+import { CredentialsSettings, notifyUserInvalidCredentials } from './credentialsUtilities'
 import {
     asString,
     CredentialsProvider,
     CredentialsId,
     credentialsProviderToTelemetryType,
+    fromString,
 } from './providers/credentials'
 import { CredentialsProviderManager } from './providers/credentialsProviderManager'
+import { getIdeProperties, isCloud9 } from '../shared/extensionUtilities'
+import { SharedCredentialsProvider } from './providers/sharedCredentialsProvider'
+import { localize } from 'vscode-nls'
+import { showViewLogsMessage } from '../shared/utilities/messages'
 
 export class LoginManager {
     private readonly defaultCredentialsRegion = 'us-east-1'
@@ -99,5 +106,124 @@ export class LoginManager {
      */
     public async logout(force?: boolean): Promise<void> {
         await this.awsContext.setCredentials(undefined, force)
+    }
+
+    private static didTryAutoConnect = false
+
+    public static async tryAutoConnect(awsContext: AwsContext = globals.awsContext): Promise<boolean> {
+        if (await awsContext.getCredentials()) {
+            return true // Already connected.
+        }
+        if (LoginManager.didTryAutoConnect) {
+            return false
+        }
+        LoginManager.didTryAutoConnect = true
+        try {
+            getLogger().debug('credentials: attempting autoconnect...')
+            const loginManager = new LoginManager(awsContext, new CredentialsStore())
+            await loginWithMostRecentCredentials(new CredentialsSettings(), loginManager)
+        } catch (err) {
+            getLogger().error('credentials: failed to auto-connect: %O', err)
+            showViewLogsMessage(localize('AWS.credentials.autoconnect.fatal', 'Exception occurred while connecting'))
+        }
+        return !!(await awsContext.getCredentials())
+    }
+}
+
+/**
+ * Auto-connects with the last-used credentials, else the "default" profile,
+ * else randomly tries the first three profiles (for Cloud9, ECS, or other
+ * container-like environments).
+ */
+export async function loginWithMostRecentCredentials(
+    settings: CredentialsSettings,
+    loginManager: LoginManager
+): Promise<void> {
+    const defaultName = 'profile:default'
+    const manager = CredentialsProviderManager.getInstance()
+    const previousCredentialsId = settings.get('profile', '')
+
+    async function tryConnect(creds: CredentialsId, popup: boolean): Promise<boolean> {
+        const provider = await manager.getCredentialsProvider(creds)
+        // 'provider' may be undefined if the last-used credentials no longer exists.
+        if (!provider) {
+            getLogger().warn('autoconnect: getCredentialsProvider() lookup failed for profile: %O', asString(creds))
+        } else if (provider.canAutoConnect()) {
+            if (!(await loginManager.login({ passive: true, providerId: creds }))) {
+                getLogger().warn('autoconnect: failed to connect: "%s"', asString(creds))
+                return false
+            }
+            getLogger().info('autoconnect: connected: %O', asString(creds))
+            if (popup) {
+                vscode.window.showInformationMessage(
+                    localize(
+                        'AWS.message.credentials.connected',
+                        'Connected to {0} with {1}',
+                        getIdeProperties().company,
+                        asString(creds)
+                    )
+                )
+            }
+            return true
+        }
+        return false
+    }
+
+    // Auto-connect if there is a recently-used profile.
+    if (previousCredentialsId) {
+        // Migrate from old Toolkits: default to "shared" provider type.
+        const loginCredentialsId = tryMakeCredentialsProviderId(previousCredentialsId) ?? {
+            credentialSource: SharedCredentialsProvider.getProviderType(),
+            credentialTypeId: previousCredentialsId,
+        }
+        if (await tryConnect(loginCredentialsId, false)) {
+            return
+        }
+        getLogger().warn('autoconnect: login failed: "%s"', previousCredentialsId)
+    }
+
+    const providerMap = await manager.getCredentialProviderNames()
+    const profileNames = Object.keys(providerMap)
+    // Look for "default" profile or exactly one (any name).
+    const defaultProfile = profileNames.includes(defaultName)
+        ? defaultName
+        : profileNames.length === 1
+        ? profileNames[0]
+        : undefined
+
+    if (!previousCredentialsId && profileNames.length === 0) {
+        await loginManager.logout(true)
+        getLogger().info('autoconnect: skipped (profileNames=%d)', profileNames.length)
+        return
+    }
+
+    // Try to auto-connect the default profile.
+    if (defaultProfile) {
+        getLogger().info('autoconnect: trying "%s"', defaultProfile)
+        if (await tryConnect(providerMap[defaultProfile], !isCloud9())) {
+            return
+        }
+    }
+
+    // Try to auto-connect up to 3 other profiles (useful for Cloud9, ECS, …).
+    for (let i = 0; i < 4 && i < profileNames.length; i++) {
+        const p = profileNames[i]
+        if (p === defaultName) {
+            continue
+        }
+        getLogger().info('autoconnect: trying "%s"', p)
+        if (await tryConnect(providerMap[p], !isCloud9())) {
+            return
+        }
+    }
+
+    await loginManager.logout(true)
+}
+
+function tryMakeCredentialsProviderId(credentials: string): CredentialsId | undefined {
+    try {
+        return fromString(credentials)
+    } catch (err) {
+        return undefined
     }
 }

--- a/src/lambda/commands/deploySamApplication.ts
+++ b/src/lambda/commands/deploySamApplication.ts
@@ -56,10 +56,15 @@ export async function deploySamApplication(
         awsContext,
         settings,
         window = getDefaultWindowFunctions(),
+        refreshFn = () => {
+            // no need to await, doesn't need to block further execution (true -> no telemetry)
+            vscode.commands.executeCommand('aws.refreshAwsExplorer', true)
+        },
     }: {
         awsContext: Pick<AwsContext, 'getCredentials' | 'getCredentialProfileName'>
         settings: SamCliSettings
         window?: WindowFunctions
+        refreshFn?: () => void
     }
 ): Promise<void> {
     let deployResult: Result = 'Succeeded'
@@ -112,8 +117,7 @@ export async function deploySamApplication(
         )
 
         await deployApplicationPromise
-        // no need to await, doesn't need to block further execution (true -> no telemetry)
-        vscode.commands.executeCommand('aws.refreshAwsExplorer', true)
+        refreshFn()
 
         // successful deploy: retain S3 bucket for quick future access
         const profile = awsContext.getCredentialProfileName()

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -38,6 +38,7 @@ import { lazyLoadSamTemplateStrings } from '../../lambda/models/samTemplates'
 import { PromptSettings } from '../settings'
 import { shared } from '../utilities/functionUtils'
 import { migrateLegacySettings, SamCliSettings } from './cli/samCliSettings'
+import { Commands } from '../vscode/commands2'
 
 const sharedDetectSamCli = shared(detectSamCli)
 
@@ -88,15 +89,18 @@ export async function activate(ctx: ExtContext): Promise<void> {
 async function registerServerlessCommands(ctx: ExtContext, settings: SamCliSettings): Promise<void> {
     lazyLoadSamTemplateStrings()
     ctx.extensionContext.subscriptions.push(
-        vscode.commands.registerCommand('aws.samcli.detect', () =>
+        Commands.register({ id: 'aws.samcli.detect', autoconnect: false }, () =>
             sharedDetectSamCli({ passive: false, showMessage: true })
         ),
-        vscode.commands.registerCommand('aws.lambda.createNewSamApp', async () => {
+        Commands.register({ id: 'aws.lambda.createNewSamApp', autoconnect: false }, async () => {
             await createNewSamApplication(ctx)
         }),
-        vscode.commands.registerCommand('aws.addSamDebugConfiguration', addSamDebugConfiguration),
-        vscode.commands.registerCommand('aws.pickAddSamDebugConfiguration', codelensUtils.pickAddSamDebugConfiguration),
-        vscode.commands.registerCommand('aws.deploySamApplication', async arg => {
+        Commands.register({ id: 'aws.addSamDebugConfiguration', autoconnect: false }, addSamDebugConfiguration),
+        Commands.register(
+            { id: 'aws.pickAddSamDebugConfiguration', autoconnect: false },
+            codelensUtils.pickAddSamDebugConfiguration
+        ),
+        Commands.register({ id: 'aws.deploySamApplication', autoconnect: true }, async arg => {
             // `arg` is one of :
             //  - undefined
             //  - regionNode (selected from AWS Explorer)

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -64,6 +64,7 @@ import {
 import { getIdeProperties, isCloud9 } from '../../extensionUtilities'
 import { resolve } from 'path'
 import globals from '../../extensionGlobals'
+import { LoginManager } from '../../../credentials/loginManager'
 
 const localize = nls.loadMessageBundle()
 
@@ -617,6 +618,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
      * Performs the EXECUTE phase of SAM run/debug.
      */
     public async invokeConfig(config: SamLaunchRequestArgs): Promise<SamLaunchRequestArgs> {
+        await LoginManager.tryAutoConnect()
         switch (config.runtimeFamily) {
             case RuntimeFamily.NodeJS: {
                 config.type = 'node'


### PR DESCRIPTION
- This builds on:
    -  https://github.com/aws/aws-toolkit-vscode/pull/1708
    - #2573 
- ~~Long-term it probably makes sense to wrap all Toolkit commands in a common class to handle auto-login.~~
    - Done:  #2584


## Problem:
7400c5f55070 #1708 changed Toolkit to attempt auto-connect only when AWS
Explorer is made visible. But the "AWS: Deploy SAM Application" command
requires credentials. SAM local Run/Debug also wants credentials since
2b347ebdf0b7.

## Solution:
Try auto-connect in the central Commands hook.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
