### PR TITLE
test/logger: avoid false positive because of slow filesystem

### DIFF
--- a/src/test/shared/logger/winstonToolkitLogger.test.ts
+++ b/src/test/shared/logger/winstonToolkitLogger.test.ts
@@ -20,9 +20,7 @@ describe('WinstonToolkitLogger', function () {
     })
 
     after(async function () {
-        if (await filesystemUtilities.fileExists(tempFolder)) {
-            await fs.remove(tempFolder)
-        }
+        await fs.remove(tempFolder)
     })
 
     it('logLevelEnabled()', function () {
@@ -293,8 +291,8 @@ describe('WinstonToolkitLogger', function () {
             testLogger.logToFile(tempLogPath)
             testLogger.error(new Error('Test start'))
             const logExists: boolean | undefined = await waitUntil(() => filesystemUtilities.fileExists(tempLogPath), {
-                timeout: 1000,
-                interval: 10,
+                timeout: 2000,
+                interval: 100,
                 truthy: true,
             })
 


### PR DESCRIPTION
ref 274a59303de770db65a86f23b0907bcf10976558 #1579

Observed in https://github.com/aws/aws-toolkit-vscode/pull/1725/checks?check_run_id=2505674292



## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
