### PR TITLE
autoconnect: fix potential use of undefined

### DIFF
--- a/src/credentials/activation.ts
+++ b/src/credentials/activation.ts
@@ -9,11 +9,13 @@ import { profileSettingKey } from '../shared/constants'
 import { CredentialsProfileMru } from '../shared/credentials/credentialsProfileMru'
 import { SettingsConfiguration } from '../shared/settingsConfiguration'
 import { LoginManager } from './loginManager'
-import { CredentialsProviderId, fromString } from './providers/credentialsProviderId'
+import { asString, CredentialsProviderId, fromString } from './providers/credentialsProviderId'
 import { CredentialsProviderManager } from './providers/credentialsProviderManager'
 import { SharedCredentialsProvider } from './providers/sharedCredentialsProvider'
 
 import * as nls from 'vscode-nls'
+import { isCloud9 } from '../shared/extensionUtilities'
+import { getLogger } from '../shared/logger/logger'
 const localize = nls.loadMessageBundle()
 
 export interface CredentialsInitializeParameters {
@@ -40,6 +42,33 @@ export async function loginWithMostRecentCredentials(
     const profileNames = Object.keys(providerMap)
     const previousCredentialsId = toolkitSettings.readSetting<string>(profileSettingKey, '')
 
+    async function tryConnect(creds: CredentialsProviderId, popup: boolean): Promise<boolean> {
+        const provider = await manager.getCredentialsProvider(creds)
+        // 'provider' may be undefined if the last-used credentials no longer exists.
+        if (!provider) {
+            getLogger().warn('autoconnect: getCredentialsProvider() lookup failed for profile: %O', asString(creds))
+        } else if (provider.canAutoConnect()) {
+            if (!(await loginManager.login({ passive: true, providerId: creds }))) {
+                getLogger().warn('autoconnect: failed to connect: %O', asString(creds))
+                return false
+            }
+            getLogger().info('autoconnect: connected: %O', asString(creds))
+            if (popup) {
+                vscode.window.showInformationMessage(
+                    localize('AWS.message.credentials.connected', 'Connected to AWS as {0}', asString(creds))
+                )
+            }
+            return true
+        }
+        return false
+    }
+
+    if (!previousCredentialsId && !(providerMap && profileNames.length === 1)) {
+        await loginManager.logout()
+        getLogger().info('autoconnect: skipped')
+        return
+    }
+
     if (previousCredentialsId) {
         // Migrate from older Toolkits - If the last providerId isn't in the new CredentialProviderId format,
         // treat it like a Shared Crdentials Provider.
@@ -47,29 +76,19 @@ export async function loginWithMostRecentCredentials(
             credentialType: SharedCredentialsProvider.getCredentialsType(),
             credentialTypeId: previousCredentialsId,
         }
-        const provider = await manager.getCredentialsProvider(loginCredentialsId)
-
-        // 'provider' may be undefined if the last-used credentials no longer exists.
-        if (provider && provider.canAutoConnect()) {
-            await loginManager.login({ passive: true, providerId: loginCredentialsId })
-        } else {
-            await loginManager.logout()
+        if (await tryConnect(loginCredentialsId, false)) {
+            return
         }
-    } else if (
-        providerMap &&
-        profileNames.length === 1 &&
-        (await manager.getCredentialsProvider(providerMap[profileNames[0]]))!.canAutoConnect()
-    ) {
-        // Auto-connect if there is exactly one profile.
-        if (await loginManager.login({ passive: true, providerId: providerMap[profileNames[0]] })) {
-            // Toast.
-            vscode.window.showInformationMessage(
-                localize('AWS.message.credentials.connected', 'Connected to AWS as {0}', profileNames[0])
-            )
-        }
-    } else {
-        await loginManager.logout()
     }
+
+    if (providerMap && profileNames.length === 1) {
+        // Auto-connect if there is exactly one profile.
+        if (await tryConnect(providerMap[profileNames[0]], !isCloud9())) {
+            return
+        }
+    }
+
+    await loginManager.logout()
 }
 
 function updateMruWhenAwsContextChanges(awsContext: AwsContext, extensionContext: vscode.ExtensionContext) {

--- a/src/credentials/providers/credentialsProviderId.ts
+++ b/src/credentials/providers/credentialsProviderId.ts
@@ -13,7 +13,7 @@ export interface CredentialsProviderId {
 }
 
 /**
- * Gets a user-friendly string represention of the given `CredentialsProvider`.
+ * Gets the string form of the given `CredentialsProvider`.
  *
  * For use in e.g. the statusbar, selecting profiles in a menu, etc.
  * Includes information related to the credentials type, as well as

--- a/src/credentials/providers/credentialsProviderManager.ts
+++ b/src/credentials/providers/credentialsProviderManager.ts
@@ -30,8 +30,8 @@ export class CredentialsProviderManager {
     }
 
     /**
-     * Returns a map of `CredentialsProviderId` "friendly names" to ids, from
-     * all credential sources.
+     * Returns a map of `CredentialsProviderId` string-forms to object-forms,
+     * from all credential sources.
      */
     public async getCredentialProviderNames(): Promise<{ [key: string]: CredentialsProviderId }> {
         const m: { [key: string]: CredentialsProviderId } = {}

--- a/src/shared/logger/winstonToolkitLogger.ts
+++ b/src/shared/logger/winstonToolkitLogger.ts
@@ -42,6 +42,9 @@ export class WinstonToolkitLogger implements Logger, vscode.Disposable {
     }
 
     public setLogLevel(logLevel: LogLevel) {
+        if (this.logger.level === logLevel) {
+            return
+        }
         // Log calls are made with explicit levels to ensure the text is output
         this.logger.log(this.logger.level, `Setting log level to: ${logLevel}`)
         this.logger.level = logLevel


### PR DESCRIPTION
Related: 09f505fff6e8 #1641

## Problem:
Similar to 09f505fff6e8, we can't assume that `getCredentialProviderNames()` returns anything valid... because `loadSharedCredentialsProfiles()` is lying to us...?

## Solution:
- Check for undefined
- Log a warning message
- Skip popup message on Cloud9

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
