### PR TITLE
Revert "telemetry: Login sets "passive" instead of skipping telemetry"

### DIFF
--- a/designs/credentials/class-diagram.svg
+++ b/designs/credentials/class-diagram.svg
@@ -24,14 +24,14 @@ class SharedCredentialsProvider {
 }
 
 interface CredentialsProviderFactory {
-    getCredentialType(): CredentialSourceId
+    getCredentialType(): string
     listProviders(): CredentialsProvider[]
     getProvider(credentialsProviderId: string): CredentialsProvider | undefined
 }
 
 
 class SharedCredentialsProviderFactory {
-    + getCredentialType(): 'sharedCredentials'
+    + getCredentialType(): 'profile'
 }
 
 class CredentialsProviderManager {

--- a/designs/credentials/credentials-management.md
+++ b/designs/credentials/credentials-management.md
@@ -22,7 +22,7 @@ A factory is capable of producing one or more Credentials Providers for a single
 
 All Credentials Provider instances are uniquely identified by a Credentials Provider Id. These consist of the following parts:
 
--   Credentials Type - a classification of the source data used to produce credentials. For example, the toolkit assigns Shared Credentials the type `sharedCredentials`
+-   Credentials Type - a classification of the source data used to produce credentials. For example, the toolkit assigns Shared Credentials the type `profile`
 -   Credentials Type Id - within a credentials type, this is a unique identifier for the source data used to produce credentials. Using Shared Credentials files as an example, each profile is used as the Id.
 
 A formatted version of the Credentials Provider Id may be surfaced to users, however it is an internal identification construct.

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
                 "yaml": "^1.9.2"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "0.0.100",
+                "@aws-toolkits/telemetry": "0.0.94",
                 "@sinonjs/fake-timers": "^7.0.5",
                 "@types/adm-zip": "^0.4.32",
                 "@types/async-lock": "^1.1.0",
@@ -109,9 +109,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "0.0.100",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-0.0.100.tgz",
-            "integrity": "sha512-RjaBm7fn4dQmYs4vJcpbwm6TwNc2dPdpETD9MDUeP+N/ocOeuCPXeyZ3Bhoxk5m+xklnv6sn+QH0sNz7a7SJgw==",
+            "version": "0.0.94",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-0.0.94.tgz",
+            "integrity": "sha512-wcls7FClzCY4uJiT7kDXo87lUqlPNm2XhjYbwEZcaaPBGRFYIxFrE2gZ5lZ1B79QjffKB52vm6/qGDWj0p8VGg==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",
@@ -4213,7 +4213,6 @@
             "resolved": "https://registry.npmjs.org/husky/-/husky-2.7.0.tgz",
             "integrity": "sha512-LIi8zzT6PyFpcYKdvWRCn/8X+6SuG2TgYYMrM6ckEYhlp44UcEduVymZGIZNLiwOUjrEud+78w/AsAiqJA/kRg==",
             "dev": true,
-            "hasInstallScript": true,
             "dependencies": {
                 "cosmiconfig": "^5.2.0",
                 "execa": "^1.0.0",
@@ -10078,9 +10077,9 @@
     },
     "dependencies": {
         "@aws-toolkits/telemetry": {
-            "version": "0.0.100",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-0.0.100.tgz",
-            "integrity": "sha512-RjaBm7fn4dQmYs4vJcpbwm6TwNc2dPdpETD9MDUeP+N/ocOeuCPXeyZ3Bhoxk5m+xklnv6sn+QH0sNz7a7SJgw==",
+            "version": "0.0.94",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-0.0.94.tgz",
+            "integrity": "sha512-wcls7FClzCY4uJiT7kDXo87lUqlPNm2XhjYbwEZcaaPBGRFYIxFrE2gZ5lZ1B79QjffKB52vm6/qGDWj0p8VGg==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -1533,7 +1533,7 @@
         "createRelease": "ts-node ./build-scripts/createRelease.ts"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "0.0.100",
+        "@aws-toolkits/telemetry": "0.0.94",
         "@sinonjs/fake-timers": "^7.0.5",
         "@types/adm-zip": "^0.4.32",
         "@types/async-lock": "^1.1.0",

--- a/src/credentials/loginManager.ts
+++ b/src/credentials/loginManager.ts
@@ -30,7 +30,6 @@ export class LoginManager {
      * @param provider  Credentials provider id
      * @returns True if the toolkit could connect with the providerId
      */
-
     public async login(args: { passive: boolean; providerId: CredentialsProviderId }): Promise<boolean> {
         let provider: CredentialsProvider | undefined
         try {
@@ -77,10 +76,11 @@ export class LoginManager {
             return false
         } finally {
             const credType = provider?.getCredentialsType2()
-            this.recordAwsSetCredentialsFn({
-                passive: args.passive,
-                credentialType: credType,
-            })
+            if (!args.passive) {
+                this.recordAwsSetCredentialsFn({
+                    credentialType: credType,
+                })
+            }
         }
     }
 

--- a/src/credentials/providers/credentialsProviderFactory.ts
+++ b/src/credentials/providers/credentialsProviderFactory.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CredentialSourceId } from '../../shared/telemetry/telemetry.gen'
 import { CredentialsProvider } from './credentialsProvider'
 import { CredentialsProviderId, isEqual } from './credentialsProviderId'
 
@@ -11,7 +10,7 @@ import { CredentialsProviderId, isEqual } from './credentialsProviderId'
  * Responsible for producing CredentialsProvider objects for a Credential Type
  */
 export interface CredentialsProviderFactory {
-    getCredentialType(): CredentialSourceId
+    getCredentialType(): string
     listProviders(): CredentialsProvider[]
     getProvider(credentialsProviderId: CredentialsProviderId): CredentialsProvider | undefined
     refresh(): Promise<void>
@@ -20,7 +19,7 @@ export interface CredentialsProviderFactory {
 export abstract class BaseCredentialsProviderFactory<T extends CredentialsProvider>
     implements CredentialsProviderFactory {
     protected providers: T[] = []
-    public abstract getCredentialType(): CredentialSourceId
+    public abstract getCredentialType(): string
 
     public listProviders(): T[] {
         return [...this.providers]

--- a/src/credentials/providers/sharedCredentialsProvider.ts
+++ b/src/credentials/providers/sharedCredentialsProvider.ts
@@ -15,7 +15,7 @@ import { SsoAccessTokenProvider } from '../sso/ssoAccessTokenProvider'
 import { CredentialsProvider } from './credentialsProvider'
 import { CredentialsProviderId } from './credentialsProviderId'
 import { SsoCredentialProvider } from './ssoCredentialProvider'
-import { CredentialSourceId, CredentialType } from '../../shared/telemetry/telemetry.gen'
+import { CredentialType } from '../../shared/telemetry/telemetry.gen'
 
 const SHARED_CREDENTIAL_PROPERTIES = {
     AWS_ACCESS_KEY_ID: 'aws_access_key_id',
@@ -36,7 +36,7 @@ const SHARED_CREDENTIAL_PROPERTIES = {
  * Represents one profile from the AWS Shared Credentials files, and produces Credentials from this profile.
  */
 export class SharedCredentialsProvider implements CredentialsProvider {
-    private static readonly CREDENTIALS_TYPE: CredentialSourceId = 'sharedCredentials'
+    private static readonly CREDENTIALS_TYPE = 'profile'
 
     private readonly profile: Profile
 
@@ -251,7 +251,7 @@ export class SharedCredentialsProvider implements CredentialsProvider {
      *
      * TODO: deprecated / why is this static?!
      */
-    public static getCredentialsType(): CredentialSourceId {
+    public static getCredentialsType(): string {
         return SharedCredentialsProvider.CREDENTIALS_TYPE
     }
 

--- a/src/credentials/providers/sharedCredentialsProviderFactory.ts
+++ b/src/credentials/providers/sharedCredentialsProviderFactory.ts
@@ -13,7 +13,6 @@ import {
 } from '../sharedCredentials'
 import { BaseCredentialsProviderFactory } from './credentialsProviderFactory'
 import { SharedCredentialsProvider } from './sharedCredentialsProvider'
-import { CredentialSourceId } from '../../shared/telemetry/telemetry.gen'
 
 export class SharedCredentialsProviderFactory extends BaseCredentialsProviderFactory<SharedCredentialsProvider> {
     private readonly logger: Logger = getLogger()
@@ -21,7 +20,7 @@ export class SharedCredentialsProviderFactory extends BaseCredentialsProviderFac
     private loadedCredentialsModificationMillis?: number
     private loadedConfigModificationMillis?: number
 
-    public getCredentialType(): CredentialSourceId {
+    public getCredentialType(): string {
         return SharedCredentialsProvider.getCredentialsType()
     }
 

--- a/src/test/credentials/provider/credentialsProviderFactory.test.ts
+++ b/src/test/credentials/provider/credentialsProviderFactory.test.ts
@@ -4,7 +4,6 @@
  */
 
 import * as assert from 'assert'
-import { CredentialSourceId } from '../../../shared/telemetry/telemetry.gen'
 import { CredentialsProvider } from '../../../credentials/providers/credentialsProvider'
 import { BaseCredentialsProviderFactory } from '../../../credentials/providers/credentialsProviderFactory'
 import { CredentialsProviderId } from '../../../credentials/providers/credentialsProviderId'
@@ -14,8 +13,8 @@ describe('BaseCredentialsProviderFactory', async function () {
      * This class exposes abstract class functionality for the purpose of testing it.
      */
     class TestCredentialsProviderFactory extends BaseCredentialsProviderFactory<CredentialsProvider> {
-        public getCredentialType(): CredentialSourceId {
-            return 'sharedCredentials'
+        public getCredentialType(): string {
+            return 'sample'
         }
 
         public getProviders(): CredentialsProvider[] {

--- a/src/test/credentials/provider/credentialsProviderManager.test.ts
+++ b/src/test/credentials/provider/credentialsProviderManager.test.ts
@@ -4,7 +4,6 @@
  */
 
 import * as assert from 'assert'
-import { CredentialSourceId } from '../../../shared/telemetry/telemetry.gen'
 import { CredentialsProvider } from '../../../credentials/providers/credentialsProvider'
 import { CredentialsProviderFactory } from '../../../credentials/providers/credentialsProviderFactory'
 import { CredentialsProviderId, isEqual } from '../../../credentials/providers/credentialsProviderId'
@@ -16,7 +15,7 @@ import { CredentialsProviderManager } from '../../../credentials/providers/crede
 class TestCredentialsProviderFactory implements CredentialsProviderFactory {
     private readonly providers: CredentialsProvider[] = []
 
-    public constructor(public readonly credentialType: CredentialSourceId, providerSubIds: string[]) {
+    public constructor(public readonly credentialType: string, providerSubIds: string[]) {
         this.providers.push(
             ...providerSubIds.map<CredentialsProvider>(subId => {
                 return ({
@@ -29,7 +28,7 @@ class TestCredentialsProviderFactory implements CredentialsProviderFactory {
         )
     }
 
-    public getCredentialType(): CredentialSourceId {
+    public getCredentialType(): string {
         return this.credentialType
     }
 
@@ -58,22 +57,22 @@ describe('CredentialsProviderManager', async function () {
     })
 
     it('getCredentialProviderNames()', async function () {
-        const factoryA = new TestCredentialsProviderFactory('sharedCredentials', ['one'])
-        const factoryB = new TestCredentialsProviderFactory('envVars', ['two', 'three'])
+        const factoryA = new TestCredentialsProviderFactory('credentialTypeA', ['one'])
+        const factoryB = new TestCredentialsProviderFactory('credentialTypeB', ['two', 'three'])
         sut.addProviderFactory(factoryA)
         sut.addProviderFactory(factoryB)
 
         const expectedCredentials = {
-            'sharedCredentials:one': {
-                credentialType: 'sharedCredentials',
+            'credentialTypeA:one': {
+                credentialType: 'credentialTypeA',
                 credentialTypeId: 'one',
             },
-            'envVars:three': {
-                credentialType: 'envVars',
+            'credentialTypeB:three': {
+                credentialType: 'credentialTypeB',
                 credentialTypeId: 'three',
             },
-            'envVars:two': {
-                credentialType: 'envVars',
+            'credentialTypeB:two': {
+                credentialType: 'credentialTypeB',
                 credentialTypeId: 'two',
             },
         }
@@ -82,8 +81,8 @@ describe('CredentialsProviderManager', async function () {
 
     describe('getAllCredentialsProviders', async function () {
         it('returns all providers', async function () {
-            const factoryA = new TestCredentialsProviderFactory('sharedCredentials', ['one'])
-            const factoryB = new TestCredentialsProviderFactory('envVars', ['two', 'three'])
+            const factoryA = new TestCredentialsProviderFactory('credentialTypeA', ['one'])
+            const factoryB = new TestCredentialsProviderFactory('credentialTypeB', ['two', 'three'])
 
             sut.addProviderFactory(factoryA)
             sut.addProviderFactory(factoryB)
@@ -94,7 +93,7 @@ describe('CredentialsProviderManager', async function () {
             assert.ok(
                 providers.some(x =>
                     isEqual(x.getCredentialsProviderId(), {
-                        credentialType: 'sharedCredentials',
+                        credentialType: 'credentialTypeA',
                         credentialTypeId: 'one',
                     })
                 ),
@@ -103,7 +102,7 @@ describe('CredentialsProviderManager', async function () {
             assert.ok(
                 providers.some(x =>
                     isEqual(x.getCredentialsProviderId(), {
-                        credentialType: 'envVars',
+                        credentialType: 'credentialTypeB',
                         credentialTypeId: 'two',
                     })
                 ),
@@ -112,7 +111,7 @@ describe('CredentialsProviderManager', async function () {
             assert.ok(
                 providers.some(x =>
                     isEqual(x.getCredentialsProviderId(), {
-                        credentialType: 'envVars',
+                        credentialType: 'credentialTypeB',
                         credentialTypeId: 'three',
                     })
                 ),
@@ -123,9 +122,9 @@ describe('CredentialsProviderManager', async function () {
 
     describe('getCredentialsProvider', async function () {
         it('returns a provider', async function () {
-            const factoryA = new TestCredentialsProviderFactory('sharedCredentials', ['default'])
+            const factoryA = new TestCredentialsProviderFactory('profile', ['default'])
             const expectedCredentialsProviderId: CredentialsProviderId = {
-                credentialType: 'sharedCredentials',
+                credentialType: 'profile',
                 credentialTypeId: 'default',
             }
 
@@ -142,12 +141,12 @@ describe('CredentialsProviderManager', async function () {
         })
 
         it('returns undefined when there is a factory but the factory does not contain a provider', async function () {
-            const factoryA = new TestCredentialsProviderFactory('sharedCredentials', ['default2'])
+            const factoryA = new TestCredentialsProviderFactory('profile', ['default2'])
 
             sut.addProviderFactory(factoryA)
 
             const provider = await sut.getCredentialsProvider({
-                credentialType: 'sharedCredentials',
+                credentialType: 'profile',
                 credentialTypeId: 'default',
             })
 
@@ -160,7 +159,7 @@ describe('CredentialsProviderManager', async function () {
             sut.addProviderFactory(factoryA)
 
             const provider = await sut.getCredentialsProvider({
-                credentialType: 'sharedCredentials',
+                credentialType: 'profile',
                 credentialTypeId: 'default',
             })
 

--- a/src/test/credentials/provider/sharedCredentialsProvider.test.ts
+++ b/src/test/credentials/provider/sharedCredentialsProvider.test.ts
@@ -48,7 +48,7 @@ describe('SharedCredentialsProvider', async function () {
         )
 
         assert.deepStrictEqual(sut.getCredentialsProviderId(), {
-            credentialType: 'sharedCredentials',
+            credentialType: 'profile',
             credentialTypeId: 'default',
         })
     })

--- a/src/test/credentials/provider/sharedCredentialsProviderFactory.test.ts
+++ b/src/test/credentials/provider/sharedCredentialsProviderFactory.test.ts
@@ -66,7 +66,7 @@ describe('SharedCredentialsProviderFactory', async function () {
         assert.ok(
             providers.find(p =>
                 isEqual(p.getCredentialsProviderId(), {
-                    credentialType: 'sharedCredentials',
+                    credentialType: 'profile',
                     credentialTypeId: validProfileName1,
                 })
             ),
@@ -75,7 +75,7 @@ describe('SharedCredentialsProviderFactory', async function () {
         assert.ok(
             providers.find(p =>
                 isEqual(p.getCredentialsProviderId(), {
-                    credentialType: 'sharedCredentials',
+                    credentialType: 'profile',
                     credentialTypeId: validProfileName2,
                 })
             ),

--- a/src/test/shared/credentials/loginManager.test.ts
+++ b/src/test/shared/credentials/loginManager.test.ts
@@ -42,7 +42,7 @@ describe('LoginManager', async function () {
         loginManager = new LoginManager(awsContext, credentialsStore, recordAwsSetCredentialsSpy)
         credentialsProvider = {
             getCredentials: sandbox.stub().resolves(sampleCredentials),
-            getCredentialsType2: sandbox.stub().returns('staticProfile'),
+            getCredentialsType2: sandbox.stub().resolves('staticProfile'),
             getCredentialsProviderId: sandbox.stub().returns(sampleCredentialsProviderId),
             getDefaultRegion: sandbox.stub().returns('someRegion'),
             getHashCode: sandbox.stub().returns('1234'),
@@ -59,18 +59,12 @@ describe('LoginManager', async function () {
         sandbox.restore()
     })
 
-    it('passive login sends telemetry with passive=true', async function () {
+    it('passive login does NOT send telemetry', async function () {
         const setCredentialsStub = sandbox.stub(awsContext, 'setCredentials')
         await loginManager.login({ passive: true, providerId: sampleCredentialsProviderId })
 
         assert.strictEqual(setCredentialsStub.callCount, 1)
-        assert.strictEqual(
-            recordAwsSetCredentialsSpy.calledOnceWith({
-                credentialType: 'staticProfile',
-                passive: true,
-            }),
-            true
-        )
+        assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, false)
     })
 
     it('non-passive login sends telemetry', async function () {
@@ -78,13 +72,7 @@ describe('LoginManager', async function () {
         await loginManager.login({ passive: false, providerId: sampleCredentialsProviderId })
 
         assert.strictEqual(setCredentialsStub.callCount, 1)
-        assert.strictEqual(
-            recordAwsSetCredentialsSpy.calledOnceWith({
-                credentialType: 'staticProfile',
-                passive: false,
-            }),
-            true
-        )
+        assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, true)
     })
 
     it('logs in with credentials (happy path)', async function () {
@@ -92,13 +80,7 @@ describe('LoginManager', async function () {
 
         await loginManager.login({ passive: false, providerId: sampleCredentialsProviderId })
         assert.strictEqual(setCredentialsStub.callCount, 1, 'Expected awsContext setCredentials to be called once')
-        assert.strictEqual(
-            recordAwsSetCredentialsSpy.calledOnceWith({
-                credentialType: 'staticProfile',
-                passive: false,
-            }),
-            true
-        )
+        assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, true)
     })
 
     it('logs out (happy path)', async function () {
@@ -107,13 +89,7 @@ describe('LoginManager', async function () {
         await loginManager.login({ passive: false, providerId: sampleCredentialsProviderId })
         await loginManager.logout()
         assert.strictEqual(setCredentialsStub.callCount, 2, 'Expected awsContext setCredentials to be called twice')
-        assert.strictEqual(
-            recordAwsSetCredentialsSpy.calledOnceWith({
-                credentialType: 'staticProfile',
-                passive: false,
-            }),
-            true
-        )
+        assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, true)
     })
 
     it('logs out if credentials could not be retrieved', async function () {
@@ -126,13 +102,7 @@ describe('LoginManager', async function () {
 
         await loginManager.login({ passive: true, providerId: sampleCredentialsProviderId })
         assert.strictEqual(setCredentialsStub.callCount, 1, 'Expected awsContext setCredentials to be called once')
-        assert.strictEqual(
-            recordAwsSetCredentialsSpy.calledOnceWith({
-                credentialType: undefined,
-                passive: true,
-            }),
-            true
-        )
+        assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, false)
     })
 
     it('logs out if an account Id could not be determined', async function () {
@@ -145,13 +115,7 @@ describe('LoginManager', async function () {
 
         await loginManager.login({ passive: false, providerId: sampleCredentialsProviderId })
         assert.strictEqual(setCredentialsStub.callCount, 1, 'Expected awsContext setCredentials to be called once')
-        assert.strictEqual(
-            recordAwsSetCredentialsSpy.calledOnceWith({
-                credentialType: 'staticProfile',
-                passive: false,
-            }),
-            true
-        )
+        assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, true)
     })
 
     it('logs out if getting an account Id throws an Error', async function () {
@@ -164,12 +128,6 @@ describe('LoginManager', async function () {
 
         await loginManager.login({ passive: false, providerId: sampleCredentialsProviderId })
         assert.strictEqual(setCredentialsStub.callCount, 1, 'Expected awsContext setCredentials to be called once')
-        assert.strictEqual(
-            recordAwsSetCredentialsSpy.calledOnceWith({
-                credentialType: 'staticProfile',
-                passive: false,
-            }),
-            true
-        )
+        assert.strictEqual(recordAwsSetCredentialsSpy.calledOnce, true)
     })
 })


### PR DESCRIPTION


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem

#1691 changed user-visible credentialId string, which also decides how `aws.credentials` is resolved from a launch config.

## Solution

revert #1691 5785aa819304142fecd82e0a7795d5aa7c900be7

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
