### PR TITLE
SAM hints: fix "aws.sam.enableCodeLenses" default

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
                 "aws.sam.enableCodeLenses": {
                     "type": "boolean",
                     "description": "%AWS.configuration.enableCodeLenses%",
-                    "default": "true"
+                    "default": true
                 }
             }
         },

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -167,17 +167,12 @@ async function activateCodeLensProviders(
 
     disposables.push(
         vscode.commands.registerCommand('aws.toggleSamCodeLenses', () => {
-            configuration.readSetting<boolean>(codelensUtils.STATE_NAME_ENABLE_CODELENSES)
-                ? configuration.writeSetting(
-                      codelensUtils.STATE_NAME_ENABLE_CODELENSES,
-                      false,
-                      vscode.ConfigurationTarget.Global
-                  )
-                : configuration.writeSetting(
-                      codelensUtils.STATE_NAME_ENABLE_CODELENSES,
-                      true,
-                      vscode.ConfigurationTarget.Global
-                  )
+            const toggled = !configuration.readSetting<boolean>(codelensUtils.STATE_NAME_ENABLE_CODELENSES)
+            configuration.writeSetting(
+                codelensUtils.STATE_NAME_ENABLE_CODELENSES,
+                toggled,
+                vscode.ConfigurationTarget.Global
+            )
         })
     )
 


### PR DESCRIPTION
## Problem:
aws.sam.enableCodeLenses was defined with default "true" (string)
instead of true (boolean), so readSetting() returned nonsense which
caused the initial invocation of the "Toggle" command to do nothing.

## Solution:
- Fix the aws.sam.enableCodeLenses defined in package.json
- Simplify the code a bit.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
