### PR TITLE
SAM debug: refresh timeout after "sam build" step

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
                 },
                 "aws.samcli.debug.attach.timeout.millis": {
                     "type": "number",
-                    "default": 30000,
+                    "default": 90000,
                     "markdownDescription": "%AWS.configuration.description.samcli.debug.attach.timeout%"
                 },
                 "aws.logLevel": {

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -374,11 +374,6 @@ export async function runLambdaFunction(
 
     await onAfterBuild()
 
-    // If the build successfully but expires the timer, reset the timer
-    if (timer.completed) {
-        timer.reset()
-    }
-
     if (!(await invokeLambdaHandler(timer, envVars, config))) {
         return config
     }

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -78,7 +78,7 @@ function makeResourceName(config: SamLaunchRequestArgs): string {
 }
 
 const SAM_LOCAL_PORT_CHECK_RETRY_INTERVAL_MILLIS: number = 125
-const SAM_LOCAL_PORT_CHECK_RETRY_TIMEOUT_MILLIS_DEFAULT: number = 30000
+const SAM_LOCAL_PORT_CHECK_RETRY_TIMEOUT_MILLIS_DEFAULT: number = 90000
 const ATTACH_DEBUGGER_RETRY_DELAY_MILLIS: number = 1000
 
 /** "sam local start-api" wrapper from the current debug-session. */

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -373,7 +373,8 @@ export async function runLambdaFunction(
     }
 
     await onAfterBuild()
-
+    timer.refresh()
+    
     if (!(await invokeLambdaHandler(timer, envVars, config))) {
         return config
     }

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -366,16 +366,15 @@ export async function runLambdaFunction(
         ...(config.aws?.region ? { AWS_DEFAULT_REGION: config.aws.region } : {}),
     }
 
-    const buildTimer = createInvokeTimer(ctx.settings)
+    const timer = createInvokeTimer(ctx.settings)
 
-    if (!(await buildLambdaHandler(buildTimer, envVars, config))) {
+    if (!(await buildLambdaHandler(timer, envVars, config))) {
         return config
     }
 
     await onAfterBuild()
 
-    const invokeTimer = createInvokeTimer(ctx.settings)
-    if (!(await invokeLambdaHandler(invokeTimer, envVars, config))) {
+    if (!(await invokeLambdaHandler(timer, envVars, config))) {
         return config
     }
 
@@ -394,7 +393,7 @@ export async function runLambdaFunction(
             getLogger('channel').info(
                 localize('AWS.output.sam.local.waiting', 'Waiting for SAM application to start...')
             )
-            await config.onWillAttachDebugger(config.debugPort!, buildTimer)
+            await config.onWillAttachDebugger(config.debugPort!, timer)
         }
         // HACK: remove non-serializable properties before attaching.
         // TODO: revisit this :)
@@ -411,7 +410,7 @@ export async function runLambdaFunction(
                     runtime: config.runtime as telemetry.Runtime,
                     result: attachResult ? 'Succeeded' : 'Failed',
                     attempts: attempts,
-                    duration: buildTimer.elapsedTime,
+                    duration: timer.elapsedTime,
                 })
             },
         })

--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -18,7 +18,7 @@ export class Timeout {
     private startTime: number
     private endTime: number
     private readonly timeoutLength: number
-    private timerPromise: Promise<undefined>
+    private readonly timerPromise: Promise<undefined>
     private timerTimeout: NodeJS.Timeout
     private timerResolve!: (value?: Promise<undefined> | undefined) => void
     private timerReject!: (value?: Error | Promise<Error> | undefined) => void
@@ -112,15 +112,6 @@ export class Timeout {
         }
 
         this._completed = true
-    }
-
-    public reset(): void {
-        this._completed = false
-        this.timerPromise = new Promise<undefined>((resolve, reject) => {
-            this.timerReject = reject
-            this.timerResolve = resolve
-        })
-        this.refresh()
     }
 }
 

--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -18,7 +18,7 @@ export class Timeout {
     private startTime: number
     private endTime: number
     private readonly timeoutLength: number
-    private readonly timerPromise: Promise<undefined>
+    private timerPromise: Promise<undefined>
     private timerTimeout: NodeJS.Timeout
     private timerResolve!: (value?: Promise<undefined> | undefined) => void
     private timerReject!: (value?: Error | Promise<Error> | undefined) => void
@@ -112,6 +112,15 @@ export class Timeout {
         }
 
         this._completed = true
+    }
+
+    public reset(): void {
+        this._completed = false
+        this.timerPromise = new Promise<undefined>((resolve, reject) => {
+            this.timerReject = reject
+            this.timerResolve = resolve
+        })
+        this.refresh()
     }
 }
 


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Some builds take a long time.  For example, the TypeScript sample template has multiple resources that each require an install and compile step.  The timer created from `createInvokeTimer` expires before reaching the invoke step.
## Solution
~~Create a reset for timers.~~
Refresh the timer.
<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
