### PR TITLE
SAM: use manifest's parent directory name for code launch configs

### DIFF
--- a/src/shared/sam/debugger/awsSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfiguration.ts
@@ -181,7 +181,7 @@ export function createCodeAwsSamDebugConfig(
     runtime: Runtime
 ): AwsSamDebuggerConfiguration {
     const workspaceRelativePath = makeWorkspaceRelativePath(folder, projectRoot)
-    const parentDir = path.basename(path.dirname(projectRoot))
+    const parentDir = path.basename(projectRoot)
 
     return {
         type: AWS_SAM_DEBUG_TYPE,
@@ -245,7 +245,7 @@ export function createApiAwsSamDebugConfig(
 function makeWorkspaceRelativePath(folder: vscode.WorkspaceFolder | undefined, target: string): string {
     if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length <= 1) {
         return folder
-            ? isCloud9()  // TODO: remove when Cloud9 supports ${workspaceFolder}.
+            ? isCloud9() // TODO: remove when Cloud9 supports ${workspaceFolder}.
                 ? getNormalizedRelativePath(folder.uri.fsPath, target)
                 : `\${workspaceFolder}/${getNormalizedRelativePath(folder.uri.fsPath, target)}`
             : target


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Code launch configs were using the manifest's parent's parent directory. 

## Solution
Go one level lower.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
