### PR TITLE
SAM runtimes: exclude dotnet5.0 on cloud9

### DIFF
--- a/src/lambda/wizards/samInitWizard.ts
+++ b/src/lambda/wizards/samInitWizard.ts
@@ -71,7 +71,7 @@ export interface CreateNewSamAppWizardContext {
 }
 
 export class DefaultCreateNewSamAppWizardContext extends WizardContext implements CreateNewSamAppWizardContext {
-    public readonly lambdaRuntimes = samLambdaCreatableRuntimes
+    public readonly lambdaRuntimes = samLambdaCreatableRuntimes()
     private readonly helpButton = createHelpButton(localize('AWS.command.help', 'View Toolkit Documentation'))
     private readonly currentCredentials: Credentials | undefined
     private readonly schemasRegions: Region[]

--- a/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
@@ -175,13 +175,13 @@ export class DefaultAwsSamDebugConfigurationValidator implements AwsSamDebugConf
                 }
             }
             // can't infer the runtime for image-based lambdas
-            if (!config.lambda?.runtime || !samImageLambdaRuntimes.has(config.lambda.runtime)) {
+            if (!config.lambda?.runtime || !samImageLambdaRuntimes().has(config.lambda.runtime)) {
                 return {
                     isValid: false,
                     message: localize(
                         'AWS.sam.debugger.missingRuntimeForImage',
                         'Run configurations for Image-based Lambdas require a valid Lambda runtime value, expected one of [{0}]',
-                        Array.from(samImageLambdaRuntimes).join(', ')
+                        Array.from(samImageLambdaRuntimes()).join(', ')
                     ),
                 }
             }

--- a/src/test/lambda/models/samLambdaRuntime.test.ts
+++ b/src/test/lambda/models/samLambdaRuntime.test.ts
@@ -11,6 +11,8 @@ import {
     getFamily,
     samZipLambdaRuntimes,
     RuntimeFamily,
+    samImageLambdaRuntimes,
+    samLambdaCreatableRuntimes,
 } from '../../../lambda/models/samLambdaRuntime'
 
 describe('compareSamLambdaRuntime', async function () {
@@ -53,5 +55,58 @@ describe('getFamily', async function () {
         samZipLambdaRuntimes.forEach(runtime => {
             assert.notStrictEqual(getFamily(runtime), RuntimeFamily.Unknown)
         })
+    })
+})
+
+describe('runtimes', function () {
+    it('cloud9', async function () {
+        assert.deepStrictEqual(samLambdaCreatableRuntimes(true).toArray().sort(), [
+            'nodejs10.x',
+            'nodejs12.x',
+            'nodejs14.x',
+            'python3.7',
+            'python3.8',
+        ])
+        assert.deepStrictEqual(samImageLambdaRuntimes(true).toArray().sort(), [
+            'nodejs10.x',
+            'nodejs12.x',
+            'nodejs14.x',
+            'python3.7',
+            'python3.8',
+        ])
+    })
+    it('vscode', async function () {
+        assert.deepStrictEqual(samLambdaCreatableRuntimes(false).toArray().sort(), [
+            'dotnet5.0',
+            'dotnetcore2.1',
+            'dotnetcore3.1',
+            'go1.x',
+            'java11',
+            'java8',
+            'java8.al2',
+            'nodejs10.x',
+            'nodejs12.x',
+            'nodejs14.x',
+            'python2.7',
+            'python3.6',
+            'python3.7',
+            'python3.8',
+        ])
+        assert.deepStrictEqual(samImageLambdaRuntimes(false).toArray().sort(), [
+            'dotnet5.0',
+            'dotnetcore2.1',
+            'dotnetcore3.1',
+            'go1.x',
+            'java11',
+            'java8',
+            'java8.al2',
+            'nodejs10.x',
+            'nodejs12.x',
+            'nodejs14.x',
+            'python2.7',
+            'python3.6',
+            'python3.7',
+            'python3.8',
+        ])
     })
 })

--- a/src/test/lambda/models/samLambdaRuntime.test.ts
+++ b/src/test/lambda/models/samLambdaRuntime.test.ts
@@ -77,7 +77,6 @@ describe('runtimes', function () {
     })
     it('vscode', async function () {
         assert.deepStrictEqual(samLambdaCreatableRuntimes(false).toArray().sort(), [
-            'dotnet5.0',
             'dotnetcore2.1',
             'dotnetcore3.1',
             'go1.x',


### PR DESCRIPTION
## Problem
- Cloud9 shows dotnet5.0 in runtime quickpick menu, but it's not supported there.
- Runtimes in each IDE are not clear, which leads to mistakes.

## Solution
- Exclude dotnet5.0 in Cloud9.
- Add tests to make the resolved runtimes super clear.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
