### PR TITLE
Invoker webview fixes

### DIFF
--- a/src/lambda/vue/samInvoke.ts
+++ b/src/lambda/vue/samInvoke.ts
@@ -34,6 +34,7 @@ import { recordSamOpenConfigUi } from '../../shared/telemetry/telemetry.gen'
 import { getSampleLambdaPayloads } from '../utils'
 import { isCloud9 } from '../../shared/extensionUtilities'
 import { SamDebugConfigProvider } from '../../shared/sam/debugger/awsSamDebugger'
+import { samLambdaCreatableRuntimes } from '../models/samLambdaRuntime'
 
 const localize = nls.loadMessageBundle()
 
@@ -51,6 +52,12 @@ export function registerSamInvokeVueCommand(context: ExtContext): vscode.Disposa
                 cssFiles: ['samInvokeForm.css'],
                 initialCalls: launchConfig
                     ? [
+                          {
+                              command: 'getRuntimes',
+                              data: {
+                                  runtimes: samLambdaCreatableRuntimes().toArray().sort(),
+                              },
+                          },
                           {
                               command: 'loadSamLaunchConfig',
                               data: {
@@ -103,6 +110,13 @@ export interface GetTemplateResponse {
     }
 }
 
+export interface GetRuntimesResponse {
+    command: 'getRuntimes'
+    data: {
+        runtimes: string[]
+    }
+}
+
 export interface SamInvokerBasicRequest {
     command: 'loadSamLaunchConfig' | 'getSamplePayload' | 'getTemplate' | 'feedback'
 }
@@ -115,7 +129,11 @@ export interface SamInvokerLaunchRequest {
 }
 
 export type SamInvokerRequest = SamInvokerBasicRequest | SamInvokerLaunchRequest
-export type SamInvokerResponse = LoadSamLaunchConfigResponse | GetSamplePayloadResponse | GetTemplateResponse
+export type SamInvokerResponse =
+    | LoadSamLaunchConfigResponse
+    | GetSamplePayloadResponse
+    | GetTemplateResponse
+    | GetRuntimesResponse
 
 async function handleFrontendToBackendMessage(
     message: SamInvokerRequest,

--- a/src/lambda/vue/samInvokeVue.ts
+++ b/src/lambda/vue/samInvokeVue.ts
@@ -98,6 +98,9 @@ export const Component = Vue.extend({
         window.addEventListener('message', ev => {
             const event = ev.data as SamInvokerResponse
             switch (event.command) {
+                case 'getRuntimes':
+                    this.runtimes = event.data.runtimes
+                    break
                 case 'getSamplePayload':
                     this.payload.value = JSON.stringify(JSON.parse(event.data.payload), undefined, 4)
                     break
@@ -152,17 +155,7 @@ export const Component = Vue.extend({
             ],
             containerBuildStr: '',
             skipNewImageCheckStr: '',
-            runtimes: [
-                'nodejs10.x',
-                'nodejs12.x',
-                'nodejs14.x',
-                'python2.7',
-                'python3.6',
-                'python3.7',
-                'python3.8',
-                'dotnetcore2.1',
-                'dotnetcore3.1',
-            ],
+            runtimes: [],
             httpMethods: ['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'OPTIONS', 'PATCH'],
             launchConfig: newLaunchConfig(),
             payload: { value: '', errorMsg: '' },
@@ -395,6 +388,16 @@ export const Component = Vue.extend({
                         v-model="launchConfig.invokeTarget.logicalId"
                     /><span class="data-view"> Logical Id from data: {{ launchConfig.invokeTarget.logicalId }}</span>
                 </div>
+                <div class="config-item">
+                    <label for="runtime-selector">Runtime</label>
+                    <select name="runtimeType" v-model="launchConfig.lambda.runtime">
+                        <option disabled>Choose a runtime...</option>
+                        <option v-for="(runtime, index) in runtimes" v-bind:value="runtime" :key="index">
+                            {{ runtime }}
+                        </option>
+                    </select>
+                    <span class="data-view">runtime in data: {{ launchConfig.lambda.runtime }}</span>
+                </div>
             </div>
             <div class="target-apigw" v-else-if="launchConfig.invokeTarget.target === 'api'">
                 <button v-on:click.prevent="loadResource">Load Resource</button><br />
@@ -416,6 +419,16 @@ export const Component = Vue.extend({
                         placeholder="Enter a resource"
                         v-model="launchConfig.invokeTarget.logicalId"
                     />
+                </div>
+                <div class="config-item">
+                    <label for="runtime-selector">Runtime</label>
+                    <select name="runtimeType" v-model="launchConfig.lambda.runtime">
+                        <option disabled>Choose a runtime...</option>
+                        <option v-for="(runtime, index) in runtimes" v-bind:value="runtime" :key="index">
+                            {{ runtime }}
+                        </option>
+                    </select>
+                    <span class="data-view">runtime in data: {{ launchConfig.lambda.runtime }}</span>
                 </div>
                 <div class="config-item">
                     <label for="path">Path</label>

--- a/src/webviews/main.ts
+++ b/src/webviews/main.ts
@@ -112,6 +112,10 @@ export async function createVueWebview<TRequest, TResponse>(params: WebviewParam
 </html>`
 
     if (params.initialCalls) {
+        // give the webview a little more time before adding content
+        if (isCloud9()) {
+            await new Promise(resolve => setTimeout(resolve, 500))
+        }
         for (const call of params.initialCalls) view.webview.postMessage(call)
     }
 

--- a/src/webviews/main.ts
+++ b/src/webviews/main.ts
@@ -112,7 +112,7 @@ export async function createVueWebview<TRequest, TResponse>(params: WebviewParam
 </html>`
 
     if (params.initialCalls) {
-        // give the webview a little more time before adding content
+        // TODO: workaround for cloud9 webviews, remove after cloud9 issue is fixed.
         if (isCloud9()) {
             await new Promise(resolve => setTimeout(resolve, 500))
         }


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
* Webview in Cloud9 was not populating with data
* aws-sam configs require a runtime when invoking an image runtime
* Runtimes were static

## Solution
* Added a 500ms delay for Cloud9 on messaging in initial webview state
* Runtime now immediately available to set for all launch config types in webview
* Dynamically message runtimes to webview on load

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
