### PR TITLE
SAM - Create a new TypeScript SAM app from template

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -496,6 +496,7 @@
     "AWS.samcli.initWizard.template.eventBridge_helloWorld.description": "Invokes a Lambda for every EC2 instance state change in your account",
     "AWS.samcli.initWizard.template.eventBridge_starterApp.description": "Invokes a Lambda based on a dynamic event trigger for an EventBridge Schema of your choice",
     "AWS.samcli.initWizard.template.stepFunctionsSampleApp.description": "Orchestrates multiple Lambdas to execute a stock trading workflow on an hourly schedule",
+    "AWS.samcli.initWizard.template.typeScriptBackendTemplate.description": "A sample TypeScript backend app with Lambda and DynamoDB",
     "AWS.samcli.initWizard.schemas.region.prompt": "Select an EventBridge Schemas Region",
     "AWS.samcli.initWizard.schemas.registry.prompt": "Select a Registry",
     "AWS.samcli.initWizard.schemas.registry.failed_to_load_resources": "Error loading registries.",

--- a/src/lambda/models/samTemplates.ts
+++ b/src/lambda/models/samTemplates.ts
@@ -15,6 +15,7 @@ export const helloWorldTemplate = 'AWS SAM Hello World'
 export const eventBridgeHelloWorldTemplate = 'AWS SAM EventBridge Hello World'
 export const eventBridgeStarterAppTemplate = 'AWS SAM EventBridge App from Scratch'
 export const stepFunctionsSampleApp = 'AWS Step Functions Sample App'
+export const typeScriptBackendTemplate = 'App Backend using TypeScript'
 export const repromptUserForTemplate = 'REQUIRES_AWS_CREDENTIALS_REPROMPT_USER_FOR_TEMPLATE'
 
 export const CLI_VERSION_STEP_FUNCTIONS_TEMPLATE = '0.52.0'
@@ -24,6 +25,7 @@ export type SamTemplate =
     | 'AWS SAM EventBridge Hello World'
     | 'AWS SAM EventBridge App from Scratch'
     | 'AWS Step Functions Sample App'
+    | 'App Backend using TypeScript'
     | 'REQUIRES_AWS_CREDENTIALS_REPROMPT_USER_FOR_TEMPLATE'
 
 export function getSamTemplateWizardOption(
@@ -46,6 +48,10 @@ export function getSamTemplateWizardOption(
         templateOptions.push(stepFunctionsSampleApp)
     }
 
+    if (supportsTypeScriptBackendTemplate(runtime)) {
+        templateOptions.push(typeScriptBackendTemplate)
+    }
+
     return ImmutableSet<SamTemplate>(templateOptions)
 }
 
@@ -59,6 +65,8 @@ export function getSamCliTemplateParameter(templateSelected: SamTemplate): strin
             return 'eventBridge-schema-app'
         case stepFunctionsSampleApp:
             return 'step-functions-sample-app'
+        case typeScriptBackendTemplate:
+            return 'quick-start-typescript-app'
         default:
             throw new Error(`${templateSelected} is not valid sam template`)
     }
@@ -83,6 +91,11 @@ export function getTemplateDescription(template: SamTemplate): string {
                 'AWS.samcli.initWizard.template.stepFunctionsSampleApp.description',
                 'Orchestrates multiple Lambdas to execute a stock trading workflow on an hourly schedule'
             )
+        case typeScriptBackendTemplate:
+            return localize(
+                'AWS.samcli.initWizard.template.typeScriptBackendTemplate.description',
+                'A sample TypeScript backend app with Lambda and DynamoDB'
+            )
         default:
             throw new Error(`No description found for template ${template}`)
     }
@@ -93,4 +106,8 @@ export function supportsStepFuntionsTemplate(samCliVersion: string): boolean {
         return false
     }
     return semver.gte(samCliVersion, CLI_VERSION_STEP_FUNCTIONS_TEMPLATE)
+}
+
+export function supportsTypeScriptBackendTemplate(runtime: Runtime): boolean {
+    return runtime === 'nodejs12.x'
 }

--- a/src/test/lambda/models/samTemplates.test.ts
+++ b/src/test/lambda/models/samTemplates.test.ts
@@ -15,6 +15,7 @@ import {
     eventBridgeHelloWorldTemplate,
     eventBridgeStarterAppTemplate,
     stepFunctionsSampleApp,
+    typeScriptBackendTemplate,
 } from '../../../lambda/models/samTemplates'
 import { Set } from 'immutable'
 
@@ -25,6 +26,20 @@ const validTemplateOptions: Set<SamTemplate> = Set<SamTemplate>([
     eventBridgeHelloWorldTemplate,
     eventBridgeStarterAppTemplate,
     stepFunctionsSampleApp,
+    typeScriptBackendTemplate,
+])
+
+const validPythonTemplateOptions: Set<SamTemplate> = Set<SamTemplate>([
+    helloWorldTemplate,
+    eventBridgeHelloWorldTemplate,
+    eventBridgeStarterAppTemplate,
+    stepFunctionsSampleApp,
+])
+
+const validNode12TemplateOptions: Set<SamTemplate> = Set<SamTemplate>([
+    helloWorldTemplate,
+    stepFunctionsSampleApp,
+    typeScriptBackendTemplate,
 ])
 
 const defaultTemplateOptions: Set<SamTemplate> = Set<SamTemplate>([helloWorldTemplate, stepFunctionsSampleApp])
@@ -39,8 +54,15 @@ describe('getSamTemplateWizardOption', function () {
                 case 'python3.8':
                     assert.deepStrictEqual(
                         result,
-                        validTemplateOptions,
-                        'Event bridge app supports all valid template options'
+                        validPythonTemplateOptions,
+                        'Python 3.x supports additional template options'
+                    )
+                    break
+                case 'nodejs12.x':
+                    assert.deepStrictEqual(
+                        result,
+                        validNode12TemplateOptions,
+                        'Node12.x supports default and TS template options'
                     )
                     break
                 default:


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
There is no option to create a TypeScript SAM app.
## Solution
Add the TypeScript template option to the SAM init wizard for the nodejs12.x runtime.
<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
