### PR TITLE
Always show 'Add SAM Debug Configuration' command

### DIFF
--- a/package.json
+++ b/package.json
@@ -739,10 +739,6 @@
                 {
                     "command": "aws.cdk.help",
                     "when": "!isCloud9"
-                },
-                {
-                    "command": "aws.addSamDebugConfig",
-                    "when": "editorLangId in samSupportedLanguages"
                 }
             ],
             "editor/title": [

--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -135,7 +135,13 @@ function makeAddCodeSamDebugCodeLens(
  */
 export async function invokeCodeLensCommandPalette(
     document: Pick<vscode.TextDocument, 'getText'>,
-    lenses: vscode.CodeLens[]
+    lenses: vscode.CodeLens[],
+    nextStep: (
+        codeConfig: AddSamDebugConfigurationInput,
+        templateConfigs: AddSamDebugConfigurationInput[],
+        openWebview: boolean,
+        continuationStep?: boolean
+    ) => Promise<void> = pickAddSamDebugConfiguration
 ): Promise<void> {
     const labelRenderRange = 200
     const handlers: (vscode.QuickPickItem & { lens?: vscode.CodeLens })[] = lenses
@@ -195,13 +201,7 @@ export async function invokeCodeLensCommandPalette(
     }
 
     // note: val.lens.command.arguments[2] should always be false (aka no invoke UI) based on the filter statement
-    // HACK: `exports.` is for the sake of sinon stubbing; you can't stub a function in the same file
-    await exports.pickAddSamDebugConfiguration(
-        val.lens.command.arguments![0],
-        val.lens.command.arguments![1],
-        val.lens.command.arguments![2],
-        true
-    )
+    await nextStep(val.lens.command.arguments![0], val.lens.command.arguments![1], val.lens.command.arguments![2], true)
 }
 
 /**

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -144,8 +144,6 @@ async function activateCodeLensProviders(
         supportedLanguages[goLensProvider.GO_LANGUAGE] = goCodeLensProvider
     }
 
-    await vscode.commands.executeCommand('setContext', 'samSupportedLanguages', supportedLanguages)
-
     disposables.push(
         vscode.languages.registerCodeLensProvider(
             [
@@ -176,11 +174,6 @@ async function activateCodeLensProviders(
         })
     )
 
-    /**
-     * This should only be callable when the current editor is a language supported by our SAM implementation
-     * (see package.json's when clause for aws.addSamDebugConfig).
-     * Error blocks should never be triggered, but messages will be provided regardless (I guess a user could tie this to a keyboard shortcut...)
-     */
     disposables.push(
         vscode.commands.registerCommand('aws.addSamDebugConfig', async () => {
             const activeEditor = vscode.window.activeTextEditor

--- a/src/test/shared/codelens/codeLensUtils.test.ts
+++ b/src/test/shared/codelens/codeLensUtils.test.ts
@@ -124,15 +124,27 @@ describe('codeLensUtils', async function () {
                 ])
             const createSpy = sandbox.spy(Picker, 'createQuickPick')
             const finalSpy = sandbox.spy(codeLensUtils, 'pickAddSamDebugConfiguration')
-            await codeLensUtils.invokeCodeLensCommandPalette(doc, [
-                /* stub handles all pick logic */
-            ])
-            await codeLensUtils.invokeCodeLensCommandPalette(doc, [
-                /* stub handles all pick logic */
-            ])
-            await codeLensUtils.invokeCodeLensCommandPalette(doc, [
-                /* stub handles all pick logic */
-            ])
+            await codeLensUtils.invokeCodeLensCommandPalette(
+                doc,
+                [
+                    /* stub handles all pick logic */
+                ],
+                finalSpy
+            )
+            await codeLensUtils.invokeCodeLensCommandPalette(
+                doc,
+                [
+                    /* stub handles all pick logic */
+                ],
+                finalSpy
+            )
+            await codeLensUtils.invokeCodeLensCommandPalette(
+                doc,
+                [
+                    /* stub handles all pick logic */
+                ],
+                finalSpy
+            )
 
             assert.ok(createSpy.calledThrice, 'Not all test payloads run')
             assert.ok(finalSpy.notCalled, 'pickAddSamDebugConfiguration called; function did not return undefined')
@@ -167,9 +179,13 @@ describe('codeLensUtils', async function () {
                 .onFirstCall()
                 .resolves(undefined)
 
-            await codeLensUtils.invokeCodeLensCommandPalette(doc, [
-                /* stub handles all pick logic */
-            ])
+            await codeLensUtils.invokeCodeLensCommandPalette(
+                doc,
+                [
+                    /* stub handles all pick logic */
+                ],
+                finalStub
+            )
 
             assert.ok(finalStub.calledOnce, 'pickAddSamDebugConfiguration not called once and only once')
             assert.ok(finalStub.calledWith(arg0, arg1, arg2), 'pickAddSamDebugConfiguration called with incorrect args')


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
"Add SAM Debug Configuration" command was inconsistent to inexperienced users
## Solution
Get rid of the conditional and let errors handle themselves.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
