### PR TITLE
SAM/Deploy: fix recently used bucket setting

### DIFF
--- a/.changes/next-release/Bug Fix-e4696f16-db39-4fa3-b140-324eeb8995d9.json
+++ b/.changes/next-release/Bug Fix-e4696f16-db39-4fa3-b140-324eeb8995d9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Settings: write 'recently used buckets' setting as JSON object"
+}

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
                     "maximum": 10000
                 },
                 "aws.manuallySelectedBuckets": {
-                    "type": "string",
+                    "type": "object",
                     "description": "%AWS.samcli.deploy.bucket.recentlyUsed%",
                     "default": []
                 },

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
                     "maximum": 10000
                 },
                 "aws.manuallySelectedBuckets": {
-                    "type": "object",
+                    "type": "string",
                     "description": "%AWS.samcli.deploy.bucket.recentlyUsed%",
                     "default": []
                 },

--- a/src/lambda/wizards/samDeployWizard.ts
+++ b/src/lambda/wizards/samDeployWizard.ts
@@ -194,6 +194,47 @@ function getSingleResponse(responses: vscode.QuickPickItem[] | undefined): strin
     return responses[0].label
 }
 
+/**
+ * The toolkit used to store saved buckets as a stringified JSON object. To ensure compatability,
+ * we need to check for this and convert them into objects.
+ */
+export function readSavedBuckets(settings: SettingsConfiguration): SavedBuckets | undefined {
+    try {
+        const buckets = settings.readSetting<SavedBuckets | string | undefined>(CHOSEN_BUCKET_KEY)
+        return typeof buckets === 'string' ? JSON.parse(buckets) : buckets
+    } catch (e) {
+        // If we fail to read settings then remove the bad data completely
+        getLogger().error('Recent bucket JSON not parseable. Rewriting recent buckets from scratch...', e)
+        settings.writeSetting(CHOSEN_BUCKET_KEY, {}, vscode.ConfigurationTarget.Global)
+        return undefined
+    }
+}
+
+/**
+ * Writes a single new saved bucket to the stored buckets setting, combining previous saved data
+ * if it exists. One saved bucket is limited per region per profile.
+ */
+export function writeSavedBucket(
+    settings: SettingsConfiguration,
+    profile: string,
+    region: string,
+    bucket: string
+): void {
+    const oldBuckets = readSavedBuckets(settings)
+
+    settings.writeSetting(
+        CHOSEN_BUCKET_KEY,
+        {
+            ...oldBuckets,
+            [profile]: {
+                ...(oldBuckets && oldBuckets[profile] ? oldBuckets[profile] : {}),
+                [region]: bucket,
+            },
+        } as SavedBuckets,
+        vscode.ConfigurationTarget.Global
+    )
+}
+
 export class DefaultSamDeployWizardContext implements SamDeployWizardContext {
     public readonly getParameters = getParameters
     public readonly getOverriddenParameters = getOverriddenParameters
@@ -947,7 +988,7 @@ async function populateS3QuickPick(
 
         let recent: string = ''
         try {
-            const existingBuckets = settings.readSetting<SavedBuckets | undefined>(CHOSEN_BUCKET_KEY)
+            const existingBuckets = readSavedBuckets(settings)
             if (existingBuckets && profile && existingBuckets[profile] && existingBuckets[profile][selectedRegion]) {
                 recent = existingBuckets[profile][selectedRegion]
                 baseItems.push({

--- a/src/lambda/wizards/samDeployWizard.ts
+++ b/src/lambda/wizards/samDeployWizard.ts
@@ -44,6 +44,10 @@ const CREATE_NEW_BUCKET = localize('AWS.command.s3.createBucket', 'Create Bucket
 const ENTER_BUCKET = localize('AWS.samcli.deploy.bucket.existingLabel', 'Enter Existing Bucket Name...')
 export const CHOSEN_BUCKET_KEY = 'manuallySelectedBuckets'
 
+export interface SavedBuckets {
+    [profile: string]: { [region: string]: string }
+}
+
 export interface SamDeployWizardResponse {
     parameterOverrides: Map<string, string>
     region: string
@@ -943,9 +947,7 @@ async function populateS3QuickPick(
 
         let recent: string = ''
         try {
-            const bucketsJson = settings.readSetting<string | undefined>(CHOSEN_BUCKET_KEY)
-            const existingBuckets = bucketsJson ? JSON.parse(bucketsJson) : undefined
-            // JSON object of type: { [profile: string]: { [region: string]: bucket } }
+            const existingBuckets = settings.readSetting<SavedBuckets | undefined>(CHOSEN_BUCKET_KEY)
             if (existingBuckets && profile && existingBuckets[profile] && existingBuckets[profile][selectedRegion]) {
                 recent = existingBuckets[profile][selectedRegion]
                 baseItems.push({

--- a/src/test/lambda/commands/deploySamApplication.test.ts
+++ b/src/test/lambda/commands/deploySamApplication.test.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs-extra'
 import * as path from 'path'
 import * as vscode from 'vscode'
 import { deploySamApplication, WindowFunctions } from '../../../lambda/commands/deploySamApplication'
-import { CHOSEN_BUCKET_KEY, SamDeployWizardResponse } from '../../../lambda/wizards/samDeployWizard'
+import { CHOSEN_BUCKET_KEY, SamDeployWizardResponse, SavedBuckets } from '../../../lambda/wizards/samDeployWizard'
 import { AwsContext } from '../../../shared/awsContext'
 import { ext } from '../../../shared/extensionGlobals'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
@@ -42,7 +42,7 @@ describe('deploySamApplication', async function () {
 
     // Bad Invoker
 
-    const badSamCliProcessInvoker = ({} as any) as SamCliProcessInvoker
+    const badSamCliProcessInvoker = {} as any as SamCliProcessInvoker
 
     const invalidSamCliContext: SamCliContext = {
         invoker: badSamCliProcessInvoker,
@@ -68,13 +68,11 @@ describe('deploySamApplication', async function () {
     // Good Invoker
 
     let invokerCalledCount: number
-    let goodSamCliProcessInvoker = new TestSamCliProcessInvoker(
-        (spawnOptions, args: any[]): ChildProcessResult => {
-            invokerCalledCount++
+    let goodSamCliProcessInvoker = new TestSamCliProcessInvoker((spawnOptions, args: any[]): ChildProcessResult => {
+        invokerCalledCount++
 
-            return new FakeChildProcessResult({})
-        }
-    )
+        return new FakeChildProcessResult({})
+    })
 
     const goodSamCliContext = (): SamCliContext => {
         return {
@@ -109,7 +107,7 @@ describe('deploySamApplication', async function () {
     }
 
     // Other support stubs
-    const placeholderCredentials = ({} as any) as AWS.Credentials
+    const placeholderCredentials = {} as any as AWS.Credentials
     let testCredentials: AWS.Credentials | undefined
     let profile: string = ''
     const awsContext: Pick<AwsContext, 'getCredentials' | 'getCredentialProfileName'> = {
@@ -169,16 +167,15 @@ describe('deploySamApplication', async function () {
 
         await waitForDeployToComplete()
         assert.strictEqual(invokerCalledCount, 3, 'Unexpected sam cli invoke count')
-        assert.deepStrictEqual(
-            settings.readSetting(CHOSEN_BUCKET_KEY, ''),
-            JSON.stringify({ [profile]: { region: 'bucket' } })
-        )
+        assert.deepStrictEqual(settings.readSetting(CHOSEN_BUCKET_KEY, ''), {
+            [profile]: { region: 'bucket' },
+        } as SavedBuckets)
     })
 
     it('overwrites recently selected bucket', async () => {
         settings.writeSetting(
             CHOSEN_BUCKET_KEY,
-            JSON.stringify({ [profile]: { region: 'oldBucket' } }),
+            { [profile]: { region: 'oldBucket' } } as SavedBuckets,
             vscode.ConfigurationTarget.Global
         )
         await deploySamApplication(
@@ -195,10 +192,9 @@ describe('deploySamApplication', async function () {
 
         await waitForDeployToComplete()
         assert.strictEqual(invokerCalledCount, 3, 'Unexpected sam cli invoke count')
-        assert.deepStrictEqual(
-            settings.readSetting(CHOSEN_BUCKET_KEY, ''),
-            JSON.stringify({ [profile]: { region: 'bucket' } })
-        )
+        assert.deepStrictEqual(settings.readSetting(CHOSEN_BUCKET_KEY, ''), {
+            [profile]: { region: 'bucket' },
+        } as SavedBuckets)
     })
 
     it('saves one bucket max to multiple regions', async () => {
@@ -284,16 +280,13 @@ describe('deploySamApplication', async function () {
 
         await waitForDeployToComplete()
         assert.strictEqual(invokerCalledCount, 12, 'Unexpected sam cli invoke count')
-        assert.deepStrictEqual(
-            settings.readSetting(CHOSEN_BUCKET_KEY, ''),
-            JSON.stringify({
-                [profile]: {
-                    region0: 'bucket3',
-                    region1: 'bucket1',
-                    region2: 'bucket2',
-                },
-            })
-        )
+        assert.deepStrictEqual(settings.readSetting(CHOSEN_BUCKET_KEY, ''), {
+            [profile]: {
+                region0: 'bucket3',
+                region1: 'bucket1',
+                region2: 'bucket2',
+            },
+        } as SavedBuckets)
     })
 
     it('saves one bucket per region per profile', async () => {
@@ -341,17 +334,14 @@ describe('deploySamApplication', async function () {
 
         await waitForDeployToComplete()
         assert.strictEqual(invokerCalledCount, 6, 'Unexpected sam cli invoke count')
-        assert.deepStrictEqual(
-            settings.readSetting(CHOSEN_BUCKET_KEY, ''),
-            JSON.stringify({
-                testAcct0: {
-                    region0: 'bucket0',
-                },
-                testAcct1: {
-                    region0: 'bucket1',
-                },
-            })
-        )
+        assert.deepStrictEqual(settings.readSetting(CHOSEN_BUCKET_KEY, ''), {
+            testAcct0: {
+                region0: 'bucket0',
+            },
+            testAcct1: {
+                region0: 'bucket1',
+            },
+        } as SavedBuckets)
     })
 
     it('informs user of error when user is not logged in', async function () {
@@ -407,18 +397,16 @@ describe('deploySamApplication', async function () {
     })
 
     it('continues deploying with initial template if invoking sam build fails', async function () {
-        goodSamCliProcessInvoker = new TestSamCliProcessInvoker(
-            (spawnOptions, args: any[]): ChildProcessResult => {
-                invokerCalledCount++
+        goodSamCliProcessInvoker = new TestSamCliProcessInvoker((spawnOptions, args: any[]): ChildProcessResult => {
+            invokerCalledCount++
 
-                const isDeployInvoke = args.some(arg => arg === 'build')
+            const isDeployInvoke = args.some(arg => arg === 'build')
 
-                return new FakeChildProcessResult({
-                    exitCode: isDeployInvoke ? -1 : 0,
-                    error: isDeployInvoke ? new Error('broken build') : undefined,
-                })
-            }
-        )
+            return new FakeChildProcessResult({
+                exitCode: isDeployInvoke ? -1 : 0,
+                error: isDeployInvoke ? new Error('broken build') : undefined,
+            })
+        })
 
         await deploySamApplication(
             {
@@ -438,18 +426,16 @@ describe('deploySamApplication', async function () {
     })
 
     it('informs user of error if invoking sam package fails', async function () {
-        goodSamCliProcessInvoker = new TestSamCliProcessInvoker(
-            (spawnOptions, args: any[]): ChildProcessResult => {
-                invokerCalledCount++
+        goodSamCliProcessInvoker = new TestSamCliProcessInvoker((spawnOptions, args: any[]): ChildProcessResult => {
+            invokerCalledCount++
 
-                const isDeployInvoke = args.some(arg => arg === 'package')
+            const isDeployInvoke = args.some(arg => arg === 'package')
 
-                return new FakeChildProcessResult({
-                    exitCode: isDeployInvoke ? -1 : 0,
-                    error: isDeployInvoke ? new Error('broken package') : undefined,
-                })
-            }
-        )
+            return new FakeChildProcessResult({
+                exitCode: isDeployInvoke ? -1 : 0,
+                error: isDeployInvoke ? new Error('broken package') : undefined,
+            })
+        })
 
         await deploySamApplication(
             {
@@ -469,18 +455,16 @@ describe('deploySamApplication', async function () {
     })
 
     it('informs user of error if invoking sam deploy fails', async function () {
-        goodSamCliProcessInvoker = new TestSamCliProcessInvoker(
-            (spawnOptions, args: any[]): ChildProcessResult => {
-                invokerCalledCount++
+        goodSamCliProcessInvoker = new TestSamCliProcessInvoker((spawnOptions, args: any[]): ChildProcessResult => {
+            invokerCalledCount++
 
-                const isDeployInvoke = args.some(arg => arg === 'deploy')
+            const isDeployInvoke = args.some(arg => arg === 'deploy')
 
-                return new FakeChildProcessResult({
-                    exitCode: isDeployInvoke ? -1 : 0,
-                    error: isDeployInvoke ? new Error('broken deploy') : undefined,
-                })
-            }
-        )
+            return new FakeChildProcessResult({
+                exitCode: isDeployInvoke ? -1 : 0,
+                error: isDeployInvoke ? new Error('broken deploy') : undefined,
+            })
+        })
 
         await deploySamApplication(
             {


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
We specified the `manuallySelectedBuckets` as an object but we were storing it as a string. 

## Solution
* Write the setting as an object. A new interface `SavedBuckets` was added to clarify the structure of saved buckets.
* Check for previously saved stringified buckets and parse them. Failed parses will reset the setting.
* Add two new tests to check the above.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
