### PR TITLE
Continue local invoke if timer expires but build is successful

### DIFF
--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -374,7 +374,7 @@ export async function runLambdaFunction(
 
     await onAfterBuild()
 
-    // If the build successfully but expires the timer, reset the timer
+    // If the build finishes successfully but expires the timer, reset the timer
     if (timer.completed) {
         timer.reset()
     }

--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -18,7 +18,7 @@ export class Timeout {
     private startTime: number
     private endTime: number
     private readonly timeoutLength: number
-    private readonly timerPromise: Promise<undefined>
+    private timerPromise: Promise<undefined>
     private timerTimeout: NodeJS.Timeout
     private timerResolve!: (value?: Promise<undefined> | undefined) => void
     private timerReject!: (value?: Error | Promise<Error> | undefined) => void
@@ -112,6 +112,15 @@ export class Timeout {
         }
 
         this._completed = true
+    }
+
+    public reset(): void {
+        this._completed = false
+        this.timerPromise = new Promise<undefined>((resolve, reject) => {
+            this.timerReject = reject
+            this.timerResolve = resolve
+        })
+        this.refresh()
     }
 }
 


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Some applications will take longer to build. The timer can expire during that time but still build successfully, which ultimately terminates the local invoke.
## Solution
Reset the timer if it has completed and the build was successful.
<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
