### PR TITLE
refactor: improve ergonomics of AWSClientBuilder

### DIFF
--- a/src/shared/awsClientBuilder.ts
+++ b/src/shared/awsClientBuilder.ts
@@ -40,7 +40,7 @@ export class DefaultAWSClientBuilder implements AWSClientBuilder {
         region?: string,
         userAgent: boolean = true
     ): Promise<T> {
-        const opt = { ...options }
+        const opt = { ...options } as ServiceConfigurationOptions
 
         if (!opt.credentials) {
             opt.credentials = await this._awsContext.getCredentials()

--- a/src/shared/clients/defaultApiGatewayClient.ts
+++ b/src/shared/clients/defaultApiGatewayClient.ts
@@ -78,10 +78,6 @@ export class DefaultApiGatewayClient implements ApiGatewayClient {
     }
 
     private async createSdkClient(): Promise<APIGateway> {
-        return await ext.sdkClientBuilder.createAndConfigureServiceClient(
-            options => new APIGateway(options),
-            undefined,
-            this.regionCode
-        )
+        return await ext.sdkClientBuilder.createAwsService(APIGateway, undefined, this.regionCode)
     }
 }

--- a/src/shared/clients/defaultCloudFormationClient.ts
+++ b/src/shared/clients/defaultCloudFormationClient.ts
@@ -52,10 +52,6 @@ export class DefaultCloudFormationClient implements CloudFormationClient {
     }
 
     private async createSdkClient(): Promise<CloudFormation> {
-        return await ext.sdkClientBuilder.createAndConfigureServiceClient(
-            options => new CloudFormation(options),
-            undefined,
-            this.regionCode
-        )
+        return await ext.sdkClientBuilder.createAwsService(CloudFormation, undefined, this.regionCode)
     }
 }

--- a/src/shared/clients/defaultCloudWatchLogsClient.ts
+++ b/src/shared/clients/defaultCloudWatchLogsClient.ts
@@ -46,10 +46,6 @@ export class DefaultCloudWatchLogsClient implements CloudWatchLogsClient {
     }
 
     protected async createSdkClient(): Promise<CloudWatchLogs> {
-        return await ext.sdkClientBuilder.createAndConfigureServiceClient(
-            options => new CloudWatchLogs(options),
-            undefined,
-            this.regionCode
-        )
+        return await ext.sdkClientBuilder.createAwsService(CloudWatchLogs, undefined, this.regionCode)
     }
 }

--- a/src/shared/clients/defaultEcrClient.ts
+++ b/src/shared/clients/defaultEcrClient.ts
@@ -70,10 +70,6 @@ export class DefaultEcrClient implements EcrClient {
     }
 
     protected async createSdkClient(): Promise<ECR> {
-        return await ext.sdkClientBuilder.createAndConfigureServiceClient(
-            options => new ECR(options),
-            undefined,
-            this.regionCode
-        )
+        return await ext.sdkClientBuilder.createAwsService(ECR, undefined, this.regionCode)
     }
 }

--- a/src/shared/clients/defaultEcsClient.ts
+++ b/src/shared/clients/defaultEcsClient.ts
@@ -71,10 +71,6 @@ export class DefaultEcsClient implements EcsClient {
     }
 
     protected async createSdkClient(): Promise<ECS> {
-        return await ext.sdkClientBuilder.createAndConfigureServiceClient(
-            options => new ECS(options),
-            undefined,
-            this.regionCode
-        )
+        return await ext.sdkClientBuilder.createAwsService(ECS, undefined, this.regionCode)
     }
 }

--- a/src/shared/clients/defaultIamClient.ts
+++ b/src/shared/clients/defaultIamClient.ts
@@ -19,10 +19,6 @@ export class DefaultIamClient implements IamClient {
     }
 
     private async createSdkClient(): Promise<IAM> {
-        return await ext.sdkClientBuilder.createAndConfigureServiceClient(
-            options => new IAM(options),
-            undefined,
-            this.regionCode
-        )
+        return await ext.sdkClientBuilder.createAwsService(IAM, undefined, this.regionCode)
     }
 }

--- a/src/shared/clients/defaultLambdaClient.ts
+++ b/src/shared/clients/defaultLambdaClient.ts
@@ -95,10 +95,6 @@ export class DefaultLambdaClient implements LambdaClient {
     }
 
     private async createSdkClient(): Promise<Lambda> {
-        return await ext.sdkClientBuilder.createAndConfigureServiceClient(
-            options => new Lambda(options),
-            undefined,
-            this.regionCode
-        )
+        return await ext.sdkClientBuilder.createAwsService(Lambda, undefined, this.regionCode)
     }
 }

--- a/src/shared/clients/defaultS3Client.ts
+++ b/src/shared/clients/defaultS3Client.ts
@@ -533,11 +533,7 @@ function buildArn({ partitionId, bucketName, key }: { partitionId: string; bucke
 async function createSdkClient(regionCode: string): Promise<S3> {
     clearInternalBucketCache()
 
-    return await ext.sdkClientBuilder.createAndConfigureServiceClient(
-        options => new S3(options),
-        { computeChecksums: true },
-        regionCode
-    )
+    return await ext.sdkClientBuilder.createAwsService(S3, { computeChecksums: true }, regionCode)
 }
 
 /**

--- a/src/shared/clients/defaultSchemaClient.ts
+++ b/src/shared/clients/defaultSchemaClient.ts
@@ -160,10 +160,6 @@ export class DefaultSchemaClient implements SchemaClient {
     }
 
     private async createSdkClient(): Promise<Schemas> {
-        return await ext.sdkClientBuilder.createAndConfigureServiceClient(
-            options => new Schemas(options),
-            undefined,
-            this.regionCode
-        )
+        return await ext.sdkClientBuilder.createAwsService(Schemas, undefined, this.regionCode)
     }
 }

--- a/src/shared/clients/defaultSsmDocumentClient.ts
+++ b/src/shared/clients/defaultSsmDocumentClient.ts
@@ -110,10 +110,6 @@ export class DefaultSsmDocumentClient implements SsmDocumentClient {
     }
 
     private async createSdkClient(): Promise<SSM> {
-        return await ext.sdkClientBuilder.createAndConfigureServiceClient(
-            options => new SSM(options),
-            undefined,
-            this.regionCode
-        )
+        return await ext.sdkClientBuilder.createAwsService(SSM, undefined, this.regionCode)
     }
 }

--- a/src/shared/clients/defaultStepFunctionsClient.ts
+++ b/src/shared/clients/defaultStepFunctionsClient.ts
@@ -68,10 +68,6 @@ export class DefaultStepFunctionsClient implements StepFunctionsClient {
     }
 
     private async createSdkClient(): Promise<StepFunctions> {
-        return await ext.sdkClientBuilder.createAndConfigureServiceClient(
-            options => new StepFunctions(options),
-            undefined,
-            this.regionCode
-        )
+        return await ext.sdkClientBuilder.createAwsService(StepFunctions, undefined, this.regionCode)
     }
 }

--- a/src/shared/clients/defaultStsClient.ts
+++ b/src/shared/clients/defaultStsClient.ts
@@ -21,12 +21,12 @@ export class DefaultStsClient implements StsClient {
     }
 
     private async createSdkClient(): Promise<STS> {
-        return await ext.sdkClientBuilder.createAndConfigureServiceClient(
-            options => {
-                options.stsRegionalEndpoints = 'regional'
-                return new STS(options)
+        return await ext.sdkClientBuilder.createAwsService(
+            STS,
+            {
+                ...this.credentials,
+                stsRegionalEndpoints: 'regional',
             },
-            this.credentials,
             this.regionCode
         )
     }

--- a/src/shared/telemetry/defaultTelemetryClient.ts
+++ b/src/shared/telemetry/defaultTelemetryClient.ts
@@ -88,8 +88,8 @@ export class DefaultTelemetryClient implements TelemetryClient {
 
         return new DefaultTelemetryClient(
             clientId,
-            await ext.sdkClientBuilder.createAndConfigureServiceClient(
-                opts => new Service(opts),
+            (await ext.sdkClientBuilder.createAwsService(
+                Service,
                 {
                     // @ts-ignore: apiConfig is internal and not in the TS declaration file
                     apiConfig: apiConfig,
@@ -98,9 +98,8 @@ export class DefaultTelemetryClient implements TelemetryClient {
                     correctClockSkew: true,
                     endpoint: DefaultTelemetryClient.DEFAULT_TELEMETRY_ENDPOINT,
                 },
-                undefined,
                 false
-            )
+            )) as ClientTelemetry
         )
     }
 }

--- a/src/test/shared/defaultAwsClientBuilder.test.ts
+++ b/src/test/shared/defaultAwsClientBuilder.test.ts
@@ -20,7 +20,7 @@ describe('DefaultAwsClientBuilder', function () {
 
         it('includes custom user-agent if no options are specified', async function () {
             const builder = new DefaultAWSClientBuilder(new FakeAwsContext())
-            const service = await builder.createAndConfigureServiceClient(opts => new FakeService(opts))
+            const service = await builder.createAwsService(FakeService)
 
             assert.strictEqual(!!service.config.customUserAgent, true)
             assert.strictEqual(
@@ -31,7 +31,7 @@ describe('DefaultAwsClientBuilder', function () {
 
         it('includes custom user-agent if not specified in options', async function () {
             const builder = new DefaultAWSClientBuilder(new FakeAwsContext())
-            const service = await builder.createAndConfigureServiceClient(opts => new FakeService(opts), {})
+            const service = await builder.createAwsService(FakeService, {})
 
             assert.strictEqual(!!service.config.customUserAgent, true)
             assert.notStrictEqual(service.config.customUserAgent, undefined)
@@ -39,7 +39,7 @@ describe('DefaultAwsClientBuilder', function () {
 
         it('does not override custom user-agent if specified in options', async function () {
             const builder = new DefaultAWSClientBuilder(new FakeAwsContext())
-            const service = await builder.createAndConfigureServiceClient(opts => new FakeService(opts), {
+            const service = await builder.createAwsService(FakeService, {
                 customUserAgent: 'CUSTOM USER AGENT',
             })
 


### PR DESCRIPTION
## Problem:
`createAndConfigureServiceClient()` is awkward to use and hard to understand because of indirection.

## Solution:
- introduce `createAwsService()`
- document it
- remove `createAndConfigureServiceClient()`


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
