### PR TITLE
Revert "build(deps-dev): bump @types/node from 10.17.35 to 15.0.3"

### DIFF
--- a/build-scripts/package.ts
+++ b/build-scripts/package.ts
@@ -79,14 +79,14 @@ function main() {
             fs.copyFileSync(packageJsonFile, `${packageJsonFile}.bk`)
             fs.copyFileSync(webpackConfigJsFile, `${webpackConfigJsFile}.bk`)
 
-            const packageJson = JSON.parse(fs.readFileSync(packageJsonFile).toString('utf-8'))
+            const packageJson = JSON.parse(fs.readFileSync(packageJsonFile, { encoding: 'UTF-8' }).toString())
             const versionSuffix = getVersionSuffix()
             const version: string = packageJson.version?.toString()
             packageJson.version = args.debug ? `1.99.0${versionSuffix}` : version.replace('-SNAPSHOT', versionSuffix)
             fs.writeFileSync(packageJsonFile, JSON.stringify(packageJson, undefined, '    '))
 
             if (args.debug) {
-                const webpackConfigJs = fs.readFileSync(webpackConfigJsFile).toString('utf-8')
+                const webpackConfigJs = fs.readFileSync(webpackConfigJsFile, { encoding: 'UTF-8' }).toString()
                 fs.writeFileSync(webpackConfigJsFile, webpackConfigJs.replace(/minimize: true/, 'minimize: false'))
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
     "requires": true,
     "packages": {
         "": {
-            "version": "1.26.0-SNAPSHOT",
+            "version": "1.25.0-SNAPSHOT",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -57,7 +57,7 @@
                 "@types/marked": "^0.6.5",
                 "@types/mime-types": "^2.1.0",
                 "@types/mocha": "^7.0.2",
-                "@types/node": "^15.0.3",
+                "@types/node": "^10.14.22",
                 "@types/readline-sync": "^1.4.3",
                 "@types/request": "^2.47.1",
                 "@types/semver": "^5.5.0",
@@ -355,9 +355,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "15.0.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.3.tgz",
-            "integrity": "sha512-/WbxFeBU+0F79z9RdEOXH4CsDga+ibi5M8uEYr91u3CkT/pdWcV8MCook+4wDPnZBexRdwWS+PiVZ2xJviAzcQ==",
+            "version": "10.17.35",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
+            "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA==",
             "dev": true
         },
         "node_modules/@types/prettier": {
@@ -9947,9 +9947,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "15.0.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.3.tgz",
-            "integrity": "sha512-/WbxFeBU+0F79z9RdEOXH4CsDga+ibi5M8uEYr91u3CkT/pdWcV8MCook+4wDPnZBexRdwWS+PiVZ2xJviAzcQ==",
+            "version": "10.17.35",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
+            "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA==",
             "dev": true
         },
         "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -1542,7 +1542,7 @@
         "@types/marked": "^0.6.5",
         "@types/mime-types": "^2.1.0",
         "@types/mocha": "^7.0.2",
-        "@types/node": "^15.0.3",
+        "@types/node": "^10.14.22",
         "@types/readline-sync": "^1.4.3",
         "@types/request": "^2.47.1",
         "@types/semver": "^5.5.0",

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -92,7 +92,7 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
                         }
                     }
                 },
-                onClose: (code: number, _: NodeJS.Signals): void => {
+                onClose: (code: number, _: string): void => {
                     this.logger.verbose(`SAM: command exited (code: ${code}): ${childProcess}`)
                     // onStdout/onStderr may print partial lines. Force a newline
                     // to ensure "Command stopped" appears on its own line.

--- a/src/ssmDocument/commands/publishDocument.ts
+++ b/src/ssmDocument/commands/publishDocument.ts
@@ -20,6 +20,7 @@ import {
     PublishSSMDocumentWizardContext,
     PublishSSMDocumentWizardResponse,
 } from '../wizards/publishDocumentWizard'
+import { stringify } from 'querystring'
 import * as telemetry from '../../shared/telemetry/telemetry'
 import { Window } from '../../shared/vscode/window'
 import { showConfirmationMessage } from '../util/util'
@@ -92,7 +93,7 @@ export async function createDocument(
         }
 
         const createResult = await client.createDocument(request)
-        logger.info(`Created Systems Manager Document successfully ${JSON.stringify(createResult.DocumentDescription)}`)
+        logger.info(`Created Systems Manager Document successfully ${stringify(createResult.DocumentDescription)}`)
         vscode.window.showInformationMessage(`Created Systems Manager Document ${wizardResponse.name} successfully`)
     } catch (err) {
         const error = err as Error
@@ -128,7 +129,7 @@ export async function updateDocument(
 
         const updateResult = await client.updateDocument(request)
 
-        logger.info(`Updated Systems Manager Document successfully ${JSON.stringify(updateResult.DocumentDescription)}`)
+        logger.info(`Updated Systems Manager Document successfully ${stringify(updateResult.DocumentDescription)}`)
         vscode.window.showInformationMessage(`Updated Systems Manager Document ${wizardResponse.name} successfully`)
 
         const isConfirmed = await showConfirmationMessage(

--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -89,10 +89,10 @@ function teardownTestLogger(testName: string) {
 }
 
 function writeLogsToFile(testName: string) {
-    const entries = testLogger!.getLoggedEntries()
-    entries.unshift(`=== Starting test "${testName}" ===`)
-    entries.push(`=== Ending test "${testName}" ===\n\n`)
-    appendFileSync(testLogOutput, entries.join('\n'), 'utf8')
+    const entries = testLogger?.getLoggedEntries()
+    entries?.unshift(`=== Starting test "${testName}" ===`)
+    entries?.push(`=== Ending test "${testName}" ===\n\n`)
+    appendFileSync(testLogOutput, entries?.join('\n'), 'utf8')
 }
 
 export function assertLogsContain(text: string, exactMatch: boolean, severity: LogLevel) {

--- a/test-scripts/launchTestUtilities.ts
+++ b/test-scripts/launchTestUtilities.ts
@@ -38,7 +38,7 @@ export async function setupVSCodeTestInstance(): Promise<string> {
     return vsCodeExecutablePath
 }
 
-export async function invokeVSCodeCli(vsCodeExecutablePath: string, args: string[]): Promise<string> {
+export async function invokeVSCodeCli(vsCodeExecutablePath: string, args: string[]): Promise<Buffer> {
     const vsCodeCliPath = resolveCliPathFromVSCodeExecutablePath(vsCodeExecutablePath)
 
     const cmdArgs = [...args]
@@ -87,7 +87,7 @@ export async function getCliArgsToDisableExtensions(
 ): Promise<string[]> {
     console.log(`Disabling all VS Code extensions *except*: ${params.except}`)
     const output = await invokeVSCodeCli(vsCodeExecutablePath, ['--list-extensions'])
-    const foundExtensions = output.split('\n')
+    const foundExtensions = output.toString('utf8').split('\n')
     const ids: string[] = []
     for (const extId of foundExtensions) {
         if (extId.trim() && !params.except.includes(extId)) {


### PR DESCRIPTION
Reverts ce3089742f9695d2ebd55df85e7ec59ddfb126fa #1758

https://github.com/aws/aws-toolkit-vscode/pull/1758#issuecomment-842555310

> This update should not be done since the node version is based off the one used by the minimum version 1.42 which is node 12:

