### PR TITLE
New SAM app: Recognize .yml extension for template

### DIFF
--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -354,10 +354,10 @@ export async function getProjectUri(
     config: Pick<CreateNewSamAppWizardResponse, 'location' | 'name'>,
     files: string[]
 ): Promise<vscode.Uri | undefined> {
-    let file: string = files[0]
-    let cfnTemplatePath: string = path.resolve(config.location.fsPath, config.name, file)
-    for (let i = 0; i < files.length; i++) {
-         file = files[i];
+    let file: string
+    let cfnTemplatePath: string
+    for (const f of files) {
+         file = f
          cfnTemplatePath = path.resolve(config.location.fsPath, config.name, file)
         
         if (await fileExists(cfnTemplatePath)) {
@@ -368,8 +368,8 @@ export async function getProjectUri(
         localize(
             'AWS.samcli.initWizard.source.error.notFound',
             'Project created successfully, but {0} file not found: {1}',
-            file,
-            cfnTemplatePath
+            file!,
+            cfnTemplatePath!
         )
     )
 }

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -354,12 +354,14 @@ export async function getProjectUri(
     config: Pick<CreateNewSamAppWizardResponse, 'location' | 'name'>,
     files: string[]
 ): Promise<vscode.Uri | undefined> {
+    if (files.length === 0) {
+        throw Error('expected "files" parameter to have at least one item')
+    }
     let file: string
     let cfnTemplatePath: string
     for (const f of files) {
          file = f
          cfnTemplatePath = path.resolve(config.location.fsPath, config.name, file)
-        
         if (await fileExists(cfnTemplatePath)) {
             return vscode.Uri.file(cfnTemplatePath)
         }

--- a/src/test/lambda/commands/createNewSamApp.test.ts
+++ b/src/test/lambda/commands/createNewSamApp.test.ts
@@ -14,6 +14,7 @@ import {
     addInitialLaunchConfiguration,
     getProjectUri,
     SAM_INIT_TEMPLATE_FILE,
+    SAM_INIT_TEMPLATE_FILE_ALT_EXT
 } from '../../../lambda/commands/createNewSamApp'
 import { LaunchConfiguration } from '../../../shared/debug/launchConfiguration'
 import { anything, capture, instance, mock, when } from 'ts-mockito'
@@ -77,6 +78,16 @@ describe('createNewSamApp', function () {
         it('returns the target file when it exists', async function () {
             assert.strictEqual(
                 normalize((await getProjectUri(fakeResponse, SAM_INIT_TEMPLATE_FILE))?.fsPath ?? ''),
+                normalize(fakeTarget)
+            )
+        })
+        it('returns the target ".yml" file when it exists', async function () {
+            fs.unlinkSync(fakeTarget)
+            tempTemplate = vscode.Uri.file(path.join(tempFolder, 'test.yml'))
+            fakeTarget = path.join(tempFolder, SAM_INIT_TEMPLATE_FILE_ALT_EXT)
+            testutil.toFile('target file', fakeTarget)
+            assert.strictEqual(
+                normalize((await getProjectUri(fakeResponse, SAM_INIT_TEMPLATE_FILE, SAM_INIT_TEMPLATE_FILE_ALT_EXT))?.fsPath ?? ''),
                 normalize(fakeTarget)
             )
         })

--- a/src/test/lambda/commands/createNewSamApp.test.ts
+++ b/src/test/lambda/commands/createNewSamApp.test.ts
@@ -13,8 +13,7 @@ import { FakeExtensionContext } from '../../fakeExtensionContext'
 import {
     addInitialLaunchConfiguration,
     getProjectUri,
-    SAM_INIT_TEMPLATE_FILE,
-    SAM_INIT_TEMPLATE_FILE_ALT_EXT
+    SAM_INIT_TEMPLATE_FILES
 } from '../../../lambda/commands/createNewSamApp'
 import { LaunchConfiguration } from '../../../shared/debug/launchConfiguration'
 import { anything, capture, instance, mock, when } from 'ts-mockito'
@@ -27,6 +26,8 @@ import {
 } from '../../../shared/sam/debugger/awsSamDebugConfiguration'
 import { ext } from '../../../shared/extensionGlobals'
 import { normalize } from '../../../shared/utilities/pathUtils'
+
+const TEMPLATE_YAML = 'template.yaml'
 
 describe('createNewSamApp', function () {
     let mockLaunchConfiguration: LaunchConfiguration
@@ -43,7 +44,7 @@ describe('createNewSamApp', function () {
         fakeContext = await FakeExtensionContext.getFakeExtContext()
         tempFolder = await makeTemporaryToolkitFolder()
         tempTemplate = vscode.Uri.file(path.join(tempFolder, 'test.yaml'))
-        fakeTarget = path.join(tempFolder, SAM_INIT_TEMPLATE_FILE)
+        fakeTarget = path.join(tempFolder, TEMPLATE_YAML)
         testutil.toFile('target file', fakeTarget)
 
         fakeWorkspaceFolder = {
@@ -77,25 +78,25 @@ describe('createNewSamApp', function () {
     describe('getProjectUri', function () {
         it('returns the target file when it exists', async function () {
             assert.strictEqual(
-                normalize((await getProjectUri(fakeResponse, SAM_INIT_TEMPLATE_FILE))?.fsPath ?? ''),
+                normalize((await getProjectUri(fakeResponse, SAM_INIT_TEMPLATE_FILES))?.fsPath ?? ''),
                 normalize(fakeTarget)
             )
         })
         it('returns the target ".yml" file when it exists', async function () {
             fs.unlinkSync(fakeTarget)
             tempTemplate = vscode.Uri.file(path.join(tempFolder, 'test.yml'))
-            fakeTarget = path.join(tempFolder, SAM_INIT_TEMPLATE_FILE_ALT_EXT)
+            fakeTarget = path.join(tempFolder, 'template.yml')
             testutil.toFile('target file', fakeTarget)
             assert.strictEqual(
-                normalize((await getProjectUri(fakeResponse, SAM_INIT_TEMPLATE_FILE, SAM_INIT_TEMPLATE_FILE_ALT_EXT))?.fsPath ?? ''),
+                normalize((await getProjectUri(fakeResponse, SAM_INIT_TEMPLATE_FILES))?.fsPath ?? ''),
                 normalize(fakeTarget)
             )
         })
         it('returns undefined when the target does not exist', async function () {
             const badResponse1 = { location: fakeResponse.location, name: 'notreal' }
             const badResponse2 = { location: vscode.Uri.parse('fake://notreal'), name: 'notafile' }
-            assert.strictEqual((await getProjectUri(badResponse1, SAM_INIT_TEMPLATE_FILE))?.fsPath, undefined)
-            assert.strictEqual((await getProjectUri(badResponse2, SAM_INIT_TEMPLATE_FILE))?.fsPath, undefined)
+            assert.strictEqual((await getProjectUri(badResponse1, SAM_INIT_TEMPLATE_FILES))?.fsPath, undefined)
+            assert.strictEqual((await getProjectUri(badResponse2, SAM_INIT_TEMPLATE_FILES))?.fsPath, undefined)
         })
     })
 
@@ -108,7 +109,7 @@ describe('createNewSamApp', function () {
             const launchConfigs = await addInitialLaunchConfiguration(
                 fakeContext,
                 fakeWorkspaceFolder,
-                (await getProjectUri(fakeResponse, SAM_INIT_TEMPLATE_FILE))!,
+                (await getProjectUri(fakeResponse, SAM_INIT_TEMPLATE_FILES))!,
                 undefined,
                 instance(mockLaunchConfiguration)
             )
@@ -197,7 +198,7 @@ describe('createNewSamApp', function () {
             const launchConfigs = await addInitialLaunchConfiguration(
                 fakeContext,
                 fakeWorkspaceFolder,
-                (await getProjectUri(fakeResponse, SAM_INIT_TEMPLATE_FILE))!,
+                (await getProjectUri(fakeResponse, SAM_INIT_TEMPLATE_FILES))!,
                 undefined,
                 instance(mockLaunchConfiguration)
             )
@@ -225,7 +226,7 @@ describe('createNewSamApp', function () {
             testutil.toFile(makeSampleSamTemplateYaml(true), tempTemplate.fsPath)
             testutil.toFile(makeSampleSamTemplateYaml(true), otherTemplate1.fsPath)
             testutil.toFile(makeSampleSamTemplateYaml(true), otherTemplate2.fsPath)
-            testutil.toFile('target file', path.join(otherFolder1, SAM_INIT_TEMPLATE_FILE))
+            testutil.toFile('target file', path.join(otherFolder1, TEMPLATE_YAML))
 
             await ext.templateRegistry.addItemToRegistry(tempTemplate)
             await ext.templateRegistry.addItemToRegistry(otherTemplate1)
@@ -234,7 +235,7 @@ describe('createNewSamApp', function () {
             const launchConfigs1 = await addInitialLaunchConfiguration(
                 fakeContext,
                 fakeWorkspaceFolder,
-                (await getProjectUri(fakeResponse, SAM_INIT_TEMPLATE_FILE))!,
+                (await getProjectUri(fakeResponse, SAM_INIT_TEMPLATE_FILES))!,
                 undefined,
                 instance(mockLaunchConfiguration)
             )
@@ -244,7 +245,7 @@ describe('createNewSamApp', function () {
                 fakeWorkspaceFolder,
                 (await getProjectUri(
                     { location: fakeWorkspaceFolder.uri, name: 'otherFolder' },
-                    SAM_INIT_TEMPLATE_FILE
+                    SAM_INIT_TEMPLATE_FILES
                 ))!,
                 undefined,
                 instance(mockLaunchConfiguration)


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
When the template extension is `.yml` instead of `.yaml`, as is the case for the TypeScript SAM template, the toolkit will give a warning that the template file was not found.
## Solution
The toolkit now looks for `template.yml` when `template.yaml` is not found.
<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
