### PR TITLE
SAM debug: target=code: require TypeScript on host system

### DIFF
--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -119,7 +119,7 @@ export async function makeTypescriptConfig(config: SamLaunchRequestArgs): Promis
 async function compileTypeScript(config: NodejsDebugConfiguration): Promise<void> {
     if (config.invokeTarget.target === 'code') {
         const tscResponse = await new ChildProcess(true, 'tsc', undefined, '-v').run()
-        if (!tscResponse.stdout.startsWith('Version') ) {
+        if (tscResponse.exitCode === 0 || !tscResponse.stdout.startsWith('Version')) {
             throw new Error('TypeScript compiler "tsc" not found.')
         }
         const samBuildOutputAppRoot = path.join(config.baseBuildDir!, 'output', path.parse(config.invokeTarget.projectRoot).name)

--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -118,6 +118,10 @@ export async function makeTypescriptConfig(config: SamLaunchRequestArgs): Promis
  */
 async function compileTypeScript(config: NodejsDebugConfiguration): Promise<void> {
     if (config.invokeTarget.target === 'code') {
+        const tscResponse = await new ChildProcess(true, 'tsc -v').run()
+        if (!tscResponse.stdout.startsWith('Version') ) {
+            throw new Error('The TypeScript compiler was not found. To install globally on your machine, run "npm install -g typescript" in the terminal.')
+        }
         const samBuildOutputAppRoot = path.join(config.baseBuildDir!, 'output', path.parse(config.invokeTarget.projectRoot).name)
         const tsconfigPath = path.join(samBuildOutputAppRoot, 'tsconfig.json')
         if ((await readdir(config.codeRoot)).includes('tsconfig.json') || (await hasFileWithSuffix(config.codeRoot, '.ts', '**/node_modules/**'))) {

--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -118,7 +118,7 @@ export async function makeTypescriptConfig(config: SamLaunchRequestArgs): Promis
  */
 async function compileTypeScript(config: NodejsDebugConfiguration): Promise<void> {
     if (config.invokeTarget.target === 'code') {
-        const tscResponse = await new ChildProcess(true, 'tsc -v').run()
+        const tscResponse = await new ChildProcess(true, 'tsc', undefined, '-v').run()
         if (!tscResponse.stdout.startsWith('Version') ) {
             throw new Error('The TypeScript compiler was not found. To install globally on your machine, run "npm install -g typescript" in the terminal.')
         }

--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -119,7 +119,7 @@ export async function makeTypescriptConfig(config: SamLaunchRequestArgs): Promis
 async function compileTypeScript(config: NodejsDebugConfiguration): Promise<void> {
     if (config.invokeTarget.target === 'code') {
         const tscResponse = await new ChildProcess(true, 'tsc', undefined, '-v').run()
-        if (tscResponse.exitCode === 0 || !tscResponse.stdout.startsWith('Version')) {
+        if (tscResponse.exitCode !== 0 || !tscResponse.stdout.startsWith('Version')) {
             throw new Error('TypeScript compiler "tsc" not found.')
         }
         const samBuildOutputAppRoot = path.join(config.baseBuildDir!, 'output', path.parse(config.invokeTarget.projectRoot).name)

--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -120,7 +120,7 @@ async function compileTypeScript(config: NodejsDebugConfiguration): Promise<void
     if (config.invokeTarget.target === 'code') {
         const tscResponse = await new ChildProcess(true, 'tsc', undefined, '-v').run()
         if (!tscResponse.stdout.startsWith('Version') ) {
-            throw new Error('The TypeScript compiler was not found. To install globally on your machine, run "npm install -g typescript" in the terminal.')
+            throw new Error('TypeScript compiler "tsc" not found.')
         }
         const samBuildOutputAppRoot = path.join(config.baseBuildDir!, 'output', path.parse(config.invokeTarget.projectRoot).name)
         const tsconfigPath = path.join(samBuildOutputAppRoot, 'tsconfig.json')


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
If the TypeScript compiler is not installed and a local invoke is called where the target is the source code, the app will not fail until the invoke step and the error is not clear.
## Solution
Check for TypeScript compiler before attempting to compile and show a clear error if it is not present.
<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
