### PR TITLE
SAM debug: fail early if Docker is not working

### DIFF
--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -17,6 +17,8 @@ import * as vscode from 'vscode'
 
 const localize = nls.loadMessageBundle()
 
+const DOCKER_NOT_REACHABLE = 'Docker is not reachable'
+
 export const WAIT_FOR_DEBUGGER_MESSAGES = {
     PYTHON: 'Debugger waiting for client...',
     PYTHON_IKPDB: 'IKP3db listening on',
@@ -89,6 +91,10 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
                             )
                             // Process will continue running, while user debugs it.
                             resolve()
+                        }
+                        if (this.debuggerAttachCues.some(cue => text.includes(DOCKER_NOT_REACHABLE))) {
+                            this.logger.verbose(`Docker is either not installed or not running`)
+                            reject()
                         }
                     }
                 },

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -81,10 +81,6 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
                     // If we have a timeout (as we do on debug) refresh the timeout as we receive text
                     params.timeout?.refresh()
                     this.logger.verbose('SAM: pid %d: stderr: %s', childProcess.pid(), removeAnsi(text))
-                    if (text.match(/Docker is not reachable/)) {
-                        vscode.window.showErrorMessage('Running AWS SAM projects locally requires Docker. Have you got it installed and running?')
-                        throw new Error('Docker is not installed or not running')
-                    }
                     if (checkForCues) {
                         // Look for messages like "Debugger attached" before returning back to caller
                         if (this.debuggerAttachCues.some(cue => text.includes(cue))) {

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -81,6 +81,10 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
                     // If we have a timeout (as we do on debug) refresh the timeout as we receive text
                     params.timeout?.refresh()
                     this.logger.verbose('SAM: pid %d: stderr: %s', childProcess.pid(), removeAnsi(text))
+                    if (text.match(/Docker is not reachable/)) {
+                        vscode.window.showErrorMessage('Running AWS SAM projects locally requires Docker. Have you got it installed and running?')
+                        throw new Error('Docker is not installed or not running')
+                    }
                     if (checkForCues) {
                         // Look for messages like "Debugger attached" before returning back to caller
                         if (this.debuggerAttachCues.some(cue => text.includes(cue))) {

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -17,8 +17,6 @@ import * as vscode from 'vscode'
 
 const localize = nls.loadMessageBundle()
 
-const DOCKER_NOT_REACHABLE = 'Docker is not reachable'
-
 export const WAIT_FOR_DEBUGGER_MESSAGES = {
     PYTHON: 'Debugger waiting for client...',
     PYTHON_IKPDB: 'IKP3db listening on',
@@ -91,10 +89,6 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
                             )
                             // Process will continue running, while user debugs it.
                             resolve()
-                        }
-                        if (this.debuggerAttachCues.some(cue => text.includes(DOCKER_NOT_REACHABLE))) {
-                            this.logger.verbose(`Docker is either not installed or not running`)
-                            reject()
                         }
                     }
                 },

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -349,7 +349,7 @@ export async function runLambdaFunction(
     onAfterBuild: () => Promise<void>
 ): Promise<SamLaunchRequestArgs> {
     // Verify if Docker is running
-    const dockerResponse = await new ChildProcess(true, 'docker', undefined, 'version').run()
+    const dockerResponse = await new ChildProcess(true, 'docker', undefined, 'ps').run()
     if (dockerResponse.exitCode !==0 || dockerResponse.stdout.includes('error during connect')) {
         throw new Error('Running AWS SAM projects locally requires Docker. Have you got it installed and running?')
     }

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -348,6 +348,11 @@ export async function runLambdaFunction(
     config: SamLaunchRequestArgs,
     onAfterBuild: () => Promise<void>
 ): Promise<SamLaunchRequestArgs> {
+    // Verify if Docker is running
+    const dockerResponse = await new ChildProcess(true, 'docker', undefined, 'version').run()
+    if (dockerResponse.exitCode !==0 || dockerResponse.stdout.includes('error during connect')) {
+        throw new Error('Running AWS SAM projects locally requires Docker. Have you got it installed and running?')
+    }
     // Switch over to the output channel so the user has feedback that we're getting things ready
     ctx.outputChannel.show(true)
     if (!config.noDebug) {

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -348,11 +348,6 @@ export async function runLambdaFunction(
     config: SamLaunchRequestArgs,
     onAfterBuild: () => Promise<void>
 ): Promise<SamLaunchRequestArgs> {
-    // Verify if Docker is running
-    const dockerResponse = await new ChildProcess(true, 'docker', undefined, 'ps').run()
-    if (dockerResponse.exitCode !==0 || dockerResponse.stdout.includes('error during connect')) {
-        throw new Error('Running AWS SAM projects locally requires Docker. Have you got it installed and running?')
-    }
     // Switch over to the output channel so the user has feedback that we're getting things ready
     ctx.outputChannel.show(true)
     if (!config.noDebug) {

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -348,6 +348,11 @@ export async function runLambdaFunction(
     config: SamLaunchRequestArgs,
     onAfterBuild: () => Promise<void>
 ): Promise<SamLaunchRequestArgs> {
+    // Verify if Docker is running
+    const dockerResponse = await new ChildProcess(true, 'docker', undefined, 'ps').run()
+    if (dockerResponse.exitCode !==0 || dockerResponse.stdout.includes('error during connect')) {
+        throw new Error('Running AWS SAM projects locally requires Docker. Have you got it installed and running?')
+    }
     // Switch over to the output channel so the user has feedback that we're getting things ready
     ctx.outputChannel.show(true)
     if (!config.noDebug) {

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -351,7 +351,7 @@ export async function runLambdaFunction(
     // Verify if Docker is running
     const dockerResponse = await new ChildProcess(true, 'docker', undefined, 'ps').run()
     if (dockerResponse.exitCode !==0 || dockerResponse.stdout.includes('error during connect')) {
-        throw new Error('Running AWS SAM projects locally requires Docker. Have you got it installed and running?')
+        throw new Error('Running AWS SAM projects locally requires Docker. Is it installed and running?')
     }
     // Switch over to the output channel so the user has feedback that we're getting things ready
     ctx.outputChannel.show(true)


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Local invoke will build and attempt to invoke before failing due to Docker either not installed or running.
## Solution
Verify if Docker is installed and running before the build step to quickly inform the user that Docker is either not installed or not running.
<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
