### PR TITLE
SAM/deploy: user can start Deploy from template.yaml

### DIFF
--- a/.changes/next-release/Feature-539b9557-6b71-4741-a943-5e8739d24a88.json
+++ b/.changes/next-release/Feature-539b9557-6b71-4741-a943-5e8739d24a88.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "File Explorer: \"Deploy SAM Application\" is available from the context-menu for template.yaml files #263"
+}

--- a/package.json
+++ b/package.json
@@ -842,6 +842,13 @@
                     "group": "z_externalLinks@1"
                 }
             ],
+            "explorer/context": [
+                {
+                    "command": "aws.deploySamApplication",
+                    "when": "isFileSystemResource == true && resourceFilename =~ /^template\\.(json|yml|yaml)$/",
+                    "group": "z_aws@1"
+                }
+            ],
             "view/item/context": [
                 {
                     "command": "aws.apig.invokeRemoteRestApi",

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -97,11 +97,15 @@ async function registerServerlessCommands(ctx: ExtContext): Promise<void> {
         }),
         vscode.commands.registerCommand('aws.addSamDebugConfiguration', addSamDebugConfiguration),
         vscode.commands.registerCommand('aws.pickAddSamDebugConfiguration', codelensUtils.pickAddSamDebugConfiguration),
-        vscode.commands.registerCommand('aws.deploySamApplication', async regionNode => {
+        vscode.commands.registerCommand('aws.deploySamApplication', async arg => {
+            // `arg` is one of :
+            //  - undefined
+            //  - regionNode (selected from AWS Explorer)
+            //  -  Uri to template.yaml (selected from File Explorer)
+
             const samDeployWizardContext = new DefaultSamDeployWizardContext(ctx)
             const samDeployWizard = async (): Promise<SamDeployWizardResponse | undefined> => {
-                const wizard = new SamDeployWizard(samDeployWizardContext, regionNode)
-
+                const wizard = new SamDeployWizard(samDeployWizardContext, arg)
                 return wizard.run()
             }
 

--- a/src/shared/watchedFiles.ts
+++ b/src/shared/watchedFiles.ts
@@ -110,7 +110,7 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
      */
     public getRegisteredItem(path: string | vscode.Uri): WatchedItem<T> | undefined {
         // fsPath is needed for Windows, it's equivalent to path on mac/linux
-        const absolutePath = (typeof path === 'string') ? path : path.fsPath
+        const absolutePath = typeof path === 'string' ? path : path.fsPath
         const normalizedPath = pathutils.normalize(absolutePath)
         this.assertAbsolute(normalizedPath)
         const item = this.registryData.get(normalizedPath)
@@ -205,7 +205,7 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
                 await this.addItemToRegistry(uri)
             }),
             watcher.onDidDelete(async uri => {
-                getLogger().verbose(`${this.name}: ,anager detected a deleted file: ${uri.fsPath}`)
+                getLogger().verbose(`${this.name}: manager detected a deleted file: ${uri.fsPath}`)
                 this.remove(uri)
             })
         )

--- a/src/test/lambda/wizards/samDeployWizard.test.ts
+++ b/src/test/lambda/wizards/samDeployWizard.test.ts
@@ -209,6 +209,26 @@ describe('SamDeployWizard', async function () {
             assert.ok(!result)
         })
 
+        it('skips template picker if passed as argument', async function () {
+            const workspaceFolderPath = normalizePath('my', 'workspace', 'folder')
+            const arg = vscode.Uri.file('/path/to/template.yaml')
+            const wizard = new SamDeployWizard(
+                new MockSamDeployWizardContext(
+                    extContext,
+                    [[vscode.Uri.file(workspaceFolderPath)]],
+                    [createQuickPickUriResponseItem(vscode.Uri.file('/wrong/template.yaml'))],
+                    [createQuickPickRegionResponseItem('asdf')],
+                    ['mys3bucketname'],
+                    [],
+                    [],
+                    ['myStackName']
+                ),
+                arg
+            )
+            const result = await wizard.run()
+            assert.deepStrictEqual(result?.template, arg)
+        })
+
         it('uses user response as template', async function () {
             const workspaceFolderPath = normalizePath('my', 'workspace', 'folder')
             const templatePath = normalizePath(workspaceFolderPath, 'template.yaml')


### PR DESCRIPTION
## Problem:

To deploy using AWS Toolkit, the order of operations is:
1. start Deploy action
2. select the relevant template.yaml

But sometimes it's easier to reach SAM template.yaml file from the VSCode File Explorer, so the order is swapped:
1. select template.yaml
2. start Deploy action

https://github.com/aws/aws-toolkit-vscode/issues/263

## Solution:
Show the Deploy action on template.yaml files.

<img width="269" alt="Screen Shot 2021-05-20 at 5 54 09 PM" src="https://user-images.githubusercontent.com/55561878/119174737-cfea7880-ba1d-11eb-90e9-127b831cd714.png">


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
