### PR TITLE
Settings: update lambda timeout setting name

### DIFF
--- a/.changes/next-release/Bug Fix-48dd227c-8804-4f2a-8f5c-54a99d1966e7.json
+++ b/.changes/next-release/Bug Fix-48dd227c-8804-4f2a-8f5c-54a99d1966e7.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "fix setting name to reflect current functionality"
+}

--- a/.changes/next-release/Bug Fix-48dd227c-8804-4f2a-8f5c-54a99d1966e7.json
+++ b/.changes/next-release/Bug Fix-48dd227c-8804-4f2a-8f5c-54a99d1966e7.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "fix setting name to reflect current functionality"
+	"description": "Add new setting `aws.samcli.lambda.timeout` and remove `aws.samcli.debug.attach.timeout.millis` setting. The new setting sets the maximum time to wait for a local Lambda to start."
 }

--- a/package.json
+++ b/package.json
@@ -106,10 +106,10 @@
                     "default": "",
                     "markdownDescription": "%AWS.configuration.description.samcli.location%"
                 },
-                "aws.samcli.debug.attach.timeout.millis": {
+                "aws.samcli.lambda.timeout": {
                     "type": "number",
                     "default": 90000,
-                    "markdownDescription": "%AWS.configuration.description.samcli.debug.attach.timeout%"
+                    "markdownDescription": "%AWS.configuration.description.samcli.lambda.timeout%"
                 },
                 "aws.logLevel": {
                     "type": "string",

--- a/package.nls.json
+++ b/package.nls.json
@@ -21,7 +21,7 @@
     "AWS.configuration.description.logLevel": "The AWS Toolkit's log level (changes reflected on restart)",
     "AWS.configuration.description.onDefaultRegionMissing": "Action to take when a Profile's default region is hidden in the Explorer. Possible values:\n* `add` - shows region in the explorer\n* `ignore` - does nothing with the region\n* `prompt` - (default) asks the user what they would like to do.",
     "AWS.configuration.description.s3.maxItemsPerPage": "Controls how many S3 items are listed before showing a node to `Load More...`.\nThis corresponds to the `MaxKeys` requested in a single call to S3. [Learn More](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html#AmazonS3-ListObjectsV2-response-MaxKeys)",
-    "AWS.configuration.description.samcli.debug.attach.timeout": "Maximum time (in milliseconds) to wait for SAM output while starting a Local Lambda session",
+    "AWS.configuration.description.samcli.lambda.timeout": "Maximum time (in milliseconds) to wait for SAM output while starting a Local Lambda session",
     "AWS.configuration.description.samcli.location": "Location of SAM CLI. SAM CLI is used to create, build, package, and deploy Serverless Applications. [Learn More](https://aws.amazon.com/serverless/sam/)",
     "AWS.configuration.description.telemetry": "Enable AWS Toolkit to send usage data to AWS.",
     "AWS.configuration.enableCodeLenses": "Enable SAM hints in source files",

--- a/src/integrationTest/integrationTestsUtilities.ts
+++ b/src/integrationTest/integrationTestsUtilities.ts
@@ -51,7 +51,7 @@ export function getTestWorkspaceFolder(): string {
 export async function configureAwsToolkitExtension(): Promise<void> {
     const configAws = vscode.workspace.getConfiguration('aws')
     // Prevent the extension from preemptively cancelling a 'sam local' run
-    await configAws.update('samcli.debug.attach.timeout.millis', 90000, false)
+    await configAws.update('samcli.lambda.timeout', 90000, false)
 }
 
 export async function configurePythonExtension(): Promise<void> {

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -78,7 +78,7 @@ function makeResourceName(config: SamLaunchRequestArgs): string {
 }
 
 const SAM_LOCAL_PORT_CHECK_RETRY_INTERVAL_MILLIS: number = 125
-const SAM_LOCAL_PORT_CHECK_RETRY_TIMEOUT_MILLIS_DEFAULT: number = 90000
+const SAM_LOCAL_TIMEOUT_DEFAULT_MILLIS: number = 90000
 const ATTACH_DEBUGGER_RETRY_DELAY_MILLIS: number = 1000
 
 /** "sam local start-api" wrapper from the current debug-session. */
@@ -366,7 +366,7 @@ export async function runLambdaFunction(
         ...(config.aws?.region ? { AWS_DEFAULT_REGION: config.aws.region } : {}),
     }
 
-    const timer = createInvokeTimer(ctx.settings)
+    const timer = createLambdaTimer(ctx.settings)
 
     if (!(await buildLambdaHandler(timer, envVars, config))) {
         return config
@@ -641,10 +641,10 @@ export function shouldAppendRelativePathToFunctionHandler(runtime: string): bool
     }
 }
 
-function createInvokeTimer(configuration: SettingsConfiguration): Timeout {
+function createLambdaTimer(configuration: SettingsConfiguration): Timeout {
     const timelimit = configuration.readSetting<number>(
-        'samcli.debug.attach.timeout.millis',
-        SAM_LOCAL_PORT_CHECK_RETRY_TIMEOUT_MILLIS_DEFAULT
+        'samcli.lambda.timeout',
+        SAM_LOCAL_TIMEOUT_DEFAULT_MILLIS
     )
 
     return new Timeout(timelimit)


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

The name is referencing only debug attachment, but the timer is being used for the entire workflow.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
