### PR TITLE
UI: new state machine

### DIFF
--- a/src/shared/wizards/stateController.ts
+++ b/src/shared/wizards/stateController.ts
@@ -1,0 +1,152 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as _ from 'lodash'
+export interface StateMachineStepResult<TState> {
+    /**
+     * The next state the controller should use for future steps.
+     */
+    nextState?: TState
+    /**
+     * Additional steps that should be added to the controller. Ignored if nextState is undefined.
+     */
+    nextSteps?: StateStepFunction<TState>[]
+    /**
+     * Repeats the current step. Ignores the next state if provided.
+     */
+    repeatStep?: boolean
+}
+
+type RecursiveReadonly<T> = {
+    readonly [Property in keyof T]: RecursiveReadonly<T[Property]> 
+}
+
+export type StateStepFunction<TState> = (state: TState) => Promise<StateMachineStepResult<TState> | TState>
+export type StateBranch<TState> = StateStepFunction<TState>[]
+
+export const WIZARD_GOBACK = undefined
+export const WIZARD_RETRY = { repeatStep: true }
+
+/**
+ * State machine with backtracking and dynamic branching functionality.
+ * Transitions are abstracted away as a 'step' function, which return both the
+ * new state and any extra steps that the machine should use.
+ */
+export class StateMachineController<TState> {
+    private previousStates: TState[] = []
+    private extraSteps = new Map<number, StateBranch<TState>>()
+    private steps: StateBranch<TState> = []
+    private internalStep: number = 0
+    private state!: TState
+
+    public constructor(private readonly initState?: TState) {
+        this.setState(this.initState)
+    }
+
+    public setState(state?: TState) {
+        this.reset()
+        this.state = state ?? {} as TState
+    }
+
+    public getState(): RecursiveReadonly<TState> {
+       return this.state
+    }
+
+    /**
+     * Reset state so the controller can be resused.
+     */
+    public reset() {
+        while (this.internalStep > 0) {
+            this.rollbackState()
+        }
+    }
+
+    /** Adds a single step to the state machine. */
+    public addStep(step: StateStepFunction<TState>): void {
+        this.steps.push(step)
+    }
+
+    public containsStep(step: StateStepFunction<TState> | undefined): boolean {
+        return step !== undefined && this.steps.indexOf(step) > -1
+    }
+
+    public get currentStep(): number { return this.internalStep + 1 }
+    public get totalSteps(): number { return this.steps.length }
+
+    protected rollbackState(): void {
+        if (this.internalStep === 0) {
+            return
+        }
+
+        if (this.extraSteps.has(this.internalStep)) {
+            this.steps.splice(this.internalStep, this.extraSteps.get(this.internalStep)!.length)
+            this.extraSteps.delete(this.internalStep)
+        }
+
+        this.state = this.previousStates.pop()!
+        this.internalStep -= 1
+    }
+
+    protected advanceState(nextState: TState): void {
+        this.previousStates.push(_.cloneDeep(this.state))
+        this.state = nextState
+        this.internalStep += 1
+    }
+
+    /**
+     * Add new steps dynamically at runtime. Only used internally.
+     */
+    protected dynamicBranch(nextSteps: StateBranch<TState> | undefined): void {
+        if (nextSteps !== undefined && nextSteps.length > 0) {
+            // This cycle detect logic could be improved. Returning to
+            // a previous step is not a cycle unless the states are equivalent.
+            if (nextSteps.filter(step => this.containsStep(step)).length !== 0) {
+                throw Error('Cycle detected in state machine conroller')
+            }
+            this.steps.splice(this.internalStep, 0, ...nextSteps)
+            this.extraSteps.set(this.internalStep, nextSteps)
+        }
+    }
+
+    protected async processNextStep(): Promise<StateMachineStepResult<TState>> {
+        const result = await this.steps[this.internalStep](this.state)
+
+        function isMachineResult(result: any): result is StateMachineStepResult<TState> {
+            return result !== undefined && 
+                (result.nextState !== undefined || result.nextSteps !== undefined || result.repeatStep !== undefined)
+        }
+
+        if (isMachineResult(result)) {
+            return result
+        } else {
+            return { nextState: result }
+        }
+    }
+
+    /**
+     * Runs the added steps until termination or failure
+     */
+    public async run(): Promise<TState | undefined> {
+        this.previousStates.push(_.cloneDeep(this.state))
+
+        while (this.internalStep < this.steps.length) {
+            const { nextState, nextSteps, repeatStep } = await this.processNextStep()
+
+            if (repeatStep === true) {
+                continue
+            } if (nextState === undefined) {
+                if (this.internalStep === 0) {
+                    return undefined
+                }
+
+                this.rollbackState()
+            } else {
+                this.advanceState(nextState as TState)
+                this.dynamicBranch(nextSteps)
+            }
+        }
+
+        return this.state
+    }
+}

--- a/src/test/shared/wizards/stateController.test.ts
+++ b/src/test/shared/wizards/stateController.test.ts
@@ -1,0 +1,192 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import * as sinon from 'sinon'
+import { StateMachineController, WIZARD_GOBACK, WIZARD_RETRY } from '../../../shared/wizards/stateController'
+
+function assertSteps<T>(controller: StateMachineController<T>, current: number, total: number, state?: T): { nextState?: T } {
+    assert.strictEqual(controller.currentStep, current)
+    assert.strictEqual(controller.totalSteps, total)
+    return { nextState: state }
+}
+
+describe('StateMachineController', function () {
+    it('runs with no steps', async function () {
+        const controller = new StateMachineController()
+        await assert.doesNotReject(controller.run())
+    })
+
+    it('handles undefined steps', async function () {
+        const controller = new StateMachineController()
+        controller.addStep(async () => ({ nextState: {}, nextSteps: undefined }))
+        await assert.doesNotReject(controller.run())
+    })
+
+    it('can be reset', async function() {
+        const controller = new StateMachineController<number>()
+        const step1 = sinon.stub()
+        const step2 = sinon.stub()
+        step1.onFirstCall().returns(1)
+        step2.onFirstCall().returns(2)
+        step1.onSecondCall().returns(3)
+        step2.onSecondCall().returns(4)
+        controller.addStep(step1)
+        controller.addStep(step2)
+
+        assert.strictEqual(await controller.run(), 2)
+        controller.reset()
+        assert.strictEqual(await controller.run(), 4)
+    })
+
+    it('detects cycle', async function() {
+        const controller = new StateMachineController<number>()
+        const step1 = sinon.stub()
+        const step2 = sinon.stub()
+        step1.returns({})
+        step2.onFirstCall().returns(WIZARD_GOBACK)
+        step2.onSecondCall().returns({ nextState: {}, nextSteps: [step1] })
+        controller.addStep(step1)
+        controller.addStep(step2)
+
+        await assert.rejects(controller.run(), /Cycle/)
+    })
+
+    describe('retry', function () {
+        it('repeats current step', async function () {
+            const controller = new StateMachineController()
+            const stub = sinon.stub()
+            stub.onFirstCall().returns(WIZARD_RETRY)
+            stub.onSecondCall().returns({})
+            controller.addStep(stub)
+
+            await controller.run()
+
+            assert.strictEqual(stub.callCount, 2)
+        })
+
+        it('does not remember state on retry', async function () {
+            const controller = new StateMachineController<{ answer: boolean }>()
+            const stub = sinon.stub()
+            stub.onFirstCall().returns({ nextState: { answer: true }, repeatStep: true })
+            stub.onSecondCall().returns({ answer: false })
+            controller.addStep(stub)
+
+            assert.strictEqual((await controller.run())?.answer, false)
+            assert.strictEqual(stub.callCount, 2)
+        })
+    })
+
+    describe('branching', function () {
+        it('supports multiple steps per branch', async function () {
+            const controller = new StateMachineController()
+            const step1 = sinon.stub()
+            const branchStep1 = sinon.stub()
+            const branchStep2 = sinon.stub()
+            step1.returns({ nextState: {}, nextSteps: [branchStep1, branchStep2] })
+            branchStep1.callsFake(state => assertSteps(controller, 2, 3, state))
+            branchStep2.returns({})
+            controller.addStep(step1)
+
+            assert.notStrictEqual(await controller.run(), undefined)
+        })
+
+        it('branches can also branch', async function () {
+            const controller = new StateMachineController()
+            const step1 = sinon.stub()
+            const branch1Step1 = sinon.stub()
+            const branch1Step2 = sinon.stub()
+            const branch2 = sinon.stub()
+            const step5 = sinon.stub()
+            step1.returns({ nextState: {}, nextSteps: [branch1Step1, branch1Step2] })
+            branch1Step1.callsFake(state => assertSteps(controller, 2, 4, state))
+            branch1Step2.returns({ nextState: {}, nextSteps: [branch2] })
+            branch2.callsFake(state => assertSteps(controller, 4, 5, state))
+            step5.returns({})
+            controller.addStep(step1)
+            controller.addStep(step5)
+
+            assert.notStrictEqual(await controller.run(), undefined)
+        })
+    })
+
+    describe('go back', function () {
+        it('goes back', async function () {
+            const controller = new StateMachineController()
+            const step1 = sinon.stub()
+            const step2 = sinon.stub()
+            step1.returns({})
+            step2.onFirstCall().returns(WIZARD_GOBACK)
+            step2.onSecondCall().returns({})
+            controller.addStep(step1)
+            controller.addStep(step2)
+
+            await controller.run()
+
+            assert.strictEqual(step1.callCount, 2)
+            sinon.assert.callOrder(step1, step2, step1, step2)
+        })
+
+        it('goes back and terminates', async function () {
+            const controller = new StateMachineController()
+            const step1 = sinon.stub()
+            const step2 = sinon.stub()
+            step1.onFirstCall().returns({})
+            step2.onFirstCall().returns(WIZARD_GOBACK)
+            step1.onSecondCall().returns(WIZARD_GOBACK)
+            controller.addStep(step1)
+            controller.addStep(step2)
+
+            assert.strictEqual(await controller.run(), undefined)
+            assert.strictEqual(step1.callCount, 2)
+            sinon.assert.callOrder(step1, step2, step1)
+        })
+
+        it('states are presereved between steps', async function () {
+            const controller = new StateMachineController<{ answer: boolean }>()
+            const step1 = sinon.stub()
+            const step2 = sinon.stub()
+            step1.onFirstCall().returns({ answer: false })
+            step2.onFirstCall().returns(WIZARD_GOBACK)
+            step1.onSecondCall().callsFake(state => {
+                assert.strictEqual(state.answer, undefined)
+                return assertSteps(controller, 1, 2, { answer: true })
+            })
+            step2.onSecondCall().callsFake(state => state)
+            controller.addStep(step1)
+            controller.addStep(step2)
+
+            assert.strictEqual((await controller.run())?.answer, true)
+        })
+
+        it('handles branches', async function () {
+            const controller = new StateMachineController<{ branch1: string, branch2: string }>()
+            const step1 = sinon.stub()
+            const branch1 = sinon.stub()
+            const branch2 = sinon.stub()
+            const step3 = sinon.stub()
+            // step1 -> branch1 -> step1 -> branch2 -> step3 -> branch2 -> step3 -> terminate
+            step1.onFirstCall().returns({ nextState: { branch2: 'no' }, nextSteps: [branch1] })
+            step1.onSecondCall().callsFake(() => {
+                assertSteps(controller, 1, 2)
+                return { nextState: { branch1: 'no' }, nextSteps: [branch2] }
+            })
+            branch1.returns(WIZARD_GOBACK)
+            branch2.callsFake(state =>
+                assertSteps(controller, 2, 3, { branch2: 'yes', branch1: state.branch1 })
+            )
+            step3.onFirstCall().returns(WIZARD_GOBACK)
+            step3.onSecondCall().callsFake(state => state)
+            controller.addStep(step1)
+            controller.addStep(step3)
+
+            const finalState = await controller.run()
+            assert.ok(finalState !== undefined)
+            assert.strictEqual(finalState.branch1, 'no')
+            assert.strictEqual(finalState.branch2, 'yes')
+            sinon.assert.callOrder(step1, branch1, step1, branch2, step3, branch2, step3)
+        })
+    })
+})


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

State machine controller that will be used in later PRs for the new wizard framework. Will eventually replace `multiStepWizard.ts` and related tests. The interface is different enough that it cannot replace it directly.

New capabilities:
* States are remembered and handled exclusively by the controller. This prevents mutation of state outside transitions.
* Multiple steps can be added to the machine at runtime as a group, allowing for dynamic branching.
* Decouples transitions from the state management logic. 
* Exposes the current step and total number of steps that the controller currently has

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
