### PR TITLE
refactor: eliminate utilities/ subdirectories

### DIFF
--- a/src/lambda/config/parameterUtils.ts
+++ b/src/lambda/config/parameterUtils.ts
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+//
+// TODO: DEPRECATED. Remove this after removing support for the legacy
+// "templates.json" support.
+//
 import * as vscode from 'vscode'
 import { CloudFormation } from '../../shared/cloudformation/cloudformation'
 import { getNormalizedRelativePath } from '../../shared/utilities/pathUtils'

--- a/src/lambda/config/samParameterCompletionItemProvider.ts
+++ b/src/lambda/config/samParameterCompletionItemProvider.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode'
 import { CloudFormation } from '../../shared/cloudformation/cloudformation'
 import { getLogger, Logger } from '../../shared/logger'
 import { getChildrenRange, loadSymbols, LoadSymbolsContext } from '../../shared/utilities/symbolUtilities'
-import { getParameterNames } from '../utilities/parameterUtils'
+import { getParameterNames } from '../config/parameterUtils'
 
 export interface SamParameterCompletionItemProviderContext extends LoadSymbolsContext {
     logger: Pick<Logger, 'warn'>

--- a/src/lambda/wizards/samDeployWizard.ts
+++ b/src/lambda/wizards/samDeployWizard.ts
@@ -28,7 +28,7 @@ import {
     WIZARD_RETRY,
 } from '../../shared/wizards/multiStepWizard'
 import { configureParameterOverrides } from '../config/configureParameterOverrides'
-import { getOverriddenParameters, getParameters } from '../utilities/parameterUtils'
+import { getOverriddenParameters, getParameters } from '../config/parameterUtils'
 import { ext } from '../../shared/extensionGlobals'
 import { EcrRepository } from '../../shared/clients/ecrClient'
 import { getSamCliVersion } from '../../shared/sam/cli/samCliContext'

--- a/src/test/cdk/detectCdkProjects.test.ts
+++ b/src/test/cdk/detectCdkProjects.test.ts
@@ -9,7 +9,7 @@ import * as vscode from 'vscode'
 import * as fs from 'fs-extra'
 import { detectCdkProjects } from '../../cdk/explorer/detectCdkProjects'
 import { makeTemporaryToolkitFolder } from '../../shared/filesystemUtilities'
-import { saveCdkJson } from './utilities/treeTestUtils'
+import { saveCdkJson } from './treeTestUtils'
 import { createTestWorkspaceFolder } from '../testUtil'
 import { FakeExtensionContext } from '../fakeExtensionContext'
 

--- a/src/test/cdk/explorer/appNode.test.ts
+++ b/src/test/cdk/explorer/appNode.test.ts
@@ -12,8 +12,8 @@ import * as appNode from '../../../cdk/explorer/nodes/appNode'
 import { ConstructNode } from '../../../cdk/explorer/nodes/constructNode'
 import { cdk } from '../../../cdk/globals'
 import { PlaceholderNode } from '../../../shared/treeview/nodes/placeholderNode'
-import { clearTestIconPaths, IconPath, setupTestIconPaths } from '../utilities/iconPathUtils'
-import * as treeUtils from '../utilities/treeTestUtils'
+import { clearTestIconPaths, IconPath, setupTestIconPaths } from '../iconPathUtils'
+import * as treeUtils from '../treeTestUtils'
 
 let sandbox: sinon.SinonSandbox
 describe('AppNode', function () {

--- a/src/test/cdk/explorer/constructNode.test.ts
+++ b/src/test/cdk/explorer/constructNode.test.ts
@@ -11,8 +11,8 @@ import { PropertyNode } from '../../../cdk/explorer/nodes/propertyNode'
 import { ConstructTreeEntity } from '../../../cdk/explorer/tree/types'
 import { cdk } from '../../../cdk/globals'
 import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
-import { clearTestIconPaths, IconPath, setupTestIconPaths } from '../utilities/iconPathUtils'
-import * as treeUtils from '../utilities/treeTestUtils'
+import { clearTestIconPaths, IconPath, setupTestIconPaths } from '../iconPathUtils'
+import * as treeUtils from '../treeTestUtils'
 
 describe('ConstructNode', function () {
     before(async function () {

--- a/src/test/cdk/iconPathUtils.ts
+++ b/src/test/cdk/iconPathUtils.ts
@@ -4,7 +4,7 @@
  */
 
 import * as vscode from 'vscode'
-import { cdk } from '../../../cdk/globals'
+import { cdk } from '../../cdk/globals'
 
 export interface IconPath {
     light: vscode.Uri

--- a/src/test/cdk/tree/treeInspector.test.ts
+++ b/src/test/cdk/tree/treeInspector.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert'
 import * as treeInspector from '../../../cdk/explorer/tree/treeInspector'
 import { CfnResourceKeys, ConstructProps, ConstructTreeEntity } from '../../../cdk/explorer/tree/types'
-import * as treeUtils from '../utilities/treeTestUtils'
+import * as treeUtils from '../treeTestUtils'
 
 describe('TreeInspector', function () {
     const testLabel = 'my label'

--- a/src/test/cdk/treeTestUtils.ts
+++ b/src/test/cdk/treeTestUtils.ts
@@ -4,7 +4,7 @@
  */
 
 import { writeFile } from 'fs-extra'
-import { ConstructTree, ConstructTreeEntity } from '../../../cdk/explorer/tree/types'
+import { ConstructTree, ConstructTreeEntity } from '../../cdk/explorer/tree/types'
 
 export async function saveCdkJson(cdkJsonPath: string) {
     const cdkJsonContent = '{ "app": "npx ts-node bin/demo-nov7.ts"}'

--- a/src/test/lambda/utilities/parameterUtils.test.ts
+++ b/src/test/lambda/utilities/parameterUtils.test.ts
@@ -12,7 +12,7 @@ import {
     getParameterNames,
     getParameters,
     GetParametersContext,
-} from '../../../lambda/utilities/parameterUtils'
+} from '../../../lambda/config/parameterUtils'
 import { getNormalizedRelativePath } from '../../../shared/utilities/pathUtils'
 
 describe('parameterUtils', async function () {

--- a/src/test/lambda/wizards/samDeployWizard.test.ts
+++ b/src/test/lambda/wizards/samDeployWizard.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert'
 import * as path from 'path'
 import * as sinon from 'sinon'
 import * as vscode from 'vscode'
-import * as paramUtils from '../../../lambda/utilities/parameterUtils'
+import * as paramUtils from '../../../lambda/config/parameterUtils'
 import * as input from '../../../shared/ui/input'
 import * as picker from '../../../shared/ui/picker'
 import {


### PR DESCRIPTION
Problem
-------
In terms of project layout, it is unnecessary to have a utilities/ subdirectory (or "module family") in various sub-topics.

Utils should live in one of:
1. the top-level (root) util/ directory, or...
2. a named module ("foo.ts", no need for "util/foo.ts"), or...
3. "util.ts" in the family subdir (not "util/\*.ts")

Solution
--------
- Move lambda/utilities/parameterUtils.ts -> lambda/config/parameterUtils.ts
- Move src/test/cdk/utilities/\*.ts -> src/test/cdk/\*.ts

Benefits:
* "Economy of patterns" (eliminate frivolous choice) makes it clear to new developers which patterns to follow. This increases consistency, which increases discoverability.
* Avoids unnecessary nesting and entropy.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
