### PR TITLE
UI: new wizard framework

### DIFF
--- a/src/lambda/wizards/samInitWizard.ts
+++ b/src/lambda/wizards/samInitWizard.ts
@@ -1,12 +1,11 @@
 /*!
- * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 import * as nls from 'vscode-nls'
 import { Credentials } from 'aws-sdk'
 import { Runtime } from 'aws-sdk/clients/lambda'
-import { Set as ImmutableSet } from 'immutable'
 import * as path from 'path'
 import * as vscode from 'vscode'
 import { SchemasDataProvider } from '../../eventSchemas/providers/schemasDataProvider'
@@ -14,415 +13,30 @@ import { SchemaClient } from '../../shared/clients/schemaClient'
 import { eventBridgeSchemasDocUrl, samInitDocUrl } from '../../shared/constants'
 import { ext } from '../../shared/extensionGlobals'
 import { Region } from '../../shared/regions/endpoints'
-import { createHelpButton } from '../../shared/ui/buttons'
-import * as input from '../../shared/ui/input'
-import * as picker from '../../shared/ui/picker'
-import {
-    MultiStepWizard,
-    promptUserForLocation,
-    WIZARD_GOBACK,
-    WIZARD_RETRY,
-    WIZARD_TERMINATE,
-    WizardContext,
-    wizardContinue,
-    WizardStep,
-} from '../../shared/wizards/multiStepWizard'
+import { createBackButton, createHelpButton } from '../../shared/ui/buttons'
 import {
     createRuntimeQuickPick,
     DependencyManager,
     getDependencyManager,
     RuntimePackageType,
-    samLambdaCreatableRuntimes,
 } from '../models/samLambdaRuntime'
 import {
     eventBridgeStarterAppTemplate,
     getSamTemplateWizardOption,
     getTemplateDescription,
-    repromptUserForTemplate,
     SamTemplate,
 } from '../models/samTemplates'
 import * as semver from 'semver'
 import { MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_IMAGE_SUPPORT } from '../../shared/sam/cli/samCliValidator'
 import * as fsutil from '../../shared/filesystemUtilities'
+import { Wizard } from '../../shared/wizards/wizard'
+import { createLocationPrompt } from '../../shared/ui/prompts'
+import { Prompter, PrompterButtons } from '../../shared/ui/prompter'
+import { createInputBox, InputBoxPrompter } from '../../shared/ui/input'
+import { createLabelQuickPick, createQuickPick } from '../../shared/ui/picker'
+import { QuickPickPrompter } from '../../shared/ui/picker'
 
 const localize = nls.loadMessageBundle()
-
-export interface CreateNewSamAppWizardContext {
-    readonly lambdaRuntimes: ImmutableSet<Runtime>
-    readonly workspaceFolders: readonly vscode.WorkspaceFolder[] | undefined
-
-    promptUserForRuntimeAndDependencyManager(
-        currRuntime?: Runtime
-    ): Promise<[Runtime, RuntimePackageType, DependencyManager | undefined] | undefined>
-    promptUserForTemplate(
-        currRuntime: Runtime,
-        packageType: RuntimePackageType,
-        currTemplate?: SamTemplate
-    ): Promise<SamTemplate | undefined>
-
-    promptUserForRegion(currRegion?: string): Promise<string | undefined>
-    promptUserForRegistry(currRegion: string, currRegistry?: string): Promise<string | undefined>
-    promptUserForSchema(currRegion: string, currRegistry: string, currSchema?: string): Promise<string | undefined>
-
-    promptUserForLocation(): Promise<vscode.Uri | undefined>
-    promptUserForName(defaultValue: string): Promise<string | undefined>
-
-    showOpenDialog(options: vscode.OpenDialogOptions): Thenable<vscode.Uri[] | undefined>
-}
-
-export class DefaultCreateNewSamAppWizardContext extends WizardContext implements CreateNewSamAppWizardContext {
-    public readonly lambdaRuntimes = samLambdaCreatableRuntimes()
-    private readonly helpButton = createHelpButton(localize('AWS.command.help', 'View Toolkit Documentation'))
-    private readonly currentCredentials: Credentials | undefined
-    private readonly schemasRegions: Region[]
-    private readonly samCliVersion: string
-
-    private readonly totalSteps: number = 4
-    private stepsToAdd = { promptUserForDependencyManager: false, promptUserForRegion: false }
-    private additionalSteps(): number {
-        let n = 0
-        if (this.stepsToAdd.promptUserForDependencyManager) {
-            n += 1
-        }
-        if (this.stepsToAdd.promptUserForRegion) {
-            n += 3
-        }
-
-        return n
-    }
-
-    public constructor(currentCredentials: Credentials | undefined, schemasRegions: Region[], samCliVersion: string) {
-        super()
-        this.currentCredentials = currentCredentials
-        this.schemasRegions = schemasRegions
-        this.samCliVersion = samCliVersion
-    }
-
-    public async promptUserForRuntimeAndDependencyManager(
-        currRuntime?: Runtime
-    ): Promise<[Runtime, RuntimePackageType, DependencyManager | undefined] | undefined> {
-        // last common step; reset additionalSteps to 0
-        this.stepsToAdd.promptUserForDependencyManager = false
-
-        const quickPick = createRuntimeQuickPick({
-            // TODO: remove check when SAM CLI version is low enough
-            showImageRuntimes: semver.gte(this.samCliVersion, MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_IMAGE_SUPPORT),
-            buttons: [this.helpButton],
-            currRuntime,
-            step: 1,
-            totalSteps: this.totalSteps,
-        })
-
-        const choices = await picker.promptUser({
-            picker: quickPick,
-            onDidTriggerButton: (button, resolve, reject) => {
-                if (button === vscode.QuickInputButtons.Back) {
-                    resolve(undefined)
-                } else if (button === this.helpButton) {
-                    vscode.env.openExternal(vscode.Uri.parse(samInitDocUrl))
-                }
-            },
-        })
-        const val = picker.verifySinglePickerOutput(choices)
-
-        if (!val) {
-            return undefined
-        }
-
-        const dependencyManager = await this.promptUserForDependencyManager(val.runtime)
-
-        return val ? [val.runtime, val.packageType, dependencyManager] : undefined
-    }
-
-    // don't preinclude currDependencyManager because it won't make sense if transitioning between runtimes
-    private async promptUserForDependencyManager(currRuntime: Runtime): Promise<DependencyManager | undefined> {
-        const dependencyManagers = getDependencyManager(currRuntime)
-        if (dependencyManagers.length === 1) {
-            return dependencyManagers[0]
-        } else {
-            this.stepsToAdd.promptUserForDependencyManager = true
-            const quickPick = picker.createQuickPick<vscode.QuickPickItem>({
-                options: {
-                    ignoreFocusOut: true,
-                    title: localize('AWS.samcli.initWizard.dependencyManager.prompt', 'Select a Dependency Manager'),
-                    step: 2,
-                    totalSteps: this.totalSteps + this.additionalSteps(),
-                },
-                buttons: [this.helpButton, vscode.QuickInputButtons.Back],
-                items: dependencyManagers.map(dependencyManager => ({
-                    label: dependencyManager,
-                })),
-            })
-
-            const choices = await picker.promptUser({
-                picker: quickPick,
-                onDidTriggerButton: (button, resolve, reject) => {
-                    if (button === vscode.QuickInputButtons.Back) {
-                        resolve(undefined)
-                    } else if (button === this.helpButton) {
-                        vscode.env.openExternal(vscode.Uri.parse(samInitDocUrl))
-                    }
-                },
-            })
-            const val = picker.verifySinglePickerOutput(choices)
-
-            return val ? (val.label as DependencyManager) : undefined
-        }
-    }
-
-    public async promptUserForTemplate(
-        currRuntime: Runtime,
-        packageType: RuntimePackageType,
-        currTemplate?: SamTemplate
-    ): Promise<SamTemplate | undefined> {
-        this.stepsToAdd.promptUserForRegion = false
-        const templates = getSamTemplateWizardOption(currRuntime, packageType, this.samCliVersion)
-        const quickPick = picker.createQuickPick<vscode.QuickPickItem>({
-            options: {
-                ignoreFocusOut: true,
-                title: localize('AWS.samcli.initWizard.template.prompt', 'Select a SAM Application Template'),
-                value: currTemplate,
-                step: 2 + this.additionalSteps(),
-                totalSteps: this.totalSteps + this.additionalSteps(),
-            },
-            buttons: [this.helpButton, vscode.QuickInputButtons.Back],
-            items: templates.toArray().map(template => ({
-                label: template,
-                alwaysShow: template === currTemplate,
-                detail:
-                    template === currTemplate
-                        ? localize('AWS.wizard.selectedPreviously', 'Selected Previously')
-                        : getTemplateDescription(template),
-            })),
-        })
-
-        const choices = await picker.promptUser({
-            picker: quickPick,
-            onDidTriggerButton: (button, resolve, reject) => {
-                if (button === vscode.QuickInputButtons.Back) {
-                    resolve(undefined)
-                } else if (button === this.helpButton) {
-                    vscode.env.openExternal(vscode.Uri.parse(samInitDocUrl))
-                }
-            },
-        })
-        const val = picker.verifySinglePickerOutput(choices)
-
-        //eventBridgeStarterAppTemplate requires aws credentials
-        if (val && val.label === eventBridgeStarterAppTemplate) {
-            if (!this.currentCredentials) {
-                vscode.window.showInformationMessage(
-                    localize(
-                        'AWS.message.info.schemas.downloadCodeBindings.generate',
-                        'You need to be connected to AWS to select {0}.',
-                        val.label
-                    )
-                )
-
-                return repromptUserForTemplate
-            }
-        }
-
-        return val ? (val.label as SamTemplate) : undefined
-    }
-
-    public async promptUserForRegion(currRegion?: string): Promise<string | undefined> {
-        // start of longer path; set additionalSteps to 3
-        this.stepsToAdd.promptUserForRegion = true
-        const quickPick = picker.createQuickPick<vscode.QuickPickItem>({
-            options: {
-                ignoreFocusOut: true,
-                title: localize('AWS.samcli.initWizard.schemas.region.prompt', 'Select an EventBridge Schemas Region'),
-                value: currRegion ? currRegion : '',
-                step: 3,
-                totalSteps: this.totalSteps + this.additionalSteps(),
-            },
-            buttons: [this.helpButton, vscode.QuickInputButtons.Back],
-            items: this.schemasRegions.map(region => ({
-                label: region.name,
-                detail: region.id,
-                alwaysShow: region.id === currRegion,
-                description:
-                    region.id === currRegion ? localize('AWS.wizard.selectedPreviously', 'Selected Previously') : '',
-            })),
-        })
-
-        const choices = await picker.promptUser({
-            picker: quickPick,
-            onDidTriggerButton: (button, resolve, reject) => {
-                if (button === vscode.QuickInputButtons.Back) {
-                    resolve(undefined)
-                } else if (button === this.helpButton) {
-                    vscode.env.openExternal(vscode.Uri.parse(eventBridgeSchemasDocUrl))
-                }
-            },
-        })
-        const val = picker.verifySinglePickerOutput(choices)
-
-        return val ? (val.detail as string) : undefined
-    }
-
-    public async promptUserForRegistry(currRegion: string, currRegistry?: string): Promise<string | undefined> {
-        const client: SchemaClient = ext.toolkitClientBuilder.createSchemaClient(currRegion)
-        const registryNames = await SchemasDataProvider.getInstance().getRegistries(
-            currRegion,
-            client,
-            this.currentCredentials!
-        )
-
-        if (!registryNames) {
-            vscode.window.showInformationMessage(
-                localize('AWS.samcli.initWizard.schemas.registry.failed_to_load_resources', 'Error loading registries.')
-            )
-
-            return undefined
-        }
-
-        const quickPick = picker.createQuickPick<vscode.QuickPickItem>({
-            options: {
-                ignoreFocusOut: true,
-                title: localize('AWS.samcli.initWizard.schemas.registry.prompt', 'Select a Registry'),
-                value: currRegistry ? currRegistry : '',
-                step: 4,
-                totalSteps: this.totalSteps + this.additionalSteps(),
-            },
-            buttons: [this.helpButton, vscode.QuickInputButtons.Back],
-            items: registryNames!.map(registry => ({
-                label: registry,
-                alwaysShow: registry === currRegistry,
-                description:
-                    registry === currRegistry ? localize('AWS.wizard.selectedPreviously', 'Selected Previously') : '',
-            })),
-        })
-
-        const choices = await picker.promptUser({
-            picker: quickPick,
-            onDidTriggerButton: (button, resolve, reject) => {
-                if (button === vscode.QuickInputButtons.Back) {
-                    resolve(undefined)
-                } else if (button === this.helpButton) {
-                    vscode.env.openExternal(vscode.Uri.parse(eventBridgeSchemasDocUrl))
-                }
-            },
-        })
-        const val = picker.verifySinglePickerOutput(choices)
-
-        return val ? val.label : undefined
-    }
-
-    public async promptUserForSchema(
-        currRegion: string,
-        currRegistry: string,
-        currSchema?: string
-    ): Promise<string | undefined> {
-        const client: SchemaClient = ext.toolkitClientBuilder.createSchemaClient(currRegion)
-        const schemas = await SchemasDataProvider.getInstance().getSchemas(
-            currRegion,
-            currRegistry,
-            client,
-            this.currentCredentials!
-        )
-
-        if (!schemas) {
-            vscode.window.showInformationMessage(
-                localize(
-                    'AWS.samcli.initWizard.schemas.failed_to_load_resources',
-                    'Error loading schemas in registry {0}.',
-                    currRegistry
-                )
-            )
-
-            return undefined
-        }
-
-        if (schemas!.length === 0) {
-            vscode.window.showInformationMessage(
-                localize('AWS.samcli.initWizard.schemas.notFound"', 'No schemas found in registry {0}.', currRegistry)
-            )
-
-            return undefined
-        }
-
-        const quickPick = picker.createQuickPick<vscode.QuickPickItem>({
-            options: {
-                ignoreFocusOut: true,
-                title: localize('AWS.samcli.initWizard.schemas.schema.prompt', 'Select a Schema'),
-                value: currSchema ? currSchema : '',
-                step: 4,
-                totalSteps: this.totalSteps + this.additionalSteps(),
-            },
-            buttons: [this.helpButton, vscode.QuickInputButtons.Back],
-            items: schemas!.map(schema => ({
-                label: schema.SchemaName!,
-                alwaysShow: schema.SchemaName === currSchema,
-                description:
-                    schema === currSchema ? localize('AWS.wizard.selectedPreviously', 'Selected Previously') : '',
-            })),
-        })
-
-        const choices = await picker.promptUser({
-            picker: quickPick,
-            onDidTriggerButton: (button, resolve, reject) => {
-                if (button === vscode.QuickInputButtons.Back) {
-                    resolve(undefined)
-                } else if (button === this.helpButton) {
-                    vscode.env.openExternal(vscode.Uri.parse(eventBridgeSchemasDocUrl))
-                }
-            },
-        })
-        const val = picker.verifySinglePickerOutput(choices)
-
-        return val ? val.label : undefined
-    }
-
-    public async promptUserForLocation(): Promise<vscode.Uri | undefined> {
-        return promptUserForLocation(this, {
-            helpButton: { button: this.helpButton, url: samInitDocUrl },
-            step: 3 + this.additionalSteps(),
-            totalSteps: this.totalSteps + this.additionalSteps(),
-        })
-    }
-
-    public async promptUserForName(defaultValue: string): Promise<string | undefined> {
-        const inputBox = input.createInputBox({
-            options: {
-                title: localize('AWS.samcli.initWizard.name.prompt', 'Enter a name for your new application'),
-                ignoreFocusOut: true,
-                step: 4 + this.additionalSteps(),
-                totalSteps: this.totalSteps + this.additionalSteps(),
-            },
-            buttons: [this.helpButton, vscode.QuickInputButtons.Back],
-        })
-        inputBox.value = defaultValue
-
-        return input.promptUser({
-            inputBox: inputBox,
-            onValidateInput: (value: string) => {
-                if (!value) {
-                    return localize('AWS.samcli.initWizard.name.error.empty', 'Application name cannot be empty')
-                }
-
-                if (value.includes(path.sep)) {
-                    return localize(
-                        'AWS.samcli.initWizard.name.error.pathSep',
-                        'The path separator ({0}) is not allowed in application names',
-                        path.sep
-                    )
-                }
-
-                return undefined
-            },
-            onDidTriggerButton: (button, resolve, reject) => {
-                if (button === vscode.QuickInputButtons.Back) {
-                    resolve(undefined)
-                } else if (button === this.helpButton) {
-                    vscode.env.openExternal(vscode.Uri.parse(samInitDocUrl))
-                }
-            },
-        })
-    }
-}
-
 export interface CreateNewSamAppWizardResponse {
     packageType: RuntimePackageType
     runtime: Runtime
@@ -435,112 +49,251 @@ export interface CreateNewSamAppWizardResponse {
     name: string
 }
 
-export class CreateNewSamAppWizard extends MultiStepWizard<CreateNewSamAppWizardResponse> {
-    private packageType?: RuntimePackageType
-    private runtime?: Runtime
-    private dependencyManager?: DependencyManager
-    private template?: SamTemplate
-    private region?: string
-    private registryName?: string
-    private schemaName?: string
-    private location?: vscode.Uri
-    private name?: string
+// TODO: split runtime and packageType into separate prompts, then use the above interface directly
+export interface CreateNewSamAppWizardForm {
+    runtimeAndPackage: {
+        packageType: RuntimePackageType
+        runtime: Runtime
+    }
+    dependencyManager: DependencyManager
+    template: SamTemplate
+    region?: string
+    registryName?: string
+    schemaName?: string
+    location: vscode.Uri
+    name: string
+}
 
-    public constructor(private readonly context: CreateNewSamAppWizardContext) {
-        super()
+export interface RuntimePlusPackage {
+    packageType: RuntimePackageType
+    runtime: Runtime
+}
+
+export interface CreateNewSamAppWizardContext {
+    readonly samButtons: PrompterButtons
+    readonly schemaButtons: PrompterButtons
+    readonly currentCredentials: Credentials | undefined, 
+    readonly schemasRegions: Region[], 
+    readonly samCliVersion: string
+    createTemplatePrompter(currRuntime: Runtime, packageType: RuntimePackageType): Prompter<SamTemplate>
+    createRegionPrompter(): Prompter<string>
+    createDependencyPrompter(currRuntime: Runtime): Prompter<DependencyManager>
+    createRegistryPrompter(currRegion: string): Prompter<string>
+    createSchemaPrompter(currRegion: string, currRegistry: string): Prompter<string>
+    createNamePrompter(defaultValue: string): Prompter<string> 
+    createRuntimePrompter(): Prompter<RuntimePlusPackage> 
+    createLocationPrompter(): Prompter<vscode.Uri>
+}
+
+
+export class DefaultCreateNewSamAppWizardContext implements CreateNewSamAppWizardContext {
+    private readonly samHelpButton = createHelpButton(samInitDocUrl)
+    private readonly schemaHelpButton = createHelpButton(eventBridgeSchemasDocUrl)
+
+    public readonly samButtons: PrompterButtons = [createBackButton(), this.samHelpButton]
+    public readonly schemaButtons: PrompterButtons = [createBackButton(), this.schemaHelpButton]
+
+    constructor(
+        public readonly currentCredentials: Credentials | undefined, 
+        public readonly schemasRegions: Region[], 
+        public readonly samCliVersion: string
+    ) {}
+
+    public createRuntimePrompter(): QuickPickPrompter<RuntimePlusPackage> {
+        return createRuntimeQuickPick({ 
+            showImageRuntimes: semver.gte(this.samCliVersion, MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_IMAGE_SUPPORT),
+            buttons: this.samButtons
+        })
     }
 
-    protected get startStep() {
-        return this.RUNTIME
+    public createTemplatePrompter(
+        currRuntime: Runtime,
+        packageType: RuntimePackageType,
+    ): QuickPickPrompter<SamTemplate> {
+        const templates = getSamTemplateWizardOption(currRuntime, packageType, this.samCliVersion)
+        const items = templates.toArray().map(template => ({
+            label: template,
+            data: template,
+            detail: getTemplateDescription(template),
+        }))
+    
+        return createQuickPick(items, { 
+            title: localize('AWS.samcli.initWizard.template.prompt', 'Select a SAM Application Template'),
+            buttons: this.samButtons,
+        })
     }
-
-    protected getResult(): CreateNewSamAppWizardResponse | undefined {
-        if (
-            !this.runtime ||
-            !this.dependencyManager ||
-            !this.packageType ||
-            !this.template ||
-            !this.location ||
-            !this.name
-        ) {
+    
+    public createRegionPrompter(): QuickPickPrompter<string> {
+        const items = this.schemasRegions.map(region => ({
+            label: region.name,
+            detail: region.id,
+            data: region.id,
+        }))
+    
+        return createQuickPick(items, { 
+            title: localize('AWS.samcli.initWizard.schemas.region.prompt', 'Select an EventBridge Schemas Region'),
+            buttons: this.samButtons,
+        })
+    }
+    
+    public createDependencyPrompter(currRuntime: Runtime): QuickPickPrompter<DependencyManager> {
+        const dependencyManagers = getDependencyManager(currRuntime)
+        const items = dependencyManagers.map(dependencyManager => ({ label: dependencyManager }))
+    
+        return createLabelQuickPick(items, {
+            title: localize('AWS.samcli.initWizard.dependencyManager.prompt', 'Select a Dependency Manager'),
+            buttons: this.samButtons,
+        })
+    }
+    
+    public createRegistryPrompter(currRegion: string): QuickPickPrompter<string> {
+        const client: SchemaClient = ext.toolkitClientBuilder.createSchemaClient(currRegion)
+        const items = SchemasDataProvider.getInstance().getRegistries(
+            currRegion,
+            client,
+            this.currentCredentials!
+        ).then(registryNames => {
+            if (!registryNames) {
+                vscode.window.showInformationMessage(
+                    localize('AWS.samcli.initWizard.schemas.registry.failed_to_load_resources', 'Error loading registries.')
+                )
+                return undefined
+            }
+    
+            return registryNames.map(registry => ({
+                label: registry,
+            }))
+        })
+    
+        return createLabelQuickPick(items, { 
+            title: localize('AWS.samcli.initWizard.schemas.registry.prompt', 'Select a Registry'),
+            buttons: this.schemaButtons,
+        })
+    }
+    
+    public createSchemaPrompter(
+        currRegion: string,
+        currRegistry: string,
+    ): QuickPickPrompter<string> {
+        const client: SchemaClient = ext.toolkitClientBuilder.createSchemaClient(currRegion)
+        const items = SchemasDataProvider.getInstance()
+            .getSchemas(currRegion, currRegistry, client, this.currentCredentials!)
+            .then(schemas => {
+                if (!schemas) {
+                    vscode.window.showInformationMessage(
+                        localize(
+                            'AWS.samcli.initWizard.schemas.failed_to_load_resources',
+                            'Error loading schemas in registry {0}.',
+                            currRegistry
+                        )
+                    )
+                    return undefined 
+                }
+    
+                if (schemas!.length === 0) {
+                    vscode.window.showInformationMessage(
+                        localize('AWS.samcli.initWizard.schemas.notFound"', 'No schemas found in registry {0}.', currRegistry)
+                    )
+                    return undefined
+                }
+    
+                return schemas!.map(schema => ({
+                    label: schema.SchemaName!,
+                }))
+            })
+    
+        return createLabelQuickPick(items, { 
+            title: localize('AWS.samcli.initWizard.schemas.schema.prompt', 'Select a Schema'),
+            buttons: this.schemaButtons,
+        })
+    }
+    
+    public createNamePrompter(defaultValue: string): InputBoxPrompter {
+        function validateName(value: string): string | undefined {
+            if (!value) {
+                return localize('AWS.samcli.initWizard.name.error.empty', 'Application name cannot be empty')
+            }
+        
+            if (value.includes(path.sep)) {
+                return localize(
+                    'AWS.samcli.initWizard.name.error.pathSep',
+                    'The path separator ({0}) is not allowed in application names',
+                    path.sep
+                )
+            }
+        
             return undefined
         }
 
-        if (this.template === eventBridgeStarterAppTemplate) {
-            if (!this.region || !this.schemaName || !this.registryName) {
-                return undefined
+        return createInputBox({
+            value: defaultValue,
+            title: localize('AWS.samcli.initWizard.name.prompt', 'Enter a name for your new application'),
+            buttons: this.samButtons,
+            validateInput: validateName,
+        })
+    }
+
+    public createLocationPrompter(): Prompter<vscode.Uri> {
+        return createLocationPrompt(vscode.workspace.workspaceFolders ?? [], this.samButtons)
+    }
+}
+
+export class CreateNewSamAppWizard extends Wizard<CreateNewSamAppWizardForm, CreateNewSamAppWizardResponse> {
+    public constructor(context: CreateNewSamAppWizardContext, initState?: CreateNewSamAppWizardForm) {
+        super({ runtimeAndPackage: {} })
+        
+        this.form.runtimeAndPackage.bindPrompter(form => context.createRuntimePrompter())
+        
+        this.form.dependencyManager.bindPrompter(
+            form => context.createDependencyPrompter(form.runtimeAndPackage.runtime!),
+            {
+                showWhen: form => form.runtimeAndPackage.runtime !== undefined && getDependencyManager(form.runtimeAndPackage.runtime).length > 1,
+                setDefault: form => form.runtimeAndPackage.runtime !== undefined ? getDependencyManager(form.runtimeAndPackage.runtime)[0] : undefined
             }
+        )
+        
+        this.form.template.bindPrompter(form =>
+            context.createTemplatePrompter(form.runtimeAndPackage.runtime!, form.runtimeAndPackage.packageType!)
+        )
+
+        this.form.region.bindPrompter(form => 
+            context.createRegionPrompter(),
+            {
+                showWhen: form => form.template === eventBridgeStarterAppTemplate,
+            }
+        )
+
+        this.form.registryName.bindPrompter(form => 
+            context.createRegistryPrompter(form.region!),
+            {
+                showWhen: form => form.template === eventBridgeStarterAppTemplate,
+            }
+        )
+
+        this.form.schemaName.bindPrompter(form => 
+            context.createSchemaPrompter(form.region!, form.registryName!),
+            {
+                showWhen: form => form.template === eventBridgeStarterAppTemplate,
+            }
+        )
+        
+        this.form.location.bindPrompter(form => context.createLocationPrompter())
+
+        this.form.name.bindPrompter(form => 
+            context.createNamePrompter(fsutil.getNonexistentFilename(form.location!.fsPath, `lambda-${form.runtimeAndPackage.runtime}`, '', 99))
+        )
+    }
+
+    public async run(): Promise<CreateNewSamAppWizardResponse | undefined> {
+        const finalState = await super.run() as CreateNewSamAppWizardForm
+
+        if (finalState === undefined) {
+            return undefined
         }
 
         return {
-            packageType: this.packageType,
-            runtime: this.runtime,
-            dependencyManager: this.dependencyManager,
-            template: this.template,
-            region: this.region,
-            registryName: this.registryName,
-            schemaName: this.schemaName,
-            location: this.location,
-            name: this.name,
+            ...finalState,
+            ...finalState.runtimeAndPackage,
         }
-    }
-
-    private readonly RUNTIME: WizardStep = async () => {
-        const result = await this.context.promptUserForRuntimeAndDependencyManager(this.runtime)
-        if (!result) {
-            return WIZARD_TERMINATE
-        }
-
-        ;[this.runtime, this.packageType, this.dependencyManager] = result
-        if (this.dependencyManager === undefined) {
-            return WIZARD_RETRY
-        }
-
-        return wizardContinue(this.TEMPLATE)
-    }
-
-    private readonly TEMPLATE: WizardStep = async () => {
-        this.template = await this.context.promptUserForTemplate(this.runtime!, this.packageType!)
-
-        if (this.template === repromptUserForTemplate) {
-            return WIZARD_RETRY
-        }
-        if (this.template === eventBridgeStarterAppTemplate) {
-            return wizardContinue(this.REGION)
-        }
-
-        return this.template ? wizardContinue(this.LOCATION) : WIZARD_GOBACK
-    }
-
-    private readonly REGION: WizardStep = async () => {
-        this.region = await this.context.promptUserForRegion()
-
-        return this.region ? wizardContinue(this.REGISTRY) : WIZARD_GOBACK
-    }
-
-    private readonly REGISTRY: WizardStep = async () => {
-        this.registryName = await this.context.promptUserForRegistry(this.region!)
-
-        return this.registryName ? wizardContinue(this.SCHEMA) : WIZARD_GOBACK
-    }
-
-    private readonly SCHEMA: WizardStep = async () => {
-        this.schemaName = await this.context.promptUserForSchema(this.region!, this.registryName!)
-
-        return this.schemaName ? wizardContinue(this.LOCATION) : WIZARD_GOBACK
-    }
-
-    private readonly LOCATION: WizardStep = async () => {
-        this.location = await this.context.promptUserForLocation()
-
-        return this.location ? wizardContinue(this.NAME) : WIZARD_GOBACK
-    }
-
-    private readonly NAME: WizardStep = async () => {
-        // Default to a name like "lambda-python3.8-1".
-        const defaultName = fsutil.getNonexistentFilename(this.location!.fsPath, `lambda-${this.runtime}`, '', 99)
-        this.name = await this.context.promptUserForName(this.name ?? defaultName)
-
-        return this.name ? WIZARD_TERMINATE : WIZARD_GOBACK
     }
 }

--- a/src/shared/ui/buttons.ts
+++ b/src/shared/ui/buttons.ts
@@ -3,21 +3,43 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { QuickInputButton, Uri } from 'vscode'
+import * as vscode from 'vscode'
+import * as nls from 'vscode-nls'
 import { ext } from '../extensionGlobals'
+import { WizardControl } from '../wizards/wizard'
+
+const localize = nls.loadMessageBundle()
+const HELP_TOOLTIP = localize('AWS.command.help', 'View Toolkit Documentation')
+
+/** Light wrapper around VS Code's buttons, adding a `onClick` callback. */
+export interface QuickInputButton<T> extends vscode.QuickInputButton {
+    onClick: (resolve: (arg: T) => void) => void
+}
 
 /**
  * Creates a QuickInputButton with a predefined help button (dark and light theme compatible)
  * Images are only loaded after extension.ts loads; this should happen on any user-facing extension usage.
  * button will exist regardless of image loading (UI tests will still see this)
+ * 
+ * @param uri Opens the URI upon clicking
  * @param tooltip Optional tooltip for button
  */
-export function createHelpButton(tooltip?: string): QuickInputButton {
-    return {
+export function createHelpButton(uri: string | vscode.Uri, tooltip: string = HELP_TOOLTIP): QuickInputButton<void> {
+    const button: vscode.QuickInputButton = {
         iconPath: {
-            light: Uri.file(ext.iconPaths.light.help),
-            dark: Uri.file(ext.iconPaths.dark.help),
+            light: vscode.Uri.file(ext.iconPaths.light.help),
+            dark: vscode.Uri.file(ext.iconPaths.dark.help),
         },
         tooltip,
     }
+    const openUri = () => vscode.env.openExternal(typeof uri === 'string' ? vscode.Uri.parse(uri) : uri)
+
+    return { ...button, onClick: openUri }
+}
+
+// Currently VS Code uses a static back button for every QuickInput, so we can't redefine any of its
+// properties without potentially affecting other extensions. Creating a wrapper is possible, but it
+// would still need to be swapped out for the real Back button when adding it to the QuickInput.
+export function createBackButton(): QuickInputButton<WizardControl> {
+    return vscode.QuickInputButtons.Back as QuickInputButton<WizardControl>
 }

--- a/src/shared/ui/input.ts
+++ b/src/shared/ui/input.ts
@@ -1,131 +1,79 @@
 /*!
- * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 import * as vscode from 'vscode'
+import { applySettings } from '../utilities/collectionUtils'
+import { WIZARD_BACK } from '../wizards/wizard'
+import { QuickInputButton } from './buttons'
+import { Prompter, PrompterButtons, PromptResult } from './prompter'
 
-/**
- * Options to configure the behavior of the input box UI.
- * Generally used to accommodate features not provided through vscode.InputBoxOptions
- */
-export interface AdditionalInputBoxOptions {
+/** Additional options to configure the `InputBox` beyond the standard API */
+interface AdditionalInputBoxOptions {
     title?: string
     step?: number
+    placeholder?: string
     totalSteps?: number
+    buttons?: PrompterButtons<string>
+    validateInput?(value: string): string | undefined
 }
 
+export type ExtendedInputBoxOptions = 
+    Omit<vscode.InputBoxOptions, 'buttons' | 'validateInput'> & AdditionalInputBoxOptions
+export type DataInputBox = Omit<vscode.InputBox, 'buttons'> & { buttons: PrompterButtons<string> }
+
 /**
- * Creates an InputBox to get a text response from the user.
- *
- * Used to wrap createInputBox and accommodate
- * a common set of features for the Toolkit.
- *
- * Parameters:
- *  options - initial InputBox configuration
- *  buttons - set of buttons to initialize the InputBox with
- * @return A new InputBox.
+ * Creates a new InputBox.
+ * 
+ * @param options Customizes the InputBox and InputBoxPrompter.
+ * @returns An InputBoxPrompter. This can be used directly with the `prompt` method or can be fed into a Wizard.
  */
-export function createInputBox({
-    options,
-    buttons,
-}: {
-    options?: vscode.InputBoxOptions & AdditionalInputBoxOptions
-    buttons?: vscode.QuickInputButton[]
-}): vscode.InputBox {
-    const inputBox = vscode.window.createInputBox()
+export function createInputBox(options?: ExtendedInputBoxOptions): InputBoxPrompter {
+    const inputBox = vscode.window.createInputBox() as DataInputBox
+    applySettings(inputBox, { ...options })
 
-    if (options) {
-        inputBox.title = options.title
-        inputBox.placeholder = options.placeHolder
-        inputBox.prompt = options.prompt
-        inputBox.step = options.step
-        inputBox.totalSteps = options.totalSteps
-        if (options.ignoreFocusOut !== undefined) {
-            inputBox.ignoreFocusOut = options.ignoreFocusOut
-        }
-
-        // TODO : Apply more options as they are needed in the future, and add corresponding tests
+    if (options?.validateInput !== undefined) {
+        inputBox.onDidChangeValue(
+            value => inputBox.validationMessage = options.validateInput!(value)
+        )
     }
 
-    if (buttons) {
-        inputBox.buttons = buttons
-    }
-
-    return inputBox
+    return new InputBoxPrompter(inputBox)
 }
 
-/**
- * Convenience method to allow the InputBox to be treated more like a dialog.
- *
- * This method shows the input box, and returns after the user enters a value, or cancels.
- * (Accepted = the user typed in a value and hit Enter, Cancelled = hide() is called or Esc is pressed)
- *
- * @param inputBox The InputBox to prompt the user with
- * @param onDidTriggerButton Optional event to trigger when the input box encounters a "Button Pressed" event.
- *  Buttons do not automatically cancel/accept the input box, caller must explicitly do this if intended.
- *
- * @returns If the InputBox was cancelled, undefined is returned. Otherwise, the string entered is returned.
- */
-export async function promptUser({
-    inputBox,
-    onValidateInput,
-    onDidTriggerButton,
-}: {
-    inputBox: vscode.InputBox
-    onValidateInput?(value: string): string | undefined
-    onDidTriggerButton?(
-        button: vscode.QuickInputButton,
-        resolve: (value: string | PromiseLike<string | undefined> | undefined) => void,
-        reject: (reason?: any) => void
-    ): void
-}): Promise<string | undefined> {
-    const disposables: vscode.Disposable[] = []
+export class InputBoxPrompter extends Prompter<string> {
+    
+    constructor(public readonly inputBox: DataInputBox) {
+        super(inputBox)
+    }
 
-    try {
-        const response = await new Promise<string | undefined>((resolve, reject) => {
-            inputBox.onDidAccept(
-                () => {
-                    if (!inputBox.validationMessage) {
-                        resolve(inputBox.value)
-                    }
-                },
-                inputBox,
-                disposables
-            )
-
-            inputBox.onDidHide(
-                () => {
-                    resolve(undefined)
-                },
-                inputBox,
-                disposables
-            )
-
-            if (onValidateInput) {
-                inputBox.onDidChangeValue(
-                    value => {
-                        inputBox.validationMessage = onValidateInput(value)
-                    },
-                    inputBox,
-                    disposables
-                )
-            }
-
-            if (onDidTriggerButton) {
-                inputBox.onDidTriggerButton(
-                    (btn: vscode.QuickInputButton) => onDidTriggerButton(btn, resolve, reject),
-                    inputBox,
-                    disposables
-                )
-            }
-
-            inputBox.show()
+    protected async promptUser(): Promise<PromptResult<string>> {
+        const promptPromise = new Promise<PromptResult<string>>(resolve => {
+            this.inputBox.onDidAccept(() => {
+                if (!this.inputBox.validationMessage) {
+                    resolve(this.inputBox.value)
+                }
+            })
+            this.inputBox.onDidHide(() => resolve(undefined)) // TODO: change to wizard exit
+            this.inputBox.onDidTriggerButton(button => {
+                if (button === vscode.QuickInputButtons.Back) {
+                    resolve(WIZARD_BACK)
+                } else {
+                    (button as QuickInputButton<string>).onClick(resolve)
+                }
+            })
+            this.inputBox.show()
         })
 
-        return response
-    } finally {
-        disposables.forEach(d => d.dispose() as void)
-        inputBox.hide()
+        return await promptPromise
+    }
+
+    public setLastResponse(picked: string): void {
+        this.inputBox.value = picked
+    }
+
+    public getLastResponse(): string | undefined {
+        return ''
     }
 }

--- a/src/shared/ui/prompter.ts
+++ b/src/shared/ui/prompter.ts
@@ -1,0 +1,71 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { isWizardControl, WizardControl } from '../wizards/wizard'
+import { QuickInputButton } from './buttons'
+import { DataQuickPickItem } from './picker'
+
+export type QuickPickDataType<T> = T | WizardControl | undefined
+
+export type MultiQuickPickResult<T> = T[] | WizardControl | undefined 
+export type PromptResult<T> = T | WizardControl | undefined
+type WizardButton<T> = QuickInputButton<T | WizardControl> | QuickInputButton<void>
+export type PrompterButtons<T=WizardControl> = readonly WizardButton<T>[]
+
+/** Checks if the user response is valid (i.e. not undefined and not a control signal) */
+export function isValidResponse<T>(response: PromptResult<T>): response is T {
+    return response !== undefined && !isWizardControl(response)
+}
+
+type Transform<T> = (result: T) => Promise<T | void>
+type DataQuickInput<T> = vscode.QuickInput & { buttons: PrompterButtons<T> }
+
+/**
+ * A generic dialog object that encapsulates the presentation and transformation of user
+ * responses to arbitrary GUIs.
+ */
+export abstract class Prompter<T> {
+    protected readonly afterCallbacks: Transform<PromptResult<T>>[] = []
+
+    constructor(private readonly input: DataQuickInput<T>) {}
+
+    public setSteps(current: number, total: number): void {
+        this.input.step = current
+        this.input.totalSteps = total
+    }
+
+    /** Adds a hook that is called after the user responds */
+    public after(callback: Transform<PromptResult<T>>): Prompter<T> {
+        this.afterCallbacks.push(callback)
+        return this
+    }
+
+    /** Applies the 'after' hooks to the user response in the order in which they were added */
+    private async applyAfterCallbacks(result: PromptResult<T>): Promise<PromptResult<T>> {
+        for (const cb of this.afterCallbacks) {
+            const transform = await cb(result)
+            if (transform !== undefined) {
+                result = transform
+            }
+        }
+        return result
+    }
+
+    /** 
+     * Opens a dialog for the user to respond to.
+     * @returns The user-response, undefined, or a special control-signal used in Wizards.
+     */
+    public async prompt(): Promise<PromptResult<T>> {
+        return this.applyAfterCallbacks(await this.promptUser())
+    }
+
+    protected abstract promptUser(): Promise<PromptResult<T>>
+    // TODO: remove DataQuickPickItem<T> | DataQuickPickItem<T>[] from these types
+    /** Implementing classes should use the argument to show the user what they last selected */
+    public abstract setLastResponse(picked?: T | DataQuickPickItem<T> | DataQuickPickItem<T>[]): void
+    /** Will not be needed if doing the above TODO */
+    public abstract getLastResponse(): T | DataQuickPickItem<T> | DataQuickPickItem<T>[] | undefined
+}

--- a/src/shared/utilities/collectionUtils.ts
+++ b/src/shared/utilities/collectionUtils.ts
@@ -248,3 +248,11 @@ export function pushIf<T>(arr: T[], condition: boolean, ...elements: T[]) {
         arr.push(...elements)
     }
 }
+
+/** 
+ * Applies `settings` to a base object. The shared properties between the settings and the object must have the
+ * same types, enforced by the TypeScript compiler.
+ */
+ export function applySettings<T1 extends Record<string, unknown>, T2 extends T1>(obj: T2, settings: T1): void {
+    Object.assign(obj, settings)
+}

--- a/src/shared/wizards/stateController.ts
+++ b/src/shared/wizards/stateController.ts
@@ -1,0 +1,141 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as _ from 'lodash'
+
+export enum ControlSignal {
+    Retry,
+    Exit,
+    Back,
+}
+
+export interface StepResult<TState> {
+    /** A mutated form of the present state. This will be passed along to the next step */
+    nextState?: TState
+    /** An array of step functions to be added immediately after the most recent step */
+    nextSteps?: StepFunction<TState>[]
+    /** Extra control instructions separate from the normal linear traversal of states */
+    controlSignal?: ControlSignal
+}
+
+/**
+ * State machine transition function. Transforms the present state into a new one, which may also
+ * include additional steps or control signals. The function can return the state directly if nothing
+ * extra is needed.
+ */
+export type StepFunction<TState> = (state: TState) => Promise<StepResult<TState> | TState>
+export type Branch<TState> = StepFunction<TState>[]
+
+/**
+ * State machine with backtracking and dynamic branching functionality.
+ * Transitions are abstracted away as a 'step' function, which return both the new state and any extra 
+ * steps that the machine should use.
+ */
+export class StateMachineController<TState> {
+    private previousStates: TState[] = []
+    private extraSteps = new Map<number, Branch<TState>>()
+    private steps: Branch<TState> = []
+    private internalStep: number = 0
+    private state!: TState
+
+    public constructor(private readonly initState: TState = {} as TState) {
+        this.setState(this.initState)
+    }
+
+    public setState(state: TState) {
+        this.state = state
+    }
+
+    public addStep(step: StepFunction<TState>): void {
+        this.steps.push(step)
+    }
+
+    public containsStep(step: StepFunction<TState> | undefined): boolean {
+        return step !== undefined && this.steps.indexOf(step) > -1
+    }
+
+    public get currentStep(): number { return this.internalStep + 1 }
+    public get totalSteps(): number { return this.steps.length }
+
+    protected rollbackState(): void {
+        if (this.extraSteps.has(this.internalStep)) {
+            this.steps.splice(this.internalStep, this.extraSteps.get(this.internalStep)!.length)
+            this.extraSteps.delete(this.internalStep)
+        }
+
+        this.state = this.previousStates.pop()!
+        this.internalStep -= 1
+    }
+
+    protected advanceState(nextState: TState): void {
+        this.previousStates.push(_.cloneDeep(this.state))
+        this.state = nextState
+        this.internalStep += 1
+    }
+
+    protected detectCycle(step: StepFunction<TState>): TState | undefined {
+        return this.previousStates.find((pastState, index) => index !== this.internalStep && 
+            (this.steps[index] === step && _.isEqual(this.state, pastState)))
+    }
+
+    /** Add new steps dynamically at runtime. Only used internally. */
+    protected dynamicBranch(nextSteps: Branch<TState> | undefined): void {
+        if (nextSteps !== undefined && nextSteps.length > 0) {
+            this.steps.splice(this.internalStep, 0, ...nextSteps)
+            this.extraSteps.set(this.internalStep, nextSteps)
+        }
+    }
+
+    protected async processNextStep(): Promise<StepResult<TState>> {
+        const result = await this.steps[this.internalStep](this.state)
+
+        function isMachineResult(result: any): result is StepResult<TState> {
+            return (result !== undefined && 
+                (result.nextState !== undefined || result.nextSteps !== undefined || result.controlSignal !== undefined))
+        }
+
+        if (isMachineResult(result)) {
+            return result
+        } else {
+            return { nextState: result }
+        }
+    }
+
+    /**
+     * Runs the added steps until termination or failure.
+     * @returns The final state or `undefined` if the machine exited.
+     */
+    public async run(): Promise<TState | undefined> {
+        this.previousStates.push(_.cloneDeep(this.state))
+
+        while (this.internalStep < this.steps.length) {
+            const cycle = this.detectCycle(this.steps[this.internalStep]) 
+            if (cycle !== undefined) {
+                throw Error('Cycle detected in state machine controller: '
+                    + `Step ${this.currentStep} -> Step ${this.previousStates.indexOf(cycle)+1}`)
+            }
+
+            const { nextState, nextSteps, controlSignal } = await this.processNextStep()
+
+            if (controlSignal === ControlSignal.Exit) {
+                return undefined
+            } if (controlSignal === ControlSignal.Retry) {
+                this.state = this.previousStates[this.internalStep]
+                continue
+            } else if (nextState === undefined || controlSignal === ControlSignal.Back) {
+                if (this.internalStep === 0) {
+                    return undefined
+                }
+
+                this.rollbackState()
+            } else {
+                this.advanceState(nextState)
+                this.dynamicBranch(nextSteps)
+            }
+        }
+
+        return this.state
+    }
+}

--- a/src/shared/wizards/wizard.ts
+++ b/src/shared/wizards/wizard.ts
@@ -1,0 +1,204 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Branch, ControlSignal, StateMachineController, StepResult, StepFunction } from './stateController'
+import * as _ from 'lodash'
+import { Prompter, PromptResult } from '../../shared/ui/prompter'
+
+interface ContextOptions<TState, TProp> {
+    /**
+     * Applies a conditional function that is evaluated after every user-input but only if the 
+     * property is either not set or not currently in the state machine. Upon evaluating true, 
+     * the bound prompter will be added as a new step. If multiple prompters resolve to true
+     * in a single resolution step then they will be added in the order in which they were
+     * bound.
+     */
+    showWhen?: (state: WizardState<TState>) => boolean
+    /**
+     * Sets a default value to the target property. This default is applied to the current state
+     * as long as the property has not been set.
+     */
+    setDefault?: (state: WizardState<TState>) => TProp | undefined
+    /**
+     * If set to true the wizard will ignore prompts for already assigned properties (default: true)
+     */
+    implicit?: boolean // not actually implemented
+}
+
+type ObjectKeys<T> = {
+    [Property in keyof T]: T[Property] extends Record<string, unknown> ? Property : never
+}[keyof T]
+
+type NonObjectKeys<T> = {
+    [Property in keyof T]: T[Property] extends Record<string, unknown> ? never : Property
+}[keyof T]
+
+/**
+ * `WizardState` must have all Object-like properties be initialized to an empty object.
+ * All other properties may be left uninitialized.
+ */
+export type WizardState<T> = {
+    [Property in ObjectKeys<T>]-?: T[Property] extends Record<string, unknown> ? 
+        WizardState<T[Property]> : never
+} & {
+    [Property in NonObjectKeys<T>]+?: T[Property] extends Record<string, unknown> ? 
+        never : T[Property]
+}
+
+// We use a symbol to safe-guard against collisions
+const WIZARD_CONTROL = Symbol()
+
+export const WIZARD_RETRY = { id: WIZARD_CONTROL, type: ControlSignal.Retry }
+export const WIZARD_BACK = { id: WIZARD_CONTROL, type: ControlSignal.Back }
+export const WIZARD_EXIT = { id: WIZARD_CONTROL, type: ControlSignal.Exit }
+
+/** Control signals allow for alterations of the normal wizard flow */
+export type WizardControl = typeof WIZARD_RETRY | typeof WIZARD_BACK | typeof WIZARD_EXIT
+
+export function isWizardControl(obj: any): obj is WizardControl {
+    return obj !== undefined && obj.id === WIZARD_CONTROL
+}
+
+function isAssigned<TProp>(obj: TProp): boolean {
+    return obj !== undefined || _.isEmpty(obj) === false 
+}
+
+type PrompterBind<TProp, TState> = (getPrompter: (state: StateWithCache<TState>) => 
+    Prompter<TProp>, options?: ContextOptions<TState, TProp>) => void
+
+interface WizardFormElement<TProp, TState> {
+    /**
+     * Binds a Prompter-provider to the specified property. The provider is called with the current Wizard
+     * state whenever the property is ready for input, and should return a Prompter object.
+     */
+    readonly bindPrompter: PrompterBind<NonNullable<TProp>, TState>
+}
+
+/** Transforms an interface into a collection of WizardFormElements */
+type WizardForm<T, TState=T> = {
+    [Property in keyof T]-?: T[Property] extends Record<string, unknown> 
+        ? (WizardForm<T[Property], TState> & WizardFormElement<T[Property], TState>)
+        : WizardFormElement<T[Property], TState>
+}
+
+// Persistent storage that exists on a per-property basis
+// Potentially useful for remembering resources when the user backs out of a step
+type StepCache = { picked?: any } & { [key: string]: any }
+type StateWithCache<TState> = TState & { stepCache: StepCache }
+
+type StepWithContext<TState, TProp> = ContextOptions<TState, TProp> & { boundStep: StepFunction<TState> }
+
+/**
+ * A generic wizard that consumes data from a series of 'prompts'. Wizards will modify a single property of
+ * their internal state with each prompt. The 'form' public property exposes functionality to add prompters
+ * with optional context.
+ */
+export abstract class Wizard<TState extends Partial<Record<keyof TState, unknown>>, TResult=TState> {
+    private readonly formData = new Map<string, StepWithContext<TState, any>>()
+    public readonly form!: WizardForm<TState> 
+    private readonly stateController!: StateMachineController<TState>
+
+    public constructor(private readonly initState: WizardState<TState>) {
+        this.form = this.createWizardForm(initState)
+        this.stateController = new StateMachineController(initState as TState)
+    }
+
+    private applyDefaults(state: TState): TState {
+        this.formData.forEach((opt, targetProp) => {
+            const current = _.get(state, targetProp)
+
+            if (!isAssigned(current) && opt.setDefault !== undefined) {
+                _.set(state, targetProp, opt.setDefault(state as WizardState<TState>))
+            }
+        })
+
+        return state
+    }
+
+    public async run(): Promise<TState | TResult | undefined> {
+        this.resolveNextSteps(
+                this.initState as TState, 
+                this.applyDefaults(Object.assign({}, this.initState as TState))
+            ).forEach(step => this.stateController.addStep(step))
+        const outputState = await this.stateController.run()
+
+        return outputState !== undefined ? this.applyDefaults(outputState) : undefined       
+    }
+
+    private createBindPrompterMethod<TProp>(prop: string): PrompterBind<TProp, TState> {
+        return (
+            prompterProvider: (form: StateWithCache<TState>) => Prompter<TProp>, 
+            options: ContextOptions<TState, TProp> = {}
+        ): void => {
+            const stepCache: StepCache = {} // Cache will be scoped into the step function, persisting it
+            const boundStep = async (state: TState): Promise<StepResult<TState>> => {
+                const stateWithCache = Object.assign({ stepCache: stepCache }, state) as StateWithCache<TState>
+                this.applyDefaults(stateWithCache)
+                const response = await this.promptUser(stateWithCache, prompterProvider(stateWithCache))
+                _.set(state, prop, response)
+
+                return { 
+                    nextState: state,
+                    nextSteps: this.resolveNextSteps(state, _.set(stateWithCache, prop, response)), 
+                    controlSignal: isWizardControl(response) ? response.type : undefined,
+                }
+            }
+            
+            this.formData.set(prop, { ...options, boundStep })
+        }
+    }
+
+    // A tiny bit of metaprogramming. Types do not exist after compilation, so we need a way to generate 
+    // something that looks like our type. The alternative is to create a TypeScript plugin to traverse 
+    // the AST and initialize typed data structures through a dummy function.
+    private createWizardForm(schema: any, path: string[] = []): WizardForm<TState> { 
+        return new Proxy({}, {
+            get: (__, prop) => {
+                if (prop !== 'bindPrompter') { 
+                    return this.createWizardForm(schema, [...path, prop.toString()])
+                }
+                return this.createBindPrompterMethod(path.join('.'))
+            }
+        }) as WizardForm<TState>
+    }
+
+    // We need to separate the original state from the state with applied defaults. 
+    // Otherwise we cannot be certain that the prompt has not occured.
+    private resolveNextSteps(originalState: TState, defaultState: TState): Branch<TState> {
+        const nextSteps: Branch<TState> = []
+        this.formData.forEach((opt, targetProp) => {
+            const current = _.get(originalState, targetProp)
+
+            if (!isAssigned(current) && !this.stateController.containsStep(opt.boundStep)) {
+                if (opt.showWhen === undefined || opt.showWhen(defaultState as WizardState<TState>) === true) {
+                    nextSteps.push(opt.boundStep)
+                }
+            }
+        })
+        return nextSteps
+    } 
+
+    private async promptUser<TProp>(
+        state: StateWithCache<TState>, 
+        prompter: Prompter<TProp>,
+    ): Promise<PromptResult<TProp>> {
+        prompter.setSteps(this.stateController.currentStep, this.stateController.totalSteps)
+
+        if (state.stepCache.picked !== undefined) {
+            prompter.setLastResponse(state.stepCache.picked)
+        }
+
+        const answer = await prompter.prompt()
+
+        if (!isWizardControl(answer) && answer !== undefined) {
+            state.stepCache.picked = prompter.getLastResponse()
+        }
+
+        // TODO: allow prompters to resolve into more prompters
+        // this allows them to chain together in case of partial-responses
+
+        return answer ?? WIZARD_BACK // Legacy code used 'undefined' to represent back
+    }
+}


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

# Closing this soon in favor of new PR 

## Details

This PR contains the 'core' of the wizard framework (basically everything). I have intentionally excluded test-related changes to make the code easier to review. This also means that **this PR will have a bunch of failing tests** which will be fixed after review. Note that I'm merging this into a separate 'refactor' branch, since I wasn't sure if we wanted to refactor all the wizard stuff in one go or have the new framework live alongside the old stuff temporarily. If the former then I'd just need to name the modified files something else. Otherwise refactoring all the wizard code wouldn't take too long since it's mainly just changing some types and removing a lot of boilerplate. 

Not planning on reworking any of the current wizard tests other than using a simple mock for compatibility. Future tests shouldn't need to be so thorough since many of the things tested are now covered by the wizard controller. An 'ideal' test should just explore different control paths in a wizard (no more 'goes back when cancelled' unit tests, etc.) to validate `showWhen` or `setDefault` clauses. Prompters with additional functionality should have their own unit tests; we should not need to test these within the wizard.

I'd recommend viewing the files first instead of the diffs since a lot of code was reworked.

# TODOs (coming soon):
* Make the existence of any property's parent object a criteria for showing the prompter
  * States effectively become (simple) dependency trees, making `showWhen` clauses much smaller and more intuitive
* Remove `quickInput` and all references from the prompter abstraction
* Differentiate between a 'local' and 'global' state as arguments to the prompter-provider callbacks
* Remove `setDefault` as a context option and instead make it apart of the `WizardForm` interface
* Remove `applySettings` (too risky, may inadvertently overwrite 'hidden' properties) 
* Make `Wizard` not abstract (inheritance does not make much sense for it)

### Keys ideas:
* There now exists a `Prompter` abstraction (found in 'prompter.ts'). The primary function here is `prompt` which returns a generic type T, a control signal (e.g. Back, Retry, etc.), or undefined (to support legacy code).
  * `QuickPickPrompter` and `InputBoxPrompter` implement this abstraction with their respective UI elements
  * Pickers now use a unified `data` property in the QuickPickItem to map items to values. So instead of having an item with `runtime: myRuntime` you would do `data: myRuntime`. Items must be constructed in this manner to be usable by `QuickPickPrompter`.
* Wizards are constructed by 'binding' functions that return a `Prompter` given the current state, plus additional contextual options. The controller construct can be found in 'wizard.ts'. 
  * All wizards expose a public read-only `form` field that gives access to `bindPrompter` on the various properties of the wizard state. Currently only a single property of the state can be modified at each step (not a limitation, more of a design choice).
  * Calling `run` on the wizard will start the IO loop, running until termination. Prompters should be assigned before starting the wizard by convention, though adding them while it's running is possible.
  * Every step the current prompter's `prompt` is called, modifying the state and handling any control signals. Some additional helper functions are used to set the steps, the last response, etc.
* The wizard controller depends on `StateMachineController` to construct a dynamic state machine at runtime using `addStep` and the `nextSteps` field of `StepResult`. Steps are built when `bindPrompter` is called, but are not added unless contextual requirements are met.
  * For example, a major context option is `showWhen`, which is a function that evaluates to a boolean given the current state. When true, the prompter is added to the machine.
  * Order is not explicitly defined. Prompters will be added as soon as they meet the desired requirements. If multiple prompters are ready to be added in a single step, then they are added in the order in which they were originally assigned.

### Example
A refactored `samInitWizard.ts` is included in this PR to show how the new wizards look when implemented. I have not included the modified QuickPicks that exist in other files (`createRuntimeQuickPick` and `createLocationQuickPick`) so this code would not work as-is. 

#### Notes:
* Prompters do not rely on the Wizard and can be used as stand-alone objects. This is useful when you only a single user-response. 
* `IteratingQuickPickController` was removed from 'picker.ts' and made into its own file (thus not included in this PR)
* All prompters have an `after` hook to handle the user's response before it is consumed by the wizard.
* `wizard.ts` uses somewhat advanced TypeScript features such as mapped and conditional types. These aren't necessary but I found them to be very powerful for ensuring type-safety. 
* Regenerating prompters every step is done because `QuickInput` objects are put into a pseudo-disposed state after accepting input. They can be reused but this requires a decent amount of extra logic. Wizard flows don't really have a high-performance requirement so the cost of recreation is negligible. 

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
