### PR TITLE
package: depend on "remote SSH" extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -1535,6 +1535,9 @@
         "newChange": "ts-node ./build-scripts/newChange.ts",
         "createRelease": "ts-node ./build-scripts/createRelease.ts"
     },
+    "extensionDependencies": [
+        "ms-vscode-remote.remote-ssh"
+    ],
     "devDependencies": {
         "@aws-toolkits/telemetry": "0.0.94",
         "@sinonjs/fake-timers": "^7.0.5",


### PR DESCRIPTION
Problem
-------
Some users may not have the Remote feature of vscode.

Solution
--------
Declare a hard dependency on it.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
