### PR TITLE
Use vscode-webview types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
                 "@types/tcp-port-used": "^1.0.0",
                 "@types/uuid": "^8.3.0",
                 "@types/vscode": "1.42.0",
+                "@types/vscode-webview": "^1.57.0",
                 "@types/xml2js": "^0.4.8",
                 "@typescript-eslint/eslint-plugin": "^4.24.0",
                 "@typescript-eslint/parser": "^4.24.0",
@@ -531,6 +532,12 @@
             "version": "1.42.0",
             "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.42.0.tgz",
             "integrity": "sha512-ds6TceMsh77Fs0Mq0Vap6Y72JbGWB8Bay4DrnJlf5d9ui2RSe1wis13oQm+XhguOeH1HUfLGzaDAoupTUtgabw==",
+            "dev": true
+        },
+        "node_modules/@types/vscode-webview": {
+            "version": "1.57.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode-webview/-/vscode-webview-1.57.0.tgz",
+            "integrity": "sha512-x3Cb/SMa1IwRHfSvKaZDZOTh4cNoG505c3NjTqGlMC082m++x/ETUmtYniDsw6SSmYzZXO8KBNhYxR0+VqymqA==",
             "dev": true
         },
         "node_modules/@types/xml2js": {
@@ -10342,6 +10349,12 @@
             "version": "1.42.0",
             "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.42.0.tgz",
             "integrity": "sha512-ds6TceMsh77Fs0Mq0Vap6Y72JbGWB8Bay4DrnJlf5d9ui2RSe1wis13oQm+XhguOeH1HUfLGzaDAoupTUtgabw==",
+            "dev": true
+        },
+        "@types/vscode-webview": {
+            "version": "1.57.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode-webview/-/vscode-webview-1.57.0.tgz",
+            "integrity": "sha512-x3Cb/SMa1IwRHfSvKaZDZOTh4cNoG505c3NjTqGlMC082m++x/ETUmtYniDsw6SSmYzZXO8KBNhYxR0+VqymqA==",
             "dev": true
         },
         "@types/xml2js": {

--- a/package.json
+++ b/package.json
@@ -1558,6 +1558,7 @@
         "@types/tcp-port-used": "^1.0.0",
         "@types/uuid": "^8.3.0",
         "@types/vscode": "1.42.0",
+        "@types/vscode-webview": "^1.57.0",
         "@types/xml2js": "^0.4.8",
         "@typescript-eslint/eslint-plugin": "^4.24.0",
         "@typescript-eslint/parser": "^4.24.0",

--- a/src/lambda/vue/samInvokeVue.ts
+++ b/src/lambda/vue/samInvokeVue.ts
@@ -4,11 +4,11 @@
  */
 
 import Vue, { VNode } from 'vue'
-import { VsCode } from '../../webviews/main'
 import { AwsSamDebuggerConfiguration } from '../../shared/sam/debugger/awsSamDebugConfiguration'
-import { AwsSamDebuggerConfigurationLoose, SamInvokerRequest, SamInvokerResponse, SamInvokeVueState } from './samInvoke'
+import { AwsSamDebuggerConfigurationLoose, SamInvokerResponse, SamInvokeVueState } from './samInvoke'
+import { WebviewApi } from 'vscode-webview'
 
-declare const vscode: VsCode<SamInvokerRequest, SamInvokeVueState>
+declare const vscode: WebviewApi<SamInvokeVueState>
 
 interface VueDataLaunchPropertyObject {
     value: string

--- a/src/webviews/main.ts
+++ b/src/webviews/main.ts
@@ -26,13 +26,6 @@ interface WebviewParams<TRequest, TResponse> {
     onDidDisposeFunction?(): void
 }
 
-// TODO: add types for the state functions
-export interface VsCode<TRequest, State> {
-    postMessage(output: TRequest): void
-    setState(state: State): void
-    getState(): State | undefined
-}
-
 export async function createVueWebview<TRequest, TResponse>(params: WebviewParams<TRequest, TResponse>) {
     const libsPath: string = path.join(params.context.extensionPath, 'media', 'libs')
     const jsPath: string = path.join(params.context.extensionPath, 'media', 'js')


### PR DESCRIPTION
VS Code now has an official type for the [webview-owned `vscode` object](https://code.visualstudio.com/updates/v1_57#_vscodewebviewdts).

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
