### PR TITLE
refactor: DRY extension-check/activate code

### DIFF
--- a/src/integrationTest/globalSetup.test.ts
+++ b/src/integrationTest/globalSetup.test.ts
@@ -8,9 +8,9 @@
  */
 import * as assert from 'assert'
 import { VSCODE_EXTENSION_ID } from '../shared/extensions'
-import { activateExtension } from './integrationTestsUtilities'
 import { getLogger } from '../shared/logger'
 import { WinstonToolkitLogger } from '../shared/logger/winstonToolkitLogger'
+import { activateExtension } from '../shared/utilities/vsCodeUtils'
 
 // ASSUMPTION: Tests are not run concurrently
 
@@ -49,7 +49,7 @@ export function setTestTimeout(testName: string | undefined, ms: number) {
 before(async function () {
     console.log('globalSetup: before()')
     // Needed for getLogger().
-    await activateExtension(VSCODE_EXTENSION_ID.awstoolkit)
+    await activateExtension(VSCODE_EXTENSION_ID.awstoolkit, false)
 
     // Log as much as possible, useful for debugging integration tests.
     getLogger().setLogLevel('debug')

--- a/src/integrationTest/integrationTestsUtilities.ts
+++ b/src/integrationTest/integrationTestsUtilities.ts
@@ -10,24 +10,6 @@ import * as vscode from 'vscode'
 const SECOND = 1000
 export const TIMEOUT = 30 * SECOND
 
-export async function activateExtension(extensionId: string): Promise<vscode.Extension<void>> {
-    console.log(`PID=${process.pid} activateExtension request: ${extensionId}`)
-    const extension: vscode.Extension<void> | undefined = vscode.extensions.getExtension(extensionId)
-
-    if (!extension) {
-        throw new Error(`Extension not found: ${extensionId}`)
-    }
-
-    if (!extension.isActive) {
-        console.log(`PID=${process.pid} Activating extension: ${extensionId}`)
-        await extension.activate()
-    } else {
-        console.log(`PID=${process.pid} Extension is already active: ${extensionId}`)
-    }
-
-    return extension
-}
-
 export async function sleep(miliseconds: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, miliseconds))
 }

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -8,6 +8,7 @@ import { Runtime } from 'aws-sdk/clients/lambda'
 import { mkdirpSync, mkdtemp, removeSync } from 'fs-extra'
 import * as path from 'path'
 import * as vscode from 'vscode'
+import * as vscodeUtils from '../../src/shared/utilities/vsCodeUtils'
 import { DependencyManager } from '../../src/lambda/models/samLambdaRuntime'
 import { helloWorldTemplate } from '../../src/lambda/models/samTemplates'
 import { getSamCliContext } from '../../src/shared/sam/cli/samCliContext'
@@ -355,10 +356,10 @@ async function stopDebugger(logMsg: string | undefined): Promise<void> {
 
 async function activateExtensions(): Promise<void> {
     console.log('Activating extensions...')
-    await testUtils.activateExtension(VSCODE_EXTENSION_ID.python)
-    await testUtils.activateExtension(VSCODE_EXTENSION_ID.go)
-    await testUtils.activateExtension(VSCODE_EXTENSION_ID.java)
-    await testUtils.activateExtension(VSCODE_EXTENSION_ID.javadebug)
+    await vscodeUtils.activateExtension(VSCODE_EXTENSION_ID.python, false)
+    await vscodeUtils.activateExtension(VSCODE_EXTENSION_ID.go, false)
+    await vscodeUtils.activateExtension(VSCODE_EXTENSION_ID.java, false)
+    await vscodeUtils.activateExtension(VSCODE_EXTENSION_ID.javadebug, false)
     console.log('Extensions activated')
 }
 

--- a/src/integrationTest/shared/codelens/samTemplateCodeLensProvider.test.ts
+++ b/src/integrationTest/shared/codelens/samTemplateCodeLensProvider.test.ts
@@ -11,8 +11,8 @@ import { SamTemplateCodeLensProvider } from '../../../shared/codelens/samTemplat
 import { LaunchConfiguration } from '../../../shared/debug/launchConfiguration'
 import { API_TARGET_TYPE, TEMPLATE_TARGET_TYPE } from '../../../shared/sam/debugger/awsSamDebugConfiguration'
 import * as workspaceUtils from '../../../shared/utilities/workspaceUtils'
-import { activateExtension } from '../../../integrationTest/integrationTestsUtilities'
 import { VSCODE_EXTENSION_ID } from '../../../shared/extensions'
+import { activateExtension } from '../../../shared/utilities/vsCodeUtils'
 
 describe('SamTemplateCodeLensProvider', async function () {
     let codeLensProvider: SamTemplateCodeLensProvider = new SamTemplateCodeLensProvider()
@@ -35,7 +35,7 @@ describe('SamTemplateCodeLensProvider', async function () {
         }
 
         // Note: redhat.vscode-yaml no longer works on vscode 1.42
-        await activateExtension(VSCODE_EXTENSION_ID.yaml)
+        await activateExtension(VSCODE_EXTENSION_ID.yaml, false)
 
         const codeLenses = await codeLensProvider.provideCodeLenses(
             document,

--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -14,17 +14,16 @@ import {
     addSamDebugConfiguration,
     AddSamDebugConfigurationInput,
 } from '../sam/debugger/commands/addSamDebugConfiguration'
-import * as javaDebug from '../sam/debugger/javaSamDebug'
-import * as pythonDebug from '../sam/debugger/pythonSamDebug'
 import { SettingsConfiguration } from '../settingsConfiguration'
 import { createQuickPick, promptUser, verifySinglePickerOutput } from '../ui/picker'
-import { localize } from '../utilities/vsCodeUtils'
+import { activateExtension, localize } from '../utilities/vsCodeUtils'
 import { getWorkspaceRelativePath } from '../utilities/workspaceUtils'
 import * as csharpCodelens from './csharpCodeLensProvider'
 import * as javaCodelens from './javaCodeLensProvider'
 import * as pythonCodelens from './pythonCodeLensProvider'
 import * as tsCodelens from './typescriptCodeLensProvider'
 import * as goCodelens from './goCodeLensProvider'
+import { VSCODE_EXTENSION_ID } from '../extensions'
 
 export type Language = 'python' | 'javascript' | 'csharp' | 'go' | 'java'
 
@@ -314,7 +313,7 @@ export async function makePythonCodeLensProvider(
                 return []
             }
             // Try to activate the Python Extension before requesting symbols from a python file
-            await pythonDebug.activatePythonExtensionIfInstalled()
+            activateExtension(VSCODE_EXTENSION_ID.python)
             if (token.isCancellationRequested) {
                 return []
             }
@@ -410,7 +409,7 @@ export async function makeJavaCodeLensProvider(
                 return []
             }
             // Try to activate the Java Extension before requesting symbols from a java file
-            await javaDebug.activateJavaExtensionIfInstalled()
+            await activateExtension(VSCODE_EXTENSION_ID.java)
             if (token.isCancellationRequested) {
                 return []
             }

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -250,9 +250,11 @@ async function activateCodeLensProviders(
 function createYamlExtensionPrompt(): void {
     const neverPromptAgain = ext.context.globalState.get<boolean>(STATE_NAME_SUPPRESS_YAML_PROMPT)
 
-    // only pop this up in VS Code and Insiders since other VS Code-like IDEs (e.g. Theia) may not have a marketplace or contain the YAML plugin
+    // Show this only in VSCode since other VSCode-like IDEs (e.g. Theia) may
+    // not have a marketplace or contain the YAML plugin.
     if (!neverPromptAgain && getIdeType() === IDE.vscode && !vscode.extensions.getExtension(VSCODE_EXTENSION_ID.yaml)) {
-        // these will all be disposed immediately after showing one so the user isn't prompted more than once per session
+        // Disposed immediately after showing one, so the user isn't prompted
+        // more than once per session.
         const yamlPromptDisposables: vscode.Disposable[] = []
 
         // user opens a template file

--- a/src/shared/sam/debugger/javaSamDebug.ts
+++ b/src/shared/sam/debugger/javaSamDebug.ts
@@ -3,24 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as vscode from 'vscode'
 import { getCodeRoot, isImageLambdaConfig } from '../../../lambda/local/debugConfiguration'
 import { RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
-import { ExtContext, VSCODE_EXTENSION_ID } from '../../extensions'
-import { getLogger } from '../../logger'
+import { ExtContext } from '../../extensions'
 import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
-import { runLambdaFunction, makeInputTemplate, waitForPort } from '../localLambdaRunner'
+import { makeInputTemplate, runLambdaFunction, waitForPort } from '../localLambdaRunner'
 import { SamLaunchRequestArgs } from './awsSamDebugger'
-
-export async function activateJavaExtensionIfInstalled() {
-    const extension = vscode.extensions.getExtension(VSCODE_EXTENSION_ID.java)
-
-    // If the extension is not installed, it is not a failure. There may be reduced functionality.
-    if (extension && !extension.isActive) {
-        getLogger().info('Java CodeLens Provider is activating the Java extension')
-        await extension.activate()
-    }
-}
 
 export async function makeJavaConfig(config: SamLaunchRequestArgs): Promise<SamLaunchRequestArgs> {
     if (!config.baseBuildDir) {

--- a/src/shared/sam/debugger/pythonSamDebug.ts
+++ b/src/shared/sam/debugger/pythonSamDebug.ts
@@ -3,29 +3,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Runtime } from 'aws-sdk/clients/lambda'
 import { writeFile } from 'fs-extra'
 import * as os from 'os'
 import * as path from 'path'
-import * as vscode from 'vscode'
 import {
-    isImageLambdaConfig,
-    PythonDebugConfiguration,
-    PythonCloud9DebugConfiguration,
-    PythonPathMapping,
+    isImageLambdaConfig, PythonCloud9DebugConfiguration, PythonDebugConfiguration, PythonPathMapping
 } from '../../../lambda/local/debugConfiguration'
 import { RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
-import { ExtContext, VSCODE_EXTENSION_ID } from '../../extensions'
+import { ext } from '../../extensionGlobals'
+import { ExtContext } from '../../extensions'
 import { fileExists, readFileAsString } from '../../filesystemUtilities'
 import { getLogger } from '../../logger'
 import * as pathutil from '../../utilities/pathUtils'
 import { getLocalRootVariants } from '../../utilities/pathUtils'
 import { Timeout } from '../../utilities/timeoutUtils'
-import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
-import { runLambdaFunction, makeInputTemplate } from '../localLambdaRunner'
-import { SamLaunchRequestArgs } from './awsSamDebugger'
-import { ext } from '../../extensionGlobals'
-import { Runtime } from 'aws-sdk/clients/lambda'
 import { getWorkspaceRelativePath } from '../../utilities/workspaceUtils'
+import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
+import { makeInputTemplate, runLambdaFunction } from '../localLambdaRunner'
+import { SamLaunchRequestArgs } from './awsSamDebugger'
 
 /** SAM will mount the --debugger-path to /tmp/lambci_debug_files */
 const DEBUGPY_WRAPPER_PATH = '/tmp/lambci_debug_files/py_debug_wrapper.py'
@@ -243,16 +239,6 @@ async function waitForIkpdb(debugPort: number, timeout: Timeout) {
     await new Promise<void>(resolve => {
         setTimeout(resolve, 2000)
     })
-}
-
-export async function activatePythonExtensionIfInstalled() {
-    const extension = vscode.extensions.getExtension(VSCODE_EXTENSION_ID.python)
-
-    // If the extension is not installed, it is not a failure. There may be reduced functionality.
-    if (extension && !extension.isActive) {
-        getLogger().info('Python CodeLens Provider is activating the python extension')
-        await extension.activate()
-    }
 }
 
 function getPythonExeAndBootstrap(runtime: Runtime) {

--- a/src/test/shared/utilities/vscodeUtils.test.ts
+++ b/src/test/shared/utilities/vscodeUtils.test.ts
@@ -1,0 +1,22 @@
+/*!
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { VSCODE_EXTENSION_ID } from '../../../shared/extensions'
+import * as vscodeUtil from '../../../shared/utilities/vsCodeUtils'
+
+describe('vscodeUtils', async function () {
+    it('activateExtension(), isExtensionActive()', async function () {
+        assert.deepStrictEqual(await vscodeUtil.activateExtension('invalid.extension'), undefined)
+        await assert.rejects(async () => {
+            await vscodeUtil.activateExtension('invalid', false)
+        })
+
+        assert.deepStrictEqual(vscodeUtil.isExtensionActive('invalid.extension'), false)
+
+        await vscodeUtil.activateExtension(VSCODE_EXTENSION_ID.awstoolkit, false)
+        assert.deepStrictEqual(vscodeUtil.isExtensionActive(VSCODE_EXTENSION_ID.awstoolkit), true)
+    })
+})


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem

Various parts of the codebase need to check if an extension is available and/or activate it, but the logic is duplicated.

## Solution

Deduplicate.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
