### PR TITLE
package: declare explicit extensionKind

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
     "name": "aws-toolkit-vscode",
     "displayName": "AWS Toolkit",
-    "description": "An extension for working with Amazon Web Services",
+    "description": "Amazon Web Services toolkit for browsing and updating cloud resources",
     "version": "1.26.0-SNAPSHOT",
+    "extensionKind": [ "workspace" ],
     "publisher": "amazonwebservices",
     "license": "Apache-2.0",
     "repository": {


### PR DESCRIPTION
Problem
-------
Not obvious how vscode classifies Toolkit.

Solution
--------
Declare the extensionKind explicitly.
This also serves as a form of documentation.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
