### PR TITLE
S3: use getBucketLocation to lookup bucket regions

### DIFF
--- a/.changes/next-release/Bug Fix-00926769-d0c3-4810-8f46-46973a0d5e49.json
+++ b/.changes/next-release/Bug Fix-00926769-d0c3-4810-8f46-46973a0d5e49.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "S3: use getBucketLocation to lookup bucket regions"
+}

--- a/.changes/next-release/Bug Fix-00926769-d0c3-4810-8f46-46973a0d5e49.json
+++ b/.changes/next-release/Bug Fix-00926769-d0c3-4810-8f46-46973a0d5e49.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "S3: use getBucketLocation to lookup bucket regions"
+	"description": "S3: improved performance in private VPC (via getBucketLocation)"
 }

--- a/src/shared/clients/defaultS3Client.ts
+++ b/src/shared/clients/defaultS3Client.ts
@@ -37,7 +37,6 @@ import {
 } from './s3Client'
 
 const DEFAULT_CONTENT_TYPE = 'application/octet-stream'
-const BUCKET_REGION_HEADER = 'x-amz-bucket-region'
 
 export class DefaultS3Client implements S3Client {
     public constructor(
@@ -412,15 +411,15 @@ export class DefaultS3Client implements S3Client {
     /**
      * Looks up the region for the given bucket
      *
-     * Note that although there is an S3#GetBucketLocation API,
-     * this is the suggested method of obtaining the region.
+     * Utilizing the getBucketLocation API to avoid cross region lookups.
      */
     private async lookupRegion(bucketName: string, s3: S3): Promise<string | undefined> {
         getLogger().debug('LookupRegion called for bucketName: %s', bucketName)
 
         try {
-            const response = await s3.headBucket({ Bucket: bucketName }).promise()
-            const region = response.$response.httpResponse.headers[BUCKET_REGION_HEADER]
+            const response = await s3.getBucketLocation({ Bucket: bucketName }).promise()
+            // getBucketLocation returns an explicit empty string location contraint for us-east-1
+            const region = response.LocationConstraint === '' ? 'us-east-1' : response.LocationConstraint
             getLogger().debug('LookupRegion returned region: %s', region)
             return region
         } catch (e) {

--- a/src/shared/clients/defaultS3Client.ts
+++ b/src/shared/clients/defaultS3Client.ts
@@ -411,7 +411,7 @@ export class DefaultS3Client implements S3Client {
     /**
      * Looks up the region for the given bucket
      *
-     * Utilizing the getBucketLocation API to avoid cross region lookups.
+     * Use the getBucketLocation API to avoid cross region lookups.
      */
     private async lookupRegion(bucketName: string, s3: S3): Promise<string | undefined> {
         getLogger().debug('LookupRegion called for bucketName: %s', bucketName)

--- a/src/shared/clients/s3Client.ts
+++ b/src/shared/clients/s3Client.ts
@@ -21,7 +21,7 @@ export interface S3Client {
      * Lists buckets in the region of the client.
      *
      * Note that S3 returns all buckets in all regions,
-     * so this incurs the cost of additional S3#HeadBucket requests for each bucket
+     * so this incurs the cost of additional S3#getBucketLocation requests for each bucket
      * to filter out buckets residing outside of the client's region.
      *
      * @throws Error if there is an error calling S3.


### PR DESCRIPTION
Problem
-------
headBucket calls are redirected to bucket local region endpoints. Cross WAN calls are expensive and not always possible.

Solution
--------
Use the getBucketLocation API to discover bucket regions staying within the client's configured region.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.