### PR TITLE
S3: Add existing bucket (WIP)

### DIFF
--- a/package.json
+++ b/package.json
@@ -968,9 +968,14 @@
                     "group": "0@2"
                 },
                 {
-                    "command": "aws.s3.createBucket",
+                    "command": "aws.s3.addBucket",
                     "when": "view == aws.explorer && viewItem == awsS3Node",
                     "group": "0@1"
+                },
+                {
+                    "command": "aws.s3.createBucket",
+                    "when": "view == aws.explorer && viewItem == awsS3Node",
+                    "group": "0@2"
                 },
                 {
                     "command": "aws.s3.downloadFileAs",
@@ -1171,6 +1176,11 @@
                 "title": "%AWS.command.s3.createFolder%",
                 "category": "AWS",
                 "icon": "$(new-folder)"
+            },
+            {
+                "command": "aws.s3.addBucket",
+                "title": "%AWS.command.s3.addBucket%",
+                "category": "AWS"
             },
             {
                 "command": "aws.s3.createBucket",

--- a/package.nls.json
+++ b/package.nls.json
@@ -160,6 +160,7 @@
     "AWS.command.quickStart.error": "There was an error retrieving the Quick Start page",
     "AWS.command.s3.downloadFileAs": "Download As...",
     "AWS.command.s3.copyPath": "Copy Path",
+    "AWS.command.s3.addBucket": "Add Existing Bucket...",
     "AWS.command.s3.createBucket": "Create Bucket...",
     "AWS.command.s3.createFolder": "Create Folder...",
     "AWS.command.s3.uploadFile": "Upload File...",

--- a/src/awsexplorer/regionNode.ts
+++ b/src/awsexplorer/regionNode.ts
@@ -59,7 +59,7 @@ export class RegionNode extends AWSTreeNodeBase {
             ...(isCloud9() ? [] : [{ serviceId: 'logs', createFn: () => new CloudWatchLogsNode(this.regionCode) }]),
             {
                 serviceId: 's3',
-                createFn: () => new S3Node(ext.toolkitClientBuilder.createS3Client(this.regionCode)),
+                createFn: () => new S3Node(ext.toolkitClientBuilder.createS3Client(this.regionCode), this.regionCode),
             },
             ...(isCloud9() ? [] : [{ serviceId: 'schemas', createFn: () => new SchemasNode(this.regionCode) }]),
             ...(isCloud9() ? [] : [{ serviceId: 'states', createFn: () => new StepFunctionsNode(this.regionCode) }]),

--- a/src/s3/activation.ts
+++ b/src/s3/activation.ts
@@ -16,6 +16,7 @@ import { S3BucketNode } from './explorer/s3BucketNode'
 import { S3FolderNode } from './explorer/s3FolderNode'
 import { S3Node } from './explorer/s3Nodes'
 import { S3FileNode } from './explorer/s3FileNode'
+import { addBucketCommand } from './commands/addBucket'
 
 /**
  * Activates S3 components.
@@ -33,6 +34,9 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
         }),
         vscode.commands.registerCommand('aws.s3.uploadFileToParent', async (node: S3FileNode) => {
             await uploadFileToParentCommand(node)
+        }),
+        vscode.commands.registerCommand('aws.s3.addBucket', async (node: S3Node) => {
+            await addBucketCommand(node)
         }),
         vscode.commands.registerCommand('aws.s3.createBucket', async (node: S3Node) => {
             await createBucketCommand(node)

--- a/src/s3/commands/addBucket.ts
+++ b/src/s3/commands/addBucket.ts
@@ -1,0 +1,50 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getLogger } from '../../shared/logger'
+import { localize } from '../../shared/utilities/vsCodeUtils'
+import { Commands } from '../../shared/vscode/commands'
+import { Window } from '../../shared/vscode/window'
+import { S3Node } from '../explorer/s3Nodes'
+import { showErrorWithLogs } from '../../shared/utilities/messages'
+import { validateBucketName } from '../util'
+
+export async function addBucketCommand(
+    node: S3Node,
+    window = Window.vscode(),
+    commands = Commands.vscode()
+): Promise<void> {
+    getLogger().debug('[s3]: addBucket called for: %O', node)
+
+    const bucketName = await window.showInputBox({
+        prompt: localize('AWS.s3.addBucket.prompt', 'Enter an existing bucket name'),
+        placeHolder: localize('AWS.s3.addBucket.placeHolder', 'Bucket Name'),
+        validateInput: validateBucketName,
+    })
+
+    if (!bucketName) {
+        getLogger().debug('[s3]: addBucket cancelled')
+        return
+    }
+
+    getLogger().info(`Adding bucket: ${bucketName}`)
+    try {
+        const bucket = await node.addBucket(bucketName)
+
+        getLogger().info('Added bucket: %O', bucket)
+        window.showInformationMessage(localize('AWS.s3.addBucket.success', 'Added bucket: {0}', bucketName))
+        await refreshNode(node, commands)
+    } catch (e) {
+        getLogger().error(`Failed to add bucket ${bucketName}: %O`, e)
+        showErrorWithLogs(
+            localize('AWS.s3.addBucket.error.general', 'Failed to add bucket: {0}', bucketName),
+            window
+        )
+    }
+}
+
+async function refreshNode(node: S3Node, commands: Commands): Promise<void> {
+    return commands.execute('aws.refreshAwsExplorerNode', node)
+}

--- a/src/s3/explorer/s3Nodes.ts
+++ b/src/s3/explorer/s3Nodes.ts
@@ -12,6 +12,7 @@ import { PlaceholderNode } from '../../shared/treeview/nodes/placeholderNode'
 import { makeChildrenNodes } from '../../shared/treeview/treeNodeUtilities'
 import { S3BucketNode } from './s3BucketNode'
 import { inspect } from 'util'
+import { AWSCommandTreeNode } from '../../shared/treeview/nodes/awsCommandTreeNode'
 
 /**
  * An AWS Explorer node representing S3.
@@ -19,7 +20,9 @@ import { inspect } from 'util'
  * Contains buckets for a specific region as child nodes.
  */
 export class S3Node extends AWSTreeNodeBase {
-    public constructor(private readonly s3: S3Client) {
+    private readonly addedBuckets: S3BucketNode[] = []
+
+    public constructor(private readonly s3: S3Client, private readonly regionCode: string) {
         super('S3', vscode.TreeItemCollapsibleState.Collapsed)
         this.contextValue = 'awsS3Node'
     }
@@ -27,15 +30,38 @@ export class S3Node extends AWSTreeNodeBase {
     public async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => {
-                const response = await this.s3.listBuckets()
-
-                return response.buckets.map(bucket => new S3BucketNode(bucket, this, this.s3))
+                return this.listBucketNodes()
             },
             getErrorNode: async (error: Error, logID: number) =>
                 new ErrorNode(this, error, logID),
             getNoChildrenPlaceholderNode: async () =>
                 new PlaceholderNode(this, localize('AWS.explorerNode.s3.noBuckets', '[No Buckets found]')),
         })
+    }
+
+    private async listBucketNodes(): Promise<(S3BucketNode | AWSCommandTreeNode)[]> {
+        try {
+            const response = await this.s3.listBuckets()
+            return response.buckets.map(bucket => new S3BucketNode(bucket, this, this.s3))
+        } catch (err) {
+            if (err.code === 'AccessDenied') {
+                if (this.addedBuckets.length === 0) {
+                    const localizedText = localize('AWS.explorerNode.s3.addBucket', 'Click to add existing bucket')
+                    return [new AWSCommandTreeNode(this, localizedText, 'aws.s3.addBucket', [this])]
+                } 
+
+                return this.addedBuckets
+            } else {
+                throw err
+            }
+        }
+    }
+
+    public async addBucket(bucketName: string): Promise<void> {
+        await this.s3.listFiles({ bucketName })
+        // For now, there isn't a good way to get a bucket's region + ARN from its name.
+        const bucket = { name: bucketName, region: this.regionCode, arn: `arn:aws:s3:::${bucketName}` }
+        this.addedBuckets.push(new S3BucketNode(bucket, this, this.s3))
     }
 
     /**

--- a/src/test/s3/commands/addBucket.test.ts
+++ b/src/test/s3/commands/addBucket.test.ts
@@ -1,17 +1,17 @@
 /*!
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 import * as assert from 'assert'
-import { createBucketCommand } from '../../../s3/commands/createBucket'
+import { addBucketCommand } from '../../../s3/commands/addBucket'
 import { S3Node } from '../../../s3/explorer/s3Nodes'
 import { S3Client } from '../../../shared/clients/s3Client'
 import { FakeCommands } from '../../shared/vscode/fakeCommands'
 import { FakeWindow } from '../../shared/vscode/fakeWindow'
 import { anything, mock, instance, when, deepEqual, verify } from '../../utilities/mockito'
 
-describe('createBucketCommand', function () {
+describe('addBucketCommand', function () {
     const bucketName = 'buc.ket-n4.m3'
     const region = 'region'
     let s3: S3Client
@@ -23,37 +23,38 @@ describe('createBucketCommand', function () {
     })
 
     it('prompts for bucket name, creates bucket, shows success, and refreshes node', async function () {
-        when(s3.createBucket(deepEqual({ bucketName }))).thenResolve({
-            bucket: { name: bucketName, region, arn: 'arn' },
+        when(s3.listFiles(deepEqual({ bucketName }))).thenResolve({
+            files: [],
+            folders: [],
         })
 
         const window = new FakeWindow({ inputBox: { input: bucketName } })
         const commands = new FakeCommands()
-        await createBucketCommand(node, window, commands)
+        await addBucketCommand(node, window, commands)
 
-        assert.strictEqual(window.inputBox.options?.prompt, 'Enter a new bucket name')
+        assert.strictEqual(window.inputBox.options?.prompt, 'Enter an existing bucket name')
         assert.strictEqual(window.inputBox.options?.placeHolder, 'Bucket Name')
 
-        assert.strictEqual(window.message.information, 'Created bucket: buc.ket-n4.m3')
+        assert.strictEqual(window.message.information, 'Added bucket: buc.ket-n4.m3')
 
         assert.strictEqual(commands.command, 'aws.refreshAwsExplorerNode')
         assert.deepStrictEqual(commands.args, [node])
     })
 
     it('does nothing when prompt is cancelled', async function () {
-        await createBucketCommand(node, new FakeWindow(), new FakeCommands())
+        await addBucketCommand(node, new FakeWindow(), new FakeCommands())
 
         verify(s3.createFolder(anything())).never()
     })
 
-    it('shows an error message and refreshes node when bucket creation fails', async function () {
-        when(s3.createBucket(anything())).thenReject(new Error('Expected failure'))
+    it('shows an error message and does nothing when adding fails', async function () {
+        when(s3.listFiles(anything())).thenReject(new Error('Expected failure'))
 
         const window = new FakeWindow({ inputBox: { input: bucketName } })
         const commands = new FakeCommands()
-        await createBucketCommand(node, window, commands)
+        await addBucketCommand(node, window, commands)
 
-        assert.ok(window.message.error?.includes('Failed to create bucket'))
+        assert.ok(window.message.error?.includes('Failed to add bucket'))
 
         assert.strictEqual(commands.command, 'aws.refreshAwsExplorerNode')
         assert.deepStrictEqual(commands.args, [node])
@@ -62,7 +63,7 @@ describe('createBucketCommand', function () {
     it('warns when bucket name is invalid', async function () {
         const window = new FakeWindow({ inputBox: { input: 'gg' } })
         const commands = new FakeCommands()
-        await createBucketCommand(node, window, commands)
+        await addBucketCommand(node, window, commands)
 
         assert.strictEqual(window.inputBox.errorMessage, 'Bucket name must be between 3 and 63 characters long')
     })

--- a/src/test/s3/commands/createFolder.test.ts
+++ b/src/test/s3/commands/createFolder.test.ts
@@ -21,6 +21,7 @@ describe('createFolderCommand', function () {
     const folderName = 'foo'
     const folderPath = 'foo/'
     const bucketName = 'bucket-name'
+    const region = 'region'
 
     let s3: S3Client
     let node: S3BucketNode
@@ -28,8 +29,8 @@ describe('createFolderCommand', function () {
     beforeEach(function () {
         s3 = mock()
         node = new S3BucketNode(
-            { name: bucketName, region: 'region', arn: 'arn' },
-            new S3Node(instance(s3)),
+            { name: bucketName, region, arn: 'arn' },
+            new S3Node(instance(s3), region),
             instance(s3)
         )
     })

--- a/src/test/s3/commands/deleteBucket.test.ts
+++ b/src/test/s3/commands/deleteBucket.test.ts
@@ -15,6 +15,7 @@ import { anything, mock, instance, when, deepEqual, verify } from '../../utiliti
 
 describe('deleteBucketCommand', function () {
     const bucketName = 'bucket-name'
+    const region = 'region'
 
     let s3: S3Client
     let parentNode: S3Node
@@ -22,8 +23,8 @@ describe('deleteBucketCommand', function () {
 
     beforeEach(function () {
         s3 = mock()
-        parentNode = new S3Node(instance(s3))
-        node = new S3BucketNode({ name: bucketName, region: 'region', arn: 'arn' }, parentNode, instance(s3))
+        parentNode = new S3Node(instance(s3), region)
+        node = new S3BucketNode({ name: bucketName, region, arn: 'arn' }, parentNode, instance(s3))
     })
 
     it('confirms deletion, deletes bucket, shows progress bar, and refreshes parent node', async function () {

--- a/src/test/s3/commands/uploadFile.test.ts
+++ b/src/test/s3/commands/uploadFile.test.ts
@@ -16,6 +16,7 @@ import { anything, mock, instance, when, capture, verify } from '../../utilities
 
 describe('uploadFileCommand', function () {
     const bucketName = 'bucket-name'
+    const region = 'region'
     const key = 'file.jpg'
     const sizeBytes = 16
     const fileLocation = vscode.Uri.file('/file.jpg')
@@ -27,8 +28,8 @@ describe('uploadFileCommand', function () {
     beforeEach(function () {
         s3 = mock()
         node = new S3BucketNode(
-            { name: bucketName, region: 'region', arn: 'arn' },
-            new S3Node(instance(s3)),
+            { name: bucketName, region, arn: 'arn' },
+            new S3Node(instance(s3), region),
             instance(s3)
         )
     })

--- a/src/test/s3/explorer/s3BucketNode.test.ts
+++ b/src/test/s3/explorer/s3BucketNode.test.ts
@@ -17,8 +17,9 @@ import { FakeWorkspace } from '../../shared/vscode/fakeWorkspace'
 
 describe('S3BucketNode', function () {
     const name = 'bucket-name'
+    const region = 'region'
     const continuationToken = 'continuationToken'
-    const bucket: Bucket = { name, region: 'region', arn: 'arn' }
+    const bucket: Bucket = { name, region, arn: 'arn' }
     const file: File = { name: 'name', key: 'key', arn: 'arn' }
     const folder: Folder = { name: 'folder', path: 'path', arn: 'arn' }
     const maxResults = 200
@@ -62,7 +63,7 @@ describe('S3BucketNode', function () {
                 section: 'aws',
                 configuration: { key: 's3.maxItemsPerPage', value: maxResults },
             })
-            const node = new S3BucketNode(bucket, new S3Node(instance(s3)), instance(s3), workspace)
+            const node = new S3BucketNode(bucket, new S3Node(instance(s3), region), instance(s3), workspace)
             const [folderNode, fileNode, ...otherNodes] = await node.getChildren()
 
             assertFolderNode(folderNode, folder)
@@ -81,7 +82,7 @@ describe('S3BucketNode', function () {
                 section: 'aws',
                 configuration: { key: 's3.maxItemsPerPage', value: maxResults },
             })
-            const node = new S3BucketNode(bucket, new S3Node(instance(s3)), instance(s3), workspace)
+            const node = new S3BucketNode(bucket, new S3Node(instance(s3), region), instance(s3), workspace)
             const [folderNode, fileNode, moreResultsNode, ...otherNodes] = await node.getChildren()
 
             assertFolderNode(folderNode, folder)

--- a/src/test/s3/explorer/s3Nodes.test.ts
+++ b/src/test/s3/explorer/s3Nodes.test.ts
@@ -11,8 +11,9 @@ import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
 import { instance, mock, when } from '../../utilities/mockito'
 
 describe('S3Node', function () {
-    const firstBucket: Bucket = { name: 'first-bucket-name', region: 'firstRegion', arn: 'firstArn' }
-    const secondBucket: Bucket = { name: 'second-bucket-name', region: 'secondRegion', arn: 'secondArn' }
+    const region = 'region'
+    const firstBucket: Bucket = { name: 'first-bucket-name', region, arn: 'firstArn' }
+    const secondBucket: Bucket = { name: 'second-bucket-name', region, arn: 'secondArn' }
 
     let s3: S3Client
 
@@ -30,7 +31,7 @@ describe('S3Node', function () {
             buckets: [firstBucket, secondBucket],
         })
 
-        const node = new S3Node(instance(s3))
+        const node = new S3Node(instance(s3), region)
         const [firstBucketNode, secondBucketNode, ...otherNodes] = await node.getChildren()
 
         assertBucketNode(firstBucketNode, firstBucket)


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
See #1793

## Solution
Allow users to add existing buckets to S3Nodes (this currently has no effect if the user's role has access to 'ListBuckets'). 
TODO: refactor some of the test code (it's basically copy-pasted)

Example (second name is an example of when the bucket exists or the user does not have access to it):
![Kapture 2021-06-14 at 14 38 44](https://user-images.githubusercontent.com/31319484/121963371-e20abe80-cd1e-11eb-9a58-c62a6b6e31af.gif)


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
