### PR TITLE
integ/test: --disable-workspace-trust

### DIFF
--- a/test-scripts/integrationTest.ts
+++ b/test-scripts/integrationTest.ts
@@ -8,6 +8,8 @@ import { runTests } from 'vscode-test'
 import { VSCODE_EXTENSION_ID } from '../src/shared/extensions'
 import { installVSCodeExtension, setupVSCodeTestInstance, getCliArgsToDisableExtensions } from './launchTestUtilities'
 
+const DISABLE_WORKSPACE_TRUST = '--disable-workspace-trust'
+
 async function setupVSCode(): Promise<string> {
     console.log('Setting up VS Code Test instance...')
     const vsCodeExecutablePath = await setupVSCodeTestInstance()
@@ -45,7 +47,7 @@ async function setupVSCode(): Promise<string> {
             vscodeExecutablePath: vsCodeExecutablePath,
             extensionDevelopmentPath: cwd,
             extensionTestsPath: testEntrypoint,
-            launchArgs: [...disableExtensions, workspacePath],
+            launchArgs: [...disableExtensions, workspacePath, DISABLE_WORKSPACE_TRUST],
         }
         console.log(`runTests() args:\n${JSON.stringify(args, undefined, 2)}`)
         const result = await runTests(args)


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

VS code 1.57 introduced a 'trust' feature that is applied to the current workspace, restricting extension access based on trust level. The insiders build allows individual extensions to have a trust level, by default they are untrusted. Untrusted extensions cannot be activated, thus failing the test. We are not particularly concerned with this functionality in regards to other extensions, so we will just disable it entirely when testing.

We should look into this more for our own extension as far as UX is concerned (what should our extension be capable of given a minimum trust level?)

Refer to this issue: https://github.com/microsoft/vscode/issues/120251

Considerations for the toolkit (to be added to `package.json`):
```javascript
capabilities:
	untrustedWorkspaces:
		{ supported: true } |
		{ supported: false, description: string } |
		{ supported: 'limited', description: string, restrictedConfigurations?: string[] }
```
By default, extensions do not support untrusted workspaces. This seems to be the best option for the toolkit for now. In other words, we do not need to update anything unless we want to add a `description` string for why we do not support untrusted workspaces.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
