### PR TITLE
UI: state machine controller (wizard framework 1/3)

### DIFF
--- a/src/shared/wizards/stateController.ts
+++ b/src/shared/wizards/stateController.ts
@@ -1,0 +1,139 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as _ from 'lodash'
+
+export enum ControlSignal { Retry, Exit, Back, Continue }
+
+export interface StepResult<TState> {
+    /** A mutated form of the present state. This will be passed along to the next step */
+    nextState?: TState
+    /** An array of step functions to be added immediately after the most recent step */
+    nextSteps?: StepFunction<TState>[]
+    /** Extra control instructions separate from the normal linear traversal of states */
+    controlSignal?: ControlSignal
+}
+
+/**
+ * State machine transition function. Transforms the present state into a new one, which may also
+ * include additional steps or control signals. The function can return the state directly if nothing
+ * extra is needed.
+ */
+export type StepFunction<TState> = (state: TState) => Promise<StepResult<TState> | TState>
+export type Branch<TState> = StepFunction<TState>[]
+
+/**
+ * State machine with backtracking and dynamic branching functionality.
+ * Transitions are abstracted away as a 'step' function, which return both the new state and any extra 
+ * steps that the machine should use.
+ */
+export class StateMachineController<TState> {
+    private previousStates: TState[] = []
+    private extraSteps = new Map<number, Branch<TState>>()
+    private steps: Branch<TState> = []
+    private internalStep: number = 0
+
+    public constructor(private state: TState = {} as TState) {
+        this.previousStates = [_.cloneDeep(state)]
+    }
+
+    public addStep(step: StepFunction<TState>): void {
+        this.steps.push(step)
+    }
+
+    public containsStep(step: StepFunction<TState> | undefined): boolean {
+        return step !== undefined && this.steps.indexOf(step) > -1
+    }
+
+    public get currentStep(): number { return this.internalStep + 1 }
+    public get totalSteps(): number { return this.steps.length }
+
+    protected rollbackState(): void { // TODO: refactor this to separate protected vs public
+        if (this.internalStep === 0) {
+            return
+        }
+
+        if (this.extraSteps.has(this.internalStep)) {
+            this.steps.splice(this.internalStep, this.extraSteps.get(this.internalStep)!.length)
+            this.extraSteps.delete(this.internalStep)
+        }
+
+        this.state = this.previousStates.pop()!
+        this.internalStep -= 1
+    }
+
+    protected advanceState(nextState: TState): void {
+        this.previousStates.push(this.state)
+        this.state = nextState
+        this.internalStep += 1
+    }
+
+    protected detectCycle(step: StepFunction<TState>): TState | undefined {
+        return this.previousStates.find((pastState, index) => index !== this.internalStep && 
+            (this.steps[index] === step && _.isEqual(this.state, pastState)))
+    }
+
+    /** Add new steps dynamically at runtime. Only used internally. */
+    protected dynamicBranch(nextSteps: Branch<TState> | undefined): void {
+        if (nextSteps !== undefined && nextSteps.length > 0) {
+            this.steps.splice(this.internalStep, 0, ...nextSteps)
+            this.extraSteps.set(this.internalStep, nextSteps)
+        }
+    }
+
+    protected async processNextStep(): Promise<StepResult<TState>> {
+        const result = await this.steps[this.internalStep](_.cloneDeep(this.state))
+
+        function isMachineResult(result: any): result is StepResult<TState> {
+            return (result !== undefined && 
+                (result.nextState !== undefined || result.nextSteps !== undefined || result.controlSignal !== undefined))
+        }
+
+        if (isMachineResult(result)) {
+            return result
+        } else {
+            return { nextState: result }
+        }
+    }
+
+    /**
+     * Runs the added steps until termination or failure.
+     * @returns The final state or `undefined` if the machine exited.
+     */
+    public async run(): Promise<TState | undefined> {
+        while (this.internalStep < this.steps.length) {
+            const cycle = this.detectCycle(this.steps[this.internalStep]) 
+            if (cycle !== undefined) {
+                throw Error('Cycle detected in state machine controller: '
+                    + `Step ${this.currentStep} -> Step ${this.previousStates.indexOf(cycle)+1}`)
+            }
+
+            const { nextState, nextSteps, controlSignal } = await this.processNextStep()
+
+            if (controlSignal === ControlSignal.Exit) {
+                return undefined
+            } if (controlSignal === ControlSignal.Retry) {
+                this.state = this.previousStates[this.internalStep]
+                continue
+            } else if (nextState === undefined || controlSignal === ControlSignal.Back) {
+                if (this.internalStep === 0) {
+                    return undefined
+                }
+
+                this.rollbackState()
+            } else {
+                this.advanceState(nextState)
+                this.dynamicBranch(nextSteps)
+            }
+        }
+
+        const result = _.cloneDeep(this.state)
+        if (this.internalStep === this.steps.length) {
+            this.rollbackState()
+        }
+
+        return result
+    }
+}

--- a/src/shared/wizards/stateController.ts
+++ b/src/shared/wizards/stateController.ts
@@ -50,7 +50,7 @@ export class StateMachineController<TState> {
     public get currentStep(): number { return this.internalStep + 1 }
     public get totalSteps(): number { return this.steps.length }
 
-    protected rollbackState(): void { // TODO: refactor this to separate protected vs public
+    protected rollbackState(): void {
         if (this.internalStep === 0) {
             return
         }

--- a/src/test/lambda/wizards/stateController.test.ts
+++ b/src/test/lambda/wizards/stateController.test.ts
@@ -1,0 +1,217 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import * as sinon from 'sinon'
+import { StateMachineController, ControlSignal, StepResult } from '../../../shared/wizards/stateController'
+
+function assertStepsPassthrough<T>(
+    controller: StateMachineController<T>, 
+    current: number, 
+    total: number, 
+    result?: StepResult<T>
+): StepResult<T> | undefined {
+    assert.strictEqual(controller.currentStep, current)
+    assert.strictEqual(controller.totalSteps, total)
+    return result
+}
+
+describe('StateMachineController', function () {
+    it('runs with no steps', async function () {
+        const controller = new StateMachineController()
+        await assert.doesNotReject(controller.run())
+    })
+
+    it('handles undefined steps', async function () {
+        const controller = new StateMachineController()
+        controller.addStep(async () => ({ nextState: {}, nextSteps: undefined }))
+        await assert.doesNotReject(controller.run())
+    })
+
+    it('can exit mid-run', async function() {
+        const controller = new StateMachineController<number>()
+        const step1 = sinon.stub()
+        const step2 = sinon.stub()
+        const step3 = sinon.stub()
+        step1.returns(0)
+        step2.returns({ controlSignal: ControlSignal.Exit })
+        step3.returns(1)
+        controller.addStep(step1)
+        controller.addStep(step2)
+        controller.addStep(step3)
+
+        assert.strictEqual(await controller.run(), undefined, 'State machine did not exit with an undefined state')
+        assert.strictEqual(step3.called, false, 'The third step should not be called')
+    })
+
+    it('detects cycle', async function() {
+        const controller = new StateMachineController<number>()
+        const step1 = sinon.stub()
+        const step2 = sinon.stub()
+        step1.returns({})
+        step2.onFirstCall().returns(undefined)
+        step2.onSecondCall().returns({ nextState: {}, nextSteps: [step1] })
+        controller.addStep(step1)
+        controller.addStep(step2)
+
+        await assert.rejects(controller.run(), /Cycle/)
+    })
+
+    it('can add the same function as a step multiple times', async function() {
+        const controller = new StateMachineController<number>()
+        const step1 = sinon.stub()
+        step1.onFirstCall().returns(0)
+        step1.onSecondCall().returns(1)
+        controller.addStep(step1)
+        controller.addStep(step1)
+
+        assert.strictEqual(await controller.run(), 1)
+    })
+
+    it('step functions do not have side effects', async function() {
+        const mystate = { mystring: '', isGood: true }
+        const controller = new StateMachineController<{ mystring: string, isGood: boolean }>(mystate)
+        const step1 = sinon.stub()
+        const step2 = sinon.stub()
+        const step3 = sinon.stub()
+        step1.callsFake(state => {
+            assert.strictEqual(state.mystring, '')
+            state.mystring = 'a string'
+            return state
+        })
+        step2.callsFake(state => {
+            const last = state.isGood
+            state.isGood = false
+            return { ...state, isGood: last }
+        })
+        step3.onFirstCall().returns(undefined)
+        step3.onSecondCall().callsFake(state => state)
+        controller.addStep(step1)
+        controller.addStep(step2)
+        controller.addStep(step3)
+
+        const result = await controller.run()
+        assert.strictEqual(result?.mystring, 'a string')
+        assert.strictEqual(result?.isGood, true)
+    })
+
+    describe('retry', function () {
+        it('repeats current step', async function () {
+            const controller = new StateMachineController()
+            const stub = sinon.stub()
+            stub.onFirstCall().returns({ controlSignal: ControlSignal.Retry })
+            stub.onSecondCall().returns({})
+            controller.addStep(stub)
+
+            await controller.run()
+
+            assert.strictEqual(stub.callCount, 2)
+        })
+
+        it('does not remember state on retry', async function () {
+            const controller = new StateMachineController<{ answer: boolean }>()
+            const stub = sinon.stub()
+            stub.onFirstCall().returns({ nextState: { answer: true }, controlSignal: ControlSignal.Retry })
+            stub.onSecondCall().returns({ answer: false })
+            controller.addStep(stub)
+
+            assert.strictEqual((await controller.run())?.answer, false)
+            assert.strictEqual(stub.callCount, 2)
+        })
+    })
+
+    describe('branching', function () {
+        it('supports multiple steps per branch', async function () {
+            const controller = new StateMachineController()
+            const step1 = sinon.stub()
+            const branchStep1 = sinon.stub()
+            const branchStep2 = sinon.stub()
+            step1.returns({ nextState: {}, nextSteps: [branchStep1, branchStep2] })
+            branchStep1.callsFake(state => assertStepsPassthrough(controller, 2, 3, { nextState: state }))
+            branchStep2.returns({})
+            controller.addStep(step1)
+
+            assert.notStrictEqual(await controller.run(), undefined)
+        })
+
+        it('branches can also branch', async function () {
+            const controller = new StateMachineController()
+            const step1 = sinon.stub()
+            const branch1Step1 = sinon.stub()
+            const branch1Step2 = sinon.stub()
+            const branch2 = sinon.stub()
+            const step5 = sinon.stub()
+            step1.returns({ nextState: {}, nextSteps: [branch1Step1, branch1Step2] })
+            branch1Step1.callsFake(state => assertStepsPassthrough(controller, 2, 4, state))
+            branch1Step2.returns({ nextState: {}, nextSteps: [branch2] })
+            branch2.callsFake(state => assertStepsPassthrough(controller, 4, 5, state))
+            step5.returns({})
+            controller.addStep(step1)
+            controller.addStep(step5)
+
+            assert.notStrictEqual(await controller.run(), undefined)
+        })
+    })
+
+    describe('go back', function () {
+        it('goes back', async function () {
+            const controller = new StateMachineController()
+            const step1 = sinon.stub()
+            const step2 = sinon.stub()
+            step1.returns({})
+            step2.onFirstCall().returns(undefined)
+            step2.onSecondCall().returns({})
+            controller.addStep(step1)
+            controller.addStep(step2)
+
+            await controller.run()
+
+            assert.strictEqual(step1.callCount, 2)
+            sinon.assert.callOrder(step1, step2, step1, step2)
+        })
+
+        it('goes back and terminates', async function () {
+            const controller = new StateMachineController()
+            const step1 = sinon.stub()
+            const step2 = sinon.stub()
+            step1.onFirstCall().returns({})
+            step2.onFirstCall().returns(undefined)
+            step1.onSecondCall().returns(undefined)
+            controller.addStep(step1)
+            controller.addStep(step2)
+
+            assert.strictEqual(await controller.run(), undefined)
+            assert.strictEqual(step1.callCount, 2)
+            sinon.assert.callOrder(step1, step2, step1)
+        })
+
+        it('handles branches', async function () {
+            const controller = new StateMachineController<{ branch1: string, branch2: string }>()
+            const step1 = sinon.stub()
+            const branch1 = sinon.stub()
+            const branch2 = sinon.stub()
+            const step3 = sinon.stub()
+            // step1 -> branch1 -> step1 -> branch2 -> step3 -> branch2 -> step3 -> terminate
+            step1.onFirstCall().returns({ nextState: { branch2: 'no' }, nextSteps: [branch1] })
+            step1.onSecondCall().callsFake(() => 
+                assertStepsPassthrough(controller, 1, 2, { nextState: { branch1: 'no', branch2: 'no' }, nextSteps: [branch2] } )
+            )
+            branch1.returns(undefined)
+            branch2.callsFake(state =>
+                assertStepsPassthrough(controller, 2, 3, { nextState: { branch2: 'yes', branch1: state.branch1 } })
+            )
+            step3.onFirstCall().returns(undefined)
+            step3.onSecondCall().callsFake(state => state)
+            controller.addStep(step1)
+            controller.addStep(step3)
+
+            const finalState = await controller.run()
+            assert.ok(finalState !== undefined)
+            assert.strictEqual(finalState.branch1, 'no')
+            assert.strictEqual(finalState.branch2, 'yes')
+            sinon.assert.callOrder(step1, branch1, step1, branch2, step3, branch2, step3)
+        })
+    })
+})


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->
### Future PRs:
* Wizard controller + `Prompter` abstraction will be second
  * This is the biggest one since it includes a testing framework
* Concrete implementations of the `Prompter` abstraction will be the final PR

### Overview
State machine controller that will be used in later PRs for the new wizard framework. Will eventually replace `multiStepWizard.ts` and related tests. The interface is different enough that it cannot replace it directly.

New capabilities:
* States are remembered and handled exclusively by the controller. This prevents mutation of state outside transitions.
* Multiple steps can be added to the machine at runtime as a group, allowing for dynamic branching.
* Decouples transitions from the state management logic. 
* Exposes the current step and total number of steps that the controller currently has.

### How does this work?
The state controller can be thought of as a higher-order state machine (a pushdown automaton) that can inject any number of new steps into its sequence at runtime. Initially, the controller will start with whatever steps are added through `addStep`. For example, say we add steps `A`, `B` and `C`, then the flow will look like this:
```
 A -> B -> C 
```

Each step is just a function that determines both the next state and whatever extra steps the controller should add. In this example, let's say step `B` decides steps `D` and `E` should be added:
```
 A -> B          C 
        \       /
          D -> E
```
Of course, if we go back a step from `D` then that branch will cease to exist, reverting back to the original flow. Step `B` is then processed once more, deciding what the next state and steps are. Since every step can create new steps, sophisticated flows can arise without compromising the resulting state. Note that in the above example, the steps should be thought of more as the _transitions_ between states, while the actual states are the arrows (initial and final state not included)

### How does this fit with other pieces?
The wizard controller will use this class to handle execution of steps and keep track of the proper state. Wizard steps encapsulate the current state plus an external input from a `Prompter` to determine the next state (assignment of a field) and next steps (what can we show given the new state?). The public 'step' fields will also be passed to `Prompter` objects so they can process them accordingly.

### Why?
Managing state in Javascript, and especially with UI, is very difficult since everything is an object. Having a separate class handling it makes life much simpler and avoids side effects.

## I will be writing documentation that will live within the repo in regards to using the new framework. This PR is more just an explanation of the individual component.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
