### PR TITLE
CloudWatch Logs: fix timestamp

### DIFF
--- a/.changes/next-release/Bug Fix-4dea5c66-129e-462f-9bfe-4c04e074b9fd.json
+++ b/.changes/next-release/Bug Fix-4dea5c66-129e-462f-9bfe-4c04e074b9fd.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CloudWatch Logs: timestamps were incorrectly shown in 12 hour notation instead of 24 hour notation"
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -74,8 +74,8 @@ export const debugNewSamAppUrl: string = isCloud9()
 export const LOCALIZED_DATE_FORMAT = 'll LTS [GMT]ZZ'
 
 // moment().format() matches Insights console timestamp, e.g.: 2019-03-04T11:40:08.781-08:00
-// TODO: Do we want this this verbose? Log stream just shows hh:mm:ss
-export const INSIGHTS_TIMESTAMP_FORMAT = 'YYYY-MM-DDThh:mm:ss.SSSZ'
+// TODO: Do we want this this verbose? Log stream just shows HH:mm:ss
+export const INSIGHTS_TIMESTAMP_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSSZ'
 
 /**
  * URI scheme for CloudWatch Logs Virtual Documents

--- a/src/test/cloudWatchLogs/registry/logStreamRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logStreamRegistry.test.ts
@@ -166,4 +166,12 @@ describe('LogStreamRegistry', async function () {
             assert.strictEqual(registry.hasLog(missingRegisteredUri), false)
         })
     })
+
+    describe('Timestamp', function () {
+        it('matches CloudWatch insights timestamps', function() {
+            const time = 1624201162222 // 2021-06-20 14:59:22.222 GMT+0
+            const timestamp = moment.utc(time).format(INSIGHTS_TIMESTAMP_FORMAT)
+            assert.strictEqual(timestamp, '2021-06-20T14:59:22.222+00:00')
+        })
+    })
 })


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->
Timestamp was 12 hour notation instead of 24.
Fixes #1820

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
