### PR TITLE
telemetry: do not record explorer refresh from 'refreshAwsExplorerNode'

### DIFF
--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -124,9 +124,12 @@ async function registerAwsExplorerCommands(
     )
 
     context.subscriptions.push(
-        vscode.commands.registerCommand('aws.refreshAwsExplorer', async () => {
-            recordAwsRefreshExplorer()
+        vscode.commands.registerCommand('aws.refreshAwsExplorer', async (emitTelemetry: boolean = true) => {
             awsExplorer.refresh()
+
+            if (emitTelemetry === true) {
+                recordAwsRefreshExplorer()
+            }
         })
     )
 

--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -170,11 +170,7 @@ async function registerAwsExplorerCommands(
 
     context.subscriptions.push(
         vscode.commands.registerCommand('aws.refreshAwsExplorerNode', async (element: AWSTreeNodeBase) => {
-            try {
-                awsExplorer.refresh(element)
-            } finally {
-                recordAwsRefreshExplorer()
-            }
+            awsExplorer.refresh(element)
         })
     )
 

--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -169,7 +169,7 @@ async function registerAwsExplorerCommands(
     )
 
     context.subscriptions.push(
-        vscode.commands.registerCommand('aws.refreshAwsExplorerNode', async (element: AWSTreeNodeBase) => {
+        vscode.commands.registerCommand('aws.refreshAwsExplorerNode', async (element: AWSTreeNodeBase | undefined) => {
             awsExplorer.refresh(element)
         })
     )

--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -124,10 +124,10 @@ async function registerAwsExplorerCommands(
     )
 
     context.subscriptions.push(
-        vscode.commands.registerCommand('aws.refreshAwsExplorer', async (emitTelemetry: boolean = true) => {
+        vscode.commands.registerCommand('aws.refreshAwsExplorer', async (passive: boolean = false) => {
             awsExplorer.refresh()
 
-            if (emitTelemetry === true) {
+            if (!passive) {
                 recordAwsRefreshExplorer()
             }
         })

--- a/src/lambda/commands/deploySamApplication.ts
+++ b/src/lambda/commands/deploySamApplication.ts
@@ -111,8 +111,8 @@ export async function deploySamApplication(
         )
 
         await deployApplicationPromise
-        // no need to await, doesn't need to block further execution
-        vscode.commands.executeCommand('aws.refreshAwsExplorerNode')
+        // no need to await, doesn't need to block further execution (false -> no telemetry)
+        vscode.commands.executeCommand('aws.refreshAwsExplorer', false)
 
         // successful deploy: retain S3 bucket for quick future access
         const profile = awsContext.getCredentialProfileName()

--- a/src/lambda/commands/deploySamApplication.ts
+++ b/src/lambda/commands/deploySamApplication.ts
@@ -111,8 +111,8 @@ export async function deploySamApplication(
         )
 
         await deployApplicationPromise
-        // no need to await, doesn't need to block further execution (false -> no telemetry)
-        vscode.commands.executeCommand('aws.refreshAwsExplorer', false)
+        // no need to await, doesn't need to block further execution (true -> no telemetry)
+        vscode.commands.executeCommand('aws.refreshAwsExplorer', true)
 
         // successful deploy: retain S3 bucket for quick future access
         const profile = awsContext.getCredentialProfileName()

--- a/src/lambda/commands/deploySamApplication.ts
+++ b/src/lambda/commands/deploySamApplication.ts
@@ -112,7 +112,7 @@ export async function deploySamApplication(
 
         await deployApplicationPromise
         // no need to await, doesn't need to block further execution
-        vscode.commands.executeCommand('aws.refreshAwsExplorer')
+        vscode.commands.executeCommand('aws.refreshAwsExplorerNode')
 
         // successful deploy: retain S3 bucket for quick future access
         const profile = awsContext.getCredentialProfileName()


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

The toolkit currently does not discriminate between user-initiated and code-initiated refreshes.
If we want to record refreshes made by our own code then we should use a separate metric.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
