### PR TITLE
cloud9: enable CloudWatch Logs component

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
                     "default": 5000,
                     "description": "%AWS.ssmDocument.ssm.maxItemsComputed.desc%"
                 },
-                "aws.cloudwatchLogs.limit": {
+                "aws.cloudWatchLogs.limit": {
                     "type": "number",
                     "default": 10000,
                     "description": "%AWS.cloudWatchLogs.limit.desc%",
@@ -694,11 +694,11 @@
                 },
                 {
                     "command": "aws.copyLogStreamName",
-                    "when": "resourceScheme == awsCloudWatchLogs && !isCloud9"
+                    "when": "resourceScheme == awsCloudWatchLogs"
                 },
                 {
                     "command": "aws.saveCurrentLogStreamContent",
-                    "when": "resourceScheme == awsCloudWatchLogs && !isCloud9"
+                    "when": "resourceScheme == awsCloudWatchLogs"
                 },
                 {
                     "command": "aws.cloudWatchLogs.viewLogStream",
@@ -785,7 +785,7 @@
                 },
                 {
                     "command": "aws.saveCurrentLogStreamContent",
-                    "when": "resourceScheme == awsCloudWatchLogs && !isCloud9",
+                    "when": "resourceScheme == awsCloudWatchLogs",
                     "group": "navigation"
                 },
                 {
@@ -797,7 +797,7 @@
             "editor/title/context": [
                 {
                     "command": "aws.copyLogStreamName",
-                    "when": "resourceScheme == awsCloudWatchLogs && !isCloud9",
+                    "when": "resourceScheme == awsCloudWatchLogs",
                     "group": "1_cutcopypaste@1"
                 }
             ],
@@ -1074,7 +1074,7 @@
                 {
                     "command": "aws.cloudWatchLogs.viewLogStream",
                     "group": "0@1",
-                    "when": "view == aws.explorer && viewItem == awsCloudWatchLogNode && !isCloud9"
+                    "when": "view == aws.explorer && viewItem == awsCloudWatchLogNode"
                 },
                 {
                     "command": "aws.ssmDocument.openLocalDocumentYaml",

--- a/src/awsexplorer/regionNode.ts
+++ b/src/awsexplorer/regionNode.ts
@@ -56,7 +56,7 @@ export class RegionNode extends AWSTreeNodeBase {
                 createFn: () => new EcrNode(ext.toolkitClientBuilder.createEcrClient(this.regionCode)),
             },
             { serviceId: 'lambda', createFn: () => new LambdaNode(this.regionCode) },
-            ...(isCloud9() ? [] : [{ serviceId: 'logs', createFn: () => new CloudWatchLogsNode(this.regionCode) }]),
+            { serviceId: 'logs', createFn: () => new CloudWatchLogsNode(this.regionCode) },
             {
                 serviceId: 's3',
                 createFn: () => new S3Node(ext.toolkitClientBuilder.createS3Client(this.regionCode)),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -225,11 +225,11 @@ export async function activate(context: vscode.ExtensionContext) {
         await activateS3(context)
 
         await activateEcr(context)
+        
+        await activateCloudWatchLogs(context, toolkitSettings)
 
         // Features which aren't currently functional in Cloud9
         if (!isCloud9()) {
-            await activateCloudWatchLogs(context, toolkitSettings)
-
             await activateSchemas({
                 context: extContext.extensionContext,
                 outputChannel: toolkitOutputChannel,


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

Notes:
* Basic workflow (right-click log group -> view log stream -> load newer and older codelenses) is successful
* Save Current Log and Copy Log Stream Name do not show up in the explorer or in the editor's top bar.
  * The above functions DO show up when you right-click an editor tab. However, this is currently causing an issue: once these options become visible in a right-click menu, they appear in the right-click menu for all other editor nodes, and persist with behavior permanently: the option in all right click menus will copy the text from the first Cloudwatch Logs editor opened, and won't be removed or overwritten by closing the tab or opening a new log stream.
* The editor is not readonly and can be written in.
  * The CWL implementation will overwrite all text on loading new entries so this is not a huge concern.
* The editor can be saved via Ctrl/Command + S.
  * This will automatically save the file based on the CWL file's URI. e.g. a log stream with URI `awsCloudWatchLogs:/aws/lambda/aaaaaaaaa-HelloWorldFunction-213F8XHPWFMY:2021/05/06/[$LATEST]D9f453fce26834e3fb8118f42e16ee3a7:us-west-2` will get saved as `~/environment/awsCloudWatchLogs:/aws/lambda/aaaaaaaaa-HelloWorldFunction-213F8XHPWFMY%3A2021/05/06/%5B%24LATEST%5D9f453fce26834e3fb8118f42e16ee3a7%3Aus-west-2`

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
