### PR TITLE
Add 'AWS: ' to codelenses in source files

### DIFF
--- a/src/integrationTest/shared/codelens/samTemplateCodeLensProvider.test.ts
+++ b/src/integrationTest/shared/codelens/samTemplateCodeLensProvider.test.ts
@@ -47,12 +47,12 @@ describe('SamTemplateCodeLensProvider', async function () {
 
         const expectedCodeLens = [
             new vscode.CodeLens(new vscode.Range(25, 4, 30, 30), {
-                title: 'Add Debug Configuration',
+                title: 'AWS: Add Debug Configuration',
                 command: 'aws.addSamDebugConfiguration',
                 arguments: [{ resourceName: 'Function2NotInLaunchJson', rootUri: templateUri }, TEMPLATE_TARGET_TYPE],
             }),
             new vscode.CodeLens(new vscode.Range(31, 4, 42, 35), {
-                title: 'Add Debug Configuration',
+                title: 'AWS: Add Debug Configuration',
                 command: 'aws.addSamDebugConfiguration',
                 arguments: [{ resourceName: 'Function3NotInLaunchJson', rootUri: templateUri }, TEMPLATE_TARGET_TYPE],
             }),
@@ -62,7 +62,7 @@ describe('SamTemplateCodeLensProvider', async function () {
             0,
             0,
             new vscode.CodeLens(new vscode.Range(37, 12, 42, 35), {
-                title: 'Add API Debug Configuration',
+                title: 'AWS: Add API Debug Configuration',
                 command: 'aws.addSamDebugConfiguration',
                 arguments: [{ resourceName: 'Function3NotInLaunchJson', rootUri: templateUri }, API_TARGET_TYPE],
             })

--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -114,8 +114,14 @@ function makeAddCodeSamDebugCodeLens(
     openWebview: boolean
 ): vscode.CodeLens {
     const title = openWebview
-        ? `${getIdeProperties().company}: ${localize('AWS.codelens.lambda.configEditor', 'Edit Debug Configuration (Beta)')}`
-        : `${getIdeProperties().company}: ${localize('AWS.command.addSamDebugConfiguration', 'Add Debug Configuration')}`
+        ? `${getIdeProperties().company}: ${localize(
+              'AWS.codelens.lambda.configEditor',
+              'Edit Debug Configuration (Beta)'
+          )}`
+        : `${getIdeProperties().company}: ${localize(
+              'AWS.command.addSamDebugConfiguration',
+              'Add Debug Configuration'
+          )}`
     const command: vscode.Command = {
         title,
         command: 'aws.pickAddSamDebugConfiguration',

--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -24,6 +24,7 @@ import * as pythonCodelens from './pythonCodeLensProvider'
 import * as tsCodelens from './typescriptCodeLensProvider'
 import * as goCodelens from './goCodeLensProvider'
 import { VSCODE_EXTENSION_ID } from '../extensions'
+import { getIdeProperties } from '../extensionUtilities'
 
 export type Language = 'python' | 'javascript' | 'csharp' | 'go' | 'java'
 
@@ -113,8 +114,8 @@ function makeAddCodeSamDebugCodeLens(
     openWebview: boolean
 ): vscode.CodeLens {
     const title = openWebview
-        ? localize('AWS.codelens.lambda.configEditor', 'Edit Debug Configuration (Beta)')
-        : localize('AWS.command.addSamDebugConfiguration', 'Add Debug Configuration')
+        ? `${getIdeProperties().company}: ${localize('AWS.codelens.lambda.configEditor', 'Edit Debug Configuration (Beta)')}`
+        : `${getIdeProperties().company}: ${localize('AWS.command.addSamDebugConfiguration', 'Add Debug Configuration')}`
     const command: vscode.Command = {
         title,
         command: 'aws.pickAddSamDebugConfiguration',

--- a/src/shared/codelens/samTemplateCodeLensProvider.ts
+++ b/src/shared/codelens/samTemplateCodeLensProvider.ts
@@ -7,6 +7,7 @@ import * as _ from 'lodash'
 import * as vscode from 'vscode'
 import { TemplateFunctionResource, TemplateSymbolResolver } from '../cloudformation/templateSymbolResolver'
 import { getConfigsMappedToTemplates, LaunchConfiguration } from '../debug/launchConfiguration'
+import { getIdeProperties } from '../extensionUtilities'
 import { TEMPLATE_TARGET_TYPE, API_TARGET_TYPE } from '../sam/debugger/awsSamDebugConfiguration'
 import { AddSamDebugConfigurationInput } from '../sam/debugger/commands/addSamDebugConfiguration'
 import { localize } from '../utilities/vsCodeUtils'
@@ -59,8 +60,14 @@ export class SamTemplateCodeLensProvider implements vscode.CodeLensProvider {
         }
         const title =
             resource.kind === 'api'
-                ? localize('AWS.command.addSamApiDebugConfiguration', 'Add API Debug Configuration')
-                : localize('AWS.command.addSamDebugConfiguration', 'Add Debug Configuration')
+                ? `${getIdeProperties().company}: ${localize(
+                    'AWS.command.addSamApiDebugConfiguration',
+                    'Add API Debug Configuration'
+                  )}`
+                : `${getIdeProperties().company}: ${localize(
+                    'AWS.command.addSamDebugConfiguration',
+                    'Add Debug Configuration'
+                  )}`
         return new vscode.CodeLens(resource.range, {
             title: title,
             command: 'aws.addSamDebugConfiguration',


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Unclear that codelenses represent AWS functionality

## Solution
Add "AWS: " (or "Amazon: " in China-vended assets) to codelenses in source files. Does not apply to CFN or SAM templates since there should be clear context that this is tied to AWS (can revisit this decision later)

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
