### PR TITLE
StepFunctions: use 'Beside' instead of 'One' to show state machine

### DIFF
--- a/src/stepFunctions/commands/visualizeStateMachine/aslVisualization.ts
+++ b/src/stepFunctions/commands/visualizeStateMachine/aslVisualization.ts
@@ -178,7 +178,7 @@ export class AslVisualization {
                     case 'viewDocument':
                         try {
                             const document = await vscode.workspace.openTextDocument(documentUri)
-                            vscode.window.showTextDocument(document, vscode.ViewColumn.One)
+                            vscode.window.showTextDocument(document, vscode.ViewColumn.Beside)
                         } catch (e) {
                             logger.error(e as Error)
                         }


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

Tests expect the new editor to show up to the right of the old one. Use 'Beside' for the editor column to achieve this. Apparently using 'One' worked for older versions but this was fixed.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
