### PR TITLE
clients: drop DEFAULT_REGION, use getCredentialDefaultregion()

### DIFF
--- a/src/awsexplorer/defaultRegion.ts
+++ b/src/awsexplorer/defaultRegion.ts
@@ -53,9 +53,6 @@ export async function checkExplorerForDefaultRegion(
     awsExplorer: AwsExplorer
 ): Promise<void> {
     const profileRegion = awsContext.getCredentialDefaultRegion()
-    if (!profileRegion) {
-        return
-    }
 
     const explorerRegions = new Set(await awsContext.getExplorerRegions())
     if (explorerRegions.has(profileRegion)) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -226,10 +226,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
         await activateSam(extContext)
 
-        await activateS3(context)
+        await activateS3(extContext)
 
         await activateEcr(context)
-        
+
         await activateCloudWatchLogs(context, toolkitSettings)
 
         // Features which aren't currently functional in Cloud9

--- a/src/s3/activation.ts
+++ b/src/s3/activation.ts
@@ -17,7 +17,6 @@ import { S3FolderNode } from './explorer/s3FolderNode'
 import { S3Node } from './explorer/s3Nodes'
 import { S3FileNode } from './explorer/s3FileNode'
 import { ext } from '../shared/extensionGlobals'
-import { DEFAULT_REGION } from '../shared/regions/regionUtilities'
 import { DefaultAwsContext } from '../shared/defaultAwsContext'
 
 /**
@@ -34,7 +33,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
         vscode.commands.registerCommand('aws.s3.uploadFile', async (node: S3BucketNode | S3FolderNode) => {
             if (!node) {
                 const awsContext = new DefaultAwsContext(ext.context)
-                const regionCode = awsContext.getCredentialDefaultRegion() ?? DEFAULT_REGION
+                const regionCode = awsContext.getCredentialDefaultRegion()
                 const s3Client = ext.toolkitClientBuilder.createS3Client(regionCode)
                 const document = vscode.window.activeTextEditor?.document.uri
                 await uploadFileCommand(s3Client, document)

--- a/src/s3/activation.ts
+++ b/src/s3/activation.ts
@@ -17,13 +17,13 @@ import { S3FolderNode } from './explorer/s3FolderNode'
 import { S3Node } from './explorer/s3Nodes'
 import { S3FileNode } from './explorer/s3FileNode'
 import { ext } from '../shared/extensionGlobals'
-import { DefaultAwsContext } from '../shared/defaultAwsContext'
+import { ExtContext } from '../shared/extensions'
 
 /**
  * Activates S3 components.
  */
-export async function activate(extensionContext: vscode.ExtensionContext): Promise<void> {
-    extensionContext.subscriptions.push(
+export async function activate(ctx: ExtContext): Promise<void> {
+    ctx.extensionContext.subscriptions.push(
         vscode.commands.registerCommand('aws.s3.copyPath', async (node: S3FolderNode | S3FileNode) => {
             await copyPathCommand(node)
         }),
@@ -32,7 +32,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
         }),
         vscode.commands.registerCommand('aws.s3.uploadFile', async (node: S3BucketNode | S3FolderNode) => {
             if (!node) {
-                const awsContext = new DefaultAwsContext(ext.context)
+                const awsContext = ctx.awsContext
                 const regionCode = awsContext.getCredentialDefaultRegion()
                 const s3Client = ext.toolkitClientBuilder.createS3Client(regionCode)
                 const document = vscode.window.activeTextEditor?.document.uri

--- a/src/shared/awsContext.ts
+++ b/src/shared/awsContext.ts
@@ -31,7 +31,7 @@ export interface AwsContext {
 
     getCredentialAccountId(): string | undefined
 
-    getCredentialDefaultRegion(): string | undefined
+    getCredentialDefaultRegion(): string
 
     getExplorerRegions(): Promise<string[]>
 

--- a/src/shared/regions/regionUtilities.ts
+++ b/src/shared/regions/regionUtilities.ts
@@ -7,12 +7,11 @@ import { AwsContext } from '../awsContext'
 import { Region } from './endpoints'
 import { RegionProvider } from './regionProvider'
 
-export const DEFAULT_REGION = 'us-east-1'
 export const DEFAULT_PARTITION = 'aws'
 export const DEFAULT_DNS_SUFFIX = 'amazonaws.com'
 
 export function getRegionsForActiveCredentials(awsContext: AwsContext, regionProvider: RegionProvider): Region[] {
-    const defaultRegionId = awsContext.getCredentialDefaultRegion() ?? DEFAULT_REGION
+    const defaultRegionId = awsContext.getCredentialDefaultRegion()
     const partitionId = regionProvider.getPartitionId(defaultRegionId) ?? DEFAULT_PARTITION
 
     return regionProvider.getRegions(partitionId)

--- a/src/stepFunctions/commands/publishStateMachine.ts
+++ b/src/stepFunctions/commands/publishStateMachine.ts
@@ -23,8 +23,6 @@ import {
 
 import { VALID_SFN_PUBLISH_FORMATS, YAML_FORMATS } from '../constants/aslFormats'
 
-const DEFAULT_REGION: string = 'us-east-1'
-
 export async function publishStateMachine(awsContext: AwsContext, outputChannel: vscode.OutputChannel) {
     const logger: Logger = getLogger()
 
@@ -58,13 +56,7 @@ export async function publishStateMachine(awsContext: AwsContext, outputChannel:
         }
     }
 
-    let region = awsContext.getCredentialDefaultRegion()
-    if (!region) {
-        region = DEFAULT_REGION
-        logger.info(
-            `Default region in credentials profile is not set. Falling back to ${DEFAULT_REGION} for publishing a state machine.`
-        )
-    }
+    const region = awsContext.getCredentialDefaultRegion()
 
     const client: StepFunctionsClient = ext.toolkitClientBuilder.createStepFunctionsClient(region)
 

--- a/src/test/shared/regions/regionUtilities.test.ts
+++ b/src/test/shared/regions/regionUtilities.test.ts
@@ -44,14 +44,14 @@ describe('getRegionsForActiveCredentials', async function () {
         fnGetRegions = sandbox.stub()
         fnGetRegions.returns(samplePartitionRegions)
 
-        awsContext = ({
+        awsContext = {
             getCredentialDefaultRegion: fnGetCredentialDefaultRegion,
-        } as any) as AwsContext
+        } as any as AwsContext
 
-        regionProvider = ({
+        regionProvider = {
             getPartitionId: fnGetPartitionId,
             getRegions: fnGetRegions,
-        } as any) as RegionProvider
+        } as any as RegionProvider
     })
 
     afterEach(function () {
@@ -66,7 +66,7 @@ describe('getRegionsForActiveCredentials', async function () {
     })
 
     it('defaults to the standard partition if no default region is found', async function () {
-        fnGetCredentialDefaultRegion.returns(undefined)
+        fnGetCredentialDefaultRegion.returns('us-east-1')
 
         getRegionsForActiveCredentials(awsContext, regionProvider)
         assert.ok(fnGetPartitionId.alwaysCalledWith('us-east-1'), 'expected default region to be used')

--- a/src/test/utilities/fakeAwsContext.ts
+++ b/src/test/utilities/fakeAwsContext.ts
@@ -59,10 +59,10 @@ export interface FakeAwsContextParams {
     contextCredentials?: AwsContextCredentials
 }
 
+const DEFAULT_REGION = 'us-east-1'
 export class FakeAwsContext implements AwsContext {
-    public onDidChangeContext: vscode.Event<ContextChangeEventsArgs> = new vscode.EventEmitter<
-        ContextChangeEventsArgs
-    >().event
+    public onDidChangeContext: vscode.Event<ContextChangeEventsArgs> =
+        new vscode.EventEmitter<ContextChangeEventsArgs>().event
     private awsContextCredentials: AwsContextCredentials | undefined
 
     public constructor(params?: FakeAwsContextParams) {
@@ -85,8 +85,8 @@ export class FakeAwsContext implements AwsContext {
         return this.awsContextCredentials?.accountId
     }
 
-    public getCredentialDefaultRegion(): string | undefined {
-        return this.awsContextCredentials?.defaultRegion
+    public getCredentialDefaultRegion(): string {
+        return this.awsContextCredentials?.defaultRegion ?? DEFAULT_REGION
     }
 
     public async getExplorerRegions(): Promise<string[]> {


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
DEFAULT_REGION was used on activate.ts

## Solution
Elevated the usage to getCredentialDefaultregion()

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
