### PR TITLE
telemetry: do not include user agent

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,4 +3,4 @@
 
 git secrets --register-aws || (echo 'Please install git-secrets https://github.com/awslabs/git-secrets to check for accidentally commited secrets!' && exit 1)
 git secrets --pre_commit_hook -- ""
-pretty-quick --staged
+node_modules/.bin/pretty-quick --staged

--- a/src/shared/telemetry/defaultTelemetryClient.ts
+++ b/src/shared/telemetry/defaultTelemetryClient.ts
@@ -14,6 +14,7 @@ import { MetricDatum } from './clienttelemetry'
 import apiConfig = require('./service-2.json')
 import { TelemetryClient } from './telemetryClient'
 import { TelemetryFeedback } from './telemetryFeedback'
+import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
 
 export class DefaultTelemetryClient implements TelemetryClient {
     public static readonly DEFAULT_IDENTITY_POOL = 'us-east-1:820fd6d1-95c0-4ca4-bffb-3f01d32da842'
@@ -91,13 +92,14 @@ export class DefaultTelemetryClient implements TelemetryClient {
             (await ext.sdkClientBuilder.createAwsService(
                 Service,
                 {
-                    // @ts-ignore: apiConfig is internal and not in the TS declaration file
+                    // apiConfig is internal and not in the TS declaration file
                     apiConfig: apiConfig,
                     region: region,
                     credentials: credentials,
                     correctClockSkew: true,
                     endpoint: DefaultTelemetryClient.DEFAULT_TELEMETRY_ENDPOINT,
-                },
+                } as ServiceConfigurationOptions,
+                undefined,
                 false
             )) as ClientTelemetry
         )

--- a/src/test/shared/defaultAwsClientBuilder.test.ts
+++ b/src/test/shared/defaultAwsClientBuilder.test.ts
@@ -18,7 +18,7 @@ describe('DefaultAwsClientBuilder', function () {
             }
         }
 
-        it('includes custom user-agent if no options are specified', async function () {
+        it('includes Toolkit user-agent if no options are specified', async function () {
             const builder = new DefaultAWSClientBuilder(new FakeAwsContext())
             const service = await builder.createAwsService(FakeService)
 
@@ -27,14 +27,6 @@ describe('DefaultAwsClientBuilder', function () {
                 service.config.customUserAgent!.replace('---Insiders', ''),
                 `AWS-Toolkit-For-VSCode/testPluginVersion Visual-Studio-Code/${version}`
             )
-        })
-
-        it('includes custom user-agent if not specified in options', async function () {
-            const builder = new DefaultAWSClientBuilder(new FakeAwsContext())
-            const service = await builder.createAwsService(FakeService, {})
-
-            assert.strictEqual(!!service.config.customUserAgent, true)
-            assert.notStrictEqual(service.config.customUserAgent, undefined)
         })
 
         it('does not override custom user-agent if specified in options', async function () {


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem

- 9edae9a accidentally removed an argument in the createAwsService() call, but it was not caught because of `@ts-ignore`.
- Also: 
    - code style: point to locally-installed pretty-quick. Don't require that `pretty-quick` is globally installed.

## Solution

- Use a cast instead of `@ts-ignore`.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
