### PR TITLE
CFN: fix bad default export

### DIFF
--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -358,7 +358,7 @@ export namespace CloudFormation {
 
         const templateAsYaml: string = await filesystemUtilities.readFileAsString(filename)
         const template = yaml.load(templateAsYaml, {
-            schema: new yaml.Schema(schema),
+            schema: schema as any,
         }) as Template
         validateTemplate(template)
 
@@ -504,7 +504,9 @@ export namespace CloudFormation {
      */
     function isRef(property: unknown): boolean {
         return (
-            typeof property === 'object' && Object.keys(property!).length === 1 && Object.keys(property!).includes('Ref')
+            typeof property === 'object' &&
+            Object.keys(property!).length === 1 &&
+            Object.keys(property!).includes('Ref')
         )
     }
 
@@ -701,7 +703,7 @@ export namespace CloudFormation {
         } = {}
     ): string | number | undefined {
         if (typeof property !== 'object') {
-            return property as string | number | undefined 
+            return property as string | number | undefined
         }
         if (isRef(property)) {
             try {


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

Webpack was resolving the schema module differently than TSC. So building with webpack resulted in a different import. Apparently js-yaml also lies about the types it accepts, so just using both exports works correctly.
ES6 modules are fun.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
