### PR TITLE
project: drop some recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,12 +1,5 @@
 {
     // See http://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
-    "recommendations": [
-        "christian-kohler.npm-intellisense",
-        "christian-kohler.path-intellisense",
-        "davidanson.vscode-markdownlint",
-        "dbaeumer.vscode-eslint",
-        "eg2.vscode-npm-script",
-        "ms-python.python"
-    ]
+    "recommendations": ["dbaeumer.vscode-eslint", "eg2.vscode-npm-script"]
 }


### PR DESCRIPTION
These extensions are not particularly related to this project, developers should install whatever they prefer for typescript/npm work.

Also markdownlint makes recommendations that are not necessarily aligned with our build tooling. Furthermore it is redundant, because our build lints itself, and prettier autoformats at commit-time.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
