### PR TITLE
CloudWatch Logs: normal placeholder

### DIFF
--- a/.changes/next-release/Bug Fix-e72a3c2c-d389-4664-8058-388265d03812.json
+++ b/.changes/next-release/Bug Fix-e72a3c2c-d389-4664-8058-388265d03812.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CloudWatch Logs: show a placeholder message instead of an error when no logs exist"
+}

--- a/src/cloudWatchLogs/explorer/cloudWatchLogsNode.ts
+++ b/src/cloudWatchLogs/explorer/cloudWatchLogsNode.ts
@@ -33,13 +33,9 @@ export class CloudWatchLogsNode extends AWSTreeNodeBase {
 
                 return [...this.logGroupNodes.values()]
             },
-            getErrorNode: async (error: Error, logID: number) =>
-                new ErrorNode(this, error, logID),
+            getErrorNode: async (error: Error, logID: number) => new ErrorNode(this, error, logID),
             getNoChildrenPlaceholderNode: async () =>
-                new PlaceholderNode(
-                    this,
-                    localize('AWS.explorerNode.cloudWatchLogs.error', 'Error loading CloudWatch Logs resources')
-                ),
+                new PlaceholderNode(this, localize('AWS.explorerNode.cloudWatchLogs.placeholder', '[No Logs found]')),
             sort: (nodeA: LogGroupNode, nodeB: LogGroupNode) => nodeA.name.localeCompare(nodeB.name),
         })
     }


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

If a user has no logs the placeholder currently looks like an error. Make the placeholder clarify that no logs exist (which is not an error).

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
