### PR TITLE
feat: add ECS credentials provider

### DIFF
--- a/.changes/next-release/Feature-159d0360-1d9d-439a-aaf4-624434216694.json
+++ b/.changes/next-release/Feature-159d0360-1d9d-439a-aaf4-624434216694.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Credentials: support for ECS container provided credentials"
+}

--- a/src/credentials/providers/ecsCredentialsProvider.ts
+++ b/src/credentials/providers/ecsCredentialsProvider.ts
@@ -1,0 +1,63 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Credentials, ECSCredentials } from 'aws-sdk'
+import { EnvironmentVariables } from '../../shared/environmentVariables'
+import { CredentialType } from '../../shared/telemetry/telemetry.gen'
+import { getStringHash } from '../../shared/utilities/textUtilities'
+import { CredentialsId, CredentialsProvider, CredentialsProviderType } from './credentials'
+
+/**
+ * Credentials received from ECS containers.
+ *
+ * @see CredentialsProviderType
+ */
+export class EcsCredentialsProvider implements CredentialsProvider {
+    private credentials: ECSCredentials | undefined
+
+    public async isAvailable(): Promise<boolean> {
+        const env = process.env as EnvironmentVariables
+        return env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI || env.AWS_CONTAINER_CREDENTIALS_FULL_URI ? true : false
+    }
+
+    public getCredentialsId(): CredentialsId {
+        return {
+            credentialSource: this.getProviderType(),
+            credentialTypeId: 'instance',
+        }
+    }
+
+    public static getProviderType(): CredentialsProviderType {
+        return 'ecs'
+    }
+
+    public getProviderType(): CredentialsProviderType {
+        return EcsCredentialsProvider.getProviderType()
+    }
+
+    public getTelemetryType(): CredentialType {
+        return 'ecsMetatdata'
+    }
+
+    public getDefaultRegion(): string | undefined {
+        const env = process.env as EnvironmentVariables
+        return env.AWS_DEFAULT_REGION
+    }
+
+    public getHashCode(): string {
+        return getStringHash(JSON.stringify(this.credentials))
+    }
+
+    public canAutoConnect(): boolean {
+        return true
+    }
+
+    public async getCredentials(): Promise<Credentials> {
+        if (!this.credentials) {
+            this.credentials = new ECSCredentials()
+        }
+        return this.credentials
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,6 +69,7 @@ import { getSamCliContext } from './shared/sam/cli/samCliContext'
 import * as extWindow from './shared/vscode/window'
 import { Ec2CredentialsProvider } from './credentials/providers/ec2CredentialsProvider'
 import { EnvVarsCredentialsProvider } from './credentials/providers/envVarsCredentialsProvider'
+import { EcsCredentialsProvider } from './credentials/providers/ecsCredentialsProvider'
 
 let localize: nls.LocalizeFunc
 
@@ -331,7 +332,7 @@ function initializeManifestPaths(extensionContext: vscode.ExtensionContext) {
 function initializeCredentialsProviderManager() {
     const manager = CredentialsProviderManager.getInstance()
     manager.addProviderFactory(new SharedCredentialsProviderFactory())
-    manager.addProviders(new Ec2CredentialsProvider(), new EnvVarsCredentialsProvider())
+    manager.addProviders(new Ec2CredentialsProvider(), new EcsCredentialsProvider(), new EnvVarsCredentialsProvider())
 }
 
 function makeEndpointsProvider(): EndpointsProvider {

--- a/src/shared/environmentVariables.ts
+++ b/src/shared/environmentVariables.ts
@@ -22,5 +22,9 @@ export interface EnvironmentVariables {
     AWS_SESSION_TOKEN?: string
     AWS_REGION?: string
 
+    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI?: string
+    AWS_CONTAINER_CREDENTIALS_FULL_URI?: string
+    AWS_DEFAULT_REGION?: string
+
     [key: string]: string | boolean | undefined
 }

--- a/src/test/credentials/provider/ecsCredentialsProvider.test.ts
+++ b/src/test/credentials/provider/ecsCredentialsProvider.test.ts
@@ -1,0 +1,57 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { ECSCredentials } from 'aws-sdk'
+import { EcsCredentialsProvider } from '../../../credentials/providers/ecsCredentialsProvider'
+import { EnvironmentVariables } from '../../../shared/environmentVariables'
+
+describe('EcsCredentialsProvider', function () {
+    const dummyUri = 'dummyUri'
+    const dummyRegion = 'dummmyRegion'
+
+    const credentialsProvider = new EcsCredentialsProvider()
+    const env = process.env as EnvironmentVariables
+
+    afterEach(function () {
+        delete env.AWS_CONTAINER_CREDENTIALS_FULL_URI
+        delete env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
+        delete env.AWS_DEFAULT_REGION
+    })
+
+    it('should be available if container full URI present', async function () {
+        env.AWS_CONTAINER_CREDENTIALS_FULL_URI = dummyUri
+
+        assert.strictEqual(await credentialsProvider.isAvailable(), true)
+    })
+
+    it('should be available if container relative URI present', async function () {
+        env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI = dummyUri
+
+        assert.strictEqual(await credentialsProvider.isAvailable(), true)
+    })
+
+    it('should be unavailable if container URIs not present', async function () {
+        assert.strictEqual(await credentialsProvider.isAvailable(), false)
+    })
+
+    it('should retrieve provided region', function () {
+        env.AWS_DEFAULT_REGION = dummyRegion
+
+        assert.strictEqual(credentialsProvider.getDefaultRegion(), dummyRegion)
+    })
+
+    it('should return undefined region when not provided', function () {
+        assert.strictEqual(credentialsProvider.getDefaultRegion(), undefined)
+    })
+
+    it('returns credentials', async function () {
+        env.AWS_CONTAINER_CREDENTIALS_FULL_URI = dummyUri
+
+        const credentials = await credentialsProvider.getCredentials()
+
+        assert(credentials instanceof ECSCredentials)
+    })
+})


### PR DESCRIPTION
## Problem
ECS container credentials can currently only be used by defining a credentials profile that specifies EcsContainer as a credential_source (added in #1833). This requires additional setup by the user.
## Solution
This change adds a credentials provider for ECS containers that auto detects running in a container. This enables a zero touch credentials setup process.

ECS exposes environment variables to running tasks (`AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` or `AWS_CONTAINER_CREDENTIALS_FULL_URI`) with the location of credentials metadata. This check is performed by the [JavaScript SDK's ECS credentials](https://github.com/aws/aws-sdk-js/blob/master/lib/credentials/remote_credentials.js#L99-L101) and is required to retrieve credentials.

Tested through VSCode remote attached to a locally running ECS container.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
