### PR TITLE
UI: wizard controller and testing framework (wizard framework 2/3)

### DIFF
--- a/src/shared/ui/prompter.ts
+++ b/src/shared/ui/prompter.ts
@@ -1,0 +1,90 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as _ from 'lodash'
+import { isValidResponse, WizardControl } from '../wizards/wizard'
+
+export type QuickPickDataType<T> = T | WizardControl | undefined
+
+export type MultiQuickPickResult<T> = T[] | WizardControl | undefined
+export type PromptResult<T> = T | WizardControl | undefined
+
+type Transform<T, R = T> = (result: T) => R | void | Promise<R | void>
+
+/**
+ * A generic dialog object that encapsulates the presentation and transformation of user
+ * responses to arbitrary GUIs.
+ */
+export abstract class Prompter<T> {
+    private disposed = false
+    protected afterCallbacks: Transform<T, any>[] = []
+
+    constructor() {}
+
+    /** The total number of steps that occured during the prompt */
+    public get totalSteps(): number {
+        return 1
+    }
+
+    // A note on the following two methods:
+    //
+    // getLastResponse/setLastReponse are used to preserve some semblance of state in
+    // between different steps. it is up to implementing classes to check for type safety
+    // since there is a possibility for the 'last response' to be from a prompter of a
+    // completely different type
+    //
+    // why not keep state with prompters?
+    //
+    // as a whole, having prompters be regenerated every step is a solution to the state management
+    // problem. if we kept the same prompters for every step, we must also know how to update them
+    // as form state is manipulated by other steps.
+
+    /** Implementing classes should use the argument to show the user what they last selected (if applicable) */
+    public abstract get lastResponse(): any
+    /** Implementing classes should return the user's response _before_ transforming into into type T */
+    public abstract set lastResponse(response: any)
+
+    /** Adds a hook that is called after the user responds */
+    public after(callback: Transform<T, PromptResult<T>>): this {
+        this.afterCallbacks.push(callback)
+        return this
+    }
+
+    /** Type-helper, allows Prompters to be mapped to different shapes */
+    public transform<R>(callback: Transform<T, R>): Prompter<R> {
+        this.afterCallbacks.push(callback)
+        return this as unknown as Prompter<R>
+    }
+
+    /** Applies the 'after' hooks to the user response in the order in which they were added */
+    private async applyAfterCallbacks(result: PromptResult<T>): Promise<PromptResult<T>> {
+        while (this.afterCallbacks.length > 0) {
+            if (!isValidResponse(result)) {
+                return result
+            }
+            const cb = this.afterCallbacks.shift()!
+            const transform: T | undefined = await cb(result)
+            if (transform !== undefined) {
+                result = transform
+            }
+        }
+        return result
+    }
+
+    /**
+     * Opens a dialog for the user to respond to.
+     * @returns The user-response, undefined, or a special control-signal used in Wizards.
+     */
+    public async prompt(): Promise<PromptResult<T>> {
+        if (this.disposed) {
+            throw new Error('Cannot call "prompt" multiple times')
+        }
+        this.disposed = true
+        return this.applyAfterCallbacks(await this.promptUser())
+    }
+
+    protected abstract promptUser(): Promise<PromptResult<T>>
+    public abstract setSteps(current: number, total: number): void
+}

--- a/src/shared/utilities/tsUtils.ts
+++ b/src/shared/utilities/tsUtils.ts
@@ -21,3 +21,13 @@ export type InterfaceNoSymbol<T> = Pick<T, NoSymbols<T>>
  * is that it cannot be re-declared for extension.
  */
 export type ClassToInterfaceType<T> = Pick<T, keyof T>
+
+type Expand<T> = T extends infer O ? { [K in keyof O]+?: O[K] } : never
+/**
+ * Forces a type to be resolved into its literal types.
+ *
+ * Normally imported types are left 'as-is' and are unable to be mapped. This alias uses
+ * type inference to effectively generate a type literal of the target type.
+ *
+ */
+export type ExpandWithObject<T> = Expand<T> extends Record<string, unknown> ? Expand<T> : never

--- a/src/shared/wizards/wizard.ts
+++ b/src/shared/wizards/wizard.ts
@@ -1,0 +1,173 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Branch, ControlSignal, StateMachineController, StepFunction } from './stateController'
+import * as _ from 'lodash'
+import { Prompter, PromptResult } from '../../shared/ui/prompter'
+import { PrompterProvider, WizardForm } from './wizardForm'
+
+/** Checks if the user response is valid (i.e. not undefined and not a control signal) */
+export function isValidResponse<T>(response: PromptResult<T>): response is T {
+    return response !== undefined && !isWizardControl(response)
+}
+
+type ObjectKeys<T> = {
+    [Property in keyof T]: T[Property] extends Record<string, unknown> ? Property : never
+}[keyof T]
+
+type NonObjectKeys<T> = {
+    [Property in keyof T]: T[Property] extends Record<string, unknown> ? never : Property
+}[keyof T]
+
+/**
+ * Reserved type. Currently makes all object-like fields required and everything else
+ * optional.
+ */
+export type WizardState<T> = {
+    [Property in ObjectKeys<T>]-?: T[Property] extends Record<string, unknown>
+        ? WizardState<Required<T[Property]>>
+        : never
+} &
+    {
+        [Property in NonObjectKeys<T>]+?: T[Property] extends Record<string, unknown> ? never : T[Property]
+    }
+
+// We use a symbol to safe-guard against collisions (alternatively this can be a class and use 'instanceof')
+const WIZARD_CONTROL = Symbol()
+const makeControlString = (type: string) => `[WIZARD_CONTROL] ${type}`
+
+export const WIZARD_RETRY = {
+    id: WIZARD_CONTROL,
+    type: ControlSignal.Retry,
+    toString: () => makeControlString('Retry'),
+}
+export const WIZARD_BACK = { id: WIZARD_CONTROL, type: ControlSignal.Back, toString: () => makeControlString('Back') }
+export const WIZARD_EXIT = { id: WIZARD_CONTROL, type: ControlSignal.Exit, toString: () => makeControlString('Exit') }
+
+/** Control signals allow for alterations of the normal wizard flow */
+export type WizardControl = typeof WIZARD_RETRY | typeof WIZARD_BACK | typeof WIZARD_EXIT
+
+export function isWizardControl(obj: any): obj is WizardControl {
+    return obj !== undefined && obj.id === WIZARD_CONTROL
+}
+
+// Persistent storage that exists on a per-property basis, side effects may occur here
+type StepCache = { picked?: any; stepOffset?: number } & { [key: string]: any }
+export type StateWithCache<TState> = TState & { stepCache: StepCache }
+
+/**
+ * A generic wizard that consumes data from a series of 'prompts'. Wizards will modify a single property of
+ * their internal state with each prompt. The 'form' public property exposes functionality to add prompters
+ * with optional context.
+ */
+export class Wizard<TState extends Partial<Record<keyof TState, unknown>>> {
+    private readonly boundSteps: Map<string, StepFunction<TState>> = new Map()
+    private readonly _form: WizardForm<TState>
+    private stateController: StateMachineController<TState>
+    private _stepOffset: number = 0
+
+    /**
+     * The offset is applied to both the current step and total number of steps. Useful if the wizard is
+     * apart of some overarching flow.
+     */
+    public set stepOffset(offset: number) {
+        this._stepOffset = offset
+    }
+    public get currentStep(): number {
+        return this._stepOffset + this.stateController.currentStep
+    }
+    public get totalSteps(): number {
+        return this._stepOffset + this.stateController.totalSteps
+    }
+
+    public get form() {
+        return this._form.body
+    }
+
+    public constructor(
+        initForm: WizardForm<TState> = new WizardForm(),
+        private readonly initState: Partial<TState> = {}
+    ) {
+        this.stateController = new StateMachineController(initState as TState)
+        this._form = initForm
+    }
+
+    private assignSteps(): void {
+        this._form.properties.forEach(prop => {
+            const provider = this._form.getPrompterProvider(prop)
+            if (!this.boundSteps.has(prop) && provider !== undefined) {
+                this.boundSteps.set(prop, this.createBoundStep(prop, provider))
+            }
+        })
+    }
+
+    public async run(): Promise<TState | undefined> {
+        this.assignSteps()
+        this.resolveNextSteps(this.initState as TState).forEach(step => this.stateController.addStep(step))
+
+        const outputState = await this.stateController.run()
+
+        return outputState !== undefined ? this._form.applyDefaults(outputState) : undefined
+    }
+
+    private createBoundStep<TProp>(prop: string, provider: PrompterProvider<TState, TProp>): StepFunction<TState> {
+        const stepCache: StepCache = {}
+
+        return async state => {
+            const stateWithCache = Object.assign({ stepCache: stepCache }, this._form.applyDefaults(state))
+            const response = await this.promptUser(
+                stateWithCache,
+                provider(stateWithCache as StateWithCache<WizardState<TState>>)
+            )
+
+            return {
+                nextState: isValidResponse(response) ? _.set(state, prop, response) : state,
+                nextSteps: this.resolveNextSteps(state),
+                controlSignal: isWizardControl(response) ? response.type : undefined,
+            }
+        }
+    }
+
+    protected resolveNextSteps(state: TState): Branch<TState> {
+        const nextSteps: Branch<TState> = []
+        const defaultState = this._form.applyDefaults(state)
+        this.boundSteps.forEach((step, targetProp) => {
+            if (
+                this._form.canShowProperty(targetProp, state, defaultState) &&
+                !this.stateController.containsStep(step)
+            ) {
+                nextSteps.push(step)
+            }
+        })
+        return nextSteps
+    }
+
+    private async promptUser<TProp>(
+        state: StateWithCache<TState>,
+        prompter: Prompter<TProp>
+    ): Promise<PromptResult<TProp>> {
+        this._stepOffset = state.stepCache.stepOffset ?? this._stepOffset
+        state.stepCache.stepOffset = this._stepOffset
+        prompter.setSteps(this.currentStep, this.totalSteps)
+
+        if (state.stepCache.picked !== undefined) {
+            prompter.lastResponse = state.stepCache.picked
+        }
+
+        const answer = await prompter.prompt()
+
+        if (isValidResponse(answer)) {
+            state.stepCache.picked = prompter.lastResponse
+        } else {
+            delete state.stepCache.stepOffset
+        }
+
+        this._stepOffset = prompter.totalSteps - 1
+
+        // Legacy code used 'undefined' to represent back, we will support the use-case
+        // but moving forward wizard implementations will explicity use 'WIZARD_BACK'
+        return answer ?? WIZARD_BACK
+    }
+}

--- a/src/shared/wizards/wizardForm.ts
+++ b/src/shared/wizards/wizardForm.ts
@@ -1,0 +1,216 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Prompter } from '../ui/prompter'
+import * as _ from 'lodash'
+import { StateWithCache, WizardState } from './wizard'
+import { ExpandWithObject } from '../utilities/tsUtils'
+
+export type PrompterProvider<TState, TProp> = (state: StateWithCache<WizardState<TState>>) => Prompter<TProp>
+
+type DefaultFunction<TState, TProp> = (state: WizardState<TState>) => TProp | undefined
+
+interface ContextOptions<TState, TProp> {
+    /**
+     * Applies a conditional function that is evaluated after every user-input but only if the
+     * property is either not set or not currently in the state machine. Upon evaluating true,
+     * the bound prompter will be added as a new step. If multiple prompters resolve to true
+     * in a single resolution step then they will be added in the order in which they were
+     * bound.
+     */
+    showWhen?: (state: WizardState<TState>) => boolean
+    /**
+     * Sets a default value to the target property. This default is applied to the current state
+     * as long as the property has not been set.
+     */
+    setDefault?: DefaultFunction<TState, TProp>
+    /**
+     * If true then prompters will only be shown if the parent object exists (default: false)
+     */
+    requireParent?: boolean
+    /**
+     * If set to true the wizard will ignore prompts for already assigned properties (default: true)
+     */
+    implicit?: boolean // not actually implemented
+}
+interface FormElement<TProp, TState> {
+    /**
+     * Binds a Prompter-provider to the specified property. The provider is called with the current Wizard
+     * state whenever the property is ready for input, and should return a Prompter object.
+     */
+    bindPrompter(provider: PrompterProvider<TState, TProp>, options?: ContextOptions<TState, TProp>): void
+    // TODO: potentially add options to this, or rethink how defaults should work
+    setDefault(defaultFunction: DefaultFunction<TState, TProp> | TProp): void
+}
+
+// These methods are only applicable to object-like elements
+interface ParentFormElement<TProp extends Record<string, any>, TState> {
+    applyForm(form: WizardForm<TProp>, options?: ContextOptions<TState, TProp>): void
+}
+
+type PrompterBind<TProp, TState> = FormElement<TProp, TState>['bindPrompter']
+type SetDefault<TProp, TState> = FormElement<TProp, TState>['setDefault']
+type ApplyForm<TProp, TState> = ParentFormElement<TProp, TState>['applyForm']
+
+/** Transforms an interface into a collection of FormElements, applied recursively */
+type Form<T, TState = T> = {
+    [Property in keyof T]-?: T[Property] extends ExpandWithObject<T[Property]>
+        ? (Form<Required<T[Property]>, TState> & FormElement<T[Property], TState>) &
+              ParentFormElement<T[Property], TState>
+        : FormElement<T[Property], TState>
+}
+
+type FormDataElement<TState, TProp> = ContextOptions<TState, TProp> & { provider?: PrompterProvider<TState, TProp> }
+
+function isAssigned<TProp>(obj: TProp): boolean {
+    return obj !== undefined || _.isEmpty(obj) === false
+}
+
+function checkParent<TState>(prop: string, state: TState, options: FormDataElement<TState, any>): boolean {
+    const parent = prop.split('.').slice(0, -1)
+    return options.requireParent === true ? parent.length !== 0 && _.get(state, parent) === undefined : false
+}
+
+type FormProperty = keyof (FormElement<any, any> & ParentFormElement<any, any>)
+const BIND_PROMPTER: FormProperty = 'bindPrompter'
+const APPLY_FORM: FormProperty = 'applyForm'
+const SET_DEFAULT: FormProperty = 'setDefault'
+
+export class WizardForm<TState extends Partial<Record<keyof TState, unknown>>> {
+    protected readonly formData = new Map<string, FormDataElement<TState, any> & { _isForm?: boolean }>()
+    public readonly body: Form<Required<TState>>
+
+    constructor() {
+        this.body = this.createWizardForm()
+    }
+
+    public get properties(): string[] {
+        return [...this.formData.keys()]
+    }
+
+    public getPrompterProvider(prop: string): PrompterProvider<TState, any> | undefined {
+        return this.formData.get(prop)?.provider
+    }
+
+    public isImplicit(prop: string): boolean {
+        return this.formData.get(prop)?.implicit ?? true
+    }
+
+    public applyDefaults(state: TState): TState {
+        const defaultState = _.cloneDeep(state)
+
+        this.formData.forEach((opt, targetProp) => {
+            const current = _.get(state, targetProp)
+
+            if (!isAssigned(current) && opt.setDefault !== undefined && !checkParent(targetProp, state, opt)) {
+                const defaultValue = opt.setDefault(state as WizardState<TState>)
+                if (defaultValue !== undefined) {
+                    _.set(defaultState, targetProp, defaultValue)
+                }
+            }
+        })
+
+        return defaultState
+    }
+
+    private applyElement(key: string, element: FormDataElement<TState, any> & { _isForm?: boolean }) {
+        this.formData.set(key, { ...this.formData.get(key), ...element })
+    }
+
+    public canShowProperty(prop: string, state: TState, defaultState: TState = this.applyDefaults(state)): boolean {
+        const current = _.get(state, prop)
+        const options = this.formData.get(prop) ?? {}
+
+        if (isAssigned(current) || checkParent(prop, state, options)) {
+            return false
+        }
+
+        if (options.showWhen !== undefined && !options.showWhen(defaultState as WizardState<TState>)) {
+            return false
+        }
+
+        return options.provider !== undefined || (options._isForm ?? false)
+    }
+
+    private convertElement<TProp>(
+        prop: string,
+        element: FormDataElement<TProp, any>,
+        options?: ContextOptions<TState, TProp>
+    ): FormDataElement<TState, any> {
+        const wrappedElement: FormDataElement<TState, any> = {}
+
+        if (element.provider !== undefined) {
+            wrappedElement.provider = state => {
+                const stateWithCache = Object.assign(_.get(state, prop, {}), { stepCache: state.stepCache })
+
+                return element.provider!(stateWithCache as StateWithCache<WizardState<TProp>>)
+            }
+        }
+
+        if (element.showWhen !== undefined || options?.showWhen !== undefined || options?.requireParent === true) {
+            wrappedElement.showWhen = state =>
+                (options?.requireParent !== true || _.get(state, prop) !== undefined) &&
+                (element.showWhen !== undefined ? element.showWhen!(_.get(state, prop, {})) : true) &&
+                (options?.showWhen !== undefined ? options.showWhen!(state) : true)
+        }
+
+        wrappedElement.setDefault =
+            element.setDefault !== undefined
+                ? state =>
+                      options?.requireParent !== true || _.get(state, prop) !== undefined
+                          ? element.setDefault!(_.get(state, prop, {}))
+                          : undefined
+                : undefined
+
+        wrappedElement.implicit = element.implicit ?? options?.implicit
+        wrappedElement.requireParent = element.requireParent ?? options?.requireParent
+
+        return wrappedElement
+    }
+
+    private createBindPrompterMethod<TProp>(prop: string): PrompterBind<TProp, TState> {
+        return (provider: PrompterProvider<TState, TProp>, options: ContextOptions<TState, TProp> = {}): void => {
+            this.applyElement(prop, { ...options, provider })
+        }
+    }
+
+    private createApplyFormMethod<TProp>(prop: string): ApplyForm<TProp, TState> {
+        return (form: WizardForm<TProp>, options?: ContextOptions<TState, TProp>) => {
+            form.formData.forEach((element, key) => {
+                this.applyElement(`${prop}.${key}`, this.convertElement(prop, element, options))
+            })
+
+            this.applyElement(prop, { _isForm: true, ...options })
+        }
+    }
+
+    private createSetDefaultMethod<TProp>(prop: string): SetDefault<TProp, TState> {
+        return (defaultFunction: DefaultFunction<TState, TProp> | TProp) =>
+            typeof defaultFunction !== 'function' // TODO: fix these types, TProp can technically be a function...
+                ? this.applyElement(prop, { setDefault: () => defaultFunction })
+                : this.applyElement(prop, { setDefault: defaultFunction as DefaultFunction<TState, TProp> })
+    }
+
+    // Generates a virtualized object with the same shape as the Form interface
+    private createWizardForm(path: string[] = []): Form<Required<TState>> {
+        return new Proxy(
+            {},
+            {
+                get: (__, prop) => {
+                    switch (prop) {
+                        case BIND_PROMPTER:
+                            return this.createBindPrompterMethod(path.join('.'))
+                        case APPLY_FORM:
+                            return this.createApplyFormMethod(path.join('.'))
+                        case SET_DEFAULT:
+                            return this.createSetDefaultMethod(path.join('.'))
+                        default:
+                            return this.createWizardForm([...path, prop.toString()])
+                    }
+                },
+            }
+        ) as Form<Required<TState>>
+    }
+}

--- a/src/test/shared/ui/prompter.test.ts
+++ b/src/test/shared/ui/prompter.test.ts
@@ -1,0 +1,49 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { Prompter, PromptResult } from '../../../shared/ui/prompter'
+
+export class SimplePrompter<T> extends Prompter<T> {
+    constructor(private readonly input: T | PromptResult<T>) {
+        super()
+    }
+    protected async promptUser(): Promise<PromptResult<T>> {
+        return this.input
+    }
+    public setSteps(current: number, total: number): void {}
+    public set lastResponse(response: any) {}
+    public get lastResponse(): any {
+        return undefined
+    }
+}
+
+describe('Prompter', function () {
+    it('returns a value', async function () {
+        const prompter = new SimplePrompter(1)
+        assert.strictEqual(await prompter.prompt(), 1)
+    })
+
+    it('can map one type to another', async function () {
+        const prompter = new SimplePrompter(1).transform(resp => resp.toString())
+        assert.strictEqual(await prompter.prompt(), '1')
+    })
+
+    it('throws error if calling prompt multiple times', async function () {
+        const prompter = new SimplePrompter(1)
+        await prompter.prompt()
+        await assert.rejects(prompter.prompt())
+    })
+
+    it('can attach multiple callbacks', async function () {
+        const prompter = new SimplePrompter(1)
+        prompter.after(resp => resp * 2)
+        prompter.after(resp => resp + 2)
+        prompter.after(resp => resp * 2)
+        prompter.after(resp => resp - 2)
+        prompter.transform(resp => resp.toString()).after(resp => `result: ${resp}`)
+        assert.strictEqual(await prompter.prompt(), 'result: 6')
+    })
+})

--- a/src/test/shared/wizards/wizard.test.ts
+++ b/src/test/shared/wizards/wizard.test.ts
@@ -1,0 +1,287 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { Prompter, PromptResult } from '../../../shared/ui/prompter'
+import { isWizardControl, Wizard, WizardState, WIZARD_BACK, WIZARD_EXIT } from '../../../shared/wizards/wizard'
+
+interface TestWizardForm {
+    prop1: string
+    prop2?: number
+    prop3: string
+    prop4: string
+    nestedProp: {
+        prop1: string
+        prop2?: boolean
+    }
+}
+
+interface AssertStepMethods {
+    /** Order is 1-indexed, e.g. onCall(1) === onFirstCall() */
+    onCall(...order: number[]): void
+    onFirstCall(): void
+    onSecondCall(): void
+    onThirdCall(): void
+    onFourthCall(): void
+    onEveryCall(): void
+}
+
+type StepTuple = [number, number]
+type StateResponse<T, S> = (state: WizardState<S>) => PromptResult<T>
+type TestResponse<T, S> = PromptResult<T> | StateResponse<T, S>
+
+function makeGreen(s: string): string {
+    return `\u001b[32m${s}\u001b[0m`
+}
+
+function makeExpectedError(message: string, actual: any, expected: any): string {
+    return `${message}\n\tActual: ${actual}\n\t${makeGreen(`Expected: ${expected}`)}`
+}
+
+/**
+ * Note: This class should be used within this test file. Use 'FormTester' instead for testing wizard implementations since
+ * it can test behavior irrespective of prompter ordering.
+ *
+ * Test prompters are instantiated with a finite set of responses. Responses can be raw data or functions applied to the
+ * current state of the wizard. A developer-friendly name can be added using 'setName'.
+ */
+class TestPrompter<T, S = any> extends Prompter<T> {
+    private readonly responses: TestResponse<T, S>[]
+    private readonly order: Map<number, StepTuple> = new Map()
+    private readonly acceptedStates: WizardState<S>[] = []
+    private _totalSteps: number = 1
+    private _lastResponse: PromptResult<T>
+    private promptCount: number = 0
+    private name: string = 'Test Prompter'
+
+    public get lastResponse(): PromptResult<T> {
+        return this._lastResponse
+    }
+    public set lastResponse(response: PromptResult<T>) {
+        if (response !== this._lastResponse) {
+            this.fail(
+                makeExpectedError('Received unexpected cached response from wizard', response, this._lastResponse)
+            )
+        }
+    }
+
+    public get totalSteps(): number {
+        return this._totalSteps
+    }
+
+    constructor(...responses: TestResponse<T, S>[]) {
+        super()
+        this.responses = responses
+    }
+
+    public async prompt(): Promise<PromptResult<T>> {
+        if (this.responses.length === this.promptCount) {
+            this.fail('Ran out of responses')
+        }
+        const resp = this.convertFunctionResponse(this.promptCount++)
+        this._lastResponse = !isWizardControl(resp) ? resp : this._lastResponse
+
+        return resp
+    }
+
+    protected promptUser(): Promise<PromptResult<T>> {
+        throw new Error('Do not call this')
+    }
+
+    public setSteps(current: number, total: number): void {
+        const expected = this.order.get(this.promptCount)
+
+        if (expected !== undefined) {
+            assert.strictEqual(current, expected[0], this.makeErrorMessage('Incorrect current step'))
+            assert.strictEqual(total, expected[1], this.makeErrorMessage('Incorrect total steps'))
+        }
+    }
+
+    //----------------------------Test helper methods go below this line----------------------------//
+
+    public acceptState(state: WizardState<S>): this {
+        this.acceptedStates[this.promptCount] = state
+        return this
+    }
+
+    private fail(message: string): void {
+        assert.fail(this.makeErrorMessage(message))
+    }
+    private makeErrorMessage(message: string): string {
+        return `[${this.name}]: ${message}`
+    }
+
+    public setName(name: string): this {
+        this.name = name
+        return this
+    }
+
+    public setTotalSteps(total: number): void {
+        this._totalSteps = total
+    }
+
+    private convertFunctionResponse(count: number = this.promptCount): PromptResult<T> {
+        let response = this.responses[count]
+        if (typeof response === 'function') {
+            if (this.acceptedStates[count] === undefined) {
+                this.fail(`Undefined state, did you forget to bind the prompter with "acceptState"?`)
+            }
+            response = (response as StateResponse<T, S>)(this.acceptedStates[count])
+        }
+        return response
+    }
+
+    /** Checks steps during execution. This should be called _before_ running the wizard. */
+    public assertSteps(current: number, total: number, when: number = 0): AssertStepMethods {
+        return {
+            onCall: (...order: number[]) => {
+                order.map(i => this.order.set(i - 1, [current, total]))
+            },
+            onFirstCall: () => {
+                this.order.set(0, [current, total])
+            },
+            onSecondCall: () => {
+                this.order.set(1, [current, total])
+            },
+            onThirdCall: () => {
+                this.order.set(2, [current, total])
+            },
+            onFourthCall: () => {
+                this.order.set(3, [current, total])
+            },
+            onEveryCall: () => {
+                ;[...Array(100).keys()].map(i => this.order.set(i, [current, total]))
+            },
+        } as AssertStepMethods
+    }
+
+    public assertCallCount(count: number): void {
+        assert.strictEqual(this.promptCount, count, this.makeErrorMessage('Called an unexpected number of times'))
+    }
+}
+
+// We only need to test execution of prompters provided by the wizard form
+describe('Wizard', function () {
+    let wizard: Wizard<TestWizardForm>
+    let helloPrompter: TestPrompter<string>
+
+    beforeEach(function () {
+        wizard = new Wizard()
+        helloPrompter = new TestPrompter(...Array(100).fill('hello')).setName('Hello')
+    })
+
+    it('binds prompter to property', async function () {
+        wizard.form.prop1.bindPrompter(() => helloPrompter)
+
+        assert.strictEqual((await wizard.run())?.prop1, 'hello')
+    })
+
+    it('processes exit signal', async function () {
+        wizard.form.prop1.bindPrompter(() => helloPrompter)
+        wizard.form.prop3.bindPrompter(() => new TestPrompter<string>(WIZARD_EXIT).setName('Exit'))
+
+        assert.strictEqual(await wizard.run(), undefined)
+        helloPrompter.assertCallCount(1)
+    })
+
+    // test is mostly redundant (state controller handles this logic) but good to have
+    it('regenerates prompters when going back', async function () {
+        const testPrompter = new TestPrompter(WIZARD_BACK, 'goodbye').setName('Goodbye')
+
+        wizard.form.prop1.bindPrompter(() => helloPrompter)
+        wizard.form.prop3.bindPrompter(() => testPrompter)
+
+        assert.deepStrictEqual(await wizard.run(), { prop1: 'hello', prop3: 'goodbye' })
+        helloPrompter.assertCallCount(2)
+        testPrompter.assertCallCount(2)
+    })
+
+    it('applies step offset', async function () {
+        const testPrompter = new TestPrompter('1')
+        wizard.stepOffset = 5
+
+        wizard.form.prop1.bindPrompter(() => testPrompter)
+
+        testPrompter.assertSteps(6, 6).onFirstCall()
+
+        assert.deepStrictEqual(await wizard.run(), { prop1: '1' })
+    })
+
+    it('does not apply control values to state when going back', async function () {
+        const noWizardControl = (state: WizardState<TestWizardForm>) => {
+            assert.strictEqual(
+                isWizardControl(state.prop2),
+                false,
+                'Wizard flow control should not appear in wizard state'
+            )
+            return 'good'
+        }
+
+        const testPrompter1 = new TestPrompter('first', noWizardControl).setName('Test 1')
+        const testPrompter2 = new TestPrompter(WIZARD_BACK, 22).setName('Test 2')
+
+        wizard.form.prop1.bindPrompter(state => testPrompter1.acceptState(state))
+        wizard.form.prop2.bindPrompter(() => testPrompter2)
+
+        assert.deepStrictEqual(await wizard.run(), { prop1: 'good', prop2: 22 })
+    })
+
+    describe('prompter state', function () {
+        // Execution order: 1 -> 2 -> 1 -> 2
+        it('accurately assigns current/total steps', async function () {
+            const testPrompter1 = new TestPrompter('1', '2', '3').setName('Test 1')
+            const testPrompter2 = new TestPrompter(WIZARD_BACK, 4).setName('Test 2')
+
+            testPrompter1.setTotalSteps(2)
+
+            wizard.form.prop1.bindPrompter(() => testPrompter1)
+            wizard.form.prop2.bindPrompter(() => testPrompter2)
+
+            testPrompter1.assertSteps(1, 2).onFirstCall()
+            testPrompter2.assertSteps(3, 3).onSecondCall()
+
+            assert.deepStrictEqual(await wizard.run(), { prop1: '2', prop2: 4 })
+            testPrompter1.assertCallCount(2)
+            testPrompter2.assertCallCount(2)
+        })
+
+        //       A --> Path 1
+        //      /             \
+        // Start               End
+        //      \             /
+        //       B --> Path 2
+        //
+        // Execution order:
+        // Start -> Path 1 -> End -> Path 1 -> Start -> Path 2 -> Start -> Path 1 -> Start -> Path 2 -> End -> Path 2 -> End
+        it('sets total steps correctly when branching', async function () {
+            const helloFunction = (state: WizardState<TestWizardForm>) =>
+                state.prop1 === 'B' ? `hello ${state.prop3}` : `extra step`
+            const testPrompterStart = new TestPrompter('A', 'B', 'A', 'B').setName('Start')
+            const testPrompterPath1 = new TestPrompter(99, WIZARD_BACK, WIZARD_BACK, 10).setName('Path 1')
+            const testPrompterPath2 = new TestPrompter(WIZARD_BACK, 'alice', 'bob').setName('Path 2')
+            const testPrompterEnd = new TestPrompter(WIZARD_BACK, WIZARD_BACK, helloFunction).setName('End')
+
+            testPrompterPath1.setTotalSteps(2)
+            testPrompterPath2.setTotalSteps(3)
+
+            wizard.form.prop1.bindPrompter(() => testPrompterStart)
+            wizard.form.prop2.bindPrompter(() => testPrompterPath1, { showWhen: state => state.prop1 === 'A' })
+            wizard.form.prop3.bindPrompter(() => testPrompterPath2, { showWhen: state => state.prop1 === 'B' })
+            wizard.form.prop4.bindPrompter(state => testPrompterEnd.acceptState(state))
+
+            testPrompterStart.assertSteps(1, 2).onEveryCall()
+            testPrompterPath1.assertSteps(2, 3).onEveryCall()
+            testPrompterPath2.assertSteps(2, 3).onEveryCall()
+            testPrompterEnd.assertSteps(4, 4).onFirstCall()
+            testPrompterEnd.assertSteps(5, 5).onCall(2, 3)
+
+            assert.deepStrictEqual(await wizard.run(), { prop1: 'B', prop3: 'bob', prop4: 'hello bob' })
+            testPrompterStart.assertCallCount(4)
+            testPrompterPath1.assertCallCount(3)
+            testPrompterPath2.assertCallCount(3)
+            testPrompterEnd.assertCallCount(3)
+        })
+    })
+})

--- a/src/test/shared/wizards/wizardForm.test.ts
+++ b/src/test/shared/wizards/wizardForm.test.ts
@@ -1,0 +1,190 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { createFormTester, FormTester } from '../../shared/wizards/wizardTestUtils'
+import { WizardForm } from '../../../shared/wizards/wizardForm'
+import { SimplePrompter } from '../ui/prompter.test'
+
+interface TestState {
+    prop1: number
+    prop2: string
+    nestedProp: NestedTestState
+}
+
+interface NestedTestState {
+    prop1?: string
+    prop2?: string
+}
+
+describe('WizardForm', function () {
+    let testForm: WizardForm<TestState>
+    let tester: FormTester<TestState>
+
+    beforeEach(function () {
+        testForm = new WizardForm()
+        tester = createFormTester(testForm)
+    })
+
+    it('can add prompter', function () {
+        testForm.body.prop1.bindPrompter(() => new SimplePrompter(0))
+        tester.prop1.assertShow()
+        assert.notStrictEqual(testForm.getPrompterProvider('prop1'), undefined)
+    })
+
+    it('shows prompter based on context', function () {
+        testForm.body.prop1.bindPrompter(() => new SimplePrompter(0), { showWhen: state => state.prop2 === 'hello' })
+        tester.prop1.assertDoesNotShow()
+        tester.prop2.applyInput('hello')
+        tester.prop1.assertShow()
+        tester.prop2.applyInput('goodbye')
+        tester.prop1.assertDoesNotShow()
+    })
+
+    it('applies default setting when field is not assigned', function () {
+        testForm.body.prop1.bindPrompter(() => new SimplePrompter(0), { setDefault: () => 100 })
+        tester.prop1.assertShow()
+        tester.prop1.assertValue(100)
+        tester.prop1.applyInput(5)
+        tester.prop1.assertDoesNotShow()
+        tester.prop1.assertValue(5)
+        tester.prop1.clearInput()
+        tester.prop1.assertShow()
+    })
+
+    // TODO: revisit this. Values should not technically know about other field defaults
+    // but allowing this behavior means loops are possible, so cycle detection would be needed
+    it('default values do not depend on other default values', function () {
+        testForm.body.prop1.setDefault(() => 100)
+        testForm.body.prop2.setDefault(state => `default: ${state.prop1}`)
+        tester.prop1.assertValue(100)
+        tester.prop2.assertValue('default: undefined')
+        tester.prop1.applyInput(50)
+        tester.prop2.assertValue('default: 50')
+    })
+
+    describe('requireParent', function () {
+        it('only show prompters when parent is defined', function () {
+            testForm.body.nestedProp.prop1.bindPrompter(() => new SimplePrompter(''), { requireParent: true })
+            testForm.body.nestedProp.prop2.bindPrompter(() => new SimplePrompter(''))
+            tester.nestedProp.prop1.assertDoesNotShow()
+            tester.nestedProp.prop2.assertShow()
+            tester.nestedProp.applyInput({})
+            tester.nestedProp.prop1.assertShow()
+            tester.nestedProp.prop2.assertShow()
+        })
+
+        it('works with "showWhen"', function () {
+            testForm.body.nestedProp.prop1.bindPrompter(() => new SimplePrompter(''), {
+                requireParent: true,
+                showWhen: state => state.prop1 === 99,
+            })
+            tester.nestedProp.prop1.assertDoesNotShow()
+            tester.prop1.applyInput(99)
+            tester.nestedProp.prop1.assertDoesNotShow()
+            tester.nestedProp.applyInput({})
+            tester.nestedProp.prop1.assertShow()
+            tester.prop1.applyInput(0)
+            tester.nestedProp.prop1.assertDoesNotShow()
+        })
+
+        it('works with "setDefault"', function () {
+            testForm.body.nestedProp.prop1.bindPrompter(() => new SimplePrompter(''), {
+                requireParent: true,
+                setDefault: () => 'default',
+            })
+            tester.nestedProp.prop1.assertValue(undefined)
+            tester.nestedProp.applyInput({})
+            tester.nestedProp.prop1.assertValue('default')
+            tester.nestedProp.prop1.applyInput('not default')
+            tester.nestedProp.prop1.assertValue('not default')
+        })
+    })
+
+    describe('addForm', function () {
+        let nestedTestForm: WizardForm<NestedTestState>
+
+        beforeEach(function () {
+            nestedTestForm = new WizardForm()
+        })
+
+        it('handles providers with undefined parents', function () {
+            testForm.body.nestedProp.prop1.bindPrompter(() => new SimplePrompter(''))
+            tester.nestedProp.prop1.assertShow()
+        })
+
+        it('can apply another form to a property', function () {
+            nestedTestForm.body.prop1.bindPrompter(() => new SimplePrompter(''))
+            testForm.body.nestedProp.applyForm(nestedTestForm)
+            tester.nestedProp.prop1.assertShow()
+        })
+
+        it('can check if a form would be shown', function () {
+            testForm.body.nestedProp.applyForm(nestedTestForm, { showWhen: state => !!state.prop1 })
+            tester.nestedProp.assertDoesNotShow()
+            tester.prop1.applyInput(1)
+            tester.nestedProp.assertShow()
+        })
+
+        it('propagates state to local forms', function () {
+            nestedTestForm.body.prop1.bindPrompter(() => new SimplePrompter(''), {
+                showWhen: state => state.prop2 === 'hello',
+            })
+            testForm.body.nestedProp.applyForm(nestedTestForm)
+            tester.nestedProp.prop1.assertDoesNotShow()
+            tester.nestedProp.prop2.applyInput('hello')
+            tester.nestedProp.prop1.assertShow()
+        })
+
+        it('can apply form with "requireParent"', function () {
+            nestedTestForm.body.prop1.bindPrompter(() => new SimplePrompter(''), {
+                showWhen: state => state.prop2 === 'hello',
+            })
+            nestedTestForm.body.prop2.setDefault(() => 'hello')
+            testForm.body.nestedProp.applyForm(nestedTestForm, { requireParent: true })
+            tester.nestedProp.prop1.assertDoesNotShow()
+            tester.nestedProp.prop2.assertValue(undefined)
+            tester.nestedProp.applyInput({})
+            tester.nestedProp.prop1.assertShow()
+        })
+
+        it('can apply form with "showWhen"', function () {
+            nestedTestForm.body.prop1.bindPrompter(() => new SimplePrompter(''), {
+                showWhen: state => state.prop2 === 'hello',
+            })
+            nestedTestForm.body.prop2.bindPrompter(() => new SimplePrompter(''), {
+                showWhen: state => state.prop1 === 'goodbye',
+            })
+
+            testForm.body.nestedProp.applyForm(nestedTestForm, { showWhen: state => state.prop2 === 'start' })
+            tester.nestedProp.assertDoesNotShowAny()
+            tester.nestedProp.applyInput({})
+            tester.nestedProp.assertDoesNotShowAny()
+            tester.nestedProp.clearInput()
+            tester.prop2.applyInput('start')
+            tester.nestedProp.assertDoesNotShowAny()
+            tester.nestedProp.prop1.applyInput('goodbye')
+            tester.nestedProp.prop2.assertShow()
+            tester.nestedProp.prop1.clearInput()
+            tester.nestedProp.prop2.applyInput('hello')
+            tester.nestedProp.prop1.assertShow()
+        })
+
+        it('can apply form with "setDefault"', function () {
+            nestedTestForm.body.prop1.bindPrompter(() => new SimplePrompter(''), { requireParent: true })
+            nestedTestForm.body.prop2.setDefault(state => (state.prop1 ? `${state.prop1}.${state.prop1}` : undefined))
+
+            testForm.body.nestedProp.applyForm(nestedTestForm, { setDefault: () => ({ prop1: 'test' }) })
+            tester.nestedProp.prop1.assertDoesNotShow()
+            tester.nestedProp.prop1.assertValue('test')
+            tester.nestedProp.prop2.assertValue(undefined)
+            tester.nestedProp.applyInput({})
+            tester.nestedProp.prop1.assertShow()
+            tester.nestedProp.applyInput({ prop1: 'new' })
+            tester.nestedProp.prop1.assertDoesNotShow()
+            tester.nestedProp.prop2.assertValue('new.new')
+        })
+    })
+})

--- a/src/test/shared/wizards/wizardTestUtils.ts
+++ b/src/test/shared/wizards/wizardTestUtils.ts
@@ -1,0 +1,146 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as _ from 'lodash'
+import * as assert from 'assert'
+import { WizardForm } from '../../../shared/wizards/wizardForm'
+import { ExpandWithObject } from '../../../shared/utilities/tsUtils'
+
+interface MockWizardFormElement<TProp> {
+    applyInput(input: TProp): void
+    clearInput(): void
+    /**
+     * Verifies the property could be shown.
+     *
+     * Passing in the order argument specifies the relative order (1-indexed) in which prompters
+     * would be shown. Properties that lack a prompter (e.g. forms) have no relative ordering.
+     */
+    assertShow(order?: number): void
+    assertShowFirst(): void
+    assertShowSecond(): void
+    assertShowThird(): void
+    assertDoesNotShow(): void
+    /** Verifies that no sub-properties of the target would show prompters. */
+    assertDoesNotShowAny(): void
+    assertValue(expected: TProp | undefined): void
+}
+
+type MockForm<T, TState = T> = {
+    [Property in keyof T]-?: T[Property] extends ExpandWithObject<T[Property]>
+        ? MockForm<Required<T[Property]>, TState> & MockWizardFormElement<T[Property]>
+        : MockWizardFormElement<T[Property]>
+}
+
+export type FormTester<T> = MockForm<Required<T>> & { showCount: number }
+
+type FormTesterMethodKey = keyof MockWizardFormElement<any>
+const APPLY_INPUT: FormTesterMethodKey = 'applyInput'
+const CLEAR_INPUT: FormTesterMethodKey = 'clearInput'
+const ASSERT_SHOW: FormTesterMethodKey = 'assertShow'
+const ASSERT_SHOW_FIRST: FormTesterMethodKey = 'assertShowFirst'
+const ASSERT_SHOW_SECOND: FormTesterMethodKey = 'assertShowSecond'
+const ASSERT_SHOW_THIRD: FormTesterMethodKey = 'assertShowThird'
+const NOT_ASSERT_SHOW: FormTesterMethodKey = 'assertDoesNotShow'
+const NOT_ASSERT_SHOW_ANY: FormTesterMethodKey = 'assertDoesNotShowAny'
+const ASSERT_VALUE: FormTesterMethodKey = 'assertValue'
+
+function failIf(cond: boolean, message?: string): void {
+    if (cond) {
+        assert.fail(message)
+    }
+}
+
+export function createFormTester<T extends Partial<T>>(form: WizardForm<T>): FormTester<T> {
+    const state = {} as T
+
+    const base = Object.defineProperty({}, 'showCount', {
+        get: () => form.properties.filter(prop => canShowPrompter(prop)).length,
+    })
+
+    function canShowPrompter(prop: string): boolean {
+        const defaultState = form.applyDefaults(state)
+
+        if (!form.canShowProperty(prop, state, defaultState)) {
+            return false
+        }
+
+        const provider = form.getPrompterProvider(prop)
+
+        return provider !== undefined && provider({} as any) !== undefined
+    }
+
+    function showableChildren(parent: string): string[] {
+        return form.properties.filter(prop => prop !== parent && prop.startsWith(parent) && canShowPrompter(prop))
+    }
+
+    function getRelativeOrder(prop: string): number {
+        return form.properties.filter(prop => canShowPrompter(prop)).indexOf(prop)
+    }
+
+    function assertOrder(prop: string, expected: number): void {
+        const order = getRelativeOrder(prop)
+
+        failIf(order === -1, `Property "${prop}" would not be shown`)
+        failIf(
+            order !== expected + 1,
+            `Property "${prop}" would be shown in the wrong order: ${order} !== ${expected + 1}`
+        )
+    }
+
+    function assertShow(prop: string, expected?: number): MockWizardFormElement<T>['assertShow'] {
+        return (order: number | undefined = expected) =>
+            order === undefined
+                ? failIf(!form.canShowProperty(prop, state), `Property "${prop}" would not be shown`)
+                : assertOrder(prop, order)
+    }
+
+    function assertShowNone(prop: string): MockWizardFormElement<T>['assertDoesNotShowAny'] {
+        return () => {
+            const children = showableChildren(prop)
+            const message = children.map(p => p.replace(`${prop}.`, '')).join('\n\t')
+
+            failIf(children.length !== 0, `Property "${prop}" would show the following:\n\t${message}`)
+        }
+    }
+
+    function createFormWrapper(path: string[] = []): FormTester<T> {
+        return new Proxy(path.length === 0 ? base : {}, {
+            get: (obj, prop, rec) => {
+                const propPath = path.join('.')
+
+                // Using a switch rather than a map since a generic index signature is not yet possible
+                switch (prop) {
+                    case APPLY_INPUT:
+                        return <TProp>(input: TProp) => _.set(state, path, input)
+                    case CLEAR_INPUT:
+                        return () => _.set(state, path, undefined)
+                    case ASSERT_SHOW:
+                        return assertShow(propPath)
+                    case ASSERT_SHOW_FIRST:
+                        return assertShow(propPath, 1)
+                    case ASSERT_SHOW_SECOND:
+                        return assertShow(propPath, 2)
+                    case ASSERT_SHOW_THIRD:
+                        return assertShow(propPath, 3)
+                    case NOT_ASSERT_SHOW:
+                        return () => failIf(form.canShowProperty(propPath, state), `Property "${prop}" would be shown`)
+                    case NOT_ASSERT_SHOW_ANY:
+                        return assertShowNone(propPath)
+                    case ASSERT_VALUE: // TODO: remove message
+                        return <TProp>(expected: TProp) =>
+                            assert.deepStrictEqual(
+                                _.get(form.applyDefaults(state), path),
+                                expected,
+                                `Property "${prop}" had unexpected value`
+                            )
+                    default:
+                        return Reflect.get(obj, prop, rec) ?? createFormWrapper([...path, prop.toString()])
+                }
+            },
+        }) as FormTester<T>
+    }
+
+    return createFormWrapper()
+}


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

Two key objects are implemented in this PR: `Wizard` and `WizardForm`. Together these two things can be thought of as the 'Wizard Controller'. Concrete UI elements are also abstracted away as a `Prompter` object to be used by the wizard. This is by far the largest PR for the wizard framework, mostly due to the increased number of tests and focus on type-safety. The implementation itself is relatively small, but the large amount of flexibility offered by the framework made specialized testing code worth the effort.

## Key Ideas

### Prompter
At the highest level, QuickPicks and QuickInputs are just a way to collect data from the user. For QuickInputs the result is just a string, while QuickPicks can have arbitrary shape. To accommodate this, the `Prompter` abstraction uses generic types and makes no assumptions about the underlying data structures used to collect user input. For convenience, the abstraction provides concrete transformation functions to map input shapes to arbitrary output shapes. As an example, a `Prompter` implementation might output a data structure (which is fully descriptive) like so:
```ts
{
  respositoryUri: 'scheme://location',
  branch: 'mybranch',
  tag: 'mytag',
}
```
But a wizard might want to map this as:
```ts
result = `${respositroyUri}:${branch}`
```
Rather than implement another prompter, transformations can just be applied to the original.

Additionally, an `after` callback is provided when an async operation is needed immediately after a response (before the next prompt). This call _is_ blocking and would prevent the next prompt from showing.

### WizardForm
`Prompter` provides the means for collecting input. However, we now need a way to assign prompters to fields. Consider a wizard that wants information in the shape of:
```ts
{
  prop1: number
  prop2?: string
}
```
The `WizardForm` provides an easy way to assign (or 'bind') prompters to specific fields. The bindings include additional options that change when the prompter is shown. Note that all binding operations expect a _function_ that generates a prompter given a state. This is done to maintain immutability across individual prompt operations. An example binding:
```ts
function createMathQuiz(num: number): Prompter<string> {
  // The prompter generation code is not in this PR, but it would like this for an InputBox
  return createInputBox({
    title: 'Math Quiz',
    placeholder: `What is ${num} + ${num}?`,
    buttons: [createHelpButton('https://en.wikipedia.org/wiki/Addition')],
  })
}

// We would actually want to validate input here but this just a toy example
form.body.prop1.bindPrompter(() => createInputBox({ title: 'Enter a number' }).transform(resp => Number(resp)))
// No transformation here because we (arbitrarily) want a string 
form.body.prop2.bindPrompter(state => createMathQuiz(state.prop2))
```
This would create a binding using the value of `prop2` as input. In many circumstances we only want to show prompters if certain prerequisites are met. For example, the following code block would only show the `prop2` binding if `prop1` is greater than 0:
```ts
form.body.prop2.bindPrompter(state => createMathQuiz(state.prop1), {
  showWhen: state => state.prop1 > 0
})
```
Additionally, all methods are type-safe. For example, TypeScript will show an error if one tried to bind a string prompter to a boolean property (it would need to be transformed). There are also a few extra options beyond `showWhen`, but these will be explored in the following PR.

It is important to note that forms have no explicit notion of ordering. In the above example, we implicitly created an ordering by requiring that `prop2` is only shown when `prop1` is greater than 0. Fields that can be shown at the same time are resolved into discrete steps by the `Wizard` implementation.

### Wizard
Everything comes together with this class. Wizards create their own `WizardForm` upon instantiation and exposes the form's body for public access when simple wizards are needed. They can also be supplied with an initial form object instead for modularity. After construction, a wizard can be ran until the completion, outputting the desired data shape defined through type parameters.

Internally, the wizard queries the form for 'showable' fields, generating steps (which are just functions) to be consumed by the state controller. All fields with bound prompters are encapsulated into functions compatible with the state machine controller. Any fields that can be shown before the wizard has started are added to the controller. A very high-level view of the algorithm executed in the bound functions:
1. Run the `Prompter`, handling control signals and setting various state signals
2. Determine which fields are 'showable' by querying the `WizardForm` with the new state
3. Return the result to the state controller to be processed

As mentioned previously, the form itself has no _explicit_ notion of ordering. The aglorithm currently just adds multiple 'showable' fields in the order in which they were bound.

Creating the wizard itself is very simple:
```ts
// both arguments are optional, but the type is inferred from the form
let wizard = new Wizard(form, initState) 

// With the above example, the wizard first prompts for `prop1`, then  _might_ prompt for 
// `prop2` if `prop1` meets the `showWhen` condition
let result = await wizard.run()

// Alternatively, we may want to pre-set `prop1` (maybe we already know what it should be)
wizard = new Wizard(form, { prop1: 10 })

// In this case `prop2` will always be prompted for, and `prop1` will never be asked
result = await wizard.run()
```

## Testing
Because the wizard consumes `WizardForm` objects, wizard implementations only need to test their specific construction of the `WizardForm`. A testing construct specifically for testing `WizardForm` objects is provided in this PR. The tests for `WizardForm` demonstrate this flow, though the prompters used are just 'dummy' prompters. Generally speaking, the implementation would bind prompters in a constructor (to preserve immutability), which a test file can then initialize and test without knowing exactly which prompters were bound.

The nature of the form object means that execution order does not exist, greatly simplifying testing. Rather than exhaustively run through every possible 'flow' of a wizard, we only need to apply a set of inputs (a state) and assert which fields would be shown given the present state. Using an example from the `WizardForm` section:
```ts
form.body.prop1.bindPrompter(state => createMathQuiz(state.prop2), {
  showWhen: state => state.prop2 > 0
})

tester = createFormTester(form)

tester.prop2.applyInput(0)
tester.prop1.assertDoesNotShow() // passes since prop2 is not greater than 0

tester.prop2.applyInput(1)
tester.prop1.assertShow() // passes since now prop2 is greater than 0

tester.prop1.applyInput('a string')
tester.prop1.assertShow() // fails since we just assigned the field, therefore it should _not_ be shown
```

### Next PR
The final PR will have concrete implementations of prompters + tests (roughly the size of the first PR)

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
