### PR TITLE
SAM Invoke Webview: fix 'Show All Fields'

### DIFF
--- a/.changes/next-release/Bug Fix-a2794092-7e1f-4b32-94f3-94f78512f1b7.json
+++ b/.changes/next-release/Bug Fix-a2794092-7e1f-4b32-94f3-94f78512f1b7.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "SAM Invoke Webview: fix 'Show All Fields' causing a blank page"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
     "requires": true,
     "packages": {
         "": {
-            "version": "1.26.0-SNAPSHOT",
+            "version": "1.28.0-SNAPSHOT",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/src/lambda/vue/samInvokeVue.ts
+++ b/src/lambda/vue/samInvokeVue.ts
@@ -454,7 +454,7 @@ export const Component = Vue.extend({
                 </div>
             </div>
             <div v-else>Select an Invoke Target</div>
-            <button @click="toggleShowAllFields">{{showAllFields ? "Show Less Fields" : "Show All Fields"}}</button>
+            <button v-on:click.prevent="toggleShowAllFields">{{showAllFields ? "Show Less Fields" : "Show All Fields"}}</button>
             <div v-if="showAllFields">
                 <h3>aws</h3>
                 <div class="config-item">


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

The 'Show All Fields' button was being treated as a form submission button, causing VS code to blank out the webview when clicking it. This bug did not affect Cloud 9.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
