### PR TITLE
tests: removed await statement from describe block

### DIFF
--- a/docs/TESTPLAN.md
+++ b/docs/TESTPLAN.md
@@ -57,6 +57,14 @@ modifications/workarounds in `src/test/testRunner.ts`.
     -   [Mocha](https://mochajs.org/) framework is used to write tests.
 -   New code requires new tests.
 
+## Best Practices
+
+-   Use `function ()` and `async function ()` syntax for `describe()` and `it()` callbacks [instead of arrow functions.](https://mochajs.org/#arrow-functions)
+-   Do NOT include any `await` functions in `describe()` blocks directly (usage within `before`, `beforeEach`, `after`, `afterEach`, and `it` blocks are fine).
+    -   This will cause the toolkit to always evaluate the `describe` block and can cause issues with either tests not running or tests always running (if other tests are running with `.only`)
+    -   Tests that require an premade value from a Promise should initialize the value as a `let` and make the `await`ed call in the `before()` statement.
+-   Remember to clean up any `.only()` statements before pushing into PRs! Otherwise, the full suite of tests won't work.
+
 ## Testing Gaps
 
 -   No handling of case where VSCode crashes.

--- a/src/test/lambda/wizards/samDeployWizard.test.ts
+++ b/src/test/lambda/wizards/samDeployWizard.test.ts
@@ -184,7 +184,11 @@ function normalizePath(...paths: string[]): string {
 }
 
 describe('SamDeployWizard', async function () {
-    const extContext = await FakeExtensionContext.getFakeExtContext()
+    let extContext: ExtContext
+    before(async function () {
+        extContext = await FakeExtensionContext.getFakeExtContext()
+    })
+
     describe('TEMPLATE', async function () {
         it('fails gracefully when no templates are found', async function () {
             const wizard = new SamDeployWizard(new MockSamDeployWizardContext(extContext, [[]], [undefined], [], []))
@@ -791,13 +795,10 @@ describe('DefaultSamDeployWizardContext', async function () {
             assert.strictEqual(output, bucketName)
         })
 
-        it('returns undefined if nothing is entered', async function() {
-            sandbox
-                .stub(input, 'promptUser')
-                .onFirstCall()
-                .returns(Promise.resolve(undefined))
+        it('returns undefined if nothing is entered', async function () {
+            sandbox.stub(input, 'promptUser').onFirstCall().returns(Promise.resolve(undefined))
             const output = await context.promptUserForS3BucketName(1, { title: 'asdf' })
-            assert.strictEqual(output, undefined) 
-        })  
+            assert.strictEqual(output, undefined)
+        })
     })
 })


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem

`await` statements directly in `describe` blocks for Mocha tests cause the `describe` block to be evaluated for every test, including running `before` and `beforeEach` statements before all other tests. Even affects tests running with a `.only`! Also causes issues with some tests not running.

## Solution

Removed an `await` statement from the SAM Deploy Wizard's tests and tested by adding a `.only` to a random test, and reveled in the fact that only that one test was run (and not the tests for the SAM Deploy Wizard). Added documentation for future reference.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
