### PR TITLE
SAM: suppress Delve error

### DIFF
--- a/src/shared/sam/debugger/goSamDebug.ts
+++ b/src/shared/sam/debugger/goSamDebug.ts
@@ -143,7 +143,7 @@ export async function makeGoConfig(config: SamLaunchRequestArgs): Promise<GoDebu
         host: 'localhost',
         port: port,
         skipFiles: [],
-        debugArgs: isImageLambda || config.noDebug ? undefined : ['-delveAPI=2'],
+        debugArgs: isImageLambda || config.noDebug ? undefined : ['-delveAPI=2', '--check-go-version=false'],
         debugAdapter: 'legacy', // Just in case the Go extension decides to make Delve DAP the default
     }
 


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

Latest Delve version no longer officially supports Go 1.14, though it should still work with it.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
