### PR TITLE
tests/integ: fix Go install

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -26,9 +26,10 @@ phases:
             - '>/dev/null pip3 install --upgrade aws-sam-cli'
             - '>/dev/null pip3 install --upgrade awscli'
             - '>/dev/null pip3 install pylint'
-            # Install Go
-            - '>/dev/null VERSION=$(curl "https://golang.org/VERSION?m=text") && wget -q "https://dl.google.com/go/$VERSION.linux-amd64.tar.gz"'
-            - '>/dev/null tar -C /usr/local -xzf $VERSION.linux-amd64.tar.gz && export PATH=$PATH:/usr/local/go/bin && go env -w GOPROXY=direct'
+            # Install latest version of Go (known to 'goenv')
+            - '>/dev/null VERSION=$(goenv install --list | tail -n 1) && goenv install $VERSION'
+            - '>/dev/null goenv global $VERSION && go env -w GOPROXY=direct'
+            - go version
             # login to DockerHub so we don't get throttled
             - docker login --username $(echo $DOCKER_HUB_TOKEN | jq -r '.username') --password $(echo $DOCKER_HUB_TOKEN | jq -r '.password') || true
 


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

CodeBuild images use `goenv` to install Go. This means they come with Go even if you do not specify a runtime. It also means you cannot upgrade the version the standard way, and instead must use `goenv` directly.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
