### PR TITLE
CFN: use YAML extension API instead of editing settings

### DIFF
--- a/src/integrationTest/cloudformation/templateRegistry.test.ts
+++ b/src/integrationTest/cloudformation/templateRegistry.test.ts
@@ -9,6 +9,7 @@ import * as fs from 'fs-extra'
 import { CloudFormationTemplateRegistry } from '../../shared/cloudformation/templateRegistry'
 import { makeSampleSamTemplateYaml, strToYamlFile } from '../../test/shared/cloudformation/cloudformationTestUtils'
 import { getTestWorkspaceFolder } from '../integrationTestsUtilities'
+import { ext } from '../../shared/extensionGlobals'
 
 /**
  * Note: these tests are pretty shallow right now. They do not test the following:
@@ -29,7 +30,7 @@ describe('CloudFormation Template Registry', async function () {
         testDir = path.join(workspaceDir, dir.toString())
         testDirNested = path.join(testDir, 'nested')
         await fs.mkdirp(testDirNested)
-        registry = new CloudFormationTemplateRegistry()
+        registry = ext.templateRegistry
     })
 
     afterEach(async function () {

--- a/src/integrationTest/cloudformation/templateRegistry.test.ts
+++ b/src/integrationTest/cloudformation/templateRegistry.test.ts
@@ -9,7 +9,8 @@ import * as fs from 'fs-extra'
 import { CloudFormationTemplateRegistry } from '../../shared/cloudformation/templateRegistry'
 import { makeSampleSamTemplateYaml, strToYamlFile } from '../../test/shared/cloudformation/cloudformationTestUtils'
 import { getTestWorkspaceFolder } from '../integrationTestsUtilities'
-import { ext } from '../../shared/extensionGlobals'
+import { CloudFormationSchemas, YamlExtension } from '../../shared/cloudformation/yamlExtension'
+import { Uri } from 'vscode'
 
 /**
  * Note: these tests are pretty shallow right now. They do not test the following:
@@ -21,16 +22,26 @@ describe('CloudFormation Template Registry', async function () {
     let testDir: string
     let testDirNested: string
     let dir: number = 0
+    let fakeSchemas: CloudFormationSchemas
+    let fakeYamlExtension: YamlExtension
 
     before(async function () {
         workspaceDir = getTestWorkspaceFolder()
+        fakeSchemas = {
+            standard: Uri.parse(path.join(workspaceDir, 'cloudformation.schema.json')),
+            sam: Uri.parse(path.join(workspaceDir, 'sam.schema.json')),
+        }
+        fakeYamlExtension = {
+            assignSchema: (path, schema) => undefined,
+            removeSchema: path => undefined,
+        }
     })
 
     beforeEach(async function () {
         testDir = path.join(workspaceDir, dir.toString())
         testDirNested = path.join(testDir, 'nested')
         await fs.mkdirp(testDirNested)
-        registry = ext.templateRegistry
+        registry = new CloudFormationTemplateRegistry(fakeSchemas, fakeYamlExtension)
     })
 
     afterEach(async function () {

--- a/src/integrationTest/globalSetup.test.ts
+++ b/src/integrationTest/globalSetup.test.ts
@@ -49,7 +49,6 @@ export function setTestTimeout(testName: string | undefined, ms: number) {
 before(async function () {
     console.log('globalSetup: before()')
     // Needed for getLogger().
-    await new Promise(r => setTimeout(r, 5000))
     await activateExtension(VSCODE_EXTENSION_ID.awstoolkit, false)
 
     // Log as much as possible, useful for debugging integration tests.

--- a/src/integrationTest/globalSetup.test.ts
+++ b/src/integrationTest/globalSetup.test.ts
@@ -49,6 +49,7 @@ export function setTestTimeout(testName: string | undefined, ms: number) {
 before(async function () {
     console.log('globalSetup: before()')
     // Needed for getLogger().
+    await new Promise(r => setTimeout(r, 5000))
     await activateExtension(VSCODE_EXTENSION_ID.awstoolkit, false)
 
     // Log as much as possible, useful for debugging integration tests.

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -13,8 +13,8 @@ import { getIdeProperties } from '../extensionUtilities'
 import { NoopWatcher } from '../watchedFiles'
 import { refreshSchemas } from './cloudformation'
 import { VSCODE_EXTENSION_ID } from '../extensions'
-import { readFileSync } from 'fs-extra'
 import * as path from 'path'
+import { activateYamlExtension, CloudFormationSchemas } from './yamlExtension'
 
 export const TEMPLATE_FILE_GLOB_PATTERN = '**/template.{yaml,yml}'
 
@@ -62,62 +62,6 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
     }
     // If setting it up worked, add it to subscriptions so it is cleaned up at exit
     extensionContext.subscriptions.push(ext.templateRegistry)
-}
-
-export interface CloudFormationSchemas {
-    standard: vscode.Uri
-    sam: vscode.Uri
-}
-
-// sourced from https://github.com/redhat-developer/vscode-yaml/blob/3d82d61ea63d3e3a9848fe6b432f8f1f452c1bec/src/schema-extension-api.ts
-// removed everything that is not currently being used
-
-interface YamlExtensionApi {
-    registerContributor(
-        schema: string,
-        requestSchema: (resource: string) => string | undefined,
-        requestSchemaContent: (uri: string) => string,
-        label?: string
-    ): boolean
-}
-
-export interface YamlExtension {
-    assignSchema(path: vscode.Uri, schema: vscode.Uri | (() => vscode.Uri)): void
-    removeSchema(path: vscode.Uri): void
-}
-
-const AWS_SCHEME = 'aws-schema'
-
-function applyScheme(scheme: string, path: vscode.Uri): vscode.Uri {
-    return vscode.Uri.parse(`${scheme}://${path.fsPath}`)
-}
-
-function evaluate(schema: vscode.Uri | (() => vscode.Uri)): vscode.Uri {
-    return schema instanceof Function ? schema() : schema
-}
-
-function activateYamlExtension(): YamlExtension {
-    const yamlExt = vscode.extensions.getExtension<YamlExtensionApi>(VSCODE_EXTENSION_ID.yaml)
-    const schemaMap = new Map<string, vscode.Uri>()
-
-    if (yamlExt !== undefined) {
-        yamlExt.activate().then(api => {
-            api.registerContributor(
-                AWS_SCHEME,
-                resource => {
-                    return schemaMap.get(resource)?.toString()
-                },
-                uri => {
-                    return readFileSync(vscode.Uri.parse(uri).fsPath).toString()
-                }
-            )
-        })
-    }
-
-    return {
-        assignSchema: (path, schema) => schemaMap.set(path.toString(), applyScheme(AWS_SCHEME, evaluate(schema))),
-        removeSchema: path => schemaMap.delete(path.toString()),
-    }
 }
 
 /**

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode'
 import { getLogger } from '../logger'
-import { activateExtension, localize } from '../utilities/vsCodeUtils'
+import { localize } from '../utilities/vsCodeUtils'
 
 import { CloudFormationTemplateRegistry } from './templateRegistry'
 import { ext } from '../extensionGlobals'
@@ -13,6 +13,8 @@ import { getIdeProperties } from '../extensionUtilities'
 import { NoopWatcher } from '../watchedFiles'
 import { refreshSchemas } from './cloudformation'
 import { VSCODE_EXTENSION_ID } from '../extensions'
+import { readFileSync } from 'fs-extra'
+import * as path from 'path'
 
 export const TEMPLATE_FILE_GLOB_PATTERN = '**/template.{yaml,yml}'
 
@@ -23,7 +25,6 @@ export const TEMPLATE_FILE_GLOB_PATTERN = '**/template.{yaml,yml}'
  * matches both /.aws-sam or /.aws-sam/<any number of characters>)
  */
 export const TEMPLATE_FILE_EXCLUDE_PATTERN = /.*[/\\]\.aws-sam([/\\].*|$)/
-
 /**
  * Creates a CloudFormationTemplateRegistry which retains the state of CloudFormation templates in a workspace.
  * This also assigns a FileSystemWatcher which will update the registry on any change to tracked templates.
@@ -31,14 +32,18 @@ export const TEMPLATE_FILE_EXCLUDE_PATTERN = /.*[/\\]\.aws-sam([/\\].*|$)/
  * @param extensionContext VS Code extension context
  */
 export async function activate(extensionContext: vscode.ExtensionContext): Promise<void> {
-    refreshSchemas(extensionContext)
-    // Note: redhat.vscode-yaml no longer works on vscode 1.42
-    if (await activateExtension(VSCODE_EXTENSION_ID.yaml)) {
+    const schemas: CloudFormationSchemas = {
+        standard: vscode.Uri.file(path.join(extensionContext.globalStoragePath, 'cloudformation.schema.json')),
+        sam: vscode.Uri.file(path.join(extensionContext.globalStoragePath, 'sam.schema.json')),
+    }
+
+    refreshSchemas(schemas)
+    if (vscode.extensions.getExtension(VSCODE_EXTENSION_ID.yaml) !== undefined) {
         addCustomTags()
     }
 
     try {
-        const registry = new CloudFormationTemplateRegistry()
+        const registry = new CloudFormationTemplateRegistry(schemas, activateYamlExtension())
         await registry.addExcludedPattern(TEMPLATE_FILE_EXCLUDE_PATTERN)
         await registry.addWatchPattern(TEMPLATE_FILE_GLOB_PATTERN)
         ext.templateRegistry = registry
@@ -53,10 +58,66 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
         getLogger().error('Failed to activate template registry', e)
         // This prevents us from breaking for any reason later if it fails to load. Since
         // Noop watcher is always empty, we will get back empty arrays with no issues.
-        ext.templateRegistry = (new NoopWatcher() as unknown) as CloudFormationTemplateRegistry
+        ext.templateRegistry = new NoopWatcher() as unknown as CloudFormationTemplateRegistry
     }
     // If setting it up worked, add it to subscriptions so it is cleaned up at exit
     extensionContext.subscriptions.push(ext.templateRegistry)
+}
+
+export interface CloudFormationSchemas {
+    standard: vscode.Uri
+    sam: vscode.Uri
+}
+
+// sourced from https://github.com/redhat-developer/vscode-yaml/blob/3d82d61ea63d3e3a9848fe6b432f8f1f452c1bec/src/schema-extension-api.ts
+// removed everything that is not currently being used
+
+interface YamlExtensionApi {
+    registerContributor(
+        schema: string,
+        requestSchema: (resource: string) => string | undefined,
+        requestSchemaContent: (uri: string) => string,
+        label?: string
+    ): boolean
+}
+
+export interface YamlExtension {
+    assignSchema(path: vscode.Uri, schema: vscode.Uri | (() => vscode.Uri)): void
+    removeSchema(path: vscode.Uri): void
+}
+
+const AWS_SCHEME = 'aws-schema'
+
+function applyScheme(scheme: string, path: vscode.Uri): vscode.Uri {
+    return vscode.Uri.parse(`${scheme}://${path.fsPath}`)
+}
+
+function evaluate(schema: vscode.Uri | (() => vscode.Uri)): vscode.Uri {
+    return schema instanceof Function ? schema() : schema
+}
+
+function activateYamlExtension(): YamlExtension {
+    const yamlExt = vscode.extensions.getExtension<YamlExtensionApi>(VSCODE_EXTENSION_ID.yaml)
+    const schemaMap = new Map<string, vscode.Uri>()
+
+    if (yamlExt !== undefined) {
+        yamlExt.activate().then(api => {
+            api.registerContributor(
+                AWS_SCHEME,
+                resource => {
+                    return schemaMap.get(resource)?.toString()
+                },
+                uri => {
+                    return readFileSync(vscode.Uri.parse(uri).fsPath).toString()
+                }
+            )
+        })
+    }
+
+    return {
+        assignSchema: (path, schema) => schemaMap.set(path.toString(), applyScheme(AWS_SCHEME, evaluate(schema))),
+        removeSchema: path => schemaMap.delete(path.toString()),
+    }
 }
 
 /**
@@ -67,34 +128,34 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 function addCustomTags(): void {
     const currentTags = vscode.workspace.getConfiguration().get<string[]>('yaml.customTags') ?? []
     const cloudFormationTags = [
-        "!And",
-        "!And sequence",
-        "!If",
-        "!If sequence",
-        "!Not",
-        "!Not sequence",
-        "!Equals",
-        "!Equals sequence",
-        "!Or",
-        "!Or sequence",
-        "!FindInMap",
-        "!FindInMap sequence",
-        "!Base64",
-        "!Join",
-        "!Join sequence",
-        "!Cidr",
-        "!Ref",
-        "!Sub",
-        "!Sub sequence",
-        "!GetAtt",
-        "!GetAZs",
-        "!ImportValue",
-        "!ImportValue sequence",
-        "!Select",
-        "!Select sequence",
-        "!Split",
-        "!Split sequence"
+        '!And',
+        '!And sequence',
+        '!If',
+        '!If sequence',
+        '!Not',
+        '!Not sequence',
+        '!Equals',
+        '!Equals sequence',
+        '!Or',
+        '!Or sequence',
+        '!FindInMap',
+        '!FindInMap sequence',
+        '!Base64',
+        '!Join',
+        '!Join sequence',
+        '!Cidr',
+        '!Ref',
+        '!Sub',
+        '!Sub sequence',
+        '!GetAtt',
+        '!GetAZs',
+        '!ImportValue',
+        '!ImportValue sequence',
+        '!Select',
+        '!Select sequence',
+        '!Split',
+        '!Split sequence',
     ]
-    const updateTags = currentTags.concat(cloudFormationTags.filter((item) => currentTags.indexOf(item) < 0))
+    const updateTags = currentTags.concat(cloudFormationTags.filter(item => currentTags.indexOf(item) < 0))
     vscode.workspace.getConfiguration().update('yaml.customTags', updateTags, vscode.ConfigurationTarget.Workspace)
 }

--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -797,7 +797,7 @@ export async function refreshSchemas(schemas: CloudFormationSchemas): Promise<vo
             cacheKey: 'cfnSchemaVersion',
         })
         await getRemoteOrCachedFile({
-            filepath: schemas.standard.fsPath,
+            filepath: schemas.sam.fsPath,
             version: details.version,
             url: details.samUrl,
             cacheKey: 'samSchemaVersion',

--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -16,7 +16,7 @@ import { HttpResourceFetcher } from '../resourcefetcher/httpResourceFetcher'
 import { ResourceFetcher } from '../resourcefetcher/resourcefetcher'
 import { FileResourceFetcher } from '../resourcefetcher/fileResourceFetcher'
 import { CompositeResourceFetcher } from '../resourcefetcher/compositeResourceFetcher'
-import { CloudFormationSchemas } from './activation'
+import { CloudFormationSchemas } from './yamlExtension'
 
 export namespace CloudFormation {
     export const SERVERLESS_API_TYPE = 'AWS::Serverless::Api'

--- a/src/shared/cloudformation/templateRegistry.ts
+++ b/src/shared/cloudformation/templateRegistry.ts
@@ -14,7 +14,7 @@ import { getLambdaDetails } from '../../lambda/utils'
 import { ext } from '../extensionGlobals'
 import { WatchedFiles, WatchedItem } from '../watchedFiles'
 import { getLogger } from '../logger'
-import { CloudFormationSchemas, YamlExtension } from './activation'
+import { CloudFormationSchemas, YamlExtension } from './yamlExtension'
 
 export interface TemplateDatum {
     path: string

--- a/src/shared/cloudformation/yamlExtension.ts
+++ b/src/shared/cloudformation/yamlExtension.ts
@@ -1,0 +1,64 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'fs-extra'
+import * as vscode from 'vscode'
+import { VSCODE_EXTENSION_ID } from '../extensions'
+
+// sourced from https://github.com/redhat-developer/vscode-yaml/blob/3d82d61ea63d3e3a9848fe6b432f8f1f452c1bec/src/schema-extension-api.ts
+// removed everything that is not currently being used
+
+interface YamlExtensionApi {
+    registerContributor(
+        schema: string,
+        requestSchema: (resource: string) => string | undefined,
+        requestSchemaContent: (uri: string) => string,
+        label?: string
+    ): boolean
+}
+
+const AWS_SCHEME = 'aws-schema'
+
+function applyScheme(scheme: string, path: vscode.Uri): vscode.Uri {
+    return vscode.Uri.parse(`${scheme}://${path.fsPath}`)
+}
+
+function evaluate(schema: vscode.Uri | (() => vscode.Uri)): vscode.Uri {
+    return schema instanceof Function ? schema() : schema
+}
+
+export interface CloudFormationSchemas {
+    standard: vscode.Uri
+    sam: vscode.Uri
+}
+
+export interface YamlExtension {
+    assignSchema(path: vscode.Uri, schema: vscode.Uri | (() => vscode.Uri)): void
+    removeSchema(path: vscode.Uri): void
+}
+
+export function activateYamlExtension(): YamlExtension {
+    const yamlExt = vscode.extensions.getExtension<YamlExtensionApi>(VSCODE_EXTENSION_ID.yaml)
+    const schemaMap = new Map<string, vscode.Uri>()
+
+    if (yamlExt !== undefined) {
+        yamlExt.activate().then(api => {
+            api.registerContributor(
+                AWS_SCHEME,
+                resource => {
+                    return schemaMap.get(resource)?.toString()
+                },
+                uri => {
+                    return readFileSync(vscode.Uri.parse(uri).fsPath).toString()
+                }
+            )
+        })
+    }
+
+    return {
+        assignSchema: (path, schema) => schemaMap.set(path.toString(), applyScheme(AWS_SCHEME, evaluate(schema))),
+        removeSchema: path => schemaMap.delete(path.toString()),
+    }
+}

--- a/src/shared/cloudformation/yamlExtension.ts
+++ b/src/shared/cloudformation/yamlExtension.ts
@@ -6,6 +6,7 @@
 import { readFileSync } from 'fs-extra'
 import * as vscode from 'vscode'
 import { VSCODE_EXTENSION_ID } from '../extensions'
+import { getLogger } from '../logger/logger'
 
 // sourced from https://github.com/redhat-developer/vscode-yaml/blob/3d82d61ea63d3e3a9848fe6b432f8f1f452c1bec/src/schema-extension-api.ts
 // removed everything that is not currently being used
@@ -44,17 +45,20 @@ export function activateYamlExtension(): YamlExtension {
     const schemaMap = new Map<string, vscode.Uri>()
 
     if (yamlExt !== undefined) {
-        yamlExt.activate().then(api => {
-            api.registerContributor(
-                AWS_SCHEME,
-                resource => {
-                    return schemaMap.get(resource)?.toString()
-                },
-                uri => {
-                    return readFileSync(vscode.Uri.parse(uri).fsPath).toString()
-                }
-            )
-        })
+        yamlExt.activate().then(
+            api => {
+                api.registerContributor(
+                    AWS_SCHEME,
+                    resource => {
+                        return schemaMap.get(resource)?.toString()
+                    },
+                    uri => {
+                        return readFileSync(vscode.Uri.parse(uri).fsPath).toString()
+                    }
+                )
+            },
+            err => getLogger().error('Failed to activate YAML extension: %O', err)
+        )
     }
 
     return {

--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -21,8 +21,7 @@ import * as fakeTelemetry from './fake/fakeTelemetryService'
 import { TestLogger } from './testLogger'
 import { FakeAwsContext } from './utilities/fakeAwsContext'
 import { initializeComputeRegion } from '../shared/extensionUtilities'
-import { activateExtension } from '../shared/utilities/vsCodeUtils'
-import { VSCODE_EXTENSION_ID } from '../shared/extensions'
+import { CloudFormationSchemas, YamlExtension } from '../shared/cloudformation/activation'
 
 const testReportDir = join(__dirname, '../../../.test-reports')
 const testLogOutput = join(testReportDir, 'testLog.log')
@@ -35,9 +34,6 @@ before(async function () {
     try {
         await remove(testLogOutput)
     } catch (e) {}
-    try {
-        await activateExtension(VSCODE_EXTENSION_ID.yaml)
-    } catch (e) {}
     mkdirpSync(testReportDir)
     // Set up global telemetry client
     const fakeContext = new FakeExtensionContext()
@@ -49,10 +45,20 @@ before(async function () {
     await initializeComputeRegion()
 })
 
+const fakeSchemas: CloudFormationSchemas = {
+    standard: '' as any,
+    sam: '' as any,
+}
+
+const fakeYamlExtension: YamlExtension = {
+    assignSchema: (path, schema) => undefined,
+    removeSchema: path => undefined,
+}
+
 beforeEach(function () {
     // Set every test up so that TestLogger is the logger used by toolkit code
     testLogger = setupTestLogger()
-    ext.templateRegistry = new CloudFormationTemplateRegistry()
+    ext.templateRegistry = new CloudFormationTemplateRegistry(fakeSchemas, fakeYamlExtension)
     ext.codelensRootRegistry = new CodelensRootRegistry()
 })
 

--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -21,7 +21,8 @@ import * as fakeTelemetry from './fake/fakeTelemetryService'
 import { TestLogger } from './testLogger'
 import { FakeAwsContext } from './utilities/fakeAwsContext'
 import { initializeComputeRegion } from '../shared/extensionUtilities'
-import { CloudFormationSchemas, YamlExtension } from '../shared/cloudformation/activation'
+import { Uri } from 'vscode'
+import { CloudFormationSchemas, YamlExtension } from '../shared/cloudformation/yamlExtension'
 
 const testReportDir = join(__dirname, '../../../.test-reports')
 const testLogOutput = join(testReportDir, 'testLog.log')
@@ -45,9 +46,10 @@ before(async function () {
     await initializeComputeRegion()
 })
 
+// These currently are only ever read by the Yaml extension, which we have stubbed out
 const fakeSchemas: CloudFormationSchemas = {
-    standard: '' as any,
-    sam: '' as any,
+    standard: Uri.parse(''),
+    sam: Uri.parse(''),
 }
 
 const fakeYamlExtension: YamlExtension = {

--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -23,6 +23,7 @@ import { FakeAwsContext } from './utilities/fakeAwsContext'
 import { initializeComputeRegion } from '../shared/extensionUtilities'
 import { Uri } from 'vscode'
 import { CloudFormationSchemas, YamlExtension } from '../shared/cloudformation/yamlExtension'
+import { lazyLoadSamTemplateStrings } from '../lambda/models/samTemplates'
 
 const testReportDir = join(__dirname, '../../../.test-reports')
 const testLogOutput = join(testReportDir, 'testLog.log')
@@ -44,6 +45,7 @@ before(async function () {
     ext.init(fakeContext, extWindow.Window.vscode())
     ext.telemetry = service
     await initializeComputeRegion()
+    lazyLoadSamTemplateStrings()
 })
 
 // These currently are only ever read by the Yaml extension, which we have stubbed out

--- a/src/test/lambda/models/samTemplates.test.ts
+++ b/src/test/lambda/models/samTemplates.test.ts
@@ -21,28 +21,31 @@ import { Set } from 'immutable'
 
 import { samZipLambdaRuntimes } from '../../../lambda/models/samLambdaRuntime'
 
-const validTemplateOptions: Set<SamTemplate> = Set<SamTemplate>([
-    helloWorldTemplate,
-    eventBridgeHelloWorldTemplate,
-    eventBridgeStarterAppTemplate,
-    stepFunctionsSampleApp,
-    typeScriptBackendTemplate,
-])
+let validTemplateOptions: Set<SamTemplate>
+let validPythonTemplateOptions: Set<SamTemplate>
+let validNode12TemplateOptions: Set<SamTemplate>
+let defaultTemplateOptions: Set<SamTemplate>
 
-const validPythonTemplateOptions: Set<SamTemplate> = Set<SamTemplate>([
-    helloWorldTemplate,
-    eventBridgeHelloWorldTemplate,
-    eventBridgeStarterAppTemplate,
-    stepFunctionsSampleApp,
-])
+before(function () {
+    validTemplateOptions = Set([
+        helloWorldTemplate,
+        eventBridgeHelloWorldTemplate,
+        eventBridgeStarterAppTemplate,
+        stepFunctionsSampleApp,
+        typeScriptBackendTemplate,
+    ])
 
-const validNode12TemplateOptions: Set<SamTemplate> = Set<SamTemplate>([
-    helloWorldTemplate,
-    stepFunctionsSampleApp,
-    typeScriptBackendTemplate,
-])
+    validPythonTemplateOptions = Set([
+        helloWorldTemplate,
+        eventBridgeHelloWorldTemplate,
+        eventBridgeStarterAppTemplate,
+        stepFunctionsSampleApp,
+    ])
 
-const defaultTemplateOptions: Set<SamTemplate> = Set<SamTemplate>([helloWorldTemplate, stepFunctionsSampleApp])
+    validNode12TemplateOptions = Set([helloWorldTemplate, stepFunctionsSampleApp, typeScriptBackendTemplate])
+
+    defaultTemplateOptions = Set([helloWorldTemplate, stepFunctionsSampleApp])
+})
 
 describe('getSamTemplateWizardOption', function () {
     it('should successfully return available templates for specific runtime', function () {

--- a/src/test/shared/cloudformation/cloudformation.test.ts
+++ b/src/test/shared/cloudformation/cloudformation.test.ts
@@ -7,11 +7,7 @@ import * as assert from 'assert'
 import * as path from 'path'
 import * as fs from 'fs-extra'
 
-import {
-    CloudFormation,
-    getManifestDetails,
-    updateYamlSchemasArray,
-} from '../../../shared/cloudformation/cloudformation'
+import { CloudFormation, getManifestDetails } from '../../../shared/cloudformation/cloudformation'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 import { SystemUtilities } from '../../../shared/systemUtilities'
 import {
@@ -22,8 +18,6 @@ import {
     makeSampleSamTemplateYaml,
     strToYamlFile,
 } from './cloudformationTestUtils'
-import { FakeWorkspace } from '../vscode/fakeWorkspace'
-import { WorkspaceConfiguration } from '../../../shared/vscode/workspace'
 
 describe('CloudFormation', function () {
     let tempFolder: string
@@ -670,62 +664,6 @@ describe('CloudFormation', function () {
 })
 
 describe('Cloudformation Utils', function () {
-    describe('updateYamlSchemasArray', function () {
-        let config: WorkspaceConfiguration
-        const cfnSchema = 'cfn'
-        const samSchema = 'sam'
-
-        beforeEach(function () {
-            config = new FakeWorkspace().getConfiguration()
-        })
-
-        it('handles adding to and removing from a nonexistent setting', function () {
-            updateYamlSchemasArray('/foo', 'cfn', config, { cfnSchema, samSchema })
-            const val: any = config.get('schemas')
-            assert.deepStrictEqual(val[cfnSchema], ['/foo'])
-            assert.deepStrictEqual(val[samSchema], undefined)
-        })
-
-        it('handles adding to and removing from a setting with an undefined value', function () {
-            config.update('schemas', undefined)
-            updateYamlSchemasArray('/foo', 'cfn', config, { cfnSchema, samSchema })
-            const val: any = config.get('schemas')
-            assert.deepStrictEqual(val[cfnSchema], ['/foo'])
-            assert.deepStrictEqual(val[samSchema], undefined)
-        })
-        it('handles adding to and removing from a setting with a blank array', function () {
-            config.update('schemas', { cfn: [], sam: [] })
-            updateYamlSchemasArray('/foo', 'cfn', config, { cfnSchema, samSchema })
-            const val: any = config.get('schemas')
-            assert.deepStrictEqual(val[cfnSchema], ['/foo'])
-            assert.deepStrictEqual(val[samSchema], [])
-        })
-
-        it('handles adding to and removing from an existing array', function () {
-            config.update('schemas', { cfn: ['/bar'], sam: ['/asdf', '/foo'] })
-            updateYamlSchemasArray('/foo', 'cfn', config, { cfnSchema, samSchema })
-            const val: any = config.get('schemas')
-            assert.deepStrictEqual(val[cfnSchema], ['/bar', '/foo'])
-            assert.deepStrictEqual(val[samSchema], ['/asdf'])
-        })
-
-        it('handles adding to and removing from a string', function () {
-            config.update('schemas', { cfn: '/bar', sam: '/foo' })
-            updateYamlSchemasArray('/foo', 'cfn', config, { cfnSchema, samSchema })
-            const val: any = config.get('schemas')
-            assert.deepStrictEqual(val[cfnSchema], ['/bar', '/foo'])
-            assert.deepStrictEqual(val[samSchema], [])
-        })
-
-        it('handles removes from strings and arrays with `none`', function () {
-            config.update('schemas', { cfn: '/bar', sam: ['/foo', '/bar'] })
-            updateYamlSchemasArray('/bar', 'none', config, { cfnSchema, samSchema })
-            const val: any = config.get('schemas')
-            assert.deepStrictEqual(val[cfnSchema], [])
-            assert.deepStrictEqual(val[samSchema], ['/foo'])
-        })
-    })
-
     describe('getManifestDetails', function () {
         it('errors if manifest is not JSON', function () {
             assert.throws(() => getManifestDetails('foo'))

--- a/src/test/shared/cloudformation/templateRegistry.test.ts
+++ b/src/test/shared/cloudformation/templateRegistry.test.ts
@@ -18,6 +18,7 @@ import { badYaml, makeSampleSamTemplateYaml, strToYamlFile } from './cloudformat
 import { assertEqualPaths, toFile } from '../../testUtil'
 import { CloudFormation } from '../../../shared/cloudformation/cloudformation'
 import { WatchedItem } from '../../../shared/watchedFiles'
+import { ext } from '../../../shared/extensionGlobals'
 
 // TODO almost all of these tests should be moved to test WatchedFiles instead
 describe('CloudFormation Template Registry', async function () {
@@ -29,7 +30,7 @@ describe('CloudFormation Template Registry', async function () {
 
         beforeEach(async function () {
             tempFolder = await makeTemporaryToolkitFolder()
-            testRegistry = new CloudFormationTemplateRegistry()
+            testRegistry = ext.templateRegistry
         })
 
         afterEach(async function () {

--- a/src/test/shared/sam/cli/samCliInit.test.ts
+++ b/src/test/shared/sam/cli/samCliInit.test.ts
@@ -48,13 +48,17 @@ describe('runSamCliInit', async function () {
 
     const sampleDependencyManager = 'npm'
 
-    const sampleSamInitArgs: SamCliInitArgs = {
-        name: 'qwerty',
-        location: '/some/path/to/code.js',
-        runtime: 'nodejs10.x',
-        template: helloWorldTemplate,
-        dependencyManager: sampleDependencyManager,
-    }
+    let sampleSamInitArgs: SamCliInitArgs
+
+    before(function () {
+        sampleSamInitArgs = {
+            name: 'qwerty',
+            location: '/some/path/to/code.js',
+            runtime: 'nodejs10.x',
+            template: helloWorldTemplate,
+            dependencyManager: sampleDependencyManager,
+        }
+    })
 
     describe('runSamCliInit with HelloWorld template', async function () {
         it('Passes init command to sam cli', async function () {
@@ -187,23 +191,28 @@ describe('runSamCliInit', async function () {
     })
 
     describe('runSamCliInit With EventBridgeStartAppTemplate', async function () {
-        const extraContent: SchemaTemplateExtraContext = {
-            AWS_Schema_registry: 'testRegistry',
-            AWS_Schema_name: 'testSchema',
-            AWS_Schema_root: 'test',
-            AWS_Schema_source: 'AWS',
-            AWS_Schema_detail_type: 'ec2',
-            user_agent: 'testAgent',
-        }
+        let extraContent: SchemaTemplateExtraContext
+        let samInitArgsWithExtraContent: SamCliInitArgs
 
-        const samInitArgsWithExtraContent: SamCliInitArgs = {
-            name: 'qwerty',
-            location: '/some/path/to/code.js',
-            runtime: 'python3.6',
-            template: eventBridgeStarterAppTemplate,
-            extraContent: extraContent,
-            dependencyManager: sampleDependencyManager,
-        }
+        before(function () {
+            extraContent = {
+                AWS_Schema_registry: 'testRegistry',
+                AWS_Schema_name: 'testSchema',
+                AWS_Schema_root: 'test',
+                AWS_Schema_source: 'AWS',
+                AWS_Schema_detail_type: 'ec2',
+                user_agent: 'testAgent',
+            }
+
+            samInitArgsWithExtraContent = {
+                name: 'qwerty',
+                location: '/some/path/to/code.js',
+                runtime: 'python3.6',
+                template: eventBridgeStarterAppTemplate,
+                extraContent: extraContent,
+                dependencyManager: sampleDependencyManager,
+            }
+        })
 
         it('Passes --extra-context for eventBridgeStarterAppTemplate', async function () {
             const processInvoker: SamCliProcessInvoker = new ExtendedTestSamCliProcessInvoker(


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

Editing the settings was causing lots of issues with our tests. The testing structure could be modified to accommodate the implementation, but it involved quite a bit of changes and is not worth it. The alternative would be to redesign the implementation, but at that point it's better just to use the API anyway.

For some reason the changes in this PR also caused Mocha to load tests in a different order, making the files with lazy-loaded template strings being loaded before the test set-up. All dependencies were moved to `before` blocks.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
