### PR TITLE
SAM/Lambda: show Toolkit-owned README file for new apps

### DIFF
--- a/.changes/next-release/Feature-d65c175d-c61e-4a9f-b428-e72f093dfcc6.json
+++ b/.changes/next-release/Feature-d65c175d-c61e-4a9f-b428-e72f093dfcc6.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "New SAM applications come with toolkit-specific instructions"
+}

--- a/resources/markdown/samReadme.md
+++ b/resources/markdown/samReadme.md
@@ -1,0 +1,32 @@
+# Developing AWS SAM Applications with the ${PRODUCTNAME}
+
+This project contains source code and supporting files for a serverless application that you can locally run, debug, and deploy to AWS with the ${PRODUCTNAME}.
+
+## Writing and Debugging Serverless Applications
+
+The code for this application will differ based on the runtime, but the path to a handler can be found in the [`template.yaml`](./template.yaml) file through a resource's `CodeUri` and `Handler` fields.
+
+The ${PRODUCTNAME} supports quick local debugging for serverless applications through ${IDE}'s debug functionality. Since this serverless application was created through the Toolkit, all included handlers are generated with launch configurations, which can be found through the dropdown next to the Run button:
+${LISTOFCONFIGURATIONS}
+
+These can be invoked locally by running the configurations, and can be debugged if breakpoints are added to the source files. Invocation parameters, including payloads and request parameters, can be edited by either using the `SAM Debug Configuration Editor` (through the ${COMMANDPALETTE} or ${CODELENS}) or by directly editing the `launch.json` file containing the launch configurations.
+
+Functions that haven't been added to the [`template.yaml`](./template.yaml) file can also be directly invoked and debugged by creating a launch configuration through the ${CODELENS} over the function declaration, for quick debugging prior to committing the function to the SAM template.
+
+## Deploying Serverless Applications
+
+You can deploy a serverless application by invoking the `AWS: Deploy SAM application` command through the Command Palette or by right-clicking the Lambda node in the ${COMPANYNAME} Explorer and entering the deployment region, a valid S3 bucket from the region, and the name of a CloudFormation stack to deploy to. You can monitor your deployment's progress through the **${COMPANYNAME} Toolkit\*\* Output Channel.
+
+## Interacting With Deployed Serverless Applications
+
+A successfully-deployed serverless application can be found in the ${COMPANYNAME} Explorer under region and CloudFormation node that the serverless application was deployed to.
+
+Lambda Functions tied to the serverless application can be invoked by right-clicking the Lambda node and selecting "Invoke on AWS".
+
+Similarly, if the Function declaration contained an API Gateway event, the API Gateway API can be found in the API Gateway node under the region node the serverless application was deployed to.
+
+## Resources
+
+General information about this SAM project can be found in the [`README.md`](./README.md) file in this folder.
+
+More information about using the ${PRODUCTNAME} with serverless applications can be found [in the ${COMPANYNAME} documentation](${DOCURL}) .

--- a/resources/markdown/samReadme.md
+++ b/resources/markdown/samReadme.md
@@ -1,31 +1,51 @@
 # Developing AWS SAM Applications with the ${PRODUCTNAME}
 
-This project contains source code and supporting files for a serverless application that you can locally run, debug, and deploy to AWS with the ${PRODUCTNAME}.
+This project contains source code and supporting files for a serverless application that you can locally run, debug, and deploy to ${COMPANYNAME} with the ${PRODUCTNAME}.
+
+A "SAM" (serverless application model) project is a project that contains a template.yaml file which is understood by ${COMPANYNAME} tooling (such as SAM CLI, and the $PRODUCTNAME}).
+
+<br />
 
 ## Writing and Debugging Serverless Applications
 
+<br />
+
 The code for this application will differ based on the runtime, but the path to a handler can be found in the [`template.yaml`](./template.yaml) file through a resource's `CodeUri` and `Handler` fields.
 
-The ${PRODUCTNAME} supports quick local debugging for serverless applications through ${IDE}'s debug functionality. Since this serverless application was created through the Toolkit, all included handlers are generated with launch configurations, which can be found through the dropdown next to the Run button:
+${PRODUCTNAME} supports local debugging for serverless applications through ${IDE}'s debugger. Since this application was created by the ${COMPANYNAME} Toolkit, launch configurations for all included handlers have been generated and can be found in the menu next to the Run button:
 ${LISTOFCONFIGURATIONS}
 
-These can be invoked locally by running the configurations, and can be debugged if breakpoints are added to the source files. Invocation parameters, including payloads and request parameters, can be edited by either using the `SAM Debug Configuration Editor` (through the ${COMMANDPALETTE} or ${CODELENS}) or by directly editing the `launch.json` file containing the launch configurations.
+You can debug the Lambda handlers locally by adding a breakpoint to the source file, then running the launch configuration. This works by using Docker on your local machine.
 
-Functions that haven't been added to the [`template.yaml`](./template.yaml) file can also be directly invoked and debugged by creating a launch configuration through the ${CODELENS} over the function declaration, for quick debugging prior to committing the function to the SAM template.
+Invocation parameters, including payloads and request parameters, can be edited by either using the `SAM Debug Configuration Editor` (through the ${COMMANDPALETTE} or ${CODELENS}) or by editing the `launch.json` file.
+
+${COMPANYNAME} Lambda functions not defined in the [`template.yaml`](./template.yaml) file can be invoked and debugged by creating a launch configuration through the ${CODELENS} over the function declaration, or with the `Add SAM Debug Configuration` command.
+
+<br />
 
 ## Deploying Serverless Applications
 
+<br />
+
 You can deploy a serverless application by invoking the `AWS: Deploy SAM application` command through the Command Palette or by right-clicking the Lambda node in the ${COMPANYNAME} Explorer and entering the deployment region, a valid S3 bucket from the region, and the name of a CloudFormation stack to deploy to. You can monitor your deployment's progress through the **${COMPANYNAME} Toolkit\*\* Output Channel.
+
+<br />
 
 ## Interacting With Deployed Serverless Applications
 
+<br />
+
 A successfully-deployed serverless application can be found in the ${COMPANYNAME} Explorer under region and CloudFormation node that the serverless application was deployed to.
 
-Lambda Functions tied to the serverless application can be invoked by right-clicking the Lambda node and selecting "Invoke on AWS".
+In the ${COMPANYNAME} Explorer, you can invoke _remote_ ${COMPANYNAME} Lambda Functions by right-clicking the Lambda node and selecting "Invoke on ${COMPANYNAME}".
 
-Similarly, if the Function declaration contained an API Gateway event, the API Gateway API can be found in the API Gateway node under the region node the serverless application was deployed to.
+Similarly, if the Function declaration contained an API Gateway event, the API Gateway API can be found in the API Gateway node under the region node the serverless application was deployed to, and can be invoked via right-clicking the API node and selecting "Invoke on ${COMPANYNAME}".
+
+<br />
 
 ## Resources
+
+<br />
 
 General information about this SAM project can be found in the [`README.md`](./README.md) file in this folder.
 

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -464,10 +464,7 @@ export async function writeToolkitReadme(
     getText: (path: string) => Promise<string> = readFileAsString
 ): Promise<boolean> {
     try {
-        const configString: string = configurations.reduce((acc, cur) => {
-            return `${acc}
-* ${cur.name}`
-        }, '')
+        const configString: string = configurations.reduce((acc, cur) => `${acc}\n* ${cur.name}`, '')
         const readme = (await getText(ext.context.asAbsolutePath(SAM_INIT_README_SOURCE)))
             .replace(/\$\{PRODUCTNAME\}/g, `${getIdeProperties().company} Toolkit For ${getIdeProperties().longName}`)
             .replace(/\$\{IDE\}/g, getIdeProperties().shortName)

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -21,7 +21,7 @@ import {
 import { ActivationReloadState, SamInitState } from '../../shared/activationReloadState'
 import { AwsContext } from '../../shared/awsContext'
 import { ext } from '../../shared/extensionGlobals'
-import { fileExists, isInDirectory } from '../../shared/filesystemUtilities'
+import { fileExists, isInDirectory, readFileAsString } from '../../shared/filesystemUtilities'
 import { getLogger } from '../../shared/logger'
 import { RegionProvider } from '../../shared/regions/regionProvider'
 import { getRegionsForActiveCredentials } from '../../shared/regions/regionUtilities'
@@ -50,11 +50,13 @@ import { debugNewSamAppUrl, launchConfigDocUrl } from '../../shared/constants'
 import { Runtime } from 'aws-sdk/clients/lambda'
 import { getIdeProperties, isCloud9 } from '../../shared/extensionUtilities'
 import { execSync } from 'child_process'
+import { writeFile } from 'fs-extra'
 
 type CreateReason = 'unknown' | 'userCancelled' | 'fileNotFound' | 'complete' | 'error'
 
 export const SAM_INIT_TEMPLATE_FILES: string[] = ['template.yaml', 'template.yml']
-export const SAM_INIT_README_FILE: string = 'README.md'
+export const SAM_INIT_README_FILE: string = 'README.TOOLKIT.md'
+export const SAM_INIT_README_SOURCE: string = 'resources/markdown/samReadme.md'
 
 export async function resumeCreateNewSamApp(
     extContext: ExtContext,
@@ -86,15 +88,18 @@ export async function resumeCreateNewSamApp(
 
         samVersion = await getSamCliVersion(getSamCliContext())
 
-        await addInitialLaunchConfiguration(
+        const configs = await addInitialLaunchConfiguration(
             extContext,
             folder,
             templateUri,
             samInitState?.isImage ? samInitState?.runtime : undefined
         )
-        isCloud9()
-            ? await vscode.workspace.openTextDocument(readmeUri)
-            : await vscode.commands.executeCommand('markdown.showPreviewToSide', readmeUri)
+        const tryOpenReadme = await writeToolkitReadme(readmeUri.fsPath, configs)
+        if (tryOpenReadme) {
+            isCloud9()
+                ? await vscode.workspace.openTextDocument(readmeUri)
+                : await vscode.commands.executeCommand('markdown.showPreviewToSide', readmeUri)
+        }
     } catch (err) {
         createResult = 'Failed'
         reason = 'error'
@@ -203,17 +208,18 @@ export async function createNewSamApplication(
         await runSamCliInit(initArguments, samCliContext)
 
         const templateUri = await getProjectUri(config, SAM_INIT_TEMPLATE_FILES)
-        const readmeUri = await getProjectUri(config, [SAM_INIT_README_FILE])
-        if (!templateUri || !readmeUri) {
+        if (!templateUri) {
             reason = 'fileNotFound'
 
             return
         }
 
+        const readmeUri = vscode.Uri.file(path.join(path.dirname(templateUri.fsPath), SAM_INIT_README_FILE))
+
         // Needs to be done or else gopls won't start
         if (goRuntimes.includes(createRuntime)) {
             try {
-                execSync('go mod tidy', { cwd: path.join(path.dirname(readmeUri.fsPath), 'hello-world') })
+                execSync('go mod tidy', { cwd: path.join(path.dirname(templateUri.fsPath), 'hello-world') })
             } catch (err) {
                 getLogger().warn(
                     localize(
@@ -277,6 +283,8 @@ export async function createNewSamApplication(
             truthy: false,
         })
 
+        let tryOpenReadme: boolean = false
+
         if (isTemplateRegistered) {
             const newLaunchConfigs = await addInitialLaunchConfiguration(
                 extContext,
@@ -284,6 +292,7 @@ export async function createNewSamApplication(
                 templateUri,
                 createRuntime
             )
+            tryOpenReadme = await writeToolkitReadme(readmeUri.fsPath, newLaunchConfigs)
             if (newLaunchConfigs && newLaunchConfigs.length > 0) {
                 showCompletionNotification(config.name, `"${newLaunchConfigs.map(config => config.name).join('", "')}"`)
             }
@@ -312,9 +321,14 @@ export async function createNewSamApplication(
 
         activationReloadState.clearSamInitState()
         // TODO: Replace when Cloud9 supports `markdown` commands
-        isCloud9()
-            ? await vscode.workspace.openTextDocument(readmeUri)
-            : await vscode.commands.executeCommand('markdown.showPreviewToSide', readmeUri)
+
+        if (tryOpenReadme) {
+            isCloud9()
+                ? await vscode.workspace.openTextDocument(readmeUri)
+                : await vscode.commands.executeCommand('markdown.showPreviewToSide', readmeUri)
+        } else {
+            await vscode.workspace.openTextDocument(templateUri)
+        }
     } catch (err) {
         createResult = 'Failed'
         reason = 'error'
@@ -435,5 +449,45 @@ async function showCompletionNotification(appName: string, configs: string): Pro
         await openLaunchJsonFile()
     } else if (action === learnMore) {
         vscode.env.openExternal(vscode.Uri.parse(debugNewSamAppUrl))
+    }
+}
+
+/**
+ * Creates a new SAM readme tailored to the IDE and created launch configs
+ * @param readmeLocation Location of new readme file
+ * @param configurations Debug configs to list in readme
+ * @returns True on success, false otherwise
+ */
+export async function writeToolkitReadme(
+    readmeLocation: string,
+    configurations: vscode.DebugConfiguration[] = [],
+    getText: (path: string) => Promise<string> = readFileAsString
+): Promise<boolean> {
+    try {
+        const configString: string = configurations.reduce((acc, cur) => {
+            return `${acc}
+* ${cur.name}`
+        }, '')
+        const readme = (await getText(ext.context.asAbsolutePath(SAM_INIT_README_SOURCE)))
+            .replace(/\$\{PRODUCTNAME\}/g, `${getIdeProperties().company} Toolkit For ${getIdeProperties().longName}`)
+            .replace(/\$\{IDE\}/g, getIdeProperties().shortName)
+            .replace(/\$\{CODELENS\}/g, getIdeProperties().codelens)
+            .replace(/\$\{COMPANYNAME\}/g, getIdeProperties().company)
+            .replace(/\$\{COMMANDPALETTE\}/g, getIdeProperties().commandPalette)
+            .replace(/\$\{LISTOFCONFIGURATIONS\}/g, configString)
+            .replace(
+                /\$\{DOCURL\}/g,
+                isCloud9()
+                    ? 'https://docs.aws.amazon.com/cloud9/latest/user-guide/serverless-apps-toolkit.html'
+                    : 'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/serverless-apps.html'
+            )
+
+        await writeFile(readmeLocation, readme)
+
+        return true
+    } catch (e) {
+        getLogger().error(`writeToolkitReadme failed, skip adding toolkit readme: ${(e as Error).message}`)
+
+        return false
     }
 }


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
User does not have good in-your-face instructions on what to do with a SAM application in the toolkit after creating one.

## Solution
Pop up a toolkit-specific readme.
* Does not include images to preserve relevance outside the toolkit/the user's computer
* Links to users' README.md and template.yaml files and external docs
  * Does not link to any files outside the SAM-created folder as there is no guarantee the pathing will be correct.

![image](https://user-images.githubusercontent.com/29374703/126839589-8ef94b1c-b6d8-446a-b28f-5ce0e76e1ba1.png)


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
