### PR TITLE
Test fix: YAML extension onSuccess errors

### DIFF
--- a/src/shared/cloudformation/templateRegistry.ts
+++ b/src/shared/cloudformation/templateRegistry.ts
@@ -14,6 +14,7 @@ import { getLambdaDetails } from '../../lambda/utils'
 import { ext } from '../extensionGlobals'
 import { WatchedFiles, WatchedItem } from '../watchedFiles'
 import { getLogger } from '../logger'
+import { WorkspaceConfiguration } from '../vscode/workspace'
 
 export interface TemplateDatum {
     path: string
@@ -21,9 +22,7 @@ export interface TemplateDatum {
 }
 
 export class CloudFormationTemplateRegistry extends WatchedFiles<CloudFormation.Template> {
-    public constructor(
-        private readonly config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('yaml')
-    ) {
+    public constructor(private readonly config: WorkspaceConfiguration = vscode.workspace.getConfiguration('yaml')) {
         super()
     }
     protected name: string = 'CloudFormationTemplateRegistry'
@@ -59,7 +58,11 @@ export class CloudFormationTemplateRegistry extends WatchedFiles<CloudFormation.
 
     // handles delete case
     public async remove(path: string | vscode.Uri): Promise<void> {
-        await updateYamlSchemasArray(typeof path === 'string' ? path : pathutils.normalize(path.fsPath), 'none', config)
+        await updateYamlSchemasArray(
+            typeof path === 'string' ? path : pathutils.normalize(path.fsPath),
+            'none',
+            this.config
+        )
         await super.remove(path)
     }
 }

--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -23,8 +23,6 @@ import { FakeAwsContext } from './utilities/fakeAwsContext'
 import { initializeComputeRegion } from '../shared/extensionUtilities'
 import { FakeWorkspace } from './shared/vscode/fakeWorkspace'
 import { WorkspaceConfiguration } from '../shared/vscode/workspace'
-// import { activateExtension } from '../shared/utilities/vsCodeUtils'
-// import { VSCODE_EXTENSION_ID } from '../shared/extensions'
 
 const testReportDir = join(__dirname, '../../../.test-reports')
 const testLogOutput = join(testReportDir, 'testLog.log')
@@ -38,11 +36,6 @@ before(async function () {
     try {
         await remove(testLogOutput)
     } catch (e) {}
-    // try {
-    //     await activateExtension('json')
-    //     await activateExtension('json-language-features')
-    //     await activateExtension(VSCODE_EXTENSION_ID.yaml)
-    // } catch (e) {}
     mkdirpSync(testReportDir)
     // Set up global telemetry client
     const fakeContext = new FakeExtensionContext()

--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -21,8 +21,8 @@ import * as fakeTelemetry from './fake/fakeTelemetryService'
 import { TestLogger } from './testLogger'
 import { FakeAwsContext } from './utilities/fakeAwsContext'
 import { initializeComputeRegion } from '../shared/extensionUtilities'
-import { activateExtension } from '../shared/utilities/vsCodeUtils'
-import { VSCODE_EXTENSION_ID } from '../shared/extensions'
+// import { activateExtension } from '../shared/utilities/vsCodeUtils'
+// import { VSCODE_EXTENSION_ID } from '../shared/extensions'
 
 const testReportDir = join(__dirname, '../../../.test-reports')
 const testLogOutput = join(testReportDir, 'testLog.log')
@@ -35,11 +35,11 @@ before(async function () {
     try {
         await remove(testLogOutput)
     } catch (e) {}
-    try {
-        await activateExtension('json')
-        await activateExtension('json-language-features')
-        await activateExtension(VSCODE_EXTENSION_ID.yaml)
-    } catch (e) {}
+    // try {
+    //     await activateExtension('json')
+    //     await activateExtension('json-language-features')
+    //     await activateExtension(VSCODE_EXTENSION_ID.yaml)
+    // } catch (e) {}
     mkdirpSync(testReportDir)
     // Set up global telemetry client
     const fakeContext = new FakeExtensionContext()

--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -36,6 +36,8 @@ before(async function () {
         await remove(testLogOutput)
     } catch (e) {}
     try {
+        await activateExtension('json')
+        await activateExtension('json-language-features')
         await activateExtension(VSCODE_EXTENSION_ID.yaml)
     } catch (e) {}
     mkdirpSync(testReportDir)

--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -21,6 +21,8 @@ import * as fakeTelemetry from './fake/fakeTelemetryService'
 import { TestLogger } from './testLogger'
 import { FakeAwsContext } from './utilities/fakeAwsContext'
 import { initializeComputeRegion } from '../shared/extensionUtilities'
+import { FakeWorkspace } from './shared/vscode/fakeWorkspace'
+import { WorkspaceConfiguration } from '../shared/vscode/workspace'
 // import { activateExtension } from '../shared/utilities/vsCodeUtils'
 // import { VSCODE_EXTENSION_ID } from '../shared/extensions'
 
@@ -29,6 +31,7 @@ const testLogOutput = join(testReportDir, 'testLog.log')
 
 // Expectation: Tests are not run concurrently
 let testLogger: TestLogger | undefined
+let config: WorkspaceConfiguration
 
 before(async function () {
     // Clean up and set up test logs
@@ -54,7 +57,8 @@ before(async function () {
 beforeEach(function () {
     // Set every test up so that TestLogger is the logger used by toolkit code
     testLogger = setupTestLogger()
-    ext.templateRegistry = new CloudFormationTemplateRegistry()
+    config = new FakeWorkspace().getConfiguration()
+    ext.templateRegistry = new CloudFormationTemplateRegistry(config)
     ext.codelensRootRegistry = new CodelensRootRegistry()
 })
 

--- a/src/test/lambda/local/debugConfiguration.test.ts
+++ b/src/test/lambda/local/debugConfiguration.test.ts
@@ -18,6 +18,8 @@ import * as path from 'path'
 import { CloudFormationTemplateRegistry } from '../../../shared/cloudformation/templateRegistry'
 import { isImageLambdaConfig } from '../../../lambda/local/debugConfiguration'
 import { ext } from '../../../shared/extensionGlobals'
+import { FakeWorkspace } from '../../shared/vscode/fakeWorkspace'
+import { WorkspaceConfiguration } from '../../../shared/vscode/workspace'
 
 describe('makeCoreCLRDebugConfiguration', async function () {
     let tempFolder: string
@@ -122,8 +124,10 @@ describe('isImageLambdaConfig', async function () {
 
     let registry: CloudFormationTemplateRegistry
     let appDir: string
+    let config: WorkspaceConfiguration
 
     beforeEach(async function () {
+        config = new FakeWorkspace().getConfiguration()
         tempFolder = await makeTemporaryToolkitFolder()
         fakeWorkspaceFolder = {
             uri: vscode.Uri.file(tempFolder),

--- a/src/test/lambda/local/debugConfiguration.test.ts
+++ b/src/test/lambda/local/debugConfiguration.test.ts
@@ -18,8 +18,6 @@ import * as path from 'path'
 import { CloudFormationTemplateRegistry } from '../../../shared/cloudformation/templateRegistry'
 import { isImageLambdaConfig } from '../../../lambda/local/debugConfiguration'
 import { ext } from '../../../shared/extensionGlobals'
-import { FakeWorkspace } from '../../shared/vscode/fakeWorkspace'
-import { WorkspaceConfiguration } from '../../../shared/vscode/workspace'
 
 describe('makeCoreCLRDebugConfiguration', async function () {
     let tempFolder: string
@@ -124,10 +122,8 @@ describe('isImageLambdaConfig', async function () {
 
     let registry: CloudFormationTemplateRegistry
     let appDir: string
-    let config: WorkspaceConfiguration
 
     beforeEach(async function () {
-        config = new FakeWorkspace().getConfiguration()
         tempFolder = await makeTemporaryToolkitFolder()
         fakeWorkspaceFolder = {
             uri: vscode.Uri.file(tempFolder),

--- a/src/test/shared/cloudformation/templateRegistry.test.ts
+++ b/src/test/shared/cloudformation/templateRegistry.test.ts
@@ -18,6 +18,8 @@ import { badYaml, makeSampleSamTemplateYaml, strToYamlFile } from './cloudformat
 import { assertEqualPaths, toFile } from '../../testUtil'
 import { CloudFormation } from '../../../shared/cloudformation/cloudformation'
 import { WatchedItem } from '../../../shared/watchedFiles'
+import { FakeWorkspace } from '../vscode/fakeWorkspace'
+import { WorkspaceConfiguration } from '../../../shared/vscode/workspace'
 
 // TODO almost all of these tests should be moved to test WatchedFiles instead
 describe('CloudFormation Template Registry', async function () {
@@ -26,8 +28,10 @@ describe('CloudFormation Template Registry', async function () {
     describe('CloudFormationTemplateRegistry', async function () {
         let testRegistry: CloudFormationTemplateRegistry
         let tempFolder: string
+        let config: WorkspaceConfiguration
 
         beforeEach(async function () {
+            config = new FakeWorkspace().getConfiguration()
             tempFolder = await makeTemporaryToolkitFolder()
             testRegistry = new CloudFormationTemplateRegistry()
         })

--- a/src/test/shared/cloudformation/templateRegistry.test.ts
+++ b/src/test/shared/cloudformation/templateRegistry.test.ts
@@ -33,7 +33,7 @@ describe('CloudFormation Template Registry', async function () {
         beforeEach(async function () {
             config = new FakeWorkspace().getConfiguration()
             tempFolder = await makeTemporaryToolkitFolder()
-            testRegistry = new CloudFormationTemplateRegistry()
+            testRegistry = new CloudFormationTemplateRegistry(config)
         })
 
         afterEach(async function () {

--- a/test-scripts/test.ts
+++ b/test-scripts/test.ts
@@ -5,8 +5,7 @@
 
 import { resolve } from 'path'
 import { runTests } from 'vscode-test'
-import { VSCODE_EXTENSION_ID } from '../src/shared/extensions'
-import { installVSCodeExtension, setupVSCodeTestInstance } from './launchTestUtilities'
+import { setupVSCodeTestInstance } from './launchTestUtilities'
 import { env } from 'process'
 
 /**
@@ -17,7 +16,6 @@ const START_UP_DELAY = 20000
 
 async function setupVSCode(): Promise<string> {
     const vsCodeExecutablePath = await setupVSCodeTestInstance()
-    await installVSCodeExtension(vsCodeExecutablePath, VSCODE_EXTENSION_ID.yaml)
     await new Promise(r => setTimeout(r, START_UP_DELAY))
     return vsCodeExecutablePath
 }


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Linus Stable/Insiders Unit Tests are failing with errors similar to:
```
     Uncaught TypeError: this.onSuccess is not a function
      at Timeout._onTimeout (/root/.vscode/extensions/redhat.vscode-yaml-0.21.1/node_modules/vscode-languageclient/lib/common/utils/async.js:36:22)
      at listOnTimeout (internal/timers.js:554:17)
      at processTimers (internal/timers.js:497:7)
```
Location is arbitrary and sporadic.


## Solution
Remove all dependence on the YAML extension existing for unit test codepaths:
* Remove YAML test extension installation
  * Note: this still made the test fail even if the extension wasn't explicitly activated!
* Remove YAML test extension activation
* All YAML extensions setting updates no longer directly use the VS Code WorkspaceConfiguration object and can be spoofed.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
