### PR TITLE
doc: move "await in describe()" note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,11 @@ See [CODE_GUIDELINES.md](./docs/CODE_GUIDELINES.md) for coding conventions.
 -   `src/testFixtures/` is excluded in `.vscode/settings.json`, to prevent VSCode
     from treating its files as project files.
 -   VSCode extension examples: <https://github.com/microsoft/vscode-extension-samples>
+-   Tests
+    -   Use `function ()` and `async function ()` syntax for `describe()` and `it()` callbacks [instead of arrow functions.](https://mochajs.org/#arrow-functions)
+    -   Do NOT include any `await` functions in `describe()` blocks directly (usage in `before`, `beforeEach`, `after`, `afterEach`, and `it` blocks is fine).
+        -   `await` in `describe()` causes the framework to always evaluate the `describe` block and can cause issues with either tests not running or always running (if other tests are marked with `.only`)
+        -   Tests that require a premade value from a Promise should initialize the value as a `let` and make the `await`ed assignment in `before()`.
 -   How to debug unresolved promise rejections:
 
     1. Declare a global unhandledRejection handler.

--- a/docs/TESTPLAN.md
+++ b/docs/TESTPLAN.md
@@ -57,14 +57,6 @@ modifications/workarounds in `src/test/testRunner.ts`.
     -   [Mocha](https://mochajs.org/) framework is used to write tests.
 -   New code requires new tests.
 
-## Best Practices
-
--   Use `function ()` and `async function ()` syntax for `describe()` and `it()` callbacks [instead of arrow functions.](https://mochajs.org/#arrow-functions)
--   Do NOT include any `await` functions in `describe()` blocks directly (usage within `before`, `beforeEach`, `after`, `afterEach`, and `it` blocks are fine).
-    -   This will cause the toolkit to always evaluate the `describe` block and can cause issues with either tests not running or tests always running (if other tests are running with `.only`)
-    -   Tests that require an premade value from a Promise should initialize the value as a `let` and make the `await`ed call in the `before()` statement.
--   Remember to clean up any `.only()` statements before pushing into PRs! Otherwise, the full suite of tests won't work.
-
 ## Testing Gaps
 
 -   No handling of case where VSCode crashes.


### PR DESCRIPTION
- TESTPLAN is an architecture/strategy document, guidelines are not
  found there.
- Removed note about .only, because it is obvious, and mentioning it in
  docs doesn't help to avoid such mistakes.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
