### PR TITLE
tests: disable extensions for unit tests

### DIFF
--- a/test-scripts/test.ts
+++ b/test-scripts/test.ts
@@ -7,12 +7,18 @@ import { resolve } from 'path'
 import { runTests } from 'vscode-test'
 import { setupVSCodeTestInstance } from './launchTestUtilities'
 import { env } from 'process'
+import { VSCODE_EXTENSION_ID } from '../src/shared/extensions'
 
 /**
  * Amount of time to wait before executing tests.
  * This gives time for extensions to initialize, otherwise the first CodeLens test will fail.
  */
 const START_UP_DELAY = 20000
+/**
+ * Extensions will be permanently disabled during unit tests.
+ * Calling 'activate' on an extension will have no effect.
+ */
+const DISABLE_EXTENSIONS = '--disable-extensions'
 
 async function setupVSCode(): Promise<string> {
     const vsCodeExecutablePath = await setupVSCodeTestInstance()
@@ -36,7 +42,7 @@ async function setupVSCode(): Promise<string> {
             extensionDevelopmentPath: rootDir,
             extensionTestsPath: testEntrypoint,
             // For verbose VSCode logs, add "--verbose --log debug". c2165cf48e62c
-            launchArgs: [testWorkspace],
+            launchArgs: [testWorkspace, DISABLE_EXTENSIONS, VSCODE_EXTENSION_ID.awstoolkit],
         })
 
         console.log(`Finished running Main test suite with result code: ${result}`)


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Other extensions running can cause problems with our unit tests, causing them to fail for non-obvious reasons. This PR disables all other extensions but our own for unit testing. Any test written that relies on other extensions should be treated as an integration test, not a unit test.

## Solution
Add '--disable-extensions' to the test entry point. Calling 'activate' on extensions will not have any effect when using this argument, so we do not need to make any code changes.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
