### PR TITLE
SAM/CFN: JSON schema improvements

### DIFF
--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -14,7 +14,7 @@ import { NoopWatcher } from '../watchedFiles'
 import { refreshSchemas } from './cloudformation'
 import { VSCODE_EXTENSION_ID } from '../extensions'
 
-export const TEMPLATE_FILE_GLOB_PATTERN = '**/template.{yaml,yml}'
+export const TEMPLATE_FILE_GLOB_PATTERN = '**/*.{yaml,yml}'
 
 /**
  * Match any file path that contains a .aws-sam folder. The way this works is:
@@ -33,9 +33,7 @@ export const TEMPLATE_FILE_EXCLUDE_PATTERN = /.*[/\\]\.aws-sam([/\\].*|$)/
 export async function activate(extensionContext: vscode.ExtensionContext): Promise<void> {
     refreshSchemas(extensionContext)
     // Note: redhat.vscode-yaml no longer works on vscode 1.42
-    if (await activateExtension(VSCODE_EXTENSION_ID.yaml)) {
-        addCustomTags()
-    }
+    activateExtension(VSCODE_EXTENSION_ID.yaml).then(addCustomTags)
 
     try {
         const registry = new CloudFormationTemplateRegistry()
@@ -53,7 +51,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
         getLogger().error('Failed to activate template registry', e)
         // This prevents us from breaking for any reason later if it fails to load. Since
         // Noop watcher is always empty, we will get back empty arrays with no issues.
-        ext.templateRegistry = (new NoopWatcher() as unknown) as CloudFormationTemplateRegistry
+        ext.templateRegistry = new NoopWatcher() as unknown as CloudFormationTemplateRegistry
     }
     // If setting it up worked, add it to subscriptions so it is cleaned up at exit
     extensionContext.subscriptions.push(ext.templateRegistry)
@@ -67,34 +65,34 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 function addCustomTags(): void {
     const currentTags = vscode.workspace.getConfiguration().get<string[]>('yaml.customTags') ?? []
     const cloudFormationTags = [
-        "!And",
-        "!And sequence",
-        "!If",
-        "!If sequence",
-        "!Not",
-        "!Not sequence",
-        "!Equals",
-        "!Equals sequence",
-        "!Or",
-        "!Or sequence",
-        "!FindInMap",
-        "!FindInMap sequence",
-        "!Base64",
-        "!Join",
-        "!Join sequence",
-        "!Cidr",
-        "!Ref",
-        "!Sub",
-        "!Sub sequence",
-        "!GetAtt",
-        "!GetAZs",
-        "!ImportValue",
-        "!ImportValue sequence",
-        "!Select",
-        "!Select sequence",
-        "!Split",
-        "!Split sequence"
+        '!And',
+        '!And sequence',
+        '!If',
+        '!If sequence',
+        '!Not',
+        '!Not sequence',
+        '!Equals',
+        '!Equals sequence',
+        '!Or',
+        '!Or sequence',
+        '!FindInMap',
+        '!FindInMap sequence',
+        '!Base64',
+        '!Join',
+        '!Join sequence',
+        '!Cidr',
+        '!Ref',
+        '!Sub',
+        '!Sub sequence',
+        '!GetAtt',
+        '!GetAZs',
+        '!ImportValue',
+        '!ImportValue sequence',
+        '!Select',
+        '!Select sequence',
+        '!Split',
+        '!Split sequence',
     ]
-    const updateTags = currentTags.concat(cloudFormationTags.filter((item) => currentTags.indexOf(item) < 0))
+    const updateTags = currentTags.concat(cloudFormationTags.filter(item => currentTags.indexOf(item) < 0))
     vscode.workspace.getConfiguration().update('yaml.customTags', updateTags, vscode.ConfigurationTarget.Workspace)
 }

--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -877,10 +877,14 @@ export async function updateYamlSchemasArray(
     // do if schemas exists or if type isn't none
     if (!(type === 'none' && !schemas)) {
         try {
-            await config.update('schemas', {
-                ...(schemas ? schemas : {}),
-                ...modifiedArrays,
-            })
+            await config.update(
+                'schemas',
+                {
+                    ...(schemas ? schemas : {}),
+                    ...modifiedArrays,
+                },
+                vscode.ConfigurationTarget.Global
+            )
         } catch (e) {
             getLogger().error('Could not write YAML schemas to configuration', e.message)
         }

--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -826,13 +826,17 @@ export async function refreshSchemas(extensionContext: vscode.ExtensionContext):
 export async function updateYamlSchemasArray(
     path: string,
     type: 'cfn' | 'sam' | 'none',
-    config: WorkspaceConfiguration | undefined,
-    paths: { cfnSchema: string; samSchema: string } = { cfnSchema: CFN_SCHEMA_PATH, samSchema: SAM_SCHEMA_PATH }
+    testOverrides?: {
+        skipExtensionLoad?: boolean
+        config?: WorkspaceConfiguration | undefined
+        paths?: { cfnSchema: string; samSchema: string }
+    }
 ): Promise<void> {
-    if (!vscode.extensions.getExtension(VSCODE_EXTENSION_ID.yaml)) {
+    if (testOverrides.skipExtensionLoad || !vscode.extensions.getExtension(VSCODE_EXTENSION_ID.yaml)) {
         return
     }
-    config = config ?? vscode.workspace.getConfiguration('yaml')
+    const paths = testOverrides.paths || { cfnSchema: CFN_SCHEMA_PATH, samSchema: SAM_SCHEMA_PATH }
+    const config = testOverrides?.config ?? vscode.workspace.getConfiguration('yaml')
     const relPath = normalizeSeparator(getWorkspaceRelativePath(path) ?? path)
     const schemas: { [key: string]: string | string[] | undefined } | undefined = config.get('schemas')
     const deleteFroms: string[] = []

--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -832,10 +832,10 @@ export async function updateYamlSchemasArray(
         paths?: { cfnSchema: string; samSchema: string }
     }
 ): Promise<void> {
-    if (testOverrides.skipExtensionLoad || !vscode.extensions.getExtension(VSCODE_EXTENSION_ID.yaml)) {
+    if (!testOverrides?.skipExtensionLoad && !vscode.extensions.getExtension(VSCODE_EXTENSION_ID.yaml)) {
         return
     }
-    const paths = testOverrides.paths || { cfnSchema: CFN_SCHEMA_PATH, samSchema: SAM_SCHEMA_PATH }
+    const paths = testOverrides?.paths ?? { cfnSchema: CFN_SCHEMA_PATH, samSchema: SAM_SCHEMA_PATH }
     const config = testOverrides?.config ?? vscode.workspace.getConfiguration('yaml')
     const relPath = normalizeSeparator(getWorkspaceRelativePath(path) ?? path)
     const schemas: { [key: string]: string | string[] | undefined } | undefined = config.get('schemas')

--- a/src/shared/cloudformation/templateRegistry.ts
+++ b/src/shared/cloudformation/templateRegistry.ts
@@ -34,7 +34,7 @@ export class CloudFormationTemplateRegistry extends WatchedFiles<CloudFormation.
         try {
             template = await CloudFormation.load(path)
         } catch (e) {
-            await updateYamlSchemasArray(path, 'none', { config: this.config })
+            await updateYamlSchemasArray(path, 'none', { config: this.config, skipExtensionLoad: !!this.config })
             return undefined
         }
 
@@ -43,16 +43,16 @@ export class CloudFormationTemplateRegistry extends WatchedFiles<CloudFormation.
         if (template.AWSTemplateFormatVersion || template.Resources) {
             if (template.Transform && template.Transform.toString().startsWith('AWS::Serverless')) {
                 // apply serverless schema
-                await updateYamlSchemasArray(path, 'sam', { config: this.config })
+                await updateYamlSchemasArray(path, 'sam', { config: this.config, skipExtensionLoad: !!this.config })
             } else {
                 // apply cfn schema
-                await updateYamlSchemasArray(path, 'cfn', { config: this.config })
+                await updateYamlSchemasArray(path, 'cfn', { config: this.config, skipExtensionLoad: !!this.config })
             }
 
             return template
         }
 
-        await updateYamlSchemasArray(path, 'none', { config: this.config })
+        await updateYamlSchemasArray(path, 'none', { config: this.config, skipExtensionLoad: !!this.config })
         return undefined
     }
 
@@ -60,6 +60,7 @@ export class CloudFormationTemplateRegistry extends WatchedFiles<CloudFormation.
     public async remove(path: string | vscode.Uri): Promise<void> {
         await updateYamlSchemasArray(typeof path === 'string' ? path : pathutils.normalize(path.fsPath), 'none', {
             config: this.config,
+            skipExtensionLoad: !!this.config,
         })
         await super.remove(path)
     }

--- a/src/shared/cloudformation/templateRegistry.ts
+++ b/src/shared/cloudformation/templateRegistry.ts
@@ -34,7 +34,7 @@ export class CloudFormationTemplateRegistry extends WatchedFiles<CloudFormation.
         try {
             template = await CloudFormation.load(path)
         } catch (e) {
-            await updateYamlSchemasArray(path, 'none', this.config)
+            await updateYamlSchemasArray(path, 'none', { config: this.config })
             return undefined
         }
 
@@ -43,26 +43,24 @@ export class CloudFormationTemplateRegistry extends WatchedFiles<CloudFormation.
         if (template.AWSTemplateFormatVersion || template.Resources) {
             if (template.Transform && template.Transform.toString().startsWith('AWS::Serverless')) {
                 // apply serverless schema
-                await updateYamlSchemasArray(path, 'sam', this.config)
+                await updateYamlSchemasArray(path, 'sam', { config: this.config })
             } else {
                 // apply cfn schema
-                await updateYamlSchemasArray(path, 'cfn', this.config)
+                await updateYamlSchemasArray(path, 'cfn', { config: this.config })
             }
 
             return template
         }
 
-        await updateYamlSchemasArray(path, 'none', this.config)
+        await updateYamlSchemasArray(path, 'none', { config: this.config })
         return undefined
     }
 
     // handles delete case
     public async remove(path: string | vscode.Uri): Promise<void> {
-        await updateYamlSchemasArray(
-            typeof path === 'string' ? path : pathutils.normalize(path.fsPath),
-            'none',
-            this.config
-        )
+        await updateYamlSchemasArray(typeof path === 'string' ? path : pathutils.normalize(path.fsPath), 'none', {
+            config: this.config,
+        })
         await super.remove(path)
     }
 }

--- a/src/shared/cloudformation/templateRegistry.ts
+++ b/src/shared/cloudformation/templateRegistry.ts
@@ -22,7 +22,7 @@ export interface TemplateDatum {
 }
 
 export class CloudFormationTemplateRegistry extends WatchedFiles<CloudFormation.Template> {
-    public constructor(private readonly config: WorkspaceConfiguration = vscode.workspace.getConfiguration('yaml')) {
+    public constructor(private readonly config?: WorkspaceConfiguration) {
         super()
     }
     protected name: string = 'CloudFormationTemplateRegistry'

--- a/src/test/shared/cloudformation/cloudformation.test.ts
+++ b/src/test/shared/cloudformation/cloudformation.test.ts
@@ -680,7 +680,7 @@ describe('Cloudformation Utils', function () {
         })
 
         it('handles adding to and removing from a nonexistent setting', function () {
-            updateYamlSchemasArray('/foo', 'cfn', config, { cfnSchema, samSchema })
+            updateYamlSchemasArray('/foo', 'cfn', { paths: { cfnSchema, samSchema }, config })
             const val: any = config.get('schemas')
             assert.deepStrictEqual(val[cfnSchema], ['/foo'])
             assert.deepStrictEqual(val[samSchema], undefined)
@@ -688,14 +688,14 @@ describe('Cloudformation Utils', function () {
 
         it('handles adding to and removing from a setting with an undefined value', function () {
             config.update('schemas', undefined)
-            updateYamlSchemasArray('/foo', 'cfn', config, { cfnSchema, samSchema })
+            updateYamlSchemasArray('/foo', 'cfn', { paths: { cfnSchema, samSchema }, config })
             const val: any = config.get('schemas')
             assert.deepStrictEqual(val[cfnSchema], ['/foo'])
             assert.deepStrictEqual(val[samSchema], undefined)
         })
         it('handles adding to and removing from a setting with a blank array', function () {
             config.update('schemas', { cfn: [], sam: [] })
-            updateYamlSchemasArray('/foo', 'cfn', config, { cfnSchema, samSchema })
+            updateYamlSchemasArray('/foo', 'cfn', { paths: { cfnSchema, samSchema }, config })
             const val: any = config.get('schemas')
             assert.deepStrictEqual(val[cfnSchema], ['/foo'])
             assert.deepStrictEqual(val[samSchema], [])
@@ -703,7 +703,7 @@ describe('Cloudformation Utils', function () {
 
         it('handles adding to and removing from an existing array', function () {
             config.update('schemas', { cfn: ['/bar'], sam: ['/asdf', '/foo'] })
-            updateYamlSchemasArray('/foo', 'cfn', config, { cfnSchema, samSchema })
+            updateYamlSchemasArray('/foo', 'cfn', { paths: { cfnSchema, samSchema }, config })
             const val: any = config.get('schemas')
             assert.deepStrictEqual(val[cfnSchema], ['/bar', '/foo'])
             assert.deepStrictEqual(val[samSchema], ['/asdf'])
@@ -711,7 +711,7 @@ describe('Cloudformation Utils', function () {
 
         it('handles adding to and removing from a string', function () {
             config.update('schemas', { cfn: '/bar', sam: '/foo' })
-            updateYamlSchemasArray('/foo', 'cfn', config, { cfnSchema, samSchema })
+            updateYamlSchemasArray('/foo', 'cfn', { paths: { cfnSchema, samSchema }, config })
             const val: any = config.get('schemas')
             assert.deepStrictEqual(val[cfnSchema], ['/bar', '/foo'])
             assert.deepStrictEqual(val[samSchema], [])
@@ -719,7 +719,7 @@ describe('Cloudformation Utils', function () {
 
         it('handles removes from strings and arrays with `none`', function () {
             config.update('schemas', { cfn: '/bar', sam: ['/foo', '/bar'] })
-            updateYamlSchemasArray('/bar', 'none', config, { cfnSchema, samSchema })
+            updateYamlSchemasArray('/bar', 'none', { paths: { cfnSchema, samSchema }, config })
             const val: any = config.get('schemas')
             assert.deepStrictEqual(val[cfnSchema], [])
             assert.deepStrictEqual(val[samSchema], ['/foo'])

--- a/src/test/shared/cloudformation/cloudformation.test.ts
+++ b/src/test/shared/cloudformation/cloudformation.test.ts
@@ -680,7 +680,7 @@ describe('Cloudformation Utils', function () {
         })
 
         it('handles adding to and removing from a nonexistent setting', function () {
-            updateYamlSchemasArray('/foo', 'cfn', { paths: { cfnSchema, samSchema }, config })
+            updateYamlSchemasArray('/foo', 'cfn', { paths: { cfnSchema, samSchema }, config, skipExtensionLoad: true })
             const val: any = config.get('schemas')
             assert.deepStrictEqual(val[cfnSchema], ['/foo'])
             assert.deepStrictEqual(val[samSchema], undefined)
@@ -688,14 +688,14 @@ describe('Cloudformation Utils', function () {
 
         it('handles adding to and removing from a setting with an undefined value', function () {
             config.update('schemas', undefined)
-            updateYamlSchemasArray('/foo', 'cfn', { paths: { cfnSchema, samSchema }, config })
+            updateYamlSchemasArray('/foo', 'cfn', { paths: { cfnSchema, samSchema }, config, skipExtensionLoad: true })
             const val: any = config.get('schemas')
             assert.deepStrictEqual(val[cfnSchema], ['/foo'])
             assert.deepStrictEqual(val[samSchema], undefined)
         })
         it('handles adding to and removing from a setting with a blank array', function () {
             config.update('schemas', { cfn: [], sam: [] })
-            updateYamlSchemasArray('/foo', 'cfn', { paths: { cfnSchema, samSchema }, config })
+            updateYamlSchemasArray('/foo', 'cfn', { paths: { cfnSchema, samSchema }, config, skipExtensionLoad: true })
             const val: any = config.get('schemas')
             assert.deepStrictEqual(val[cfnSchema], ['/foo'])
             assert.deepStrictEqual(val[samSchema], [])
@@ -703,7 +703,7 @@ describe('Cloudformation Utils', function () {
 
         it('handles adding to and removing from an existing array', function () {
             config.update('schemas', { cfn: ['/bar'], sam: ['/asdf', '/foo'] })
-            updateYamlSchemasArray('/foo', 'cfn', { paths: { cfnSchema, samSchema }, config })
+            updateYamlSchemasArray('/foo', 'cfn', { paths: { cfnSchema, samSchema }, config, skipExtensionLoad: true })
             const val: any = config.get('schemas')
             assert.deepStrictEqual(val[cfnSchema], ['/bar', '/foo'])
             assert.deepStrictEqual(val[samSchema], ['/asdf'])
@@ -711,7 +711,7 @@ describe('Cloudformation Utils', function () {
 
         it('handles adding to and removing from a string', function () {
             config.update('schemas', { cfn: '/bar', sam: '/foo' })
-            updateYamlSchemasArray('/foo', 'cfn', { paths: { cfnSchema, samSchema }, config })
+            updateYamlSchemasArray('/foo', 'cfn', { paths: { cfnSchema, samSchema }, config, skipExtensionLoad: true })
             const val: any = config.get('schemas')
             assert.deepStrictEqual(val[cfnSchema], ['/bar', '/foo'])
             assert.deepStrictEqual(val[samSchema], [])
@@ -719,7 +719,7 @@ describe('Cloudformation Utils', function () {
 
         it('handles removes from strings and arrays with `none`', function () {
             config.update('schemas', { cfn: '/bar', sam: ['/foo', '/bar'] })
-            updateYamlSchemasArray('/bar', 'none', { paths: { cfnSchema, samSchema }, config })
+            updateYamlSchemasArray('/bar', 'none', { paths: { cfnSchema, samSchema }, config, skipExtensionLoad: true })
             const val: any = config.get('schemas')
             assert.deepStrictEqual(val[cfnSchema], [])
             assert.deepStrictEqual(val[samSchema], ['/foo'])


### PR DESCRIPTION
Improvements from an internal bug bash:
* Don't block our extension load on the YAML extension's load
* Always create a new WorkspaceConfiguration object. Appears that the WorkspaceConfiguration will only pull the values from when it was created, in this case, it was bulldozing YAML schema definitions if you added them while the toolkit was activated and you saved a template file
* Only attempt to write to settings if the YAML extension is available.
* Add `file:/` to the YAML files. Existing impl worked on Windows, and Windows breaks if `file://` is used. Checking to see if this fixes Mac and Windows impls.

Additionally, now checks ALL `.yaml` and `.yml` files in a workspace. Unsure if this will significantly affect startup, but shouldn't explicitly block extension activation (aside from adding to the event loop).

TODO: Batch initial writes to the settings file?

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
