### PR TITLE
extensions: start Git extension API wrapper

### DIFF
--- a/src/shared/extensions.ts
+++ b/src/shared/extensions.ts
@@ -20,6 +20,7 @@ export const VSCODE_EXTENSION_ID = {
     go: 'golang.go',
     java: 'redhat.java',
     javadebug: 'vscjava.vscode-java-debug',
+    git: 'vscode.git',
 }
 
 /**

--- a/src/shared/extensions/git.ts
+++ b/src/shared/extensions/git.ts
@@ -93,20 +93,24 @@ export class GitExtension {
         //
         // TODO: make a promise 'pipe' function
         if (branches.length === 0) {
-            return promisify(execFile)(this.api.git.path, ['ls-remote', '--heads', remote.fetchUrl ?? ''])
-                .then(({ stdout }) => stdout.toString())
-                .then(output => output.split(/\r?\n/))
-                .then(output =>
-                    output.map(branch => ({
+            try {
+                const { stdout } = await promisify(execFile)(this.api.git.path, [
+                    'ls-remote',
+                    '--heads',
+                    remote.fetchUrl ?? '',
+                ])
+                return stdout
+                    .toString()
+                    .split(/\r?\n/)
+                    .map(branch => ({
                         name: branch.replace(/.*refs\/heads\//, 'head/'),
                         remote: remote.name,
                         type: GitTypes.RefType.RemoteHead,
                     }))
-                )
-                .catch(err => {
-                    getLogger().verbose(`git: failed to get branches for remote "${remote.fetchUrl}": %O`, err)
-                    return []
-                })
+            } catch (err) {
+                getLogger().verbose(`git: failed to get branches for remote "${remote.fetchUrl}": %O`, err)
+                return []
+            }
         }
 
         return branches

--- a/src/shared/extensions/git.ts
+++ b/src/shared/extensions/git.ts
@@ -40,7 +40,7 @@ export class GitExtension {
             return
         }
 
-        const whenActive = () => {
+        const onAfterActive = () => {
             this.api = ext.exports.enabled ? ext.exports.getAPI(1) : undefined
             ext.exports.onDidChangeEnablement(enabled => {
                 this.api = enabled ? ext.exports.getAPI(1) : undefined
@@ -48,9 +48,9 @@ export class GitExtension {
         }
 
         if (ext.isActive) {
-            whenActive()
+            onAfterActive()
         } else {
-            ext.activate().then(whenActive)
+            ext.activate().then(onAfterActive)
         }
     }
 

--- a/src/shared/extensions/git.ts
+++ b/src/shared/extensions/git.ts
@@ -1,0 +1,124 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import * as vscode from 'vscode'
+import * as GitTypes from '../../../types/git.d'
+import { VSCODE_EXTENSION_ID } from '../extensions'
+import { getLogger } from '../logger/logger'
+
+/**
+ * Wrapper around the internal VS Code Git extension.
+ *
+ * The Git extension is a special case in that its API has an additional 'enablement' mechanism where-in
+ * the extension may be active, but its features have intentionally been disabled by the user. The current
+ * implementation 'silenty' (it still logs something) fails when the API is disabled since the common case
+ * uses these methods supplementary to other functionality rather than as a dependency. A caller can always
+ * check the `enabled` field to decisively determine if the extension is active.
+ */
+export class GitExtension {
+    private api?: GitTypes.API
+
+    public get enabled(): boolean {
+        return this.api !== undefined
+    }
+
+    constructor() {
+        this.init()
+    }
+
+    private init(): void {
+        const ext = vscode.extensions.getExtension<GitTypes.GitExtension>(VSCODE_EXTENSION_ID.git)
+
+        if (ext === undefined) {
+            getLogger().info(
+                `The "${VSCODE_EXTENSION_ID.git}" extension was not found. Git related features will be disabled.`
+            )
+            return
+        }
+
+        const whenActive = () => {
+            this.api = ext.exports.enabled ? ext.exports.getAPI(1) : undefined
+            ext.exports.onDidChangeEnablement(enabled => {
+                this.api = enabled ? ext.exports.getAPI(1) : undefined
+            })
+        }
+
+        if (ext.isActive) {
+            whenActive()
+        } else {
+            ext.activate().then(whenActive)
+        }
+    }
+
+    /**
+     * Returns all remotes currently associated with the workspace.
+     *
+     * If Git is disabled, this returns an empty array.
+     */
+    public getRemotes(): GitTypes.Remote[] {
+        if (this.api === undefined) {
+            getLogger().verbose(`git: api is disabled, returning empty array of remotes`)
+            return []
+        }
+
+        const remotes: GitTypes.Remote[] = []
+        this.api.repositories.forEach(repo => remotes.push(...repo.state.remotes))
+        return remotes
+    }
+
+    /**
+     * Returns all branches associated with the specified remote.
+     *
+     * If the remote does not exist within the current workspace, the branches will be fetched directly
+     * using the `fetchUrl` property of the remote. Returns an empty array if Git is disabled.
+     */
+    public async getBranchesForRemote(remote: GitTypes.Remote): Promise<GitTypes.Branch[]> {
+        if (this.api === undefined) {
+            getLogger().verbose(`git: api is disabled, returning empty array of branches`)
+            return []
+        }
+
+        const branches: GitTypes.Branch[] = []
+
+        const repos = this.api.repositories.filter(
+            repo => repo.state.remotes.filter(other => other.fetchUrl === remote.fetchUrl).length > 0
+        )
+
+        repos.forEach(repo =>
+            branches.push(
+                ...repo.state.refs.filter(
+                    (ref: GitTypes.Ref) => ref.type === GitTypes.RefType.RemoteHead && !ref.name?.endsWith('HEAD')
+                )
+            )
+        )
+
+        // We'll be 'smart' and try to get branches directly if the user is using a URL not associated with
+        // their current workspace. Currently no way to sort by the latest commited branch using 'ls-remote'
+        // This might be possible with the extension API directly but I could not find anything. Ideally
+        // we want to avoid messing with the user's repositories/settings as much as possible.
+        //
+        // TODO: make a promise 'pipe' function
+        if (branches.length === 0) {
+            return promisify(execFile)(this.api.git.path, ['ls-remote', '--heads', remote.fetchUrl ?? ''])
+                .then(({ stdout }) => stdout.toString())
+                .then(output => output.split(/\r?\n/))
+                .then(output =>
+                    output.map(branch => ({
+                        name: branch.replace(/.*refs\/heads\//, 'head/'),
+                        remote: remote.name,
+                        type: GitTypes.RefType.RemoteHead,
+                    }))
+                )
+                .catch(err => {
+                    getLogger().verbose(`git: failed to get branches for remote "${remote.fetchUrl}": %O`, err)
+                    return []
+                })
+        }
+
+        return branches
+    }
+}

--- a/src/shared/extensions/git.ts
+++ b/src/shared/extensions/git.ts
@@ -13,10 +13,10 @@ import { getLogger } from '../logger/logger'
 /**
  * Wrapper around the internal VS Code Git extension.
  *
- * The Git extension is a special case in that its API has an additional 'enablement' mechanism where-in
- * the extension may be active, but its features have intentionally been disabled by the user. The current
- * implementation 'silenty' (it still logs something) fails when the API is disabled since the common case
- * uses these methods supplementary to other functionality rather than as a dependency. A caller can always
+ * The Git extension is a special case in that its {@link GitTypes.API API} has an additional 'enablement'
+ * mechanism where-in the extension may be active, but its features have intentionally been disabled by the user.
+ * The current implementation 'silenty' (it still logs something) fails when the API is disabled since the common
+ * case uses these methods supplementary to other functionality rather than as a dependency. A caller can always
  * check the `enabled` field to decisively determine if the extension is active.
  */
 export class GitExtension {
@@ -26,11 +26,7 @@ export class GitExtension {
         return this.api !== undefined
     }
 
-    constructor() {
-        this.init()
-    }
-
-    private init(): void {
+    public constructor() {
         const ext = vscode.extensions.getExtension<GitTypes.GitExtension>(VSCODE_EXTENSION_ID.git)
 
         if (ext === undefined) {
@@ -40,18 +36,12 @@ export class GitExtension {
             return
         }
 
-        const onAfterActive = () => {
+        ext.activate().then(() => {
             this.api = ext.exports.enabled ? ext.exports.getAPI(1) : undefined
             ext.exports.onDidChangeEnablement(enabled => {
                 this.api = enabled ? ext.exports.getAPI(1) : undefined
             })
-        }
-
-        if (ext.isActive) {
-            onAfterActive()
-        } else {
-            ext.activate().then(onAfterActive)
-        }
+        })
     }
 
     /**

--- a/types/git.d.ts
+++ b/types/git.d.ts
@@ -1,0 +1,338 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Sourced from:
+// https://github.com/microsoft/vscode/blob/104bc571e956e4af623905ef10dfcc8f0fdac625/extensions/git/src/api/git.d.ts
+// Note that this file should be imported as 'git.d' since it contains enums and thus must be compiled.
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Uri, Event, Disposable, ProviderResult } from 'vscode'
+export { ProviderResult } from 'vscode'
+
+export interface Git {
+    readonly path: string
+}
+
+export interface InputBox {
+    value: string
+}
+
+export const enum ForcePushMode {
+    Force,
+    ForceWithLease,
+}
+
+export const enum RefType {
+    Head,
+    RemoteHead,
+    Tag,
+}
+
+export interface Ref {
+    readonly type: RefType
+    readonly name?: string
+    readonly commit?: string
+    readonly remote?: string
+}
+
+export interface UpstreamRef {
+    readonly remote: string
+    readonly name: string
+}
+
+export interface Branch extends Ref {
+    readonly upstream?: UpstreamRef
+    readonly ahead?: number
+    readonly behind?: number
+}
+
+export interface Commit {
+    readonly hash: string
+    readonly message: string
+    readonly parents: string[]
+    readonly authorDate?: Date
+    readonly authorName?: string
+    readonly authorEmail?: string
+    readonly commitDate?: Date
+}
+
+export interface Submodule {
+    readonly name: string
+    readonly path: string
+    readonly url: string
+}
+
+export interface Remote {
+    readonly name: string
+    readonly fetchUrl?: string
+    readonly pushUrl?: string
+    readonly isReadOnly: boolean
+}
+
+export const enum Status {
+    INDEX_MODIFIED,
+    INDEX_ADDED,
+    INDEX_DELETED,
+    INDEX_RENAMED,
+    INDEX_COPIED,
+
+    MODIFIED,
+    DELETED,
+    UNTRACKED,
+    IGNORED,
+    INTENT_TO_ADD,
+
+    ADDED_BY_US,
+    ADDED_BY_THEM,
+    DELETED_BY_US,
+    DELETED_BY_THEM,
+    BOTH_ADDED,
+    BOTH_DELETED,
+    BOTH_MODIFIED,
+}
+
+export interface Change {
+    /**
+     * Returns either `originalUri` or `renameUri`, depending
+     * on whether this change is a rename change. When
+     * in doubt always use `uri` over the other two alternatives.
+     */
+    readonly uri: Uri
+    readonly originalUri: Uri
+    readonly renameUri: Uri | undefined
+    readonly status: Status
+}
+
+export interface RepositoryState {
+    readonly HEAD: Branch | undefined
+    readonly refs: Ref[]
+    readonly remotes: Remote[]
+    readonly submodules: Submodule[]
+    readonly rebaseCommit: Commit | undefined
+
+    readonly mergeChanges: Change[]
+    readonly indexChanges: Change[]
+    readonly workingTreeChanges: Change[]
+
+    readonly onDidChange: Event<void>
+}
+
+export interface RepositoryUIState {
+    readonly selected: boolean
+    readonly onDidChange: Event<void>
+}
+
+/**
+ * Log options.
+ */
+export interface LogOptions {
+    /** Max number of log entries to retrieve. If not specified, the default is 32. */
+    readonly maxEntries?: number
+    readonly path?: string
+}
+
+export interface CommitOptions {
+    all?: boolean | 'tracked'
+    amend?: boolean
+    signoff?: boolean
+    signCommit?: boolean
+    empty?: boolean
+    noVerify?: boolean
+    requireUserConfig?: boolean
+}
+
+export interface FetchOptions {
+    remote?: string
+    ref?: string
+    all?: boolean
+    prune?: boolean
+    depth?: number
+}
+
+export interface BranchQuery {
+    readonly remote?: boolean
+    readonly pattern?: string
+    readonly count?: number
+    readonly contains?: string
+}
+
+export interface Repository {
+    readonly rootUri: Uri
+    readonly inputBox: InputBox
+    readonly state: RepositoryState
+    readonly ui: RepositoryUIState
+
+    getConfigs(): Promise<{ key: string; value: string }[]>
+    getConfig(key: string): Promise<string>
+    setConfig(key: string, value: string): Promise<string>
+    getGlobalConfig(key: string): Promise<string>
+
+    getObjectDetails(treeish: string, path: string): Promise<{ mode: string; object: string; size: number }>
+    detectObjectType(object: string): Promise<{ mimetype: string; encoding?: string }>
+    buffer(ref: string, path: string): Promise<Buffer>
+    show(ref: string, path: string): Promise<string>
+    getCommit(ref: string): Promise<Commit>
+
+    clean(paths: string[]): Promise<void>
+
+    apply(patch: string, reverse?: boolean): Promise<void>
+    diff(cached?: boolean): Promise<string>
+    diffWithHEAD(): Promise<Change[]>
+    diffWithHEAD(path: string): Promise<string>
+    diffWith(ref: string): Promise<Change[]>
+    diffWith(ref: string, path: string): Promise<string>
+    diffIndexWithHEAD(): Promise<Change[]>
+    diffIndexWithHEAD(path: string): Promise<string>
+    diffIndexWith(ref: string): Promise<Change[]>
+    diffIndexWith(ref: string, path: string): Promise<string>
+    diffBlobs(object1: string, object2: string): Promise<string>
+    diffBetween(ref1: string, ref2: string): Promise<Change[]>
+    diffBetween(ref1: string, ref2: string, path: string): Promise<string>
+
+    hashObject(data: string): Promise<string>
+
+    createBranch(name: string, checkout: boolean, ref?: string): Promise<void>
+    deleteBranch(name: string, force?: boolean): Promise<void>
+    getBranch(name: string): Promise<Branch>
+    getBranches(query: BranchQuery): Promise<Ref[]>
+    setBranchUpstream(name: string, upstream: string): Promise<void>
+
+    getMergeBase(ref1: string, ref2: string): Promise<string>
+
+    status(): Promise<void>
+    checkout(treeish: string): Promise<void>
+
+    addRemote(name: string, url: string): Promise<void>
+    removeRemote(name: string): Promise<void>
+    renameRemote(name: string, newName: string): Promise<void>
+
+    fetch(options?: FetchOptions): Promise<void>
+    fetch(remote?: string, ref?: string, depth?: number): Promise<void>
+    pull(unshallow?: boolean): Promise<void>
+    push(remoteName?: string, branchName?: string, setUpstream?: boolean, force?: ForcePushMode): Promise<void>
+
+    blame(path: string): Promise<string>
+    log(options?: LogOptions): Promise<Commit[]>
+
+    commit(message: string, opts?: CommitOptions): Promise<void>
+}
+
+export interface RemoteSource {
+    readonly name: string
+    readonly description?: string
+    readonly url: string | string[]
+}
+
+export interface RemoteSourceProvider {
+    readonly name: string
+    readonly icon?: string // codicon name
+    readonly supportsQuery?: boolean
+    getRemoteSources(query?: string): ProviderResult<RemoteSource[]>
+    getBranches?(url: string): ProviderResult<string[]>
+    publishRepository?(repository: Repository): Promise<void>
+}
+
+export interface Credentials {
+    readonly username: string
+    readonly password: string
+}
+
+export interface CredentialsProvider {
+    getCredentials(host: Uri): ProviderResult<Credentials>
+}
+
+export interface PushErrorHandler {
+    handlePushError(
+        repository: Repository,
+        remote: Remote,
+        refspec: string,
+        error: Error & { gitErrorCode: GitErrorCodes }
+    ): Promise<boolean>
+}
+
+export type APIState = 'uninitialized' | 'initialized'
+
+export interface PublishEvent {
+    repository: Repository
+    branch?: string
+}
+
+export interface API {
+    readonly state: APIState
+    readonly onDidChangeState: Event<APIState>
+    readonly onDidPublish: Event<PublishEvent>
+    readonly git: Git
+    readonly repositories: Repository[]
+    readonly onDidOpenRepository: Event<Repository>
+    readonly onDidCloseRepository: Event<Repository>
+
+    toGitUri(uri: Uri, ref: string): Uri
+    getRepository(uri: Uri): Repository | null
+    init(root: Uri): Promise<Repository | null>
+    openRepository(root: Uri): Promise<Repository | null>
+
+    registerRemoteSourceProvider(provider: RemoteSourceProvider): Disposable
+    registerCredentialsProvider(provider: CredentialsProvider): Disposable
+    registerPushErrorHandler(handler: PushErrorHandler): Disposable
+}
+
+export interface GitExtension {
+    readonly enabled: boolean
+    readonly onDidChangeEnablement: Event<boolean>
+
+    /**
+     * Returns a specific API version.
+     *
+     * Throws error if git extension is disabled. You can listed to the
+     * [GitExtension.onDidChangeEnablement](#GitExtension.onDidChangeEnablement) event
+     * to know when the extension becomes enabled/disabled.
+     *
+     * @param version Version number.
+     * @returns API instance
+     */
+    getAPI(version: 1): API
+}
+
+export const enum GitErrorCodes {
+    BadConfigFile = 'BadConfigFile',
+    AuthenticationFailed = 'AuthenticationFailed',
+    NoUserNameConfigured = 'NoUserNameConfigured',
+    NoUserEmailConfigured = 'NoUserEmailConfigured',
+    NoRemoteRepositorySpecified = 'NoRemoteRepositorySpecified',
+    NotAGitRepository = 'NotAGitRepository',
+    NotAtRepositoryRoot = 'NotAtRepositoryRoot',
+    Conflict = 'Conflict',
+    StashConflict = 'StashConflict',
+    UnmergedChanges = 'UnmergedChanges',
+    PushRejected = 'PushRejected',
+    RemoteConnectionError = 'RemoteConnectionError',
+    DirtyWorkTree = 'DirtyWorkTree',
+    CantOpenResource = 'CantOpenResource',
+    GitNotFound = 'GitNotFound',
+    CantCreatePipe = 'CantCreatePipe',
+    PermissionDenied = 'PermissionDenied',
+    CantAccessRemote = 'CantAccessRemote',
+    RepositoryNotFound = 'RepositoryNotFound',
+    RepositoryIsLocked = 'RepositoryIsLocked',
+    BranchNotFullyMerged = 'BranchNotFullyMerged',
+    NoRemoteReference = 'NoRemoteReference',
+    InvalidBranchName = 'InvalidBranchName',
+    BranchAlreadyExists = 'BranchAlreadyExists',
+    NoLocalChanges = 'NoLocalChanges',
+    NoStashFound = 'NoStashFound',
+    LocalChangesOverwritten = 'LocalChangesOverwritten',
+    NoUpstreamBranch = 'NoUpstreamBranch',
+    IsInSubmodule = 'IsInSubmodule',
+    WrongCase = 'WrongCase',
+    CantLockRef = 'CantLockRef',
+    CantRebaseMultipleBranches = 'CantRebaseMultipleBranches',
+    PatchDoesNotApply = 'PatchDoesNotApply',
+    NoPathFound = 'NoPathFound',
+    UnknownPath = 'UnknownPath',
+}


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

Wraps some of the Git API functionality in a new class. A wrapper is used since it appears some of the API calls are lacking in their capability, thus we sometimes want to use `git` directly. I'm open to ideas though in terms of how this wrapper should act in various circumstances. I was using it in a pretty narrow way so it may be that this solution is not ideal.

I'm currently thinking of making extension wrappers always 'silently' (but with logs) fail when the extension does not exist or is not enabled. The idea being that we do not want to be strictly dependent on other extensions; they should _enhance_ our own functionality. Of course, a caller can always check for enablement of the wrapper since there are definitely circumstances where behavior should be determined based off what extensions are available.

TODO: start expanding our integration tests to include other extensions

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
