### PR TITLE
Apprunner: add client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "adm-zip": "^0.4.13",
                 "amazon-states-language-service": "^1.6.4",
                 "async-lock": "^1.3.0",
-                "aws-sdk": "2.960",
+                "aws-sdk": "^2.960.0",
                 "aws-ssm-document-language-service": "^1.0.0",
                 "bytes": "^3.1.0",
                 "cross-spawn": "^7.0.3",
@@ -6890,21 +6890,6 @@
             },
             "engines": {
                 "node": ">=8.17.0"
-            }
-        },
-        "node_modules/tmp/node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "dev": true,
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/tough-cookie": {
@@ -13864,17 +13849,6 @@
             "dev": true,
             "requires": {
                 "rimraf": "^3.0.0"
-            },
-            "dependencies": {
-                "rimraf": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-                    "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-                    "dev": true,
-                    "requires": {
-                        "glob": "^7.1.3"
-                    }
-                }
             }
         },
         "tough-cookie": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "adm-zip": "^0.4.13",
                 "amazon-states-language-service": "^1.6.4",
                 "async-lock": "^1.3.0",
-                "aws-sdk": "^2.882.0",
+                "aws-sdk": "2.960",
                 "aws-ssm-document-language-service": "^1.0.0",
                 "bytes": "^3.1.0",
                 "cross-spawn": "^7.0.3",
@@ -1398,9 +1398,10 @@
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "node_modules/aws-sdk": {
-            "version": "2.882.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.882.0.tgz",
-            "integrity": "sha512-MC1tKQdvIBmSQmyFmS6McGGPrN6yvHmhP0SS0ovx+zF/BbvHPTpi5hIgqPSAkdb8/s0I16QtbwiLQgPT2pf1tA==",
+            "version": "2.960.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.960.0.tgz",
+            "integrity": "sha512-e3KNZ5x0uzBNbVLbGUO2xrMRonUPpmXxgyZ/MaHx5yOQIv9G2a7dei/TvrMa9rl4MFCScGLw1LjbYb7CrdbMBQ==",
+            "hasInstallScript": true,
             "dependencies": {
                 "buffer": "4.9.2",
                 "events": "1.1.1",
@@ -9463,9 +9464,9 @@
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "aws-sdk": {
-            "version": "2.882.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.882.0.tgz",
-            "integrity": "sha512-MC1tKQdvIBmSQmyFmS6McGGPrN6yvHmhP0SS0ovx+zF/BbvHPTpi5hIgqPSAkdb8/s0I16QtbwiLQgPT2pf1tA==",
+            "version": "2.960.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.960.0.tgz",
+            "integrity": "sha512-e3KNZ5x0uzBNbVLbGUO2xrMRonUPpmXxgyZ/MaHx5yOQIv9G2a7dei/TvrMa9rl4MFCScGLw1LjbYb7CrdbMBQ==",
             "requires": {
                 "buffer": "4.9.2",
                 "events": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1957,7 +1957,7 @@
         "adm-zip": "^0.4.13",
         "amazon-states-language-service": "^1.6.4",
         "async-lock": "^1.3.0",
-        "aws-sdk": "2.960",
+        "aws-sdk": "^2.960.0",
         "aws-ssm-document-language-service": "^1.0.0",
         "bytes": "^3.1.0",
         "cross-spawn": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -1957,7 +1957,7 @@
         "adm-zip": "^0.4.13",
         "amazon-states-language-service": "^1.6.4",
         "async-lock": "^1.3.0",
-        "aws-sdk": "^2.882.0",
+        "aws-sdk": "2.960",
         "aws-ssm-document-language-service": "^1.0.0",
         "bytes": "^3.1.0",
         "cross-spawn": "^7.0.3",

--- a/src/shared/clients/apprunnerClient.ts
+++ b/src/shared/clients/apprunnerClient.ts
@@ -1,0 +1,70 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AppRunner } from 'aws-sdk'
+import { ext } from '../../shared/extensionGlobals'
+import { ClassToInterfaceType } from '../utilities/tsUtils'
+
+export type AppRunnerClient = ClassToInterfaceType<DefaultAppRunnerClient>
+
+export class DefaultAppRunnerClient {
+    public constructor(public readonly regionCode: string) {}
+
+    public async createService(request: AppRunner.CreateServiceRequest): Promise<AppRunner.CreateServiceResponse> {
+        return (await this.createSdkClient()).createService(request).promise()
+    }
+
+    public async listServices(request: AppRunner.ListServicesRequest): Promise<AppRunner.ListServicesResponse> {
+        return (await this.createSdkClient()).listServices(request).promise()
+    }
+
+    public async pauseService(request: AppRunner.PauseServiceRequest): Promise<AppRunner.PauseServiceResponse> {
+        return (await this.createSdkClient()).pauseService(request).promise()
+    }
+
+    public async resumeService(request: AppRunner.ResumeServiceRequest): Promise<AppRunner.ResumeServiceResponse> {
+        return (await this.createSdkClient()).resumeService(request).promise()
+    }
+
+    public async updateService(request: AppRunner.UpdateServiceRequest): Promise<AppRunner.UpdateServiceResponse> {
+        return (await this.createSdkClient()).updateService(request).promise()
+    }
+
+    public async createConnection(
+        request: AppRunner.CreateConnectionRequest
+    ): Promise<AppRunner.CreateConnectionResponse> {
+        return (await this.createSdkClient()).createConnection(request).promise()
+    }
+
+    public async listConnections(
+        request: AppRunner.ListConnectionsRequest
+    ): Promise<AppRunner.ListConnectionsResponse> {
+        return (await this.createSdkClient()).listConnections(request).promise()
+    }
+
+    public async describeService(
+        request: AppRunner.DescribeServiceRequest
+    ): Promise<AppRunner.DescribeServiceResponse> {
+        return (await this.createSdkClient()).describeService(request).promise()
+    }
+
+    public async startDeployment(
+        request: AppRunner.StartDeploymentRequest
+    ): Promise<AppRunner.StartDeploymentResponse> {
+        return (await this.createSdkClient()).startDeployment(request).promise()
+    }
+
+    public async listOperations(request: AppRunner.ListOperationsRequest): Promise<AppRunner.ListOperationsResponse> {
+        return (await this.createSdkClient()).listOperations(request).promise()
+    }
+
+    public async deleteService(request: AppRunner.DeleteServiceRequest): Promise<AppRunner.DeleteServiceResponse> {
+        return (await this.createSdkClient()).deleteService(request).promise()
+    }
+
+    protected async createSdkClient(): Promise<AppRunner> {
+        return await ext.sdkClientBuilder.createAwsService(AppRunner, undefined, this.regionCode)
+    }
+}

--- a/src/shared/clients/toolkitClientBuilder.ts
+++ b/src/shared/clients/toolkitClientBuilder.ts
@@ -19,6 +19,7 @@ import { DefaultS3Client, S3Client } from './s3Client'
 import { RegionProvider } from '../regions/regionProvider'
 import { DEFAULT_PARTITION } from '../regions/regionUtilities'
 import { ClassToInterfaceType } from '../utilities/tsUtils'
+import { AppRunnerClient, DefaultAppRunnerClient } from './apprunnerClient'
 
 export type ToolkitClientBuilder = ClassToInterfaceType<DefaultToolkitClientBuilder>
 export class DefaultToolkitClientBuilder {
@@ -70,5 +71,9 @@ export class DefaultToolkitClientBuilder {
 
     public createSsmClient(regionCode: string): SsmDocumentClient {
         return new DefaultSsmDocumentClient(regionCode)
+    }
+
+    public createAppRunnerClient(regionCode: string): AppRunnerClient {
+        return new DefaultAppRunnerClient(regionCode)
     }
 }

--- a/src/test/shared/clients/mockClients.ts
+++ b/src/test/shared/clients/mockClients.ts
@@ -2,7 +2,7 @@
  * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { S3 } from 'aws-sdk'
+import { AppRunner, S3 } from 'aws-sdk'
 import { APIGateway, CloudFormation, CloudWatchLogs, IAM, Lambda, Schemas, StepFunctions, STS, SSM } from 'aws-sdk'
 import { ApiGatewayClient } from '../../../shared/clients/apiGatewayClient'
 import { CloudFormationClient } from '../../../shared/clients/cloudFormationClient'
@@ -37,6 +37,7 @@ import {
     ListObjectVersionsResponse,
     DeleteObjectsResponse,
 } from '../../../shared/clients/s3Client'
+import { AppRunnerClient } from '../../../shared/clients/apprunnerClient'
 
 interface Clients {
     apiGatewayClient: ApiGatewayClient
@@ -51,6 +52,7 @@ interface Clients {
     stsClient: StsClient
     s3Client: S3Client
     ssmDocumentClient: SsmDocumentClient
+    apprunnerClient: AppRunnerClient
 }
 
 export class MockToolkitClientBuilder implements ToolkitClientBuilder {
@@ -69,8 +71,13 @@ export class MockToolkitClientBuilder implements ToolkitClientBuilder {
             stsClient: new MockStsClient({}),
             s3Client: new MockS3Client({}),
             ssmDocumentClient: new MockSsmDocumentClient(),
+            apprunnerClient: new MockAppRunnerClient(),
             ...overrideClients,
         }
+    }
+
+    public createAppRunnerClient(regionCode: string): AppRunnerClient {
+        return this.clients.apprunnerClient
     }
 
     public createApiGatewayClient(regionCode: string): ApiGatewayClient {
@@ -536,5 +543,63 @@ export class MockS3Client implements S3Client {
         this.deleteObject = deleteObject
         this.deleteObjects = deleteObjects
         this.deleteBucket = deleteBucket
+    }
+}
+
+export class MockAppRunnerClient implements AppRunnerClient {
+    public readonly regionCode: string = ''
+
+    public constructor() {}
+
+    public async createService(request: AppRunner.CreateServiceRequest): Promise<AppRunner.CreateServiceResponse> {
+        throw new Error('Not implemented')
+    }
+
+    public async listServices(request: AppRunner.ListServicesRequest): Promise<AppRunner.ListServicesResponse> {
+        throw new Error('Not implemented')
+    }
+
+    public async pauseService(request: AppRunner.PauseServiceRequest): Promise<AppRunner.PauseServiceResponse> {
+        throw new Error('Not implemented')
+    }
+
+    public async resumeService(request: AppRunner.ResumeServiceRequest): Promise<AppRunner.ResumeServiceResponse> {
+        throw new Error('Not implemented')
+    }
+
+    public async updateService(request: AppRunner.UpdateServiceRequest): Promise<AppRunner.UpdateServiceResponse> {
+        throw new Error('Not implemented')
+    }
+
+    public async createConnection(
+        request: AppRunner.CreateConnectionRequest
+    ): Promise<AppRunner.CreateConnectionResponse> {
+        throw new Error('Not implemented')
+    }
+
+    public async listConnections(
+        request: AppRunner.ListConnectionsRequest
+    ): Promise<AppRunner.ListConnectionsResponse> {
+        throw new Error('Not implemented')
+    }
+
+    public async describeService(
+        request: AppRunner.DescribeServiceRequest
+    ): Promise<AppRunner.DescribeServiceResponse> {
+        throw new Error('Not implemented')
+    }
+
+    public async startDeployment(
+        request: AppRunner.StartDeploymentRequest
+    ): Promise<AppRunner.StartDeploymentResponse> {
+        throw new Error('Not implemented')
+    }
+
+    public async listOperations(request: AppRunner.ListOperationsRequest): Promise<AppRunner.ListOperationsResponse> {
+        throw new Error('Not implemented')
+    }
+
+    public async deleteService(request: AppRunner.DeleteServiceRequest): Promise<AppRunner.DeleteServiceResponse> {
+        throw new Error('Not implemented')
     }
 }


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

Adds the client. Nothing fancy.

Side note: can we get rid of `MockToolkitClientBuilder`?? We have a big discrepancy in how our tests mock SDK clients. Some tests use these hand-made mocks, others use `mockito`. I'm in favor of just using `mockito`.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
