### PR TITLE
App Runner: wizard implementations

### DIFF
--- a/src/apprunner/wizards/apprunnerCreateServiceWizard.ts
+++ b/src/apprunner/wizards/apprunnerCreateServiceWizard.ts
@@ -92,7 +92,7 @@ function createInstanceStep(): Prompter<AppRunner.InstanceConfiguration> {
     ]
 
     const items: picker.DataQuickPickItem<AppRunner.InstanceConfiguration>[] = enumerations.map(e => ({
-        label: `${e[0]} vCPU${e[0] > 1 ? 's' : ''}, ${e[1]} GBs Memory`,
+        label: `${e[0]} vCPUs, ${e[1]} GBs Memory`,
         data: { Cpu: `${e[0]} vCPU`, Memory: `${e[1]} GB` },
     }))
 

--- a/src/apprunner/wizards/apprunnerCreateServiceWizard.ts
+++ b/src/apprunner/wizards/apprunnerCreateServiceWizard.ts
@@ -1,0 +1,227 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AppRunner } from 'aws-sdk'
+import * as nls from 'vscode-nls'
+import {
+    createBackButton,
+    createExitButton,
+    createHelpButton,
+    QuickInputButton,
+    QuickInputToggleButton,
+} from '../../shared/ui/buttons'
+import { ext } from '../../shared/extensionGlobals'
+import { IamClient } from '../../shared/clients/iamClient'
+import * as input from '../../shared/ui/inputPrompter'
+import * as picker from '../../shared/ui/pickerPrompter'
+import { Prompter } from '../../shared/ui/prompter'
+import { Wizard, WizardState } from '../../shared/wizards/wizard'
+import { AppRunnerImageRepositoryForm, ImageRepositorySource } from './imageRepositoryWizard'
+import { AppRunnerCodeRepositoryForm, CodeRepositorySource } from './codeRepositoryWizard'
+import { WizardForm } from '../../shared/wizards/wizardForm'
+import * as vscode from 'vscode'
+import { AppRunnerClient } from '../../shared/clients/apprunnerClient'
+import { BasicExitPrompterProvider } from '../../shared/ui/common/exitPrompter'
+import { GitExtension } from '../../shared/extensions/git'
+
+const localize = nls.loadMessageBundle()
+
+function makeDeployButtons() {
+    const autoDeploymentsEnable: QuickInputButton<void> = {
+        iconPath: new vscode.ThemeIcon('sync-ignored'),
+        tooltip: localize('AWS.apprunner.buttons.enableAutoDeploy', 'Turn on automatic deployment'),
+    }
+
+    const autoDeploymentsDisable: QuickInputButton<void> = {
+        iconPath: new vscode.ThemeIcon('sync'),
+        tooltip: localize('AWS.apprunner.buttons.disableAutoDeploy', 'Turn off automatic deployment'),
+    }
+
+    return [autoDeploymentsDisable, autoDeploymentsEnable]
+}
+
+export function makeDeploymentButton() {
+    const [autoDeploymentsDisable, autoDeploymentsEnable] = makeDeployButtons()
+
+    return new QuickInputToggleButton(autoDeploymentsDisable, autoDeploymentsEnable, {
+        onCallback: showDeploymentCostNotifcation,
+    })
+}
+
+function makeButtons() {
+    return [
+        createHelpButton('https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html'),
+        createBackButton(),
+        createExitButton(),
+    ]
+}
+
+export interface CreateAppRunnerServiceContext {
+    readonly iamClient: IamClient
+    readonly apprunnerClient: AppRunnerClient
+    readonly autoDeployButton: QuickInputToggleButton
+    readonly codeRepositoryForm: WizardForm<CodeRepositorySource>
+    readonly imageRepositoryForm: WizardForm<ImageRepositorySource>
+}
+
+export class DefaultCreateAppRunnerServiceContext implements CreateAppRunnerServiceContext {
+    public readonly iamClient: IamClient
+    public readonly apprunnerClient: AppRunnerClient
+    public readonly autoDeployButton: QuickInputToggleButton
+    public readonly codeRepositoryForm: WizardForm<CodeRepositorySource>
+    public readonly imageRepositoryForm: WizardForm<ImageRepositorySource>
+
+    constructor(public readonly region: string, public readonly git: GitExtension) {
+        const ecrClient = ext.toolkitClientBuilder.createEcrClient(region)
+
+        this.iamClient = ext.toolkitClientBuilder.createIamClient(region)
+        this.apprunnerClient = ext.toolkitClientBuilder.createAppRunnerClient(region)
+        this.autoDeployButton = makeDeploymentButton()
+        this.codeRepositoryForm = new AppRunnerCodeRepositoryForm(this.apprunnerClient, git, this.autoDeployButton)
+        this.imageRepositoryForm = new AppRunnerImageRepositoryForm(ecrClient, this.iamClient, this.autoDeployButton)
+    }
+}
+
+// I'm sure this code could be reused in many places
+const validateName = (name: string) => {
+    const badNameRegExp = /[^A-Za-z0-9-_]/g
+    if (!name || name.length < 4) {
+        return localize('AWS.apprunner.createService.name.validation', 'Service names must be at least 4 characters')
+    } else if (name.length > 40) {
+        return localize(
+            'AWS.apprunner.createService.name.validationExceeds',
+            'Service names cannot be more than 40 characters'
+        )
+    } else if (name.match(/\s/)) {
+        return localize(
+            'AWS.apprunner.createService.name.validationWhitespace',
+            'Service names cannot contain whitespace'
+        )
+    }
+
+    let matches = name.match(badNameRegExp)
+    if (name[0] === '_' || name[0] === '-') {
+        matches = matches ? [name[0]].concat(matches) : [name[0]]
+    }
+    if (matches && matches.length > 0) {
+        return localize(
+            'AWS.apprunner.createService.name.validationBadChar',
+            'Invalid character(s): {0}',
+            Array.from(new Set(matches)).join('')
+        )
+    }
+
+    return undefined
+}
+
+function createInstanceStep(): Prompter<AppRunner.InstanceConfiguration> {
+    const enumerations = [
+        [1, 2],
+        [1, 3],
+        [2, 4],
+    ]
+
+    const items: picker.DataQuickPickItem<AppRunner.InstanceConfiguration>[] = enumerations.map(e => ({
+        label: `${e[0]} vCPU${e[0] > 1 ? 's' : ''}, ${e[1]} GBs Memory`,
+        data: { Cpu: `${e[0]} vCPU`, Memory: `${e[1]} GB` },
+    }))
+
+    return picker.createQuickPick(items, {
+        title: localize('AWS.apprunner.createService.selectInstanceConfig.title', 'Select instance configuration'),
+        buttons: makeButtons(),
+    })
+}
+
+function showDeploymentCostNotifcation(): void {
+    const shouldShow = ext.context.globalState.get('apprunner.deployments.notifyPricing', true)
+
+    if (shouldShow) {
+        const notice = localize(
+            'aws.apprunner.createService.priceNotice.message',
+            'App Runner automatic deployments incur an additional cost.'
+        )
+        const viewPricing = localize('aws.apprunner.createService.priceNotice.view', 'View Pricing')
+        const dontShow = localize('aws.generic.doNotShowAgain', "Don't Show Again")
+        const pricingUri = vscode.Uri.parse('https://aws.amazon.com/apprunner/pricing/')
+
+        vscode.window.showInformationMessage(notice, viewPricing, dontShow).then(button => {
+            if (button === viewPricing) {
+                vscode.env.openExternal(pricingUri)
+                showDeploymentCostNotifcation()
+            } else if (button === dontShow) {
+                ext.context.globalState.update('apprunner.deployments.notifyPricing', false)
+            }
+        })
+    }
+}
+
+function createSourcePrompter(
+    autoDeployButton: QuickInputToggleButton
+): Prompter<CreateServiceRequest['SourceConfiguration']> {
+    const ecrPath = {
+        label: 'ECR',
+        data: { ImageRepository: {} } as ImageRepositorySource,
+        detail: localize(
+            'AWS.apprunner.createService.ecr.detail',
+            'Create a service from a public or private Elastic Container Registry repository'
+        ),
+    }
+
+    const repositoryPath = {
+        label: 'Repository',
+        data: { CodeRepository: {} } as CodeRepositorySource,
+        detail: localize('AWS.apprunner.createService.repository.detail', 'Create a service from a GitHub repository'),
+    }
+
+    return picker.createQuickPick([ecrPath, repositoryPath], {
+        title: localize('AWS.apprunner.createService.sourceType.title', 'Select a source code location type'),
+        buttons: [autoDeployButton, ...makeButtons()],
+    })
+}
+
+export type CreateServiceRequest = Omit<AppRunner.CreateServiceRequest, 'SourceConfiguration'> & {
+    SourceConfiguration: CodeRepositorySource | ImageRepositorySource
+}
+
+export class CreateAppRunnerServiceForm extends WizardForm<CreateServiceRequest> {
+    public constructor(context: CreateAppRunnerServiceContext) {
+        super()
+        const form = this.body
+
+        form.SourceConfiguration.bindPrompter(() => createSourcePrompter(context.autoDeployButton))
+
+        form.SourceConfiguration.applyForm(context.imageRepositoryForm, {
+            showWhen: state => state.SourceConfiguration?.ImageRepository !== undefined,
+        })
+        form.SourceConfiguration.applyForm(context.codeRepositoryForm, {
+            showWhen: state => state.SourceConfiguration?.CodeRepository !== undefined,
+        })
+
+        form.ServiceName.bindPrompter(() =>
+            input.createInputBox({
+                title: localize('AWS.apprunner.createService.name.title', 'Name your service'),
+                validateInput: validateName, // TODO: we can check if names match any already made services
+                buttons: makeButtons(),
+            })
+        )
+
+        form.InstanceConfiguration.bindPrompter(() => createInstanceStep())
+    }
+}
+
+export class CreateAppRunnerServiceWizard extends Wizard<CreateServiceRequest> {
+    public constructor(
+        context: CreateAppRunnerServiceContext,
+        initState: WizardState<AppRunner.CreateServiceRequest> = {},
+        implicitState: WizardState<AppRunner.CreateServiceRequest> = {}
+    ) {
+        super({
+            initForm: new CreateAppRunnerServiceForm(context),
+            initState,
+            implicitState,
+            exitPrompterProvider: new BasicExitPrompterProvider(),
+        })
+    }
+}

--- a/src/apprunner/wizards/codeRepositoryWizard.ts
+++ b/src/apprunner/wizards/codeRepositoryWizard.ts
@@ -1,0 +1,267 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AppRunner } from 'aws-sdk'
+import * as nls from 'vscode-nls'
+import {
+    createBackButton,
+    createExitButton,
+    createHelpButton,
+    createRefreshButton,
+    QuickInputToggleButton,
+} from '../../shared/ui/buttons'
+import { Remote } from '../../../types/git.d'
+import { GitExtension } from '../../shared/extensions/git'
+import * as input from '../../shared/ui/inputPrompter'
+import * as vscode from 'vscode'
+import * as picker from '../../shared/ui/pickerPrompter'
+import { CachedFunction, Prompter, CachedPrompter } from '../../shared/ui/prompter'
+import { WizardForm } from '../../shared/wizards/wizardForm'
+import { createVariablesPrompter } from '../../shared/ui/common/variablesPrompter'
+import { AppRunnerClient } from '../../shared/clients/apprunnerClient'
+import { makeDeploymentButton } from './apprunnerCreateServiceWizard'
+import { ConnectionSummary } from 'aws-sdk/clients/apprunner'
+
+const localize = nls.loadMessageBundle()
+
+function makeButtons() {
+    return [
+        createHelpButton('https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html'),
+        createBackButton(),
+        createExitButton(),
+    ]
+}
+
+function validateCommand(command: string): string | undefined {
+    if (command == '') {
+        return localize('AWS.apprunner.command.invalid', 'Command cannot be empty')
+    }
+
+    return undefined
+}
+
+function createRepoPrompter(git: GitExtension): Prompter<Remote> {
+    const remotes = git.getRemotes()
+    const userInputString = localize('AWS.apprunner.createService.customRepo', 'Enter GitHub URL')
+    const items = remotes.map(remote => ({ label: remote.name, detail: remote.fetchUrl, data: remote }))
+    return picker.createQuickPick(items, {
+        title: localize('AWS.apprunner.createService.selectRepository.title', 'Select a remote GitHub repository'),
+        placeholder: localize(
+            'AWS.apprunner.createService.selectRepository.placeholder',
+            'Select a remote repository or enter a URL'
+        ),
+        filterBoxInputSettings: {
+            label: userInputString,
+            transform: resp => ({ name: 'UserRemote', isReadOnly: true, fetchUrl: resp }),
+        },
+        buttons: makeButtons(),
+    })
+}
+
+function createBranchPrompter(git: GitExtension, cache: { [key: string]: any }, repo: string = ''): Prompter<string> {
+    const last = cache[repo]
+    const branchItems =
+        last ??
+        git.getBranchesForRemote({ name: '', fetchUrl: repo } as any).then(branches => {
+            const branchItems = branches
+                .filter(b => b.name !== undefined && b.name !== '')
+                .map(branch => ({
+                    label: branch.name!.split('/').slice(1).join('/'),
+                }))
+            cache[repo] = branchItems
+            return branchItems
+        })
+    const userInputString = localize('AWS.apprunner.createService.customRepo', 'Enter branch name')
+    return picker.createLabelQuickPick(branchItems, {
+        title: localize('AWS.apprunner.createService.selectBranch.title', 'Select a branch'),
+        filterBoxInputSettings: {
+            label: userInputString,
+            transform: resp => resp,
+        },
+        buttons: makeButtons(),
+        placeholder: localize(
+            'AWS.apprunner.createService.selectBranch.placeholder',
+            'Select a branch or enter a branch name'
+        ),
+    })
+}
+
+function createRuntimePrompter(): Prompter<AppRunner.Runtime> {
+    const items = [
+        { label: 'python3', data: 'PYTHON_3' },
+        { label: 'nodejs12', data: 'NODEJS_12' },
+    ]
+
+    return picker.createQuickPick(items, {
+        title: localize('AWS.apprunner.createService.selectRuntime.title', 'Select a runtime'),
+        buttons: makeButtons(),
+    })
+}
+
+function createBuildCommandPrompter(runtime: AppRunner.Runtime): Prompter<string> {
+    const buildCommandMap = {
+        python: 'pip install -r requirements.txt',
+        node: 'npm install',
+    } as { [key: string]: string }
+
+    return input.createInputBox({
+        title: localize('AWS.apprunner.createService.buildCommand.title', 'Enter a build command'),
+        buttons: makeButtons(),
+        placeholder:
+            buildCommandMap[Object.keys(buildCommandMap).filter(key => runtime.toLowerCase().includes(key))[0]],
+        validateInput: validateCommand,
+    })
+}
+
+function createStartCommandPrompter(runtime: AppRunner.Runtime): Prompter<string> {
+    const startCommandMap = {
+        python: 'python runapp.py',
+        node: 'node app.js',
+    } as { [key: string]: string }
+
+    return input.createInputBox({
+        title: localize('AWS.apprunner.createService.startCommand.title', 'Enter a start command'),
+        buttons: makeButtons(),
+        placeholder:
+            startCommandMap[Object.keys(startCommandMap).filter(key => runtime.toLowerCase().includes(key))[0]],
+        validateInput: validateCommand,
+    })
+}
+
+function createPortPrompter(): Prompter<string> {
+    const validatePort = (port: string) => {
+        if (isNaN(Number(port)) || port === '') {
+            return localize('AWS.apprunner.createService.selectPort.invalidPort', 'Port must be a number')
+        }
+
+        return undefined
+    }
+
+    return input.createInputBox({
+        validateInput: validatePort,
+        title: localize('AWS.apprunner.createService.selectPort.title', 'Enter a port for the new service'),
+        placeholder: 'Enter a port',
+        buttons: makeButtons(),
+    })
+}
+
+export class ConnectionPrompter extends CachedPrompter<ConnectionSummary> {
+    public constructor(private readonly client: AppRunnerClient) {
+        super()
+    }
+
+    protected load(): Promise<picker.DataQuickPickItem<ConnectionSummary>[]> {
+        return this.client.listConnections({}).then(resp => {
+            const connections = resp.ConnectionSummaryList.filter(conn => conn.Status === 'AVAILABLE').map(conn => ({
+                label: conn.ConnectionName!,
+                data: conn,
+            }))
+
+            if (connections.length === 0) {
+                return [
+                    {
+                        label: 'No connections found',
+                        detail: 'Create a new GitHub connection for App Runner',
+                        data: {} as any,
+                        invalidSelection: true,
+                        onClick: vscode.env.openExternal.bind(
+                            vscode.env,
+                            vscode.Uri.parse(`https://docs.aws.amazon.com/apprunner/latest/dg/manage-connections.html`)
+                        ),
+                    },
+                ]
+            } else {
+                return connections
+            }
+        })
+    }
+
+    protected createPrompter(loader: CachedFunction<ConnectionPrompter['load']>): Prompter<ConnectionSummary> {
+        const connections = loader()
+        const refreshButton = createRefreshButton()
+        const prompter = picker.createQuickPick(connections, {
+            title: localize('AWS.apprunner.createService.selectConnection.title', 'Select a connection'),
+            buttons: [refreshButton, ...makeButtons()],
+        })
+
+        const refresh = () => {
+            loader.clearCache()
+            prompter.clearAndLoadItems(loader())
+        }
+
+        refreshButton.onClick = refresh
+
+        return prompter
+    }
+}
+
+function createCodeRepositorySubForm(git: GitExtension): WizardForm<AppRunner.CodeRepository> {
+    const subform = new WizardForm<AppRunner.CodeRepository>()
+    const form = subform.body
+
+    form.RepositoryUrl.bindPrompter(() => createRepoPrompter(git).transform(r => r.fetchUrl!))
+
+    form.SourceCodeVersion.Value.bindPrompter(state =>
+        createBranchPrompter(git, state.stepCache, state.RepositoryUrl).transform(resp =>
+            resp.replace(`${state.RepositoryUrl}/`, '')
+        )
+    )
+
+    const configDetail = localize(
+        'AWS.apprunner.createService.configSource.detail',
+        'App Runner will read "apprunner.yaml" in the root of your repository for configuration details'
+    )
+    const apiLabel = localize('AWS.apprunner.createService.configSource.apiLabel', 'Configure all settings here')
+    const repoLabel = localize('AWS.apprunner.createService.configSource.repoLabel', 'Use configuration file')
+
+    form.CodeConfiguration.ConfigurationSource.bindPrompter(() => {
+        return picker.createQuickPick(
+            [
+                { label: apiLabel, data: 'API' },
+                { label: repoLabel, data: 'REPOSITORY', detail: configDetail },
+            ],
+            {
+                title: localize('AWS.apprunner.createService.configSource.title', 'Choose configuration source'),
+                buttons: makeButtons(),
+            }
+        )
+    })
+
+    form.SourceCodeVersion.Type.setDefault(() => 'BRANCH')
+
+    const codeConfigForm = new WizardForm<AppRunner.CodeConfigurationValues>()
+    codeConfigForm.body.Runtime.bindPrompter(() => createRuntimePrompter())
+    codeConfigForm.body.BuildCommand.bindPrompter(state => createBuildCommandPrompter(state.Runtime!))
+    codeConfigForm.body.StartCommand.bindPrompter(state => createStartCommandPrompter(state.Runtime!))
+    codeConfigForm.body.Port.bindPrompter(() => createPortPrompter())
+    codeConfigForm.body.RuntimeEnvironmentVariables.bindPrompter(() => createVariablesPrompter(makeButtons()))
+    // TODO: ask user if they would like to save their parameters into an App Runner config file
+
+    form.CodeConfiguration.CodeConfigurationValues.applyForm(codeConfigForm, {
+        showWhen: state => state.CodeConfiguration?.ConfigurationSource === 'API',
+    })
+
+    return subform
+}
+
+export type CodeRepositorySource = AppRunner.SourceConfiguration
+
+export class AppRunnerCodeRepositoryForm extends WizardForm<CodeRepositorySource> {
+    constructor(
+        client: AppRunnerClient,
+        git: GitExtension,
+        autoDeployButton: QuickInputToggleButton = makeDeploymentButton()
+    ) {
+        super()
+        const form = this.body
+        const connectionPrompter = new ConnectionPrompter(client)
+
+        form.AuthenticationConfiguration.ConnectionArn.bindPrompter(
+            connectionPrompter.transform(conn => conn.ConnectionArn!)
+        )
+        form.CodeRepository.applyForm(createCodeRepositorySubForm(git))
+        form.AutoDeploymentsEnabled.setDefault(() => autoDeployButton.state === 'on')
+    }
+}

--- a/src/apprunner/wizards/imageRepositoryWizard.ts
+++ b/src/apprunner/wizards/imageRepositoryWizard.ts
@@ -37,6 +37,7 @@ function makeButtons() {
 }
 
 const PUBLIC_ECR = 'public.ecr.aws'
+const APP_RUNNER_ECR_ENTITY = 'build.apprunner.amazonaws'
 
 export type TaggedEcrRepository = EcrRepository & { tag?: string }
 
@@ -222,7 +223,7 @@ export class AppRunnerImageRepositoryForm extends WizardForm<ImageRepositorySour
         const form = this.body
         const rolePrompter = new RolePrompter(iamClient, {
             title: localize('AWS.apprunner.createService.selectRole.title', 'Select a role to pull from ECR'),
-            filter: role => (role.AssumeRolePolicyDocument ?? '').includes('build.apprunner.amazonaws.com'),
+            filter: role => (role.AssumeRolePolicyDocument ?? '').includes(APP_RUNNER_ECR_ENTITY),
             createRole: createEcrRole.bind(undefined, iamClient),
         })
 

--- a/src/apprunner/wizards/imageRepositoryWizard.ts
+++ b/src/apprunner/wizards/imageRepositoryWizard.ts
@@ -108,7 +108,7 @@ function createImagePrompter(
             return 'tag cannot be empty'
         }
 
-        const privateRegExp = /[0-9]+.dkr.ecr.[a-zA-z0-9\-]+.amazonaws.com/
+        const privateRegExp = /[0-9]+\.dkr\.ecr\.[a-zA-z0-9\-]+\.amazonaws\.com/
 
         if (options.noPublicMessage && userInputParts[0].startsWith(PUBLIC_ECR)) {
             return options.noPublicMessage

--- a/src/apprunner/wizards/imageRepositoryWizard.ts
+++ b/src/apprunner/wizards/imageRepositoryWizard.ts
@@ -215,9 +215,7 @@ function createImageRepositorySubForm(
 
     return subform
 }
-
-export type ImageRepositorySource = AppRunner.SourceConfiguration
-export class AppRunnerImageRepositoryForm extends WizardForm<ImageRepositorySource> {
+export class AppRunnerImageRepositoryForm extends WizardForm<AppRunner.SourceConfiguration> {
     constructor(ecrClient: EcrClient, iamClient: IamClient, autoDeployButton = makeDeploymentButton()) {
         super()
         const form = this.body

--- a/src/apprunner/wizards/imageRepositoryWizard.ts
+++ b/src/apprunner/wizards/imageRepositoryWizard.ts
@@ -1,0 +1,238 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AppRunner, IAM } from 'aws-sdk'
+import {
+    createBackButton,
+    createExitButton,
+    createHelpButton,
+    QuickInputButton,
+    QuickInputToggleButton,
+} from '../../shared/ui/buttons'
+import { toArrayAsync } from '../../shared/utilities/collectionUtils'
+import { EcrClient, EcrRepository } from '../../shared/clients/ecrClient'
+import * as input from '../../shared/ui/inputPrompter'
+import * as picker from '../../shared/ui/pickerPrompter'
+import { Prompter } from '../../shared/ui/prompter'
+import { Wizard, WizardControl } from '../../shared/wizards/wizard'
+import { WizardPrompter } from '../../shared/ui/wizardPrompter'
+
+import * as nls from 'vscode-nls'
+import { WizardForm } from '../../shared/wizards/wizardForm'
+import { createVariablesPrompter } from '../../shared/ui/common/variablesPrompter'
+import { makeDeploymentButton } from './apprunnerCreateServiceWizard'
+import { IamClient } from '../../shared/clients/iamClient'
+import { RolePrompter } from '../../shared/ui/common/rolePrompter'
+
+const localize = nls.loadMessageBundle()
+
+function makeButtons() {
+    return [
+        createHelpButton('https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html'),
+        createBackButton(),
+        createExitButton(),
+    ]
+}
+
+const PUBLIC_ECR = 'public.ecr.aws'
+
+export type TaggedEcrRepository = EcrRepository & { tag?: string }
+
+interface ImagePrompterOptions {
+    noPublicMessage?: string
+    extraButtons?: QuickInputButton<void | WizardControl>
+}
+
+function createEcrRole(client: IamClient): Promise<IAM.Role> {
+    const policy = {
+        Version: '2008-10-17',
+        Statement: [
+            {
+                Sid: '',
+                Effect: 'Allow',
+                Principal: {
+                    Service: ['build.apprunner.amazonaws.com'],
+                },
+                Action: 'sts:AssumeRole',
+            },
+        ],
+    }
+    const ecrPolicy = 'arn:aws:iam::aws:policy/service-role/AWSAppRunnerServicePolicyForECRAccess'
+
+    return client
+        .createRole({
+            RoleName: `AppRunnerECRAccessRole${Math.floor(Math.random() * 1000000000) + 1000}`,
+            AssumeRolePolicyDocument: JSON.stringify(policy),
+        })
+        .then(resp => {
+            const role = resp.Role
+            return client.attachRolePolicy({ RoleName: role.RoleName, PolicyArn: ecrPolicy }).then(() => role)
+        })
+}
+
+function createImagePrompter(
+    ecrClient: EcrClient,
+    cache: { [key: string]: any },
+    options: ImagePrompterOptions = {}
+): picker.QuickPickPrompter<TaggedEcrRepository> {
+    const last = cache['repos']
+    const imageRepos =
+        last ??
+        toArrayAsync(ecrClient.describeRepositories()).then(resp => {
+            const repos = resp.map(repo => ({ label: repo.repositoryName, detail: repo.repositoryUri, data: repo }))
+            cache['repos'] = repos
+            return repos
+        })
+    const customUserInputLabel = localize('AWS.apprunner.createService.selectImageRepo.input', 'Custom ECR URL')
+    const customUserInputTransform = (resp: string) => {
+        const userInputParts = resp.split(':')
+
+        return {
+            repositoryArn: '',
+            repositoryName: 'UserDefined',
+            repositoryUri: userInputParts[0],
+            tag: userInputParts[1]?.trim() ?? 'latest',
+        }
+    }
+
+    const ecrUriValidator = (input: string) => {
+        const userInputParts = input.split(':')
+
+        if (userInputParts.length > 2) {
+            return 'colon should be used to delimit tag'
+        }
+
+        if (userInputParts.length === 2 && userInputParts[1].trim() === '') {
+            return 'tag cannot be empty'
+        }
+
+        const privateRegExp = /[0-9]+.dkr.ecr.[a-zA-z0-9\-]+.amazonaws.com/
+
+        if (options.noPublicMessage && userInputParts[0].startsWith(PUBLIC_ECR)) {
+            return options.noPublicMessage
+        }
+
+        if (!userInputParts[0].startsWith(PUBLIC_ECR) && !userInputParts[0].match(privateRegExp)) {
+            return 'not a valid ECR URL'
+        }
+    }
+
+    const customUserInputValidator = (input: string) => {
+        const message = ecrUriValidator(input)
+        return message !== undefined ? `$(close) Invalid input: ${message}` : undefined
+    }
+
+    return picker.createQuickPick<TaggedEcrRepository>(imageRepos, {
+        title: localize('AWS.apprunner.createService.selectImageRepo.title', 'Select or enter an image repository'),
+        placeholder: '123456789012.dkr.ecr.us-east-1.amazonaws.com/myrepo:latest',
+        filterBoxInputSettings: {
+            label: customUserInputLabel,
+            transform: customUserInputTransform,
+            validator: customUserInputValidator,
+        },
+        buttons: makeButtons(),
+    })
+}
+
+function createPortPrompter(): Prompter<string> {
+    const validatePort = (port: string) => {
+        if (isNaN(Number(port)) || port === '') {
+            return localize('AWS.apprunner.createService.selectPort.invalidPort', 'Port must be a number')
+        }
+
+        return undefined
+    }
+
+    return input.createInputBox({
+        validateInput: validatePort,
+        title: localize('AWS.apprunner.createService.selectPort.title', 'Enter a port for the new service'),
+        placeholder: 'Enter a port',
+        buttons: makeButtons(),
+    })
+}
+
+function createTagPrompter(
+    ecrClient: EcrClient,
+    imageRepo: EcrRepository,
+    cache: { [key: string]: any }
+): picker.QuickPickPrompter<string> {
+    const last: picker.DataQuickPickItem<TaggedEcrRepository>[] = cache[imageRepo.repositoryName]
+    const tagItems =
+        last ??
+        toArrayAsync(ecrClient.describeTags(imageRepo.repositoryName)).then(tags => {
+            const tagT = tags.map(tag => ({ label: tag }))
+            cache[imageRepo.repositoryName] = tagT
+            return tagT
+        })
+
+    return picker.createLabelQuickPick(tagItems, {
+        title: localize('AWS.apprunner.createService.selectTag.title', 'Select an ECR tag'),
+        placeholder: 'latest',
+        buttons: makeButtons(),
+    })
+}
+
+export class ImageIdentifierForm extends WizardForm<{ repo: TaggedEcrRepository }> {
+    constructor(ecrClient: EcrClient, options: ImagePrompterOptions = {}) {
+        super()
+
+        this.body.repo.bindPrompter(state => createImagePrompter(ecrClient, state.stepCache, options))
+        this.body.repo.tag.bindPrompter(state => createTagPrompter(ecrClient, state.repo!, state.stepCache), {
+            requireParent: true,
+        })
+    }
+}
+
+function createImageRepositorySubForm(
+    ecrClient: EcrClient,
+    autoDeployButton: QuickInputToggleButton
+): WizardForm<AppRunner.ImageRepository> {
+    const subform = new WizardForm<AppRunner.ImageRepository>()
+    const form = subform.body
+
+    // note: this is intentionally initialized only once to preserve caches
+    const imageIdentifierWizard = new Wizard({
+        initForm: new ImageIdentifierForm(ecrClient),
+    })
+
+    form.ImageIdentifier.bindPrompter(() =>
+        new WizardPrompter(imageIdentifierWizard).transform(resp => `${resp.repo.repositoryUri}:${resp.repo.tag}`)
+    )
+
+    function isPublic(imageRepo: string): boolean {
+        return imageRepo.search(/^public.ecr.aws/) !== -1
+    }
+
+    form.ImageRepositoryType.setDefault(state =>
+        state.ImageIdentifier !== undefined ? (isPublic(state.ImageIdentifier) ? 'ECR_PUBLIC' : 'ECR') : undefined
+    )
+
+    form.ImageConfiguration.Port.bindPrompter(() => createPortPrompter())
+    form.ImageConfiguration.RuntimeEnvironmentVariables.bindPrompter(() => createVariablesPrompter(makeButtons()))
+
+    return subform
+}
+
+export type ImageRepositorySource = AppRunner.SourceConfiguration
+export class AppRunnerImageRepositoryForm extends WizardForm<ImageRepositorySource> {
+    constructor(ecrClient: EcrClient, iamClient: IamClient, autoDeployButton = makeDeploymentButton()) {
+        super()
+        const form = this.body
+        const rolePrompter = new RolePrompter(iamClient, {
+            title: localize('AWS.apprunner.createService.selectRole.title', 'Select a role to pull from ECR'),
+            filter: role => (role.AssumeRolePolicyDocument ?? '').includes('build.apprunner.amazonaws.com'),
+            createRole: createEcrRole.bind(undefined, iamClient),
+        })
+
+        form.ImageRepository.applyForm(createImageRepositorySubForm(ecrClient, autoDeployButton))
+        form.AuthenticationConfiguration.AccessRoleArn.bindPrompter(
+            rolePrompter.transform(resp => resp.Arn),
+            {
+                showWhen: form => form.ImageRepository?.ImageRepositoryType === 'ECR',
+            }
+        )
+        form.AutoDeploymentsEnabled.setDefault(() => autoDeployButton.state === 'on')
+    }
+}

--- a/src/shared/clients/iamClient.ts
+++ b/src/shared/clients/iamClient.ts
@@ -11,12 +11,23 @@ export type IamClient = ClassToInterfaceType<DefaultIamClient>
 export class DefaultIamClient {
     public constructor(public readonly regionCode: string) {}
 
-    public async listRoles(): Promise<IAM.ListRolesResponse> {
-        const listRolesPageSize = 1000
+    public async listRoles(request: IAM.ListRolesRequest = {}): Promise<IAM.ListRolesResponse> {
         const sdkClient = await this.createSdkClient()
-        const response = await sdkClient.listRoles({ MaxItems: listRolesPageSize }).promise()
+        const response = await sdkClient.listRoles(request).promise()
 
         return response
+    }
+
+    public async createRole(request: IAM.CreateRoleRequest): Promise<IAM.CreateRoleResponse> {
+        const sdkClient = await this.createSdkClient()
+        const response = await sdkClient.createRole(request).promise()
+
+        return response
+    }
+
+    public async attachRolePolicy(request: IAM.AttachRolePolicyRequest): Promise<void> {
+        const sdkClient = await this.createSdkClient()
+        await sdkClient.attachRolePolicy(request).promise()
     }
 
     private async createSdkClient(): Promise<IAM> {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -85,3 +85,10 @@ export const CLOUDWATCH_LOGS_SCHEME = 'awsCloudWatchLogs'
 export const COPY_TO_CLIPBOARD_INFO_TIMEOUT_MS = 5000
 
 export const LAMBDA_PACKAGE_TYPE_IMAGE = 'Image'
+
+// URLs for App Runner
+export const APPRUNNER_CONNECTION_HELP_URL =
+    'https://docs.aws.amazon.com/apprunner/latest/dg/manage-create.html#manage-create.create.github'
+export const APPRUNNER_CONFIGURATION_HELP_URL = 'https://docs.aws.amazon.com/apprunner/latest/dg/manage-configure.html'
+export const APPRUNNER_RUNTIME_HELP_URL = 'https://docs.aws.amazon.com/apprunner/latest/dg/service-source-code.html'
+export const APPRUNNER_PRICING_URL = 'https://aws.amazon.com/apprunner/pricing/'

--- a/src/shared/ui/buttons.ts
+++ b/src/shared/ui/buttons.ts
@@ -5,8 +5,9 @@
 
 import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
+import { documentationUrl } from '../constants'
 import { ext } from '../extensionGlobals'
-import { WizardControl } from '../wizards/wizard'
+import { WizardControl, WIZARD_EXIT, WIZARD_RETRY } from '../wizards/wizard'
 
 const localize = nls.loadMessageBundle()
 const HELP_TOOLTIP = localize('AWS.command.help', 'View Toolkit Documentation')
@@ -28,7 +29,10 @@ export interface QuickInputButton<T> extends vscode.QuickInputButton {
  * @param tooltip Optional tooltip for button
  * @param url Optional URL to open when button is clicked
  */
-export function createHelpButton(uri: string | vscode.Uri, tooltip: string = HELP_TOOLTIP): QuickInputLinkButton {
+export function createHelpButton(
+    uri: string | vscode.Uri = documentationUrl,
+    tooltip: string = HELP_TOOLTIP
+): QuickInputLinkButton {
     const iconPath = {
         light: vscode.Uri.file(ext.iconPaths.light.help),
         dark: vscode.Uri.file(ext.iconPaths.dark.help),
@@ -53,9 +57,80 @@ export class QuickInputLinkButton implements QuickInputButton<void> {
     }
 }
 
+type ButtonState = 'on' | 'off'
+interface ToggleButtonOptions {
+    initState?: ButtonState
+    onCallback?: () => void
+    offCallBack?: () => void
+}
+
+/**
+ * Basic toggle button. Swaps icons whenever clicked.
+ */
+export class QuickInputToggleButton implements QuickInputButton<WizardControl> {
+    private _state: ButtonState
+
+    public get iconPath(): vscode.QuickInputButton['iconPath'] {
+        return this._state === 'on' ? this.onState.iconPath : this.offState.iconPath
+    }
+
+    public get tooltip(): string | undefined {
+        return this._state === 'on' ? this.onState.tooltip : this.offState.tooltip
+    }
+
+    /** The current state of the button, either 'on' or 'off' */
+    public get state(): ButtonState {
+        return this._state
+    }
+
+    constructor(
+        private readonly onState: vscode.QuickInputButton,
+        private readonly offState: vscode.QuickInputButton,
+        private readonly options: ToggleButtonOptions = {}
+    ) {
+        this._state = options?.initState ?? 'off'
+    }
+
+    public onClick(): WizardControl {
+        this._state = this._state === 'on' ? 'off' : 'on'
+
+        if (this._state === 'on' && this.options.onCallback !== undefined) {
+            this.options.onCallback()
+        }
+        if (this._state === 'off' && this.options.offCallBack !== undefined) {
+            this.options.offCallBack()
+        }
+
+        return WIZARD_RETRY
+    }
+}
+
 // Currently VS Code uses a static back button for every QuickInput, so we can't redefine any of its
 // properties without potentially affecting other extensions. Creating a wrapper is possible, but it
 // would still need to be swapped out for the real Back button when adding it to the QuickInput.
 export function createBackButton(): QuickInputButton<WizardControl> {
     return vscode.QuickInputButtons.Back as QuickInputButton<WizardControl>
+}
+
+export function createExitButton(): QuickInputButton<WizardControl> {
+    return {
+        iconPath: new vscode.ThemeIcon('close'),
+        tooltip: localize('AWS.generic.exit', 'Exit'),
+        onClick: () => WIZARD_EXIT,
+    }
+}
+
+export function createRefreshButton(): QuickInputButton<void> {
+    return {
+        iconPath: new vscode.ThemeIcon('refresh'),
+        tooltip: localize('AWS.generic.refresh', 'Refresh'),
+    }
+}
+
+/** Creates a '+' button. Usually used to add new resources during a prompt. */
+export function createPlusButton(tooltip?: string): QuickInputButton<void> {
+    return {
+        iconPath: new vscode.ThemeIcon('plus'),
+        tooltip,
+    }
 }

--- a/src/shared/ui/common/exitPrompter.ts
+++ b/src/shared/ui/common/exitPrompter.ts
@@ -1,0 +1,50 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { localize } from '../../utilities/vsCodeUtils'
+import { StepEstimator } from '../../wizards/wizard'
+import { createQuickPick } from '../pickerPrompter'
+import { Prompter, CachedPrompter, PromptResult } from '../prompter'
+
+class BasicExitPrompter extends Prompter<boolean> {
+    private _isStart = true
+
+    public get lastResponse(): any {
+        return undefined
+    }
+
+    public set lastResponse(response: any) {}
+    protected async promptUser(): Promise<PromptResult<boolean>> {
+        if (this._isStart) {
+            return true
+        }
+
+        const prompter = createQuickPick(
+            [
+                { label: localize('AWS.generic.response.no', 'No'), data: false },
+                { label: localize('AWS.generic.response.yes', 'Yes'), data: true },
+            ],
+            {
+                title: localize('AWS.wizards.exit.title', 'Exit wizard?'),
+            }
+        )
+
+        return await prompter.prompt()
+    }
+    public setSteps(current: number, total: number): void {
+        // Exit was initiated from the first step, so the prompt would be step 2
+        this._isStart = current === 2
+    }
+    public setStepEstimator(estimator: StepEstimator<boolean>): void {}
+}
+
+export class BasicExitPrompterProvider extends CachedPrompter<boolean, any> {
+    protected load(...args: any) {
+        return undefined
+    }
+    protected createPrompter(loader: any, state: any): Prompter<boolean> {
+        return new BasicExitPrompter()
+    }
+}

--- a/src/shared/ui/common/rolePrompter.ts
+++ b/src/shared/ui/common/rolePrompter.ts
@@ -1,0 +1,135 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IAM } from 'aws-sdk'
+import { IamClient } from '../../clients/iamClient'
+import {
+    createBackButton,
+    createExitButton,
+    createHelpButton,
+    createPlusButton,
+    createRefreshButton,
+    PrompterButtons,
+    QuickInputButton,
+} from '../buttons'
+import { createQuickPick, DataQuickPickItem, QuickPickPrompter } from '../pickerPrompter'
+import { CachedFunction, Prompter, CachedPrompter } from '../prompter'
+import * as nls from 'vscode-nls'
+import * as vscode from 'vscode'
+import { getLogger } from '../../logger/logger'
+import { showErrorWithLogs } from '../../utilities/messages'
+
+const localize = nls.loadMessageBundle()
+
+const createRoleTooltip = localize('AWS.generic.createRole', 'Create Role...')
+
+interface RolePrompterOptions {
+    title?: string
+    helpUri?: vscode.Uri
+    filter?: (role: IAM.Role) => boolean
+    createRole?: () => Promise<IAM.Role>
+}
+
+export class RolePrompter extends CachedPrompter<IAM.Role> {
+    private refreshButton: QuickInputButton<void>
+    private createRoleButton?: QuickInputButton<void>
+    private buttons: PrompterButtons<IAM.Role>
+
+    public constructor(private readonly client: IamClient, private readonly options: RolePrompterOptions = {}) {
+        super()
+
+        this.refreshButton = createRefreshButton()
+        const buttons = [this.refreshButton]
+
+        if (this.options.createRole !== undefined) {
+            this.createRoleButton = createPlusButton(createRoleTooltip)
+            buttons.push(this.createRoleButton)
+        }
+
+        buttons.push(createHelpButton(this.options.helpUri), createExitButton(), createBackButton())
+
+        this.buttons = buttons
+    }
+
+    protected load(): Promise<DataQuickPickItem<IAM.Role>[]> {
+        return this.client.listRoles().then(resp => {
+            const roles = resp.Roles.filter(this.options.filter ?? (() => true)).map(role => ({
+                label: role.RoleName,
+                data: role,
+            }))
+
+            return roles
+        })
+    }
+
+    private addCreateRoleCallback(
+        prompter: QuickPickPrompter<IAM.Role>,
+        loader: CachedFunction<RolePrompter['load']>
+    ): void {
+        if (this.options.createRole === undefined) {
+            return
+        }
+
+        const makeRole = () => {
+            const temp = prompter.quickPick.items[0]?.invalidSelection ? [] : prompter.quickPick.items
+            const appendedItems = this.options.createRole!()
+                .then(role => [...temp, { label: role.RoleName, data: role }])
+                .catch(err => {
+                    getLogger().error('role prompter: Failed to create new role: %O', err)
+                    showErrorWithLogs(localize('AWS.rolePrompter.createRole.failed', 'Failed to create new role'))
+                    return [...temp]
+                })
+            appendedItems.then(items => loader.supplantLast(items))
+            prompter.clearAndLoadItems(appendedItems)
+        }
+
+        this.createRoleButton!.onClick = makeRole
+    }
+
+    private checkNoRoles(roles: ReturnType<RolePrompter['load']>): ReturnType<RolePrompter['load']> {
+        return roles.then(items => {
+            const detail =
+                this.options.createRole !== undefined
+                    ? localize('AWS.rolePrompter.noRoles.detail', 'Click the "+" to generate a new role')
+                    : undefined
+
+            if (items.length === 0) {
+                return [
+                    {
+                        label: localize('AWS.rolePrompter.noRoles.title', 'No valid roles found'),
+                        data: {} as any,
+                        invalidSelection: true, // TODO: if invalid is true then data can be any?
+                        detail,
+                    },
+                ]
+            }
+
+            return items
+        })
+    }
+
+    protected createPrompter(loader: CachedFunction<RolePrompter['load']>): Prompter<IAM.Role> {
+        let roles = loader()
+
+        if (roles instanceof Promise) {
+            roles = this.checkNoRoles(roles)
+        }
+
+        const prompter = createQuickPick(roles, {
+            title: this.options.title,
+            buttons: this.buttons,
+        })
+
+        const refresh = () => {
+            loader.clearCache()
+            prompter.clearAndLoadItems(loader())
+        }
+
+        this.refreshButton.onClick = refresh
+        this.addCreateRoleCallback(prompter, loader)
+
+        return prompter
+    }
+}

--- a/src/shared/ui/common/variablesPrompter.ts
+++ b/src/shared/ui/common/variablesPrompter.ts
@@ -1,0 +1,99 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import * as fs from 'fs-extra'
+import { showErrorWithLogs } from '../../utilities/messages'
+import { WIZARD_RETRY } from '../../wizards/wizard'
+import { createQuickPick, QuickPickPrompter } from '../pickerPrompter'
+import * as nls from 'vscode-nls'
+import { PrompterButtons } from '../buttons'
+import { promisifyThenable } from '../../utilities/vsCodeUtils'
+
+const localize = nls.loadMessageBundle()
+
+function isMatchArray(obj: any): obj is RegExpMatchArray {
+    return obj !== undefined && (obj.groups !== undefined || Array.isArray(obj))
+}
+
+function unquote(str: string): string {
+    const isSingleQuoted = str[0] === "'" && str[str.length - 1] === "'"
+    const isDoubleQuoted = str[0] === '"' && str[str.length - 1] === '"'
+
+    if (isSingleQuoted || isDoubleQuoted) {
+        str = str.substr(1, str.length - 1)
+    }
+
+    if (isDoubleQuoted) {
+        str = str.replace(/\\n/g, '\n')
+    }
+
+    return str
+}
+
+function parseEnvFile(contents: string): { [key: string]: string } {
+    return contents
+        .split(/\r?\n/)
+        .map(line => line.match(/^\s*([\w.-]+)\s*=\s*(.*)?\s*$/))
+        .filter(isMatchArray)
+        .map(match => ({ [match[1]]: unquote(match[2] ?? '').trim() }))
+        .reduce((a, b) => Object.assign(a, b))
+}
+
+// TODO: create key/value pair prompter
+// Format:
+// [TITLE]       [+][-][?]
+// + button calls new prompter to set key/value pair
+// - button removes currently highlighted pair
+// also add a 'load from file' button (always show)
+// there will be a 'Done' button that returns the resulting list (always show)
+// each input would be label: key description: value
+
+/**
+ * Creates a optional prompt for environment variables.
+ *
+ * Currently, the only accepted file format are `.env` files:
+ * KEY1=VALUE2
+ * KEY2=VALUE2
+ * ...
+ *
+ * @param buttons Optional buttons to add
+ * @returns A {@link QuickPickPrompter} that returns data in the shape of Node's process `env` variable
+ */
+export function createVariablesPrompter(
+    buttons?: PrompterButtons<string>
+): QuickPickPrompter<{ [name: string]: string }> {
+    const openDialog = () => {
+        return promisifyThenable(vscode.window.showOpenDialog({ canSelectMany: false }))
+            .then(resp => {
+                if (resp === undefined) {
+                    throw new Error('Closed dialog')
+                }
+
+                return resp[0].fsPath
+            })
+            .then(path => fs.promises.readFile(path))
+            .then(contents => parseEnvFile(contents.toString()))
+            .catch(err => {
+                if (err.message !== 'Closed dialog') {
+                    showErrorWithLogs(
+                        localize('AWS.environmentVariables.prompt.failed', 'Failed to read environment variables')
+                    )
+                }
+
+                return WIZARD_RETRY
+            })
+    }
+
+    const items = [
+        { label: localize('AWS.generic.skip', 'Skip'), data: {} },
+        { label: localize('AWS.generic.useFile', 'Use file...'), data: openDialog },
+    ]
+
+    return createQuickPick<{ [name: string]: string }>(items, {
+        title: localize('AWS.environmentVariables.prompt.title', 'Configure environment variables'),
+        buttons: buttons,
+    })
+}

--- a/src/shared/ui/inputPrompter.ts
+++ b/src/shared/ui/inputPrompter.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode'
 import { applyPrimitives } from '../utilities/collectionUtils'
-import { WIZARD_BACK } from '../wizards/wizard'
+import { StepEstimator, WIZARD_BACK, WIZARD_EXIT } from '../wizards/wizard'
 import { QuickInputButton, PrompterButtons } from './buttons'
 import { Prompter, PromptResult } from './prompter'
 
@@ -35,6 +35,7 @@ export const DEFAULT_INPUTBOX_OPTIONS: vscode.InputBoxOptions = {
 export function createInputBox(options?: ExtendedInputBoxOptions): InputBoxPrompter {
     const inputBox = vscode.window.createInputBox() as InputBox
     applyPrimitives(inputBox, { ...DEFAULT_INPUTBOX_OPTIONS, ...options })
+    inputBox.buttons = options?.buttons ?? []
 
     const prompter = new InputBoxPrompter(inputBox)
 
@@ -100,7 +101,7 @@ export class InputBoxPrompter extends Prompter<string> {
                     resolve(this.inputBox.value)
                 }
             })
-            this.inputBox.onDidHide(() => resolve(undefined))
+            this.inputBox.onDidHide(() => resolve(WIZARD_EXIT))
             this.inputBox.onDidTriggerButton(button => {
                 if (button === vscode.QuickInputButtons.Back) {
                     resolve(WIZARD_BACK)
@@ -115,5 +116,9 @@ export class InputBoxPrompter extends Prompter<string> {
         }).finally(() => this.inputBox.dispose())
 
         return await promptPromise
+    }
+
+    public setStepEstimator(estimator: StepEstimator<string>): void {
+        // TODO: implement this
     }
 }

--- a/src/shared/ui/pickerPrompter.ts
+++ b/src/shared/ui/pickerPrompter.ts
@@ -5,9 +5,9 @@
 
 import * as vscode from 'vscode'
 
-import { WIZARD_BACK } from '../wizards/wizard'
+import { StepEstimator, WIZARD_BACK, WIZARD_EXIT } from '../wizards/wizard'
 import { QuickInputButton, PrompterButtons } from './buttons'
-import { Prompter, PromptResult } from './prompter'
+import { Prompter, PromptResult, Transform } from './prompter'
 import { applyPrimitives } from '../utilities/collectionUtils'
 
 /** Settings applied when using a QuickPickPrompter in 'filter-box input' mode. */
@@ -16,6 +16,13 @@ interface FilterBoxInputSettings<T> {
     label: string
     /** Parses the user's input into a the desired type. */
     transform: (v: string) => PromptResult<T>
+    /** The inverse must be provided if using implicit state. */
+    inverse?: (output: PromptResult<T>) => string
+    /**
+     * Checks for any errors in the input.
+     * Returned strings are shown in the 'detail' part of the user-input QuickPickItem.
+     */
+    validator?: (input: string) => string | undefined
 }
 
 // Note: 'placeHolder' and 'onDidSelectItem' are ommited since they do not make since the context of the Prompter
@@ -36,6 +43,8 @@ export type ExtendedQuickPickOptions<T> = Omit<
      * using the filter box as input.
      */
     filterBoxInputSettings?: FilterBoxInputSettings<T>
+    /** Used to sort QuickPick items after loading new ones */
+    compare?: (a: DataQuickPickItem<T>, b: DataQuickPickItem<T>) => number
 }
 
 export const DEFAULT_QUICKPICK_OPTIONS: vscode.QuickPickOptions = {
@@ -49,7 +58,12 @@ type LabelQuickPickItem<T> = vscode.QuickPickItem & { label: T }
  * Attaches additional information as `data` to a QuickPickItem. Alternatively, `data` can be a function that
  * returns a Promise, evaluated after the user selects the item.
  */
-export type DataQuickPickItem<T> = vscode.QuickPickItem & { data: QuickPickData<T> }
+export type DataQuickPickItem<T> = vscode.QuickPickItem & {
+    data: QuickPickData<T>
+    invalidSelection?: boolean
+    onClick?: () => any | Promise<any>
+}
+
 export type DataQuickPick<T> = Omit<vscode.QuickPick<DataQuickPickItem<T>>, 'buttons'> & { buttons: PrompterButtons<T> }
 
 export const CUSTOM_USER_INPUT = Symbol()
@@ -74,6 +88,7 @@ export function createQuickPick<T>(
     const picker = vscode.window.createQuickPick<DataQuickPickItem<T>>() as DataQuickPick<T>
     options = { ...DEFAULT_QUICKPICK_OPTIONS, ...options }
     applyPrimitives(picker, { ...DEFAULT_QUICKPICK_OPTIONS, ...options })
+    picker.buttons = options.buttons ?? []
 
     const prompter =
         options.filterBoxInputSettings !== undefined
@@ -104,6 +119,27 @@ export function createLabelQuickPick<T extends string>(
     )
 }
 
+function acceptItems<T>(picker: DataQuickPick<T>, resolve: (items: DataQuickPickItem<T>[]) => void): void {
+    if (picker.selectedItems.length === 0) {
+        return
+    }
+
+    picker.selectedItems.forEach(item => (item.onClick !== undefined ? item.onClick() : undefined))
+
+    if (picker.selectedItems.some(item => item.invalidSelection)) {
+        return
+    }
+
+    // TODO: if data is a function => Promise then we need to invoke the function and wait for the Promise
+    // to resolve, then we can return (and we should set the picker to be busy/disabled)
+
+    resolve(Array.from(picker.selectedItems))
+}
+
+function castDatumToItems<T>(...datum: T[]): DataQuickPickItem<T>[] {
+    return datum.map(data => ({ label: '', data }))
+}
+
 /**
  * Sets up the QuickPick events. Reject is intentionally not used since errors should be handled through
  * control signals, not exceptions.
@@ -113,15 +149,15 @@ function promptUser<T>(
     onDidShowEmitter: vscode.EventEmitter<void>
 ): Promise<DataQuickPickItem<T>[] | undefined> {
     return new Promise<DataQuickPickItem<T>[] | undefined>(resolve => {
-        picker.onDidAccept(() => picker.selectedItems.length > 0 && resolve(Array.from(picker.selectedItems)))
-        picker.onDidHide(() => resolve(undefined))
+        picker.onDidAccept(() => acceptItems(picker, resolve))
+        picker.onDidHide(() => resolve(castDatumToItems(WIZARD_EXIT)))
         picker.onDidTriggerButton(button => {
             if (button === vscode.QuickInputButtons.Back) {
-                resolve([{ label: '', data: WIZARD_BACK }])
+                resolve(castDatumToItems(WIZARD_BACK))
             } else if ((button as QuickInputButton<T>).onClick !== undefined) {
                 const response = (button as QuickInputButton<T>).onClick!()
                 if (response !== undefined) {
-                    resolve([{ label: '', data: response }])
+                    resolve(castDatumToItems(response))
                 }
             }
         })
@@ -131,28 +167,51 @@ function promptUser<T>(
 }
 
 /**
+ * Atempts to recover a QuickPick item given an already processed response.
+ *
+ * This is generally required when the prompter is being used in a 'saved' state, such as when updating forms
+ * that were already submitted. Failed recoveries simply return undefined, which means that the last selected
+ * item is unknown (generally the default in this case is to select the first item).
+ */
+function recoverItemFromData<T>(data: T, items: readonly DataQuickPickItem<T>[]): DataQuickPickItem<T> | undefined {
+    const stringified = JSON.stringify(data)
+
+    return items.find(item => {
+        if (typeof item.data === 'object') {
+            return stringified === JSON.stringify(item.data)
+        }
+
+        return typeof item.data === 'function' ? false : data === item.data
+    })
+}
+
+/**
  * A generic UI element that presents a list of items for the user to select. Wraps around {@link vscode.QuickPick QuickPick}.
  */
 export class QuickPickPrompter<T> extends Prompter<T> {
+    protected _estimator?: StepEstimator<T>
     protected _lastPicked?: DataQuickPickItem<T>
     private onDidShowEmitter: vscode.EventEmitter<void> = new vscode.EventEmitter()
     /** Event that is fired immediately after the prompter is shown. */
     public onDidShow: vscode.Event<void> = this.onDidShowEmitter.event
 
     public set lastResponse(response: DataQuickPickItem<T> | undefined) {
-        if (response === undefined || !isDataQuickPickItem(response)) {
-            return
-        }
-
-        this.selectItems(response)
+        this.setLastResponse(response)
     }
 
     public get lastResponse() {
         return this._lastPicked
     }
 
-    constructor(public readonly quickPick: DataQuickPick<T>) {
+    constructor(
+        public readonly quickPick: DataQuickPick<T>,
+        protected readonly compare?: ExtendedQuickPickOptions<T>['compare']
+    ) {
         super()
+    }
+
+    public transform<R>(callback: Transform<T, R>): QuickPickPrompter<R> {
+        return super.transform(callback) as QuickPickPrompter<R>
     }
 
     public setSteps(current: number, total: number): void {
@@ -160,18 +219,8 @@ export class QuickPickPrompter<T> extends Prompter<T> {
         this.quickPick.totalSteps = total
     }
 
-    protected async promptUser(): Promise<PromptResult<T>> {
-        const choices = await promptUser(this.quickPick, this.onDidShowEmitter)
-        this.onDidShowEmitter.dispose()
-
-        if (choices === undefined) {
-            return choices
-        }
-
-        this._lastPicked = choices[0]
-        const result = choices[0].data
-
-        return result instanceof Function ? await result() : result
+    public clearItems(): void {
+        this.quickPick.items = []
     }
 
     /**
@@ -193,6 +242,7 @@ export class QuickPickPrompter<T> extends Prompter<T> {
         }
     }
 
+    // TODO: add options to this to clear items _before_ loading them
     /**
      * Loads items into the QuickPick. Can accept an array or a Promise for items. Promises will cause the
      * QuickPick to become 'busy', disabling user-input until loading is finished. Items are appended to
@@ -221,6 +271,104 @@ export class QuickPickPrompter<T> extends Prompter<T> {
             picker.items = picker.items.concat(items)
             this.selectItems(...previousSelected)
             return Promise.resolve()
+        }
+    }
+
+    /**
+     * Clears the prompter, then loads new items. Will automatically attempt to select the previously
+     * selected items. This is a combination of {@link QuickPickPrompter.loadItems loadItems} and
+     * {@link QuickPickPrompter.clearItems clearItems}.
+     *
+     * @param items Items to load
+     * @returns Promise that is resolved upon completion
+     */
+    public clearAndLoadItems(items: Promise<DataQuickPickItem<T>[]> | DataQuickPickItem<T>[]): Promise<void> {
+        const previousSelected = [...this.quickPick.activeItems]
+        this.clearItems()
+        return this.loadItems(items).then(() => this.selectItems(...previousSelected))
+    }
+
+    protected async promptUser(): Promise<PromptResult<T>> {
+        await this.setEstimatorHook()
+        const choices = await promptUser(this.quickPick, this.onDidShowEmitter)
+        this.onDidShowEmitter.dispose()
+
+        if (choices === undefined) {
+            return choices
+        }
+
+        this._lastPicked = choices[0]
+        const result = choices[0].data
+
+        return result instanceof Function ? await result() : result
+    }
+
+    public setLastResponse(picked: T | DataQuickPickItem<T> | undefined): void {
+        // TODO: figure out how to recover from implicit responses
+        if (picked === undefined) {
+            return
+        } else if (!isDataQuickPickItem(picked)) {
+            const recovered = recoverItemFromData(picked, this.quickPick.items)
+            this.quickPick.activeItems = this.quickPick.items.filter(item => item.label === recovered?.label)
+        } else {
+            this.quickPick.activeItems = this.quickPick.items.filter(item => item.label === picked.label)
+        }
+
+        if (this.quickPick.activeItems.length === 0) {
+            this.quickPick.activeItems = [this.quickPick.items[0]]
+        }
+    }
+
+    public setStepEstimator(estimator: StepEstimator<T>): void {
+        this._estimator = estimator
+    }
+
+    private async setEstimatorHook(): Promise<void> {
+        if (this._estimator === undefined) {
+            return
+        }
+
+        function hashItem(item: DataQuickPickItem<any>): string {
+            return `${item.label}:${item.description ?? ''}:${item.detail ?? ''}`
+        }
+
+        const estimates = new Map<string, number>()
+
+        const setEstimate = (item: DataQuickPickItem<T>) => {
+            if (item.data instanceof Function) {
+                return item
+                    .data()
+                    .then(data => this.applyTransforms(data))
+                    .then(result => this._estimator!(result))
+                    .then(estimate => estimates.set(hashItem(item), estimate))
+            } else {
+                const transformed = this.applyTransforms(item.data)
+                const estimate = this._estimator!(transformed)
+                estimates.set(hashItem(item), estimate)
+            }
+        }
+
+        const promises = this.quickPick.items.map(setEstimate)
+
+        const current: number = this.quickPick.step!
+        const total: number = this.quickPick.totalSteps!
+
+        this.quickPick.onDidChangeActive(async active => {
+            if (active.length === 0) {
+                return
+            }
+
+            const sets = active.filter(item => !estimates.has(hashItem(item))).map(setEstimate)
+            await sets[0]
+            const estimate = estimates.get(hashItem(active[0])) ?? 0
+            this.setSteps(current, total + estimate)
+        })
+
+        // We await the first promise before returning to guarantee that there is no 'stutter'
+        // when showing the current/total step numbers
+        if (promises.length > 0) {
+            await promises[0]
+            this.setSteps(current, total + estimates.get(hashItem(this.quickPick.items[0]))!)
         }
     }
 }
@@ -265,6 +413,8 @@ export class FilterBoxQuickPickPrompter<T> extends QuickPickPrompter<T> {
 
     private addFilterBoxInput(): void {
         const picker = this.quickPick as DataQuickPick<T | symbol>
+        const validator = (input: string) =>
+            this.settings.validator !== undefined ? this.settings.validator(input) : undefined
         const items = picker.items.filter(item => item.data !== CUSTOM_USER_INPUT)
         const { label } = this.settings
 
@@ -275,6 +425,8 @@ export class FilterBoxQuickPickPrompter<T> extends QuickPickPrompter<T> {
                     description: value,
                     alwaysShow: true,
                     data: CUSTOM_USER_INPUT,
+                    invalidSelection: validator(value) !== undefined,
+                    detail: validator(value),
                 } as DataQuickPickItem<T | symbol>
 
                 picker.items = [customUserInputItem, ...items]

--- a/src/shared/ui/pickerPrompter.ts
+++ b/src/shared/ui/pickerPrompter.ts
@@ -45,6 +45,10 @@ export type ExtendedQuickPickOptions<T> = Omit<
     filterBoxInputSettings?: FilterBoxInputSettings<T>
     /** Used to sort QuickPick items after loading new ones */
     compare?: (a: DataQuickPickItem<T>, b: DataQuickPickItem<T>) => number
+    /** Item to show if no items were loaded */
+    placeholderItem?: DataQuickPickItem<T>
+    /** Item to show if there was an error loading items */
+    errorItem?: DataQuickPickItem<T>
 }
 
 export const DEFAULT_QUICKPICK_OPTIONS: vscode.QuickPickOptions = {

--- a/src/shared/ui/prompter.ts
+++ b/src/shared/ui/prompter.ts
@@ -4,14 +4,14 @@
  */
 
 import * as _ from 'lodash'
-import { isValidResponse, WizardControl } from '../wizards/wizard'
+import { isValidResponse, StateWithCache, StepEstimator, WizardControl } from '../wizards/wizard'
 
 export type QuickPickDataType<T> = T | WizardControl | undefined
 
 export type MultiQuickPickResult<T> = T[] | WizardControl | undefined
 export type PromptResult<T> = T | WizardControl | undefined
 
-type Transform<T, R = T> = (result: T) => R
+export type Transform<T, R = T> = (result: T) => R
 
 /**
  * A generic abstraction of 'prompt' UIs. Returns the user's input by calling the {@link Prompter.prompt prompt}
@@ -28,11 +28,15 @@ export abstract class Prompter<T> {
         return 1
     }
 
+    // TODO: add this to have a standard title across prompts
+    // public abstract set title(title: string)
+
     /** Implementing classes should use the argument to show the user what they last selected (if applicable) */
     public abstract get lastResponse(): any
     /** Implementing classes should return the user's response _before_ transforming into into type T */
     public abstract set lastResponse(response: any)
 
+    // TODO: we need the inverse transform to recover inputs across flows
     /** Type-helper, allows Prompters to be mapped to different shapes */
     public transform<R>(callback: Transform<T, R>): Prompter<R> {
         this.transforms.push(callback)
@@ -40,7 +44,7 @@ export abstract class Prompter<T> {
     }
 
     /** Applies transformations to the user response in the order in which they were added */
-    private applyTransforms(result: PromptResult<T>): PromptResult<T> {
+    protected applyTransforms(result: PromptResult<T>): PromptResult<T> {
         for (const cb of this.transforms) {
             if (!isValidResponse(result)) {
                 return result
@@ -50,6 +54,7 @@ export abstract class Prompter<T> {
                 result = transform
             }
         }
+
         return result
     }
 
@@ -65,6 +70,108 @@ export abstract class Prompter<T> {
         return this.applyTransforms(await this.promptUser())
     }
 
+    /** Sets a 'step estimator' function used to predict how many steps are remaining in a given flow */
+    public abstract setStepEstimator(estimator: StepEstimator<T>): void
     protected abstract promptUser(): Promise<PromptResult<T>>
     public abstract setSteps(current: number, total: number): void
+}
+
+export interface CachedPrompter<T, TState extends Record<string, unknown>> {
+    (state: StateWithCache<TState, T>): Prompter<T>
+}
+
+type Cacheable = (...args: (string | number | boolean | undefined)[]) => NonNullable<any>
+
+/**
+ * A wrapped function that can cache both synchronous and asynchronous return types.
+ *
+ * Pending promises are returned as-is, while resolved promises are 'unboxed' into their promised type.
+ */
+export interface CachedFunction<F extends (...args: any) => any> {
+    (...args: Parameters<F>): ReturnType<F> extends Promise<infer Inner> ? ReturnType<F> | Inner : ReturnType<F>
+    clearCache(): void
+    supplantLast(result: ReturnType<F> extends Promise<infer Inner> ? Inner : ReturnType<F>): void
+}
+
+// TODO: this currently just caches primitive arguments which is not very flexible
+// there is a 'cache-object' library that could make sense here. we could just cache the entire
+// argument list itself and not worry about types
+function createCachedFunction<F extends Cacheable>(
+    loader: F,
+    cache: { [key: string]: ReturnType<F> } = {},
+    keys: Set<string> = new Set()
+): CachedFunction<F> {
+    const wrapped = (...args: Parameters<F>) => {
+        const key =
+            args
+                .map(arg => (arg ?? '').toString())
+                .map(arg => (arg === '' ? arg : `${arg}${arg.length}`))
+                .join() + '0' // Cannot index with an empty string
+
+        if (cache[key] !== undefined) {
+            return cache[key]
+        }
+
+        const resolved = loader(...args)
+        cache[key] = resolved as any
+        keys.add(key)
+
+        if (resolved instanceof Promise) {
+            return resolved.then(result => {
+                cache[key] = result
+                return result
+            })
+        }
+
+        return resolved
+    }
+
+    const clearCache = () => {
+        keys.forEach(key => delete cache[key])
+        keys.clear()
+    }
+
+    const supplantLast = (result: ReturnType<F>) => {
+        if (keys.size === 0) {
+            throw new Error('Cannot evict an empty cache')
+        }
+        cache[[...keys.values()].pop()!] = result
+    }
+
+    return Object.assign(wrapped, { clearCache, supplantLast })
+}
+
+// Rebinds the Function function body to instead call the extended class method
+const EXECUTE_CALLEE = 'return arguments.callee.call.apply(arguments.callee, arguments)'
+/**
+ * Convenience class that lightly wraps the creation of a Prompter with the loading of whatever resources
+ * are required. The 'load' call is wrapped with a cache for automatic caching of its results.
+ */
+export abstract class CachedPrompter<
+    T,
+    TState extends Record<string, unknown> = Record<string, unknown>
+> extends Function {
+    private usedKeys = new Set<string>()
+    protected transforms: Transform<T, any>[] = []
+
+    public constructor() {
+        super(EXECUTE_CALLEE)
+    }
+
+    public transform<R>(callback: Transform<T, R>): CachedPrompter<R, TState> {
+        this.transforms.push(callback)
+        return this as unknown as CachedPrompter<R, TState>
+    }
+
+    public call(state: StateWithCache<TState, T>): Prompter<T> {
+        const cachedLoad = createCachedFunction(this.load.bind(this), state.stepCache, this.usedKeys)
+        const prompter = this.createPrompter(cachedLoad, state)
+
+        this.transforms.map(prompter.transform.bind(prompter))
+
+        return prompter
+    }
+
+    protected abstract load(...args: any): any
+    protected abstract createPrompter(loader: CachedFunction<any>, state: TState): Prompter<T>
 }

--- a/src/shared/ui/wizardPrompter.ts
+++ b/src/shared/ui/wizardPrompter.ts
@@ -1,0 +1,56 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { StepEstimator, Wizard } from '../wizards/wizard'
+import { Prompter, PromptResult } from './prompter'
+
+/**
+ * Wraps {@link Wizard} object into its own {@link Prompter}, allowing wizards to use other
+ * wizards in their flows.
+ */
+export class WizardPrompter<T> extends Prompter<T> {
+    public get lastResponse(): any {
+        return undefined
+    }
+    public set lastResponse(response: any) {}
+
+    private stepOffset: number = 0
+    private response: T | undefined
+
+    constructor(private readonly wizard: Wizard<T>) {
+        super()
+    }
+
+    public setSteps(current: number, total: number): void {
+        if (this.wizard.currentStep === 1) {
+            this.wizard.stepOffset = [current - 1, total - 1]
+        }
+
+        this.stepOffset = total - 1
+    }
+
+    public get totalSteps(): number {
+        return this.wizard.totalSteps - this.stepOffset
+    }
+
+    public setStepEstimator(estimator: StepEstimator<T>): void {
+        const estimates = new Map<string, number>()
+
+        this.wizard.parentEstimator = state => {
+            const key = JSON.stringify(state)
+            const transformed = this.applyTransforms(state)
+            const estimate = estimator(transformed)
+
+            estimates.set(key, estimate)
+
+            return estimate
+        }
+    }
+
+    protected async promptUser(): Promise<PromptResult<T>> {
+        this.response = await this.wizard.run()
+        return this.response
+    }
+}

--- a/src/shared/utilities/vsCodeUtils.ts
+++ b/src/shared/utilities/vsCodeUtils.ts
@@ -90,7 +90,10 @@ export function isExtensionActive(extId: string): boolean {
  * @param silent  Return undefined on failure, instead of throwing
  * @returns Extension object, or undefined on failure if `silent`
  */
-export async function activateExtension(extId: string, silent: boolean = true): Promise<vscode.Extension<void> | undefined> {
+export async function activateExtension(
+    extId: string,
+    silent: boolean = true
+): Promise<vscode.Extension<void> | undefined> {
     let loggerInitialized: boolean
     try {
         getLogger()
@@ -128,4 +131,11 @@ export async function activateExtension(extId: string, silent: boolean = true): 
     }
 
     return extension
+}
+
+/**
+ * Convenience function to make a Thenable into a Promise.
+ */
+export function promisifyThenable<T>(thenable: Thenable<T>): Promise<T> {
+    return new Promise((resolve, reject) => thenable.then(resolve, reject))
 }

--- a/src/shared/wizards/wizard.ts
+++ b/src/shared/wizards/wizard.ts
@@ -6,7 +6,7 @@
 import { Branch, ControlSignal, StateMachineController, StepFunction } from './stateController'
 import * as _ from 'lodash'
 import { Prompter, PromptResult } from '../../shared/ui/prompter'
-import { CachedPrompter, WizardForm } from './wizardForm'
+import { PrompterProvider, WizardForm } from './wizardForm'
 
 /** Checks if the user response is valid (i.e. not undefined and not a control signal) */
 export function isValidResponse<T>(response: PromptResult<T>): response is T {
@@ -99,6 +99,11 @@ export class Wizard<TState extends Partial<Record<keyof TState, unknown>>> {
         return this._form.body
     }
 
+    /** The internal wizard form with bound prompters. This can be applied to other wizards. */
+    public get boundForm() {
+        return this._form
+    }
+
     private _estimator: ((state: TState) => number) | undefined
     public set parentEstimator(estimator: (state: TState) => number) {
         this._estimator = estimator
@@ -161,7 +166,7 @@ export class Wizard<TState extends Partial<Record<keyof TState, unknown>>> {
         }
     }
 
-    private createBoundStep<TProp>(prop: string, provider: CachedPrompter<TState, TProp>): StepFunction<TState> {
+    private createBoundStep<TProp>(prop: string, provider: PrompterProvider<TState, TProp>): StepFunction<TState> {
         const stepCache: StepCache = {}
 
         return async state => {
@@ -203,7 +208,7 @@ export class Wizard<TState extends Partial<Record<keyof TState, unknown>>> {
 
     private async promptUser<TProp>(
         state: StateWithCache<TState, TProp>,
-        provider: CachedPrompter<TState, TProp>,
+        provider: PrompterProvider<TState, TProp>,
         impliedResponse?: TProp
     ): Promise<PromptResult<TProp>> {
         const prompter = provider(state as StateWithCache<WizardState<TState>, TProp>)

--- a/src/shared/wizards/wizard.ts
+++ b/src/shared/wizards/wizard.ts
@@ -6,7 +6,7 @@
 import { Branch, ControlSignal, StateMachineController, StepFunction } from './stateController'
 import * as _ from 'lodash'
 import { Prompter, PromptResult } from '../../shared/ui/prompter'
-import { PrompterProvider, WizardForm } from './wizardForm'
+import { CachedPrompter, WizardForm } from './wizardForm'
 
 /** Checks if the user response is valid (i.e. not undefined and not a control signal) */
 export function isValidResponse<T>(response: PromptResult<T>): response is T {
@@ -53,9 +53,21 @@ export function isWizardControl(obj: any): obj is WizardControl {
     return obj !== undefined && obj.id === WIZARD_CONTROL
 }
 
+export interface StepEstimator<T> {
+    (response: PromptResult<T>): number
+}
+
 // Persistent storage that exists on a per-property basis, side effects may occur here
-type StepCache = { picked?: any; stepOffset?: number } & { [key: string]: any }
-export type StateWithCache<TState> = TState & { stepCache: StepCache }
+type StepCache = { picked?: any; stepOffset?: [number, number] } & { [key: string]: any }
+export type StateWithCache<TState, TProp> = TState & { stepCache: StepCache; estimator: StepEstimator<TProp> }
+
+export interface WizardOptions<TState> {
+    readonly initForm?: WizardForm<TState>
+    readonly initState?: Partial<TState>
+    /** Provides a way to apply inputs to Prompters as if the user has already responded */
+    readonly implicitState?: Partial<TState>
+    readonly exitPrompterProvider?: (state: TState) => Prompter<boolean>
+}
 
 /**
  * A generic wizard that consumes data from a series of {@link Prompter prompters}. The 'form' public property
@@ -66,32 +78,37 @@ export class Wizard<TState extends Partial<Record<keyof TState, unknown>>> {
     private readonly boundSteps: Map<string, StepFunction<TState>> = new Map()
     private readonly _form: WizardForm<TState>
     private stateController: StateMachineController<TState>
-    private _stepOffset: number = 0
+    private _stepOffset: [number, number] = [0, 0]
+    private _exitStep?: StepFunction<TState>
 
     /**
      * The offset is applied to both the current step and total number of steps. Useful if the wizard is
      * apart of some overarching flow.
      */
-    public set stepOffset(offset: number) {
+    public set stepOffset(offset: [number, number]) {
         this._stepOffset = offset
     }
     public get currentStep(): number {
-        return this._stepOffset + this.stateController.currentStep
+        return this._stepOffset[0] + this.stateController.currentStep
     }
     public get totalSteps(): number {
-        return this._stepOffset + this.stateController.totalSteps
+        return this._stepOffset[1] + this.stateController.totalSteps
     }
 
     public get form() {
         return this._form.body
     }
 
-    public constructor(
-        initForm: WizardForm<TState> = new WizardForm(),
-        private readonly initState: Partial<TState> = {}
-    ) {
-        this.stateController = new StateMachineController(initState as TState)
-        this._form = initForm
+    private _estimator: ((state: TState) => number) | undefined
+    public set parentEstimator(estimator: (state: TState) => number) {
+        this._estimator = estimator
+    }
+
+    public constructor(private readonly options: WizardOptions<TState> = {}) {
+        this.stateController = new StateMachineController(options.initState as TState)
+        this._form = options.initForm ?? new WizardForm()
+        this._exitStep =
+            options.exitPrompterProvider !== undefined ? this.createExitStep(options.exitPrompterProvider) : undefined
     }
 
     private assignSteps(): void {
@@ -105,22 +122,62 @@ export class Wizard<TState extends Partial<Record<keyof TState, unknown>>> {
 
     public async run(): Promise<TState | undefined> {
         this.assignSteps()
-        this.resolveNextSteps(this.initState as TState).forEach(step => this.stateController.addStep(step))
+        this.resolveNextSteps((this.options.initState ?? {}) as TState).forEach(step =>
+            this.stateController.addStep(step)
+        )
 
         const outputState = await this.stateController.run()
 
         return outputState !== undefined ? this._form.applyDefaults(outputState) : undefined
     }
 
-    private createBoundStep<TProp>(prop: string, provider: PrompterProvider<TState, TProp>): StepFunction<TState> {
+    private createStepEstimator<TProp>(state: TState, prop: string): StepEstimator<TProp> {
+        state = _.cloneDeep(state)
+
+        return response => {
+            if (response !== undefined && !isValidResponse(response)) {
+                return 0
+            }
+
+            _.set(state, prop, response)
+            const estimate = this.resolveNextSteps(state).length
+            const parentEstimate = this._estimator !== undefined ? this._estimator(state) : 0
+            _.set(state, prop, undefined)
+
+            return estimate + parentEstimate
+        }
+    }
+
+    private createExitStep(provider: NonNullable<WizardOptions<TState>['exitPrompterProvider']>): StepFunction<TState> {
+        return async state => {
+            const prompter = provider(state)
+            prompter.setSteps(this.currentStep, this.totalSteps)
+            const didExit = await prompter.prompt()
+
+            return {
+                nextState: state,
+                controlSignal: didExit ? ControlSignal.Exit : ControlSignal.Back,
+            }
+        }
+    }
+
+    private createBoundStep<TProp>(prop: string, provider: CachedPrompter<TState, TProp>): StepFunction<TState> {
         const stepCache: StepCache = {}
 
         return async state => {
-            const stateWithCache = Object.assign({ stepCache: stepCache }, this._form.applyDefaults(state))
-            const response = await this.promptUser(
-                stateWithCache,
-                provider(stateWithCache as StateWithCache<WizardState<TState>>)
+            const stateWithCache = Object.assign(
+                { stepCache: stepCache, estimator: this.createStepEstimator(state, prop) },
+                this._form.applyDefaults(state)
             )
+            const impliedResponse = _.get(this.options.implicitState ?? {}, prop)
+            const response = await this.promptUser(stateWithCache, provider, impliedResponse)
+
+            if (response === WIZARD_EXIT && this._exitStep !== undefined) {
+                return {
+                    nextState: state,
+                    nextSteps: [this._exitStep],
+                }
+            }
 
             return {
                 nextState: isValidResponse(response) ? _.set(state, prop, response) : state,
@@ -145,26 +202,37 @@ export class Wizard<TState extends Partial<Record<keyof TState, unknown>>> {
     }
 
     private async promptUser<TProp>(
-        state: StateWithCache<TState>,
-        prompter: Prompter<TProp>
+        state: StateWithCache<TState, TProp>,
+        provider: CachedPrompter<TState, TProp>,
+        impliedResponse?: TProp
     ): Promise<PromptResult<TProp>> {
+        const prompter = provider(state as StateWithCache<WizardState<TState>, TProp>)
+
         this._stepOffset = state.stepCache.stepOffset ?? this._stepOffset
         state.stepCache.stepOffset = this._stepOffset
         prompter.setSteps(this.currentStep, this.totalSteps)
+        prompter.setStepEstimator(state.estimator)
 
         if (state.stepCache.picked !== undefined) {
             prompter.lastResponse = state.stepCache.picked
+        } else if (impliedResponse !== undefined) {
+            prompter.lastResponse = impliedResponse
         }
 
         const answer = await prompter.prompt()
 
         if (isValidResponse(answer)) {
             state.stepCache.picked = prompter.lastResponse
-        } else {
+        }
+
+        if (!isValidResponse(answer)) {
             delete state.stepCache.stepOffset
         }
 
-        this._stepOffset = prompter.totalSteps - 1
+        this._stepOffset = [
+            this._stepOffset[0] + prompter.totalSteps - 1,
+            this._stepOffset[1] + prompter.totalSteps - 1,
+        ]
 
         // Legacy code used 'undefined' to represent back, we will support the use-case
         // but moving forward wizard implementations will explicity use 'WIZARD_BACK'

--- a/src/shared/wizards/wizardForm.ts
+++ b/src/shared/wizards/wizardForm.ts
@@ -51,7 +51,7 @@ interface FormElement<TProp, TState> {
 
 // These methods are only applicable to object-like elements
 interface ParentFormElement<TProp extends Record<string, any>, TState> {
-    applyForm(
+    applyBoundForm(
         form: WizardForm<TProp>,
         options?: Pick<ContextOptions<TState, TProp>, 'showWhen' | 'requireParent'>
     ): void
@@ -59,7 +59,7 @@ interface ParentFormElement<TProp extends Record<string, any>, TState> {
 
 type PrompterBind<TProp, TState> = FormElement<TProp, TState>['bindPrompter']
 type SetDefault<TProp, TState> = FormElement<TProp, TState>['setDefault']
-type ApplyForm<TProp, TState> = ParentFormElement<TProp, TState>['applyForm']
+type ApplyBoundForm<TProp, TState> = ParentFormElement<TProp, TState>['applyBoundForm']
 
 /** Transforms an interface into a collection of FormElements, applied recursively */
 type Form<T, TState = T> = {
@@ -82,7 +82,7 @@ function checkParent<TState>(prop: string, state: TState, options: FormDataEleme
 
 type FormProperty = keyof (FormElement<any, any> & ParentFormElement<any, any>)
 const BIND_PROMPTER: FormProperty = 'bindPrompter'
-const APPLY_FORM: FormProperty = 'applyForm'
+const APPLY_FORM: FormProperty = 'applyBoundForm'
 const SET_DEFAULT: FormProperty = 'setDefault'
 
 /**
@@ -194,7 +194,7 @@ export class WizardForm<TState extends Partial<Record<keyof TState, unknown>>> {
         }
     }
 
-    private createApplyFormMethod<TProp>(prop: string): ApplyForm<TProp, TState> {
+    private createApplyFormMethod<TProp>(prop: string): ApplyBoundForm<TProp, TState> {
         return (form: WizardForm<TProp>, options?: ContextOptions<TState, TProp>) => {
             form.formData.forEach((element, key) => {
                 // TODO: use an assert here to ensure that no elements are rewritten

--- a/src/shared/wizards/wizardForm.ts
+++ b/src/shared/wizards/wizardForm.ts
@@ -8,10 +8,13 @@ import * as _ from 'lodash'
 import { StateWithCache, WizardState } from './wizard'
 import { ExpandWithObject } from '../utilities/tsUtils'
 
-export type PrompterProvider<TState, TProp> = (state: StateWithCache<WizardState<TState>>) => Prompter<TProp>
+export type CachedPrompter<TState, TProp> = (state: StateWithCache<WizardState<TState>, TProp>) => Prompter<TProp>
 
 type DefaultFunction<TState, TProp> = (state: WizardState<TState>) => TProp | undefined
 
+// *************************************************************************************//
+// TODO: add a 'ContextBuilder' object that just pipes these options to the destination //
+// *************************************************************************************//
 interface ContextOptions<TState, TProp> {
     /**
      * Applies a conditional function that is evaluated after every user-input but only if the
@@ -31,23 +34,27 @@ interface ContextOptions<TState, TProp> {
      */
     requireParent?: boolean
     /**
-     * If set to true the wizard will ignore prompts for already assigned properties (default: true)
+     * Used to determine which prompter should be shown when multiple prompters are able to be
+     * show in a single instance. A lower order will be shown before a higher order.
      */
-    implicit?: boolean // not actually implemented
+    relativeOrder?: number
 }
 interface FormElement<TProp, TState> {
     /**
      * Binds a Prompter-provider to the specified property. The provider is called with the current Wizard
      * state whenever the property is ready for input, and should return a Prompter object.
      */
-    bindPrompter(provider: PrompterProvider<TState, TProp>, options?: ContextOptions<TState, TProp>): void
+    bindPrompter(provider: CachedPrompter<TState, TProp>, options?: ContextOptions<TState, TProp>): void
     // TODO: potentially add options to this, or rethink how defaults should work
     setDefault(defaultFunction: DefaultFunction<TState, TProp> | TProp): void
 }
 
 // These methods are only applicable to object-like elements
 interface ParentFormElement<TProp extends Record<string, any>, TState> {
-    applyForm(form: WizardForm<TProp>, options?: ContextOptions<TState, TProp>): void
+    applyForm(
+        form: WizardForm<TProp>,
+        options?: Pick<ContextOptions<TState, TProp>, 'showWhen' | 'requireParent'>
+    ): void
 }
 
 type PrompterBind<TProp, TState> = FormElement<TProp, TState>['bindPrompter']
@@ -62,7 +69,7 @@ type Form<T, TState = T> = {
         : FormElement<T[Property], TState>
 }
 
-type FormDataElement<TState, TProp> = ContextOptions<TState, TProp> & { provider?: PrompterProvider<TState, TProp> }
+type FormDataElement<TState, TProp> = ContextOptions<TState, TProp> & { provider?: CachedPrompter<TState, TProp> }
 
 function isAssigned<TProp>(obj: TProp): boolean {
     return obj !== undefined || _.isEmpty(obj) === false
@@ -83,7 +90,7 @@ const SET_DEFAULT: FormProperty = 'setDefault'
  * the generic type. Properties can the be queried for their bound prompters by consuming classes.
  */
 export class WizardForm<TState extends Partial<Record<keyof TState, unknown>>> {
-    protected readonly formData = new Map<string, FormDataElement<TState, any> & { _isForm?: boolean }>()
+    protected readonly formData = new Map<string, FormDataElement<TState, any>>()
     public readonly body: Form<Required<TState>>
 
     constructor() {
@@ -91,15 +98,11 @@ export class WizardForm<TState extends Partial<Record<keyof TState, unknown>>> {
     }
 
     public get properties(): string[] {
-        return [...this.formData.keys()]
+        return [...this.formData.keys()].sort(this.compareOrder.bind(this))
     }
 
-    public getPrompterProvider(prop: string): PrompterProvider<TState, any> | undefined {
+    public getPrompterProvider(prop: string): CachedPrompter<TState, any> | undefined {
         return this.formData.get(prop)?.provider
-    }
-
-    public isImplicit(prop: string): boolean {
-        return this.formData.get(prop)?.implicit ?? true
     }
 
     public applyDefaults(state: TState): TState {
@@ -119,7 +122,14 @@ export class WizardForm<TState extends Partial<Record<keyof TState, unknown>>> {
         return defaultState
     }
 
-    private applyElement(key: string, element: FormDataElement<TState, any> & { _isForm?: boolean }) {
+    private compareOrder(key1: string, key2: string): number {
+        const f1 = this.formData.get(key1)
+        const f2 = this.formData.get(key2)
+
+        return (f1?.relativeOrder ?? Number.MAX_VALUE) - (f2?.relativeOrder ?? Number.MAX_VALUE)
+    }
+
+    private applyElement(key: string, element: FormDataElement<TState, any>) {
         this.formData.set(key, { ...this.formData.get(key), ...element })
     }
 
@@ -135,7 +145,7 @@ export class WizardForm<TState extends Partial<Record<keyof TState, unknown>>> {
             return false
         }
 
-        return options.provider !== undefined || (options._isForm ?? false)
+        return options.provider !== undefined
     }
 
     private convertElement<TProp>(
@@ -147,9 +157,12 @@ export class WizardForm<TState extends Partial<Record<keyof TState, unknown>>> {
 
         if (element.provider !== undefined) {
             wrappedElement.provider = state => {
-                const stateWithCache = Object.assign(_.get(state, prop, {}), { stepCache: state.stepCache })
+                const stateWithCache = Object.assign(_.get(state, prop, {}), {
+                    stepCache: state.stepCache,
+                    estimator: state.estimator,
+                })
 
-                return element.provider!(stateWithCache as StateWithCache<WizardState<TProp>>)
+                return element.provider!(stateWithCache as StateWithCache<WizardState<TProp>, any>)
             }
         }
 
@@ -164,18 +177,19 @@ export class WizardForm<TState extends Partial<Record<keyof TState, unknown>>> {
             element.setDefault !== undefined
                 ? state =>
                       options?.requireParent !== true || _.get(state, prop) !== undefined
-                          ? element.setDefault!(_.get(state, prop, {}))
+                          ? options?.showWhen === undefined || options.showWhen(state)
+                              ? element.setDefault!(_.get(state, prop, {}))
+                              : undefined
                           : undefined
                 : undefined
 
-        wrappedElement.implicit = element.implicit ?? options?.implicit
-        wrappedElement.requireParent = element.requireParent ?? options?.requireParent
+        wrappedElement.requireParent = element.requireParent
 
         return wrappedElement
     }
 
     private createBindPrompterMethod<TProp>(prop: string): PrompterBind<TProp, TState> {
-        return (provider: PrompterProvider<TState, TProp>, options: ContextOptions<TState, TProp> = {}): void => {
+        return (provider: CachedPrompter<TState, TProp>, options: ContextOptions<TState, TProp> = {}): void => {
             this.applyElement(prop, { ...options, provider })
         }
     }
@@ -183,10 +197,9 @@ export class WizardForm<TState extends Partial<Record<keyof TState, unknown>>> {
     private createApplyFormMethod<TProp>(prop: string): ApplyForm<TProp, TState> {
         return (form: WizardForm<TProp>, options?: ContextOptions<TState, TProp>) => {
             form.formData.forEach((element, key) => {
+                // TODO: use an assert here to ensure that no elements are rewritten
                 this.applyElement(`${prop}.${key}`, this.convertElement(prop, element, options))
             })
-
-            this.applyElement(prop, { _isForm: true, ...options })
         }
     }
 

--- a/src/shared/wizards/wizardForm.ts
+++ b/src/shared/wizards/wizardForm.ts
@@ -8,7 +8,7 @@ import * as _ from 'lodash'
 import { StateWithCache, WizardState } from './wizard'
 import { ExpandWithObject } from '../utilities/tsUtils'
 
-export type CachedPrompter<TState, TProp> = (state: StateWithCache<WizardState<TState>, TProp>) => Prompter<TProp>
+export type PrompterProvider<TState, TProp> = (state: StateWithCache<WizardState<TState>, TProp>) => Prompter<TProp>
 
 type DefaultFunction<TState, TProp> = (state: WizardState<TState>) => TProp | undefined
 
@@ -44,7 +44,7 @@ interface FormElement<TProp, TState> {
      * Binds a Prompter-provider to the specified property. The provider is called with the current Wizard
      * state whenever the property is ready for input, and should return a Prompter object.
      */
-    bindPrompter(provider: CachedPrompter<TState, TProp>, options?: ContextOptions<TState, TProp>): void
+    bindPrompter(provider: PrompterProvider<TState, TProp>, options?: ContextOptions<TState, TProp>): void
     // TODO: potentially add options to this, or rethink how defaults should work
     setDefault(defaultFunction: DefaultFunction<TState, TProp> | TProp): void
 }
@@ -69,7 +69,7 @@ type Form<T, TState = T> = {
         : FormElement<T[Property], TState>
 }
 
-type FormDataElement<TState, TProp> = ContextOptions<TState, TProp> & { provider?: CachedPrompter<TState, TProp> }
+type FormDataElement<TState, TProp> = ContextOptions<TState, TProp> & { provider?: PrompterProvider<TState, TProp> }
 
 function isAssigned<TProp>(obj: TProp): boolean {
     return obj !== undefined || _.isEmpty(obj) === false
@@ -101,7 +101,7 @@ export class WizardForm<TState extends Partial<Record<keyof TState, unknown>>> {
         return [...this.formData.keys()].sort(this.compareOrder.bind(this))
     }
 
-    public getPrompterProvider(prop: string): CachedPrompter<TState, any> | undefined {
+    public getPrompterProvider(prop: string): PrompterProvider<TState, any> | undefined {
         return this.formData.get(prop)?.provider
     }
 
@@ -189,7 +189,7 @@ export class WizardForm<TState extends Partial<Record<keyof TState, unknown>>> {
     }
 
     private createBindPrompterMethod<TProp>(prop: string): PrompterBind<TProp, TState> {
-        return (provider: CachedPrompter<TState, TProp>, options: ContextOptions<TState, TProp> = {}): void => {
+        return (provider: PrompterProvider<TState, TProp>, options: ContextOptions<TState, TProp> = {}): void => {
             this.applyElement(prop, { ...options, provider })
         }
     }

--- a/src/test/apprunner/wizards/codeRepositoryWizard.test.ts
+++ b/src/test/apprunner/wizards/codeRepositoryWizard.test.ts
@@ -1,0 +1,202 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import * as sinon from 'sinon'
+import * as picker from '../../../shared/ui/pickerPrompter'
+import * as assert from 'assert'
+import { AppRunner } from 'aws-sdk'
+import { createFormTester, FormTester } from '../../shared/wizards/wizardTestUtils'
+import {
+    AppRunnerCodeRepositoryForm,
+    CodeRepositorySource,
+    ConnectionPrompter,
+} from '../../../apprunner/wizards/codeRepositoryWizard'
+import { AppRunnerClient } from '../../../shared/clients/apprunnerClient'
+import { ConnectionSummary } from 'aws-sdk/clients/apprunner'
+import { Prompter } from '../../../shared/ui/prompter'
+import { WIZARD_EXIT } from '../../../shared/wizards/wizard'
+import { exposeEmitters, ExposeEmitters } from '../../shared/vscode/testUtils'
+
+describe('AppRunnerCodeRepositoryForm', function () {
+    let tester: FormTester<CodeRepositorySource>
+    let repoTester: FormTester<AppRunner.CodeRepository>
+
+    beforeEach(function () {
+        const form = new AppRunnerCodeRepositoryForm({} as any, {} as any) // git api will never be called
+        tester = createFormTester(form)
+        repoTester = tester.CodeRepository
+    })
+
+    it('prompts for GitHub connection first', function () {
+        tester.AuthenticationConfiguration.ConnectionArn.assertShowFirst()
+    })
+
+    it('prompts for repository URL and branch', function () {
+        repoTester.RepositoryUrl.assertShow()
+        repoTester.SourceCodeVersion.Value.assertShow()
+        repoTester.SourceCodeVersion.Type.assertValue('BRANCH')
+    })
+
+    it('does not prompt for code configuration if "API" is not set', function () {
+        repoTester.CodeConfiguration.ConfigurationSource.applyInput('REPOSITORY')
+        repoTester.CodeConfiguration.CodeConfigurationValues.assertDoesNotShowAny()
+    })
+
+    it('adds all steps under CodeConfigurationValues if "API" is set', function () {
+        const codeconfig = repoTester.CodeConfiguration
+        const codevalues = codeconfig.CodeConfigurationValues
+
+        codevalues.assertDoesNotShowAny()
+        codeconfig.ConfigurationSource.applyInput('API')
+        codevalues.BuildCommand.assertShow()
+        codevalues.Runtime.assertShow()
+        codevalues.RuntimeEnvironmentVariables.assertShow()
+        codevalues.StartCommand.assertShow()
+        codevalues.Port.assertShow()
+    })
+
+    it('sets "AutoDeploymentsEnabled" to false by default', function () {
+        tester.AutoDeploymentsEnabled.assertValue(false)
+    })
+})
+
+type ConnectionStatus = 'AVAILABLE' | 'PENDING_HANDSHAKE' | 'ERROR' | 'DELETED'
+
+describe('ConnectionPrompter', function () {
+    let connections: ConnectionSummary[]
+    let prompterProvider: ConnectionPrompter
+    let sandbox: sinon.SinonSandbox
+    let fakePicker: ExposeEmitters<vscode.QuickPick<picker.DataQuickPickItem<string>>, 'onDidTriggerButton'>
+    let prompter: Prompter<ConnectionSummary>
+    let itemsPromise: Promise<void>
+    let openExternal: sinon.SinonSpy<Parameters<typeof vscode.env.openExternal>>
+
+    const fakeState = {
+        stepCache: {},
+        estimator: () => 0,
+    }
+
+    const fakeApprunnerClient: AppRunnerClient = {
+        listConnections: (request: any) =>
+            Promise.resolve({
+                ConnectionSummaryList: connections,
+            }),
+    } as any
+
+    function makeConnection(name: string, arn: string, status: ConnectionStatus = 'AVAILABLE'): ConnectionSummary {
+        return {
+            ConnectionName: name,
+            ConnectionArn: arn,
+            Status: status,
+        }
+    }
+
+    before(function () {
+        sandbox = sinon.createSandbox()
+        openExternal = sinon.stub(vscode.env, 'openExternal')
+        sinon.stub(picker, 'createQuickPick').callsFake((items, options) => {
+            fakePicker = exposeEmitters(vscode.window.createQuickPick(), ['onDidTriggerButton'])
+            fakePicker.buttons = options?.buttons ?? [] // TODO: use 'applyPrimitives'
+            const prompter = new picker.QuickPickPrompter(fakePicker as any)
+            itemsPromise = prompter.loadItems(items)
+
+            return prompter
+        })
+    })
+
+    beforeEach(function () {
+        connections = [
+            makeConnection('connection-name-1', 'connection-arn-1'),
+            makeConnection('connection-name-2', 'connection-arn-2'),
+        ]
+        fakeState.stepCache = {}
+        prompterProvider = new ConnectionPrompter(fakeApprunnerClient)
+    })
+
+    afterEach(function () {
+        sandbox.restore()
+        openExternal.resetHistory()
+    })
+
+    after(function () {
+        sinon.restore()
+    })
+
+    function onShow(picker: typeof fakePicker): Promise<void> {
+        return new Promise(resolve => {
+            picker.onDidChangeActive(actives => {
+                if (actives.length > 0) {
+                    resolve()
+                }
+            })
+        })
+    }
+
+    it('lists connections', async function () {
+        prompter = prompterProvider(fakeState)
+        await itemsPromise
+        fakePicker.items.forEach((item, index) => {
+            assert.strictEqual(item.data, connections[index])
+        })
+    })
+
+    it('can accept a connection', async function () {
+        prompter = prompterProvider(fakeState)
+        await itemsPromise
+        const result = prompter.prompt()
+        await onShow(fakePicker)
+        fakePicker.selectedItems = fakePicker.activeItems
+        assert.strictEqual(await result, connections[0])
+    })
+
+    it('lists only available connections', async function () {
+        const original = [...connections]
+        connections.push(makeConnection('pending', 'pending', 'PENDING_HANDSHAKE'))
+        connections.push(makeConnection('error', 'error', 'ERROR'))
+        connections.unshift(makeConnection('deleted', 'deleted', 'DELETED'))
+
+        prompter = prompterProvider(fakeState)
+        await itemsPromise
+        fakePicker.items.forEach((item, index) => {
+            assert.strictEqual(item.data, original[index])
+        })
+    })
+
+    it('can refresh connections', async function () {
+        prompter = prompterProvider(fakeState)
+        await itemsPromise
+        const result = prompter.prompt()
+        await onShow(fakePicker)
+        connections.push(makeConnection('new-connection', 'new-arn'))
+        fakePicker.onDidChangeActive(() => {
+            if (fakePicker.items.length > 2) {
+                fakePicker.selectedItems = [fakePicker.items[2]]
+            }
+        })
+        fakePicker.fireOnDidTriggerButton(fakePicker.buttons.filter(b => b.tooltip === 'Refresh')[0])
+        assert.strictEqual(await result, connections[2])
+    })
+
+    it('shows an option to create a new connection when no connections are available', async function () {
+        connections = []
+
+        prompter = prompterProvider(fakeState)
+        await itemsPromise
+        assert.strictEqual(fakePicker.items.length, 1)
+        assert.strictEqual(fakePicker.items[0].invalidSelection, true)
+        assert.strictEqual(fakePicker.items[0].label, 'No connections found')
+        const result = prompter.prompt()
+        await onShow(fakePicker)
+
+        fakePicker.selectedItems = fakePicker.activeItems
+        fakePicker.hide()
+        assert.strictEqual(await result, WIZARD_EXIT)
+        assert.strictEqual(
+            openExternal.firstCall.args[0].toString(),
+            'https://docs.aws.amazon.com/apprunner/latest/dg/manage-connections.html'
+        )
+    })
+})

--- a/src/test/apprunner/wizards/codeRepositoryWizard.test.ts
+++ b/src/test/apprunner/wizards/codeRepositoryWizard.test.ts
@@ -9,20 +9,22 @@ import * as picker from '../../../shared/ui/pickerPrompter'
 import * as assert from 'assert'
 import { AppRunner } from 'aws-sdk'
 import { createWizardTester, WizardTester } from '../../shared/wizards/wizardTestUtils'
-import { AppRunnerCodeRepositoryForm, ConnectionPrompter } from '../../../apprunner/wizards/codeRepositoryWizard'
+import { AppRunnerCodeRepositoryWizard, ConnectionPrompter } from '../../../apprunner/wizards/codeRepositoryWizard'
 import { AppRunnerClient } from '../../../shared/clients/apprunnerClient'
 import { ConnectionSummary } from 'aws-sdk/clients/apprunner'
 import { Prompter } from '../../../shared/ui/prompter'
 import { WIZARD_EXIT } from '../../../shared/wizards/wizard'
 import { exposeEmitters, ExposeEmitters } from '../../shared/vscode/testUtils'
+import { APPRUNNER_CONNECTION_HELP_URL } from '../../../shared/constants'
 
-describe('AppRunnerCodeRepositoryForm', function () {
+describe('AppRunnerCodeRepositoryWizard', function () {
     let tester: WizardTester<AppRunner.SourceConfiguration>
     let repoTester: WizardTester<AppRunner.CodeRepository>
 
     beforeEach(function () {
-        const form = new AppRunnerCodeRepositoryForm({} as any, {} as any) // git api will never be called
-        tester = createWizardTester(form)
+        // apprunner client and git api will never be called
+        const wizard = new AppRunnerCodeRepositoryWizard({} as any, {} as any)
+        tester = createWizardTester(wizard)
         repoTester = tester.CodeRepository
     })
 
@@ -190,9 +192,6 @@ describe('ConnectionPrompter', function () {
         fakePicker.selectedItems = fakePicker.activeItems
         fakePicker.hide()
         assert.strictEqual(await result, WIZARD_EXIT)
-        assert.strictEqual(
-            openExternal.firstCall.args[0].toString(),
-            'https://docs.aws.amazon.com/apprunner/latest/dg/manage-connections.html'
-        )
+        assert.strictEqual(openExternal.firstCall.args[0].toString(), APPRUNNER_CONNECTION_HELP_URL)
     })
 })

--- a/src/test/apprunner/wizards/codeRepositoryWizard.test.ts
+++ b/src/test/apprunner/wizards/codeRepositoryWizard.test.ts
@@ -8,12 +8,8 @@ import * as sinon from 'sinon'
 import * as picker from '../../../shared/ui/pickerPrompter'
 import * as assert from 'assert'
 import { AppRunner } from 'aws-sdk'
-import { createFormTester, FormTester } from '../../shared/wizards/wizardTestUtils'
-import {
-    AppRunnerCodeRepositoryForm,
-    CodeRepositorySource,
-    ConnectionPrompter,
-} from '../../../apprunner/wizards/codeRepositoryWizard'
+import { createWizardTester, WizardTester } from '../../shared/wizards/wizardTestUtils'
+import { AppRunnerCodeRepositoryForm, ConnectionPrompter } from '../../../apprunner/wizards/codeRepositoryWizard'
 import { AppRunnerClient } from '../../../shared/clients/apprunnerClient'
 import { ConnectionSummary } from 'aws-sdk/clients/apprunner'
 import { Prompter } from '../../../shared/ui/prompter'
@@ -21,12 +17,12 @@ import { WIZARD_EXIT } from '../../../shared/wizards/wizard'
 import { exposeEmitters, ExposeEmitters } from '../../shared/vscode/testUtils'
 
 describe('AppRunnerCodeRepositoryForm', function () {
-    let tester: FormTester<CodeRepositorySource>
-    let repoTester: FormTester<AppRunner.CodeRepository>
+    let tester: WizardTester<AppRunner.SourceConfiguration>
+    let repoTester: WizardTester<AppRunner.CodeRepository>
 
     beforeEach(function () {
         const form = new AppRunnerCodeRepositoryForm({} as any, {} as any) // git api will never be called
-        tester = createFormTester(form)
+        tester = createWizardTester(form)
         repoTester = tester.CodeRepository
     })
 

--- a/src/test/apprunner/wizards/createServiceWizard.test.ts
+++ b/src/test/apprunner/wizards/createServiceWizard.test.ts
@@ -51,6 +51,10 @@ describe('CreateServiceWizard', function () {
             tester.InstanceConfiguration.assertShowThird()
         })
 
+        it('sets auto-deployment to "off" by default', function () {
+            tester.SourceConfiguration.AutoDeploymentsEnabled.assertValue(false)
+        })
+
         it('prompts for ECR or GitHub repository', function () {
             tester.SourceConfiguration.assertShow()
             tester.SourceConfiguration.CodeRepository.assertDoesNotShowAny()

--- a/src/test/apprunner/wizards/createServiceWizard.test.ts
+++ b/src/test/apprunner/wizards/createServiceWizard.test.ts
@@ -4,41 +4,34 @@
  */
 
 import * as _ from 'lodash'
-import {
-    CreateAppRunnerServiceForm,
-    CreateServiceRequest,
-} from '../../../apprunner/wizards/apprunnerCreateServiceWizard'
-import { createFormTester, FormTester } from '../../../test/shared/wizards/wizardTestUtils'
-import { IamClient } from '../../../shared/clients/iamClient'
-import { AppRunnerImageRepositoryForm } from '../../../apprunner/wizards/imageRepositoryWizard'
-import { AppRunnerCodeRepositoryForm } from '../../../apprunner/wizards/codeRepositoryWizard'
-import { EcrClient } from '../../../shared/clients/ecrClient'
-import { AppRunnerClient } from '../../../shared/clients/apprunnerClient'
-import { GitExtension } from '../../../shared/extensions/git'
-import { QuickInputToggleButton } from '../../../shared/ui/buttons'
+import { createWizardTester, WizardTester } from '../../../test/shared/wizards/wizardTestUtils'
+import { AppRunner } from 'aws-sdk'
+import { CreateAppRunnerServiceWizard } from '../../../apprunner/wizards/apprunnerCreateServiceWizard'
+import { ext } from '../../../shared/extensionGlobals'
 
 describe('CreateServiceWizard', function () {
-    let tester: FormTester<CreateServiceRequest>
+    let tester: WizardTester<AppRunner.CreateServiceRequest>
+    let lastClientBuilder: typeof ext.toolkitClientBuilder
 
-    beforeEach(function () {
-        const iamClient: IamClient = {} as any
-        const ecrClient: EcrClient = {} as any
-        const apprunnerClient: AppRunnerClient = {} as any
-        const gitExtension: GitExtension = {} as any
-
-        const fakeContext = {
-            iamClient,
-            apprunnerClient,
-            imageRepositoryForm: new AppRunnerImageRepositoryForm(ecrClient, iamClient),
-            codeRepositoryForm: new AppRunnerCodeRepositoryForm(apprunnerClient, gitExtension),
-            autoDeployButton: new QuickInputToggleButton({} as any, {} as any),
-        }
-
-        const form = new CreateAppRunnerServiceForm(fakeContext)
-        tester = createFormTester(form)
+    before(function () {
+        lastClientBuilder = ext.toolkitClientBuilder
+        ext.toolkitClientBuilder = {
+            createAppRunnerClient: () => ({} as any),
+            createEcrClient: () => ({} as any),
+            createIamClient: () => ({} as any),
+        } as any
     })
 
-    describe('CreateAppRunnerServiceForm', function () {
+    beforeEach(function () {
+        const wizard = new CreateAppRunnerServiceWizard('')
+        tester = createWizardTester(wizard)
+    })
+
+    after(function () {
+        ext.toolkitClientBuilder = lastClientBuilder
+    })
+
+    describe('CreateAppRunnerServiceWizard', function () {
         it('prompts for source first', function () {
             tester.SourceConfiguration.assertShowFirst()
         })

--- a/src/test/apprunner/wizards/createServiceWizard.test.ts
+++ b/src/test/apprunner/wizards/createServiceWizard.test.ts
@@ -1,0 +1,73 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as _ from 'lodash'
+import {
+    CreateAppRunnerServiceForm,
+    CreateServiceRequest,
+} from '../../../apprunner/wizards/apprunnerCreateServiceWizard'
+import { createFormTester, FormTester } from '../../../test/shared/wizards/wizardTestUtils'
+import { IamClient } from '../../../shared/clients/iamClient'
+import { AppRunnerImageRepositoryForm } from '../../../apprunner/wizards/imageRepositoryWizard'
+import { AppRunnerCodeRepositoryForm } from '../../../apprunner/wizards/codeRepositoryWizard'
+import { EcrClient } from '../../../shared/clients/ecrClient'
+import { AppRunnerClient } from '../../../shared/clients/apprunnerClient'
+import { GitExtension } from '../../../shared/extensions/git'
+import { QuickInputToggleButton } from '../../../shared/ui/buttons'
+
+describe('CreateServiceWizard', function () {
+    let tester: FormTester<CreateServiceRequest>
+
+    beforeEach(function () {
+        const iamClient: IamClient = {} as any
+        const ecrClient: EcrClient = {} as any
+        const apprunnerClient: AppRunnerClient = {} as any
+        const gitExtension: GitExtension = {} as any
+
+        const fakeContext = {
+            iamClient,
+            apprunnerClient,
+            imageRepositoryForm: new AppRunnerImageRepositoryForm(ecrClient, iamClient),
+            codeRepositoryForm: new AppRunnerCodeRepositoryForm(apprunnerClient, gitExtension),
+            autoDeployButton: new QuickInputToggleButton({} as any, {} as any),
+        }
+
+        const form = new CreateAppRunnerServiceForm(fakeContext)
+        tester = createFormTester(form)
+    })
+
+    describe('CreateAppRunnerServiceForm', function () {
+        it('prompts for source first', function () {
+            tester.SourceConfiguration.assertShowFirst()
+        })
+
+        it('prompts for role ARN if choosing private ECR', function () {
+            tester.SourceConfiguration.applyInput({ ImageRepository: { ImageRepositoryType: 'ECR' } as any })
+            tester.SourceConfiguration.AuthenticationConfiguration.AccessRoleArn.assertShow()
+        })
+
+        it('prompts for connection ARN if choosing Repository', function () {
+            tester.SourceConfiguration.applyInput({ CodeRepository: {} as any })
+            tester.SourceConfiguration.AuthenticationConfiguration.ConnectionArn.assertShow()
+        })
+
+        it('prompts for name before instance', function () {
+            tester.ServiceName.assertShowSecond() // TODO: write a 'assertShowBefore' that accepts another form element as input
+            tester.InstanceConfiguration.assertShowThird()
+        })
+
+        it('prompts for ECR or GitHub repository', function () {
+            tester.SourceConfiguration.assertShow()
+            tester.SourceConfiguration.CodeRepository.assertDoesNotShowAny()
+            tester.SourceConfiguration.ImageRepository.assertDoesNotShowAny()
+
+            tester.SourceConfiguration.applyInput({ CodeRepository: {} as any })
+            tester.SourceConfiguration.CodeRepository.assertShowAny()
+
+            tester.SourceConfiguration.applyInput({ ImageRepository: {} as any })
+            tester.SourceConfiguration.ImageRepository.assertShowAny()
+        })
+    })
+})

--- a/src/test/apprunner/wizards/imageRepositoryWizard.test.ts
+++ b/src/test/apprunner/wizards/imageRepositoryWizard.test.ts
@@ -6,18 +6,18 @@
 import { AppRunner } from 'aws-sdk'
 import { createWizardTester, WizardTester } from '../../shared/wizards/wizardTestUtils'
 import {
-    AppRunnerImageRepositoryForm,
+    AppRunnerImageRepositoryWizard,
     ImageIdentifierForm,
     TaggedEcrRepository,
 } from '../../../apprunner/wizards/imageRepositoryWizard'
 
-describe('AppRunnerImageRepositoryForm', function () {
+describe('AppRunnerImageRepositoryWizard', function () {
     let tester: WizardTester<AppRunner.SourceConfiguration>
     let repoTester: WizardTester<AppRunner.ImageRepository>
 
     beforeEach(function () {
-        const form = new AppRunnerImageRepositoryForm({} as any, {} as any) // ecr will never be called
-        tester = createWizardTester(form)
+        const wizard = new AppRunnerImageRepositoryWizard({} as any, {} as any) // the clients will never be called
+        tester = createWizardTester(wizard)
         repoTester = tester.ImageRepository
     })
 

--- a/src/test/apprunner/wizards/imageRepositoryWizard.test.ts
+++ b/src/test/apprunner/wizards/imageRepositoryWizard.test.ts
@@ -1,0 +1,71 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AppRunner } from 'aws-sdk'
+import { createFormTester, FormTester } from '../../shared/wizards/wizardTestUtils'
+import {
+    AppRunnerImageRepositoryForm,
+    ImageIdentifierForm,
+    ImageRepositorySource,
+    TaggedEcrRepository,
+} from '../../../apprunner/wizards/imageRepositoryWizard'
+
+describe('AppRunnerImageRepositoryForm', function () {
+    let tester: FormTester<ImageRepositorySource>
+    let repoTester: FormTester<AppRunner.ImageRepository>
+
+    beforeEach(function () {
+        const form = new AppRunnerImageRepositoryForm({} as any, {} as any) // ecr will never be called
+        tester = createFormTester(form)
+        repoTester = tester.ImageRepository
+    })
+
+    it('prompts for identifier, port, and environment variables', function () {
+        repoTester.ImageIdentifier.assertShow()
+        repoTester.ImageConfiguration.Port.assertShow()
+        repoTester.ImageConfiguration.RuntimeEnvironmentVariables.assertShow()
+        repoTester.assertShowCount(3)
+    })
+
+    it('sets image repository type', function () {
+        repoTester.ImageRepositoryType.assertValue(undefined)
+        repoTester.ImageIdentifier.applyInput('public.ecr.aws.com/testimage:latest')
+        repoTester.ImageRepositoryType.assertValue('ECR_PUBLIC')
+        repoTester.ImageIdentifier.applyInput('12351232424.dkr.ecr.us-east-1.amazonaws.com/testrepo:latest')
+        repoTester.ImageRepositoryType.assertValue('ECR')
+    })
+
+    it('sets "AutoDeploymentsEnabled" to false by default', function () {
+        tester.AutoDeploymentsEnabled.assertValue(false)
+    })
+
+    it('prompts for role if not public', function () {
+        repoTester.ImageRepositoryType.applyInput('ECR')
+        tester.AuthenticationConfiguration.AccessRoleArn.assertShow()
+
+        repoTester.ImageRepositoryType.applyInput('ECR_PUBLIC')
+        tester.AuthenticationConfiguration.AccessRoleArn.assertDoesNotShow()
+    })
+})
+
+describe('ImageIdentifierForm', function () {
+    let tester: FormTester<{ repo: TaggedEcrRepository }>
+
+    beforeEach(function () {
+        const form = new ImageIdentifierForm({} as any) // ecr will never be called
+        tester = createFormTester(form)
+    })
+
+    it('asks for tag if not provided', function () {
+        tester.repo.tag.assertDoesNotShow()
+        tester.repo.applyInput({ repositoryName: 'name', repositoryArn: '', repositoryUri: '' })
+        tester.repo.tag.assertShow()
+    })
+
+    it('skips tag step if given', function () {
+        tester.repo.applyInput({ repositoryName: 'name', repositoryArn: '', repositoryUri: '', tag: 'latest' })
+        tester.repo.tag.assertDoesNotShow()
+    })
+})

--- a/src/test/apprunner/wizards/imageRepositoryWizard.test.ts
+++ b/src/test/apprunner/wizards/imageRepositoryWizard.test.ts
@@ -4,21 +4,20 @@
  */
 
 import { AppRunner } from 'aws-sdk'
-import { createFormTester, FormTester } from '../../shared/wizards/wizardTestUtils'
+import { createWizardTester, WizardTester } from '../../shared/wizards/wizardTestUtils'
 import {
     AppRunnerImageRepositoryForm,
     ImageIdentifierForm,
-    ImageRepositorySource,
     TaggedEcrRepository,
 } from '../../../apprunner/wizards/imageRepositoryWizard'
 
 describe('AppRunnerImageRepositoryForm', function () {
-    let tester: FormTester<ImageRepositorySource>
-    let repoTester: FormTester<AppRunner.ImageRepository>
+    let tester: WizardTester<AppRunner.SourceConfiguration>
+    let repoTester: WizardTester<AppRunner.ImageRepository>
 
     beforeEach(function () {
         const form = new AppRunnerImageRepositoryForm({} as any, {} as any) // ecr will never be called
-        tester = createFormTester(form)
+        tester = createWizardTester(form)
         repoTester = tester.ImageRepository
     })
 
@@ -51,11 +50,11 @@ describe('AppRunnerImageRepositoryForm', function () {
 })
 
 describe('ImageIdentifierForm', function () {
-    let tester: FormTester<{ repo: TaggedEcrRepository }>
+    let tester: WizardTester<{ repo: TaggedEcrRepository }>
 
     beforeEach(function () {
         const form = new ImageIdentifierForm({} as any) // ecr will never be called
-        tester = createFormTester(form)
+        tester = createWizardTester(form)
     })
 
     it('asks for tag if not provided', function () {

--- a/src/test/shared/clients/mockClients.ts
+++ b/src/test/shared/clients/mockClients.ts
@@ -333,6 +333,12 @@ export class MockIamClient implements IamClient {
     public constructor({ listRoles = async () => ({ Roles: [] }) }: { listRoles?(): Promise<IAM.ListRolesResponse> }) {
         this.listRoles = listRoles
     }
+    public createRole(request: IAM.CreateRoleRequest): Promise<IAM.CreateRoleResponse> {
+        throw new Error('Method not implemented.')
+    }
+    public attachRolePolicy(request: IAM.AttachRolePolicyRequest): Promise<void> {
+        throw new Error('Method not implemented.')
+    }
 }
 
 export class MockLambdaClient implements LambdaClient {

--- a/src/test/shared/ui/inputPrompter.test.ts
+++ b/src/test/shared/ui/inputPrompter.test.ts
@@ -82,7 +82,7 @@ describe('InputBoxPrompter', function () {
 
         it('buttons can return values', async function () {
             const button: QuickInputButton<string> = {
-                iconPath: '',
+                iconPath: vscode.Uri.parse(''),
                 onClick: () => 'answer',
             }
             inputBox.buttons = [button]
@@ -95,7 +95,7 @@ describe('InputBoxPrompter', function () {
 
         it('buttons with void return type do not close the prompter', async function () {
             const button: QuickInputButton<void> = {
-                iconPath: '',
+                iconPath: vscode.Uri.parse(''),
                 onClick: () => {},
             }
             inputBox.buttons = [button]

--- a/src/test/shared/ui/pickerPrompter.test.ts
+++ b/src/test/shared/ui/pickerPrompter.test.ts
@@ -246,15 +246,15 @@ describe('FilterBoxQuickPickPrompter', function () {
                     items[0]?.detail?.includes('NaN') &&
                     items[0]?.invalidSelection
                 ) {
-                    picker.selectedItems = [picker.items[0]]
-                    disposable.dispose()
-                    picker.value = ''
-                    picker.fireOnDidChangeValue('')
                     picker.onDidChangeActive(items => {
                         if (items.length > 0) {
                             picker.selectedItems = [picker.items[0]]
                         }
                     })
+                    picker.selectedItems = [picker.items[0]]
+                    disposable.dispose()
+                    picker.value = ''
+                    picker.fireOnDidChangeValue('')
                 }
             })
 

--- a/src/test/shared/ui/pickerPrompter.test.ts
+++ b/src/test/shared/ui/pickerPrompter.test.ts
@@ -110,13 +110,13 @@ describe('QuickPickPrompter', function () {
     })
 
     it('can accept input from buttons', async function () {
-        const testButton = { iconPath: '', onClick: () => 5 }
+        const testButton = { iconPath: vscode.Uri.parse(''), onClick: () => 5 }
         testPrompter.onDidShow(() => picker.fireOnDidTriggerButton(testButton))
         assert.strictEqual(await testPrompter.prompt(), 5)
     })
 
     it('does not close if button does not return anything', async function () {
-        const testButton = { iconPath: '', onClick: () => {} }
+        const testButton = { iconPath: vscode.Uri.parse(''), onClick: () => {} }
         testPrompter.onDidShow(() => {
             picker.fireOnDidTriggerButton(testButton)
             picker.selectedItems = [testItems[0]]
@@ -131,47 +131,19 @@ describe('QuickPickPrompter', function () {
         assert.strictEqual(testPrompter.lastResponse, testItems[1])
     })
 
-    it('preserves the current active selection when loading', async function () {
-        testPrompter.selectItems(testItems[2])
-        await testPrompter.loadItems([{ label: 'test4', data: 3 }])
-        assert.strictEqual(picker.activeItems[0], testItems[2])
-        assert.strictEqual(picker.items.length, 4)
-    })
-
-    it('can set last response', function () {
-        testPrompter.lastResponse = testItems[2]
+    it('can set last response', async function () {
+        testPrompter.setLastResponse(testItems[2])
         assert.deepStrictEqual(picker.activeItems, [testItems[2]])
     })
 
-    it('can load multiple batches of items in parallel', async function () {
-        await Promise.all([
-            testPrompter.loadItems(Promise.resolve([{ label: 'test4', data: 3 }])),
-            testPrompter.loadItems(Promise.resolve([{ label: 'test5', data: 4 }])),
-            testPrompter.loadItems(Promise.resolve([{ label: 'test6', data: 5 }])),
-            testPrompter.loadItems([
-                { label: 'test7', data: 6 },
-                { label: 'test8', data: 7 },
-            ]),
-        ])
-        assert.strictEqual(testPrompter.quickPick.items.length, 8)
-        assert.strictEqual(new Set(testPrompter.quickPick.items.map(i => i.label)).size, 8)
+    it('tries to recover last reponse from partial data', async function () {
+        testPrompter.setLastResponse(2)
+        assert.deepStrictEqual(picker.activeItems, [testItems[2]])
     })
 
-    it('shows first item if last response does not exist', function () {
-        testPrompter.lastResponse = { label: 'item4', data: 3 }
+    it('shows first item if last response does not exist', async function () {
+        testPrompter.setLastResponse({ label: 'item4', data: 3 })
         assert.deepStrictEqual(picker.activeItems, [testItems[0]])
-    })
-
-    it('can set a new active selection', async function () {
-        picker.onDidChangeActive(active => {
-            if (active[0].data === testItems[2].data) {
-                picker.selectedItems = active
-            }
-        })
-        testPrompter.onDidShow(() => testPrompter.selectItems(testItems[2]))
-        const result = testPrompter.prompt()
-
-        assert.strictEqual(await result, testItems[2].data)
     })
 })
 
@@ -185,6 +157,7 @@ describe('FilterBoxQuickPickPrompter', function () {
     const filterBoxInputSettings = {
         label: 'Enter a number',
         transform: (resp: string) => Number.parseInt(resp),
+        validator: (resp: string) => (Number.isNaN(Number.parseInt(resp)) ? 'NaN' : undefined),
     }
 
     let picker: ExposeEmitters<DataQuickPick<number>, 'onDidChangeValue'>
@@ -260,5 +233,34 @@ describe('FilterBoxQuickPickPrompter', function () {
         })
 
         assert.strictEqual(await loadAndPrompt(), Number(input))
+    })
+
+    it('validates the custom input', async function () {
+        const input = 'not a number'
+
+        testPrompter.onDidShow(() => {
+            const disposable = picker.onDidChangeActive(items => {
+                if (
+                    items[0]?.description === input &&
+                    items[0]?.detail?.includes('NaN') &&
+                    items[0]?.invalidSelection
+                ) {
+                    picker.selectedItems = [picker.items[0]]
+                    disposable.dispose()
+                    picker.value = ''
+                    picker.fireOnDidChangeValue('')
+                    picker.onDidChangeActive(items => {
+                        if (items.length > 0) {
+                            picker.selectedItems = [picker.items[0]]
+                        }
+                    })
+                }
+            })
+
+            picker.value = input
+            picker.fireOnDidChangeValue(input)
+        })
+
+        assert.strictEqual(await loadAndPrompt(), testItems[0].data)
     })
 })

--- a/src/test/shared/ui/pickerPrompter.test.ts
+++ b/src/test/shared/ui/pickerPrompter.test.ts
@@ -160,7 +160,7 @@ describe('FilterBoxQuickPickPrompter', function () {
         validator: (resp: string) => (Number.isNaN(Number.parseInt(resp)) ? 'NaN' : undefined),
     }
 
-    let picker: ExposeEmitters<DataQuickPick<number>, 'onDidChangeValue'>
+    let picker: ExposeEmitters<DataQuickPick<number>, 'onDidChangeValue' | 'onDidAccept'>
     let testPrompter: FilterBoxQuickPickPrompter<number>
 
     function addTimeout(): void {
@@ -172,7 +172,7 @@ describe('FilterBoxQuickPickPrompter', function () {
     }
 
     beforeEach(function () {
-        picker = exposeEmitters(vscode.window.createQuickPick(), ['onDidChangeValue'])
+        picker = exposeEmitters(vscode.window.createQuickPick(), ['onDidChangeValue', 'onDidAccept'])
         testPrompter = new FilterBoxQuickPickPrompter(picker, filterBoxInputSettings)
         addTimeout()
     })
@@ -225,6 +225,7 @@ describe('FilterBoxQuickPickPrompter', function () {
             picker.onDidChangeActive(active => {
                 if (active[0]?.description !== undefined) {
                     picker.selectedItems = [active[0]]
+                    picker.fireOnDidAccept()
                 }
             })
 

--- a/src/test/shared/ui/prompter.test.ts
+++ b/src/test/shared/ui/prompter.test.ts
@@ -5,6 +5,7 @@
 
 import * as assert from 'assert'
 import { Prompter, PromptResult } from '../../../shared/ui/prompter'
+import { StepEstimator } from '../../../shared/wizards/wizard'
 
 export class SimplePrompter<T> extends Prompter<T> {
     constructor(private readonly input: T | PromptResult<T>) {
@@ -14,6 +15,7 @@ export class SimplePrompter<T> extends Prompter<T> {
         return this.input
     }
     public setSteps(current: number, total: number): void {}
+    public setStepEstimator(estimator: StepEstimator<T>): void {}
     public set lastResponse(response: any) {}
     public get lastResponse(): any {
         return undefined

--- a/src/test/shared/ui/prompters/rolePrompter.test.ts
+++ b/src/test/shared/ui/prompters/rolePrompter.test.ts
@@ -1,0 +1,85 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as _ from 'lodash'
+import * as assert from 'assert'
+import * as picker from '../../../../shared/ui/pickerPrompter'
+import * as vscode from 'vscode'
+import { IAM } from 'aws-sdk'
+import { IamClient } from '../../../../shared/clients/iamClient'
+import { RolePrompter } from '../../../../shared/ui/common/rolePrompter'
+import { instance, mock, when } from 'ts-mockito'
+import { exposeEmitters, ExposeEmitters } from '../../vscode/testUtils'
+
+describe('RolePrompter', function () {
+    let roleResponse: IAM.ListRolesResponse
+    let newRole: IAM.Role
+    let mockIamClient: IamClient
+    let prompterProvider: RolePrompter
+    let prompter: picker.QuickPickPrompter<IAM.Role>
+
+    let picker: ExposeEmitters<vscode.QuickPick<picker.DataQuickPickItem<IAM.Role>>, 'onDidTriggerButton'>
+
+    beforeEach(function () {
+        roleResponse = {
+            Roles: [
+                {
+                    RoleName: 'test-role1',
+                    Arn: 'test-arn1',
+                } as any,
+            ],
+        }
+
+        newRole = {
+            RoleName: 'new-role',
+            Arn: 'new-arn',
+        } as any
+
+        mockIamClient = mock()
+        when(mockIamClient.listRoles()).thenResolve(roleResponse)
+        prompterProvider = new RolePrompter(instance(mockIamClient), { createRole: () => Promise.resolve(newRole) })
+        prompter = prompterProvider({ stepCache: {} } as any) as picker.QuickPickPrompter<IAM.Role>
+        picker = exposeEmitters(prompter.quickPick, ['onDidTriggerButton'])
+    })
+
+    it('prompts for role', async function () {
+        picker.onDidChangeActive(items => {
+            if (items.length > 0) {
+                picker.selectedItems = [items[0]]
+            }
+        })
+
+        assert.strictEqual(await prompter.prompt(), roleResponse.Roles[0])
+    })
+
+    it('can refresh', async function () {
+        picker.onDidChangeActive(() => {
+            if (picker.items.length === 2) {
+                picker.selectedItems = [picker.items[1]]
+            }
+        })
+
+        prompter.onDidShow(() => {
+            roleResponse.Roles.push({ RoleName: 'test-role2', Arn: 'test-arn2' } as any)
+            picker.fireOnDidTriggerButton(picker.buttons.filter(b => b.tooltip === 'Refresh')[0])
+        })
+
+        assert.strictEqual(await prompter.prompt(), roleResponse.Roles[1])
+    })
+
+    it('can create a new role', async function () {
+        picker.onDidChangeActive(() => {
+            if (picker.items.length === 2) {
+                picker.selectedItems = [picker.items[0]]
+            }
+        })
+
+        prompter.onDidShow(() => {
+            picker.fireOnDidTriggerButton(picker.buttons.filter(b => b.tooltip === 'Create Role...')[0])
+        })
+
+        assert.strictEqual(await prompter.prompt(), newRole)
+    })
+})

--- a/src/test/shared/ui/prompters/rolePrompter.test.ts
+++ b/src/test/shared/ui/prompters/rolePrompter.test.ts
@@ -19,7 +19,6 @@ describe('RolePrompter', function () {
     let mockIamClient: IamClient
     let prompterProvider: RolePrompter
     let prompter: picker.QuickPickPrompter<IAM.Role>
-
     let picker: ExposeEmitters<vscode.QuickPick<picker.DataQuickPickItem<IAM.Role>>, 'onDidTriggerButton'>
 
     beforeEach(function () {
@@ -62,8 +61,17 @@ describe('RolePrompter', function () {
         })
 
         prompter.onDidShow(() => {
-            roleResponse.Roles.push({ RoleName: 'test-role2', Arn: 'test-arn2' } as any)
-            picker.fireOnDidTriggerButton(picker.buttons.filter(b => b.tooltip === 'Refresh')[0])
+            if (picker.items.length === 0) {
+                picker.onDidChangeActive(() => {
+                    if (picker.items.length === 1) {
+                        roleResponse.Roles.push({ RoleName: 'test-role2', Arn: 'test-arn2' } as any)
+                        picker.fireOnDidTriggerButton(picker.buttons.filter(b => b.tooltip === 'Refresh')[0])
+                    }
+                })
+            } else {
+                roleResponse.Roles.push({ RoleName: 'test-role2', Arn: 'test-arn2' } as any)
+                picker.fireOnDidTriggerButton(picker.buttons.filter(b => b.tooltip === 'Refresh')[0])
+            }
         })
 
         assert.strictEqual(await prompter.prompt(), roleResponse.Roles[1])
@@ -72,12 +80,20 @@ describe('RolePrompter', function () {
     it('can create a new role', async function () {
         picker.onDidChangeActive(() => {
             if (picker.items.length === 2) {
-                picker.selectedItems = [picker.items[0]]
+                picker.selectedItems = [picker.items[1]]
             }
         })
 
         prompter.onDidShow(() => {
-            picker.fireOnDidTriggerButton(picker.buttons.filter(b => b.tooltip === 'Create Role...')[0])
+            if (picker.items.length === 0) {
+                picker.onDidChangeActive(() => {
+                    if (picker.items.length === 1) {
+                        picker.fireOnDidTriggerButton(picker.buttons.filter(b => b.tooltip === 'Create Role...')[0])
+                    }
+                })
+            } else {
+                picker.fireOnDidTriggerButton(picker.buttons.filter(b => b.tooltip === 'Create Role...')[0])
+            }
         })
 
         assert.strictEqual(await prompter.prompt(), newRole)

--- a/src/test/shared/wizards/wizardForm.test.ts
+++ b/src/test/shared/wizards/wizardForm.test.ts
@@ -4,9 +4,10 @@
  */
 
 import * as assert from 'assert'
-import { createFormTester, FormTester } from '../../shared/wizards/wizardTestUtils'
+import { createWizardTester, WizardTester } from '../../shared/wizards/wizardTestUtils'
 import { WizardForm } from '../../../shared/wizards/wizardForm'
 import { SimplePrompter } from '../ui/prompter.test'
+import { Wizard } from '../../../shared/wizards/wizard'
 
 interface TestState {
     prop1: number
@@ -20,30 +21,32 @@ interface NestedTestState {
 }
 
 describe('WizardForm', function () {
-    let testForm: WizardForm<TestState>
-    let tester: FormTester<TestState>
+    let testWizard: Wizard<TestState>
+    let testForm: Wizard<TestState>['form']
+    let tester: WizardTester<TestState>
 
     beforeEach(function () {
-        testForm = new WizardForm()
-        tester = createFormTester(testForm)
+        testWizard = new Wizard()
+        testForm = testWizard.form
+        tester = createWizardTester(testWizard)
     })
 
     it('can add prompter', function () {
-        testForm.body.prop1.bindPrompter(() => new SimplePrompter(0))
+        testForm.prop1.bindPrompter(() => new SimplePrompter(0))
         tester.prop1.assertShow()
-        assert.notStrictEqual(testForm.getPrompterProvider('prop1'), undefined)
+        assert.notStrictEqual(testWizard.boundForm.getPrompterProvider('prop1'), undefined)
     })
 
     it('uses relative order', function () {
-        testForm.body.prop1.bindPrompter(() => new SimplePrompter(0), { relativeOrder: 1 })
-        testForm.body.prop2.bindPrompter(() => new SimplePrompter(''), { relativeOrder: 0 })
+        testForm.prop1.bindPrompter(() => new SimplePrompter(0), { relativeOrder: 1 })
+        testForm.prop2.bindPrompter(() => new SimplePrompter(''), { relativeOrder: 0 })
 
         tester.prop2.assertShowFirst()
         tester.prop1.assertShowSecond()
     })
 
     it('shows prompter based on context', function () {
-        testForm.body.prop1.bindPrompter(() => new SimplePrompter(0), { showWhen: state => state.prop2 === 'hello' })
+        testForm.prop1.bindPrompter(() => new SimplePrompter(0), { showWhen: state => state.prop2 === 'hello' })
         tester.prop1.assertDoesNotShow()
         tester.prop2.applyInput('hello')
         tester.prop1.assertShow()
@@ -52,7 +55,7 @@ describe('WizardForm', function () {
     })
 
     it('applies default setting when field is not assigned', function () {
-        testForm.body.prop1.bindPrompter(() => new SimplePrompter(0), { setDefault: () => 100 })
+        testForm.prop1.bindPrompter(() => new SimplePrompter(0), { setDefault: () => 100 })
         tester.prop1.assertShow()
         tester.prop1.assertValue(100)
         tester.prop1.applyInput(5)
@@ -65,8 +68,8 @@ describe('WizardForm', function () {
     // TODO: revisit this. Values should not technically know about other field defaults
     // but allowing this behavior means loops are possible, so cycle detection would be needed
     it('default values do not depend on other default values', function () {
-        testForm.body.prop1.setDefault(() => 100)
-        testForm.body.prop2.setDefault(state => `default: ${state.prop1}`)
+        testForm.prop1.setDefault(() => 100)
+        testForm.prop2.setDefault(state => `default: ${state.prop1}`)
         tester.prop1.assertValue(100)
         tester.prop2.assertValue('default: undefined')
         tester.prop1.applyInput(50)
@@ -75,8 +78,8 @@ describe('WizardForm', function () {
 
     describe('requireParent', function () {
         it('only show prompters when parent is defined', function () {
-            testForm.body.nestedProp.prop1.bindPrompter(() => new SimplePrompter(''), { requireParent: true })
-            testForm.body.nestedProp.prop2.bindPrompter(() => new SimplePrompter(''))
+            testForm.nestedProp.prop1.bindPrompter(() => new SimplePrompter(''), { requireParent: true })
+            testForm.nestedProp.prop2.bindPrompter(() => new SimplePrompter(''))
             tester.nestedProp.prop1.assertDoesNotShow()
             tester.nestedProp.prop2.assertShow()
             tester.nestedProp.applyInput({})
@@ -85,7 +88,7 @@ describe('WizardForm', function () {
         })
 
         it('works with "showWhen"', function () {
-            testForm.body.nestedProp.prop1.bindPrompter(() => new SimplePrompter(''), {
+            testForm.nestedProp.prop1.bindPrompter(() => new SimplePrompter(''), {
                 requireParent: true,
                 showWhen: state => state.prop1 === 99,
             })
@@ -99,7 +102,7 @@ describe('WizardForm', function () {
         })
 
         it('works with "setDefault"', function () {
-            testForm.body.nestedProp.prop1.bindPrompter(() => new SimplePrompter(''), {
+            testForm.nestedProp.prop1.bindPrompter(() => new SimplePrompter(''), {
                 requireParent: true,
                 setDefault: () => 'default',
             })
@@ -119,13 +122,13 @@ describe('WizardForm', function () {
         })
 
         it('handles providers with undefined parents', function () {
-            testForm.body.nestedProp.prop1.bindPrompter(() => new SimplePrompter(''))
+            testForm.nestedProp.prop1.bindPrompter(() => new SimplePrompter(''))
             tester.nestedProp.prop1.assertShow()
         })
 
         it('can apply another form to a property', function () {
             nestedTestForm.body.prop1.bindPrompter(() => new SimplePrompter(''))
-            testForm.body.nestedProp.applyForm(nestedTestForm)
+            testForm.nestedProp.applyForm(nestedTestForm)
             tester.nestedProp.prop1.assertShow()
         })
 
@@ -133,7 +136,7 @@ describe('WizardForm', function () {
             nestedTestForm.body.prop1.bindPrompter(() => new SimplePrompter(''), {
                 showWhen: state => state.prop2 === 'hello',
             })
-            testForm.body.nestedProp.applyForm(nestedTestForm)
+            testForm.nestedProp.applyForm(nestedTestForm)
             tester.nestedProp.prop1.assertDoesNotShow()
             tester.nestedProp.prop2.applyInput('hello')
             tester.nestedProp.prop1.assertShow()
@@ -144,7 +147,7 @@ describe('WizardForm', function () {
                 showWhen: state => state.prop2 === 'hello',
             })
             nestedTestForm.body.prop2.setDefault(() => 'hello')
-            testForm.body.nestedProp.applyForm(nestedTestForm, { requireParent: true })
+            testForm.nestedProp.applyForm(nestedTestForm, { requireParent: true })
             tester.nestedProp.prop1.assertDoesNotShow()
             tester.nestedProp.prop2.assertValue(undefined)
             tester.nestedProp.applyInput({})
@@ -159,7 +162,7 @@ describe('WizardForm', function () {
                 showWhen: state => state.prop1 === 'goodbye',
             })
 
-            testForm.body.nestedProp.applyForm(nestedTestForm, { showWhen: state => state.prop2 === 'start' })
+            testForm.nestedProp.applyForm(nestedTestForm, { showWhen: state => state.prop2 === 'start' })
             tester.nestedProp.assertDoesNotShowAny()
             tester.nestedProp.applyInput({})
             tester.nestedProp.assertDoesNotShowAny()

--- a/src/test/shared/wizards/wizardForm.test.ts
+++ b/src/test/shared/wizards/wizardForm.test.ts
@@ -128,7 +128,7 @@ describe('WizardForm', function () {
 
         it('can apply another form to a property', function () {
             nestedTestForm.body.prop1.bindPrompter(() => new SimplePrompter(''))
-            testForm.nestedProp.applyForm(nestedTestForm)
+            testForm.nestedProp.applyBoundForm(nestedTestForm)
             tester.nestedProp.prop1.assertShow()
         })
 
@@ -136,7 +136,7 @@ describe('WizardForm', function () {
             nestedTestForm.body.prop1.bindPrompter(() => new SimplePrompter(''), {
                 showWhen: state => state.prop2 === 'hello',
             })
-            testForm.nestedProp.applyForm(nestedTestForm)
+            testForm.nestedProp.applyBoundForm(nestedTestForm)
             tester.nestedProp.prop1.assertDoesNotShow()
             tester.nestedProp.prop2.applyInput('hello')
             tester.nestedProp.prop1.assertShow()
@@ -147,7 +147,7 @@ describe('WizardForm', function () {
                 showWhen: state => state.prop2 === 'hello',
             })
             nestedTestForm.body.prop2.setDefault(() => 'hello')
-            testForm.nestedProp.applyForm(nestedTestForm, { requireParent: true })
+            testForm.nestedProp.applyBoundForm(nestedTestForm, { requireParent: true })
             tester.nestedProp.prop1.assertDoesNotShow()
             tester.nestedProp.prop2.assertValue(undefined)
             tester.nestedProp.applyInput({})
@@ -162,7 +162,7 @@ describe('WizardForm', function () {
                 showWhen: state => state.prop1 === 'goodbye',
             })
 
-            testForm.nestedProp.applyForm(nestedTestForm, { showWhen: state => state.prop2 === 'start' })
+            testForm.nestedProp.applyBoundForm(nestedTestForm, { showWhen: state => state.prop2 === 'start' })
             tester.nestedProp.assertDoesNotShowAny()
             tester.nestedProp.applyInput({})
             tester.nestedProp.assertDoesNotShowAny()

--- a/src/test/shared/wizards/wizardForm.test.ts
+++ b/src/test/shared/wizards/wizardForm.test.ts
@@ -34,6 +34,14 @@ describe('WizardForm', function () {
         assert.notStrictEqual(testForm.getPrompterProvider('prop1'), undefined)
     })
 
+    it('uses relative order', function () {
+        testForm.body.prop1.bindPrompter(() => new SimplePrompter(0), { relativeOrder: 1 })
+        testForm.body.prop2.bindPrompter(() => new SimplePrompter(''), { relativeOrder: 0 })
+
+        tester.prop2.assertShowFirst()
+        tester.prop1.assertShowSecond()
+    })
+
     it('shows prompter based on context', function () {
         testForm.body.prop1.bindPrompter(() => new SimplePrompter(0), { showWhen: state => state.prop2 === 'hello' })
         tester.prop1.assertDoesNotShow()
@@ -121,13 +129,6 @@ describe('WizardForm', function () {
             tester.nestedProp.prop1.assertShow()
         })
 
-        it('can check if a form would be shown', function () {
-            testForm.body.nestedProp.applyForm(nestedTestForm, { showWhen: state => !!state.prop1 })
-            tester.nestedProp.assertDoesNotShow()
-            tester.prop1.applyInput(1)
-            tester.nestedProp.assertShow()
-        })
-
         it('propagates state to local forms', function () {
             nestedTestForm.body.prop1.bindPrompter(() => new SimplePrompter(''), {
                 showWhen: state => state.prop2 === 'hello',
@@ -170,21 +171,6 @@ describe('WizardForm', function () {
             tester.nestedProp.prop1.clearInput()
             tester.nestedProp.prop2.applyInput('hello')
             tester.nestedProp.prop1.assertShow()
-        })
-
-        it('can apply form with "setDefault"', function () {
-            nestedTestForm.body.prop1.bindPrompter(() => new SimplePrompter(''), { requireParent: true })
-            nestedTestForm.body.prop2.setDefault(state => (state.prop1 ? `${state.prop1}.${state.prop1}` : undefined))
-
-            testForm.body.nestedProp.applyForm(nestedTestForm, { setDefault: () => ({ prop1: 'test' }) })
-            tester.nestedProp.prop1.assertDoesNotShow()
-            tester.nestedProp.prop1.assertValue('test')
-            tester.nestedProp.prop2.assertValue(undefined)
-            tester.nestedProp.applyInput({})
-            tester.nestedProp.prop1.assertShow()
-            tester.nestedProp.applyInput({ prop1: 'new' })
-            tester.nestedProp.prop1.assertDoesNotShow()
-            tester.nestedProp.prop2.assertValue('new.new')
         })
     })
 })

--- a/src/test/shared/wizards/wizardTestUtils.ts
+++ b/src/test/shared/wizards/wizardTestUtils.ts
@@ -21,10 +21,12 @@ interface MockWizardFormElement<TProp> {
     assertShowFirst(): void
     assertShowSecond(): void
     assertShowThird(): void
+    assertShowAny(): void
     assertDoesNotShow(): void
     /** Verifies that no sub-properties of the target would show prompters. */
     assertDoesNotShowAny(): void
     assertValue(expected: TProp | undefined): void
+    assertShowCount(count: number): void
 }
 
 type MockForm<T, TState = T> = {
@@ -33,8 +35,6 @@ type MockForm<T, TState = T> = {
         : MockWizardFormElement<T[Property]>
 }
 
-export type FormTester<T> = MockForm<Required<T>> & { showCount: number }
-
 type FormTesterMethodKey = keyof MockWizardFormElement<any>
 const APPLY_INPUT: FormTesterMethodKey = 'applyInput'
 const CLEAR_INPUT: FormTesterMethodKey = 'clearInput'
@@ -42,9 +42,13 @@ const ASSERT_SHOW: FormTesterMethodKey = 'assertShow'
 const ASSERT_SHOW_FIRST: FormTesterMethodKey = 'assertShowFirst'
 const ASSERT_SHOW_SECOND: FormTesterMethodKey = 'assertShowSecond'
 const ASSERT_SHOW_THIRD: FormTesterMethodKey = 'assertShowThird'
+const ASSERT_SHOW_ANY: FormTesterMethodKey = 'assertShowAny'
 const NOT_ASSERT_SHOW: FormTesterMethodKey = 'assertDoesNotShow'
 const NOT_ASSERT_SHOW_ANY: FormTesterMethodKey = 'assertDoesNotShowAny'
 const ASSERT_VALUE: FormTesterMethodKey = 'assertValue'
+const SHOW_COUNT: FormTesterMethodKey = 'assertShowCount'
+
+export type FormTester<T> = MockForm<Required<T>> & Pick<MockWizardFormElement<any>, typeof SHOW_COUNT>
 
 function failIf(cond: boolean, message?: string): void {
     if (cond) {
@@ -55,10 +59,6 @@ function failIf(cond: boolean, message?: string): void {
 export function createFormTester<T extends Partial<T>>(form: WizardForm<T>): FormTester<T> {
     const state = {} as T
 
-    const base = Object.defineProperty({}, 'showCount', {
-        get: () => form.properties.filter(prop => canShowPrompter(prop)).length,
-    })
-
     function canShowPrompter(prop: string): boolean {
         const defaultState = form.applyDefaults(state)
 
@@ -68,7 +68,7 @@ export function createFormTester<T extends Partial<T>>(form: WizardForm<T>): For
 
         const provider = form.getPrompterProvider(prop)
 
-        return provider !== undefined && provider({} as any) !== undefined
+        return provider !== undefined // && provider({ stepCache: {} } as any) !== undefined
     }
 
     function showableChildren(parent: string): string[] {
@@ -84,8 +84,8 @@ export function createFormTester<T extends Partial<T>>(form: WizardForm<T>): For
 
         failIf(order === -1, `Property "${prop}" would not be shown`)
         failIf(
-            order !== expected + 1,
-            `Property "${prop}" would be shown in the wrong order: ${order} !== ${expected + 1}`
+            order !== expected - 1,
+            `Property "${prop}" would be shown in the wrong order: ${order + 1} !== ${expected}`
         )
     }
 
@@ -105,41 +105,56 @@ export function createFormTester<T extends Partial<T>>(form: WizardForm<T>): For
         }
     }
 
-    function createFormWrapper(path: string[] = []): FormTester<T> {
-        return new Proxy(path.length === 0 ? base : {}, {
-            get: (obj, prop, rec) => {
-                const propPath = path.join('.')
+    function assertValue<TProp>(path: string): MockWizardFormElement<TProp>['assertValue'] {
+        const actual = _.get(form.applyDefaults(state), path)
 
-                // Using a switch rather than a map since a generic index signature is not yet possible
-                switch (prop) {
-                    case APPLY_INPUT:
-                        return <TProp>(input: TProp) => _.set(state, path, input)
-                    case CLEAR_INPUT:
-                        return () => _.set(state, path, undefined)
-                    case ASSERT_SHOW:
-                        return assertShow(propPath)
-                    case ASSERT_SHOW_FIRST:
-                        return assertShow(propPath, 1)
-                    case ASSERT_SHOW_SECOND:
-                        return assertShow(propPath, 2)
-                    case ASSERT_SHOW_THIRD:
-                        return assertShow(propPath, 3)
-                    case NOT_ASSERT_SHOW:
-                        return () => failIf(form.canShowProperty(propPath, state), `Property "${prop}" would be shown`)
-                    case NOT_ASSERT_SHOW_ANY:
-                        return assertShowNone(propPath)
-                    case ASSERT_VALUE: // TODO: remove message
-                        return <TProp>(expected: TProp) =>
-                            assert.deepStrictEqual(
-                                _.get(form.applyDefaults(state), path),
-                                expected,
-                                `Property "${prop}" had unexpected value`
-                            )
-                    default:
-                        return Reflect.get(obj, prop, rec) ?? createFormWrapper([...path, prop.toString()])
-                }
-            },
-        }) as FormTester<T>
+        return (expected: TProp) =>
+            failIf(actual !== expected, `Property "${path}" had unexpected value: ${actual} !== ${expected}`)
+    }
+
+    function createFormWrapper(path: string[] = []): FormTester<T> {
+        return new Proxy(
+            {},
+            {
+                get: (obj, prop, rec) => {
+                    const propPath = path.join('.')
+
+                    // Using a switch rather than a map since a generic index signature is not yet possible
+                    switch (prop) {
+                        case APPLY_INPUT:
+                            return <TProp>(input: TProp) => _.set(state, path, input)
+                        case CLEAR_INPUT:
+                            return () => _.set(state, path, undefined)
+                        case ASSERT_SHOW:
+                            return assertShow(propPath)
+                        case ASSERT_SHOW_FIRST:
+                            return assertShow(propPath, 1)
+                        case ASSERT_SHOW_SECOND:
+                            return assertShow(propPath, 2)
+                        case ASSERT_SHOW_THIRD:
+                            return assertShow(propPath, 3)
+                        case ASSERT_SHOW_ANY:
+                            return () =>
+                                failIf(
+                                    showableChildren(propPath).length === 0,
+                                    `No properties of "${propPath}" would be shown`
+                                )
+                        case NOT_ASSERT_SHOW:
+                            return () =>
+                                failIf(form.canShowProperty(propPath, state), `Property "${propPath}" would be shown`)
+                        case NOT_ASSERT_SHOW_ANY:
+                            return assertShowNone(propPath)
+                        case ASSERT_VALUE:
+                            return assertValue(propPath)
+                        case SHOW_COUNT:
+                            return (count: number) =>
+                                assert.strictEqual(form.properties.filter(prop => canShowPrompter(prop)).length, count)
+                        default:
+                            return Reflect.get(obj, prop, rec) ?? createFormWrapper([...path, prop.toString()])
+                    }
+                },
+            }
+        ) as FormTester<T>
     }
 
     return createFormWrapper()

--- a/src/test/shared/wizards/wizardTestUtils.ts
+++ b/src/test/shared/wizards/wizardTestUtils.ts
@@ -5,8 +5,9 @@
 
 import * as _ from 'lodash'
 import * as assert from 'assert'
-import { WizardForm } from '../../../shared/wizards/wizardForm'
 import { ExpandWithObject } from '../../../shared/utilities/tsUtils'
+import { Wizard } from '../../../shared/wizards/wizard'
+import { WizardForm } from '../../../shared/wizards/wizardForm'
 
 interface MockWizardFormElement<TProp> {
     applyInput(input: TProp): void
@@ -48,7 +49,7 @@ const NOT_ASSERT_SHOW_ANY: FormTesterMethodKey = 'assertDoesNotShowAny'
 const ASSERT_VALUE: FormTesterMethodKey = 'assertValue'
 const SHOW_COUNT: FormTesterMethodKey = 'assertShowCount'
 
-export type FormTester<T> = MockForm<Required<T>> & Pick<MockWizardFormElement<any>, typeof SHOW_COUNT>
+export type WizardTester<T> = MockForm<Required<T>> & Pick<MockWizardFormElement<any>, typeof SHOW_COUNT>
 
 function failIf(cond: boolean, message?: string): void {
     if (cond) {
@@ -56,7 +57,8 @@ function failIf(cond: boolean, message?: string): void {
     }
 }
 
-export function createFormTester<T extends Partial<T>>(form: WizardForm<T>): FormTester<T> {
+export function createWizardTester<T extends Partial<T>>(wizard: Wizard<T> | WizardForm<T>): WizardTester<T> {
+    const form = wizard instanceof Wizard ? wizard.boundForm : wizard
     const state = {} as T
 
     function canShowPrompter(prop: string): boolean {
@@ -112,7 +114,7 @@ export function createFormTester<T extends Partial<T>>(form: WizardForm<T>): For
             failIf(actual !== expected, `Property "${path}" had unexpected value: ${actual} !== ${expected}`)
     }
 
-    function createFormWrapper(path: string[] = []): FormTester<T> {
+    function createFormWrapper(path: string[] = []): WizardTester<T> {
         return new Proxy(
             {},
             {
@@ -154,7 +156,7 @@ export function createFormTester<T extends Partial<T>>(form: WizardForm<T>): For
                     }
                 },
             }
-        ) as FormTester<T>
+        ) as WizardTester<T>
     }
 
     return createFormWrapper()


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

There's some extensions to the wizard framework here, mainly just adding a way to have an 'exit' prompt and functionality to estimate the # of steps that would be needed if the user goes down a certain path.

The majority of this PR is just creating a variety of different prompts and then routing them to the correct location. Due to limited time some things aren't _quite_ how I would like them. For example, many of the very simple prompts are not directly tested (like enter a port, name, etc.). 

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
