### PR TITLE
Refreshes Step Functions tree after creation

### DIFF
--- a/src/stepFunctions/commands/publishStateMachine.ts
+++ b/src/stepFunctions/commands/publishStateMachine.ts
@@ -22,6 +22,7 @@ import {
 } from '../wizards/publishStateMachineWizard'
 
 import { VALID_SFN_PUBLISH_FORMATS, YAML_FORMATS } from '../constants/aslFormats'
+import { refreshStepFunctionsTree } from '../explorer/stepFunctionsNodes'
 
 export async function publishStateMachine(awsContext: AwsContext, outputChannel: vscode.OutputChannel) {
     const logger: Logger = getLogger()
@@ -67,6 +68,7 @@ export async function publishStateMachine(awsContext: AwsContext, outputChannel:
         ).run()
         if (wizardResponse?.createResponse) {
             await createStateMachine(wizardResponse.createResponse, text, outputChannel, region, client)
+            refreshStepFunctionsTree(region)
         } else if (wizardResponse?.updateResponse) {
             await updateStateMachine(wizardResponse.updateResponse, text, outputChannel, region, client)
         }

--- a/src/stepFunctions/explorer/stepFunctionsNodes.ts
+++ b/src/stepFunctions/explorer/stepFunctionsNodes.ts
@@ -18,8 +18,19 @@ import { PlaceholderNode } from '../../shared/treeview/nodes/placeholderNode'
 import { makeChildrenNodes } from '../../shared/treeview/treeNodeUtilities'
 import { toArrayAsync, toMap, updateInPlace } from '../../shared/utilities/collectionUtils'
 import { listStateMachines } from '../../stepFunctions/utils'
+import { Commands } from '../../shared/vscode/commands'
 
 export const CONTEXT_VALUE_STATE_MACHINE = 'awsStateMachineNode'
+
+const sfnNodeMap = new Map<string, StepFunctionsNode>()
+
+export function refreshStepFunctionsTree(regionCode: string) {
+    const node = sfnNodeMap.get(regionCode)
+
+    if (node) {
+        Commands.vscode().execute('aws.refreshAwsExplorerNode', node)
+    }
+}
 
 /**
  * An AWS Explorer node representing the Step Functions Service.
@@ -31,6 +42,8 @@ export class StepFunctionsNode extends AWSTreeNodeBase {
     public constructor(private readonly regionCode: string) {
         super('Step Functions', vscode.TreeItemCollapsibleState.Collapsed)
         this.stateMachineNodes = new Map<string, StateMachineNode>()
+
+        sfnNodeMap.set(regionCode, this)
     }
 
     public async getChildren(): Promise<AWSTreeNodeBase[]> {
@@ -40,8 +53,7 @@ export class StepFunctionsNode extends AWSTreeNodeBase {
 
                 return [...this.stateMachineNodes.values()]
             },
-            getErrorNode: async (error: Error, logID: number) =>
-                new ErrorNode(this, error, logID),
+            getErrorNode: async (error: Error, logID: number) => new ErrorNode(this, error, logID),
             getNoChildrenPlaceholderNode: async () =>
                 new PlaceholderNode(
                     this,


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
#993 After creation of new state machine user needs to refresh the explorer manually to see it. 

## Solution
I store references to State Machine nodes in a regionalized map so that I can refresh them from outside of the tree structure through `refreshStepFucntionsTree` function.

After creating state machine I call `refreshStepFunctionsTree` function to refresh the state machines for given region in the AWS Explorer. 

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
