### PR TITLE
RegionNode: clear children on refresh

### DIFF
--- a/src/awsexplorer/regionNode.ts
+++ b/src/awsexplorer/regionNode.ts
@@ -19,6 +19,7 @@ import { AWSTreeNodeBase } from '../shared/treeview/nodes/awsTreeNodeBase'
 import { StepFunctionsNode } from '../stepFunctions/explorer/stepFunctionsNodes'
 import { DEFAULT_PARTITION } from '../shared/regions/regionUtilities'
 import { SsmDocumentNode } from '../ssmDocument/explorer/ssmDocumentNode'
+import { LoadMoreNode } from '../shared/treeview/nodes/loadMoreNode'
 
 /**
  * An AWS Explorer node representing a region.
@@ -71,7 +72,16 @@ export class RegionNode extends AWSTreeNodeBase {
         }
     }
 
+    private tryClearChildren(): void {
+        this.childNodes.forEach(cn => {
+            if ('clearChildren' in cn) {
+                ;(cn as AWSTreeNodeBase & LoadMoreNode).clearChildren()
+            }
+        })
+    }
+
     public async getChildren(): Promise<AWSTreeNodeBase[]> {
+        this.tryClearChildren()
         return this.childNodes
     }
 


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Refreshing the AWS Explorer will not properly refresh nodes that implement the LoadMoreNode interface. (Currently this affects ECS)
## Solution
Executing the general refresh will search for nodes with a clearChildren method and execute. Calling a refresh directly on a node will not execute the clearChildren method.
<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
