### PR TITLE
telemetry: record ECS credentials source as "ecs"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
                 "yaml-cfn": "^0.3.0"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "1.0.6",
+                "@aws-toolkits/telemetry": "1.0.9",
                 "@sinonjs/fake-timers": "^7.0.5",
                 "@types/adm-zip": "^0.4.34",
                 "@types/async-lock": "^1.1.3",
@@ -106,9 +106,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.6.tgz",
-            "integrity": "sha512-9I2TuHF5SWmEBu0oLEFWKMeh3hB8r+zH/tXq9XIlaYF+nG092q5dkO7MQQweBDhGWoHcMLGthD+e9Oyoe5zoFQ==",
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.9.tgz",
+            "integrity": "sha512-hm0k/2IFVyHgd304lbtkmiQ9Dzq2a3N5vWhGzO4tinFFzv3a90QsNB6czYfeMpbYNuxt6+KWLydAk7yFZBdpbg==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",
@@ -8379,9 +8379,9 @@
     },
     "dependencies": {
         "@aws-toolkits/telemetry": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.6.tgz",
-            "integrity": "sha512-9I2TuHF5SWmEBu0oLEFWKMeh3hB8r+zH/tXq9XIlaYF+nG092q5dkO7MQQweBDhGWoHcMLGthD+e9Oyoe5zoFQ==",
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.9.tgz",
+            "integrity": "sha512-hm0k/2IFVyHgd304lbtkmiQ9Dzq2a3N5vWhGzO4tinFFzv3a90QsNB6czYfeMpbYNuxt6+KWLydAk7yFZBdpbg==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -1906,7 +1906,7 @@
         "createRelease": "ts-node ./build-scripts/createRelease.ts"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "1.0.6",
+        "@aws-toolkits/telemetry": "1.0.9",
         "@sinonjs/fake-timers": "^7.0.5",
         "@types/adm-zip": "^0.4.34",
         "@types/async-lock": "^1.1.3",

--- a/src/credentials/providers/credentials.ts
+++ b/src/credentials/providers/credentials.ts
@@ -27,9 +27,7 @@ export interface CredentialsId {
  * @param credentials  Value to be formatted.
  */
 export function asString(credentials: CredentialsId): string {
-    return [credentials.credentialSource, credentials.credentialTypeId].join(
-        CREDENTIALS_PROVIDER_ID_SEPARATOR
-    )
+    return [credentials.credentialSource, credentials.credentialTypeId].join(CREDENTIALS_PROVIDER_ID_SEPARATOR)
 }
 
 export function fromString(credentials: string): CredentialsId {
@@ -54,7 +52,6 @@ export function isEqual(idA: CredentialsId, idB: CredentialsId): boolean {
     return idA.credentialSource === idB.credentialSource && idA.credentialTypeId === idB.credentialTypeId
 }
 
-
 /**
  * Credentials source type, broadly describes the kind of thing that supplied the credentials.
  *
@@ -69,17 +66,18 @@ export function isEqual(idA: CredentialsId, idB: CredentialsId): boolean {
  *
  * Compare the similar concept `telemetry.CredentialSourceId`.
  */
-export type CredentialsProviderType = typeof credentialsProviderType[number];
-export const credentialsProviderType = ['profile', 'ec2', 'ecs', 'env'] as const;
+export type CredentialsProviderType = typeof credentialsProviderType[number]
+export const credentialsProviderType = ['profile', 'ec2', 'ecs', 'env'] as const
 
 /**
  * Lossy map of CredentialsProviderType to telemetry.CredentialSourceId
  */
 export function credentialsProviderToTelemetryType(o: CredentialsProviderType): telemetry.CredentialSourceId {
-    switch(o) {
+    switch (o) {
         case 'ec2':
-        case 'ecs':
             return 'ec2'
+        case 'ecs':
+            return 'ecs'
         case 'env':
             return 'envVars'
         case 'profile':


### PR DESCRIPTION

## Problem

ECS IMDS credentials source is recorded as "ec2".

## Solution

Update logic to use new "ecs" credentials source defined in
https://github.com/aws/aws-toolkit-common/pull/183


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
