### PR TITLE
SAM/CFN JSON schema: use URIs instead of plain strings

### DIFF
--- a/.changes/next-release/Bug Fix-716213c0-0281-477f-b556-92631bce89a5.json
+++ b/.changes/next-release/Bug Fix-716213c0-0281-477f-b556-92631bce89a5.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "SAM/CFN: fix JSON schema path causing a symlink on some operating systems"
+}

--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -833,7 +833,11 @@ export async function updateYamlSchemasArray(
         paths?: { cfnSchema: string; samSchema: string }
     }
 ): Promise<void> {
-    if (!opts?.skipExtensionLoad && !vscode.extensions.getExtension(VSCODE_EXTENSION_ID.yaml)) {
+    if (
+        (!opts?.skipExtensionLoad && !vscode.extensions.getExtension(VSCODE_EXTENSION_ID.yaml)) ||
+        !cfnSchemaUri ||
+        !samSchemaUri
+    ) {
         return
     }
     const paths = opts?.paths ?? {

--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -776,7 +776,7 @@ const MANIFEST_URL = 'https://api.github.com/repos/awslabs/goformation/releases/
  * @param extensionContext
  */
 export async function refreshSchemas(extensionContext: vscode.ExtensionContext): Promise<void> {
-    // Cast the paths to
+    // Convert the paths to URIs which is what the YAML extension expects
     cfnSchemaUri = vscode.Uri.file(
         normalizeSeparator(path.join(extensionContext.globalStoragePath, 'cloudformation.schema.json'))
     )

--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -833,16 +833,21 @@ export async function updateYamlSchemasArray(
         paths?: { cfnSchema: string; samSchema: string }
     }
 ): Promise<void> {
+    const paths = opts?.paths ?? {
+        cfnSchema: cfnSchemaUri?.toString(),
+        samSchema: samSchemaUri?.toString(),
+    }
+
+    // URIs are not guaranteed to be loaded when this function is called.
+    // We should always return if they're undefined.
     if (
-        !opts?.skipExtensionLoad &&
-        (!vscode.extensions.getExtension(VSCODE_EXTENSION_ID.yaml) || !cfnSchemaUri || !samSchemaUri)
+        (!opts?.skipExtensionLoad && !vscode.extensions.getExtension(VSCODE_EXTENSION_ID.yaml)) ||
+        !paths.cfnSchema ||
+        !paths.samSchema
     ) {
         return
     }
-    const paths = opts?.paths ?? {
-        cfnSchema: cfnSchemaUri.toString(),
-        samSchema: samSchemaUri.toString(),
-    }
+
     const config = opts?.config ?? vscode.workspace.getConfiguration('yaml')
     const relPath = normalizeSeparator(getWorkspaceRelativePath(path) ?? path)
     const schemas: { [key: string]: string | string[] | undefined } | undefined = config.get('schemas')

--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -834,9 +834,8 @@ export async function updateYamlSchemasArray(
     }
 ): Promise<void> {
     if (
-        (!opts?.skipExtensionLoad && !vscode.extensions.getExtension(VSCODE_EXTENSION_ID.yaml)) ||
-        !cfnSchemaUri ||
-        !samSchemaUri
+        !opts?.skipExtensionLoad &&
+        (!vscode.extensions.getExtension(VSCODE_EXTENSION_ID.yaml) || !cfnSchemaUri || !samSchemaUri)
     ) {
         return
     }


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

The YAML extension expects a URI path for schemas. It appears to also handle encoding correctly. Tested locally, need to verify that this works on other OS.

ref #1932
<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
