### PR TITLE
SAM/CFN JSON schema: write downloaded schema from memory

### DIFF
--- a/.changes/next-release/Bug Fix-92436df0-2443-4376-bfbf-3ae02abbd504.json
+++ b/.changes/next-release/Bug Fix-92436df0-2443-4376-bfbf-3ae02abbd504.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "SAM/CFN JSON schema: schemas now load correctly on first-load"
+}

--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -5,7 +5,7 @@
 
 import * as path from 'path'
 import * as vscode from 'vscode'
-import { mkdirSync, writeFile } from 'fs-extra'
+import { mkdirSync, writeFile, writeFileSync } from 'fs-extra'
 import { schema } from 'yaml-cfn'
 import * as yaml from 'js-yaml'
 import * as filesystemUtilities from '../filesystemUtilities'
@@ -933,10 +933,11 @@ export async function getRemoteOrCachedFile(params: {
         fetchers.push(
             new HttpResourceFetcher(params.url, {
                 showUrl: true,
-                pipeLocation: params.filepath,
                 // updates curr version
-                onSuccess: () =>
-                    vscode.workspace.getConfiguration(extensionSettingsPrefix).update(params.cacheKey, params.version),
+                onSuccess: contents => {
+                    writeFileSync(params.filepath, contents)
+                    vscode.workspace.getConfiguration(extensionSettingsPrefix).update(params.cacheKey, params.version)
+                },
             })
         )
     }


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Whenever the schemas need to be downloaded (i.e. first-time load or an update) they are currently being written to disk with a writestream. Normally not a big deal, however, the YAML extension may try to load the partial schema, requiring a reload to fix things.

## Solution
Write to disk after retrieving the full contents in memory (only for schemas, write streams are normally a good thing)

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
