### PR TITLE
telemetry: Send the correct value for active regions

### DIFF
--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -71,8 +71,6 @@ export async function activate(args: {
         })
     )
 
-    recordVscodeActiveRegions({ value: awsExplorer.getRegionNodesSize() })
-
     args.awsContextTrees.addTree(awsExplorer)
 
     updateAwsExplorerWhenAwsContextCredentialsChange(awsExplorer, args.awsContext, ext.context)

--- a/src/credentials/loginManager.ts
+++ b/src/credentials/loginManager.ts
@@ -48,6 +48,7 @@ export class LoginManager {
             if (!accountId) {
                 throw new Error('Could not determine Account Id for credentials')
             }
+            recordVscodeActiveRegions({ value: (await this.awsContext.getExplorerRegions()).length })
 
             await this.awsContext.setCredentials({
                 credentials: storedCredentials.credentials,
@@ -55,7 +56,6 @@ export class LoginManager {
                 accountId: accountId,
                 defaultRegion: provider.getDefaultRegion(),
             })
-            recordVscodeActiveRegions({ value: (await this.awsContext.getExplorerRegions()).length })
 
             return true
         } catch (err) {

--- a/src/credentials/loginManager.ts
+++ b/src/credentials/loginManager.ts
@@ -6,7 +6,7 @@
 import { AwsContext } from '../shared/awsContext'
 import { getAccountId } from '../shared/credentials/accountId'
 import { getLogger } from '../shared/logger'
-import { recordAwsSetCredentials } from '../shared/telemetry/telemetry'
+import { recordAwsSetCredentials, recordVscodeActiveRegions } from '../shared/telemetry/telemetry'
 import { CredentialsStore } from './credentialsStore'
 import { notifyUserInvalidCredentials } from './credentialsUtilities'
 import { asString, CredentialsProvider, CredentialsId } from './providers/credentials'
@@ -55,6 +55,7 @@ export class LoginManager {
                 accountId: accountId,
                 defaultRegion: provider.getDefaultRegion(),
             })
+            recordVscodeActiveRegions({ value: (await this.awsContext.getExplorerRegions()).length })
 
             return true
         } catch (err) {


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
The `recordVscodeActiveRegions` telemetry was sending before the explorer was created during startup.  This caused the value for the metric to read 0, which was incorrect.
## Solution
Moved the telemetry call to a different step in the login process and now uses the number of regions that were stored in the globalState which does not need the explorer.
<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
