### PR TITLE
credentials: use SDK to parse credentials if not using 'source_profile'

### DIFF
--- a/src/credentials/providers/sharedCredentialsProvider.ts
+++ b/src/credentials/providers/sharedCredentialsProvider.ts
@@ -152,8 +152,9 @@ export class SharedCredentialsProvider implements CredentialsProvider {
 
     /**
      * Patches 'source_profile' credentials as static representations, which the SDK can handle in all cases.
-     * Returns undefined if no `source_profile` property exists. Otherwise we would prevent the SDK from re-reading
-     * the shared credential files if they were to change.
+     * 
+     * XXX: Returns undefined if no `source_profile` property exists. Else we would prevent the SDK from re-reading
+     * the shared credential files if they were to change. #1953
      *
      * The SDK is unable to resolve `source_profile` fields when the source profile uses SSO/MFA/credential_process.
      * We can handle this resolution ourselves, giving the SDK the resolved credentials by 'pre-loading' them.

--- a/src/credentials/providers/sharedCredentialsProvider.ts
+++ b/src/credentials/providers/sharedCredentialsProvider.ts
@@ -152,27 +152,31 @@ export class SharedCredentialsProvider implements CredentialsProvider {
 
     /**
      * Patches 'source_profile' credentials as static representations, which the SDK can handle in all cases.
+     * Returns undefined if no `source_profile` property exists. Otherwise we would prevent the SDK from re-reading
+     * the shared credential files if they were to change.
      *
      * The SDK is unable to resolve `source_profile` fields when the source profile uses SSO/MFA/credential_process.
      * We can handle this resolution ourselves, giving the SDK the resolved credentials by 'pre-loading' them.
      */
-    private async patchSourceCredentials(): Promise<ParsedIniData> {
+    private async patchSourceCredentials(): Promise<ParsedIniData | undefined> {
+        if (!hasProfileProperty(this.profile, SHARED_CREDENTIAL_PROPERTIES.SOURCE_PROFILE)) {
+            return undefined
+        }
+
         const loadedCreds: ParsedIniData = {}
 
-        if (hasProfileProperty(this.profile, SHARED_CREDENTIAL_PROPERTIES.SOURCE_PROFILE)) {
-            const source = new SharedCredentialsProvider(
-                this.profile[SHARED_CREDENTIAL_PROPERTIES.SOURCE_PROFILE]!,
-                this.allSharedCredentialProfiles
-            )
-            const creds = await source.getCredentials()
-            loadedCreds[this.profile[SHARED_CREDENTIAL_PROPERTIES.SOURCE_PROFILE]!] = {
-                [SHARED_CREDENTIAL_PROPERTIES.AWS_ACCESS_KEY_ID]: creds.accessKeyId,
-                [SHARED_CREDENTIAL_PROPERTIES.AWS_SECRET_ACCESS_KEY]: creds.secretAccessKey,
-                [SHARED_CREDENTIAL_PROPERTIES.AWS_SESSION_TOKEN]: creds.sessionToken,
-            }
-            loadedCreds[this.profileName] = {
-                [SHARED_CREDENTIAL_PROPERTIES.MFA_SERIAL]: source.profile[SHARED_CREDENTIAL_PROPERTIES.MFA_SERIAL],
-            }
+        const source = new SharedCredentialsProvider(
+            this.profile[SHARED_CREDENTIAL_PROPERTIES.SOURCE_PROFILE]!,
+            this.allSharedCredentialProfiles
+        )
+        const creds = await source.getCredentials()
+        loadedCreds[this.profile[SHARED_CREDENTIAL_PROPERTIES.SOURCE_PROFILE]!] = {
+            [SHARED_CREDENTIAL_PROPERTIES.AWS_ACCESS_KEY_ID]: creds.accessKeyId,
+            [SHARED_CREDENTIAL_PROPERTIES.AWS_SECRET_ACCESS_KEY]: creds.secretAccessKey,
+            [SHARED_CREDENTIAL_PROPERTIES.AWS_SESSION_TOKEN]: creds.sessionToken,
+        }
+        loadedCreds[this.profileName] = {
+            [SHARED_CREDENTIAL_PROPERTIES.MFA_SERIAL]: source.profile[SHARED_CREDENTIAL_PROPERTIES.MFA_SERIAL],
         }
 
         loadedCreds[this.profileName] = {
@@ -189,7 +193,7 @@ export class SharedCredentialsProvider implements CredentialsProvider {
             throw new Error(`Profile ${this.profileName} is not a valid Credential Profile: ${validationMessage}`)
         }
 
-        const loadedCreds: ParsedIniData = await this.patchSourceCredentials()
+        const loadedCreds = await this.patchSourceCredentials()
 
         //  SSO entry point
         if (this.isSsoProfile()) {
@@ -249,7 +253,7 @@ export class SharedCredentialsProvider implements CredentialsProvider {
         }
     }
 
-    private makeCredentialsProvider(loadedCreds: ParsedIniData): AWS.CredentialProvider {
+    private makeCredentialsProvider(loadedCreds?: ParsedIniData): AWS.CredentialProvider {
         const logger = getLogger()
 
         if (hasProfileProperty(this.profile, SHARED_CREDENTIAL_PROPERTIES.CREDENTIAL_SOURCE)) {
@@ -295,7 +299,7 @@ export class SharedCredentialsProvider implements CredentialsProvider {
         throw new Error(`Shared Credentials profile ${this.profileName} is not supported`)
     }
 
-    private makeSharedIniFileCredentialsProvider(loadedCreds: ParsedIniData): AWS.CredentialProvider {
+    private makeSharedIniFileCredentialsProvider(loadedCreds?: ParsedIniData): AWS.CredentialProvider {
         const assumeRole = async (credentials: AWS.Credentials, params: AssumeRoleParams) => {
             const region = this.getDefaultRegion() ?? 'us-east-1'
             const stsClient = ext.toolkitClientBuilder.createStsClient(region, { credentials })
@@ -312,10 +316,12 @@ export class SharedCredentialsProvider implements CredentialsProvider {
             profile: this.profileName,
             mfaCodeProvider: async mfaSerial => await getMfaTokenFromUser(mfaSerial, this.profileName),
             roleAssumer: assumeRole,
-            loadedConfig: Promise.resolve({
-                credentialsFile: loadedCreds,
-                configFile: {},
-            } as SharedConfigFiles),
+            loadedConfig: loadedCreds
+                ? Promise.resolve({
+                      credentialsFile: loadedCreds,
+                      configFile: {},
+                  } as SharedConfigFiles)
+                : undefined,
         })
     }
 


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Migrating to SDK v3 introduced a regression where credentials were not updated as the credentials file changed. This was because the new 'patching' logic assumed the profile data within the provider was accurate (it was not).

We should look towards some simple integration tests for credentials. This would also allow 'safer' updates to the system in the future.

## Solution
Let the SDK parse the file when `source_profile` is not being used, exerting the original behavior.

Note that the original behavior is likely an 'accident' and highly unintuitive. The provider class contains information about the shared-ini files that is no longer in-sync with what the SDK will read. But since it does have the desired effect I suppose it falls into 'it's not a bug, it's a feature'

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
