### PR TITLE
telemetry: use 'validate credentials' instead of 'set' to capture more information

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
                 "yaml-cfn": "^0.3.0"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "1.0.9",
+                "@aws-toolkits/telemetry": "1.0.11",
                 "@sinonjs/fake-timers": "^7.0.5",
                 "@types/adm-zip": "^0.4.34",
                 "@types/async-lock": "^1.1.3",
@@ -977,9 +977,9 @@
             "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.9.tgz",
-            "integrity": "sha512-hm0k/2IFVyHgd304lbtkmiQ9Dzq2a3N5vWhGzO4tinFFzv3a90QsNB6czYfeMpbYNuxt6+KWLydAk7yFZBdpbg==",
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.11.tgz",
+            "integrity": "sha512-kZV3r1aQEskCDuNkB60YXhXwUIqkzidHF9l4bl/2NMDlzmXYUjUnVZj3MUSSVoKUEDc30QyP0VRHXT9o2Oc63g==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",
@@ -10197,9 +10197,9 @@
             }
         },
         "@aws-toolkits/telemetry": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.9.tgz",
-            "integrity": "sha512-hm0k/2IFVyHgd304lbtkmiQ9Dzq2a3N5vWhGzO4tinFFzv3a90QsNB6czYfeMpbYNuxt6+KWLydAk7yFZBdpbg==",
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.11.tgz",
+            "integrity": "sha512-kZV3r1aQEskCDuNkB60YXhXwUIqkzidHF9l4bl/2NMDlzmXYUjUnVZj3MUSSVoKUEDc30QyP0VRHXT9o2Oc63g==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -2058,7 +2058,7 @@
         "createRelease": "ts-node ./build-scripts/createRelease.ts"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "1.0.9",
+        "@aws-toolkits/telemetry": "1.0.11",
         "@sinonjs/fake-timers": "^7.0.5",
         "@types/adm-zip": "^0.4.34",
         "@types/async-lock": "^1.1.3",

--- a/src/test/shared/credentials/loginManager.test.ts
+++ b/src/test/shared/credentials/loginManager.test.ts
@@ -21,6 +21,7 @@ describe('LoginManager', async function () {
         setCredentials: () => {
             throw new Error('This test was not initialized')
         },
+        getExplorerRegions: () => [],
     } as any as AwsContext
     const sampleCredentials = {} as any as AWS.Credentials
     const sampleCredentialsId: CredentialsId = {

--- a/src/test/shared/credentials/loginManager.test.ts
+++ b/src/test/shared/credentials/loginManager.test.ts
@@ -12,6 +12,7 @@ import { CredentialsProviderManager } from '../../../credentials/providers/crede
 import { AwsContext } from '../../../shared/awsContext'
 import * as accountId from '../../../shared/credentials/accountId'
 import { CredentialsStore } from '../../../credentials/credentialsStore'
+import { recordAwsValidateCredentials } from '../../../shared/telemetry/telemetry.gen'
 
 describe('LoginManager', async function () {
     let sandbox: sinon.SinonSandbox
@@ -26,6 +27,8 @@ describe('LoginManager', async function () {
         credentialSource: 'profile',
         credentialTypeId: 'someId',
     }
+    const credentialType = 'staticProfile'
+    const credentialSourceId = 'sharedCredentials'
 
     const credentialsStore = new CredentialsStore()
 
@@ -33,13 +36,13 @@ describe('LoginManager', async function () {
     let credentialsProvider: CredentialsProvider
     let getAccountIdStub: sinon.SinonStub<[AWS.Credentials, string], Promise<string | undefined>>
     let getCredentialsProviderStub: sinon.SinonStub<[CredentialsId], Promise<CredentialsProvider | undefined>>
-    let recordAwsSetCredentialsSpy: any
+    let recordAwsValidateCredentialsSpy: sinon.SinonSpy<Parameters<typeof recordAwsValidateCredentials>, any>
 
     beforeEach(async function () {
         sandbox = sinon.createSandbox()
-        recordAwsSetCredentialsSpy = sandbox.spy()
+        recordAwsValidateCredentialsSpy = sandbox.spy(recordAwsValidateCredentials)
 
-        loginManager = new LoginManager(awsContext, credentialsStore, recordAwsSetCredentialsSpy)
+        loginManager = new LoginManager(awsContext, credentialsStore, recordAwsValidateCredentialsSpy)
         credentialsProvider = {
             getCredentials: sandbox.stub().resolves(sampleCredentials),
             getProviderType: sandbox.stub().returns('profile'),
@@ -61,64 +64,49 @@ describe('LoginManager', async function () {
         sandbox.restore()
     })
 
+    function assertTelemetry(expected: Parameters<typeof recordAwsValidateCredentials>[0]): void {
+        assert.deepStrictEqual(recordAwsValidateCredentialsSpy.args[0][0], expected)
+    }
+
     it('passive login sends telemetry with passive=true', async function () {
+        const passive = true
         const setCredentialsStub = sandbox.stub(awsContext, 'setCredentials')
-        await loginManager.login({ passive: true, providerId: sampleCredentialsId })
+        await loginManager.login({ passive, providerId: sampleCredentialsId })
 
         assert.strictEqual(setCredentialsStub.callCount, 1)
-        assert.strictEqual(
-            recordAwsSetCredentialsSpy.calledOnceWith({
-                credentialType: 'staticProfile',
-                passive: true,
-            }),
-            true
-        )
+        assertTelemetry({ result: 'Succeeded', passive, credentialType, credentialSourceId })
     })
 
     it('non-passive login sends telemetry', async function () {
+        const passive = false
         const setCredentialsStub = sandbox.stub(awsContext, 'setCredentials')
-        await loginManager.login({ passive: false, providerId: sampleCredentialsId })
+        await loginManager.login({ passive, providerId: sampleCredentialsId })
 
         assert.strictEqual(setCredentialsStub.callCount, 1)
-        assert.strictEqual(
-            recordAwsSetCredentialsSpy.calledOnceWith({
-                credentialType: 'staticProfile',
-                passive: false,
-            }),
-            true
-        )
+        assertTelemetry({ result: 'Succeeded', passive, credentialType, credentialSourceId })
     })
 
     it('logs in with credentials (happy path)', async function () {
+        const passive = false
         const setCredentialsStub = sandbox.stub(awsContext, 'setCredentials')
 
-        await loginManager.login({ passive: false, providerId: sampleCredentialsId })
+        await loginManager.login({ passive, providerId: sampleCredentialsId })
         assert.strictEqual(setCredentialsStub.callCount, 1, 'Expected awsContext setCredentials to be called once')
-        assert.strictEqual(
-            recordAwsSetCredentialsSpy.calledOnceWith({
-                credentialType: 'staticProfile',
-                passive: false,
-            }),
-            true
-        )
+        assertTelemetry({ result: 'Succeeded', passive, credentialType, credentialSourceId })
     })
 
     it('logs out (happy path)', async function () {
+        const passive = false
         const setCredentialsStub = sandbox.stub(awsContext, 'setCredentials')
 
-        await loginManager.login({ passive: false, providerId: sampleCredentialsId })
+        await loginManager.login({ passive, providerId: sampleCredentialsId })
         await loginManager.logout()
         assert.strictEqual(setCredentialsStub.callCount, 2, 'Expected awsContext setCredentials to be called twice')
-        assert.strictEqual(
-            recordAwsSetCredentialsSpy.calledOnceWith({
-                credentialType: 'staticProfile',
-                passive: false,
-            }),
-            true
-        )
+        assertTelemetry({ result: 'Succeeded', passive, credentialType, credentialSourceId })
     })
 
     it('logs out if credentials could not be retrieved', async function () {
+        const passive = true
         getCredentialsProviderStub.reset()
         getCredentialsProviderStub.resolves(undefined)
         const setCredentialsStub = sandbox.stub(awsContext, 'setCredentials').callsFake(async credentials => {
@@ -126,18 +114,13 @@ describe('LoginManager', async function () {
             assert.strictEqual(credentials, undefined)
         })
 
-        await loginManager.login({ passive: true, providerId: sampleCredentialsId })
+        await loginManager.login({ passive, providerId: sampleCredentialsId })
         assert.strictEqual(setCredentialsStub.callCount, 1, 'Expected awsContext setCredentials to be called once')
-        assert.strictEqual(
-            recordAwsSetCredentialsSpy.calledOnceWith({
-                credentialType: undefined,
-                passive: true,
-            }),
-            true
-        )
+        assertTelemetry({ result: 'Failed', passive, credentialType: undefined, credentialSourceId: undefined })
     })
 
     it('logs out if an account Id could not be determined', async function () {
+        const passive = false
         getAccountIdStub.reset()
         getAccountIdStub.resolves(undefined)
         const setCredentialsStub = sandbox.stub(awsContext, 'setCredentials').callsFake(async credentials => {
@@ -145,18 +128,13 @@ describe('LoginManager', async function () {
             assert.strictEqual(credentials, undefined)
         })
 
-        await loginManager.login({ passive: false, providerId: sampleCredentialsId })
+        await loginManager.login({ passive, providerId: sampleCredentialsId })
         assert.strictEqual(setCredentialsStub.callCount, 1, 'Expected awsContext setCredentials to be called once')
-        assert.strictEqual(
-            recordAwsSetCredentialsSpy.calledOnceWith({
-                credentialType: 'staticProfile',
-                passive: false,
-            }),
-            true
-        )
+        assertTelemetry({ result: 'Failed', passive, credentialType, credentialSourceId })
     })
 
     it('logs out if getting an account Id throws an Error', async function () {
+        const passive = false
         getAccountIdStub.reset()
         getAccountIdStub.throws('Simulating getAccountId throwing an Error')
         const setCredentialsStub = sandbox.stub(awsContext, 'setCredentials').callsFake(async credentials => {
@@ -164,14 +142,8 @@ describe('LoginManager', async function () {
             assert.strictEqual(credentials, undefined)
         })
 
-        await loginManager.login({ passive: false, providerId: sampleCredentialsId })
+        await loginManager.login({ passive, providerId: sampleCredentialsId })
         assert.strictEqual(setCredentialsStub.callCount, 1, 'Expected awsContext setCredentials to be called once')
-        assert.strictEqual(
-            recordAwsSetCredentialsSpy.calledOnceWith({
-                credentialType: 'staticProfile',
-                passive: false,
-            }),
-            true
-        )
+        assertTelemetry({ result: 'Failed', passive, credentialType, credentialSourceId })
     })
 })


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

'set credentials' isn't a very useful metric and also does not belong in the login manager file. The `login` method is doing a bunch of validating and throws when it fails. So having the metric refer to 'validation' makes more sense.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
