### PR TITLE
Adds render of SFN State Machine from AWS Explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1033,9 +1033,14 @@
                     "group": "0@1"
                 },
                 {
-                    "command": "aws.executeStateMachine",
+                    "command": "aws.renderStateMachineGraph",
                     "when": "view == aws.explorer && viewItem == awsStateMachineNode && !isCloud9",
                     "group": "0@2"
+                },
+                {
+                    "command": "aws.executeStateMachine",
+                    "when": "view == aws.explorer && viewItem == awsStateMachineNode && !isCloud9",
+                    "group": "0@3"
                 },
                 {
                     "command": "aws.s3.createBucket",
@@ -1542,6 +1547,16 @@
             {
                 "command": "aws.executeStateMachine",
                 "title": "%AWS.command.executeStateMachine%",
+                "category": "%AWS.title%",
+                "cloud9": {
+                    "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
+            },
+            {
+                "command": "aws.renderStateMachineGraph",
+                "title": "%AWS.command.renderStateMachineGraph%",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -171,6 +171,7 @@
     "AWS.command.viewSchemaItem": "View Schema",
     "AWS.command.searchSchema": "Search Schemas",
     "AWS.command.executeStateMachine": "Start Execution...",
+    "AWS.command.renderStateMachineGraph": "Render graph",
     "AWS.command.copyArn": "Copy ARN",
     "AWS.command.copyName": "Copy Name",
     "AWS.command.downloadStateMachineDefinition": "Download Definition...",

--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -165,6 +165,18 @@ async function registerAwsExplorerCommands(
     )
 
     context.subscriptions.push(
+        vscode.commands.registerCommand(
+            'aws.renderStateMachineGraph',
+            async (node: StateMachineNode) =>
+                await downloadStateMachineDefinition({
+                    stateMachineNode: node,
+                    outputChannel: toolkitOutputChannel,
+                    isDownloadAndRender: true,
+                })
+        )
+    )
+
+    context.subscriptions.push(
         vscode.commands.registerCommand('aws.copyArn', async (node: AWSResourceNode) => await copyArnCommand(node))
     )
 

--- a/src/stepFunctions/activation.ts
+++ b/src/stepFunctions/activation.ts
@@ -40,11 +40,11 @@ async function registerStepFunctionCommands(
     const visualizationManager = new AslVisualizationManager(extensionContext)
 
     extensionContext.subscriptions.push(
-        vscode.commands.registerCommand('aws.previewStateMachine', async () => {
+        vscode.commands.registerCommand('aws.previewStateMachine', async (textEditor?: vscode.TextEditor) => {
             try {
                 return await visualizationManager.visualizeStateMachine(
                     extensionContext.globalState,
-                    vscode.window.activeTextEditor
+                    textEditor || vscode.window.activeTextEditor
                 )
             } finally {
                 telemetry.recordStepfunctionsPreviewstatemachine()

--- a/src/stepFunctions/commands/downloadStateMachineDefinition.ts
+++ b/src/stepFunctions/commands/downloadStateMachineDefinition.ts
@@ -19,6 +19,7 @@ import { StateMachineNode } from '../explorer/stepFunctionsNodes'
 export async function downloadStateMachineDefinition(params: {
     outputChannel: vscode.OutputChannel
     stateMachineNode: StateMachineNode
+    isDownloadAndRender?: boolean
 }) {
     const logger: Logger = getLogger()
     let downloadResult: Result = 'Succeeded'
@@ -31,15 +32,25 @@ export async function downloadStateMachineDefinition(params: {
             params.stateMachineNode.details.stateMachineArn
         )
 
-        const wsPath = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.fsPath : '/'
-        let filePath = path.join(wsPath, params.stateMachineNode.details.name + '.asl.json')
-        const fileInfo = await vscode.window.showSaveDialog({ defaultUri: vscode.Uri.file(filePath) })
-        if (fileInfo) {
-            filePath = fileInfo.fsPath
-            fs.writeFileSync(filePath, stateMachineDetails.definition, 'utf8')
-            const openPath = vscode.Uri.file(filePath)
-            const doc = await vscode.workspace.openTextDocument(openPath)
-            vscode.window.showTextDocument(doc)
+        if (params.isDownloadAndRender) {
+            const doc = await vscode.workspace.openTextDocument({
+                language: 'asl',
+                content: stateMachineDetails.definition,
+            })
+
+            const textEditor = await vscode.window.showTextDocument(doc)
+            await vscode.commands.executeCommand('aws.previewStateMachine', textEditor)
+        } else {
+            const wsPath = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.fsPath : '/'
+            let filePath = path.join(wsPath, params.stateMachineNode.details.name + '.asl.json')
+            const fileInfo = await vscode.window.showSaveDialog({ defaultUri: vscode.Uri.file(filePath) })
+            if (fileInfo) {
+                filePath = fileInfo.fsPath
+                fs.writeFileSync(filePath, stateMachineDetails.definition, 'utf8')
+                const openPath = vscode.Uri.file(filePath)
+                const doc = await vscode.workspace.openTextDocument(openPath)
+                vscode.window.showTextDocument(doc)
+            }
         }
     } catch (err) {
         const error = err as Error


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Ability to render Step Functions form AWS Explorer



## Solution
I added "Render graph" option to state machine menu in AWS Explorer. On clicking it state machine as an "unsaved" text document will be showed alongside with a graph rendering of it, will be shown. 

<img width="1425" alt="Screen Shot 2021-08-18 at 10 34 31 AM" src="https://user-images.githubusercontent.com/6964729/129945322-d61e8c82-f749-49a3-9c8e-d6b8163ad7b6.png">

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
