### PR TITLE
SAM: skip '--env-vars' option when no environment variables are present

### DIFF
--- a/.changes/next-release/Bug Fix-2d168a17-4543-410f-95d4-7f8d6f935342.json
+++ b/.changes/next-release/Bug Fix-2d168a17-4543-410f-95d4-7f8d6f935342.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "SAM: the Toolkit now correctly skips sending '--env-vars' when no environment variables are present in the launch config"
+}

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -246,13 +246,13 @@ export class SamCliLocalInvokeInvocation {
             this.args.templatePath,
         ]
 
+        pushIf(invokeArgs, this.args.eventPath !== NO_FILE, '--event', this.args.eventPath)
         pushIf(
             invokeArgs,
             this.args.environmentVariablePath !== NO_FILE,
             '--env-vars',
             this.args.environmentVariablePath
         )
-        pushIf(invokeArgs, this.args.eventPath !== NO_FILE, '--env-vars', this.args.eventPath)
         pushIf(invokeArgs, !!this.args.debugPort, '-d', this.args.debugPort!)
         pushIf(invokeArgs, !!this.args.dockerNetwork, '--docker-network', this.args.dockerNetwork!)
         pushIf(invokeArgs, !!this.args.skipPullImage, '--skip-pull-image')

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -14,6 +14,7 @@ import { removeAnsi } from '../../utilities/textUtilities'
 import { ext } from '../../extensionGlobals'
 import { DefaultSamCliProcessInvokerContext, SamCliProcessInvokerContext } from './samCliProcessInvokerContext'
 import * as vscode from 'vscode'
+import { NO_FILE } from '../debugger/awsSamDebugger'
 
 const localize = nls.loadMessageBundle()
 
@@ -166,7 +167,7 @@ export interface SamCliLocalInvokeInvocationArguments {
     /**
      * Location of the file containing the environment variables to invoke the Lambda Function against.
      */
-    environmentVariablePath?: string
+    environmentVariablePath: string
     /**
      * Environment variables set when invoking the SAM process (NOT passed to the Lambda).
      */
@@ -243,11 +244,15 @@ export class SamCliLocalInvokeInvocation {
             this.args.templateResourceName,
             '--template',
             this.args.templatePath,
-            '--event',
-            this.args.eventPath,
         ]
 
-        pushIf(invokeArgs, !!this.args.environmentVariablePath, '--env-vars', this.args.environmentVariablePath!)
+        pushIf(
+            invokeArgs,
+            this.args.environmentVariablePath !== NO_FILE,
+            '--env-vars',
+            this.args.environmentVariablePath
+        )
+        pushIf(invokeArgs, this.args.eventPath !== NO_FILE, '--env-vars', this.args.eventPath)
         pushIf(invokeArgs, !!this.args.debugPort, '-d', this.args.debugPort!)
         pushIf(invokeArgs, !!this.args.dockerNetwork, '--docker-network', this.args.dockerNetwork!)
         pushIf(invokeArgs, !!this.args.skipPullImage, '--skip-pull-image')

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -166,7 +166,7 @@ export interface SamCliLocalInvokeInvocationArguments {
     /**
      * Location of the file containing the environment variables to invoke the Lambda Function against.
      */
-    environmentVariablePath: string
+    environmentVariablePath?: string
     /**
      * Environment variables set when invoking the SAM process (NOT passed to the Lambda).
      */
@@ -245,10 +245,9 @@ export class SamCliLocalInvokeInvocation {
             this.args.templatePath,
             '--event',
             this.args.eventPath,
-            '--env-vars',
-            this.args.environmentVariablePath,
         ]
 
+        pushIf(invokeArgs, !!this.args.environmentVariablePath, '--env-vars', this.args.environmentVariablePath!)
         pushIf(invokeArgs, !!this.args.debugPort, '-d', this.args.debugPort!)
         pushIf(invokeArgs, !!this.args.dockerNetwork, '--docker-network', this.args.dockerNetwork!)
         pushIf(invokeArgs, !!this.args.skipPullImage, '--skip-pull-image')

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -292,7 +292,7 @@ export class SamCliLocalInvokeInvocation {
             throw new Error(`template path does not exist: ${this.args.templatePath}`)
         }
 
-        if (!(await fileExists(this.args.eventPath))) {
+        if (this.args.eventPath !== NO_FILE && !(await fileExists(this.args.eventPath))) {
             throw new Error(`event path does not exist: ${this.args.eventPath}`)
         }
     }

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -14,7 +14,6 @@ import { removeAnsi } from '../../utilities/textUtilities'
 import { ext } from '../../extensionGlobals'
 import { DefaultSamCliProcessInvokerContext, SamCliProcessInvokerContext } from './samCliProcessInvokerContext'
 import * as vscode from 'vscode'
-import { NO_FILE } from '../debugger/awsSamDebugConfiguration'
 
 const localize = nls.loadMessageBundle()
 
@@ -163,11 +162,11 @@ export interface SamCliLocalInvokeInvocationArguments {
     /**
      * Location of the file containing the Lambda Function event payload.
      */
-    eventPath: string
+    eventPath?: string
     /**
      * Location of the file containing the environment variables to invoke the Lambda Function against.
      */
-    environmentVariablePath: string
+    environmentVariablePath?: string
     /**
      * Environment variables set when invoking the SAM process (NOT passed to the Lambda).
      */
@@ -246,13 +245,8 @@ export class SamCliLocalInvokeInvocation {
             this.args.templatePath,
         ]
 
-        pushIf(invokeArgs, this.args.eventPath !== NO_FILE, '--event', this.args.eventPath)
-        pushIf(
-            invokeArgs,
-            this.args.environmentVariablePath !== NO_FILE,
-            '--env-vars',
-            this.args.environmentVariablePath
-        )
+        pushIf(invokeArgs, !!this.args.eventPath, '--event', this.args.eventPath)
+        pushIf(invokeArgs, !!this.args.environmentVariablePath, '--env-vars', this.args.environmentVariablePath)
         pushIf(invokeArgs, !!this.args.debugPort, '-d', this.args.debugPort!)
         pushIf(invokeArgs, !!this.args.dockerNetwork, '--docker-network', this.args.dockerNetwork!)
         pushIf(invokeArgs, !!this.args.skipPullImage, '--skip-pull-image')
@@ -292,7 +286,7 @@ export class SamCliLocalInvokeInvocation {
             throw new Error(`template path does not exist: ${this.args.templatePath}`)
         }
 
-        if (this.args.eventPath !== NO_FILE && !(await fileExists(this.args.eventPath))) {
+        if (this.args.eventPath !== undefined && !(await fileExists(this.args.eventPath))) {
             throw new Error(`event path does not exist: ${this.args.eventPath}`)
         }
     }

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -14,7 +14,7 @@ import { removeAnsi } from '../../utilities/textUtilities'
 import { ext } from '../../extensionGlobals'
 import { DefaultSamCliProcessInvokerContext, SamCliProcessInvokerContext } from './samCliProcessInvokerContext'
 import * as vscode from 'vscode'
-import { NO_FILE } from '../debugger/awsSamDebugger'
+import { NO_FILE } from '../debugger/awsSamDebugConfiguration'
 
 const localize = nls.loadMessageBundle()
 

--- a/src/shared/sam/cli/samCliStartApi.ts
+++ b/src/shared/sam/cli/samCliStartApi.ts
@@ -6,7 +6,7 @@
 import { fileExists } from '../../filesystemUtilities'
 import { getLogger } from '../../logger'
 import { pushIf } from '../../utilities/collectionUtils'
-import { NO_FILE } from '../debugger/awsSamDebugger'
+import { NO_FILE } from '../debugger/awsSamDebugConfiguration'
 
 export interface SamCliStartApiArguments {
     /**

--- a/src/shared/sam/cli/samCliStartApi.ts
+++ b/src/shared/sam/cli/samCliStartApi.ts
@@ -15,7 +15,7 @@ export interface SamCliStartApiArguments {
     /**
      * Location of the file containing the environment variables to invoke the Lambda Function against.
      */
-    environmentVariablePath: string
+    environmentVariablePath?: string
     /**
      * Environment variables set when invoking the SAM process (NOT passed to the Lambda).
      */
@@ -71,10 +71,9 @@ export async function buildSamCliStartApiArguments(args: SamCliStartApiArguments
         ...(getLogger().logLevelEnabled('debug') ? ['--debug'] : []),
         '--template',
         args.templatePath,
-        '--env-vars',
-        args.environmentVariablePath,
     ]
 
+    pushIf(invokeArgs, !!args.environmentVariablePath, '--env-vars', args.environmentVariablePath!)
     pushIf(invokeArgs, !!args.port, '--port', args.port!)
     pushIf(invokeArgs, !!args.debugPort, '--debug-port', args.debugPort!)
     pushIf(invokeArgs, !!args.dockerNetwork, '--docker-network', args.dockerNetwork!)

--- a/src/shared/sam/cli/samCliStartApi.ts
+++ b/src/shared/sam/cli/samCliStartApi.ts
@@ -6,6 +6,7 @@
 import { fileExists } from '../../filesystemUtilities'
 import { getLogger } from '../../logger'
 import { pushIf } from '../../utilities/collectionUtils'
+import { NO_FILE } from '../debugger/awsSamDebugger'
 
 export interface SamCliStartApiArguments {
     /**
@@ -15,7 +16,7 @@ export interface SamCliStartApiArguments {
     /**
      * Location of the file containing the environment variables to invoke the Lambda Function against.
      */
-    environmentVariablePath?: string
+    environmentVariablePath: string
     /**
      * Environment variables set when invoking the SAM process (NOT passed to the Lambda).
      */
@@ -73,7 +74,7 @@ export async function buildSamCliStartApiArguments(args: SamCliStartApiArguments
         args.templatePath,
     ]
 
-    pushIf(invokeArgs, !!args.environmentVariablePath, '--env-vars', args.environmentVariablePath!)
+    pushIf(invokeArgs, args.environmentVariablePath !== NO_FILE, '--env-vars', args.environmentVariablePath)
     pushIf(invokeArgs, !!args.port, '--port', args.port!)
     pushIf(invokeArgs, !!args.debugPort, '--debug-port', args.debugPort!)
     pushIf(invokeArgs, !!args.dockerNetwork, '--docker-network', args.dockerNetwork!)

--- a/src/shared/sam/cli/samCliStartApi.ts
+++ b/src/shared/sam/cli/samCliStartApi.ts
@@ -6,7 +6,6 @@
 import { fileExists } from '../../filesystemUtilities'
 import { getLogger } from '../../logger'
 import { pushIf } from '../../utilities/collectionUtils'
-import { NO_FILE } from '../debugger/awsSamDebugConfiguration'
 
 export interface SamCliStartApiArguments {
     /**
@@ -16,7 +15,7 @@ export interface SamCliStartApiArguments {
     /**
      * Location of the file containing the environment variables to invoke the Lambda Function against.
      */
-    environmentVariablePath: string
+    environmentVariablePath?: string
     /**
      * Environment variables set when invoking the SAM process (NOT passed to the Lambda).
      */
@@ -74,7 +73,7 @@ export async function buildSamCliStartApiArguments(args: SamCliStartApiArguments
         args.templatePath,
     ]
 
-    pushIf(invokeArgs, args.environmentVariablePath !== NO_FILE, '--env-vars', args.environmentVariablePath)
+    pushIf(invokeArgs, !!args.environmentVariablePath, '--env-vars', args.environmentVariablePath)
     pushIf(invokeArgs, !!args.port, '--port', args.port!)
     pushIf(invokeArgs, !!args.debugPort, '--debug-port', args.debugPort!)
     pushIf(invokeArgs, !!args.dockerNetwork, '--docker-network', args.dockerNetwork!)

--- a/src/shared/sam/debugger/awsSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfiguration.ts
@@ -21,10 +21,15 @@ export * from './awsSamDebugConfiguration.gen'
 export const AWS_SAM_DEBUG_TYPE = 'aws-sam'
 export const DIRECT_INVOKE_TYPE = 'direct-invoke'
 export const TEMPLATE_TARGET_TYPE = 'template' as const
-export const CODE_TARGET_TYPE = 'code' as const 
+export const CODE_TARGET_TYPE = 'code' as const
 export const API_TARGET_TYPE = 'api' as const
 export const AWS_SAM_DEBUG_REQUEST_TYPES = [DIRECT_INVOKE_TYPE]
 export const AWS_SAM_DEBUG_TARGET_TYPES = [TEMPLATE_TARGET_TYPE, CODE_TARGET_TYPE, API_TARGET_TYPE]
+/**
+ * Used to denote that no file exists for any options that expect a file path
+ * TODO: remove this and do it correctly by using undefined
+ */
+export const NO_FILE = 'NO_FILE' as const
 export type AwsSamTargetType = 'api' | 'code' | 'template'
 
 export type TargetProperties = AwsSamDebuggerConfiguration['invokeTarget']

--- a/src/shared/sam/debugger/awsSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfiguration.ts
@@ -25,11 +25,7 @@ export const CODE_TARGET_TYPE = 'code' as const
 export const API_TARGET_TYPE = 'api' as const
 export const AWS_SAM_DEBUG_REQUEST_TYPES = [DIRECT_INVOKE_TYPE]
 export const AWS_SAM_DEBUG_TARGET_TYPES = [TEMPLATE_TARGET_TYPE, CODE_TARGET_TYPE, API_TARGET_TYPE]
-/**
- * Used to denote that no file exists for any options that expect a file path
- * TODO: remove this and do it correctly by using undefined
- */
-export const NO_FILE = 'NO_FILE' as const
+
 export type AwsSamTargetType = 'api' | 'code' | 'template'
 
 export type TargetProperties = AwsSamDebuggerConfiguration['invokeTarget']

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -114,7 +114,7 @@ export interface SamLaunchRequestArgs extends AwsSamDebuggerConfiguration {
      *
      * The file contains the event payload JSON to be consumed by SAM.
      */
-    eventPayloadFile: string
+    eventPayloadFile?: string
 
     /**
      * Path to the (generated) `env-vars.json` file placed in `baseBuildDir` for SAM to discover.
@@ -122,7 +122,7 @@ export interface SamLaunchRequestArgs extends AwsSamDebuggerConfiguration {
      * The file contains a JSON map of environment variables to be consumed by
      * SAM, resolved from `template.yaml` and/or `lambda.environmentVariables`.
      */
-    envFile: string
+    envFile?: string
 
     //
     // Debug properties (when user runs with debugging enabled).

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -65,6 +65,12 @@ import { getIdeProperties, isCloud9 } from '../../extensionUtilities'
 const localize = nls.loadMessageBundle()
 
 /**
+ * Used to denote that no file exists for any options that expect a file path
+ * TODO: remove this and do it correctly by using undefined
+ */
+export const NO_FILE = 'NO_FILE' as const
+
+/**
  * SAM-specific launch attributes (which are not part of the DAP).
  *
  * Schema for these attributes lives in package.json
@@ -122,7 +128,7 @@ export interface SamLaunchRequestArgs extends AwsSamDebuggerConfiguration {
      * The file contains a JSON map of environment variables to be consumed by
      * SAM, resolved from `template.yaml` and/or `lambda.environmentVariables`.
      */
-    envFile?: string
+    envFile: string
 
     //
     // Debug properties (when user runs with debugging enabled).

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -65,12 +65,6 @@ import { getIdeProperties, isCloud9 } from '../../extensionUtilities'
 const localize = nls.loadMessageBundle()
 
 /**
- * Used to denote that no file exists for any options that expect a file path
- * TODO: remove this and do it correctly by using undefined
- */
-export const NO_FILE = 'NO_FILE' as const
-
-/**
  * SAM-specific launch attributes (which are not part of the DAP).
  *
  * Schema for these attributes lives in package.json

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -122,7 +122,7 @@ export interface SamLaunchRequestArgs extends AwsSamDebuggerConfiguration {
      * The file contains a JSON map of environment variables to be consumed by
      * SAM, resolved from `template.yaml` and/or `lambda.environmentVariables`.
      */
-    envFile: string
+    envFile?: string
 
     //
     // Debug properties (when user runs with debugging enabled).

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -411,6 +411,8 @@ export async function runLambdaFunction(
         // eslint-disable-next-line @typescript-eslint/unbound-method
         config.onWillAttachDebugger = undefined
         config.samLocalInvokeCommand = undefined
+        // Some extensions will attempt to read the envFile path, which we don't want
+        delete (config as any).envFile
 
         await attachDebugger({
             debugConfig: config,

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -35,7 +35,6 @@ import { DefaultSamCliLocationProvider } from './cli/samCliLocator'
 import { getSamCliContext, getSamCliVersion } from './cli/samCliContext'
 import { CloudFormation } from '../cloudformation/cloudformation'
 import { getIdeProperties } from '../extensionUtilities'
-import { NO_FILE } from './debugger/awsSamDebugConfiguration'
 
 const localize = nls.loadMessageBundle()
 
@@ -389,7 +388,7 @@ export async function runLambdaFunction(
     if (!config.noDebug) {
         if (config.invokeTarget.target === 'api') {
             const payload =
-                config.eventPayloadFile === NO_FILE
+                config.eventPayloadFile === undefined
                     ? {}
                     : JSON.parse(await readFile(config.eventPayloadFile, { encoding: 'utf-8' }))
             // Send the request to the local API server.
@@ -411,8 +410,6 @@ export async function runLambdaFunction(
         // eslint-disable-next-line @typescript-eslint/unbound-method
         config.onWillAttachDebugger = undefined
         config.samLocalInvokeCommand = undefined
-        // Some extensions will attempt to read the envFile path, which we don't want
-        delete (config as any).envFile
 
         await attachDebugger({
             debugConfig: config,
@@ -691,8 +688,8 @@ async function showDebugConsole(): Promise<void> {
  * @param config
  */
 export async function makeJsonFiles(config: SamLaunchRequestArgs): Promise<void> {
-    config.eventPayloadFile = NO_FILE
-    config.envFile = NO_FILE
+    config.eventPayloadFile = undefined
+    config.envFile = undefined
 
     // env-vars.json (NB: effectively ignored for the `target=code` case).
     const configEnv = config.lambda?.environmentVariables ?? {}

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -21,7 +21,7 @@ import { Timeout } from '../utilities/timeoutUtils'
 import { tryGetAbsolutePath } from '../utilities/workspaceUtils'
 import { SamCliBuildInvocation, SamCliBuildInvocationArguments } from './cli/samCliBuild'
 import { SamCliLocalInvokeInvocation, SamCliLocalInvokeInvocationArguments } from './cli/samCliLocalInvoke'
-import { NO_FILE, SamLaunchRequestArgs } from './debugger/awsSamDebugger'
+import { SamLaunchRequestArgs } from './debugger/awsSamDebugger'
 import { asEnvironmentVariables } from '../../credentials/credentialsUtilities'
 import { buildSamCliStartApiArguments } from './cli/samCliStartApi'
 import { DefaultSamCliProcessInvoker } from './cli/samCliInvoker'
@@ -35,6 +35,7 @@ import { DefaultSamCliLocationProvider } from './cli/samCliLocator'
 import { getSamCliContext, getSamCliVersion } from './cli/samCliContext'
 import { CloudFormation } from '../cloudformation/cloudformation'
 import { getIdeProperties } from '../extensionUtilities'
+import { NO_FILE } from './debugger/awsSamDebugConfiguration'
 
 const localize = nls.loadMessageBundle()
 

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -685,11 +685,13 @@ async function showDebugConsole(): Promise<void> {
  */
 export async function makeJsonFiles(config: SamLaunchRequestArgs): Promise<void> {
     config.eventPayloadFile = path.join(config.baseBuildDir!, 'event.json')
-    config.envFile = path.join(config.baseBuildDir!, 'env-vars.json')
 
     // env-vars.json (NB: effectively ignored for the `target=code` case).
     const env = JSON.stringify(getEnvironmentVariables(makeResourceName(config), config.lambda?.environmentVariables))
-    await writeFile(config.envFile, env)
+    if (Object.keys(env).length !== 0) {
+        config.envFile = path.join(config.baseBuildDir!, 'env-vars.json')
+        await writeFile(config.envFile, env)
+    }
 
     // container-env-vars.json
     if (config.containerEnvVars) {

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -388,7 +388,10 @@ export async function runLambdaFunction(
 
     if (!config.noDebug) {
         if (config.invokeTarget.target === 'api') {
-            const payload = JSON.parse(await readFile(config.eventPayloadFile, { encoding: 'utf-8' }))
+            const payload =
+                config.eventPayloadFile === NO_FILE
+                    ? {}
+                    : JSON.parse(await readFile(config.eventPayloadFile, { encoding: 'utf-8' }))
             // Send the request to the local API server.
             await requestLocalApi(ctx, config.api!, config.apiPort!, payload)
             // Wait for cue messages ("Starting debugger" etc.) before attach.

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -687,8 +687,9 @@ export async function makeJsonFiles(config: SamLaunchRequestArgs): Promise<void>
     config.eventPayloadFile = path.join(config.baseBuildDir!, 'event.json')
 
     // env-vars.json (NB: effectively ignored for the `target=code` case).
-    const env = JSON.stringify(getEnvironmentVariables(makeResourceName(config), config.lambda?.environmentVariables))
-    if (Object.keys(env).length !== 0) {
+    const configEnv = config.lambda?.environmentVariables ?? {}
+    if (Object.keys(configEnv).length !== 0) {
+        const env = JSON.stringify(getEnvironmentVariables(makeResourceName(config), configEnv))
         config.envFile = path.join(config.baseBuildDir!, 'env-vars.json')
         await writeFile(config.envFile, env)
     }

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -27,7 +27,7 @@ import {
     APIGatewayProperties,
     PathMapping,
 } from '../../../../shared/sam/debugger/awsSamDebugConfiguration'
-import { SamDebugConfigProvider, SamLaunchRequestArgs } from '../../../../shared/sam/debugger/awsSamDebugger'
+import { NO_FILE, SamDebugConfigProvider, SamLaunchRequestArgs } from '../../../../shared/sam/debugger/awsSamDebugger'
 import * as debugConfiguration from '../../../../lambda/local/debugConfiguration'
 import * as pathutil from '../../../../shared/utilities/pathUtils'
 import { FakeExtensionContext } from '../../../fakeExtensionContext'
@@ -112,7 +112,9 @@ async function assertEqualNoDebugTemplateTarget(
     input: any,
     expected: SamLaunchRequestArgs,
     folder: vscode.WorkspaceFolder,
-    debugConfigProvider: SamDebugConfigProvider
+    debugConfigProvider: SamDebugConfigProvider,
+    envFile?: string,
+    eventPayloadFile?: string
 ) {
     ;(input as any).noDebug = true
     const actualNoDebug = (await debugConfigProvider.makeConfig(folder, input))!
@@ -123,8 +125,8 @@ async function assertEqualNoDebugTemplateTarget(
         debugPort: undefined,
         port: -1,
         baseBuildDir: actualNoDebug.baseBuildDir,
-        envFile: `${actualNoDebug.baseBuildDir}/env-vars.json`,
-        eventPayloadFile: `${actualNoDebug.baseBuildDir}/event.json`,
+        envFile: envFile ?? `${actualNoDebug.baseBuildDir}/env-vars.json`,
+        eventPayloadFile: eventPayloadFile ?? `${actualNoDebug.baseBuildDir}/event.json`,
     }
     assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug)
 }
@@ -976,8 +978,8 @@ describe('SamDebugConfigurationProvider', async function () {
                 containerEnvVars: {
                     NODE_OPTIONS: `--inspect-brk=0.0.0.0:${actual.debugPort} --max-http-header-size 81920`,
                 },
-                envFile: `${actual.baseBuildDir}/env-vars.json`,
-                eventPayloadFile: `${actual.baseBuildDir}/event.json`,
+                envFile: NO_FILE,
+                eventPayloadFile: NO_FILE,
                 codeRoot: appDir,
                 apiPort: undefined,
                 debugPort: actual.debugPort,
@@ -1091,13 +1093,13 @@ Outputs:
                 remoteRoot: 'somethingRemote',
                 baseBuildDir: actualWithPathMapping.baseBuildDir,
                 containerEnvFile: `${actualWithPathMapping.baseBuildDir}/container-env-vars.json`,
-                envFile: `${actualWithPathMapping.baseBuildDir}/env-vars.json`,
-                eventPayloadFile: `${actualWithPathMapping.baseBuildDir}/event.json`,
+                envFile: NO_FILE,
+                eventPayloadFile: NO_FILE,
             }
             assertEqualLaunchConfigs(actualWithPathMapping, expectedWithPathMapping)
 
             // Test noDebug=true.
-            await assertEqualNoDebugTemplateTarget(input, expected, folder, debugConfigProvider)
+            await assertEqualNoDebugTemplateTarget(input, expected, folder, debugConfigProvider, NO_FILE, NO_FILE)
         })
 
         it('target=api: javascript', async function () {
@@ -1252,8 +1254,8 @@ Outputs:
                     uri: vscode.Uri.file(appDir),
                 },
                 baseBuildDir: actual.baseBuildDir, // Random, sanity-checked by assertEqualLaunchConfigs().
-                envFile: `${actual.baseBuildDir}/env-vars.json`,
-                eventPayloadFile: `${actual.baseBuildDir}/event.json`,
+                envFile: NO_FILE,
+                eventPayloadFile: NO_FILE,
                 codeRoot: expectedCodeRoot, // Normalized to absolute path.
                 apiPort: undefined,
                 debugPort: actual.debugPort,
@@ -1283,8 +1285,7 @@ Outputs:
             }
 
             assertEqualLaunchConfigs(actual, expectedDebug)
-            assertFileText(expected.envFile, '{"HelloWorldFunction":{}}')
-            assertFileText(expected.eventPayloadFile, '{}')
+
             assertFileText(
                 expected.templatePath,
                 `Resources:
@@ -1314,8 +1315,8 @@ Outputs:
                 debuggerPath: undefined,
                 debugPort: undefined,
                 baseBuildDir: actualNoDebug.baseBuildDir,
-                envFile: `${actualNoDebug.baseBuildDir}/env-vars.json`,
-                eventPayloadFile: `${actualNoDebug.baseBuildDir}/event.json`,
+                envFile: NO_FILE,
+                eventPayloadFile: NO_FILE,
             }
             delete expectedNoDebug.processName
             delete expectedNoDebug.pipeTransport
@@ -1358,8 +1359,8 @@ Outputs:
                     uri: vscode.Uri.file(appDir),
                 },
                 baseBuildDir: actual.baseBuildDir, // Random, sanity-checked by assertEqualLaunchConfigs().
-                envFile: `${actual.baseBuildDir}/env-vars.json`,
-                eventPayloadFile: `${actual.baseBuildDir}/event.json`,
+                envFile: NO_FILE,
+                eventPayloadFile: NO_FILE,
                 codeRoot: expectedCodeRoot, // Normalized to absolute path.
                 apiPort: undefined,
                 debugPort: actual.debugPort,
@@ -1389,8 +1390,7 @@ Outputs:
             }
 
             assertEqualLaunchConfigs(actual, expectedDebug)
-            assertFileText(expectedDebug.envFile, '{"HelloWorldFunction":{}}')
-            assertFileText(expectedDebug.eventPayloadFile, '{}')
+
             assertFileText(
                 expectedDebug.templatePath,
                 `Resources:
@@ -1420,8 +1420,8 @@ Outputs:
                 debuggerPath: undefined,
                 debugPort: undefined,
                 baseBuildDir: actualNoDebug.baseBuildDir,
-                envFile: `${actualNoDebug.baseBuildDir}/env-vars.json`,
-                eventPayloadFile: `${actualNoDebug.baseBuildDir}/event.json`,
+                envFile: NO_FILE,
+                eventPayloadFile: NO_FILE,
             }
             delete expectedNoDebug.processName
             delete expectedNoDebug.pipeTransport
@@ -1764,8 +1764,8 @@ Outputs:
                     uri: vscode.Uri.file(appDir),
                 },
                 baseBuildDir: actual.baseBuildDir, // Random, sanity-checked by assertEqualLaunchConfigs().
-                envFile: `${actual.baseBuildDir}/env-vars.json`,
-                eventPayloadFile: `${actual.baseBuildDir}/event.json`,
+                envFile: NO_FILE,
+                eventPayloadFile: NO_FILE,
                 codeRoot: expectedCodeRoot, // Normalized to absolute path.
                 apiPort: undefined,
                 debugPort: actual.debugPort,
@@ -1810,8 +1810,7 @@ Outputs:
             }
 
             assertEqualLaunchConfigs(actual, expected)
-            assertFileText(expected.envFile, '{"HelloWorld":{}}')
-            assertFileText(expected.eventPayloadFile, '{}')
+
             assertFileText(
                 expected.templatePath,
                 `Resources:
@@ -1858,8 +1857,8 @@ Outputs:
                     anotherRemote: 'anotherLocal',
                 },
                 baseBuildDir: actualWithPathMapping.baseBuildDir,
-                envFile: `${actualWithPathMapping.baseBuildDir}/env-vars.json`,
-                eventPayloadFile: `${actualWithPathMapping.baseBuildDir}/event.json`,
+                envFile: NO_FILE,
+                eventPayloadFile: NO_FILE,
             }
             assertEqualLaunchConfigs(actualWithPathMapping, expectedWithPathMapping)
 
@@ -1877,8 +1876,8 @@ Outputs:
                 debuggerPath: undefined,
                 debugPort: undefined,
                 baseBuildDir: actualNoDebug.baseBuildDir,
-                envFile: `${actualNoDebug.baseBuildDir}/env-vars.json`,
-                eventPayloadFile: `${actualNoDebug.baseBuildDir}/event.json`,
+                envFile: NO_FILE,
+                eventPayloadFile: NO_FILE,
             }
             delete expectedNoDebug.processName
             delete expectedNoDebug.pipeTransport
@@ -2343,7 +2342,7 @@ Outputs:
                     uri: vscode.Uri.file(appDir),
                 },
                 baseBuildDir: actual.baseBuildDir, // Random, sanity-checked by assertEqualLaunchConfigs().
-                envFile: `${actual.baseBuildDir}/env-vars.json`,
+                envFile: NO_FILE,
                 eventPayloadFile: `${actual.baseBuildDir}/event.json`,
                 codeRoot: pathutil.normalize(path.join(appDir, 'hello_world')),
                 debugArgs: [
@@ -2388,7 +2387,6 @@ Outputs:
             }
 
             assertEqualLaunchConfigs(actual, expected)
-            assertFileText(expected.envFile, '{"helloworld":{}}')
             assert.strictEqual(readFileSync(actual.eventPayloadFile, 'utf-8'), readFileSync(absPayloadPath, 'utf-8'))
             assertFileText(
                 expected.templatePath,
@@ -2433,7 +2431,7 @@ Outputs:
                 },
                 pathMappings: inputWithPathMapping.lambda.pathMappings,
                 baseBuildDir: actualWithPathMapping.baseBuildDir,
-                envFile: `${actualWithPathMapping.baseBuildDir}/env-vars.json`,
+                envFile: NO_FILE,
                 eventPayloadFile: `${actualWithPathMapping.baseBuildDir}/event.json`,
             }
             assertEqualLaunchConfigs(actualWithPathMapping, expectedWithPathMapping)
@@ -2451,7 +2449,7 @@ Outputs:
                 port: -1,
                 handlerName: 'app.lambda_handler',
                 baseBuildDir: actualNoDebug.baseBuildDir,
-                envFile: `${actualNoDebug.baseBuildDir}/env-vars.json`,
+                envFile: NO_FILE,
                 eventPayloadFile: `${actualNoDebug.baseBuildDir}/event.json`,
             }
             assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug)
@@ -2491,8 +2489,8 @@ Outputs:
                     uri: vscode.Uri.file(appDir),
                 },
                 baseBuildDir: actual.baseBuildDir, // Random, sanity-checked by assertEqualLaunchConfigs().
-                envFile: `${actual.baseBuildDir}/env-vars.json`,
-                eventPayloadFile: `${actual.baseBuildDir}/event.json`,
+                envFile: NO_FILE,
+                eventPayloadFile: NO_FILE,
                 codeRoot: pathutil.normalize(path.join(appDir, 'python3.7-plain-sam-app/hello_world')),
                 debugArgs: [
                     `/tmp/lambci_debug_files/py_debug_wrapper.py --listen 0.0.0.0:${actual.debugPort} --wait-for-client --log-to-stderr --debug`,
@@ -2537,8 +2535,6 @@ Outputs:
             }
 
             assertEqualLaunchConfigs(actual, expected)
-            assertFileText(expected.envFile, '{"HelloWorldFunction":{}}')
-            assertFileText(expected.eventPayloadFile, '{}')
 
             assertFileText(
                 expected.templatePath,
@@ -2633,14 +2629,14 @@ Outputs:
                 },
                 pathMappings: inputWithPathMapping.lambda.pathMappings,
                 baseBuildDir: actualWithPathMapping.baseBuildDir,
-                envFile: `${actualWithPathMapping.baseBuildDir}/env-vars.json`,
-                eventPayloadFile: `${actualWithPathMapping.baseBuildDir}/event.json`,
+                envFile: NO_FILE,
+                eventPayloadFile: NO_FILE,
             }
             assertEqualLaunchConfigs(actualWithPathMapping, expectedWithPathMapping)
 
             // Test noDebug=true.
             expected.handlerName = 'app.lambda_handler'
-            await assertEqualNoDebugTemplateTarget(input, expected, folder, debugConfigProvider)
+            await assertEqualNoDebugTemplateTarget(input, expected, folder, debugConfigProvider, NO_FILE, NO_FILE)
         })
 
         it('target=api: python 3.7 (deep project tree)', async function () {
@@ -2686,8 +2682,8 @@ Outputs:
                     uri: vscode.Uri.file(appDir),
                 },
                 baseBuildDir: actual.baseBuildDir, // Random, sanity-checked by assertEqualLaunchConfigs().
-                envFile: `${actual.baseBuildDir}/env-vars.json`,
-                eventPayloadFile: `${actual.baseBuildDir}/event.json`,
+                envFile: NO_FILE,
+                eventPayloadFile: NO_FILE,
                 codeRoot: pathutil.normalize(path.join(appDir, 'python3.7-plain-sam-app/hello_world')),
                 debugArgs: [
                     `/tmp/lambci_debug_files/py_debug_wrapper.py --listen 0.0.0.0:${actual.debugPort} --wait-for-client --log-to-stderr --debug`,
@@ -2735,8 +2731,6 @@ Outputs:
             }
 
             assertEqualLaunchConfigs(actual, expected)
-            assertFileText(expected.envFile, '{"HelloWorldFunction":{}}')
-            assertFileText(expected.eventPayloadFile, '{}')
 
             assertFileText(
                 expected.templatePath,
@@ -2806,7 +2800,7 @@ Outputs:
 
             // Test noDebug=true.
             expected.handlerName = 'app.lambda_handler'
-            await assertEqualNoDebugTemplateTarget(input, expected, folder, debugConfigProvider)
+            await assertEqualNoDebugTemplateTarget(input, expected, folder, debugConfigProvider, NO_FILE, NO_FILE)
         })
 
         it('target=template: Image python 3.7', async function () {
@@ -2847,8 +2841,8 @@ Outputs:
                     uri: vscode.Uri.file(appDir),
                 },
                 baseBuildDir: actual.baseBuildDir, // Random, sanity-checked by assertEqualLaunchConfigs().
-                envFile: `${actual.baseBuildDir}/env-vars.json`,
-                eventPayloadFile: `${actual.baseBuildDir}/event.json`,
+                envFile: NO_FILE,
+                eventPayloadFile: NO_FILE,
                 codeRoot: pathutil.normalize(path.join(appDir, 'python3.7-image-sam-app/hello_world')),
                 debugArgs: [
                     `/var/lang/bin/python3.7 /tmp/lambci_debug_files/py_debug_wrapper.py --listen 0.0.0.0:${actual.debugPort} --wait-for-client --log-to-stderr /var/runtime/bootstrap --debug`,
@@ -2894,8 +2888,6 @@ Outputs:
             }
 
             assertEqualLaunchConfigs(actual, expected)
-            assertFileText(expected.envFile, '{"HelloWorldFunction":{}}')
-            assertFileText(expected.eventPayloadFile, '{}')
 
             assertFileText(
                 expected.templatePath,
@@ -2971,8 +2963,8 @@ Outputs:
                 },
                 pathMappings: inputWithPathMapping.lambda.pathMappings,
                 baseBuildDir: actualWithPathMapping.baseBuildDir,
-                envFile: `${actualWithPathMapping.baseBuildDir}/env-vars.json`,
-                eventPayloadFile: `${actualWithPathMapping.baseBuildDir}/event.json`,
+                envFile: NO_FILE,
+                eventPayloadFile: NO_FILE,
             }
             assertEqualLaunchConfigs(actualWithPathMapping, expectedWithPathMapping)
 
@@ -2988,8 +2980,8 @@ Outputs:
                 debugPort: undefined,
                 port: -1,
                 baseBuildDir: actualNoDebug.baseBuildDir,
-                envFile: `${actualNoDebug.baseBuildDir}/env-vars.json`,
-                eventPayloadFile: `${actualNoDebug.baseBuildDir}/event.json`,
+                envFile: NO_FILE,
+                eventPayloadFile: NO_FILE,
             }
             assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug)
         })
@@ -3070,7 +3062,7 @@ Outputs:
                     uri: vscode.Uri.file(appDir),
                 },
                 baseBuildDir: actual.baseBuildDir, // Random, sanity-checked by assertEqualLaunchConfigs().
-                envFile: `${actual.baseBuildDir}/env-vars.json`,
+                envFile: NO_FILE,
                 eventPayloadFile: `${actual.baseBuildDir}/event.json`,
                 codeRoot: pathutil.normalize(path.join(appDir, 'hello_world')),
                 debugArgs: [
@@ -3103,7 +3095,6 @@ Outputs:
             }
 
             assertEqualLaunchConfigs(actual, expected)
-            assertFileText(expected.envFile, '{"helloworld":{}}')
             assert.strictEqual(
                 readFileSync(actual.eventPayloadFile, 'utf-8'),
                 readFileSync(input.lambda.payload.path, 'utf-8')
@@ -3136,7 +3127,7 @@ Outputs:
                 port: -1,
                 handlerName: 'app.lambda_handler',
                 baseBuildDir: actualNoDebug.baseBuildDir,
-                envFile: `${actualNoDebug.baseBuildDir}/env-vars.json`,
+                envFile: NO_FILE,
                 eventPayloadFile: `${actualNoDebug.baseBuildDir}/event.json`,
             }
             assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug)
@@ -3178,8 +3169,8 @@ Outputs:
                     uri: vscode.Uri.file(appDir),
                 },
                 baseBuildDir: actual.baseBuildDir, // Random, sanity-checked by assertEqualLaunchConfigs().
-                envFile: `${actual.baseBuildDir}/env-vars.json`,
-                eventPayloadFile: `${actual.baseBuildDir}/event.json`,
+                envFile: NO_FILE,
+                eventPayloadFile: NO_FILE,
                 codeRoot: pathutil.normalize(path.join(appDir, 'python3.7-plain-sam-app/hello_world')),
                 apiPort: undefined,
                 debugArgs: [
@@ -3212,8 +3203,6 @@ Outputs:
             }
 
             assertEqualLaunchConfigs(actual, expected)
-            assertFileText(expected.envFile, '{"HelloWorldFunction":{}}')
-            assertFileText(expected.eventPayloadFile, '{}')
 
             assertFileText(
                 expected.templatePath,
@@ -3294,8 +3283,8 @@ Outputs:
                 port: -1,
                 handlerName: 'app.lambda_handler',
                 baseBuildDir: actualNoDebug.baseBuildDir,
-                envFile: `${actualNoDebug.baseBuildDir}/env-vars.json`,
-                eventPayloadFile: `${actualNoDebug.baseBuildDir}/event.json`,
+                envFile: NO_FILE,
+                eventPayloadFile: NO_FILE,
             }
             assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug)
         })
@@ -3346,7 +3335,7 @@ Outputs:
                 },
                 baseBuildDir: actual.baseBuildDir, // Random, sanity-checked by assertEqualLaunchConfigs().
                 envFile: `${actual.baseBuildDir}/env-vars.json`,
-                eventPayloadFile: `${actual.baseBuildDir}/event.json`,
+                eventPayloadFile: NO_FILE,
                 codeRoot: pathutil.normalize(path.join(tempDir, 'codeuri')), // Normalized to absolute path.
                 apiPort: undefined,
                 debugPort: actual.debugPort,
@@ -3389,7 +3378,6 @@ Outputs:
 
             assertEqualLaunchConfigs(actual, expected)
             assertFileText(expected.envFile, '{"myResource":{"var1":"2","var2":"1"}}')
-            assertFileText(expected.eventPayloadFile, '{}')
 
             assertFileText(
                 expected.templatePath,
@@ -3495,7 +3483,7 @@ Resources:
                 },
                 baseBuildDir: actual.baseBuildDir, // Random, sanity-checked by assertEqualLaunchConfigs().
                 envFile: `${actual.baseBuildDir}/env-vars.json`,
-                eventPayloadFile: `${actual.baseBuildDir}/event.json`,
+                eventPayloadFile: NO_FILE,
                 codeRoot: pathutil.normalize(path.join(tempDir, 'codeuri')), // Normalized to absolute path.
                 apiPort: undefined,
                 debugPort: actual.debugPort,

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -26,8 +26,9 @@ import {
     createApiAwsSamDebugConfig,
     APIGatewayProperties,
     PathMapping,
+    NO_FILE,
 } from '../../../../shared/sam/debugger/awsSamDebugConfiguration'
-import { NO_FILE, SamDebugConfigProvider, SamLaunchRequestArgs } from '../../../../shared/sam/debugger/awsSamDebugger'
+import { SamDebugConfigProvider, SamLaunchRequestArgs } from '../../../../shared/sam/debugger/awsSamDebugger'
 import * as debugConfiguration from '../../../../lambda/local/debugConfiguration'
 import * as pathutil from '../../../../shared/utilities/pathUtils'
 import { FakeExtensionContext } from '../../../fakeExtensionContext'


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Toolkit would send the environment variables option and override any settings defined in a SAM config file.

## Solution
Do not send the option if no variables are defined. 
**Caveat:** users cannot use relative paths in their SAM config file. They will need to in-line the environment variables OR use an absolute path

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
