### PR TITLE
settings: support developer-only settings

### DIFF
--- a/src/credentials/awsCredentialsStatusBarItem.ts
+++ b/src/credentials/awsCredentialsStatusBarItem.ts
@@ -29,14 +29,15 @@ export async function initializeAwsCredentialsStatusBarItem(
         'The current credentials used by the {0} Toolkit.\n\nClick this status bar item to use different credentials.',
         getIdeProperties().company
     )
+
     statusBarItem.show()
     updateCredentialsStatusBarItem(statusBarItem)
 
     context.subscriptions.push(statusBarItem)
 
     context.subscriptions.push(
-        awsContext.onDidChangeContext(async (awsContextChangedEvent: ContextChangeEventsArgs) => {
-            updateCredentialsStatusBarItem(statusBarItem, awsContextChangedEvent.profileName)
+        awsContext.onDidChangeContext(async (ev: ContextChangeEventsArgs) => {
+            updateCredentialsStatusBarItem(statusBarItem, ev.profileName, ev.developerMode)
         })
     )
 }
@@ -44,9 +45,16 @@ export async function initializeAwsCredentialsStatusBarItem(
 // Resolves when the status bar reaches its final state
 export async function updateCredentialsStatusBarItem(
     statusBarItem: vscode.StatusBarItem,
-    credentialsId?: string
+    credentialsId?: string,
+    developerMode?: boolean
 ): Promise<void> {
     clearTimeout(timeoutID)
+
+    if (developerMode) {
+        ;(statusBarItem as any).backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground')
+    } else {
+        ;(statusBarItem as any).backgroundColor = undefined
+    }
 
     // Shows confirmation text in the status bar message
     let delay = 0

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -100,6 +100,7 @@ export async function activate(context: vscode.ExtensionContext) {
         const endpointsProvider = makeEndpointsProvider()
 
         const awsContext = new DefaultAwsContext(context)
+        ext.awsContext = awsContext
         const awsContextTrees = new AwsContextTreeCollection()
         const regionProvider = new DefaultRegionProvider(endpointsProvider)
         const credentialsStore = new CredentialsStore()

--- a/src/shared/awsContext.ts
+++ b/src/shared/awsContext.ts
@@ -17,6 +17,7 @@ export interface AwsContextCredentials {
 export interface ContextChangeEventsArgs {
     readonly profileName?: string
     readonly accountId?: string
+    readonly developerMode?: boolean
 }
 
 // Represents a credential profile and zero or more regions.
@@ -40,6 +41,8 @@ export interface AwsContext {
     addExplorerRegion(...regions: string[]): Promise<void>
     // removes one or more regions from the user's preferred set
     removeExplorerRegion(...regions: string[]): Promise<void>
+
+    setDeveloperMode(enable: boolean): Promise<void>
 }
 
 export class NoActiveCredentialError extends Error {

--- a/src/shared/extensionUtilities.ts
+++ b/src/shared/extensionUtilities.ts
@@ -11,7 +11,7 @@ import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 import { ext } from '../shared/extensionGlobals'
 import { readFileAsString } from './filesystemUtilities'
-import { getLogger } from './logger'
+import { getLogger, getNullLogger } from './logger'
 import { VSCODE_EXTENSION_ID, EXTENSION_ALPHA_VERSION } from './extensions'
 import { DefaultSettingsConfiguration } from './settingsConfiguration'
 import { BaseTemplates } from './templates/baseTemplates'
@@ -45,11 +45,12 @@ export enum IDE {
 let computeRegion: string | undefined = NOT_INITIALIZED
 
 export function getIdeType(): IDE {
-    const settings = new DefaultSettingsConfiguration('aws')
+    // Use null logger to avoid circular dependency, getIdeType() is called early in startup.
+    const settings = new DefaultSettingsConfiguration('aws', getNullLogger())
     if (
         vscode.env.appName === CLOUD9_APPNAME ||
         vscode.env.appName === CLOUD9_CN_APPNAME ||
-        !!settings.readSetting<boolean>('forceCloud9', false)
+        !!settings.readDevSetting<boolean>('aws.forceCloud9', 'boolean', true)
     ) {
         return IDE.cloud9
     }

--- a/src/shared/extensionUtilities.ts
+++ b/src/shared/extensionUtilities.ts
@@ -11,7 +11,7 @@ import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 import { ext } from '../shared/extensionGlobals'
 import { readFileAsString } from './filesystemUtilities'
-import { getLogger, getNullLogger } from './logger'
+import { getLogger } from './logger'
 import { VSCODE_EXTENSION_ID, EXTENSION_ALPHA_VERSION } from './extensions'
 import { DefaultSettingsConfiguration } from './settingsConfiguration'
 import { BaseTemplates } from './templates/baseTemplates'
@@ -45,8 +45,7 @@ export enum IDE {
 let computeRegion: string | undefined = NOT_INITIALIZED
 
 export function getIdeType(): IDE {
-    // Use null logger to avoid circular dependency, getIdeType() is called early in startup.
-    const settings = new DefaultSettingsConfiguration('aws', getNullLogger())
+    const settings = new DefaultSettingsConfiguration('aws')
     if (
         vscode.env.appName === CLOUD9_APPNAME ||
         vscode.env.appName === CLOUD9_CN_APPNAME ||

--- a/src/shared/logger/logger.ts
+++ b/src/shared/logger/logger.ts
@@ -67,9 +67,7 @@ export function compareLogLevel(l1: LogLevel, l2: LogLevel): number {
 export function getLogger(type?: 'channel' | 'debugConsole' | 'main'): Logger {
     const logger = toolkitLoggers[type ?? 'main']
     if (!logger) {
-        throw new Error(
-            'Logger not initialized. Extension code should call initialize() from shared/logger/activation, test code should call setLogger().'
-        )
+        return new ConsoleLogger()
     }
 
     return logger
@@ -93,6 +91,39 @@ export class NullLogger implements Logger {
         return 0
     }
     public error(message: string | Error, ...meta: any[]): number {
+        return 0
+    }
+    public getLogById(logID: number, file: Uri): string | undefined {
+        return undefined
+    }
+}
+
+/**
+ * Fallback to console.log() if getLogger() is requested before logging is fully initialized.
+ */
+export class ConsoleLogger implements Logger {
+    public setLogLevel(logLevel: LogLevel) {}
+    public logLevelEnabled(logLevel: LogLevel): boolean {
+        return false
+    }
+    public debug(message: string | Error, ...meta: any[]): number {
+        console.trace(message, meta)
+        return 0
+    }
+    public verbose(message: string | Error, ...meta: any[]): number {
+        console.debug(message, meta)
+        return 0
+    }
+    public info(message: string | Error, ...meta: any[]): number {
+        console.info(message, meta)
+        return 0
+    }
+    public warn(message: string | Error, ...meta: any[]): number {
+        console.warn(message, meta)
+        return 0
+    }
+    public error(message: string | Error, ...meta: any[]): number {
+        console.error(message, meta)
         return 0
     }
     public getLogById(logID: number, file: Uri): string | undefined {

--- a/src/shared/settingsConfiguration.ts
+++ b/src/shared/settingsConfiguration.ts
@@ -6,16 +6,48 @@
 import * as vscode from 'vscode'
 import { getLogger } from './logger'
 import * as packageJson from '../../package.json'
+import { ClassToInterfaceType } from './utilities/tsUtils'
+import { ext } from './extensionGlobals'
+import { isCI } from './vscode/env'
 
 /**
  * Wraps the VSCode configuration API and provides Toolkit-related
  * configuration functions.
  */
-export interface SettingsConfiguration {
-    readSetting<T>(settingKey: string): T | undefined
-    readSetting<T>(settingKey: string, defaultValue: T): T
+export type SettingsConfiguration = ClassToInterfaceType<DefaultSettingsConfiguration>
 
-    // array values are serialized as a comma-delimited string
+export type AwsDevSetting = 'aws.developer.foo1' | 'aws.developer.foo2'
+
+type JSPrimitiveTypeName =
+    | 'undefined'
+    | 'object'
+    | 'boolean'
+    | 'number'
+    | 'bigint'
+    | 'string'
+    | 'symbol'
+    | 'function'
+    | 'object'
+
+export class DefaultSettingsConfiguration implements SettingsConfiguration {
+    public constructor(private readonly extensionSettingsPrefix: string = 'aws') {}
+    public readSetting<T>(settingKey: string): T | undefined
+    public readSetting<T>(settingKey: string, defaultValue: T): T
+
+    /**
+     * Reads a vscode setting.
+     */
+    public readSetting<T>(settingKey: string, defaultValue?: T): T | undefined {
+        const settings = vscode.workspace.getConfiguration(this.extensionSettingsPrefix)
+
+        if (!settings) {
+            return defaultValue
+        }
+
+        const val = settings.get<T>(settingKey)
+        return val ?? defaultValue
+    }
+
     /**
      * Sets a config value.
      *
@@ -29,24 +61,6 @@ export interface SettingsConfiguration {
      *
      * @returns true on success, else false
      */
-    writeSetting<T>(settingKey: string, value: T | undefined, target: vscode.ConfigurationTarget): Promise<boolean>
-}
-
-// default configuration settings handler for production release
-export class DefaultSettingsConfiguration implements SettingsConfiguration {
-    public constructor(public readonly extensionSettingsPrefix: string) {}
-
-    public readSetting<T>(settingKey: string, defaultValue?: T): T | undefined {
-        const settings = vscode.workspace.getConfiguration(this.extensionSettingsPrefix)
-
-        if (!settings) {
-            return defaultValue
-        }
-
-        const val = settings.get<T>(settingKey)
-        return val ?? defaultValue
-    }
-
     public async writeSetting<T>(settingKey: string, value: T, target: vscode.ConfigurationTarget): Promise<boolean> {
         try {
             const settings = vscode.workspace.getConfiguration(this.extensionSettingsPrefix)
@@ -138,5 +152,43 @@ export class DefaultSettingsConfiguration implements SettingsConfiguration {
         if (!(m as any)[name]) {
             throw Error(`config: unknown aws.suppressPrompts item: "${name}"`)
         }
+    }
+
+    public readDevSetting<T>(key: AwsDevSetting): string
+    public readDevSetting<T>(key: AwsDevSetting, type: JSPrimitiveTypeName, silent: boolean): T | undefined
+
+    /**
+     * Gets the value of a developer only setting.
+     *
+     * TODO: show a dialog if this is used, and/or make a UI change (such as
+     * changing the AWS Explorer color) so that it's obvious that Toolkit is in
+     * "Developer mode". Throw an error in CI.
+     */
+    public readDevSetting<T>(
+        key: AwsDevSetting,
+        type: JSPrimitiveTypeName = 'string',
+        silent: boolean = false
+    ): T | undefined {
+        const config = vscode.workspace.getConfiguration()
+        const val = config.get<T>(key)
+        if (val === undefined) {
+            const msg = `settings: readDevSetting(): setting "${key}": not found`
+            if (!silent && !isCI()) {
+                throw Error(`AWS Toolkit: ${msg}`)
+            }
+            // Do not log; the common case is that a developer setting does _not_ exist.
+            return undefined
+        }
+
+        const actualType = typeof val
+        if (actualType !== type) {
+            const msg = `settings: readDevSetting(): setting "${key}": got ${actualType}, expected ${type}`
+            if (!silent) {
+                throw Error(`AWS Toolkit: ${msg}`)
+            }
+            getLogger().error(msg)
+            return undefined
+        }
+        return val
     }
 }

--- a/src/shared/settingsConfiguration.ts
+++ b/src/shared/settingsConfiguration.ts
@@ -189,6 +189,10 @@ export class DefaultSettingsConfiguration implements SettingsConfiguration {
             getLogger().error(msg)
             return undefined
         }
+
+        if (ext.awsContext) {
+            ext.awsContext.setDeveloperMode(true)
+        }
         return val
     }
 }

--- a/src/shared/vscode/env.ts
+++ b/src/shared/vscode/env.ts
@@ -31,3 +31,10 @@ class DefaultEnv implements Env {
         return vscode.env.clipboard
     }
 }
+
+/**
+ * Returns true if the current build is running on CI (build server).
+ */
+export function isCI(): boolean {
+    return undefined !== process.env['CODEBUILD_BUILD_ID']
+}

--- a/src/test/utilities/fakeAwsContext.ts
+++ b/src/test/utilities/fakeAwsContext.ts
@@ -70,6 +70,8 @@ export class FakeAwsContext implements AwsContext {
         this.awsContextCredentials = params?.contextCredentials
     }
 
+    public async setDeveloperMode(enable: boolean): Promise<void> {}
+
     public async setCredentials(credentials?: AwsContextCredentials): Promise<void> {
         this.awsContextCredentials = credentials
     }

--- a/src/test/utilities/testSettingsConfiguration.ts
+++ b/src/test/utilities/testSettingsConfiguration.ts
@@ -3,13 +3,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SettingsConfiguration } from '../../shared/settingsConfiguration'
+import { AwsDevSetting, SettingsConfiguration } from '../../shared/settingsConfiguration'
 
 /**
  * Test utility class with an in-memory Settings Configuration key-value storage
  */
 export class TestSettingsConfiguration implements SettingsConfiguration {
     private readonly _data: { [key: string]: any } = {}
+
+    public async disablePrompt(promptName: string): Promise<void> {}
+
+    public async isPromptEnabled(promptName: string): Promise<boolean> {
+        return true
+    }
+
+    public async getSuppressPromptSetting(promptName: string): Promise<{ [prompt: string]: boolean } | undefined> {
+        return {}
+    }
 
     public readSetting<T>(settingKey: string, defaultValue?: T | undefined): T | undefined {
         return this._data[settingKey] as T
@@ -18,5 +28,9 @@ export class TestSettingsConfiguration implements SettingsConfiguration {
     public async writeSetting<T>(settingKey: string, value: T, target?: any): Promise<boolean> {
         this._data[settingKey] = value
         return true
+    }
+
+    public readDevSetting<T>(key: AwsDevSetting, type: string = 'string', silent: boolean = false): T | undefined {
+        return undefined
     }
 }


### PR DESCRIPTION
- Add some structure to support temporary settings whose values should not be  committed.
- Start reworking the SettingsConfiguration class.
- Change the AWS statusbar when a developer setting is active:
    - <img width="309" alt="Screen Shot 2021-09-15 at 6 20 26 PM" src="https://user-images.githubusercontent.com/55561878/133534234-170fdafc-a221-4147-b0c8-4b2a77f8265f.png">



<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
