### PR TITLE
logs: Add stacktrace to activation error logging

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -22,7 +22,7 @@
     "AWS.cdk.explorerNode.app.noStacks": "[No stacks in this App]",
     "AWS.channel.remoteInvoke": "{0} Remote Invocations",
     "AWS.channel.aws.toolkit": "{0} Toolkit",
-    "AWS.channel.aws.toolkit.activation.error": "Error Activating {0} Toolkit: {1}",
+    "AWS.channel.aws.toolkit.activation.error": "Error Activating {0} Toolkit: {1} \n{2}",
     "AWS.codelens.failToInitialize": "Failed to activate template registry. {0} will not appear on SAM template files.",
     "AWS.codelens.failToInitializeCode": "Failed to activate Lambda handler {0}",
     "AWS.codelens.lambda.configEditor": "Edit Debug Configuration (Beta)",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -257,9 +257,10 @@ export async function activate(context: vscode.ExtensionContext) {
         getLogger('channel').error(
             localize(
                 'AWS.channel.aws.toolkit.activation.error',
-                'Error Activating {0} Toolkit: {1}',
+                'Error Activating {0} Toolkit: {1} \n{2}',
                 getIdeProperties().company,
-                (error as Error).message
+                (error as Error).message,
+                (error as Error).stack
             )
         )
         throw error


### PR DESCRIPTION


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
C9 will have no access to the stack trace if the toolkit fails to
activate.
## Solution
 Log the stack trace when the extension fails to activate.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
