### PR TITLE
"Create Lambda SAM App": enable markdown view in Cloud9

### DIFF
--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -96,9 +96,7 @@ export async function resumeCreateNewSamApp(
         )
         const tryOpenReadme = await writeToolkitReadme(readmeUri.fsPath, configs)
         if (tryOpenReadme) {
-            isCloud9()
-                ? await vscode.workspace.openTextDocument(readmeUri)
-                : await vscode.commands.executeCommand('markdown.showPreviewToSide', readmeUri)
+            await vscode.commands.executeCommand('markdown.showPreviewToSide', readmeUri)
         }
     } catch (err) {
         createResult = 'Failed'
@@ -317,9 +315,7 @@ export async function createNewSamApplication(
         // TODO: Replace when Cloud9 supports `markdown` commands
 
         if (tryOpenReadme) {
-            isCloud9()
-                ? await vscode.workspace.openTextDocument(readmeUri)
-                : await vscode.commands.executeCommand('markdown.showPreviewToSide', readmeUri)
+            await vscode.commands.executeCommand('markdown.showPreviewToSide', readmeUri)
         } else {
             await vscode.workspace.openTextDocument(templateUri)
         }


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Cloud9 opens the toolkit readme as a text file instead of a Markdown preview

## Solution
Open it as a markdown preview
<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
