### PR TITLE
Close and reopen files before retrying codelenses

### DIFF
--- a/src/integrationTest/integrationTestsUtilities.ts
+++ b/src/integrationTest/integrationTestsUtilities.ts
@@ -6,6 +6,7 @@
 import * as assert from 'assert'
 import { waitUntil } from '../shared/utilities/timeoutUtils'
 import * as vscode from 'vscode'
+import { focusAndCloseTab } from '../shared/utilities/vsCodeUtils'
 
 const SECOND = 1000
 export const TIMEOUT = 30 * SECOND
@@ -14,8 +15,12 @@ export async function sleep(miliseconds: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, miliseconds))
 }
 
-// Retrieves CodeLenses from VS Code
+/**
+ * Retrieves CodeLenses from VS Code
+ * NOTE: File must be open in an editor or else command will fail.
+ */
 export async function getCodeLenses(uri: vscode.Uri): Promise<vscode.CodeLens[] | undefined> {
+    // const editor = vscode.window.visibleTextEditors
     return vscode.commands.executeCommand('vscode.executeCodeLensProvider', uri)
 }
 
@@ -75,6 +80,15 @@ export async function configureGoExtension(): Promise<void> {
     await vscode.commands.executeCommand('go.tools.install', [gopls, dlv])
 }
 
+export async function openSamAppFile(applicationPath: string): Promise<vscode.Uri> {
+    const document = await vscode.workspace.openTextDocument(applicationPath)
+
+    return document.uri
+}
+
+/**
+ * NOTE: File must be open in an editor or else command will fail.
+ */
 export async function getAddConfigCodeLens(
     documentUri: vscode.Uri,
     timeout: number,
@@ -104,6 +118,9 @@ export async function getAddConfigCodeLens(
             } catch (e) {
                 console.log(`sam.test.ts: getAddConfigCodeLens() on "${documentUri.fsPath}" failed, retrying:\n${e}`)
             }
+
+            await focusAndCloseTab(documentUri)
+            await openSamAppFile(documentUri.fsPath)
 
             return undefined
         },

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -26,6 +26,7 @@ import { ext } from '../shared/extensionGlobals'
 import { AwsSamTargetType } from '../shared/sam/debugger/awsSamDebugConfiguration'
 import { closeAllEditors } from '../shared/utilities/vsCodeUtils'
 import { insertTextIntoFile } from '../shared/utilities/textUtilities'
+import { openSamAppFile } from './integrationTestsUtilities'
 const projectFolder = testUtils.getTestWorkspaceFolder()
 
 /* Test constants go here */
@@ -262,12 +263,6 @@ const scenarios: TestScenario[] = [
     // { runtime: 'dotnetcore2.1', path: 'src/HelloWorld/Function.cs', debugSessionType: 'coreclr', language: 'csharp' },
     // { runtime: 'dotnetcore3.1', path: 'src/HelloWorld/Function.cs', debugSessionType: 'coreclr', language: 'csharp' },
 ]
-
-async function openSamAppFile(applicationPath: string): Promise<vscode.Uri> {
-    const document = await vscode.workspace.openTextDocument(applicationPath)
-
-    return document.uri
-}
 
 function tryRemoveFolder(fullPath: string) {
     try {

--- a/src/shared/utilities/vsCodeUtils.ts
+++ b/src/shared/utilities/vsCodeUtils.ts
@@ -139,3 +139,17 @@ export async function activateExtension(
 export function promisifyThenable<T>(thenable: Thenable<T>): Promise<T> {
     return new Promise((resolve, reject) => thenable.then(resolve, reject))
 }
+
+export async function focusAndCloseTab(
+    uri: vscode.Uri,
+    editor?: vscode.TextEditor,
+    window = vscode.window,
+    workspace = vscode.workspace
+): Promise<void> {
+    const doc = editor ? editor.document : await workspace.openTextDocument(uri)
+    await window.showTextDocument(doc, {
+        preview: false,
+        viewColumn: editor?.viewColumn,
+    })
+    await vscode.commands.executeCommand('workbench.action.closeActiveEditor')
+}


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem

Java codelenses are frequently breaking integ tests. Appears to be tied to the final tests constantly in curr/insiders builds.

## Solution

Unsure, this PR is to throw things at the wall and see what sticks. If all integ tests are successful (or at least aren't failing the way they've been failing lately: no codelenses after 1 min), will rerun integ tests 2x more times to ensure they're fixed before pulling out of draft.

Theories:
* (currently testing): Codelens loading stalled because file was opened too fast after creation. Close and reopen file.
  * (close tab functionality from here: https://github.com/aws/aws-toolkit-vscode/pull/1888 ; if this is the solution, will merge this function into that PR)
* Java extension is running out of memory or is getting tripped up somehow.
  * Solution unknown: we can't kill the extension. Potentially run multiple, smaller integ tests?

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
