### PR TITLE
UriHandler: add implementation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,6 +72,7 @@ import { Ec2CredentialsProvider } from './credentials/providers/ec2CredentialsPr
 import { EnvVarsCredentialsProvider } from './credentials/providers/envVarsCredentialsProvider'
 import { EcsCredentialsProvider } from './credentials/providers/ecsCredentialsProvider'
 import { SchemaService } from './shared/schemas'
+import { UriHandler } from './shared/vscode/uriHandler'
 
 let localize: nls.LocalizeFunc
 
@@ -138,6 +139,9 @@ export async function activate(context: vscode.ExtensionContext) {
         await ext.telemetry.start()
         await ext.schemaService.start()
 
+        const uriHandler = new UriHandler()
+        context.subscriptions.push(vscode.window.registerUriHandler(uriHandler))
+
         const extContext: ExtContext = {
             extensionContext: context,
             awsContext: awsContext,
@@ -147,6 +151,7 @@ export async function activate(context: vscode.ExtensionContext) {
             outputChannel: toolkitOutputChannel,
             telemetryService: ext.telemetry,
             credentialsStore,
+            uriHandler,
         }
 
         // Used as a command for decoration-only codelenses.

--- a/src/shared/extensions.ts
+++ b/src/shared/extensions.ts
@@ -10,6 +10,7 @@ import { SettingsConfiguration } from './settingsConfiguration'
 import { TelemetryService } from './telemetry/telemetryService'
 import { CredentialsStore } from '../credentials/credentialsStore'
 import { SamCliContext } from './sam/cli/samCliContext'
+import { UriHandler } from './vscode/uriHandler'
 
 export const VSCODE_EXTENSION_ID = {
     awstoolkit: 'amazonwebservices.aws-toolkit-vscode',
@@ -35,6 +36,7 @@ export interface ExtContext {
     outputChannel: vscode.OutputChannel
     telemetryService: TelemetryService
     credentialsStore: CredentialsStore
+    uriHandler: UriHandler
 }
 
 /**

--- a/src/shared/vscode/uriHandler.ts
+++ b/src/shared/vscode/uriHandler.ts
@@ -42,7 +42,7 @@ export class UriHandler implements vscode.UriHandler {
             parsedQuery = parser ? await parser(query) : query
         } catch (err) {
             showViewLogsMessage(localize('AWS.uriHandler.parser.failed', 'Failed to parse URI query: {0}', uri.query))
-            getLogger().error(`UriHandler: parsing failed for path "${uri.path}": %O`, err)
+            getLogger().error(`UriHandler: query parsing failed for path "${uri.path}": %O`, err)
             return
         }
 

--- a/src/shared/vscode/uriHandler.ts
+++ b/src/shared/vscode/uriHandler.ts
@@ -26,10 +26,10 @@ export class UriHandler implements vscode.UriHandler {
     public async handleUri(uri: vscode.Uri): Promise<void> {
         getLogger().verbose(`UriHandler: received request on path "${uri.path}"`)
 
+        const uriNoQuery = uri.with({ query: undefined }).toString()
+
         if (!this.handlers.has(uri.path)) {
-            ext.window.showErrorMessage(
-                localize('AWS.uriHandler.nohandler', 'No handler found for: {0}', uri.toString())
-            )
+            ext.window.showErrorMessage(localize('AWS.uriHandler.nohandler', 'No handler found for: {0}', uriNoQuery))
             getLogger().verbose(`UriHandler: no valid handler found for "${uri.path}"`)
             return
         }
@@ -41,7 +41,7 @@ export class UriHandler implements vscode.UriHandler {
             const query = querystring.parse(uri.query)
             parsedQuery = parser ? await parser(query) : query
         } catch (err) {
-            showViewLogsMessage(localize('AWS.uriHandler.parser.failed', 'Failed to parse URI query: {0}', uri.query))
+            showViewLogsMessage(localize('AWS.uriHandler.parser.failed', 'Failed to parse URI query: {0}', uriNoQuery))
             getLogger().error(`UriHandler: query parsing failed for path "${uri.path}": %O`, err)
             return
         }
@@ -50,7 +50,7 @@ export class UriHandler implements vscode.UriHandler {
             // This await is needed to catch unhandled rejected Promises
             return await handler(parsedQuery)
         } catch (err) {
-            showViewLogsMessage(localize('AWS.uriHandler.handler.failed', 'Failed to handle URI: {0}', uri.toString()))
+            showViewLogsMessage(localize('AWS.uriHandler.handler.failed', 'Failed to handle URI: {0}', uriNoQuery))
             getLogger().error(`UriHandler: unexpected exception when handling "${uri.path}": %O`, err)
         }
     }

--- a/src/shared/vscode/uriHandler.ts
+++ b/src/shared/vscode/uriHandler.ts
@@ -1,0 +1,70 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import * as querystring from 'querystring'
+import { getLogger } from '../logger/logger'
+
+export type PathHandler<T> = (query: T) => Promise<void> | void
+export type QueryParser<T> = (query: querystring.ParsedUrlQuery) => Promise<T> | T | never
+
+interface HandlerWithParser<T> {
+    handler: PathHandler<T>
+    parser?: QueryParser<T>
+}
+
+export class UriHandler implements vscode.UriHandler {
+    private handlers: Map<string, HandlerWithParser<any>> = new Map()
+
+    public async handleUri(uri: vscode.Uri): Promise<void> {
+        getLogger().verbose(`UriHandler: received request on path "${uri.path}"`)
+
+        if (!this.handlers.has(uri.path)) {
+            getLogger().verbose(`UriHandler: no valid handler not found for "${uri.path}"`)
+            return
+        }
+
+        const { handler, parser } = this.handlers.get(uri.path)!
+        let parsedQuery: Parameters<typeof handler>[0]
+
+        try {
+            const query = querystring.parse(uri.query)
+            parsedQuery = parser ? await parser(query) : query
+        } catch (err) {
+            getLogger().error(`UriHandler: parsing failed for path "${uri.path}": %O`, err)
+            return
+        }
+
+        try {
+            // This await is needed to catch unhandled rejected Promises
+            return await handler(parsedQuery)
+        } catch (err) {
+            getLogger().error(`UriHandler: unexpected exception when handling "${uri.path}": %O`, err)
+        }
+    }
+
+    /**
+     * Registers a new handler for external URIs targeting the extension.
+     *
+     * @param path Target 'path', e.g. '/foo/bar'
+     * @param handler Callback fired when the extension receives a URI that matches the path
+     * @param parser Optional callback to parse the query prior to calling the handler
+     *
+     * @returns A disposable to remove the handler
+     * @throws When a handler has already been registered
+     */
+    public registerHandler<T = querystring.ParsedUrlQuery>(
+        path: string,
+        handler: PathHandler<T>,
+        parser?: QueryParser<T>
+    ): vscode.Disposable {
+        if (this.handlers.has(path)) {
+            throw new Error(`UriHandler: "${path}" has already been registered`)
+        }
+
+        this.handlers.set(path, { handler, parser })
+        return { dispose: () => this.handlers.delete(path) }
+    }
+}

--- a/src/test/fakeExtensionContext.ts
+++ b/src/test/fakeExtensionContext.ts
@@ -24,6 +24,7 @@ import {
 } from '../shared/sam/cli/samCliValidator'
 import { FakeChildProcessResult, TestSamCliProcessInvoker } from './shared/sam/cli/testSamCliProcessInvoker'
 import { ChildProcessResult } from '../shared/utilities/childProcess'
+import { UriHandler } from '../shared/vscode/uriHandler'
 
 export interface FakeMementoStorage {
     [key: string]: any
@@ -93,11 +94,9 @@ export class FakeExtensionContext implements vscode.ExtensionContext {
         const awsContext = new FakeAwsContext()
         const samCliContext = () => {
             return {
-                invoker: new TestSamCliProcessInvoker(
-                    (spawnOptions, args: any[]): ChildProcessResult => {
-                        return new FakeChildProcessResult({})
-                    }
-                ),
+                invoker: new TestSamCliProcessInvoker((spawnOptions, args: any[]): ChildProcessResult => {
+                    return new FakeChildProcessResult({})
+                }),
                 validator: new FakeSamCliValidator(MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_GO_SUPPORT),
             } as SamCliContext
         }
@@ -115,6 +114,7 @@ export class FakeExtensionContext implements vscode.ExtensionContext {
             outputChannel: outputChannel,
             telemetryService: telemetryService,
             credentialsStore: new CredentialsStore(),
+            uriHandler: new UriHandler(),
         }
     }
 }

--- a/src/test/shared/vscode/uriHandler.test.ts
+++ b/src/test/shared/vscode/uriHandler.test.ts
@@ -1,0 +1,72 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import { ParsedUrlQuery as Query } from 'querystring'
+import { UriHandler } from '../../../shared/vscode/uriHandler'
+
+describe('UriHandler', function () {
+    const TEST_PATH = '/my/path'
+    let uriHandler: UriHandler
+
+    function makeUri(query?: string): vscode.Uri {
+        return vscode.Uri.parse(`scheme://authority${TEST_PATH}${query !== undefined ? `?${query}` : ''}`)
+    }
+
+    beforeEach(function () {
+        uriHandler = new UriHandler()
+    })
+
+    it('can register a handler', async function () {
+        uriHandler.registerHandler(TEST_PATH, q => assert.strictEqual(q['key'], 'value'))
+        return uriHandler.handleUri(makeUri('key=value'))
+    })
+
+    it('uses parser if available', async function () {
+        uriHandler.registerHandler(
+            TEST_PATH,
+            q => assert.strictEqual(q.myNumber, 123),
+            (q: Query) => ({ myNumber: Number(q['myString']) })
+        )
+        return uriHandler.handleUri(makeUri('myString=123'))
+    })
+
+    it('can handle lists', async function () {
+        uriHandler.registerHandler(TEST_PATH, q => assert.deepStrictEqual(q['list'], ['1', '2', '3']))
+        return uriHandler.handleUri(makeUri('list=1&list=2&list=3'))
+    })
+
+    it('can dispose handlers', async function () {
+        return new Promise((resolve, reject) => {
+            uriHandler.registerHandler(TEST_PATH, () => reject(new Error('this should not be called'))).dispose()
+            uriHandler.handleUri(makeUri()).then(resolve)
+        })
+    })
+
+    it('throws when registering handler for same path', function () {
+        uriHandler.registerHandler(TEST_PATH, () => {})
+        assert.throws(() => uriHandler.registerHandler(TEST_PATH, () => {}))
+    })
+
+    it('catches errors thrown by the parser', function (done) {
+        const handler = () => done(new Error('this should not be called'))
+        const parser = () => {
+            throw new Error()
+        }
+
+        uriHandler.registerHandler(TEST_PATH, handler, parser)
+        assert.doesNotReject(uriHandler.handleUri(makeUri('key=value'))).then(done, done)
+    })
+
+    it('catches errors thrown by the handler', async function () {
+        const handler = () => {
+            throw new Error()
+        }
+
+        uriHandler.registerHandler(TEST_PATH, handler)
+        return assert.doesNotReject(uriHandler.handleUri(makeUri()))
+    })
+})


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
There can only be a single registered handler per extension, but we want to handle different 'paths' with separate components.

## Solution
Add new `UriHandler` to allow for more than one handler within the extension. Most of the logic is error handling, otherwise exceptions would be swallowed up by the extension host as rejected promises. Callers can optionally add a `parser` callback to narrow the type of the query prior to calling the handler. 

TODO:
Add a way to surface localized strings to the user as error notifications for better UX. 
How should we handle URIs with sensitive information? Right now the class will not log the query component as that's where anything sensitive would be.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
