### PR TITLE
localization: add special type [Experimental]

### DIFF
--- a/src/apprunner/activation.ts
+++ b/src/apprunner/activation.ts
@@ -17,7 +17,7 @@ import { ExtContext } from '../shared/extensions'
 
 const localize = nls.loadMessageBundle()
 
-const commandMap = new Map<[command: string, errorMessage: string], (...args: any) => Promise<any>>()
+const commandMap = new Map<[command: string, errorMessage: nls.LocalizedString], (...args: any) => Promise<any>>()
 
 const CREATE_SERVICE_FAILED = localize('aws.apprunner.createService.failed', 'Failed to create App Runner service')
 const CREATE_SERVICE_ECR_FAILED = localize(

--- a/src/apprunner/commands/pauseService.ts
+++ b/src/apprunner/commands/pauseService.ts
@@ -5,6 +5,7 @@
 
 import * as telemetry from '../../shared/telemetry/telemetry'
 import * as vscode from 'vscode'
+import { confirm, cancel } from '../../shared/localizedText'
 import { DefaultSettingsConfiguration } from '../../shared/settingsConfiguration'
 import { showConfirmationMessage } from '../../shared/utilities/messages'
 import { AppRunnerServiceNode } from '../explorer/apprunnerServiceNode'
@@ -25,7 +26,7 @@ export async function pauseService(node: AppRunnerServiceNode): Promise<void> {
             'Your service will be unavailable while paused. ' +
                 'You can resume the service once the pause operation is complete.'
         )
-        const confirmationOptions = { prompt: notifyPrompt, confirm: 'Confirm', cancel: 'Cancel' }
+        const confirmationOptions = { prompt: notifyPrompt, confirm, cancel }
 
         if (shouldNotify && !(await showConfirmationMessage(confirmationOptions, vscode.window))) {
             telemetryResult = 'Cancelled'

--- a/src/eventSchemas/commands/downloadSchemaItemCode.ts
+++ b/src/eventSchemas/commands/downloadSchemaItemCode.ts
@@ -398,7 +398,8 @@ export class CodeExtractor {
 }
 
 class UserNotifiedError extends Error {
-    public constructor(message?: string | undefined) {
+    public message!: nls.LocalizedString
+    public constructor(message?: nls.LocalizedString | undefined) {
         super(message)
     }
 }

--- a/src/shared/localizedText.ts
+++ b/src/shared/localizedText.ts
@@ -7,18 +7,16 @@ import * as nls from 'vscode-nls'
 import { getIdeProperties } from './extensionUtilities'
 const localize = nls.loadMessageBundle()
 
-export const yes: string = localize('AWS.generic.response.yes', 'Yes')
-export const no: string = localize('AWS.generic.response.no', 'No')
-export const localizedDelete: string = localize('AWS.generic.delete', 'Delete')
-export const cancel: string = localize('AWS.generic.cancel', 'Cancel')
-export const help: string = localize('AWS.generic.help', 'Help')
-export const invalidNumberWarning: string = localize(
-    'AWS.validateTime.error.invalidNumber',
-    'Input must be a positive number'
-)
-export const viewDocs: string = localize('AWS.generic.viewDocs', 'View Documentation')
+export const yes = localize('AWS.generic.response.yes', 'Yes')
+export const no = localize('AWS.generic.response.no', 'No')
+export const localizedDelete = localize('AWS.generic.delete', 'Delete')
+export const confirm = localize('AWS.generic.confirm', 'Confirm')
+export const cancel = localize('AWS.generic.cancel', 'Cancel')
+export const help = localize('AWS.generic.help', 'Help')
+export const invalidNumberWarning = localize('AWS.validateTime.error.invalidNumber', 'Input must be a positive number')
+export const viewDocs = localize('AWS.generic.viewDocs', 'View Documentation')
 
-export function checklogs(): string {
+export function checklogs(): nls.LocalizedString {
     const message = localize(
         'AWS.error.check.logs',
         'Check the logs by running the "View {0} Toolkit Logs" command from the {1}.',

--- a/src/shared/utilities/messages.ts
+++ b/src/shared/utilities/messages.ts
@@ -4,6 +4,7 @@
  */
 
 import * as vscode from 'vscode'
+import { LocalizedString } from 'vscode-nls'
 import { getLogger, showLogOutputChannel } from '../../shared/logger'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { Window } from '../../shared/vscode/window'
@@ -11,7 +12,7 @@ import { ext } from '../extensionGlobals'
 import { getIdeProperties, isCloud9 } from '../extensionUtilities'
 import { Timeout } from './timeoutUtils'
 
-export function makeFailedWriteMessage(filename: string): string {
+export function makeFailedWriteMessage(filename: string): LocalizedString {
     const message = localize('AWS.failedToWrite', '{0}: Failed to write "{1}".', getIdeProperties().company, filename)
 
     return message
@@ -28,7 +29,7 @@ export function makeFailedWriteMessage(filename: string): string {
  * dismissed, and returns the selected button text.
  */
 export async function showViewLogsMessage(
-    message: string,
+    message: LocalizedString,
     window: Window = ext.window,
     kind: 'info' | 'warn' | 'error' = 'error',
     extraItems: string[] = []
@@ -66,7 +67,7 @@ export async function showViewLogsMessage(
  * @param window the window.
  */
 export async function showConfirmationMessage(
-    { prompt, confirm, cancel }: { prompt: string; confirm: string; cancel: string },
+    { prompt, confirm, cancel }: { prompt: LocalizedString; confirm: LocalizedString; cancel: LocalizedString },
     window: Window
 ): Promise<boolean> {
     const confirmItem: vscode.MessageItem = { title: confirm }

--- a/src/shared/utilities/tsUtils.ts
+++ b/src/shared/utilities/tsUtils.ts
@@ -31,3 +31,13 @@ type Expand<T> = T extends infer O ? { [K in keyof O]+?: O[K] } : never
  *
  */
 export type ExpandWithObject<T> = Expand<T> extends Record<string, unknown> ? Expand<T> : never
+
+// Special class to embed a hidden 'key' into a type
+abstract class NominalKey<K> {
+    protected abstract __type__: K
+}
+/**
+ * Creates a 'nominal' type given a base type and a key. These types do _not_ exist at runtime and are
+ * meant to be used to constrain primitives.
+ */
+export type NominalType<T, K> = T & NominalKey<K>

--- a/src/shared/vscode/localize.d.ts
+++ b/src/shared/vscode/localize.d.ts
@@ -1,0 +1,22 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as nls from 'vscode-nls'
+import { NominalType } from '../../shared/utilities/tsUtils'
+
+type PatchOverloadedReturnType<T, R> = T extends {
+    (...args: infer P1): infer R1
+    (...args: infer P2): infer R2
+}
+    ? {
+          (...args: P1): R1 extends string ? R : never
+          (...args: P2): R2 extends string ? R : never
+      }
+    : never
+
+declare module 'vscode-nls' {
+    type LocalizedString = NominalType<string, 'localized'>
+    function loadMessageBundle(file?: string): PatchOverloadedReturnType<nls.LocalizeFunc, LocalizedString>
+}

--- a/src/test/shared/utilities/messageUtilities.test.ts
+++ b/src/test/shared/utilities/messageUtilities.test.ts
@@ -4,15 +4,16 @@
  */
 
 import * as assert from 'assert'
+import { LocalizedString } from 'vscode-nls'
 import { showConfirmationMessage, showViewLogsMessage, showOutputMessage } from '../../../shared/utilities/messages'
 import { MockOutputChannel } from '../../mockOutputChannel'
 import { FakeWindow } from '../../shared/vscode/fakeWindow'
 
 describe('messages', function () {
     describe('showConfirmationMessage', function () {
-        const prompt = 'prompt'
-        const confirm = 'confirm'
-        const cancel = 'cancel'
+        const prompt = 'prompt' as LocalizedString
+        const confirm = 'confirm' as LocalizedString
+        const cancel = 'cancel' as LocalizedString
 
         it('confirms warning message when the user clicks confirm', async function () {
             const window = new FakeWindow({ message: { warningSelection: confirm } })
@@ -45,7 +46,7 @@ describe('messages', function () {
     })
 
     describe('showErrorWithLogs', function () {
-        const message = 'message'
+        const message = 'message' as LocalizedString
 
         it('shows error message with a button to view logs', async function () {
             const window = new FakeWindow({ message: { errorSelection: 'View Logs...' } })


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
All user-facing strings should be ran through the `localize` function so they can be extracted later for translation. We currently have no way to enforce this programmatically; we must review code and verify that contributors are localizing their strings.

## Solution
Add a special `LocalizedString` type returned by any `localize` call. We can now write functions that accept _only_ a localized string. This PR has move parts of the `messages.ts` file to use this type.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
