### PR TITLE
UI: fix edge case when retrying a prompt

### DIFF
--- a/.changes/next-release/Bug Fix-fad1ddc6-c92c-45a5-aecb-9091a9d67f52.json
+++ b/.changes/next-release/Bug Fix-fad1ddc6-c92c-45a5-aecb-9091a9d67f52.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "App Runner: fix issue with create wizard failing at the end after backing out of the select file dialog"
+}

--- a/src/shared/wizards/stateController.ts
+++ b/src/shared/wizards/stateController.ts
@@ -131,7 +131,6 @@ export class StateMachineController<TState> {
                 return undefined
             }
             if (controlSignal === ControlSignal.Retry) {
-                this.state = this.previousStates[this.internalStep]
                 continue
             } else if (nextState === undefined || controlSignal === ControlSignal.Back) {
                 if (this.internalStep === 0) {


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
When closing out of a dialog (e.g to select a file), the prompt is 'retried' by the wizard controller. There is a logic bug in the state machine where it instead uses the _last_ state rather than maintaining the current state. This is probably an artifact from previous iterations. The bug was never caught since `WIZARD_RETRY` is only used a single time in the wizard flow under specific circumstances. 

## Solution
Fix bug and add test to prevent regressions.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
