### PR TITLE
credentials: Reconnect to SSO profile

### DIFF
--- a/.changes/next-release/Feature-21fa11e4-498b-4279-b201-209aad3594d1.json
+++ b/.changes/next-release/Feature-21fa11e4-498b-4279-b201-209aad3594d1.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Credentials: SSO profiles will reconnect on startup if the token is still valid"
+}

--- a/src/credentials/providers/sharedCredentialsProvider.ts
+++ b/src/credentials/providers/sharedCredentialsProvider.ts
@@ -106,10 +106,7 @@ export class SharedCredentialsProvider implements CredentialsProvider {
     public canAutoConnect(): boolean {
         // check if SSO token is still valid
         if (this.isSsoProfile()) {
-            return new DiskCache().loadAccessToken(this.profile[SHARED_CREDENTIAL_PROPERTIES.SSO_START_URL]!) ===
-                undefined
-                ? false
-                : true
+            return !!new DiskCache().loadAccessToken(this.profile[SHARED_CREDENTIAL_PROPERTIES.SSO_START_URL]!)
         }
         return !hasProfileProperty(this.profile, SHARED_CREDENTIAL_PROPERTIES.MFA_SERIAL)
     }

--- a/src/credentials/providers/sharedCredentialsProvider.ts
+++ b/src/credentials/providers/sharedCredentialsProvider.ts
@@ -106,10 +106,8 @@ export class SharedCredentialsProvider implements CredentialsProvider {
     public canAutoConnect(): boolean {
         // check if SSO token is still valid
         if (this.isSsoProfile()) {
-            const ssoCredentialProvider = this.makeSsoProvider()
-            return ssoCredentialProvider.ssoAccessTokenProvider.cache.loadAccessToken(
-                this.profile[SHARED_CREDENTIAL_PROPERTIES.SSO_START_URL]!
-            ) === undefined
+            return new DiskCache().loadAccessToken(this.profile[SHARED_CREDENTIAL_PROPERTIES.SSO_START_URL]!) ===
+                undefined
                 ? false
                 : true
         }

--- a/src/credentials/providers/ssoCredentialProvider.ts
+++ b/src/credentials/providers/ssoCredentialProvider.ts
@@ -17,7 +17,7 @@ export class SsoCredentialProvider {
         private ssoAccount: string,
         private ssoRole: string,
         private ssoClient: SSO,
-        public ssoAccessTokenProvider: SsoAccessTokenProvider
+        private ssoAccessTokenProvider: SsoAccessTokenProvider
     ) {}
 
     public async refreshCredentials(): Promise<Credentials> {

--- a/src/credentials/providers/ssoCredentialProvider.ts
+++ b/src/credentials/providers/ssoCredentialProvider.ts
@@ -17,18 +17,17 @@ export class SsoCredentialProvider {
         private ssoAccount: string,
         private ssoRole: string,
         private ssoClient: SSO,
-        private ssoAccessTokenProvider: SsoAccessTokenProvider
+        public ssoAccessTokenProvider: SsoAccessTokenProvider
     ) {}
 
     public async refreshCredentials(): Promise<Credentials> {
         try {
             const accessToken = await this.ssoAccessTokenProvider.accessToken()
-            const roleCredentials = await this.ssoClient
-                .getRoleCredentials({
-                    accountId: this.ssoAccount,
-                    roleName: this.ssoRole,
-                    accessToken: accessToken.accessToken,
-                })
+            const roleCredentials = await this.ssoClient.getRoleCredentials({
+                accountId: this.ssoAccount,
+                roleName: this.ssoRole,
+                accessToken: accessToken.accessToken,
+            })
 
             return {
                 accessKeyId: roleCredentials.roleCredentials!.accessKeyId!,

--- a/src/credentials/sso/ssoAccessTokenProvider.ts
+++ b/src/credentials/sso/ssoAccessTokenProvider.ts
@@ -48,7 +48,7 @@ export class SsoAccessTokenProvider {
         private ssoRegion: string,
         private ssoUrl: string,
         private ssoOidcClient: SSOOIDC,
-        private cache: DiskCache
+        public cache: DiskCache
     ) {}
 
     public async accessToken(): Promise<SsoAccessToken> {
@@ -135,8 +135,7 @@ export class SsoAccessTokenProvider {
             startUrl: this.ssoUrl,
         }
         try {
-            const authorizationResponse = await this.ssoOidcClient
-                .startDeviceAuthorization(authorizationParams)
+            const authorizationResponse = await this.ssoOidcClient.startDeviceAuthorization(authorizationParams)
             const openedPortalLink = await openSsoPortalLink(authorizationResponse)
             if (!openedPortalLink) {
                 throw Error(`User has canceled SSO login`)

--- a/src/credentials/sso/ssoAccessTokenProvider.ts
+++ b/src/credentials/sso/ssoAccessTokenProvider.ts
@@ -48,7 +48,7 @@ export class SsoAccessTokenProvider {
         private ssoRegion: string,
         private ssoUrl: string,
         private ssoOidcClient: SSOOIDC,
-        public cache: DiskCache
+        private cache: DiskCache
     ) {}
 
     public async accessToken(): Promise<SsoAccessToken> {


### PR DESCRIPTION

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
SSO profiles do not reconnect automatically on start up, even
if the token is still valid.
## Solution
If the most recent credentials were a SSO profile, check if
the token is still valid. Continue login if it is, but do not attempt to
refresh if the token is no longer valid.
<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
