### PR TITLE
docs: .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# To use this file (requires git 2.23):
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# style
+e003b28a7cef217b809d7dc2e54f38f15d1b3920

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ To develop this project, install these dependencies:
     -   NPM version: 7.x or higher
 -   [Typescript](https://www.typescriptlang.org/)
 -   [Git](https://git-scm.com/downloads)
+    -   (optional) Set `git blame` to ignore noise-commits: `git config blame.ignoreRevsFile .git-blame-ignore-revs`
 -   [AWS `git secrets`](https://github.com/awslabs/git-secrets)
 -   (optional) [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
 -   (optional) [Docker](https://docs.docker.com/get-docker/)


### PR DESCRIPTION


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem

`git blame` can be polluted by style-only commits e.g. e003b28a7cef217b809d7dc2e54f38f15d1b3920

## Solution

- Add a `.git-blame-ignore-revs`.
    - This is the current quasi-conventional name AFAICT.
- Currently not possible for git to automatically find this file. Each developer needs to do this one-time step:
    - `git config blame.ignoreRevsFile .git-blame-ignore-revs`

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
