### PR TITLE
test: do not fail if temp dir cleanup fails

### DIFF
--- a/src/test/shared/logger/winstonToolkitLogger.test.ts
+++ b/src/test/shared/logger/winstonToolkitLogger.test.ts
@@ -6,7 +6,6 @@
 import * as assert from 'assert'
 import * as path from 'path'
 import * as filesystemUtilities from '../../../shared/filesystemUtilities'
-import * as fs from 'fs-extra'
 import * as vscode from 'vscode'
 import { WinstonToolkitLogger } from '../../../shared/logger/winstonToolkitLogger'
 import { MockOutputChannel } from '../../mockOutputChannel'
@@ -20,7 +19,7 @@ describe('WinstonToolkitLogger', function () {
     })
 
     after(async function () {
-        await fs.remove(tempFolder)
+        await filesystemUtilities.tryRemoveFolder(tempFolder)
     })
 
     it('logLevelEnabled()', function () {


### PR DESCRIPTION
Problem
-------
Sometimes `winstonToolkitLogger.test.ts` fails like this:

    "after all" hook for "throws when logging to a disposed object":
    Error: ENOTEMPTY: directory not empty, rmdir 'C:\Users\RUNNER~1\AppData\Local\Temp\aws-toolkit-vscode\vsctkXgBlt7'

Solution
--------
Make the delete a best-effort attempt. On CI it doesn't matter if the
temp dir remains. On a local Windows desktop, the temp dir should be
cleaned up by the OS (sooner or later).

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
