### PR TITLE
SAM: wire timeout into build step

### DIFF
--- a/.changes/next-release/Bug Fix-de3aab83-3133-475f-b60c-27dba54b6248.json
+++ b/.changes/next-release/Bug Fix-de3aab83-3133-475f-b60c-27dba54b6248.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "SAM: refresh timeout timer during build step"
+}

--- a/src/credentials/credentialsUtilities.ts
+++ b/src/credentials/credentialsUtilities.ts
@@ -88,13 +88,13 @@ export async function resolveProviderWithCancel(
         }
     }, CREDENTIALS_PROGRESS_DELAY)
 
-    return (await waitTimeout(provider, timeout, {
+    return await waitTimeout(provider, timeout, {
+        allowUndefined: false,
         onCancel: () => {
             throw new Error(`Request to get credentials for "${profile}" cancelled`)
         },
         onExpire: () => {
             throw new Error(`Request to get credentials for "${profile}" expired`)
         },
-        allowUndefined: false,
-    })) as Credentials
+    })
 }

--- a/src/integrationTest/integrationTestsUtilities.ts
+++ b/src/integrationTest/integrationTestsUtilities.ts
@@ -7,8 +7,8 @@ import * as assert from 'assert'
 import { waitUntil } from '../shared/utilities/timeoutUtils'
 import * as vscode from 'vscode'
 
-// This is intentionally set below normal build times to test timeout behavior
-const LAMBDA_SESSION_TIMEOUT = 30000
+// java8.al2 image does a while to pull
+const LAMBDA_SESSION_TIMEOUT = 60000
 
 export async function sleep(miliseconds: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, miliseconds))

--- a/src/integrationTest/integrationTestsUtilities.ts
+++ b/src/integrationTest/integrationTestsUtilities.ts
@@ -7,8 +7,8 @@ import * as assert from 'assert'
 import { waitUntil } from '../shared/utilities/timeoutUtils'
 import * as vscode from 'vscode'
 
-const SECOND = 1000
-export const TIMEOUT = 30 * SECOND
+// This is intentionally set below normal build times to test timeout behavior
+const LAMBDA_SESSION_TIMEOUT = 20000
 
 export async function sleep(miliseconds: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, miliseconds))
@@ -32,8 +32,8 @@ export function getTestWorkspaceFolder(): string {
 
 export async function configureAwsToolkitExtension(): Promise<void> {
     const configAws = vscode.workspace.getConfiguration('aws')
-    // Prevent the extension from preemptively cancelling a 'sam local' run
-    await configAws.update('samcli.lambda.timeout', 90000, false)
+    // This changes how long the toolkit will wait for SAM CLI output before ending a session
+    await configAws.update('samcli.lambda.timeout', LAMBDA_SESSION_TIMEOUT, false)
 }
 
 export async function configurePythonExtension(): Promise<void> {

--- a/src/integrationTest/integrationTestsUtilities.ts
+++ b/src/integrationTest/integrationTestsUtilities.ts
@@ -8,7 +8,7 @@ import { waitUntil } from '../shared/utilities/timeoutUtils'
 import * as vscode from 'vscode'
 
 // This is intentionally set below normal build times to test timeout behavior
-const LAMBDA_SESSION_TIMEOUT = 20000
+const LAMBDA_SESSION_TIMEOUT = 30000
 
 export async function sleep(miliseconds: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, miliseconds))

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -31,8 +31,8 @@ const projectFolder = testUtils.getTestWorkspaceFolder()
 /* Test constants go here */
 const CODELENS_TIMEOUT: number = 60000
 const CODELENS_RETRY_INTERVAL: number = 200
-// This is intentionally set below normal build times to test timeout behavior
-const DEBUG_TIMEOUT: number = 20000
+// note: this refers to the _test_ timeout, not the invocation timeout
+const DEBUG_TIMEOUT: number = 120000
 const NO_DEBUG_SESSION_TIMEOUT: number = 5000
 const NO_DEBUG_SESSION_INTERVAL: number = 100
 

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -31,7 +31,8 @@ const projectFolder = testUtils.getTestWorkspaceFolder()
 /* Test constants go here */
 const CODELENS_TIMEOUT: number = 60000
 const CODELENS_RETRY_INTERVAL: number = 200
-const DEBUG_TIMEOUT: number = 120000
+// This is intentionally set below normal build times to test timeout behavior
+const DEBUG_TIMEOUT: number = 20000
 const NO_DEBUG_SESSION_TIMEOUT: number = 5000
 const NO_DEBUG_SESSION_INTERVAL: number = 100
 

--- a/src/shared/sam/cli/samCliBuild.ts
+++ b/src/shared/sam/cli/samCliBuild.ts
@@ -8,6 +8,8 @@ import { getLogger, Logger } from '../../logger'
 import { logAndThrowIfUnexpectedExitCode, SamCliProcessInvoker } from './samCliInvokerUtils'
 import { pushIf } from '../../utilities/collectionUtils'
 import { localize } from '../../utilities/vsCodeUtils'
+import { Timeout, waitTimeout } from '../../utilities/timeoutUtils'
+import { ChildProcessResult } from '../../utilities/childProcess'
 
 export interface SamCliBuildInvocationArguments {
     /**
@@ -88,7 +90,7 @@ export class SamCliBuildInvocation {
      *
      * @returns Process exit code, or -1 if `SamCliBuildInvocation` stopped the process and stored a failure message in `SamCliBuildInvocation.failure()`.
      */
-    public async execute(): Promise<number> {
+    public async execute(timer?: Timeout): Promise<number> {
         await this.validate()
 
         const invokeArgs: string[] = [
@@ -125,21 +127,41 @@ export class SamCliBuildInvocation {
                     'AWS.sam.build.failure.diskSpace',
                     '"sam build" failed. Check system disk space.'
                 )
+            } else if (timer !== undefined) {
+                timer.refresh()
             }
         }
 
-        const childProcessResult = await this.args.invoker.invoke({
+        let childProcessResult: Promise<ChildProcessResult | void> = this.args.invoker.invoke({
             spawnOptions: { env },
             arguments: invokeArgs,
             onStdout: checkFailure,
             onStderr: checkFailure,
         })
 
-        if (this._failure) {
+        // TODO: add `Timeout` support to `ChildProcess` itself instead of wrapping the promise
+        if (timer) {
+            childProcessResult = waitTimeout(childProcessResult, timer, {
+                allowUndefined: false,
+                completeTimeout: false,
+                onExpire: () => {
+                    this.args.invoker.stop()
+                    this._failure = localize(
+                        'AWS.sam.build.failure.timeout',
+                        '"sam build" failed. Timed out waiting for build.'
+                    )
+                },
+            })
+        }
+
+        const result = await childProcessResult
+
+        if (this._failure || result === undefined) {
             return -1
         }
-        logAndThrowIfUnexpectedExitCode(childProcessResult, 0)
-        return childProcessResult.exitCode
+
+        logAndThrowIfUnexpectedExitCode(result, 0)
+        return result.exitCode
     }
 
     private async validate(): Promise<void> {

--- a/src/shared/sam/cli/samCliBuild.ts
+++ b/src/shared/sam/cli/samCliBuild.ts
@@ -142,7 +142,6 @@ export class SamCliBuildInvocation {
         // TODO: add `Timeout` support to `ChildProcess` itself instead of wrapping the promise
         if (timer) {
             childProcessResult = waitTimeout(childProcessResult, timer, {
-                allowUndefined: false,
                 completeTimeout: false,
                 onExpire: () => {
                     this.args.invoker.stop()

--- a/src/shared/sam/cli/samCliBuild.ts
+++ b/src/shared/sam/cli/samCliBuild.ts
@@ -120,7 +120,7 @@ export class SamCliBuildInvocation {
             ...this.args.environmentVariables,
         }
 
-        const checkFailure = (text: string): void => {
+        const onOutput = (text: string): void => {
             if (text.match(/(RuntimeError: Container does not exist)/)) {
                 this.args.invoker.stop()
                 this._failure = localize(
@@ -135,8 +135,8 @@ export class SamCliBuildInvocation {
         let childProcessResult: Promise<ChildProcessResult | void> = this.args.invoker.invoke({
             spawnOptions: { env },
             arguments: invokeArgs,
-            onStdout: checkFailure,
-            onStderr: checkFailure,
+            onStdout: onOutput,
+            onStderr: onOutput,
         })
 
         // TODO: add `Timeout` support to `ChildProcess` itself instead of wrapping the promise

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -179,7 +179,7 @@ async function buildLambdaHandler(
 
     try {
         const samBuild = new SamCliBuildInvocation(samCliArgs)
-        await samBuild.execute()
+        await samBuild.execute(timer)
         if (samBuild.failure()) {
             getLogger('debugConsole').error(samBuild.failure()!)
             throw new Error(samBuild.failure())

--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -190,7 +190,7 @@ export function waitTimeout<T, R = void, B extends boolean = true>(
             if ((opt.allowUndefined ?? true) !== true) {
                 throw new Error(TIMEOUT_UNEXPECTED_RESOLVE)
             }
-            return undefined as true extends typeof opt.allowUndefined ? undefined : never
+            return undefined as any
         })
         .catch(err => {
             if (opt.onExpire && (err as Error).message === TIMEOUT_EXPIRED_MESSAGE) {

--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -184,13 +184,14 @@ export function waitTimeout<T, R = void, B extends boolean = true>(
 
     return Promise.race([promise, timeout.timer])
         .then(obj => {
+            const allowUndefined = (opt.allowUndefined ?? true) as B
             if (obj !== undefined) {
                 return obj
             }
-            if (opt.allowUndefined !== true) {
+            if (allowUndefined !== true) {
                 throw new Error(TIMEOUT_UNEXPECTED_RESOLVE)
             }
-            return undefined as true extends typeof opt.allowUndefined ? undefined : never
+            return undefined as true extends typeof allowUndefined ? undefined : never
         })
         .catch(err => {
             if (opt.onExpire && (err as Error).message === TIMEOUT_EXPIRED_MESSAGE) {

--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -177,21 +177,20 @@ export function waitTimeout<T, R = void, B extends boolean = true>(
         onCancel?: () => R
         completeTimeout?: boolean
     } = {}
-): Promise<T | R | (true extends B ? undefined : never)> {
+): Promise<T | R | (true extends typeof opt.allowUndefined ? undefined : never)> {
     if (typeof promise === 'function') {
         promise = promise()
     }
 
     return Promise.race([promise, timeout.timer])
         .then(obj => {
-            const allowUndefined = (opt.allowUndefined ?? true) as B
             if (obj !== undefined) {
                 return obj
             }
-            if (allowUndefined !== true) {
+            if ((opt.allowUndefined ?? true) !== true) {
                 throw new Error(TIMEOUT_UNEXPECTED_RESOLVE)
             }
-            return undefined as true extends typeof allowUndefined ? undefined : never
+            return undefined as true extends typeof opt.allowUndefined ? undefined : never
         })
         .catch(err => {
             if (opt.onExpire && (err as Error).message === TIMEOUT_EXPIRED_MESSAGE) {

--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -168,29 +168,29 @@ export async function waitUntil<T>(
  *
  * @returns A Promise that returns if successful, or rejects when the Timeout was cancelled or expired.
  */
-export function waitTimeout<T>(
+export function waitTimeout<T, R = void, B extends boolean = true>(
     promise: Promise<T> | (() => Promise<T>),
-    timeout: Timeout,
+    timeout: Timeout, // TODO: potentially type 'completed' timers differently from active ones
     opt: {
-        allowUndefined?: boolean
-        onExpire?: () => T | undefined
-        onCancel?: () => T | undefined
+        allowUndefined?: B
+        onExpire?: () => R
+        onCancel?: () => R
         completeTimeout?: boolean
     } = {}
-): Promise<T | undefined> {
+): Promise<T | R | (true extends B ? undefined : never)> {
     if (typeof promise === 'function') {
         promise = promise()
     }
 
     return Promise.race([promise, timeout.timer])
         .then(obj => {
-            if (opt.allowUndefined === false && obj === undefined) {
-                throw new Error(TIMEOUT_UNEXPECTED_RESOLVE)
-            }
             if (obj !== undefined) {
                 return obj
             }
-            return undefined
+            if (opt.allowUndefined !== true) {
+                throw new Error(TIMEOUT_UNEXPECTED_RESOLVE)
+            }
+            return undefined as true extends typeof opt.allowUndefined ? undefined : never
         })
         .catch(err => {
             if (opt.onExpire && (err as Error).message === TIMEOUT_EXPIRED_MESSAGE) {


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Timeout was never wired through

## Solution
Add it

`Timeout` should be an argument of the `ChildProcess` class as a whole, but that requires a good chunk of refactoring.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
