### PR TITLE
Adds option to visualize asl in both asl-yaml and yaml

### DIFF
--- a/.changes/next-release/Feature-66d9f363-dc3a-4e49-b6f0-e3febc1ef981.json
+++ b/.changes/next-release/Feature-66d9f363-dc3a-4e49-b6f0-e3febc1ef981.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Option to render Step Functions ASL file in YAML format that is not marked as asl-yaml."
+}

--- a/src/stepFunctions/commands/visualizeStateMachine/aslVisualization.ts
+++ b/src/stepFunctions/commands/visualizeStateMachine/aslVisualization.ts
@@ -13,7 +13,7 @@ import { getLogger, Logger } from '../../../shared/logger'
 import { isDocumentValid } from '../../utils'
 import * as yaml from 'yaml'
 
-import { YAML_ASL } from '../../constants/aslFormats'
+import { YAML_FORMATS } from '../../constants/aslFormats'
 
 const YAML_OPTIONS: yaml.Options = {
     merge: false,
@@ -64,7 +64,7 @@ export class AslVisualization {
 
     public async sendUpdateMessage(updatedTextDocument: vscode.TextDocument) {
         const logger: Logger = getLogger()
-        const isYaml = updatedTextDocument.languageId === YAML_ASL
+        const isYaml = YAML_FORMATS.includes(updatedTextDocument.languageId)
         const text = this.getText(updatedTextDocument)
         let stateMachineData = text
         let yamlErrors: string[] = []


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
#1477 - Error when users try to render Step Functions ASL in YAML format that is not marked as "asl-yaml"

## Solution
Added "yaml" format to list of formats being converted to json before checking validity. 

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
