### PR TITLE
settings: validate suppressPrompts calls, rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,15 +188,15 @@
                     "type": "object",
                     "description": "%AWS.configuration.description.suppressPrompts%",
                     "default": {
-                        "suppressApprunnerNotifyPricing": false,
-                        "suppressYamlExtPrompt": false
+                        "apprunnerNotifyPricing": false,
+                        "yamlExtPrompt": false
                     },
                     "properties": {
-                        "suppressApprunnerNotifyPricing": {
+                        "apprunnerNotifyPricing": {
                             "type": "boolean",
                             "default": false
                         },
-                        "suppressYamlExtPrompt": {
+                        "yamlExtPrompt": {
                             "type": "boolean",
                             "default": false
                         }

--- a/package.nls.json
+++ b/package.nls.json
@@ -42,7 +42,7 @@
     "AWS.configuration.description.samcli.location": "Location of SAM CLI. SAM CLI is used to create, build, package, and deploy Serverless Applications. [Learn More](https://aws.amazon.com/serverless/sam/)",
     "AWS.configuration.description.telemetry": "Enable AWS Toolkit to send usage data to AWS.",
     "AWS.configuration.description.telemetry.cn": "Enable Amazon Toolkit to send usage data to Amazon.",
-    "AWS.configuration.description.suppressPrompts": "List of prompts to suppress.",
+    "AWS.configuration.description.suppressPrompts": "Optional prompts",
     "AWS.configuration.enableCodeLenses": "Enable SAM hints in source files",
     "AWS.stepFunctions.asl.format.enable.desc": "Enables the default formatter used with Amazon States Language files",
     "AWS.stepFunctions.asl.maxItemsComputed.desc": "The maximum number of outline symbols and folding regions computed (limited for performance reasons).",

--- a/src/apprunner/wizards/deploymentButton.ts
+++ b/src/apprunner/wizards/deploymentButton.ts
@@ -34,7 +34,7 @@ function makeDeployButtons() {
 
 async function showDeploymentCostNotification(): Promise<void> {
     const settingsConfig = new DefaultSettingsConfiguration(extensionSettingsPrefix)
-    if (await settingsConfig.shouldDisplayPrompt('suppressApprunnerNotifyPricing')) {
+    if (await settingsConfig.isPromptEnabled('apprunnerNotifyPricing')) {
         const notice = localize(
             'aws.apprunner.createService.priceNotice.message',
             'App Runner automatic deployments incur an additional cost.'
@@ -48,7 +48,7 @@ async function showDeploymentCostNotification(): Promise<void> {
                 vscode.env.openExternal(pricingUri)
                 await showDeploymentCostNotification()
             } else if (button === dontShow) {
-                settingsConfig.disablePrompt('suppressApprunnerNotifyPricing')
+                settingsConfig.disablePrompt('apprunnerNotifyPricing')
             }
         })
     }

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -38,8 +38,6 @@ import { lazyLoadSamTemplateStrings } from '../../lambda/models/samTemplates'
 import { extensionSettingsPrefix } from '../constants'
 const localize = nls.loadMessageBundle()
 
-const STATE_NAME_SUPPRESS_YAML_PROMPT = 'suppressYamlExtPrompt'
-
 /**
  * Activate SAM-related functionality.
  */
@@ -256,7 +254,7 @@ async function createYamlExtensionPrompt(): Promise<void> {
     // Show this only in VSCode since other VSCode-like IDEs (e.g. Theia) may
     // not have a marketplace or contain the YAML plugin.
     if (
-        (await settingsConfig.shouldDisplayPrompt(STATE_NAME_SUPPRESS_YAML_PROMPT)) &&
+        (await settingsConfig.isPromptEnabled('yamlExtPrompt')) &&
         getIdeType() === IDE.vscode &&
         !vscode.extensions.getExtension(VSCODE_EXTENSION_ID.yaml)
     ) {
@@ -349,7 +347,7 @@ async function promptInstallYamlPlugin(fileName: string, disposables: vscode.Dis
                 }
                 break
             case permanentlySuppress:
-                settingsConfig.disablePrompt(STATE_NAME_SUPPRESS_YAML_PROMPT)
+                settingsConfig.disablePrompt('yamlExtPrompt')
         }
     }
 }

--- a/src/shared/settingsConfiguration.ts
+++ b/src/shared/settingsConfiguration.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode'
 import { getLogger } from './logger'
+import * as packageJson from '../../package.json'
 
 /**
  * Wraps the VSCode configuration API and provides Toolkit-related
@@ -61,6 +62,8 @@ export class DefaultSettingsConfiguration implements SettingsConfiguration {
      * @param promptName Name of prompt to suppress
      */
     public async disablePrompt(promptName: string): Promise<void> {
+        this.validatePromptSetting(promptName)
+
         const setting = await this.getSuppressPromptSetting(promptName)
         if (setting === undefined || setting[promptName]) {
             return
@@ -68,12 +71,15 @@ export class DefaultSettingsConfiguration implements SettingsConfiguration {
         setting[promptName] = true
         await this.writeSetting('suppressPrompts', setting, vscode.ConfigurationTarget.Global)
     }
+
     /**
-     * Verifies if a prompt should be displayed again.
-     * @param promptName Name of the prompt
+     * Returns true if a prompt is enabled, else false.
+     * @param promptName Prompt id
      * @returns False when prompt has been suppressed
      */
-    public async shouldDisplayPrompt(promptName: string): Promise<boolean> {
+    public async isPromptEnabled(promptName: string): Promise<boolean> {
+        this.validatePromptSetting(promptName)
+
         const promptSetting = await this.getSuppressPromptSetting(promptName)
         if (promptSetting !== undefined && promptSetting[promptName]) {
             return false
@@ -82,12 +88,15 @@ export class DefaultSettingsConfiguration implements SettingsConfiguration {
     }
 
     /**
-     * Gets the 'aws.suppressPrompts' setting. This will reset the setting to default if it does not
-     * recieve an object or the prompt's value is not a boolean.
+     * Gets an 'aws.suppressPrompts' for prompt `promptName`. Resets to a
+     * default value if the user setting has an invalid type.
+     *
      * @param promptName
-     * @returns The settings object
+     * @returns settings object
      */
     public async getSuppressPromptSetting(promptName: string): Promise<{ [prompt: string]: boolean } | undefined> {
+        this.validatePromptSetting(promptName)
+
         try {
             const setting = this.readSetting<{ [prompt: string]: boolean }>('suppressPrompts')
             if (setting === undefined) {
@@ -118,6 +127,16 @@ export class DefaultSettingsConfiguration implements SettingsConfiguration {
             return setting
         } catch (e) {
             getLogger().error('Failed to get the setting: suppressPrompts', e)
+        }
+    }
+
+    /**
+     * Throws an error if `name` is not a valid 'aws.suppressPrompts' setting.
+     */
+    private validatePromptSetting(name: string): void {
+        const m = packageJson.contributes.configuration.properties['aws.suppressPrompts'].properties
+        if (!(m as any)[name]) {
+            throw Error(`config: unknown aws.suppressPrompts item: "${name}"`)
         }
     }
 }

--- a/src/test/shared/settingsConfiguration.test.ts
+++ b/src/test/shared/settingsConfiguration.test.ts
@@ -84,20 +84,24 @@ describe('DefaultSettingsConfiguration', function () {
 
     describe('disablePrompt', async function () {
         let defaultSetting: any
-        const promptName = 'promptName'
-        before(async function () {
-            // This gets the default settings
+        const promptName = 'apprunnerNotifyPricing'
+        beforeEach(async function () {
+            // Force the default settings.
             await sut.writeSetting(PROMPT_SETTING_KEY, {}, vscode.ConfigurationTarget.Global)
             defaultSetting = sut.readSetting(PROMPT_SETTING_KEY)
         })
 
         const scenarios = [
             {
-                testValue: { promptName: true, other: false },
-                expected: { promptName: true, other: false },
+                testValue: { apprunnerNotifyPricing: true, other: false },
+                expected: { apprunnerNotifyPricing: true, other: false },
                 desc: 'stays suppressed',
             },
-            { testValue: { promptName: false }, expected: { promptName: true }, desc: 'suppresses prompt' },
+            {
+                testValue: { apprunnerNotifyPricing: false },
+                expected: { apprunnerNotifyPricing: true },
+                desc: 'suppresses prompt',
+            },
             { testValue: undefined, expected: undefined, desc: 'writes nothing if undefined' },
         ]
         scenarios.forEach(scenario => {
@@ -107,11 +111,15 @@ describe('DefaultSettingsConfiguration', function () {
                 assert.deepStrictEqual(sut.readSetting(PROMPT_SETTING_KEY), { ...defaultSetting, ...scenario.expected })
             })
         })
+
+        it('validates', async function () {
+            assert.rejects(sut.disablePrompt('invalidPrompt'))
+        })
     })
 
-    describe('getSuppressPromptSetting & shouldDisplayPrompt', async function () {
+    describe('getSuppressPromptSetting, isPromptEnabled', async function () {
         let defaultSetting: any
-        const promptName = 'promptName'
+        const promptName = 'apprunnerNotifyPricing'
 
         before(async function () {
             await sut.writeSetting(PROMPT_SETTING_KEY, {}, vscode.ConfigurationTarget.Global)
@@ -120,15 +128,15 @@ describe('DefaultSettingsConfiguration', function () {
 
         const scenarios = [
             {
-                testValue: { promptName: false },
+                testValue: { apprunnerNotifyPricing: false },
                 expected: true,
-                promptAfter: { promptName: false },
+                promptAfter: { apprunnerNotifyPricing: false },
                 desc: 'true when not suppressed',
             },
             {
-                testValue: { promptName: true },
+                testValue: { apprunnerNotifyPricing: true },
                 expected: false,
-                promptAfter: { promptName: true },
+                promptAfter: { apprunnerNotifyPricing: true },
                 desc: 'false when suppressed',
             },
             {
@@ -138,9 +146,9 @@ describe('DefaultSettingsConfiguration', function () {
                 desc: 'true when not found',
             },
             {
-                testValue: { promptName: 7 },
+                testValue: { apprunnerNotifyPricing: 7 },
                 expected: true,
-                promptAfter: { promptName: false },
+                promptAfter: { apprunnerNotifyPricing: false },
                 desc: 'true when prompt has wrong type',
             },
             { testValue: 'badType', expected: true, promptAfter: {}, desc: 'reset setting if wrong type' },
@@ -149,13 +157,18 @@ describe('DefaultSettingsConfiguration', function () {
         scenarios.forEach(scenario => {
             it(scenario.desc, async () => {
                 await sut.writeSetting(PROMPT_SETTING_KEY, scenario.testValue, vscode.ConfigurationTarget.Global)
-                const result = await sut.shouldDisplayPrompt(promptName)
+                const result = await sut.isPromptEnabled(promptName)
                 assert.deepStrictEqual(result, scenario.expected)
                 assert.deepStrictEqual(sut.readSetting(PROMPT_SETTING_KEY), {
                     ...defaultSetting,
                     ...scenario.promptAfter,
                 })
             })
+        })
+
+        it('validates', async function () {
+            await assert.rejects(sut.isPromptEnabled('invalidPrompt'))
+            await assert.rejects(sut.getSuppressPromptSetting('invalidPrompt'))
         })
     })
 })

--- a/src/test/shared/settingsConfiguration.test.ts
+++ b/src/test/shared/settingsConfiguration.test.ts
@@ -102,18 +102,19 @@ describe('DefaultSettingsConfiguration', function () {
                 expected: { apprunnerNotifyPricing: true },
                 desc: 'suppresses prompt',
             },
-            { testValue: undefined, expected: undefined, desc: 'writes nothing if undefined' },
         ]
         scenarios.forEach(scenario => {
             it(scenario.desc, async () => {
                 await sut.writeSetting(PROMPT_SETTING_KEY, scenario.testValue, vscode.ConfigurationTarget.Global)
                 await sut.disablePrompt(promptName)
-                assert.deepStrictEqual(sut.readSetting(PROMPT_SETTING_KEY), { ...defaultSetting, ...scenario.expected })
+                const actual = sut.readSetting(PROMPT_SETTING_KEY)
+                const expected = { ...defaultSetting, ...scenario.expected }
+                assert.deepStrictEqual(actual, expected)
             })
         })
 
         it('validates', async function () {
-            assert.rejects(sut.disablePrompt('invalidPrompt'))
+            await assert.rejects(sut.disablePrompt('invalidPrompt'))
         })
     })
 

--- a/src/test/templates/sam/samTemplateGenerator.test.ts
+++ b/src/test/templates/sam/samTemplateGenerator.test.ts
@@ -122,52 +122,52 @@ describe('SamTemplateGenerator', function () {
     })
 
     it('errs if resource name is missing', async function () {
-        assert.rejects(
+        await assert.rejects(
             new SamTemplateGenerator()
                 .withCodeUri(sampleCodeUriValue)
                 .withFunctionHandler(sampleFunctionHandlerValue)
                 .withRuntime(sampleRuntimeValue)
                 .generate(templateFilename),
-            'Missing value: at least one of ResourceName or TemplateResources'
+            new Error('Missing value: at least one of ResourceName or TemplateResources')
         )
 
         assert.strictEqual(await SystemUtilities.fileExists(templateFilename), false)
     })
 
     it('errs if function handler is missing', async function () {
-        assert.rejects(
+        await assert.rejects(
             new SamTemplateGenerator()
                 .withCodeUri(sampleCodeUriValue)
                 .withRuntime(sampleRuntimeValue)
                 .withResourceName(sampleResourceNameValue)
                 .generate(templateFilename),
-            'Missing value: Handler'
+            new Error('Missing value: Handler')
         )
 
         assert.strictEqual(await SystemUtilities.fileExists(templateFilename), false)
     })
 
     it('errs if code uri is missing', async function () {
-        assert.rejects(
+        await assert.rejects(
             new SamTemplateGenerator()
                 .withFunctionHandler(sampleFunctionHandlerValue)
                 .withRuntime(sampleRuntimeValue)
                 .withResourceName(sampleResourceNameValue)
                 .generate(templateFilename),
-            'Missing value: CodeUri'
+            new Error('Missing value: CodeUri')
         )
 
         assert.strictEqual(await SystemUtilities.fileExists(templateFilename), false)
     })
 
     it('errs if runtime is missing', async function () {
-        assert.rejects(
+        await assert.rejects(
             new SamTemplateGenerator()
                 .withCodeUri(sampleCodeUriValue)
                 .withFunctionHandler(sampleFunctionHandlerValue)
                 .withResourceName(sampleResourceNameValue)
                 .generate(templateFilename),
-            'Missing value: Runtime'
+            new Error('Missing value: Runtime')
         )
 
         assert.strictEqual(await SystemUtilities.fileExists(templateFilename), false)

--- a/src/test/templates/sam/samTemplateGenerator.test.ts
+++ b/src/test/templates/sam/samTemplateGenerator.test.ts
@@ -122,70 +122,54 @@ describe('SamTemplateGenerator', function () {
     })
 
     it('errs if resource name is missing', async function () {
-        const error: Error = await assertThrowsError(async () => {
-            await new SamTemplateGenerator()
+        assert.rejects(
+            new SamTemplateGenerator()
                 .withCodeUri(sampleCodeUriValue)
                 .withFunctionHandler(sampleFunctionHandlerValue)
                 .withRuntime(sampleRuntimeValue)
-                .generate(templateFilename)
-        })
+                .generate(templateFilename),
+            'Missing value: at least one of ResourceName or TemplateResources'
+        )
 
-        assert.ok(error)
-        assert.strictEqual(error.message, 'Missing value: at least one of ResourceName or TemplateResources')
         assert.strictEqual(await SystemUtilities.fileExists(templateFilename), false)
     })
 
     it('errs if function handler is missing', async function () {
-        const error: Error = await assertThrowsError(async () => {
-            await new SamTemplateGenerator()
+        assert.rejects(
+            new SamTemplateGenerator()
                 .withCodeUri(sampleCodeUriValue)
                 .withRuntime(sampleRuntimeValue)
                 .withResourceName(sampleResourceNameValue)
-                .generate(templateFilename)
-        })
+                .generate(templateFilename),
+            'Missing value: Handler'
+        )
 
-        assert.ok(error)
-        assert.strictEqual(error.message, 'Missing value: Handler')
         assert.strictEqual(await SystemUtilities.fileExists(templateFilename), false)
     })
 
     it('errs if code uri is missing', async function () {
-        const error: Error = await assertThrowsError(async () => {
-            await new SamTemplateGenerator()
+        assert.rejects(
+            new SamTemplateGenerator()
                 .withFunctionHandler(sampleFunctionHandlerValue)
                 .withRuntime(sampleRuntimeValue)
                 .withResourceName(sampleResourceNameValue)
-                .generate(templateFilename)
-        })
+                .generate(templateFilename),
+            'Missing value: CodeUri'
+        )
 
-        assert.ok(error)
-        assert.strictEqual(error.message, 'Missing value: CodeUri')
         assert.strictEqual(await SystemUtilities.fileExists(templateFilename), false)
     })
 
     it('errs if runtime is missing', async function () {
-        const error: Error = await assertThrowsError(async () => {
-            await new SamTemplateGenerator()
+        assert.rejects(
+            new SamTemplateGenerator()
                 .withCodeUri(sampleCodeUriValue)
                 .withFunctionHandler(sampleFunctionHandlerValue)
                 .withResourceName(sampleResourceNameValue)
-                .generate(templateFilename)
-        })
+                .generate(templateFilename),
+            'Missing value: Runtime'
+        )
 
-        assert.ok(error)
-        assert.strictEqual(error.message, 'Missing value: Runtime')
         assert.strictEqual(await SystemUtilities.fileExists(templateFilename), false)
     })
-
-    async function assertThrowsError(fn: () => Thenable<any>): Promise<Error> {
-        try {
-            await fn()
-        } catch (err) {
-            if (err instanceof Error) {
-                return err
-            }
-        }
-
-        throw new Error('function did not throw error as expected')
-    }
 })


### PR DESCRIPTION
followup to #1937

- Validate the promptName by inspecting package.json.
- Rename subitems to "apprunnerNotifyPricing", "yamlExtPrompt". Don't
  need "suppress" in the names, it is redundant and looks strange in the
  UI.

## before/after

![image](https://user-images.githubusercontent.com/55561878/133519007-0b57cb42-8857-4388-ae75-3741c16c842f.png)



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
