### PR TITLE
Logging: add decorator

### DIFF
--- a/src/shared/logger/logger.ts
+++ b/src/shared/logger/logger.ts
@@ -26,6 +26,8 @@ export interface Logger {
     /** Returns true if the given log level is being logged.  */
     logLevelEnabled(logLevel: LogLevel): boolean
     getLogById(logID: number, file: Uri): string | undefined
+    /** A 'name' used to prefix log messages with */
+    name?: string
 }
 
 /**

--- a/src/shared/logger/winstonToolkitLogger.ts
+++ b/src/shared/logger/winstonToolkitLogger.ts
@@ -16,6 +16,7 @@ import { OutputChannelTransport } from './outputChannelTransport'
 // LRU cache would work well, currently it just dumps the least recently added log
 const LOGMAP_SIZE: number = 1000
 export class WinstonToolkitLogger implements Logger, vscode.Disposable {
+    public name?: string
     private readonly logger: winston.Logger
     private disposed: boolean = false
     private idCounter: number = 0
@@ -34,7 +35,9 @@ export class WinstonToolkitLogger implements Logger, vscode.Disposable {
                         return info.message
                     }
 
-                    return `${info.timestamp} [${info.level.toUpperCase()}]: ${info.message}`
+                    const nameLabel = this.name ? `(${this.name})` : ''
+
+                    return `${info.timestamp} [${info.level.toUpperCase()}]: ${nameLabel} ${info.message}`
                 })
             ),
             level: logLevel,

--- a/src/shared/resourcefetcher/httpResourceFetcher.ts
+++ b/src/shared/resourcefetcher/httpResourceFetcher.ts
@@ -8,10 +8,12 @@ import * as fs from 'fs'
 import * as request from 'request'
 import { VSCODE_EXTENSION_ID } from '../extensions'
 import { getLogger, Logger } from '../logger'
+import { logging } from '../utilities/decorators'
 import { ResourceFetcher } from './resourcefetcher'
 
+@logging
 export class HttpResourceFetcher implements ResourceFetcher {
-    private readonly logger: Logger = getLogger()
+    public readonly logger: Logger = getLogger()
 
     /**
      *

--- a/src/shared/utilities/decorators.ts
+++ b/src/shared/utilities/decorators.ts
@@ -1,0 +1,23 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Logger } from '../logger/logger'
+
+export function logging<T extends new (...args: any) => { logger: Logger }>(constructor: T) {
+    let _logger: Logger | undefined
+    const name = constructor.name
+    Object.defineProperty(constructor.prototype, 'logger', {
+        get: () => {
+            if (_logger === undefined) {
+                throw new Error(`Class "${name}" accessed logger before assigning it`)
+            }
+            return _logger
+        },
+        set: (v: Logger) => {
+            v.name = name
+            _logger = v
+        },
+    })
+}

--- a/src/test/shared/utilities/decorators.test.ts
+++ b/src/test/shared/utilities/decorators.test.ts
@@ -22,6 +22,17 @@ describe('@logging', function () {
     })
 
     @logging
+    class ChildTest extends Test {
+        constructor() {
+            super()
+        }
+    }
+
+    it('can override parent decorators', function () {
+        assert.strictEqual(new ChildTest().logger.name, 'ChildTest')
+    })
+
+    @logging
     class BadType {
         public logger!: Logger
     }

--- a/src/test/shared/utilities/decorators.test.ts
+++ b/src/test/shared/utilities/decorators.test.ts
@@ -1,0 +1,32 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { getNullLogger, Logger } from '../../../shared/logger'
+import { logging } from '../../../shared/utilities/decorators'
+
+describe('@logging', function () {
+    @logging
+    class Test {
+        public logger: Logger
+
+        constructor() {
+            this.logger = getNullLogger()
+        }
+    }
+
+    it('sets name of logger', function () {
+        assert.strictEqual(new Test().logger.name, 'Test')
+    })
+
+    @logging
+    class BadType {
+        public logger!: Logger
+    }
+
+    it('throws if trying to access unassigned logger', function () {
+        assert.throws(() => new BadType().logger)
+    })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
         "moduleResolution": "node",
         "rootDirs": ["src", "third-party"],
         "resolveJsonModule": true,
+        "experimentalDecorators": true,
         /* Strict Type-Checking Option */
         "strict": true /* enable all strict type-checking options */,
         /* Additional Checks */


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

Adds a decorator that injects the class name into log statements. Classes need to declare a public `logger` field to use the decorator (there's no way TypeScript-y way of enforcing this through private/protected fields). There's a few different ways of adding the class information but this seems like the most 'user-friendly'.

I changed one class for now to use it. Should be straightforward to move the rest though.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
