### PR TITLE
ec2MetadataClient: handle broken endpoint, bad response

### DIFF
--- a/src/shared/clients/ec2MetadataClient.ts
+++ b/src/shared/clients/ec2MetadataClient.ts
@@ -23,22 +23,27 @@ export class DefaultEc2MetadataClient {
 
     public constructor(private metadata: MetadataService = DefaultEc2MetadataClient.getMetadataService()) {}
 
-    getInstanceIdentity(): Promise<InstanceIdentity> {
+    public getInstanceIdentity(): Promise<InstanceIdentity> {
         return this.invoke<InstanceIdentity>('/latest/dynamic/instance-identity/document')
     }
 
-    getIamInfo(): Promise<IamInfo> {
+    public getIamInfo(): Promise<IamInfo> {
         return this.invoke<IamInfo>('/latest/meta-data/iam/info')
     }
 
-    private invoke<T>(path: string): Promise<T> {
+    public invoke<T>(path: string): Promise<T> {
         return new Promise((resolve, reject) => {
             this.metadata.request(path, (err, response) => {
                 if (err) {
                     reject(err)
+                    return
                 }
-                const jsonResponse: T = JSON.parse(response)
-                resolve(jsonResponse)
+                try {
+                    const jsonResponse: T = JSON.parse(response)
+                    resolve(jsonResponse)
+                } catch (e) {
+                    reject(`Ec2MetadataClient: invalid response from "${path}": ${response}\nerror: ${e}`)
+                }
             })
         })
     }

--- a/src/test/credentials/provider/ec2CredentialsProvider.test.ts
+++ b/src/test/credentials/provider/ec2CredentialsProvider.test.ts
@@ -23,7 +23,7 @@ describe('Ec2CredentialsProvider', function () {
         credentialsProvider = new Ec2CredentialsProvider(instance(mockMetadata))
     })
 
-    it('should be valid if EC2 metadata service resolves valid IAM status', async function () {
+    it('is valid if EC2 metadata service resolves valid IAM status', async function () {
         mockClient({
             identity: {} as InstanceIdentity,
             validIam: true,
@@ -31,21 +31,21 @@ describe('Ec2CredentialsProvider', function () {
         assert.strictEqual(await credentialsProvider.isAvailable(), true)
     })
 
-    it('should be invalid if EC2 metadata resolves invalid IAM status', async function () {
+    it('is invalid if EC2 metadata resolves invalid IAM status', async function () {
         mockClient({
             validIam: false,
         })
         assert.strictEqual(await credentialsProvider.isAvailable(), false)
     })
 
-    it('should be invalid if EC2 metadata service fails to resolve', async function () {
+    it('is invalid if EC2 metadata service fails to resolve', async function () {
         mockClient({
             fail: true,
         })
         assert.strictEqual(await credentialsProvider.isAvailable(), false)
     })
 
-    it('should only validate once per instance', async function () {
+    it('only validates once per instance', async function () {
         mockClient({
             identity: mockIdentity,
             validIam: true,
@@ -57,7 +57,7 @@ describe('Ec2CredentialsProvider', function () {
         } catch (err) {}
     })
 
-    it('should return EC2 retrieved region if available', async function () {
+    it('returns EC2 retrieved region if available', async function () {
         mockClient({
             identity: mockIdentity,
             validIam: true,
@@ -67,7 +67,7 @@ describe('Ec2CredentialsProvider', function () {
         assert.strictEqual(credentialsProvider.getDefaultRegion(), dummyRegion)
     })
 
-    it('should return undefined region when not available', async function () {
+    it('returns undefined region when not available', async function () {
         mockClient({
             identity: {} as InstanceIdentity,
             validIam: true,

--- a/src/test/shared/extensionUtilities.test.ts
+++ b/src/test/shared/extensionUtilities.test.ts
@@ -134,7 +134,7 @@ describe('extensionUtilities', function () {
     })
 })
 
-describe('initializeComputeRegion & getComputeRegion', async function () {
+describe('initializeComputeRegion, getComputeRegion', async function () {
     const metadataService = new DefaultEc2MetadataClient()
 
     let sandbox: sinon.SinonSandbox
@@ -182,5 +182,9 @@ describe('initializeComputeRegion & getComputeRegion', async function () {
 
         await initializeComputeRegion(metadataService, false)
         assert.strictEqual(getComputeRegion(), undefined)
+    })
+
+    it('handles invalid endpoint or invalid response', async function () {
+        await assert.rejects(metadataService.invoke('/bogus/path'))
     })
 })


### PR DESCRIPTION
Problem:

Control continues even after reject()/resolve().
https://stackoverflow.com/a/32536083/152142
So Ec2MetadataClient.invoke() tried to parse nonsense even after `err`
was received.

Solution:
- add `return` to Ec2MetadataClient.invoke()
- defensive: also try/catch JSON.parse()

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
