### PR TITLE
SAM/typescript: skip "tsc" for plain JS; fix if source dir has special chars

### DIFF
--- a/.changes/next-release/Bug Fix-1939a4d6-c76f-48c6-84f1-d4955dd4490a.json
+++ b/.changes/next-release/Bug Fix-1939a4d6-c76f-48c6-84f1-d4955dd4490a.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "SAM/nodejs: do not check for \"tsc\" (typescript compiler) for plain javascript projects"
+}

--- a/.changes/next-release/Bug Fix-f2997a0c-7d2a-4074-9ad7-e377cc1dcdb9.json
+++ b/.changes/next-release/Bug Fix-f2997a0c-7d2a-4074-9ad7-e377cc1dcdb9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "SAM/typescript: fix run/debug for target=code if source dir name has special chars"
+}

--- a/.changes/next-release/Feature-d7430e98-ef86-49bb-a792-69a0abadacf5.json
+++ b/.changes/next-release/Feature-d7430e98-ef86-49bb-a792-69a0abadacf5.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "SAM/typescript: search node_modules in the workspace for \"tsc\" typescript compiler"
+}

--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -3,20 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { writeFileSync } from 'fs-extra'
 import * as path from 'path'
 import * as vscode from 'vscode'
-import { readdir, writeFileSync } from 'fs-extra'
 import { isImageLambdaConfig, NodejsDebugConfiguration } from '../../../lambda/local/debugConfiguration'
 import { RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
+import * as systemutil from '../../../shared/systemUtilities'
+import { ChildProcess } from '../../../shared/utilities/childProcess'
 import * as pathutil from '../../../shared/utilities/pathUtils'
 import { ExtContext } from '../../extensions'
+import { getLogger } from '../../logger'
 import { findParentProjectFile } from '../../utilities/workspaceUtils'
 import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
-import { runLambdaFunction, makeInputTemplate, waitForPort } from '../localLambdaRunner'
+import { makeInputTemplate, runLambdaFunction, waitForPort } from '../localLambdaRunner'
 import { SamLaunchRequestArgs } from './awsSamDebugger'
-import { getLogger } from '../../logger'
-import { ChildProcess } from '../../../shared/utilities/childProcess'
-import { hasFileWithSuffix } from '../../../shared/filesystemUtilities'
 
 /**
  * Launches and attaches debugger to a SAM Node project.
@@ -113,44 +113,72 @@ export async function makeTypescriptConfig(config: SamLaunchRequestArgs): Promis
 }
 
 /**
- * For non-template debug configs (target = code), compile the project
- * using a temporary default tsconfig.json file.
+ * Compiles non-template (target=code) debug configs, using a temporary default
+ * tsconfig.json file.
+ *
+ * Assumes that `sam build` was already performed.
  */
 async function compileTypeScript(config: NodejsDebugConfiguration): Promise<void> {
-    if (config.invokeTarget.target === 'code') {
-        const tscResponse = await new ChildProcess(true, 'tsc', undefined, '-v').run()
-        if (tscResponse.exitCode !== 0 || !tscResponse.stdout.startsWith('Version')) {
-            throw new Error('TypeScript compiler "tsc" not found.')
+    if (!config.baseBuildDir) {
+        throw Error('invalid state: config.baseBuildDir was not set')
+    }
+    if (config.invokeTarget.target !== 'code') {
+        return
+    }
+
+    async function findTsOrTsConfig(dir: string, child: boolean): Promise<string | undefined> {
+        const glob = (child ? '*/' : '') + '{*.ts,tsconfig.json}'
+        const found = await vscode.workspace.findFiles(new vscode.RelativePattern(dir, glob), '**/node_modules/**', 1)
+        if (found.length === 0) {
+            return undefined
         }
-        const samBuildOutputAppRoot = path.join(
-            config.baseBuildDir!,
-            'output',
-            path.parse(config.invokeTarget.projectRoot).name
-        )
-        const tsconfigPath = path.join(samBuildOutputAppRoot, 'tsconfig.json')
-        if (
-            (await readdir(config.codeRoot)).includes('tsconfig.json') ||
-            (await hasFileWithSuffix(config.codeRoot, '.ts', '**/node_modules/**'))
-        ) {
-            //  This default config is a modified version from the AWS Toolkit for JetBrain's tsconfig file. https://github.com/aws/aws-toolkit-jetbrains/blob/911c54252d6a4271ee6cacf0ea1023506c4b504a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsLambdaBuilder.kt#L60
-            const defaultTsconfig = {
-                compilerOptions: {
-                    target: 'es6',
-                    module: 'commonjs',
-                    typeRoots: ['node_modules/@types'],
-                    types: ['node'],
-                    rootDir: '.',
-                    inlineSourceMap: true,
-                },
-            }
-            try {
-                writeFileSync(tsconfigPath, JSON.stringify(defaultTsconfig, undefined, 4))
-                getLogger('channel').info('Compiling TypeScript')
-                await new ChildProcess(true, 'tsc', undefined, '--project', samBuildOutputAppRoot).run()
-            } catch (error) {
-                getLogger('channel').error(`Compile Error: ${error}`)
-                throw Error('Failed to compile typescript Lambda')
-            }
-        }
+        return found[0].fsPath
+    }
+
+    // Require tsconfig.json or *.ts in the top-level of the source app, to
+    // indicate a typescript Lambda. #2086
+    // Note: we don't use this tsconfig.json for compiling the target=code
+    // Lambda app below, instead we generate a minimal one.
+    const isTsApp = (await findTsOrTsConfig(config.codeRoot, false)) !== undefined
+    if (!isTsApp) {
+        return
+    }
+
+    const buildOutputDir = path.join(config.baseBuildDir, 'output')
+    const buildDirTsFile = await findTsOrTsConfig(buildOutputDir, true)
+    if (!buildDirTsFile) {
+        // Should never happen: `sam build` should have copied the tsconfig.json from the source app dir.
+        throw new Error(`tsconfig.json or *.ts not found in: "${buildOutputDir}/*"`)
+    }
+    // XXX: `sam` may rename the CodeUri (and thus "output/<app>/" dir) if the
+    // original "<app>/" dir contains special chars, so get it this way. #2086
+    const buildDirApp = path.dirname(buildDirTsFile)
+    const buildDirTsConfig = path.join(buildDirApp, 'tsconfig.json')
+
+    const tsc = await systemutil.SystemUtilities.findTypescriptCompiler()
+    if (!tsc) {
+        throw new Error('TypeScript compiler "tsc" not found in node_modules/ or the system.')
+    }
+
+    // Default config.
+    // Adapted from: https://github.com/aws/aws-toolkit-jetbrains/blob/911c54252d6a4271ee6cacf0ea1023506c4b504a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsLambdaBuilder.kt#L60
+    const defaultTsconfig = {
+        compilerOptions: {
+            target: 'es6',
+            module: 'commonjs',
+            typeRoots: ['node_modules/@types'],
+            types: ['node'],
+            rootDir: '.',
+            inlineSourceMap: true,
+        },
+    }
+    try {
+        // Overwrite the tsconfig.json copied by `sam build`.
+        writeFileSync(buildDirTsConfig, JSON.stringify(defaultTsconfig, undefined, 4))
+        getLogger('channel').info(`Compiling TypeScript with: "${tsc}"`)
+        await new ChildProcess(true, tsc, undefined, '--project', buildDirApp).run()
+    } catch (error) {
+        getLogger('channel').error(`TypeScript compile error: ${error}`)
+        throw Error('Failed to compile TypeScript Lambda')
     }
 }

--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -175,10 +175,10 @@ async function compileTypeScript(config: NodejsDebugConfiguration): Promise<void
     try {
         // Overwrite the tsconfig.json copied by `sam build`.
         writeFileSync(buildDirTsConfig, JSON.stringify(defaultTsconfig, undefined, 4))
-        getLogger('channel').info(`Compiling TypeScript with: "${tsc}"`)
+        getLogger('channel').info(`Compiling TypeScript app with: "${tsc}"`)
         await new ChildProcess(true, tsc, undefined, '--project', buildDirApp).run()
     } catch (error) {
         getLogger('channel').error(`TypeScript compile error: ${error}`)
-        throw Error('Failed to compile TypeScript Lambda')
+        throw Error('Failed to compile TypeScript app')
     }
 }

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -185,8 +185,8 @@ async function buildLambdaHandler(
             throw new Error(samBuild.failure())
         }
         // build successful: use output template path for invocation
-        // XXX: reassignment
         await remove(config.templatePath)
+        // XXX: reassignment
         config.templatePath = path.join(samBuildOutputFolder, 'template.yaml')
         getLogger('channel').info(localize('AWS.output.building.sam.application.complete', 'Build complete.'))
         return true

--- a/src/test/testUtil.ts
+++ b/src/test/testUtil.ts
@@ -5,6 +5,7 @@
 
 import * as assert from 'assert'
 import * as path from 'path'
+import * as fs from 'fs-extra'
 import * as vscode from 'vscode'
 import * as fsextra from 'fs-extra'
 import * as FakeTimers from '@sinonjs/fake-timers'
@@ -97,4 +98,18 @@ export function assertFileText(file: string, expected: string, message?: string 
 export async function tickPromise<T>(promise: Promise<T>, clock: FakeTimers.InstalledClock, t: number): Promise<T> {
     clock.tick(t)
     return await promise
+}
+
+/**
+ * Creates an executable file (including any parent directories) with the given contents.
+ */
+export function createExecutableFile(filepath: string, contents: string): void {
+    fs.mkdirpSync(path.dirname(filepath))
+    if (process.platform === 'win32') {
+        fs.writeFileSync(filepath, `@echo OFF$\r\n${contents}\r\n`)
+        
+    } else {
+        fs.writeFileSync(filepath, contents)
+        fs.chmodSync(filepath, 0o744)
+    }
 }


### PR DESCRIPTION
## Problems:
1. Toolkit checks for "tsc" for plain javascript Lambdas.
2. Toolkit only checks global $PATH for "tsc". #1487
3. If the source project dir containing the Lambda being run/debugged   has a hyphen (or other special chars), our `compileTypeScript()`   codepath will fail because `sam build` uses a "scrubbed" name in the temporary build output dir.

## Solutions:
1. Skip "tsc" check if tsconfig.json or `*.ts` is not found in the top-level of the app dir.
2. Also look for "tsc" in the workspace node_modules/ dir.
3. Change the logic in `compileTypeScript()` to look for "output/*/tsconfig.json"   instead of using `config.invokeTarget.projectRoot`.
   - Alternatives considered:
     1. add a property to samCliBuild.ts.
         - problem: needs to inspect the CodeUri or use a similar findFiles() approach.
     2. in localLambdaRunner.ts:buildLambdaHandler(): mutate `config.codeRoot` (like how we already mutate `config.templatePath`).
         - problem: this adds technical debt
         - problem: requires consumers to understand the ordering and have special knowledge of when `config.codeRoot` has the wanted value.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
