### PR TITLE
fix(telemetry): SAM CLI should inherit Toolkit telemetry setting

### DIFF
--- a/src/test/shared/sam/cli/samCliInvokerUtils.test.ts
+++ b/src/test/shared/sam/cli/samCliInvokerUtils.test.ts
@@ -85,6 +85,7 @@ describe('addTelemetryEnvVar', async function () {
             cwd: '/foo',
             env: {
                 AWS_TOOLING_USER_AGENT: result.env?.['AWS_TOOLING_USER_AGENT'],
+                SAM_CLI_TELEMETRY: '0',
                 AWS_REGION: 'us-east-1',
             },
         })


### PR DESCRIPTION
# Problem:

- SAM CLI is an implicit dependency of AWS Toolkit, but if the customer  disables Toolkit telemetry, that choice isn't applied to SAM CLI's own telemetry.
- SAM CLI telemetry messages are very noisy in the Toolkit logs.
    - Note: when the Toolkit log-level is "debug", we invoke SAM CLI      with `sam --debug`.

# Solution:
- When the customer has disabled AWS Toolkit telemetry, reflect that in SAM CLI invocations by setting an [env var](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-telemetry.html):
  ```
  SAM_CLI_TELEMETRY=0
  ```
- Reduces CI logs by 400 lines.
- before:
  ```
  2023-09-29 22:09:58 [VERBOSE]: stderr: 2023-09-29 22:09:58,967 | Telemetry endpoint configured to be https://aws-serverless-tools-telemetry.us-west-2.amazonaws.com/metrics
  2023-09-29 22:09:58 [VERBOSE]: stderr: 2023-09-29 22:09:58,973 | Telemetry endpoint configured to be https://aws-serverless-tools-telemetry.us-west-2.amazonaws.com/metrics
  2023-09-29 22:09:58 [VERBOSE]: stderr: 2023-09-29 22:09:58,973 | Sending Telemetry: {'metrics': [{'commandRun': {'requestId': 'c676ac68-9e8e-4bdb-b7a3-69488d5b31c3', 'installationId': 'fc43f435-e8ba-4f9c-a905-a5f64bbcb6a2', 'sessionId': 'ca07ba9c-c856-4a17-bad1-05d06ec0447a', 'executionEnvironment': 'AWSCodeBuild', 'ci': True, 'pyversion': '3.10.12', 'samcliVersion': '1.94.0', 'awsProfileProvided': False, 'debugFlagProvided': True, 'region': '', 'commandName': 'sam build', 'metricSpecificAttributes': {'projectType': 'CFN', 'gitOrigin': None, 'projectName': 'b404669a6e496d0c9cc117229b17f443fb375168d14b426dc94025e393f40113', 'initialCommit': None}, 'duration': 26295, 'exitReason': 'success', 'exitCode': 0}}]}
  2023-09-29 22:09:58,973 | Unable to find Click Context for getting session_id.
  2023-09-29 22:09:58 [VERBOSE]: stderr: 2023-09-29 22:09:58,975 | Sending Telemetry: {'metrics': [{'events': {'requestId': '7203adeb-c6ed-49ab-8d0d-b729f56debf4', 'installationId': 'fc43f435-e8ba-4f9c-a905-a5f64bbcb6a2', 'sessionId': 'ca07ba9c-c856-4a17-bad1-05d06ec0447a', 'executionEnvironment': 'AWSCodeBuild', 'ci': True, 'pyversion': '3.10.12', 'samcliVersion': '1.94.0', 'metricSpecificAttributes': {'events': [{'event_name': 'SamConfigFileExtension', 'event_value': '.toml', 'thread_id': '6e01f234a91a4f49abb1c12d3a030e99', 'time_stamp': '2023-09-29 22:09:32.653', 'exception_name': None}, {'event_name': 'BuildWorkflowUsed', 'event_value': 'nodejs-npm', 'thread_id': 'e761a23adae449c4a8eda09fa655de47', 'time_stamp': '2023-09-29 22:09:32.786', 'exception_name': None}, {'event_name': 'BuildFunctionRuntime', 'event_value': 'nodejs16.x', 'thread_id': 'ec4c0a9911494ddf9608db7041d1edf6', 'time_stamp': '2023-09-29 22:09:32.786', 'exception_name': None}, {'event_name': 'BuildWorkflowUsed', 'event_value': 'nodejs-npm', 'thread_id': '66a77cf36f734613b8571e32548a054f', 'time_stamp': '2023-09-29 22:09:32.792', 'exception_name': None}]}}}]}
  2023-09-29 22:09:59 [VERBOSE]: stderr: 2023-09-29 22:09:59,174 | Telemetry response: 200
  2023-09-29 22:09:59 [VERBOSE]: stderr: 2023-09-29 22:09:59,177 | Telemetry response: 200
  ```
- after:
  ```
  2023-09-30 16:24:53,795 | Telemetry endpoint configured to be https://aws-serverless-tools-telemetry.us-west-2.amazonaws.com/metrics
  2023-09-30 16:24:53 [VERBOSE]: stderr: 2023-09-30 16:24:53,795 | Unable to find Click Context for getting session_id.
  ```


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
