### PR TITLE
types: fix `makeChildrenNodes` and `childNodeLoader` types

### DIFF
--- a/src/apigateway/explorer/apiGatewayNodes.ts
+++ b/src/apigateway/explorer/apiGatewayNodes.ts
@@ -35,14 +35,13 @@ export class ApiGatewayNode extends AWSTreeNodeBase {
 
                 return [...this.apiNodes.values()]
             },
-            getErrorNode: async (error: Error, logID: number) => 
-                new ErrorNode(this, error, logID),
+            getErrorNode: async (error: Error, logID: number) => new ErrorNode(this, error, logID),
             getNoChildrenPlaceholderNode: async () =>
                 new PlaceholderNode(
                     this,
                     localize('AWS.explorerNode.apigateway.noApis', '[No API Gateway REST APIs found]')
                 ),
-            sort: (nodeA: RestApiNode, nodeB: RestApiNode) => nodeA.label!.localeCompare(nodeB.label!),
+            sort: (nodeA, nodeB) => nodeA.label!.localeCompare(nodeB.label!),
         })
     }
 

--- a/src/apprunner/explorer/apprunnerNode.ts
+++ b/src/apprunner/explorer/apprunnerNode.ts
@@ -39,8 +39,7 @@ export class AppRunnerNode extends AWSTreeNodeBase {
                     this,
                     localize('AWS.explorerNode.apprunner.noServices', '[No App Runner services found]')
                 ),
-            sort: (nodeA: AppRunnerServiceNode, nodeB: AppRunnerServiceNode) =>
-                nodeA.label!.localeCompare(nodeB.label!),
+            sort: (nodeA, nodeB) => nodeA.label!.localeCompare(nodeB.label!),
         })
     }
 

--- a/src/awsexplorer/awsExplorer.ts
+++ b/src/awsexplorer/awsExplorer.ts
@@ -143,7 +143,7 @@ export class AwsExplorer implements vscode.TreeDataProvider<AWSTreeNodeBase>, Re
                 throw error
             },
             getNoChildrenPlaceholderNode: async () => this.ROOT_NODE_ADD_REGION,
-            sort: (nodeA: RegionNode, nodeB: RegionNode) => nodeA.regionName.localeCompare(nodeB.regionName),
+            sort: (nodeA, nodeB) => nodeA.regionName.localeCompare(nodeB.regionName),
         })
     }
 }

--- a/src/awsexplorer/childNodeCache.ts
+++ b/src/awsexplorer/childNodeCache.ts
@@ -11,8 +11,8 @@ import { ChildNodePage } from './childNodeLoader'
  *
  * Allows for easier appending to the node's children and less error-prone (resetting) of the node's internal state.
  */
-export class ChildNodeCache {
-    private _children: AWSTreeNodeBase[] = []
+export class ChildNodeCache<T extends AWSTreeNodeBase = AWSTreeNodeBase> {
+    private _children: T[] = []
     private _continuationToken: string | undefined = undefined
     private _isPristine: boolean = true
 
@@ -22,7 +22,7 @@ export class ChildNodeCache {
      * Once this has been called, the cache is no longer considered pristine ({@link isPristine} will return false).
      * This is true even if the original state of the cache remains unchanged (all items appended are empty/undefined).
      */
-    public appendPage(page: ChildNodePage): void {
+    public appendPage(page: ChildNodePage<T>): void {
         this._children = [...this._children, ...page.newChildren]
         this._continuationToken = page.newContinuationToken
         this._isPristine = false
@@ -31,7 +31,7 @@ export class ChildNodeCache {
     /**
      * The list of children nodes previously appended to the cache.
      */
-    public get children(): AWSTreeNodeBase[] {
+    public get children(): T[] {
         return this._children
     }
 

--- a/src/cloudWatchLogs/explorer/cloudWatchLogsNode.ts
+++ b/src/cloudWatchLogs/explorer/cloudWatchLogsNode.ts
@@ -45,7 +45,7 @@ export abstract class CloudWatchLogsBase extends AWSTreeNodeBase {
             getErrorNode: async (error: Error, logID: number) => new ErrorNode(this, error, logID),
             getNoChildrenPlaceholderNode: async () =>
                 new PlaceholderNode(this, localize('AWS.explorerNode.cloudWatchLogs.placeholder', '[No Logs found]')),
-            sort: (nodeA: LogGroupNode, nodeB: LogGroupNode) => nodeA.name.localeCompare(nodeB.name),
+            sort: (nodeA, nodeB) => nodeA.name.localeCompare(nodeB.name),
         })
     }
 

--- a/src/ecr/explorer/ecrNode.ts
+++ b/src/ecr/explorer/ecrNode.ts
@@ -32,12 +32,10 @@ export class EcrNode extends AWSTreeNodeBase {
 
                 return response.map(item => new EcrRepositoryNode(this, this.ecr, item))
             },
-            getErrorNode: async (error: Error, logID: number) =>
-                new ErrorNode(this, error, logID),
+            getErrorNode: async (error: Error, logID: number) => new ErrorNode(this, error, logID),
             getNoChildrenPlaceholderNode: async () =>
                 new PlaceholderNode(this, localize('AWS.explorerNode.ecr.noRepositories', '[No repositories found]')),
-            sort: (item1: EcrRepositoryNode, item2: EcrRepositoryNode) =>
-                item1.repository.repositoryName.localeCompare(item2.repository.repositoryName),
+            sort: (item1, item2) => item1.repository.repositoryName.localeCompare(item2.repository.repositoryName),
         })
     }
 

--- a/src/ecr/explorer/ecrRepositoryNode.ts
+++ b/src/ecr/explorer/ecrRepositoryNode.ts
@@ -45,7 +45,7 @@ export class EcrRepositoryNode extends AWSTreeNodeBase implements AWSResourceNod
             getErrorNode: async (error: Error, logID: number) => new ErrorNode(this, error, logID),
             getNoChildrenPlaceholderNode: async () =>
                 new PlaceholderNode(this, localize('AWS.explorerNode.ecr.noTags', '[No tags found]')),
-            sort: (item1: EcrTagNode, item2: EcrTagNode) => item1.tag.localeCompare(item2.tag),
+            sort: (item1, item2) => item1.tag.localeCompare(item2.tag),
         })
     }
 

--- a/src/eventSchemas/explorer/registryItemNode.ts
+++ b/src/eventSchemas/explorer/registryItemNode.ts
@@ -50,11 +50,10 @@ export class RegistryItemNode extends AWSTreeNodeBase {
 
                 return [...this.schemaNodes.values()]
             },
-            getErrorNode: async (error: Error, logID: number) =>
-                new ErrorNode(this, error, logID),
+            getErrorNode: async (error: Error, logID: number) => new ErrorNode(this, error, logID),
             getNoChildrenPlaceholderNode: async () =>
                 new PlaceholderNode(this, localize('AWS.explorerNode.registry.noSchemas', '[No Registry Schemas]')),
-            sort: (nodeA: SchemaItemNode, nodeB: SchemaItemNode) => nodeA.schemaName.localeCompare(nodeB.schemaName),
+            sort: (nodeA, nodeB) => nodeA.schemaName.localeCompare(nodeB.schemaName),
         })
     }
 

--- a/src/eventSchemas/explorer/schemasNode.ts
+++ b/src/eventSchemas/explorer/schemasNode.ts
@@ -35,12 +35,10 @@ export class SchemasNode extends AWSTreeNodeBase {
 
                 return [...this.registryNodes.values()]
             },
-            getErrorNode: async (error: Error, logID: number) =>
-                new ErrorNode(this, error, logID),
+            getErrorNode: async (error: Error, logID: number) => new ErrorNode(this, error, logID),
             getNoChildrenPlaceholderNode: async () =>
                 new PlaceholderNode(this, localize('AWS.explorerNode.schemas.noRegistry', '[No Schema Registries]')),
-            sort: (nodeA: RegistryItemNode, nodeB: RegistryItemNode) =>
-                nodeA.registryName.localeCompare(nodeB.registryName),
+            sort: (nodeA, nodeB) => nodeA.registryName.localeCompare(nodeB.registryName),
         })
     }
 

--- a/src/lambda/explorer/cloudFormationNodes.ts
+++ b/src/lambda/explorer/cloudFormationNodes.ts
@@ -39,12 +39,10 @@ export class CloudFormationNode extends AWSTreeNodeBase {
 
                 return [...this.stackNodes.values()]
             },
-            getErrorNode: async (error: Error, logID: number) =>
-                new ErrorNode(this, error, logID),
+            getErrorNode: async (error: Error, logID: number) => new ErrorNode(this, error, logID),
             getNoChildrenPlaceholderNode: async () =>
                 new PlaceholderNode(this, localize('AWS.explorerNode.cloudformation.noStacks', '[No Stacks found]')),
-            sort: (nodeA: CloudFormationStackNode, nodeB: CloudFormationStackNode) =>
-                nodeA.stackName.localeCompare(nodeB.stackName),
+            sort: (nodeA, nodeB) => nodeA.stackName.localeCompare(nodeB.stackName),
         })
     }
 
@@ -107,15 +105,13 @@ export class CloudFormationStackNode extends AWSTreeNodeBase implements AWSResou
 
                 return [...this.functionNodes.values()]
             },
-            getErrorNode: async (error: Error, logID: number) =>
-                new ErrorNode(this, error, logID),
+            getErrorNode: async (error: Error, logID: number) => new ErrorNode(this, error, logID),
             getNoChildrenPlaceholderNode: async () =>
                 new PlaceholderNode(
                     this,
                     localize('AWS.explorerNode.cloudFormation.noFunctions', '[Stack has no Lambda Functions]')
                 ),
-            sort: (nodeA: LambdaFunctionNode, nodeB: LambdaFunctionNode) =>
-                nodeA.functionName.localeCompare(nodeB.functionName),
+            sort: (nodeA, nodeB) => nodeA.functionName.localeCompare(nodeB.functionName),
         })
     }
 

--- a/src/lambda/explorer/lambdaNodes.ts
+++ b/src/lambda/explorer/lambdaNodes.ts
@@ -45,8 +45,7 @@ export class LambdaNode extends AWSTreeNodeBase {
             getErrorNode: async (error: Error, logID: number) => new ErrorNode(this, error, logID),
             getNoChildrenPlaceholderNode: async () =>
                 new PlaceholderNode(this, localize('AWS.explorerNode.lambda.noFunctions', '[No Functions found]')),
-            sort: (nodeA: LambdaFunctionNode, nodeB: LambdaFunctionNode) =>
-                nodeA.functionName.localeCompare(nodeB.functionName),
+            sort: (nodeA, nodeB) => nodeA.functionName.localeCompare(nodeB.functionName),
         })
     }
 

--- a/src/s3/explorer/s3BucketNode.ts
+++ b/src/s3/explorer/s3BucketNode.ts
@@ -32,7 +32,7 @@ import { S3Node } from './s3Nodes'
  * Represents an S3 bucket that may contain folders and/or objects.
  */
 export class S3BucketNode extends AWSTreeNodeBase implements AWSResourceNode, LoadMoreNode {
-    private readonly childLoader: ChildNodeLoader
+    private readonly childLoader = new ChildNodeLoader(this, token => this.loadPage(token))
 
     public constructor(
         public readonly bucket: Bucket,
@@ -47,7 +47,6 @@ export class S3BucketNode extends AWSTreeNodeBase implements AWSResourceNode, Lo
             light: vscode.Uri.file(ext.iconPaths.light.s3),
         }
         this.contextValue = 'awsS3BucketNode'
-        this.childLoader = new ChildNodeLoader(this, token => this.loadPage(token))
     }
 
     public async getChildren(): Promise<AWSTreeNodeBase[]> {
@@ -71,7 +70,7 @@ export class S3BucketNode extends AWSTreeNodeBase implements AWSResourceNode, Lo
         this.childLoader.clearChildren()
     }
 
-    private async loadPage(continuationToken: string | undefined): Promise<ChildNodePage> {
+    private async loadPage(continuationToken: string | undefined): Promise<ChildNodePage<S3FolderNode | S3FileNode>> {
         getLogger().debug(`Loading page for %O using continuationToken %s`, this, continuationToken)
         const response = await this.s3.listFiles({
             bucketName: this.bucket.name,

--- a/src/s3/explorer/s3FolderNode.ts
+++ b/src/s3/explorer/s3FolderNode.ts
@@ -31,7 +31,7 @@ import { getLogger } from '../../shared/logger'
  * Represents a folder in an S3 bucket that may contain subfolders and/or objects.
  */
 export class S3FolderNode extends AWSTreeNodeBase implements AWSResourceNode, LoadMoreNode {
-    private readonly childLoader: ChildNodeLoader
+    private readonly childLoader = new ChildNodeLoader(this, token => this.loadPage(token))
 
     public constructor(
         public readonly bucket: Bucket,
@@ -43,7 +43,6 @@ export class S3FolderNode extends AWSTreeNodeBase implements AWSResourceNode, Lo
         this.tooltip = folder.path
         this.iconPath = folderIconPath()
         this.contextValue = 'awsS3FolderNode'
-        this.childLoader = new ChildNodeLoader(this, token => this.loadPage(token))
     }
 
     public async getChildren(): Promise<AWSTreeNodeBase[]> {
@@ -67,7 +66,7 @@ export class S3FolderNode extends AWSTreeNodeBase implements AWSResourceNode, Lo
         this.childLoader.clearChildren()
     }
 
-    private async loadPage(continuationToken: string | undefined): Promise<ChildNodePage> {
+    private async loadPage(continuationToken: string | undefined): Promise<ChildNodePage<S3FolderNode | S3FileNode>> {
         getLogger().debug(`Loading page for %O using continuationToken %s`, this, continuationToken)
         const response = await this.s3.listFiles({
             bucketName: this.bucket.name,

--- a/src/shared/treeview/treeNodeUtilities.ts
+++ b/src/shared/treeview/treeNodeUtilities.ts
@@ -19,7 +19,7 @@ export async function makeChildrenNodes<
     getNoChildrenPlaceholderNode?(): Promise<P>
     getErrorNode(error: Error, logID: number): Promise<E>
     sort?(a: T, b: T): number
-}): Promise<T[] | P[] | E[]> {
+}): Promise<T[] | [P] | [E]> {
     try {
         const nodes = await parameters.getChildNodes()
 

--- a/src/shared/treeview/treeNodeUtilities.ts
+++ b/src/shared/treeview/treeNodeUtilities.ts
@@ -18,7 +18,7 @@ export async function makeChildrenNodes<
     getChildNodes(): Promise<T[]>
     getNoChildrenPlaceholderNode?(): Promise<P>
     getErrorNode(error: Error, logID: number): Promise<E>
-    sort?(a: T, b: T): number
+    sort?: (a: T, b: T) => number
 }): Promise<T[] | [P] | [E]> {
     try {
         const nodes = await parameters.getChildNodes()

--- a/src/shared/treeview/treeNodeUtilities.ts
+++ b/src/shared/treeview/treeNodeUtilities.ts
@@ -10,29 +10,32 @@ import { AWSTreeNodeBase } from './nodes/awsTreeNodeBase'
  * Produces a list of child nodes using handlers to consistently populate the
  * list when errors occur or if the list would otherwise be empty.
  */
-export async function makeChildrenNodes(parameters: {
-    getChildNodes(): Promise<AWSTreeNodeBase[]>
-    getNoChildrenPlaceholderNode?(): Promise<AWSTreeNodeBase>
-    getErrorNode(error: Error, logID: number): Promise<AWSTreeNodeBase>
-    sort?(a: AWSTreeNodeBase, b: AWSTreeNodeBase): number
-}): Promise<AWSTreeNodeBase[]> {
-    let childNodes: AWSTreeNodeBase[] = []
+export async function makeChildrenNodes<
+    T extends AWSTreeNodeBase,
+    P extends AWSTreeNodeBase,
+    E extends AWSTreeNodeBase
+>(parameters: {
+    getChildNodes(): Promise<T[]>
+    getNoChildrenPlaceholderNode?(): Promise<P>
+    getErrorNode(error: Error, logID: number): Promise<E>
+    sort?(a: T, b: T): number
+}): Promise<T[] | P[] | E[]> {
     try {
-        childNodes.push(...(await parameters.getChildNodes()))
+        const nodes = await parameters.getChildNodes()
 
-        if (childNodes.length === 0 && parameters.getNoChildrenPlaceholderNode) {
-            childNodes.push(await parameters.getNoChildrenPlaceholderNode())
+        if (nodes.length === 0 && parameters.getNoChildrenPlaceholderNode) {
+            return [await parameters.getNoChildrenPlaceholderNode()]
         }
 
         if (parameters.sort) {
-            childNodes = childNodes.sort((a, b) => parameters.sort!(a, b))
+            nodes.sort((a, b) => parameters.sort!(a, b))
         }
+
+        return nodes
     } catch (err) {
         const error = err as Error
-        const logID: number = getLogger().error(err as Error)
+        const logID: number = getLogger().error(error)
 
-        childNodes.push(await parameters.getErrorNode(error, logID))
+        return [await parameters.getErrorNode(error, logID)]
     }
-
-    return childNodes
 }

--- a/src/ssmDocument/explorer/documentTypeNode.ts
+++ b/src/ssmDocument/explorer/documentTypeNode.ts
@@ -43,15 +43,13 @@ export class DocumentTypeNode extends AWSTreeNodeBase {
 
                 return [...this.registryNodes.values()]
             },
-            getErrorNode: async (error: Error, logID: number) =>
-                new ErrorNode(this, error, logID),
+            getErrorNode: async (error: Error, logID: number) => new ErrorNode(this, error, logID),
             getNoChildrenPlaceholderNode: async () =>
                 new PlaceholderNode(
                     this,
                     localize('AWS.explorerNode.ssmDocument.noRegistry', '[No Systems Manager Document Registries]')
                 ),
-            sort: (nodeA: RegistryItemNode, nodeB: RegistryItemNode) =>
-                nodeA.registryName.localeCompare(nodeB.registryName),
+            sort: (nodeA, nodeB) => nodeA.registryName.localeCompare(nodeB.registryName),
         })
     }
 

--- a/src/ssmDocument/explorer/registryItemNode.ts
+++ b/src/ssmDocument/explorer/registryItemNode.ts
@@ -51,15 +51,13 @@ export class RegistryItemNode extends AWSTreeNodeBase {
 
                 return [...this.documentNodes.values()]
             },
-            getErrorNode: async (error: Error, logID: number) =>
-                new ErrorNode(this, error, logID),
+            getErrorNode: async (error: Error, logID: number) => new ErrorNode(this, error, logID),
             getNoChildrenPlaceholderNode: async () =>
                 new PlaceholderNode(
                     this,
                     localize('AWS.explorerNode.documentType.noSsmDocument', `[No documents found]`)
                 ),
-            sort: (nodeA: DocumentItemNode, nodeB: DocumentItemNode) =>
-                nodeA.documentName.localeCompare(nodeB.documentName),
+            sort: (nodeA, nodeB) => nodeA.documentName.localeCompare(nodeB.documentName),
         })
     }
 

--- a/src/ssmDocument/explorer/ssmDocumentNode.ts
+++ b/src/ssmDocument/explorer/ssmDocumentNode.ts
@@ -31,15 +31,13 @@ export class SsmDocumentNode extends AWSTreeNodeBase {
 
                 return [...this.documentTypeNodes.values()]
             },
-            getErrorNode: async (error: Error, logID: number) =>
-                new ErrorNode(this, error, logID),
+            getErrorNode: async (error: Error, logID: number) => new ErrorNode(this, error, logID),
             getNoChildrenPlaceholderNode: async () =>
                 new PlaceholderNode(
                     this,
                     localize('AWS.explorerNode.registry.noSsmDocument', `[No documentType found]`)
                 ),
-            sort: (nodeA: DocumentTypeNode, nodeB: DocumentTypeNode) =>
-                nodeA.documentType.localeCompare(nodeB.documentType),
+            sort: (nodeA, nodeB) => nodeA.documentType.localeCompare(nodeB.documentType),
         })
     }
 

--- a/src/stepFunctions/explorer/stepFunctionsNodes.ts
+++ b/src/stepFunctions/explorer/stepFunctionsNodes.ts
@@ -59,8 +59,7 @@ export class StepFunctionsNode extends AWSTreeNodeBase {
                     this,
                     localize('AWS.explorerNode.stepfunctions.noStateMachine', '[No State Machines found]')
                 ),
-            sort: (nodeA: StateMachineNode, nodeB: StateMachineNode) =>
-                nodeA.functionName.localeCompare(nodeB.functionName),
+            sort: (nodeA, nodeB) => nodeA.functionName.localeCompare(nodeB.functionName),
         })
     }
 


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

They did not use generics despite being pretty generic constructs. This meant callers had to use hard casts (or explicit annotations) to get their code to appear well-typed. Now the types are correctly inferred.


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
