### PR TITLE
telemetry: developer-mode override

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,10 +76,10 @@ You can also use these NPM tasks (see `npm run` for the full list):
 
 ### Guidelines
 
-- Project patterns and practices: [CODE_GUIDELINES.md](./docs/CODE_GUIDELINES.md)
-- [VS Code Extension Guidelines](https://code.visualstudio.com/api/references/extension-guidelines)
-- [VS Code API Documentation](https://code.visualstudio.com/api/references/vscode-api)
-- [VS Code Extension Capabilities](https://code.visualstudio.com/api/extension-capabilities/common-capabilities)
+-   Project patterns and practices: [CODE_GUIDELINES.md](./docs/CODE_GUIDELINES.md)
+-   [VS Code Extension Guidelines](https://code.visualstudio.com/api/references/extension-guidelines)
+-   [VS Code API Documentation](https://code.visualstudio.com/api/references/vscode-api)
+-   [VS Code Extension Capabilities](https://code.visualstudio.com/api/extension-capabilities/common-capabilities)
 
 ### Technical notes
 
@@ -228,6 +228,14 @@ all tests and provides the build result via the _Details_ link as shown below.
 Besides the typical develop/test/run cycle describe above, there are
 some tools for special cases such as build tasks, generating telemetry,
 generating SDKs, etc.
+
+### Toolkit developer settings (`aws.dev.*`)
+
+The [AwsDevSetting](https://github.com/aws/aws-toolkit-vscode/blob/d52416408aca7e68ff685137f0fe263581f44cfc/src/shared/settingsConfiguration.ts#L19)
+type defines various developer-only settings that change the behavior of the
+Toolkit for testing and development purposes. To use a setting just add it to
+your `settings.json`. At runtime if the Toolkit reads any of these settings,
+the "AWS" statusbar item will [change its color](https://github.com/aws/aws-toolkit-vscode/blob/d52416408aca7e68ff685137f0fe263581f44cfc/src/credentials/awsCredentialsStatusBarItem.ts#L58).
 
 ### AWS SDK generator
 

--- a/src/shared/settingsConfiguration.ts
+++ b/src/shared/settingsConfiguration.ts
@@ -16,7 +16,7 @@ import * as logger from './logger'
  */
 export type SettingsConfiguration = ClassToInterfaceType<DefaultSettingsConfiguration>
 
-export type AwsDevSetting = 'aws.forceCloud9' | 'aws.developer.foo1' | 'aws.developer.foo2'
+export type AwsDevSetting = 'aws.forceCloud9' | 'aws.dev.forceTelemetry' | 'aws.dev.foo'
 
 type JSPrimitiveTypeName =
     | 'undefined'

--- a/src/shared/telemetry/defaultTelemetryClient.ts
+++ b/src/shared/telemetry/defaultTelemetryClient.ts
@@ -15,6 +15,7 @@ import apiConfig = require('./service-2.json')
 import { TelemetryClient } from './telemetryClient'
 import { TelemetryFeedback } from './telemetryFeedback'
 import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
+import { DefaultSettingsConfiguration } from '../settingsConfiguration'
 
 export class DefaultTelemetryClient implements TelemetryClient {
     public static readonly DEFAULT_IDENTITY_POOL = 'us-east-1:820fd6d1-95c0-4ca4-bffb-3f01d32da842'
@@ -23,6 +24,7 @@ export class DefaultTelemetryClient implements TelemetryClient {
     private static readonly PRODUCT_NAME = 'AWS Toolkit For VS Code'
 
     private readonly logger = getLogger()
+    private readonly settings = new DefaultSettingsConfiguration('aws')
 
     private constructor(private readonly clientId: string, private readonly client: ClientTelemetry) {}
 
@@ -37,7 +39,10 @@ export class DefaultTelemetryClient implements TelemetryClient {
                 return undefined
             }
 
-            if (isReleaseVersion()) {
+            if (
+                isReleaseVersion() ||
+                this.settings.readDevSetting<boolean>('aws.dev.forceTelemetry', 'boolean', true)
+            ) {
                 await this.client
                     .postMetrics({
                         AWSProduct: DefaultTelemetryClient.PRODUCT_NAME,


### PR DESCRIPTION
Allow developers to enable telemetry in non-production builds.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
