### PR TITLE
build(deps): unwrap UMD imports for JSON language service

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,7 +67,7 @@ const baseConfig = {
                 ],
             },
             {
-                test: /node_modules[\\|/](amazon-states-language-service)/,
+                test: /node_modules[\\|/](amazon-states-language-service|vscode-json-languageservice)/,
                 use: { loader: 'umd-compat-loader' },
             },
         ],


### PR DESCRIPTION
The vscode-json-languageservice module includes ESM and UMD emits, but sets the UMD output as the main one. Our webpack config needs extra configuration to ignore UMD distributions to avoid issues like this, but for now we can use the compatibility loader to unwrap the UMD import as we're already using it for the ASL server.