### PR TITLE
More resources: fix configure quick pick

### DIFF
--- a/src/moreResources/commands/configure.ts
+++ b/src/moreResources/commands/configure.ts
@@ -17,7 +17,7 @@ export async function configureResources(): Promise<boolean> {
     const quickPickItems: vscode.QuickPickItem[] = []
     for (const typeName of types) {
         const resource = supportedResources[typeName as keyof typeof supportedResources] as ResourceMetadata
-        if (resource.operations.includes('LIST')) {
+        if (resource.operations?.includes('LIST')) {
             quickPickItems.push({
                 label: typeName,
                 picked: configuration ? configuration.includes(typeName) : false,


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

Using 'glob' imports includes named exports as well as 'default'. This is usually fine, but since we're using webpack/build tools these imports are being wrapped and can include extra keys (e.g. 'default') which can cause issues when iterating over them.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
