### PR TITLE
cloudControl: restrict to read-only for Cloud9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1257,12 +1257,12 @@
                 },
                 {
                     "command": "aws.moreResources.configure",
-                    "when": "view == aws.explorer && viewItem == moreResourcesRootNode",
+                    "when": "view == aws.explorer && viewItem == moreResourcesRootNode && !isCloud9",
                     "group": "1@1"
                 },
                 {
                     "command": "aws.moreResources.configure",
-                    "when": "view == aws.explorer && viewItem == moreResourcesRootNode",
+                    "when": "view == aws.explorer && viewItem == moreResourcesRootNode && !isCloud9",
                     "group": "inline@1"
                 },
                 {
@@ -1282,22 +1282,22 @@
                 },
                 {
                     "command": "aws.moreResources.createResource",
-                    "when": "view == aws.explorer && viewItem =~ /^(.*)(Creatable)(.*)(ResourceTypeNode)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(.*)(Creatable)(.*)(ResourceTypeNode)$/ && !isCloud9",
                     "group": "2@1"
                 },
                 {
                     "command": "aws.moreResources.createResource",
-                    "when": "view == aws.explorer && viewItem =~ /^(.*)(Creatable)(.*)(ResourceTypeNode)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(.*)(Creatable)(.*)(ResourceTypeNode)$/ && !isCloud9",
                     "group": "inline@1"
                 },
                 {
                     "command": "aws.moreResources.updateResource",
-                    "when": "view == aws.explorer && viewItem =~ /^(.*)(Updatable)(.*)(ResourceNode)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(.*)(Updatable)(.*)(ResourceNode)$/ && !isCloud9",
                     "group": "2@1"
                 },
                 {
                     "command": "aws.moreResources.deleteResource",
-                    "when": "view == aws.explorer && viewItem =~ /^(.*)(Deletable)(.*)(ResourceNode)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(.*)(Deletable)(.*)(ResourceNode)$/ && !isCloud9",
                     "group": "2@2"
                 },
                 {

--- a/src/moreResources/activation.ts
+++ b/src/moreResources/activation.ts
@@ -43,7 +43,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         }),
         vscode.commands.registerCommand('aws.moreResources.configure', async (node: MoreResourcesNode) => {
             if (await configureResources()) {
-                await vscode.commands.executeCommand('aws.refreshAwsExplorerNode', node)
+                node.refresh()
             }
         }),
         vscode.commands.registerCommand('aws.moreResources.createResource', async (node: ResourceTypeNode) => {
@@ -53,7 +53,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             if (await deleteResource(node.parent.cloudControl, node.parent.typeName, node.identifier)) {
                 await resourceManager.close(resourceManager.toUri(node)!)
                 node.parent.clearChildren()
-                await vscode.commands.executeCommand('aws.refreshAwsExplorerNode', node.parent)
+                node.parent.refresh()
             }
         }),
         vscode.commands.registerCommand('aws.moreResources.updateResource', async (node: ResourceNode) => {

--- a/src/moreResources/awsResourceManager.ts
+++ b/src/moreResources/awsResourceManager.ts
@@ -19,6 +19,7 @@ import { getTabSizeSetting } from '../shared/utilities/editorUtilities'
 import { ResourceNode } from './explorer/nodes/resourceNode'
 import { ResourceTypeNode } from './explorer/nodes/resourceTypeNode'
 import { ext } from '../shared/extensionGlobals'
+import { isCloud9 } from '../shared/extensionUtilities'
 
 export const RESOURCE_FILE_GLOB_PATTERN = '**/*.awsResource.json'
 
@@ -71,7 +72,7 @@ export class AwsResourceManager {
             }
 
             const doc = await vscode.workspace.openTextDocument(uri)
-            if (existing) {
+            if (existing && !isCloud9()) {
                 await this.close(existing)
             }
 

--- a/src/moreResources/commands/configure.ts
+++ b/src/moreResources/commands/configure.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode'
 import { localize } from '../../shared/utilities/vsCodeUtils'
-import * as supportedResources from '../model/supported_resources.json'
+import supportedResources = require('../model/supported_resources.json')
 import { recordDynamicresourceSelectResources } from '../../shared/telemetry/telemetry'
 import { ResourceMetadata } from '../explorer/nodes/moreResourcesNode'
 const types = Object.keys(supportedResources)

--- a/src/moreResources/explorer/nodes/moreResourcesNode.ts
+++ b/src/moreResources/explorer/nodes/moreResourcesNode.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as supportedResources from '../../model/supported_resources.json'
+import supportedResources = require('../../model/supported_resources.json')
 import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 import { CloudFormationClient } from '../../../shared/clients/cloudFormationClient'
@@ -16,6 +16,7 @@ import { ResourceTypeNode } from './resourceTypeNode'
 import { CloudFormation } from 'aws-sdk'
 import { CloudControlClient } from '../../../shared/clients/cloudControlClient'
 import { ext } from '../../../shared/extensionGlobals'
+import { isCloud9 } from '../../../shared/extensionUtilities'
 
 const localize = nls.loadMessageBundle()
 
@@ -61,9 +62,10 @@ export class MoreResourcesNode extends AWSTreeNodeBase {
     }
 
     public async updateChildren(): Promise<void> {
-        const enabledResources = vscode.workspace
-            .getConfiguration('aws')
-            .get<string[]>('moreResources.enabledResources')
+        const enabledResources = !isCloud9()
+            ? vscode.workspace.getConfiguration('aws').get<string[]>('moreResources.enabledResources')
+            : Object.keys(supportedResources)
+
         if (enabledResources) {
             const availableTypes: Map<string, CloudFormation.TypeSummary> = toMap(
                 await toArrayAsync(this.cloudFormation.listTypes()),


### PR DESCRIPTION
## Problem
Not all functionality currently exists in the C9 extension API to fully support all CloudControl features. This leads to a broken experience when attempting to modify or configure the available resources in the explorer.

## Solution
This change limits CloudControl on C9 to read-only support for resources. It also makes a UX change to list all supported resource types in the explorer view since configuring them is not currently possible.

<img width="1373" alt="image" src="https://user-images.githubusercontent.com/14608226/136851661-8aef5082-0fd4-448a-af46-12ae8cc6a0c0.png">

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
