### PR TITLE
StepFunctions: list all roles

### DIFF
--- a/src/shared/clients/iamClient.ts
+++ b/src/shared/clients/iamClient.ts
@@ -5,17 +5,45 @@
 
 import { IAM } from 'aws-sdk'
 import { ext } from '../extensionGlobals'
+import { getLogger } from '../logger/logger'
 import { ClassToInterfaceType } from '../utilities/tsUtils'
 
 export type IamClient = ClassToInterfaceType<DefaultIamClient>
+
+/** Do not pull more than this many pages. */
+const maxPages = 500
+
 export class DefaultIamClient {
     public constructor(public readonly regionCode: string) {}
 
-    public async listRoles(request: IAM.ListRolesRequest = {}): Promise<IAM.ListRolesResponse> {
+    /** Iterates all roles. */
+    public async *getRoles(request: IAM.ListRolesRequest = {}): AsyncIterableIterator<IAM.Role> {
+        request = { ...request }
         const sdkClient = await this.createSdkClient()
-        const response = await sdkClient.listRoles(request).promise()
 
-        return response
+        for (let i = 0; true; i++) {
+            const response = await sdkClient.listRoles(request).promise()
+            for (const role of response.Roles) {
+                yield role
+            }
+            if (!response.IsTruncated) {
+                break
+            }
+            if (i > maxPages) {
+                getLogger().warn('getRoles: too many pages')
+                break
+            }
+            request.Marker = response.Marker
+        }
+    }
+
+    /** Gets all roles. */
+    public async listRoles(request: IAM.ListRolesRequest = {}): Promise<IAM.Role[]> {
+        const roles: IAM.Role[] = []
+        for await (const role of this.getRoles(request)) {
+            roles.push(role)
+        }
+        return roles
     }
 
     public async createRole(request: IAM.CreateRoleRequest): Promise<IAM.CreateRoleResponse> {

--- a/src/shared/ui/common/rolePrompter.ts
+++ b/src/shared/ui/common/rolePrompter.ts
@@ -54,13 +54,13 @@ export class RolePrompter extends CachedPrompter<IAM.Role> {
     }
 
     protected load(): Promise<DataQuickPickItem<IAM.Role>[]> {
-        return this.client.listRoles().then(resp => {
-            const roles = resp.Roles.filter(this.options.filter ?? (() => true)).map(role => ({
+        return this.client.listRoles().then(roles => {
+            const filtered = roles.filter(this.options.filter ?? (() => true)).map(role => ({
                 label: role.RoleName,
                 data: role,
             }))
 
-            return roles
+            return filtered
         })
     }
 

--- a/src/stepFunctions/wizards/publishStateMachineWizard.ts
+++ b/src/stepFunctions/wizards/publishStateMachineWizard.ts
@@ -188,7 +188,12 @@ export class DefaultPublishStateMachineWizardContext extends WizardContext imple
 
     public async loadIamRoles() {
         if (!this.iamRoles) {
-            this.iamRoles = (await this.iamClient.listRoles()).Roles.filter(isStepFunctionsRole)
+            this.iamRoles = []
+            for await (const role of this.iamClient.getRoles()) {
+                if (isStepFunctionsRole(role)) {
+                    this.iamRoles.push(role)
+                }
+            }
         }
     }
 

--- a/src/test/shared/clients/mockClients.ts
+++ b/src/test/shared/clients/mockClients.ts
@@ -65,7 +65,7 @@ export class MockToolkitClientBuilder implements ToolkitClientBuilder {
             cloudWatchLogsClient: new MockCloudWatchLogsClient(),
             ecsClient: new MockEcsClient({}),
             ecrClient: new MockEcrClient({}),
-            iamClient: new MockIamClient({}),
+            iamClient: new MockIamClient(),
             lambdaClient: new MockLambdaClient({}),
             schemaClient: new MockSchemaClient(),
             stepFunctionsClient: new MockStepFunctionsClient(),
@@ -328,10 +328,13 @@ export class MockEcsClient implements EcsClient {
 
 export class MockIamClient implements IamClient {
     public readonly regionCode = ''
-    public readonly listRoles: () => Promise<IAM.ListRolesResponse>
 
-    public constructor({ listRoles = async () => ({ Roles: [] }) }: { listRoles?(): Promise<IAM.ListRolesResponse> }) {
-        this.listRoles = listRoles
+    public constructor() {}
+    public listRoles(request?: IAM.ListRolesRequest): Promise<IAM.Role[]> {
+        throw new Error('Method not implemented.')
+    }
+    public getRoles(request: IAM.ListRolesRequest = {}): AsyncIterableIterator<IAM.Role> {
+        throw new Error('Method not implemented.')
     }
     public createRole(request: IAM.CreateRoleRequest): Promise<IAM.CreateRoleResponse> {
         throw new Error('Method not implemented.')

--- a/src/test/shared/ui/prompters/rolePrompter.test.ts
+++ b/src/test/shared/ui/prompters/rolePrompter.test.ts
@@ -37,7 +37,7 @@ describe('RolePrompter', function () {
         } as any
 
         mockIamClient = mock()
-        when(mockIamClient.listRoles()).thenResolve(roleResponse)
+        when(mockIamClient.listRoles()).thenResolve(roleResponse.Roles)
         prompterProvider = new RolePrompter(instance(mockIamClient), { createRole: () => Promise.resolve(newRole) })
         prompter = prompterProvider({ stepCache: {} } as any) as picker.QuickPickPrompter<IAM.Role>
         picker = exposeEmitters(prompter.quickPick, ['onDidTriggerButton'])


### PR DESCRIPTION
## Problem:
In the SFN "Publish" command, the "Roles" selection searches only the
first page of IAM roles. It claims "no roles found" even though roles exist in
the AWS account.

## Solution:
- Handle paging.

![image](https://user-images.githubusercontent.com/55561878/137223569-7bdd4738-f4e0-40dd-9672-acb7749ae55f.png)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
