### PR TITLE
cloudControl: remove maxResults setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,13 +223,6 @@
                     "items": {
                         "type": "string"
                     }
-                },
-                "aws.resources.maxItemsPerPage": {
-                    "type": "number",
-                    "default": 50,
-                    "minimum": 3,
-                    "maximum": 1000,
-                    "markdownDescription": "%AWS.configuration.description.resources.maxItemsPerPage%"
                 }
             }
         },

--- a/package.nls.json
+++ b/package.nls.json
@@ -45,7 +45,6 @@
     "AWS.configuration.description.suppressPrompts": "Optional prompts",
     "AWS.configuration.enableCodeLenses": "Enable SAM hints in source files",
     "AWS.configuration.description.resources.enabledResources": "AWS resources to display in the 'Resources' portion of the explorer.",
-    "AWS.configuration.description.resources.maxItemsPerPage": "Controls how many resources are listed before showing a node to `Load More...`.",
     "AWS.configuration.description.experiments": "Try experimental features and give feedback. Note that experimental features may be removed at any time.\n * `jsonResourceModification` - Enables basic JSON-based create, update, and delete support for cloud resources through the Resources node in the AWS Explorer",
     "AWS.stepFunctions.asl.format.enable.desc": "Enables the default formatter used with Amazon States Language files",
     "AWS.stepFunctions.asl.maxItemsComputed.desc": "The maximum number of outline symbols and folding regions computed (limited for performance reasons).",

--- a/src/dynamicResources/explorer/nodes/resourceTypeNode.ts
+++ b/src/dynamicResources/explorer/nodes/resourceTypeNode.ts
@@ -97,10 +97,8 @@ export class ResourceTypeNode extends AWSTreeNodeBase implements LoadMoreNode {
 
     private async loadPage(continuationToken: string | undefined): Promise<ChildNodePage<ResourceNode>> {
         getLogger().debug(`Loading page for %O using continuationToken %s`, this, continuationToken)
-        const maxResults = this.getMaxItemsPerPage()
         const response = await this.cloudControl.listResources({
             TypeName: this.typeName,
-            MaxResults: maxResults,
             NextToken: continuationToken,
         })
 
@@ -119,10 +117,6 @@ export class ResourceTypeNode extends AWSTreeNodeBase implements LoadMoreNode {
             newContinuationToken: response.NextToken,
             newChildren: [...newResources],
         }
-    }
-
-    private getMaxItemsPerPage(): number | undefined {
-        return vscode.workspace.getConfiguration('aws').get<number>('resources.maxItemsPerPage')
     }
 
     private static getFriendlyName(typeName: string): string {

--- a/src/test/dynamicResources/explorer/resourceTypeNode.test.ts
+++ b/src/test/dynamicResources/explorer/resourceTypeNode.test.ts
@@ -173,7 +173,6 @@ describe('ResourceTypeNode', function () {
             cloudControl.listResources(
                 deepEqual({
                     TypeName: FAKE_TYPE_NAME,
-                    MaxResults: anything(),
                     NextToken: anything(),
                 })
             )


### PR DESCRIPTION
## Problem
CloudControl currently does not respect the maxResults setting which could lead to customer confusion when modifying this value.

## Solution
Remove the setting for now.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
