### PR TITLE
fix(UI): product name on config page, China branding

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,12 @@
     "contributes": {
         "configuration": {
             "type": "object",
-            "title": "%AWS.configuration.title%",
+            "title": "%AWS.productName%",
+            "cloud9": {
+                "cn": {
+                    "title": "%AWS.productName.cn%"
+                }
+            },
             "properties": {
                 "aws.profile": {
                     "type": "string",
@@ -2260,6 +2265,11 @@
                 "id": "getStarted",
                 "title": "%AWS.walkthrough.gettingStarted.title%",
                 "description": "%AWS.walkthrough.gettingStarted.description%",
+                "cloud9": {
+                    "cn": {
+                        "description": "%AWS.walkthrough.gettingStarted.description.cn%"
+                    }
+                },
                 "steps": [
                     {
                         "id": "connect",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,6 +1,8 @@
 {
     "AWS.title": "AWS",
     "AWS.title.cn": "Amazon",
+    "AWS.productName": "AWS Toolkit",
+    "AWS.productName.cn": "Amazon Toolkit",
     "AWS.vscode.shortName": "VS Code",
     "AWS.vscode.longName": "Visual Studio Code",
     "AWS.vscode.commandPalette": "Command Palette",
@@ -32,7 +34,6 @@
     "AWS.codelens.failToInitialize": "Failed to activate template registry. {0} will not appear on SAM template files.",
     "AWS.codelens.failToInitializeCode": "Failed to activate Lambda handler {0}",
     "AWS.codelens.lambda.configEditor": "Edit Debug Configuration",
-    "AWS.configuration.title": "AWS Configuration",
     "AWS.configuration.profileDescription": "The name of the credential profile to obtain credentials from.",
     "AWS.configuration.description.logLevel": "The AWS Toolkit's log level (changes reflected on restart)",
     "AWS.configuration.description.logLevel.cn": "The Amazon Toolkit's log level (changes reflected on restart)",
@@ -600,7 +601,8 @@
     "AWS.picker.dynamic.noItemsFound.label": "[No items found]",
     "AWS.picker.dynamic.errorNode.label": "There was an error retrieving more items.",
     "AWS.walkthrough.gettingStarted.title": "Get Started with AWS",
-    "AWS.walkthrough.gettingStarted.description": "These walkthroughs help you set up the AWS Toolkit for Visual Studio Code.",
+    "AWS.walkthrough.gettingStarted.description": "These walkthroughs help you set up the AWS Toolkit.",
+    "AWS.walkthrough.gettingStarted.description.cn": "These walkthroughs help you set up the Amazon Toolkit.",
     "AWS.walkthrough.gettingStarted.connect": "Connect to AWS",
     "AWS.walkthrough.gettingStarted.changeRegions": "Change AWS Regions",
     "AWS.walkthrough.gettingStarted.setupToolchain": "Configure your toolchain"


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem

1. Product name in the configuration page should be the product name, not "AWS Configuration"
    - "Azure" extension is wrong.
1. "Walkthroughs" title was not China-branded

## Solution

![image](https://user-images.githubusercontent.com/55561878/137352379-e204e699-1a99-419b-b6d1-3c6c6cc89235.png)
### 

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
