### PR TITLE
fix(test): intermittent failure in pickerPrompter.test.ts

### DIFF
--- a/src/test/credentials/provider/ssoAccessTokenProvider.test.ts
+++ b/src/test/credentials/provider/ssoAccessTokenProvider.test.ts
@@ -13,7 +13,7 @@ import { StartDeviceAuthorizationResponse } from 'aws-sdk/clients/ssooidc'
 import { SsoClientRegistration } from '../../../credentials/sso/ssoClientRegistration'
 
 describe('SsoAccessTokenProvider', function () {
-    const sandbox = sinon.createSandbox()
+    let sandbox: sinon.SinonSandbox
 
     const ssoRegion = 'fakeRegion'
     const ssoUrl = 'fakeUrl'
@@ -66,6 +66,10 @@ describe('SsoAccessTokenProvider', function () {
 
     before(function () {
         clock = FakeTimers.install()
+    })
+
+    beforeEach(function () {
+        sandbox = sinon.createSandbox()
     })
 
     afterEach(async function () {

--- a/src/test/shared/ui/prompters/rolePrompter.test.ts
+++ b/src/test/shared/ui/prompters/rolePrompter.test.ts
@@ -18,13 +18,14 @@ import { QuickPickPrompter } from '../../../../shared/ui/pickerPrompter'
 const TEST_HELP_URI = vscode.Uri.parse('https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html')
 
 describe('RolePrompter', function () {
-    const sandbox = sinon.createSandbox()
+    let sandbox: sinon.SinonSandbox
     let roles: IAM.Role[]
     let newRole: IAM.Role
     let mockIamClient: IamClient
     let tester: QuickPickTester<IAM.Role>
 
     beforeEach(function () {
+        sandbox = sinon.createSandbox()
         roles = [
             {
                 RoleName: 'test-role1',
@@ -46,7 +47,7 @@ describe('RolePrompter', function () {
         tester = createQuickPickTester(prompter)
     })
 
-    after(function () {
+    afterEach(function () {
         sandbox.restore()
     })
 

--- a/src/test/ssmDocument/commands/publishDocument.test.ts
+++ b/src/test/ssmDocument/commands/publishDocument.test.ts
@@ -60,7 +60,7 @@ const mockDoc: vscode.TextDocument = {
 }
 
 describe('publishSSMDocument', async function () {
-    let sandbox = sinon.createSandbox()
+    let sandbox: sinon.SinonSandbox
     const fakeAwsContext = new FakeAwsContext()
     const fakeRegionProvider = new FakeRegionProvider()
 
@@ -142,7 +142,7 @@ describe('publishSSMDocument', async function () {
             createSsmClient: sandbox.stub().returns(ssmDocumentClient),
         }
 
-        ext.toolkitClientBuilder = (clientBuilder as any) as ToolkitClientBuilder
+        ext.toolkitClientBuilder = clientBuilder as any as ToolkitClientBuilder
     }
 })
 


### PR DESCRIPTION
## Problem:

1. since f7c3dc0961c969d3b240eef8adf21ee116133a47 #2168 , seeing these CI failures:
   ```
   QuickPickPrompter
        can select an item:
      Uncaught TypeError: this.onSuccess is not a function
       at Timeout._onTimeout (.vscode-test/vscode-linux-x64-1.42.0/VSCode-linux-x64/resources/app/extensions/json-language-features/client/dist/jsonMain.js:9:106345)
   ...
   "after each" hook for "creates a new prompter when given an AsyncIterable":
      Uncaught TypeError: this.onSuccess is not a function
       at Timeout._onTimeout (.vscode-test/vscode-linux-x64-1.42.0/VSCode-linux-x64/resources/app/extensions/json-language-features/client/dist/jsonMain.js:9:106345)
   ```

## Solution:
1. ensure sinon.createSandbox() in beforeEach()
2. ensure restore() in afterEach()

related
- https://github.com/aws/aws-toolkit-vscode/issues/1281
- https://github.com/aws/aws-toolkit-vscode/issues/1233

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
