### PR TITLE
cloudControl: handle unsupported resource actions

### DIFF
--- a/src/dynamicResources/commands/deleteResource.ts
+++ b/src/dynamicResources/commands/deleteResource.ts
@@ -58,6 +58,22 @@ export async function deleteResource(
                 )
                 return true
             } catch (e) {
+                const error = e as Error
+                if (error.name === 'UnsupportedActionException') {
+                    result = 'Cancelled'
+                    getLogger().warn(
+                        `Resource type ${typeName} does not support DELETE action in ${cloudControl.regionCode}`
+                    )
+                    window.showWarningMessage(
+                        localize(
+                            'aws.resources.deleteResource.unsupported',
+                            'Resource type {0} does not currently support delete in {1}',
+                            typeName,
+                            cloudControl.regionCode
+                        )
+                    )
+                    return false
+                }
                 result = 'Failed'
                 getLogger().error(`Failed to delete resource type ${typeName} identifier ${identifier}: %O`, e)
                 showViewLogsMessage(

--- a/src/dynamicResources/commands/saveResource.ts
+++ b/src/dynamicResources/commands/saveResource.ts
@@ -97,13 +97,28 @@ export async function createResource(
                 return identifier
             } catch (e) {
                 const error = e as Error
-                result = 'Failed'
-                getLogger().error(`Failed to create resource type ${typeName}: %O`, error.message)
-                showViewLogsMessage(
-                    localize('aws.resources.createResource.failure', 'Failed to create resource ({0})', typeName),
-                    window
-                )
-                throw e
+                if (error.name === 'UnsupportedActionException') {
+                    result = 'Cancelled'
+                    getLogger().warn(
+                        `Resource type ${typeName} does not support CREATE action in ${cloudControl.regionCode}`
+                    )
+                    window.showWarningMessage(
+                        localize(
+                            'aws.resources.createResource.unsupported',
+                            '{0} does not currently support resource creation in {1}',
+                            typeName,
+                            cloudControl.regionCode
+                        )
+                    )
+                } else {
+                    result = 'Failed'
+                    getLogger().error(`Failed to create resource type ${typeName}: %O`, error.message)
+                    showViewLogsMessage(
+                        localize('aws.resources.createResource.failure', 'Failed to create resource ({0})', typeName),
+                        window
+                    )
+                    throw e
+                }
             } finally {
                 recordDynamicresourceMutateResource({
                     dynamicResourceOperation: 'Create',
@@ -169,21 +184,37 @@ export async function updateResource(
                 return true
             } catch (e) {
                 const error = e as Error
-                result = 'Failed'
-                getLogger().error(
-                    `Failed to update resource type ${typeName} identifier ${identifier}: %O`,
-                    error.message
-                )
-                showViewLogsMessage(
-                    localize(
-                        'aws.resources.updateResource.failure',
-                        'Failed to update resource {0} ({1})',
-                        identifier,
-                        typeName
-                    ),
-                    window
-                )
-                throw e
+                if (error.name === 'UnsupportedActionException') {
+                    result = 'Cancelled'
+                    getLogger().warn(
+                        `Resource type ${typeName} does not support UPDATE action in ${cloudControl.regionCode}`
+                    )
+                    window.showWarningMessage(
+                        localize(
+                            'aws.resources.createResource.unsupported',
+                            '{0} does not currently support resource updating in {1}',
+                            typeName,
+                            cloudControl.regionCode
+                        )
+                    )
+                    return false
+                } else {
+                    result = 'Failed'
+                    getLogger().error(
+                        `Failed to update resource type ${typeName} identifier ${identifier}: %O`,
+                        error.message
+                    )
+                    showViewLogsMessage(
+                        localize(
+                            'aws.resources.updateResource.failure',
+                            'Failed to update resource {0} ({1})',
+                            identifier,
+                            typeName
+                        ),
+                        window
+                    )
+                    throw e
+                }
             } finally {
                 recordDynamicresourceMutateResource({
                     dynamicResourceOperation: 'Update',

--- a/src/test/dynamicResources/commands/deleteResource.test.ts
+++ b/src/test/dynamicResources/commands/deleteResource.test.ts
@@ -72,4 +72,18 @@ describe('deleteResource', function () {
 
         assert.ok(window.message.error?.startsWith(`Failed to delete resource ${FAKE_IDENTIFIER} (${FAKE_TYPE})`))
     })
+
+    it('shows a warning if unsupported action', async function () {
+        sandbox.stub(cloudControl, 'deleteResource').callsFake(async () => {
+            const error = new Error('fake exception')
+            error.name = 'UnsupportedActionException'
+            throw error
+        })
+
+        const window = new FakeWindow({ message: { warningSelection: 'Delete' } })
+
+        await deleteResource(cloudControl, FAKE_TYPE, FAKE_IDENTIFIER, window)
+
+        assert.ok(window.message.warning?.startsWith(`Resource type ${FAKE_TYPE} does not currently support delete`))
+    })
 })

--- a/src/test/dynamicResources/commands/saveResource.test.ts
+++ b/src/test/dynamicResources/commands/saveResource.test.ts
@@ -86,6 +86,24 @@ describe('createResource', function () {
         }
         assert.fail('Expected exception, but none was thrown.')
     })
+
+    it('shows a warning if unsupported action', async function () {
+        const error = new Error('fake exception')
+        error.name = 'UnsupportedActionException'
+        when(
+            mockCloudControl.createResource(
+                deepEqual({
+                    TypeName: FAKE_TYPE,
+                    DesiredState: FAKE_DEFINITION,
+                })
+            )
+        ).thenReject(error)
+        const window = new FakeWindow()
+
+        await createResource(FAKE_TYPE, FAKE_DEFINITION, instance(mockCloudControl), window)
+
+        assert.ok(window.message.warning?.startsWith(`${FAKE_TYPE} does not currently support resource creation`))
+    })
 })
 
 describe('updateResource', function () {
@@ -171,5 +189,23 @@ describe('updateResource', function () {
 
         verify(mockCloudControl.updateResource(anything())).never()
         assert.ok(window.message.warning?.startsWith(`Update cancelled`))
+    })
+
+    it('shows a warning if unsupported action', async function () {
+        const patchJson = JSON.stringify(FAKE_DIFF)
+        const error = new Error('fake exception')
+        error.name = 'UnsupportedActionException'
+        when(
+            mockCloudControl.updateResource(
+                deepEqual({
+                    TypeName: FAKE_TYPE,
+                    Identifier: FAKE_IDENTIFIER,
+                    PatchDocument: patchJson,
+                })
+            )
+        ).thenReject(error)
+        const window = new FakeWindow()
+        await updateResource(FAKE_TYPE, FAKE_IDENTIFIER, FAKE_DEFINITION, instance(mockCloudControl), window, FAKE_DIFF)
+        assert.ok(window.message.warning?.startsWith(`${FAKE_TYPE} does not currently support resource updating`))
     })
 })

--- a/src/test/dynamicResources/explorer/resourceTypeNode.test.ts
+++ b/src/test/dynamicResources/explorer/resourceTypeNode.test.ts
@@ -120,6 +120,17 @@ describe('ResourceTypeNode', function () {
         assertNodeListOnlyContainsErrorNode(childNodes)
     })
 
+    it('has a placeholder node for a child if unsupported action', async function () {
+        cloudControl = mock()
+        const error = new Error('foo')
+        error.name = 'UnsupportedActionException'
+        when(cloudControl.listResources(anything())).thenThrow(error)
+        testNode = generateTestNode(instance(cloudControl))
+
+        const childNodes = await testNode.getChildren()
+        assertNodeListOnlyContainsPlaceholderNode(childNodes)
+    })
+
     it('has Documented contextValue if documentation available', function () {
         mockCloudControlClient(resourceIdentifiers)
 


### PR DESCRIPTION
## Problem
CloudControl resources do not necessarily support the same actions across all supported regions. Our manifest currently does not expose capabilities at this level of granularity. This leads to errors being surfaced to the user when they encounter an unsupported action.

## Solution
This change adds error handling for UnsupportedActionExceptions for all CloudControl operations, including better UX in this case and Cancelled telemetry results.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
