### PR TITLE
cloudControl: guard against undefined type schema values

### DIFF
--- a/.changes/next-release/Bug Fix-6eced317-695e-4b2d-90b6-f66151808474.json
+++ b/.changes/next-release/Bug Fix-6eced317-695e-4b2d-90b6-f66151808474.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Resources: Better handling of unsupported resource actions"
+}

--- a/.changes/next-release/Bug Fix-7d02b7b3-fae8-4ffe-ac36-22f1ba2f96f1.json
+++ b/.changes/next-release/Bug Fix-7d02b7b3-fae8-4ffe-ac36-22f1ba2f96f1.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Resources: Filter S3 bucket resources by region in list view"
+}

--- a/.changes/next-release/Bug Fix-7e820feb-c6bc-4d2a-836a-f1c877f72b3f.json
+++ b/.changes/next-release/Bug Fix-7e820feb-c6bc-4d2a-836a-f1c877f72b3f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Resources: Exclude resource types that do not support LIST in Cloud9"
+}

--- a/.changes/next-release/Bug Fix-cf2cdebd-6284-46d1-aabb-42d2f184bc45.json
+++ b/.changes/next-release/Bug Fix-cf2cdebd-6284-46d1-aabb-42d2f184bc45.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Resources: Handle undefined type schema properties"
+}

--- a/src/dynamicResources/awsResourceManager.ts
+++ b/src/dynamicResources/awsResourceManager.ts
@@ -221,13 +221,13 @@ type Schema = {
 }
 
 export interface TypeSchema {
-    typeName: string
-    description: string
-    properties: any
-    definitions: any
-    readOnlyProperties: string[]
-    createOnlyProperties: string[]
-    writeOnlyProperties: string[]
-    required: string[]
-    primaryIdentifier: string[]
+    typeName?: string
+    description?: string
+    properties?: any
+    primaryIdentifier?: string[]
+    definitions?: any
+    readOnlyProperties?: string[]
+    createOnlyProperties?: string[]
+    writeOnlyProperties?: string[]
+    required?: string[]
 }

--- a/src/dynamicResources/commands/openResource.ts
+++ b/src/dynamicResources/commands/openResource.ts
@@ -79,38 +79,43 @@ export async function openResource(
 export function getDiagnostics(schema: TypeSchema, doc: vscode.TextDocument): vscode.Diagnostic[] {
     const diagnostics: vscode.Diagnostic[] = []
     const text = doc.getText()
-    for (const property of schema.createOnlyProperties) {
-        const propertyName = getPropertyName(property)
-        const range = getPropertyRange(propertyName, text, doc)
-        if (range) {
-            diagnostics.push(
-                new vscode.Diagnostic(
-                    range,
-                    localize(
-                        'AWS.message.information.resources.createOnlyProperty',
-                        '"{0}" is a create-only property and cannot be modified on an existing resource',
-                        propertyName
-                    ),
-                    vscode.DiagnosticSeverity.Information
+    if (schema.createOnlyProperties) {
+        for (const property of schema.createOnlyProperties) {
+            const propertyName = getPropertyName(property)
+            const range = getPropertyRange(propertyName, text, doc)
+            if (range) {
+                diagnostics.push(
+                    new vscode.Diagnostic(
+                        range,
+                        localize(
+                            'AWS.message.information.resources.createOnlyProperty',
+                            '"{0}" is a create-only property and cannot be modified on an existing resource',
+                            propertyName
+                        ),
+                        vscode.DiagnosticSeverity.Information
+                    )
                 )
-            )
+            }
         }
     }
-    for (const property of schema.readOnlyProperties) {
-        const propertyName = getPropertyName(property)
-        const range = getPropertyRange(propertyName, text, doc)
-        if (range) {
-            diagnostics.push(
-                new vscode.Diagnostic(
-                    range,
-                    localize(
-                        'AWS.message.information.resources.readOnlyProperty',
-                        '"{0}" is a read-only property and cannot be modified',
-                        propertyName
-                    ),
-                    vscode.DiagnosticSeverity.Information
+
+    if (schema.readOnlyProperties) {
+        for (const property of schema.readOnlyProperties) {
+            const propertyName = getPropertyName(property)
+            const range = getPropertyRange(propertyName, text, doc)
+            if (range) {
+                diagnostics.push(
+                    new vscode.Diagnostic(
+                        range,
+                        localize(
+                            'AWS.message.information.resources.readOnlyProperty',
+                            '"{0}" is a read-only property and cannot be modified',
+                            propertyName
+                        ),
+                        vscode.DiagnosticSeverity.Information
+                    )
                 )
-            )
+            }
         }
     }
     return diagnostics


### PR DESCRIPTION
## Problem
Not all properties of type schemas are required and they are not always returned by all resource types. This can result in errors specifically for required property metadata.

## Solution
Treat all schema data is optional and defensively use properties.

## License
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
