### PR TITLE
feat(settings): getSetting() validates setting

### DIFF
--- a/src/test/utilities/testSettingsConfiguration.ts
+++ b/src/test/utilities/testSettingsConfiguration.ts
@@ -25,6 +25,14 @@ export class TestSettingsConfiguration implements SettingsConfiguration {
         return this._data[settingKey] as T
     }
 
+    public getSetting<T>(
+        key: string,
+        type?: 'string',
+        opt?: { silent?: 'no' | 'yes' | 'notfound' | undefined; logging?: boolean | undefined }
+    ): T | undefined {
+        throw new Error('Method not implemented.')
+    }
+
     public async writeSetting<T>(settingKey: string, value: T, target?: any): Promise<boolean> {
         this._data[settingKey] = value
         return true


### PR DESCRIPTION
## Problem:
1. Settings values are not validated.
2. readSetting() only works with the prefix given to the
   SettingsConfiguration constructor, so a different object needs to be
   created just to read different settings.

## Solution:
1. Add getSetting()
    - Accepts any key. Doesn't care about the SettingsConfiguration "prefix".
    - Validates the setting type.
2. Deprecate readSetting(). It and the "prefix" thing will be removed
   later.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
