### PR TITLE
Deprecate dotnetcore2.1 runtime

### DIFF
--- a/.changes/next-release/Breaking Change-5d915a6a-c625-4161-95e5-8b21cffc1e04.json
+++ b/.changes/next-release/Breaking Change-5d915a6a-c625-4161-95e5-8b21cffc1e04.json
@@ -1,0 +1,4 @@
+{
+	"type": "Breaking Change",
+	"description": "DEPRECATION: SAM actions using `dotnetcore2.1` runtime (Phase 2 Lambda deprecation)"
+}

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -141,7 +141,6 @@ const scenarios: TestScenario[] = [
         language: 'go',
         dependencyManager: 'mod',
     },
-    // { runtime: 'dotnetcore2.1', path: 'src/HelloWorld/Function.cs', debugSessionType: 'coreclr', language: 'csharp' },
     // { runtime: 'dotnetcore3.1', path: 'src/HelloWorld/Function.cs', debugSessionType: 'coreclr', language: 'csharp' },
 
     // images
@@ -236,7 +235,6 @@ const scenarios: TestScenario[] = [
         language: 'java',
         dependencyManager: 'maven',
     },
-    // { runtime: 'dotnetcore2.1', path: 'src/HelloWorld/Function.cs', debugSessionType: 'coreclr', language: 'csharp' },
     // { runtime: 'dotnetcore3.1', path: 'src/HelloWorld/Function.cs', debugSessionType: 'coreclr', language: 'csharp' },
 ]
 

--- a/src/lambda/models/samLambdaRuntime.ts
+++ b/src/lambda/models/samLambdaRuntime.ts
@@ -36,7 +36,7 @@ export const pythonRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>([
 ])
 export const goRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>(['go1.x'])
 export const javaRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>(['java11', 'java8', 'java8.al2'])
-export const dotNetRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>(['dotnetcore2.1', 'dotnetcore3.1'])
+export const dotNetRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>(['dotnetcore3.1'])
 
 /**
  * Deprecated runtimes can be found at https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html

--- a/src/test/lambda/models/samLambdaRuntime.test.ts
+++ b/src/test/lambda/models/samLambdaRuntime.test.ts
@@ -83,7 +83,6 @@ describe('runtimes', function () {
     })
     it('vscode', function () {
         assert.deepStrictEqual(samLambdaCreatableRuntimes(false).toArray().sort(), [
-            'dotnetcore2.1',
             'dotnetcore3.1',
             'go1.x',
             'java11',
@@ -98,7 +97,6 @@ describe('runtimes', function () {
         ])
         assert.deepStrictEqual(samImageLambdaRuntimes(false).toArray().sort(), [
             'dotnet5.0',
-            'dotnetcore2.1',
             'dotnetcore3.1',
             'go1.x',
             'java11',

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -1589,7 +1589,7 @@ describe('SamDebugConfigurationProvider', async function () {
                     projectRoot: 'src/HelloWorld',
                 },
                 lambda: {
-                    runtime: 'dotnetcore2.1',
+                    runtime: 'dotnetcore3.1',
                 },
             }
             const actual = (await debugConfigProvider.makeConfig(folder, input))! as SamLaunchRequestArgs
@@ -1598,7 +1598,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const expected: SamLaunchRequestArgs = {
                 awsCredentials: undefined,
                 request: 'attach', // Input "direct-invoke", output "attach".
-                runtime: 'dotnetcore2.1', // lambdaModel.dotNetRuntimes[0],
+                runtime: 'dotnetcore3.1', // lambdaModel.dotNetRuntimes[0],
                 runtimeFamily: lambdaModel.RuntimeFamily.DotNetCore,
                 useIkpdb: false,
                 type: AWS_SAM_DEBUG_TYPE,
@@ -1665,7 +1665,7 @@ describe('SamDebugConfigurationProvider', async function () {
       Handler: HelloWorld::HelloWorld.Function::FunctionHandler
       CodeUri: >-
         ${input.invokeTarget.projectRoot}
-      Runtime: dotnetcore2.1
+      Runtime: dotnetcore3.1
 `
             )
 
@@ -1764,7 +1764,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const expected: SamLaunchRequestArgs = {
                 awsCredentials: undefined,
                 request: 'attach', // Input "direct-invoke", output "attach".
-                runtime: 'dotnetcore2.1', // lambdaModel.dotNetRuntimes[0],
+                runtime: 'dotnetcore3.1', // lambdaModel.dotNetRuntimes[0],
                 runtimeFamily: lambdaModel.RuntimeFamily.DotNetCore,
                 useIkpdb: false,
                 type: AWS_SAM_DEBUG_TYPE,
@@ -1896,7 +1896,7 @@ describe('SamDebugConfigurationProvider', async function () {
                     logicalId: 'HelloWorldFunction',
                 },
                 lambda: {
-                    runtime: 'dotnetcore2.1',
+                    runtime: 'dotnetcore3.1',
                     environmentVariables: {
                         'test-envvar-1': 'test value 1',
                     },
@@ -1917,7 +1917,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const expected: SamLaunchRequestArgs = {
                 awsCredentials: undefined,
                 request: 'attach', // Input "direct-invoke", output "attach".
-                runtime: 'dotnetcore2.1', // lambdaModel.dotNetRuntimes[0],
+                runtime: 'dotnetcore3.1', // lambdaModel.dotNetRuntimes[0],
                 runtimeFamily: lambdaModel.RuntimeFamily.DotNetCore,
                 useIkpdb: false,
                 type: AWS_SAM_DEBUG_TYPE,

--- a/src/testFixtures/workspaceFolder/csharp2.1-image-sam-app/src/HelloWorld/aws-lambda-tools-defaults.json
+++ b/src/testFixtures/workspaceFolder/csharp2.1-image-sam-app/src/HelloWorld/aws-lambda-tools-defaults.json
@@ -12,7 +12,7 @@
     "region": "",
     "configuration": "Release",
     "framework": "netcoreapp2.1",
-    "function-runtime": "dotnetcore2.1",
+    "function-runtime": "dotnetcore3.1",
     "function-memory-size": 256,
     "function-timeout": 30,
     "function-handler": "HelloWorld::HelloWorld.Function::FunctionHandler"

--- a/src/testFixtures/workspaceFolder/csharp2.1-image-sam-app/template.yaml
+++ b/src/testFixtures/workspaceFolder/csharp2.1-image-sam-app/template.yaml
@@ -23,6 +23,6 @@ Resources:
                         Path: /hello
                         Method: get
         Metadata:
-            DockerTag: dotnetcore2.1-v1
+            DockerTag: dotnetcore3.1-v1
             DockerContext: ./src/HelloWorld
             Dockerfile: Dockerfile

--- a/src/testFixtures/workspaceFolder/csharp2.1-plain-sam-app/template.yaml
+++ b/src/testFixtures/workspaceFolder/csharp2.1-plain-sam-app/template.yaml
@@ -14,7 +14,7 @@ Resources:
         Properties:
             CodeUri: ./src/HelloWorld/
             Handler: HelloWorld::HelloWorld.Function::FunctionHandler
-            Runtime: dotnetcore2.1
+            Runtime: dotnetcore3.1
             Events:
                 HelloWorld:
                     Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api


### PR DESCRIPTION
Runtime `dotnetcore2.1` has hit [Phase 2 Deprecation in Lambda](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html), meaning that Lambdas running with `dotnetcore2.1` can no longer be created or updated. As such, there is no reason to maintain support in VS Code.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
