### PR TITLE
cloudControl: add Cloud9 CN branding for commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -2006,60 +2006,110 @@
             {
                 "command": "aws.resources.copyIdentifier",
                 "title": "%AWS.command.resources.copyIdentifier%",
-                "category": "%AWS.title%"
+                "category": "%AWS.title%",
+                "cloud9": {
+                    "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
             },
             {
                 "command": "aws.resources.openResourcePreview",
                 "title": "%AWS.generic.preview%",
                 "category": "%AWS.title%",
-                "icon": "$(open-preview)"
+                "icon": "$(open-preview)",
+                "cloud9": {
+                    "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
             },
             {
                 "command": "aws.resources.createResource",
                 "title": "%AWS.generic.create%",
                 "category": "%AWS.title%",
-                "icon": "$(add)"
+                "icon": "$(add)",
+                "cloud9": {
+                    "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
             },
             {
                 "command": "aws.resources.deleteResource",
                 "title": "%AWS.generic.promptDelete%",
-                "category": "%AWS.title%"
+                "category": "%AWS.title%",
+                "cloud9": {
+                    "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
             },
             {
                 "command": "aws.resources.updateResource",
                 "title": "%AWS.generic.promptUpdate%",
                 "category": "%AWS.title%",
-                "icon": "$(pencil)"
+                "icon": "$(pencil)",
+                "cloud9": {
+                    "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
             },
             {
                 "command": "aws.resources.updateResourceInline",
                 "title": "%AWS.generic.promptUpdate%",
                 "category": "%AWS.title%",
-                "icon": "$(pencil)"
+                "icon": "$(pencil)",
+                "cloud9": {
+                    "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
             },
             {
                 "command": "aws.resources.saveResource",
                 "title": "%AWS.generic.save%",
                 "category": "%AWS.title%",
-                "icon": "$(save)"
+                "icon": "$(save)",
+                "cloud9": {
+                    "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
             },
             {
                 "command": "aws.resources.closeResource",
                 "title": "%AWS.generic.close%",
                 "category": "%AWS.title%",
-                "icon": "$(close)"
+                "icon": "$(close)",
+                "cloud9": {
+                    "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
             },
             {
                 "command": "aws.resources.viewDocs",
                 "title": "%AWS.generic.viewDocs%",
                 "category": "%AWS.title%",
-                "icon": "$(book)"
+                "icon": "$(book)",
+                "cloud9": {
+                    "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
             },
             {
                 "command": "aws.resources.configure",
                 "title": "%AWS.command.resources.configure%",
                 "category": "%AWS.title%",
-                "icon": "$(gear)"
+                "icon": "$(gear)",
+                "cloud9": {
+                    "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
             },
             {
                 "command": "aws.apprunner.createService",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,7 +63,7 @@ import { ExtContext } from './shared/extensions'
 import { activate as activateApiGateway } from './apigateway/activation'
 import { activate as activateStepFunctions } from './stepFunctions/activation'
 import { activate as activateSsmDocument } from './ssmDocument/activation'
-import { activate as activateCloudApi } from './dynamicResources/activation'
+import { activate as activateDynamicResources } from './dynamicResources/activation'
 import { activate as activateAppRunner } from './apprunner/activation'
 import { CredentialsStore } from './credentials/credentialsStore'
 import { getSamCliContext } from './shared/sam/cli/samCliContext'
@@ -240,7 +240,8 @@ export async function activate(context: vscode.ExtensionContext) {
         await activateEcr(context)
 
         await activateCloudWatchLogs(context, toolkitSettings)
-        await activateCloudApi(context)
+
+        await activateDynamicResources(context)
 
         // Features which aren't currently functional in Cloud9
         if (!isCloud9()) {


### PR DESCRIPTION
## Problem
CloudControl commands are not currently CN localized.

## Solution
Localize CN branding for commands.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
