### PR TITLE
cloudControl: avoid redundant editor closing

### DIFF
--- a/.changes/next-release/Bug Fix-e3752045-17ab-4620-ae97-438c00d24bae.json
+++ b/.changes/next-release/Bug Fix-e3752045-17ab-4620-ae97-438c00d24bae.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "cloudControl: Avoid redundant close of active editor when resource documents are explicitly closed"
+}

--- a/.changes/next-release/Bug Fix-e3752045-17ab-4620-ae97-438c00d24bae.json
+++ b/.changes/next-release/Bug Fix-e3752045-17ab-4620-ae97-438c00d24bae.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "cloudControl: Avoid redundant close of active editor when resource documents are explicitly closed"
+	"description": "Resources: Avoid redundant close of active editor when resource documents are explicitly closed"
 }

--- a/src/dynamicResources/activation.ts
+++ b/src/dynamicResources/activation.ts
@@ -109,7 +109,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             }
         }),
         vscode.workspace.onDidCloseTextDocument(closeDocumentEvent => {
-            resourceManager.close(closeDocumentEvent.uri)
+            resourceManager.close(closeDocumentEvent.uri, true)
         }),
         vscode.languages.registerCodeLensProvider(
             {

--- a/src/dynamicResources/awsResourceManager.ts
+++ b/src/dynamicResources/awsResourceManager.ts
@@ -91,6 +91,7 @@ export class AwsResourceManager {
             getLogger().debug(`resourceManager: closing ${uri}`)
 
             if (!isEditorClosed) {
+                // grab focus back to the desired document before closing the active editor
                 await vscode.window.showTextDocument(uri)
                 await vscode.commands.executeCommand('workbench.action.closeActiveEditor')
             }

--- a/src/dynamicResources/awsResourceManager.ts
+++ b/src/dynamicResources/awsResourceManager.ts
@@ -85,13 +85,15 @@ export class AwsResourceManager {
         }
     }
 
-    public async close(uri: vscode.Uri): Promise<void> {
+    public async close(uri: vscode.Uri, isEditorClosed?: boolean): Promise<void> {
         const path = uri.toString()
         if (this.openResources.has(path)) {
             getLogger().debug(`resourceManager: closing ${uri}`)
 
-            await vscode.window.showTextDocument(uri)
-            await vscode.commands.executeCommand('workbench.action.closeActiveEditor')
+            if (!isEditorClosed) {
+                await vscode.window.showTextDocument(uri)
+                await vscode.commands.executeCommand('workbench.action.closeActiveEditor')
+            }
 
             if (uri.scheme === 'file') {
                 remove(uri.fsPath)


### PR DESCRIPTION
## Problem
We close the active editor at the conclusion of several actions including resource save, create, and close of the editor mode. This is desired behavior. However we also unnecessarily close the editor when a document close event occurs. In Cloud9 this results in unnecessary flickering as the closed document is briefly visible before being re-closed.

## Solution
Add a flag to indicate the editor is already closed and only perform cleanup actions.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
