### PR TITLE
Webviews: add framework code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,14 +9,20 @@
             "name": "Extension",
             "type": "extensionHost",
             "request": "launch",
+            "debugWebviews": true,
+            "rendererDebugOptions": {
+                "urlFilter": "*amazonwebservices.aws-toolkit-vscode*",
+                "webRoot": "${workspaceFolder}"
+            },
             "runtimeExecutable": "${execPath}",
             "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
             "env": {
                 "AWS_TOOLKIT_IGNORE_WEBPACK_BUNDLE": "true",
-                "SSMDOCUMENT_LANGUAGESERVER_PORT": "6010"
+                "SSMDOCUMENT_LANGUAGESERVER_PORT": "6010",
+                "WEBPACK_DEVELOPER_SERVER": "http://localhost:8080"
             },
             "outFiles": ["${workspaceFolder}/dist/**/*.js"],
-            "preLaunchTask": "npm: watch"
+            "preLaunchTask": "watch"
         },
         {
             "name": "Attach to ASL Server",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,19 +4,36 @@
     "version": "2.0.0",
     "tasks": [
         {
+            "label": "watch",
             "type": "npm",
             "script": "watch",
             "problemMatcher": "$tsc-watch",
             "isBackground": true,
-            "presentation": {
-                "reveal": "never"
-            },
             "group": {
                 "kind": "build",
                 "isDefault": true
             },
-            "runOptions": {
-                "runOn": "folderOpen"
+            "dependsOn": ["serve"]
+        },
+        {
+            "label": "serve",
+            "type": "npm",
+            "script": "serve",
+            "group": "build",
+            "isBackground": true,
+            "problemMatcher": {
+                "owner": "custom",
+                "pattern": {
+                    "regexp": ".",
+                    "file": 1,
+                    "location": 2,
+                    "message": 3
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "Project is running at",
+                    "endsPattern": "compiled successfully"
+                }
             }
         },
         {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 An overview of the architecture for various components within the Toolkit.
 
-## Webviews
+## Webviews (Vue framework)
 
 The current implementation uses Vue 3 with Single File Components (SFCs) for modularity. Each webview
 is bundled into a single file and packaged into the toolkit at release time. Vue applications may be composed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,103 @@
+# Architecture
+
+An overview of the architecture for various components within the Toolkit.
+
+## Webviews
+
+The current implementation uses Vue 3 with Single File Components (SFCs) for modularity. Each webview
+is bundled into a single file and packaged into the toolkit at release time. Each component is able to
+act independently, however, they must respect the following principles:
+
+1. State can only be stored in a child component if it is not being used for two-way communication (via events)
+2. If there is two-way communication, store state in the parent
+3. Data should flow down, actions should flow up
+
+Be very mindful about state managment; violating these principles will lead to buggy and hard-to-debug software.
+
+### Bundling
+
+Each webview is bundled into a single file to speed up load times as well as isolate the 'web' modules from the 'node' modules. Webview bundles are automatically generated on compilation by targeting `entry.ts` files when located under a `vue` directory. All bundles are placed directly under `dist`.
+
+Generated bundle names map based off their path relative to `src`: `src/foo/vue/bar/entry.ts` -> `fooBarVue.js`
+
+Running the extension in development mode (e.g. via the `Extension` launch task) starts a local server to automatically rebuild and serve webviews in real-time via hot-module reloading.
+
+### Client/Server
+
+The VS Code API restricts our Webviews to a single `postMessage` function. To simplify developing Webviews, we use a basic client/server architecture to handle message passing between the view and the extension.
+
+Webview (frontend) clients can be created via `WebviewClientFactory`. This generates a simple Proxy to send messages to the extension, mapping the function name to the command name. Unique IDs are also generated to stop requests from receiving extraneous responses. It is **highly** recommened to use the [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar) extension for syntax highlighting and type-checking when working with SFCs.
+
+Commands and events are defined on the backend via `compileVueWebview` or `compileVueWebviewView` for the special view case. This takes a configuration object that contains information about the webview, such as the
+name of the main script, the panel id, and the commands/events that the backend provides. This returns a class that can be instantiated into the webview. Webviews can then be executed by calling `start` with any initial data (if applicable). Webviews can be cleared of their internal state without reloading the HTML by calling `clear` with any re-initialization data (if applicable).
+
+### Examples
+
+-   Creating and executing a webview:
+
+    ```ts
+    const VueWebview = compileVueWebview({
+        id: 'my.view',
+        title: 'A title',
+        webviewJs: 'myView.js',
+        start: (param?: string) => param ?? 'foo',
+        events: {
+            onBar: new vscode.EventEmitter<number>(),
+        },
+        commands: {
+            foo: () => 'hello!',
+        },
+    })
+
+    // `context` is `ExtContext` provided on activation
+    const view = new VueWebview(context)
+    view.start('some data')
+    view.emitters.onFoo.fire(1)
+
+    // Export a class so the frontend code can use it for types
+    export class MyView extends VueWebview {}
+    ```
+
+-   Creating the client on the frontend:
+
+    ```ts
+    import { MyView } from './backend.ts'
+    const client = WebviewClientFactory.create<MyView>()
+    ```
+
+-   A basic request/response with error handling:
+
+    ```ts
+    client
+        .foo()
+        .then(response => console.log(response))
+        .catch(err => console.log(err))
+    ```
+
+    The backend protocol is allowed to throw errors. These result in rejected Promises on the frontend.
+
+-   Registering for events:
+
+    ```ts
+    client.onBar(num => console.log(num))
+    ```
+
+-   Retrieving initialization data by calling the `init` method:
+
+    ```ts
+    client.init(data => console.log(data))
+    ```
+
+    Note that data is retrieved only **once**. Subsequent calls made by the same webview resolve `undefined` unless the state is cleared either by `clear` or refreshing the view.
+
+-   Submitting a result (this destroys the view on success):
+
+    ```ts
+    client.submit(result).catch(err => console.error('Something went wrong!'))
+    ```
+
+    `submit` does nothing on views registered as a `WebviewView` as they cannot be disposed of by the extension.
+
+### Testing
+
+Currently only manual testing is done. Future work will include setting up some basic unit testing capacity via `JSDOM` and `Vue Testing Library`. Strict type-checking may also be enforced on SFCs; currently the type-checking only exists locally due to gaps in the type definitions for the DOM provided by Vue/TypeScript.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,8 +5,9 @@ An overview of the architecture for various components within the Toolkit.
 ## Webviews
 
 The current implementation uses Vue 3 with Single File Components (SFCs) for modularity. Each webview
-is bundled into a single file and packaged into the toolkit at release time. Each component is able to
-act independently, however, they must respect the following principles:
+is bundled into a single file and packaged into the toolkit at release time. Vue applications may be composed
+of individual components in a parent/child heiracrchy. Each component is able to act independently within an
+application, however, they must respect the following principles:
 
 1. State can only be stored in a child component if it is not being used for two-way communication (via events)
 2. If there is two-way communication, store state in the parent
@@ -24,7 +25,8 @@ Running the extension in development mode (e.g. via the `Extension` launch task)
 
 ### Client/Server
 
-The VS Code API restricts our Webviews to a single `postMessage` function. To simplify developing Webviews, we use a basic client/server architecture to handle message passing between the view and the extension.
+The VS Code API restricts our Webviews to a single `postMessage` function. To simplify developing Webviews, we use a client/server architecture to handle message passing between the view and the extension. This does not mean that clients are restricted to 1 message = 1 response, rather, the frontend ("client")
+needs to send the first message.
 
 Webview (frontend) clients can be created via `WebviewClientFactory`. This generates a simple Proxy to send messages to the extension, mapping the function name to the command name. Unique IDs are also generated to stop requests from receiving extraneous responses. It is **highly** recommened to use the [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar) extension for syntax highlighting and type-checking when working with SFCs.
 

--- a/media/css/base.css
+++ b/media/css/base.css
@@ -62,6 +62,10 @@ input[type='number'][data-invalid='true'] {
     border: 1px solid var(--vscode-inputValidation-errorBorder);
     border-bottom: 0;
 }
+input:disabled {
+    /* TODO: use VSC webcomponent library instead */
+    filter: brightness(0.8);
+}
 .input-validation {
     color: var(--vscode-inputValidation-errorForeground);
     background: var(--vscode-inputValidation-errorBackground);
@@ -111,7 +115,7 @@ button,
     padding: 8px;
 }
 button,
-.button-theme-primary:hover {
+.button-theme-primary:hover:not(:disabled) {
     background: var(--vscode-button-hoverBackground);
 }
 .button-theme-secondary {
@@ -119,12 +123,16 @@ button,
     background: var(--vscode-button-secondaryBackground);
     border: 1px solid var(--vscode-button-border);
 }
-.button-theme-secondary:hover {
+.button-theme-secondary:hover:not(:disabled) {
     background: var(--vscode-button-secondaryHoverBackground);
 }
 .button-theme-soft {
     color: var(--vscode-settings-textInputForeground);
     background: var(--vscode-settings-textInputBackground);
+}
+button:disabled {
+    /* TODO: use VSC webcomponent library instead */
+    filter: brightness(0.8);
 }
 
 /* Text area */
@@ -134,10 +142,105 @@ textarea {
     border: 1px solid var(--vscode-settings-textInputBorder);
 }
 
+/* Badge */
+.badge {
+    color: var(--vscode-activityBarBadge-foreground);
+    background-color: var(--vscode-activityBarBadge-background);
+    padding: 3px 8px;
+    font-size: 0.75rem;
+    border-radius: 16px;
+    white-space: nowrap;
+}
+
+.label-context {
+    display: block;
+    padding: 0 0 4px 0;
+}
+.option-label {
+    display: block;
+    /* max-width: 560px; */
+    padding: 0 0 8px 0;
+}
+
+/* Layout */
+.ml-0 {
+    margin-left: 0px;
+}
+.ml-2 {
+    margin-left: 2px;
+}
+.ml-4 {
+    margin-left: 4px;
+}
+.ml-8 {
+    margin-left: 8px;
+}
+.ml-16 {
+    margin-left: 16px;
+}
+.mr-0 {
+    margin-right: 0px;
+}
+.mr-2 {
+    margin-right: 2px;
+}
+.mr-4 {
+    margin-right: 4px;
+}
+.mr-8 {
+    margin-right: 8px;
+}
+.mr-16 {
+    margin-right: 16px;
+}
+.mt-0 {
+    margin-top: 0px;
+}
+.mt-2 {
+    margin-top: 2px;
+}
+.mt-4 {
+    margin-top: 4px;
+}
+.mt-8 {
+    margin-top: 8px;
+}
+.mt-16 {
+    margin-top: 16px;
+}
+.mb-0 {
+    margin-bottom: 0px;
+}
+.mb-2 {
+    margin-bottom: 2px;
+}
+.mb-4 {
+    margin-bottom: 4px;
+}
+.mb-8 {
+    margin-bottom: 8px;
+}
+.mb-16 {
+    margin-bottom: 16px;
+}
+
+/* Basic 16px icon class */
+.icon {
+    display: inline;
+    height: 16px;
+    width: 16px;
+    padding: 8px;
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
 /* Misc. */
 .no-spacing {
     margin: 0;
     padding: 0;
+}
+.no-wrap {
+    white-space: nowrap;
 }
 .soft {
     color: var(--vscode-input-placeholderForeground);
@@ -145,6 +248,12 @@ textarea {
 .container {
     background: var(--vscode-menu-background);
 }
-.wrapper {
+.display-contents {
     display: contents;
+}
+.button-container {
+    display: flex;
+    align-items: flex-start;
+    flex-direction: row;
+    margin: 16px 0 0 0;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,8 @@
                 "vue-loader": "^16.8.1",
                 "vue-style-loader": "^4.1.3",
                 "webpack": "^5.59.1",
-                "webpack-cli": "^4.9.1"
+                "webpack-cli": "^4.9.1",
+                "webpack-dev-server": "^4.4.0"
             },
             "engines": {
                 "vscode": "^1.44.2"
@@ -1650,6 +1651,15 @@
             "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
             "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
         },
+        "node_modules/@types/http-proxy": {
+            "version": "1.17.7",
+            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.7.tgz",
+            "integrity": "sha512-9hdj6iXH64tHSLTY+Vt2eYOGzSogC+JQ2H7bdPWkuh7KXP5qLllWx++t+K9Wk556c3dkDdPws/SpMRi0sdCT1w==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/js-yaml": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.3.tgz",
@@ -1724,6 +1734,12 @@
             "dependencies": {
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/retry": {
+            "version": "0.12.1",
+            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+            "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
+            "dev": true
         },
         "node_modules/@types/semver": {
             "version": "7.3.9",
@@ -2271,6 +2287,19 @@
             "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
             "dev": true
         },
+        "node_modules/accepts": {
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+            "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+            "dev": true,
+            "dependencies": {
+                "mime-types": "~2.1.24",
+                "negotiator": "0.6.2"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/acorn": {
             "version": "7.4.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -2319,6 +2348,19 @@
             },
             "engines": {
                 "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/aggregate-error": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+            "dev": true,
+            "dependencies": {
+                "clean-stack": "^2.0.0",
+                "indent-string": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/ajv": {
@@ -2422,6 +2464,18 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/ansi-html-community": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+            "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
+            "dev": true,
+            "engines": [
+                "node >= 0.8.0"
+            ],
+            "bin": {
+                "ansi-html": "bin/ansi-html"
+            }
+        },
         "node_modules/ansi-regex": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -2510,6 +2564,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/array-flatten": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+            "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
+            "dev": true
         },
         "node_modules/array-union": {
             "version": "2.1.0",
@@ -2789,6 +2849,12 @@
                 }
             ]
         },
+        "node_modules/batch": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+            "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+            "dev": true
+        },
         "node_modules/big-integer": {
             "version": "1.6.50",
             "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.50.tgz",
@@ -2834,6 +2900,65 @@
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
             "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
             "dev": true
+        },
+        "node_modules/body-parser": {
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+            "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+            "dev": true,
+            "dependencies": {
+                "bytes": "3.1.0",
+                "content-type": "~1.0.4",
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "http-errors": "1.7.2",
+                "iconv-lite": "0.4.24",
+                "on-finished": "~2.3.0",
+                "qs": "6.7.0",
+                "raw-body": "2.4.0",
+                "type-is": "~1.6.17"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/body-parser/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/body-parser/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "node_modules/body-parser/node_modules/qs": {
+            "version": "6.7.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+            "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/bonjour": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
+            "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+            "dev": true,
+            "dependencies": {
+                "array-flatten": "^2.1.0",
+                "deep-equal": "^1.0.1",
+                "dns-equal": "^1.0.0",
+                "dns-txt": "^2.0.2",
+                "multicast-dns": "^6.0.1",
+                "multicast-dns-service-types": "^1.1.0"
+            }
         },
         "node_modules/boolbase": {
             "version": "1.0.0",
@@ -2920,6 +3045,12 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "dev": true
+        },
+        "node_modules/buffer-indexof": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+            "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
             "dev": true
         },
         "node_modules/buffer-indexof-polyfill": {
@@ -3148,6 +3279,15 @@
                 "webpack": ">=4.0.1"
             }
         },
+        "node_modules/clean-stack": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/cli-color": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.1.tgz",
@@ -3372,10 +3512,121 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/compressible": {
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+            "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+            "dev": true,
+            "dependencies": {
+                "mime-db": ">= 1.43.0 < 2"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/compression": {
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+            "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+            "dev": true,
+            "dependencies": {
+                "accepts": "~1.3.5",
+                "bytes": "3.0.0",
+                "compressible": "~2.0.16",
+                "debug": "2.6.9",
+                "on-headers": "~1.0.2",
+                "safe-buffer": "5.1.2",
+                "vary": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/compression/node_modules/bytes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+            "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/compression/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/compression/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "node_modules/compression/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
+        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "node_modules/connect-history-api-fallback": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+            "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/content-disposition": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+            "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+            "dev": true,
+            "dependencies": {
+                "safe-buffer": "5.1.2"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/content-disposition/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
+        },
+        "node_modules/content-type": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+            "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie-signature": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+            "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
             "dev": true
         },
         "node_modules/core-util-is": {
@@ -3555,10 +3806,83 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/deep-equal": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+            "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+            "dev": true,
+            "dependencies": {
+                "is-arguments": "^1.0.4",
+                "is-date-object": "^1.0.1",
+                "is-regex": "^1.0.4",
+                "object-is": "^1.0.1",
+                "object-keys": "^1.1.1",
+                "regexp.prototype.flags": "^1.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+        },
+        "node_modules/default-gateway": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
+            "integrity": "sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==",
+            "dev": true,
+            "dependencies": {
+                "execa": "^5.0.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/default-gateway/node_modules/execa": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/default-gateway/node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-gateway/node_modules/human-signals": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.17.0"
+            }
         },
         "node_modules/defer-to-connect": {
             "version": "2.0.1",
@@ -3568,10 +3892,74 @@
                 "node": ">=10"
             }
         },
+        "node_modules/define-lazy-prop": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
+            "dependencies": {
+                "object-keys": "^1.0.12"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/del": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
+            "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+            "dev": true,
+            "dependencies": {
+                "globby": "^11.0.1",
+                "graceful-fs": "^4.2.4",
+                "is-glob": "^4.0.1",
+                "is-path-cwd": "^2.2.0",
+                "is-path-inside": "^3.0.2",
+                "p-map": "^4.0.0",
+                "rimraf": "^3.0.2",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/denodeify": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
             "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
+            "dev": true
+        },
+        "node_modules/depd": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/destroy": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+            "dev": true
+        },
+        "node_modules/detect-node": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+            "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
             "dev": true
         },
         "node_modules/diff": {
@@ -3593,6 +3981,31 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/dns-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+            "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
+            "dev": true
+        },
+        "node_modules/dns-packet": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
+            "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
+            "dev": true,
+            "dependencies": {
+                "ip": "^1.1.0",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/dns-txt": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+            "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+            "dev": true,
+            "dependencies": {
+                "buffer-indexof": "^1.0.0"
             }
         },
         "node_modules/doctrine": {
@@ -3707,6 +4120,12 @@
                 "safe-buffer": "~5.1.0"
             }
         },
+        "node_modules/ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+            "dev": true
+        },
         "node_modules/electron-to-chromium": {
             "version": "1.3.877",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.877.tgz",
@@ -3732,6 +4151,15 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
             "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+        },
+        "node_modules/encodeurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/end-of-stream": {
             "version": "1.4.4",
@@ -3889,6 +4317,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+            "dev": true
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
@@ -4299,6 +4733,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/event-emitter": {
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
@@ -4323,6 +4766,12 @@
                 "stream-combiner": "^0.2.2",
                 "through": "^2.3.8"
             }
+        },
+        "node_modules/eventemitter3": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+            "dev": true
         },
         "node_modules/events": {
             "version": "1.1.1",
@@ -4354,6 +4803,89 @@
             "funding": {
                 "url": "https://github.com/sindresorhus/execa?sponsor=1"
             }
+        },
+        "node_modules/express": {
+            "version": "4.17.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+            "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+            "dev": true,
+            "dependencies": {
+                "accepts": "~1.3.7",
+                "array-flatten": "1.1.1",
+                "body-parser": "1.19.0",
+                "content-disposition": "0.5.3",
+                "content-type": "~1.0.4",
+                "cookie": "0.4.0",
+                "cookie-signature": "1.0.6",
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "finalhandler": "~1.1.2",
+                "fresh": "0.5.2",
+                "merge-descriptors": "1.0.1",
+                "methods": "~1.1.2",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.3",
+                "path-to-regexp": "0.1.7",
+                "proxy-addr": "~2.0.5",
+                "qs": "6.7.0",
+                "range-parser": "~1.2.1",
+                "safe-buffer": "5.1.2",
+                "send": "0.17.1",
+                "serve-static": "1.14.1",
+                "setprototypeof": "1.1.1",
+                "statuses": "~1.5.0",
+                "type-is": "~1.6.18",
+                "utils-merge": "1.0.1",
+                "vary": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.10.0"
+            }
+        },
+        "node_modules/express/node_modules/array-flatten": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+            "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+            "dev": true
+        },
+        "node_modules/express/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/express/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "node_modules/express/node_modules/path-to-regexp": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+            "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+            "dev": true
+        },
+        "node_modules/express/node_modules/qs": {
+            "version": "6.7.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+            "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/express/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
         },
         "node_modules/ext": {
             "version": "1.6.0",
@@ -4452,6 +4984,18 @@
                 "reusify": "^1.0.4"
             }
         },
+        "node_modules/faye-websocket": {
+            "version": "0.11.4",
+            "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+            "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+            "dev": true,
+            "dependencies": {
+                "websocket-driver": ">=0.5.1"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
         "node_modules/fd-slicer": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -4489,6 +5033,39 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/finalhandler": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+            "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+            "dev": true,
+            "dependencies": {
+                "debug": "2.6.9",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.3",
+                "statuses": "~1.5.0",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/finalhandler/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/finalhandler/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
         },
         "node_modules/find-up": {
             "version": "5.0.0",
@@ -4539,6 +5116,44 @@
             "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
             "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
         },
+        "node_modules/follow-redirects": {
+            "version": "1.14.5",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+            "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/forwarded": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+            "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/fresh": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/from": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
@@ -4557,6 +5172,12 @@
             "engines": {
                 "node": ">=12"
             }
+        },
+        "node_modules/fs-monkey": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
+            "integrity": "sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==",
+            "dev": true
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
@@ -4804,6 +5425,12 @@
                 "node": ">=4.x"
             }
         },
+        "node_modules/handle-thing": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
+            "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
+            "dev": true
+        },
         "node_modules/handlebars": {
             "version": "4.7.7",
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
@@ -4858,6 +5485,21 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+            "dev": true,
+            "dependencies": {
+                "has-symbols": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/hash-sum": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
@@ -4885,6 +5527,54 @@
                 "node": ">=10"
             }
         },
+        "node_modules/hpack.js": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+            "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+            "dev": true,
+            "dependencies": {
+                "inherits": "^2.0.1",
+                "obuf": "^1.0.0",
+                "readable-stream": "^2.0.1",
+                "wbuf": "^1.1.0"
+            }
+        },
+        "node_modules/hpack.js/node_modules/readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/hpack.js/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
+        },
+        "node_modules/hpack.js/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/html-entities": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
+            "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==",
+            "dev": true
+        },
         "node_modules/htmlparser2": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -4909,6 +5599,54 @@
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
             "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
         },
+        "node_modules/http-deceiver": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+            "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
+            "dev": true
+        },
+        "node_modules/http-errors": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+            "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+            "dev": true,
+            "dependencies": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.1.1",
+                "statuses": ">= 1.5.0 < 2",
+                "toidentifier": "1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/http-errors/node_modules/inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "node_modules/http-parser-js": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
+            "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==",
+            "dev": true
+        },
+        "node_modules/http-proxy": {
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+            "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+            "dev": true,
+            "dependencies": {
+                "eventemitter3": "^4.0.0",
+                "follow-redirects": "^1.0.0",
+                "requires-port": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
         "node_modules/http-proxy-agent": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -4921,6 +5659,34 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/http-proxy-middleware": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.1.tgz",
+            "integrity": "sha512-cfaXRVoZxSed/BmkA7SwBVNI9Kj7HFltaE5rqYOub5kWzWZ+gofV2koVN1j2rMW7pEfSSlCHGJ31xmuyFyfLOg==",
+            "dev": true,
+            "dependencies": {
+                "@types/http-proxy": "^1.17.5",
+                "http-proxy": "^1.18.1",
+                "is-glob": "^4.0.1",
+                "is-plain-obj": "^3.0.0",
+                "micromatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/http-proxy-middleware/node_modules/is-plain-obj": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+            "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/http2-wrapper": {
@@ -5056,6 +5822,15 @@
                 "node": ">=0.8.19"
             }
         },
+        "node_modules/indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -5071,6 +5846,33 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
+        "node_modules/internal-ip": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-6.2.0.tgz",
+            "integrity": "sha512-D8WGsR6yDt8uq7vDMu7mjcR+yRMm3dW8yufyChmszWRjcSHuxLBkR3GdS2HZAjodsaGuCvXeEJpueisXJULghg==",
+            "dev": true,
+            "dependencies": {
+                "default-gateway": "^6.0.0",
+                "ipaddr.js": "^1.9.1",
+                "is-ip": "^3.1.0",
+                "p-event": "^4.2.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/internal-ip?sponsor=1"
+            }
+        },
+        "node_modules/internal-ip/node_modules/ipaddr.js": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
         "node_modules/interpret": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
@@ -5080,12 +5882,27 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/ip": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+            "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+            "dev": true
+        },
         "node_modules/ip-regex": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
             "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/ipaddr.js": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
+            "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10"
             }
         },
         "node_modules/is": {
@@ -5095,6 +5912,22 @@
             "dev": true,
             "engines": {
                 "node": "*"
+            }
+        },
+        "node_modules/is-arguments": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+            "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-arrayish": {
@@ -5130,6 +5963,36 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-date-object": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+            "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+            "dev": true,
+            "dependencies": {
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "dev": true,
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-extendable": {
@@ -5174,6 +6037,18 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-ip": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+            "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+            "dev": true,
+            "dependencies": {
+                "ip-regex": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5181,6 +6056,24 @@
             "dev": true,
             "engines": {
                 "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-path-cwd": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+            "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/is-path-inside": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/is-plain-obj": {
@@ -5210,6 +6103,22 @@
             "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
             "dev": true
         },
+        "node_modules/is-regex": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+            "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-stream": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -5237,6 +6146,18 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
             "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+        },
+        "node_modules/is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
+            "dependencies": {
+                "is-docker": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/is2": {
             "version": "2.0.7",
@@ -5824,6 +6745,27 @@
             "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
             "dev": true
         },
+        "node_modules/media-typer": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/memfs": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.3.0.tgz",
+            "integrity": "sha512-BEE62uMfKOavX3iG7GYX43QJ+hAeeWnwIAuJ/R6q96jaMtiLzhsxHJC8B1L7fK7Pt/vXDRwb3SG/yBpNGDPqzg==",
+            "dev": true,
+            "dependencies": {
+                "fs-monkey": "1.0.3"
+            },
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
         "node_modules/memoizee": {
             "version": "0.4.15",
             "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
@@ -5846,6 +6788,12 @@
             "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
             "dev": true
         },
+        "node_modules/merge-descriptors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+            "dev": true
+        },
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5859,6 +6807,15 @@
             "dev": true,
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/methods": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+            "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/micromatch": {
@@ -5921,6 +6878,12 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+            "dev": true
         },
         "node_modules/minimatch": {
             "version": "3.0.4",
@@ -6142,6 +7105,25 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
+        "node_modules/multicast-dns": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
+            "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+            "dev": true,
+            "dependencies": {
+                "dns-packet": "^1.3.1",
+                "thunky": "^1.0.2"
+            },
+            "bin": {
+                "multicast-dns": "cli.js"
+            }
+        },
+        "node_modules/multicast-dns-service-types": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+            "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
+            "dev": true
+        },
         "node_modules/multimatch": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
@@ -6199,6 +7181,15 @@
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
         },
+        "node_modules/negotiator": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+            "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/neo-async": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -6231,6 +7222,15 @@
             "dev": true,
             "dependencies": {
                 "@sinonjs/commons": "^1.7.0"
+            }
+        },
+        "node_modules/node-forge": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+            "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 6.0.0"
             }
         },
         "node_modules/node-releases": {
@@ -6313,6 +7313,58 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/object-is": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+            "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/obuf": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+            "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+            "dev": true
+        },
+        "node_modules/on-finished": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+            "dev": true,
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/on-headers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6339,6 +7391,23 @@
             },
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/open": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+            "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+            "dev": true,
+            "dependencies": {
+                "define-lazy-prop": "^2.0.0",
+                "is-docker": "^2.1.1",
+                "is-wsl": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -6397,6 +7466,30 @@
                 "node": ">=8"
             }
         },
+        "node_modules/p-event": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
+            "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+            "dev": true,
+            "dependencies": {
+                "p-timeout": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -6425,6 +7518,46 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-map": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+            "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+            "dev": true,
+            "dependencies": {
+                "aggregate-error": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-retry": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
+            "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+            "dev": true,
+            "dependencies": {
+                "@types/retry": "^0.12.0",
+                "retry": "^0.13.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/p-timeout": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+            "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+            "dev": true,
+            "dependencies": {
+                "p-finally": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/p-try": {
@@ -6488,6 +7621,15 @@
             "dev": true,
             "dependencies": {
                 "parse5": "^6.0.1"
+            }
+        },
+        "node_modules/parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/path-exists": {
@@ -6948,6 +8090,28 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/proxy-addr": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+            "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+            "dev": true,
+            "dependencies": {
+                "forwarded": "0.2.0",
+                "ipaddr.js": "1.9.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/proxy-addr/node_modules/ipaddr.js": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
         "node_modules/pump": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -7028,6 +8192,30 @@
             "dev": true,
             "dependencies": {
                 "safe-buffer": "^5.1.0"
+            }
+        },
+        "node_modules/range-parser": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/raw-body": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+            "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+            "dev": true,
+            "dependencies": {
+                "bytes": "3.1.0",
+                "http-errors": "1.7.2",
+                "iconv-lite": "0.4.24",
+                "unpipe": "1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/read": {
@@ -7142,6 +8330,22 @@
             "dependencies": {
                 "is-core-module": "^2.2.0",
                 "path-parse": "^1.0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/regexp.prototype.flags": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+            "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -7277,6 +8481,12 @@
             "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
             "dev": true
         },
+        "node_modules/requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+            "dev": true
+        },
         "node_modules/resolve": {
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
@@ -7324,6 +8534,15 @@
             "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
             "dependencies": {
                 "lowercase-keys": "^2.0.0"
+            }
+        },
+        "node_modules/retry": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 4"
             }
         },
         "node_modules/reusify": {
@@ -7427,6 +8646,21 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
+        "node_modules/select-hose": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+            "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+            "dev": true
+        },
+        "node_modules/selfsigned": {
+            "version": "1.10.11",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.11.tgz",
+            "integrity": "sha512-aVmbPOfViZqOZPgRBT0+3u4yZFHpmnIghLMlAcb5/xhp5ZtB/RVnKhz5vl2M32CLXAqR4kha9zfhNg0Lf/sxKA==",
+            "dev": true,
+            "dependencies": {
+                "node-forge": "^0.10.0"
+            }
+        },
         "node_modules/semver": {
             "version": "7.3.5",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -7441,6 +8675,51 @@
                 "node": ">=10"
             }
         },
+        "node_modules/send": {
+            "version": "0.17.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+            "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+            "dev": true,
+            "dependencies": {
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "~1.7.2",
+                "mime": "1.6.0",
+                "ms": "2.1.1",
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.1",
+                "statuses": "~1.5.0"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/send/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/send/node_modules/debug/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "node_modules/send/node_modules/ms": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+            "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+            "dev": true
+        },
         "node_modules/serialize-javascript": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
@@ -7448,6 +8727,81 @@
             "dev": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
+            }
+        },
+        "node_modules/serve-index": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+            "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+            "dev": true,
+            "dependencies": {
+                "accepts": "~1.3.4",
+                "batch": "0.6.1",
+                "debug": "2.6.9",
+                "escape-html": "~1.0.3",
+                "http-errors": "~1.6.2",
+                "mime-types": "~2.1.17",
+                "parseurl": "~1.3.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/serve-index/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/serve-index/node_modules/http-errors": {
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+            "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+            "dev": true,
+            "dependencies": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.1.0",
+                "statuses": ">= 1.4.0 < 2"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/serve-index/node_modules/inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "node_modules/serve-index/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "node_modules/serve-index/node_modules/setprototypeof": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+            "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+            "dev": true
+        },
+        "node_modules/serve-static": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+            "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+            "dev": true,
+            "dependencies": {
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.3",
+                "send": "0.17.1"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
             }
         },
         "node_modules/set-blocking": {
@@ -7460,6 +8814,12 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
             "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+            "dev": true
+        },
+        "node_modules/setprototypeof": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+            "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
             "dev": true
         },
         "node_modules/shallow-clone": {
@@ -7574,6 +8934,27 @@
                 "url": "https://github.com/chalk/slice-ansi?sponsor=1"
             }
         },
+        "node_modules/sockjs": {
+            "version": "0.3.21",
+            "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.21.tgz",
+            "integrity": "sha512-DhbPFGpxjc6Z3I+uX07Id5ZO2XwYsWOrYjaSeieES78cq+JaJvVe5q/m1uvjIQhXinhIeCFRH6JgXe+mvVMyXw==",
+            "dev": true,
+            "dependencies": {
+                "faye-websocket": "^0.11.3",
+                "uuid": "^3.4.0",
+                "websocket-driver": "^0.7.4"
+            }
+        },
+        "node_modules/sockjs/node_modules/uuid": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+            "dev": true,
+            "bin": {
+                "uuid": "bin/uuid"
+            }
+        },
         "node_modules/source-list-map": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -7611,6 +8992,36 @@
             "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
             "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
         },
+        "node_modules/spdy": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
+            "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
+            "dev": true,
+            "dependencies": {
+                "debug": "^4.1.0",
+                "handle-thing": "^2.0.0",
+                "http-deceiver": "^1.2.7",
+                "select-hose": "^2.0.0",
+                "spdy-transport": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/spdy-transport": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+            "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
+            "dev": true,
+            "dependencies": {
+                "debug": "^4.1.0",
+                "detect-node": "^2.0.4",
+                "hpack.js": "^2.1.6",
+                "obuf": "^1.1.2",
+                "readable-stream": "^3.0.6",
+                "wbuf": "^1.7.3"
+            }
+        },
         "node_modules/split": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
@@ -7634,6 +9045,15 @@
             "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
             "engines": {
                 "node": "*"
+            }
+        },
+        "node_modules/statuses": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+            "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/stream-combiner": {
@@ -7942,6 +9362,12 @@
                 "xtend": "~4.0.1"
             }
         },
+        "node_modules/thunky": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+            "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+            "dev": true
+        },
         "node_modules/time-stamp": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
@@ -7983,6 +9409,15 @@
             },
             "engines": {
                 "node": ">=8.0"
+            }
+        },
+        "node_modules/toidentifier": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+            "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.6"
             }
         },
         "node_modules/traverse": {
@@ -8144,6 +9579,19 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/type-is": {
+            "version": "1.6.18",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+            "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+            "dev": true,
+            "dependencies": {
+                "media-typer": "0.3.0",
+                "mime-types": "~2.1.24"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/typed-rest-client": {
             "version": "1.8.6",
             "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.6.tgz",
@@ -8237,6 +9685,15 @@
                 "node": ">= 10.0.0"
             }
         },
+        "node_modules/unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/unzipper": {
             "version": "0.10.11",
             "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
@@ -8319,6 +9776,15 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
+        "node_modules/utils-merge": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
         "node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -8332,6 +9798,15 @@
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
             "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
             "dev": true
+        },
+        "node_modules/vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/vinyl": {
             "version": "2.2.1",
@@ -8896,6 +10371,15 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/wbuf": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+            "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+            "dev": true,
+            "dependencies": {
+                "minimalistic-assert": "^1.0.0"
+            }
+        },
         "node_modules/webpack": {
             "version": "5.59.1",
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.59.1.tgz",
@@ -9039,6 +10523,119 @@
                 "node": ">=10.17.0"
             }
         },
+        "node_modules/webpack-dev-middleware": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.2.1.tgz",
+            "integrity": "sha512-Kx1X+36Rn9JaZcQMrJ7qN3PMAuKmEDD9ZISjUj3Cgq4A6PtwYsC4mpaKotSRYH3iOF6HsUa8viHKS59FlyVifQ==",
+            "dev": true,
+            "dependencies": {
+                "colorette": "^2.0.10",
+                "memfs": "^3.2.2",
+                "mime-types": "^2.1.31",
+                "range-parser": "^1.2.1",
+                "schema-utils": "^3.1.0"
+            },
+            "engines": {
+                "node": ">= 12.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^4.0.0 || ^5.0.0"
+            }
+        },
+        "node_modules/webpack-dev-server": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.4.0.tgz",
+            "integrity": "sha512-+S0XRIbsopVjPFjCO8I07FXYBWYqkFmuP56ucGMTs2hA/gV4q2M9xTmNo5Tg4o8ffRR+Nm3AsXnQXxKRyYovrA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-html-community": "^0.0.8",
+                "bonjour": "^3.5.0",
+                "chokidar": "^3.5.2",
+                "colorette": "^2.0.10",
+                "compression": "^1.7.4",
+                "connect-history-api-fallback": "^1.6.0",
+                "del": "^6.0.0",
+                "express": "^4.17.1",
+                "graceful-fs": "^4.2.6",
+                "html-entities": "^2.3.2",
+                "http-proxy-middleware": "^2.0.0",
+                "internal-ip": "^6.2.0",
+                "ipaddr.js": "^2.0.1",
+                "open": "^8.0.9",
+                "p-retry": "^4.5.0",
+                "portfinder": "^1.0.28",
+                "schema-utils": "^3.1.0",
+                "selfsigned": "^1.10.11",
+                "serve-index": "^1.9.1",
+                "sockjs": "^0.3.21",
+                "spdy": "^4.0.2",
+                "strip-ansi": "^7.0.0",
+                "url": "^0.11.0",
+                "webpack-dev-middleware": "^5.2.1",
+                "ws": "^8.1.0"
+            },
+            "bin": {
+                "webpack-dev-server": "bin/webpack-dev-server.js"
+            },
+            "engines": {
+                "node": ">= 12.13.0"
+            },
+            "peerDependencies": {
+                "webpack": "^4.37.0 || ^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "webpack-cli": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/webpack-dev-server/node_modules/ansi-regex": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+            "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/webpack-dev-server/node_modules/punycode": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+            "dev": true
+        },
+        "node_modules/webpack-dev-server/node_modules/strip-ansi": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+            "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/webpack-dev-server/node_modules/url": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+            "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+            "dev": true,
+            "dependencies": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            }
+        },
         "node_modules/webpack-merge": {
             "version": "5.8.0",
             "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
@@ -9102,6 +10699,29 @@
             "dev": true,
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/websocket-driver": {
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+            "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+            "dev": true,
+            "dependencies": {
+                "http-parser-js": ">=0.5.1",
+                "safe-buffer": ">=5.1.0",
+                "websocket-extensions": ">=0.1.1"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/websocket-extensions": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+            "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
             }
         },
         "node_modules/which": {
@@ -9256,6 +10876,27 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "node_modules/ws": {
+            "version": "8.2.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+            "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/xml": {
             "version": "1.0.1",
@@ -10848,6 +12489,15 @@
             "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
             "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
         },
+        "@types/http-proxy": {
+            "version": "1.17.7",
+            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.7.tgz",
+            "integrity": "sha512-9hdj6iXH64tHSLTY+Vt2eYOGzSogC+JQ2H7bdPWkuh7KXP5qLllWx++t+K9Wk556c3dkDdPws/SpMRi0sdCT1w==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/js-yaml": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.3.tgz",
@@ -10922,6 +12572,12 @@
             "requires": {
                 "@types/node": "*"
             }
+        },
+        "@types/retry": {
+            "version": "0.12.1",
+            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+            "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
+            "dev": true
         },
         "@types/semver": {
             "version": "7.3.9",
@@ -11374,6 +13030,16 @@
             "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
             "dev": true
         },
+        "accepts": {
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+            "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+            "dev": true,
+            "requires": {
+                "mime-types": "~2.1.24",
+                "negotiator": "0.6.2"
+            }
+        },
         "acorn": {
             "version": "7.4.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -11405,6 +13071,16 @@
             "dev": true,
             "requires": {
                 "debug": "4"
+            }
+        },
+        "aggregate-error": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+            "dev": true,
+            "requires": {
+                "clean-stack": "^2.0.0",
+                "indent-string": "^4.0.0"
             }
         },
         "ajv": {
@@ -11485,6 +13161,12 @@
                 "ansi-wrap": "0.1.0"
             }
         },
+        "ansi-html-community": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+            "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
+            "dev": true
+        },
         "ansi-regex": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -11548,6 +13230,12 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
             "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
+            "dev": true
+        },
+        "array-flatten": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+            "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
             "dev": true
         },
         "array-union": {
@@ -11768,6 +13456,12 @@
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
+        "batch": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+            "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+            "dev": true
+        },
         "big-integer": {
             "version": "1.6.50",
             "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.50.tgz",
@@ -11801,6 +13495,61 @@
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
             "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
             "dev": true
+        },
+        "body-parser": {
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+            "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+            "dev": true,
+            "requires": {
+                "bytes": "3.1.0",
+                "content-type": "~1.0.4",
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "http-errors": "1.7.2",
+                "iconv-lite": "0.4.24",
+                "on-finished": "~2.3.0",
+                "qs": "6.7.0",
+                "raw-body": "2.4.0",
+                "type-is": "~1.6.17"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.7.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+                    "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+                    "dev": true
+                }
+            }
+        },
+        "bonjour": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
+            "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+            "dev": true,
+            "requires": {
+                "array-flatten": "^2.1.0",
+                "deep-equal": "^1.0.1",
+                "dns-equal": "^1.0.0",
+                "dns-txt": "^2.0.2",
+                "multicast-dns": "^6.0.1",
+                "multicast-dns-service-types": "^1.1.0"
+            }
         },
         "boolbase": {
             "version": "1.0.0",
@@ -11871,6 +13620,12 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "dev": true
+        },
+        "buffer-indexof": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+            "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
             "dev": true
         },
         "buffer-indexof-polyfill": {
@@ -12030,6 +13785,12 @@
             "integrity": "sha512-g38K9Cm5WRwlaH6g03B9OEz/0qRizI+2I7n+Gz+L5DxXJAPAiWQvwlYNm1V1jkdpUv95bOe/ASm2vfi/G560jQ==",
             "dev": true,
             "requires": {}
+        },
+        "clean-stack": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+            "dev": true
         },
         "cli-color": {
             "version": "2.0.1",
@@ -12231,10 +13992,104 @@
             "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
             "dev": true
         },
+        "compressible": {
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+            "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+            "dev": true,
+            "requires": {
+                "mime-db": ">= 1.43.0 < 2"
+            }
+        },
+        "compression": {
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+            "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+            "dev": true,
+            "requires": {
+                "accepts": "~1.3.5",
+                "bytes": "3.0.0",
+                "compressible": "~2.0.16",
+                "debug": "2.6.9",
+                "on-headers": "~1.0.2",
+                "safe-buffer": "5.1.2",
+                "vary": "~1.1.2"
+            },
+            "dependencies": {
+                "bytes": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+                    "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
+                }
+            }
+        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "connect-history-api-fallback": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+            "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+            "dev": true
+        },
+        "content-disposition": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+            "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.2"
+            },
+            "dependencies": {
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
+                }
+            }
+        },
+        "content-type": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+            "dev": true
+        },
+        "cookie": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+            "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+            "dev": true
+        },
+        "cookie-signature": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+            "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
             "dev": true
         },
         "core-util-is": {
@@ -12359,20 +14214,123 @@
                 }
             }
         },
+        "deep-equal": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+            "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+            "dev": true,
+            "requires": {
+                "is-arguments": "^1.0.4",
+                "is-date-object": "^1.0.1",
+                "is-regex": "^1.0.4",
+                "object-is": "^1.0.1",
+                "object-keys": "^1.1.1",
+                "regexp.prototype.flags": "^1.2.0"
+            }
+        },
         "deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+        },
+        "default-gateway": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
+            "integrity": "sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==",
+            "dev": true,
+            "requires": {
+                "execa": "^5.0.0"
+            },
+            "dependencies": {
+                "execa": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+                    "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^7.0.3",
+                        "get-stream": "^6.0.0",
+                        "human-signals": "^2.1.0",
+                        "is-stream": "^2.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^4.0.1",
+                        "onetime": "^5.1.2",
+                        "signal-exit": "^3.0.3",
+                        "strip-final-newline": "^2.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+                    "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+                    "dev": true
+                },
+                "human-signals": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+                    "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+                    "dev": true
+                }
+            }
         },
         "defer-to-connect": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
             "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="
         },
+        "define-lazy-prop": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+            "dev": true
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
+            "requires": {
+                "object-keys": "^1.0.12"
+            }
+        },
+        "del": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
+            "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+            "dev": true,
+            "requires": {
+                "globby": "^11.0.1",
+                "graceful-fs": "^4.2.4",
+                "is-glob": "^4.0.1",
+                "is-path-cwd": "^2.2.0",
+                "is-path-inside": "^3.0.2",
+                "p-map": "^4.0.0",
+                "rimraf": "^3.0.2",
+                "slash": "^3.0.0"
+            }
+        },
         "denodeify": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
             "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
+            "dev": true
+        },
+        "depd": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+            "dev": true
+        },
+        "destroy": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+            "dev": true
+        },
+        "detect-node": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+            "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
             "dev": true
         },
         "diff": {
@@ -12388,6 +14346,31 @@
             "dev": true,
             "requires": {
                 "path-type": "^4.0.0"
+            }
+        },
+        "dns-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+            "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
+            "dev": true
+        },
+        "dns-packet": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
+            "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
+            "dev": true,
+            "requires": {
+                "ip": "^1.1.0",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "dns-txt": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+            "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+            "dev": true,
+            "requires": {
+                "buffer-indexof": "^1.0.0"
             }
         },
         "doctrine": {
@@ -12483,6 +14466,12 @@
                 }
             }
         },
+        "ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+            "dev": true
+        },
         "electron-to-chromium": {
             "version": "1.3.877",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.877.tgz",
@@ -12505,6 +14494,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
             "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+        },
+        "encodeurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+            "dev": true
         },
         "end-of-stream": {
             "version": "1.4.4",
@@ -12633,6 +14628,12 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
             "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "dev": true
+        },
+        "escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
             "dev": true
         },
         "escape-string-regexp": {
@@ -12937,6 +14938,12 @@
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true
         },
+        "etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+            "dev": true
+        },
         "event-emitter": {
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
@@ -12962,6 +14969,12 @@
                 "through": "^2.3.8"
             }
         },
+        "eventemitter3": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+            "dev": true
+        },
         "events": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
@@ -12982,6 +14995,85 @@
                 "onetime": "^5.1.0",
                 "signal-exit": "^3.0.2",
                 "strip-final-newline": "^2.0.0"
+            }
+        },
+        "express": {
+            "version": "4.17.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+            "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+            "dev": true,
+            "requires": {
+                "accepts": "~1.3.7",
+                "array-flatten": "1.1.1",
+                "body-parser": "1.19.0",
+                "content-disposition": "0.5.3",
+                "content-type": "~1.0.4",
+                "cookie": "0.4.0",
+                "cookie-signature": "1.0.6",
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "finalhandler": "~1.1.2",
+                "fresh": "0.5.2",
+                "merge-descriptors": "1.0.1",
+                "methods": "~1.1.2",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.3",
+                "path-to-regexp": "0.1.7",
+                "proxy-addr": "~2.0.5",
+                "qs": "6.7.0",
+                "range-parser": "~1.2.1",
+                "safe-buffer": "5.1.2",
+                "send": "0.17.1",
+                "serve-static": "1.14.1",
+                "setprototypeof": "1.1.1",
+                "statuses": "~1.5.0",
+                "type-is": "~1.6.18",
+                "utils-merge": "1.0.1",
+                "vary": "~1.1.2"
+            },
+            "dependencies": {
+                "array-flatten": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+                    "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "path-to-regexp": {
+                    "version": "0.1.7",
+                    "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+                    "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.7.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+                    "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+                    "dev": true
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
+                }
             }
         },
         "ext": {
@@ -13074,6 +15166,15 @@
                 "reusify": "^1.0.4"
             }
         },
+        "faye-websocket": {
+            "version": "0.11.4",
+            "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+            "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+            "dev": true,
+            "requires": {
+                "websocket-driver": ">=0.5.1"
+            }
+        },
         "fd-slicer": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -13104,6 +15205,38 @@
             "dev": true,
             "requires": {
                 "to-regex-range": "^5.0.1"
+            }
+        },
+        "finalhandler": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+            "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.3",
+                "statuses": "~1.5.0",
+                "unpipe": "~1.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
             }
         },
         "find-up": {
@@ -13143,6 +15276,24 @@
             "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
             "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
         },
+        "follow-redirects": {
+            "version": "1.14.5",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+            "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
+            "dev": true
+        },
+        "forwarded": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+            "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+            "dev": true
+        },
+        "fresh": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+            "dev": true
+        },
         "from": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
@@ -13158,6 +15309,12 @@
                 "jsonfile": "^6.0.1",
                 "universalify": "^2.0.0"
             }
+        },
+        "fs-monkey": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
+            "integrity": "sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==",
+            "dev": true
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -13336,6 +15493,12 @@
             "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
             "dev": true
         },
+        "handle-thing": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
+            "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
+            "dev": true
+        },
         "handlebars": {
             "version": "4.7.7",
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
@@ -13370,6 +15533,15 @@
             "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
             "dev": true
         },
+        "has-tostringtag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.2"
+            }
+        },
         "hash-sum": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
@@ -13391,6 +15563,56 @@
                 "lru-cache": "^6.0.0"
             }
         },
+        "hpack.js": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+            "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "obuf": "^1.0.0",
+                "readable-stream": "^2.0.1",
+                "wbuf": "^1.1.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
+            }
+        },
+        "html-entities": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
+            "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==",
+            "dev": true
+        },
         "htmlparser2": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -13408,6 +15630,50 @@
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
             "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
         },
+        "http-deceiver": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+            "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
+            "dev": true
+        },
+        "http-errors": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+            "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+            "dev": true,
+            "requires": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.1.1",
+                "statuses": ">= 1.5.0 < 2",
+                "toidentifier": "1.0.0"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
+                }
+            }
+        },
+        "http-parser-js": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
+            "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==",
+            "dev": true
+        },
+        "http-proxy": {
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+            "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+            "dev": true,
+            "requires": {
+                "eventemitter3": "^4.0.0",
+                "follow-redirects": "^1.0.0",
+                "requires-port": "^1.0.0"
+            }
+        },
         "http-proxy-agent": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -13417,6 +15683,27 @@
                 "@tootallnate/once": "1",
                 "agent-base": "6",
                 "debug": "4"
+            }
+        },
+        "http-proxy-middleware": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.1.tgz",
+            "integrity": "sha512-cfaXRVoZxSed/BmkA7SwBVNI9Kj7HFltaE5rqYOub5kWzWZ+gofV2koVN1j2rMW7pEfSSlCHGJ31xmuyFyfLOg==",
+            "dev": true,
+            "requires": {
+                "@types/http-proxy": "^1.17.5",
+                "http-proxy": "^1.18.1",
+                "is-glob": "^4.0.1",
+                "is-plain-obj": "^3.0.0",
+                "micromatch": "^4.0.2"
+            },
+            "dependencies": {
+                "is-plain-obj": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+                    "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+                    "dev": true
+                }
             }
         },
         "http2-wrapper": {
@@ -13508,6 +15795,12 @@
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
             "dev": true
         },
+        "indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "dev": true
+        },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -13523,10 +15816,36 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
+        "internal-ip": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-6.2.0.tgz",
+            "integrity": "sha512-D8WGsR6yDt8uq7vDMu7mjcR+yRMm3dW8yufyChmszWRjcSHuxLBkR3GdS2HZAjodsaGuCvXeEJpueisXJULghg==",
+            "dev": true,
+            "requires": {
+                "default-gateway": "^6.0.0",
+                "ipaddr.js": "^1.9.1",
+                "is-ip": "^3.1.0",
+                "p-event": "^4.2.0"
+            },
+            "dependencies": {
+                "ipaddr.js": {
+                    "version": "1.9.1",
+                    "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+                    "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+                    "dev": true
+                }
+            }
+        },
         "interpret": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
             "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+            "dev": true
+        },
+        "ip": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+            "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
             "dev": true
         },
         "ip-regex": {
@@ -13534,11 +15853,27 @@
             "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
             "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
         },
+        "ipaddr.js": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
+            "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==",
+            "dev": true
+        },
         "is": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
             "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
             "dev": true
+        },
+        "is-arguments": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+            "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            }
         },
         "is-arrayish": {
             "version": "0.3.2",
@@ -13568,6 +15903,21 @@
             "requires": {
                 "has": "^1.0.3"
             }
+        },
+        "is-date-object": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+            "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+            "dev": true,
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "dev": true
         },
         "is-extendable": {
             "version": "1.0.1",
@@ -13599,10 +15949,31 @@
                 "is-extglob": "^2.1.1"
             }
         },
+        "is-ip": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+            "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+            "dev": true,
+            "requires": {
+                "ip-regex": "^4.0.0"
+            }
+        },
         "is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true
+        },
+        "is-path-cwd": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+            "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+            "dev": true
+        },
+        "is-path-inside": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
             "dev": true
         },
         "is-plain-obj": {
@@ -13626,6 +15997,16 @@
             "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
             "dev": true
         },
+        "is-regex": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+            "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
         "is-stream": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -13641,6 +16022,15 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
             "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+        },
+        "is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
+            "requires": {
+                "is-docker": "^2.0.0"
+            }
         },
         "is2": {
             "version": "2.0.7",
@@ -14123,6 +16513,21 @@
             "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
             "dev": true
         },
+        "media-typer": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+            "dev": true
+        },
+        "memfs": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.3.0.tgz",
+            "integrity": "sha512-BEE62uMfKOavX3iG7GYX43QJ+hAeeWnwIAuJ/R6q96jaMtiLzhsxHJC8B1L7fK7Pt/vXDRwb3SG/yBpNGDPqzg==",
+            "dev": true,
+            "requires": {
+                "fs-monkey": "1.0.3"
+            }
+        },
         "memoizee": {
             "version": "0.4.15",
             "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
@@ -14147,6 +16552,12 @@
                 }
             }
         },
+        "merge-descriptors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+            "dev": true
+        },
         "merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -14157,6 +16568,12 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true
+        },
+        "methods": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+            "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
             "dev": true
         },
         "micromatch": {
@@ -14198,6 +16615,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
             "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+        },
+        "minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+            "dev": true
         },
         "minimatch": {
             "version": "3.0.4",
@@ -14370,6 +16793,22 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
+        "multicast-dns": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
+            "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+            "dev": true,
+            "requires": {
+                "dns-packet": "^1.3.1",
+                "thunky": "^1.0.2"
+            }
+        },
+        "multicast-dns-service-types": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+            "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
+            "dev": true
+        },
         "multimatch": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
@@ -14418,6 +16857,12 @@
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
         },
+        "negotiator": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+            "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+            "dev": true
+        },
         "neo-async": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -14453,6 +16898,12 @@
                     }
                 }
             }
+        },
+        "node-forge": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+            "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+            "dev": true
         },
         "node-releases": {
             "version": "2.0.1",
@@ -14510,6 +16961,43 @@
             "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
             "dev": true
         },
+        "object-is": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+            "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            }
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
+        },
+        "obuf": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+            "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+            "dev": true
+        },
+        "on-finished": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+            "dev": true,
+            "requires": {
+                "ee-first": "1.1.1"
+            }
+        },
+        "on-headers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+            "dev": true
+        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -14533,6 +17021,17 @@
             "dev": true,
             "requires": {
                 "mimic-fn": "^2.1.0"
+            }
+        },
+        "open": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+            "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+            "dev": true,
+            "requires": {
+                "define-lazy-prop": "^2.0.0",
+                "is-docker": "^2.1.1",
+                "is-wsl": "^2.2.0"
             }
         },
         "optionator": {
@@ -14576,6 +17075,21 @@
             "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
             "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="
         },
+        "p-event": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
+            "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+            "dev": true,
+            "requires": {
+                "p-timeout": "^3.1.0"
+            }
+        },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+            "dev": true
+        },
         "p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -14592,6 +17106,34 @@
             "dev": true,
             "requires": {
                 "p-limit": "^3.0.2"
+            }
+        },
+        "p-map": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+            "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+            "dev": true,
+            "requires": {
+                "aggregate-error": "^3.0.0"
+            }
+        },
+        "p-retry": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
+            "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+            "dev": true,
+            "requires": {
+                "@types/retry": "^0.12.0",
+                "retry": "^0.13.1"
+            }
+        },
+        "p-timeout": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+            "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+            "dev": true,
+            "requires": {
+                "p-finally": "^1.0.0"
             }
         },
         "p-try": {
@@ -14646,6 +17188,12 @@
             "requires": {
                 "parse5": "^6.0.1"
             }
+        },
+        "parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "dev": true
         },
         "path-exists": {
             "version": "4.0.0",
@@ -14988,6 +17536,24 @@
             "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
             "dev": true
         },
+        "proxy-addr": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+            "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+            "dev": true,
+            "requires": {
+                "forwarded": "0.2.0",
+                "ipaddr.js": "1.9.1"
+            },
+            "dependencies": {
+                "ipaddr.js": {
+                    "version": "1.9.1",
+                    "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+                    "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+                    "dev": true
+                }
+            }
+        },
         "pump": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -15035,6 +17601,24 @@
             "dev": true,
             "requires": {
                 "safe-buffer": "^5.1.0"
+            }
+        },
+        "range-parser": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "dev": true
+        },
+        "raw-body": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+            "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+            "dev": true,
+            "requires": {
+                "bytes": "3.1.0",
+                "http-errors": "1.7.2",
+                "iconv-lite": "0.4.24",
+                "unpipe": "1.0.0"
             }
         },
         "read": {
@@ -15122,6 +17706,16 @@
                         "path-parse": "^1.0.6"
                     }
                 }
+            }
+        },
+        "regexp.prototype.flags": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+            "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
             }
         },
         "regexpp": {
@@ -15229,6 +17823,12 @@
             "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
             "dev": true
         },
+        "requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+            "dev": true
+        },
         "resolve": {
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
@@ -15270,6 +17870,12 @@
             "requires": {
                 "lowercase-keys": "^2.0.0"
             }
+        },
+        "retry": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "dev": true
         },
         "reusify": {
             "version": "1.0.4",
@@ -15327,12 +17933,73 @@
                 "ajv-keywords": "^3.5.2"
             }
         },
+        "select-hose": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+            "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+            "dev": true
+        },
+        "selfsigned": {
+            "version": "1.10.11",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.11.tgz",
+            "integrity": "sha512-aVmbPOfViZqOZPgRBT0+3u4yZFHpmnIghLMlAcb5/xhp5ZtB/RVnKhz5vl2M32CLXAqR4kha9zfhNg0Lf/sxKA==",
+            "dev": true,
+            "requires": {
+                "node-forge": "^0.10.0"
+            }
+        },
         "semver": {
             "version": "7.3.5",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
             "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
             "requires": {
                 "lru-cache": "^6.0.0"
+            }
+        },
+        "send": {
+            "version": "0.17.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+            "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "~1.7.2",
+                "mime": "1.6.0",
+                "ms": "2.1.1",
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.1",
+                "statuses": "~1.5.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    },
+                    "dependencies": {
+                        "ms": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                            "dev": true
+                        }
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
             }
         },
         "serialize-javascript": {
@@ -15342,6 +18009,74 @@
             "dev": true,
             "requires": {
                 "randombytes": "^2.1.0"
+            }
+        },
+        "serve-index": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+            "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+            "dev": true,
+            "requires": {
+                "accepts": "~1.3.4",
+                "batch": "0.6.1",
+                "debug": "2.6.9",
+                "escape-html": "~1.0.3",
+                "http-errors": "~1.6.2",
+                "mime-types": "~2.1.17",
+                "parseurl": "~1.3.2"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "http-errors": {
+                    "version": "1.6.3",
+                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+                    "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+                    "dev": true,
+                    "requires": {
+                        "depd": "~1.1.2",
+                        "inherits": "2.0.3",
+                        "setprototypeof": "1.1.0",
+                        "statuses": ">= 1.4.0 < 2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "setprototypeof": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+                    "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+                    "dev": true
+                }
+            }
+        },
+        "serve-static": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+            "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+            "dev": true,
+            "requires": {
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.3",
+                "send": "0.17.1"
             }
         },
         "set-blocking": {
@@ -15354,6 +18089,12 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
             "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+            "dev": true
+        },
+        "setprototypeof": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+            "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
             "dev": true
         },
         "shallow-clone": {
@@ -15445,6 +18186,25 @@
                 "is-fullwidth-code-point": "^3.0.0"
             }
         },
+        "sockjs": {
+            "version": "0.3.21",
+            "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.21.tgz",
+            "integrity": "sha512-DhbPFGpxjc6Z3I+uX07Id5ZO2XwYsWOrYjaSeieES78cq+JaJvVe5q/m1uvjIQhXinhIeCFRH6JgXe+mvVMyXw==",
+            "dev": true,
+            "requires": {
+                "faye-websocket": "^0.11.3",
+                "uuid": "^3.4.0",
+                "websocket-driver": "^0.7.4"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+                    "dev": true
+                }
+            }
+        },
         "source-list-map": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -15476,6 +18236,33 @@
             "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
             "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
         },
+        "spdy": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
+            "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.0",
+                "handle-thing": "^2.0.0",
+                "http-deceiver": "^1.2.7",
+                "select-hose": "^2.0.0",
+                "spdy-transport": "^3.0.0"
+            }
+        },
+        "spdy-transport": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+            "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.0",
+                "detect-node": "^2.0.4",
+                "hpack.js": "^2.1.6",
+                "obuf": "^1.1.2",
+                "readable-stream": "^3.0.6",
+                "wbuf": "^1.7.3"
+            }
+        },
         "split": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
@@ -15494,6 +18281,12 @@
             "version": "0.0.10",
             "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
             "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+        },
+        "statuses": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+            "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+            "dev": true
         },
         "stream-combiner": {
             "version": "0.2.2",
@@ -15728,6 +18521,12 @@
                 "xtend": "~4.0.1"
             }
         },
+        "thunky": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+            "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+            "dev": true
+        },
         "time-stamp": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
@@ -15761,6 +18560,12 @@
             "requires": {
                 "is-number": "^7.0.0"
             }
+        },
+        "toidentifier": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+            "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+            "dev": true
         },
         "traverse": {
             "version": "0.3.9",
@@ -15871,6 +18676,16 @@
             "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
             "dev": true
         },
+        "type-is": {
+            "version": "1.6.18",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+            "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+            "dev": true,
+            "requires": {
+                "media-typer": "0.3.0",
+                "mime-types": "~2.1.24"
+            }
+        },
         "typed-rest-client": {
             "version": "1.8.6",
             "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.6.tgz",
@@ -15943,6 +18758,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
             "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        },
+        "unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "dev": true
         },
         "unzipper": {
             "version": "0.10.11",
@@ -16030,6 +18851,12 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
+        "utils-merge": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+            "dev": true
+        },
         "uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -16039,6 +18866,12 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
             "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+            "dev": true
+        },
+        "vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
             "dev": true
         },
         "vinyl": {
@@ -16513,6 +19346,15 @@
                 "graceful-fs": "^4.1.2"
             }
         },
+        "wbuf": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+            "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+            "dev": true,
+            "requires": {
+                "minimalistic-assert": "^1.0.0"
+            }
+        },
         "webpack": {
             "version": "5.59.1",
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.59.1.tgz",
@@ -16629,6 +19471,85 @@
                 }
             }
         },
+        "webpack-dev-middleware": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.2.1.tgz",
+            "integrity": "sha512-Kx1X+36Rn9JaZcQMrJ7qN3PMAuKmEDD9ZISjUj3Cgq4A6PtwYsC4mpaKotSRYH3iOF6HsUa8viHKS59FlyVifQ==",
+            "dev": true,
+            "requires": {
+                "colorette": "^2.0.10",
+                "memfs": "^3.2.2",
+                "mime-types": "^2.1.31",
+                "range-parser": "^1.2.1",
+                "schema-utils": "^3.1.0"
+            }
+        },
+        "webpack-dev-server": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.4.0.tgz",
+            "integrity": "sha512-+S0XRIbsopVjPFjCO8I07FXYBWYqkFmuP56ucGMTs2hA/gV4q2M9xTmNo5Tg4o8ffRR+Nm3AsXnQXxKRyYovrA==",
+            "dev": true,
+            "requires": {
+                "ansi-html-community": "^0.0.8",
+                "bonjour": "^3.5.0",
+                "chokidar": "^3.5.2",
+                "colorette": "^2.0.10",
+                "compression": "^1.7.4",
+                "connect-history-api-fallback": "^1.6.0",
+                "del": "^6.0.0",
+                "express": "^4.17.1",
+                "graceful-fs": "^4.2.6",
+                "html-entities": "^2.3.2",
+                "http-proxy-middleware": "^2.0.0",
+                "internal-ip": "^6.2.0",
+                "ipaddr.js": "^2.0.1",
+                "open": "^8.0.9",
+                "p-retry": "^4.5.0",
+                "portfinder": "^1.0.28",
+                "schema-utils": "^3.1.0",
+                "selfsigned": "^1.10.11",
+                "serve-index": "^1.9.1",
+                "sockjs": "^0.3.21",
+                "spdy": "^4.0.2",
+                "strip-ansi": "^7.0.0",
+                "url": "^0.11.0",
+                "webpack-dev-middleware": "^5.2.1",
+                "ws": "^8.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+                    "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+                    "dev": true
+                },
+                "punycode": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+                    "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^6.0.1"
+                    }
+                },
+                "url": {
+                    "version": "0.11.0",
+                    "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+                    "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+                    "dev": true,
+                    "requires": {
+                        "punycode": "1.3.2",
+                        "querystring": "0.2.0"
+                    }
+                }
+            }
+        },
         "webpack-merge": {
             "version": "5.8.0",
             "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
@@ -16648,6 +19569,23 @@
                 "source-list-map": "^2.0.1",
                 "source-map": "^0.6.1"
             }
+        },
+        "websocket-driver": {
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+            "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+            "dev": true,
+            "requires": {
+                "http-parser-js": ">=0.5.1",
+                "safe-buffer": ">=5.1.0",
+                "websocket-extensions": ">=0.1.1"
+            }
+        },
+        "websocket-extensions": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+            "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+            "dev": true
         },
         "which": {
             "version": "2.0.2",
@@ -16780,6 +19718,13 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "ws": {
+            "version": "8.2.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+            "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+            "dev": true,
+            "requires": {}
         },
         "xml": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -2369,7 +2369,8 @@
         "generateTelemetry": "node node_modules/@aws-toolkits/telemetry/lib/generateTelemetry.js --extraInput=src/shared/telemetry/vscodeTelemetry.json --output=src/shared/telemetry/telemetry.gen.ts",
         "generateConfigurationAttributes": "ts-node ./build-scripts/generateConfigurationAttributes.ts",
         "newChange": "ts-node ./build-scripts/newChange.ts",
-        "createRelease": "ts-node ./build-scripts/createRelease.ts"
+        "createRelease": "ts-node ./build-scripts/createRelease.ts",
+        "serve": "webpack serve --config-name vue-hmr --mode development"
     },
     "devDependencies": {
         "@aws-toolkits/telemetry": "1.0.21",
@@ -2430,7 +2431,8 @@
         "vue-loader": "^16.8.1",
         "vue-style-loader": "^4.1.3",
         "webpack": "^5.59.1",
-        "webpack-cli": "^4.9.1"
+        "webpack-cli": "^4.9.1",
+        "webpack-dev-server": "^4.4.0"
     },
     "dependencies": {
         "@aws-sdk/client-sso": "^3.16.0",

--- a/src/lambda/vue/entry.ts
+++ b/src/lambda/vue/entry.ts
@@ -3,8 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// temporary, we should be able to generate these entry point files from components
 import { createApp } from 'vue'
 import component from './samInvokeComponent.vue'
-const app = createApp(component)
+
+const create = () => createApp(component)
+const app = create()
 app.mount('#vue-app')
+
+window.addEventListener('remount', () => {
+    app.unmount()
+    create().mount('#vue-app')
+})

--- a/src/webviews/client.ts
+++ b/src/webviews/client.ts
@@ -1,0 +1,211 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EventEmitter } from 'vscode'
+import { WebviewApi } from 'vscode-webview'
+import { VueWebview, VueWebviewPanel, VueWebviewView } from './main'
+import { Protocol } from './server'
+
+declare const vscode: WebviewApi<any>
+
+interface MessageBase<U extends string = string> {
+    id: string
+    command: U
+}
+
+export interface Message<T = any, U extends string = string> extends MessageBase<U> {
+    data: T | Error
+    event?: false
+    error?: boolean
+}
+
+interface EventMessage<T = any, U extends string = string> extends MessageBase<U> {
+    event: true
+    data: T
+    command: U
+}
+
+/**
+ * Message used for delivering errors. The `data` field is a stringified `Error`.
+ * Currently only `Error` instances are rebuilt, though it is possible to extend this.
+ */
+interface ErrorMessage<U extends string = string> extends MessageBase<U> {
+    error: true
+    data: string
+    command: U
+}
+
+type ClientCommands<T> = {
+    readonly [P in keyof T]: T[P] extends EventEmitter<infer P>
+        ? (listener: (e: P) => void) => Promise<{ dispose: () => void }>
+        : OmitThisParameter<T[P]> extends (...args: infer P) => infer R
+        ? (...args: P) => R extends Promise<any> ? R : Promise<R>
+        : never
+}
+
+export type WebviewClient<T> = ClientCommands<T>
+/**
+ * Used to create a new 'WebviewClient' to communicate with the backend.
+ */
+export class WebviewClientFactory {
+    /** Used to generate unique ids per request/message. */
+    private static counter = 0
+    /** Set to true the first time a client is created. */
+    private static initialized = false
+    /** All listeners (except the 'global' commands) registered to `message`. */
+    private static messageListeners: Set<() => any> = new Set()
+
+    /**
+     * Sets up 'global' commands used internally for special functionality that is otherwise
+     * not exposed to the frontend or backend code.
+     */
+    private static registerGlobalCommands() {
+        const remountEvent = new Event('remount')
+
+        window.addEventListener('message', (event: { data: Message }) => {
+            const { command } = event.data
+            if (command === '$clear') {
+                vscode.setState({})
+                this.messageListeners.forEach(listener => this.removeListener(listener))
+                window.dispatchEvent(remountEvent)
+            }
+        })
+    }
+
+    /**
+     * Adds a new listener to the `message` event.
+     */
+    private static addListener(listener: (...args: any) => void): void {
+        this.messageListeners.add(listener)
+        window.addEventListener('message', listener)
+    }
+
+    /**
+     * Removes the listener from the backing store and unregisters it from the window.
+     */
+    private static removeListener(listener: (...args: any) => void): void {
+        this.messageListeners.delete(listener)
+        window.removeEventListener('message', listener)
+    }
+
+    /**
+     * Sends a request to the backend server. This effectively wraps a 'message' event into a Promise.
+     * Registered listeners are automatically disposed of after receiving the desired message. Arguments
+     * are 'de-proxied' and parsed into plain objects.
+     *
+     * If no response has been received after 5 minutes, the Promise is rejected and listener removed.
+     *
+     * @param id Message ID. Should be unique to each individual request.
+     * @param command Identifier associated with the backend command.
+     * @param args Arguments to pass to the backend command.
+     *
+     * @returns The backend's response as a Promise.
+     */
+    private static sendRequest<T extends any[], R, U extends string>(
+        id: string,
+        command: U,
+        args: T
+    ): Promise<R | { dispose: () => void }> {
+        const deproxied = JSON.parse(JSON.stringify(args))
+        const response = new Promise<R | { dispose: () => void }>((resolve, reject) => {
+            const listener = (event: { data: Message<R, U> | ErrorMessage<U> }) => {
+                const message = event.data
+
+                if (id !== message.id) {
+                    return
+                }
+
+                this.removeListener(listener)
+                window.clearTimeout(timeout)
+
+                if (message.error === true) {
+                    const revived = JSON.parse(message.data as string)
+                    reject(new Error(revived.message))
+                } else if (message.event) {
+                    if (typeof args[0] !== 'function') {
+                        reject(new Error(`Expected frontend event handler to be a function: ${command}`))
+                    }
+                    resolve(this.registerEventHandler(command, args[0]))
+                } else {
+                    resolve(message.data as R) // TODO: interfaces need a bit of refinement in terms of types
+                }
+            }
+
+            const timeout = setTimeout(() => {
+                this.removeListener(listener)
+                reject(new Error(`Timed out while waiting for response: id: ${id}, command: ${command}`))
+            }, 300000)
+
+            this.addListener(listener)
+        })
+
+        vscode.postMessage({ id, command, data: deproxied } as Message<T, U>)
+        return response
+    }
+
+    private static registerEventHandler<T extends (e: R) => void, R, U extends string>(
+        command: U,
+        args: T
+    ): { dispose: () => void } {
+        const listener = (event: { data: Message<R, U> | EventMessage<R, U> }) => {
+            const message = event.data
+
+            if (message.command !== command) {
+                return
+            }
+
+            if (!message.event) {
+                throw new Error(`Expected backend handler to be an event emitter: ${command}`)
+            }
+
+            args(message.data)
+        }
+        this.addListener(listener)
+
+        return { dispose: () => this.removeListener(listener) }
+    }
+
+    /**
+     * Creates a new client. These clients are defined by their types; they do not have any knowledge
+     * of the backend protocol other than the specified type.
+     */
+    public static create<T extends VueWebview<any>>(): WebviewClient<T['protocol']>
+    public static create<T extends VueWebviewPanel<any>>(): WebviewClient<T['protocol']>
+    public static create<T extends VueWebviewView<any>>(): WebviewClient<T['protocol']>
+    public static create<T extends Protocol<any, any>>(): WebviewClient<T>
+    public static create<T extends ClientCommands<T>>(): WebviewClient<T>
+    public static create<T extends Protocol<any, any>>(): WebviewClient<T> {
+        if (!this.initialized) {
+            this.initialized = true
+            this.registerGlobalCommands()
+        }
+
+        return new Proxy(
+            {},
+            {
+                set: () => {
+                    throw new TypeError('Cannot set property to webview client')
+                },
+                get: (_, prop) => {
+                    if (typeof prop !== 'string') {
+                        console.warn(`Tried to index webview client with non-string property: ${String(prop)}`)
+                        return
+                    }
+
+                    if (prop === 'init') {
+                        const state = vscode.getState() ?? {}
+                        if (state['__once']) {
+                            return () => Promise.resolve()
+                        }
+                        vscode.setState(Object.assign(state, { __once: true }))
+                    }
+
+                    const id = (this.counter++).toString()
+                    return (...args: any) => this.sendRequest(id, prop, args)
+                },
+            }
+        ) as WebviewClient<T>
+    }
+}

--- a/src/webviews/components/settingsPanel.vue
+++ b/src/webviews/components/settingsPanel.vue
@@ -29,6 +29,7 @@
 <script lang="ts">
 import { WebviewApi } from 'vscode-webview'
 import { defineComponent } from 'vue'
+import saveData from '../mixins/saveData'
 
 declare const vscode: WebviewApi<{ [key: string]: VueModel }>
 
@@ -37,8 +38,8 @@ let count = 0
 interface VueModel {
     collapsed: boolean
     buttonId: string
-    subPane?: HTMLElement
     lastHeight?: number
+    subPane?: HTMLElement
 }
 
 /**
@@ -58,47 +59,30 @@ export default defineComponent({
         return {
             collapsed: this.$props.startCollapsed ?? false,
             buttonId: `settings-panel-button-${count}`,
+            lastHeight: undefined,
         } as VueModel
     },
+    mixins: [saveData],
     methods: {
-        updateState() {
-            if (this.id === undefined || this.id === '') {
-                return
+        updateHeight(el: Element & { style?: CSSStyleDeclaration }) {
+            if (el.style) {
+                this.lastHeight = el.scrollHeight
+                el.style.setProperty('--max-height', `${this.lastHeight}px`)
             }
-
-            vscode.setState(
-                Object.assign(vscode.getState() ?? {}, {
-                    [this.id]: {
-                        collapsed: this.collapsed,
-                        lastHeight: this.lastHeight,
-                    },
-                })
-            )
         },
-        updateHeight(el: Element & { style: CSSStyleDeclaration }) {
-            this.lastHeight = el.scrollHeight
-            this.updateState()
-            el.style.setProperty('--max-height', `${this.lastHeight}px`)
-        },
-    },
-    created() {
-        if (this.id === undefined || this.id === '') {
-            return
-        }
-
-        const lastState: Partial<VueModel> = (vscode.getState() ?? {})[this.id]
-
-        // TODO: make recurse
-        Object.keys(lastState ?? {}).forEach(key => {
-            this.$data[key] = lastState[key] ?? this.$data[key]
-        })
     },
     mounted() {
         this.subPane = this.$refs.subPane as HTMLElement | undefined
         this.lastHeight = this.collapsed ? this.lastHeight : this.subPane?.scrollHeight ?? this.lastHeight
 
-        // TODO: write preload as a directive or global
-        ;(this.$refs.button as HTMLElement | undefined)?.classList.remove('preload-transition')
+        // TODO: write 'initial-style' as a directive
+        // it will force a style until the first render
+        // or just use Vue's transition element, but this is pretty heavy
+        this.$nextTick(() => {
+            setTimeout(() => {
+                ;(this.$refs.button as HTMLElement | undefined)?.classList.remove('preload-transition')
+            }, 100)
+        })
     },
 })
 </script>
@@ -118,7 +102,7 @@ export default defineComponent({
     padding: 1rem;
     overflow: hidden;
 }
-.sub-pane .button-container:first-child {
+:deep(.sub-pane div:first-child) {
     margin-top: 0;
 }
 .collapse-leave-from {

--- a/src/webviews/components/settingsPanel.vue
+++ b/src/webviews/components/settingsPanel.vue
@@ -143,8 +143,11 @@ body.vscode-dark .collapse-button {
 body.vscode-light .collapse-button {
     background-image: url('/resources/light/expand-less.svg');
 }
-.collapse-button:checked {
+.collapse-button {
     transform: rotate(180deg);
+}
+.collapse-button:checked {
+    transform: rotate(90deg);
 }
 .settings-panel {
     background: var(--vscode-menu-background);

--- a/src/webviews/main.ts
+++ b/src/webviews/main.ts
@@ -4,68 +4,302 @@
  */
 
 import * as path from 'path'
+import * as semver from 'semver'
 import * as vscode from 'vscode'
+import { ExtContext } from '../shared/extensions'
 import { ExtensionUtilities, isCloud9 } from '../shared/extensionUtilities'
+import { getLogger } from '../shared/logger'
+import {
+    CompileContext,
+    DataFromOptions,
+    OptionsToProtocol,
+    OutputFromOptions,
+    PropsFromOptions,
+    registerWebviewServer,
+    SubmitFromOptions,
+    WebviewCompileOptions,
+} from './server'
 
-interface WebviewParams<TRequest, TResponse> {
-    id: string
-    name: string
+interface WebviewParams {
+    /** The entry-point into the webview. */
     webviewJs: string
-    context: vscode.ExtensionContext
-    /** Initial calls are posted whenever the webview is regenerated (e.g. the webview was moved to another panel) */
-    initialCalls?: TResponse[]
-    persistSessions?: boolean
-    persistWithoutFocus?: boolean
+    /** Styling sheets to use, applied to the entire webview. If none are provided, `base.css` is used by default. */
     cssFiles?: string[]
-    jsFiles?: string[]
+    /** Additional JS files to loaded in. */
     libFiles?: string[]
-    onDidReceiveMessageFunction(
-        request: TRequest,
-        postMessageFn: (response: TResponse) => Thenable<boolean>,
-        destroyWebviewFn: () => any
-    ): void
-    onDidDisposeFunction?(): void
 }
 
-export async function createVueWebview<TRequest, TResponse>(params: WebviewParams<TRequest, TResponse>) {
-    const libsPath: string = path.join(params.context.extensionPath, 'media', 'libs')
-    const jsPath: string = path.join(params.context.extensionPath, 'media', 'js')
-    const cssPath: string = path.join(params.context.extensionPath, 'media', 'css')
-    const webviewPath: string = path.join(params.context.extensionPath, 'dist')
-    const resourcesPath: string = path.join(params.context.extensionPath, 'resources')
+interface WebviewPanelParams extends WebviewParams {
+    /** ID of the webview which should be globally unique per view. */
+    id: string
+    /** Title of the webview panel. This is shown in the editor tab. */
+    title: string
+    /** Preserves the webview when not focused by the user. This has a performance penalty and should be avoided. */
+    retainContextWhenHidden?: boolean
+    /**  View column to initally show the view in. Defaults to split view. */
+    viewColumn?: vscode.ViewColumn
+}
 
-    const view = vscode.window.createWebviewPanel(
-        params.id,
-        params.name,
-        // Cloud9 opens the webview in the bottom pane unless a second pane already exists on the main level.
-        isCloud9() ? vscode.ViewColumn.Two : vscode.ViewColumn.Beside,
-        {
-            enableScripts: true,
-            localResourceRoots: [
-                vscode.Uri.file(libsPath),
-                vscode.Uri.file(jsPath),
-                vscode.Uri.file(cssPath),
-                vscode.Uri.file(webviewPath),
-                vscode.Uri.file(resourcesPath),
-            ],
-            // HACK: Cloud9 does not have get/setState support. Remove when it does.
-            retainContextWhenHidden: isCloud9() ? true : params.persistWithoutFocus,
+interface WebviewViewParams extends WebviewParams {
+    /** ID of the webview which must be the same as the one used in `package.json`. */
+    id: string
+    /** Title of the view. Defaults to the title set in `package.json` is not provided. */
+    title?: string
+    /** Optional 'description' text applied to the title. */
+    description?: string
+}
+
+export interface VueWebview<Options extends WebviewCompileOptions> {
+    /**
+     * Reset the view with new data. Resolves false if the view was unable to be cleared.
+     */
+    clear(...data: DataFromOptions<Options>): Promise<boolean>
+    /**
+     * Event emitters registered by the view. Can be used by backend logic to trigger events in the view.
+     */
+    readonly emitters: Options['events']
+    /**
+     * This exists only for use by the client.
+     * Trying to access it on the backend will result in an error.
+     */
+    readonly protocol: OptionsToProtocol<Options>
+}
+
+/**
+ * A compiled webview created from {@link compileVueWebview}.
+ */
+export interface VueWebviewPanel<Options extends WebviewCompileOptions> extends VueWebview<Options> {
+    /**
+     * Shows the webview with the given parameters.
+     *
+     * @param data Data to initialize the view with. The exact meaning of this is highly dependent on the view type.
+     *
+     * @returns A Promise that is resolved once the view is closed. Can return an object if the view supports `submit`.
+     */
+    start(...data: DataFromOptions<Options>): Promise<OutputFromOptions<Options> | undefined>
+    /**
+     * The underlying {@link vscode.WebviewPanel}.
+     *
+     * This may be undefined if the view has not been started yet, or if the view was disposed.
+     */
+    readonly panel?: vscode.WebviewPanel
+}
+
+export interface VueWebviewView<Options extends WebviewCompileOptions> extends VueWebview<Options> {
+    /**
+     * Finalizes the view registration with initial data.
+     *
+     * @param data Data to initialize the view with. The exact meaning of this is highly dependent on the view type.
+     */
+    start(...data: DataFromOptions<Options>): void
+    /**
+     * The underlying {@link vscode.WebviewView}.
+     *
+     * This may be undefined if the view has not been started yet, or if the view was disposed.
+     */
+    readonly view?: vscode.WebviewView
+}
+
+function copyEmitters(events?: WebviewCompileOptions['events']): WebviewCompileOptions['events'] {
+    const copyEmitters = {} as typeof events
+    Object.keys(events ?? {}).forEach(k => {
+        Object.assign(copyEmitters, { [k]: new vscode.EventEmitter() })
+    })
+    return copyEmitters
+}
+
+/**
+ * Generates an anonymous class whose instances have the interface {@link VueWebviewPanel}.
+ *
+ * You can give this class a name by extending off of it:
+ * ```ts
+ * export class MyWebview extends compileVueWebview(...) {}
+ * const view = new MyWebview()
+ * view.show()
+ * ```
+ *
+ * @param params Required parameters are defined by {@link WebviewPanelParams}, optional parameters are defined by {@link WebviewCompileOptions}
+ *
+ * @returns An anonymous class that can instantiate instances of {@link VueWebviewPanel}.
+ */
+export function compileVueWebview<Options extends WebviewCompileOptions>(
+    params: WebviewPanelParams & Options & { commands?: CompileContext<Options> }
+): { new (context: ExtContext): VueWebviewPanel<Options> } {
+    return class implements VueWebviewPanel<Options> {
+        private _panel?: vscode.WebviewPanel
+        private initialData?: PropsFromOptions<Options>
+        public readonly emitters: Options['events']
+
+        public get panel() {
+            return this._panel
         }
+
+        public get protocol(): OptionsToProtocol<Options> {
+            throw new Error('Cannot access the webview protocol on the backend.')
+        }
+
+        constructor(private readonly context: ExtContext) {
+            this.emitters = copyEmitters(params.events)
+        }
+
+        public async start(...data: DataFromOptions<Options>): Promise<OutputFromOptions<Options> | undefined> {
+            // TODO: potentially fix this type. If no `start` is defined then it defauls to the args
+            // `start` may just be a required type, though sometimes we don't care about initializing the view
+            this.initialData = (await params.start?.(...data)) ?? data
+            this._panel = createWebviewPanel({ ...params, context: this.context })
+
+            const panel = this._panel
+            return new Promise<OutputFromOptions<Options> | undefined>(resolve => {
+                const onDispose = panel.onDidDispose(() => resolve(undefined))
+
+                if (params.commands) {
+                    const submit = async (response: SubmitFromOptions<Options>) => {
+                        const result = (await params.submit?.(response)) ?? response
+                        if (result) {
+                            onDispose.dispose()
+                            panel.dispose()
+                            resolve(result)
+                        }
+                    }
+                    const init = async () => this.initialData
+                    const modifiedWebview = Object.assign(panel.webview, {
+                        dispose: () => panel.dispose(),
+                        context: this.context,
+                        emitters: this.emitters,
+                    })
+                    Object.defineProperty(modifiedWebview, 'data', { get: () => this.initialData })
+                    registerWebviewServer(modifiedWebview, { init, submit, ...params.commands, ...this.emitters })
+                }
+            })
+        }
+
+        public async clear(...data: DataFromOptions<Options>): Promise<boolean> {
+            this.initialData = (await params.start?.(...data)) ?? data
+            return this._panel?.webview.postMessage({ command: '$clear' }) ?? false
+        }
+    } as any
+}
+
+const MIN_WEBVIEW_VIEW_VERSION = '1.50.0'
+
+/**
+ * This is the {@link vscode.WebviewView} version of {@link compileVueWebview}.
+ *
+ * The biggest difference is that only a single view per-id can exist at a time, while multiple panels can exist per-id.
+ * Views also cannot register handlers for `submit`; any `submit` commands made by the fronend are ignored.
+ *
+ * @param params Required parameters are defined by {@link WebviewViewParams}, optional parameters are defined by {@link WebviewCompileOptions}
+ *
+ * @returns An anonymous class that can instantiate instances of {@link VueWebviewView}.
+ */
+export function compileVueWebviewView<Options extends WebviewCompileOptions>(
+    params: WebviewViewParams & Omit<Options, 'submit'> & { commands?: CompileContext<Options> }
+): { new (context: ExtContext): VueWebviewView<Options> } {
+    return class implements VueWebviewView<Options> {
+        private _view?: vscode.WebviewView
+        private initialData?: PropsFromOptions<Options>
+        public readonly emitters: Options['events']
+
+        public get view() {
+            return this._view
+        }
+
+        public get protocol(): OptionsToProtocol<Options> {
+            throw new Error('Cannot access the webview protocol on the backend.')
+        }
+
+        constructor(private readonly context: ExtContext) {
+            this.emitters = copyEmitters(params.events)
+        }
+
+        public start(...data: DataFromOptions<Options>): void {
+            if (this._view) {
+                throw new Error('VueWebviewView has already been started.')
+            }
+
+            if (semver.lt(vscode.version, MIN_WEBVIEW_VIEW_VERSION)) {
+                const warnData = `${vscode.version} < ${MIN_WEBVIEW_VIEW_VERSION} (id: ${params.id})`
+                getLogger().warn(`VS Code version is too low to support WebviewViews: ${warnData}`)
+                return
+            }
+
+            vscode.window.registerWebviewViewProvider(params.id, {
+                resolveWebviewView: async view => {
+                    view.title = params.title ?? view.title
+                    view.description = params.description ?? view.description
+                    updateWebview(view.webview, { ...params, context: this.context })
+                    this.initialData = (await params.start?.(...data)) ?? data
+                    this._view = view
+
+                    if (params.commands) {
+                        const init = async () => this.initialData
+                        const modifiedWebview = Object.assign(view.webview, {
+                            dispose: () => {}, // currently does nothing for `view` type webviews
+                            context: this.context,
+                            emitters: this.emitters,
+                        })
+                        Object.defineProperty(modifiedWebview, 'data', { get: () => this.initialData })
+                        registerWebviewServer(modifiedWebview, { init, ...params.commands, ...this.emitters })
+                    }
+                },
+            })
+        }
+
+        public async clear(...data: DataFromOptions<Options>): Promise<boolean> {
+            this.initialData = (await params.start?.(...data)) ?? data
+            return this._view?.webview.postMessage({ command: '$clear' }) ?? false
+        }
+    } as any
+}
+
+/**
+ * Creates a brand new webview panel, setting some basic initial parameters and updating the webview.
+ */
+function createWebviewPanel(params: WebviewPanelParams & { context: ExtContext }): vscode.WebviewPanel {
+    const panel = vscode.window.createWebviewPanel(
+        params.id,
+        params.title,
+        {
+            viewColumn: isCloud9() ? vscode.ViewColumn.Two : params.viewColumn ?? vscode.ViewColumn.Beside,
+        },
+        { retainContextWhenHidden: isCloud9() || params.retainContextWhenHidden }
     )
+    updateWebview(panel.webview, params)
+
+    return panel
+}
+
+/**
+ * Mutates a webview, applying various options and a static HTML page to bootstrap the Vue code.
+ */
+function updateWebview(webview: vscode.Webview, params: WebviewParams & { context: ExtContext }): vscode.Webview {
+    const context = params.context.extensionContext
+    const libsPath: string = path.join(context.extensionPath, 'media', 'libs')
+    const jsPath: string = path.join(context.extensionPath, 'media', 'js')
+    const cssPath: string = path.join(context.extensionPath, 'media', 'css')
+    const webviewPath: string = path.join(context.extensionPath, 'dist')
+    const resourcesPath: string = path.join(context.extensionPath, 'resources')
+
+    webview.options = {
+        enableScripts: true,
+        enableCommandUris: true,
+        localResourceRoots: [
+            vscode.Uri.file(libsPath),
+            vscode.Uri.file(jsPath),
+            vscode.Uri.file(cssPath),
+            vscode.Uri.file(webviewPath),
+            vscode.Uri.file(resourcesPath),
+        ],
+    }
 
     const loadLibs = ExtensionUtilities.getFilesAsVsCodeResources(
         libsPath,
         ['vue.min.js', ...(params.libFiles ?? [])],
-        view.webview
-    ).concat(
-        ExtensionUtilities.getFilesAsVsCodeResources(
-            jsPath,
-            ['loadVsCodeApi.js', ...(params.jsFiles ?? [])],
-            view.webview
-        )
-    )
+        webview
+    ).concat(ExtensionUtilities.getFilesAsVsCodeResources(jsPath, ['loadVsCodeApi.js'], webview))
 
-    const loadCss = ExtensionUtilities.getFilesAsVsCodeResources(cssPath, [...(params.cssFiles ?? [])], view.webview)
+    const cssFiles = params.cssFiles ?? [isCloud9() ? 'base-cloud9.css' : 'base.css']
+    const loadCss = ExtensionUtilities.getFilesAsVsCodeResources(cssPath, [...cssFiles], webview)
 
     let scripts: string = ''
     let stylesheets: string = ''
@@ -78,63 +312,243 @@ export async function createVueWebview<TRequest, TResponse>(params: WebviewParam
         stylesheets = stylesheets.concat(`<link rel="stylesheet" href="${element}">\n\n`)
     })
 
-    const mainScript: vscode.Uri = view.webview.asWebviewUri(vscode.Uri.file(path.join(webviewPath, params.webviewJs)))
+    const mainScript = webview.asWebviewUri(vscode.Uri.file(path.join(webviewPath, params.webviewJs)))
 
-    view.title = params.name
-    view.webview.html = `<html>
+    webview.html = resolveWebviewHtml({
+        scripts,
+        stylesheets,
+        main: mainScript,
+        webviewJs: params.webviewJs,
+        cspSource: updateCspSource(webview.cspSource),
+    })
+
+    return webview
+}
+
+/**
+ * Resolves the webview HTML based off whether we're running from a development server or bundled extension.
+ */
+function resolveWebviewHtml(params: {
+    scripts: string
+    stylesheets: string
+    cspSource: string
+    webviewJs: string
+    main: vscode.Uri
+}): string {
+    const resolvedParams = { ...params, connectSource: 'none' }
+    const LOCAL_SERVER = process.env.WEBPACK_DEVELOPER_SERVER
+
+    if (LOCAL_SERVER) {
+        const local = vscode.Uri.parse(LOCAL_SERVER)
+        resolvedParams.cspSource = `${params.cspSource} ${local.toString()}`
+        resolvedParams.main = local.with({ path: `/${params.webviewJs}` })
+        resolvedParams.connectSource = `'self' ws:`
+    }
+
+    return `<html>
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        
+
         <meta
             http-equiv="Content-Security-Policy"
             content=
                 "default-src 'none';
-                img-src ${view.webview.cspSource} https:;
-                script-src ${view.webview.cspSource};
-                style-src ${view.webview.cspSource} 'unsafe-inline';
+                connect-src ${resolvedParams.connectSource};
+                img-src ${resolvedParams.cspSource} https:;
+                script-src ${resolvedParams.cspSource};
+                style-src ${resolvedParams.cspSource} 'unsafe-inline';
                 font-src 'self' data:;"
         >
     </head>
     <body>
         <div id="vue-app"></div>
         <!-- Dependencies -->
-        ${scripts}
-        ${stylesheets}
+        ${resolvedParams.scripts}
+        ${resolvedParams.stylesheets}
         <!-- Main -->
-        <script src="${mainScript}"></script>
+        <script src="${resolvedParams.main}"></script>
     </body>
 </html>`
+}
 
-    if (params.initialCalls) {
-        view.webview.onDidReceiveMessage((message: any) => {
-            if (message.command === 'initialized') {
-                for (const call of params.initialCalls!) view.webview.postMessage(call)
-            }
-        })
+/**
+ * Updates the CSP source for webviews with an allowed source for AWS endpoints when running in
+ * Cloud9 environments. Possible this can be further scoped to specific C9 CDNs or removed entirely
+ * if C9 injects this.
+ */
+export function updateCspSource(baseSource: string) {
+    return isCloud9() ? `https://*.amazonaws.com ${baseSource}` : baseSource
+}
+
+/**
+ * To preserve compatability with our min-version types we are declaring only portions of the latest API.
+ *
+ * Introduced in VS Code 1.50.0. Types sourced from:
+ * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ccaaa6ab6a4168c8644fd3c391c8bff9e485734b/types/vscode/index.d.ts
+ */
+declare module 'vscode' {
+    /**
+     * A webview based view.
+     */
+    export interface WebviewView {
+        /**
+         * Identifies the type of the webview view, such as `'hexEditor.dataView'`.
+         */
+        readonly viewType: string
+
+        /**
+         * The underlying webview for the view.
+         */
+        readonly webview: Webview
+
+        /**
+         * View title displayed in the UI.
+         *
+         * The view title is initially taken from the extension `package.json` contribution.
+         */
+        title?: string
+
+        /**
+         * Human-readable string which is rendered less prominently in the title.
+         */
+        description?: string
+
+        /**
+         * Event fired when the view is disposed.
+         *
+         * Views are disposed when they are explicitly hidden by a user (this happens when a user
+         * right clicks in a view and unchecks the webview view).
+         *
+         * Trying to use the view after it has been disposed throws an exception.
+         */
+        readonly onDidDispose: Event<void>
+
+        /**
+         * Tracks if the webview is currently visible.
+         *
+         * Views are visible when they are on the screen and expanded.
+         */
+        readonly visible: boolean
+
+        /**
+         * Event fired when the visibility of the view changes.
+         *
+         * Actions that trigger a visibility change:
+         *
+         * - The view is collapsed or expanded.
+         * - The user switches to a different view group in the sidebar or panel.
+         *
+         * Note that hiding a view using the context menu instead disposes of the view and fires `onDidDispose`.
+         */
+        readonly onDidChangeVisibility: Event<void>
+
+        /**
+         * Reveal the view in the UI.
+         *
+         * If the view is collapsed, this will expand it.
+         *
+         * @param preserveFocus When `true` the view will not take focus.
+         */
+        show(preserveFocus?: boolean): void
     }
 
-    view.webview.onDidReceiveMessage(
-        // type the any if necessary
-        (message: any) => {
-            params.onDidReceiveMessageFunction(
-                message,
-                response => view.webview.postMessage(response),
-                // tslint:disable-next-line: no-unsafe-any
-                () => view.dispose()
-            )
-        },
-        undefined,
-        params.context.subscriptions
-    )
+    /**
+     * Additional information the webview view being resolved.
+     *
+     * @param T Type of the webview's state.
+     */
+    interface WebviewViewResolveContext<T = unknown> {
+        /**
+         * Persisted state from the webview content.
+         *
+         * To save resources, the editor normally deallocates webview documents (the iframe content) that are not visible.
+         * For example, when the user collapse a view or switches to another top level activity in the sidebar, the
+         * `WebviewView` itself is kept alive but the webview's underlying document is deallocated. It is recreated when
+         * the view becomes visible again.
+         *
+         * You can prevent this behavior by setting `retainContextWhenHidden` in the `WebviewOptions`. However this
+         * increases resource usage and should be avoided wherever possible. Instead, you can use persisted state to
+         * save off a webview's state so that it can be quickly recreated as needed.
+         *
+         * To save off a persisted state, inside the webview call `acquireVsCodeApi().setState()` with
+         * any json serializable object. To restore the state again, call `getState()`. For example:
+         *
+         * ```js
+         * // Within the webview
+         * const vscode = acquireVsCodeApi();
+         *
+         * // Get existing state
+         * const oldState = vscode.getState() || { value: 0 };
+         *
+         * // Update state
+         * setState({ value: oldState.value + 1 })
+         * ```
+         *
+         * The editor ensures that the persisted state is saved correctly when a webview is hidden and across
+         * editor restarts.
+         */
+        readonly state: T | undefined
+    }
 
-    view.onDidDispose(
-        () => {
-            if (params.onDidDisposeFunction) {
-                params.onDidDisposeFunction()
+    export interface WebviewViewProvider {
+        /**
+         * Revolves a webview view.
+         *
+         * `resolveWebviewView` is called when a view first becomes visible. This may happen when the view is
+         * first loaded or when the user hides and then shows a view again.
+         *
+         * @param webviewView Webview view to restore. The provider should take ownership of this view. The
+         *    provider must set the webview's `.html` and hook up all webview events it is interested in.
+         * @param context Additional metadata about the view being resolved.
+         * @param token Cancellation token indicating that the view being provided is no longer needed.
+         *
+         * @return Optional thenable indicating that the view has been fully resolved.
+         */
+        resolveWebviewView(
+            webviewView: WebviewView,
+            context: WebviewViewResolveContext,
+            token: CancellationToken
+        ): Thenable<void> | void
+    }
+
+    export namespace window {
+        /**
+         * Register a new provider for webview views.
+         *
+         * @param viewId Unique id of the view. This should match the `id` from the
+         *   `views` contribution in the package.json.
+         * @param provider Provider for the webview views.
+         *
+         * @return Disposable that unregisters the provider.
+         */
+        export function registerWebviewViewProvider(
+            viewId: string,
+            provider: WebviewViewProvider,
+            options?: {
+                /**
+                 * Content settings for the webview created for this view.
+                 */
+                readonly webviewOptions?: {
+                    /**
+                     * Controls if the webview element itself (iframe) is kept around even when the view
+                     * is no longer visible.
+                     *
+                     * Normally the webview's html context is created when the view becomes visible
+                     * and destroyed when it is hidden. Extensions that have complex state
+                     * or UI can set the `retainContextWhenHidden` to make the editor keep the webview
+                     * context around, even when the webview moves to a background tab. When a webview using
+                     * `retainContextWhenHidden` becomes hidden, its scripts and other dynamic content are suspended.
+                     * When the view becomes visible again, the context is automatically restored
+                     * in the exact same state it was in originally. You cannot send messages to a
+                     * hidden webview, even with `retainContextWhenHidden` enabled.
+                     *
+                     * `retainContextWhenHidden` has a high memory overhead and should only be used if
+                     * your view's context cannot be quickly saved and restored.
+                     */
+                    readonly retainContextWhenHidden?: boolean
+                }
             }
-        },
-        undefined,
-        params.context.subscriptions
-    )
+        ): Disposable
+    }
 }

--- a/src/webviews/mixins/saveData.ts
+++ b/src/webviews/mixins/saveData.ts
@@ -1,0 +1,66 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { WebviewApi } from 'vscode-webview'
+import * as Vue from 'vue'
+declare const vscode: WebviewApi<{ [key: string]: any }>
+
+/* Keep track of registered IDs to warn if duplicates appears */
+const _unids = new Set<string>()
+
+// Upon remounting we need to clear whatever IDs we have stored
+window.addEventListener('remount', () => _unids.clear())
+
+/**
+ * A mixin for saving component data state.
+ *
+ * This is added prior to the component's own create method. This will save the component state anytime
+ * something in 'data' changes, even for deeply nested properties. Keep in mind that all components share
+ * a single global state object; we must assign a globally unique identifier to components to correctly
+ * recover state upon refresh.
+ *
+ * Components with duplicated IDs will not be able to recover state.
+ */
+const saveData: Vue.ComponentOptionsMixin = {
+    created() {
+        if (this.$data === undefined) {
+            return
+        }
+        const state = vscode.getState() ?? {}
+
+        // TODO: add error handling, logs, etc.
+        this.$options._count = ((this.$options._count as number | undefined) ?? 0) + 1
+        const unid = this.id ?? `${this.name ?? `DEFAULT-${_unids.size}`}-${this.$options._count}`
+        this.$options._unid = unid
+
+        if (_unids.has(unid)) {
+            console.warn(`Component "${unid}" already exists. State-saving functionality will be disabled.`)
+            return
+        }
+
+        _unids.add(unid)
+        const old = state[unid] ?? {}
+
+        Object.keys(this.$data).forEach(k => {
+            this.$data[k] = old[k] ?? this.$data[k]
+        })
+
+        Object.keys(this.$data).forEach(k => {
+            this.$watch(
+                k,
+                (v: any) => {
+                    const globalState = vscode.getState() ?? {}
+                    const componentState = Object.assign(globalState[unid] ?? {}, {
+                        [k]: JSON.parse(JSON.stringify(v)),
+                    })
+                    vscode.setState(Object.assign(globalState, { [unid]: componentState }))
+                },
+                { deep: true }
+            )
+        })
+    },
+}
+
+export default saveData

--- a/src/webviews/server.ts
+++ b/src/webviews/server.ts
@@ -1,0 +1,151 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { ExtContext } from '../shared/extensions'
+import { getLogger } from '../shared/logger'
+import { Message } from './client'
+
+interface Command<T extends any[] = any, R = any> {
+    (...args: T): R | never
+    (this: WebviewServer, ...args: T): R | never
+}
+
+export interface Protocol<U = any, S = any> {
+    /**
+     * Called when the frontend wants to submit the webview. If the result is valid, the webview is closed.
+     */
+    submit?: (result: S) => Promise<void> | void | never
+    /**
+     * Initial data to load. This is called only once, even if the view is refreshed.
+     * Further calls return undefined.
+     */
+    init?: () => Promise<U | undefined>
+    [key: string]: Command<any, any> | vscode.EventEmitter<any> | undefined
+}
+
+export interface Commands {
+    [key: string]: Command<any, any> | undefined
+}
+
+export interface Events {
+    [key: string]: vscode.EventEmitter<any>
+}
+
+export interface WebviewCompileOptions<
+    C extends Commands = any,
+    E extends Events = any,
+    D extends any[] = any[],
+    S = any,
+    O = any,
+    P extends any = any
+> {
+    /**
+     * Events emitters provided by the backend. Note that whatever is passed into this option is
+     * only used for type and key generation. Do not assume the same reference will exist on instantiation.
+     */
+    events?: E
+    /**
+     * Commands provided by the backend. These are called with a `this` type with the following shape:
+     * ```ts
+     * interface {
+     *    emitters: typeof events
+     *    arguments: typeof validateData
+     * }
+     * ```
+     * Merged with {@link WebviewServer}
+     */
+    commands?: C
+    /**
+     * Called when the webview is started.
+     *
+     * Whatever is returned by this function is then passed into the frontend code via {@link Protocol.init}.
+     * Note that if this function is not provided or if it returns `undefined` then the arguments are passed directly
+     * to the frontend code. This function and {@link WebviewCompileOptions.submit} can be thought of as 'glue' code
+     * that exists as interfaces between the frontend/backend logic. The purpose is primarily to infer types, though
+     * it can also be used for pre/post processing of the inputs/outputs of the webview.
+     */
+    start?(this: ThisType<WebviewServer>, ...args: D): Promise<P> | P
+    /**
+     * Called when the webview calls {@link Protocol.submit}.
+     *
+     * Whatever is returned by this function is then forwarded to the creator of the webview. If this function does not
+     * exist, or if it returns `undefined`, then `result` is passed directly. A successful submission will close the
+     * webview, disposing any related listeners or handlers. Submissions can be rejected by throwing an error.
+     */
+    submit?(this: ThisType<WebviewServer>, result: S): Promise<O> | O
+}
+
+export type CompileContext<T> = T extends WebviewCompileOptions<any, infer E>
+    ? ThisType<WebviewServer & { emitters: E } & { data: ReturnType<NonNullable<T['start']>> }>
+    : never
+export type SubmitFromOptions<O> = O extends WebviewCompileOptions<any, any, any, infer S> ? S : never
+export type DataFromOptions<O> = O extends WebviewCompileOptions<any, any, infer D> ? D : never
+export type OutputFromOptions<O> = O extends WebviewCompileOptions<any, any, any, any, infer O> ? O : never
+export type PropsFromOptions<O> = O extends WebviewCompileOptions<any, any, any, any, any, infer P> ? P : never
+export type OptionsToProtocol<O> = O extends WebviewCompileOptions<infer C, infer E, any, infer S, any, infer P>
+    ? {
+          submit: (result: S) => Promise<void> | void | never
+          init: () => Promise<P | undefined> | P | undefined
+      } & C &
+          E
+    : never
+
+export type WebviewServer = vscode.Webview & {
+    context: ExtContext
+    dispose(): void
+}
+
+/**
+ * Sets up an event listener for the webview to call registered commands.
+ *
+ * @param webview Target webview to add the event hook.
+ * @param commands Commands to register.
+ */
+export function registerWebviewServer(webview: WebviewServer, commands: Protocol): vscode.Disposable {
+    return webview.onDidReceiveMessage(async (event: Message) => {
+        const { id, command, data } = event
+        const metadata: Omit<Message, 'id' | 'command' | 'data'> = {}
+
+        const handler = commands[command]
+
+        if (!handler) {
+            return getLogger().warn(`Received invalid message from client: ${command}`)
+        }
+
+        if (handler instanceof vscode.EventEmitter) {
+            // TODO: make server dipose of event if client calls `dispose`
+            handler.event(e => webview.postMessage({ command, event: true, data: e }))
+            getLogger().verbose(`Registered event handler for: ${command}`)
+            return webview.postMessage({ id, command, event: true })
+        }
+
+        // TODO: these commands could potentially have sensitive data, we don't want to log in that case
+        getLogger().debug(`Webview called command "${command}" with args: %O`, data)
+
+        let result: any
+        try {
+            result = await handler.call(webview, ...data)
+            // For now undefined means we should not send any data back
+            // Later on the commands should specify how undefined is handled
+            if (result === undefined) {
+                return
+            }
+        } catch (err) {
+            if (!(err instanceof Error)) {
+                getLogger().debug(`Webview server threw on comamnd "${command}" but it was not an error: `, err)
+                return
+            }
+            result = JSON.stringify(err, Object.getOwnPropertyNames(err))
+            delete result.stack // Already being logged anyway
+            metadata.error = true
+            getLogger().error(`Webview server failed on command "${command}": %O`, err)
+        }
+
+        // TODO: check if webview has been disposed of before posting message (not necessary but nice)
+        // We also get a boolean value back, maybe retry sending on false?
+        webview.postMessage({ id, command, data: result, ...metadata })
+    })
+}

--- a/src/webviews/util.ts
+++ b/src/webviews/util.ts
@@ -1,0 +1,45 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PropType } from 'vue'
+
+/**
+ * Creates an anonymous class whose constructor automatically applies default values.
+ *
+ * Mostly just used for Vue as the types expect a class. Otherwise one would need to
+ * manually describe constructor parameters and assignments for every field.
+ *
+ * Example (type inferred):
+ * ```ts
+ * export const MyClass = createClass({
+ *     foo: 0,
+ *     bar: 'a' as 'a' | 'b',
+ * })
+ * ```
+ *
+ * @param defaults Defaults to use during construction.
+ *
+ * @returns Anonymous class. Use `typeof MyClass` to extract its type.
+ */
+export function createClass<T>(defaults: T): { new (initial?: Partial<T>): T }
+export function createClass<T>(defaults: Partial<T>, required: true): { new (initial: T): T }
+export function createClass<T>(defaults: T): { new (initial?: Partial<T>): T } | { new (initial: T): T } {
+    return class {
+        constructor(initial: T | Partial<T> = {}) {
+            Object.assign(this, defaults, initial)
+        }
+    } as any
+}
+
+/**
+ * Creates a Vue 'type' from a class. Note that nothing is actually created; a type is only inferred from the `Model`.
+ *
+ * @param Model Model class, usually created from {@link createClass}.
+ *
+ * @returns The {@link Object} class with the typed coerced as a {@link PropType} for the `Model` instance.
+ */
+export function createType<T extends new (obj: any) => any>(Model: T): PropType<InstanceType<T>> {
+    return Object
+}


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->
### Big diff is from adding `webpack-dev-server` as a dev-dependency

Adds framework code to develop robust (and type-safe!) webviews. Also adds support for `WebviewView`, though they are not currently used.

Main goals:
* Establish style conventions through common code
* Increase modularity by abstracting away the `window`/`message` event-based communication protocol
* Increase developer productivity with faster iteration loops (hot-module reloads) and 'failing quickly' (types are easier to add/maintain)
* Ensure consistency of state retention through mixins (see `src/webviews/saveData.ts`)
* Open an avenue for common testing constructs via uniform entry points.

See `docs/ARCHITECTURE.md` for an overview plus some small examples of usage.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
