### PR TITLE
SAM run/debug: target=api, proper fix for 'got' issue

### DIFF
--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -470,9 +470,6 @@ async function requestLocalApi(
         headers: api?.headers,
         method: reqMethod,
         retry: {
-            limit: RETRY_LIMIT,
-            statusCodes: [],
-            methods: [reqMethod],
             calculateDelay: obj => {
                 if (obj.error.response !== undefined) {
                     getLogger().debug('Local API response: %s : %O', uri, obj.error.response.statusMessage)

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -475,12 +475,18 @@ async function requestLocalApi(
             methods: [reqMethod],
             calculateDelay: obj => {
                 if (obj.error.response !== undefined) {
-                    getLogger().debug('Local API response: %s : %O', uri, JSON.stringify(obj.error.response))
+                    getLogger().debug('Local API response: %s : %O', uri, obj.error.response.statusMessage)
                 }
-                if (obj.error.code === 'ETIMEDOUT') {
+                if (
+                    obj.error.code === 'ETIMEDOUT' ||
+                    obj.attemptCount > RETRY_LIMIT ||
+                    obj.error.response?.statusCode === 403
+                ) {
                     return 0
                 }
-                getLogger().debug(`Local API: retry (${obj.attemptCount} of ${RETRY_LIMIT}): ${uri}: ${obj.error}`)
+                getLogger().debug(
+                    `Local API: retry (${obj.attemptCount} of ${RETRY_LIMIT}): ${uri}: ${obj.error.message}`
+                )
                 return RETRY_DELAY
             },
         },
@@ -496,7 +502,10 @@ async function requestLocalApi(
             getLogger().info('Local API is alive: %s', uri)
             return
         }
-        const msg = `Local API failed to respond (${err.code}) after ${RETRY_LIMIT} retries, path: ${api?.path}, error: ${err}`
+        const msg =
+            err.response?.statusCode === 403
+                ? `Local API failed to respond to path: ${api?.path}`
+                : `Local API failed to respond (${err.code}) after ${RETRY_LIMIT} retries, path: ${api?.path}, error: ${err.message}`
         getLogger('channel').error(msg)
         throw new Error(msg)
     })

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -470,6 +470,8 @@ async function requestLocalApi(
         headers: api?.headers,
         method: reqMethod,
         retry: {
+            // note: `calculateDelay` overrides the default function, so any functionality normally specified in the
+            // retry options needs to be implemented yourself
             calculateDelay: obj => {
                 if (obj.error.response !== undefined) {
                     getLogger().debug('Local API response: %s : %O', uri, obj.error.response.statusMessage)


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

Changed the logic to explicitly check for `attemptCount` and 403 error code
Supposedly `got` is only supposed to retry on the codes I've specified, but that doesn't appear to be the case.  `limit` was also being ignored, causing some confusion on what needed to be checked on retry. 


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
