### PR TITLE
Webviews: clean-up listeners for the WebviewView case

### DIFF
--- a/src/webviews/server.ts
+++ b/src/webviews/server.ts
@@ -105,7 +105,14 @@ export type WebviewServer = vscode.Webview & {
  * @param commands Commands to register.
  */
 export function registerWebviewServer(webview: WebviewServer, commands: Protocol): vscode.Disposable {
-    return webview.onDidReceiveMessage(async (event: Message) => {
+    const eventListeners: vscode.Disposable[] = []
+    const disposeListeners = () => {
+        while (eventListeners.length) {
+            eventListeners.pop()?.dispose()
+        }
+    }
+
+    const messageListener = webview.onDidReceiveMessage(async (event: Message) => {
         const { id, command, data } = event
         const metadata: Omit<Message, 'id' | 'command' | 'data'> = {}
 
@@ -115,9 +122,13 @@ export function registerWebviewServer(webview: WebviewServer, commands: Protocol
             return getLogger().warn(`Received invalid message from client: ${command}`)
         }
 
+        if (id === '0') {
+            disposeListeners() // Webview reloaded, dispose all listeners
+        }
+
         if (handler instanceof vscode.EventEmitter) {
             // TODO: make server dipose of event if client calls `dispose`
-            handler.event(e => webview.postMessage({ command, event: true, data: e }))
+            eventListeners.push(handler.event(e => webview.postMessage({ command, event: true, data: e })))
             getLogger().verbose(`Registered event handler for: ${command}`)
             return webview.postMessage({ id, command, event: true })
         }
@@ -148,4 +159,6 @@ export function registerWebviewServer(webview: WebviewServer, commands: Protocol
         // We also get a boolean value back, maybe retry sending on false?
         webview.postMessage({ id, command, data: result, ...metadata })
     })
+
+    return { dispose: () => (messageListener.dispose(), disposeListeners()) }
 }


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
`WebviewView` is handled slightly differently in that the underlying panel is not completely disposed off when collapsing the pane.

## Solution
Dispose of the listeners when the webview is reloaded or when the view is disposed.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
