### PR TITLE
Logs: remove/change some noisy logging code

### DIFF
--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -100,6 +100,9 @@ that is a net cost.
     able to react to them in some way. This could be showing an error message,
     attaching metadata to the error, or retrying the failed action. Do not just
     log and rethrow the error without additional context as to where the error occured.
+-   Do not log a stack trace unless it's truly a fatal exception. Stack traces are
+    noisy and mostly useless in production because the extension is 'bundled', removing
+    anything useful from the trace.
 -   Refactoring tools allow us to avoid "premature abstraction". Avoid wrappers
     until the need is clear and obvious.
 

--- a/src/shared/resourcefetcher/compositeResourceFetcher.ts
+++ b/src/shared/resourcefetcher/compositeResourceFetcher.ts
@@ -21,27 +21,13 @@ export class CompositeResourceFetcher implements ResourceFetcher {
      * Returns the contents of the resource from the first fetcher that successfully retrieves it, or undefined if the resource could not be retrieved.
      */
     public async get(): Promise<string | undefined> {
-        try {
-            for (const fetcher of this.fetchers) {
-                const contents = await this.tryGet(fetcher)
-                if (contents) {
-                    return contents
-                }
+        for (const fetcher of this.fetchers) {
+            const contents = await fetcher.get().catch(err => {
+                this.logger.debug('Error loading resource from resource fetcher: %s', (err as Error).message)
+            })
+            if (contents) {
+                return contents
             }
-        } catch (err) {
-            this.logger.error('Error loading resource from resource fetchers: %O', err as Error)
-
-            return undefined
-        }
-    }
-
-    private async tryGet(fetcher: ResourceFetcher): Promise<string | undefined> {
-        try {
-            return await fetcher.get()
-        } catch (err) {
-            this.logger.error('Error loading resource from resource fetcher: %O', err as Error)
-
-            return undefined
         }
     }
 }

--- a/src/shared/resourcefetcher/fileResourceFetcher.ts
+++ b/src/shared/resourcefetcher/fileResourceFetcher.ts
@@ -21,7 +21,7 @@ export class FileResourceFetcher implements ResourceFetcher {
 
             return (await fs.readFile(this.filepath)).toString()
         } catch (err) {
-            this.logger.error(`Error loading resource from ${this.filepath}: %O`, err as Error)
+            this.logger.verbose(`Error loading resource from ${this.filepath}: %s`, (err as Error).message)
 
             return undefined
         }

--- a/src/shared/resourcefetcher/httpResourceFetcher.ts
+++ b/src/shared/resourcefetcher/httpResourceFetcher.ts
@@ -36,7 +36,7 @@ interface FetcherStreams {
     requestStream: Request // `got` doesn't add the correct types to 'on' for some reason
     /** Stream writing to the file system. */
     fsStream: fs.WriteStream
-    /** Promise that resolves when all streams have closed, */
+    /** Promise that resolves when all streams have closed. This is rejected on error. */
     done: Promise<void>
 }
 
@@ -92,7 +92,7 @@ export class HttpResourceFetcher implements ResourceFetcher {
 
             return contents
         } catch (err) {
-            this.logger.error(`Error downloading ${this.logText()}: %O`, err as Error)
+            this.logger.verbose(`Error downloading ${this.logText()}: %s`, (err as Error).message)
 
             return undefined
         }

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -78,11 +78,17 @@ export class SchemaService {
 
         const batch = this.updateQueue.splice(0, this.updateQueue.length)
         for (const mapping of batch) {
-            const handler = this.handlers.get(mapping.type)
+            const { type, schema, path } = mapping
+            const handler = this.handlers.get(type)
             if (!handler) {
-                throw new Error(`no registered handler for type ${mapping.type}`)
+                throw new Error(`no registered handler for type ${type}`)
             }
-            getLogger().debug('schema service: handle %s mapping: %s -> %$s', mapping.type, path, mapping.path)
+            getLogger().debug(
+                'schema service: handle %s mapping: %s -> %s',
+                type,
+                schema?.toString() ?? '[removed]',
+                path
+            )
             await handler.handleUpdate(mapping, this.schemas)
         }
     }
@@ -141,7 +147,7 @@ export async function getDefaultSchemas(extensionContext: vscode.ExtensionContex
             sam: samSchemaUri,
         }
     } catch (e) {
-        getLogger().error('Could not refresh schemas:', (e as Error).message)
+        getLogger().verbose('Could not refresh schemas: %s', (e as Error).message)
         return undefined
     }
 }

--- a/src/webviews/server.ts
+++ b/src/webviews/server.ts
@@ -150,9 +150,9 @@ export function registerWebviewServer(webview: WebviewServer, commands: Protocol
                 return
             }
             result = JSON.stringify(err, Object.getOwnPropertyNames(err))
-            delete result.stack // Already being logged anyway
+            delete result.stack // Not relevant to frontend code, we only care about the message
             metadata.error = true
-            getLogger().error(`Webview server failed on command "${command}": %O`, err)
+            getLogger().debug(`Webview server failed on command "${command}": %s`, err.message)
         }
 
         // TODO: check if webview has been disposed of before posting message (not necessary but nice)


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

Fetchers log the error as an error and then return undefined. If something can be handled by just returning undefined then it definitely wasn't an error we really cared about. Also, we should refrain from just dumping the whole stack trace every time an error occurs. It better be an error that truly was unhandled to dump the stack. Especially since the names are mangled in the bundled extension, so it's pretty much useless in production too.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
