### PR TITLE
ECS: add auto install of SSM plugin

### DIFF
--- a/src/ecs/commands/runCommandInContainer.ts
+++ b/src/ecs/commands/runCommandInContainer.ts
@@ -16,7 +16,7 @@ import { DefaultSettingsConfiguration, SettingsConfiguration } from '../../share
 import { extensionSettingsPrefix } from '../../shared/constants'
 import { showOutputMessage, showViewLogsMessage } from '../../shared/utilities/messages'
 import { ext } from '../../shared/extensionGlobals'
-import { AWS_CLIS, getCliCommand, installCli } from '../../shared/utilities/cliUtils'
+import { getOrInstallCli } from '../../shared/utilities/cliUtils'
 
 export async function runCommandInContainer(
     node: EcsContainerNode,
@@ -118,14 +118,8 @@ export async function runCommandInContainer(
         if (!command) {
             return
         }
-        let ssmPlugin: string | undefined
-        if (!settings.readDevSetting<boolean>('aws.dev.forceInstallTools', 'boolean', true)) {
-            ssmPlugin = await getCliCommand(AWS_CLIS['session-manager-plugin']!)
-        }
 
-        if (!ssmPlugin) {
-            ssmPlugin = await installCli('session-manager-plugin', true)
-        }
+        const ssmPlugin = await getOrInstallCli('session-manager-plugin', true, window, settings)
 
         if (!ssmPlugin) {
             result = 'Failed'

--- a/src/shared/utilities/cliUtils.ts
+++ b/src/shared/utilities/cliUtils.ts
@@ -19,6 +19,8 @@ import { Window } from '../vscode/window'
 import * as nls from 'vscode-nls'
 import { Timeout } from './timeoutUtils'
 import { showMessageWithCancel } from './messages'
+import { DefaultSettingsConfiguration, SettingsConfiguration } from '../settingsConfiguration'
+import { extensionSettingsPrefix } from '../constants'
 const localize = nls.loadMessageBundle()
 
 const msgDownloading = localize('AWS.installProgress.downloading', 'downloading...')
@@ -41,13 +43,13 @@ interface Cli {
     name: string
 }
 
-type AwsClis = telemetry.ToolId
+type AwsClis = 'session-manager-plugin'
 
 /**
  * CLIs and their full filenames and download paths for their respective OSes
  * TODO: Add SAM? Other CLIs?
  */
-export const AWS_CLIS: { [cli in AwsClis]?: Cli } = {
+export const AWS_CLIS: { [cli in AwsClis]: Cli } = {
     'session-manager-plugin': {
         command: {
             unix: path.join('sessionmanagerplugin', 'bin', 'session-manager-plugin'),
@@ -306,6 +308,23 @@ async function installSsmCli(
             throw new InvalidPlatformError(`Platform ${process.platform} is not supported for CLI autoinstallation.`)
         }
     }
+}
+
+export async function getOrInstallCli(
+    cli: AwsClis,
+    confirm: boolean,
+    window: Window = Window.vscode(),
+    settings: SettingsConfiguration = new DefaultSettingsConfiguration(extensionSettingsPrefix)
+): Promise<string | undefined> {
+    let cliCommand: string | undefined
+    if (!settings.readDevSetting<boolean>('aws.dev.forceInstallTools', 'boolean', true)) {
+        cliCommand = await getCliCommand(AWS_CLIS[cli])
+    }
+
+    if (!cliCommand) {
+        cliCommand = await installCli(cli, confirm, window)
+    }
+    return cliCommand
 }
 
 // TODO: uncomment for AWS CLI installation

--- a/src/shared/utilities/cliUtils.ts
+++ b/src/shared/utilities/cliUtils.ts
@@ -43,7 +43,7 @@ interface Cli {
     name: string
 }
 
-type AwsClis = 'session-manager-plugin'
+type AwsClis = Pick<telemetry.ToolId, 'session-manager-plugin'>
 
 /**
  * CLIs and their full filenames and download paths for their respective OSes

--- a/src/shared/utilities/cliUtils.ts
+++ b/src/shared/utilities/cliUtils.ts
@@ -43,7 +43,7 @@ interface Cli {
     name: string
 }
 
-type AwsClis = Pick<telemetry.ToolId, 'session-manager-plugin'>
+type AwsClis = Extract<telemetry.ToolId, 'session-manager-plugin'>
 
 /**
  * CLIs and their full filenames and download paths for their respective OSes

--- a/src/test/ecs/commands/runCommandInContainer.test.ts
+++ b/src/test/ecs/commands/runCommandInContainer.test.ts
@@ -5,6 +5,7 @@
 import * as assert from 'assert'
 import * as picker from '../../../shared/ui/picker'
 import * as sinon from 'sinon'
+import * as cliUtils from '../../../shared/utilities/cliUtils'
 import { runCommandInContainer } from '../../../ecs/commands/runCommandInContainer'
 import { EcsContainerNode } from '../../../ecs/explorer/ecsContainerNode'
 import { DefaultEcsClient, EcsClient } from '../../../shared/clients/ecsClient'
@@ -51,6 +52,7 @@ describe('runCommandInContainer', function () {
         sandbox.stub(ecs, 'listTasks').resolves(taskListTwo)
         sandbox.stub(ecs, 'describeTasks').resolves(describedTasksOne)
         sandbox.stub(picker, 'promptUser').resolves(chosenTask)
+        sandbox.stub(cliUtils, 'getOrInstallCli').resolves('session-manager-plugin')
         sandbox.stub(ecs, 'executeCommand').resolves({} as ECS.ExecuteCommandRequest)
 
         const window = new FakeWindow({ inputBox: { input: 'ls' } })
@@ -65,6 +67,7 @@ describe('runCommandInContainer', function () {
         sandbox.stub(ecs, 'describeServices').resolves(serviceNoDeployments)
         sandbox.stub(ecs, 'listTasks').resolves(taskListOne)
         sandbox.stub(ecs, 'describeTasks').resolves(describedTasksOne)
+        sandbox.stub(cliUtils, 'getOrInstallCli').resolves('session-manager-plugin')
         sandbox.stub(ecs, 'executeCommand').resolves({} as ECS.ExecuteCommandRequest)
         const pickerStub = sandbox.stub(picker, 'promptUser')
 


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
The SSM Plugin is required for ECS Exec.
## Solution
Implement auto installation utility before it is used.
<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
