### PR TITLE
utils: refactor `ChildProcess` to support more things

### DIFF
--- a/src/shared/resourcefetcher/httpResourceFetcher.ts
+++ b/src/shared/resourcefetcher/httpResourceFetcher.ts
@@ -9,7 +9,7 @@ import * as https from 'https'
 import * as vscode from 'vscode'
 import * as semver from 'semver'
 import * as stream from 'stream'
-import got, { Response, RequestError } from 'got'
+import got, { Response, RequestError, CancelError } from 'got'
 import urlToOptions from 'got/dist/source/core/utils/url-to-options'
 import Request from 'got/dist/source/core'
 import { VSCODE_EXTENSION_ID } from '../extensions'
@@ -51,7 +51,7 @@ export class HttpResourceFetcher implements ResourceFetcher {
      * @param {boolean} params.showUrl Whether or not to the URL in log statements.
      * @param {string} params.friendlyName If URL is not shown, replaces the URL with this text.
      * @param {function} params.onSuccess Function to execute on successful request. No effect if piping to a location.
-     * @param {Timeout} params.timeout Timeout token to abort/cancel the request. Similar to `AbortSignal`. Only used if using a pipe.
+     * @param {Timeout} params.timeout Timeout token to abort/cancel the request. Similar to `AbortSignal`.
      */
     public constructor(
         private readonly url: string,
@@ -86,7 +86,7 @@ export class HttpResourceFetcher implements ResourceFetcher {
 
     private async downloadRequest(): Promise<string | undefined> {
         try {
-            const contents = (await this.getResponseFromGetRequest()).body
+            const contents = (await this.getResponseFromGetRequest(this.params.timeout)).body
             if (this.params.onSuccess) {
                 this.params.onSuccess(contents)
             }
@@ -95,7 +95,8 @@ export class HttpResourceFetcher implements ResourceFetcher {
 
             return contents
         } catch (err) {
-            this.logger.verbose(`Error downloading ${this.logText()}: %s`, (err as Error).message)
+            const error = err as CancelError | { message?: string; code?: number }
+            this.logger.verbose(`Error downloading ${this.logText()}: %s`, error.message ?? error.code)
 
             return undefined
         }
@@ -125,11 +126,18 @@ export class HttpResourceFetcher implements ResourceFetcher {
         return { requestStream, fsStream, done }
     }
 
-    private async getResponseFromGetRequest(): Promise<Response<string>> {
+    private async getResponseFromGetRequest(timeout?: Timeout): Promise<Response<string>> {
         const requester = semver.lt(vscode.version, MIN_VERSION_FOR_GOT) ? patchedGot : got
-        return requester(this.url, {
+        const promise = requester(this.url, {
             headers: { 'User-Agent': VSCODE_EXTENSION_ID.awstoolkit },
-        }).catch((err: RequestError) => {
+        })
+        timeout?.timer.catch(err => promise.cancel(err.message))
+
+        return promise.catch((err: RequestError | CancelError) => {
+            // Cancel error has no sensitive info
+            if (err instanceof CancelError) {
+                throw err
+            }
             throw { code: err.code } // Swallow URL since it may contain sensitive data
         })
     }

--- a/src/shared/resourcefetcher/httpResourceFetcher.ts
+++ b/src/shared/resourcefetcher/httpResourceFetcher.ts
@@ -95,7 +95,7 @@ export class HttpResourceFetcher implements ResourceFetcher {
 
             return contents
         } catch (err) {
-            this.logger.error(`Error downloading ${this.logText()}: %O`, err as Error)
+            this.logger.verbose(`Error downloading ${this.logText()}: %s`, (err as Error).message)
 
             return undefined
         }

--- a/src/shared/sam/cli/samCliInvoker.ts
+++ b/src/shared/sam/cli/samCliInvoker.ts
@@ -65,30 +65,24 @@ export class DefaultSamCliProcessInvoker implements SamCliProcessInvoker {
         }
 
         const samCommand = sam.path ? sam.path : 'sam'
-        this.childProcess = new ChildProcess(
-            logging,
-            samCommand,
-            invokeOptions.spawnOptions,
-            ...invokeOptions.arguments
-        )
+        this.childProcess = new ChildProcess(samCommand, invokeOptions.arguments, {
+            logging: options?.logging,
+            spawnOptions: invokeOptions.spawnOptions,
+        })
 
         getLogger('channel').info(localize('AWS.running.command', 'Running command: {0}', `${this.childProcess}`))
         log.verbose(`running: ${this.childProcess}`)
-        return await this.childProcess.run(
-            (text: string) => {
+        return await this.childProcess.run({
+            onStdout(text: string) {
                 getLogger('debugConsole').info(text)
                 log.verbose(`stdout: ${text}`)
-                if (options?.onStdout) {
-                    options.onStdout(text)
-                }
+                options?.onStdout?.call(this, text)
             },
-            (text: string) => {
+            onStderr(text: string) {
                 getLogger('debugConsole').info(text)
                 log.verbose(`stderr: ${text}`)
-                if (options?.onStderr) {
-                    options.onStderr(text)
-                }
-            }
-        )
+                options?.onStderr?.call(this, text)
+            },
+        })
     }
 }

--- a/src/shared/sam/cli/samCliInvoker.ts
+++ b/src/shared/sam/cli/samCliInvoker.ts
@@ -73,15 +73,15 @@ export class DefaultSamCliProcessInvoker implements SamCliProcessInvoker {
         getLogger('channel').info(localize('AWS.running.command', 'Running command: {0}', `${this.childProcess}`))
         log.verbose(`running: ${this.childProcess}`)
         return await this.childProcess.run({
-            onStdout(text: string) {
+            onStdout: (text, context) => {
                 getLogger('debugConsole').info(text)
                 log.verbose(`stdout: ${text}`)
-                options?.onStdout?.call(this, text)
+                options?.onStdout?.(text, context)
             },
-            onStderr(text: string) {
+            onStderr: (text, context) => {
                 getLogger('debugConsole').info(text)
                 log.verbose(`stderr: ${text}`)
-                options?.onStderr?.call(this, text)
+                options?.onStderr?.(text, context)
             },
         })
     }

--- a/src/shared/sam/cli/samCliInvokerUtils.ts
+++ b/src/shared/sam/cli/samCliInvokerUtils.ts
@@ -5,13 +5,13 @@
 
 import { SpawnOptions } from 'child_process'
 import { getLogger } from '../../logger'
-import { ChildProcessResult, ChildProcessStartArguments } from '../../utilities/childProcess'
+import { ChildProcessResult, ChildProcessOptions } from '../../utilities/childProcess'
 
 export interface SamCliProcessInvokeOptions {
     spawnOptions?: SpawnOptions
     arguments?: string[]
-    onStdout?: ChildProcessStartArguments['onStdout']
-    onStderr?: ChildProcessStartArguments['onStderr']
+    onStdout?: ChildProcessOptions['onStdout']
+    onStderr?: ChildProcessOptions['onStderr']
     /** Log command invocations (default: true). */
     logging?: boolean
 }

--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -173,7 +173,7 @@ async function compileTypeScript(config: NodejsDebugConfiguration): Promise<void
         // Overwrite the tsconfig.json copied by `sam build`.
         writeFileSync(buildDirTsConfig, JSON.stringify(defaultTsconfig, undefined, 4))
         getLogger('channel').info(`Compiling TypeScript app with: "${tsc}"`)
-        await new ChildProcess(true, tsc, undefined, '--project', buildDirApp).run()
+        await new ChildProcess(tsc, ['--project', buildDirApp]).run()
     } catch (error) {
         getLogger('channel').error(`TypeScript compile error: ${error}`)
         throw Error('Failed to compile TypeScript app')

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -337,7 +337,7 @@ export async function runLambdaFunction(
     onAfterBuild: () => Promise<void>
 ): Promise<SamLaunchRequestArgs> {
     // Verify if Docker is running
-    const dockerResponse = await new ChildProcess(false, 'docker', undefined, 'ps').run()
+    const dockerResponse = await new ChildProcess('docker', ['ps'], { logging: false }).run()
     if (dockerResponse.exitCode !== 0 || dockerResponse.stdout.includes('error during connect')) {
         throw new Error('Running AWS SAM projects locally requires Docker. Is it installed and running?')
     }

--- a/src/shared/systemUtilities.ts
+++ b/src/shared/systemUtilities.ts
@@ -81,7 +81,7 @@ export class SystemUtilities {
             if (vsc !== 'code' && !fs.existsSync(vsc)) {
                 continue
             }
-            const proc = new ChildProcess(true, vsc, undefined, '--version')
+            const proc = new ChildProcess(vsc, ['--version'])
             const r = await proc.run()
             if (r.exitCode === 0) {
                 SystemUtilities.vscPath = vsc
@@ -109,7 +109,7 @@ export class SystemUtilities {
 
         for (const tsc of tscPaths) {
             // Try to run "tsc -v".
-            const result = await new ChildProcess(true, tsc, undefined, '-v').run()
+            const result = await new ChildProcess(tsc, ['-v']).run()
             if (result.exitCode === 0 && result.stdout.includes('Version')) {
                 return tsc
             }
@@ -124,7 +124,6 @@ export class SystemUtilities {
      */
     public static async findSshPath(): Promise<string | undefined> {
         if (SystemUtilities.sshPath !== undefined) {
-            // TODO: cache the fs call rather than use a single variable
             return SystemUtilities.sshPath
         }
 
@@ -136,12 +135,11 @@ export class SystemUtilities {
             '/usr/bin/ssh',
             'C:/Windows/System32/OpenSSH/ssh.exe',
         ]
-
         for (const p of paths) {
             if (!p || ('ssh' !== p && !fs.existsSync(p))) {
                 continue
             }
-            const proc = new ChildProcess(true, p, undefined, '-G', 'x')
+            const proc = new ChildProcess(p, ['-G', 'x'])
             const r = await proc.run()
             if (r.exitCode === 0) {
                 SystemUtilities.sshPath = p
@@ -166,7 +164,7 @@ export class SystemUtilities {
             if (!p || ('git' !== p && !fs.existsSync(p))) {
                 continue
             }
-            const proc = new ChildProcess(true, p, undefined, '--version')
+            const proc = new ChildProcess(p, ['--version'])
             const r = await proc.run()
             if (r.exitCode === 0) {
                 SystemUtilities.gitPath = p
@@ -189,7 +187,7 @@ export class SystemUtilities {
             if (!p || ('bash' !== p && !fs.existsSync(p))) {
                 continue
             }
-            const proc = new ChildProcess(true, p, undefined, '--version')
+            const proc = new ChildProcess(p, ['--version'])
             const r = await proc.run()
             if (r.exitCode === 0) {
                 SystemUtilities.bashPath = p

--- a/src/shared/utilities/childProcess.ts
+++ b/src/shared/utilities/childProcess.ts
@@ -154,11 +154,7 @@ export class ChildProcess {
                     throw new Error('Timeout token was already completed.')
                 }
 
-                timeout.timer
-                    .catch(err => err)
-                    .then(err => {
-                        errorHandler(err ?? new Error('Timeout token completed'), true)
-                    })
+                timeout.timer.catch(err => errorHandler(err, true))
             }
 
             // Async.

--- a/src/shared/utilities/childProcess.ts
+++ b/src/shared/utilities/childProcess.ts
@@ -26,8 +26,6 @@ export interface ChildProcessOptions {
     collect?: boolean
     /** Wait until streams close to resolve the process result. (default: true) */
     waitForStreams?: boolean
-    /** Try to kill the process on any error. (default: true) */
-    stopOnError?: boolean
     /** Forcefully kill the process on an error. (default: false) */
     useForceStop?: boolean
     /** Rejects the Promise on any error. Can also use a callback for custom errors. (default: false) */
@@ -127,12 +125,11 @@ export class ChildProcess {
         // Defaults
         mergedOptions.collect ??= true
         mergedOptions.waitForStreams ??= true
-        mergedOptions.stopOnError ??= true
 
         return new Promise<ChildProcessResult>((resolve, reject) => {
             const errorHandler = (error: Error, force = mergedOptions.useForceStop) => {
                 this.processErrors.push(error)
-                if (mergedOptions.stopOnError && !this.stopped) {
+                if (!this.stopped) {
                     this.stop(force)
                 }
                 if (rejectOnError) {

--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -9,6 +9,12 @@ export const TIMEOUT_EXPIRED_MESSAGE = 'Timeout token expired'
 export const TIMEOUT_CANCELLED_MESSAGE = 'Timeout token cancelled'
 export const TIMEOUT_UNEXPECTED_RESOLVE = 'Promise resolved with an unexpected object'
 
+export class TimeoutError extends Error {
+    constructor(public readonly type: 'expired' | 'cancelled' = 'expired') {
+        super(type === 'cancelled' ? TIMEOUT_CANCELLED_MESSAGE : TIMEOUT_EXPIRED_MESSAGE)
+    }
+}
+
 /**
  * Timeout that can handle both cancellation token-style and time limit-style timeout situations. Timeouts
  * cannot be used after 'complete' has been called or if the Timeout expired.
@@ -38,7 +44,7 @@ export class Timeout {
         })
 
         this.timerTimeout = setTimeout(() => {
-            this.timerReject(new Error(TIMEOUT_EXPIRED_MESSAGE))
+            this.timerReject(new TimeoutError('expired'))
             this._completed = true
         }, timeoutLength)
     }
@@ -108,7 +114,7 @@ export class Timeout {
         clearTimeout(this.timerTimeout!)
 
         if (reject) {
-            this.timerReject(new Error(TIMEOUT_CANCELLED_MESSAGE))
+            this.timerReject(new TimeoutError('cancelled'))
         } else {
             this.timerResolve()
         }

--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -10,7 +10,7 @@ export const TIMEOUT_CANCELLED_MESSAGE = 'Timeout token cancelled'
 export const TIMEOUT_UNEXPECTED_RESOLVE = 'Promise resolved with an unexpected object'
 
 export class TimeoutError extends Error {
-    constructor(public readonly type: 'expired' | 'cancelled' = 'expired') {
+    public constructor(public readonly type: 'expired' | 'cancelled') {
         super(type === 'cancelled' ? TIMEOUT_CANCELLED_MESSAGE : TIMEOUT_EXPIRED_MESSAGE)
     }
 }

--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -102,6 +102,9 @@ export class Timeout {
     /**
      * Marks the Timeout token as being completed, preventing further use and locking in the elapsed time.
      *
+     * Note that completing the token but not rejecting it is equivalent to 'freeing' any resources associated
+     * with the timer, given that they do not wait for the timer Promise to resolve.
+     *
      * @param reject Rejects the token with a cancelled error message
      */
     public complete(reject?: boolean): void {

--- a/src/test/lambda/local/debugConfiguration.test.ts
+++ b/src/test/lambda/local/debugConfiguration.test.ts
@@ -3,324 +3,291 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as assert from 'assert'
+import { chmod, ensureDir, writeFile } from 'fs-extra'
 import * as os from 'os'
-import * as vscode from 'vscode'
-import * as fs from 'fs-extra'
-import { RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
-import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
-import { DefaultSamLocalInvokeCommand } from '../../../shared/sam/cli/samCliLocalInvoke'
-import { makeCoreCLRDebugConfiguration } from '../../../shared/sam/debugger/csharpSamDebug'
-import * as testutil from '../../testUtil'
-import { SamLaunchRequestArgs } from '../../../shared/sam/debugger/awsSamDebugger'
-import * as pathutil from '../../../shared/utilities/pathUtils'
 import * as path from 'path'
-import { CloudFormationTemplateRegistry } from '../../../shared/cloudformation/templateRegistry'
-import { getArchitecture, isImageLambdaConfig } from '../../../lambda/local/debugConfiguration'
-import { ext } from '../../../shared/extensionGlobals'
-import { CloudFormation } from '../../../shared/cloudformation/cloudformation'
+import * as semver from 'semver'
+import {
+    DotNetCoreDebugConfiguration,
+    DOTNET_CORE_DEBUGGER_PATH,
+    getCodeRoot,
+    isImageLambdaConfig,
+} from '../../../lambda/local/debugConfiguration'
+import { RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
+import * as pathutil from '../../../shared/utilities/pathUtils'
+import { ExtContext } from '../../extensions'
+import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
+import { runLambdaFunction, waitForPort } from '../localLambdaRunner'
+import { SamLaunchRequestArgs } from './awsSamDebugger'
+import { ChildProcess } from '../../utilities/childProcess'
+import { HttpResourceFetcher } from '../../resourcefetcher/httpResourceFetcher'
+import { ext } from '../../extensionGlobals'
+import { getLogger } from '../../logger'
+import { Window } from '../../vscode/window'
 
-describe('makeCoreCLRDebugConfiguration', function () {
-    let tempFolder: string
-    let fakeWorkspaceFolder: vscode.WorkspaceFolder
+import * as nls from 'vscode-nls'
+import { getSamCliVersion } from '../cli/samCliContext'
+import { MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_DOTNET_31_SUPPORT } from '../cli/samCliValidator'
+const localize = nls.loadMessageBundle()
 
-    beforeEach(async function () {
-        tempFolder = await makeTemporaryToolkitFolder()
-        fakeWorkspaceFolder = {
-            uri: vscode.Uri.file(tempFolder),
-            name: 'It was me, fakeWorkspaceFolder!',
-            index: 0,
-        }
-    })
+/**
+ * Gathers and sets launch-config info by inspecting the workspace and creating
+ * temp files/directories as needed.
+ *
+ * Does NOT execute/invoke SAM, docker, etc.
+ */
+export async function makeCsharpConfig(config: SamLaunchRequestArgs): Promise<SamLaunchRequestArgs> {
+    if (!config.baseBuildDir) {
+        throw Error('invalid state: config.baseBuildDir was not set')
+    }
+    config.codeRoot = getCodeRoot(config.workspaceFolder, config)!
+    // TODO: avoid the reassignment
+    // TODO: walk the tree to find .sln, .csproj ?
+    const originalCodeRoot = config.codeRoot
+    config.codeRoot = getSamProjectDirPathForFile(config.templatePath)
 
-    afterEach(async function () {
-        await fs.remove(tempFolder)
-    })
-
-    async function makeFakeSamLaunchConfig() {
-        const config: SamLaunchRequestArgs = {
-            name: 'fake-launch-config',
-            workspaceFolder: fakeWorkspaceFolder,
-            codeRoot: fakeWorkspaceFolder.uri.fsPath,
-            runtimeFamily: RuntimeFamily.DotNetCore,
-            type: 'coreclr',
-            request: 'attach',
-            // cfnTemplate?: CloudFormation.Template
-            runtime: 'fakedotnet',
-            handlerName: 'fakehandlername',
-            noDebug: false,
-            apiPort: 4242,
-            debugPort: 4243,
-
-            baseBuildDir: '/fake/build/dir/',
-            envFile: '/fake/build/dir/env-vars.json',
-            eventPayloadFile: '/fake/build/dir/event.json',
-            documentUri: vscode.Uri.parse('/fake/path/foo.txt'),
-            templatePath: '/fake/sam/path',
-            samLocalInvokeCommand: new DefaultSamLocalInvokeCommand(),
-
-            //debuggerPath?:
-
-            invokeTarget: {
-                target: 'code',
-                lambdaHandler: 'fakehandlername',
-                projectRoot: fakeWorkspaceFolder.uri.fsPath,
-            },
-        }
-        return config
+    config = {
+        ...config,
+        type: 'coreclr',
+        request: config.noDebug ? 'launch' : 'attach',
+        runtimeFamily: RuntimeFamily.DotNetCore,
     }
 
-    async function makeConfig({ codeUri = tempFolder }: { codeUri?: string; port?: number }) {
-        const fakeLaunchConfig = await makeFakeSamLaunchConfig()
-        return makeCoreCLRDebugConfiguration(fakeLaunchConfig, codeUri)
+    if (!config.noDebug) {
+        config = await makeCoreCLRDebugConfiguration(config, originalCodeRoot)
     }
 
-    describe('windows', function () {
-        if (os.platform() === 'win32') {
-            it('massages drive letters to uppercase', async function () {
-                const config = await makeConfig({})
-                assert.strictEqual(
-                    config.windows.pipeTransport.pipeCwd.substring(0, 1),
-                    tempFolder.substring(0, 1).toUpperCase()
+    return config
+}
+
+/**
+ * Launches and attaches debugger to a SAM dotnet (csharp) project.
+ *
+ * We spin up a C# Lambda Docker container, download and build the debugger for
+ * Linux, then mount it with the SAM app on run. User's C# workspace dir will
+ * have a `.vsdbg` dir after the first run.
+ */
+export async function invokeCsharpLambda(
+    ctx: ExtContext,
+    config: SamLaunchRequestArgs,
+    window: Window = Window.vscode()
+): Promise<SamLaunchRequestArgs> {
+    config.samLocalInvokeCommand = new DefaultSamLocalInvokeCommand([WAIT_FOR_DEBUGGER_MESSAGES.DOTNET])
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    config.onWillAttachDebugger = waitForPort
+
+    if (!config.noDebug) {
+        const samCliVersion = await getSamCliVersion(ctx.samCliContext())
+        // TODO: Remove this when min sam version is >= 1.4.0
+        if (semver.lt(samCliVersion, MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_DOTNET_31_SUPPORT)) {
+            window.showWarningMessage(
+                localize(
+                    'AWS.output.sam.local.no.net.3.1.debug',
+                    'Debugging dotnetcore3.1 lambdas requires a minimum SAM CLI version of 1.4.0. Function will run locally without debug.'
                 )
+            )
+            config.noDebug = true
+        } else if (config.architecture === 'arm64') {
+            window.showWarningMessage(
+                localize(
+                    'AWS.output.sam.local.no.arm.net.3.1.debug',
+                    'The vsdbg debugger does not currently support the arm64 architecture. Function will run locally without debug.'
+                )
+            )
+            getLogger().warn('SAM Invoke: Attempting to debug dotnet on ARM - removing debug flag.')
+            config.noDebug = true
+        }
+    }
+    return await runLambdaFunction(ctx, config, async () => {
+        if (!config.noDebug) {
+            await _installDebugger({
+                debuggerPath: config.debuggerPath!,
             })
         }
+    })
+}
 
-        it('uses powershell', async function () {
-            const config = await makeConfig({})
-            assert.strictEqual(config.windows.pipeTransport.pipeProgram, 'powershell')
-        })
+interface InstallDebuggerArgs {
+    debuggerPath: string
+}
 
-        it('uses the specified port', async function () {
-            const config = await makeConfig({})
-            assert.strictEqual(
-                config.windows.pipeTransport.pipeArgs.some(arg => arg.includes(config.debugPort!.toString())),
-                true
+function getDebuggerPath(parentFolder: string): string {
+    return path.resolve(parentFolder, '.vsdbg')
+}
+
+async function _installDebugger({ debuggerPath }: InstallDebuggerArgs): Promise<void> {
+    await ensureDir(debuggerPath)
+
+    try {
+        getLogger('channel').info(
+            localize(
+                'AWS.samcli.local.invoke.debugger.install',
+                'Installing .NET Core Debugger to {0}...',
+                debuggerPath
             )
+        )
+
+        const vsDbgVersion = 'latest'
+        // TODO: If vsdbg works with qemu, have this detect Architecture and swap to `linux-arm64` if ARM.
+        // See https://github.com/OmniSharp/omnisharp-vscode/issues/3277 ;
+        // qemu appears to set PrivateTmp=true : https://github.com/qemu/qemu/blob/326ff8dd09556fc2e257196c49f35009700794ac/contrib/systemd/qemu-pr-helper.service#L8 ?
+        const vsDbgRuntime = 'linux-x64'
+
+        const installScriptPath = await downloadInstallScript(debuggerPath)
+
+        let installCommand: string
+        let installArgs: string[]
+        if (os.platform() == 'win32') {
+            const windir = process.env['WINDIR']
+            if (!windir) {
+                throw new Error('Environment variable `WINDIR` not defined')
+            }
+
+            installCommand = `${windir}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`
+            installArgs = [
+                '-NonInteractive',
+                '-NoProfile',
+                '-WindowStyle',
+                'Hidden',
+                '-ExecutionPolicy',
+                'RemoteSigned',
+                '-File',
+                installScriptPath,
+                '-Version',
+                vsDbgVersion,
+                '-RuntimeID',
+                vsDbgRuntime,
+                '-InstallPath',
+                debuggerPath,
+            ]
+        } else {
+            installCommand = installScriptPath
+            installArgs = ['-v', vsDbgVersion, '-r', vsDbgRuntime, '-l', debuggerPath]
+        }
+
+        const childProcess = new ChildProcess(installCommand, installArgs)
+
+        const install = await childProcess.run({
+            onStdout: (text: string) => {
+                ext.outputChannel.append(text)
+            },
+            onStderr: (text: string) => {
+                ext.outputChannel.append(text)
+            },
         })
-    })
-    describe('*nix', function () {
-        it('uses the default shell', async function () {
-            const config = await makeConfig({})
 
-            assert.strictEqual(config.pipeTransport.pipeProgram, 'sh')
-        })
-
-        it('uses the specified port', async function () {
-            const config = await makeConfig({})
-
-            assert.strictEqual(
-                config.pipeTransport.pipeArgs.some(arg => arg.includes(config.debugPort!.toString())),
-                true
+        if (install.exitCode) {
+            throw new Error(`command failed (exit code: ${install.exitCode}): ${installCommand}`)
+        }
+    } catch (err) {
+        getLogger('channel').info(
+            localize(
+                'AWS.samcli.local.invoke.debugger.install.failed',
+                'Error installing .NET Core Debugger: {0}',
+                err instanceof Error ? (err as Error).message : String(err)
             )
+        )
+
+        throw err
+    }
+}
+
+async function downloadInstallScript(debuggerPath: string): Promise<string> {
+    let installScriptUrl: string
+    let installScriptPath: string
+    if (os.platform() == 'win32') {
+        installScriptUrl = 'https://aka.ms/getvsdbgps1'
+        installScriptPath = path.join(debuggerPath, 'installVsdbgScript.ps1')
+    } else {
+        installScriptUrl = 'https://aka.ms/getvsdbgsh'
+        installScriptPath = path.join(debuggerPath, 'installVsdbgScript.sh')
+    }
+
+    const installScriptFetcher = new HttpResourceFetcher(installScriptUrl, { showUrl: true })
+    const installScript = await installScriptFetcher.get()
+    if (!installScript) {
+        throw Error(`Failed to download ${installScriptUrl}`)
+    }
+
+    await writeFile(installScriptPath, installScript, 'utf8')
+    await chmod(installScriptPath, 0o700)
+
+    return installScriptPath
+}
+
+function getSamProjectDirPathForFile(filepath: string): string {
+    return pathutil.normalize(path.dirname(filepath))
+}
+
+/**
+ * Creates a CLR launch-config composed with the given `config`.
+ */
+export async function makeCoreCLRDebugConfiguration(
+    config: SamLaunchRequestArgs,
+    codeUri: string
+): Promise<DotNetCoreDebugConfiguration> {
+    if (config.noDebug) {
+        throw Error(`SAM debug: invalid config ${config}`)
+    }
+    const pipeArgs = ['-c', `docker exec -i $(docker ps -q -f publish=${config.debugPort}) \${debuggerCommand}`]
+    config.debuggerPath = pathutil.normalize(getDebuggerPath(codeUri))
+    await ensureDir(config.debuggerPath)
+
+    const isImageLambda = isImageLambdaConfig(config)
+
+    if (isImageLambda && !config.noDebug) {
+        config.containerEnvVars = {
+            _AWS_LAMBDA_DOTNET_DEBUGGING: '1',
+        }
+    }
+
+    if (os.platform() === 'win32') {
+        // Coerce drive letter to uppercase. While Windows is case-insensitive, sourceFileMap is case-sensitive.
+        codeUri = codeUri.replace(pathutil.DRIVE_LETTER_REGEX, match => match.toUpperCase())
+    }
+
+    if (isImageLambda) {
+        // default build path, in dotnet image-based templates
+        // Not needed for ZIP lambdas, because SAM prevents dotnet from being
+        // built in-container thus PDBs already point to the user workspace.
+        if (!config.sourceFileMap) {
+            config.sourceFileMap = {}
+        }
+        config.sourceFileMap['/build'] = codeUri
+    }
+
+    if (config.lambda?.pathMappings !== undefined) {
+        if (!config.sourceFileMap) {
+            config.sourceFileMap = {}
+        }
+        // we could safely leave this entry in, but might as well give the user full control if they're specifying mappings
+        delete config.sourceFileMap['/build']
+        config.lambda.pathMappings.forEach(mapping => {
+            // this looks weird because we're mapping the PDB path to the local workspace
+            config.sourceFileMap[mapping.remoteRoot] = mapping.localRoot
         })
-    })
-})
+    }
 
-describe('isImageLambdaConfig', function () {
-    let tempFolder: string
-    let fakeWorkspaceFolder: vscode.WorkspaceFolder
-
-    let registry: CloudFormationTemplateRegistry
-    let appDir: string
-
-    beforeEach(async function () {
-        tempFolder = await makeTemporaryToolkitFolder()
-        fakeWorkspaceFolder = {
-            uri: vscode.Uri.file(tempFolder),
-            name: 'It was me, fakeWorkspaceFolder!',
-            index: 0,
-        }
-        registry = ext.templateRegistry
-        appDir = pathutil.normalize(path.join(testutil.getProjectDir(), 'testFixtures/workspaceFolder/'))
-    })
-
-    it('true for Image-backed template', async function () {
-        const templatePath = vscode.Uri.file(path.join(appDir, 'python3.7-image-sam-app/template.yaml'))
-        await registry.addItemToRegistry(templatePath)
-
-        const input = {
-            name: 'fake-launch-config',
-            workspaceFolder: fakeWorkspaceFolder,
-            codeRoot: fakeWorkspaceFolder.uri.fsPath,
-            runtimeFamily: RuntimeFamily.DotNetCore,
-            request: 'launch',
-            type: 'launch',
-            runtime: 'fakedotnet',
-            handlerName: 'fakehandlername',
-            envFile: '/fake/build/dir/env-vars.json',
-            eventPayloadFile: '/fake/build/dir/event.json',
-            documentUri: vscode.Uri.parse('/fake/path/foo.txt'),
-            templatePath: '/fake/sam/path',
-            invokeTarget: {
-                target: 'template',
-                templatePath: templatePath.fsPath,
-                logicalId: 'HelloWorldFunction',
-                lambdaHandler: 'fakehandlername',
-                projectRoot: fakeWorkspaceFolder.uri.fsPath,
+    return {
+        ...config,
+        runtimeFamily: RuntimeFamily.DotNetCore,
+        request: 'attach',
+        // Since SAM CLI 1.0 we cannot assume PID=1. So use processName=dotnet
+        // instead of processId=1.
+        processName: 'dotnet',
+        pipeTransport: {
+            pipeProgram: 'sh',
+            pipeArgs,
+            debuggerPath: DOTNET_CORE_DEBUGGER_PATH,
+            pipeCwd: codeUri,
+        },
+        windows: {
+            pipeTransport: {
+                pipeProgram: 'powershell',
+                pipeArgs,
+                debuggerPath: DOTNET_CORE_DEBUGGER_PATH,
+                pipeCwd: codeUri,
             },
-        } as SamLaunchRequestArgs
-
-        assert.strictEqual(isImageLambdaConfig(input), true)
-    })
-
-    it('false for ZIP-backed template', async function () {
-        const templatePath = vscode.Uri.file(path.join(appDir, 'python3.7-plain-sam-app/template.yaml'))
-        await registry.addItemToRegistry(templatePath)
-
-        const input = {
-            name: 'fake-launch-config',
-            workspaceFolder: fakeWorkspaceFolder,
-            codeRoot: fakeWorkspaceFolder.uri.fsPath,
-            runtimeFamily: RuntimeFamily.DotNetCore,
-            request: 'launch',
-            type: 'launch',
-            runtime: 'fakedotnet',
-            handlerName: 'fakehandlername',
-            envFile: '/fake/build/dir/env-vars.json',
-            eventPayloadFile: '/fake/build/dir/event.json',
-            documentUri: vscode.Uri.parse('/fake/path/foo.txt'),
-            templatePath: '/fake/sam/path',
-            invokeTarget: {
-                target: 'template',
-                templatePath: templatePath.fsPath,
-                logicalId: 'HelloWorldFunction',
-                lambdaHandler: 'fakehandlername',
-                projectRoot: fakeWorkspaceFolder.uri.fsPath,
-            },
-        } as SamLaunchRequestArgs
-
-        assert.strictEqual(isImageLambdaConfig(input), false)
-    })
-
-    it('false for code-type', async function () {
-        const input = {
-            name: 'fake-launch-config',
-            workspaceFolder: fakeWorkspaceFolder,
-            codeRoot: fakeWorkspaceFolder.uri.fsPath,
-            runtimeFamily: RuntimeFamily.DotNetCore,
-            request: 'launch',
-            type: 'launch',
-            runtime: 'fakedotnet',
-            handlerName: 'fakehandlername',
-            envFile: '/fake/build/dir/env-vars.json',
-            eventPayloadFile: '/fake/build/dir/event.json',
-            documentUri: vscode.Uri.parse('/fake/path/foo.txt'),
-            invokeTarget: {
-                target: 'code',
-                lambdaHandler: 'fakehandlername',
-                projectRoot: fakeWorkspaceFolder.uri.fsPath,
-            },
-        } as SamLaunchRequestArgs
-
-        assert.strictEqual(isImageLambdaConfig(input), false)
-    })
-})
-
-describe('getArchitecture', function () {
-    it('returns a valid architecture from a template', function () {
-        const resource: CloudFormation.Resource = {
-            Type: 'AWS::Serverless::Function',
-            Properties: {
-                CodeUri: 'foo',
-                Handler: 'foo',
-                Architectures: ['arm64'],
-            },
-        }
-        const template: CloudFormation.Template = {
-            Resources: {
-                myResource: resource,
-            },
-        }
-        assert.strictEqual(
-            getArchitecture(template, resource, {
-                target: 'template',
-                logicalId: 'myResource',
-                templatePath: 'foo',
-            }),
-            'arm64'
-        )
-    })
-
-    it('returns x86_64 for an invalid architecture from a template', function () {
-        const resource: CloudFormation.Resource = {
-            Type: 'AWS::Serverless::Function',
-            Properties: {
-                CodeUri: 'foo',
-                Handler: 'foo',
-                Architectures: ['powerPc' as 'x86_64'],
-            },
-        }
-        const template: CloudFormation.Template = {
-            Resources: {
-                myResource: resource,
-            },
-        }
-        assert.strictEqual(
-            getArchitecture(template, resource, {
-                target: 'template',
-                logicalId: 'myResource',
-                templatePath: 'foo',
-            }),
-            'x86_64'
-        )
-    })
-
-    it('returns a valid architecture from CodeTargetProperties', function () {
-        assert.strictEqual(
-            getArchitecture(undefined, undefined, {
-                lambdaHandler: 'foo',
-                projectRoot: 'foo',
-                target: 'code',
-                architecture: 'arm64',
-            }),
-            'arm64'
-        )
-    })
-
-    it('returns x86_64 for an invalid architecture from CodeTargetProperties', function () {
-        assert.strictEqual(
-            getArchitecture(undefined, undefined, {
-                lambdaHandler: 'foo',
-                projectRoot: 'foo',
-                target: 'code',
-                architecture: 'powerPc' as 'x86_64',
-            }),
-            'x86_64'
-        )
-    })
-
-    it('returns undefined if no value is present in the template', function () {
-        const resource: CloudFormation.Resource = {
-            Type: 'AWS::Serverless::Function',
-            Properties: {
-                CodeUri: 'foo',
-                Handler: 'foo',
-            },
-        }
-        const template: CloudFormation.Template = {
-            Resources: {
-                myResource: resource,
-            },
-        }
-        assert.strictEqual(
-            getArchitecture(template, resource, {
-                target: 'template',
-                logicalId: 'myResource',
-                templatePath: 'foo',
-            }),
-            undefined
-        )
-    })
-
-    it('returns undefined if no value is present in CodeTargetProperties', function () {
-        assert.strictEqual(
-            getArchitecture(undefined, undefined, {
-                lambdaHandler: 'foo',
-                projectRoot: 'foo',
-                target: 'code',
-            }),
-            undefined
-        )
-    })
-})
+        },
+    }
+}

--- a/src/test/shared/utilities/childProcess.test.ts
+++ b/src/test/shared/utilities/childProcess.test.ts
@@ -293,12 +293,12 @@ describe('ChildProcess', async function () {
                 const command = path.join(tempFolder, `test-script.${isWindows ? 'bat' : 'sh'}`)
 
                 if (isWindows) {
-                    writeBatchFile(command, ['@echo 1', '@echo 2', '@echo 3', 'SLEEP 20', 'exit 1'].join(os.EOL))
+                    writeBatchFile(command, ['@echo %1', '@echo %2', '@echo "%3"', 'SLEEP 20', 'exit 1'].join(os.EOL))
                 } else {
-                    writeShellFile(command, ['echo 1', 'echo 2', 'echo 3', 'sleep 20', 'exit 1'].join(os.EOL))
+                    writeShellFile(command, ['echo $1', 'echo $2', 'echo "$3"', 'sleep 20', 'exit 1'].join(os.EOL))
                 }
 
-                childProcess = new ChildProcess(command, [], { collect: false })
+                childProcess = new ChildProcess(command, ['1', '2'], { collect: false })
             })
 
             it('can report errors', async function () {
@@ -336,18 +336,20 @@ describe('ChildProcess', async function () {
                 assert.notStrictEqual(result.exitCode, 1)
             })
 
-            it('can override base options', async function () {
+            it('can merge with base options', async function () {
                 const result = await childProcess.run({
                     collect: true,
                     stopOnError: true,
                     waitForStreams: false,
+                    extraArgs: ['4'],
                     onStdout(text) {
-                        if (text.includes('3')) {
-                            this.reportError('Got 3')
+                        if (text.includes('4')) {
+                            this.reportError('Got 4')
                         }
                     },
                 })
                 assert.ok(result.stdout.length !== 0)
+                assert.ok(result.error?.message.includes('Got 4'))
             })
 
             it('uses `Timeout` objects', async function () {

--- a/src/test/shared/utilities/childProcess.test.ts
+++ b/src/test/shared/utilities/childProcess.test.ts
@@ -304,9 +304,9 @@ describe('ChildProcess', async function () {
             it('can report errors', async function () {
                 const result = childProcess.run({
                     rejectOnError: true,
-                    onStdout(text) {
+                    onStdout: (text, context) => {
                         if (text.includes('2')) {
-                            this.reportError('Got 2')
+                            context.reportError('Got 2')
                         }
                     },
                 })
@@ -318,8 +318,8 @@ describe('ChildProcess', async function () {
                 return await assert.rejects(() =>
                     childProcess.run({
                         rejectOnError: true,
-                        onStdout() {
-                            this.reportError('An error')
+                        onStdout: (text, context) => {
+                            context.reportError('An error')
                         },
                     })
                 )
@@ -329,8 +329,8 @@ describe('ChildProcess', async function () {
                 const result = await childProcess.run({
                     stopOnError: true,
                     waitForStreams: false,
-                    onStdout() {
-                        this.reportError('An error')
+                    onStdout: (text, context) => {
+                        context.reportError('An error')
                     },
                 })
                 assert.notStrictEqual(result.exitCode, 1)
@@ -342,9 +342,9 @@ describe('ChildProcess', async function () {
                     stopOnError: true,
                     waitForStreams: false,
                     extraArgs: ['4'],
-                    onStdout(text) {
+                    onStdout: (text, context) => {
                         if (text.includes('4')) {
-                            this.reportError('Got 4')
+                            context.reportError('Got 4')
                         }
                     },
                 })
@@ -368,8 +368,8 @@ describe('ChildProcess', async function () {
                 await childProcess.run({
                     stopOnError: true,
                     waitForStreams: false,
-                    onStdout() {
-                        this.reportError('Got stuff')
+                    onStdout: (text, context) => {
+                        context.reportError('Got stuff')
                     },
                 })
 

--- a/src/test/shared/utilities/childProcess.test.ts
+++ b/src/test/shared/utilities/childProcess.test.ts
@@ -9,7 +9,8 @@ import * as os from 'os'
 import * as path from 'path'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 import { ChildProcess, ChildProcessResult } from '../../../shared/utilities/childProcess'
-import { waitUntil } from '../../../shared/utilities/timeoutUtils'
+import { sleep } from '../../../shared/utilities/promiseUtilities'
+import { Timeout, waitUntil } from '../../../shared/utilities/timeoutUtils'
 
 describe('ChildProcess', async function () {
     let tempFolder: string
@@ -30,7 +31,7 @@ describe('ChildProcess', async function () {
                 const batchFile = path.join(tempFolder, 'test-script.bat')
                 writeBatchFile(batchFile)
 
-                const childProcess = new ChildProcess(true, batchFile)
+                const childProcess = new ChildProcess(batchFile)
 
                 const result = await childProcess.run()
 
@@ -49,7 +50,7 @@ describe('ChildProcess', async function () {
 
                 writeWindowsCommandFile(command)
 
-                const childProcess = new ChildProcess(true, command)
+                const childProcess = new ChildProcess(command)
 
                 const result = await childProcess.run()
 
@@ -64,7 +65,7 @@ describe('ChildProcess', async function () {
                 const batchFile = path.join(tempFolder, 'test-script.bat')
                 writeBatchFile(batchFile)
 
-                const childProcess = new ChildProcess(true, batchFile)
+                const childProcess = new ChildProcess(batchFile)
 
                 // We want to verify that the error is thrown even if the first
                 // invocation is still in progress, so we don't await the promise.
@@ -83,7 +84,7 @@ describe('ChildProcess', async function () {
                 const scriptFile = path.join(tempFolder, 'test-script.sh')
                 writeShellFile(scriptFile)
 
-                const childProcess = new ChildProcess(true, scriptFile)
+                const childProcess = new ChildProcess(scriptFile)
 
                 const result = await childProcess.run()
 
@@ -98,7 +99,7 @@ describe('ChildProcess', async function () {
                 const scriptFile = path.join(tempFolder, 'test-script.sh')
                 writeShellFile(scriptFile)
 
-                const childProcess = new ChildProcess(true, scriptFile)
+                const childProcess = new ChildProcess(scriptFile)
 
                 // We want to verify that the error is thrown even if the first
                 // invocation is still in progress, so we don't await the promise.
@@ -128,7 +129,7 @@ describe('ChildProcess', async function () {
                 writeShellFile(command)
             }
 
-            const childProcess = new ChildProcess(true, command)
+            const childProcess = new ChildProcess(command)
 
             const result = await childProcess.run()
 
@@ -142,7 +143,7 @@ describe('ChildProcess', async function () {
         it('reports error for missing executable', async function () {
             const batchFile = path.join(tempFolder, 'nonExistentScript')
 
-            const childProcess = new ChildProcess(true, batchFile)
+            const childProcess = new ChildProcess(batchFile)
 
             const result = await childProcess.run()
 
@@ -173,19 +174,14 @@ describe('ChildProcess', async function () {
         }
     })
 
-    describe('start', async function () {
+    describe('run', async function () {
         async function assertRegularRun(childProcess: ChildProcess): Promise<void> {
-            await new Promise<void>(async (resolve, reject) => {
-                await childProcess.start({
-                    onStdout: text => {
-                        assert.strictEqual(text, 'hi' + os.EOL, 'Unexpected stdout')
-                    },
-                    onClose: (code, signal) => {
-                        assert.strictEqual(code, 0, 'Unexpected close code')
-                        resolve()
-                    },
-                })
+            const result = await childProcess.run({
+                onStdout: text => {
+                    assert.strictEqual(text, 'hi' + os.EOL, 'Unexpected stdout')
+                },
             })
+            assert.strictEqual(result.exitCode, 0, 'Unexpected close code')
         }
 
         if (process.platform === 'win32') {
@@ -193,7 +189,7 @@ describe('ChildProcess', async function () {
                 const batchFile = path.join(tempFolder, 'test-script.bat')
                 writeBatchFile(batchFile)
 
-                const childProcess = new ChildProcess(true, batchFile)
+                const childProcess = new ChildProcess(batchFile)
 
                 await assertRegularRun(childProcess)
             })
@@ -206,7 +202,7 @@ describe('ChildProcess', async function () {
 
                 writeWindowsCommandFile(command)
 
-                const childProcess = new ChildProcess(true, command)
+                const childProcess = new ChildProcess(command)
 
                 await assertRegularRun(childProcess)
             })
@@ -215,14 +211,14 @@ describe('ChildProcess', async function () {
                 const batchFile = path.join(tempFolder, 'test-script.bat')
                 writeBatchFile(batchFile)
 
-                const childProcess = new ChildProcess(true, batchFile)
+                const childProcess = new ChildProcess(batchFile)
 
                 // We want to verify that the error is thrown even if the first
                 // invocation is still in progress, so we don't await the promise.
-                childProcess.start({})
+                childProcess.run()
 
                 try {
-                    await childProcess.start({})
+                    await childProcess.run()
                 } catch (err) {
                     return
                 }
@@ -236,7 +232,7 @@ describe('ChildProcess', async function () {
                 const scriptFile = path.join(tempFolder, 'test-script.sh')
                 writeShellFile(scriptFile)
 
-                const childProcess = new ChildProcess(true, scriptFile)
+                const childProcess = new ChildProcess(scriptFile)
 
                 await assertRegularRun(childProcess)
             })
@@ -245,14 +241,14 @@ describe('ChildProcess', async function () {
                 const scriptFile = path.join(tempFolder, 'test-script.sh')
                 writeShellFile(scriptFile)
 
-                const childProcess = new ChildProcess(true, scriptFile)
+                const childProcess = new ChildProcess(scriptFile)
 
                 // We want to verify that the error is thrown even if the first
                 // invocation is still in progress, so we don't await the promise.
-                childProcess.start({})
+                childProcess.run()
 
                 try {
-                    await childProcess.start({})
+                    await childProcess.run()
                 } catch (err) {
                     return
                 }
@@ -275,7 +271,7 @@ describe('ChildProcess', async function () {
                 writeShellFile(command)
             }
 
-            const childProcess = new ChildProcess(true, command)
+            const childProcess = new ChildProcess(command)
 
             await assertRegularRun(childProcess)
         })
@@ -283,15 +279,95 @@ describe('ChildProcess', async function () {
         it('reports error for missing executable', async function () {
             const batchFile = path.join(tempFolder, 'nonExistentScript')
 
-            const childProcess = new ChildProcess(true, batchFile)
+            const childProcess = new ChildProcess(batchFile)
 
-            await new Promise<void>(async (resolve, reject) => {
-                await childProcess.start({
-                    onClose: (code, signal) => {
-                        assert.notStrictEqual(code, 0, 'Expected an error close code')
-                        resolve()
+            const result = await childProcess.run()
+            assert.notStrictEqual(result.exitCode, 0, 'Expected an error close code')
+        })
+
+        describe('Extra options', function () {
+            let childProcess: ChildProcess
+
+            beforeEach(function () {
+                const isWindows = process.platform === 'win32'
+                const command = path.join(tempFolder, `test-script.${isWindows ? 'bat' : 'sh'}`)
+
+                if (isWindows) {
+                    writeBatchFile(command, ['@echo 1', '@echo 2', '@echo 3', 'SLEEP 20', 'exit 1'].join(os.EOL))
+                } else {
+                    writeShellFile(command, ['echo 1', 'echo 2', 'echo 3', 'sleep 20', 'exit 1'].join(os.EOL))
+                }
+
+                childProcess = new ChildProcess(command, [], { collect: false })
+            })
+
+            it('can report errors', async function () {
+                const result = childProcess.run({
+                    rejectOnError: true,
+                    onStdout(text) {
+                        if (text.includes('2')) {
+                            this.reportError('Got 2')
+                        }
                     },
                 })
+
+                return assert.rejects(result, { message: 'Got 2' })
+            })
+
+            it('can reject on errors if `rejectOnError` is set', async function () {
+                return await assert.rejects(() =>
+                    childProcess.run({
+                        rejectOnError: true,
+                        onStdout() {
+                            this.reportError('An error')
+                        },
+                    })
+                )
+            })
+
+            it('can kill the process if `stopOnError` is set', async function () {
+                const result = await childProcess.run({
+                    stopOnError: true,
+                    waitForStreams: false,
+                    onStdout() {
+                        this.reportError('An error')
+                    },
+                })
+                assert.notStrictEqual(result.exitCode, 1)
+            })
+
+            it('can override base options', async function () {
+                const result = await childProcess.run({
+                    collect: true,
+                    stopOnError: true,
+                    waitForStreams: false,
+                    onStdout(text) {
+                        if (text.includes('3')) {
+                            this.reportError('Got 3')
+                        }
+                    },
+                })
+                assert.ok(result.stdout.length !== 0)
+            })
+
+            it('uses `Timeout` objects', async function () {
+                await childProcess.run({
+                    stopOnError: true,
+                    waitForStreams: false,
+                    timeout: new Timeout(10),
+                })
+                assert.strictEqual(childProcess.result()?.signal, 'SIGTERM')
+                assert.notStrictEqual(childProcess.result()?.error, undefined)
+            })
+
+            it('rejects if using a completed timer', async function () {
+                const timer = new Timeout(10)
+                timer.complete()
+                await assert.rejects(childProcess.run({ timeout: timer }))
+                assert.strictEqual(childProcess.result(), undefined)
+                // Just make sure no process was ever ran
+                await sleep(20)
+                assert.strictEqual(childProcess.result(), undefined)
             })
         })
     })
@@ -302,7 +378,7 @@ describe('ChildProcess', async function () {
                 const batchFile = path.join(tempFolder, 'test-script.bat')
                 writeBatchFileWithDelays(batchFile)
 
-                const childProcess = new ChildProcess(true, batchFile)
+                const childProcess = new ChildProcess(batchFile)
 
                 // `await` is intentionally not used, we want to check the process while it runs.
                 childProcess.run()
@@ -317,7 +393,7 @@ describe('ChildProcess', async function () {
                 const batchFile = path.join(tempFolder, 'test-script.bat')
                 writeBatchFileWithDelays(batchFile)
 
-                const childProcess = new ChildProcess(true, batchFile)
+                const childProcess = new ChildProcess(batchFile)
 
                 // `await` is intentionally not used, we want to check the process while it runs.
                 childProcess.run()
@@ -336,7 +412,7 @@ describe('ChildProcess', async function () {
                 const scriptFile = path.join(tempFolder, 'test-script.sh')
                 writeShellFileWithDelays(scriptFile)
 
-                const childProcess = new ChildProcess(true, 'sh', {}, scriptFile)
+                const childProcess = new ChildProcess('sh', [scriptFile])
 
                 // `await` is intentionally not used, we want to check the process while it runs.
                 childProcess.run()
@@ -351,7 +427,7 @@ describe('ChildProcess', async function () {
                 const scriptFile = path.join(tempFolder, 'test-script.sh')
                 writeShellFileWithDelays(scriptFile)
 
-                const childProcess = new ChildProcess(true, scriptFile)
+                const childProcess = new ChildProcess(scriptFile)
 
                 // `await` is intentionally not used, we want to check the process while it runs.
                 childProcess.run()
@@ -366,8 +442,8 @@ describe('ChildProcess', async function () {
         } // END Unix-only tests
     })
 
-    function writeBatchFile(filename: string): void {
-        fs.writeFileSync(filename, '@echo hi')
+    function writeBatchFile(filename: string, contents?: string): void {
+        fs.writeFileSync(filename, contents ?? '@echo hi')
     }
 
     function writeBatchFileWithDelays(filename: string): void {
@@ -382,8 +458,8 @@ describe('ChildProcess', async function () {
         fs.writeFileSync(filename, `@echo OFF${os.EOL}echo hi`)
     }
 
-    function writeShellFile(filename: string): void {
-        fs.writeFileSync(filename, 'echo hi')
+    function writeShellFile(filename: string, contents?: string): void {
+        fs.writeFileSync(filename, contents ?? 'echo hi')
         fs.chmodSync(filename, 0o744)
     }
 

--- a/src/test/shared/utilities/childProcess.test.ts
+++ b/src/test/shared/utilities/childProcess.test.ts
@@ -362,6 +362,20 @@ describe('ChildProcess', async function () {
                 assert.notStrictEqual(childProcess.result()?.error, undefined)
             })
 
+            it('still runs if the timer completed (not rejected) after starting', async function () {
+                const timer = new Timeout(10)
+                setTimeout(() => timer.complete())
+                await childProcess.run({
+                    stopOnError: true,
+                    waitForStreams: false,
+                    onStdout() {
+                        this.reportError('Got stuff')
+                    },
+                })
+
+                assert.strictEqual(childProcess.result()?.error?.message, 'Got stuff')
+            })
+
             it('rejects if using a completed timer', async function () {
                 const timer = new Timeout(10)
                 timer.complete()

--- a/src/test/shared/utilities/childProcess.test.ts
+++ b/src/test/shared/utilities/childProcess.test.ts
@@ -325,9 +325,8 @@ describe('ChildProcess', async function () {
                 )
             })
 
-            it('can kill the process if `stopOnError` is set', async function () {
+            it('kills the process if an error is reported', async function () {
                 const result = await childProcess.run({
-                    stopOnError: true,
                     waitForStreams: false,
                     onStdout: (text, context) => {
                         context.reportError('An error')
@@ -339,7 +338,6 @@ describe('ChildProcess', async function () {
             it('can merge with base options', async function () {
                 const result = await childProcess.run({
                     collect: true,
-                    stopOnError: true,
                     waitForStreams: false,
                     extraArgs: ['4'],
                     onStdout: (text, context) => {
@@ -354,7 +352,6 @@ describe('ChildProcess', async function () {
 
             it('uses `Timeout` objects', async function () {
                 await childProcess.run({
-                    stopOnError: true,
                     waitForStreams: false,
                     timeout: new Timeout(10),
                 })
@@ -366,7 +363,6 @@ describe('ChildProcess', async function () {
                 const timer = new Timeout(10)
                 setTimeout(() => timer.complete())
                 await childProcess.run({
-                    stopOnError: true,
                     waitForStreams: false,
                     onStdout: (text, context) => {
                         context.reportError('Got stuff')


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
The current `ChildProcess` is pretty rigid and doesn't offer a lot of customization despite being used in many modules. It also requires both the command and its arguments up-front rather than waiting until it is ran. This doesn't help much for composition, though it does make the object well-behaved when looking at it in isolation.

## Solution
Re-arrange the constructor arguments for ergonomics. Also make `args` not a rest parameter. Usually if you have optional parameters you don't want a rest parameter as well. Removed the old `run` since all it did was just wrap `start` in a Promise. `run` can now merge in with the base options, allowing for some amount of information hiding that previously was not possible.

Also the process is now killed by default on an error in one of:
1. the process stream
2. the stdout stream
3. the stderr stream

The stdout/stderr streams may bubble up some errors to the process stream so something to keep in mind. This PR just treats them all the same for simplicity, but it could lead to problems if one tries to perform side-effects based off errors (not advised...).

There's a few other things here but it's best to just look at the code. Mainly just allowing callbacks to access a context object for better composition.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
