### PR TITLE
IoT: fix policy editing bug with C9

### DIFF
--- a/src/iot/commands/editPolicyVersion.ts
+++ b/src/iot/commands/editPolicyVersion.ts
@@ -41,7 +41,7 @@ export async function showPolicyContent(
     const prettyPolicyContent = policyFormatter(rawPolicyContent, tabSize)
     const newDoc = await vscode.workspace.openTextDocument({
         language: 'json',
+        content: prettyPolicyContent,
     })
-    const editor = await vscode.window.showTextDocument(newDoc, vscode.ViewColumn.One, false)
-    await editor.edit(edit => edit.insert(new vscode.Position(/*line*/ 0, /*character*/ 0), prettyPolicyContent))
+    await vscode.window.showTextDocument(newDoc, vscode.ViewColumn.One, false)
 }


### PR DESCRIPTION
## Problem
Existing implementation threw `methodNotSupported` exceptions upon performing an edit on a newly created `TextDocument`.

## Solution
Create the `TextDocument` with the desired content directly.

<img width="303" alt="image" src="https://user-images.githubusercontent.com/14608226/142029940-ce1d9bc1-2f35-4b3a-b016-56acd935d410.png">

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
