### PR TITLE
Fix major issues from bug bash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1112,6 +1112,11 @@
                     "group": "inline@1"
                 },
                 {
+                    "command": "aws.iot.createPolicy",
+                    "when": "view == aws.explorer && viewItem == awsIotPoliciesNode",
+                    "group": "inline@1"
+                },
+                {
                     "command": "aws.iot.deletePolicy",
                     "when": "view == aws.explorer && viewItem =~ /^(awsIotPolicyNode.WithVersions)$/",
                     "group": "inline@1"
@@ -1834,10 +1839,6 @@
                 "command": "aws.iot.createPolicyVersion",
                 "title": "%AWS.command.iot.createPolicyVersion%",
                 "category": "%AWS.title%",
-                "icon": {
-                    "light": "resources/light/plus.svg",
-                    "dark": "resources/dark/plus.svg"
-                },
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"

--- a/src/iot/commands/createCert.ts
+++ b/src/iot/commands/createCert.ts
@@ -4,14 +4,13 @@
  */
 
 import * as vscode from 'vscode'
-import * as localizedText from '../../shared/localizedText'
 import * as fs from 'fs-extra'
 import * as path from 'path'
 import { getLogger } from '../../shared/logger'
 import { Commands } from '../../shared/vscode/commands'
 import { Window } from '../../shared/vscode/window'
 import { localize } from '../../shared/utilities/vsCodeUtils'
-import { showViewLogsMessage, showConfirmationMessage } from '../../shared/utilities/messages'
+import { showViewLogsMessage } from '../../shared/utilities/messages'
 import { IotCertsFolderNode } from '../explorer/iotCertFolderNode'
 import { fileExists } from '../../shared/filesystemUtilities'
 import { Iot } from 'aws-sdk'
@@ -30,19 +29,6 @@ export async function createCertificateCommand(
     commands = Commands.vscode()
 ): Promise<void> {
     getLogger().debug('CreateCertificate called for %O', node)
-
-    const isConfirmed = await showConfirmationMessage(
-        {
-            prompt: localize('AWS.iot.createCert.prompt', 'Create a new X.509 certificate and RSA key pair?'),
-            confirm: localize('AWS.iot.createCert.confirm', 'Confirm'),
-            cancel: localizedText.cancel,
-        },
-        window
-    )
-    if (!isConfirmed) {
-        getLogger().info('CreateCertificate canceled')
-        return
-    }
 
     const folderLocation = await promptFunc(window)
     if (!folderLocation) {

--- a/src/iot/commands/createPolicy.ts
+++ b/src/iot/commands/createPolicy.ts
@@ -25,6 +25,7 @@ export async function createPolicyCommand(
     const policyName = await window.showInputBox({
         prompt: localize('AWS.iot.createPolicy.prompt', 'Enter a new policy name'),
         placeHolder: localize('AWS.iot.createPolicy.placeHolder', 'Policy Name'),
+        validateInput: validatePolicyName,
     })
 
     if (!policyName) {
@@ -77,4 +78,25 @@ export async function getPolicyDocument(window: Window): Promise<Buffer | undefi
     }
 
     return data
+}
+
+/**
+ * Validates a Policy name for the CreatePolicy API. See
+ * https://docs.aws.amazon.com/iot/latest/apireference/API_CreatePolicy.html
+ * for more information. Pattern: `[\w+=,.@-]+`.
+ */
+function validatePolicyName(name: string): string | undefined {
+    if (name.length < 1 || name.length > 128) {
+        return localize(
+            'AWS.iot.validatePolicyName.error.invalidLength',
+            'Policy name must be between 1 and 128 characters long'
+        )
+    }
+    if (!/^[\w+=,.@-]+$/.test(name)) {
+        return localize(
+            'AWS.iot.validatePolicyName.error.invalidCharacters',
+            "Policy name must only contain characters that are alphanumeric, or one of the following symbols: '+', '=', ',', '.', '@', '-'"
+        )
+    }
+    return undefined
 }

--- a/src/iot/commands/createThing.ts
+++ b/src/iot/commands/createThing.ts
@@ -27,6 +27,7 @@ export async function createThingCommand(
     const thingName = await window.showInputBox({
         prompt: localize('AWS.iot.createThing.prompt', 'Enter a new Thing name'),
         placeHolder: localize('AWS.iot.createThing.placeHolder', 'Thing Name'),
+        validateInput: validateThingName,
     })
 
     if (!thingName) {
@@ -47,4 +48,25 @@ export async function createThingCommand(
 
     //Refresh the Things Folder node
     await node.refreshNode(commands)
+}
+
+/**
+ * Validates a Thing name for the CreateThing API. See
+ * https://docs.aws.amazon.com/iot/latest/apireference/API_CreateThing.html
+ * for more information. Pattern: `[a-zA-Z0-9:_-]+`.
+ */
+function validateThingName(name: string): string | undefined {
+    if (name.length < 1 || name.length > 128) {
+        return localize(
+            'AWS.iot.validateThingName.error.invalidLength',
+            'Thing name must be between 1 and 128 characters long'
+        )
+    }
+    if (!/^[a-zA-Z0-9:_-]+$/.test(name)) {
+        return localize(
+            'AWS.iot.validateThingName.error.invalidCharacters',
+            'Thing name must only contain alphanumeric characters, hyphens, underscores, or colons'
+        )
+    }
+    return undefined
 }

--- a/src/test/iot/commands/createCert.test.ts
+++ b/src/test/iot/commands/createCert.test.ts
@@ -49,11 +49,9 @@ describe('createCertificateCommand', function () {
     it('prompts for save location, creates certificate, and saves to filesystem', async function () {
         when(iot.createCertificateAndKeys(deepEqual({ setAsActive: false }))).thenResolve(certificate)
 
-        const window = new FakeWindow({ message: { warningSelection: 'Confirm' } })
+        const window = new FakeWindow()
         const commands = new FakeCommands()
         await createCertificateCommand(node, promptFolder, saveFiles, window, commands)
-
-        assert.strictEqual(window.message.warning, 'Create a new X.509 certificate and RSA key pair?')
 
         assert.strictEqual(window.message.information, 'Created certificate new-certificate')
 
@@ -63,18 +61,9 @@ describe('createCertificateCommand', function () {
         assert.deepStrictEqual(commands.args, [node])
     })
 
-    it('does nothing when creation is canceled', async function () {
-        const window = new FakeWindow({ message: { warningSelection: 'Cancel' } })
-        const commands = new FakeCommands()
-        await createCertificateCommand(node, promptFolder, saveFiles, window, commands)
-
-        verify(iot.createCertificateAndKeys(anything())).never()
-        assert.strictEqual(commands.command, undefined)
-    })
-
     it('does nothing when no save folder is selected', async function () {
         saveLocation = undefined
-        const window = new FakeWindow({ message: { warningSelection: 'Confirm' } })
+        const window = new FakeWindow()
         const commands = new FakeCommands()
         await createCertificateCommand(node, promptFolder, saveFiles, window, commands)
 
@@ -85,7 +74,7 @@ describe('createCertificateCommand', function () {
     it('shows an error message if creating certificate fails', async function () {
         when(iot.createCertificateAndKeys(anything())).thenReject(new Error('Expected failure'))
 
-        const window = new FakeWindow({ message: { warningSelection: 'Confirm' } })
+        const window = new FakeWindow()
         const commands = new FakeCommands()
         await createCertificateCommand(node, promptFolder, saveFiles, window, commands)
 
@@ -97,7 +86,7 @@ describe('createCertificateCommand', function () {
     it('shows an error message if created certificate is invalid', async function () {
         when(iot.createCertificateAndKeys(deepEqual({ setAsActive: false }))).thenResolve({})
 
-        const window = new FakeWindow({ message: { warningSelection: 'Confirm' } })
+        const window = new FakeWindow()
         const commands = new FakeCommands()
         await createCertificateCommand(node, promptFolder, saveFiles, window, commands)
 
@@ -110,7 +99,7 @@ describe('createCertificateCommand', function () {
         when(iot.createCertificateAndKeys(deepEqual({ setAsActive: false }))).thenResolve(certificate)
         saveSuccess = false
 
-        const window = new FakeWindow({ message: { warningSelection: 'Confirm' } })
+        const window = new FakeWindow()
         const commands = new FakeCommands()
         await createCertificateCommand(node, promptFolder, saveFiles, window, commands)
 
@@ -124,7 +113,7 @@ describe('createCertificateCommand', function () {
         when(iot.deleteCertificate(anything())).thenReject(new Error('Expected failure'))
         saveSuccess = false
 
-        const window = new FakeWindow({ message: { warningSelection: 'Confirm' } })
+        const window = new FakeWindow()
         const commands = new FakeCommands()
         await createCertificateCommand(node, promptFolder, saveFiles, window, commands)
 

--- a/src/test/iot/commands/createPolicy.test.ts
+++ b/src/test/iot/commands/createPolicy.test.ts
@@ -58,7 +58,7 @@ describe('createPolicyCommand', function () {
         verify(iot.createPolicy(anything())).never()
     })
 
-    it('warns when thing name has invalid length', async function () {
+    it('warns when policy name has invalid length', async function () {
         const window = new FakeWindow({ inputBox: { input: '' } })
         const commands = new FakeCommands()
         await createPolicyCommand(node, getPolicy, window, commands)
@@ -66,7 +66,7 @@ describe('createPolicyCommand', function () {
         assert.strictEqual(window.inputBox.errorMessage, 'Policy name must be between 1 and 128 characters long')
     })
 
-    it('warns when thing name is invalid', async function () {
+    it('warns when policy name has invalid characters', async function () {
         const window = new FakeWindow({ inputBox: { input: 'illegal/characters' } })
         const commands = new FakeCommands()
         await createPolicyCommand(node, getPolicy, window, commands)

--- a/src/test/iot/commands/createPolicy.test.ts
+++ b/src/test/iot/commands/createPolicy.test.ts
@@ -58,6 +58,25 @@ describe('createPolicyCommand', function () {
         verify(iot.createPolicy(anything())).never()
     })
 
+    it('warns when thing name has invalid length', async function () {
+        const window = new FakeWindow({ inputBox: { input: '' } })
+        const commands = new FakeCommands()
+        await createPolicyCommand(node, getPolicy, window, commands)
+
+        assert.strictEqual(window.inputBox.errorMessage, 'Policy name must be between 1 and 128 characters long')
+    })
+
+    it('warns when thing name is invalid', async function () {
+        const window = new FakeWindow({ inputBox: { input: 'illegal/characters' } })
+        const commands = new FakeCommands()
+        await createPolicyCommand(node, getPolicy, window, commands)
+
+        assert.strictEqual(
+            window.inputBox.errorMessage,
+            "Policy name must only contain characters that are alphanumeric, or one of the following symbols: '+', '=', ',', '.', '@', '-'"
+        )
+    })
+
     it('does nothing when policy document is not read', async function () {
         returnUndefined = true
         const window = new FakeWindow({ inputBox: { input: policyName } })

--- a/src/test/iot/commands/createThing.test.ts
+++ b/src/test/iot/commands/createThing.test.ts
@@ -46,6 +46,25 @@ describe('createThingCommand', function () {
         verify(iot.createThing(anything())).never()
     })
 
+    it('warns when thing name has invalid length', async function () {
+        const window = new FakeWindow({ inputBox: { input: '' } })
+        const commands = new FakeCommands()
+        await createThingCommand(node, window, commands)
+
+        assert.strictEqual(window.inputBox.errorMessage, 'Thing name must be between 1 and 128 characters long')
+    })
+
+    it('warns when thing name is invalid', async function () {
+        const window = new FakeWindow({ inputBox: { input: 'illegal/characters' } })
+        const commands = new FakeCommands()
+        await createThingCommand(node, window, commands)
+
+        assert.strictEqual(
+            window.inputBox.errorMessage,
+            'Thing name must only contain alphanumeric characters, hyphens, underscores, or colons'
+        )
+    })
+
     it('shows an error message and refreshes node when thing creation fails', async function () {
         when(iot.createThing(anything())).thenReject(new Error('Expected failure'))
 

--- a/src/test/iot/commands/createThing.test.ts
+++ b/src/test/iot/commands/createThing.test.ts
@@ -54,7 +54,7 @@ describe('createThingCommand', function () {
         assert.strictEqual(window.inputBox.errorMessage, 'Thing name must be between 1 and 128 characters long')
     })
 
-    it('warns when thing name is invalid', async function () {
+    it('warns when thing name has invalid characters', async function () {
         const window = new FakeWindow({ inputBox: { input: 'illegal/characters' } })
         const commands = new FakeCommands()
         await createThingCommand(node, window, commands)


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
* The Policies folder node does not have an `+` to create a policy as the Things and Certificates folders do.
* The user is unnecessarily prompted for confirmation when creating a certificate, and then again when selecting a download location.
* There is no input validation for Thing or Policy names.

## Solution
- [x] Add plus icon to Policies node.
- [x] Remove extraneous confirmation message.
- [x] Add input name validation for Thing and Policy names.


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
