### PR TITLE
Add IoT Explorer to quickstart

### DIFF
--- a/README.quickstart.cloud9.md
+++ b/README.quickstart.cloud9.md
@@ -13,6 +13,7 @@ See [Get help](#get-help) for support.
     -   CloudFormation stacks
     -   [CloudWatch Logs](https://docs.aws.amazon.com/cloud9/latest/user-guide/cloudwatch-logs-toolkit.html)
     -   ECR
+    -   IoT explorer
     -   Lambda functions
     -   S3 explorer
 -   [AWS Serverless Applications (SAM)](#sam-and-lambda)

--- a/README.quickstart.vscode.md
+++ b/README.quickstart.vscode.md
@@ -14,6 +14,7 @@ See [Setup](#additional-setup-steps) for installation requirements, or [Get help
     -   CloudWatch Logs
     -   ECR
     -   EventBridge schemas
+    -   IoT explorer
     -   Lambda functions
     -   S3 explorer
     -   Step Functions

--- a/README.quickstart.vscode.md
+++ b/README.quickstart.vscode.md
@@ -14,7 +14,7 @@ See [Setup](#additional-setup-steps) for installation requirements, or [Get help
     -   CloudWatch Logs
     -   ECR
     -   EventBridge schemas
-    -   IoT explorer
+    -   [IoT explorer](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/iot-start.html)
     -   Lambda functions
     -   S3 explorer
     -   Step Functions


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
- IoT Explorer does not have an entry in the quickstart guide.

## Solution
- Add quickstart entry for IoT Explorer

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
