### PR TITLE
fix(login): stuck at "Connecting..."

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -270,8 +270,6 @@
     "AWS.explorerNode.registry.error": "Error loading registry schema items",
     "AWS.explorerNode.registry.noSchemas": "[No Registry Schemas]",
     "AWS.explorerNode.registry.registryName.Not.Found": "Registry name not found",
-    "AWS.explorerNode.connecting.label": "Connecting...",
-    "AWS.explorerNode.connecting.tooltip": "Connecting...",
     "AWS.explorerNode.signIn": "Connect to {0}...",
     "AWS.explorerNode.signIn.tooltip": "Click here to select credentials for the {0} Toolkit",
     "AWS.explorerNode.error.label": "Failed to load resources (click for logs)",

--- a/src/credentials/activation.ts
+++ b/src/credentials/activation.ts
@@ -77,6 +77,7 @@ export async function loginWithMostRecentCredentials(
         if (await tryConnect(loginCredentialsId, false)) {
             return
         }
+        getLogger().warn('autoconnect: failed to login "%s"', previousCredentialsId)
     }
 
     const providerMap = await manager.getCredentialProviderNames()

--- a/src/credentials/loginManager.ts
+++ b/src/credentials/loginManager.ts
@@ -98,7 +98,7 @@ export class LoginManager {
     /**
      * Removes Credentials from the Toolkit. Essentially the Toolkit becomes "logged out".
      */
-    public async logout(): Promise<void> {
-        await this.awsContext.setCredentials(undefined)
+    public async logout(force?: boolean): Promise<void> {
+        await this.awsContext.setCredentials(undefined, force)
     }
 }

--- a/src/credentials/loginManager.ts
+++ b/src/credentials/loginManager.ts
@@ -69,15 +69,13 @@ export class LoginManager {
         } catch (err) {
             // TODO: don't hardcode logic using error message, have a 'type' field instead
             if (!(err as Error).message.includes('cancel')) {
-                notifyUserInvalidCredentials(args.providerId)
-                getLogger().error(
-                    `Error trying to connect to AWS with Credentials Provider ${asString(
-                        args.providerId
-                    )}. Toolkit will now disconnect from AWS. %O`,
-                    err as Error
-                )
+                const msg = `login: failed to connect with "${asString(args.providerId)}": ${(err as Error).message}`
+                if (!args.passive) {
+                    notifyUserInvalidCredentials(args.providerId)
+                    getLogger().error(msg)
+                }
             } else {
-                getLogger().info(`Cancelled getting credentials from provider: ${asString(args.providerId)}`)
+                getLogger().info(`login: cancelled credentials request from "${asString(args.providerId)}"`)
             }
 
             await this.logout()

--- a/src/shared/awsContext.ts
+++ b/src/shared/awsContext.ts
@@ -59,9 +59,12 @@ export class DefaultAwsContext implements AwsContext {
     /**
      * Sets the credentials to be used by the Toolkit.
      * Passing in undefined represents that there are no active credentials.
+     *
+     * @param credentials  Sets the Toolkit global credentials
+     * @param force  Force emit of "changed" event (useful on startup)
      */
-    public async setCredentials(credentials?: AwsContextCredentials): Promise<void> {
-        if (JSON.stringify(this.currentCredentials) === JSON.stringify(credentials)) {
+    public async setCredentials(credentials?: AwsContextCredentials, force?: boolean): Promise<void> {
+        if (!force && JSON.stringify(this.currentCredentials) === JSON.stringify(credentials)) {
             // Do nothing. Besides performance, this avoids infinite loops.
             return
         }


### PR DESCRIPTION
## Problem
1. For new users (or systems, e.g. a new Cloud9 env) autoconnect is
   skipped if there are multiple profiles.
2. If autoconnect is skipped, AWS Explorer shows "Connecting..." even
   though it is not doing anything.

## Solution
1. On new systems with multiple profiles, try the "default" profile.
2. Set the Explorer text to "Connect to AWS..." if autoconnect fails.

## Testing

- Tested with
    1. zero profiles,
    2. exactly one but no "default",
    3. exactly one "default",
    4. multiple including "default",
    5. multiple but no "default".
- TODO: will add tests for the autoconnect codepaths after migrating to SDK v3.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
