### PR TITLE
feat(autoconnect): try up to 3 non-default profiles

### DIFF
--- a/.changes/next-release/Bug Fix-24b2dcff-9177-4c02-8d75-803abbe08262.json
+++ b/.changes/next-release/Bug Fix-24b2dcff-9177-4c02-8d75-803abbe08262.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Improve auto-connect reliability"
+}

--- a/.changes/next-release/Bug Fix-7427c4fd-dc23-4334-8da1-a18a69290772.json
+++ b/.changes/next-release/Bug Fix-7427c4fd-dc23-4334-8da1-a18a69290772.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Toolkit appeared stuck at \"Connecting...\""
+}

--- a/src/credentials/loginManager.ts
+++ b/src/credentials/loginManager.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { TimeoutError } from '../shared/utilities/timeoutUtils'
 import { AwsContext } from '../shared/awsContext'
 import { getAccountId } from '../shared/credentials/accountId'
 import { getLogger } from '../shared/logger'
@@ -67,8 +68,7 @@ export class LoginManager {
             telemetryResult = 'Succeeded'
             return true
         } catch (err) {
-            // TODO: don't hardcode logic using error message, have a 'type' field instead
-            if (!(err as Error).message.includes('cancel')) {
+            if (!TimeoutError.isCancelled(err)) {
                 const msg = `login: failed to connect with "${asString(args.providerId)}": ${(err as Error).message}`
                 if (!args.passive) {
                     notifyUserInvalidCredentials(args.providerId)

--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -13,6 +13,10 @@ export class TimeoutError extends Error {
     public constructor(public readonly type: 'expired' | 'cancelled') {
         super(type === 'cancelled' ? TIMEOUT_CANCELLED_MESSAGE : TIMEOUT_EXPIRED_MESSAGE)
     }
+
+    public static isCancelled(err: any): err is TimeoutError & { type: 'cancelled' } {
+        return err instanceof TimeoutError && err.type === 'cancelled'
+    }
 }
 
 /**


### PR DESCRIPTION
Followup to #2315

Useful for Cloud9 and other ECS-like envs. Example:

    2021-11-18 17:51:08 [INFO]: autoconnect: trying "profile:default"
    2021-11-18 17:51:09 [WARN]: autoconnect: failed to connect: 'profile:default'
    2021-11-18 17:51:09 [INFO]: autoconnect: trying "profile:sso-test"
    2021-11-18 17:51:09 [INFO]: autoconnect: trying "profile:foo-dev"
    2021-11-18 17:51:10 [INFO]: autoconnect: connected: 'profile:foo-dev'

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem

## Solution

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
