### PR TITLE
CDK: make CDK project detection over 20x faster

### DIFF
--- a/.changes/next-release/Bug Fix-d9deac78-e348-4692-b769-23a939fd68b1.json
+++ b/.changes/next-release/Bug Fix-d9deac78-e348-4692-b769-23a939fd68b1.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "CDK: fixed performance issue with project detection"
+	"description": "CDK: fixed performance issue with project detection. Detection is no longer limited to a depth of two directories."
 }

--- a/.changes/next-release/Bug Fix-d9deac78-e348-4692-b769-23a939fd68b1.json
+++ b/.changes/next-release/Bug Fix-d9deac78-e348-4692-b769-23a939fd68b1.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CDK: fixed performance issue with project detection"
+}

--- a/src/cdk/explorer/detectCdkProjects.ts
+++ b/src/cdk/explorer/detectCdkProjects.ts
@@ -30,7 +30,7 @@ async function detectCdkProjectsFromWorkspaceFolder(
 ): Promise<CdkAppLocation[]> {
     const result = []
     const pattern = new vscode.RelativePattern(workspaceFolder, '**/cdk.json')
-    const cdkJsonFiles = await vscode.workspace.findFiles(pattern)
+    const cdkJsonFiles = await vscode.workspace.findFiles(pattern, '**/node_modules/**')
 
     for await (const cdkJson of cdkJsonFiles) {
         try {


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

Use `vscode.workspace.findFiles` instead of iterating over files.

`detectCdkProjects` went from taking >2000ms to ~50ms on my machine with the Toolkit repository as a fixture.

Oh also the tests for `detectCdkProjects` are an example of _good_ tests (thanks @awschristou !). I was able to change the implementation details without needing to update the tests.

Fixes: #2312

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
