### PR TITLE
Schemas: catch errors for invalid settings configurations

### DIFF
--- a/.changes/next-release/Bug Fix-5b2f31be-37c7-4566-a0e4-3fdbb47fab79.json
+++ b/.changes/next-release/Bug Fix-5b2f31be-37c7-4566-a0e4-3fdbb47fab79.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Schemas: handle errors for invalid settings configurations on activation"
+}

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -203,7 +203,7 @@ export async function getRemoteOrCachedFile(params: {
  * Lifted near-verbatim from the cfn-lint VSCode extension.
  * https://github.com/aws-cloudformation/cfn-lint-visual-studio-code/blob/629de0bac4f36cfc6534e409a6f6766a2240992f/client/src/extension.ts#L56
  */
-function addCustomTags(): void {
+async function addCustomTags(): Promise<void> {
     const settingName = 'yaml.customTags'
     const currentTags = vscode.workspace.getConfiguration().get<string[]>(settingName) ?? []
     if (!Array.isArray(currentTags)) {
@@ -245,7 +245,13 @@ function addCustomTags(): void {
     const missingTags = cloudFormationTags.filter(item => !currentTags.includes(item))
     if (missingTags.length > 0) {
         const updateTags = currentTags.concat(missingTags)
-        vscode.workspace.getConfiguration().update('yaml.customTags', updateTags, vscode.ConfigurationTarget.Global)
+        try {
+            await vscode.workspace
+                .getConfiguration()
+                .update('yaml.customTags', updateTags, vscode.ConfigurationTarget.Global)
+        } catch (err) {
+            getLogger().warn('schemas: failed to add CFN YAML tags: %s', (err as Error).message)
+        }
     }
 }
 
@@ -261,7 +267,7 @@ export class YamlSchemaHandler implements SchemaHandler {
             if (!ext) {
                 return
             }
-            addCustomTags()
+            await addCustomTags()
             this.yamlExtension = ext
         }
 
@@ -323,9 +329,14 @@ function getJsonSettings(workspaceConfig?: vscode.WorkspaceConfiguration): JSONS
     return config.get('schemas') ?? []
 }
 
+// TODO: we should be using a shared settings class for error handling, not accessing the API directly
 async function setJsonSettings(settings: JSONSchemaSettings[], workspaceConfig?: vscode.WorkspaceConfiguration) {
     const config = workspaceConfig ?? vscode.workspace.getConfiguration('json')
-    await config.update('schemas', settings, vscode.ConfigurationTarget.Global)
+    try {
+        await config.update('schemas', settings, vscode.ConfigurationTarget.Global)
+    } catch (err) {
+        getLogger().warn('schemas: failed to update JSON schemas: %s', (err as Error).message)
+    }
 }
 
 function filterJsonSettings(settings: JSONSchemaSettings[], predicate: (fileName: string) => boolean) {


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

We were not catching errors that can occur from updating the settings configuration.

TODO:
Update `SettingsConfiguration` to not be scoped down to only our own settings. We should be using these classes with error handling built-in by default whenever we want side-effects (like messing with settings)

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
