### PR TITLE
S3: fix `uploadFileToParent`

### DIFF
--- a/.changes/next-release/Bug Fix-9305895c-8be2-411d-a84b-086b78787f69.json
+++ b/.changes/next-release/Bug Fix-9305895c-8be2-411d-a84b-086b78787f69.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "S3: fix 'Upload to Parent...' command"
+}

--- a/src/s3/activation.ts
+++ b/src/s3/activation.ts
@@ -34,7 +34,7 @@ export async function activate(ctx: ExtContext): Promise<void> {
         vscode.commands.registerCommand('aws.s3.downloadFileAs', async (node: S3FileNode) => {
             await downloadFileAsCommand(node)
         }),
-        vscode.commands.registerCommand('aws.s3.uploadFile', async (node: S3BucketNode | S3FolderNode) => {
+        vscode.commands.registerCommand('aws.s3.uploadFile', async (node?: S3BucketNode | S3FolderNode) => {
             if (!node) {
                 const awsContext = ctx.awsContext
                 const regionCode = awsContext.getCredentialDefaultRegion()

--- a/src/s3/commands/uploadFileToParent.ts
+++ b/src/s3/commands/uploadFileToParent.ts
@@ -12,5 +12,5 @@ import { S3FileNode } from '../explorer/s3FileNode'
  */
 export async function uploadFileToParentCommand(node: S3FileNode): Promise<void> {
     getLogger().debug('UploadFileToParent called for %O', node)
-    return vscode.commands.executeCommand('aws.s3.uploadFile', [node.parent])
+    return vscode.commands.executeCommand('aws.s3.uploadFile', node.parent)
 }

--- a/src/s3/commands/uploadFileToParent.ts
+++ b/src/s3/commands/uploadFileToParent.ts
@@ -3,14 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as vscode from 'vscode'
 import { getLogger } from '../../shared/logger'
 import { S3FileNode } from '../explorer/s3FileNode'
+import { uploadFileCommand } from './uploadFile'
 
 /**
  * Uploads a file to the parent bucket or folder.
  */
 export async function uploadFileToParentCommand(node: S3FileNode): Promise<void> {
     getLogger().debug('UploadFileToParent called for %O', node)
-    return vscode.commands.executeCommand('aws.s3.uploadFile', node.parent)
+    const parent = node.parent
+    return uploadFileCommand(parent.s3, parent)
 }


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

Fixes issue where 'Upload to Parent...'  does not work.

Using `executeCommand` on commands we register is fragile and should be avoided in general. We lose out on type safety for little benefit. If we _must_ use the commands API then creating interfaces with stricter types is preferred. 

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
