### PR TITLE
Add IoT improvements

### DIFF
--- a/.changes/next-release/Feature-b93e984e-1c2d-4b78-aafe-2e3264c95f45.json
+++ b/.changes/next-release/Feature-b93e984e-1c2d-4b78-aafe-2e3264c95f45.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "IoT: add attached policies in Things subtree"
+}

--- a/package.json
+++ b/package.json
@@ -1149,7 +1149,7 @@
                 },
                 {
                     "command": "aws.iot.attachPolicy",
-                    "when": "view == aws.explorer && viewItem =~ /^awsIotCertificateNode.Policies/",
+                    "when": "view == aws.explorer && viewItem =~ /^awsIotCertificateNode.(Things|Policies)/",
                     "group": "inline@1"
                 },
                 {
@@ -1314,7 +1314,7 @@
                 },
                 {
                     "command": "aws.iot.attachPolicy",
-                    "when": "view == aws.explorer && viewItem =~ /^awsIotCertificateNode.Policies/",
+                    "when": "view == aws.explorer && viewItem =~ /^awsIotCertificateNode.(Things|Policies)/",
                     "group": "0@1"
                 },
                 {

--- a/src/iot/commands/createPolicy.ts
+++ b/src/iot/commands/createPolicy.ts
@@ -95,7 +95,7 @@ function validatePolicyName(name: string): string | undefined {
     if (!/^[\w+=,.@-]+$/.test(name)) {
         return localize(
             'AWS.iot.validatePolicyName.error.invalidCharacters',
-            "Policy name must only contain characters that are alphanumeric, or one of the following symbols: '+', '=', ',', '.', '@', '-'"
+            'Policy name must contain only alphanumeric characters and/or the following: +=.,@-'
         )
     }
     return undefined

--- a/src/iot/commands/createPolicyVersion.ts
+++ b/src/iot/commands/createPolicyVersion.ts
@@ -49,6 +49,6 @@ export async function createPolicyVersionCommand(
         return
     }
 
-    //Refresh the Policy folder node so that this node's children are cleared
-    await node.parent.refreshNode(commands)
+    //Refresh the node
+    node.refresh()
 }

--- a/src/iot/commands/setDefaultPolicy.ts
+++ b/src/iot/commands/setDefaultPolicy.ts
@@ -45,7 +45,5 @@ export async function setDefaultPolicy(
 }
 
 async function refreshBase(node: IotPolicyWithVersionsNode, commands: Commands): Promise<void> {
-    const parent = node.parent
-    parent.clearChildren()
-    return commands.execute('aws.refreshAwsExplorerNode', parent)
+    return commands.execute('aws.refreshAwsExplorerNode', node)
 }

--- a/src/iot/explorer/iotCertFolderNode.ts
+++ b/src/iot/explorer/iotCertFolderNode.ts
@@ -68,7 +68,7 @@ export class IotCertsFolderNode extends AWSTreeNodeBase implements LoadMoreNode 
             response.certificates
                 ?.filter(cert => cert.certificateArn && cert.certificateId && cert.status && cert.creationDate)
                 .map(
-                    cert =>
+                    async cert =>
                         new IotCertWithPoliciesNode(
                             {
                                 arn: cert.certificateArn!,
@@ -77,14 +77,17 @@ export class IotCertsFolderNode extends AWSTreeNodeBase implements LoadMoreNode 
                                 creationDate: cert.creationDate!,
                             },
                             this,
-                            this.iot
+                            this.iot,
+                            await this.iot.listThingsForCert({ principal: cert.certificateArn! })
                         )
                 ) ?? []
+
+        const resolvedCerts = await Promise.all(newCerts)
 
         getLogger().debug(`Loaded certificates: %O`, newCerts)
         return {
             newContinuationToken: response.nextMarker ?? undefined,
-            newChildren: [...newCerts],
+            newChildren: [...resolvedCerts],
         }
     }
 

--- a/src/iot/explorer/iotCertificateNode.ts
+++ b/src/iot/explorer/iotCertificateNode.ts
@@ -31,6 +31,8 @@ const CONTEXT_BASE = 'awsIotCertificateNode'
  * Certificate Folder Node as a parent.
  */
 export abstract class IotCertificateNode extends AWSTreeNodeBase implements AWSResourceNode {
+    private readonly childLoader = new ChildNodeLoader(this, token => this.loadPage(token))
+
     public constructor(
         public readonly certificate: IotCertificate,
         public readonly parent: IotCertsFolderNode | IotThingNode,
@@ -58,47 +60,6 @@ export abstract class IotCertificateNode extends AWSTreeNodeBase implements AWSR
 
     public update(): void {
         return undefined
-    }
-
-    public get arn(): string {
-        return this.certificate.arn
-    }
-
-    public get name(): string {
-        return this.certificate.id
-    }
-
-    public [inspect.custom](): string {
-        return `IotCertificateNode (certificate=${this.certificate.id})`
-    }
-}
-
-export class IotThingCertNode extends IotCertificateNode {
-    public constructor(
-        public readonly certificate: IotCertificate,
-        public readonly parent: IotThingNode,
-        public readonly iot: IotClient,
-        protected readonly workspace = Workspace.vscode()
-    ) {
-        super(certificate, parent, iot, vscode.TreeItemCollapsibleState.None, workspace)
-        this.contextValue = `${CONTEXT_BASE}.Things.${this.certificate.activeStatus}`
-    }
-}
-
-/**
- * Represents an IoT Certificate with the Certificate Folder Node as parent.
- */
-export class IotCertWithPoliciesNode extends IotCertificateNode implements LoadMoreNode {
-    private readonly childLoader = new ChildNodeLoader(this, token => this.loadPage(token))
-
-    public constructor(
-        public readonly certificate: IotCertificate,
-        public readonly parent: IotCertsFolderNode,
-        public readonly iot: IotClient,
-        protected readonly workspace = Workspace.vscode()
-    ) {
-        super(certificate, parent, iot, vscode.TreeItemCollapsibleState.Collapsed, workspace)
-        this.contextValue = `${CONTEXT_BASE}.Policies.${this.certificate.activeStatus}`
     }
 
     public async getChildren(): Promise<AWSTreeNodeBase[]> {
@@ -152,5 +113,44 @@ export class IotCertWithPoliciesNode extends IotCertificateNode implements LoadM
 
     private getMaxItemsPerPage(): number | undefined {
         return this.workspace.getConfiguration('aws').get<number>('iot.maxItemsPerPage')
+    }
+
+    public get arn(): string {
+        return this.certificate.arn
+    }
+
+    public get name(): string {
+        return this.certificate.id
+    }
+
+    public [inspect.custom](): string {
+        return `IotCertificateNode (certificate=${this.certificate.id})`
+    }
+}
+
+export class IotThingCertNode extends IotCertificateNode {
+    public constructor(
+        public readonly certificate: IotCertificate,
+        public readonly parent: IotThingNode,
+        public readonly iot: IotClient,
+        protected readonly workspace = Workspace.vscode()
+    ) {
+        super(certificate, parent, iot, vscode.TreeItemCollapsibleState.Collapsed, workspace)
+        this.contextValue = `${CONTEXT_BASE}.Things.${this.certificate.activeStatus}`
+    }
+}
+
+/**
+ * Represents an IoT Certificate with the Certificate Folder Node as parent.
+ */
+export class IotCertWithPoliciesNode extends IotCertificateNode implements LoadMoreNode {
+    public constructor(
+        public readonly certificate: IotCertificate,
+        public readonly parent: IotCertsFolderNode,
+        public readonly iot: IotClient,
+        protected readonly workspace = Workspace.vscode()
+    ) {
+        super(certificate, parent, iot, vscode.TreeItemCollapsibleState.Collapsed, workspace)
+        this.contextValue = `${CONTEXT_BASE}.Policies.${this.certificate.activeStatus}`
     }
 }

--- a/src/iot/explorer/iotCertificateNode.ts
+++ b/src/iot/explorer/iotCertificateNode.ts
@@ -38,6 +38,7 @@ export abstract class IotCertificateNode extends AWSTreeNodeBase implements AWSR
         public readonly parent: IotCertsFolderNode | IotThingNode,
         public readonly iot: IotClient,
         collapsibleState: vscode.TreeItemCollapsibleState,
+        public readonly things?: string[],
         protected readonly workspace = Workspace.vscode()
     ) {
         //Show only 8 characters in the explorer instead of the full 64. The entire
@@ -45,10 +46,11 @@ export abstract class IotCertificateNode extends AWSTreeNodeBase implements AWSR
         super(certificate.id.substring(0, 8).concat('...'), collapsibleState)
         this.tooltip = localize(
             'AWS.explorerNode.iot.certTooltip',
-            '{0}\nStatus: {1}\nCreated: {2}',
+            '{0}\nStatus: {1}\nCreated: {2}{3}',
             this.certificate.id,
             this.certificate.activeStatus,
-            moment(this.certificate.creationDate).format(LOCALIZED_DATE_FORMAT)
+            moment(this.certificate.creationDate).format(LOCALIZED_DATE_FORMAT),
+            things?.length ?? 0 > 0 ? `\nAttached to: ${things!.join(', ')}` : ''
         )
         this.iconPath = {
             dark: vscode.Uri.file(ext.iconPaths.dark.certificate),
@@ -133,9 +135,10 @@ export class IotThingCertNode extends IotCertificateNode {
         public readonly certificate: IotCertificate,
         public readonly parent: IotThingNode,
         public readonly iot: IotClient,
+        public readonly things?: string[],
         protected readonly workspace = Workspace.vscode()
     ) {
-        super(certificate, parent, iot, vscode.TreeItemCollapsibleState.Collapsed, workspace)
+        super(certificate, parent, iot, vscode.TreeItemCollapsibleState.Collapsed, things, workspace)
         this.contextValue = `${CONTEXT_BASE}.Things.${this.certificate.activeStatus}`
     }
 }
@@ -148,9 +151,10 @@ export class IotCertWithPoliciesNode extends IotCertificateNode implements LoadM
         public readonly certificate: IotCertificate,
         public readonly parent: IotCertsFolderNode,
         public readonly iot: IotClient,
+        public readonly things?: string[],
         protected readonly workspace = Workspace.vscode()
     ) {
-        super(certificate, parent, iot, vscode.TreeItemCollapsibleState.Collapsed, workspace)
+        super(certificate, parent, iot, vscode.TreeItemCollapsibleState.Collapsed, things, workspace)
         this.contextValue = `${CONTEXT_BASE}.Policies.${this.certificate.activeStatus}`
     }
 }

--- a/src/iot/explorer/iotPolicyFolderNode.ts
+++ b/src/iot/explorer/iotPolicyFolderNode.ts
@@ -20,6 +20,12 @@ import { IotPolicyWithVersionsNode } from './iotPolicyNode'
 import { IotNode } from './iotNodes'
 import { Commands } from '../../shared/vscode/commands'
 
+//Length of certificate ID. The certificate ID is the last segment of the ARN.
+const CERT_ID_LENGTH = 64
+
+//Number of digits of the certificate ID to show
+const CERT_PREVIEW_LENGTH = 8
+
 /**
  * Represents the group of all IoT Policies.
  */
@@ -73,7 +79,7 @@ export class IotPolicyFolderNode extends AWSTreeNodeBase implements LoadMoreNode
                             this,
                             this.iot,
                             (await this.iot.listPolicyTargets({ policyName: policy.policyName! })).map(certId =>
-                                certId.substr(certId.length - 8, 8)
+                                certId.substr(certId.length - CERT_ID_LENGTH, CERT_PREVIEW_LENGTH)
                             )
                         )
                 ) ?? []

--- a/src/iot/explorer/iotPolicyNode.ts
+++ b/src/iot/explorer/iotPolicyNode.ts
@@ -31,10 +31,16 @@ export class IotPolicyNode extends AWSTreeNodeBase implements AWSResourceNode {
         public readonly parent: IotPolicyFolderNode | IotCertificateNode,
         public readonly iot: IotClient,
         collapsibleState: vscode.TreeItemCollapsibleState,
+        certs?: string[],
         protected readonly workspace = Workspace.vscode()
     ) {
         super(policy.name, collapsibleState)
-        this.tooltip = policy.name
+        this.tooltip = localize(
+            'AWS.explorerNode.iot.policyToolTip',
+            '{0}{1}',
+            policy.name,
+            certs?.length ?? 0 > 0 ? `\nAttached to: ${certs?.join(', ')}` : ''
+        )
         this.iconPath = {
             dark: vscode.Uri.file(ext.iconPaths.dark.policy),
             light: vscode.Uri.file(ext.iconPaths.light.policy),
@@ -62,7 +68,7 @@ export class IotPolicyCertNode extends IotPolicyNode {
         public readonly iot: IotClient,
         protected readonly workspace = Workspace.vscode()
     ) {
-        super(policy, parent, iot, vscode.TreeItemCollapsibleState.None, workspace)
+        super(policy, parent, iot, vscode.TreeItemCollapsibleState.None, undefined, workspace)
         this.contextValue = 'awsIotPolicyNode.Certificates'
     }
 }
@@ -74,9 +80,10 @@ export class IotPolicyWithVersionsNode extends IotPolicyNode {
         public readonly policy: IotPolicy,
         public readonly parent: IotPolicyFolderNode,
         public readonly iot: IotClient,
+        certs?: string[],
         protected readonly workspace = Workspace.vscode()
     ) {
-        super(policy, parent, iot, vscode.TreeItemCollapsibleState.Collapsed, workspace)
+        super(policy, parent, iot, vscode.TreeItemCollapsibleState.Collapsed, certs, workspace)
         this.contextValue = 'awsIotPolicyNode.WithVersions'
         this.versionNodes = new Map<string, IotPolicyVersionNode>()
     }

--- a/src/iot/explorer/iotPolicyNode.ts
+++ b/src/iot/explorer/iotPolicyNode.ts
@@ -88,6 +88,9 @@ export class IotPolicyWithVersionsNode extends IotPolicyNode {
 
                 return [...this.versionNodes.values()]
             },
+            sort: (a: IotPolicyVersionNode, b: IotPolicyVersionNode) => {
+                return b.version.createDate!.getTime() - a.version.createDate!.getTime()
+            },
             getErrorNode: async (error: Error, logID: number) => new ErrorNode(this, error, logID),
             getNoChildrenPlaceholderNode: async () =>
                 new PlaceholderNode(this, localize('AWS.explorerNode.iot.noVersions', '[No Policy Versions found]')),

--- a/src/iot/explorer/iotPolicyNode.ts
+++ b/src/iot/explorer/iotPolicyNode.ts
@@ -12,7 +12,7 @@ import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 import { Workspace } from '../../shared/vscode/workspace'
 import { inspect } from 'util'
 import { IotPolicyFolderNode } from './iotPolicyFolderNode'
-import { IotCertWithPoliciesNode } from './iotCertificateNode'
+import { IotCertificateNode } from './iotCertificateNode'
 import { IotPolicyVersionNode } from './iotPolicyVersionNode'
 import { makeChildrenNodes } from '../../shared/treeview/treeNodeUtilities'
 import { PlaceholderNode } from '../../shared/treeview/nodes/placeholderNode'
@@ -28,7 +28,7 @@ import { Commands } from '../../shared/vscode/commands'
 export class IotPolicyNode extends AWSTreeNodeBase implements AWSResourceNode {
     public constructor(
         public readonly policy: IotPolicy,
-        public readonly parent: IotPolicyFolderNode | IotCertWithPoliciesNode,
+        public readonly parent: IotPolicyFolderNode | IotCertificateNode,
         public readonly iot: IotClient,
         collapsibleState: vscode.TreeItemCollapsibleState,
         protected readonly workspace = Workspace.vscode()
@@ -58,7 +58,7 @@ export class IotPolicyNode extends AWSTreeNodeBase implements AWSResourceNode {
 export class IotPolicyCertNode extends IotPolicyNode {
     public constructor(
         public readonly policy: IotPolicy,
-        public readonly parent: IotCertWithPoliciesNode,
+        public readonly parent: IotCertificateNode,
         public readonly iot: IotClient,
         protected readonly workspace = Workspace.vscode()
     ) {

--- a/src/iot/explorer/iotPolicyVersionNode.ts
+++ b/src/iot/explorer/iotPolicyVersionNode.ts
@@ -55,8 +55,6 @@ export class IotPolicyVersionNode extends AWSTreeNodeBase implements AWSResource
             version.versionId,
             version.isDefaultVersion ? '*' : ''
         )
-        // View policy by clicking the node in the explorer view
-        this.command = { title: 'View', command: 'aws.iot.viewPolicyVersion', arguments: [this] }
         this.contextValue = 'awsIotPolicyVersionNode.' + (this.isDefault ? 'DEFAULT' : 'NONDEFAULT')
     }
 

--- a/src/iot/explorer/iotPolicyVersionNode.ts
+++ b/src/iot/explorer/iotPolicyVersionNode.ts
@@ -35,6 +35,8 @@ export class IotPolicyVersionNode extends AWSTreeNodeBase implements AWSResource
                 version.isDefaultVersion ? '*' : ''
             )
         )
+        // View policy by clicking the node in the explorer view
+        this.command = { title: 'View', command: 'aws.iot.viewPolicyVersion', arguments: [this] }
         this.update(version)
     }
 

--- a/src/iot/explorer/iotPolicyVersionNode.ts
+++ b/src/iot/explorer/iotPolicyVersionNode.ts
@@ -35,8 +35,6 @@ export class IotPolicyVersionNode extends AWSTreeNodeBase implements AWSResource
                 version.isDefaultVersion ? '*' : ''
             )
         )
-        // View policy by clicking the node in the explorer view
-        this.command = { title: 'View', command: 'aws.iot.viewPolicyVersion', arguments: [this] }
         this.update(version)
     }
 
@@ -51,6 +49,14 @@ export class IotPolicyVersionNode extends AWSTreeNodeBase implements AWSResource
             this.isDefault ? 'DEFAULT\n' : '',
             moment(this.version.createDate).format(LOCALIZED_DATE_FORMAT)
         )
+        this.label = localize(
+            'AWS.explorerNode.iot.versionName',
+            'Version {0}{1}',
+            version.versionId,
+            version.isDefaultVersion ? '*' : ''
+        )
+        // View policy by clicking the node in the explorer view
+        this.command = { title: 'View', command: 'aws.iot.viewPolicyVersion', arguments: [this] }
         this.contextValue = 'awsIotPolicyVersionNode.' + (this.isDefault ? 'DEFAULT' : 'NONDEFAULT')
     }
 

--- a/src/test/iot/commands/attachPolicy.test.ts
+++ b/src/test/iot/commands/attachPolicy.test.ts
@@ -15,6 +15,7 @@ import { FakeCommands } from '../../shared/vscode/fakeCommands'
 import { DataQuickPickItem } from '../../../shared/ui/pickerPrompter'
 import { PromptResult } from '../../../shared/ui/prompter'
 import { Window } from '../../../shared/vscode/window'
+import { IotNode } from '../../../iot/explorer/iotNodes'
 
 describe('attachPolicyCommand', function () {
     const certId = 'iot-certificate'
@@ -37,7 +38,7 @@ describe('attachPolicyCommand', function () {
         iot = mock()
         certNode = new IotCertWithPoliciesNode(
             { id: certId, arn: 'arn', activeStatus: 'ACTIVE', creationDate: new Date() },
-            {} as IotCertsFolderNode,
+            new IotCertsFolderNode(instance(iot), new IotNode(instance(iot))),
             instance(iot)
         )
         policies = [
@@ -54,9 +55,6 @@ describe('attachPolicyCommand', function () {
         await attachPolicyCommand(certNode, prompt, window, commands)
 
         verify(iot.attachPolicy(deepEqual({ policyName: 'policy1', target: 'arn' }))).once()
-
-        assert.strictEqual(commands.command, 'aws.refreshAwsExplorerNode')
-        assert.deepStrictEqual(commands.args, [certNode])
     })
 
     it('shows an error message if policies are not fetched', async function () {

--- a/src/test/iot/commands/createPolicy.test.ts
+++ b/src/test/iot/commands/createPolicy.test.ts
@@ -73,7 +73,7 @@ describe('createPolicyCommand', function () {
 
         assert.strictEqual(
             window.inputBox.errorMessage,
-            "Policy name must only contain characters that are alphanumeric, or one of the following symbols: '+', '=', ',', '.', '@', '-'"
+            'Policy name must contain only alphanumeric characters and/or the following: +=.,@-'
         )
     })
 

--- a/src/test/iot/commands/createPolicyVersion.test.ts
+++ b/src/test/iot/commands/createPolicyVersion.test.ts
@@ -48,9 +48,6 @@ describe('createPolicyVersionCommand', function () {
         assert.strictEqual(window.message.information, 'Created new version of test-policy')
 
         verify(iot.createPolicyVersion(deepEqual({ policyName, policyDocument, setAsDefault: true }))).once()
-
-        assert.strictEqual(commands.command, 'aws.refreshAwsExplorerNode')
-        assert.deepStrictEqual(commands.args, [parentNode])
     })
 
     it('does nothing when policy document is not read', async function () {
@@ -59,7 +56,6 @@ describe('createPolicyVersionCommand', function () {
         await createPolicyVersionCommand(node, getPolicy, window, commands)
 
         verify(iot.createPolicyVersion(anything())).never()
-        assert.strictEqual(commands.command, undefined)
     })
 
     it('shows an error message when JSON is invalid', async function () {
@@ -71,8 +67,6 @@ describe('createPolicyVersionCommand', function () {
         assert.ok(window.message.error?.includes('Failed to create new version of test-policy'))
 
         verify(iot.createPolicyVersion(anything())).never()
-
-        assert.strictEqual(commands.command, undefined)
     })
 
     it('shows an error message if creating version fails', async function () {
@@ -83,7 +77,5 @@ describe('createPolicyVersionCommand', function () {
         await createPolicyVersionCommand(node, getPolicy, window, commands)
 
         assert.ok(window.message.error?.includes('Failed to create new version of test-policy'))
-
-        assert.strictEqual(commands.command, undefined)
     })
 })

--- a/src/test/iot/commands/detachPolicy.test.ts
+++ b/src/test/iot/commands/detachPolicy.test.ts
@@ -12,6 +12,7 @@ import { IotClient } from '../../../shared/clients/iotClient'
 import { FakeCommands } from '../../shared/vscode/fakeCommands'
 import { FakeWindow } from '../../shared/vscode/fakeWindow'
 import { anything, mock, instance, when, deepEqual, verify } from '../../utilities/mockito'
+import { IotNode } from '../../../iot/explorer/iotNodes'
 
 describe('detachPolicyCommand', function () {
     const policyName = 'test-policy'
@@ -24,7 +25,7 @@ describe('detachPolicyCommand', function () {
         iot = mock()
         parentNode = new IotCertWithPoliciesNode(
             { id: 'id', arn: target, activeStatus: 'ACTIVE', creationDate: new Date() },
-            {} as IotCertsFolderNode,
+            new IotCertsFolderNode(instance(iot), new IotNode(instance(iot))),
             instance(iot)
         )
         node = new IotPolicyCertNode({ name: policyName, arn: 'arn' }, parentNode, instance(iot))
@@ -38,9 +39,6 @@ describe('detachPolicyCommand', function () {
         assert.strictEqual(window.message.warning, 'Are you sure you want to detach policy test-policy?')
 
         verify(iot.detachPolicy(deepEqual({ policyName, target }))).once()
-
-        assert.strictEqual(commands.command, 'aws.refreshAwsExplorerNode')
-        assert.deepStrictEqual(commands.args, [parentNode])
     })
 
     it('does nothing when cancelled', async function () {
@@ -58,8 +56,5 @@ describe('detachPolicyCommand', function () {
         await detachPolicyCommand(node, window, commands)
 
         assert.ok(window.message.error?.includes('Failed to detach test-policy'))
-
-        assert.strictEqual(commands.command, 'aws.refreshAwsExplorerNode')
-        assert.deepStrictEqual(commands.args, [parentNode])
     })
 })

--- a/src/test/iot/commands/setDefaultPolicy.test.ts
+++ b/src/test/iot/commands/setDefaultPolicy.test.ts
@@ -14,7 +14,7 @@ import { FakeCommands } from '../../shared/vscode/fakeCommands'
 import { FakeWindow } from '../../shared/vscode/fakeWindow'
 import { anything, mock, instance, when, deepEqual, verify } from '../../utilities/mockito'
 
-describe('copyEndpointCommand', function () {
+describe('setDefaultPolicy', function () {
     const policyName = 'test-policy'
     let iot: IotClient
     let node: IotPolicyVersionNode

--- a/src/test/iot/explorer/iotCertFolderNode.test.ts
+++ b/src/test/iot/explorer/iotCertFolderNode.test.ts
@@ -46,6 +46,7 @@ describe('IotCertFolderNode', function () {
                 certificates: [cert],
                 nextMarker: undefined,
             })
+            when(iot.listThingsForCert(deepEqual({ principal: 'arn' }))).thenResolve([])
 
             const workspace = new FakeWorkspace({
                 section: 'aws',
@@ -63,6 +64,7 @@ describe('IotCertFolderNode', function () {
                 certificates: [cert],
                 nextMarker,
             })
+            when(iot.listPolicyTargets(deepEqual({ policyName: 'policy' }))).thenResolve([])
 
             const workspace = new FakeWorkspace({
                 section: 'aws',

--- a/src/test/iot/explorer/iotCertificateNode.test.ts
+++ b/src/test/iot/explorer/iotCertificateNode.test.ts
@@ -50,7 +50,13 @@ describe('IotCertificateNode', function () {
                 section: 'aws',
                 configuration: { key: 'iot.maxItemsPerPage', value: pageSize },
             })
-            const node = new IotCertWithPoliciesNode(cert, {} as IotCertsFolderNode, instance(iot), workspace)
+            const node = new IotCertWithPoliciesNode(
+                cert,
+                {} as IotCertsFolderNode,
+                instance(iot),
+                undefined,
+                workspace
+            )
             const [policyNode, ...otherNodes] = await node.getChildren()
 
             assertPolicyNode(policyNode, expectedPolicy)
@@ -69,7 +75,13 @@ describe('IotCertificateNode', function () {
                 section: 'aws',
                 configuration: { key: 'iot.maxItemsPerPage', value: pageSize },
             })
-            const node = new IotCertWithPoliciesNode(cert, {} as IotCertsFolderNode, instance(iot), workspace)
+            const node = new IotCertWithPoliciesNode(
+                cert,
+                {} as IotCertsFolderNode,
+                instance(iot),
+                undefined,
+                workspace
+            )
             const [policyNode, moreResultsNode, ...otherNodes] = await node.getChildren()
 
             assertPolicyNode(policyNode, expectedPolicy)

--- a/src/test/iot/explorer/iotPolicyFolderNode.test.ts
+++ b/src/test/iot/explorer/iotPolicyFolderNode.test.ts
@@ -41,6 +41,7 @@ describe('IotPolicyFolderNode', function () {
                 policies: [policy],
                 nextMarker: undefined,
             })
+            when(iot.listPolicyTargets(deepEqual({ policyName: 'policy' }))).thenResolve([])
 
             const workspace = new FakeWorkspace({
                 section: 'aws',
@@ -58,6 +59,7 @@ describe('IotPolicyFolderNode', function () {
                 policies: [policy],
                 nextMarker,
             })
+            when(iot.listPolicyTargets(deepEqual({ policyName: 'policy' }))).thenResolve([])
 
             const workspace = new FakeWorkspace({
                 section: 'aws',

--- a/src/test/iot/explorer/iotPolicyNode.test.ts
+++ b/src/test/iot/explorer/iotPolicyNode.test.ts
@@ -48,6 +48,7 @@ describe('IotPolicyNode', function () {
                 expectedPolicy,
                 {} as IotPolicyFolderNode,
                 instance(iot),
+                undefined,
                 workspace
             )
             const [policyVersionNode, ...otherNodes] = await node.getChildren()


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
This addresses some concerns and suggestions from the bug bash prior to the release of the IoT explorer:
* Policies attached to certs are not visible in the **Things** subtree, making it hard to see the policies applied to a Thing.
* In the **Certificates** subtree, the user is unable to see to what Things a certificate is attached until the user tries to delete the cert. Same for policies in the **Policies** subtree.
* The policy document would be easier to view if it appeared when clicking the node, instead of having to right click and select it from the context menu.

## Solution
- [x] Made attached policies viewable in **Things** subtree
- [x] Added list of attached things/certs viewable when hovering over the cert/policy.
- [ ] Triggered the "view policy" command when clicking on the policy version node. However, this did not seem ideal since accidentally clicking the node multiple times in succession opens multiple editor tabs, so it might be better to just leave it. The change was reverted.

Additionally, the following changes and cleanups were made:
* Sort the policy version nodes to allow using the available `.refresh()` on the parent node instead of having to define a new refresh command that clears its children every time.
* Rephrase the validation message when creating a policy to a shorter one that is more similar with what is shown in the AWS Console.
* Fix some typos.

Remaining work/suggestions from bug bash:
* Prompt user to type thing name when trying to delete thing. This is consistent with the AWS Console and for how this toolkit handles deleting S3 buckets.
* Suggest currently open file when uploading a new policy document instead of immediately opening the file explorer. This is similar to what is done for S3's file upload
* Refactor the use of `LoadMoreNode`s for attachments to the `updateInPlace()` scheme that's prevalently used. While there may be hundreds of Things/Certificates/Policies in an account, an individual Thing ideally should only have one attached cert.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
