### PR TITLE
ECS exec: enable/disable notification

### DIFF
--- a/src/ecs/commands/updateEnableExecuteCommandFlag.ts
+++ b/src/ecs/commands/updateEnableExecuteCommandFlag.ts
@@ -38,6 +38,9 @@ export async function updateEnableExecuteCommandFlag(
     const redundantActionMessage = enable
         ? localize('AWS.command.ecs.enableEcsExec.alreadyEnabled', 'ECS Exec is already enabled for this service')
         : localize('AWS.command.ecs.enableEcsExec.alreadyDisabled', 'ECS Exec is already disabled for this service')
+    const updatingServiceMessage = enable
+        ? localize('AWS.ecs.updateService.enable', 'Enabling ECS Exec for service: {0}', node.service.serviceName)
+        : localize('AWS.ecs.updateService.disable', 'Disabling ECS Exec for service: {0}', node.service.serviceName)
 
     let result: 'Succeeded' | 'Failed' | 'Cancelled'
     if (enable === hasExecEnabled) {
@@ -58,7 +61,8 @@ export async function updateEnableExecuteCommandFlag(
         await node.ecs.updateService(node.service.clusterArn!, node.name, enable)
         result = 'Succeeded'
         node.parent.clearChildren()
-        commands.execute('aws.refreshAwsExplorerNode', node.parent)
+        node.parent.refresh()
+        window.showInformationMessage(updatingServiceMessage)
     } catch (e) {
         result = 'Failed'
         window.showErrorMessage((e as Error).message)


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
* There is no visual indication that the command to enable or disable an ECS service was run.
* The current implementation for refresh after an enable command could potentially not work in Cloud 9.
## Solution
* Add a notification when a service is enabled or disabled.
* Set the parent cluster node to refresh after a enable or disable command.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
