### PR TITLE
telemetry: prerelease build can optionally send metrics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,9 @@ You can also use these NPM tasks (see `npm run` for the full list):
 -   VSCode extensions have a [100MB](https://github.com/Microsoft/vscode-vsce/issues/179) file size limit.
 -   `src/testFixtures/` is excluded in `.vscode/settings.json`, to prevent VSCode
     from treating its files as project files.
+-   The codebase provides [globals](https://github.com/aws/aws-toolkit-vscode/blob/c6ad8ecd602fab64b563519dc2a455ee0b252dde/src/shared/extensionGlobals.ts#L55),
+    which must be used instead of some common javascript globals. In particular, clock-related things like `Date` and `setTimeout`
+    must not be used directly, instead use `globals.clock.Date` and `globals.clock.setTimeout`. [#2343](https://github.com/aws/aws-toolkit-vscode/pull/2343)
 -   VSCode extension examples: <https://github.com/microsoft/vscode-extension-samples>
 -   Tests
     -   Use `function ()` and `async function ()` syntax for `describe()` and `it()` callbacks [instead of arrow functions.](https://mochajs.org/#arrow-functions)
@@ -236,6 +239,12 @@ type defines various developer-only settings that change the behavior of the
 Toolkit for testing and development purposes. To use a setting just add it to
 your `settings.json`. At runtime if the Toolkit reads any of these settings,
 the "AWS" statusbar item will [change its color](https://github.com/aws/aws-toolkit-vscode/blob/d52416408aca7e68ff685137f0fe263581f44cfc/src/credentials/awsCredentialsStatusBarItem.ts#L58).
+
+### Telemetry in prerelease builds
+
+Normally, a non-release VSIX of AWS Toolkit will not send telemetry. Sometimes
+you might want to override this, when sharing a build with a beta-tester
+audience. To enable telemetry to in a non-release build, set [forceTelemetry = true]().
 
 ### AWS SDK generator
 

--- a/build-scripts/package.ts
+++ b/build-scripts/package.ts
@@ -29,14 +29,20 @@ function parseArgs() {
     //   2: foo
 
     const args = {
+        /** Produce an unoptimized VSIX. Include git SHA in version string. */
         debug: false,
     }
+    const givenArgs = process.argv.slice(2)
 
-    if (process.argv[2] === '--debug') {
-        args.debug = true
-    } else if (process.argv[2]) {
-        throw Error(`invalid argument: ${process.argv[2]}`)
+    const validOptions = ['--debug']
+
+    for (const a of givenArgs) {
+        if (!validOptions.includes(a)) {
+            throw Error(`invalid argument: ${a}`)
+        }
     }
+
+    args.debug = givenArgs.includes('--debug')
 
     return args
 }
@@ -46,7 +52,7 @@ function parseArgs() {
  * a prerelease/nightly/edge/preview build.
  */
 function isRelease(): boolean {
-    return (child_process.execSync('git tag -l --contains HEAD').toString() !== '')
+    return child_process.execSync('git tag -l --contains HEAD').toString() !== ''
 }
 
 /**

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -6,6 +6,8 @@
 import { isCloud9 } from './extensionUtilities'
 
 export const extensionSettingsPrefix: string = 'aws'
+/** Enable telemetry, even in a prerelease build. */
+export const forceTelemetry: boolean = false
 export const regionSettingKey: string = 'region'
 export const profileSettingKey: string = 'profile'
 

--- a/src/shared/telemetry/defaultTelemetryClient.ts
+++ b/src/shared/telemetry/defaultTelemetryClient.ts
@@ -14,6 +14,7 @@ import apiConfig = require('./service-2.json')
 import { TelemetryClient } from './telemetryClient'
 import { TelemetryFeedback } from './telemetryFeedback'
 import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
+import * as constants from '../constants'
 import { DefaultSettingsConfiguration } from '../settingsConfiguration'
 import globals from '../extensionGlobals'
 
@@ -40,7 +41,7 @@ export class DefaultTelemetryClient implements TelemetryClient {
             }
 
             if (
-                isReleaseVersion() ||
+                isReleaseVersion(constants.forceTelemetry) ||
                 this.settings.readDevSetting<boolean>('aws.dev.forceTelemetry', 'boolean', true)
             ) {
                 await this.client

--- a/src/shared/vscode/env.ts
+++ b/src/shared/vscode/env.ts
@@ -53,8 +53,8 @@ try {
  * Returns true if the current build is a production build (as opposed to a
  * prerelease/test/nightly build)
  */
-export function isReleaseVersion(): boolean {
-    return !semver.prerelease(extensionVersion) && extensionVersion !== TEST_VERSION
+export function isReleaseVersion(prereleaseOk: boolean = false): boolean {
+    return (prereleaseOk || !semver.prerelease(extensionVersion)) && extensionVersion !== TEST_VERSION
 }
 
 export { extensionVersion }


### PR DESCRIPTION
ref #2361

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem

Some test builds are shared with beta testers where telemetry is wanted.

## Solution

Introduce `constants.forceTelemetry`.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
