### PR TITLE
Telemetry: add way to test what metrics would be emitted

### DIFF
--- a/src/shared/extensionGlobals.ts
+++ b/src/shared/extensionGlobals.ts
@@ -13,6 +13,7 @@ import { CloudFormationTemplateRegistry } from './cloudformation/templateRegistr
 import { RegionProvider } from './regions/regionProvider'
 import { CodelensRootRegistry } from './sam/codelensRootRegistry'
 import { SchemaService } from './schemas'
+import { TelemetryLogger } from './telemetry/telemetryLogger'
 import { TelemetryService } from './telemetry/telemetryService'
 import { Window } from './vscode/window'
 
@@ -68,7 +69,7 @@ interface ToolkitGlobals {
     regionProvider: RegionProvider
     sdkClientBuilder: AWSClientBuilder
     toolkitClientBuilder: ToolkitClientBuilder
-    telemetry: TelemetryService
+    telemetry: TelemetryService & { logger: TelemetryLogger }
     templateRegistry: CloudFormationTemplateRegistry
     schemaService: SchemaService
     codelensRootRegistry: CodelensRootRegistry

--- a/src/shared/logger/index.ts
+++ b/src/shared/logger/index.ts
@@ -5,11 +5,10 @@
 
 // This file is the common import file, intended for use by most extension code.
 // It surfaces Logger and related interfaces, types, and retrieval.
-import * as loggableType from './loggableType'
 import * as logger from './logger'
 export { showLogOutputChannel } from './outputChannel'
 
-export type Loggable = loggableType.Loggable
+export type Loggable = Error | string
 
 export type Logger = logger.Logger
 export type LogLevel = logger.LogLevel

--- a/src/shared/logger/loggableType.ts
+++ b/src/shared/logger/loggableType.ts
@@ -1,9 +1,0 @@
-/*!
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
- * Loggable types: Error, string
- */
-export type Loggable = Error | string

--- a/src/shared/settingsConfiguration.ts
+++ b/src/shared/settingsConfiguration.ts
@@ -20,7 +20,6 @@ export type AwsDevSetting =
     | 'aws.forceCloud9'
     | 'aws.dev.forceTelemetry'
     | 'aws.dev.forceInstallTools'
-    | 'aws.dev.foo'
     | 'aws.dev.telemetryEndpoint'
     | 'aws.dev.telemetryUserPool'
 

--- a/src/shared/settingsConfiguration.ts
+++ b/src/shared/settingsConfiguration.ts
@@ -16,7 +16,13 @@ import globals from './extensionGlobals'
  */
 export type SettingsConfiguration = ClassToInterfaceType<DefaultSettingsConfiguration>
 
-export type AwsDevSetting = 'aws.forceCloud9' | 'aws.dev.forceTelemetry' | 'aws.dev.forceInstallTools' | 'aws.dev.foo'
+export type AwsDevSetting =
+    | 'aws.forceCloud9'
+    | 'aws.dev.forceTelemetry'
+    | 'aws.dev.forceInstallTools'
+    | 'aws.dev.foo'
+    | 'aws.dev.telemetryEndpoint'
+    | 'aws.dev.telemetryUserPool'
 
 type JSPrimitiveTypeName =
     | 'undefined'

--- a/src/shared/telemetry/defaultTelemetryClient.ts
+++ b/src/shared/telemetry/defaultTelemetryClient.ts
@@ -17,20 +17,28 @@ import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
 import { DefaultSettingsConfiguration } from '../settingsConfiguration'
 import globals from '../extensionGlobals'
 
+interface TelemetryConfiguration {
+    readonly endpoint: string
+    readonly identityPool: string
+}
+
 export class DefaultTelemetryClient implements TelemetryClient {
     private static readonly DEFAULT_IDENTITY_POOL = 'us-east-1:820fd6d1-95c0-4ca4-bffb-3f01d32da842'
     private static readonly DEFAULT_TELEMETRY_ENDPOINT = 'https://client-telemetry.us-east-1.amazonaws.com'
     private static readonly PRODUCT_NAME = 'AWS Toolkit For VS Code'
-    private static endpoint: string
-    public static identityPool: string
 
-    static {
+    private static initializeConfig(): TelemetryConfiguration {
         const settings = new DefaultSettingsConfiguration()
-        const userPool = settings.readDevSetting<string>('aws.dev.telemetryUserPool', 'string', true)
+        const identityPool = settings.readDevSetting<string>('aws.dev.telemetryUserPool', 'string', true)
         const endpoint = settings.readDevSetting<string>('aws.dev.telemetryEndpoint', 'string', true)
-        this.identityPool = userPool ?? this.DEFAULT_IDENTITY_POOL
-        this.endpoint = endpoint ?? this.DEFAULT_TELEMETRY_ENDPOINT
+
+        return {
+            endpoint: endpoint ?? this.DEFAULT_TELEMETRY_ENDPOINT,
+            identityPool: identityPool ?? this.DEFAULT_IDENTITY_POOL,
+        }
     }
+
+    public static config = DefaultTelemetryClient.initializeConfig()
 
     private readonly logger = getLogger()
     private readonly settings = new DefaultSettingsConfiguration()
@@ -115,7 +123,7 @@ export class DefaultTelemetryClient implements TelemetryClient {
                     region: region,
                     credentials: credentials,
                     correctClockSkew: true,
-                    endpoint: DefaultTelemetryClient.endpoint,
+                    endpoint: DefaultTelemetryClient.config.endpoint,
                 } as ServiceConfigurationOptions,
                 undefined,
                 false

--- a/src/shared/telemetry/defaultTelemetryClient.ts
+++ b/src/shared/telemetry/defaultTelemetryClient.ts
@@ -18,13 +18,22 @@ import { DefaultSettingsConfiguration } from '../settingsConfiguration'
 import globals from '../extensionGlobals'
 
 export class DefaultTelemetryClient implements TelemetryClient {
-    public static readonly DEFAULT_IDENTITY_POOL = 'us-east-1:820fd6d1-95c0-4ca4-bffb-3f01d32da842'
-    public static readonly DEFAULT_TELEMETRY_ENDPOINT = 'https://client-telemetry.us-east-1.amazonaws.com'
-
+    private static readonly DEFAULT_IDENTITY_POOL = 'us-east-1:820fd6d1-95c0-4ca4-bffb-3f01d32da842'
+    private static readonly DEFAULT_TELEMETRY_ENDPOINT = 'https://client-telemetry.us-east-1.amazonaws.com'
     private static readonly PRODUCT_NAME = 'AWS Toolkit For VS Code'
+    private static endpoint: string
+    public static identityPool: string
+
+    static {
+        const settings = new DefaultSettingsConfiguration()
+        const userPool = settings.readDevSetting<string>('aws.dev.telemetryUserPool', 'string', true)
+        const endpoint = settings.readDevSetting<string>('aws.dev.telemetryEndpoint', 'string', true)
+        this.identityPool = userPool ?? this.DEFAULT_IDENTITY_POOL
+        this.endpoint = endpoint ?? this.DEFAULT_TELEMETRY_ENDPOINT
+    }
 
     private readonly logger = getLogger()
-    private readonly settings = new DefaultSettingsConfiguration('aws')
+    private readonly settings = new DefaultSettingsConfiguration()
 
     private constructor(private readonly clientId: string, private readonly client: ClientTelemetry) {}
 
@@ -106,7 +115,7 @@ export class DefaultTelemetryClient implements TelemetryClient {
                     region: region,
                     credentials: credentials,
                     correctClockSkew: true,
-                    endpoint: DefaultTelemetryClient.DEFAULT_TELEMETRY_ENDPOINT,
+                    endpoint: DefaultTelemetryClient.endpoint,
                 } as ServiceConfigurationOptions,
                 undefined,
                 false

--- a/src/shared/telemetry/defaultTelemetryPublisher.ts
+++ b/src/shared/telemetry/defaultTelemetryPublisher.ts
@@ -80,7 +80,7 @@ export class DefaultTelemetryPublisher implements TelemetryPublisher {
     }
 
     public static async fromDefaultIdentityPool(clientId: string): Promise<IdentityPublisherTuple> {
-        return this.fromIdentityPool(clientId, DefaultTelemetryClient.DEFAULT_IDENTITY_POOL)
+        return this.fromIdentityPool(clientId, DefaultTelemetryClient.identityPool)
     }
 
     /**

--- a/src/shared/telemetry/defaultTelemetryPublisher.ts
+++ b/src/shared/telemetry/defaultTelemetryPublisher.ts
@@ -80,7 +80,7 @@ export class DefaultTelemetryPublisher implements TelemetryPublisher {
     }
 
     public static async fromDefaultIdentityPool(clientId: string): Promise<IdentityPublisherTuple> {
-        return this.fromIdentityPool(clientId, DefaultTelemetryClient.identityPool)
+        return this.fromIdentityPool(clientId, DefaultTelemetryClient.config.identityPool)
     }
 
     /**

--- a/src/shared/telemetry/defaultTelemetryService.ts
+++ b/src/shared/telemetry/defaultTelemetryService.ts
@@ -22,8 +22,6 @@ import { ACCOUNT_METADATA_KEY, AccountStatus, COMPUTE_REGION_KEY } from './telem
 import { TelemetryLogger } from './telemetryLogger'
 import globals from '../extensionGlobals'
 
-type FlushListener = () => void
-
 export class DefaultTelemetryService implements TelemetryService {
     public static readonly TELEMETRY_COGNITO_ID_KEY = 'telemetryId'
     public static readonly TELEMETRY_CLIENT_ID_KEY = 'telemetryClientId'
@@ -36,7 +34,6 @@ export class DefaultTelemetryService implements TelemetryService {
 
     private _flushPeriod: number
     private _timer?: NodeJS.Timer
-    private _listeners: FlushListener[] = []
     private publisher?: TelemetryPublisher
     private readonly _eventQueue: MetricDatum[]
     private readonly _telemetryLogger = new TelemetryLogger()
@@ -100,11 +97,6 @@ export class DefaultTelemetryService implements TelemetryService {
         }
     }
 
-    /** Very basic event register method without a means to dispose of the subscription */
-    public onFlush(listener: FlushListener): void {
-        this._listeners.push(listener)
-    }
-
     public get telemetryEnabled(): boolean {
         return this._telemetryEnabled
     }
@@ -166,7 +158,6 @@ export class DefaultTelemetryService implements TelemetryService {
                 this.publisher.enqueue(...this._eventQueue)
                 await this.publisher.flush()
                 this.clearRecords()
-                this._listeners.forEach(l => l())
             }
         }
     }

--- a/src/shared/telemetry/defaultTelemetryService.ts
+++ b/src/shared/telemetry/defaultTelemetryService.ts
@@ -189,7 +189,7 @@ export class DefaultTelemetryService implements TelemetryService {
             }
 
             // grab our Cognito identityId
-            const poolId = DefaultTelemetryClient.identityPool
+            const poolId = DefaultTelemetryClient.config.identityPool
             const identityMapJson = this.context.globalState.get<string>(
                 DefaultTelemetryService.TELEMETRY_COGNITO_ID_KEY,
                 '[]'

--- a/src/shared/telemetry/defaultTelemetryService.ts
+++ b/src/shared/telemetry/defaultTelemetryService.ts
@@ -137,11 +137,7 @@ export class DefaultTelemetryService implements TelemetryService {
             const actualAwsContext = awsContext || this.awsContext
             const eventWithCommonMetadata = this.injectCommonMetadata(event, actualAwsContext)
             this._eventQueue.push(eventWithCommonMetadata)
-            getLogger().debug(`telemetry: passive=${event.Passive ? 1 : 0} ${event.MetricName}`)
-
-            if (!isReleaseVersion()) {
-                this._telemetryLogger.log(eventWithCommonMetadata)
-            }
+            this._telemetryLogger.log(eventWithCommonMetadata)
         }
     }
 

--- a/src/shared/telemetry/telemetryLogger.ts
+++ b/src/shared/telemetry/telemetryLogger.ts
@@ -1,0 +1,80 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MetricDatum, MetadataEntry } from './clienttelemetry'
+
+interface MetadataQuery {
+    /** Metric name to look up in the log */
+    readonly metricName: string
+    /** Returns the metric containing the metadata instead of just the metadata (default: false) */
+    readonly returnMetric?: boolean
+    /** Attributes to filter out of the metadata */
+    readonly filters?: string[]
+}
+
+interface MetricQuery extends MetadataQuery {
+    readonly returnMetric: true
+}
+
+interface Metadata {
+    [key: string]: string | boolean | undefined
+}
+
+export type Query = MetricQuery | MetadataQuery
+
+/**
+ * Simple class to log queryable metrics.
+ *
+ * Does not track any other telemetry APIs such as feedback.
+ */
+export class TelemetryLogger {
+    private readonly _metrics: MetricDatum[] = []
+
+    public get metricCount(): number {
+        return this._metrics.length
+    }
+
+    public log(...metrics: MetricDatum[]): void {
+        this._metrics.push(...metrics)
+    }
+
+    /**
+     * Queries against the log, returning matched entries.
+     * By default this returns just the metadata, though it can return the entire metric by
+     * setting `selectMetadata` to false.
+     *
+     * **All metadata values are casted to strings by the telemetry client**
+     */
+    public query(query: MetricQuery): MetricDatum[]
+    public query(query: MetadataQuery): Metadata[]
+    public query(query: Query): Metadata[] | MetricDatum[] {
+        const metrics = this._metrics.filter(m => m.MetricName === query.metricName)
+
+        if (!query.returnMetric) {
+            return metrics.map(m => m.Metadata ?? []).map(m => this.mapMetadata(m, query.filters ?? []))
+        }
+
+        return metrics
+    }
+
+    public reset(): void {
+        this._metrics.length = 0
+    }
+
+    private isValidEntry(datum: MetadataEntry): datum is Required<MetadataEntry> {
+        return datum.Key !== undefined && datum.Value !== undefined
+    }
+
+    /**
+     * Telemetry currently sends metadata as an array of key/value pairs, but this is unintuitive for JS
+     */
+    private mapMetadata(metadata: Required<MetricDatum>['Metadata'], filters: string[]): Metadata {
+        const result: Metadata = {}
+        return metadata
+            .filter(this.isValidEntry.bind(this))
+            .filter(a => !filters.includes(a.Key))
+            .reduce((a, b) => ((a[b.Key] = b.Value), a), result)
+    }
+}

--- a/src/shared/telemetry/telemetryLogger.ts
+++ b/src/shared/telemetry/telemetryLogger.ts
@@ -19,7 +19,7 @@ interface MetricQuery extends MetadataQuery {
 }
 
 interface Metadata {
-    [key: string]: string | boolean | undefined
+    [key: string]: string | undefined
 }
 
 export type Query = MetricQuery | MetadataQuery

--- a/src/shared/telemetry/telemetryService.ts
+++ b/src/shared/telemetry/telemetryService.ts
@@ -10,7 +10,6 @@ import { TelemetryFeedback } from './telemetryFeedback'
 export interface TelemetryService {
     telemetryEnabled: boolean
     persistFilePath: string
-    records: ReadonlyArray<MetricDatum>
 
     start(): Promise<void>
     shutdown(): Promise<void>

--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -43,10 +43,6 @@ before(async function () {
     fakeContext.globalStoragePath = (await createTestWorkspaceFolder('globalStoragePath')).uri.fsPath
     initialize(fakeContext, extWindow.Window.vscode())
     initializeIconPaths(fakeContext)
-    const fakeAws = new FakeAwsContext()
-    const fakeTelemetryPublisher = new fakeTelemetry.FakeTelemetryPublisher()
-    const service = new DefaultTelemetryService(fakeContext, fakeAws, undefined, fakeTelemetryPublisher)
-    globals.telemetry = service
     await initializeComputeRegion()
 })
 
@@ -60,6 +56,7 @@ beforeEach(function () {
     globals.templateRegistry = new CloudFormationTemplateRegistry()
     globals.codelensRootRegistry = new CodelensRootRegistry()
     globals.schemaService = new SchemaService(globals.context)
+    globals.telemetry = initTelemetry()
 })
 
 afterEach(function () {
@@ -123,4 +120,14 @@ export function assertLogsContain(text: string, exactMatch: boolean, severity: L
             ),
         `Expected to find "${text}" in the logs as type "${severity}"`
     )
+}
+
+// This reset the global since extension activation will replace our test version at test time.
+function initTelemetry(): DefaultTelemetryService {
+    const fakeAws = new FakeAwsContext()
+    const fakeTelemetryPublisher = new fakeTelemetry.FakeTelemetryPublisher()
+    const service = new DefaultTelemetryService(globals.context, fakeAws, undefined, fakeTelemetryPublisher)
+    service.telemetryEnabled = true
+
+    return service
 }

--- a/src/test/shared/credentials/loginManager.test.ts
+++ b/src/test/shared/credentials/loginManager.test.ts
@@ -12,8 +12,7 @@ import { CredentialsProviderManager } from '../../../credentials/providers/crede
 import { AwsContext } from '../../../shared/awsContext'
 import * as accountId from '../../../shared/credentials/accountId'
 import { CredentialsStore } from '../../../credentials/credentialsStore'
-import { recordAwsValidateCredentials } from '../../../shared/telemetry/telemetry.gen'
-import globals from '../../../shared/extensionGlobals'
+import { assertTelemetryCurried } from '../../testUtil'
 
 describe('LoginManager', async function () {
     let sandbox: sinon.SinonSandbox
@@ -64,20 +63,7 @@ describe('LoginManager', async function () {
         sandbox.restore()
     })
 
-    function assertTelemetry(expected: Parameters<typeof recordAwsValidateCredentials>[0]): void {
-        const passive = expected.passive
-        const query = { metricName: 'aws_validateCredentials', filters: ['awsAccount'] }
-        delete expected['passive']
-
-        const metadata = globals.telemetry.logger.query(query)
-        assert.strictEqual(metadata.length, 1)
-        assert.deepStrictEqual(metadata[0], expected)
-
-        if (passive !== undefined) {
-            const metric = globals.telemetry.logger.query({ ...query, returnMetric: true })
-            assert.strictEqual(metric[0].Passive, passive)
-        }
-    }
+    const assertTelemetry = assertTelemetryCurried('aws_validateCredentials')
 
     it('passive login sends telemetry with passive=true', async function () {
         const passive = true

--- a/src/test/shared/settingsConfiguration.test.ts
+++ b/src/test/shared/settingsConfiguration.test.ts
@@ -242,6 +242,10 @@ describe('DefaultSettingsConfiguration', function () {
         })
 
         it('throws if not production if key does not exist (silent=false)', function () {
+            // Skip for devs who have this flag set as we cannot write to the settings
+            if (sut.readDevSetting<boolean>(TEST_SETTING, 'boolean', true) !== undefined) {
+                this.skip()
+            }
             Object.defineProperty(env, 'isReleaseVersion', { value: () => false })
             assert.throws(() => sut.readDevSetting(TEST_SETTING, 'boolean', false))
         })

--- a/src/test/shared/telemetry/defaultTelemetryPublisher.test.ts
+++ b/src/test/shared/telemetry/defaultTelemetryPublisher.test.ts
@@ -5,10 +5,10 @@
 
 import * as assert from 'assert'
 import AWS = require('aws-sdk')
-import globals from '../../../shared/extensionGlobals'
 import { DefaultTelemetryPublisher } from '../../../shared/telemetry/defaultTelemetryPublisher'
 import { TelemetryClient } from '../../../shared/telemetry/telemetryClient'
 import { TelemetryFeedback } from '../../../shared/telemetry/telemetryFeedback'
+import { fakeMetric } from './defaultTelemetryService.test'
 
 class MockTelemetryClient implements TelemetryClient {
     public feedback?: TelemetryFeedback
@@ -40,21 +40,15 @@ describe('DefaultTelemetryPublisher', function () {
 
     it('enqueues events', function () {
         const publisher = new DefaultTelemetryPublisher('', '', new AWS.Credentials('', ''), new MockTelemetryClient())
-        publisher.enqueue(
-            ...[{ MetricName: 'name', Value: 1, Unit: 'None', EpochTimestamp: new globals.clock.Date().getTime() }]
-        )
+        publisher.enqueue(fakeMetric({ metricName: 'name' }))
         assert.strictEqual(publisher.queue.length, 1)
-        publisher.enqueue(
-            ...[{ MetricName: 'name3', Value: 1, Unit: 'None', EpochTimestamp: new globals.clock.Date().getTime() }]
-        )
+        publisher.enqueue(fakeMetric({ metricName: 'name2' }))
         assert.strictEqual(publisher.queue.length, 2)
     })
 
     it('can flush single event', async function () {
         const publisher = new DefaultTelemetryPublisher('', '', new AWS.Credentials('', ''), new MockTelemetryClient())
-        publisher.enqueue(
-            ...[{ MetricName: 'name', Value: 1, Unit: 'None', EpochTimestamp: new globals.clock.Date().getTime() }]
-        )
+        publisher.enqueue(fakeMetric({ metricName: 'name' }))
 
         assert.strictEqual(publisher.queue.length, 1)
 
@@ -63,9 +57,7 @@ describe('DefaultTelemetryPublisher', function () {
     })
 
     it('retains queue on flush failure', async function () {
-        const batch = [
-            { MetricName: 'name', Value: 1, Unit: 'None', EpochTimestamp: new globals.clock.Date().getTime() },
-        ]
+        const batch = [fakeMetric({ metricName: 'name' })]
         const publisher = new DefaultTelemetryPublisher(
             '',
             '',

--- a/src/test/shared/telemetry/defaultTelemetryService.test.ts
+++ b/src/test/shared/telemetry/defaultTelemetryService.test.ts
@@ -56,12 +56,6 @@ describe('DefaultTelemetryService', function () {
         sandbox.stub(globals, 'telemetry').value(service)
     }
 
-    async function tickFlush() {
-        const flushed = new Promise<void>(r => service.onFlush(r))
-        await clock.tickAsync(testFlushPeriod + 1)
-        await flushed
-    }
-
     before(function () {
         sandbox = sinon.createSandbox()
     })
@@ -126,16 +120,11 @@ describe('DefaultTelemetryService', function () {
         await service.start()
         assert.notStrictEqual(service.timer, undefined)
 
-        await tickFlush()
-        assert.strictEqual(mockPublisher.flushCount, 1)
-        assert.strictEqual(mockPublisher.queue.length, 2)
-
-        service.record(fakeMetric())
+        clock.tick(testFlushPeriod)
         await service.shutdown()
 
-        await tickFlush()
-        assert.strictEqual(mockPublisher.flushCount, 2)
-        assert.strictEqual(mockPublisher.queue.length, 4)
+        assert.strictEqual(mockPublisher.flushCount, 1)
+        assert.strictEqual(mockPublisher.queue.length, 2)
     })
 
     it('events automatically inject the active account id into the metadata', async function () {

--- a/src/test/shared/telemetry/defaultTelemetryService.test.ts
+++ b/src/test/shared/telemetry/defaultTelemetryService.test.ts
@@ -134,7 +134,7 @@ describe('DefaultTelemetryService', function () {
 
         assert.strictEqual(logger.metricCount, 1)
 
-        const metrics = logger.query({ metricName: 'name', returnMetric: true })
+        const metrics = logger.queryFull({ metricName: 'name' })
         assertMetadataContainsTestAccount(metrics[0], DEFAULT_TEST_ACCOUNT_ID)
     })
 
@@ -145,10 +145,10 @@ describe('DefaultTelemetryService', function () {
         await service.shutdown()
 
         assert.strictEqual(logger.metricCount, 2)
-        const startEvents = logger.query({ metricName: 'session_start', returnMetric: true })
+        const startEvents = logger.queryFull({ metricName: 'session_start' })
         assertMetadataContainsTestAccount(startEvents[0], AccountStatus.NotApplicable)
 
-        const shutdownEvents = logger.query({ metricName: 'session_start', returnMetric: true })
+        const shutdownEvents = logger.queryFull({ metricName: 'session_start' })
         assertMetadataContainsTestAccount(shutdownEvents[0], AccountStatus.NotApplicable)
     })
 
@@ -159,7 +159,7 @@ describe('DefaultTelemetryService', function () {
         service.record(fakeMetric({ metricName: 'name' }))
         assert.strictEqual(logger.metricCount, 1)
 
-        const metricDatum = logger.query({ metricName: 'name', returnMetric: true })
+        const metricDatum = logger.queryFull({ metricName: 'name' })
         assertMetadataContainsTestAccount(metricDatum[0], AccountStatus.Invalid)
     })
 
@@ -167,7 +167,7 @@ describe('DefaultTelemetryService', function () {
         service.record(fakeMetric({ metricName: 'name' }))
         assert.strictEqual(logger.metricCount, 1)
 
-        const metricData = logger.query({ metricName: 'name', returnMetric: true })
+        const metricData = logger.queryFull({ metricName: 'name' })
         assertMetadataContainsTestAccount(metricData[0], AccountStatus.NotSet)
     })
 

--- a/src/test/testUtil.ts
+++ b/src/test/testUtil.ts
@@ -9,7 +9,7 @@ import * as fs from 'fs-extra'
 import * as vscode from 'vscode'
 import * as fsextra from 'fs-extra'
 import * as FakeTimers from '@sinonjs/fake-timers'
-
+import * as telemetry from '../shared/telemetry/telemetry'
 import * as pathutil from '../shared/utilities/pathUtils'
 import { makeTemporaryToolkitFolder, tryRemoveFolder } from '../shared/filesystemUtilities'
 import globals from '../shared/extensionGlobals'
@@ -127,3 +127,83 @@ export function installFakeClock(): FakeTimers.InstalledClock {
         shouldAdvanceTime: false,
     })
 }
+
+type Telemetry = Omit<typeof telemetry, 'millisecondsSince'>
+// hard-coded, need significant updates to the codgen to make these kinds of things easier
+type Namespace =
+    | 'vpc'
+    | 'sns'
+    | 'sqs'
+    | 's3'
+    | 'session'
+    | 'schemas'
+    | 'sam'
+    | 'redshift'
+    | 'rds'
+    | 'lambda'
+    | 'aws'
+    | 'ecs'
+    | 'ecr'
+    | 'cdk'
+    | 'apprunner'
+    | 'dynamicresource'
+    | 'toolkit'
+    | 'cloudwatchinsights'
+    | 'iam'
+    | 'ec2'
+    | 'dynamodb'
+    | 'codecommit'
+    | 'cloudwatchlogs'
+    | 'beanstalk'
+    | 'cloudfront'
+    | 'apigateway'
+    | 'vscode'
+type NameFromFunction<T extends keyof Telemetry> = T extends `record${infer P}`
+    ? Uncapitalize<P> extends `${Namespace}${infer L}`
+        ? Uncapitalize<P> extends `${infer N}${L}`
+            ? `${N}_${Uncapitalize<L>}`
+            : never
+        : never
+    : never
+type MetricName = NameFromFunction<keyof Telemetry>
+type FunctionNameFromName<S extends MetricName> = S extends `${infer N}_${infer M}`
+    ? `record${Capitalize<N>}${Capitalize<M>}`
+    : never
+type FunctionFromName<S extends MetricName> = FunctionNameFromName<S> extends keyof Telemetry
+    ? Telemetry[FunctionNameFromName<S>]
+    : never
+type TelemetryMetric<K extends MetricName> = NonNullable<Parameters<FunctionFromName<K>>[0]>
+
+/**
+ * Finds the first emitted telemetry metric with the given name, then checks if the metadata fields
+ * match the expected values.
+ */
+export function assertTelemetry<K extends MetricName>(name: K, expected: TelemetryMetric<K>): void | never {
+    const expectedCopy = { ...(expected as Record<string, unknown>) } as NonNullable<
+        Parameters<Telemetry[keyof Telemetry]>[0]
+    >
+    const passive = expectedCopy?.passive
+    const query = { metricName: name, filters: ['awsAccount'] }
+    delete expectedCopy['passive']
+
+    Object.keys(expectedCopy).forEach(
+        k => ((expectedCopy as Record<string, string>)[k] = (expectedCopy as Record<string, any>)[k]?.toString())
+    )
+
+    const metadata = globals.telemetry.logger.query(query)
+    assert.ok(metadata.length > 0, `Telemetry did not contain any metrics with the name "${name}"`)
+    assert.deepStrictEqual(metadata[0], expectedCopy)
+
+    if (passive !== undefined) {
+        const metric = globals.telemetry.logger.queryFull(query)
+        assert.strictEqual(metric[0].Passive, passive)
+    }
+}
+
+/**
+ * Curried form of {@link assertTelemetry} for when you want partial application.
+ */
+export const assertTelemetryCurried =
+    <K extends MetricName>(name: K) =>
+    (expected: TelemetryMetric<K>) =>
+        assertTelemetry(name, expected)


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Developers cannot easily test telemetry metrics emitted during test execution.

## Solution
Add 'logger' to keep track of recorded metrics. Lots of rough edges still since our telemetry system maps all metadata to strings...
Though I guess it makes sense to leave it as-is because the logger is storing what will actually be sent to out vs. what the module code sent in. Could also add some temporary logic to intercept metrics prior to being mapped, or perhaps just move the mapping logic.

## TODO:
This PR is just the first half for better telemetry inspection. The next half is hooking up the code to Winston.
In release the logger will just use the current behavior, but in dev it'll output more info.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
