### PR TITLE
ECS: bug: only 10 services can described per call

### DIFF
--- a/src/shared/clients/ecsClient.ts
+++ b/src/shared/clients/ecsClient.ts
@@ -14,7 +14,7 @@ export type EcsResourceAndToken = {
     nextToken?: string
 }
 
-const MAX_RESULTS_PER_RESPONSE = 100
+const MAX_RESULTS_PER_RESPONSE = 10
 export class DefaultEcsClient {
     public constructor(public readonly regionCode: string) {}
 


### PR DESCRIPTION


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
#2362 
While listing service arns from a cluster can result in up to
100 service arns, only 10 can be described per SDK call.

## Solution
Set the max requests per list and describe call to 10. Each
page of results will now show up to 10 Clusters/Services.
<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
