### PR TITLE
extensions: lazily activate git

### DIFF
--- a/src/apprunner/wizards/codeRepositoryWizard.ts
+++ b/src/apprunner/wizards/codeRepositoryWizard.ts
@@ -42,10 +42,11 @@ function validateCommand(command: string): string | undefined {
 }
 
 function createRepoPrompter(git: GitExtension): QuickPickPrompter<Remote> {
-    const remotes = git.getRemotes()
+    const mapRemote = (remote: Remote) => ({ label: remote.name, detail: remote.fetchUrl, data: remote })
+    const remotes = git.getRemotes().then(r => r.map(mapRemote))
     const userInputString = localize('AWS.apprunner.createService.customRepo', 'Enter GitHub URL')
-    const items = remotes.map(remote => ({ label: remote.name, detail: remote.fetchUrl, data: remote }))
-    return createQuickPick(items, {
+
+    return createQuickPick(remotes, {
         title: localize('AWS.apprunner.createService.selectRepository.title', 'Select a remote GitHub repository'),
         placeholder: localize(
             'AWS.apprunner.createService.selectRepository.placeholder',

--- a/src/integrationTest/shared/extensions/git.test.ts
+++ b/src/integrationTest/shared/extensions/git.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert'
 import * as bytes from 'bytes'
 import * as vscode from 'vscode'
 import * as GitTypes from '../../../../types/git'
-import { GitExtension, ExtendedRepository } from '../../../shared/extensions/git'
+import { GitExtension, Repository } from '../../../shared/extensions/git'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 import { realpath } from 'fs-extra'
 import { execFileSync } from 'child_process'
@@ -101,7 +101,7 @@ describe('GitExtension', function () {
 
     it('can detect opening a repository', async function () {
         const newRepoUri = vscode.Uri.file(await realpath(await makeTemporaryToolkitFolder()))
-        const onOpen = new Promise<ExtendedRepository>((resolve, reject) => {
+        const onOpen = new Promise<Repository>((resolve, reject) => {
             git.onDidOpenRepository(repo => {
                 if (repo.rootUri.fsPath === newRepoUri.fsPath) {
                     resolve(repo)
@@ -115,7 +115,7 @@ describe('GitExtension', function () {
     })
 
     it('can detect changed branch', async function () {
-        const wrapped = git.repositories.find(r => r.rootUri.fsPath === testRepo.rootUri.fsPath)
+        const wrapped = (await git.getRepositories()).find(r => r.rootUri.fsPath === testRepo.rootUri.fsPath)
         if (!wrapped) {
             throw new Error('Failed to find repository')
         }
@@ -136,7 +136,7 @@ describe('GitExtension', function () {
 
     it('can list remotes and branches', async function () {
         const TARGET_BRANCH = `${TEST_REMOTE_NAME}/${TEST_REMOTE_BRANCH}`
-        const remote = git.getRemotes().find(r => r.name === TEST_REMOTE_NAME)
+        const remote = (await git.getRemotes()).find(r => r.name === TEST_REMOTE_NAME)
         assert.ok(remote, `Did not find "${TEST_REMOTE_NAME}" in list of remotes`)
         await testRepo.fetch({ remote: TEST_REMOTE_NAME, ref: TEST_REMOTE_BRANCH }).catch(parseGitError)
         const branch = (await git.getBranchesForRemote(remote)).find(branch => branch.name === TARGET_BRANCH)


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
We don't want to activate another extension until we need to use it, but we also want to ensure that a method works without having to make a separate call.

## Solution
Check activation promise for every call. Decorators would help reduce boilerplate here if we reuse this pattern elsewhere.
Also just renamed things for consistency.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
