### PR TITLE
Lambda updates wait for Lambda State updates

### DIFF
--- a/src/shared/clients/lambdaClient.ts
+++ b/src/shared/clients/lambdaClient.ts
@@ -87,6 +87,8 @@ export class DefaultLambdaClient {
                 })
                 .promise()
             getLogger().debug('updateFunctionCode returned response: %O', response)
+            await client.waitFor('functionUpdated', { FunctionName: name }).promise()
+
             return response
         } catch (e) {
             getLogger().error('Failed to run updateFunctionCode: %O', e)


### PR DESCRIPTION
Lambda now uses Lambda States to determine whether or not create/update calls are successful. Most of our operations are run through SAM/CFN but we do need to respect the state for direct code updates.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
