### PR TITLE
logging: make log file moved notification more consistent

### DIFF
--- a/src/shared/logger/activation.ts
+++ b/src/shared/logger/activation.ts
@@ -222,7 +222,7 @@ async function createLogWatcher(logPath: string): Promise<vscode.Disposable> {
             return
         }
         checking = true
-        const exists = await fs.pathExists(logPath).catch(() => false)
+        const exists = await fs.pathExists(logPath).catch(() => true)
         if (!exists) {
             vscode.window.showWarningMessage(
                 localize('AWS.log.logFileMove', 'The log file for this session has been moved or deleted.')

--- a/src/shared/logger/activation.ts
+++ b/src/shared/logger/activation.ts
@@ -227,10 +227,10 @@ async function createLogWatcher(logPath: string): Promise<vscode.Disposable> {
             vscode.window.showWarningMessage(
                 localize('AWS.log.logFileMove', 'The log file for this session has been moved or deleted.')
             )
-            watcher?.close()
+            watcher.close()
         }
         checking = false
     })
 
-    return { dispose: () => watcher?.close() }
+    return { dispose: () => watcher.close() }
 }

--- a/src/shared/logger/activation.ts
+++ b/src/shared/logger/activation.ts
@@ -217,6 +217,9 @@ async function createLogWatcher(logPath: string): Promise<vscode.Disposable> {
     }
 
     let checking = false
+    // TODO: fs.watch() has many problems, consider instead:
+    //   - https://github.com/paulmillr/chokidar
+    //   - https://www.npmjs.com/package/fb-watchman
     const watcher = fs.watch(logPath, async eventType => {
         if (checking || eventType !== 'rename') {
             return


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
The deleted log file detection logic seems to be inconsistent, sometimes firing even when the log file was definitely not removed. This is likely due to the `rename` event being fired from more than just file moved/deleted (may be OS specific?).

## Solution
Just check if the file exists after the event is fired.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
