### PR TITLE
credentials: normalize field names

### DIFF
--- a/.changes/next-release/Bug Fix-d771a209-92f1-43fd-b9b7-3585a3112c7b.json
+++ b/.changes/next-release/Bug Fix-d771a209-92f1-43fd-b9b7-3585a3112c7b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Credentials: profile field names no longer need to be all lowercase"
+}

--- a/src/credentials/sharedCredentials.ts
+++ b/src/credentials/sharedCredentials.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as vscode from 'vscode'
 import { join } from 'path'
 import { loadSharedConfigFiles, Profile, SharedConfigFiles } from '../shared/credentials/credentialsFile'
 import { EnvironmentVariables } from '../shared/environmentVariables'
@@ -23,7 +24,11 @@ export function getConfigFilename(): string {
 
 export async function loadSharedCredentialsProfiles(): Promise<Map<string, Profile>> {
     const profiles = new Map<string, Profile>()
-    const profileData = await loadSharedConfigFiles()
+    // These should eventually be changed to use `parse` to allow for credentials from other file systems
+    const profileData = await loadSharedConfigFiles({
+        config: vscode.Uri.file(getConfigFilename()),
+        credentials: vscode.Uri.file(getCredentialsFilename()),
+    })
 
     const profileNames = getAllProfileNames(profileData)
 

--- a/src/shared/credentials/credentialsFile.ts
+++ b/src/shared/credentials/credentialsFile.ts
@@ -99,8 +99,8 @@ function parseIni(iniData: string): ParsedIniData {
         } else if (currentSection) {
             const item = line.match(/^\s*(.+?)\s*=\s*(.+?)\s*$/)
             if (item) {
-                map[currentSection] = map[currentSection] || {}
-                map[currentSection][item[1]] = item[2]
+                const profile = (map[currentSection] ??= {})
+                profile[item[1].toLowerCase()] = item[2]
             }
         }
     }

--- a/src/shared/credentials/credentialsFile.ts
+++ b/src/shared/credentials/credentialsFile.ts
@@ -3,32 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// ***************************************************************************
-// Note: Supplied by the AWS Javascript SDK team, from their upcoming v3 SDK.
-// Once that release is GA and we switch over, we can remove this copy and use
-// their version.
-// ***************************************************************************
+import * as vscode from 'vscode'
 
-import { copy, writeFile } from 'fs-extra'
-import { homedir } from 'os'
-import { join, sep } from 'path'
-import { EnvironmentVariables } from '../environmentVariables'
-import { fileExists, readFileAsString } from '../filesystemUtilities'
-
-export interface SharedConfigInit {
+export interface SharedConfigPaths {
     /**
-     * The path at which to locate the ini credentials file. Defaults to the
-     * value of the `AWS_SHARED_CREDENTIALS_FILE` environment variable (if
-     * defined) or `~/.aws/credentials` otherwise.
+     * The path at which to locate the ini credentials file. No data will be read if not provided.
      */
-    filepath?: string
+    credentials?: vscode.Uri
 
     /**
-     * The path at which to locate the ini config file. Defaults to the value of
-     * the `AWS_CONFIG_FILE` environment variable (if defined) or
-     * `~/.aws/config` otherwise.
+     * The path at which to locate the ini config file. No data will be read if not provided.
      */
-    configFilepath?: string
+    config?: vscode.Uri
 }
 
 export interface Profile {
@@ -36,7 +22,7 @@ export interface Profile {
 }
 
 export interface ParsedIniData {
-    [key: string]: Profile
+    [key: string]: Profile | undefined
 }
 
 export interface SharedConfigFiles {
@@ -44,12 +30,10 @@ export interface SharedConfigFiles {
     configFile: ParsedIniData
 }
 
-export async function loadSharedConfigFiles(init: SharedConfigInit = {}): Promise<SharedConfigFiles> {
+export async function loadSharedConfigFiles(init: SharedConfigPaths = {}): Promise<SharedConfigFiles> {
     const [configFile, credentialsFile] = await Promise.all([
-        /* tslint:disable await-promise */
-        loadConfigFile(init.configFilepath),
-        loadCredentialsFile(init.filepath),
-        /* tslint:enable await-promise */
+        loadConfigFile(init.config),
+        loadCredentialsFile(init.credentials),
     ])
 
     return {
@@ -58,49 +42,30 @@ export async function loadSharedConfigFiles(init: SharedConfigInit = {}): Promis
     }
 }
 
-async function loadConfigFile(configFilePath?: string): Promise<ParsedIniData> {
-    const env = process.env as EnvironmentVariables
-    if (!configFilePath) {
-        configFilePath = env.AWS_CONFIG_FILE || join(getHomeDir(), '.aws', 'config')
-    }
+const fileNotFound = vscode.FileSystemError.FileNotFound().code
+async function fileExists(uri: vscode.Uri): Promise<boolean> {
+    return vscode.workspace.fs.stat(uri).then(
+        () => true,
+        err => !(err instanceof vscode.FileSystemError && err.code === fileNotFound)
+    )
+}
 
-    if (!(await fileExists(configFilePath))) {
+async function loadConfigFile(configUri?: vscode.Uri): Promise<ParsedIniData> {
+    if (!configUri || !(await fileExists(configUri))) {
         return {}
     }
 
-    return normalizeConfigFile(parseIni(await readFileAsString(configFilePath)))
+    const text = new TextDecoder().decode(await vscode.workspace.fs.readFile(configUri))
+    return normalizeConfigFile(parseIni(text))
 }
 
-async function loadCredentialsFile(credentialsFilePath?: string): Promise<ParsedIniData> {
-    const env = process.env as EnvironmentVariables
-    if (!credentialsFilePath) {
-        credentialsFilePath = env.AWS_SHARED_CREDENTIALS_FILE || join(getHomeDir(), '.aws', 'credentials')
-    }
-
-    if (!(await fileExists(credentialsFilePath))) {
+async function loadCredentialsFile(credentialsUri?: vscode.Uri): Promise<ParsedIniData> {
+    if (!credentialsUri || !(await fileExists(credentialsUri))) {
         return {}
     }
 
-    return parseIni(await readFileAsString(credentialsFilePath))
-}
-
-// TODO: FOR POC-DEMOS ONLY, NOT FOR PRODUCTION USE!
-// REMOVE_BEFORE_RELEASE
-// This is nowhere near resilient enough :-)
-export async function saveProfile(name: string, accessKey: string, secretKey: string): Promise<void> {
-    const env = process.env as EnvironmentVariables
-    const filepath = env.AWS_SHARED_CREDENTIALS_FILE || join(getHomeDir(), '.aws', 'credentials')
-
-    // even though poc concept code, let's preserve the user's file!
-    await copy(filepath, `${filepath}.bak_vscode`, { overwrite: true })
-
-    const data = `${await readFileAsString(filepath)}
-[${name}]
-aws_access_key_id=${accessKey}
-aws_secret_access_key=${secretKey}
-`
-
-    await writeFile(filepath, data, 'utf8')
+    const text = new TextDecoder().decode(await vscode.workspace.fs.readFile(credentialsUri))
+    return parseIni(text)
 }
 
 const profileKeyRegex = /^profile\s(["'])?([^\1]+)\1$/
@@ -112,8 +77,7 @@ function normalizeConfigFile(data: ParsedIniData): ParsedIniData {
         } else {
             const matches = profileKeyRegex.exec(key)
             if (matches) {
-                // @ts-ignore
-                const [_1, _2, normalizedKey] = matches
+                const normalizedKey = matches[2]
                 if (normalizedKey) {
                     map[normalizedKey] = data[key]
                 }
@@ -142,21 +106,4 @@ function parseIni(iniData: string): ParsedIniData {
     }
 
     return map
-}
-
-function getHomeDir(): string {
-    const env = process.env as EnvironmentVariables
-    const { HOME, USERPROFILE, HOMEPATH, HOMEDRIVE = `C:${sep}` } = env
-
-    if (HOME) {
-        return HOME
-    }
-    if (USERPROFILE) {
-        return USERPROFILE
-    }
-    if (HOMEPATH) {
-        return `${HOMEDRIVE}${HOMEPATH}`
-    }
-
-    return homedir()
 }

--- a/src/test/shared/credentials/userCredentialsUtils.test.ts
+++ b/src/test/shared/credentials/userCredentialsUtils.test.ts
@@ -149,7 +149,7 @@ describe('UserCredentialsUtils', function () {
         profileNames.forEach(profileName => {
             fileContents += `[${profileName}]
 aws_access_key_id = FAKEKEY
-aws_secret_access_key = FAKESECRET
+aws_SecRet_aCCess_key = FAKESECRET
 REGION = us-weast-3
 `
         })

--- a/src/test/shared/credentials/userCredentialsUtils.test.ts
+++ b/src/test/shared/credentials/userCredentialsUtils.test.ts
@@ -7,7 +7,8 @@ import * as assert from 'assert'
 import * as fs from 'fs-extra'
 import * as path from 'path'
 
-import { loadSharedConfigFiles, SharedConfigFiles } from '../../../shared/credentials/credentialsFile'
+import { Uri } from 'vscode'
+import { loadSharedConfigFiles } from '../../../shared/credentials/credentialsFile'
 import { UserCredentialsUtils } from '../../../shared/credentials/userCredentialsUtils'
 import { EnvironmentVariables } from '../../../shared/environmentVariables'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
@@ -108,23 +109,37 @@ describe('UserCredentialsUtils', function () {
             }
             await UserCredentialsUtils.generateCredentialsFile(creds)
 
-            const sharedConfigFiles: SharedConfigFiles = await loadSharedConfigFiles()
+            const sharedConfigFiles = await loadSharedConfigFiles({ credentials: Uri.file(credentialsFilename) })
             assert(typeof sharedConfigFiles === 'object', 'sharedConfigFiles should be an object')
             const profiles = sharedConfigFiles.credentialsFile
             assert(typeof profiles === 'object', 'profiles should be an object')
-            assert(profiles[profileName], 'profiles should be truthy')
+            const profile = profiles[profileName]
+            assert.ok(profile)
             assert.strictEqual(
-                profiles[profileName].aws_access_key_id,
+                profile.aws_access_key_id,
                 creds.accessKey,
-                `creds.accessKey: "${profiles[profileName].aws_access_key_id}" !== "${creds.accessKey}"`
+                `creds.accessKey: "${profile.aws_access_key_id}" !== "${creds.accessKey}"`
             )
             assert.strictEqual(
-                profiles[profileName].aws_secret_access_key,
+                profile.aws_secret_access_key,
                 creds.secretKey,
-                `creds.secretKey: "${profiles[profileName].aws_access_key_id}" !== "${creds.secretKey}"`
+                `creds.secretKey: "${profile.aws_access_key_id}" !== "${creds.secretKey}"`
             )
             await fs.access(credentialsFilename, fs.constants.R_OK).catch(_err => assert(false, 'Should be readable'))
             await fs.access(credentialsFilename, fs.constants.W_OK).catch(_err => assert(false, 'Should be writeable'))
+        })
+    })
+
+    describe('loadSharedConfigFiles', function () {
+        it('normalizes fields by making them lowercase', async function () {
+            const credentialsFilename = path.join(tempFolder, 'credentials-generation-test')
+            const profileName = 'someRandomProfileName'
+
+            createCredentialsFile(credentialsFilename, [profileName])
+
+            const sharedConfigFiles = await loadSharedConfigFiles({ credentials: Uri.file(credentialsFilename) })
+            const profiles = sharedConfigFiles.credentialsFile
+            assert.strictEqual(profiles[profileName]?.region, 'us-weast-3')
         })
     })
 
@@ -135,6 +150,7 @@ describe('UserCredentialsUtils', function () {
             fileContents += `[${profileName}]
 aws_access_key_id = FAKEKEY
 aws_secret_access_key = FAKESECRET
+REGION = us-weast-3
 `
         })
 


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Credential field names (e.g. `aws_access_key_id`) should be case-insensitive, but right now we read them as-is.

See #2394

## Solution
Normalize them when parsing the files.

Also removed dead code in a second commit and started using VS Code's URI + `fs` API. We should prefer URIs and the `fs` API whenever possible as they cover many edge cases we may not otherwise consider (though that doesn't matter much here).

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
