### PR TITLE
util: AsyncCollection

### DIFF
--- a/src/shared/utilities/asyncCollection.ts
+++ b/src/shared/utilities/asyncCollection.ts
@@ -23,14 +23,14 @@ export interface AsyncCollection<T> extends AsyncIterable<T> {
     toMap<K extends StringProperty<T>, U extends string = never>(
         selector: KeySelector<T, U> | K
     ): Promise<Map<Coalesce<U, T[K]>, T>>
+    /** Returns an iterator directly from the underlying generator, preserving values returned. */
     iterator(): AsyncIterator<T, T | void>
 }
 
 /**
  * Converts an async generator function to an {@link AsyncCollection}
  *
- * Uses closures to capture generator functions after each transformation. Generator functions are not called
- * until a 'final' operation is taken by either:
+ * Generation is "lazy", i.e. the generator is not called until a resolving operation:
  *  * Iterating over them using `for await (...)`
  *  * Iterating over them using `.next()`
  *  * Calling one of the conversion functions `toMap` or `promise`

--- a/src/shared/utilities/asyncCollection.ts
+++ b/src/shared/utilities/asyncCollection.ts
@@ -27,7 +27,7 @@ export interface AsyncCollection<T> extends AsyncIterable<T> {
 }
 
 /**
- * Converts an AsyncIterable to an {@link AsyncCollection}
+ * Converts an async generator function to an {@link AsyncCollection}
  *
  * Uses closures to capture generator functions after each transformation. Generator functions are not called
  * until a 'final' operation is taken by either:

--- a/src/shared/utilities/asyncCollection.ts
+++ b/src/shared/utilities/asyncCollection.ts
@@ -71,7 +71,7 @@ async function* mapGenerator<T, U, R = T>(
     while (true) {
         const { value, done } = await generator.next()
         if (done) {
-            return value !== undefined ? (fn(value) as Awaited<U>) : undefined
+            return value !== undefined ? fn(value) : undefined
         }
         if (value !== undefined) {
             yield fn(value)
@@ -92,7 +92,7 @@ async function* filterGenerator<T, U extends T, R = T>(
             continue
         }
         if (done) {
-            return value as Awaited<U>
+            return value
         }
         yield value
     }
@@ -119,7 +119,7 @@ async function* delegateGenerator<T, U, R = T>(
             }
         }
         if (done) {
-            return last as Awaited<U> | undefined
+            return last
         }
     }
 }

--- a/src/shared/utilities/asyncCollection.ts
+++ b/src/shared/utilities/asyncCollection.ts
@@ -1,0 +1,190 @@
+/*!
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NeverCoalesce } from './tsUtils'
+
+/**
+ * High-level abstraction over async generator functions of the form `async function*` {@link AsyncGenerator}
+ */
+export interface AsyncCollection<T> extends AsyncIterable<T> {
+    /** Flattens the collection 1-level deep */
+    flatten(): AsyncCollection<SafeUnboxIterable<T>>
+    /** Applies a mapping transform to the output generator */
+    map<U>(fn: (obj: T) => U): AsyncCollection<U>
+    /** Filters out results which will _not_ be passed on to further transformations. */
+    filter<U extends T>(predicate: AsyncPredicate<T, U>): AsyncCollection<U>
+    /** Uses only the first 'count' number of values returned by the generator. */
+    take(count: number): AsyncCollection<T>
+    /** Converts the collection to a Promise, resolving to an array of all values returned by the generator. */
+    promise(): Promise<T[]>
+    /** Converts the collection to a Map, using either a property of the item or a function to select keys. */
+    toMap<K extends StringProperty<T>, U extends string = never>(
+        selector: KeySelector<T, U> | K
+    ): Promise<Map<NeverCoalesce<U, T[K]>, T>>
+    iterator(): AsyncIterator<T, T | void>
+}
+
+/**
+ * Converts an AsyncIterable to an {@link AsyncCollection}
+ *
+ * Uses closures to capture generator functions after each transformation. Generator functions are not called
+ * until a 'final' operation is taken by either:
+ *  * Iterating over them using `for await (...)`
+ *  * Iterating over them using `.next()`
+ *  * Calling one of the conversion functions `toMap` or `promise`
+ *
+ * Collections are *immutable* in the sense that any transformation will not consume the underlying generator
+ * function. That is, any 'final' operation uses its own contextually bound generator function separate from
+ * any predecessor collections.
+ */
+export function toCollection<T>(generator: () => AsyncGenerator<T, T | undefined | void>): AsyncCollection<T> {
+    async function* unboxIter() {
+        const last = yield* generator()
+        if (last !== undefined) {
+            yield last
+        }
+    }
+
+    const iterable: AsyncIterable<T> = {
+        [Symbol.asyncIterator]: unboxIter,
+    }
+
+    return Object.assign(iterable, {
+        flatten: () => toCollection<SafeUnboxIterable<T>>(() => delegateGenerator(generator(), flatten)),
+        filter: <U extends T>(predicate: AsyncPredicate<T, U>) =>
+            toCollection<U>(() => filterGenerator<T, U>(generator(), predicate)),
+        map: <U>(fn: (item: T) => U) => toCollection<U>(() => mapGenerator(generator(), fn)),
+        take: (count: number) => toCollection(() => delegateGenerator(generator(), takeFrom(count))),
+        promise: () => promise(iterable),
+        toMap: <U extends string = never, K extends StringProperty<T> = never>(selector: KeySelector<T, U> | K) =>
+            asyncIterableToMap(iterable, selector),
+        iterator: generator,
+    })
+}
+
+async function* mapGenerator<T, U, R = T>(
+    generator: AsyncGenerator<T, R | undefined | void>,
+    fn: (item: T | R) => U
+): AsyncGenerator<U, U | undefined> {
+    while (true) {
+        const { value, done } = await generator.next()
+        if (done) {
+            return value !== undefined ? (fn(value) as Awaited<U>) : undefined
+        }
+        if (value !== undefined) {
+            yield fn(value)
+        }
+    }
+}
+
+async function* filterGenerator<T, U extends T, R = T>(
+    generator: AsyncGenerator<T, R | undefined | void>,
+    predicate: AsyncPredicate<T | R, U>
+): AsyncGenerator<U, U | undefined> {
+    while (true) {
+        const { value, done } = await generator.next()
+        if (value === undefined || !predicate(value)) {
+            if (done) {
+                break
+            }
+            continue
+        }
+        if (done) {
+            return value as Awaited<U>
+        }
+        yield value
+    }
+}
+
+async function* delegateGenerator<T, U, R = T>(
+    generator: AsyncGenerator<T, R | undefined | void>,
+    fn: (item: T | R, ret: () => void) => AsyncGenerator<U, void>
+): AsyncGenerator<U, U | undefined> {
+    while (true) {
+        let last: U | undefined
+        const { value, done } = await generator.next()
+        if (value !== undefined) {
+            const delegate = fn(value, generator.return.bind(generator))
+            while (true) {
+                const sub = await delegate.next()
+                if (sub.done) {
+                    break
+                }
+                last = sub.value
+                if (!done) {
+                    yield last
+                }
+            }
+        }
+        if (done) {
+            return last as Awaited<U> | undefined
+        }
+    }
+}
+
+async function* flatten<T, U extends SafeUnboxIterable<T>>(item: T) {
+    if (isIterable<U>(item)) {
+        yield* item
+    } else {
+        yield item as U
+    }
+}
+
+function takeFrom<T>(count: number) {
+    return async function* (item: T, ret: () => void) {
+        if (--count < 0) {
+            return ret()
+        }
+        yield item
+    }
+}
+
+/** Either 'unbox' an Iterable value or leave it as-is if it's not an Iterable */
+type SafeUnboxIterable<T> = T extends Iterable<infer U> ? U : T
+
+function isIterable<T>(obj: any): obj is Iterable<T> {
+    return obj !== undefined && typeof obj[Symbol.iterator] === 'function'
+}
+
+async function promise<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+    const result: T[] = []
+
+    for await (const item of iterable) {
+        result.push(item)
+    }
+
+    return result
+}
+
+type AsyncPredicate<T, U extends T> = ((item: T) => item is U) | ((item: T) => Promise<boolean> | boolean)
+
+function addToMap<T, U extends string>(map: Map<string, T>, selector: KeySelector<T, U> | StringProperty<T>, item: T) {
+    const key = typeof selector === 'function' ? selector(item) : item[selector]
+    if (key) {
+        if (map.has(key as keyof typeof map['keys'])) {
+            throw new Error(`Duplicate key found when converting AsyncIterable to map: ${key}`)
+        }
+
+        map.set(key as keyof typeof map['keys'], item)
+    }
+}
+
+// Type 'U' is constrained to be either a key of 'T' or a string returned by a function parsing 'T'
+type KeySelector<T, U extends string> = (item: T) => U | undefined
+type StringProperty<T> = { [P in keyof T]: T[P] extends string ? P : never }[keyof T]
+
+// TODO: apply this to different iterables and replace the old 'map' code
+async function asyncIterableToMap<T, K extends StringProperty<T>, U extends string = never>(
+    iterable: AsyncIterable<T>,
+    selector: KeySelector<T, U> | K
+): Promise<Map<NeverCoalesce<U, T[K]>, T>> {
+    const result = new Map<NeverCoalesce<U, T[K] & string>, T>()
+
+    for await (const item of iterable) {
+        addToMap(result, selector, item)
+    }
+
+    return result
+}

--- a/src/shared/utilities/asyncCollection.ts
+++ b/src/shared/utilities/asyncCollection.ts
@@ -14,7 +14,7 @@ export interface AsyncCollection<T> extends AsyncIterable<T> {
     /** Applies a mapping transform to the output generator */
     map<U>(fn: (obj: T) => U): AsyncCollection<U>
     /** Filters out results which will _not_ be passed on to further transformations. */
-    filter<U extends T>(predicate: AsyncPredicate<T, U>): AsyncCollection<U>
+    filter<U extends T>(predicate: Predicate<T, U>): AsyncCollection<U>
     /** Uses only the first 'count' number of values returned by the generator. */
     take(count: number): AsyncCollection<T>
     /** Converts the collection to a Promise, resolving to an array of all values returned by the generator. */
@@ -53,7 +53,7 @@ export function toCollection<T>(generator: () => AsyncGenerator<T, T | undefined
 
     return Object.assign(iterable, {
         flatten: () => toCollection<SafeUnboxIterable<T>>(() => delegateGenerator(generator(), flatten)),
-        filter: <U extends T>(predicate: AsyncPredicate<T, U>) =>
+        filter: <U extends T>(predicate: Predicate<T, U>) =>
             toCollection<U>(() => filterGenerator<T, U>(generator(), predicate)),
         map: <U>(fn: (item: T) => U) => toCollection<U>(() => mapGenerator(generator(), fn)),
         take: (count: number) => toCollection(() => delegateGenerator(generator(), takeFrom(count))),
@@ -81,7 +81,7 @@ async function* mapGenerator<T, U, R = T>(
 
 async function* filterGenerator<T, U extends T, R = T>(
     generator: AsyncGenerator<T, R | undefined | void>,
-    predicate: AsyncPredicate<T | R, U>
+    predicate: Predicate<T | R, U>
 ): AsyncGenerator<U, U | undefined> {
     while (true) {
         const { value, done } = await generator.next()
@@ -158,7 +158,7 @@ async function promise<T>(iterable: AsyncIterable<T>): Promise<T[]> {
     return result
 }
 
-type AsyncPredicate<T, U extends T> = ((item: T) => item is U) | ((item: T) => Promise<boolean> | boolean)
+type Predicate<T, U extends T> = ((item: T) => item is U) | ((item: T) => boolean)
 
 function addToMap<T, U extends string>(map: Map<string, T>, selector: KeySelector<T, U> | StringProperty<T>, item: T) {
     const key = typeof selector === 'function' ? selector(item) : item[selector]

--- a/src/shared/utilities/asyncCollection.ts
+++ b/src/shared/utilities/asyncCollection.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { NeverCoalesce } from './tsUtils'
+import { Coalesce } from './tsUtils'
 
 /**
  * High-level abstraction over async generator functions of the form `async function*` {@link AsyncGenerator}
@@ -22,7 +22,7 @@ export interface AsyncCollection<T> extends AsyncIterable<T> {
     /** Converts the collection to a Map, using either a property of the item or a function to select keys. */
     toMap<K extends StringProperty<T>, U extends string = never>(
         selector: KeySelector<T, U> | K
-    ): Promise<Map<NeverCoalesce<U, T[K]>, T>>
+    ): Promise<Map<Coalesce<U, T[K]>, T>>
     iterator(): AsyncIterator<T, T | void>
 }
 
@@ -179,8 +179,8 @@ type StringProperty<T> = { [P in keyof T]: T[P] extends string ? P : never }[key
 async function asyncIterableToMap<T, K extends StringProperty<T>, U extends string = never>(
     iterable: AsyncIterable<T>,
     selector: KeySelector<T, U> | K
-): Promise<Map<NeverCoalesce<U, T[K]>, T>> {
-    const result = new Map<NeverCoalesce<U, T[K] & string>, T>()
+): Promise<Map<Coalesce<U, T[K]>, T>> {
+    const result = new Map<Coalesce<U, T[K] & string>, T>()
 
     for await (const item of iterable) {
         addToMap(result, selector, item)

--- a/src/shared/utilities/collectionUtils.ts
+++ b/src/shared/utilities/collectionUtils.ts
@@ -4,7 +4,7 @@
  */
 
 import { AsyncCollection, toCollection } from './asyncCollection'
-import { SharedProp, AccumulatableKeys, NeverCoalesce } from './tsUtils'
+import { SharedProp, AccumulableKeys, NeverCoalesce } from './tsUtils'
 
 export function union<T>(a: Iterable<T>, b: Iterable<T>): Set<T> {
     const result = new Set<T>()
@@ -282,12 +282,12 @@ export function isAsyncIterable(obj: any): obj is AsyncIterable<unknown> {
 /**
  * Converts a 'paged' API request to a collection of sequential API requests
  * based off a 'mark' (the paginated token field) and a `prop` which is an
- * accumulatable property on the response interface.
+ * Accumulable property on the response interface.
  *
  * @param requester Asynchronous function to make the API requests with
  * @param request Initial request to apply to the API calls
  * @param mark A property name of the paginated token field shared by the input/output shapes
- * @param prop A property name of an 'accumulatable' field in the output shape
+ * @param prop A property name of an 'Accumulable' field in the output shape
  * @returns An {@link AsyncCollection} resolving to the type described by the `prop` field
  */
 export function pageableToCollection<
@@ -295,7 +295,7 @@ export function pageableToCollection<
     TResponse,
     TTokenProp extends SharedProp<TRequest, TResponse>,
     TTokenType extends TRequest[TTokenProp] & TResponse[TTokenProp],
-    TResult extends AccumulatableKeys<TResponse> = never
+    TResult extends AccumulableKeys<TResponse> = never
 >(
     requester: (request: TRequest) => Promise<TResponse>,
     request: TRequest,

--- a/src/shared/utilities/collectionUtils.ts
+++ b/src/shared/utilities/collectionUtils.ts
@@ -4,7 +4,7 @@
  */
 
 import { AsyncCollection, toCollection } from './asyncCollection'
-import { SharedProp, AccumulableKeys, NeverCoalesce } from './tsUtils'
+import { SharedProp, AccumulableKeys, Coalesce } from './tsUtils'
 
 export function union<T>(a: Iterable<T>, b: Iterable<T>): Set<T> {
     const result = new Set<T>()
@@ -301,11 +301,11 @@ export function pageableToCollection<
     request: TRequest,
     mark: TTokenProp,
     prop?: TResult
-): AsyncCollection<NeverCoalesce<TResponse[TResult], TResponse>> {
+): AsyncCollection<Coalesce<TResponse[TResult], TResponse>> {
     async function* gen() {
         do {
             const response: TResponse = await requester(request)
-            const result = (prop ? response[prop] : response) as NeverCoalesce<TResponse[TResult], TResponse>
+            const result = (prop ? response[prop] : response) as Coalesce<TResponse[TResult], TResponse>
             if (!response[mark]) {
                 return result
             }

--- a/src/shared/utilities/tsUtils.ts
+++ b/src/shared/utilities/tsUtils.ts
@@ -31,3 +31,24 @@ type Expand<T> = T extends infer O ? { [K in keyof O]+?: O[K] } : never
  *
  */
 export type ExpandWithObject<T> = Expand<T> extends Record<string, unknown> ? Expand<T> : never
+
+/**
+ * Given two types, this yields a type that includes only the fields where both types were the exact same
+ * This is _almost_ equivalent to (T1 | T2) & T2 & T2, except that this type is distributive
+ */
+export type SharedTypes<T1, T2> = {
+    [P in keyof T1 & keyof T2]: (T1[P] | T2[P]) & T1[P] & T2[P]
+}
+
+/* All of the string keys of the shared type */
+export type SharedProp<T1, T2> = string & keyof SharedTypes<T1, T2>
+
+/* Any key that can be accumulated (i.e. an array) */
+export type AccumulatableKeys<T> = NonNullable<
+    {
+        [P in keyof T]: NonNullable<T[P]> extends any[] ? P : never
+    }[keyof T]
+>
+
+/** Similar to the nullish coalescing operator, but for types that can never occur */
+export type NeverCoalesce<T, U> = [T] extends [never] ? U : T

--- a/src/shared/utilities/tsUtils.ts
+++ b/src/shared/utilities/tsUtils.ts
@@ -51,4 +51,4 @@ export type AccumulableKeys<T> = NonNullable<
 >
 
 /** Similar to the nullish coalescing operator, but for types that can never occur */
-export type NeverCoalesce<T, U> = [T] extends [never] ? U : T
+export type Coalesce<T, U> = [T] extends [never] ? U : T

--- a/src/shared/utilities/tsUtils.ts
+++ b/src/shared/utilities/tsUtils.ts
@@ -44,7 +44,7 @@ export type SharedTypes<T1, T2> = {
 export type SharedProp<T1, T2> = string & keyof SharedTypes<T1, T2>
 
 /* Any key that can be accumulated (i.e. an array) */
-export type AccumulatableKeys<T> = NonNullable<
+export type AccumulableKeys<T> = NonNullable<
     {
         [P in keyof T]: NonNullable<T[P]> extends any[] ? P : never
     }[keyof T]

--- a/src/test/shared/utilities/asyncCollection.test.ts
+++ b/src/test/shared/utilities/asyncCollection.test.ts
@@ -1,0 +1,151 @@
+/*!
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { toCollection } from '../../../shared/utilities/asyncCollection'
+
+describe('AsyncCollection', function () {
+    const items = [
+        { name: 'item1', data: 0 },
+        { name: 'item2', data: 1 },
+        { name: 'item3', data: 2 },
+    ]
+
+    async function* gen() {
+        yield 0
+        yield 1
+        yield 2
+    }
+
+    async function* genPage() {
+        yield [0, 1, 2]
+        yield [3, 4, 5]
+        yield [6, 7, 8]
+    }
+
+    async function* genItem() {
+        yield items[0]
+        yield items[1]
+        yield items[2]
+    }
+
+    it('can be iterated over', async function () {
+        const collection = toCollection(gen)
+        const expected = [0, 1, 2]
+        for await (const o of collection) {
+            assert.strictEqual(o, expected.shift())
+        }
+    })
+
+    it('can turn into a Promise', async function () {
+        const promise = toCollection(gen).promise()
+        assert.deepStrictEqual(await promise, [0, 1, 2])
+    })
+
+    it('can turn into a map using property key', async function () {
+        const map = await toCollection(genItem).toMap('name')
+        items.forEach(v => assert.strictEqual(map.get(v.name), v))
+    })
+
+    it('can turn into a map using function', async function () {
+        const map = await toCollection(genItem).toMap(i => i.data.toString())
+        items.forEach(v => assert.strictEqual(map.get(v.data.toString()), v))
+    })
+
+    it('can map', async function () {
+        const mapped = toCollection(gen)
+            .map(o => o + 1)
+            .map(o => o.toString())
+            .map(s => `${s}!`)
+        assert.deepStrictEqual(await mapped.promise(), ['1!', '2!', '3!'])
+    })
+
+    it('can flatten', async function () {
+        const flat = toCollection(genPage).flatten()
+        const expected = Array(9)
+            .fill(0)
+            .map((_, i) => i)
+        assert.deepStrictEqual(await flat.promise(), expected)
+    })
+
+    it('can filter', async function () {
+        const filtered = toCollection(genPage)
+            .filter(o => o.includes(5))
+            .flatten()
+        const expected = [3, 4, 5]
+        assert.deepStrictEqual(await filtered.promise(), expected)
+    })
+
+    it('can take', async function () {
+        const take = toCollection(gen).take(2)
+        assert.deepStrictEqual(await take.promise(), [0, 1])
+    })
+
+    it('returns nothing if using non-positive count', async function () {
+        const takeZero = toCollection(gen).take(0)
+        const takeNeg1 = toCollection(gen).take(-1)
+        assert.deepStrictEqual(await takeZero.promise(), [])
+        assert.deepStrictEqual(await takeNeg1.promise(), [])
+    })
+
+    it('is immutable', async function () {
+        const x = toCollection(gen)
+        const y = x.map(o => o + 1)
+        const z = y
+            .filter(o => o !== 1)
+            .map(o => [o, o])
+            .flatten()
+
+        assert.deepStrictEqual(await x.promise(), [0, 1, 2])
+        assert.deepStrictEqual(await y.promise(), [1, 2, 3])
+        assert.deepStrictEqual(await z.promise(), [2, 2, 3, 3])
+    })
+
+    it('does not iterate over the generator when applying transformations', async function () {
+        let callCount = 0
+        async function* count() {
+            while (callCount < 1000) {
+                yield callCount++
+            }
+        }
+
+        const x = toCollection(count)
+            .filter(o => o > 1)
+            .map(o => [o, o * o])
+            .flatten()
+        await new Promise(r => setImmediate(r))
+        assert.strictEqual(callCount, 0)
+        assert.deepStrictEqual(await x.take(6).promise(), [2, 4, 3, 9, 4, 16])
+        assert.strictEqual(callCount, 6)
+    })
+
+    describe('errors', function () {
+        async function* error() {
+            throw new Error()
+            yield 0
+        }
+
+        it('bubbles errors up when using a promise', async function () {
+            const errorPromise = toCollection(error)
+                .map(o => o)
+                .filter(_ => true)
+                .flatten()
+                .promise()
+            await assert.rejects(errorPromise)
+        })
+
+        it('bubbles errors up when iterating', async function () {
+            const errorIter = toCollection(error)
+                .map(o => o)
+                .filter(_ => true)
+                .flatten()
+            const iterate = async () => {
+                for await (const _ of errorIter) {
+                }
+            }
+            await assert.rejects(iterate)
+        })
+    })
+})


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

To make it easier to handle pagination, I've added a new utility interface called AsyncCollection. This basically allows you to treat async generators/iterables as if they were a static collection. This is great since we can manipulate them in a declarative way; no more while loops to iterate over the elements and check for done. It also helps to abstract away async generators, which most callers don't really care about. You can still iterate over the collection as if it were an AsyncIterable, but again the common-case is we just want all the results. This is provided by a promise method which outputs all results in an array.

Benefits:
* Much better ergonomics and type safety for mapping paginated API calls
* Flexible. The collection does not hide the fact that things come in pages, so it can be used in `ChildNodeLoader`
* Able to map generators themselves, which is important when generators have special meaning behind their 'return' value.
* Collections can be passed around and recognized as `AsyncIterable`, hiding implementation details 

Example (with CWL):
```ts
interface LogGroup extends CloudWatchLogs.LogGroup {
    logGroupName: string
    storedBytes: number
}
function isValidLogGroup(obj?: CloudWatchLogs.LogGroup): obj is LogGroup {
    return !!obj && typeof obj.logGroupName === 'string' && typeof obj.storedBytes === 'number'
}
const requester = (request: CloudWatchLogs.DescribeLogGroupsRequest) => this.invokeDescribeLogGroups(request, sdkClient)
const collection = pageableToCollection(requester, request, 'nextToken', 'logGroups')
const groups = collection.flatten().filter(isValidLogGroup).promise() // type is Promise<LogGroup[]>
```

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
