### PR TITLE
tests: fix unreliable ChildProcess 'can report errors'

### DIFF
--- a/src/test/shared/utilities/childProcess.test.ts
+++ b/src/test/shared/utilities/childProcess.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert'
 import * as fs from 'fs-extra'
 import * as os from 'os'
 import * as path from 'path'
-import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
+import { makeTemporaryToolkitFolder, tryRemoveFolder } from '../../../shared/filesystemUtilities'
 import { ChildProcess, ChildProcessResult } from '../../../shared/utilities/childProcess'
 import { sleep } from '../../../shared/utilities/promiseUtilities'
 import { Timeout, waitUntil } from '../../../shared/utilities/timeoutUtils'
@@ -22,7 +22,7 @@ describe('ChildProcess', async function () {
     })
 
     afterEach(async function () {
-        await fs.remove(tempFolder)
+        await tryRemoveFolder(tempFolder)
     })
 
     describe('run', async function () {

--- a/src/test/shared/utilities/childProcess.test.ts
+++ b/src/test/shared/utilities/childProcess.test.ts
@@ -304,6 +304,7 @@ describe('ChildProcess', async function () {
             it('can report errors', async function () {
                 const result = childProcess.run({
                     rejectOnError: true,
+                    useForceStop: true,
                     onStdout: (text, context) => {
                         if (text.includes('2')) {
                             context.reportError('Got 2')


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
One of the `ChildProcess` test cases sometimes doesn't free the script before exiting (only on Windows?)

## Solution
Use force stop plus `tryRemoveFolder`

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
