### PR TITLE
utils: check for C9 before using VSC FS API

### DIFF
--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -86,7 +86,7 @@ async function tryAutoConnect(awsContext: AwsContext) {
             await loginWithMostRecentCredentials(toolkitSettings, loginManager)
         }
     } catch (err) {
-        getLogger().error('credentials: failed to auto-connect: %O', (err as Error).message)
+        getLogger().error('credentials: failed to auto-connect: %O', err)
         showViewLogsMessage(localize('AWS.credentials.autoconnect.fatal', 'Exception occurred while connecting'))
     }
 }

--- a/src/shared/credentials/credentialsFile.ts
+++ b/src/shared/credentials/credentialsFile.ts
@@ -4,6 +4,7 @@
  */
 
 import * as vscode from 'vscode'
+import { SystemUtilities } from '../systemUtilities'
 
 export interface SharedConfigPaths {
     /**
@@ -42,30 +43,20 @@ export async function loadSharedConfigFiles(init: SharedConfigPaths = {}): Promi
     }
 }
 
-const fileNotFound = vscode.FileSystemError.FileNotFound().code
-async function fileExists(uri: vscode.Uri): Promise<boolean> {
-    return vscode.workspace.fs.stat(uri).then(
-        () => true,
-        err => !(err instanceof vscode.FileSystemError && err.code === fileNotFound)
-    )
-}
-
 async function loadConfigFile(configUri?: vscode.Uri): Promise<ParsedIniData> {
-    if (!configUri || !(await fileExists(configUri))) {
+    if (!configUri || !(await SystemUtilities.fileExists(configUri))) {
         return {}
     }
 
-    const text = new TextDecoder().decode(await vscode.workspace.fs.readFile(configUri))
-    return normalizeConfigFile(parseIni(text))
+    return normalizeConfigFile(parseIni(await SystemUtilities.readFile(configUri)))
 }
 
 async function loadCredentialsFile(credentialsUri?: vscode.Uri): Promise<ParsedIniData> {
-    if (!credentialsUri || !(await fileExists(credentialsUri))) {
+    if (!credentialsUri || !(await SystemUtilities.fileExists(credentialsUri))) {
         return {}
     }
 
-    const text = new TextDecoder().decode(await vscode.workspace.fs.readFile(credentialsUri))
-    return parseIni(text)
+    return parseIni(await SystemUtilities.readFile(credentialsUri))
 }
 
 const profileKeyRegex = /^profile\s(["'])?([^\1]+)\1$/

--- a/src/shared/systemUtilities.ts
+++ b/src/shared/systemUtilities.ts
@@ -41,7 +41,7 @@ export class SystemUtilities {
     }
 
     public static async readFile(file: string | vscode.Uri): Promise<string> {
-        const uri = typeof file === 'string' ? vscode.Uri.parse(file) : file
+        const uri = typeof file === 'string' ? vscode.Uri.file(file) : file
         const decoder = new TextDecoder()
 
         if (isCloud9()) {
@@ -52,7 +52,7 @@ export class SystemUtilities {
     }
 
     public static async fileExists(file: string | vscode.Uri): Promise<boolean> {
-        const uri = typeof file === 'string' ? vscode.Uri.parse(file) : file
+        const uri = typeof file === 'string' ? vscode.Uri.file(file) : file
 
         if (isCloud9()) {
             return new Promise<boolean>(resolve => fs.access(uri.fsPath, err => resolve(!err)))


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
The `workspace.fs` API does not work on C9 (this broke credential parsing)

## Solution
Use `fs` for C9, otherwise use the API

## Motivation/Context
URIs are better for describing locations of objects compared to plain strings. VS Code's URI class handles things like normalization and validation for us. It also allows us to use `workspace.fs` so we can correctly handle virtual file systems. 

There will be some hiccups with moving towards URIs (like this PR) but it's worth it in the long run.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
