### PR TITLE
tests: skip S3 editor tests on minimum

### DIFF
--- a/src/test/s3/util/fileViewerManager.test.ts
+++ b/src/test/s3/util/fileViewerManager.test.ts
@@ -201,6 +201,9 @@ describe('FileViewerManager', function () {
         }
 
         beforeEach(function () {
+            if (vscode.version.startsWith('1.44')) {
+                this.skip()
+            }
             resetCalls(workspace)
         })
 


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
The tests are unreliable on min version

## Solution
Skip them

I've noticed that in general, tests that utilize more of the real VS Code API are unreliable on our min version. Is this something we should be concerned about? I don't want to skip these tests, but to support them means adding more logic to reduce flakiness. I suppose we could also use Mocha's `retry` only for min ver?

We should discuss this more in our testing strategy for C9.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
