### PR TITLE
ECS: show valid tasks that are starting

### DIFF
--- a/src/ecs/wizards/executeCommand.ts
+++ b/src/ecs/wizards/executeCommand.ts
@@ -58,7 +58,7 @@ function createTaskPrompter(node: EcsContainerNode) {
         buttons: createCommonButtons(ecsExecToolkitGuideUrl),
         noItemsFoundItem: {
             label: localize('AWS.command.ecs.runCommandInContainer.noTasks', 'No valid tasks for this container.'),
-            description: localize(
+            detail: localize(
                 'AWS.command.ecs.runCommandInContainer.noTasks.description',
                 'If command execution was recently enabled, try again in a few minutes.'
             ),

--- a/src/ecs/wizards/executeCommand.ts
+++ b/src/ecs/wizards/executeCommand.ts
@@ -5,6 +5,7 @@
 
 import { ECS } from 'aws-sdk'
 import { ecsExecToolkitGuideUrl } from '../../shared/constants'
+import { isCloud9 } from '../../shared/extensionUtilities'
 import { createCommonButtons } from '../../shared/ui/buttons'
 import { createInputBox } from '../../shared/ui/inputPrompter'
 import { createQuickPick, DataQuickPickItem } from '../../shared/ui/pickerPrompter'
@@ -24,7 +25,7 @@ function createValidTaskFilter(containerName: string) {
             c => c?.name === containerName && c.managedAgents?.find(a => a.name === 'ExecuteCommandAgent')
         )
 
-        return t.taskArn !== undefined && t.lastStatus === 'RUNNING' && managed
+        return t.taskArn !== undefined && managed
     }
 }
 
@@ -38,10 +39,17 @@ function createTaskPrompter(node: EcsContainerNode) {
         return (await node.describeTasks(taskArns)).filter(createValidTaskFilter(node.containerName)).map(task => {
             // The last 32 digits of the task arn is the task identifier
             const taskId = task.taskArn.substring(task.taskArn.length - 32)
+            const invalidSelection = task.lastStatus !== 'RUNNING'
+
             return {
-                label: taskId,
+                label: `${invalidSelection && !isCloud9() ? '$(error) ' : ''}${taskId}`,
                 detail: `Status: ${task.lastStatus}  Desired status: ${task.desiredStatus}`,
+                description:
+                    invalidSelection && task.desiredStatus === 'RUNNING'
+                        ? 'Task starting, try again later.'
+                        : undefined,
                 data: taskId,
+                invalidSelection,
             }
         })
     })()
@@ -49,9 +57,14 @@ function createTaskPrompter(node: EcsContainerNode) {
         title: localize('AWS.command.ecs.runCommandInContainer.chooseTask', 'Choose a task'),
         buttons: createCommonButtons(ecsExecToolkitGuideUrl),
         noItemsFoundItem: {
-            label: localize('AWS.command.ecs.runCommandInContainer.noTasks', 'No running tasks for this container.'),
+            label: localize('AWS.command.ecs.runCommandInContainer.noTasks', 'No valid tasks for this container.'),
+            description: localize(
+                'AWS.command.ecs.runCommandInContainer.noTasks.description',
+                'If command execution was recently enabled, try again in a few minutes.'
+            ),
             data: WIZARD_BACK,
         },
+        compare: (a, b) => (a.invalidSelection ? 1 : b.invalidSelection ? -1 : 0),
     })
 }
 

--- a/src/ecs/wizards/executeCommand.ts
+++ b/src/ecs/wizards/executeCommand.ts
@@ -57,7 +57,7 @@ function createTaskPrompter(node: EcsContainerNode) {
         title: localize('AWS.command.ecs.runCommandInContainer.chooseTask', 'Choose a task'),
         buttons: createCommonButtons(ecsExecToolkitGuideUrl),
         noItemsFoundItem: {
-            label: localize('AWS.command.ecs.runCommandInContainer.noTasks', 'No valid tasks for this container.'),
+            label: localize('AWS.command.ecs.runCommandInContainer.noTasks', 'No valid tasks for this container'),
             detail: localize(
                 'AWS.command.ecs.runCommandInContainer.noTasks.description',
                 'If command execution was recently enabled, try again in a few minutes.'


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
It's not clear to users that valid tasks are starting but aren't ready yet.

## Solution
Show it within the UI:
![Screen Shot 2022-01-11 at 5 31 10 PM](https://user-images.githubusercontent.com/31319484/149050595-b90fe892-ce18-4452-8e5b-daf86214f3ab.png)

Doesn't handle niche edge-cases (like tasks with agents that are stopping)
These are just shown as invalid and sorted to the bottom for all cases.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
