### PR TITLE
tests: wait for active S3 editor to have matching contents

### DIFF
--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -23,10 +23,11 @@ import { setTestTimeout } from './globalSetup.test'
 import { waitUntil } from '../shared/utilities/timeoutUtils'
 import { AwsSamDebuggerConfiguration } from '../shared/sam/debugger/awsSamDebugConfiguration.gen'
 import { AwsSamTargetType } from '../shared/sam/debugger/awsSamDebugConfiguration'
-import { closeAllEditors } from '../shared/utilities/vsCodeUtils'
 import { insertTextIntoFile } from '../shared/utilities/textUtilities'
 import { sleep } from '../shared/utilities/promiseUtilities'
 import globals from '../shared/extensionGlobals'
+import { closeAllEditors } from '../test/testUtil'
+
 const projectFolder = testUtils.getTestWorkspaceFolder()
 
 /* Test constants go here */

--- a/src/integrationTest/stepFunctions/visualizeStateMachine.test.ts
+++ b/src/integrationTest/stepFunctions/visualizeStateMachine.test.ts
@@ -10,7 +10,7 @@ import * as vscode from 'vscode'
 import { MessageObject } from '../../stepFunctions/commands/visualizeStateMachine/aslVisualization'
 import { makeTemporaryToolkitFolder } from '../../shared/filesystemUtilities'
 import { spy } from 'sinon'
-import { closeAllEditors } from '../../shared/utilities/vsCodeUtils'
+import { closeAllEditors } from '../../test/testUtil'
 
 const sampleStateMachine = `
 	 {

--- a/src/shared/utilities/vsCodeUtils.ts
+++ b/src/shared/utilities/vsCodeUtils.ts
@@ -8,7 +8,7 @@ import * as nls from 'vscode-nls'
 import globals from '../extensionGlobals'
 
 import { getLogger } from '../logger/logger'
-import { Timeout, waitTimeout, waitUntil } from './timeoutUtils'
+import { Timeout, waitTimeout } from './timeoutUtils'
 
 // TODO: Consider NLS initialization/configuration here & have packages to import localize from here
 export const localize = nls.loadMessageBundle()
@@ -41,37 +41,6 @@ export function folderIconPath(): vscode.ThemeIcon | { light: vscode.Uri; dark: 
         }
     } else {
         return vscode.ThemeIcon.Folder
-    }
-}
-
-/**
- * Executes the close all editors command and waits for all visible editors to disappear
- */
-export async function closeAllEditors() {
-    await vscode.commands.executeCommand('workbench.action.closeAllEditors')
-
-    // The output channel counts as an editor, but you can't really close that...
-    const noVisibleEditor: boolean | undefined = await waitUntil(
-        async () => {
-            const visibleEditors = vscode.window.visibleTextEditors.filter(
-                editor => !editor.document.fileName.includes('extension-output') // Output channels are named with the prefix 'extension-output'
-            )
-
-            return visibleEditors.length === 0
-        },
-        {
-            timeout: 2500, // Arbitrary values. Should succeed except when VS Code is lagging heavily.
-            interval: 250,
-            truthy: true,
-        }
-    )
-
-    if (!noVisibleEditor) {
-        throw new Error(
-            `Editor "${
-                vscode.window.activeTextEditor!.document.fileName
-            }" was still open after executing "closeAllEditors"`
-        )
     }
 }
 

--- a/src/shared/vscode/env.ts
+++ b/src/shared/vscode/env.ts
@@ -5,6 +5,7 @@
 
 import * as semver from 'semver'
 import * as vscode from 'vscode'
+import * as packageJson from '../../../package.json'
 
 /**
  * Components associated with {@link module:vscode.env}.
@@ -58,3 +59,11 @@ export function isReleaseVersion(prereleaseOk: boolean = false): boolean {
 }
 
 export { extensionVersion }
+
+/**
+ * Returns true if the extension is being ran on the minimum version of VS Code as defined
+ * by the `engine` field in `package.json`
+ */
+export function isMinVer(): boolean {
+    return vscode.version.startsWith(packageJson.engines.vscode.replace(/\^\~/, ''))
+}

--- a/src/shared/vscode/env.ts
+++ b/src/shared/vscode/env.ts
@@ -62,7 +62,7 @@ export { extensionVersion }
 
 /**
  * Returns true if the extension is being ran on the minimum version of VS Code as defined
- * by the `engine` field in `package.json`
+ * by the `engines` field in `package.json`
  */
 export function isMinVer(): boolean {
     return vscode.version.startsWith(packageJson.engines.vscode.replace(/\^\~/, ''))

--- a/src/shared/vscode/env.ts
+++ b/src/shared/vscode/env.ts
@@ -64,6 +64,6 @@ export { extensionVersion }
  * Returns true if the extension is being ran on the minimum version of VS Code as defined
  * by the `engines` field in `package.json`
  */
-export function isMinVer(): boolean {
+export function isMinimumVersion(): boolean {
     return vscode.version.startsWith(packageJson.engines.vscode.replace(/\^\~/, ''))
 }

--- a/src/test/s3/util/fileViewerManager.test.ts
+++ b/src/test/s3/util/fileViewerManager.test.ts
@@ -24,7 +24,7 @@ import { SeverityLevel } from '../../shared/vscode/message'
 import { SettingsConfiguration } from '../../../shared/settingsConfiguration'
 import { TestSettingsConfiguration } from '../../utilities/testSettingsConfiguration'
 import { join } from 'path'
-import { assertTextEditorContains } from '../../testUtil'
+import { assertTextEditorContains, closeAllEditors } from '../../testUtil'
 
 const bucket = new DefaultBucket({
     name: 'bucket-name',
@@ -143,12 +143,6 @@ describe('FileViewerManager', function () {
     let workspace: typeof vscode.workspace
     let commands: typeof vscode.commands
     let settings: SettingsConfiguration
-
-    async function closeAllEditors() {
-        // Derived by inspecting 'Keyboard Shortcuts' via command `>Preferences: Open Keyboard Shortcuts`
-        // Tests will pass without it but good to clean state regardless
-        await vscode.commands.executeCommand('openEditors.closeAll')
-    }
 
     beforeEach(function () {
         s3 = mock()

--- a/src/test/s3/util/fileViewerManager.test.ts
+++ b/src/test/s3/util/fileViewerManager.test.ts
@@ -24,7 +24,7 @@ import { SeverityLevel } from '../../shared/vscode/message'
 import { SettingsConfiguration } from '../../../shared/settingsConfiguration'
 import { TestSettingsConfiguration } from '../../utilities/testSettingsConfiguration'
 import { join } from 'path'
-import { waitUntil } from '../../../shared/utilities/timeoutUtils'
+import { assertTextEditorContains } from '../../testUtil'
 
 const bucket = new DefaultBucket({
     name: 'bucket-name',
@@ -164,29 +164,6 @@ describe('FileViewerManager', function () {
 
     async function closeEditor() {
         await vscode.commands.executeCommand('workbench.action.closeActiveEditor')
-    }
-
-    /**
-     * Waits for _any_ active text editor to appear and have the desired contents.
-     * This is important since their may be delays between showing a new document and
-     * updates to the `activeTextEditor` field.
-     */
-    async function assertTextEditorContains(contents: string): Promise<void | never> {
-        const editor = await waitUntil(
-            async () => {
-                if (vscode.window.activeTextEditor?.document.getText() === contents) {
-                    return vscode.window.activeTextEditor
-                }
-            },
-            { interval: 5 }
-        )
-
-        if (!vscode.window.activeTextEditor) {
-            throw new Error('No active text editor found')
-        }
-        if (!editor) {
-            assert.strictEqual(vscode.window.activeTextEditor.document.getText(), contents)
-        }
     }
 
     it('prompts if file size is greater than 4MB', async function () {

--- a/src/test/s3/util/fileViewerManager.test.ts
+++ b/src/test/s3/util/fileViewerManager.test.ts
@@ -144,6 +144,12 @@ describe('FileViewerManager', function () {
     let commands: typeof vscode.commands
     let settings: SettingsConfiguration
 
+    async function closeAllEditors() {
+        // Derived by inspecting 'Keyboard Shortcuts' via command `>Preferences: Open Keyboard Shortcuts`
+        // Tests will pass without it but good to clean state regardless
+        await vscode.commands.executeCommand('openEditors.closeAll')
+    }
+
     beforeEach(function () {
         s3 = mock()
         fs = new VirualFileSystem()
@@ -162,9 +168,9 @@ describe('FileViewerManager', function () {
         )
     })
 
-    async function closeEditor() {
-        await vscode.commands.executeCommand('workbench.action.closeActiveEditor')
-    }
+    afterEach(async function () {
+        await closeAllEditors()
+    })
 
     it('prompts if file size is greater than 4MB', async function () {
         fileViewerManager.openInReadMode({ ...bigImage, bucket })
@@ -201,7 +207,6 @@ describe('FileViewerManager', function () {
             mockOpen(textFile1)
             await fileViewerManager.openInReadMode({ ...textFile1, bucket })
             await assertTextEditorContains(textFile1.content.toString())
-            await closeEditor()
         })
 
         it('closes the read-only tab when opening in edit mode', async function () {
@@ -214,7 +219,6 @@ describe('FileViewerManager', function () {
             await fileViewerManager.openInEditMode({ ...textFile1, bucket })
 
             verify(commands.executeCommand('workbench.action.closeActiveEditor')).once()
-            await closeEditor()
         })
 
         it('can open in edit mode, showing a warning with two options', async function () {
@@ -228,7 +232,6 @@ describe('FileViewerManager', function () {
             await fileViewerManager.openInEditMode({ ...textFile1, bucket })
 
             await assertTextEditorContains(textFile1.content.toString())
-            await closeEditor()
             await shownMessage
         })
 

--- a/src/test/testUtil.ts
+++ b/src/test/testUtil.ts
@@ -246,11 +246,11 @@ export async function closeAllEditors(): Promise<unknown> {
             throw Error('openEditors.closeAll is available in min version, remove me!')
         }
         // Derived by inspecting 'Keyboard Shortcuts' via command `>Preferences: Open Keyboard Shortcuts`
-        // Tests will pass without it but good to clean state regardless
+        // `workbench.action.closeAllEditors` is unreliable and should not be used if possible
         return await vscode.commands.executeCommand('openEditors.closeAll')
     }
 
-    // Remove the below code when `openEditors.closeAll` is available in all versions
+    // Remove the below code (all of it) when `openEditors.closeAll` is available in all versions
     await vscode.commands.executeCommand('workbench.action.closeAllEditors')
 
     // The output channel counts as an editor, but you can't really close that...

--- a/src/test/testUtil.ts
+++ b/src/test/testUtil.ts
@@ -211,7 +211,7 @@ export const assertTelemetryCurried =
 
 /**
  * Waits for _any_ active text editor to appear and have the desired contents.
- * This is important since their may be delays between showing a new document and
+ * This is important since there may be delays between showing a new document and
  * updates to the `activeTextEditor` field.
  *
  * Assumes that only a single document will be edited while polling. The contents of

--- a/src/test/testUtil.ts
+++ b/src/test/testUtil.ts
@@ -14,7 +14,7 @@ import * as pathutil from '../shared/utilities/pathUtils'
 import { makeTemporaryToolkitFolder, tryRemoveFolder } from '../shared/filesystemUtilities'
 import globals from '../shared/extensionGlobals'
 import { waitUntil } from '../shared/utilities/timeoutUtils'
-import { isReleaseVersion } from '../shared/vscode/env'
+import { isMinVer, isReleaseVersion } from '../shared/vscode/env'
 
 const testTempDirs: string[] = []
 
@@ -242,7 +242,7 @@ export async function assertTextEditorContains(contents: string): Promise<void |
  */
 export async function closeAllEditors(): Promise<unknown> {
     if ((await vscode.commands.getCommands()).includes('openEditors.closeAll')) {
-        if (vscode.version.startsWith('1.44') && !isReleaseVersion()) {
+        if (isMinVer() && !isReleaseVersion()) {
             throw Error('openEditors.closeAll is available in min version, remove me!')
         }
         // Derived by inspecting 'Keyboard Shortcuts' via command `>Preferences: Open Keyboard Shortcuts`

--- a/src/test/testUtil.ts
+++ b/src/test/testUtil.ts
@@ -14,7 +14,7 @@ import * as pathutil from '../shared/utilities/pathUtils'
 import { makeTemporaryToolkitFolder, tryRemoveFolder } from '../shared/filesystemUtilities'
 import globals from '../shared/extensionGlobals'
 import { waitUntil } from '../shared/utilities/timeoutUtils'
-import { isMinVer, isReleaseVersion } from '../shared/vscode/env'
+import { isMinimumVersion, isReleaseVersion } from '../shared/vscode/env'
 
 const testTempDirs: string[] = []
 
@@ -242,7 +242,7 @@ export async function assertTextEditorContains(contents: string): Promise<void |
  */
 export async function closeAllEditors(): Promise<unknown> {
     if ((await vscode.commands.getCommands()).includes('openEditors.closeAll')) {
-        if (isMinVer() && !isReleaseVersion()) {
+        if (isMinimumVersion() && !isReleaseVersion()) {
             throw Error('openEditors.closeAll is available in min version, remove me!')
         }
         // Derived by inspecting 'Keyboard Shortcuts' via command `>Preferences: Open Keyboard Shortcuts`


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
S3 editor tests still not reliable

## Solution
Attempt 2 at improving stability by waiting for specific contents rather than _any_ active text editor. 

The pattern of waiting for certain things to happen will become increasing common as we use more of the real VS Code API. This is just because we're dealing with of a lot of asynchronous things that otherwise have no explicit sequence of events. Luckily I think it's mostly a 'one-and-done' type of deal; once we figure out the nuances with each API, the test code can be re-used elsewhere.

I'll be making some dummy commits against this PR over the day to see if this change truly made things more stable.

Once VS Code has a better API for managing tabs, this code can be made so much more reliable. It's just right now there's very little way to inspect what the user is actually seeing.
<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
