### PR TITLE
ECS: show when container node has no running tasks

### DIFF
--- a/.changes/next-release/Feature-8fa21b2e-2510-4d9e-b5ab-8a6b331c7b4b.json
+++ b/.changes/next-release/Feature-8fa21b2e-2510-4d9e-b5ab-8a6b331c7b4b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "ECS: Container node displays when there is no running containers"
+}

--- a/package.nls.json
+++ b/package.nls.json
@@ -185,6 +185,7 @@
     "AWS.ecs.disableEcsExec": "Disable Command Execution",
     "AWS.ecs.runCommandInContainer": "Run command in container",
     "AWS.ecs.runCommandInContainer.error": "Failed to execute command in container.",
+    "AWS.ecs.containerNode.noTasks": "no running tasks",
     "AWS.command.ecs.runCommandInContainer.warnBeforeExecute": "Command may modify the running container {0}. Are you sure?",
     "AWS.command.ecs.runCommandInContainer.viewOutput": "View Output",
     "AWS.command.ecs.runCommandInContainer.noPluginFound": "This feature requires the SSM Session Manager plugin (session-manager-plugin) to be installed and available on your $PATH",

--- a/package.nls.json
+++ b/package.nls.json
@@ -185,7 +185,6 @@
     "AWS.ecs.disableEcsExec": "Disable Command Execution",
     "AWS.ecs.runCommandInContainer": "Run command in container",
     "AWS.ecs.runCommandInContainer.error": "Failed to execute command in container.",
-    "AWS.ecs.containerNode.noTasks": "no running tasks",
     "AWS.command.ecs.runCommandInContainer.warnBeforeExecute": "Command may modify the running container {0}. Are you sure?",
     "AWS.command.ecs.runCommandInContainer.viewOutput": "View Output",
     "AWS.command.ecs.runCommandInContainer.noPluginFound": "This feature requires the SSM Session Manager plugin (session-manager-plugin) to be installed and available on your $PATH",

--- a/src/ecs/explorer/ecsContainerNode.ts
+++ b/src/ecs/explorer/ecsContainerNode.ts
@@ -2,9 +2,6 @@
  * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import * as nls from 'vscode-nls'
-const localize = nls.loadMessageBundle()
-
 import * as vscode from 'vscode'
 import { EcsClient } from '../../shared/clients/ecsClient'
 import globals from '../../shared/extensionGlobals'
@@ -14,7 +11,6 @@ import { EcsServiceNode } from './ecsServiceNode'
 const CONTEXT_EXEC_ENABLED = 'awsEcsContainerNodeExecEnabled'
 const CONTEXT_EXEC_DISABLED = 'awsEcsContainerNodeExecDisabled'
 const TASK_STATUS_RUNNING = 'RUNNING'
-const MAX_RESULTS = 1
 
 export class EcsContainerNode extends AWSTreeNodeBase {
     public constructor(
@@ -35,7 +31,7 @@ export class EcsContainerNode extends AWSTreeNodeBase {
     }
 
     public listTasks() {
-        return this.ecs.listTasks(this.clusterArn, this.serviceName)
+        return this.ecs.listTasks({ cluster: this.clusterArn, serviceName: this.serviceName })
     }
 
     public describeTasks(tasks: string[]) {
@@ -43,8 +39,16 @@ export class EcsContainerNode extends AWSTreeNodeBase {
     }
 
     private async hasRunningTasks(): Promise<boolean> {
-        const tasks = await this.ecs.listTasks(this.clusterArn, this.serviceName, TASK_STATUS_RUNNING, MAX_RESULTS)
-        return tasks.length > 0
+        return (
+            (
+                await this.ecs.listTasks({
+                    cluster: this.clusterArn,
+                    serviceName: this.serviceName,
+                    desiredStatus: TASK_STATUS_RUNNING,
+                    maxResults: 1,
+                })
+            ).length > 0
+        )
     }
 
     public async updateRunningTasks(): Promise<void> {

--- a/src/ecs/explorer/ecsContainerNode.ts
+++ b/src/ecs/explorer/ecsContainerNode.ts
@@ -10,11 +10,11 @@ import { EcsClient } from '../../shared/clients/ecsClient'
 import globals from '../../shared/extensionGlobals'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 import { EcsServiceNode } from './ecsServiceNode'
-import { Commands } from '../../shared/vscode/commands'
 
 const CONTEXT_EXEC_ENABLED = 'awsEcsContainerNodeExecEnabled'
 const CONTEXT_EXEC_DISABLED = 'awsEcsContainerNodeExecDisabled'
 const TASK_STATUS_RUNNING = 'RUNNING'
+const MAX_RESULTS = 1
 
 export class EcsContainerNode extends AWSTreeNodeBase {
     public constructor(
@@ -43,13 +43,8 @@ export class EcsContainerNode extends AWSTreeNodeBase {
     }
 
     private async hasRunningTasks(): Promise<boolean> {
-        const tasks = await this.ecs.listTasks(this.clusterArn, this.serviceName, TASK_STATUS_RUNNING)
+        const tasks = await this.ecs.listTasks(this.clusterArn, this.serviceName, TASK_STATUS_RUNNING, MAX_RESULTS)
         return tasks.length > 0
-    }
-
-    public async refresh(commands: Commands = Commands.vscode()): Promise<void> {
-        await this.updateRunningTasks()
-        return commands.execute('aws.refreshAwsExplorerNode', this)
     }
 
     public async updateRunningTasks(): Promise<void> {

--- a/src/ecs/explorer/ecsContainerNode.ts
+++ b/src/ecs/explorer/ecsContainerNode.ts
@@ -2,11 +2,12 @@
  * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+import * as nls from 'vscode-nls'
+const localize = nls.loadMessageBundle()
 
 import * as vscode from 'vscode'
 import { EcsClient } from '../../shared/clients/ecsClient'
 import globals from '../../shared/extensionGlobals'
-
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 import { EcsServiceNode } from './ecsServiceNode'
 
@@ -19,11 +20,15 @@ export class EcsContainerNode extends AWSTreeNodeBase {
         public readonly serviceName: string,
         public readonly clusterArn: string,
         public readonly ecs: EcsClient,
-        public readonly parent: EcsServiceNode
+        public readonly parent: EcsServiceNode,
+        private readonly hasRunningTasks: boolean
     ) {
         super(containerName)
         this.tooltip = containerName
         this.contextValue = this.parent.service.enableExecuteCommand ? CONTEXT_EXEC_ENABLED : CONTEXT_EXEC_DISABLED
+        this.description = !this.hasRunningTasks
+            ? `[${localize('AWS.ecs.containerNode.noTasks', 'no running tasks')}]`
+            : false
 
         this.iconPath = {
             dark: vscode.Uri.file(globals.iconPaths.dark.container),

--- a/src/ecs/explorer/ecsContainerNode.ts
+++ b/src/ecs/explorer/ecsContainerNode.ts
@@ -2,6 +2,9 @@
  * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+import * as nls from 'vscode-nls'
+const localize = nls.loadMessageBundle()
+
 import * as vscode from 'vscode'
 import { EcsClient } from '../../shared/clients/ecsClient'
 import globals from '../../shared/extensionGlobals'
@@ -51,7 +54,9 @@ export class EcsContainerNode extends AWSTreeNodeBase {
         )
     }
 
-    public async updateRunningTasks(): Promise<void> {
-        this.description = (await this.hasRunningTasks()) ? false : `[no running tasks]`
+    public async updateNodeDescription(): Promise<void> {
+        this.description = (await this.hasRunningTasks())
+            ? false
+            : localize('AWS.explorerNode.ecs.noRunningTasks', '[no running tasks]')
     }
 }

--- a/src/ecs/explorer/ecsServiceNode.ts
+++ b/src/ecs/explorer/ecsServiceNode.ts
@@ -18,6 +18,7 @@ import globals from '../../shared/extensionGlobals'
 
 const CONTEXT_EXEC_ENABLED = 'awsEcsServiceNode.ENABLED'
 const CONTEXT_EXEC_DISABLED = 'awsEcsServiceNode.DISABLED'
+const TASK_STATUS_RUNNING = 'RUNNING'
 
 export class EcsServiceNode extends AWSTreeNodeBase implements AWSResourceNode {
     public constructor(
@@ -39,8 +40,15 @@ export class EcsServiceNode extends AWSTreeNodeBase implements AWSResourceNode {
         return await makeChildrenNodes({
             getChildNodes: async () => {
                 const containerNames = await this.ecs.getContainerNames(this.service.taskDefinition!)
-                return containerNames.map(
-                    name => new EcsContainerNode(name, this.name, this.parent.arn, this.ecs, this)
+                return await Promise.all(
+                    containerNames.map(async name => {
+                        const tasks = await this.ecs.listTasks(
+                            this.service.clusterArn!,
+                            this.service.serviceName!,
+                            TASK_STATUS_RUNNING
+                        )
+                        return new EcsContainerNode(name, this.name, this.parent.arn, this.ecs, this, tasks.length > 0)
+                    })
                 )
             },
             getErrorNode: async (error: Error, logID: number) => new ErrorNode(this, error, logID),

--- a/src/ecs/explorer/ecsServiceNode.ts
+++ b/src/ecs/explorer/ecsServiceNode.ts
@@ -39,13 +39,12 @@ export class EcsServiceNode extends AWSTreeNodeBase implements AWSResourceNode {
         return await makeChildrenNodes({
             getChildNodes: async () => {
                 const containerNames = await this.ecs.getContainerNames(this.service.taskDefinition!)
-                const childNodes = containerNames.map(name => {
-                    return new EcsContainerNode(name, this.name, this.parent.arn, this.ecs, this)
-                })
+                const childNodes = containerNames.map(
+                    name => new EcsContainerNode(name, this.name, this.parent.arn, this.ecs, this)
+                )
                 for (const node of childNodes) {
-                    await node.updateRunningTasks()
+                    await node.updateNodeDescription()
                 }
-
                 return childNodes
             },
             getErrorNode: async (error: Error, logID: number) => new ErrorNode(this, error, logID),

--- a/src/ecs/explorer/ecsServiceNode.ts
+++ b/src/ecs/explorer/ecsServiceNode.ts
@@ -42,9 +42,12 @@ export class EcsServiceNode extends AWSTreeNodeBase implements AWSResourceNode {
                 const childNodes = containerNames.map(
                     name => new EcsContainerNode(name, this.name, this.parent.arn, this.ecs, this)
                 )
+
+                const childPromises = []
                 for (const node of childNodes) {
-                    await node.updateNodeDescription()
+                    childPromises.push(node.updateNodeDescription())
                 }
+                await Promise.all(childPromises)
                 return childNodes
             },
             getErrorNode: async (error: Error, logID: number) => new ErrorNode(this, error, logID),

--- a/src/shared/clients/ecsClient.ts
+++ b/src/shared/clients/ecsClient.ts
@@ -59,11 +59,7 @@ export class DefaultEcsClient {
         return containerNames ?? []
     }
 
-    public async listTasks(
-        cluster: string,
-        serviceName: string,
-        taskStatus: string | undefined = undefined
-    ): Promise<string[]> {
+    public async listTasks(cluster: string, serviceName: string, taskStatus?: string): Promise<string[]> {
         const sdkClient = await this.createSdkClient()
 
         const params: ECS.ListTasksRequest = { cluster: cluster, serviceName: serviceName, desiredStatus: taskStatus }

--- a/src/shared/clients/ecsClient.ts
+++ b/src/shared/clients/ecsClient.ts
@@ -59,10 +59,14 @@ export class DefaultEcsClient {
         return containerNames ?? []
     }
 
-    public async listTasks(cluster: string, serviceName: string): Promise<string[]> {
+    public async listTasks(
+        cluster: string,
+        serviceName: string,
+        taskStatus: string | undefined = undefined
+    ): Promise<string[]> {
         const sdkClient = await this.createSdkClient()
 
-        const params: ECS.ListTasksRequest = { cluster: cluster, serviceName: serviceName }
+        const params: ECS.ListTasksRequest = { cluster: cluster, serviceName: serviceName, desiredStatus: taskStatus }
         const listTasksResponse = await sdkClient.listTasks(params).promise()
         return listTasksResponse.taskArns ?? []
     }

--- a/src/shared/clients/ecsClient.ts
+++ b/src/shared/clients/ecsClient.ts
@@ -59,21 +59,9 @@ export class DefaultEcsClient {
         return containerNames ?? []
     }
 
-    public async listTasks(
-        cluster: string,
-        serviceName: string,
-        taskStatus?: string,
-        maxResults?: number
-    ): Promise<string[]> {
+    public async listTasks(args: ECS.ListTasksRequest): Promise<string[]> {
         const sdkClient = await this.createSdkClient()
-
-        const params: ECS.ListTasksRequest = {
-            cluster: cluster,
-            serviceName: serviceName,
-            desiredStatus: taskStatus,
-            maxResults: maxResults,
-        }
-        const listTasksResponse = await sdkClient.listTasks(params).promise()
+        const listTasksResponse = await sdkClient.listTasks(args).promise()
         return listTasksResponse.taskArns ?? []
     }
 

--- a/src/shared/clients/ecsClient.ts
+++ b/src/shared/clients/ecsClient.ts
@@ -59,10 +59,20 @@ export class DefaultEcsClient {
         return containerNames ?? []
     }
 
-    public async listTasks(cluster: string, serviceName: string, taskStatus?: string): Promise<string[]> {
+    public async listTasks(
+        cluster: string,
+        serviceName: string,
+        taskStatus?: string,
+        maxResults?: number
+    ): Promise<string[]> {
         const sdkClient = await this.createSdkClient()
 
-        const params: ECS.ListTasksRequest = { cluster: cluster, serviceName: serviceName, desiredStatus: taskStatus }
+        const params: ECS.ListTasksRequest = {
+            cluster: cluster,
+            serviceName: serviceName,
+            desiredStatus: taskStatus,
+            maxResults: maxResults,
+        }
         const listTasksResponse = await sdkClient.listTasks(params).promise()
         return listTasksResponse.taskArns ?? []
     }

--- a/src/test/shared/clients/mockClients.ts
+++ b/src/test/shared/clients/mockClients.ts
@@ -360,7 +360,7 @@ export class MockEcsClient implements EcsClient {
     public readonly getClusters: (nextToken?: string) => Promise<EcsResourceAndToken>
     public readonly getServices: (cluster: string, nextToken?: string) => Promise<EcsResourceAndToken>
     public readonly getContainerNames: (taskDefinition: string) => Promise<string[]>
-    public readonly listTasks: (cluster: string, serviceName: string) => Promise<string[]>
+    public readonly listTasks: (args: ECS.ListTasksRequest) => Promise<string[]>
     public readonly describeTasks: (cluster: string, tasks: string[]) => Promise<ECS.Task[]>
     public readonly updateService: (cluster: string, serviceName: string, enable: boolean) => Promise<void>
     public readonly describeServices: (cluster: string, services: string[]) => Promise<ECS.Service[]>


### PR DESCRIPTION

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Containers may have no running tasks but still allow for a user
to start the 'Run Command' wizard.
## Solution
Show in the explorer when a container has no running tasks.

## Screenshots
![no running tasks](https://user-images.githubusercontent.com/25124281/149406768-9ebc99fc-6bae-4be4-b1f2-5ac55375e1ae.png)

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
