### PR TITLE
fix(CI): remove old packages

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -20,7 +20,7 @@ phases:
             - '>/dev/null apt-get -qq update'
             - '>/dev/null apt-get -qq install -y ca-certificates'
             # Install other needed dependencies
-            - '>/dev/null apt-get -qq install -y jq python2.7 python-pip python3.6 python3.7 python3.8 python3-pip python3-distutils'
+            - '>/dev/null apt-get -qq install -y jq python3.6 python3.7 python3.8 python3-pip python3-distutils'
             - '>/dev/null apt-get -qq install -y libgtk-3-dev libxss1 xvfb libnss3-dev libasound2 libasound2-plugins libsecret-1-0'
             - '>/dev/null apt-get -qq install -y java-1.8.0-amazon-corretto-jdk java-11-amazon-corretto-jdk'
             - '>/dev/null pip3 install --upgrade aws-sam-cli'


### PR DESCRIPTION
LinuxBuildImage.STANDARD_5_0 (ubuntu 20) does not have these packages.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem

## Solution

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
