### PR TITLE
ECS: bug fix, verify node before run command

### DIFF
--- a/src/ecs/activation.ts
+++ b/src/ecs/activation.ts
@@ -2,6 +2,8 @@
  * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+import * as nls from 'vscode-nls'
+const localize = nls.loadMessageBundle()
 
 import * as vscode from 'vscode'
 import { ExtContext } from '../shared/extensions'
@@ -10,10 +12,21 @@ import { runCommandInContainer } from './commands/runCommandInContainer'
 import { EcsContainerNode } from './explorer/ecsContainerNode'
 import { EcsServiceNode } from './explorer/ecsServiceNode'
 import { ecsDocumentationUrl } from '../shared/constants'
+import { getLogger } from '../shared/logger'
 
 export async function activate(ctx: ExtContext): Promise<void> {
     ctx.extensionContext.subscriptions.push(
         vscode.commands.registerCommand('aws.ecs.runCommandInContainer', async (node: EcsContainerNode) => {
+            if (!(node instanceof EcsContainerNode)) {
+                getLogger().error('Cannot run command on node: %O', node)
+                vscode.window.showErrorMessage(
+                    localize(
+                        'AWS.explorerNode.notLoaded',
+                        'This resource may not be fully loaded yet. Please try again.'
+                    )
+                )
+                return
+            }
             await runCommandInContainer(node)
         })
     )

--- a/src/ecs/activation.ts
+++ b/src/ecs/activation.ts
@@ -17,6 +17,7 @@ import { getLogger } from '../shared/logger'
 export async function activate(ctx: ExtContext): Promise<void> {
     ctx.extensionContext.subscriptions.push(
         vscode.commands.registerCommand('aws.ecs.runCommandInContainer', async (node: EcsContainerNode) => {
+            // VS Code will rarely call the command with `undefined` if the tree is still loading
             if (!(node instanceof EcsContainerNode)) {
                 getLogger().error('Cannot run command on node: %O', node)
                 vscode.window.showErrorMessage(

--- a/src/ecs/commands/runCommandInContainer.ts
+++ b/src/ecs/commands/runCommandInContainer.ts
@@ -26,13 +26,6 @@ export async function runCommandInContainer(
     outputChannel = globals.outputChannel,
     settings: SettingsConfiguration = new DefaultSettingsConfiguration(extensionSettingsPrefix)
 ): Promise<void> {
-    if (!(node instanceof EcsContainerNode)) {
-        getLogger().error('Cannot run command on node that has not loaded')
-        window.showErrorMessage(
-            localize('AWS.explorerNode.notLoaded', 'This resource may not be fully loaded yet. Please try again.')
-        )
-        return
-    }
     getLogger().debug('RunCommandInContainer called for: %O', node.containerName)
     let result: 'Succeeded' | 'Failed' | 'Cancelled' = 'Cancelled'
     let status: vscode.Disposable | undefined

--- a/src/ecs/commands/runCommandInContainer.ts
+++ b/src/ecs/commands/runCommandInContainer.ts
@@ -26,6 +26,13 @@ export async function runCommandInContainer(
     outputChannel = globals.outputChannel,
     settings: SettingsConfiguration = new DefaultSettingsConfiguration(extensionSettingsPrefix)
 ): Promise<void> {
+    if (!(node instanceof EcsContainerNode)) {
+        getLogger().error('Cannot run command on node that has not loaded')
+        window.showErrorMessage(
+            localize('AWS.explorerNode.notLoaded', 'This resource may not be fully loaded yet. Please try again.')
+        )
+        return
+    }
     getLogger().debug('RunCommandInContainer called for: %O', node.containerName)
     let result: 'Succeeded' | 'Failed' | 'Cancelled' = 'Cancelled'
     let status: vscode.Disposable | undefined


### PR DESCRIPTION


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
If a command on a node is executed before the node has
completely loaded, it will error.
## Solution
Verify the node exists and is typed before attempting to
execute the command.
<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
