### PR TITLE
Codelens providers do not throw errors if source file is not in workspace folder

### DIFF
--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -44,7 +44,7 @@ export async function makeCodeLenses({
     const workspaceFolder: vscode.WorkspaceFolder | undefined = vscode.workspace.getWorkspaceFolder(document.uri)
 
     if (!workspaceFolder) {
-        getLogger().error(`Source file ${document.uri} is external to the current workspace.`)
+        getLogger().error(`makeCodeLenses: source file is external to workspace: ${document.uri}`)
 
         return []
     }

--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -44,7 +44,9 @@ export async function makeCodeLenses({
     const workspaceFolder: vscode.WorkspaceFolder | undefined = vscode.workspace.getWorkspaceFolder(document.uri)
 
     if (!workspaceFolder) {
-        throw new Error(`Source file ${document.uri} is external to the current workspace.`)
+        getLogger().error(`Source file ${document.uri} is external to the current workspace.`)
+
+        return []
     }
 
     const lenses: vscode.CodeLens[] = []


### PR DESCRIPTION
## Problem
We're throwing an uncaught error if trying to provide codelenses to files outside the workspace folder.

## Solution
Error log and return a blank array instead of throwing

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
