### PR TITLE
tests: add way to test webviews

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -64,7 +64,8 @@
                 "TEST_REPORT_DIR": "${workspaceFolder}/.test-reports",
                 "TEST_FILE": "null",
                 "AWS_TOOLKIT_IGNORE_WEBPACK_BUNDLE": "true",
-                "NO_COVERAGE": "true"
+                "NO_COVERAGE": "true",
+                "WEBPACK_DEVELOPER_SERVER": "http://localhost:8080"
             },
             "outFiles": ["${workspaceFolder}/dist/src/test/**/*.js"],
             "preLaunchTask": "${defaultBuildTask}"
@@ -84,7 +85,8 @@
                 "TEST_REPORT_DIR": "${workspaceFolder}/.test-reports",
                 "TEST_FILE": "${relativeFileDirname}/${fileBasenameNoExtension}",
                 "AWS_TOOLKIT_IGNORE_WEBPACK_BUNDLE": "true",
-                "NO_COVERAGE": "true"
+                "NO_COVERAGE": "true",
+                "WEBPACK_DEVELOPER_SERVER": "http://localhost:8080"
             },
             "outFiles": ["${workspaceFolder}/dist/.vscode/*", "${workspaceFolder}/dist/src/test/**/*.js"],
             "preLaunchTask": "${defaultBuildTask}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "aws-toolkit-vscode",
-            "version": "1.35.0-SNAPSHOT",
+            "version": "1.36.0-SNAPSHOT",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2891,7 +2891,7 @@
         "recompile": "npm run clean && npm run compile",
         "watch": "npm run buildScripts && tsc -watch -p ./",
         "postinstall": "ts-node ./build-scripts/generateServiceClient.ts && npm run generateTelemetry && npm run generateConfigurationAttributes",
-        "testCompile": "tsc -p ./ && npm run buildScripts",
+        "testCompile": "tsc -p ./ && npm run buildScripts && webpack --config-name vue --mode development",
         "test": "npm run testCompile && ts-node ./test-scripts/test.ts",
         "integrationTest": "npm run testCompile && ts-node ./test-scripts/integrationTest.ts",
         "lint": "eslint -c .eslintrc.js --ext .ts .",

--- a/src/lambda/vue/samInvokeBackend.ts
+++ b/src/lambda/vue/samInvokeBackend.ts
@@ -41,7 +41,7 @@ const localize = nls.loadMessageBundle()
 const VueWebview = compileVueWebview({
     id: 'createLambda',
     title: localize('AWS.command.launchConfigForm.title', 'SAM Debug Configuration Editor'),
-    webviewJs: 'lambdaVue.js',
+    webviewJs: 'src/lambda/vue/entry.js',
     commands: {
         getRuntimes: () => samLambdaCreatableRuntimes().toArray().sort(),
         getTemplate,
@@ -81,7 +81,6 @@ export interface AwsSamDebuggerConfigurationLoose extends AwsSamDebuggerConfigur
  * Open a quick pick containing the names of launch configs in the `launch.json` array.
  * Filter out non-supported launch configs.
  * Call back into the webview with the selected launch config.
- * @param postMessageFn
  */
 async function loadSamLaunchConfig(): Promise<AwsSamDebuggerConfiguration | undefined> {
     // TODO: Find a better way to infer this. Might need another arg from the frontend (depends on the context in which the launch config is made?)
@@ -125,7 +124,6 @@ interface SampleQuickPickItem extends vscode.QuickPickItem {
 /**
  * Open a quick pick containing upstream sample payloads.
  * Call back into the webview with the contents of the payload to add to the JSON field.
- * @param postMessageFn
  */
 async function getSamplePayload(): Promise<string | undefined> {
     try {

--- a/src/lambda/vue/samInvokeFrontend.ts
+++ b/src/lambda/vue/samInvokeFrontend.ts
@@ -138,16 +138,16 @@ export default defineComponent({
             this.headers.errorMsg = ''
             this.stageVariables.errorMsg = ''
         },
-        launch() {
+        async launch() {
             const config = this.formatConfig()
-            config && client.invokeLaunchConfig(config)
+            config && (await client.invokeLaunchConfig(config))
         },
-        save() {
+        async save() {
             const config = this.formatConfig()
-            config && client.saveLaunchConfig(config)
+            config && (await client.saveLaunchConfig(config))
         },
-        loadConfig() {
-            client.loadSamLaunchConfig().then(config => this.parseConfig(config))
+        async loadConfig() {
+            this.parseConfig(await client.loadSamLaunchConfig())
         },
         parseConfig(config?: AwsSamDebuggerConfiguration) {
             if (!config) {
@@ -174,18 +174,18 @@ export default defineComponent({
             this.skipNewImageCheck = config.sam?.skipNewImageCheck ?? false
             this.msg = `Loaded config ${config}`
         },
-        loadPayload() {
+        async loadPayload() {
             this.resetJsonErrors()
-            client.getSamplePayload().then(sample => {
+            await client.getSamplePayload().then(sample => {
                 if (!sample) {
                     return
                 }
                 this.payload.value = JSON.stringify(JSON.parse(sample), undefined, 4)
             })
         },
-        loadResource() {
+        async loadResource() {
             this.resetJsonErrors()
-            client.getTemplate().then(template => {
+            await client.getTemplate().then(template => {
                 if (!template) {
                     return
                 }

--- a/src/lambda/vue/samInvokeFrontend.ts
+++ b/src/lambda/vue/samInvokeFrontend.ts
@@ -9,6 +9,7 @@ import { AwsSamDebuggerConfigurationLoose, SamInvokeWebview } from './samInvokeB
 import settingsPanel from '../../webviews/components/settingsPanel.vue'
 import { WebviewClientFactory } from '../../webviews/client'
 import saveData from '../../webviews/mixins/saveData'
+import reporter from '../../webviews/mixins/reporter'
 
 const client = WebviewClientFactory.create<SamInvokeWebview>()
 
@@ -116,7 +117,7 @@ export default defineComponent({
             this.runtimes = runtimes
         })
     },
-    mixins: [saveData],
+    mixins: [saveData, reporter],
     data(): SamInvokeVueData {
         return {
             ...initData(),

--- a/src/test/fakeExtensionContext.ts
+++ b/src/test/fakeExtensionContext.ts
@@ -4,6 +4,7 @@
  */
 
 import * as vscode from 'vscode'
+import { resolve } from 'path'
 import { CredentialsStore } from '../credentials/credentialsStore'
 import { DefaultSettingsConfiguration } from '../shared/settingsConfiguration'
 import { DefaultTelemetryService } from '../shared/telemetry/defaultTelemetryService'
@@ -41,7 +42,10 @@ export class FakeExtensionContext implements vscode.ExtensionContext {
     public storagePath: string | undefined
     public logPath: string = ''
 
-    private _extensionPath: string = ''
+    // Seems to be the most reliable way to set the extension path (unfortunately)
+    // TODO: figure out a robust way to source the project directory that is invariant to entry point
+    // Using `package.json` as a reference point seems to make the most sense
+    private _extensionPath: string = resolve(__dirname, '../../..')
     private _globalStoragePath: string = '.'
 
     public constructor(preload?: FakeExtensionState) {

--- a/src/test/lambda/vue/samInvoke.test.ts
+++ b/src/test/lambda/vue/samInvoke.test.ts
@@ -20,6 +20,7 @@ import { CloudFormationTemplateRegistry } from '../../../shared/cloudformation/t
 import { makeTemporaryToolkitFolder, tryRemoveFolder } from '../../../shared/filesystemUtilities'
 import { toFile } from '../../testUtil'
 import { makeSampleSamTemplateYaml } from '../../shared/cloudformation/cloudformationTestUtils'
+import { sleep } from '../../../shared/utilities/promiseUtilities'
 
 describe('Sam Invoke Vue Backend', () => {
     let context: ExtContext
@@ -48,6 +49,18 @@ describe('Sam Invoke Vue Backend', () => {
         assert.deepStrictEqual(runtimes, samLambdaCreatableRuntimes().toArray().sort())
 
         server.panel?.dispose()
+    })
+
+    it('can inspect', async function () {
+        sinon.restore()
+        context.extensionContext.extensionPath = '/Users/sijaden/VSCode/aws-toolkit-vscode' // xxx
+
+        const server = new SamInvokeWebview(context)
+        server.start()
+
+        await sleep(3000)
+        const s = await server.inspect()
+        console.log(s)
     })
 
     it('can get a template from the user', async function () {

--- a/src/test/lambda/vue/samInvoke.test.ts
+++ b/src/test/lambda/vue/samInvoke.test.ts
@@ -3,11 +3,80 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as vscode from 'vscode'
 import * as assert from 'assert'
+import * as sinon from 'sinon'
+import * as path from 'path'
+import * as picker from '../../../shared/ui/picker'
 import { finalizeConfig } from '../../../lambda/vue/samInvokeBackend'
 import { AwsSamDebuggerConfiguration } from '../../../shared/sam/debugger/awsSamDebugConfiguration'
+import { SamInvokeWebview } from '../../../lambda/vue/samInvokeBackend'
+import { createTestWindow, TestWindow } from '../../shared/vscode/window'
+import { FakeExtensionContext } from '../../fakeExtensionContext'
+import { samLambdaCreatableRuntimes } from '../../../lambda/models/samLambdaRuntime'
+import { ExtContext } from '../../../shared/extensions'
+import globals from '../../../shared/extensionGlobals'
+import { CloudFormationTemplateRegistry } from '../../../shared/cloudformation/templateRegistry'
+import { makeTemporaryToolkitFolder, tryRemoveFolder } from '../../../shared/filesystemUtilities'
+import { toFile } from '../../testUtil'
+import { makeSampleSamTemplateYaml } from '../../shared/cloudformation/cloudformationTestUtils'
 
 describe('Sam Invoke Vue Backend', () => {
+    let context: ExtContext
+    let window: TestWindow
+    let tempFolder: string
+
+    beforeEach(async function () {
+        context = await FakeExtensionContext.getFakeExtContext()
+        window = createTestWindow()
+        tempFolder = await makeTemporaryToolkitFolder()
+        sinon.stub(vscode, 'window').value(window)
+    })
+
+    afterEach(async function () {
+        sinon.restore()
+        await tryRemoveFolder(tempFolder)
+    })
+
+    it('can get runtimes', async function () {
+        const server = new SamInvokeWebview(context)
+        server.start()
+
+        const panel = await window.waitForWebviewPanel<SamInvokeWebview>('SAM Debug Configuration')
+        const runtimes = await panel.client.getRuntimes()
+
+        assert.deepStrictEqual(runtimes, samLambdaCreatableRuntimes().toArray().sort())
+
+        server.panel?.dispose()
+    })
+
+    it('can get a template from the user', async function () {
+        // Setup some fake templates
+        const template1 = vscode.Uri.file(path.join(tempFolder, 'test1.yaml'))
+        const template2 = vscode.Uri.file(path.join(tempFolder, 'test2.yaml'))
+        toFile(makeSampleSamTemplateYaml(true), template1.fsPath)
+        toFile(makeSampleSamTemplateYaml(true), template2.fsPath)
+
+        const registry = new CloudFormationTemplateRegistry()
+        await registry.addItemToRegistry(template1)
+        await registry.addItemToRegistry(template2)
+
+        sinon.stub(globals, 'templateRegistry').value(registry)
+
+        const server = new SamInvokeWebview(context)
+        server.start()
+
+        // Unfortunately we need to stub `picker` here
+        sinon.stub(picker, 'promptUser').callsFake(async args => [args.picker.items[0]])
+
+        const panel = await window.waitForWebviewPanel<SamInvokeWebview>('SAM Debug Configuration')
+        const template = await panel.client.getTemplate()
+
+        assert.strictEqual(vscode.Uri.file(template?.template ?? '').fsPath, template1.fsPath)
+
+        server.panel?.dispose()
+    })
+
     describe('finalizeConfig', () => {
         it('prunes configs correctly', () => {
             const configs: { input: AwsSamDebuggerConfiguration; output: AwsSamDebuggerConfiguration }[] = [

--- a/src/test/shared/vscode/window.ts
+++ b/src/test/shared/vscode/window.ts
@@ -4,14 +4,26 @@
  */
 
 import * as vscode from 'vscode'
+import { VueWebviewPanel } from '../../../webviews/main'
+import { instrumentPanel, TestWebviewPanel } from '../../webviews/panel'
 import { SeverityLevel, ShownMessage, TestMessage } from './message'
 
 type Window = typeof vscode.window
 
-export interface TestWindow {
+export interface TestWindowProps {
     onDidShowMessage: vscode.Event<ShownMessage>
     waitForMessage(expected: string | RegExp, timeout?: number): Promise<ShownMessage>
+    /** Waits for a webview panel to be created, matched on title */
+    waitForWebviewPanel<T extends VueWebviewPanel<any>>(
+        expected: string | RegExp,
+        timeout?: number
+    ): Promise<TestWebviewPanel<T>>
 }
+
+/**
+ * Merged view of {@link vscode.window} and fields provied by {@link TestWindowProps}
+ */
+export type TestWindow = Window & TestWindowProps
 
 // TODO: it's better to just buffer event emitters until they have a listener
 function fireNext<T>(emitter: vscode.EventEmitter<T>, data?: T): void {
@@ -22,11 +34,14 @@ function fireNext<T>(emitter: vscode.EventEmitter<T>, data?: T): void {
  * A test window proxies {@link vscode.window}, intercepting calls whilst
  * allowing for introspection and mocking as-needed.
  */
-export function createTestWindow(): Window & TestWindow {
+export function createTestWindow(): TestWindow {
     // TODO: write mix-in Proxy factory function
     const onDidShowMessageEmitter = new vscode.EventEmitter<ShownMessage>()
+    const onDidCreateWebviewPanelEmitter = new vscode.EventEmitter<vscode.WebviewPanel & { client: any }>()
 
-    return new Proxy(vscode.window, {
+    // We should always store a reference in case test code stubs the `vscode` module
+    const window = vscode.window
+    return new Proxy(window, {
         get: (target, prop, recv) => {
             if (prop === 'onDidShowMessage') {
                 return onDidShowMessageEmitter.event
@@ -47,6 +62,22 @@ export function createTestWindow(): Window & TestWindow {
                     })
                 }
             }
+            if (prop === 'waitForWebviewPanel') {
+                return (expected: string | RegExp, timeout: number = 5000) => {
+                    return new Promise<vscode.WebviewPanel & { client: any }>((resolve, reject) => {
+                        const d = onDidCreateWebviewPanelEmitter.event(panel => {
+                            if (panel.title.match(expected)) {
+                                d.dispose()
+                                resolve(panel)
+                            }
+                        })
+                        setTimeout(() => {
+                            d.dispose()
+                            reject(new Error(`Timed out waiting for panel: ${expected}`))
+                        }, timeout)
+                    })
+                }
+            }
             if (prop === 'showInformationMessage') {
                 return TestMessage.create(SeverityLevel.Information, message =>
                     fireNext(onDidShowMessageEmitter, message)
@@ -57,6 +88,14 @@ export function createTestWindow(): Window & TestWindow {
             }
             if (prop === 'showErrorMessage') {
                 return TestMessage.create(SeverityLevel.Error, message => fireNext(onDidShowMessageEmitter, message))
+            }
+            if (prop === 'createWebviewPanel') {
+                return (...args: Parameters<Window['createWebviewPanel']>) => {
+                    const panel = instrumentPanel(window.createWebviewPanel(...args))
+                    onDidCreateWebviewPanelEmitter.fire(panel)
+
+                    return panel
+                }
             }
             return Reflect.get(target, prop, recv)
         },

--- a/src/test/webviews/panel.ts
+++ b/src/test/webviews/panel.ts
@@ -1,0 +1,74 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { getLogger } from '../../shared/logger/logger'
+import { WebviewClient } from '../../webviews/client'
+import { VueWebviewPanel } from '../../webviews/main'
+import { createTestClient } from './util'
+
+/**
+ * Swaps in the `webview` field with something we can manipulate.
+ *
+ * **This function mutates!**
+ */
+function hijackWebview<T extends { webview: vscode.Webview }>(target: T, webview: vscode.Webview): T {
+    Object.defineProperty(target, 'webview', { get: () => webview })
+
+    return target
+}
+
+/**
+ * A very basic webview that can intercept messages produced by backend logic, simulating responses
+ * produced by the frontend through {@link handler}.
+ */
+export class TestWebview implements vscode.Webview {
+    private readonly _onDidReceiveMessage = new vscode.EventEmitter<any>()
+    public readonly onDidReceiveMessage = this._onDidReceiveMessage.event
+
+    public html = ''
+    public cspSource = ''
+
+    public constructor(
+        protected readonly handler: (message: any) => any,
+        public readonly options: vscode.WebviewOptions
+    ) {}
+
+    public get messageEmitter() {
+        return this._onDidReceiveMessage
+    }
+
+    public asWebviewUri(localResource: vscode.Uri): vscode.Uri {
+        return localResource
+    }
+
+    public async postMessage(message: any): Promise<boolean> {
+        try {
+            await this.handler(message)
+
+            return true
+        } catch (e) {
+            getLogger().error(`Unexpected error from webview message handler: %O`, e)
+            return false
+        }
+    }
+}
+
+export type TestWebviewPanel<T extends VueWebviewPanel<any>> = vscode.WebviewPanel & {
+    readonly client: WebviewClient<T['protocol']>
+}
+
+/**
+ * Swaps in the `webview` component of a panel with our own. This doesn't affect how VS Code treats the panel, but it
+ * does give us control over interactions within our code.
+ */
+export function instrumentPanel(panel: vscode.WebviewPanel): TestWebviewPanel<any> {
+    const receiver = new vscode.EventEmitter<any>()
+    const webview = new TestWebview(receiver.fire.bind(receiver), panel.webview.options)
+    const client = createTestClient(receiver.event, webview.messageEmitter)
+    const modifiedPanel = Object.assign(hijackWebview(panel, webview), { client })
+
+    return modifiedPanel
+}

--- a/src/test/webviews/util.ts
+++ b/src/test/webviews/util.ts
@@ -1,0 +1,84 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { EventEmitter } from 'vscode'
+import { WebviewClient, WebviewClientAgent } from '../../webviews/client'
+import { VueWebview } from '../../webviews/main'
+
+/**
+ * Creates a minimalistic implementation of a {@link WebviewClient} suitable for testing backend logic.
+ *
+ * This re-uses {@link WebviewClientAgent}.
+ */
+export function createTestClient<T extends VueWebview<any>>(
+    receiver: EventEmitter<any>['event'],
+    emitter: EventEmitter<any>
+): WebviewClient<T['protocol']> {
+    type Listener = Parameters<typeof window['addEventListener']>[1]
+    type Window = ConstructorParameters<typeof WebviewClientAgent>[0]
+
+    const listeners: Record<string, Listener[]> = {}
+
+    const dispatch = (event: Event) => {
+        for (const listener of listeners[event.type] ?? []) {
+            if (typeof listener === 'function') {
+                listener(event)
+            } else {
+                listener.handleEvent(event)
+            }
+        }
+
+        return true // Not technically true to spec but good enough
+    }
+
+    const window: Window = {
+        addEventListener: (...args: Parameters<typeof window['addEventListener']>) => {
+            const [type, listener] = args
+            ;(listeners[type] ??= []).push(listener)
+        },
+        removeEventListener: (...args: Parameters<typeof window['removeEventListener']>) => {
+            const [type, listener] = args
+            const arr = listeners[type] ?? []
+            const ind = arr.indexOf(listener)
+
+            if (ind !== -1) {
+                arr.splice(ind, 1)
+            }
+        },
+        dispatchEvent: dispatch,
+        clearTimeout: clearTimeout,
+    }
+
+    const agent = new WebviewClientAgent(window, {
+        // Testing state is not needed right now
+        getState: () => {},
+        setState: state => state,
+        postMessage: message => emitter.fire(message),
+    })
+
+    // TODO: add clean-up logic
+    receiver(e => dispatch(new MessageEvent('message', { data: e })))
+
+    let counter = 0
+    return new Proxy<WebviewClient<T['protocol']>>({} as any, {
+        set: () => {
+            throw new TypeError('Cannot set property to webview client')
+        },
+        get: (_, prop) => {
+            // Why can't Typescript do CFA with asserts using `typeof` ???
+            if (typeof prop !== 'string') {
+                assert.fail(`Client property must be a string, got symbol: ${String(prop)}`)
+            }
+            const id = String(counter++)
+
+            // hard-coded timeout time of 5 seconds for testing
+            return (...args: any) => agent.sendRequest(id, prop, args, 5000)
+        },
+        getPrototypeOf() {
+            return Object
+        },
+    })
+}

--- a/src/webviews/client.ts
+++ b/src/webviews/client.ts
@@ -45,6 +45,21 @@ type ClientCommands<T> = {
         : never
 }
 
+export interface ClientQuery {
+    readonly target?: string
+}
+export interface ClientStatus {
+    readonly id?: string
+    readonly name?: string
+    readonly data: Record<string, any>
+}
+
+export interface GlobalProtocol extends Protocol {
+    $inspect: EventEmitter<ClientQuery>
+    $report: (status: ClientStatus) => void
+    $clear: () => void
+}
+
 /** Can be created by {@link WebviewClientFactory} */
 export type WebviewClient<T> = ClientCommands<T>
 
@@ -86,7 +101,8 @@ export class WebviewClientAgent {
 
     /**
      * Sets up 'global' commands used internally for special functionality that is otherwise
-     * not exposed to the frontend or backend code.
+     * not exposed to the frontend or backend code. This is intended for persistent listeners
+     * that are not directly tied to the application.
      */
     private registerGlobalCommands() {
         const remountEvent = new Event('remount')
@@ -204,6 +220,7 @@ export class WebviewClientFactory {
     public static create<T extends VueWebview<any>>(): WebviewClient<T['protocol']>
     public static create<T extends VueWebviewPanel<any>>(): WebviewClient<T['protocol']>
     public static create<T extends VueWebviewView<any>>(): WebviewClient<T['protocol']>
+    public static create<T extends Protocol<any, any>>(): WebviewClient<T>
     public static create<T extends Protocol<any, any>>(): WebviewClient<T> {
         const agent = (this._agent ??= new WebviewClientAgent(window, vscode))
 

--- a/src/webviews/client.ts
+++ b/src/webviews/client.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EventEmitter } from 'vscode'
+import type { EventEmitter } from 'vscode'
 import { WebviewApi } from 'vscode-webview'
 import { VueWebview, VueWebviewPanel, VueWebviewView } from './main'
 import { Protocol } from './server'
@@ -62,7 +62,10 @@ export class WebviewClientAgent {
     private readonly _disposables: { dispose: () => void }[] = []
 
     public constructor(protected readonly window: Window, protected readonly vscode: VscodeApi) {
-        this.registerGlobalCommands()
+        // Explicitly check for its presence as `Event` is not available in Node
+        if (globalThis.Event) {
+            this.registerGlobalCommands()
+        }
     }
 
     /**

--- a/src/webviews/client.ts
+++ b/src/webviews/client.ts
@@ -46,8 +46,16 @@ type ClientCommands<T> = {
 }
 
 export interface ClientQuery {
+    /** A component name or id. If not provided, all components will respond to the query. */
     readonly target?: string
 }
+
+export interface ClientCommand {
+    readonly target: string
+    readonly method: string
+    readonly args: any[]
+}
+
 export interface ClientStatus {
     readonly id?: string
     readonly name?: string
@@ -56,6 +64,7 @@ export interface ClientStatus {
 
 export interface GlobalProtocol extends Protocol {
     $inspect: EventEmitter<ClientQuery>
+    $execute: EventEmitter<ClientCommand>
     $report: (status: ClientStatus) => void
     $clear: () => void
 }

--- a/src/webviews/mixins/reporter.ts
+++ b/src/webviews/mixins/reporter.ts
@@ -1,0 +1,37 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Vue from 'vue'
+import { WebviewClientFactory, GlobalProtocol } from '../client'
+
+/**
+ * Mixin for instrumenting components for testing.
+ */
+const reporter: Vue.ComponentOptionsMixin = {
+    created() {
+        if (this.$data === undefined) {
+            return
+        }
+
+        const format = (message: string) =>
+            console.log(`${this.name ?? 'unknown'} (${this.id ?? 'unknown'}): ${message}`)
+        const client = WebviewClientFactory.create<GlobalProtocol>()
+
+        client.$inspect(event => {
+            if (this.name && event.target && event.target !== this.name) {
+                console.log(format(`Ignoring inspection request for ${event.target}`))
+                return
+            }
+
+            // There is no consistent scheme for determining a name.
+            // Components should set names and/or ids as-needed.
+            client.$report({ name: this.name, id: this.id, data: this.$data }).catch(err => {
+                console.warn(format(`Failed to send $inspect response: ${err.message}`))
+            })
+        })
+    },
+}
+
+export default reporter

--- a/src/webviews/mixins/saveData.ts
+++ b/src/webviews/mixins/saveData.ts
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { WebviewApi } from 'vscode-webview'
 import * as Vue from 'vue'
+import { WebviewApi } from 'vscode-webview'
+
 declare const vscode: WebviewApi<{ [key: string]: any }>
 
 /* Keep track of registered IDs to warn if duplicates appears */

--- a/types/vue-types.d.ts
+++ b/types/vue-types.d.ts
@@ -3,11 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// temporary ambient declaration
-// this does not really extract types from vue components
-// it just prevents TSC from complaining when trying to import them
+/**
+ * Ambient declaration that describes what '.vue' files export.
+ *
+ * Typescript is unable to parse Vue SFCs, so cannot populate the template types.
+ */
 declare module '*.vue' {
-    import { defineComponent } from 'vue'
-    const Component: ReturnType<typeof defineComponent>
+    import { Component } from 'vue'
+    const Component: Component
     export default Component
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -94,26 +94,21 @@ const baseConfig = {
 }
 
 /**
- * Generates a name given a filepath to an entry file.
- * Example: `src/lambda/vue/entry.ts` -> `lambdaVue.js`
+ * Renames all Vue entry files to be `entry`, located within the same directory.
+ * Example: `src/lambda/vue/entry.ts` -> `dist/src/lambda/vue/entry.js`
  * @param {string} file
  */
 const createVueBundleName = file => {
-    return path
-        .relative('src', path.dirname(file))
-        .split(path.sep)
-        .filter(s => s !== 'vue')
-        .map((s, i) => (i ? s.charAt(0).toUpperCase().concat(s.slice(1)) : s))
-        .concat('Vue')
-        .join('')
+    return path.relative(__dirname, file).split('.').slice(0, -1).join(path.sep)
 }
 
 /**
- * Generates Vue entry points if the filename is called `entry.ts` and is under a `vue` directory.
+ * Generates Vue entry points if the filename is matches `targetPattern` (default: entry.ts)
+ * and is under a `vue` directory.
  */
-const createVueEntries = () => {
+const createVueEntries = (targetPattern = 'entry.ts') => {
     return glob
-        .sync(path.resolve(__dirname, 'src', '**', 'vue', '**', 'entry.ts'))
+        .sync(path.resolve(__dirname, 'src', '**', 'vue', '**', targetPattern))
         .map(f => ({ name: createVueBundleName(f), path: f }))
         .reduce((a, b) => ((a[b.name] = b.path), a), {})
 }


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
No tests for webviews

## Solution
Add a way to test them.

~~The test code currently keeps frontend/backend logic mostly separate, though it might be possible to connect them.~~Tests for the backend should have a behavior very close to what you would expect in production.~~ Frontend tests currently use a mock to simulate the 'server' for simplicity. Dealing with the DOM is already quite a bit of work, don't really want to add in the two-way communication just yet.~~ 

Frontend test code has been removed. Only tests that work against the backend logic exist now.

## Breaking Changes
* Vues are bundled to a different location now. Their path is now 1:1 with the `entry` file for each Vue app. This affects #2449; the fix is just changing the path.

## Remaining Work
* Add method to instrument webview views (not panels)
  * These are created differently so they need a different entry point 
* Add logic to instrument Vue components in a 'test' mode

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
