### PR TITLE
fix(ci): install python3.6, python3.7

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -5,6 +5,8 @@ env:
         AWS_TOOLKIT_TEST_USER_DIR: '/tmp/'
         AWS_TOOLKIT_TEST_NO_COLOR: '1'
         NO_COVERAGE: 'true'
+        # Suppress noisy apt-get/dpkg warnings like "debconf: unable to initialize frontend: Dialog").
+        DEBIAN_FRONTEND: 'noninteractive'
 
 phases:
     install:
@@ -19,25 +21,30 @@ phases:
             - '>/dev/null apt-get -qq install -y apt-transport-https'
             - '>/dev/null apt-get -qq update'
             - '>/dev/null apt-get -qq install -y ca-certificates'
+            - 'apt-get install --reinstall ca-certificates'
+            - 'add-apt-repository -y ppa:deadsnakes/ppa'
             # Install other needed dependencies
-            - '>/dev/null apt-get -qq install -y jq python3.6 python3.7 python3.8 python3-pip python3-distutils'
+            - 'apt-get -qq install -y jq python3.6 python3.7 python3.8 python3-pip python3-distutils'
+            # Fail early if any of these not found.
+            - 'python3.6 --version'
+            - 'python3.7 --version'
+            - 'python3.8 --version'
+            - 'python3.9 --version'
             - '>/dev/null apt-get -qq install -y libgtk-3-dev libxss1 xvfb libnss3-dev libasound2 libasound2-plugins libsecret-1-0'
             - '>/dev/null apt-get -qq install -y java-1.8.0-amazon-corretto-jdk java-11-amazon-corretto-jdk'
             - '>/dev/null pip3 install --upgrade aws-sam-cli'
+            # Print info about sam (version, location, …).
+            - 'pip3 show aws-sam-cli'
             - '>/dev/null pip3 install --upgrade awscli'
             - '>/dev/null pip3 install pylint'
             # Install latest version of Go (known to 'goenv')
-            - '>/dev/null VERSION=$(goenv install --list | tail -n 1) && goenv install $VERSION'
+            - '>/dev/null VERSION=$(goenv install --list | tail -n 1) && 2>/dev/null goenv install $VERSION'
             - '>/dev/null goenv global $VERSION && go env -w GOPROXY=direct'
             - go version
             # login to DockerHub so we don't get throttled
             - docker login --username $(echo $DOCKER_HUB_TOKEN | jq -r '.username') --password $(echo $DOCKER_HUB_TOKEN | jq -r '.password') || true
             # increase file watcher count so CodeLens tests do not fail unexpectedly (ENOSPC error)
             - sysctl fs.inotify.max_user_watches=524288
-            # update git so integ tests pass
-            # TODO: remove when git version >= 2.27.0 is included in CI image
-            - '>/dev/null apt-get -qq install -y git'
-            - git --version
 
     pre_build:
         commands:

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -77,7 +77,6 @@ const scenarios: TestScenario[] = [
         language: 'javascript',
         dependencyManager: 'npm',
     },
-    /*
     {
         runtime: 'python3.6',
         displayName: 'python3.6 (ZIP)',
@@ -94,7 +93,6 @@ const scenarios: TestScenario[] = [
         language: 'python',
         dependencyManager: 'pip',
     },
-    */
     {
         runtime: 'python3.8',
         displayName: 'python3.8 (ZIP)',
@@ -165,7 +163,6 @@ const scenarios: TestScenario[] = [
         language: 'javascript',
         dependencyManager: 'npm',
     },
-    /*
     {
         runtime: 'python3.6',
         displayName: 'python3.6 (Image)',
@@ -184,7 +181,6 @@ const scenarios: TestScenario[] = [
         language: 'python',
         dependencyManager: 'pip',
     },
-    */
     {
         runtime: 'python3.8',
         displayName: 'python3.8 (Image)',


### PR DESCRIPTION
fix #2486

python3.6/3.7 aren't in `/usr` :

```
[Container] 2022/02/24 23:32:04 Running command find /usr -name 'python*' | grep 'python3..$'
/usr/include/x86_64-linux-gnu/python3.8
/usr/include/python3.8
/usr/bin/python3.8
/usr/lib/python3.8
/usr/lib/python3.9
/usr/local/lib/python3.8
/usr/local/aws-cli/v2/2.2.44/dist/include/python3.8
/usr/local/aws-cli/v2/2.2.44/dist/lib/python3.8
/usr/share/doc/python3.8
/usr/share/lintian/overrides/python3.8
/usr/share/binfmts/python3.8
```

Just for reference, `sam` in $PATH looks fine.

```
[Container] 2022/02/25 00:05:39 Running command pip3 show aws-sam-cli
Name: aws-sam-cli
Version: 1.40.0
Location: /root/.pyenv/versions/3.9.5/lib/python3.9/site-packages
...

[Container] 2022/02/25 00:05:50 Running command /root/.pyenv/shims/sam --version
SAM CLI, version 1.40.0
```