### PR TITLE
feat(lambda,sam): add support for dotnet6 (.NET 6)

### DIFF
--- a/.changes/next-release/Feature-71234bfa-7e72-404f-801b-f5f831741eb7.json
+++ b/.changes/next-release/Feature-71234bfa-7e72-404f-801b-f5f831741eb7.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "SAM/Lambda: add support for .NET 6 (dotnet6)"
+}

--- a/README.quickstart.vscode.md
+++ b/README.quickstart.vscode.md
@@ -96,7 +96,7 @@ contextual documentation, as shown below.
 
 The Toolkit _local SAM debugging_ feature supports these Lambda runtimes:
 
--   C# (.NET Core 2.1, 3.1; .NET 5.0)
+-   C# (.NET Core 2.1, 3.1; .NET 5.0, .NET 6.0)
 -   Go (1.x)
 -   Java (8, 8.al2, 11)
 -   JavaScript/TypeScript (Node.js 12.x, 14.x)

--- a/src/lambda/models/samLambdaRuntime.ts
+++ b/src/lambda/models/samLambdaRuntime.ts
@@ -36,7 +36,7 @@ export const pythonRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>([
 ])
 export const goRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>(['go1.x'])
 export const javaRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>(['java11', 'java8', 'java8.al2'])
-export const dotNetRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>(['dotnetcore3.1'])
+export const dotNetRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>(['dotnetcore3.1', 'dotnet6'])
 
 /**
  * Deprecated runtimes can be found at https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html
@@ -83,7 +83,6 @@ export const samArmLambdaRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>
 // Cloud9 supports a subset of runtimes for debugging.
 // * .NET is not supported
 // * Python3.6 is not supported for debugging by IKP3db
-// for some reason, ImmutableSet does not like `ImmutableSet.union().filter()`; initialize union set here.
 const cloud9SupportedBaseRuntimes: ImmutableSet<Runtime> = ImmutableSet.union([nodeJsRuntimes, pythonRuntimes])
 const cloud9SupportedCreateRuntimes = cloud9SupportedBaseRuntimes.filter(
     (runtime: string) => !['python3.6'].includes(runtime)

--- a/src/test/lambda/models/samLambdaRuntime.test.ts
+++ b/src/test/lambda/models/samLambdaRuntime.test.ts
@@ -83,6 +83,7 @@ describe('runtimes', function () {
     })
     it('vscode', function () {
         assert.deepStrictEqual(samLambdaCreatableRuntimes(false).toArray().sort(), [
+            'dotnet6',
             'dotnetcore3.1',
             'go1.x',
             'java11',
@@ -97,6 +98,7 @@ describe('runtimes', function () {
         ])
         assert.deepStrictEqual(samImageLambdaRuntimes(false).toArray().sort(), [
             'dotnet5.0',
+            'dotnet6',
             'dotnetcore3.1',
             'go1.x',
             'java11',


### PR DESCRIPTION


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem

SAM CLI  1.40 supports dotnet6 (.NET 6), but Toolkit does not.

## Solution

Enable dotnet6 in Toolkit.

- manual testing:
    - created dotnet6 "image" app using "Create new SAM Lambda app" command
        - codelens appears on function in src/HelloWorld/Function.cs
        - initiated debugging, sam pulled docker image `mcr.microsoft.com/dotnet/sdk:6.0`
        - lambda ran in docker container, debugger hit breakpoint
    - created dotnet6 "zip" (managed) app using "Create new SAM Lambda app" command
        - codelens appears on function in src/HelloWorld/Function.cs
        - initiated debugging, sam pulled docker image `public.ecr.aws/sam/emulation-dotnet6:rapid-1.40.0-x86_64`
        - lambda ran in docker container
        - debugger hit breakpoint, can step through code, inspect variables.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
