### PR TITLE
feat(lambda,sam): enable TypeScript "Hello world" template

### DIFF
--- a/.changes/next-release/Feature-3b21b22a-f9aa-4e17-a5ac-2372f74f5c10.json
+++ b/.changes/next-release/Feature-3b21b22a-f9aa-4e17-a5ac-2372f74f5c10.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "SAM/Lambda: \"Create SAM Lambda Application\" can choose TypeScript \"Hello World\" template for nodejs14.x"
+}

--- a/src/lambda/models/samTemplates.ts
+++ b/src/lambda/models/samTemplates.ts
@@ -13,6 +13,7 @@ import { RuntimePackageType } from './samLambdaRuntime'
 import { getIdeProperties } from '../../shared/extensionUtilities'
 
 export let helloWorldTemplate = 'helloWorldUninitialized'
+export let helloWorldTypescriptTemplate = 'helloWorldTypescriptUninitialized'
 export let eventBridgeHelloWorldTemplate = 'eventBridgeHelloWorldUninitialized'
 export let eventBridgeStarterAppTemplate = 'eventBridgeStarterAppUnintialized'
 export let stepFunctionsSampleApp = 'stepFunctionsSampleAppUnintialized'
@@ -33,6 +34,11 @@ export function lazyLoadSamTemplateStrings(): void {
         '{0} SAM Hello World',
         getIdeProperties().company
     )
+    helloWorldTypescriptTemplate = localize(
+        'AWS.samcli.initWizard.template.helloWorldTypescript.name',
+        '{0} SAM Hello World (TypeScript)',
+        getIdeProperties().company
+    )
     eventBridgeHelloWorldTemplate = localize(
         'AWS.samcli.initWizard.template.helloWorld.name',
         '{0} SAM EventBridge Hello World',
@@ -50,12 +56,16 @@ export function lazyLoadSamTemplateStrings(): void {
     )
 }
 
-export function getSamTemplateWizardOption(
+export function getSamTemplateWizardOptions(
     runtime: Runtime,
     packageType: RuntimePackageType,
     samCliVersion: string
 ): ImmutableSet<SamTemplate> {
     const templateOptions = Array<SamTemplate>(helloWorldTemplate)
+
+    if (runtime === 'nodejs14.x') {
+        templateOptions.push(helloWorldTypescriptTemplate)
+    }
 
     if (packageType === 'Image') {
         // only supports hello world for now
@@ -70,7 +80,7 @@ export function getSamTemplateWizardOption(
         templateOptions.push(stepFunctionsSampleApp)
     }
 
-    if (supportsTypeScriptBackendTemplate(runtime)) {
+    if (runtime === 'nodejs12.x') {
         templateOptions.push(typeScriptBackendTemplate)
     }
 
@@ -81,6 +91,8 @@ export function getSamCliTemplateParameter(templateSelected: SamTemplate): strin
     switch (templateSelected) {
         case helloWorldTemplate:
             return 'hello-world'
+        case helloWorldTypescriptTemplate:
+            return 'hello-world-typescript'
         case eventBridgeHelloWorldTemplate:
             return 'eventBridge-hello-world'
         case eventBridgeStarterAppTemplate:
@@ -98,6 +110,11 @@ export function getTemplateDescription(template: SamTemplate): string {
     switch (template) {
         case helloWorldTemplate:
             return localize('AWS.samcli.initWizard.template.helloWorld.description', 'A basic SAM app')
+        case helloWorldTypescriptTemplate:
+            return localize(
+                'AWS.samcli.initWizard.template.helloWorldTypescript.description',
+                'A basic SAM TypeScript app'
+            )
         case eventBridgeHelloWorldTemplate:
             return localize(
                 'AWS.samcli.initWizard.template.eventBridge_helloWorld.description',
@@ -128,8 +145,4 @@ export function supportsStepFuntionsTemplate(samCliVersion: string): boolean {
         return false
     }
     return semver.gte(samCliVersion, CLI_VERSION_STEP_FUNCTIONS_TEMPLATE)
-}
-
-export function supportsTypeScriptBackendTemplate(runtime: Runtime): boolean {
-    return runtime === 'nodejs12.x'
 }

--- a/src/lambda/wizards/samInitWizard.ts
+++ b/src/lambda/wizards/samInitWizard.ts
@@ -23,7 +23,7 @@ import {
 } from '../models/samLambdaRuntime'
 import {
     eventBridgeStarterAppTemplate,
-    getSamTemplateWizardOption,
+    getSamTemplateWizardOptions,
     getTemplateDescription,
     SamTemplate,
 } from '../models/samTemplates'
@@ -69,7 +69,7 @@ function createSamTemplatePrompter(
     packageType: RuntimePackageType,
     samCliVersion: string
 ): QuickPickPrompter<SamTemplate> {
-    const templates = getSamTemplateWizardOption(currRuntime, packageType, samCliVersion)
+    const templates = getSamTemplateWizardOptions(currRuntime, packageType, samCliVersion)
     const items = templates.toArray().map(template => ({
         label: template,
         data: template,

--- a/src/test/lambda/models/samTemplates.test.ts
+++ b/src/test/lambda/models/samTemplates.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert'
 import {
     CLI_VERSION_STEP_FUNCTIONS_TEMPLATE,
     getSamCliTemplateParameter,
-    getSamTemplateWizardOption,
+    getSamTemplateWizardOptions,
     getTemplateDescription,
     repromptUserForTemplate,
     SamTemplate,
@@ -53,7 +53,7 @@ before(function () {
 describe('getSamTemplateWizardOption', function () {
     it('should successfully return available templates for specific runtime', function () {
         for (const runtime of samZipLambdaRuntimes.values()) {
-            const result = getSamTemplateWizardOption(runtime, 'Zip', CLI_VERSION_STEP_FUNCTIONS_TEMPLATE)
+            const result = getSamTemplateWizardOptions(runtime, 'Zip', CLI_VERSION_STEP_FUNCTIONS_TEMPLATE)
             switch (runtime) {
                 case 'python3.6':
                 case 'python3.7':
@@ -85,7 +85,7 @@ describe('getSamTemplateWizardOption', function () {
 
     it('should not return Step Functions templates for a SAM CLI version that does not support them', function () {
         for (const runtime of samZipLambdaRuntimes.values()) {
-            const result = getSamTemplateWizardOption(runtime, 'Zip', '0.40.0')
+            const result = getSamTemplateWizardOptions(runtime, 'Zip', '0.40.0')
             assert(!result.contains(stepFunctionsSampleApp))
         }
     })


### PR DESCRIPTION
## blocked

hangs at:

    2022-02-25 08:40:34 [INFO]: Using esbuild for bundling Node.js and TypeScript is a beta feature.
    Please confirm if you would like to proceed with using esbuild to build your function.
    You can also enable this beta feature with 'sam build --beta-features'. [y/N]:

ref https://github.com/aws/aws-sam-cli-app-templates/pull/184

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem

## Solution

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
