### PR TITLE
fix(sam/debug): revert Python 3.6 bootstrap location

### DIFF
--- a/src/shared/sam/debugger/pythonSamDebug.ts
+++ b/src/shared/sam/debugger/pythonSamDebug.ts
@@ -246,7 +246,7 @@ function getPythonExeAndBootstrap(runtime: Runtime) {
     // https://github.com/aws/aws-sam-cli/blob/7d5101a8edeb575b6925f9adecf28f47793c403c/samcli/local/docker/lambda_debug_settings.py
     switch (runtime) {
         case 'python3.6':
-            return { python: '/var/lang/bin/python3.6', bootstrap: '/var/runtime/bootstrap.py' }
+            return { python: '/var/lang/bin/python3.6', bootstrap: '/var/runtime/awslambda/bootstrap.py' }
         case 'python3.7':
             return { python: '/var/lang/bin/python3.7', bootstrap: '/var/runtime/bootstrap' }
         case 'python3.8':


### PR DESCRIPTION
Lambda will publish a new image that has an alias from
/var/runtime/awslambda/bootstrap.py => /var/runtime/bootstrap.py

The Toolkit must choose one or the other. Many customers have images
with the old path. So to minimize error, we continue using the old path
(which will work with the Lambda image having the alias).

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem

## Solution

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
