### PR TITLE
feat(resources): enable multiselect in Cloud9

### DIFF
--- a/.changes/next-release/Feature-a4cd1f7e-d66e-4b21-9a59-a948615b600a.json
+++ b/.changes/next-release/Feature-a4cd1f7e-d66e-4b21-9a59-a948615b600a.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Cloud9: user can choose which Resources to show"
+}

--- a/package.json
+++ b/package.json
@@ -1527,12 +1527,12 @@
                 },
                 {
                     "command": "aws.resources.configure",
-                    "when": "view == aws.explorer && viewItem == resourcesRootNode && !isCloud9",
+                    "when": "view == aws.explorer && viewItem == resourcesRootNode",
                     "group": "1@1"
                 },
                 {
                     "command": "aws.resources.configure",
-                    "when": "view == aws.explorer && viewItem == resourcesRootNode && !isCloud9",
+                    "when": "view == aws.explorer && viewItem == resourcesRootNode",
                     "group": "inline@1"
                 },
                 {

--- a/src/dynamicResources/explorer/nodes/resourcesNode.ts
+++ b/src/dynamicResources/explorer/nodes/resourcesNode.ts
@@ -14,7 +14,6 @@ import { toArrayAsync, toMap, updateInPlace } from '../../../shared/utilities/co
 import { ResourceTypeNode } from './resourceTypeNode'
 import { CloudFormation } from 'aws-sdk'
 import { CloudControlClient } from '../../../shared/clients/cloudControlClient'
-import { isCloud9 } from '../../../shared/extensionUtilities'
 import { memoizedGetResourceTypes, ResourceTypeMetadata } from '../../model/resources'
 import globals from '../../../shared/extensionGlobals'
 
@@ -62,9 +61,7 @@ export class ResourcesNode extends AWSTreeNodeBase {
 
     public async updateChildren(): Promise<void> {
         const resourceTypes = memoizedGetResourceTypes()
-        const enabledResources = !isCloud9()
-            ? vscode.workspace.getConfiguration('aws').get<string[]>('resources.enabledResources')
-            : resourceTypes.keys()
+        const enabledResources = vscode.workspace.getConfiguration('aws').get<string[]>('resources.enabledResources')
 
         if (enabledResources) {
             const availableTypes: Map<string, CloudFormation.TypeSummary> = toMap(

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -318,7 +318,6 @@ export async function createNewSamApplication(
         }
 
         activationReloadState.clearSamInitState()
-        // TODO: Replace when Cloud9 supports `markdown` commands
 
         if (tryOpenReadme) {
             await vscode.commands.executeCommand('markdown.showPreviewToSide', readmeUri)


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem

In Cloud9, user cannot choose which Resources to show/hide.

## Solution

![image](https://user-images.githubusercontent.com/55561878/156444753-4f3c2a31-17af-4d70-9587-881336034185.png)


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
