### PR TITLE
feat(schemas,sam): Add Golang to EventBridge Schemas

### DIFF
--- a/.changes/next-release/Feature-489f795c-9a8f-4055-92d6-51c561ae58a9.json
+++ b/.changes/next-release/Feature-489f795c-9a8f-4055-92d6-51c561ae58a9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "\"Adding Go (Golang) as a supported language for code binding generation through the EventBridge Schemas service\""
+}

--- a/src/eventSchemas/models/schemaCodeLangs.ts
+++ b/src/eventSchemas/models/schemaCodeLangs.ts
@@ -5,13 +5,15 @@
 
 import { Runtime } from 'aws-sdk/clients/lambda'
 import { Set as ImmutableSet } from 'immutable'
+import { goRuntimes } from '../../lambda/models/samLambdaRuntime'
 
 export const JAVA = 'Java 8+'
 export const PYTHON = 'Python 3.6+'
 export const TYPESCRIPT = 'Typescript 3+'
-export type SchemaCodeLangs = 'Java 8+' | 'Python 3.6+' | 'Typescript 3+'
+export const GO = 'Go 1+'
+export type SchemaCodeLangs = 'Java 8+' | 'Python 3.6+' | 'Typescript 3+' | 'Go 1+'
 
-export const schemaCodeLangs: ImmutableSet<SchemaCodeLangs> = ImmutableSet([JAVA, PYTHON, TYPESCRIPT])
+export const schemaCodeLangs: ImmutableSet<SchemaCodeLangs> = ImmutableSet([JAVA, PYTHON, TYPESCRIPT, GO])
 
 const javaDetail = {
     apiValue: 'Java8',
@@ -28,6 +30,11 @@ const typescriptDetail = {
     extension: '.ts',
 }
 
+const goDetail = {
+    apiValue: 'Go1',
+    extension: '.go',
+}
+
 export function getLanguageDetails(language: SchemaCodeLangs): {
     apiValue: string
     extension: string
@@ -39,18 +46,20 @@ export function getLanguageDetails(language: SchemaCodeLangs): {
             return pythonDetail
         case TYPESCRIPT:
             return typescriptDetail
+        case GO:
+            return goDetail
         default:
             throw new Error(`Language ${language} is not supported as Schema Code Language`)
     }
 }
 
 export function supportsEventBridgeTemplates(runtime: Runtime): boolean {
-    return ['python3.6', 'python3.7', 'python3.8', 'python3.9'].includes(runtime)
+    return ['python3.6', 'python3.7', 'python3.8', 'python3.9', 'go1.x'].includes(runtime)
 }
 
 export function getApiValueForSchemasDownload(runtime: Runtime): string {
     if (supportsEventBridgeTemplates(runtime)) {
-        return 'Python36'
+        return goRuntimes.has(runtime) ? 'Go1' : 'Python36'
     }
 
     throw new Error(`Runtime ${runtime} is not supported by eventBridge application`)

--- a/src/test/eventSchemas/model/schemaCodeLangs.test.ts
+++ b/src/test/eventSchemas/model/schemaCodeLangs.test.ts
@@ -35,6 +35,11 @@ describe('getApiValueForSchemasDownload', function () {
                     assert.strictEqual(result, 'Python36', 'Api value used by schemas api')
                     break
                 }
+                case 'go1.x': {
+                    const result = getApiValueForSchemasDownload(runtime)
+                    assert.strictEqual(result, 'Go1', 'Api value used by schemas api')
+                    break
+                }
                 default: {
                     const errorMessage = `Runtime ${runtime} is not supported by eventBridge application`
                     assert.throws(

--- a/src/test/lambda/models/samTemplates.test.ts
+++ b/src/test/lambda/models/samTemplates.test.ts
@@ -25,6 +25,7 @@ import { samZipLambdaRuntimes } from '../../../lambda/models/samLambdaRuntime'
 let validTemplateOptions: Set<SamTemplate>
 let validPythonTemplateOptions: Set<SamTemplate>
 let validNode12TemplateOptions: Set<SamTemplate>
+let validGoTemplateOptions: Set<SamTemplate>
 let defaultTemplateOptions: Set<SamTemplate>
 
 before(function () {
@@ -46,6 +47,13 @@ before(function () {
     ])
 
     validNode12TemplateOptions = Set([helloWorldTemplate, stepFunctionsSampleApp, typeScriptBackendTemplate])
+
+    validGoTemplateOptions = Set([
+        helloWorldTemplate,
+        eventBridgeHelloWorldTemplate,
+        eventBridgeStarterAppTemplate,
+        stepFunctionsSampleApp,
+    ])
 
     defaultTemplateOptions = Set([helloWorldTemplate, stepFunctionsSampleApp])
 })
@@ -70,6 +78,13 @@ describe('getSamTemplateWizardOption', function () {
                         result,
                         validNode12TemplateOptions,
                         'Node12.x supports default and TS template options'
+                    )
+                    break
+                case 'go1.x':
+                    assert.deepStrictEqual(
+                        result,
+                        validGoTemplateOptions,
+                        'Go 1.x supports additional template options'
                     )
                     break
                 default:


### PR DESCRIPTION
## Problem
EventBridge Schemas now supports Golang as a language to generate code bindings with. VSCode Toolkit currently supports Java, Python, and Typescript for Schemas code generating and generating SAM EventBridge applications.

## Solution
Added Golang (go1.x) to the list of supported languages for schemas code generation and EventBridge templates for SAM. 

Pull Requests Open: 
For EventBridge SAM templates: https://github.com/aws/aws-sam-cli-app-templates/pull/183
For SAM CLI: https://github.com/aws/aws-sam-cli/pull/3657

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
