### PR TITLE
SAM: Notify/Help for possible stuck deployments

### DIFF
--- a/src/lambda/commands/deploySamApplication.ts
+++ b/src/lambda/commands/deploySamApplication.ts
@@ -12,6 +12,7 @@ import { AwsContext, NoActiveCredentialError } from '../../shared/awsContext'
 import { DefaultCloudFormationClient } from '../../shared/clients/cloudFormationClient'
 import { awsConsoleUrl, awsHealthStatusUrl, stuckCfnDeploymentUrl } from '../../shared/constants'
 import globals from '../../shared/extensionGlobals'
+import { getIdeProperties } from '../../shared/extensionUtilities'
 
 import { makeTemporaryToolkitFolder, tryRemoveFolder } from '../../shared/filesystemUtilities'
 import { checklogs } from '../../shared/localizedText'
@@ -331,9 +332,17 @@ function notifyDuringLongDeployment(deployParameters: DeploySamApplicationParame
         const stack = (await cfnClient.describeStacks(deployParameters.destinationStackName)).Stacks
         if (stack !== undefined) {
             const helpLink = localize('AWS.samcli.deploy.stuckStackHelpLink', 'View docs')
-            const awsConsole = localize('AWS.samcli.deploy.goToCfnDashboard', 'Go to AWS console')
+            const awsConsole = localize(
+                'AWS.samcli.deploy.goToCfnDashboard',
+                'Go to {0} console',
+                getIdeProperties().company
+            )
             const contWaiting = localize('AWS.samcli.deploy.contiueWaiting', 'Continue waiting')
-            const viewAwsStatus = localize('AWS.samcli.deploy.viewAwsStatus', 'View AWS status')
+            const viewAwsStatus = localize(
+                'AWS.samcli.deploy.viewAwsStatus',
+                'View {0} status',
+                getIdeProperties().company
+            )
             const stackStuckMessage = localize(
                 'AWS.sam.deploy.stackStuckWarning',
                 'Your deployment seems to be taking a while. If this is unexpected, it may be stuck in progress. What would you like to do?'
@@ -350,5 +359,5 @@ function notifyDuringLongDeployment(deployParameters: DeploySamApplicationParame
                     }
                 })
         }
-    }, 600000)
+    }, 10000)
 }

--- a/src/shared/clients/cloudFormationClient.ts
+++ b/src/shared/clients/cloudFormationClient.ts
@@ -82,6 +82,11 @@ export class DefaultCloudFormationClient {
             .promise()
     }
 
+    public async describeStacks(name: string): Promise<CloudFormation.DescribeStacksOutput> {
+        const client = this.createSdkClient()
+        return await (await client).describeStacks({ StackName: name }).promise()
+    }
+
     private async createSdkClient(): Promise<CloudFormation> {
         return await globals.sdkClientBuilder.createAwsService(CloudFormation, undefined, this.regionCode)
     }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -74,6 +74,16 @@ export const ecsDocumentationUrl: string = 'https://docs.aws.amazon.com/AmazonEC
 export const ecsExecToolkitGuideUrl: string =
     'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/ecs-exec.html'
 
+// URL for stuck CFN deployment help
+export const stuckCfnDeploymentUrl =
+    'https://aws.amazon.com/premiumsupport/knowledge-center/cloudformation-stack-stuck-progress/'
+
+// URL for AWS service health status
+export const awsHealthStatusUrl = 'https://status.aws.amazon.com/'
+
+// URL for AWS console
+export const awsConsoleUrl = 'https://aws.amazon.com/console/'
+
 /**
  * Moment format for rendering readable dates.
  *

--- a/src/test/shared/clients/mockClients.ts
+++ b/src/test/shared/clients/mockClients.ts
@@ -178,6 +178,11 @@ export class MockCloudFormationClient implements CloudFormationClient {
         ) => Promise<CloudFormation.DescribeStackResourcesOutput> = async (name: string) => ({
             StackResources: [],
         }),
+        public readonly describeStacks: (name: string) => Promise<CloudFormation.DescribeStacksOutput> = async (
+            name: string
+        ) => ({
+            Stacks: [],
+        }),
 
         public readonly describeType: (typeName: string) => Promise<CloudFormation.DescribeTypeOutput> = async (
             typeName: string


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
CloudFormation stacks can get stuck in a state where they do
not immediately rollback or progress. This usually happens when a
resource has an error while updating/creating/deleting, leaving the
stack in a stuck state until the resource times out.
Solution: 

## Solution
After an amount of time has passed since the start of a CFN
stack deployment, a notification will appear and give the user options
to view help documentation, view AWS health status, go to the AWS
console, or continue waiting.
<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
