### PR TITLE
Better telemetry cache handling

### DIFF
--- a/src/test/shared/telemetry/defaultTelemetryService.test.ts
+++ b/src/test/shared/telemetry/defaultTelemetryService.test.ts
@@ -7,6 +7,7 @@ import * as assert from 'assert'
 import * as FakeTimers from '@sinonjs/fake-timers'
 import * as sinon from 'sinon'
 import * as fs from 'fs-extra'
+import * as path from 'path'
 import { DefaultTelemetryService } from '../../../shared/telemetry/defaultTelemetryService'
 import { AccountStatus } from '../../../shared/telemetry/telemetryTypes'
 import { FakeExtensionContext } from '../../fakeExtensionContext'
@@ -42,6 +43,7 @@ describe('DefaultTelemetryService', function () {
     let mockPublisher: FakeTelemetryPublisher
     let service: DefaultTelemetryService
     let logger: TelemetryLogger
+    let tempTelemetryFile: string
 
     function initService(awsContext = new FakeAwsContext()): DefaultTelemetryService {
         const newService = new DefaultTelemetryService(mockContext, awsContext, undefined, mockPublisher)
@@ -66,10 +68,14 @@ describe('DefaultTelemetryService', function () {
         service = initService()
         logger = service.logger
         clock = installFakeClock()
+        tempTelemetryFile = path.join(mockContext.globalStoragePath, 'TEMP_CACHE')
     })
 
     afterEach(async function () {
         await fs.remove(service.persistFilePath)
+        if (fs.existsSync(tempTelemetryFile)) {
+            await fs.remove(tempTelemetryFile)
+        }
         sandbox.restore()
         clock.uninstall()
     })
@@ -86,24 +92,23 @@ describe('DefaultTelemetryService', function () {
         assert.strictEqual(mockPublisher.feedback, feedback)
     })
 
-    it('assertPassiveTelemetry() throws if active, non-cached metric is emitted during startup', async function () {
-        // Simulate cached telemetry by prepopulating records before start().
-        // (Normally readEventsFromCache() does this.)
-        service.record(fakeMetric({ value: 1, passive: true }))
-        service.record(fakeMetric({ value: 2, passive: true }))
-        // Active *cached* metric.
-        service.record(fakeMetric({ value: 4, passive: false }))
-        await service.start()
+    it('assertPassiveTelemetry() throws if it sees non-passive metrics in the general queue', async function () {
+        // metrics in cache are entirely ignored
+        writeMetricsToTempFile([
+            fakeMetric({ value: 1, passive: false }),
+            fakeMetric({ value: 2, passive: true }),
+            fakeMetric({ value: 3, passive: true }),
+            fakeMetric({ value: 4, passive: false }),
+        ])
 
+        await service.start(tempTelemetryFile)
         // Passive *non-cached* metric.
         service.record(fakeMetric({ value: 5, passive: true }))
-
         // Must *not* throw.
         service.assertPassiveTelemetry(false)
 
         // Active *non-cached* metric.
         service.record(fakeMetric({ value: 6, passive: false }))
-
         // Must throw.
         assert.throws(() => {
             service.assertPassiveTelemetry(false)
@@ -115,16 +120,39 @@ describe('DefaultTelemetryService', function () {
     it('publishes periodically if user has said ok', async function () {
         stubGlobal()
 
-        service.record(fakeMetric())
-
-        await service.start()
+        await service.start(tempTelemetryFile)
         assert.notStrictEqual(service.timer, undefined)
+
+        service.record(fakeMetric())
 
         clock.tick(testFlushPeriod)
         await service.shutdown()
 
         assert.strictEqual(mockPublisher.flushCount, 1)
-        assert.strictEqual(mockPublisher.queue.length, 2)
+        assert.strictEqual(mockPublisher.queue.length, 2) // includes session start telemetry
+    })
+
+    it('publishes on start if a user has cached telmetry', async function () {
+        writeMetricsToTempFile([fakeMetric()])
+        stubGlobal()
+
+        await service.start(tempTelemetryFile)
+        assert.notStrictEqual(service.timer, undefined)
+        await service.shutdown()
+
+        assert.strictEqual(mockPublisher.flushCount, 1)
+        assert.strictEqual(mockPublisher.queue.length, 1)
+    })
+
+    it('skips initial publish if cache is empty', async function () {
+        stubGlobal()
+
+        await service.start(tempTelemetryFile)
+        assert.notStrictEqual(service.timer, undefined)
+        await service.shutdown()
+
+        assert.strictEqual(mockPublisher.flushCount, 0)
+        assert.strictEqual(mockPublisher.queue.length, 0)
     })
 
     it('events automatically inject the active account id into the metadata', async function () {
@@ -141,7 +169,7 @@ describe('DefaultTelemetryService', function () {
     it('events with `session` namespace do not have an account tied to them', async function () {
         stubGlobal()
 
-        await service.start()
+        await service.start(tempTelemetryFile)
         await service.shutdown()
 
         assert.strictEqual(logger.metricCount, 2)
@@ -175,7 +203,7 @@ describe('DefaultTelemetryService', function () {
         stubGlobal()
 
         service.telemetryEnabled = false
-        await service.start()
+        await service.start(tempTelemetryFile)
 
         // telemetry off: events are never recorded
         service.record(fakeMetric({ metricName: 'name' }))
@@ -201,5 +229,9 @@ describe('DefaultTelemetryService', function () {
             metadata.some(item => item.Key === 'awsAccount' && item.Value === expectedAccountId),
             'Expected metadata to contain the test account'
         )
+    }
+
+    function writeMetricsToTempFile(datum: ClientTelemetry.MetricDatum[]): void {
+        fs.writeFileSync(tempTelemetryFile, JSON.stringify(datum))
     }
 })


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Abnormally large telemetry caches break the toolkit (call stack overflow). This can be generated when the telemetry cache is loaded in, have more telemetry added, and the session is closed before telemetry can be pushed, further building the cache.

This also fixes some additional telemetry cache-related issues

## Solution
Multiple fixes:
* Process telemetry cache immediately on loading, skipping the telemetry queue. This prevents telemetry from compounding.
  * Due to this, the `assertPassiveTelemetry` ignores the cache entirely. Any active telemetry in queue at invocation will throw an error.
  * This does present an issue where if the cache is loaded into memory and the session is killed mid-telemetry push, telemetry will be lost. This feels like an extreme edge case since invocation will probably finish. Failures still re-push into the telemetry queue.
* Telemetry cache is stored in a temp array during processing and is immediately cleared. This prevents edge cases where telemetry can be added while the queue is being processed, and deleted following processing.
* Abnormally large telemetry cache files (>1000 entries, might expand) are never saved to a file. We've experienced call stack overflows with files that were allowed to grow to 25 MB.
* Condensed cache filter calls. No reason to make two passes, only adds to the call stack.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
