### PR TITLE
ECS: handle missing ecs exec permissions

### DIFF
--- a/src/ecs/commands/runCommandInContainer.ts
+++ b/src/ecs/commands/runCommandInContainer.ts
@@ -12,7 +12,11 @@ import { getLogger } from '../../shared/logger'
 import { ChildProcess } from '../../shared/utilities/childProcess'
 import { EcsContainerNode } from '../explorer/ecsContainerNode'
 import { recordEcsRunExecuteCommand } from '../../shared/telemetry/telemetry.gen'
-import { ecsRequiredPermissionsUrl, INSIGHTS_TIMESTAMP_FORMAT } from '../../shared/constants'
+import {
+    ecsRequiredIamPermissionsUrl,
+    ecsRequiredTaskPermissionsUrl,
+    INSIGHTS_TIMESTAMP_FORMAT,
+} from '../../shared/constants'
 import { showOutputMessage, showViewLogsMessage } from '../../shared/utilities/messages'
 import { getOrInstallCli } from '../../shared/utilities/cliUtils'
 import { removeAnsi } from '../../shared/utilities/textUtilities'
@@ -21,6 +25,7 @@ import { CommandWizard } from '../wizards/executeCommand'
 import { CancellationError } from '../../shared/utilities/timeoutUtils'
 import { isCloud9 } from '../../shared/extensionUtilities'
 import { PromptSettings } from '../../shared/settings'
+import { viewDocs } from '../../shared/localizedText'
 
 // Required SSM permissions for the task IAM role, see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html#ecs-exec-enabling-and-using
 const REQUIRED_SSM_PERMISSIONS = [
@@ -71,7 +76,7 @@ export async function runCommandInContainer(
                 )
                 .then(selection => {
                     if (selection === viewDocsItem) {
-                        vscode.env.openExternal(vscode.Uri.parse(ecsRequiredPermissionsUrl))
+                        vscode.env.openExternal(vscode.Uri.parse(ecsRequiredTaskPermissionsUrl))
                     }
                 })
             result = 'Failed'
@@ -109,14 +114,28 @@ export async function runCommandInContainer(
         })
 
         result = 'Succeeded'
-    } catch (error) {
-        if (CancellationError.isUserCancelled(error)) {
+    } catch (err) {
+        const error = err as Error
+        if (CancellationError.isUserCancelled(err)) {
             return
         }
 
         result = 'Failed'
-        getLogger().error('ecs: Failed to execute command in container, %O', error)
-        showViewLogsMessage(localize('AWS.ecs.runCommandInContainer.error', 'Failed to execute command in container.'))
+        const failedMessage = localize('AWS.ecs.runCommandInContainer.error', 'Failed to execute command in container.')
+        const missingPermissions = localize(
+            'AWS.ecs.runCommandInContainer.missingPermissions',
+            `Insufficient user role permissions for "Execute Command". See documentation for required permissions.`
+        )
+        getLogger().error('ecs: Failed to execute command in container, %O', err)
+        if (error.name === 'AccessDeniedException') {
+            showViewLogsMessage(missingPermissions, window, 'error', [viewDocs]).then(selection => {
+                if (selection === viewDocs) {
+                    vscode.env.openExternal(vscode.Uri.parse(ecsRequiredIamPermissionsUrl))
+                }
+            })
+        } else {
+            showViewLogsMessage(failedMessage)
+        }
     } finally {
         recordEcsRunExecuteCommand({ result: result, ecsExecuteCommandType: 'command' })
         status?.dispose()

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -72,8 +72,10 @@ export const debugNewSamAppUrl: string = isCloud9()
 export const ecsDocumentationUrl: string = 'https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html'
 export const ecsExecToolkitGuideUrl: string =
     'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/ecs-exec.html'
-export const ecsRequiredPermissionsUrl: string =
+export const ecsRequiredTaskPermissionsUrl: string =
     'https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html#ecs-exec-enabling-and-using'
+export const ecsRequiredIamPermissionsUrl: string =
+    'https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html#ecs-exec-best-practices-limit-access-execute-command'
 
 /**
  * Moment format for rendering readable dates.


### PR DESCRIPTION
Problem: 
Solution:If a user is missing the necessary ecs permission to execute
commands, a generic failed message will show when they attempt to run a
command in a container.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
If a user is missing the necessary ecs permission to execute
commands, a generic failed message will show when they attempt to run a
command in a container.
## Solution
If a user is missing the necessary ecs permission to execute
commands, a generic failed message will show when they attempt to run a
command in a container.

## Screenshot

<!---


    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
