### PR TITLE
util/services: support service request listeners

### DIFF
--- a/src/shared/awsClientBuilder.ts
+++ b/src/shared/awsClientBuilder.ts
@@ -31,7 +31,6 @@ type ServiceOptions = ServiceConfigurationOptions & {
      * const service = await builder.createAwsService(FakeService, {
      *     onRequestSetup: [
      *         req => {
-     *             const serviceName = req.service.constructor.name
      *             console.log('req: %O [%O]', req.operation, req.params)
      *             req.on('error', e => (errorCount += !e.originalError ? 1 : 0))
      *         },

--- a/src/test/shared/defaultAwsClientBuilder.test.ts
+++ b/src/test/shared/defaultAwsClientBuilder.test.ts
@@ -47,7 +47,7 @@ describe('DefaultAwsClientBuilder', function () {
                 let errorCount = 0
 
                 const service = await builder.createAwsService(FakeService, {
-                    requestListeners: [
+                    onRequest: [
                         request => {
                             const serviceName = request.service.constructor.name
 
@@ -86,9 +86,7 @@ describe('DefaultAwsClientBuilder', function () {
 
                 const expected = getDescriptors(Original)
                 const builder = new DefaultAWSClientBuilder(new FakeAwsContext())
-                const service = await builder.createAwsService(Original, {
-                    requestListeners: [request => {}],
-                })
+                const service = await builder.createAwsService(Original, { onRequest: () => {} })
 
                 assert.deepStrictEqual(getDescriptors(Original), expected)
                 assert.ok(service instanceof Original)

--- a/src/test/shared/defaultAwsClientBuilder.test.ts
+++ b/src/test/shared/defaultAwsClientBuilder.test.ts
@@ -47,7 +47,7 @@ describe('DefaultAwsClientBuilder', function () {
                 let errorCount = 0
 
                 const service = await builder.createAwsService(FakeService, {
-                    onRequest: [
+                    onRequestSetup: [
                         request => {
                             const serviceName = request.service.constructor.name
 
@@ -86,7 +86,7 @@ describe('DefaultAwsClientBuilder', function () {
 
                 const expected = getDescriptors(Original)
                 const builder = new DefaultAWSClientBuilder(new FakeAwsContext())
-                const service = await builder.createAwsService(Original, { onRequest: () => {} })
+                const service = await builder.createAwsService(Original, { onRequestSetup: () => {} })
 
                 assert.deepStrictEqual(getDescriptors(Original), expected)
                 assert.ok(service instanceof Original)

--- a/src/test/shared/defaultAwsClientBuilder.test.ts
+++ b/src/test/shared/defaultAwsClientBuilder.test.ts
@@ -5,7 +5,6 @@
 
 import * as assert from 'assert'
 import { AWSError, Request, Service } from 'aws-sdk'
-import { util } from 'prettier'
 import { version } from 'vscode'
 import { AWSClientBuilder, DefaultAWSClientBuilder } from '../../shared/awsClientBuilder'
 import { FakeAwsContext } from '../utilities/fakeAwsContext'

--- a/src/test/shared/defaultAwsClientBuilder.test.ts
+++ b/src/test/shared/defaultAwsClientBuilder.test.ts
@@ -43,10 +43,7 @@ describe('DefaultAwsClientBuilder', function () {
                     apiConfig: { operations: { FakeOperation: {} } },
                     onRequestSetup: [
                         request => {
-                            const serviceName = request.service.constructor.name
-
-                            // No subclass = no service name
-                            assert.strictEqual(serviceName, '')
+                            assert.ok(request.service instanceof Service)
                             assert.strictEqual(request.operation, 'FakeOperation')
                             assert.deepStrictEqual(request.params, { foo: 'bar' })
 

--- a/src/test/shared/defaultAwsClientBuilder.test.ts
+++ b/src/test/shared/defaultAwsClientBuilder.test.ts
@@ -4,13 +4,19 @@
  */
 
 import * as assert from 'assert'
-import { Service } from 'aws-sdk'
+import { AWSError, Request, Service } from 'aws-sdk'
 import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
 import { version } from 'vscode'
-import { DefaultAWSClientBuilder } from '../../shared/awsClientBuilder'
+import { AWSClientBuilder, DefaultAWSClientBuilder } from '../../shared/awsClientBuilder'
 import { FakeAwsContext } from '../utilities/fakeAwsContext'
 
 describe('DefaultAwsClientBuilder', function () {
+    let builder: AWSClientBuilder
+
+    beforeEach(function () {
+        builder = new DefaultAWSClientBuilder(new FakeAwsContext())
+    })
+
     describe('createAndConfigureSdkClient', function () {
         class FakeService extends Service {
             public constructor(config?: ServiceConfigurationOptions) {
@@ -19,7 +25,6 @@ describe('DefaultAwsClientBuilder', function () {
         }
 
         it('includes Toolkit user-agent if no options are specified', async function () {
-            const builder = new DefaultAWSClientBuilder(new FakeAwsContext())
             const service = await builder.createAwsService(FakeService)
 
             assert.strictEqual(!!service.config.customUserAgent, true)
@@ -30,12 +35,71 @@ describe('DefaultAwsClientBuilder', function () {
         })
 
         it('does not override custom user-agent if specified in options', async function () {
-            const builder = new DefaultAWSClientBuilder(new FakeAwsContext())
             const service = await builder.createAwsService(FakeService, {
                 customUserAgent: 'CUSTOM USER AGENT',
             })
 
             assert.strictEqual(service.config.customUserAgent, 'CUSTOM USER AGENT')
+        })
+
+        describe('request listeners', function () {
+            it('calls listener with correct type', async function () {
+                let errorCount = 0
+
+                const service = await builder.createAwsService(FakeService, {
+                    requestListeners: [
+                        request => {
+                            const serviceName = request.service.constructor.name
+
+                            assert.strictEqual(serviceName, 'FakeService')
+                            assert.strictEqual(request.operation, 'FakeOperation')
+                            assert.deepStrictEqual(request.params, { foo: 'bar' })
+
+                            request.on('error', e => (errorCount += !e.originalError ? 1 : 0))
+                        },
+                    ],
+                })
+
+                async function assertRequest() {
+                    const request = service.makeRequest('FakeOperation', { foo: 'bar' }).promise()
+                    await assert.rejects(request, /Missing region in config/)
+                }
+
+                await assertRequest()
+                assert.strictEqual(errorCount, 1)
+
+                await assertRequest()
+                assert.strictEqual(errorCount, 2)
+            })
+
+            it('can add listeners without affecting the original class', async function () {
+                let callCount = 0
+
+                const getDescriptors = (ctor: new (...args: any[]) => any) =>
+                    Object.getOwnPropertyDescriptors(Object.getPrototypeOf(ctor))
+
+                const Original = class extends Service {
+                    public override setupRequestListeners(request: Request<any, AWSError>): void {
+                        callCount += 1
+                    }
+                }
+
+                const expected = getDescriptors(Original)
+                const builder = new DefaultAWSClientBuilder(new FakeAwsContext())
+                const service = await builder.createAwsService(Original, {
+                    requestListeners: [request => {}],
+                })
+
+                assert.deepStrictEqual(getDescriptors(Original), expected)
+                assert.ok(service instanceof Original)
+
+                // This is just a reference compare. Unbound methods don't matter here.
+                // eslint-disable-next-line @typescript-eslint/unbound-method
+                assert.notStrictEqual(service.setupRequestListeners, Original.prototype.setupRequestListeners)
+
+                await assert.rejects(service.makeRequest('Foo').promise())
+                assert.strictEqual(callCount, 1)
+            })
         })
     })
 })


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
We can't easily add request listeners to service clients in a cross-cutting fashion

## Solution
Add option for request listeners. Kept light for simplicity, though it would be wise to build simple interfaces against `Request` as to not couple too much with v2 of the SDK.

Example:
```ts
const service = await builder.createAwsService(FooService, {
    requestListeners: [
        request => request.on('error', e => console.log(e)),
    ],
})
```

Note that when request events are fired is highly dependent on the SDK. Any implementations should keep this in mind. For example, 'error' may fire more than once for a single request.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
