### PR TITLE
SAM run/debug: remove strict retry limit for "local API" debugger attachment

### DIFF
--- a/.changes/next-release/Bug Fix-983cd27f-6bfe-449d-9fbe-a78776800a8b.json
+++ b/.changes/next-release/Bug Fix-983cd27f-6bfe-449d-9fbe-a78776800a8b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "SAM run/debug: slow debugger attachment for API configurations now shows a cancellable notification instead of automatically failing"
+}


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Hard-coded retry limit means the debugger can fail to attach if SAM CLI takes too long to start.
See: https://github.com/aws/aws-toolkit-vscode/issues/2446#issuecomment-1023484906

## Solution
Retry indefinitely until the user cancels. The amount of additional logic was kept very minimal, so the UX as far as error reporting goes is still not great.

![Screen Shot 2022-03-22 at 1 11 48 PM](https://user-images.githubusercontent.com/31319484/159567644-0dff8196-6e39-47d7-a843-2b8fe5a97c36.png)

### Testing
Tested manually. A good way to simulate slower machines is to add a sleep in `DefaultSamLocalInvokeCommand` right before the process is ran.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
