### PR TITLE
HttpResourceFetcher: always use patched `got` for Cloud9

### DIFF
--- a/src/shared/resourcefetcher/httpResourceFetcher.ts
+++ b/src/shared/resourcefetcher/httpResourceFetcher.ts
@@ -6,8 +6,6 @@
 import * as fs from 'fs'
 import * as http from 'http'
 import * as https from 'https'
-import * as vscode from 'vscode'
-import * as semver from 'semver'
 import * as stream from 'stream'
 import got, { Response, RequestError, CancelError } from 'got'
 import urlToOptions from 'got/dist/source/core/utils/url-to-options'
@@ -16,6 +14,7 @@ import { VSCODE_EXTENSION_ID } from '../extensions'
 import { getLogger, Logger } from '../logger'
 import { ResourceFetcher } from './resourcefetcher'
 import { Timeout, CancellationError, CancelEvent } from '../utilities/timeoutUtils'
+import { isCloud9 } from '../extensionUtilities'
 
 // XXX: patched Got module for compatability with older VS Code versions (e.g. Cloud9)
 // `got` has also deprecated `urlToOptions`
@@ -27,9 +26,6 @@ const patchedGot = got.extend({
         return http.request({ ...options, ...urlToOptions(url) }, callback)
     },
 })
-// I can't track down the real version but this seems close enough
-// VSC 1.44.2 seems to work, but on C9 it does not?
-const MIN_VERSION_FOR_GOT = '1.47.0'
 
 /** Promise that resolves/rejects when all streams close. Can also access streams directly. */
 type FetcherResult = Promise<void> & {
@@ -112,7 +108,7 @@ export class HttpResourceFetcher implements ResourceFetcher {
 
     // TODO: make pipeLocation a vscode.Uri
     private pipeGetRequest(pipeLocation: string, timeout?: Timeout): FetcherResult {
-        const requester = semver.lt(vscode.version, MIN_VERSION_FOR_GOT) ? patchedGot : got
+        const requester = isCloud9() ? patchedGot : got
         const requestStream = requester.stream(this.url, { headers: { 'User-Agent': VSCODE_EXTENSION_ID.awstoolkit } })
         const fsStream = fs.createWriteStream(pipeLocation)
 
@@ -136,7 +132,7 @@ export class HttpResourceFetcher implements ResourceFetcher {
     }
 
     private async getResponseFromGetRequest(timeout?: Timeout): Promise<Response<string>> {
-        const requester = semver.lt(vscode.version, MIN_VERSION_FOR_GOT) ? patchedGot : got
+        const requester = isCloud9() ? patchedGot : got
         const promise = requester(this.url, {
             headers: { 'User-Agent': VSCODE_EXTENSION_ID.awstoolkit },
         })


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Default `got` does not work on Cloud9, even after upgrading

## Solution
Always use the 'patched' version. Previously, there was a hard-coded version to toggle usage of the 'patched' version. The assumption was that the issue was specific to the VS Code version (not Cloud9), but clearly that's not the case.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
