### PR TITLE
fix(cloud9): don't show welcome message

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -421,7 +421,6 @@
     "AWS.message.prompt.selectCDKWorkspace.placeholder": "Select CDK workspace",
     "AWS.message.prompt.selectCDKApplication.placeholder": "Select CDK application",
     "AWS.message.prompt.selectCDKStateMachine.placeholder": "Select a State Machine",
-    "AWS.message.prompt.quickStart.toastMessage": "You are now using {0} Toolkit version {1}",
     "AWS.message.prompt.region.hide.title": "Select a region to hide from the {0} Explorer",
     "AWS.message.prompt.region.show.title": "Select a region to show in the {0} Explorer",
     "AWS.message.prompt.copyButtonLabel": "Copy",

--- a/src/shared/extensionUtilities.ts
+++ b/src/shared/extensionUtilities.ts
@@ -276,25 +276,20 @@ export function setMostRecentVersion(context: vscode.ExtensionContext): void {
 
 /**
  * Shows a message with a link to the quickstart page.
- * In cloud9, directly opens quickstart instead
  */
-async function showOrPromptQuickstart(): Promise<void> {
-    if (isCloud9()) {
+async function promptQuickstart(): Promise<void> {
+    const view = localize('AWS.command.quickStart', 'View Quick Start')
+    const prompt = await vscode.window.showInformationMessage(
+        localize(
+            'AWS.message.prompt.quickStart.toastMessage',
+            'You are now using {0} Toolkit {1}',
+            getIdeProperties().company,
+            extensionVersion
+        ),
+        view
+    )
+    if (prompt === view) {
         vscode.commands.executeCommand('aws.quickStart')
-    } else {
-        const view = localize('AWS.command.quickStart', 'View Quick Start')
-        const prompt = await vscode.window.showInformationMessage(
-            localize(
-                'AWS.message.prompt.quickStart.toastMessage',
-                'You are now using {0} Toolkit version {1}',
-                getIdeProperties().company,
-                extensionVersion
-            ),
-            view
-        )
-        if (prompt === view) {
-            vscode.commands.executeCommand('aws.quickStart')
-        }
     }
 }
 
@@ -323,8 +318,9 @@ export function showWelcomeMessage(context: vscode.ExtensionContext): void {
     try {
         if (isDifferentVersion(context)) {
             setMostRecentVersion(context)
-            // the welcome toast should be nonblocking.
-            showOrPromptQuickstart()
+            if (!isCloud9()) {
+                promptQuickstart()
+            }
         }
     } catch (err) {
         // swallow error and don't block extension load


### PR DESCRIPTION
## Problem

In ephemeral environments such as Cloud9, the welcome message is
redundant.

## Solution
Don't show the message on Cloud9.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
