### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/dynamicResources/commands/openResource.ts
+++ b/src/dynamicResources/commands/openResource.ts
@@ -123,7 +123,7 @@ export function getDiagnostics(schema: TypeSchema, doc: vscode.TextDocument): vs
 
 function getPropertyName(property: string) {
     // the returned format is `/properties/<propertyName>`
-    return property.substr(property.lastIndexOf('/') + 1)
+    return property.slice(property.lastIndexOf('/') + 1)
 }
 
 function getPropertyRange(property: string, text: string, doc: vscode.TextDocument): vscode.Range | undefined {

--- a/src/dynamicResources/explorer/nodes/resourceTypeNode.ts
+++ b/src/dynamicResources/explorer/nodes/resourceTypeNode.ts
@@ -146,6 +146,6 @@ export class ResourceTypeNode extends AWSTreeNodeBase implements LoadMoreNode {
     }
 
     private static getFriendlyName(typeName: string): string {
-        return typeName.startsWith('AWS::') ? typeName.substr(5) : typeName
+        return typeName.startsWith('AWS::') ? typeName.slice(5) : typeName
     }
 }

--- a/src/iot/explorer/iotPolicyFolderNode.ts
+++ b/src/iot/explorer/iotPolicyFolderNode.ts
@@ -79,7 +79,7 @@ export class IotPolicyFolderNode extends AWSTreeNodeBase implements LoadMoreNode
                             this,
                             this.iot,
                             (await this.iot.listPolicyTargets({ policyName: policy.policyName! })).map(certId =>
-                                certId.substr(certId.length - CERT_ID_LENGTH, CERT_PREVIEW_LENGTH)
+                                certId.slice(-CERT_ID_LENGTH, -CERT_ID_LENGTH + CERT_PREVIEW_LENGTH)
                             )
                         )
                 ) ?? []

--- a/src/lambda/commands/downloadLambda.ts
+++ b/src/lambda/commands/downloadLambda.ts
@@ -232,5 +232,5 @@ function computeLambdaRoot(lambdaLocation: string, functionNode: LambdaFunctionN
 
     const lambdaIndex = normalizedLocation.indexOf(`/${lambdaDetails.fileName}`)
 
-    return lambdaIndex > -1 ? normalizedLocation.substr(0, lambdaIndex) : path.dirname(normalizedLocation)
+    return lambdaIndex > -1 ? normalizedLocation.slice(0, lambdaIndex) : path.dirname(normalizedLocation)
 }

--- a/src/shared/ui/common/variablesPrompter.ts
+++ b/src/shared/ui/common/variablesPrompter.ts
@@ -23,7 +23,7 @@ function unquote(str: string): string {
     const isDoubleQuoted = str[0] === '"' && str[str.length - 1] === '"'
 
     if (isSingleQuoted || isDoubleQuoted) {
-        str = str.substr(1, str.length - 1)
+        str = str.slice(1, -1)
     }
 
     if (isDoubleQuoted) {


### PR DESCRIPTION
## Problem

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated.

## Solution

We replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
