### PR TITLE
feat(logging): store logs in logUri instead of globalStorage

### DIFF
--- a/src/shared/logger/activation.ts
+++ b/src/shared/logger/activation.ts
@@ -145,8 +145,7 @@ function getLogPath(): string {
         return logPath
     }
 
-    // TODO: use context.logUri ?
-    const logsDir = path.join(globals.context.globalStorageUri.fsPath, 'logs')
+    const logsDir = globals.context.logUri.fsPath
 
     return path.join(logsDir, makeLogFilename())
 }


### PR DESCRIPTION
## todo

- [ ] test in cloud9

## Problem:
vscode has a logUri (formerly logPath) for placing logs in OS-specific locations.

## Solution:
Use logUri instead of a `globalStorageUri` subdirectory.

`logPath` (later replaced by `logUri`) was introduced in 2018: https://github.com/microsoft/vscode/commit/bbfcc67dc94e1b741d2507f5538ddccc7d8d70e6

ref #1692
ref #1694
ref https://github.com/microsoft/vscode/issues/43275

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
