### PR TITLE
fix(api-gateway): correct issue with resource names in webview

### DIFF
--- a/.changes/next-release/Bug Fix-d243fc5e-2336-4c1a-91da-385d56ba923d.json
+++ b/.changes/next-release/Bug Fix-d243fc5e-2336-4c1a-91da-385d56ba923d.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fixed issue with API Gateway 'Invoke on AWS' resource names always showing 'resource.path'"
+}

--- a/src/apigateway/vue/invokeApi.vue
+++ b/src/apigateway/vue/invokeApi.vue
@@ -9,16 +9,12 @@
         <select v-model="selectedApiResource" v-on:change="setApiResource">
             <option disabled value="">Select a resource</option>
             <option
-                v-for="resource in Object.keys(initialData.Resources)"
-                :key="initialData.Resources[resource].id"
-                :disabled="!initialData.Resources[resource].resourceMethods"
-                :value="initialData.Resources[resource].id"
+                v-for="resource in initialData.Resources"
+                :key="resource.id"
+                :disabled="!resource.resourceMethods"
+                :value="resource.id"
             >
-                {{
-                    `resource.path${
-                        initialData.Resources[resource].resourceMethods === undefined ? ' -- No methods' : ''
-                    }`
-                }}
+                {{ `${resource.path}${resource.resourceMethods === undefined ? ' -- No methods' : ''}` }}
             </option>
         </select>
         <h3>Select a method:</h3>


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Resource names in the 'Invoke on AWS' webview would always show as 'resource.path'

## Solution
Put the reference in the template string.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
