### PR TITLE
fix(telemetry): remove redundant check

### DIFF
--- a/src/integrationTest/shared/codelens/samTemplateCodeLensProvider.test.ts
+++ b/src/integrationTest/shared/codelens/samTemplateCodeLensProvider.test.ts
@@ -5,6 +5,7 @@
 
 import * as assert from 'assert'
 import * as vscode from 'vscode'
+import * as semver from 'semver'
 import { anything, instance, mock, when } from 'ts-mockito'
 import { TemplateSymbolResolver } from '../../../shared/cloudformation/templateSymbolResolver'
 import { SamTemplateCodeLensProvider } from '../../../shared/codelens/samTemplateCodeLensProvider'
@@ -30,7 +31,11 @@ describe('SamTemplateCodeLensProvider', async function () {
     })
 
     it('provides a CodeLens for a file with a new resource', async function () {
-        // Note: redhat.vscode-yaml no longer works on vscode 1.44.2
+        // redhat.vscode-yaml requires vscode 1.52
+        // https://github.com/redhat-developer/vscode-yaml/blob/main/package.json
+        if (semver.lt(vscode.version, '1.52.0')) {
+            this.skip()
+        }
         await activateExtension(VSCODE_EXTENSION_ID.yaml, false)
 
         const codeLenses = await codeLensProvider.provideCodeLenses(

--- a/src/shared/telemetry/defaultTelemetryClient.ts
+++ b/src/shared/telemetry/defaultTelemetryClient.ts
@@ -6,7 +6,7 @@
 import { Credentials, Service } from 'aws-sdk'
 import * as os from 'os'
 import * as vscode from 'vscode'
-import { extensionVersion, isAutomation, isReleaseVersion } from '../vscode/env'
+import { extensionVersion, isAutomation } from '../vscode/env'
 import { getLogger } from '../logger'
 import * as ClientTelemetry from './clienttelemetry'
 import { MetricDatum } from './clienttelemetry'
@@ -55,7 +55,7 @@ export class DefaultTelemetryClient implements TelemetryClient {
                 return undefined
             }
 
-            if (!isAutomation() || isReleaseVersion()) {
+            if (!isAutomation()) {
                 await this.client
                     .postMetrics({
                         AWSProduct: DefaultTelemetryClient.PRODUCT_NAME,


### PR DESCRIPTION
## Problem 1
- checking isReleaseVersion() is no longer needed because we just `!isAutomation()`. ref #2528
- **Solution:** remove the check

## Problem 2
- Language-specific, third-party extensions may not support older versions of vscode, then the integ tests start failing.
    - https://github.com/golang/vscode-go/blob/089cf1321315bd169468611957269564831f4970/package.json#L92
    - https://github.com/redhat-developer/vscode-yaml/blob/c09167284842953506b462efd2ed6396bd18216b/package.json#L27
- **Solution:** Skip integ tests if the vscode version does not meet the version required by the third-party extension.

## Future

 should probably store the version in this structure: https://github.com/aws/aws-toolkit-vscode/blob/a33b236db904132785f0e01acc48a155af0b0402/src/shared/extensions.ts#L14-L24

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->
<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
