### PR TITLE
feat(explorer): "Show AWS Commands"

### DIFF
--- a/.changes/next-release/Feature-e0e893f6-8b9e-4753-93e3-96998ec5bf23.json
+++ b/.changes/next-release/Feature-e0e893f6-8b9e-4753-93e3-96998ec5bf23.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "added `Show AWS Commands...` command to AWS Explorer menu"
+}

--- a/package.json
+++ b/package.json
@@ -724,6 +724,10 @@
                     "when": "false"
                 },
                 {
+                    "command": "aws.listCommands",
+                    "when": "false"
+                },
+                {
                     "command": "aws.downloadSchemaItemCode",
                     "when": "false"
                 },
@@ -1075,6 +1079,11 @@
                     "command": "aws.login",
                     "when": "view == aws.explorer",
                     "group": "1_account@1"
+                },
+                {
+                    "command": "aws.listCommands",
+                    "when": "view == aws.explorer",
+                    "group": "1_account@2"
                 },
                 {
                     "command": "aws.showRegion",
@@ -2247,6 +2256,17 @@
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
+            },
+            {
+                "command": "aws.listCommands",
+                "title": "%AWS.command.listCommands%",
+                "category": "%AWS.title%",
+                "cloud9": {
+                    "cn": {
+                        "title": "%AWS.command.listCommands.cn%",
                         "category": "%AWS.title.cn%"
                     }
                 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -205,6 +205,8 @@
     "AWS.command.renderStateMachineGraph": "Render graph",
     "AWS.command.copyArn": "Copy ARN",
     "AWS.command.copyName": "Copy Name",
+    "AWS.command.listCommands": "Show AWS Commands...",
+    "AWS.command.listCommands.cn": "Show Amazon Commands...",
     "AWS.command.downloadStateMachineDefinition": "Download Definition...",
     "AWS.command.searchSchemaPerRegistry": "Search Schemas in Registry",
     "AWS.command.submitFeedback": "Send Feedback...",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -156,16 +156,14 @@ export async function activate(context: vscode.ExtensionContext) {
             credentialsStore,
         }
 
-        // Used as a command for decoration-only codelenses.
-        context.subscriptions.push(vscode.commands.registerCommand('aws.doNothingCommand', () => {}))
-
         context.subscriptions.push(
-            vscode.commands.registerCommand('aws.login', async () => await globals.awsContextCommands.onCommandLogin())
-        )
-        context.subscriptions.push(
-            vscode.commands.registerCommand(
-                'aws.logout',
-                async () => await globals.awsContextCommands.onCommandLogout()
+            // No-op command used for decoration-only codelenses.
+            vscode.commands.registerCommand('aws.doNothingCommand', () => {}),
+            vscode.commands.registerCommand('aws.login', () => globals.awsContextCommands.onCommandLogin()),
+            vscode.commands.registerCommand('aws.logout', () => globals.awsContextCommands.onCommandLogout()),
+            // "Show AWS Commands..."
+            vscode.commands.registerCommand('aws.listCommands', () =>
+                vscode.commands.executeCommand('workbench.action.quickOpen', `> ${getIdeProperties().company}:`)
             )
         )
 


### PR DESCRIPTION


## Problem
Feedback suggests that customers have trouble finding Toolkit commands, or aren't accustomed to using the VSCode command palette.

## Solution
Add a command that lists all Toolkit commands, and put it at the top of the main AWS Explorer menu.


<img width="271" alt="image" src="https://user-images.githubusercontent.com/55561878/162327731-2da98dec-1aba-48bc-bb7a-8466ed271ec9.png">

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
