### PR TITLE
feat(sam debug): pass active credentials to the Docker container

### DIFF
--- a/.changes/next-release/Feature-8a4d8884-b775-4e24-9077-58cc5b1cb841.json
+++ b/.changes/next-release/Feature-8a4d8884-b775-4e24-9077-58cc5b1cb841.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "SAM run/debug now uses the current active credentials (if the `aws.credentials` launch-config field is not set)"
+}

--- a/src/credentials/credentialsStore.ts
+++ b/src/credentials/credentialsStore.ts
@@ -93,14 +93,17 @@ export class CredentialsStore {
     }
 }
 
+/**
+ * Gets credentials, and tries to refresh them if necessary.
+ */
 export async function getCredentialsFromStore(
     credentialsId: CredentialsId,
     credentialsStore: CredentialsStore
-): Promise<AWS.Credentials> {
+): Promise<AWS.Credentials | undefined> {
     const provider = await CredentialsProviderManager.getInstance().getCredentialsProvider(credentialsId)
     if (!provider) {
         credentialsStore.invalidateCredentials(credentialsId)
-        throw new Error(`Could not find Credentials Provider for ${asString(credentialsId)}`)
+        return undefined
     }
 
     const cachedCredentials = await credentialsStore.upsertCredentials(credentialsId, provider)

--- a/src/credentials/credentialsUtilities.ts
+++ b/src/credentials/credentialsUtilities.ts
@@ -6,16 +6,14 @@
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
-import globals from '../shared/extensionGlobals'
-
 import * as vscode from 'vscode'
 import { Credentials } from '@aws-sdk/types'
 import { credentialHelpUrl } from '../shared/constants'
 import { Profile } from '../shared/credentials/credentialsFile'
+import globals from '../shared/extensionGlobals'
 import { isCloud9 } from '../shared/extensionUtilities'
-import { CredentialsId, asString } from './providers/credentials'
-import { waitTimeout, Timeout } from '../shared/utilities/timeoutUtils'
-import { showMessageWithCancel } from '../shared/utilities/messages'
+import { showMessageWithCancel, showViewLogsMessage } from '../shared/utilities/messages'
+import { Timeout, waitTimeout } from '../shared/utilities/timeoutUtils'
 import { fromExtensionManifest } from '../shared/settings'
 
 const CREDENTIALS_TIMEOUT = 300000 // 5 minutes
@@ -34,28 +32,21 @@ export function asEnvironmentVariables(credentials: Credentials): NodeJS.Process
     return environmentVariables
 }
 
-export function notifyUserInvalidCredentials(credentialProviderId: CredentialsId): void {
+export function notifyUserInvalidCredentials(credentialsId: string): void {
     const getHelp = localize('AWS.generic.message.getHelp', 'Get Help...')
-    const viewLogs = localize('AWS.generic.message.viewLogs', 'View Logs...')
-    // TODO: getHelp link does not have a corresponding doc page in Cloud9 as of initial launch.
-    const buttons = isCloud9() ? [viewLogs] : [getHelp, viewLogs]
+    // TODO: getHelp page for Cloud9.
+    const buttons = isCloud9() ? [] : [getHelp]
 
-    vscode.window
-        .showErrorMessage(
-            localize(
-                'AWS.message.credentials.invalid',
-                'Invalid Credentials {0}, see logs for more information.',
-                asString(credentialProviderId)
-            ),
-            ...buttons
-        )
-        .then((selection: string | undefined) => {
-            if (selection === getHelp) {
-                vscode.env.openExternal(vscode.Uri.parse(credentialHelpUrl))
-            } else if (selection === viewLogs) {
-                vscode.commands.executeCommand('aws.viewLogs')
-            }
-        })
+    showViewLogsMessage(
+        localize('AWS.message.credentials.invalid', 'Invalid credentials: {0}', credentialsId),
+        vscode.window,
+        'error',
+        buttons
+    ).then((selection: string | undefined) => {
+        if (selection === getHelp) {
+            vscode.env.openExternal(vscode.Uri.parse(credentialHelpUrl))
+        }
+    })
 }
 
 export function hasProfileProperty(profile: Profile, propertyName: string): boolean {

--- a/src/credentials/loginManager.ts
+++ b/src/credentials/loginManager.ts
@@ -68,14 +68,15 @@ export class LoginManager {
             telemetryResult = 'Succeeded'
             return true
         } catch (err) {
+            const credentialsId = asString(args.providerId)
             if (!CancellationError.isUserCancelled(err)) {
-                const msg = `login: failed to connect with "${asString(args.providerId)}": ${(err as Error).message}`
+                const msg = `login: failed to connect with "${credentialsId}": ${(err as Error).message}`
                 if (!args.passive) {
-                    notifyUserInvalidCredentials(args.providerId)
+                    notifyUserInvalidCredentials(credentialsId)
                     getLogger().error(msg)
                 }
             } else {
-                getLogger().info(`login: cancelled credentials request from "${asString(args.providerId)}"`)
+                getLogger().info(`login: cancelled credentials request from "${credentialsId}"`)
             }
 
             await this.logout()

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -41,7 +41,7 @@ import {
 import { readFileSync } from 'fs-extra'
 import { CredentialsStore } from '../../../../credentials/credentialsStore'
 import { CredentialsProviderManager } from '../../../../credentials/providers/credentialsProviderManager'
-import { Credentials } from 'aws-sdk'
+import { Credentials } from '@aws-sdk/types'
 import { ExtContext } from '../../../../shared/extensions'
 import { mkdir, remove } from 'fs-extra'
 import { getLogger } from '../../../../shared/logger/logger'
@@ -139,10 +139,20 @@ describe('SamDebugConfigurationProvider', async function () {
     let fakeContext: ExtContext
     let sandbox: sinon.SinonSandbox
     const resourceName = 'myResource'
-    const mockedCredentials = new Credentials('access', 'secret', 'session')
+    const fakeCredentials: Credentials = {
+        accessKeyId: 'fake-access-id',
+        secretAccessKey: 'fake-secret',
+        sessionToken: 'fake-session',
+    }
 
     beforeEach(async function () {
         fakeContext = await FakeExtensionContext.getFakeExtContext()
+        fakeContext.awsContext.setCredentials({
+            accountId: '9888888',
+            credentials: fakeCredentials,
+            credentialsId: 'profile:fake',
+            defaultRegion: 'us-west-2',
+        })
         debugConfigProvider = new SamDebugConfigProvider(fakeContext)
         sandbox = sinon.createSandbox()
 
@@ -538,7 +548,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
             const expected: SamLaunchRequestArgs = {
                 type: AWS_SAM_DEBUG_TYPE,
-                awsCredentials: undefined,
+                awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'nodejs12.x',
                 runtimeFamily: lambdaModel.RuntimeFamily.NodeJS,
@@ -689,7 +699,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
             const expected: SamLaunchRequestArgs = {
                 type: AWS_SAM_DEBUG_TYPE,
-                awsCredentials: undefined,
+                awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'nodejs12.x',
                 runtimeFamily: lambdaModel.RuntimeFamily.NodeJS,
@@ -843,7 +853,7 @@ describe('SamDebugConfigurationProvider', async function () {
 
             const expected: SamLaunchRequestArgs = {
                 type: AWS_SAM_DEBUG_TYPE,
-                awsCredentials: undefined,
+                awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'nodejs14.x',
                 runtimeFamily: lambdaModel.RuntimeFamily.NodeJS,
@@ -969,7 +979,7 @@ describe('SamDebugConfigurationProvider', async function () {
 
             const expected: SamLaunchRequestArgs = {
                 type: AWS_SAM_DEBUG_TYPE,
-                awsCredentials: undefined,
+                awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'nodejs12.x',
                 runtimeFamily: lambdaModel.RuntimeFamily.NodeJS,
@@ -1107,7 +1117,7 @@ describe('SamDebugConfigurationProvider', async function () {
 
             const expected: SamLaunchRequestArgs = {
                 type: AWS_SAM_DEBUG_TYPE,
-                awsCredentials: undefined,
+                awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'nodejs14.x',
                 runtimeFamily: lambdaModel.RuntimeFamily.NodeJS,
@@ -1186,7 +1196,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const actual = (await debugConfigProvider.makeConfig(folder, input))! as SamLaunchRequestArgs
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
             const expected: SamLaunchRequestArgs = {
-                awsCredentials: undefined,
+                awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'java11',
                 runtimeFamily: lambdaModel.RuntimeFamily.Java,
@@ -1288,7 +1298,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const actual = (await debugConfigProvider.makeConfig(folder, input))! as SamLaunchRequestArgs
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
             const expected: SamLaunchRequestArgs = {
-                awsCredentials: undefined,
+                awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'java11',
                 runtimeFamily: lambdaModel.RuntimeFamily.Java,
@@ -1401,7 +1411,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const actual = (await debugConfigProvider.makeConfig(folder, input))! as SamLaunchRequestArgs
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
             const expected: SamLaunchRequestArgs = {
-                awsCredentials: undefined,
+                awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'java11',
                 runtimeFamily: lambdaModel.RuntimeFamily.Java,
@@ -1500,7 +1510,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const actual = (await debugConfigProvider.makeConfig(folder, input))! as SamLaunchRequestArgs
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
             const expected: SamLaunchRequestArgs = {
-                awsCredentials: undefined,
+                awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'java11',
                 runtimeFamily: lambdaModel.RuntimeFamily.Java,
@@ -1596,7 +1606,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const codeRoot = input.invokeTarget.projectRoot
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
             const expected: SamLaunchRequestArgs = {
-                awsCredentials: undefined,
+                awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'dotnetcore3.1', // lambdaModel.dotNetRuntimes[0],
                 runtimeFamily: lambdaModel.RuntimeFamily.DotNetCore,
@@ -1762,7 +1772,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const codeRoot = `${appDir}/src/HelloWorld`
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
             const expected: SamLaunchRequestArgs = {
-                awsCredentials: undefined,
+                awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'dotnetcore3.1', // lambdaModel.dotNetRuntimes[0],
                 runtimeFamily: lambdaModel.RuntimeFamily.DotNetCore,
@@ -1915,7 +1925,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const codeRoot = `${appDir}/src/HelloWorld`
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
             const expected: SamLaunchRequestArgs = {
-                awsCredentials: undefined,
+                awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'dotnetcore3.1', // lambdaModel.dotNetRuntimes[0],
                 runtimeFamily: lambdaModel.RuntimeFamily.DotNetCore,
@@ -2079,7 +2089,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
             // Expected result with noDebug=false.
             const expected: SamLaunchRequestArgs = {
-                awsCredentials: undefined,
+                awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'python3.7',
                 runtimeFamily: lambdaModel.RuntimeFamily.Python,
@@ -2225,7 +2235,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
             // Expected result with noDebug=false.
             const expected: SamLaunchRequestArgs = {
-                awsCredentials: undefined,
+                awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'python3.7',
                 runtimeFamily: lambdaModel.RuntimeFamily.Python,
@@ -2351,7 +2361,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
             // Expected result with noDebug=false.
             const expected: SamLaunchRequestArgs = {
-                awsCredentials: undefined,
+                awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'python3.7',
                 runtimeFamily: lambdaModel.RuntimeFamily.Python,
@@ -2443,7 +2453,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
             // Expected result with noDebug=false.
             const expected: SamLaunchRequestArgs = {
-                awsCredentials: undefined,
+                awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'python3.7',
                 runtimeFamily: lambdaModel.RuntimeFamily.Python,
@@ -2616,7 +2626,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
             // Expected result with noDebug=false.
             const expected: SamLaunchRequestArgs = {
-                awsCredentials: undefined,
+                awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'python3.7',
                 runtimeFamily: lambdaModel.RuntimeFamily.Python,
@@ -2722,7 +2732,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
             // Expected result with noDebug=false.
             const expected: SamLaunchRequestArgs = {
-                awsCredentials: undefined,
+                awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'python3.7',
                 runtimeFamily: lambdaModel.RuntimeFamily.Python,
@@ -2788,7 +2798,13 @@ describe('SamDebugConfigurationProvider', async function () {
             assertEqualLaunchConfigs(actualNoDebug, expectedNoDebug)
         })
 
-        it('debugconfig with aws section', async function () {
+        it('debugconfig with "aws" section', async function () {
+            // Simluates credentials in "aws.credentials" launch-config field.
+            const configCredentials: Credentials = {
+                accessKeyId: 'access-from-config',
+                secretAccessKey: 'secret-from-config',
+                sessionToken: 'session-from-config',
+            }
             const mockCredentialsStore: CredentialsStore = new CredentialsStore()
 
             const credentialsProvider: CredentialsProvider = {
@@ -2811,7 +2827,7 @@ describe('SamDebugConfigurationProvider', async function () {
             getCredentialsProviderStub.resolves(credentialsProvider)
             const upsertStub = sandbox.stub(mockCredentialsStore, 'upsertCredentials')
             upsertStub.resolves({
-                credentials: mockedCredentials,
+                credentials: configCredentials,
                 credentialsHashCode: 'unimportant',
             })
             const debugConfigProviderMockCredentials = new SamDebugConfigProvider({
@@ -2861,7 +2877,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const tempDir = path.dirname(actual.codeRoot)
 
             const expected: SamLaunchRequestArgs = {
-                awsCredentials: mockedCredentials,
+                awsCredentials: configCredentials,
                 ...awsSection,
                 type: AWS_SAM_DEBUG_TYPE,
                 useIkpdb: false,
@@ -2949,7 +2965,7 @@ describe('SamDebugConfigurationProvider', async function () {
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
             const expected: SamLaunchRequestArgs = {
                 type: AWS_SAM_DEBUG_TYPE,
-                awsCredentials: undefined,
+                awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'go1.x',
                 runtimeFamily: lambdaModel.RuntimeFamily.Go,


### PR DESCRIPTION
todo

- [ ] force autoconnect on sam-debug (if AWS panel hasn't been revealed yet)
    - #1715 

## Problem:
When running/debugging a local Lambda, Toolkit does not use the current active credentials. This is inconsistent with other actions (e.g `aws.deploySamApplication`) and other Toolkits such as aws-toolkit-jetbrains.

Also the `aws.credentials` launch-config field is not well-known.

## Solution:
If the `aws.credentials` launch-config field is not set, pass the current Toolkit credentials to `sam local invoke` as environment variables.

## Reference:
Motivation for the `aws.credentials` launch-config field:
https://github.com/aws/aws-toolkit-vscode/pull/933#discussion_r377387302

## Test cases:
1. set "aws.credentials" in launch-config overrides current active  credentials
2. without "aws.credentials", current Toolkit credentials are used in  the `sam local invoke` call.

Sample Lambda function code (correctly lists the buckets associated with the credentials):

    const s3 = require("@aws-sdk/client-s3")
    exports.lambdaHandlerN12 = async (event, context) => {
        const c = new s3.S3()
        const buckets = await c.listBuckets({})
        console.log('s3 files %O', buckets);
        return {
            statusCode: 200,
            body: JSON.stringify(buckets)
        };
    };

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
