### PR TITLE
Codelens: show without manifest file

### DIFF
--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -89,7 +89,7 @@ export async function makeCodeLenses({
             }
             const codeConfig: AddSamDebugConfigurationInput = {
                 resourceName: handler.handlerName,
-                rootUri: handler.manifestUri,
+                rootUri: handler.rootUri,
                 runtimeFamily,
             }
             lenses.push(

--- a/src/shared/codelens/csharpCodeLensProvider.ts
+++ b/src/shared/codelens/csharpCodeLensProvider.ts
@@ -53,7 +53,7 @@ export async function getLambdaHandlerCandidates(document: vscode.TextDocument):
             return {
                 filename: document.uri.fsPath,
                 handlerName,
-                manifestUri: assemblyUri,
+                rootUri: assemblyUri,
                 range: lambdaHandlerComponents.handlerRange,
             }
         }

--- a/src/shared/codelens/goCodeLensProvider.ts
+++ b/src/shared/codelens/goCodeLensProvider.ts
@@ -66,7 +66,7 @@ export async function getLambdaHandlerCandidates(document: vscode.TextDocument):
             return {
                 filename,
                 handlerName: basename(dirname(filename)),
-                manifestUri: modFile,
+                rootUri: modFile,
                 range: symbol.range,
             }
         })

--- a/src/shared/codelens/javaCodeLensProvider.ts
+++ b/src/shared/codelens/javaCodeLensProvider.ts
@@ -31,9 +31,11 @@ export interface JavaLambdaHandlerComponents {
 
 export async function getLambdaHandlerCandidates(document: vscode.TextDocument): Promise<LambdaHandlerCandidate[]> {
     const rootUri =
-        ((await findParentProjectFile(document.uri, /^.*pom.xml$/)) ??
-            (await findParentProjectFile(document.uri, /^.*build.gradle$/))) ||
-        document.uri
+        (await findParentProjectFile(document.uri, /^.*pom.xml$/)) ??
+        (await findParentProjectFile(document.uri, /^.*build.gradle$/))
+    if (!rootUri) {
+        return []
+    }
 
     const symbols: vscode.DocumentSymbol[] =
         (await vscode.commands.executeCommand('vscode.executeDocumentSymbolProvider', document.uri)) || []

--- a/src/shared/codelens/javaCodeLensProvider.ts
+++ b/src/shared/codelens/javaCodeLensProvider.ts
@@ -30,12 +30,10 @@ export interface JavaLambdaHandlerComponents {
 }
 
 export async function getLambdaHandlerCandidates(document: vscode.TextDocument): Promise<LambdaHandlerCandidate[]> {
-    const manifestUri =
-        (await findParentProjectFile(document.uri, /^.*pom.xml$/)) ??
-        (await findParentProjectFile(document.uri, /^.*build.gradle$/))
-    if (!manifestUri) {
-        return []
-    }
+    const rootUri =
+        ((await findParentProjectFile(document.uri, /^.*pom.xml$/)) ??
+            (await findParentProjectFile(document.uri, /^.*build.gradle$/))) ||
+        document.uri
 
     const symbols: vscode.DocumentSymbol[] =
         (await vscode.commands.executeCommand('vscode.executeDocumentSymbolProvider', document.uri)) || []
@@ -46,7 +44,7 @@ export async function getLambdaHandlerCandidates(document: vscode.TextDocument):
         return {
             filename: document.uri.fsPath,
             handlerName,
-            manifestUri: manifestUri,
+            rootUri: rootUri,
             range: lambdaHandlerComponents.handlerRange,
         }
     })

--- a/src/shared/codelens/pythonCodeLensProvider.ts
+++ b/src/shared/codelens/pythonCodeLensProvider.ts
@@ -19,15 +19,13 @@ export const PYTHON_ALLFILES: vscode.DocumentFilter[] = [
 export const PYTHON_BASE_PATTERN = '**/requirements.txt'
 
 export async function getLambdaHandlerCandidates(uri: vscode.Uri): Promise<LambdaHandlerCandidate[]> {
-    const requirementsFile = await findParentProjectFile(uri, /^requirements\.txt$/)
-    if (!requirementsFile) {
-        return []
-    }
+    const rootUri = (await findParentProjectFile(uri, /^requirements\.txt$/)) || uri
+
     const filename = uri.fsPath
     const parsedPath = path.parse(filename)
     // Python handler paths are slash separated and don't include the file extension
     const handlerPath = path
-        .relative(path.parse(requirementsFile.fsPath).dir, path.join(parsedPath.dir, parsedPath.name))
+        .relative(path.parse(rootUri.fsPath).dir, path.join(parsedPath.dir, parsedPath.name))
         .split(path.sep)
         .join('/')
 
@@ -39,7 +37,7 @@ export async function getLambdaHandlerCandidates(uri: vscode.Uri): Promise<Lambd
         return {
             filename,
             handlerName: `${handlerPath}.${symbol.name}`,
-            manifestUri: requirementsFile,
+            rootUri: rootUri,
             range: symbol.range,
         }
     })

--- a/src/shared/codelens/typescriptCodeLensProvider.ts
+++ b/src/shared/codelens/typescriptCodeLensProvider.ts
@@ -28,11 +28,11 @@ export const TYPESCRIPT_ALL_FILES: vscode.DocumentFilter[] = [
 export const JAVASCRIPT_BASE_PATTERN = '**/package.json'
 
 export async function getLambdaHandlerCandidates(document: vscode.TextDocument): Promise<LambdaHandlerCandidate[]> {
-    const packageJsonFile = await findParentProjectFile(document.uri, /^package\.json$/)
-
-    if (!packageJsonFile) {
-        return []
-    }
+    // let packageJsonFile = await findParentProjectFile(document.uri, /^package\.json$/)
+    // if (!packageJsonFile) {
+    //     packageJsonFile = document.uri
+    // }
+    const rootUri = (await findParentProjectFile(document.uri, /^package\.json$/)) || document.uri
 
     const search: TypescriptLambdaHandlerSearch = new TypescriptLambdaHandlerSearch(
         document.uri.fsPath,
@@ -44,7 +44,7 @@ export async function getLambdaHandlerCandidates(document: vscode.TextDocument):
     // (eg: src/app.handler) instead of only the pure handler name (eg: app.handler)
     // Without this, the CodeLens command is unable to resolve a match back to a sam template.
     // This is done to address https://github.com/aws/aws-toolkit-vscode/issues/757
-    return await finalizeTsHandlers(unprocessedHandlers, document.uri, packageJsonFile)
+    return await finalizeTsHandlers(unprocessedHandlers, document.uri, rootUri)
 }
 
 /**
@@ -52,20 +52,20 @@ export async function getLambdaHandlerCandidates(document: vscode.TextDocument):
  * Also adds `package.json` path
  * @param handlers Rootless handlers to apply relative paths to
  * @param uri URI of the file containing these Lambda Handlers
- * @param packageJsonFileUri URI of `package.json` file
+ * @param rootUri URI of `package.json` file or the source file if there isn't one found.
  */
 async function finalizeTsHandlers(
     handlers: RootlessLambdaHandlerCandidate[],
     fileUri: vscode.Uri,
-    packageJsonFileUri: vscode.Uri
+    rootUri: vscode.Uri
 ): Promise<LambdaHandlerCandidate[]> {
-    const relativePath = path.relative(path.dirname(packageJsonFileUri.fsPath), path.dirname(fileUri.fsPath))
+    const relativePath = path.relative(path.dirname(rootUri.fsPath), path.dirname(fileUri.fsPath))
 
     return handlers.map(handler => {
         return {
             filename: handler.filename,
             handlerName: normalizeSeparator(path.join(relativePath, handler.handlerName)),
-            manifestUri: packageJsonFileUri,
+            rootUri: rootUri,
             range: handler.range,
         }
     })

--- a/src/shared/codelens/typescriptCodeLensProvider.ts
+++ b/src/shared/codelens/typescriptCodeLensProvider.ts
@@ -28,10 +28,6 @@ export const TYPESCRIPT_ALL_FILES: vscode.DocumentFilter[] = [
 export const JAVASCRIPT_BASE_PATTERN = '**/package.json'
 
 export async function getLambdaHandlerCandidates(document: vscode.TextDocument): Promise<LambdaHandlerCandidate[]> {
-    // let packageJsonFile = await findParentProjectFile(document.uri, /^package\.json$/)
-    // if (!packageJsonFile) {
-    //     packageJsonFile = document.uri
-    // }
     const rootUri = (await findParentProjectFile(document.uri, /^package\.json$/)) || document.uri
 
     const search: TypescriptLambdaHandlerSearch = new TypescriptLambdaHandlerSearch(

--- a/src/shared/lambdaHandlerSearch.ts
+++ b/src/shared/lambdaHandlerSearch.ts
@@ -12,7 +12,7 @@ export interface AbsoluteCharOffset {
 export type RangeOrCharOffset = Range | AbsoluteCharOffset
 
 export interface LambdaHandlerCandidate extends RootlessLambdaHandlerCandidate {
-    manifestUri: Uri
+    rootUri: Uri
 }
 
 export interface RootlessLambdaHandlerCandidate {


### PR DESCRIPTION

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
#2564
Codelenses (for in code potential lambda handlers) only appear for files with an associated manifest
file. Lambdas that are downloaded will not have template.yaml file or a
manifest file and therefore no codelens appears, but can still be invoked locally.
## Solution
The manifest file was mainly used to find the project root. In
the absence of such file, use the source file as the project root.
<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
