### PR TITLE
fix(s3): handle file paths with reserved characters

### DIFF
--- a/.changes/next-release/Bug Fix-dde17524-db50-4ba9-864a-c33514f35c82.json
+++ b/.changes/next-release/Bug Fix-dde17524-db50-4ba9-864a-c33514f35c82.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "S3 File Viewer: file paths containing reserved URI characters are now handled correctly"
+}

--- a/package.json
+++ b/package.json
@@ -2851,6 +2851,13 @@
                     "label": "${path}",
                     "separator": "\\"
                 }
+            },
+            {
+                "scheme": "s3*",
+                "formatting": {
+                    "label": "[S3] ${path}",
+                    "separator": "/"
+                }
             }
         ],
         "walkthroughs": [

--- a/src/s3/fileViewerManager.ts
+++ b/src/s3/fileViewerManager.ts
@@ -10,7 +10,6 @@ import * as S3 from '../shared/clients/s3Client'
 import { getLogger } from '../shared/logger'
 import { showConfirmationMessage } from '../shared/utilities/messages'
 import { localize } from '../shared/utilities/vsCodeUtils'
-import { parse } from '@aws-sdk/util-arn-parser'
 import { CancellationError } from '../shared/utilities/timeoutUtils'
 import { downloadFile } from './commands/downloadFileAs'
 import { s3FileViewerHelpUrl } from '../shared/constants'
@@ -362,12 +361,10 @@ export class S3FileViewerManager {
     }
 
     private static fileToUri(file: S3File, mode: TabMode): vscode.Uri {
-        const parts = parse(file.arn)
-        const fileName = path.basename(parts.resource)
-        const fsPath = path.join(file.bucket.region, path.dirname(parts.resource), `[S3] ${fileName}`)
+        const scheme = mode === TabMode.Read ? S3_READ_SCHEME : S3_EDIT_SCHEME
 
-        return vscode.Uri.parse(fsPath).with({
-            scheme: mode === TabMode.Read ? S3_READ_SCHEME : S3_EDIT_SCHEME,
+        return vscode.Uri.parse(`${scheme}:`, true).with({
+            path: ['', file.bucket.region, file.bucket.name, file.key].join('/'),
         })
     }
 }

--- a/src/test/s3/util/fileViewerManager.test.ts
+++ b/src/test/s3/util/fileViewerManager.test.ts
@@ -21,7 +21,6 @@ import { createTestWindow, TestWindow } from '../../shared/vscode/window'
 import { anything, instance, mock, when, resetCalls, verify } from '../../utilities/mockito'
 import { MockOutputChannel } from '../../mockOutputChannel'
 import { SeverityLevel } from '../../shared/vscode/message'
-import { join } from 'path'
 import { assertTextEditorContains, closeAllEditors } from '../../testUtil'
 import { PromptSettings } from '../../../shared/settings'
 
@@ -175,16 +174,17 @@ describe('FileViewerManager', function () {
     })
 
     describe('opens text files', function () {
-        const textFile1Contents = Buffer.from('contents', 'utf-8')
+        const textFile1Contents = Buffer.from('test1 contents', 'utf-8')
         const textFile1 = makeFile('test1.txt', textFile1Contents)
-        const textFile2Contents = Buffer.from('contents', 'utf-8')
+        const textFile2Contents = Buffer.from('test2 contents', 'utf-8')
         const textFile2 = makeFile('test2.txt', textFile2Contents)
 
         function mockOpen(file: ReturnType<typeof makeFile>, scheme: string = S3_READ_SCHEME) {
-            const expectedPath = join('/', bucket.region, bucket.name, `[S3] ${file.name}`)
+            const expectedPath = `/${bucket.region}/${bucket.name}/${file.key}`
+
             when(workspace.openTextDocument(anything())).thenCall(async (uri: vscode.Uri) => {
                 assert.strictEqual(uri.scheme, scheme)
-                assert.strictEqual(uri.fsPath, expectedPath)
+                assert.strictEqual(uri.path, expectedPath)
                 // Currently easier to open a new document, though this isn't _exactly_ what the user would see
                 return vscode.workspace.openTextDocument({ content: file.content.toString() })
             })
@@ -240,8 +240,14 @@ describe('FileViewerManager', function () {
             verify(workspace.openTextDocument(anything())).twice()
             await assertTextEditorContains(textFile1.content.toString())
         })
-    })
 
-    // TODO: test non-text files
-    // this is a bit trickier since it uses webviews, not `TextEditor`
+        it('can open an S3 file with reserved URI characters', async function () {
+            const contents = Buffer.from('text', 'utf-8')
+            const file = makeFile('us-west-2:3cff280c/file.txt', contents)
+
+            mockOpen(file)
+            await fileViewerManager.openInReadMode({ ...file, bucket })
+            await assertTextEditorContains(contents.toString())
+        })
+    })
 })

--- a/src/test/testUtil.ts
+++ b/src/test/testUtil.ts
@@ -236,7 +236,7 @@ export async function assertTextEditorContains(contents: string): Promise<void |
     if (!editor) {
         const actual = vscode.window.activeTextEditor.document
         const documentName = actual.uri.toString(true)
-        const message = `Document "${documentName}" contained ${actual.getText()}, expected: ${contents}`
+        const message = `Document "${documentName}" contained "${actual.getText()}", expected: "${contents}"`
         assert.strictEqual(actual.getText(), contents, message)
     }
 }

--- a/src/test/testUtil.ts
+++ b/src/test/testUtil.ts
@@ -232,8 +232,12 @@ export async function assertTextEditorContains(contents: string): Promise<void |
     if (!vscode.window.activeTextEditor) {
         throw new Error('No active text editor found')
     }
+
     if (!editor) {
-        assert.strictEqual(vscode.window.activeTextEditor.document.getText(), contents)
+        const actual = vscode.window.activeTextEditor.document
+        const documentName = actual.uri.toString(true)
+        const message = `Document "${documentName}" contained ${actual.getText()}, expected: ${contents}`
+        assert.strictEqual(actual.getText(), contents, message)
     }
 }
 


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Users would see an error such as `aws.s3.editFile:[UriError]: Scheme contains illegal characters.` when opening a file with a reserved URI character (e.g. `:`)

See #2581

## Solution
Do not use `path`. Just assign the path directly to the URI. This removed the `[S3]` prefix which is unfortunate but it was getting encoded weirdly.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
