### PR TITLE
refactor(lambda): use wizard code for `uploadLambdaCommand`

### DIFF
--- a/src/lambda/commands/uploadLambda.ts
+++ b/src/lambda/commands/uploadLambda.ts
@@ -53,9 +53,9 @@ export async function uploadLambdaCommand(functionNode: LambdaFunctionNode) {
         configuration: functionNode.configuration,
     }
 
-    const response = await new UploadLambdaWizard(lambda).run()
-
     try {
+        const response = await new UploadLambdaWizard(lambda).run()
+
         if (response?.uploadType === 'zip') {
             await runUploadLambdaZipFile(lambda, response.targetUri)
             result = 'Succeeded'

--- a/src/lambda/commands/uploadLambda.ts
+++ b/src/lambda/commands/uploadLambda.ts
@@ -9,10 +9,9 @@ import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
 import * as AdmZip from 'adm-zip'
-import * as fs from 'fs'
+import * as fs from 'fs-extra'
 import * as path from 'path'
-import { showConfirmationMessage } from '../../shared/utilities/messages'
-
+import { showConfirmationMessage, showViewLogsMessage } from '../../shared/utilities/messages'
 import { fileExists, makeTemporaryToolkitFolder, tryRemoveFolder } from '../../shared/filesystemUtilities'
 import * as localizedText from '../../shared/localizedText'
 import { getLogger } from '../../shared/logger'
@@ -20,13 +19,25 @@ import { SamCliBuildInvocation } from '../../shared/sam/cli/samCliBuild'
 import { getSamCliContext } from '../../shared/sam/cli/samCliContext'
 import * as telemetry from '../../shared/telemetry/telemetry'
 import { SamTemplateGenerator } from '../../shared/templates/sam/samTemplateGenerator'
-import { createQuickPick, promptUser, verifySinglePickerOutput } from '../../shared/ui/picker'
 import { Window } from '../../shared/vscode/window'
 import { LambdaFunctionNode } from '../explorer/lambdaFunctionNode'
 import { addCodiconToString } from '../../shared/utilities/textUtilities'
 import { getLambdaDetails } from '../utils'
 import { getIdeProperties } from '../../shared/extensionUtilities'
+import { createQuickPick, DataQuickPickItem } from '../../shared/ui/pickerPrompter'
+import { createCommonButtons } from '../../shared/ui/buttons'
+import { StepEstimator, Wizard, WIZARD_BACK } from '../../shared/wizards/wizard'
+import { createSingleFileDialog } from '../../shared/ui/common/openDialog'
+import { Prompter, PromptResult } from '../../shared/ui/prompter'
+import { ToolkitError } from '../../shared/toolkitError'
+import { FunctionConfiguration } from 'aws-sdk/clients/lambda'
 import globals from '../../shared/extensionGlobals'
+
+interface LambdaFunction {
+    readonly name: string
+    readonly region: string
+    readonly configuration?: FunctionConfiguration
+}
 
 /**
  * Executes the "Upload Lambda..." command.
@@ -35,57 +46,143 @@ import globals from '../../shared/extensionGlobals'
  * @param functionNode Function node from AWS Explorer
  */
 export async function uploadLambdaCommand(functionNode: LambdaFunctionNode) {
-    const result = await selectUploadTypeAndRunUpload(functionNode)
+    let result: telemetry.Result = 'Cancelled'
+    const lambda = {
+        name: functionNode.functionName,
+        region: functionNode.regionCode,
+        configuration: functionNode.configuration,
+    }
 
-    telemetry.recordLambdaUpdateFunctionCode({
-        result,
-        runtime: functionNode.configuration.Runtime as telemetry.Runtime | undefined,
-    })
+    const response = await new UploadLambdaWizard(lambda).run()
+
+    try {
+        if (response?.uploadType === 'zip') {
+            await runUploadLambdaZipFile(lambda, response.targetUri)
+            result = 'Succeeded'
+        } else if (response?.uploadType === 'directory' && response.directoryUploadType) {
+            result = (await runUploadDirectory(lambda, response.directoryUploadType, response.targetUri)) ?? result
+            result = 'Succeeded'
+        }
+        // TODO(sijaden): potentially allow the wizard to easily support tagged-union states
+    } catch (err) {
+        result = 'Failed'
+        if (err instanceof ToolkitError) {
+            showViewLogsMessage(`Could not upload lambda: ${err.message}`)
+            getLogger().error(`Lambda upload failed: %O`, err.cause ?? err)
+        } else {
+            throw err
+        }
+    } finally {
+        telemetry.recordLambdaUpdateFunctionCode({
+            result,
+            runtime: lambda.configuration.Runtime as telemetry.Runtime | undefined,
+        })
+    }
 }
 
 /**
  * Selects the type of file to upload (zip/dir) and proceeds with the rest of the workflow.
  * @param functionNode Function node from AWS Explorer
  */
-async function selectUploadTypeAndRunUpload(functionNode: LambdaFunctionNode): Promise<telemetry.Result> {
-    const uploadZipItem: vscode.QuickPickItem = {
-        label: addCodiconToString('file-zip', localize('AWS.generic.filetype.zipfile', 'ZIP Archive')),
-    }
-    const uploadDirItem: vscode.QuickPickItem = {
-        label: addCodiconToString('folder', localize('AWS.generic.filetype.directory', 'Directory')),
-    }
-
-    // TODO: Add help button? Consult with doc writers.
-    const picker = createQuickPick({
-        options: {
-            canPickMany: false,
-            ignoreFocusOut: true,
-            title: localize('AWS.lambda.upload.title', 'Select Upload Type'),
-            step: 1,
-            totalSteps: 1,
+function createUploadTypePrompter() {
+    const items: DataQuickPickItem<'zip' | 'directory'>[] = [
+        {
+            label: addCodiconToString('file-zip', localize('AWS.generic.filetype.zipfile', 'ZIP Archive')),
+            data: 'zip',
         },
-        items: [uploadZipItem, uploadDirItem],
-        buttons: [vscode.QuickInputButtons.Back],
+        {
+            label: addCodiconToString('folder', localize('AWS.generic.filetype.directory', 'Directory')),
+            data: 'directory',
+        },
+    ]
+
+    return createQuickPick(items, {
+        title: localize('AWS.lambda.upload.title', 'Select Upload Type'),
+        buttons: createCommonButtons(),
     })
-    const response = verifySinglePickerOutput(
-        await promptUser({
-            picker: picker,
-            onDidTriggerButton: (button, resolve, reject) => {
-                if (button === vscode.QuickInputButtons.Back) {
-                    resolve(undefined)
-                }
-            },
+}
+
+function createDirectoryUploadPrompter() {
+    const items: DataQuickPickItem<'zip' | 'sam'>[] = [
+        {
+            label: addCodiconToString('exclude', localizedText.no),
+            detail: localize(
+                'AWS.lambda.upload.prebuiltDir.detail',
+                '{0} Toolkit will upload a ZIP of the selected directory.',
+                getIdeProperties().company
+            ),
+            data: 'zip',
+        },
+        {
+            label: addCodiconToString('gear', localizedText.yes),
+            detail: localize(
+                'AWS.lambda.upload.unbuiltDir.detail',
+                '{0} Toolkit will attempt to build the selected directory using the sam build command.',
+                getIdeProperties().company
+            ),
+            data: 'sam',
+        },
+    ]
+
+    return createQuickPick(items, {
+        title: localize('AWS.lambda.upload.buildDirectory.title', 'Build directory?'),
+        buttons: createCommonButtons(),
+    })
+}
+
+function createConfirmDeploymentPrompter(lambda: LambdaFunction) {
+    // TODO(sijaden): make this a quick pick? Tried to keep as close to possible as the original impl.
+    return new (class extends Prompter<boolean> {
+        protected promptUser(): Promise<PromptResult<boolean>> {
+            return confirmLambdaDeployment(lambda) || WIZARD_BACK
+        }
+
+        // Stubs. Need to thin-out the `Prompter` interface to avoid this.
+        public setStepEstimator(estimator: StepEstimator<boolean>): void {}
+        public setSteps(current: number, total: number): void {}
+
+        public set recentItem(response: any) {}
+        public get recentItem(): any {
+            return undefined
+        }
+    })()
+}
+
+interface UploadLambdaWizardState {
+    readonly uploadType: 'zip' | 'directory'
+    readonly targetUri: vscode.Uri
+    readonly directoryUploadType?: 'zip' | 'sam'
+    readonly confirmedDeploy: boolean
+}
+
+class UploadLambdaWizard extends Wizard<UploadLambdaWizardState> {
+    constructor(lambda: LambdaFunction) {
+        super()
+
+        this.form.uploadType.bindPrompter(() => createUploadTypePrompter())
+
+        this.form.targetUri.bindPrompter(({ uploadType }) => {
+            if (uploadType === 'directory') {
+                return createSingleFileDialog({
+                    canSelectFolders: true,
+                    canSelectFiles: false,
+                })
+            } else {
+                return createSingleFileDialog({
+                    canSelectFolders: false,
+                    canSelectFiles: true,
+                    filters: {
+                        'ZIP archive': ['zip'],
+                    },
+                })
+            }
         })
-    )
 
-    if (!response) {
-        return 'Cancelled'
-    }
+        this.form.directoryUploadType.bindPrompter(() => createDirectoryUploadPrompter(), {
+            showWhen: ({ uploadType }) => uploadType === 'directory',
+        })
 
-    if (response === uploadZipItem) {
-        return await runUploadLambdaZipFile(functionNode)
-    } else {
-        return await runUploadDirectory(functionNode)
+        this.form.confirmedDeploy.bindPrompter(() => createConfirmDeploymentPrompter(lambda))
     }
 }
 
@@ -95,99 +192,24 @@ async function selectUploadTypeAndRunUpload(functionNode: LambdaFunctionNode): P
  * @param window Wrapper around vscode.window functionality for testing
  */
 async function runUploadDirectory(
-    functionNode: LambdaFunctionNode,
+    lambda: Required<LambdaFunction>,
+    type: 'zip' | 'sam',
+    parentDir: vscode.Uri,
     window = Window.vscode()
-): Promise<telemetry.Result> {
-    const parentDir = await selectFolderForUpload()
-
-    if (!parentDir) {
-        return await selectUploadTypeAndRunUpload(functionNode)
-    }
-
-    const zipDirItem: vscode.QuickPickItem = {
-        label: addCodiconToString('exclude', localizedText.no),
-        detail: localize(
-            'AWS.lambda.upload.prebuiltDir.detail',
-            '{0} Toolkit will upload a ZIP of the selected directory.',
-            getIdeProperties().company
-        ),
-    }
-    const buildDirItem: vscode.QuickPickItem = {
-        label: addCodiconToString('gear', localizedText.yes),
-        detail: localize(
-            'AWS.lambda.upload.unbuiltDir.detail',
-            '{0} Toolkit will attempt to build the selected directory using the sam build command.',
-            getIdeProperties().company
-        ),
-    }
-
-    // TODO: Add help button? Consult with doc writers.
-    const picker = createQuickPick({
-        options: {
-            canPickMany: false,
-            ignoreFocusOut: true,
-            title: localize('AWS.lambda.upload.buildDirectory.title', 'Build directory?'),
-            step: 2,
-            totalSteps: 2,
-        },
-        items: [zipDirItem, buildDirItem],
-        buttons: [vscode.QuickInputButtons.Back],
-    })
-    const response = verifySinglePickerOutput(
-        await promptUser({
-            picker: picker,
-            onDidTriggerButton: (button, resolve, reject) => {
-                if (button === vscode.QuickInputButtons.Back) {
-                    resolve(undefined)
-                }
-            },
-        })
-    )
-
-    if (!response) {
-        return await selectUploadTypeAndRunUpload(functionNode)
-    }
-
-    if (!(await confirmLambdaDeployment(functionNode))) {
-        return 'Cancelled'
-    }
-
-    if (response === zipDirItem) {
+) {
+    if (type === 'zip') {
         return await window.withProgress(
             {
                 location: vscode.ProgressLocation.Notification,
                 cancellable: false,
             },
             async progress => {
-                return await zipAndUploadDirectory(functionNode, parentDir.fsPath, progress)
+                return await zipAndUploadDirectory(lambda, parentDir.fsPath, progress)
             }
         )
     } else {
-        return await runUploadLambdaWithSamBuild(functionNode, parentDir)
+        return await runUploadLambdaWithSamBuild(lambda, parentDir)
     }
-}
-
-/**
- * Selects a folder for upload. Returns selected folder URI on success.
- * Otherwise, returns undefined if nothing is selected or if more than one folder is selected (should never happen)
- * Does not vet return URI type; this is left up to VS Code.
- * @param window Wrapper around vscode.window functionality for testing
- */
-async function selectFolderForUpload(window = Window.vscode()): Promise<vscode.Uri | undefined> {
-    const workspaceFolders = vscode.workspace.workspaceFolders || []
-
-    const parentDirArr = await window.showOpenDialog({
-        canSelectFolders: true,
-        canSelectFiles: false,
-        canSelectMany: false,
-        defaultUri: workspaceFolders[0]?.uri,
-    })
-
-    if (!parentDirArr || parentDirArr.length !== 1) {
-        return undefined
-    }
-
-    return parentDirArr[0]
 }
 
 /**
@@ -201,13 +223,13 @@ async function selectFolderForUpload(window = Window.vscode()): Promise<vscode.U
  * @param window Wrapper around vscode.window functionality for testing
  */
 async function runUploadLambdaWithSamBuild(
-    functionNode: LambdaFunctionNode,
+    lambda: Required<LambdaFunction>,
     parentDir: vscode.Uri,
     window = Window.vscode()
-): Promise<telemetry.Result> {
+) {
     // Detect if handler is present and provide strong guidance against proceeding if not.
     try {
-        const handlerFile = path.join(parentDir.fsPath, getLambdaDetails(functionNode.configuration).fileName)
+        const handlerFile = path.join(parentDir.fsPath, getLambdaDetails(lambda.configuration).fileName)
         if (!(await fileExists(handlerFile))) {
             const isConfirmed = await showConfirmationMessage(
                 {
@@ -215,7 +237,7 @@ async function runUploadLambdaWithSamBuild(
                         'AWS.lambda.upload.handlerNotFound',
                         "{0} Toolkit can't find a file corresponding to handler: {1} at filepath {2}.\n\nThis directory likely will not work with this function.\n\nProceed with upload anyway?",
                         getIdeProperties().company,
-                        functionNode.configuration.Handler,
+                        lambda.configuration.Handler,
                         handlerFile
                     ),
                     confirm: localizedText.yes,
@@ -258,9 +280,9 @@ async function runUploadLambdaWithSamBuild(
                     ),
                 })
                 await new SamTemplateGenerator()
-                    .withFunctionHandler(functionNode.configuration.Handler!)
+                    .withFunctionHandler(lambda.configuration.Handler!)
                     .withResourceName(resourceName)
-                    .withRuntime(functionNode.configuration.Runtime!)
+                    .withRuntime(lambda.configuration.Runtime!)
                     .withCodeUri(parentDir.fsPath)
                     .generate(templatePath)
 
@@ -283,13 +305,9 @@ async function runUploadLambdaWithSamBuild(
                 }).execute()
 
                 // App builds into a folder named after the resource name. Zip the contents of that, not the whole output dir.
-                return await zipAndUploadDirectory(functionNode, path.join(buildDir, resourceName), progress)
-            } catch (e) {
-                const err = e as Error
-                window.showErrorMessage(err.message)
-                getLogger().error('runUploadLambdaWithSamBuild failed: ', err.message)
-
-                return 'Failed'
+                return await zipAndUploadDirectory(lambda, path.join(buildDir, resourceName), progress)
+            } catch (err) {
+                throw new ToolkitError('Failed to build directory', { cause: err as Error })
             } finally {
                 await tryRemoveFolder(tempDir)
             }
@@ -299,16 +317,16 @@ async function runUploadLambdaWithSamBuild(
 
 /**
  * Confirms whether or not the user wants to deploy the Lambda as it is a destructive action.
- * @param functionNode Function node from AWS Explorer
+ * @param functionName Name of the Lambda function
  * @param window Wrapper around vscode.window functionality for testing
  */
-async function confirmLambdaDeployment(functionNode: LambdaFunctionNode, window = Window.vscode()): Promise<boolean> {
+async function confirmLambdaDeployment(lambda: LambdaFunction, window = Window.vscode()): Promise<boolean> {
     const isConfirmed = await showConfirmationMessage(
         {
             prompt: localize(
                 'AWS.lambda.upload.confirm',
                 'This will immediately publish the selected code as the $LATEST version of Lambda: {0}.\n\nContinue?',
-                functionNode.functionName
+                lambda.name
             ),
             confirm: localizedText.yes,
             cancel: localizedText.no,
@@ -325,116 +343,71 @@ async function confirmLambdaDeployment(functionNode: LambdaFunctionNode, window 
 
 /**
  * Prompts the user to select a `.zip` file for upload to Lambda, confirms, and attempts to upload.
- * @param functionNode Function node from AWS Explorer
  * @param window Wrapper around vscode.window functionality for testing
  */
-async function runUploadLambdaZipFile(
-    functionNode: LambdaFunctionNode,
-    window = Window.vscode()
-): Promise<telemetry.Result> {
-    const workspaceFolders = vscode.workspace.workspaceFolders || []
-
-    const zipFileArr = await window.showOpenDialog({
-        canSelectFolders: false,
-        canSelectFiles: true,
-        canSelectMany: false,
-        defaultUri: workspaceFolders[0]?.uri,
-        filters: {
-            'ZIP archive': ['zip'],
+async function runUploadLambdaZipFile(lambda: LambdaFunction, zipFileUri: vscode.Uri, window = Window.vscode()) {
+    return await window.withProgress(
+        {
+            location: vscode.ProgressLocation.Notification,
+            cancellable: false,
         },
-    })
-
-    if (!zipFileArr || zipFileArr.length !== 1) {
-        return 'Cancelled'
-    }
-
-    const isConfirmed = await confirmLambdaDeployment(functionNode)
-
-    return isConfirmed
-        ? await window.withProgress(
-              {
-                  location: vscode.ProgressLocation.Notification,
-                  cancellable: false,
-              },
-              async progress => {
-                  try {
-                      const zipFile = fs.readFileSync(zipFileArr[0].fsPath)
-                      return await uploadZipBuffer(functionNode, zipFile, progress)
-                  } catch (e) {
-                      const err = e as Error
-                      Window.vscode().showErrorMessage(err.message)
-                      getLogger().error('runUploadLambdaZipFile failed: ', err.message)
-
-                      return 'Failed'
-                  }
-              }
-          )
-        : 'Cancelled'
+        async progress => {
+            const zipFile = await fs.readFile(zipFileUri.fsPath).catch(err => {
+                throw new ToolkitError('Failed to read zip', { cause: err })
+            })
+            return await uploadZipBuffer(lambda, zipFile, progress)
+        }
+    )
 }
 
 /**
  * Zips a selected directory in memory and attempts to upload archive to Lambda
- * @param functionNode Function node from AWS Explorer
  * @param path Directory path to zip
  * @param progress Progress notification for displaying a status message
  */
 async function zipAndUploadDirectory(
-    functionNode: LambdaFunctionNode,
+    lambda: LambdaFunction,
     path: string,
     progress: vscode.Progress<{
         message?: string | undefined
         increment?: number | undefined
     }>
-): Promise<telemetry.Result> {
-    try {
-        progress.report({ message: localize('AWS.lambda.upload.progress.archivingDir', 'Archiving files...') })
-        const zipBuffer = await new Promise<Buffer>(resolve => {
-            const zip = new AdmZip()
-            zip.addLocalFolder(path)
-            resolve(zip.toBuffer())
-        })
+) {
+    progress.report({ message: localize('AWS.lambda.upload.progress.archivingDir', 'Archiving files...') })
+    const zipBuffer = await new Promise<Buffer>((resolve, reject) => {
+        const zip = new AdmZip()
+        zip.addLocalFolder(path)
+        zip.toBuffer(resolve, reject)
+    }).catch(err => {
+        throw new ToolkitError('Failed to archive directory', { cause: err })
+    })
 
-        return await uploadZipBuffer(functionNode, zipBuffer, progress)
-    } catch (e) {
-        const err = e as Error
-        Window.vscode().showErrorMessage(err.message)
-        getLogger().error('zipAndUploadDirectory failed: ', err.message)
-
-        return 'Failed'
-    }
+    return await uploadZipBuffer(lambda, zipBuffer, progress)
 }
 
 /**
  * Attempts to upload Buffer representation of a `.zip` file to an existing Lambda function
- * @param functionNode Function node from AWS Explorer
  * @param zip Buffer to upload to Lambda
  * @param progress Progress notification for displaying a status message
  * @param lambdaClient Overwriteable Lambda client for testing purposes
  */
 async function uploadZipBuffer(
-    functionNode: LambdaFunctionNode,
+    lambda: LambdaFunction,
     zip: Buffer,
     progress: vscode.Progress<{
         message?: string | undefined
         increment?: number | undefined
     }>,
-    lambdaClient = globals.toolkitClientBuilder.createLambdaClient(functionNode.regionCode)
-): Promise<telemetry.Result> {
-    try {
-        progress.report({
-            message: localize('AWS.lambda.upload.progress.uploadingArchive', 'Uploading archive to Lambda...'),
-        })
-        await lambdaClient.updateFunctionCode(functionNode.configuration.FunctionName!, zip)
+    lambdaClient = globals.toolkitClientBuilder.createLambdaClient(lambda.region)
+) {
+    progress.report({
+        message: localize('AWS.lambda.upload.progress.uploadingArchive', 'Uploading archive to Lambda...'),
+    })
+    await lambdaClient.updateFunctionCode(lambda.name, zip).catch(err => {
+        throw new ToolkitError('Failed to upload zip archive', { cause: err })
+    })
 
-        Window.vscode().showInformationMessage(
-            localize('AWS.lambda.upload.done', 'Successfully uploaded Lambda function {0}', functionNode.functionName)
-        )
-        return 'Succeeded'
-    } catch (e) {
-        const err = e as Error
-        Window.vscode().showErrorMessage(err.message)
-        getLogger().error('uploadZipBuffer failed: ', err.message)
-
-        return 'Failed'
-    }
+    Window.vscode().showInformationMessage(
+        localize('AWS.lambda.upload.done', 'Successfully uploaded Lambda function {0}', lambda.name)
+    )
 }

--- a/src/lambda/commands/uploadLambda.ts
+++ b/src/lambda/commands/uploadLambda.ts
@@ -70,7 +70,8 @@ export async function uploadLambdaCommand(functionNode: LambdaFunctionNode) {
             showViewLogsMessage(`Could not upload lambda: ${err.message}`)
             getLogger().error(`Lambda upload failed: %O`, err.cause ?? err)
         } else {
-            throw err
+            showViewLogsMessage(`Could not upload lambda (unexpected exception)`)
+            getLogger().error(`Lambda upload failed: %O`, err)
         }
     } finally {
         telemetry.recordLambdaUpdateFunctionCode({

--- a/src/shared/ui/common/openDialog.ts
+++ b/src/shared/ui/common/openDialog.ts
@@ -1,0 +1,54 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { StepEstimator, WIZARD_BACK } from '../../wizards/wizard'
+import { Prompter, PromptResult } from '../prompter'
+
+/**
+ * Implementation of {@link vscode.window.showOpenDialog showOpenDialog} as a {@link Prompter}.
+ */
+export class OpenDialogPrompter extends Prompter<vscode.Uri[]> {
+    private _recentItem: vscode.Uri[] = []
+    public get recentItem(): vscode.Uri[] {
+        return this._recentItem
+    }
+    public set recentItem(response: vscode.Uri[]) {
+        // TODO(sijaden): should add a check for accidently using the getter/setter instead of the private field
+        // using the setter -> results in a stack overflow...
+        this._recentItem = response
+    }
+    constructor(private readonly options: vscode.OpenDialogOptions = {}) {
+        super()
+        // TODO(sijaden): ideally the `recentItem` should be all the files the user had previously selected, though
+        // currently this is not possible
+        this._recentItem = options.defaultUri ? [options.defaultUri] : []
+    }
+    protected async promptUser(): Promise<PromptResult<vscode.Uri[]>> {
+        const files = await vscode.window.showOpenDialog({
+            ...this.options,
+            defaultUri: this._recentItem[0],
+        })
+        this._recentItem = files ?? this._recentItem
+
+        return files ?? WIZARD_BACK
+    }
+
+    // Stub functions. This do not mean anything for this dialog.
+    public setStepEstimator(estimator: StepEstimator<vscode.Uri[]>): void {}
+    public setSteps(current: number, total: number): void {}
+}
+
+type DialogOptions = Omit<vscode.OpenDialogOptions, 'canSelectMany'>
+
+export function createMultiFileDialog(options?: DialogOptions): Prompter<vscode.Uri[]> {
+    const defaultUri = vscode.workspace.workspaceFolders?.[0]?.uri
+    return new OpenDialogPrompter({ defaultUri, ...options, canSelectMany: true })
+}
+
+export function createSingleFileDialog(options?: DialogOptions): Prompter<vscode.Uri> {
+    const defaultUri = vscode.workspace.workspaceFolders?.[0]?.uri
+    return new OpenDialogPrompter({ defaultUri, ...options, canSelectMany: false }).transform(r => r[0])
+}


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

### This PR is for https://github.com/aws/aws-toolkit-vscode/pull/2588

## Problem
Legacy code is hard to change/improve because it's tightly coupled to UI.

## Solution
Split up control flow from UI, then tighten the interfaces to make it obvious what the code truly depends on.

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
