### PR TITLE
feat(tests): SAM JSON-schema regression tests

### DIFF
--- a/src/integrationTest/schema/schema.test.ts
+++ b/src/integrationTest/schema/schema.test.ts
@@ -1,0 +1,59 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    getTestSchemas,
+    JSONObject,
+    unmarshal,
+    assertDefinitionProperty,
+    assertProperty,
+    assertRef,
+    assertDefinition,
+} from '../../test/shared/schema/testUtils'
+
+describe('Sam Schema Regression', function () {
+    let samSchema: JSONObject
+
+    before(async function () {
+        ;({ samSchema } = await getTestSchemas())
+    })
+
+    it('has Policy Templates', function () {
+        const samPolicyTemplate = 'AWS::Serverless::Function.SAMPolicyTemplate'
+        assertDefinitionProperty(samSchema, samPolicyTemplate, 'S3WritePolicy')
+        assertDefinitionProperty(samSchema, samPolicyTemplate, 'DynamoDBWritePolicy')
+        assertDefinitionProperty(samSchema, samPolicyTemplate, 'SSMParameterReadPolicy')
+        assertDefinitionProperty(samSchema, samPolicyTemplate, 'AWSSecretsManagerGetSecretValuePolicy')
+    })
+
+    it('has property Domain in AWS::Serverless::Api', function () {
+        const domainLocation = unmarshal(
+            samSchema,
+            'definitions',
+            'AWS::Serverless::Api',
+            'properties',
+            'Properties',
+            'properties'
+        )
+        assertProperty(domainLocation, 'Domain')
+        assertRef(unmarshal(domainLocation, 'Domain'), 'Api.DomainConfiguration')
+
+        assertDefinition(samSchema, 'AWS::Serverless::Api.DomainConfiguration')
+        assertDefinition(samSchema, 'AWS::Serverless::Api.MutualTlsAuthentication')
+        assertDefinition(samSchema, 'AWS::Serverless::Api.Route53Configuration')
+    })
+
+    it('has Property Version in AWS::Serverless::Function.IAMPolicyDocument and AWS::Serverless::StateMachine.IAMPolicyDocument', function () {
+        assertDefinitionProperty(samSchema, 'AWS::Serverless::Function.IAMPolicyDocument', 'Version')
+        assertDefinitionProperty(samSchema, 'AWS::Serverless::StateMachine.IAMPolicyDocument', 'Version')
+    })
+
+    it('has Property RequestModel and RequestParameters in AWS::Serverless::Function.ApiEvent', function () {
+        assertDefinitionProperty(samSchema, 'AWS::Serverless::Function.ApiEvent', 'RequestModel')
+        assertDefinitionProperty(samSchema, 'AWS::Serverless::Function.ApiEvent', 'RequestParameters')
+        assertDefinition(samSchema, 'AWS::Serverless::Function.RequestModel')
+        assertDefinition(samSchema, 'AWS::Serverless::Function.RequestParameter')
+    })
+})

--- a/src/integrationTest/schema/schema.test.ts
+++ b/src/integrationTest/schema/schema.test.ts
@@ -4,7 +4,7 @@
  */
 
 import {
-    getTestSchemas,
+    getCITestSchemas,
     JSONObject,
     unmarshal,
     assertDefinitionProperty,
@@ -17,7 +17,7 @@ describe('Sam Schema Regression', function () {
     let samSchema: JSONObject
 
     before(async function () {
-        ;({ samSchema } = await getTestSchemas())
+        ;({ samSchema } = await getCITestSchemas())
     })
 
     it('has Policy Templates', function () {

--- a/src/shared/extensions/git.ts
+++ b/src/shared/extensions/git.ts
@@ -364,6 +364,7 @@ export class GitExtension {
 
                         return execFileAsync(api.git.path, ['cat-file', type, hash], {
                             cwd: tmpDir,
+                            maxBuffer: 1024 * 1024 * 5,
                         }).then(({ stdout }) => stdout)
                     },
                 }))

--- a/src/test/shared/schema/testUtils.ts
+++ b/src/test/shared/schema/testUtils.ts
@@ -1,0 +1,133 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import * as path from 'path'
+import { FakeExtensionContext } from '../../fakeExtensionContext'
+import { getDefaultSchemas } from '../../../shared/schemas'
+import { fromFile } from '../../testUtil'
+import { GitExtension } from '../../../shared/extensions/git'
+
+export type JSONValue = string | boolean | number | null | JSONValue[] | JSONObject
+
+export interface JSONObject {
+    [key: string]: JSONValue
+}
+
+export interface TestSchemas {
+    samSchema: JSONObject
+    cfnSchema: JSONObject
+}
+
+async function getCITestSchemas(): Promise<TestSchemas> {
+    const fetchUrl = 'https://github.com/awslabs/goformation'
+    const repo = await GitExtension.instance.listAllRemoteFiles({
+        fetchUrl,
+    })
+
+    const samFilePath = path.join('schema', 'sam.schema.json')
+    const samSchemaFile = await repo.files.find(f => f.name === samFilePath)?.read()
+    if (!samSchemaFile) {
+        throw new Error(`Unable to find the sam schema file in path ${samFilePath} in repository ${fetchUrl}`)
+    }
+
+    const cfnFilePath = path.join('schema', 'cloudformation.schema.json')
+    const cfnSchemaFile = await repo.files.find(f => f.name === cfnFilePath)?.read()
+    if (!cfnSchemaFile) {
+        throw new Error(
+            `Unable to find the cloudformation schema file in path ${cfnFilePath} in repository ${fetchUrl}`
+        )
+    }
+
+    repo.dispose()
+
+    const samSchema = JSON.parse(samSchemaFile)
+    const cfnSchema = JSON.parse(cfnSchemaFile)
+    return {
+        samSchema,
+        cfnSchema,
+    }
+}
+
+export async function getTestSchemas(): Promise<TestSchemas> {
+    if (process.env.GITHUB_ACTIONS) {
+        return getCITestSchemas()
+    }
+
+    const fakeContext = await FakeExtensionContext.create()
+
+    const schemas = await getDefaultSchemas(fakeContext)
+    if (schemas === undefined) {
+        throw new Error('An error occured when fetching the schemas. View the logs for more information.')
+    }
+
+    const samSchemaFile = fromFile(schemas.sam.fsPath)
+    const samSchema = JSON.parse(samSchemaFile)
+
+    const cfnSchemaFile = fromFile(schemas.cfn.fsPath)
+    const cfnSchema = JSON.parse(cfnSchemaFile)
+    return {
+        samSchema,
+        cfnSchema,
+    }
+}
+
+/**
+ * Assert whether or not name exists under definitionName in the JSON schema
+ * @param schema The JSON schema
+ * @param definitionName The name of the definition to use
+ * @param name The name of the property to look for
+ */
+export function assertDefinitionProperty(schema: JSONObject, definitionName: string, name: string): void | never {
+    const definitionProperties = unmarshal(schema, 'definitions', definitionName, 'properties')
+    assertProperty(definitionProperties, name)
+}
+
+/**
+ * Assert whether name exists at an arbitary location in the JSON schema
+ * @param arbitrarySchemaLocation An arbitary location in the JSON schema
+ * @param name The name of the property to look for
+ */
+export function assertProperty(arbitrarySchemaLocation: JSONObject, name: string): void | never {
+    assert.ok(name in arbitrarySchemaLocation, `Property ${name} was not found in the "Properties" object`)
+}
+
+/**
+ * Assert whether a reference exists at definitionLocation to referenceName in the JSON Schema
+ * @param definitionLocation A location in the JSON schema
+ * @param referenceName A name of a reference to look for
+ */
+export function assertRef(definitionLocation: JSONObject, referenceName: string): void | never {
+    const definitionRef = definitionLocation['$ref']
+    if (definitionRef !== `#/definitions/AWS::Serverless::${referenceName}`) {
+        assert.fail(`The reference for ${definitionRef} did not point to ${referenceName}`)
+    }
+}
+
+/**
+ * Assert that definitionName is in the JSON schemas definitions
+ * @param schema The JSON schema to use
+ * @param definitionName The name of the definition to check
+ */
+export function assertDefinition(schema: JSONObject, definitionName: string): void | never {
+    if (!(definitionName in (schema['definitions'] as JSONObject))) {
+        assert.fail(`Definition for ${definitionName} not found`)
+    }
+}
+
+/**
+ * Traverse through the initial JSON object, visiting all of the properties.
+ * Only suitable for accessing JSON objects.
+ * @param initialObject the object you want to start the traversal at
+ * @param properties the properties you want to visit and traverse into
+ * @returns The location in initialObject after visiting all of properties
+ */
+export function unmarshal(initialObject: JSONObject, ...properties: string[]) {
+    let processedObject = initialObject
+    for (const propertyName of properties) {
+        processedObject = processedObject[propertyName] as JSONObject
+    }
+    return processedObject
+}

--- a/src/test/shared/schema/testUtils.ts
+++ b/src/test/shared/schema/testUtils.ts
@@ -5,9 +5,6 @@
 
 import * as assert from 'assert'
 import * as path from 'path'
-import { FakeExtensionContext } from '../../fakeExtensionContext'
-import { getDefaultSchemas } from '../../../shared/schemas'
-import { fromFile } from '../../testUtil'
 import { GitExtension } from '../../../shared/extensions/git'
 
 export type JSONValue = string | boolean | number | null | JSONValue[] | JSONObject
@@ -21,7 +18,7 @@ export interface TestSchemas {
     cfnSchema: JSONObject
 }
 
-async function getCITestSchemas(): Promise<TestSchemas> {
+export async function getCITestSchemas(): Promise<TestSchemas> {
     const fetchUrl = 'https://github.com/awslabs/goformation'
     const repo = await GitExtension.instance.listAllRemoteFiles({
         fetchUrl,
@@ -44,29 +41,6 @@ async function getCITestSchemas(): Promise<TestSchemas> {
     repo.dispose()
 
     const samSchema = JSON.parse(samSchemaFile)
-    const cfnSchema = JSON.parse(cfnSchemaFile)
-    return {
-        samSchema,
-        cfnSchema,
-    }
-}
-
-export async function getTestSchemas(): Promise<TestSchemas> {
-    if (process.env.GITHUB_ACTIONS) {
-        return getCITestSchemas()
-    }
-
-    const fakeContext = await FakeExtensionContext.create()
-
-    const schemas = await getDefaultSchemas(fakeContext)
-    if (schemas === undefined) {
-        throw new Error('An error occured when fetching the schemas. View the logs for more information.')
-    }
-
-    const samSchemaFile = fromFile(schemas.sam.fsPath)
-    const samSchema = JSON.parse(samSchemaFile)
-
-    const cfnSchemaFile = fromFile(schemas.cfn.fsPath)
     const cfnSchema = JSON.parse(cfnSchemaFile)
     return {
         samSchema,


### PR DESCRIPTION
Signed-off-by: Joshua Pinkney <jpink@amazon.com>

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Currently we have no way of testing whether or not any schema changes in the [goformation](https://github.com/awslabs/goformation) project causes regressions in this project. 

## Solution
This PR introduces a pretty easy way to verify that certain definitions are available in the JSON schema provided by the goformation project. It only deals with verifying definitions, properties and references. We could add support for verifying types but every time the schema changes we would have to manually update our tests with new types, etc so it might be a bit of a pain over time.

I've also added regression tests for all the JSON schema issues I closed last week.

Related issue: https://github.com/aws/aws-toolkit-vscode/issues/2597

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
