### PR TITLE
feat(eventSchemas): Open schemas directly when clicking on schema item nodes

### DIFF
--- a/.changes/next-release/Feature-f746c8b0-a0e4-47e3-9583-0e746d6ac490.json
+++ b/.changes/next-release/Feature-f746c8b0-a0e4-47e3-9583-0e746d6ac490.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Open schemas directly when clicking on schema item nodes"
+}

--- a/src/eventSchemas/explorer/schemaItemNode.ts
+++ b/src/eventSchemas/explorer/schemaItemNode.ts
@@ -12,6 +12,7 @@ import { SchemaClient } from '../../shared/clients/schemaClient'
 
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 import { toArrayAsync } from '../../shared/utilities/collectionUtils'
+import { localize } from '../../shared/utilities/vsCodeUtils'
 
 export class SchemaItemNode extends AWSTreeNodeBase {
     public constructor(
@@ -25,6 +26,11 @@ export class SchemaItemNode extends AWSTreeNodeBase {
         this.iconPath = {
             dark: Uri.file(globals.iconPaths.dark.schema),
             light: Uri.file(globals.iconPaths.light.schema),
+        }
+        this.command = {
+            command: 'aws.viewSchemaItem',
+            title: localize('AWS.command.viewSchemaItem', 'Open Schema'),
+            arguments: [this],
         }
     }
 


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Currently, clicking on a schema item node doesn't do anything. This is a bit confusing since we define onclick actions for things like s3 file nodes.

## Solution
Open up the schema when clicking on a schema item node.

Related issue: https://github.com/aws/aws-toolkit-vscode/issues/2608

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
