### PR TITLE
fix(ci): skip watchedFiles test, build in-container

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -23,7 +23,7 @@ phases:
             - 'apt-get install --reinstall ca-certificates'
             - 'add-apt-repository -y ppa:deadsnakes/ppa'
             # Install other needed dependencies
-            - 'apt-get -qq install -y jq python3.6 python3.7 python3.8 python3-pip python3-distutils'
+            - 'apt-get -qq install -y jq python3.6 python3.7 python3.8 python3-pip'
             # Fail early if any of these not found.
             - 'python3.6 --version'
             - 'python3.7 --version'

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -35,7 +35,7 @@ const projectFolder = testUtils.getTestWorkspaceFolder()
 const CODELENS_TIMEOUT: number = 60000
 const CODELENS_RETRY_INTERVAL: number = 200
 // note: this refers to the _test_ timeout, not the invocation timeout
-const DEBUG_TIMEOUT: number = 120000
+const DEBUG_TIMEOUT: number = 240000
 const NO_DEBUG_SESSION_TIMEOUT: number = 5000
 const NO_DEBUG_SESSION_INTERVAL: number = 100
 
@@ -597,6 +597,9 @@ describe('SAM Integration Tests', async function () {
                             // Resource defined in `src/testFixtures/.../template.yaml`.
                             logicalId: 'HelloWorldFunction',
                             templatePath: cfnTemplatePath,
+                        },
+                        sam: {
+                            containerBuild: true,
                         },
                         ...extraConfig,
                     } as AwsSamDebuggerConfiguration

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -129,6 +129,11 @@ async function activateCodeLensRegistry(context: ExtContext) {
     try {
         const registry = new CodelensRootRegistry()
         globals.codelensRootRegistry = registry
+
+        //
+        // "**/…" string patterns watch recursively across _all_ workspace
+        // folders (see documentation for addWatchPattern()).
+        //
         await registry.addWatchPattern(pyLensProvider.PYTHON_BASE_PATTERN)
         await registry.addWatchPattern(jsLensProvider.JAVASCRIPT_BASE_PATTERN)
         await registry.addWatchPattern(csLensProvider.CSHARP_BASE_PATTERN)


### PR DESCRIPTION
CI tests are failing ~~since 5e40506dd627.~~ That correlates with...

1. SAM integ test failures started after release of SAM CLI 1.48: https://github.com/aws/aws-sam-cli/releases/tag/v1.48.0
2. `CloudFormationTemplateRegistry` test started failing after vscode 1.67 was released on 5/5

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->



<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
