### PR TITLE
feat(dev): add internal tools module 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1013,6 +1013,10 @@
                 {
                     "command": "aws.renderStateMachineGraph",
                     "when": "false"
+                },
+                {
+                    "command": "aws.dev.openMenu",
+                    "when": "aws.isDevMode"
                 }
             ],
             "editor/title": [
@@ -2760,6 +2764,12 @@
                         "category": "%AWS.title.cn%"
                     }
                 }
+            },
+            {
+                "command": "aws.dev.openMenu",
+                "title": "Open Developer Menu",
+                "category": "AWS (Developer)",
+                "enablement": "aws.isDevMode"
             }
         ],
         "jsonValidation": [

--- a/src/dev/activation.ts
+++ b/src/dev/activation.ts
@@ -145,6 +145,7 @@ class ObjectEditor {
         vscode.workspace.onDidCloseTextDocument(doc => {
             const key = this.fs.uriToKey(doc.uri)
             this.tabs.get(key)?.dispose()
+            this.tabs.delete(key)
         })
 
         vscode.workspace.registerFileSystemProvider(ObjectEditor.scheme, this.fs)

--- a/src/dev/activation.ts
+++ b/src/dev/activation.ts
@@ -1,0 +1,230 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { ExtContext } from '../shared/extensions'
+import { createCommonButtons } from '../shared/ui/buttons'
+import { createQuickPick } from '../shared/ui/pickerPrompter'
+import { DevSettings } from '../shared/settings'
+import { FileProvider, VirualFileSystem } from '../shared/virtualFilesystem'
+import { Commands } from '../shared/vscode/commands2'
+import { createInputBox } from '../shared/ui/inputPrompter'
+import { Wizard } from '../shared/wizards/wizard'
+
+interface MenuOption {
+    readonly label: string
+    readonly description?: string
+    readonly detail?: string
+    readonly executor: (ctx: ExtContext) => Promise<unknown> | unknown
+}
+
+/**
+ * Currently contains all known developer tools.
+ *
+ * Options are displayed as quick-pick items. The {@link MenuOption.executor} callback is ran
+ * if the user selects an option. There is no support for name-spacing. Just add the relevant
+ * feature/module as a description so it can be moved around easier.
+ */
+const menuOptions: Record<string, MenuOption> = {
+    editStorage: {
+        label: 'Edit Storage',
+        description: 'VS Code',
+        detail: 'Edit a key in global/secret storage as a JSON document',
+        executor: openStorageFromInput,
+    },
+}
+
+/**
+ * Enables internal developer tools.
+ *
+ * Commands prefixed with `AWS (Developer)` will appear so long as a developer setting is active.
+ *
+ * See {@link DevSettings} for more information.
+ */
+export function activate(ctx: ExtContext): void {
+    const devSettings = DevSettings.instance
+
+    async function updateMode() {
+        const enablement = Object.keys(devSettings.activeSettings).length > 0
+        await vscode.commands.executeCommand('setContext', 'aws.isDevMode', enablement)
+    }
+
+    ctx.extensionContext.subscriptions.push(
+        devSettings.onDidChangeActiveSettings(updateMode),
+        vscode.commands.registerCommand('aws.dev.openMenu', () => openMenu(ctx, menuOptions))
+    )
+
+    updateMode()
+
+    const editor = new ObjectEditor(ctx.extensionContext)
+    ctx.extensionContext.subscriptions.push(openStorageCommand.register(editor))
+}
+
+function entries<T extends Record<string, U>, U>(obj: T): { [P in keyof T]: [P, T[P]] }[keyof T][] {
+    return Object.entries(obj) as { [P in keyof T]: [P, T[P]] }[keyof T][]
+}
+
+async function openMenu(ctx: ExtContext, options: typeof menuOptions): Promise<void> {
+    const items = entries(options).map(([_, v]) => ({
+        label: v.label,
+        detail: v.detail,
+        description: v.description,
+        skipEstimate: true,
+        data: v.executor.bind(undefined, ctx),
+    }))
+
+    const prompter = createQuickPick(items, {
+        title: 'Developer Menu',
+        buttons: createCommonButtons(),
+    })
+
+    await prompter.prompt()
+}
+
+function isSecrets(obj: vscode.Memento | vscode.SecretStorage): obj is vscode.SecretStorage {
+    return (obj as vscode.SecretStorage).store !== undefined
+}
+
+class VirtualObjectFile implements FileProvider {
+    private readonly onDidChangeEmitter = new vscode.EventEmitter<void>()
+    public readonly onDidChange = this.onDidChangeEmitter.event
+
+    public constructor(private readonly storage: vscode.Memento | vscode.SecretStorage, private readonly key: string) {}
+
+    public stat(): { ctime: number; mtime: number; size: number } {
+        // This would need to be filled out to track conflicts
+        return { ctime: 0, mtime: 0, size: 0 }
+    }
+
+    public async read(): Promise<Uint8Array> {
+        const encoder = new TextEncoder()
+
+        return encoder.encode(await this.readStore(this.key))
+    }
+
+    public async write(content: Uint8Array): Promise<void> {
+        const decoder = new TextDecoder()
+        const value = JSON.parse(decoder.decode(content))
+
+        await this.updateStore(this.key, value)
+    }
+
+    private async readStore(key: string): Promise<string> {
+        // Could potentially show `undefined` in the editor instead of an empty string
+        if (isSecrets(this.storage)) {
+            const value = (await this.storage.get(key)) ?? ''
+            return JSON.stringify(JSON.parse(value), undefined, 4)
+        } else {
+            return JSON.stringify(this.storage.get(key, {}), undefined, 4)
+        }
+    }
+
+    private async updateStore(key: string, value: unknown): Promise<unknown> {
+        if (isSecrets(this.storage)) {
+            return this.storage.store(key, JSON.stringify(value))
+        } else {
+            return this.storage.update(key, value)
+        }
+    }
+}
+
+interface Tab {
+    readonly editor: vscode.TextEditor
+    dispose(): void
+}
+
+class ObjectEditor {
+    private static readonly scheme = 'aws-dev'
+
+    private readonly fs = new VirualFileSystem()
+    private readonly tabs: Map<string, Tab> = new Map()
+
+    public constructor(private readonly context: vscode.ExtensionContext) {
+        vscode.workspace.onDidCloseTextDocument(doc => {
+            const key = this.fs.uriToKey(doc.uri)
+            this.tabs.get(key)?.dispose()
+        })
+
+        vscode.workspace.registerFileSystemProvider(ObjectEditor.scheme, this.fs)
+    }
+
+    public async openStorage(type: 'globals' | 'secrets', key: string): Promise<void> {
+        switch (type) {
+            case 'globals':
+                return this.openState(this.context.globalState, key)
+            case 'secrets':
+                return this.openState(this.context.secrets, key)
+        }
+    }
+
+    private async openState(storage: vscode.Memento | vscode.SecretStorage, key: string): Promise<void> {
+        const uri = this.uriFromKey(key, storage)
+        const tab = this.tabs.get(this.fs.uriToKey(uri))
+
+        if (tab) {
+            await vscode.window.showTextDocument(tab.editor.document)
+        } else {
+            const newTab = await this.createTab(storage, key)
+            const newKey = this.fs.uriToKey(newTab.editor.document.uri)
+            this.tabs.set(newKey, newTab)
+        }
+    }
+
+    private async createTab(storage: vscode.Memento | vscode.SecretStorage, key: string): Promise<Tab> {
+        const uri = this.uriFromKey(key, storage)
+        const disposable = this.fs.registerProvider(uri, new VirtualObjectFile(storage, key))
+        const document = await vscode.workspace.openTextDocument(uri)
+        const withLanguage = await vscode.languages.setTextDocumentLanguage(document, 'json')
+        const editor = await vscode.window.showTextDocument(withLanguage)
+
+        return {
+            editor,
+            dispose: () => disposable.dispose(),
+        }
+    }
+
+    private uriFromKey(key: string, storage: vscode.Memento | vscode.SecretStorage): vscode.Uri {
+        const prefix = isSecrets(storage) ? 'secrets' : 'globals'
+
+        return vscode.Uri.parse(`${ObjectEditor.scheme}:`, true).with({
+            path: `/${prefix}/${key}`,
+        })
+    }
+}
+
+async function openStorageFromInput() {
+    const wizard = new (class extends Wizard<{ target: 'globals' | 'secrets'; key: string }> {
+        constructor() {
+            super()
+
+            this.form.target.bindPrompter(() =>
+                createQuickPick(
+                    [
+                        { label: 'Global State', data: 'globals' },
+                        { label: 'Secrets', data: 'secrets' },
+                    ],
+                    {
+                        title: 'Select a storage type',
+                    }
+                )
+            )
+
+            this.form.key.bindPrompter(({ target }) =>
+                createInputBox({
+                    title: 'Enter a key',
+                    placeholder: target === 'globals' ? 'region' : '',
+                })
+            )
+        }
+    })()
+
+    const response = await wizard.run()
+
+    if (response) {
+        return openStorageCommand.execute(response.target, response.key)
+    }
+}
+
+export const openStorageCommand = Commands.from(ObjectEditor).declareOpenStorage('_aws.dev.openStorage')

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,6 +51,7 @@ import { activate as activateDynamicResources } from './dynamicResources/activat
 import { activate as activateEcs } from './ecs/activation'
 import { activate as activateAppRunner } from './apprunner/activation'
 import { activate as activateIot } from './iot/activation'
+import { activate as activateDev } from './dev/activation'
 import { CredentialsStore } from './credentials/credentialsStore'
 import { getSamCliContext } from './shared/sam/cli/samCliContext'
 import * as extWindow from './shared/vscode/window'
@@ -127,6 +128,12 @@ export async function activate(context: vscode.ExtensionContext) {
             invokeOutputChannel: remoteInvokeOutputChannel,
             telemetryService: globals.telemetry,
             credentialsStore,
+        }
+
+        try {
+            activateDev(extContext)
+        } catch (error) {
+            getLogger().debug(`Developer Tools (internal): failed to activate: ${(error as Error).message}`)
         }
 
         context.subscriptions.push(

--- a/src/shared/vscode/secrets.ts
+++ b/src/shared/vscode/secrets.ts
@@ -1,0 +1,58 @@
+/*!
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Sourced from https://github.com/microsoft/vscode/blob/238c19cc7727511d495d67d2ce1e0ec0638de2ce/src/vscode-dts/vscode.d.ts
+// This API was added in 1.53. Not supported in Cloud9.
+declare module 'vscode' {
+    export interface ExtensionContext {
+        /**
+         * A storage utility for secrets. Secrets are persisted across reloads and are independent of the
+         * current opened {@link workspace.workspaceFolders workspace}.
+         */
+        readonly secrets: SecretStorage
+    }
+
+    /**
+     * The event data that is fired when a secret is added or removed.
+     */
+    export interface SecretStorageChangeEvent {
+        /**
+         * The key of the secret that has changed.
+         */
+        readonly key: string
+    }
+
+    /**
+     * Represents a storage utility for secrets, information that is
+     * sensitive.
+     */
+    export interface SecretStorage {
+        /**
+         * Retrieve a secret that was stored with key. Returns undefined if there
+         * is no password matching that key.
+         * @param key The key the secret was stored under.
+         * @returns The stored value or `undefined`.
+         */
+        get(key: string): Thenable<string | undefined>
+
+        /**
+         * Store a secret under a given key.
+         * @param key The key to store the secret under.
+         * @param value The secret.
+         */
+        store(key: string, value: string): Thenable<void>
+
+        /**
+         * Remove a secret from storage.
+         * @param key The key the secret was stored under.
+         */
+        delete(key: string): Thenable<void>
+
+        /**
+         * Fires when a secret is stored or deleted.
+         */
+        onDidChange: Event<SecretStorageChangeEvent>
+    }
+}

--- a/src/test/fakeExtensionContext.ts
+++ b/src/test/fakeExtensionContext.ts
@@ -48,6 +48,7 @@ export class FakeExtensionContext implements vscode.ExtensionContext {
     public storageUri: vscode.Uri | undefined
     public logUri: vscode.Uri = vscode.Uri.file('file://fake/log/uri')
     public extensionMode: vscode.ExtensionMode = vscode.ExtensionMode.Test
+    public secrets = new SecretStorage()
 
     private _extensionPath: string = ''
     private _globalStoragePath: string = '.'
@@ -145,6 +146,27 @@ class FakeMemento implements vscode.Memento {
         this._storage[key] = value
 
         return Promise.resolve()
+    }
+}
+
+class SecretStorage implements vscode.SecretStorage {
+    private _onDidChange = new vscode.EventEmitter<vscode.SecretStorageChangeEvent>()
+    public readonly onDidChange = this._onDidChange.event
+
+    public constructor(private readonly storage: Record<string, string> = {}) {}
+
+    public async get(key: string): Promise<string | undefined> {
+        return this.storage[key]
+    }
+
+    public async store(key: string, value: string): Promise<void> {
+        this.storage[key] = value
+        this._onDidChange.fire({ key })
+    }
+
+    public async delete(key: string): Promise<void> {
+        delete this.storage[key]
+        this._onDidChange.fire({ key })
     }
 }
 


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
We don't leverage the VS Code API to boost our own productivity

## Solution
Add a new module for "developer tools". This is basically an extension of `DevSettings`.
Currently just has a single command to edit an arbitrary key in `globalState` or `secrets`.
You need to have a 'dev setting' enabled to see it. Can be anything.

### Example
Here's an example of me editing the AWS explorer 'regions' state (the Toolkit would reflect these changes on reload)
![Kapture 2022-05-10 at 12 26 54](https://user-images.githubusercontent.com/31319484/167707039-3fc3d85b-3977-44f9-aa05-3ed29874c862.gif)


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
