### PR TITLE
fix(logging): reduce settings migration noise in edge case

### DIFF
--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -594,17 +594,18 @@ export class DevSettings extends Settings.define('aws.dev', DEV_SETTINGS) {
  * Simple utility function to 'migrate' a setting from one key to another.
  *
  * Currently only used for simple migrations where we are not concerned about maintaining the
- * legacy definition.
+ * legacy definition. Only migrates to global settings.
  */
 export async function migrateSetting<T, U = T>(
     from: { key: string; type: TypeConstructor<T> },
     to: { key: string; transform?: (value: T) => U }
 ) {
+    // TODO(sijaden): we should handle other targets besides 'global'
     const config = vscode.workspace.getConfiguration()
     const hasLatest = config.inspect(to.key)?.globalValue !== undefined
     const logPrefix = `Settings migration ("${from.key}" -> "${to.key}")`
 
-    if (hasLatest) {
+    if (hasLatest || !config.has(from.key)) {
         return true
     }
 
@@ -613,10 +614,11 @@ export async function migrateSetting<T, U = T>(
         const newVal = to.transform?.(oldVal) ?? oldVal
 
         await config.update(to.key, newVal, vscode.ConfigurationTarget.Global)
+        getLogger().debug(`${logPrefix}: succeeded`)
 
         return true
     } catch (error) {
-        getLogger().verbose(`${logPrefix}: conversion failed: ${error}`)
+        getLogger().verbose(`${logPrefix}: failed: ${error}`)
 
         return false
     }


### PR DESCRIPTION
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

## Problem
Migration was a bit noisy if the user had no settings to migrate

## Solution
Skip migration if the setting isn't present

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
