### PR TITLE
fix: incorrect use of 'vscode-nls', always enable "Upload Lambda" context-menu item

### DIFF
--- a/.changes/next-release/Feature-38b84656-bfe1-44f6-af07-a4010ece1029.json
+++ b/.changes/next-release/Feature-38b84656-bfe1-44f6-af07-a4010ece1029.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "\"Upload Lambda\" from any folder in VS Code File Explorer"
+}

--- a/package.json
+++ b/package.json
@@ -1155,12 +1155,12 @@
             "explorer/context": [
                 {
                     "command": "aws.deploySamApplication",
-                    "when": "isFileSystemResource == true && resourceFilename =~ /^template\\.(json|yml|yaml)$/",
+                    "when": "isFileSystemResource && resourceFilename =~ /^template\\.(json|yml|yaml)$/",
                     "group": "z_aws@1"
                 },
                 {
                     "command": "aws.uploadLambda",
-                    "when": "isFileSystemResource == true && resourceFilename =~ /^template\\.(json|yml|yaml)$/ || (explorerResourceIsFolder && isCloud9)",
+                    "when": "explorerResourceIsFolder || isFileSystemResource && resourceFilename =~ /^template\\.(json|yml|yaml)$/",
                     "group": "z_aws@2"
                 }
             ],

--- a/src/credentials/loginManager.ts
+++ b/src/credentials/loginManager.ts
@@ -22,9 +22,11 @@ import {
 import { CredentialsProviderManager } from './providers/credentialsProviderManager'
 import { getIdeProperties, isCloud9 } from '../shared/extensionUtilities'
 import { SharedCredentialsProvider } from './providers/sharedCredentialsProvider'
-import { localize } from 'vscode-nls'
 import { showViewLogsMessage } from '../shared/utilities/messages'
 import { isAutomation } from '../shared/vscode/env'
+
+import * as nls from 'vscode-nls'
+const localize = nls.loadMessageBundle()
 
 export class LoginManager {
     private readonly defaultCredentialsRegion = 'us-east-1'

--- a/src/lambda/commands/uploadLambda.ts
+++ b/src/lambda/commands/uploadLambda.ts
@@ -530,7 +530,7 @@ export function getFunctionNames(file: vscode.Uri, region: string): string[] | u
         }
         return names.length > 0 ? names : undefined
     } catch (error) {
-        getLogger().info('lambda: Error parsing .application.json: %s', (error as Error).message)
+        getLogger().error('lambda: failed to parse .application.json: %s', (error as Error).message)
     }
 }
 


### PR DESCRIPTION
## Problem

1. Improper use of vscode-nls causes a runtime error.
1. Grouped expressions are not supported in vscode's package.json `with` clauses.

## Solution

1. Fix the vscode-nls import.
1. Enable "Upload to Lambda" on all folders.


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
