### PR TITLE
fix(schemas.ts): no schema updates if local cache is missing

### DIFF
--- a/src/shared/resourcefetcher/compositeResourceFetcher.ts
+++ b/src/shared/resourcefetcher/compositeResourceFetcher.ts
@@ -6,6 +6,7 @@
 import { getLogger, Logger } from '../logger'
 import { ResourceFetcher } from './resourcefetcher'
 
+// TODO: replace this with something more generic like Log.all(...)
 export class CompositeResourceFetcher implements ResourceFetcher {
     private readonly logger: Logger = getLogger()
     private readonly fetchers: ResourceFetcher[]

--- a/src/shared/resourcefetcher/resourcefetcher.ts
+++ b/src/shared/resourcefetcher/resourcefetcher.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// TODO: this is just a "thunk". Replace it with something more generic.
 export interface ResourceFetcher {
     /**
      * Returns the contents of the resource, or undefined if the resource could not be retrieved.

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -10,10 +10,8 @@ import globals from './extensionGlobals'
 import { activateYamlExtension, YamlExtension } from './extensions/yaml'
 import * as filesystemUtilities from './filesystemUtilities'
 import { getLogger } from './logger'
-import { CompositeResourceFetcher } from './resourcefetcher/compositeResourceFetcher'
 import { FileResourceFetcher } from './resourcefetcher/fileResourceFetcher'
 import { getPropertyFromJsonUrl, HttpResourceFetcher } from './resourcefetcher/httpResourceFetcher'
-import { ResourceFetcher } from './resourcefetcher/resourcefetcher'
 import { Settings } from './settings'
 import { once } from './utilities/functionUtils'
 import { normalizeSeparator } from './utilities/pathUtils'
@@ -50,6 +48,7 @@ export class SchemaService {
     public constructor(
         private readonly extensionContext: vscode.ExtensionContext,
         opts?: {
+            /** Assigned in start(). */
             schemas?: Schemas
             updatePeriod?: number
             handlers?: Map<SchemaType, SchemaHandler>
@@ -147,6 +146,8 @@ export async function getDefaultSchemas(extensionContext: vscode.ExtensionContex
         }
     } catch (e) {
         getLogger().verbose('Could not refresh schemas: %s', (e as Error).message)
+        // this.schemas will be undefined for the rest of the session, so
+        // processUpdates() will never do its work.
         return undefined
     }
 }
@@ -171,28 +172,36 @@ export async function getRemoteOrCachedFile(params: {
     if (!(await filesystemUtilities.fileExists(dir))) {
         mkdirSync(dir, { recursive: true })
     }
-    const cachedVersion = params.extensionContext.globalState.get<string>(params.cacheKey)
-    const fetchers: ResourceFetcher[] = []
-    if (params.version && params.version !== cachedVersion) {
-        fetchers.push(
-            new HttpResourceFetcher(params.url, {
-                showUrl: true,
-                // updates curr version
-                onSuccess: contents => {
-                    writeFileSync(params.filepath, contents)
-                    params.extensionContext.globalState.update(params.cacheKey, params.version)
-                },
-            })
-        )
-    }
-    fetchers.push(new FileResourceFetcher(params.filepath))
-    const fetcher = new CompositeResourceFetcher(...fetchers)
 
-    const result = await fetcher.get()
-    if (!result) {
-        throw new Error(`could not resolve schema at ${params.filepath}`)
+    const cachedVersion = params.extensionContext.globalState.get<string>(params.cacheKey)
+    const outdated = params.version && params.version !== cachedVersion
+    if (!outdated) {
+        // Check that the cached file actually can be fetched. Else we might
+        // never update the cache.
+        const fileFetcher = new FileResourceFetcher(params.filepath)
+        const content = await fileFetcher.get().catch(err => {
+            getLogger().debug('failed to load cached resource: %s', (err as Error).message)
+        })
+        if (content) {
+            return content
+        }
     }
-    return result
+
+    const httpFetcher = new HttpResourceFetcher(params.url, {
+        showUrl: true,
+        // updates curr version
+        onSuccess: contents => {
+            writeFileSync(params.filepath, contents)
+            params.extensionContext.globalState.update(params.cacheKey, params.version)
+        },
+    })
+    const content = await httpFetcher.get().catch(err => {
+        getLogger().debug('failed to load cached resource: %s', (err as Error).message)
+    })
+    if (!content) {
+        throw new Error(`failed to resolve schema: ${params.filepath}`)
+    }
+    return content
 }
 
 /**


### PR DESCRIPTION
## Problem:
If the `cachedVersion` stored in globalState matches the remote version,
getRemoteOrCachedFile() assumes that there is actually a cached file on
disk, and will never try the HTTP resource.

## Solution:
Actually try to read the cached file. If it fails, try to get it from
HTTP.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
