### PR TITLE
refactor(fetcher): drop redundant catch/log

### DIFF
--- a/src/shared/resourcefetcher/compositeResourceFetcher.ts
+++ b/src/shared/resourcefetcher/compositeResourceFetcher.ts
@@ -24,7 +24,7 @@ export class CompositeResourceFetcher implements ResourceFetcher {
     public async get(): Promise<string | undefined> {
         for (const fetcher of this.fetchers) {
             const contents = await fetcher.get().catch(err => {
-                this.logger.debug('Error loading resource from resource fetcher: %s', (err as Error).message)
+                this.logger.debug('fetch failed: %s', (err as Error).message)
             })
             if (contents) {
                 return contents

--- a/src/shared/resourcefetcher/fileResourceFetcher.ts
+++ b/src/shared/resourcefetcher/fileResourceFetcher.ts
@@ -17,12 +17,10 @@ export class FileResourceFetcher implements ResourceFetcher {
      */
     public async get(): Promise<string | undefined> {
         try {
-            this.logger.verbose(`Loading resource from ${this.filepath}`)
-
+            this.logger.verbose('loading file resource: "%s"', this.filepath)
             return (await fs.readFile(this.filepath)).toString()
         } catch (err) {
-            this.logger.verbose(`Error loading resource from ${this.filepath}: %s`, (err as Error).message)
-
+            this.logger.verbose('failed to load file resource: "%s": %s', this.filepath, (err as Error).message)
             return undefined
         }
     }

--- a/src/shared/resourcefetcher/httpResourceFetcher.ts
+++ b/src/shared/resourcefetcher/httpResourceFetcher.ts
@@ -65,12 +65,12 @@ export class HttpResourceFetcher implements ResourceFetcher {
     public get(): Promise<string | undefined>
     public get(pipeLocation: string): FetcherResult
     public get(pipeLocation?: string): Promise<string | undefined> | FetcherResult {
-        this.logger.verbose(`Downloading ${this.logText()}`)
+        this.logger.verbose(`downloading: ${this.logText()}`)
 
         if (pipeLocation) {
             const result = this.pipeGetRequest(pipeLocation, this.params.timeout)
             result.fsStream.on('exit', () => {
-                this.logger.verbose(`Finished downloading ${this.logText()}`)
+                this.logger.verbose(`downloaded: ${this.logText()}`)
             })
 
             return result
@@ -87,12 +87,12 @@ export class HttpResourceFetcher implements ResourceFetcher {
                 this.params.onSuccess(contents)
             }
 
-            this.logger.verbose(`Finished downloading ${this.logText()}`)
+            this.logger.verbose(`downloaded: ${this.logText()}`)
 
             return contents
         } catch (err) {
             const error = err as CancelError | { message?: string; code?: number }
-            this.logger.verbose(`Error downloading ${this.logText()}: %s`, error.message ?? error.code)
+            this.logger.verbose(`download failed: %s: %s`, this.logText(), error.message ?? error.code)
 
             return undefined
         }
@@ -175,7 +175,7 @@ export async function getPropertyFromJsonUrl(
                 return json[property]
             }
         } catch (err) {
-            getLogger().error(`JSON at ${url} not parsable: ${err}`)
+            getLogger().error(`JSON parsing failed for "${url}": ${(err as Error).message}`)
         }
     }
 }

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -179,9 +179,7 @@ export async function getRemoteOrCachedFile(params: {
         // Check that the cached file actually can be fetched. Else we might
         // never update the cache.
         const fileFetcher = new FileResourceFetcher(params.filepath)
-        const content = await fileFetcher.get().catch(err => {
-            getLogger().debug('failed to load cached resource: %s', (err as Error).message)
-        })
+        const content = await fileFetcher.get()
         if (content) {
             return content
         }
@@ -195,9 +193,7 @@ export async function getRemoteOrCachedFile(params: {
             params.extensionContext.globalState.update(params.cacheKey, params.version)
         },
     })
-    const content = await httpFetcher.get().catch(err => {
-        getLogger().debug('failed to fetch HTTP resource: %s', (err as Error).message)
-    })
+    const content = await httpFetcher.get()
     if (!content) {
         throw new Error(`failed to resolve schema: ${params.filepath}`)
     }


### PR DESCRIPTION
## Problem:
fileResourceFetcher and httpResourceFetcher already catch exceptions and
log a failure message, and are so documented. So `get().catch(…)` in
`schemas.ts` is redundant.

## Solution:
- remove `catch(…)` in `schemas.ts`
- cleanup log messages in fetcher impls.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->

<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
