### PR TITLE
fix(ci): disable codecov "patch" check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,11 +15,7 @@ coverage:
             default:
                 threshold: 1
                 informational: true
-        patch:
-            default:
-                threshold: 1
-                only_pulls: true
-                informational: false
+        patch: no
         changes: no
 
 comment: off


### PR DESCRIPTION
The codecov "patch" check fails too often, is far too noisy, is not
actionable. Codecov is too unreliable.

At this point, codecov is merely a way to see coverage stats over time,
and to be able to glance at PRs to see if they measurably affected code
coverage (assuming codecov actually works on the PR).



<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
