### PR TITLE
feat(feedback): always enable "Send" button

### DIFF
--- a/.changes/next-release/Feature-585b135b-349f-4db0-bf8a-9a483bd9b20e.json
+++ b/.changes/next-release/Feature-585b135b-349f-4db0-bf8a-9a483bd9b20e.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "\"Send Feedback\" form always enables Send button and doesn't require text input"
+}

--- a/src/feedback/commands/submitFeedback.ts
+++ b/src/feedback/commands/submitFeedback.ts
@@ -59,7 +59,12 @@ export async function submitFeedbackMessage(
     }
 ) {
     const logger = getLogger()
-    logger.info(`Submitting ${message.sentiment} feedback`)
+
+    if (!message.sentiment) {
+        logger.error(`feedback failed, invalid sentiment: "${message.sentiment}"`)
+        server.postMessage({ statusCode: 'Failure', error: 'Choose a reaction (smile/frown)' })
+        return
+    }
 
     try {
         await constructs.telemetryService.postFeedback({
@@ -68,7 +73,7 @@ export async function submitFeedbackMessage(
         })
     } catch (err) {
         const errorMessage = (err as Error).message || 'Failed to submit feedback'
-        logger.error(`Failed to submit ${message.sentiment} feedback: ${errorMessage}`)
+        logger.error(`feedback failed: "${message.sentiment}": ${errorMessage}`)
         server.postMessage({ statusCode: 'Failure', error: errorMessage })
 
         telemetry.recordFeedbackResult({ result: 'Failed' })
@@ -76,7 +81,7 @@ export async function submitFeedbackMessage(
         return
     }
 
-    logger.info(`Successfully submitted ${message.sentiment} feedback`)
+    logger.info(`feedback sent: "${message.sentiment}"`)
 
     telemetry.recordFeedbackResult({ result: 'Succeeded' })
 

--- a/src/feedback/vue/submitFeedback.vue
+++ b/src/feedback/vue/submitFeedback.vue
@@ -34,20 +34,14 @@
             </div>
         </div>
 
-        <p>
-            <input v-if="isSubmitting" type="submit" value="Submitting..." disabled />
-            <input
-                v-else
-                type="submit"
-                @click="submitFeedback"
-                :disabled="comment.length === 0 || comment.length > 2000 || sentiment === ''"
-                value="Submit"
-            />
-        </p>
-
-        <div id="error" v-if="error !== ''">
+        <div id="error" v-if="error !== ''" style="float: right">
             <strong>{{ error }}</strong>
         </div>
+
+        <p>
+            <input v-if="isSubmitting" type="submit" value="Submitting..." disabled />
+            <input v-else type="submit" @click="submitFeedback" :disabled="comment.length > 2000" value="Send" />
+        </p>
     </div>
 </template>
 


### PR DESCRIPTION
## Problem:
The "Send" button is disabled until feedback is entered, and it's not
obvious what is expected.

## Solution:
Always enable the "Send" button, but show informative message if
a "sentiment" (smile/frown) was not chosen.

fix #2640
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
-->


<!---
    Other details:
    - Related issues: link to any related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
