### PR TITLE
telemetry: AWS filetypes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
                 "yaml-cfn": "^0.3.1"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "1.0.42",
+                "@aws-toolkits/telemetry": "1.0.49",
                 "@sinonjs/fake-timers": "^8.1.0",
                 "@types/adm-zip": "^0.4.34",
                 "@types/async-lock": "^1.1.3",
@@ -2252,9 +2252,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.42",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.42.tgz",
-            "integrity": "sha512-DM721p2lN/z1n0E6cmTAB85EL6bfE+gxtQNIooF9QyKYZQL0wUnk4mWPZzOnfNKm9q6nqmzS/YIPSLwc+aMdEQ==",
+            "version": "1.0.49",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.49.tgz",
+            "integrity": "sha512-gCHetHqwIK048u8EnjctD4gcRi4KUN2cS5JZbOR1jMJmKF0e2v1xe/BbI3ubnmTlfuFFmWsn1pfdqGr94541aw==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",
@@ -15395,9 +15395,9 @@
             }
         },
         "@aws-toolkits/telemetry": {
-            "version": "1.0.42",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.42.tgz",
-            "integrity": "sha512-DM721p2lN/z1n0E6cmTAB85EL6bfE+gxtQNIooF9QyKYZQL0wUnk4mWPZzOnfNKm9q6nqmzS/YIPSLwc+aMdEQ==",
+            "version": "1.0.49",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.49.tgz",
+            "integrity": "sha512-gCHetHqwIK048u8EnjctD4gcRi4KUN2cS5JZbOR1jMJmKF0e2v1xe/BbI3ubnmTlfuFFmWsn1pfdqGr94541aw==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -2938,7 +2938,7 @@
         "report": "nyc report --reporter=html --reporter=json"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "1.0.42",
+        "@aws-toolkits/telemetry": "1.0.49",
         "@sinonjs/fake-timers": "^8.1.0",
         "@types/adm-zip": "^0.4.34",
         "@types/async-lock": "^1.1.3",

--- a/src/dynamicResources/awsResourceManager.ts
+++ b/src/dynamicResources/awsResourceManager.ts
@@ -197,11 +197,15 @@ export class AwsResourceManager {
             }
         }
 
-        globals.schemaService.registerMapping({
-            path: file.fsPath,
-            type: 'json',
-            schema: location,
-        })
+        globals.schemaService.registerMapping(
+            {
+                path: file.fsPath,
+                type: 'json',
+                schema: location,
+            },
+            // Flush immediately so the onDidOpenTextDocument handler can work.
+            true
+        )
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,6 +41,7 @@ import { activate as activateEcr } from './ecr/activation'
 import { activate as activateSam } from './shared/sam/activation'
 import { activate as activateTelemetry } from './shared/telemetry/activation'
 import { activate as activateS3 } from './s3/activation'
+import * as awsFiletypes from './shared/awsFiletypes'
 import * as telemetry from './shared/telemetry/telemetry'
 import { ExtContext } from './shared/extensions'
 import { activate as activateApiGateway } from './apigateway/activation'
@@ -118,6 +119,7 @@ export async function activate(context: vscode.ExtensionContext) {
         await activateTelemetry(context, awsContext, settings)
         await globals.telemetry.start()
         await globals.schemaService.start()
+        awsFiletypes.activate()
 
         const extContext: ExtContext = {
             extensionContext: context,

--- a/src/shared/awsFiletypes.ts
+++ b/src/shared/awsFiletypes.ts
@@ -1,0 +1,114 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import * as path from 'path'
+import * as constants from '../shared/constants'
+import * as aslFormats from '../stepFunctions/constants/aslFormats'
+import * as telemetry from './telemetry/telemetry'
+import * as pathutil from '../shared/utilities/pathUtils'
+import * as fsutil from '../shared/filesystemUtilities'
+import * as sysutil from '../shared/systemUtilities'
+import * as collectionUtil from '../shared/utilities/collectionUtils'
+import globals from './extensionGlobals'
+
+/** AWS filetypes: vscode language ids */
+export const awsFiletypeLangIds = {
+    /** vscode language ids registered by AWS Toolkit or other AWS extensions for handling. */
+    awsOwned: [aslFormats.JSON_ASL, aslFormats.YAML_ASL, constants.ssmJson, constants.ssmYaml],
+    /** generic vscode language ids that possibly are AWS filetypes  */
+    ambiguous: ['ini', 'plaintext', aslFormats.JSON_TYPE, aslFormats.YAML_TYPE],
+}
+
+/**
+ * Maps vscode language ids to AWS filetypes for telemetry.
+ */
+export function langidToAwsFiletype(langId: string): telemetry.AwsFiletype {
+    switch (langId) {
+        case constants.ssmJson:
+        case constants.ssmYaml:
+            return 'ssmDocument'
+        case aslFormats.JSON_ASL:
+        case aslFormats.YAML_ASL:
+            return 'stepfunctionsAsl'
+        default:
+            return 'other'
+    }
+}
+
+/** Returns true if file `f` is somewhere in `~/.aws`. */
+export function isAwsConfig(f: string): boolean {
+    const awsDir = path.join(sysutil.SystemUtilities.getHomeDirectory(), '.aws')
+    if (fsutil.isInDirectory(awsDir, f)) {
+        return true
+    }
+    return false
+}
+
+export function isAwsFiletype(doc: vscode.TextDocument): boolean | undefined {
+    if (awsFiletypeLangIds.awsOwned.includes(doc.languageId)) {
+        return true
+    }
+    if (isAwsConfig(doc.fileName)) {
+        return true
+    }
+    if (awsFiletypeLangIds.ambiguous.includes(doc.languageId)) {
+        return undefined // Maybe
+    }
+    return false
+}
+
+export function activate(): void {
+    globals.context.subscriptions.push(
+        // TODO: onDidChangeTextDocument ?
+        vscode.workspace.onDidOpenTextDocument(async (doc: vscode.TextDocument) => {
+            const isAwsFileExt = isAwsFiletype(doc)
+            const isSchemaHandled = globals.schemaService.isMapped(doc.uri)
+            const isCfnTemplate = !!globals.templateRegistry.registeredItems.find(
+                t => pathutil.normalize(t.path) === pathutil.normalize(doc.fileName)
+            )
+            if (!isAwsFileExt && !isSchemaHandled && !isCfnTemplate) {
+                return
+            }
+
+            let fileExt: string | undefined = path.extname(doc.fileName)
+            fileExt = fileExt ? fileExt : undefined // Telemetry client will fail on empty string.
+
+            // TODO: ask templateRegistry if this is SAM or CFN.
+            // TODO: ask schemaService for the precise filetype.
+            let telemKind = isAwsConfig(doc.fileName) ? 'awsCredentials' : langidToAwsFiletype(doc.languageId)
+            if (telemKind === 'other') {
+                telemKind = isCfnTemplate ? 'cloudformationSam' : isSchemaHandled ? 'cloudformation' : 'other'
+            }
+
+            // HACK: for "~/.aws/foo" vscode sometimes _only_ emits "~/.aws/foo.git".
+            if (telemKind === 'awsCredentials' && fileExt === '.git') {
+                fileExt = undefined
+            }
+
+            if (await isSameMetricPending(telemKind, fileExt)) {
+                return // Avoid redundant/duplicate metrics.
+            }
+
+            telemetry.recordFileEditAwsFile({
+                awsFiletype: telemKind,
+                passive: true,
+                result: 'Succeeded',
+                filenameExt: fileExt,
+            })
+        }, undefined)
+    )
+}
+
+async function isSameMetricPending(filetype: string, fileExt: string | undefined): Promise<boolean> {
+    const pendingMetrics = await collectionUtil.first(
+        globals.telemetry.findIter(m => {
+            const m1 = m.Metadata?.find(o => o.Key === 'awsFiletype')
+            const m2 = m.Metadata?.find(o => o.Key === 'filenameExt')
+            return m.MetricName === 'file_editAwsFile' && m1?.Value === filetype && m2?.Value === fileExt
+        })
+    )
+    return !!pendingMetrics
+}

--- a/src/shared/extensions/yaml.ts
+++ b/src/shared/extensions/yaml.ts
@@ -34,6 +34,7 @@ function evaluate(schema: vscode.Uri | (() => vscode.Uri)): vscode.Uri {
 export interface YamlExtension {
     assignSchema(path: vscode.Uri, schema: vscode.Uri | (() => vscode.Uri)): void
     removeSchema(path: vscode.Uri): void
+    getSchema(path: vscode.Uri): vscode.Uri | undefined
 }
 
 export async function activateYamlExtension(): Promise<YamlExtension | undefined> {
@@ -61,5 +62,6 @@ export async function activateYamlExtension(): Promise<YamlExtension | undefined
     return {
         assignSchema: (path, schema) => schemaMap.set(path.toString(), applyScheme(AWS_SCHEME, evaluate(schema))),
         removeSchema: path => schemaMap.delete(path.toString()),
+        getSchema: path => schemaMap.get(path.toString()),
     }
 }

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -166,18 +166,26 @@ function createSettingsClass<T extends TypeDescriptor>(section: string, descript
     type Inner = FromDescriptor<T>
 
     // Class names are not always stable, especially when bundling
-    function makeLogger(name = 'Settings') {
+    function makeLogger(name = 'Settings', loglevel: 'debug' | 'error') {
         const prefix = `${isNameMangled() ? 'Settings' : name} (${section})`
-        return (message: string) => getLogger().debug(`${prefix}: ${message}`)
+        return (message: string) =>
+            loglevel === 'debug'
+                ? getLogger().debug(`${prefix}: ${message}`)
+                : getLogger().error(`${prefix}: ${message}`)
     }
 
     return class AnonymousSettings implements TypedSettings<Inner> {
         private readonly config = this.settings.getSection(section)
         private readonly disposables: vscode.Disposable[] = []
         // TODO(sijaden): add metadata prop to `Logger` so we don't need to make one-off log functions
-        protected readonly log = makeLogger(Object.getPrototypeOf(this)?.constructor?.name)
+        protected readonly log = makeLogger(Object.getPrototypeOf(this)?.constructor?.name, 'debug')
+        protected readonly logErr = makeLogger(Object.getPrototypeOf(this)?.constructor?.name, 'error')
 
-        public constructor(private readonly settings: ClassToInterfaceType<Settings> = Settings.instance) {}
+        public constructor(
+            private readonly settings: ClassToInterfaceType<Settings> = Settings.instance,
+            /** Throw an exception if the user config is invalid or the caller type doesn't match the stored type. */
+            private readonly throwInvalid: boolean = isAutomation()
+        ) {}
 
         public get onDidChange() {
             return this.getChangedEmitter().event
@@ -186,14 +194,11 @@ function createSettingsClass<T extends TypeDescriptor>(section: string, descript
         public get<K extends keyof Inner>(key: K & string, defaultValue?: Inner[K]) {
             try {
                 return this.getOrThrow(key, defaultValue)
-            } catch (error) {
-                this.log(`failed to read key "${key}": ${error}`)
-
-                if (isAutomation() || defaultValue === undefined) {
-                    throw new Error(`Failed to read key "${key}": ${error}`)
+            } catch (e) {
+                if (this.throwInvalid || defaultValue === undefined) {
+                    throw new Error(`Failed to read key "${key}": ${e}`)
                 }
-
-                this.log(`using default value for "${key}"`)
+                this.logErr(`using default for key "${key}", read failed: ${(e as Error).message ?? '?'}`)
 
                 return defaultValue
             }
@@ -255,8 +260,13 @@ function createSettingsClass<T extends TypeDescriptor>(section: string, descript
 
                 for (const key of props.filter(isDifferent)) {
                     this.log(`key "${key}" changed`)
-                    store[key] = this.get(key)
-                    emitter.fire({ key })
+                    try {
+                        store[key] = this.get(key)
+                        emitter.fire({ key })
+                    } catch {
+                        // getChangedEmitter() can't provide a default value so
+                        // we must silence errors here. Logging is done by this.get().
+                    }
                 }
             })
 

--- a/src/shared/telemetry/activation.ts
+++ b/src/shared/telemetry/activation.ts
@@ -17,7 +17,6 @@ import { fromExtensionManifest, openSettings, Settings } from '../settings'
 
 const LEGACY_SETTINGS_TELEMETRY_VALUE_DISABLE = 'Disable'
 const LEGACY_SETTINGS_TELEMETRY_VALUE_ENABLE = 'Enable'
-const TELEMETRY_SETTING_DEFAULT = true
 
 export const noticeResponseViewSettings = localize('AWS.telemetry.notificationViewSettings', 'Settings')
 export const noticeResponseOk = localize('AWS.telemetry.notificationOk', 'OK')
@@ -37,7 +36,13 @@ const CURRENT_TELEMETRY_NOTICE_VERSION = 2
 export async function activate(extensionContext: vscode.ExtensionContext, awsContext: AwsContext, settings: Settings) {
     globals.telemetry = new DefaultTelemetryService(extensionContext, awsContext, getComputeRegion())
 
-    const config = new TelemetryConfig(settings)
+    const config = new TelemetryConfig(
+        settings,
+        // Disable `throwInvalid` because:
+        //   1. Telemetry must never prevent normal Toolkit operation.
+        //   2. For tests, bad data is intentional, so these errors add unwanted noise in the test logs.
+        false
+    )
     globals.telemetry.telemetryEnabled = config.isEnabled()
 
     extensionContext.subscriptions.push(
@@ -50,7 +55,7 @@ export async function activate(extensionContext: vscode.ExtensionContext, awsCon
 
     // Prompt user about telemetry if they haven't been
     if (!isCloud9() && !hasUserSeenTelemetryNotice(extensionContext)) {
-        showTelemetryNotice(extensionContext, config)
+        showTelemetryNotice(extensionContext)
     }
 }
 
@@ -71,17 +76,7 @@ export function convertLegacy(value: unknown): boolean {
 
 export class TelemetryConfig extends fromExtensionManifest('aws', { telemetry: convertLegacy }) {
     public isEnabled(): boolean {
-        try {
-            return this.get('telemetry', TELEMETRY_SETTING_DEFAULT)
-        } catch (error) {
-            vscode.window.showErrorMessage(
-                localize(
-                    'AWS.message.error.settings.telemetry.invalid_type',
-                    'The aws.telemetry value must be a boolean'
-                )
-            )
-            return TELEMETRY_SETTING_DEFAULT
-        }
+        return this.get('telemetry', true)
     }
 }
 
@@ -101,7 +96,7 @@ export async function setHasUserSeenTelemetryNotice(extensionContext: vscode.Ext
  * Prompts user to Enable/Disable/Defer on Telemetry, then
  * handles the response appropriately.
  */
-function showTelemetryNotice(extensionContext: vscode.ExtensionContext, config: TelemetryConfig) {
+function showTelemetryNotice(extensionContext: vscode.ExtensionContext) {
     getLogger().verbose('Showing telemetry notice')
 
     const telemetryNoticeText: string = localize(

--- a/src/shared/telemetry/telemetryLogger.ts
+++ b/src/shared/telemetry/telemetryLogger.ts
@@ -45,6 +45,10 @@ export class TelemetryLogger {
         return this._metrics.length
     }
 
+    public clear(): void {
+        this._metrics.length = 0
+    }
+
     public log(metric: MetricDatum): void {
         const msg = `telemetry: emitted metric "${metric.MetricName}"`
         if (!isReleaseVersion()) {

--- a/src/shared/telemetry/telemetryService.ts
+++ b/src/shared/telemetry/telemetryService.ts
@@ -9,7 +9,7 @@ import * as path from 'path'
 import { v4 as uuidv4 } from 'uuid'
 import { ExtensionContext } from 'vscode'
 import { AwsContext } from '../awsContext'
-import { isReleaseVersion } from '../vscode/env'
+import { isReleaseVersion, isAutomation } from '../vscode/env'
 import { getLogger } from '../logger'
 import { MetricDatum } from './clienttelemetry'
 import { DefaultTelemetryClient } from './telemetryClient'
@@ -88,11 +88,15 @@ export class DefaultTelemetryService {
             globals.clock.clearTimeout(this._timer)
             this._timer = undefined
         }
-        const currTime = new globals.clock.Date()
-        recordSessionEnd({ value: currTime.getTime() - this.startTime.getTime() })
 
-        // only write events to disk if telemetry is enabled at shutdown time
-        if (this.telemetryEnabled) {
+        // Only write events to disk at shutdown time if:
+        //   1. telemetry is enabled
+        //   2. we are not in CI or a test suite run
+        if (this.telemetryEnabled && !isAutomation()) {
+            const currTime = new globals.clock.Date()
+            // This is noisy when running tests in vscode.
+            recordSessionEnd({ value: currTime.getTime() - this.startTime.getTime() })
+
             try {
                 await writeFile(this.persistFilePath, JSON.stringify(this._eventQueue))
             } catch {}
@@ -299,6 +303,19 @@ export class DefaultTelemetryService {
                 getLogger().error(msg)
             } else {
                 throw Error(msg)
+            }
+        }
+    }
+
+    /**
+     * Queries the current pending (not flushed) metrics.
+     *
+     * @note The underlying metrics queue may be updated or flushed at any time while this iterates.
+     */
+    public async *findIter(predicate: (m: MetricDatum) => boolean): AsyncIterable<MetricDatum> {
+        for (const m of this._eventQueue) {
+            if (predicate(m)) {
+                yield m
             }
         }
     }

--- a/src/test/dynamicResources/awsResourceManager.test.ts
+++ b/src/test/dynamicResources/awsResourceManager.test.ts
@@ -185,7 +185,7 @@ describe('ResourceManager', function () {
 
     it('registers schema mappings when opening in edit', async function () {
         const editor = await resourceManager.open(resourceNode, false)
-        verify(schemaService.registerMapping(anything())).once()
+        verify(schemaService.registerMapping(anything(), anything())).once()
 
         // eslint-disable-next-line @typescript-eslint/unbound-method
         const [mapping] = capture(schemaService.registerMapping).last()
@@ -212,7 +212,8 @@ describe('ResourceManager', function () {
     it('deletes resource mapping on file close', async function () {
         const editor = await resourceManager.open(resourceNode, false)
         await resourceManager.close(editor.document.uri)
-        verify(schemaService.registerMapping(anything())).twice()
+        verify(schemaService.registerMapping(anything())).once()
+        verify(schemaService.registerMapping(anything(), anything())).once()
 
         // eslint-disable-next-line @typescript-eslint/unbound-method
         const [mapping] = capture(schemaService.registerMapping).last()

--- a/src/test/shared/awsFiletypes.test.ts
+++ b/src/test/shared/awsFiletypes.test.ts
@@ -1,0 +1,99 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import * as assert from 'assert'
+import * as path from 'path'
+import globals from '../../shared/extensionGlobals'
+import * as sysutil from '../../shared/systemUtilities'
+import * as testUtil from '../testUtil'
+import * as workspaceUtils from '../../shared/utilities/workspaceUtils'
+import { toArrayAsync } from '../../shared/utilities/collectionUtils'
+import { waitUntil } from '../../shared/utilities/timeoutUtils'
+
+describe('awsFiletypes', function () {
+    let awsConfigUri: vscode.Uri | undefined
+    let cfnUri: vscode.Uri | undefined
+
+    beforeEach(async function () {
+        testUtil.closeAllEditors()
+
+        // Create a dummy file in ~/.aws on the system.
+        // Note: We consider _any_ file in ~/.aws to be an "AWS config" file,
+        // so this will trigger "file_editAwsFile" telemetry.
+        const awsConfigFile = path.join(sysutil.SystemUtilities.getHomeDirectory(), '.aws/test_awstoolkit')
+        awsConfigUri = vscode.Uri.file(awsConfigFile)
+        testUtil.toFile('Test file from the aws-toolkit-vscode test suite.', awsConfigFile)
+
+        const cfnFile = workspaceUtils.tryGetAbsolutePath(
+            vscode.workspace.workspaceFolders?.[0],
+            'python3.7-plain-sam-app/template.yaml'
+        )
+        cfnUri = vscode.Uri.file(cfnFile)
+    })
+
+    after(async function () {
+        testUtil.closeAllEditors()
+    })
+
+    it('emit telemetry when opened by user', async function () {
+        await globals.templateRegistry.addItemToRegistry(cfnUri!)
+        await vscode.commands.executeCommand('vscode.open', cfnUri)
+        await vscode.commands.executeCommand('vscode.open', awsConfigUri)
+        await vscode.workspace.openTextDocument({
+            content: 'test content for SSM JSON',
+            language: 'ssm-json',
+        })
+
+        const r = await waitUntil(
+            async () => {
+                const metrics = await toArrayAsync(
+                    globals.telemetry.findIter(m => {
+                        return m.MetricName === 'file_editAwsFile'
+                    })
+                )
+                return metrics.length >= 3 ? metrics : undefined
+            },
+            { interval: 200, timeout: 5000 }
+        )
+
+        assert(r, 'did not emit expected telemetry')
+        assert(r.length === 3, 'emitted file_editAwsFile too many times')
+        const m1filetype = r[0].Metadata?.find(o => o.Key === 'awsFiletype')?.Value
+        const m2filetype = r[1].Metadata?.find(o => o.Key === 'awsFiletype')?.Value
+        const m3filetype = r[2].Metadata?.find(o => o.Key === 'awsFiletype')?.Value
+        assert.strictEqual(m1filetype, 'cloudformationSam')
+        assert.strictEqual(m2filetype, 'awsCredentials')
+        assert.strictEqual(m3filetype, 'ssmDocument')
+    })
+
+    it('emit telemetry exactly once per filetype in a given flush window', async function () {
+        await globals.templateRegistry.addItemToRegistry(cfnUri!)
+        await vscode.commands.executeCommand('vscode.open', cfnUri)
+        async function getMetrics() {
+            return await waitUntil(
+                async () => {
+                    const metrics = await toArrayAsync(
+                        globals.telemetry.findIter(m => {
+                            return m.MetricName === 'file_editAwsFile'
+                        })
+                    )
+                    return metrics.length > 0 ? metrics : undefined
+                },
+                { interval: 200, timeout: 5000 }
+            )
+        }
+        // Wait for metrics...
+        await getMetrics()
+        testUtil.closeAllEditors()
+        await vscode.commands.executeCommand('vscode.open', cfnUri)
+        await vscode.commands.executeCommand('vscode.open', cfnUri)
+
+        // Get metrics again (result should be the same)...
+        const r = await getMetrics()
+        assert.notStrictEqual(r, undefined, 'did not emit expected telemetry')
+        assert.strictEqual(r?.length, 1, 'emitted file_editAwsFile too many times')
+    })
+})

--- a/src/test/shared/settingsConfiguration.test.ts
+++ b/src/test/shared/settingsConfiguration.test.ts
@@ -5,7 +5,6 @@
 
 import * as assert from 'assert'
 import * as vscode from 'vscode'
-import * as env from '../../shared/vscode/env'
 import { DevSettings, Experiments, fromExtensionManifest, PromptSettings, Settings } from '../../shared/settings'
 import { TestSettings } from '../utilities/testSettingsConfiguration'
 import { ClassToInterfaceType } from '../../shared/utilities/tsUtils'
@@ -208,14 +207,9 @@ describe('DevSetting', function () {
     })
 
     it('only throws in automation', async function () {
-        const previousDesc = Object.getOwnPropertyDescriptor(env, 'isAutomation')
-        assert.ok(previousDesc)
-
+        const noAutomation = new DevSettings(settings, false)
         await settings.update(`aws.dev.${TEST_SETTING}`, 'junk')
-        Object.defineProperty(env, 'isAutomation', { value: () => false })
-        assert.strictEqual(sut.get(TEST_SETTING, true), true)
-
-        Object.defineProperty(env, 'isAutomation', previousDesc)
+        assert.strictEqual(noAutomation.get(TEST_SETTING, true), true)
     })
 })
 

--- a/src/test/shared/telemetry/activation.test.ts
+++ b/src/test/shared/telemetry/activation.test.ts
@@ -79,7 +79,12 @@ describe('Telemetry on activation', function () {
     let sut: TelemetryConfig
 
     beforeEach(function () {
-        sut = new TelemetryConfig(settings)
+        sut = new TelemetryConfig(
+            settings,
+            // Disable `throwInvalid`. These tests intentionally try invalid
+            // data, so the errors are unwanted noise in the test logs.
+            false
+        )
     })
 
     afterEach(async function () {

--- a/src/test/utilities/collectionUtils.ts
+++ b/src/test/utilities/collectionUtils.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// TODO: what is the point of this? should it live in src/shared/utilities/collectionUtils.ts ?
 export async function* asyncGenerator<T>(items: T[]): AsyncIterableIterator<T> {
     yield* items
 }


### PR DESCRIPTION
## Problem:
No telemetry for AWS filetypes.

## Solution:

Solution:
- Set an `onDidOpenTextDocument` handler
    - Checks if the opened file is an "AWS filetype" by asking these services:
        - `schemaService`
        - `templateRegistry`
        - `awsFiletypes`
    - TODO: only if edited? (`onDidChangeTextDocument`)
    - TODO:is it worth adding "Resources" filetypes?
- Emit the `file_editAwsFile` metric.
  - Currently "passive". May change later.
- Add TelemetryLogger.clear() so that tests can clear the global logger
  state before querying.
    - TODO: can we eliminate TelemetryLogger (just use the
      TelemetryService directly)?


## TODO:

- ~~tests~~
- ~~passive or active?~~

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
