### PR TITLE
test: check tech debt for old nodejs versions

### DIFF
--- a/src/shared/extensionUtilities.ts
+++ b/src/shared/extensionUtilities.ts
@@ -329,11 +329,7 @@ export function showWelcomeMessage(context: vscode.ExtensionContext): void {
 }
 
 /**
- * Creates a modal to display OS, AWS Toolkit, and VS Code
- * versions and allows user to copy to clipboard
- * Also prints to the toolkit output channel
- *
- * @param toolkitOutputChannel VS Code Output Channel
+ * Shows info about the extension and its environment.
  */
 export async function aboutToolkit(): Promise<void> {
     const toolkitEnvDetails = getToolkitEnvironmentDetails()
@@ -353,16 +349,21 @@ export function getToolkitEnvironmentDetails(): string {
     const osArch = os.arch()
     const osRelease = os.release()
     const vsCodeVersion = vscode.version
+    const node = process.versions.node ? `node: ${process.versions.node}\n` : 'node: ?\n'
+    const electron = process.versions.electron ? `electron: ${process.versions.electron}\n` : ''
+
     const envDetails = localize(
         'AWS.message.toolkitInfo',
-        'OS:  {0} {1} {2}\n{3} Extension Host Version:  {4}\n{5} Toolkit Version:  {6}\n',
+        'OS: {0} {1} {2}\n{3} extension host:  {4}\n{5} Toolkit:  {6}\n{7}{8}',
         osType,
         osArch,
         osRelease,
         getIdeProperties().longName,
         vsCodeVersion,
         getIdeProperties().company,
-        extensionVersion
+        extensionVersion,
+        node,
+        electron
     )
 
     return envDetails

--- a/src/shared/vscode/env.ts
+++ b/src/shared/vscode/env.ts
@@ -88,3 +88,10 @@ export function isMinimumVersion(): boolean {
 export function getMinVscodeVersion(): string {
     return packageJson.engines.vscode.replace(/[^~]/, '')
 }
+
+/**
+ * Returns the minimum nodejs version declared in `package.json`.
+ */
+export function getMinNodejsVersion(): string {
+    return packageJson.devDependencies['@types/node'].replace(/[^~]/, '')
+}

--- a/src/test/techdebt.test.ts
+++ b/src/test/techdebt.test.ts
@@ -5,13 +5,13 @@
 
 import * as assert from 'assert'
 import * as semver from 'semver'
-import { getMinVscodeVersion } from '../shared/vscode/env'
+import * as env from '../shared/vscode/env'
 
 // Checks project config and dependencies, to remind us to remove old things
 // when possible.
 describe('tech debt', function () {
     it('vscode minimum version', async function () {
-        const minVscode = getMinVscodeVersion()
+        const minVscode = env.getMinVscodeVersion()
 
         assert.ok(
             semver.lt(minVscode, '1.53.0'),
@@ -21,6 +21,20 @@ describe('tech debt', function () {
         assert.ok(
             semver.lt(minVscode, '1.51.0'),
             'remove filesystemUtilities.findFile(), use vscode.workspace.findFiles() instead'
+        )
+    })
+
+    it('nodejs minimum version', async function () {
+        const minNodejs = env.getMinNodejsVersion()
+
+        assert.ok(
+            semver.lt(minNodejs, '16.0.0'),
+            'remove require("perf_hooks").performance workarounds, use globalThis.performance instead (always available since nodejs 16.x)'
+        )
+
+        assert.ok(
+            semver.lt(minNodejs, '16.0.0'),
+            'with node16+, we can now use AbortController to cancel Node things (child processes, HTTP requests, etc.)'
         )
     })
 })


### PR DESCRIPTION
## Problem

some code is using workarounds for older nodejs versions.

## Solution

- add a test that fails when the minimum nodejs version is 16+
- show nodejs version in the `About Toolkit` command

<img width="232" alt="image" src="https://user-images.githubusercontent.com/55561878/170328356-19ec43a2-0847-4d8c-a381-acea51cd6179.png">

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
