### PR TITLE
fix(stepFunctions): add correct keybinding clause for `aws.previewStateMachine`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2828,7 +2828,7 @@
                 "command": "aws.previewStateMachine",
                 "key": "ctrl+shift+v",
                 "mac": "cmd+shift+v",
-                "when": "editorTextFocus && (editorLangId == asl || editorLangId == asl-yaml)"
+                "when": "editorTextFocus && editorLangId == asl || editorTextFocus && editorLangId == asl-yaml"
             }
         ],
         "grammars": [

--- a/src/awsexplorer/localExplorer.ts
+++ b/src/awsexplorer/localExplorer.ts
@@ -52,5 +52,8 @@ export function createLocalExplorerView(): vscode.TreeView<TreeNode> {
         }
     })
 
+    // Legacy CDK behavior. Mostly useful for C9 as they do not have inline buttons.
+    view.onDidChangeVisibility(({ visible }) => visible && cdkNode.refresh())
+
     return view
 }

--- a/src/stepFunctions/activation.ts
+++ b/src/stepFunctions/activation.ts
@@ -52,6 +52,7 @@ async function registerStepFunctionCommands(
          */
         vscode.commands.registerCommand('aws.previewStateMachine', async (arg?: vscode.TextEditor | vscode.Uri) => {
             try {
+                arg ??= vscode.window.activeTextEditor
                 const input = arg instanceof vscode.Uri ? arg : arg?.document
 
                 if (!input) {

--- a/src/stepFunctions/commands/visualizeStateMachine/aslVisualizationCDKManager.ts
+++ b/src/stepFunctions/commands/visualizeStateMachine/aslVisualizationCDKManager.ts
@@ -36,7 +36,7 @@ export class AslVisualizationCDKManager extends AbstractAslVisualizationManager<
         try {
             await this.cache.updateCache(globalStorage)
 
-            const textDocument = await vscode.workspace.openTextDocument(templateUri)
+            const textDocument = await vscode.workspace.openTextDocument(templateUri.with({ fragment: '' }))
             const newVisualization = new AslVisualizationCDK(textDocument, templateUri.fsPath, resourceName)
             this.handleNewVisualization(this.getKey(uri), newVisualization)
 


### PR DESCRIPTION
## Problem
Apparently they have integ tests? 
And I guess the only case where the command wouldn't have an argument would be for keybindings.
But the keybindings in `package.json` was broken. Hmm.

## Solution
Fix the keybindings in `package.json`
Update the command to infer the editor (this is not correct in all cases but good enough to maintain C9 compat)
Add fix for odd C9 <---> URI behavior

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
