### PR TITLE
fix(settings): add logic to detect changes in deeply-nested settings

### DIFF
--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -248,10 +248,14 @@ function createSettingsClass<T extends TypeDescriptor>(section: string, descript
             //
             // So if `aws.foo.bar` changed, this would fire with data `{ key: 'bar' }`
             const props = keys(descriptor)
+            const store = toRecord(props, p => this.get(p))
             const emitter = new vscode.EventEmitter<{ readonly key: keyof T }>()
             const listener = this.settings.onDidChangeSection(section, event => {
-                for (const key of props.filter(p => event.affectsConfiguration(p))) {
+                const isDifferent = (p: keyof T & string) => event.affectsConfiguration(p) || store[p] !== this.get(p)
+
+                for (const key of props.filter(isDifferent)) {
                     this.log(`key "${key}" changed`)
+                    store[key] = this.get(key)
                     emitter.fire({ key })
                 }
             })


### PR DESCRIPTION
## Problem
`affectsConfiguration` quite literally just checks if the _exact_ configuration key was modified. This is problematic for nested settings which the user can update as-if they were individual things.

For example, if the user updated `aws.experiments.jsonResourceModification`, VS Code will just say `aws.experiments` changed. But a big part of our `Settings` abstraction is that we don't need to worry about what exactly VSC says is a setting or isn't. I'll see about opening a ticket for VSC to discuss the whole configuration stuff more because tying these config keys + schemas directly to the UI is problematic.

## Solution
Add a bit of logic for change detection plus a test. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
