### PR TITLE
[Experimental] feat(telemetry): add way to record metadata in isolation

### DIFF
--- a/src/apprunner/activation.ts
+++ b/src/apprunner/activation.ts
@@ -4,88 +4,90 @@
  */
 
 import * as vscode from 'vscode'
-import * as telemetry from '../shared/telemetry/telemetry'
 import * as nls from 'vscode-nls'
 import { showViewLogsMessage } from '../shared/utilities/messages'
 import { AppRunnerServiceNode } from './explorer/apprunnerServiceNode'
 import { getLogger } from '../shared/logger/logger'
 import { createAppRunnerService } from './commands/createService'
-import { pauseService } from './commands/pauseService'
-import { deleteService } from './commands/deleteService'
 import { createFromEcr } from './commands/createServiceFromEcr'
 import { ExtContext } from '../shared/extensions'
+import { Commands } from '../shared/vscode/commands2'
+import { instrument, MetricName } from '../shared/telemetry/recorder'
 
 const localize = nls.loadMessageBundle()
 
-const commandMap = new Map<[command: string, errorMessage: string], (...args: any) => Promise<any>>()
-
-const CREATE_SERVICE_FAILED = localize('aws.apprunner.createService.failed', 'Failed to create App Runner service')
-const CREATE_SERVICE_ECR_FAILED = localize(
-    'aws.apprunner.createServiceFromEcr.failed',
-    'Failed to create App Runner service from ECR'
-)
-const PAUSE_SERVICE_FAILED = localize('aws.apprunner.pauseService.failed', 'Failed to pause App Runner service')
-const RESUME_SERVICE_FAILED = localize('aws.apprunner.resumeService.failed', 'Failed to resume App Runner service')
-const COPY_SERVICE_URL_FAILED = localize('aws.apprunner.copyServiceUrl.failed', 'Failed to copy App Runner service URL')
-const OPEN_SERVICE_FAILED = localize('aws.apprunner.open.failed', 'Failed to open App Runner service')
-const DEPLOY_SERVICE_FAILED = localize(
-    'aws.apprunner.startDeployment.failed',
-    'Failed to start deployment of App Runner service'
-)
-const DELETE_SERVICE_FAILED = localize('aws.apprunner.deleteService.failed', 'Failed to delete App Runner service')
-
-const copyUrl = async (node: AppRunnerServiceNode) => {
-    await vscode.env.clipboard.writeText(node.url)
-    telemetry.recordApprunnerCopyServiceUrl({ passive: false })
-}
-const openUrl = async (node: AppRunnerServiceNode) => {
-    await vscode.env.openExternal(vscode.Uri.parse(node.url))
-    telemetry.recordApprunnerOpenServiceUrl({ passive: false })
+interface CommandMetadata {
+    readonly errorMessage: string
+    readonly metricName: MetricName
 }
 
-const resumeService = async (node: AppRunnerServiceNode) => {
-    let telemetryResult: telemetry.Result = 'Failed'
-    try {
-        await node.resume()
-        telemetryResult = 'Succeeded'
-    } finally {
-        telemetry.recordApprunnerResumeService({ result: telemetryResult, passive: false })
-    }
-}
+const commandMap = new Map<string, CommandMetadata & { readonly command: (...args: any[]) => unknown }>()
 
-const deployService = async (node: AppRunnerServiceNode) => {
-    let telemetryResult: telemetry.Result = 'Failed'
-    try {
-        await node.deploy()
-        telemetryResult = 'Succeeded'
-    } finally {
-        telemetry.recordApprunnerStartDeployment({ result: telemetryResult, passive: false })
-    }
-}
+commandMap.set('aws.apprunner.createService', {
+    command: createAppRunnerService,
+    metricName: 'ApprunnerCreateService',
+    errorMessage: localize('aws.apprunner.createService.failed', 'Failed to create App Runner service'),
+})
 
-commandMap.set(['aws.apprunner.createService', CREATE_SERVICE_FAILED], createAppRunnerService)
-commandMap.set(['aws.apprunner.createServiceFromEcr', CREATE_SERVICE_ECR_FAILED], createFromEcr)
-commandMap.set(['aws.apprunner.pauseService', PAUSE_SERVICE_FAILED], pauseService)
-commandMap.set(['aws.apprunner.resumeService', RESUME_SERVICE_FAILED], resumeService)
-commandMap.set(['aws.apprunner.copyServiceUrl', COPY_SERVICE_URL_FAILED], copyUrl)
-commandMap.set(['aws.apprunner.open', OPEN_SERVICE_FAILED], openUrl)
-commandMap.set(['aws.apprunner.startDeployment', DEPLOY_SERVICE_FAILED], deployService)
-commandMap.set(['aws.apprunner.deleteService', DELETE_SERVICE_FAILED], deleteService)
+commandMap.set('aws.apprunner.createServiceFromEcr', {
+    command: createFromEcr,
+    metricName: 'ApprunnerCreateService',
+    errorMessage: localize('aws.apprunner.createEcr.failed', 'Failed to create App Runner service from ECR'),
+})
+
+commandMap.set('aws.apprunner.pauseService', {
+    command: (node: AppRunnerServiceNode) => node.pause(),
+    metricName: 'ApprunnerPauseService',
+    errorMessage: localize('aws.apprunner.pauseService.failed', 'Failed to pause App Runner service'),
+})
+
+commandMap.set('aws.apprunner.resumeService', {
+    command: (node: AppRunnerServiceNode) => node.resume(),
+    metricName: 'ApprunnerResumeService',
+    errorMessage: localize('aws.apprunner.resumeService.failed', 'Failed to resume App Runner service'),
+})
+
+commandMap.set('aws.apprunner.copyServiceUrl', {
+    command: (node: AppRunnerServiceNode) => vscode.env.clipboard.writeText(node.url),
+    metricName: 'ApprunnerCopyServiceUrl',
+    errorMessage: localize('aws.apprunner.copyServiceUrl.failed', 'Failed to copy App Runner service URL'),
+})
+
+commandMap.set('aws.apprunner.open', {
+    command: (node: AppRunnerServiceNode) => vscode.env.openExternal(vscode.Uri.parse(node.url)),
+    metricName: 'ApprunnerOpenServiceUrl',
+    errorMessage: localize('aws.apprunner.open.failed', 'Failed to open App Runner service'),
+})
+
+commandMap.set('aws.apprunner.startDeployment', {
+    command: (node: AppRunnerServiceNode) => node.deploy(),
+    metricName: 'ApprunnerStartDeployment',
+    errorMessage: localize('aws.apprunner.deploy.failed', 'Failed to start deployment of App Runner service'),
+})
+
+commandMap.set('aws.apprunner.deleteService', {
+    command: (node: AppRunnerServiceNode) => node.delete(),
+    metricName: 'ApprunnerDeleteService',
+    errorMessage: localize('aws.apprunner.deleteService.failed', 'Failed to delete App Runner service'),
+})
 
 /**
  * Activates App Runner
  */
 export async function activate(context: ExtContext): Promise<void> {
-    commandMap.forEach((command, tuple) => {
-        context.extensionContext.subscriptions.push(
-            vscode.commands.registerCommand(tuple[0], async (...args: any) => {
-                try {
-                    await command(...args)
-                } catch (err) {
-                    getLogger().error(`${tuple[1]}: %O`, err)
-                    showViewLogsMessage(tuple[1])
-                }
-            })
-        )
-    })
+    function register(id: string, fn: (...args: any[]) => unknown, metadata: CommandMetadata) {
+        const withTelem = instrument(metadata.metricName, async (...args: any[]) => {
+            try {
+                await fn(...args)
+            } catch (err) {
+                getLogger().error(`${metadata.errorMessage}: %O`, err)
+                showViewLogsMessage(metadata.errorMessage)
+            }
+        })
+
+        return Commands.register(id, withTelem)
+    }
+
+    const registeredCommands = Array.from(commandMap.entries()).map(([id, data]) => register(id, data.command, data))
+    context.extensionContext.subscriptions.push(...registeredCommands)
 }

--- a/src/apprunner/commands/createService.ts
+++ b/src/apprunner/commands/createService.ts
@@ -3,38 +3,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as telemetry from '../../shared/telemetry/telemetry'
+import { getTelemetryLogger } from '../../shared/telemetry/recorder'
 import { AppRunnerNode } from '../explorer/apprunnerNode'
 import { CreateAppRunnerServiceWizard } from '../wizards/apprunnerCreateServiceWizard'
 
 export async function createAppRunnerService(node: AppRunnerNode): Promise<void> {
-    let telemetryResult: telemetry.Result = 'Failed'
-    let source: telemetry.AppRunnerServiceSource | undefined = undefined
-
-    try {
-        const wizard = new CreateAppRunnerServiceWizard(node.region)
-        const result = await wizard.run()
-        if (result === undefined) {
-            telemetryResult = 'Cancelled'
-            return
-        }
-
-        await node.createService(result)
-        source =
-            result.SourceConfiguration.CodeRepository !== undefined
-                ? 'repository'
-                : result.SourceConfiguration.ImageRepository !== undefined
-                ? result.SourceConfiguration.ImageRepository.ImageRepositoryType === 'ECR_PUBLIC'
-                    ? 'ecrPublic'
-                    : 'ecr'
-                : undefined
-        telemetryResult = 'Succeeded'
-    } finally {
-        telemetry.recordApprunnerCreateService({
-            result: telemetryResult,
-            // If we cancel there is no source type (so this should be optional)
-            appRunnerServiceSource: source as any,
-            passive: false,
-        })
+    const wizard = new CreateAppRunnerServiceWizard(node.region)
+    const result = await wizard.run()
+    if (result === undefined) {
+        getTelemetryLogger('ApprunnerCreateService').recordResult('Cancelled')
+        return
     }
+
+    await node.createService(result)
+    const source =
+        result.SourceConfiguration.CodeRepository !== undefined
+            ? 'repository'
+            : result.SourceConfiguration.ImageRepository !== undefined
+            ? result.SourceConfiguration.ImageRepository.ImageRepositoryType === 'ECR_PUBLIC'
+                ? 'ecrPublic'
+                : 'ecr'
+            : undefined
+
+    getTelemetryLogger('ApprunnerCreateService').recordAppRunnerServiceSource(source as any)
 }

--- a/src/apprunner/commands/createServiceFromEcr.ts
+++ b/src/apprunner/commands/createServiceFromEcr.ts
@@ -3,47 +3,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as telemetry from '../../shared/telemetry/telemetry'
 import * as vscode from 'vscode'
 import { EcrRepositoryNode } from '../../ecr/explorer/ecrRepositoryNode'
 import { EcrTagNode } from '../../ecr/explorer/ecrTagNode'
 
 import { CreateAppRunnerServiceWizard } from '../wizards/apprunnerCreateServiceWizard'
 import globals from '../../shared/extensionGlobals'
+import { getTelemetryLogger } from '../../shared/telemetry/recorder'
 
 export async function createFromEcr(node: EcrTagNode | EcrRepositoryNode): Promise<void> {
-    let telemetryResult: telemetry.Result = 'Failed'
+    getTelemetryLogger('ApprunnerCreateService').recordAppRunnerServiceSource('ecr')
 
-    try {
-        const ecrNode = (node as any).tag === undefined ? (node as EcrRepositoryNode) : (node as EcrTagNode).parent
-        const client = globals.toolkitClientBuilder.createAppRunnerClient(ecrNode.regionCode)
-        const wizard = new CreateAppRunnerServiceWizard(ecrNode.regionCode, {
-            SourceConfiguration: {
-                ImageRepository: {
-                    ImageIdentifier: `${ecrNode.repository.repositoryUri}:${(node as any).tag ?? 'latest'}`,
-                    ImageRepositoryType: 'ECR',
-                    ImageConfiguration: {},
-                },
-                AuthenticationConfiguration: {},
+    const ecrNode = (node as any).tag === undefined ? (node as EcrRepositoryNode) : (node as EcrTagNode).parent
+    const client = globals.toolkitClientBuilder.createAppRunnerClient(ecrNode.regionCode)
+    const wizard = new CreateAppRunnerServiceWizard(ecrNode.regionCode, {
+        SourceConfiguration: {
+            ImageRepository: {
+                ImageIdentifier: `${ecrNode.repository.repositoryUri}:${(node as any).tag ?? 'latest'}`,
+                ImageRepositoryType: 'ECR',
+                ImageConfiguration: {},
             },
-        })
-        const result = await wizard.run()
+            AuthenticationConfiguration: {},
+        },
+    })
+    const result = await wizard.run()
 
-        if (result === undefined) {
-            telemetryResult = 'Cancelled'
-            return
-        }
-
-        await client.createService(result)
-        vscode.commands.executeCommand('aws.refreshAwsExplorer', true)
-        telemetryResult = 'Succeeded'
-    } finally {
-        telemetry.recordApprunnerCreateService({
-            result: telemetryResult,
-            appRunnerServiceSource: 'ecr',
-            passive: false,
-        })
+    if (result === undefined) {
+        getTelemetryLogger('ApprunnerCreateService').recordResult('Cancelled')
+        return
     }
 
-    return undefined
+    await client.createService(result)
+    vscode.commands.executeCommand('aws.refreshAwsExplorer', true)
 }

--- a/src/apprunner/commands/deleteService.ts
+++ b/src/apprunner/commands/deleteService.ts
@@ -3,41 +3,35 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as telemetry from '../../shared/telemetry/telemetry'
-import { createHelpButton } from '../../shared/ui/buttons'
-import { createInputBox } from '../../shared/ui/inputPrompter'
-import { AppRunnerServiceNode } from '../explorer/apprunnerServiceNode'
 import * as nls from 'vscode-nls'
-import { isValidResponse } from '../../shared/wizards/wizard'
-import { getTelemetryLogger } from '../../shared/telemetry/recorder'
 const localize = nls.loadMessageBundle()
 
-function validateName(name: string) {
-    if (name !== 'delete') {
-        return localize('AWS.apprunner.deleteService.name.invalid', `Type 'delete' to confirm`)
-    }
-
-    return undefined
-}
+import * as vscode from 'vscode'
+import * as telemetry from '../../shared/telemetry/telemetry'
+import * as localizedText from '../../shared/localizedText'
+import { AppRunnerServiceNode } from '../explorer/apprunnerServiceNode'
+import { getTelemetryLogger } from '../../shared/telemetry/recorder'
 
 export async function deleteService(node: AppRunnerServiceNode): Promise<void> {
     const appRunnerServiceStatus = node.info.Status as telemetry.AppRunnerServiceStatus
 
+    getTelemetryLogger('ApprunnerDeleteService').recordPassive(false)
     getTelemetryLogger('ApprunnerDeleteService').recordAppRunnerServiceStatus(appRunnerServiceStatus)
 
-    const inputBox = createInputBox({
-        title: localize('AWS.apprunner.deleteService.title', 'Delete App Runner service'),
-        placeholder: localize('AWS.apprunner.deleteService.placeholder', 'delete'),
-        buttons: [createHelpButton('https://docs.aws.amazon.com/apprunner/latest/dg/manage-delete.html')],
-        validateInput: validateName,
-    })
+    const prompt = localize('AWS.apprunner.deleteService.title', 'Delete App Runner service?')
+    const items = [
+        { title: localizedText.ok },
+        { title: localizedText.help },
+        { title: localizedText.cancel, isCloseAffordance: true },
+    ]
+    const resp = await vscode.window.showWarningMessage(prompt, { modal: true }, ...items)
 
-    const userInput = await inputBox.prompt()
-
-    if (!isValidResponse(userInput)) {
+    if (resp?.title === localizedText.ok) {
+        await node.delete()
+    } else if (resp?.title === localizedText.help) {
+        const uri = vscode.Uri.parse('https://docs.aws.amazon.com/apprunner/latest/dg/manage-delete.html')
+        await vscode.env.openExternal(uri)
+    } else {
         getTelemetryLogger('ApprunnerDeleteService').recordResult('Cancelled')
-        return
     }
-
-    await node.delete()
 }

--- a/src/apprunner/commands/pauseService.ts
+++ b/src/apprunner/commands/pauseService.ts
@@ -7,36 +7,26 @@ import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
 import * as vscode from 'vscode'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import * as localizedText from '../../shared/localizedText'
 import { showConfirmationMessage } from '../../shared/utilities/messages'
 import { AppRunnerServiceNode } from '../explorer/apprunnerServiceNode'
 import { PromptSettings } from '../../shared/settings'
+import { getTelemetryLogger } from '../../shared/telemetry/recorder'
 
 export async function pauseService(node: AppRunnerServiceNode): Promise<void> {
-    let telemetryResult: telemetry.Result = 'Failed'
+    const prompts = PromptSettings.instance
+    const shouldNotify = await prompts.isPromptEnabled('apprunnerNotifyPause')
+    const notifyPrompt = localize(
+        'aws.apprunner.pauseService.notify',
+        'Your service will be unavailable while paused. ' +
+            'You can resume the service once the pause operation is complete.'
+    )
+    const confirmationOptions = { prompt: notifyPrompt, confirm: localizedText.ok, cancel: localizedText.cancel }
 
-    try {
-        const prompts = PromptSettings.instance
-        const shouldNotify = await prompts.isPromptEnabled('apprunnerNotifyPause')
-        const notifyPrompt = localize(
-            'aws.apprunner.pauseService.notify',
-            'Your service will be unavailable while paused. ' +
-                'You can resume the service once the pause operation is complete.'
-        )
-        const confirmationOptions = { prompt: notifyPrompt, confirm: localizedText.ok, cancel: localizedText.cancel }
-
-        if (shouldNotify && !(await showConfirmationMessage(confirmationOptions, vscode.window))) {
-            telemetryResult = 'Cancelled'
-            return
-        }
-
-        await node.pause()
-        telemetryResult = 'Succeeded'
-    } finally {
-        telemetry.recordApprunnerPauseService({
-            result: telemetryResult,
-            passive: false,
-        })
+    if (shouldNotify && !(await showConfirmationMessage(confirmationOptions, vscode.window))) {
+        getTelemetryLogger('ApprunnerPauseService').recordResult('Cancelled')
+        return
     }
+
+    await node.pause()
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -202,7 +202,7 @@ export async function activate(context: vscode.ExtensionContext) {
             remoteInvokeOutputChannel,
         })
 
-        await activateAppRunner(extContext)
+        activateAppRunner(extContext)
 
         await activateApiGateway({
             extContext: extContext,

--- a/src/shared/logger/logger.ts
+++ b/src/shared/logger/logger.ts
@@ -107,7 +107,7 @@ export class ConsoleLogger implements Logger {
         return false
     }
     public debug(message: string | Error, ...meta: any[]): number {
-        console.trace(message, meta)
+        console.debug(message, meta)
         return 0
     }
     public verbose(message: string | Error, ...meta: any[]): number {

--- a/src/shared/telemetry/recorder.ts
+++ b/src/shared/telemetry/recorder.ts
@@ -1,0 +1,189 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as telemetry from './telemetry'
+import { getLogger, Logger } from '../logger'
+import { AsyncLocalStorage } from 'async_hooks'
+
+interface Metric<T> {
+    start(): ActiveMetric<T>
+    record(data: T): void
+}
+
+type ActiveMetric<T = unknown> = TelemetryRecorder<Required<T>> & Has<T> & { stop(this: T): void }
+
+interface Has<T> {
+    has<U, K extends keyof T>(this: U, ...props: K[]): this is U & { readonly [P in K]-?: T[P] }
+}
+
+interface TelemetryEvent<T = unknown> {
+    readonly name: string
+    readonly source: string
+    readonly value: T
+    readonly timestamp: Date // could use `perf_hooks`
+}
+
+interface RecordFunction<T, K extends keyof T> {
+    <U>(this: U, value: T[K]): U & { readonly [P in K]: T[P] }
+}
+
+type TelemetryRecorder<T> = {
+    readonly [P in keyof T as `record${Capitalize<P & string>}`]: RecordFunction<T, P>
+}
+
+// This works fine for prototyping, but since we already codegen telemetry, we should generate
+// the static calls as well to avoid `Proxy`
+
+function createRecorder<T, U extends Record<string, any>>(
+    inner: U,
+    source: string,
+    queue: TelemetryEvent[]
+): U & TelemetryRecorder<T> {
+    function uncapitalize(s: string): string {
+        return `${s[0].toLowerCase()}${s.slice(1)}`
+    }
+
+    const proxy = new Proxy(inner, {
+        get: (target, prop, receiver) => {
+            if (typeof prop !== 'string') {
+                throw new TypeError(`Invalid telemetry recorder key: ${String(prop)}`)
+            }
+
+            const name = uncapitalize(prop.replace('record', ''))
+
+            if (!prop.startsWith('record')) {
+                // We should find the last event with the same name but this works for now
+                return Reflect.get(target, prop, receiver) ?? queue.find(e => e.name === name)
+            }
+
+            return <U>(value: U) => {
+                queue.push({ value, source, name, timestamp: new Date() })
+                Reflect.set(target, name, value, receiver)
+
+                return proxy
+            }
+        },
+    }) as U & TelemetryRecorder<T>
+
+    return proxy
+}
+
+function startMetric<T>(id: string, record: (data: T) => void): ActiveMetric<T> {
+    const queue = storage.getStore()?.telemetry.queue ?? []
+    const createTime = new Date()
+
+    function stop() {
+        const result: Record<string, any> = { createTime }
+        result.duration = Date.now() - createTime.getTime()
+
+        for (const event of queue.filter(event => event.source === id)) {
+            result[event.name] = event.value
+        }
+
+        // We are currently unable to do any validation here as it is implemented
+        // inside the generated `record...` functions.
+        record(result as T)
+    }
+
+    function has(this: Partial<T>, ...props: (keyof T)[]): boolean {
+        return props.map(p => this[p] !== undefined).reduce((a, b) => a && b, true)
+    }
+
+    return createRecorder({ stop, record, has }, id, queue) as ActiveMetric<T>
+}
+
+type Telemetry = Omit<typeof telemetry, 'millisecondsSince'>
+type RemoveRecord<T> = T extends `record${infer U}` ? U : T
+type Metadata<P extends keyof Telemetry> = NonNullable<Parameters<Telemetry[P]>[0]>
+
+type MappedMetrics = {
+    [P in keyof Telemetry as RemoveRecord<P>]: Metric<Metadata<P>>
+}
+
+const metrics = {} as MappedMetrics
+
+for (const [k, v] of Object.entries(telemetry)) {
+    const name = k.replace('record', '') as keyof MappedMetrics
+    const start = () => startMetric<any>(name, v)
+    metrics[name] = { start } as any
+}
+
+interface ExecutionContext {
+    readonly name: string
+    readonly logger: Logger
+    readonly telemetry: { readonly queue: TelemetryEvent[] }
+}
+
+const storage = new AsyncLocalStorage<ExecutionContext>()
+
+/**
+ * Runs a function with an {@link ExecutionContext}, containing context-specific observability
+ * utilities such as telemetry and logging.
+ */
+export function run<F extends (...args: any[]) => any>(name: string, fn: F, ...args: Parameters<F>): ReturnType<F> {
+    const context = {
+        name,
+        logger: getLogger(),
+        telemetry: { queue: [] },
+    }
+
+    return storage.run(context, fn, ...args)
+}
+
+type TelemetryLogger = {
+    [P in keyof Telemetry as RemoveRecord<P>]: TelemetryRecorder<Required<Metadata<P>>>
+}
+
+export type MetricName = keyof TelemetryLogger
+
+export function getTelemetryLogger<T extends keyof TelemetryLogger>(metric: T): TelemetryLogger[T] {
+    const queue = storage.getStore()?.telemetry?.queue ?? []
+
+    return createRecorder({}, metric, queue) as TelemetryLogger[T]
+}
+
+export function instrument<T extends keyof TelemetryLogger, U extends (...args: any[]) => unknown>(
+    metric: T,
+    fn: U
+): (...args: Parameters<U>) => ReturnType<U> {
+    const start = (...args: Parameters<U>) => {
+        type Base = Parameters<Telemetry['recordApigatewayCopyUrl']>[0]
+        const activeMetric = metrics[metric].start() as unknown as ActiveMetric<Base>
+
+        function handleFailed(error: unknown): never {
+            if (!activeMetric.has('result')) {
+                activeMetric.recordResult('Failed').stop()
+            } else {
+                activeMetric.stop()
+            }
+
+            throw error
+        }
+
+        function handleSuccess<T>(val: T): T {
+            if (!activeMetric.has('result')) {
+                activeMetric.recordResult('Succeeded').stop()
+            } else {
+                activeMetric.stop()
+            }
+
+            return val
+        }
+
+        try {
+            const ret = fn(...args) as ReturnType<U>
+
+            if (ret instanceof Promise) {
+                return ret.then(handleSuccess).catch(handleFailed) as ReturnType<U>
+            }
+
+            return handleSuccess(ret)
+        } catch (error) {
+            handleFailed(error)
+        }
+    }
+
+    return (...args) => run(metric, start, ...args)
+}

--- a/src/test/apprunner/commands/deleteService.test.ts
+++ b/src/test/apprunner/commands/deleteService.test.ts
@@ -1,0 +1,61 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import * as assert from 'assert'
+import * as sinon from 'sinon'
+import { Commands } from '../../../shared/vscode/commands2'
+import { createTestWindow } from '../../shared/vscode/window'
+import { AppRunnerServiceNode } from '../../../apprunner/explorer/apprunnerServiceNode'
+import { assertTelemetry } from '../../testUtil'
+
+describe('deleteService', function () {
+    afterEach(function () {
+        sinon.restore()
+    })
+
+    it('emits a "Cancelled" result on cancel', async function () {
+        const command = await Commands.get('aws.apprunner.deleteService')
+        assert.ok(command, 'Expected command to exist')
+
+        const testWindow = createTestWindow()
+        sinon.replace(vscode, 'window', testWindow)
+
+        const node: AppRunnerServiceNode = { info: { Status: 'CREATE_FAILED' } } as any
+
+        const pendingMessage = testWindow.waitForMessage(/Delete/)
+        pendingMessage.then(m => m.selectItem('Cancel'))
+        await command.execute(node)
+
+        assertTelemetry('apprunner_deleteService', {
+            passive: false,
+            result: 'Cancelled',
+            appRunnerServiceStatus: 'CREATE_FAILED',
+        })
+    })
+
+    it('emits service status metadata when running the command', async function () {
+        const command = await Commands.get('aws.apprunner.deleteService')
+        assert.ok(command, 'Expected command to exist')
+
+        const testWindow = createTestWindow()
+        sinon.replace(vscode, 'window', testWindow)
+
+        const node: AppRunnerServiceNode = {
+            info: { Status: 'CREATE_FAILED' },
+            async delete() {},
+        } as any
+
+        const pendingMessage = testWindow.waitForMessage(/Delete/)
+        pendingMessage.then(m => m.selectItem('OK'))
+        await command.execute(node)
+
+        assertTelemetry('apprunner_deleteService', {
+            passive: false,
+            result: 'Succeeded',
+            appRunnerServiceStatus: 'CREATE_FAILED',
+        })
+    })
+})


### PR DESCRIPTION
## Problem
Our telemetry requires us to record everything in one big data blob at the end of execution. This means everything we might care about needs to be stored somewhere during execution. Storing everything we care about becomes impractical for larger features as we might only know the value in some subset of the total execution flow. While this can be solved by using global variables, we definitely don't want that to become a pattern.

## Solution
Using `AsyncStorage` to give a execution its own metadata queue to dump data into. We then record the metric after the execution ends. I modified the App Runner feature to use this as an example. It's still clunky though because the telemetry code generation needs to be changed for this to work nicely.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
