### PR TITLE
fix(build): get rid of noisy module error

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -116,6 +116,10 @@ const vueConfig = {
     name: 'vue',
     target: 'web',
     entry: createVueEntries(),
+    output: {
+        ...baseConfig.output,
+        libraryTarget: 'this',
+    },
     module: {
         rules: baseConfig.module.rules.concat(
             {


### PR DESCRIPTION
## Problem
Webpack was using CJS as the library target for bundled browser code
This caused a harmless error message to show up in the console

## Solution
Use `this` assignment as the library target

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
