### PR TITLE
Bump amazon-states-language-service dependency to ^1.7.2

### DIFF
--- a/.changes/next-release/Bug Fix-13d65c25-8be7-458a-8c16-081996e70da9.json
+++ b/.changes/next-release/Bug Fix-13d65c25-8be7-458a-8c16-081996e70da9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Bump amazon-states-language-service dependency to ^1.7.2 to allow state machines with non-object values for Parameters property"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "aws-toolkit-vscode",
-            "version": "1.38.0-SNAPSHOT",
+            "version": "1.39.0-SNAPSHOT",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -17,7 +17,7 @@
                 "@aws-sdk/credential-provider-sso": "^3.38.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
                 "adm-zip": "^0.5.9",
-                "amazon-states-language-service": "^1.7.1",
+                "amazon-states-language-service": "^1.7.2",
                 "async-lock": "^1.3.0",
                 "aws-sdk": "^2.1048.0",
                 "aws-ssm-document-language-service": "^1.0.0",
@@ -4058,9 +4058,9 @@
             }
         },
         "node_modules/amazon-states-language-service": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.7.1.tgz",
-            "integrity": "sha512-OsBrlivTLw0YP8+aPzYbaCTsKArZX024m6Gg75a0XYZwq1wktt1Eil+0me8MSJP6l5NC37qbnDWOPV83CXLlSQ==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.7.2.tgz",
+            "integrity": "sha512-TUCv5/Z/NAqhBUmwS/0oFRFvXmd/8yyNW48Qu/9MRud0GK0k9c5Kdf2vdL0azOl7qIXDi82Emc89MBJEZuydkQ==",
             "dependencies": {
                 "js-yaml": "^3.14.0",
                 "vscode-json-languageservice": "3.4.9",
@@ -16887,9 +16887,9 @@
             "requires": {}
         },
         "amazon-states-language-service": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.7.1.tgz",
-            "integrity": "sha512-OsBrlivTLw0YP8+aPzYbaCTsKArZX024m6Gg75a0XYZwq1wktt1Eil+0me8MSJP6l5NC37qbnDWOPV83CXLlSQ==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.7.2.tgz",
+            "integrity": "sha512-TUCv5/Z/NAqhBUmwS/0oFRFvXmd/8yyNW48Qu/9MRud0GK0k9c5Kdf2vdL0azOl7qIXDi82Emc89MBJEZuydkQ==",
             "requires": {
                 "js-yaml": "^3.14.0",
                 "vscode-json-languageservice": "3.4.9",

--- a/package.json
+++ b/package.json
@@ -3005,7 +3005,7 @@
         "@aws-sdk/credential-provider-sso": "^3.38.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
         "adm-zip": "^0.5.9",
-        "amazon-states-language-service": "^1.7.1",
+        "amazon-states-language-service": "^1.7.2",
         "async-lock": "^1.3.0",
         "aws-sdk": "^2.1048.0",
         "aws-ssm-document-language-service": "^1.0.0",


### PR DESCRIPTION
## Problem
Customers are not able to provide non-object values for the `Parameters` property in their Step Functions state machines. This behaviour is not consistent with the linting done in the AWS Console, which permits the value to be any type. 

## Solution
The schema for the `Parameters` property was updated to accept any type in https://github.com/aws/amazon-states-language-service/pull/83. Bumping the package version to `^1.7.2` to pull in this change. 

## Testing 
Confirmed that non-object values are permitted for the `Parameters` property when bumping the version to `^1.7.2`. 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
