### PR TITLE
fix(git): prevent users from passing additional flags to ls-remote

### DIFF
--- a/src/shared/extensions/git.ts
+++ b/src/shared/extensions/git.ts
@@ -252,7 +252,7 @@ export class GitExtension {
         // TODO: make a promise 'pipe' function
         if (branches.length === 0) {
             try {
-                const { stdout } = await execFileAsync(api.git.path, ['ls-remote', '--heads', remote.fetchUrl ?? ''])
+                const { stdout } = await execFileAsync(api.git.path, ['ls-remote', '--heads', '--', remote.fetchUrl ?? ''])
                 return stdout
                     .toString()
                     .split(/\r?\n/)


### PR DESCRIPTION
before:
```
error: unknown option `test'
```

after:
```
fatal: strange pathname '--test' blocked
```

## Problem
Users can provide flags to be passed to `ls-remote`

## Solution
POSIX guidelines state that any arguments after `--` should be treated as operands instead of flags

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
