### PR TITLE
fix(cdk): address more C9 edge-cases

### DIFF
--- a/src/awsexplorer/localExplorer.ts
+++ b/src/awsexplorer/localExplorer.ts
@@ -58,7 +58,9 @@ export function createLocalExplorerView(): vscode.TreeView<TreeNode> {
 
     // Cloud9 will only refresh when refreshing the entire tree
     if (isCloud9()) {
-        cdkNode.onDidChangeChildren(() => treeDataProvider.refresh())
+        roots.forEach(node => {
+            node.onDidChangeChildren?.(() => treeDataProvider.refresh())
+        })
     }
 
     return view

--- a/src/awsexplorer/localExplorer.ts
+++ b/src/awsexplorer/localExplorer.ts
@@ -9,6 +9,7 @@ import { cdkNode } from '../cdk/explorer/rootNode'
 import { ResourceTreeDataProvider, TreeNode } from '../shared/treeview/resourceTreeDataProvider'
 import { once } from '../shared/utilities/functionUtils'
 import { AppNode } from '../cdk/explorer/nodes/appNode'
+import { isCloud9 } from '../shared/extensionUtilities'
 
 export interface RootNode extends TreeNode {
     canShow?(): Promise<boolean> | boolean
@@ -54,6 +55,11 @@ export function createLocalExplorerView(): vscode.TreeView<TreeNode> {
 
     // Legacy CDK behavior. Mostly useful for C9 as they do not have inline buttons.
     view.onDidChangeVisibility(({ visible }) => visible && cdkNode.refresh())
+
+    // Cloud9 will only refresh when refreshing the entire tree
+    if (isCloud9()) {
+        cdkNode.onDidChangeChildren(() => treeDataProvider.refresh())
+    }
 
     return view
 }

--- a/src/cdk/explorer/detectCdkProjects.ts
+++ b/src/cdk/explorer/detectCdkProjects.ts
@@ -23,7 +23,7 @@ export async function detectCdkProjects(
 
     projects.forEach(p => results.set(p.cdkJsonUri.toString(), p))
 
-    return Array.from(projects.values())
+    return Array.from(results.values())
 }
 
 async function detectCdkProjectsFromWorkspaceFolder(

--- a/src/cdk/explorer/nodes/appNode.ts
+++ b/src/cdk/explorer/nodes/appNode.ts
@@ -19,7 +19,7 @@ import { createPlaceholderItem } from '../../../shared/treeview/utils'
  * Existence of apps is determined by the presence of `cdk.json` in a workspace folder
  */
 export class AppNode implements TreeNode {
-    public readonly id = this.makeId()
+    public readonly id = this.location.cdkJsonUri.toString()
     public readonly resource = this.location
     public readonly treeItem: vscode.TreeItem
 
@@ -57,12 +57,6 @@ export class AppNode implements TreeNode {
                 ),
             ]
         }
-    }
-
-    private makeId() {
-        const rootUri = vscode.Uri.joinPath(this.location.cdkJsonUri, '..')
-
-        return vscode.workspace.asRelativePath(rootUri)
     }
 
     private createTreeItem() {

--- a/src/test/cdk/detectCdkProjects.test.ts
+++ b/src/test/cdk/detectCdkProjects.test.ts
@@ -85,6 +85,20 @@ describe('detectCdkProjects', function () {
         assert.strictEqual(actual.length, 0)
     })
 
+    it('de-dupes identical projects`', async function () {
+        workspaceFolders.push(workspaceFolders[0])
+
+        try {
+            const cdkJsonUri = vscode.Uri.joinPath(workspaceFolders[0].uri, 'cdk.json')
+            await saveCdkJson(cdkJsonUri.fsPath)
+
+            const actual = await detectCdkProjects(workspaceFolders)
+            assert.strictEqual(actual.length, 1)
+        } finally {
+            workspaceFolders.pop()
+        }
+    })
+
     it('takes into account `output` from cdk.json to build tree.json path', async function () {
         const cdkJsonUri = vscode.Uri.joinPath(workspaceFolders[0].uri, 'cdk.json')
         await writeJSON(cdkJsonUri.fsPath, { app: 'npx ts-node bin/demo-nov7.ts', output: 'build/cdk.out' })

--- a/src/test/cdk/explorer/appNode.test.ts
+++ b/src/test/cdk/explorer/appNode.test.ts
@@ -26,7 +26,7 @@ describe('AppNode', function () {
     it('uses the `cdk.json` uri as its id', async function () {
         const testNode = getTestNode()
 
-        assert.strictEqual(testNode.id, vscode.Uri.parse(cdkJsonPath).toString())
+        assert.strictEqual(testNode.id, vscode.Uri.file(cdkJsonPath).toString())
     })
 
     it('initializes label and tooltip', async function () {

--- a/src/test/cdk/explorer/appNode.test.ts
+++ b/src/test/cdk/explorer/appNode.test.ts
@@ -23,6 +23,12 @@ describe('AppNode', function () {
     const cdkJsonPath = path.join(getTestWorkspaceFolder(), workspaceFolderName, 'cdk.json')
     const treePath = path.join(cdkJsonPath, '..', 'cdk.out', 'tree.json')
 
+    it('uses the `cdk.json` uri as its id', async function () {
+        const testNode = getTestNode()
+
+        assert.strictEqual(testNode.id, vscode.Uri.parse(cdkJsonPath).toString())
+    })
+
     it('initializes label and tooltip', async function () {
         const testNode = getTestNode()
 


### PR DESCRIPTION
## Problem
* C9 creates a new workspace folder when creating a new CDK app for some reason
* C9 doesn't listen for `onDidChangeTreeData` correctly (can't refresh a child node)

## Solution
Make the item IDs extremely precise and add a `isCloud9` check when refreshing.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
