### PR TITLE
fix(schema support): fix yaml schemas occasionally not getting associated with cfn/sam yaml files

### DIFF
--- a/.changes/next-release/Bug Fix-4ce9962e-2b34-4e0b-9201-d23e0c5e7901.json
+++ b/.changes/next-release/Bug Fix-4ce9962e-2b34-4e0b-9201-d23e0c5e7901.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix issue where occasionally yaml schemas weren't getting loaded for cfn/sam"
+}

--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -365,7 +365,7 @@ export namespace CloudFormation {
         [key: string]: Resource | undefined
     }
 
-    export async function load(filename: string): Promise<Template> {
+    export async function load(filename: string, validate: boolean = true): Promise<Template> {
         if (!(await SystemUtilities.fileExists(filename))) {
             throw new Error(`Template file not found: ${filename}`)
         }
@@ -374,7 +374,10 @@ export namespace CloudFormation {
         const template = yaml.load(templateAsYaml, {
             schema: schema as any,
         }) as Template
-        validateTemplate(template)
+
+        if (validate) {
+            validateTemplate(template)
+        }
 
         return template
     }

--- a/src/shared/cloudformation/templateRegistry.ts
+++ b/src/shared/cloudformation/templateRegistry.ts
@@ -28,7 +28,7 @@ export class CloudFormationTemplateRegistry extends WatchedFiles<CloudFormation.
 
         let template: CloudFormation.Template | undefined
         try {
-            template = await CloudFormation.load(path)
+            template = await CloudFormation.load(path, false)
         } catch (e) {
             globals.schemaService.registerMapping({ path, type: 'yaml', schema: undefined })
             return undefined

--- a/src/test/shared/cloudformation/cloudformation.test.ts
+++ b/src/test/shared/cloudformation/cloudformation.test.ts
@@ -151,6 +151,24 @@ describe('CloudFormation', function () {
             const template = await CloudFormation.load(filename)
             assert.strictEqual(template.Resources!['TestResource']?.Properties?.CodeUri, '')
         })
+
+        it('Loads invalid YAML when validation is disabled', async function () {
+            // handler is missing
+            const invalidYamlStr: string = `AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Resources:
+    TestResource:
+        Type: ${CloudFormation.SERVERLESS_FUNCTION_TYPE}
+        Properties:
+            CodeUri: asdf
+            Runtime: runtime
+            Timeout: 1
+            Environment:
+                Variables:
+                    ENVVAR: envvar`
+            await strToYamlFile(invalidYamlStr, filename)
+            await assert.doesNotReject(CloudFormation.load(filename, false))
+        })
     })
 
     describe('save', async function () {


### PR DESCRIPTION
## Problem
Currently yaml schema association to cfn/sam yaml files sometimes fails because `cloudformation.load` does additional validation on the yaml document (basically checks if some fields exist on the resources). In some cases, this can cause the `cloudformation.load` to fail, resulting in the schema not getting applied to the cfn/sam yaml files when it should be.

## Solution
Add the option to specify whether or not the yaml document should be validated when being loaded. This will allow us to disable upfront validation done while loading the file so that the schema is properly associated and then subsequently validated by vscode-yaml.

Ideally I would have like to have an integration test for this but vscode-yaml doesn't provide any way for us to get the current schema associated for the file 😢  

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
