### PR TITLE
build(deps): bump typescript to 4.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "semver": "^7.3.5",
                 "strip-ansi": "^5.2.0",
                 "tcp-port-used": "^1.0.1",
-                "typescript": "^4.6.4",
+                "typescript": "^4.7.2",
                 "uuid": "^8.3.2",
                 "vscode-languageclient": "^6.1.4",
                 "vscode-languageserver": "^6.1.1",
@@ -12012,9 +12012,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.6.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-            "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+            "version": "4.7.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+            "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -23010,9 +23010,9 @@
             }
         },
         "typescript": {
-            "version": "4.6.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-            "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg=="
+            "version": "4.7.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+            "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A=="
         },
         "uc.micro": {
             "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -3024,7 +3024,7 @@
         "semver": "^7.3.5",
         "strip-ansi": "^5.2.0",
         "tcp-port-used": "^1.0.1",
-        "typescript": "^4.6.4",
+        "typescript": "^4.7.2",
         "uuid": "^8.3.2",
         "vscode-languageclient": "^6.1.4",
         "vscode-languageserver": "^6.1.1",

--- a/src/test/shared/vscode/testUtils.ts
+++ b/src/test/shared/vscode/testUtils.ts
@@ -13,8 +13,7 @@ type InterceptEmitters<T, K extends keyof T> = {
     [P in K as `fire${Capitalize<P & string>}`]: T[P] extends vscode.Event<infer R>
         ? vscode.EventEmitter<R>['fire']
         : never
-} &
-    T // prettier really wants to keep this T separate
+} & T // prettier really wants to keep this T separate
 type FilteredKeys<T> = { [P in keyof T]: T[P] extends never ? never : P }[keyof T]
 type NoNever<T> = Pick<T, FilteredKeys<T>>
 
@@ -49,7 +48,9 @@ export function exposeEmitters<T, K extends EventEmitters<T>>(obj: T, keys: K[])
     })
 
     if (keys.length > 0) {
-        throw new Error(`exposeEmitters(): failed to find emitters for keys ${keys.map(k => `"${k}"`).join(', ')}`)
+        throw new Error(
+            `exposeEmitters(): failed to find emitters for keys ${keys.map(k => `"${String(k)}"`).join(', ')}`
+        )
     }
 
     return obj as any


### PR DESCRIPTION
Typescript 4.7 has some great new features:
* Generic function instantiation
* Explicit variance notation
* Extends/infer short-hand (finally...)
* Better CFA, esp. for indexed fields
* ES module support

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
