### PR TITLE
fix(telemetry): lift local defs into aws-toolkit-common

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
                 "yaml-cfn": "^0.3.1"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.53",
+                "@aws-toolkits/telemetry": "^1.0.54",
                 "@sinonjs/fake-timers": "^8.1.0",
                 "@types/adm-zip": "^0.4.34",
                 "@types/async-lock": "^1.1.3",
@@ -2252,9 +2252,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.53",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.53.tgz",
-            "integrity": "sha512-LsuUyx7biI2uL9YpMJPlHNdWHyFJAEcIHVPSAqUHTv08O9naJkXcxqUvvu3voJEL6ikSAsfcMzlKdx68TCAudw==",
+            "version": "1.0.54",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.54.tgz",
+            "integrity": "sha512-6Y1QE7MBpvup0rDspZCkSFqnKnnB2bQNJXoCiTWChHtUIYV1vIlQgq0GNjMpjwDS6vqjsUJa04RVGNpa9lqM4g==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",
@@ -15395,9 +15395,9 @@
             }
         },
         "@aws-toolkits/telemetry": {
-            "version": "1.0.53",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.53.tgz",
-            "integrity": "sha512-LsuUyx7biI2uL9YpMJPlHNdWHyFJAEcIHVPSAqUHTv08O9naJkXcxqUvvu3voJEL6ikSAsfcMzlKdx68TCAudw==",
+            "version": "1.0.54",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.54.tgz",
+            "integrity": "sha512-6Y1QE7MBpvup0rDspZCkSFqnKnnB2bQNJXoCiTWChHtUIYV1vIlQgq0GNjMpjwDS6vqjsUJa04RVGNpa9lqM4g==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
                 "yaml-cfn": "^0.3.1"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "1.0.49",
+                "@aws-toolkits/telemetry": "^1.0.53",
                 "@sinonjs/fake-timers": "^8.1.0",
                 "@types/adm-zip": "^0.4.34",
                 "@types/async-lock": "^1.1.3",
@@ -2252,9 +2252,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.49",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.49.tgz",
-            "integrity": "sha512-gCHetHqwIK048u8EnjctD4gcRi4KUN2cS5JZbOR1jMJmKF0e2v1xe/BbI3ubnmTlfuFFmWsn1pfdqGr94541aw==",
+            "version": "1.0.53",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.53.tgz",
+            "integrity": "sha512-LsuUyx7biI2uL9YpMJPlHNdWHyFJAEcIHVPSAqUHTv08O9naJkXcxqUvvu3voJEL6ikSAsfcMzlKdx68TCAudw==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",
@@ -15395,9 +15395,9 @@
             }
         },
         "@aws-toolkits/telemetry": {
-            "version": "1.0.49",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.49.tgz",
-            "integrity": "sha512-gCHetHqwIK048u8EnjctD4gcRi4KUN2cS5JZbOR1jMJmKF0e2v1xe/BbI3ubnmTlfuFFmWsn1pfdqGr94541aw==",
+            "version": "1.0.53",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.53.tgz",
+            "integrity": "sha512-LsuUyx7biI2uL9YpMJPlHNdWHyFJAEcIHVPSAqUHTv08O9naJkXcxqUvvu3voJEL6ikSAsfcMzlKdx68TCAudw==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -2938,7 +2938,7 @@
         "report": "nyc report --reporter=html --reporter=json"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.53",
+        "@aws-toolkits/telemetry": "^1.0.54",
         "@sinonjs/fake-timers": "^8.1.0",
         "@types/adm-zip": "^0.4.34",
         "@types/async-lock": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -2938,7 +2938,7 @@
         "report": "nyc report --reporter=html --reporter=json"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "1.0.49",
+        "@aws-toolkits/telemetry": "^1.0.53",
         "@sinonjs/fake-timers": "^8.1.0",
         "@types/adm-zip": "^0.4.34",
         "@types/async-lock": "^1.1.3",

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -107,13 +107,16 @@ export async function resumeCreateNewSamApp(
         getLogger().error('Error resuming new SAM Application: %O', err as Error)
     } finally {
         activationReloadState.clearSamInitState()
+        const arch = samInitState?.architecture as telemetry.Architecture
         telemetry.recordSamInit({
             lambdaPackageType: samInitState?.isImage ? 'Image' : 'Zip',
+            lambdaArchitecture: arch,
+            // Legacy field, redundant with lambdaArchitecture. #2676
+            architecture: arch,
             result: createResult,
             reason: reason,
             runtime: samInitState?.runtime as telemetry.Runtime,
             version: samVersion,
-            architecture: samInitState?.architecture as telemetry.Architecture,
         })
     }
 }
@@ -340,11 +343,13 @@ export async function createNewSamApplication(
     } finally {
         telemetry.recordSamInit({
             lambdaPackageType: lambdaPackageType,
+            lambdaArchitecture: initArguments?.architecture,
+            // Legacy field, redundant with lambdaArchitecture. #2676
+            architecture: initArguments?.architecture,
             result: createResult,
             reason: reason,
             runtime: createRuntime as telemetry.Runtime,
             version: samVersion,
-            architecture: initArguments?.architecture,
         })
     }
 }

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -107,12 +107,10 @@ export async function resumeCreateNewSamApp(
         getLogger().error('Error resuming new SAM Application: %O', err as Error)
     } finally {
         activationReloadState.clearSamInitState()
-        const arch = samInitState?.architecture as telemetry.Architecture
+        const arch = samInitState?.architecture as telemetry.LambdaArchitecture
         telemetry.recordSamInit({
             lambdaPackageType: samInitState?.isImage ? 'Image' : 'Zip',
             lambdaArchitecture: arch,
-            // Legacy field, redundant with lambdaArchitecture. #2676
-            architecture: arch,
             result: createResult,
             reason: reason,
             runtime: samInitState?.runtime as telemetry.Runtime,
@@ -344,8 +342,6 @@ export async function createNewSamApplication(
         telemetry.recordSamInit({
             lambdaPackageType: lambdaPackageType,
             lambdaArchitecture: initArguments?.architecture,
-            // Legacy field, redundant with lambdaArchitecture. #2676
-            architecture: initArguments?.architecture,
             result: createResult,
             reason: reason,
             runtime: createRuntime as telemetry.Runtime,

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -218,6 +218,8 @@ async function invokeLambdaHandler(
                 runtime: config.runtime as telemetry.Runtime,
                 debug: !config.noDebug,
                 httpMethod: config.api?.httpMethod,
+                lambdaArchitecture: config.architecture,
+                // Legacy field, redundant with lambdaArchitecture. #2676
                 architecture: config.architecture,
             })
         }
@@ -305,11 +307,13 @@ async function invokeLambdaHandler(
             }
             telemetry.recordLambdaInvokeLocal({
                 lambdaPackageType: isImageLambdaConfig(config) ? 'Image' : 'Zip',
+                lambdaArchitecture: config.architecture,
+                // Legacy field, redundant with lambdaArchitecture. #2676
+                architecture: config.architecture,
                 result: invokeResult,
                 runtime: config.runtime as telemetry.Runtime,
                 debug: !config.noDebug,
                 version: samVersion,
-                architecture: config.architecture,
             })
         }
 
@@ -402,11 +406,13 @@ export async function runLambdaFunction(
             onRecordAttachDebuggerMetric: (attachResult: boolean | undefined, attempts: number): void => {
                 telemetry.recordSamAttachDebugger({
                     lambdaPackageType: isImageLambdaConfig(config) ? 'Image' : 'Zip',
+                    lambdaArchitecture: config.architecture,
+                    // Legacy field, redundant with lambdaArchitecture. #2676
+                    architecture: config.architecture,
                     runtime: config.runtime as telemetry.Runtime,
                     result: attachResult ? 'Succeeded' : 'Failed',
                     attempts: attempts,
                     duration: timer.elapsedTime,
-                    architecture: config.architecture,
                 })
             },
         })

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -219,8 +219,6 @@ async function invokeLambdaHandler(
                 debug: !config.noDebug,
                 httpMethod: config.api?.httpMethod,
                 lambdaArchitecture: config.architecture,
-                // Legacy field, redundant with lambdaArchitecture. #2676
-                architecture: config.architecture,
             })
         }
 
@@ -308,8 +306,6 @@ async function invokeLambdaHandler(
             telemetry.recordLambdaInvokeLocal({
                 lambdaPackageType: isImageLambdaConfig(config) ? 'Image' : 'Zip',
                 lambdaArchitecture: config.architecture,
-                // Legacy field, redundant with lambdaArchitecture. #2676
-                architecture: config.architecture,
                 result: invokeResult,
                 runtime: config.runtime as telemetry.Runtime,
                 debug: !config.noDebug,
@@ -407,8 +403,6 @@ export async function runLambdaFunction(
                 telemetry.recordSamAttachDebugger({
                     lambdaPackageType: isImageLambdaConfig(config) ? 'Image' : 'Zip',
                     lambdaArchitecture: config.architecture,
-                    // Legacy field, redundant with lambdaArchitecture. #2676
-                    architecture: config.architecture,
                     runtime: config.runtime as telemetry.Runtime,
                     result: attachResult ? 'Succeeded' : 'Failed',
                     attempts: attempts,

--- a/src/shared/telemetry/vscodeTelemetry.json
+++ b/src/shared/telemetry/vscodeTelemetry.json
@@ -16,12 +16,6 @@
             "name": "starterTemplate",
             "type": "string",
             "description": "Starter template chosen during create document"
-        },
-        {
-            "name": "architecture",
-            "type": "string",
-            "description": "SAM Application architecture",
-            "allowedValues": ["x86_64", "arm64"]
         }
     ],
     "metrics": [
@@ -144,55 +138,6 @@
                 {
                     "type": "result"
                 }
-            ]
-        },
-        {
-            "name": "sam_init",
-            "description": "Called when initing a sam application",
-            "metadata": [
-                { "type": "result" },
-                { "type": "runtime", "required": false },
-                { "type": "templateName", "required": false },
-                { "type": "version", "required": false },
-                { "type": "lambdaPackageType", "required": false },
-                { "type": "reason", "required": false },
-                { "type": "eventBridgeSchema", "required": false },
-                { "type": "architecture", "required": false }
-            ]
-        },
-        {
-            "name": "apigateway_invokeLocal",
-            "description": "Invoking one simulated API Gateway call using the SAM cli",
-            "metadata": [
-                { "type": "runtime", "required": false },
-                { "type": "httpMethod", "required": false },
-                { "type": "result" },
-                { "type": "debug" },
-                { "type": "architecture", "required": false }
-            ]
-        },
-        {
-            "name": "lambda_invokeLocal",
-            "description": "Called when invoking lambdas locally (with SAM in most toolkits)",
-            "metadata": [
-                { "type": "runtime", "required": false },
-                { "type": "version", "required": false },
-                { "type": "lambdaPackageType" },
-                { "type": "result" },
-                { "type": "debug" },
-                { "type": "architecture", "required": false }
-            ]
-        },
-        {
-            "name": "sam_attachDebugger",
-            "description": "Called after trying to attach a debugger to a local sam invoke",
-            "metadata": [
-                { "type": "result" },
-                { "type": "lambdaPackageType" },
-                { "type": "runtime" },
-                { "type": "attempts" },
-                { "type": "duration" },
-                { "type": "architecture", "required": false }
             ]
         }
     ]


### PR DESCRIPTION
todo

- ~~bump dependency after https://github.com/aws/aws-toolkit-common/pull/324 is merged~~

## Problem

local telemetry defs should be in aws-toolkit-common

## Solution

move them. https://github.com/aws/aws-toolkit-common/pull/324


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
