### PR TITLE
fix(telemetry): aws_refreshCredentials is passive

### DIFF
--- a/src/shared/telemetry/vscodeTelemetry.json
+++ b/src/shared/telemetry/vscodeTelemetry.json
@@ -28,6 +28,7 @@
         {
             "name": "aws_refreshCredentials",
             "description": "Emitted when credentials are automatically refreshed by the AWS SDK",
+            "passive": true,
             "metadata": [
                 {
                     "type": "result"


### PR DESCRIPTION
## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
