### PR TITLE
feat(links): add console deep-linking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1016,6 +1016,10 @@
                     "when": "false"
                 },
                 {
+                    "command": "aws.deepLinks.openResource",
+                    "when": "false"
+                },
+                {
                     "command": "aws.dev.openMenu",
                     "when": "aws.isDevMode"
                 }
@@ -1648,6 +1652,11 @@
                     "command": "aws.cdk.viewDocs",
                     "when": "viewItem == awsCdkRootNode",
                     "group": "0@2"
+                },
+                {
+                    "command": "aws.deepLinks.openResource",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsCloudFormationFunctionNode|awsStateMachineNode|awsCloudFormationNode|awsCloudWatchLogNode|awsS3BucketNode|awsS3FolderNode|awsS3FileNode|awsApiGatewayNode|awsEcrRepositoryNode|awsIotThingNode)$|^(awsAppRunnerServiceNode|awsEcsServiceNode|awsIotCertificateNode|awsIotPolicyNode|awsIotPolicyVersionNode)/",
+                    "group": "2@3"
                 }
             ]
         },
@@ -2764,6 +2773,11 @@
                         "category": "%AWS.title.cn%"
                     }
                 }
+            },
+            {
+                "command": "aws.deepLinks.openResource",
+                "title": "%AWS.command.deepLinks.openResource%",
+                "category": "%AWS.title%"
             },
             {
                 "command": "aws.dev.openMenu",

--- a/package.nls.json
+++ b/package.nls.json
@@ -160,6 +160,7 @@
     "AWS.command.apprunner.copyServiceUrl": "Copy Service URL",
     "AWS.command.apprunner.open": "Open in Browser",
     "AWS.command.apprunner.startDeployment": "Start Deployment",
+    "AWS.command.deepLinks.openResource": "Open resource in browser...",
     "AWS.command.resources.copyIdentifier": "Copy Identifier",
     "AWS.command.resources.configure": "Show Resources...",
     "AWS.lambda.explorerTitle": "Explorer",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,6 +65,7 @@ import { join } from 'path'
 import { initializeIconPaths } from './shared/icons'
 import { Settings } from './shared/settings'
 import { isReleaseVersion } from './shared/vscode/env'
+import { activate as activateDeepLinks } from './shared/deeplinks/activation'
 
 let localize: nls.LocalizeFunc
 
@@ -235,6 +236,8 @@ export async function activate(context: vscode.ExtensionContext) {
         }
 
         await activateStepFunctions(context, awsContext, toolkitOutputChannel)
+
+        activateDeepLinks(extContext)
 
         showWelcomeMessage(context)
 

--- a/src/shared/clients/stsClient.ts
+++ b/src/shared/clients/stsClient.ts
@@ -3,9 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import globals from '../extensionGlobals'
+
 import { STS } from 'aws-sdk'
 import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
-import globals from '../extensionGlobals'
+import { CancellationToken } from 'vscode'
+import { addCancellationToken, RequestExtras } from '../awsClientBuilder'
 import { ClassToInterfaceType } from '../utilities/tsUtils'
 
 export type StsClient = ClassToInterfaceType<DefaultStsClient>
@@ -25,6 +28,31 @@ export class DefaultStsClient {
         const sdkClient = await this.createSdkClient()
         const response = await sdkClient.getCallerIdentity().promise()
         return response
+    }
+
+    public async getFederationToken(
+        request: Partial<STS.GetFederationTokenRequest> = {},
+        cancellationToken?: CancellationToken
+    ): Promise<STS.GetFederationTokenResponse & { Credentials: STS.Credentials }> {
+        const sdkClient = await this.createSdkClient()
+        const req = sdkClient.getFederationToken({
+            Name: 'FederationViaAWSToolkitForVSCode',
+            DurationSeconds: 900,
+            PolicyArns: [{ arn: 'arn:aws:iam::aws:policy/AdministratorAccess' }],
+            ...request,
+        })
+
+        if (cancellationToken) {
+            addCancellationToken(cancellationToken)(req as unknown as typeof req & RequestExtras)
+        }
+
+        const response = await req.promise()
+
+        if (!response.Credentials) {
+            throw new Error('"getFederationToken" returned invalid credentials')
+        }
+
+        return response as STS.GetFederationTokenResponse & { Credentials: STS.Credentials }
     }
 
     private async createSdkClient(): Promise<STS> {

--- a/src/shared/deeplinks/activation.ts
+++ b/src/shared/deeplinks/activation.ts
@@ -1,0 +1,72 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as nls from 'vscode-nls'
+const localize = nls.loadMessageBundle()
+
+import * as vscode from 'vscode'
+import * as telemetry from '../../shared/telemetry/telemetry'
+import { Arn, isArn, parse } from './arn'
+import { Commands } from '../vscode/commands2'
+import { ExtContext } from '../extensions'
+import { ArnScanner } from './scanner'
+import { AWSResourceNode, isAwsResourceNode } from '../treeview/nodes/awsResourceNode'
+import { ConsoleLinkBuilder } from './builder'
+import { AWSTreeNodeBase } from '../treeview/nodes/awsTreeNodeBase'
+import { getLogger } from '../logger'
+import { showViewLogsMessage } from '../utilities/messages'
+
+// known bugs:
+// * S3 directory links are unreliable. Looks like their link format needs updates.
+// * API gateway ARNs need to specify a 'resource' to work correctly
+
+// TODO: remove S3Folder and APIG from nodes for now
+
+export function activate(context: ExtContext): void {
+    const scanner = new ArnScanner(target => openArnCommand.build(target).asUri())
+
+    context.extensionContext.subscriptions.push(
+        vscode.languages.registerDocumentLinkProvider({ pattern: '**/*' }, scanner),
+        openArnCommand.register()
+    )
+}
+
+function openResourceCommand(target?: AWSResourceNode | Arn | string | unknown) {
+    if (target instanceof AWSTreeNodeBase && isAwsResourceNode(target)) {
+        return openArn(target.arn, 'Explorer')
+    } else if (typeof target === 'string' || isArn(target)) {
+        return openArn(target, 'Editor')
+    } else {
+        getLogger().error('Links: unknown object was not an ARN or did not have an ARN: %O', target)
+        showViewLogsMessage(localize('aws.deepLinks.unknownResource', 'Unable to open a resource without an ARN'))
+    }
+}
+
+async function openArn(input: string | Arn, source: 'Editor' | 'Explorer'): Promise<void> {
+    let result: telemetry.Result = 'Failed'
+
+    // TODO: show status bar + optional cancel if it takes too long to open the link
+    try {
+        const arn = typeof input === 'string' ? parse(input) : input
+        const builder = new ConsoleLinkBuilder(arn.region)
+        const link = await builder.getLinkFromArn(arn)
+
+        await vscode.env.openExternal(link)
+    } catch (error) {
+        result = 'Failed'
+        const message = localize(
+            'aws.deepLinks.genericError',
+            `Failed to open resource: {0}`,
+            error instanceof Error ? error.message : String(error)
+        )
+
+        getLogger().error(`Links: failed to open resource: %O`, error)
+        await vscode.window.showErrorMessage(message)
+    } finally {
+        telemetry.recordDeeplinkOpen({ result, source, passive: false })
+    }
+}
+
+const openArnCommand = Commands.declare('aws.deepLinks.openResource', () => openResourceCommand)

--- a/src/shared/deeplinks/arn.ts
+++ b/src/shared/deeplinks/arn.ts
@@ -1,0 +1,101 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { hasStringProps } from '../utilities/tsUtils'
+
+// The AWS SDK v3 has an ARN parser util, however, it is too simple to be useful
+// for parsing user input or files.
+
+export interface Arn {
+    readonly partition: string
+    readonly service: string
+    readonly region: string
+    readonly accountId: string
+    readonly resource: string
+}
+
+export interface ParseResult {
+    readonly data: Arn
+    readonly offset: number
+    readonly text: string
+}
+
+export function toString(arn: Arn): string {
+    return `arn:${arn.partition}:${arn.service}:${arn.region}:${arn.accountId}:${arn.resource}`
+}
+
+export function isArn(obj: unknown): obj is Arn {
+    const props: (keyof Arn)[] = ['partition', 'service', 'region', 'accountId', 'resource']
+
+    return typeof obj === 'object' && !!obj && hasStringProps(obj, ...props)
+}
+
+export function parse(text: string): Arn {
+    const { value, done } = parseAll(text).next()
+
+    if (done) {
+        throw new Error('Not a valid ARN') // We can obviously do better
+    }
+
+    return value.data
+}
+
+export function* parseAll(text: string): Generator<ParseResult> {
+    const regexp = new RegExp(arnRegexp.source, arnRegexp.flags)
+    let match: RegExpExecArray | null
+
+    // A simple two-step parsing strategy could be used here to find malformed ARNs in addition
+    // to valid ones. The first pass finds the candidates, the 2nd drills into specific resource types.
+    while ((match = regexp.exec(text))) {
+        yield {
+            data: mapMatch(match),
+            text: match[0],
+            offset: match.index,
+        }
+    }
+}
+
+const unescaped = [
+    /arn:/,
+    /(?<partition1>(?:aws)|(?:aws-cn)|(?:aws-us-gov)):/,
+    /(?<service1>[\w\-]{1,128}):/,
+    /(?<region1>[\w\-]{0,128}):/,
+    /(?<accountId1>[0-9]{0,128}):/,
+    /(?<resource1>[^\s]{0,2048}[^\s'",.!])/,
+]
+
+const escaped = [
+    /arn:/,
+    /(?<partition2>(?:aws)|(?:aws-cn)|(?:aws-us-gov)):/,
+    /(?<service2>[\w\-]{1,128}):/,
+    /(?<region2>[\w\-]{0,128}):/,
+    /(?<accountId2>[0-9]{0,128}):/,
+    /(?<resource2>.{0,2048})/,
+]
+
+const r1 = unescaped.reduce((a, b) => new RegExp(a.source + b.source), new RegExp(''))
+const r2 = escaped.reduce((a, b) => new RegExp(a.source + b.source), new RegExp(''))
+const arnRegexp = new RegExp(`(?:${r1.source})|(?:(?<quote>'|")${r2.source}\\k<quote>)`, 'g')
+
+// Safety: unit tests make sure that these keys are accurate
+function getKey(groups: Record<string, string>, key: string): string {
+    return groups[`${key}1`] ?? groups[`${key}2`]
+}
+
+function mapMatch(match: RegExpExecArray): Arn {
+    const groups = match.groups
+
+    if (!groups) {
+        throw new Error('No match groups found')
+    }
+
+    return {
+        partition: getKey(groups, 'partition'),
+        service: getKey(groups, 'service'),
+        region: getKey(groups, 'region'),
+        accountId: getKey(groups, 'accountId'),
+        resource: getKey(groups, 'resource'),
+    }
+}

--- a/src/shared/deeplinks/builder.ts
+++ b/src/shared/deeplinks/builder.ts
@@ -1,0 +1,127 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Uri, CancellationToken } from 'vscode'
+import { DefaultStsClient, StsClient } from '../clients/stsClient'
+import { getLogger } from '../logger'
+import { Arn, toString } from './arn'
+import { RequestError } from 'got/dist/source'
+import { buildLoginUri, consoleProxyUri, FederatedAccess, getFederatedAccess } from './federation'
+import { withCancellationToken } from '../utilities/gotUtils'
+import { isCloud9 } from '../extensionUtilities'
+
+const DEEP_LINK_PATH = '/go/view'
+const EXPIRATION_TOLERANCE = 30000
+
+export class ConsoleLinkBuilder {
+    // Storing a token per-region is somewhat redundant, though it does 'future-proof' this code
+    private static readonly accessTokens: { [region: string]: FederatedAccess | undefined } = {}
+    private readonly client: StsClient
+
+    public constructor(region?: string)
+    public constructor(client: StsClient)
+    public constructor(arg?: string | StsClient) {
+        this.client = !arg || typeof arg === 'string' ? new DefaultStsClient(arg || 'us-east-1') : arg
+    }
+
+    /**
+     * Resolves a link to the AWS console, redirecting the user to the {@link path} after automatically
+     * logging in. Links will start to expire immediately after creation. Do not cache or store these
+     * links as callers have no way of knowing if they're expired or not.
+     *
+     * Example:
+     * ```ts
+     * const builder = new ConsoleLinkBuilder()
+     * const link = await builder.getFederatedLink('/console/home')
+     *
+     * // takes the user to the console (IAD) with a temporary login
+     * vscode.env.openExternal(link)
+     * ```
+     */
+    public async getFederatedLink(path: string, cancellationToken?: CancellationToken): Promise<Uri> {
+        const accessToken = await this.getAccessToken(cancellationToken)
+
+        return buildLoginUri(accessToken, this.client.regionCode, path)
+    }
+
+    /**
+     * Attempts to get a link to the console for the given {@link arn}.
+     *
+     * This may return a federated link, though it is best-effort as being logged-in is not a requirement.
+     * See {@link getFederatedLink} for more information about federation.
+     *
+     * ARNs are partially validated prior to generating a link. There are multiple modes of failure, so callers
+     * are expected to handle errors generally.
+     */
+    public async getLinkFromArn(arn: string | Arn, cancellationToken?: CancellationToken): Promise<Uri> {
+        const resolved = typeof arn === 'string' ? arn : toString(arn)
+        const deepLink = await this.getConsoleLink(resolved, cancellationToken)
+
+        // Cloud9 doesn't need federation as they are already in the console
+        if (isCloud9()) {
+            return deepLink
+        }
+
+        const target = await this.getFederatedLink(`${DEEP_LINK_PATH}/${resolved}`, cancellationToken).catch(err => {
+            getLogger().info(`Links: unable to get federated link, opening "${resolved}" without federated access`)
+            getLogger().verbose(`Links: failed to get federated link: %O`, err)
+
+            return deepLink
+        })
+
+        return target
+    }
+
+    private timeRemaining(token: FederatedAccess): number {
+        return token.expiration.getUTCMilliseconds() - Date.now() - EXPIRATION_TOLERANCE
+    }
+
+    private async getAccessToken(cancellationToken?: CancellationToken): Promise<string> {
+        const token = ConsoleLinkBuilder.accessTokens[this.client.regionCode]
+
+        if (!token || this.timeRemaining(token) <= 0) {
+            getLogger().debug('Links: no valid federation token, getting new one')
+            const newToken = await getFederatedAccess(this.client, cancellationToken)
+
+            return (ConsoleLinkBuilder.accessTokens[this.client.regionCode] = newToken).secret
+        }
+
+        return token.secret
+    }
+
+    // The response returns a header "x-amzn-redirectiontype" that can either be 'detail' or 'home' to refer
+    // to the destination type. We can just ignore that for now though.
+    //
+    // Links returned by this method are good as-is, but it's recommended to use them as a federated link if
+    // they're being automatically opened. If the user just wants the link itself, then skip the federation step.
+    private async getConsoleLink(arn: string, cancellationToken?: CancellationToken): Promise<Uri> {
+        const target = new URL(consoleProxyUri(this.client.regionCode, DEEP_LINK_PATH).toString(true))
+        target.searchParams.set('arn', arn)
+
+        const response = await withCancellationToken(cancellationToken)(target.href, { followRedirect: false }).catch(
+            error => {
+                if (error instanceof RequestError) {
+                    if (error.response?.statusCode === 400) {
+                        throw new Error('ARN was malformed or request was invalid')
+                    } else if (error.response?.statusCode === 404) {
+                        throw new Error('Resource not supported')
+                    }
+                }
+
+                throw error
+            }
+        )
+
+        if (response.statusCode !== 302) {
+            throw new Error(`Unexpected status code: ${response.statusCode}. Expected redirect (302).`)
+        }
+
+        if (!response.headers.location) {
+            throw new Error('Expected redirect to contain "location" header')
+        }
+
+        return Uri.parse(response.headers.location)
+    }
+}

--- a/src/shared/deeplinks/federation.ts
+++ b/src/shared/deeplinks/federation.ts
@@ -1,0 +1,101 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Uri, CancellationToken } from 'vscode'
+import { StsClient } from '../clients/stsClient'
+import { withCancellationToken } from '../utilities/gotUtils'
+
+/**
+ * The proxy URI automatically redirects to the correct console endpoint based off region.
+ */
+export function consoleProxyUri(region: string, path = '/'): Uri {
+    return Uri.parse(`https://${region}.console.${consoleTld()}`).with({ path })
+}
+
+/**
+ * Creates a new URI that automatically logins into the console using a federation token
+ * via {@link getFederatedAccess}.
+ *
+ * The {@link path} argument is relative to the console and must start with a slash (`/`).
+ * Paths are always URI encoded; any encoding beforehand may lead to unexpected results.
+ */
+export function buildLoginUri(token: string, region: string, path = '/'): Uri {
+    if (!path.startsWith('/')) {
+        throw new Error('URI path should start with `/`')
+    }
+
+    // Currently have to use this weird combo of URL + URI due to a double-encoding bug
+    // with VS Code's URI: https://github.com/microsoft/vscode/issues/85930
+    // Otherwise we could just use `consoleProxyUri` here.
+    //
+    // Possible workaround for opening links (not document links): https://github.com/microsoft/vscode/pull/141944
+
+    // TODO: we should discover the correct partition from the region
+
+    const url = new URL(federationUrl(region))
+    const destination = `https://${region}.console.${consoleTld()}${path}`
+
+    url.searchParams.set('Action', 'login')
+    url.searchParams.set('SigninToken', token)
+    url.searchParams.set('Destination', destination)
+
+    return Uri.parse(url.href)
+}
+
+export interface FederatedAccess {
+    readonly secret: string
+    readonly expiration: Date
+}
+
+/**
+ * Creates a new access token with permissions equal to the currently assumed role.
+ *
+ * The expiration time is inferred and may have some degree of inaccuracy.
+ */
+export async function getFederatedAccess(
+    client: StsClient,
+    cancellationToken?: CancellationToken
+): Promise<FederatedAccess> {
+    const federationToken = await client.getFederationToken({}, cancellationToken)
+    const url = new URL(federationUrl(client.regionCode))
+
+    url.searchParams.set('Action', 'getSigninToken')
+    url.searchParams.set('SessionType', 'json')
+    url.searchParams.set(
+        'Session',
+        JSON.stringify({
+            sessionId: federationToken.Credentials.AccessKeyId,
+            sessionKey: federationToken.Credentials.SecretAccessKey,
+            sessionToken: federationToken.Credentials.SessionToken,
+        })
+    )
+
+    const response = await withCancellationToken(cancellationToken)(url.href).json<{ SigninToken: string }>()
+
+    return {
+        secret: response.SigninToken,
+        expiration: federationToken.Credentials.Expiration,
+    }
+}
+
+type SupportedPartition = 'aws' | 'aws-cn' | 'aws-us-gov'
+
+function consoleTld(partition: SupportedPartition = 'aws'): string {
+    switch (partition) {
+        case 'aws':
+            return 'aws.amazon.com'
+        case 'aws-cn':
+            return 'amazonaws.com.cn'
+        case 'aws-us-gov':
+            return 'amazonaws-us-gov.com'
+    }
+}
+
+function federationUrl(region: string, partition: SupportedPartition = 'aws'): string {
+    const topLevelDomain = partition === 'aws-cn' ? 'signin.amazonaws.cn' : `signin.${consoleTld(partition)}`
+    const subDomain = ['us-east-1', 'us-gov-west-1', 'cn-north-1'].includes(region) ? '' : `${region}.`
+
+    return `https://${subDomain}${topLevelDomain}/federation`
+}

--- a/src/shared/deeplinks/scanner.ts
+++ b/src/shared/deeplinks/scanner.ts
@@ -1,0 +1,48 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as nls from 'vscode-nls'
+const localize = nls.loadMessageBundle()
+
+import * as vscode from 'vscode'
+import { parseAll, Arn } from './arn'
+
+/**
+ * Provides links in a document, derived from ARNs.
+ */
+export class ArnScanner implements vscode.DocumentLinkProvider {
+    public constructor(private readonly redirect: (target: Arn) => vscode.Uri) {}
+
+    public provideDocumentLinks(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.DocumentLink[] {
+        const links: vscode.DocumentLink[] = []
+
+        for (let currentLine = 0; currentLine < document.lineCount && !token.isCancellationRequested; currentLine++) {
+            const line = document.lineAt(currentLine)
+
+            if (line.isEmptyOrWhitespace) {
+                continue
+            }
+
+            for (const [range, result] of this.getCandidates(currentLine, line.text, token)) {
+                const link = new vscode.DocumentLink(range, this.redirect(result.data))
+                link.tooltip = localize('aws.deepLinks.documentLink.tooltip', 'Open resource in browser')
+                links.push(link)
+            }
+        }
+
+        return links
+    }
+
+    private *getCandidates(lineNumber: number, text: string, token: vscode.CancellationToken) {
+        for (const result of parseAll(text)) {
+            const range = new vscode.Range(lineNumber, result.offset, lineNumber, result.offset + result.text.length)
+            yield [range, result] as const
+
+            if (token.isCancellationRequested) {
+                break
+            }
+        }
+    }
+}

--- a/src/shared/treeview/nodes/awsResourceNode.ts
+++ b/src/shared/treeview/nodes/awsResourceNode.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { AWSTreeNodeBase } from './awsTreeNodeBase'
+
 export interface AWSResourceNode {
     /**
      * Returns the ARN of the AWS resource. All nodes should return an ARN or throw an Error if not found.
@@ -13,4 +15,11 @@ export interface AWSResourceNode {
      * Returns the name of the AWS resource.
      */
     readonly name: string
+}
+
+export function isAwsResourceNode(node: AWSTreeNodeBase): node is AWSTreeNodeBase & AWSResourceNode {
+    return (
+        typeof (node as unknown as AWSResourceNode).arn === 'string' &&
+        typeof (node as unknown as AWSResourceNode).name === 'string'
+    )
 }

--- a/src/shared/utilities/gotUtils.ts
+++ b/src/shared/utilities/gotUtils.ts
@@ -1,0 +1,53 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as http from 'http'
+import * as https from 'https'
+import got, { Got, GotReturn } from 'got'
+import urlToOptions from 'got/dist/source/core/utils/url-to-options'
+import { userAgent } from '../vscode/env'
+import { CancellationError, isCancelEvent } from './timeoutUtils'
+import { CancellationToken } from 'vscode'
+import { isCloud9 } from '../extensionUtilities'
+
+// XXX: patched Got module for compatability with Cloud9
+// `got` has also deprecated `urlToOptions`
+export function patchedGot(): Got {
+    if (!isCloud9()) {
+        return got
+    }
+
+    return got.extend({
+        request: (url, options, callback) => {
+            if (url.protocol === 'https:') {
+                return https.request({ ...options, ...urlToOptions(url) }, callback)
+            }
+            return http.request({ ...options, ...urlToOptions(url) }, callback)
+        },
+    })
+}
+
+export function withCancellationToken(cancellationToken?: CancellationToken, target = got): Got {
+    function isCancellable(obj: unknown): obj is { cancel(): void } {
+        return typeof obj === 'object' && !!obj && typeof (obj as any).cancel === 'function'
+    }
+
+    function cancel(event: unknown, request: GotReturn): void {
+        const response = isCancelEvent(event) ? new CancellationError(event.agent) : undefined
+        isCancellable(request) ? request.cancel(response?.message) : request.destroy(response)
+    }
+
+    return target.extend({
+        headers: { 'User-Agent': userAgent() },
+        handlers: [
+            (options, next) => {
+                const request = next(options)
+                cancellationToken?.onCancellationRequested(event => cancel(event, request))
+
+                return request
+            },
+        ],
+    })
+}

--- a/src/shared/utilities/tsUtils.ts
+++ b/src/shared/utilities/tsUtils.ts
@@ -3,12 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export const getPropAs = <T>(obj: any, key: string) => {
-    return (
-        obj as any as {
-            [key: string]: T
+export function hasStringProps<T extends Record<string, any>, K extends string[]>(
+    obj: T,
+    ...props: K
+): obj is T & { [P in K[number]]: string } {
+    for (const p of props) {
+        if (typeof obj[p] !== 'string') {
+            return false
         }
-    )[key]
+    }
+    return true
 }
 
 export function isNonNullable<T>(obj: T): obj is NonNullable<T> {

--- a/src/shared/vscode/env.ts
+++ b/src/shared/vscode/env.ts
@@ -95,3 +95,9 @@ export function getMinVscodeVersion(): string {
 export function getMinNodejsVersion(): string {
     return packageJson.devDependencies['@types/node'].replace(/[^~]/, '')
 }
+
+export function userAgent() {
+    const platformName = vscode.env.appName.replace(/\s/g, '-')
+
+    return `AWS-Toolkit-For-VSCode/${extensionVersion} ${platformName}/${vscode.version}`
+}

--- a/src/test/shared/credentials/accountId.test.ts
+++ b/src/test/shared/credentials/accountId.test.ts
@@ -23,7 +23,7 @@ describe('getAccountId', function () {
         assumeRole: () => {
             throw new Error('This test was not initialized')
         },
-    }
+    } as any
 
     const clientBuilder = {
         createStsClient: (): StsClient => {

--- a/src/test/shared/deeplinks/arn.test.ts
+++ b/src/test/shared/deeplinks/arn.test.ts
@@ -1,0 +1,117 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { Arn, parse, parseAll, ParseResult, toString } from '../../../shared/deeplinks/arn'
+
+describe('ARNs', function () {
+    interface TestCase {
+        readonly input: string
+        readonly expected?: string
+    }
+
+    it('can be converted to a string', function () {
+        const arn: Arn = {
+            partition: 'aws',
+            service: 'slackbot',
+            region: 'af-south-1',
+            accountId: '',
+            resource: 'my/resource/',
+        }
+
+        assert.strictEqual(toString(arn), 'arn:aws:slackbot:af-south-1::my/resource/')
+    })
+
+    describe('valid cases', function () {
+        const cases: Record<string, TestCase> = {
+            'no region': { input: 'arn:aws:iam::123456789012:user/Development/product-abc_1234/*' },
+            'no account or region': { input: 'arn:aws:s3:::my_corporate_bucket/Development/*' },
+            'single quotes': {
+                input: "'arn:aws:s3:::testbucket/sam_squirrel_1.jpg'",
+                expected: 'arn:aws:s3:::testbucket/sam_squirrel_1.jpg',
+            },
+            'double quotes': {
+                input: '"arn:aws:states:us-east-1:000000:stateMachine:MyStateMachine"',
+                expected: 'arn:aws:states:us-east-1:000000:stateMachine:MyStateMachine',
+            },
+            spaces: {
+                input: '  \n arn:aws:iot:us-weast-99:123567:cert/h123khqkwjhsdi12   /asas123jasasd\nasjkdk',
+                expected: 'arn:aws:iot:us-weast-99:123567:cert/h123khqkwjhsdi12',
+            },
+            'spaces and commas': {
+                input: '   //,  arn:aws:apigateway:us-west-2::/apis/h123kas,\n    arn:aws:s3::::::',
+                expected: 'arn:aws:apigateway:us-west-2::/apis/h123kas',
+            },
+            'quoted spaces': {
+                input: "  'arn:aws:ecr:us-east-1:8134918:r e p o'   ",
+                expected: 'arn:aws:ecr:us-east-1:8134918:r e p o',
+            },
+            'quoted punctuation': {
+                input: '"arn:aws:s3:::bucket/file."',
+                expected: 'arn:aws:s3:::bucket/file.',
+            },
+        }
+
+        for (const [name, { input, expected }] of Object.entries(cases)) {
+            it(`can parse ARNs with ${name}`, function () {
+                const result = parse(input)
+                assert.strictEqual(toString(result), expected ?? input)
+            })
+        }
+    })
+
+    describe('invalid cases', function () {
+        const cases: Record<string, TestCase> = {
+            'partial values': { input: 'arn:::' },
+            'a bad partition': { input: 'arn:bad:s3:::testbucket/sam_squirrel_1.jpg' },
+            'an invalid account': { input: 'arn:aws:iot:us-weast-99:acccccoount1234:cert/h123khqkwjhsdi12' },
+            'no service': { input: 'arn:aws::::' },
+            'non-alphanumeric services': { input: 'arn:aws:s3?:::/' },
+            'non-alphanumeric regions': { input: 'arn:aws:lambda:us.weast]1:0123456:my_handler' },
+        }
+
+        for (const [name, { input }] of Object.entries(cases)) {
+            it(`throws on ARNs with ${name}`, function () {
+                assert.throws(() => parse(input))
+            })
+        }
+    })
+
+    describe('parseAll', function () {
+        it('returns the exact matched text', function () {
+            const input = 'arn: "arn:aws:cloudformation:east:1234:stack/3hj4kjsh21io3/f1de8d4e1"'
+            const { value, done } = parseAll(input).next()
+
+            assert.ok(!done)
+            assert.strictEqual(value.text, '"arn:aws:cloudformation:east:1234:stack/3hj4kjsh21io3/f1de8d4e1"')
+        })
+
+        it('can parse multiple ARNs from text', function () {
+            const input = `
+/* one arn is arn:aws:apigateway:us-west-2::/apis/h123kas,\n  but this is not: arn:aws: arn:s3:::::: and
+definitely neither is this "arn:aws:iot:us-weast-99:acccccoount1234:cert/h123khqkwjhsdi12"
+*/
+
+some other ARNs: arn:aws:s3:::testbucket/sam_squirrel_1.jpg, "arn:aws:states:us-east-1:000000:stateMachine:MyStateMachine"
+as well as arn:aws:iot:us-east-1:7687686789:policy/new-policy.
+`
+            const result = Array.from(parseAll(input))
+            const str = (r: ParseResult) => toString(r.data)
+
+            assert.strictEqual(result.length, 4)
+
+            assert.strictEqual(str(result[0]), 'arn:aws:apigateway:us-west-2::/apis/h123kas')
+            assert.strictEqual(str(result[1]), 'arn:aws:s3:::testbucket/sam_squirrel_1.jpg')
+            assert.strictEqual(str(result[2]), 'arn:aws:states:us-east-1:000000:stateMachine:MyStateMachine')
+            assert.strictEqual(str(result[3]), 'arn:aws:iot:us-east-1:7687686789:policy/new-policy')
+
+            // Recommended to just generate these expected values if changing the input
+            assert.strictEqual(result[0].offset, 15)
+            assert.strictEqual(result[1].offset, 217)
+            assert.strictEqual(result[2].offset, 261)
+            assert.strictEqual(result[3].offset, 334)
+        })
+    })
+})

--- a/src/test/shared/deeplinks/scanner.test.ts
+++ b/src/test/shared/deeplinks/scanner.test.ts
@@ -1,0 +1,78 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import * as assert from 'assert'
+import { ArnScanner } from '../../../shared/deeplinks/scanner'
+
+// With modern tools, ARNs don't appear in hand-written files that frequently.
+// They're usually encountered as output from tooling. The credentials `config`
+// file is one place where IAM roles commonly show up.
+//
+// CFN templates also commonly contain ARNs, but they tend to show up as templated
+// patterns instead of absolute values. Which we have no good way of resolving.
+
+const sampleConfig = `
+[profile admin]
+region = us-west-2
+role_arn = arn:aws:iam::1234567890:role/Admin
+source_profile = base
+role_session_name = admin
+
+[profile read-only]
+region = us-west-2
+role_arn = arn:aws:iam::1234567890:role/ReadOnly
+source_profile = base
+role_session_name = read-only
+`
+
+describe('ArnScanner', function () {
+    // This isn't exactly what the Console uses but it's good enough for a test
+    const baseUrl = 'https://console.aws.amazon.com/iamv2/home'
+    const getDocument = () => vscode.workspace.openTextDocument({ content: sampleConfig })
+
+    it('provides links for ARNs', async function () {
+        const document = await getDocument()
+        const tokenSource = new vscode.CancellationTokenSource()
+        const scanner = new ArnScanner(arn => vscode.Uri.parse(`${baseUrl}#${arn.resource}`))
+        const links = scanner.provideDocumentLinks(document, tokenSource.token)
+
+        assert.strictEqual(links.length, 2)
+        assert.strictEqual(links[0].target?.toString(true), `${baseUrl}#role/Admin`)
+        assert.strictEqual(links[1].target?.toString(true), `${baseUrl}#role/ReadOnly`)
+        assert.deepStrictEqual(links[0].range, new vscode.Range(3, 11, 3, 45))
+        assert.deepStrictEqual(links[1].range, new vscode.Range(9, 11, 9, 48))
+    })
+
+    it('does not provide links if given a cancelled token', async function () {
+        const document = await getDocument()
+        const tokenSource = new vscode.CancellationTokenSource()
+        tokenSource.cancel()
+
+        const scanner = new ArnScanner(() => {
+            throw new Error('No links should be provided')
+        })
+        const links = scanner.provideDocumentLinks(document, tokenSource.token)
+
+        assert.strictEqual(links.length, 0)
+    })
+
+    // This test currently covers an impossible scenario as `provideDocumentLinks` is not async
+    // There is no way for the VS Code API to cancel the token as the event loop is never ran
+    it('stops providing links if cancelled while parsing', async function () {
+        const document = await getDocument()
+        const tokenSource = new vscode.CancellationTokenSource()
+
+        const scanner = new ArnScanner(arn => {
+            tokenSource.cancel()
+            return vscode.Uri.parse(`${baseUrl}#${arn.resource}`)
+        })
+
+        const links = scanner.provideDocumentLinks(document, tokenSource.token)
+
+        assert.strictEqual(links.length, 1)
+        assert.strictEqual(links[0].target?.toString(true), `${baseUrl}#role/Admin`)
+    })
+})


### PR DESCRIPTION
## Problem
The Toolkit is pretty good at showing the user their resources, but we lack all the features the AWS Console has for manipulating them.

## Solution
Add a way to go from ARN straight to the AWS Console. Current entry points are any text editors (including the output channel) and the AWS Explorer. 


### TODO
* Add status bar and cancel 
* Add setting to not automatically federate as it's not always desirable
* Finish writing tests and basic code clean-up

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
