### PR TITLE
fix(s3): presigned URL silently fails

### DIFF
--- a/src/shared/clients/s3Client.ts
+++ b/src/shared/clients/s3Client.ts
@@ -310,7 +310,7 @@ export class DefaultS3Client {
         const operation = request.operation ? request.operation : 'getObject'
         const s3 = await this.createS3()
 
-        const url = s3.getSignedUrl(operation, {
+        const url = await s3.getSignedUrlPromise(operation, {
             Bucket: request.bucketName,
             Key: request.key,
             Body: request.body,


### PR DESCRIPTION
## Problem:
Presigned URL service call returns only "https://s3.us-west-2.amazonaws.com/"
without any of the token material.

## Solution:
Use the promise API.

aws-sdk-js source:
https://github.com/aws/aws-sdk-js/blob/13972722111c801e3455353f7eeca6116566bf3b/lib/services/s3.js#L911

TODO: root cause

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
