### PR TITLE
feat(ui): sticky buttons everywhere

### DIFF
--- a/.changes/next-release/Bug Fix-c23296a6-e165-4532-aad9-3ef885d69277.json
+++ b/.changes/next-release/Bug Fix-c23296a6-e165-4532-aad9-3ef885d69277.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "S3 \"Presigned URL\" feature may silently fail #2687"
+}

--- a/.changes/next-release/Feature-87ca1b13-8fee-442d-bf0d-651e70451eba.json
+++ b/.changes/next-release/Feature-87ca1b13-8fee-442d-bf0d-651e70451eba.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "UI: buttons for Lambda invoke, API invoke, and other forms are now always visible at the top of the form"
+}

--- a/media/css/base-cloud9.css
+++ b/media/css/base-cloud9.css
@@ -169,7 +169,7 @@ body.vscode-dark .settings-panel {
 body.vscode-light .settings-panel {
     background: rgba(var(--shade), 0.02) !important;
 }
-#invoke-button-container {
+.button-container {
     border: none !important;
     background: none !important;
 }

--- a/media/css/base.css
+++ b/media/css/base.css
@@ -117,6 +117,7 @@ button,
 button,
 .button-theme-primary:hover:not(:disabled) {
     background: var(--vscode-button-hoverBackground);
+    cursor: pointer;
 }
 .button-theme-secondary {
     color: var(--vscode-button-secondaryForeground);
@@ -125,6 +126,7 @@ button,
 }
 .button-theme-secondary:hover:not(:disabled) {
     background: var(--vscode-button-secondaryHoverBackground);
+    cursor: pointer;
 }
 .button-theme-soft {
     color: var(--vscode-settings-textInputForeground);
@@ -251,9 +253,24 @@ textarea {
 .display-contents {
     display: contents;
 }
+
 .button-container {
     display: flex;
     align-items: flex-start;
     flex-direction: row;
-    margin: 16px 0 0 0;
+    /* margin: 16px 0 0 0; */
+    padding: 10px;
+    position: sticky;
+    top: 10px;
+    justify-content: flex-end;
+    border-bottom: 1px solid var(--vscode-menu-separatorBackground);
+    /**
+     * HACK: Using background-color alpha as a workaround because "opacity" affects children.
+     * TODO: Is there a way to use alpha with var(--vscode-menu-background) ?
+     */
+    /* background-color: rgba(0, 0, 0, 0.1); */
+}
+
+.button-container h1 {
+    margin: 0px;
 }

--- a/src/apigateway/vue/invokeApi.vue
+++ b/src/apigateway/vue/invokeApi.vue
@@ -1,10 +1,20 @@
 /*! * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved. * SPDX-License-Identifier: Apache-2.0 */
 
 <template>
-    <h1>Invoke methods on {{ initialData.ApiName }} ({{ initialData.ApiId }})</h1>
-    <pre>{{ initialData.ApiArn }}</pre>
-    <br />
     <div id="app">
+        <div class="container button-container" style="justify-content: space-between">
+            <h1>API: {{ initialData.ApiName }} ({{ initialData.ApiId }})</h1>
+            <div v-if="errors.length">
+                <b>Validation error(s):</b>
+                <ul>
+                    <li v-for="error in errors" :key="error">{{ error }}</li>
+                </ul>
+            </div>
+            <div>
+                <button class="" @click="sendInput" :disabled="isLoading">{{ invokeText }}</button>
+            </div>
+        </div>
+        <pre>{{ initialData.ApiArn }}</pre>
         <h3>Select a resource:</h3>
         <select v-model="selectedApiResource" v-on:change="setApiResource">
             <option disabled value="">Select a resource</option>
@@ -32,16 +42,7 @@
         <input type="text" v-model="queryString" />
         <br />
         <br />
-        <textarea rows="20" cols="90" v-model="jsonInput"></textarea>
-        <br />
-        <button class="mt-16 mb-16" @click="sendInput" :disabled="isLoading">{{ invokeText }}</button>
-        <br />
-        <div v-if="errors.length">
-            <b>Please correct the following error(s):</b>
-            <ul>
-                <li v-for="error in errors" :key="error">{{ error }}</li>
-            </ul>
-        </div>
+        <textarea style="width: 100%; margin-bottom: 10px" rows="10" cols="90" v-model="jsonInput"></textarea>
     </div>
 </template>
 

--- a/src/eventSchemas/vue/searchSchemas.vue
+++ b/src/eventSchemas/vue/searchSchemas.vue
@@ -1,8 +1,17 @@
 <template>
-    <h1>
-        {{ initialData.Header }}
-    </h1>
     <div id="app">
+        <div class="container button-container" style="justify-content: space-between">
+            <h1>{{ initialData.Header }}</h1>
+            <div>
+                <input
+                    type="submit"
+                    :disabled="downloadDisabled"
+                    v-on:click="downloadClicked"
+                    value="Download Code Bindings"
+                />
+            </div>
+        </div>
+
         <div id="search_input">
             <input type="search" v-model="searchText" :placeholder="initialData.SearchInputPlaceholder" />
         </div>
@@ -23,8 +32,6 @@
                 <textarea readonly v-model="schemaContent"></textarea>
             </div>
         </div>
-
-        <input type="submit" :disabled="downloadDisabled" v-on:click="downloadClicked" value="Download Code Bindings" />
     </div>
 </template>
 

--- a/src/feedback/vue/submitFeedback.vue
+++ b/src/feedback/vue/submitFeedback.vue
@@ -2,7 +2,16 @@
 
 <template>
     <div>
-        <h1>Feedback for AWS Toolkit</h1>
+        <div class="container button-container" style="justify-content: space-between">
+            <h1>Feedback for AWS Toolkit</h1>
+            <div id="error" v-if="error !== ''" style="margin-right: 10px">
+                <strong>{{ error }}</strong>
+            </div>
+            <div>
+                <input v-if="isSubmitting" type="submit" value="Submitting..." disabled />
+                <input v-else type="submit" @click="submitFeedback" :disabled="comment.length > 2000" value="Send" />
+            </div>
+        </div>
 
         <h3 id="sentiment-heading">How was your experience?</h3>
         <div>
@@ -15,33 +24,27 @@
         <h3 id="feedback-heading">Feedback</h3>
 
         <div>
-            <textarea style="width: 100%" rows="10" cols="90" v-model="comment"></textarea>
             <div>
-                <div
-                    style="float: right; font-size: smaller"
-                    id="remaining"
-                    :class="comment.length > 2000 ? 'exceeds-max-length' : ''"
-                >
-                    {{ 2000 - comment.length }} characters remaining
-                </div>
-                <div>
-                    <em
-                        >Feedback is <b>anonymous</b>. If you need a reply,
-                        <a href="https://github.com/aws/aws-toolkit-vscode/issues/new/choose">contact us on GitHub</a
-                        >.</em
+                <div style="margin-bottom: 10px">
+                    <div
+                        style="float: right; font-size: smaller"
+                        id="remaining"
+                        :class="comment.length > 2000 ? 'exceeds-max-length' : ''"
                     >
+                        {{ 2000 - comment.length }} characters remaining
+                    </div>
+                    <div>
+                        <em
+                            >Feedback is <b>anonymous</b>. If you need a reply,
+                            <a href="https://github.com/aws/aws-toolkit-vscode/issues/new/choose"
+                                >contact us on GitHub</a
+                            >.</em
+                        >
+                    </div>
                 </div>
             </div>
+            <textarea style="width: 100%; margin-bottom: 10px" rows="10" cols="90" v-model="comment"></textarea>
         </div>
-
-        <div id="error" v-if="error !== ''" style="float: right">
-            <strong>{{ error }}</strong>
-        </div>
-
-        <p>
-            <input v-if="isSubmitting" type="submit" value="Submitting..." disabled />
-            <input v-else type="submit" @click="submitFeedback" :disabled="comment.length > 2000" value="Send" />
-        </p>
     </div>
 </template>
 

--- a/src/lambda/vue/configEditor/samInvoke.css
+++ b/src/lambda/vue/configEditor/samInvoke.css
@@ -30,17 +30,6 @@ textarea {
     color: rgb(218, 31, 31);
 }
 
-#invoke-button-container {
-    padding: 15px 15px;
-    position: sticky;
-    bottom: 20px;
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-end;
-    border: 1px solid var(--vscode-menu-separatorBackground);
-    margin-top: 32px;
-}
-
 .required {
     color: red;
 }

--- a/src/lambda/vue/configEditor/samInvokeComponent.vue
+++ b/src/lambda/vue/configEditor/samInvokeComponent.vue
@@ -6,11 +6,16 @@
 <template>
     <form class="invoke-lambda-form">
         <h1>Edit SAM Debug Configuration</h1>
+        <div class="container button-container" id="invoke-button-container">
+            <button class="" v-on:click.prevent="launch">Invoke</button>
+            <button class="form-buttons" v-on:click.prevent="loadConfig">Load Existing Config</button>
+            <button class="form-buttons" v-on:click.prevent="save">Save</button>
+        </div>
         <p>
             <em>
-                Using this form you can create, edit, and run launch configs of <code>type:aws-sam</code>. When you
+                Using this form you can create, edit, and run launch-configs of <code>type:aws-sam</code>. When you
                 <strong>Invoke</strong> the launch config, {{ company }} Toolkit calls SAM CLI and attaches the debugger
-                to the code runing in a local Docker container.
+                to the code running in a local Docker container.
             </em>
         </p>
         <settings-panel id="config-panel" title="Configuration" description="">
@@ -271,10 +276,5 @@
             <span class="data-view">payload from data: {{ payload }} </span>
             <div class="input-validation" v-if="payload.errorMsg">Error parsing JSON: {{ payload.errorMsg }}</div>
         </settings-panel>
-        <div class="container" id="invoke-button-container">
-            <button class="" v-on:click.prevent="launch">Invoke</button>
-            <button class="form-buttons" v-on:click.prevent="loadConfig">Load Existing Config</button>
-            <button class="form-buttons" v-on:click.prevent="save">Save</button>
-        </div>
     </form>
 </template>

--- a/src/lambda/vue/remoteInvoke/remoteInvoke.vue
+++ b/src/lambda/vue/remoteInvoke/remoteInvoke.vue
@@ -1,8 +1,12 @@
 /*! * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved. * SPDX-License-Identifier: Apache-2.0 */
 
 <template>
-    <h1>Invoke function {{ initialData.FunctionName }}</h1>
-    <p style="margin-bottom: 5px; margin-top: 0; margin-right: 5px">ARN: {{ initialData.FunctionArn }}</p>
+    <div class="container button-container" style="justify-content: space-between">
+        <h1>Function {{ initialData.FunctionName }}</h1>
+        <div><button v-on:click="sendInput">Invoke</button></div>
+    </div>
+
+    <p style="margin-bottom: 5px; margin-top: 10px; margin-right: 5px">ARN: {{ initialData.FunctionArn }}</p>
 
     <p style="margin-top: 0">Region: {{ initialData.FunctionRegion }}</p>
 
@@ -21,9 +25,7 @@
     </select>
     <br />
     <br />
-    <textarea rows="20" cols="90" v-model="sampleText"></textarea>
-    <br />
-    <button class="mt-16 mb-16" v-on:click="sendInput">Invoke</button>
+    <textarea style="width: 100%; margin-bottom: 10px" rows="10" cols="90" v-model="sampleText"></textarea>
 </template>
 
 <script lang="ts">

--- a/src/stepFunctions/vue/executeStateMachine/executeStateMachine.vue
+++ b/src/stepFunctions/vue/executeStateMachine/executeStateMachine.vue
@@ -20,18 +20,20 @@
         <div>
             <input type="radio" v-model="inputChoice" value="file" />
             <label for="file"> Select a file </label>
-            <br />
-            <br />
-            <div :style="{ visibility: fileInputVisible ? 'visible' : 'hidden' }">
-                <label class="custom-file-upload">
-                    <input type="file" @change="processFile($event)" />
-                    Choose File
-                </label>
-                <span class="custom-file-name">{{ selectedFile }}</span>
-            </div>
         </div>
-        <div :style="{ visibility: textAreaVisible ? 'visible' : 'hidden', marginBottom: '10px' }">
+        <div :style="{ visibility: fileInputVisible ? 'visible' : 'hidden' }">
+            <br />
+            <label class="custom-file-upload">
+                <input type="file" @change="processFile($event)" />
+                Choose File
+            </label>
+            <span class="custom-file-name">{{ selectedFile }}</span>
+            <br />
+            <br />
+        </div>
+        <div :style="{ visibility: textAreaVisible ? 'visible' : 'hidden' }">
             <textarea
+                style="width: 100%; margin-bottom: 10px"
                 rows="10"
                 v-model="executionInput"
                 v-bind:readonly="inputChoice == 'file'"

--- a/src/stepFunctions/vue/executeStateMachine/executeStateMachine.vue
+++ b/src/stepFunctions/vue/executeStateMachine/executeStateMachine.vue
@@ -1,8 +1,15 @@
 /*! * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved. * SPDX-License-Identifier: Apache-2.0 */
 
 <template>
-    <h1>Start Execution: {{ initialData.name }}</h1>
     <div id="app">
+        <div class="container button-container" style="justify-content: space-between">
+            <div style="float: left">
+                <b>{{ initialData.name }}</b>
+            </div>
+            <div>
+                <input type="submit" v-on:click="sendInput" value="Execute" />
+            </div>
+        </div>
         <div>
             <label class="input-header"> Execution Input </label>
         </div>
@@ -26,7 +33,7 @@
         </div>
         <br />
         <br />
-        <div :style="{ visibility: textAreaVisible ? 'visible' : 'hidden' }">
+        <div :style="{ visibility: textAreaVisible ? 'visible' : 'hidden', marginBottom: '10px' }">
             <textarea
                 rows="10"
                 v-model="executionInput"
@@ -34,9 +41,6 @@
                 v-bind:placeholder="placeholderJson"
             ></textarea>
         </div>
-        <br />
-        <input type="submit" v-on:click="sendInput" value="Execute" />
-        <br />
     </div>
 </template>
 

--- a/src/stepFunctions/vue/executeStateMachine/executeStateMachine.vue
+++ b/src/stepFunctions/vue/executeStateMachine/executeStateMachine.vue
@@ -3,13 +3,12 @@
 <template>
     <div id="app">
         <div class="container button-container" style="justify-content: space-between">
-            <div style="float: left">
-                <b>{{ initialData.name }}</b>
-            </div>
+            <h1>{{ initialData.name }}</h1>
             <div>
                 <input type="submit" v-on:click="sendInput" value="Execute" />
             </div>
         </div>
+        <br />
         <div>
             <label class="input-header"> Execution Input </label>
         </div>

--- a/src/stepFunctions/vue/executeStateMachine/executeStateMachine.vue
+++ b/src/stepFunctions/vue/executeStateMachine/executeStateMachine.vue
@@ -30,8 +30,6 @@
                 <span class="custom-file-name">{{ selectedFile }}</span>
             </div>
         </div>
-        <br />
-        <br />
         <div :style="{ visibility: textAreaVisible ? 'visible' : 'hidden', marginBottom: '10px' }">
             <textarea
                 rows="10"

--- a/src/webviews/main.ts
+++ b/src/webviews/main.ts
@@ -17,9 +17,7 @@ interface WebviewParams {
     webviewJs: string
 
     /**
-     * Styling sheets to use, applied to the entire webview.
-     *
-     * If none are provided, `base.css` is used by default.
+     * Stylesheets to use in addition to "base.css".
      */
     cssFiles?: string[]
 
@@ -372,7 +370,8 @@ function updateWebview(ctx: vscode.ExtensionContext, webview: vscode.Webview, pa
         webview
     ).concat(ExtensionUtilities.getFilesAsVsCodeResources(jsPath, ['loadVsCodeApi.js'], webview))
 
-    const cssFiles = params.cssFiles ?? [isCloud9() ? 'base-cloud9.css' : 'base.css']
+    const baseCss = isCloud9() ? 'base-cloud9.css' : 'base.css'
+    const cssFiles = [baseCss, ...(params.cssFiles ?? [])]
     const loadCss = ExtensionUtilities.getFilesAsVsCodeResources(cssPath, [...cssFiles], webview)
 
     let scripts: string = ''


### PR DESCRIPTION
## Problem:
- Forms don't share base.css by default.
- Buttons are hidden at the bottom of many forms in random locations.

## Solution:
- Include base.css by default in all forms.
- Move buttons to a "sticky" floating div at the top of all forms.
    - Also put the title in there.

<img width="754" alt="image" src="https://user-images.githubusercontent.com/55561878/172965213-a356fdf3-9352-4d02-b57c-d45ba64a67ba.png">

<img width="644" alt="image" src="https://user-images.githubusercontent.com/55561878/172965366-06e35738-6554-4df5-be12-672f3ab5a4a9.png">

<img width="620" alt="image" src="https://user-images.githubusercontent.com/55561878/172965466-9bbd4886-bd0b-43b2-86fc-068935269bc0.png">




<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
