### PR TITLE
fix(ci): failing macos build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "aws-toolkit-vscode",
-            "version": "1.39.0-SNAPSHOT",
+            "version": "1.40.0-SNAPSHOT",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -75,7 +75,7 @@
                 "@types/xml2js": "^0.4.8",
                 "@typescript-eslint/eslint-plugin": "^5.15.0",
                 "@typescript-eslint/parser": "^5.15.0",
-                "@vscode/test-electron": "^2.1.3",
+                "@vscode/test-electron": "^2.1.4",
                 "@vue/compiler-sfc": "^3.2.26",
                 "circular-dependency-plugin": "^5.2.2",
                 "css-loader": "^6.5.1",
@@ -3607,9 +3607,9 @@
             "dev": true
         },
         "node_modules/@vscode/test-electron": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.3.tgz",
-            "integrity": "sha512-ps/yJ/9ToUZtR1dHfWi1mDXtep1VoyyrmGKC3UnIbScToRQvbUjyy1VMqnMEW3EpMmC3g7+pyThIPtPyCLHyow==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.4.tgz",
+            "integrity": "sha512-tHHAWNVwl8C7nyezHAHdNPWkksdXWvmae6bt4k1tJ9hvMm6QIIk95Mkutl82XHcD60mdP46EHDGU+xFsAvygOQ==",
             "dev": true,
             "dependencies": {
                 "http-proxy-agent": "^4.0.1",
@@ -16494,9 +16494,9 @@
             "dev": true
         },
         "@vscode/test-electron": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.3.tgz",
-            "integrity": "sha512-ps/yJ/9ToUZtR1dHfWi1mDXtep1VoyyrmGKC3UnIbScToRQvbUjyy1VMqnMEW3EpMmC3g7+pyThIPtPyCLHyow==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.4.tgz",
+            "integrity": "sha512-tHHAWNVwl8C7nyezHAHdNPWkksdXWvmae6bt4k1tJ9hvMm6QIIk95Mkutl82XHcD60mdP46EHDGU+xFsAvygOQ==",
             "dev": true,
             "requires": {
                 "http-proxy-agent": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -2963,7 +2963,7 @@
         "@types/xml2js": "^0.4.8",
         "@typescript-eslint/eslint-plugin": "^5.15.0",
         "@typescript-eslint/parser": "^5.15.0",
-        "@vscode/test-electron": "^2.1.3",
+        "@vscode/test-electron": "^2.1.4",
         "@vue/compiler-sfc": "^3.2.26",
         "circular-dependency-plugin": "^5.2.2",
         "css-loader": "^6.5.1",


### PR DESCRIPTION
## Problem:
macos CI fails with:

    Setting up VS Code test instance, version: insiders
    Downloading VS Code insiders from https://update.code.visualstudio.com/latest/darwin/insider
    Error: read ECONNRESET
        at TLSWrap.onStreamRead (internal/stream_base_commons.js:209:20) {
      errno: -54,
      code: 'ECONNRESET',
      syscall: 'read'
    }

## Solution:
Update vscode-test which includes a fix:
https://github.com/microsoft/vscode-test/pull/152
https://github.com/microsoft/vscode/issues/151588


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
