### PR TITLE
test(schema): Add regresion test for AddDefaultAuthorizerToCorsPreflight

### DIFF
--- a/src/integrationTest/schema/schema.test.ts
+++ b/src/integrationTest/schema/schema.test.ts
@@ -56,4 +56,8 @@ describe('Sam Schema Regression', function () {
         assertDefinition(samSchema, 'AWS::Serverless::Function.RequestModel')
         assertDefinition(samSchema, 'AWS::Serverless::Function.RequestParameter')
     })
+
+    it('has Property AddDefaultAuthorizerToCorsPreflight in AWS::Serverless::Api.Auth', function () {
+        assertDefinitionProperty(samSchema, 'AWS::Serverless::Api.Auth', 'AddDefaultAuthorizerToCorsPreflight')
+    })
 })


### PR DESCRIPTION
## Problem
After fixing AddDefaultAuthorizerToCorsPreflight for https://github.com/aws/aws-toolkit-vscode/issues/2627, no regression test was added

## Solution
Add in the regression test
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
