### PR TITLE
fix(lambda): auto-connect when running `Upload Lambda`

### DIFF
--- a/.changes/next-release/Bug Fix-67cd5ec0-60ff-4f6d-8055-681a084aeaec.json
+++ b/.changes/next-release/Bug Fix-67cd5ec0-60ff-4f6d-8055-681a084aeaec.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "The `Upload Lambda` command now automatically causes the Toolkit to login"
+}

--- a/src/lambda/activation.ts
+++ b/src/lambda/activation.ts
@@ -13,6 +13,7 @@ import { ExtContext } from '../shared/extensions'
 import globals from '../shared/extensionGlobals'
 import { invokeRemoteLambda } from './vue/remoteInvoke/invokeLambda'
 import { registerSamInvokeVueCommand } from './vue/configEditor/samInvokeBackend'
+import { Commands } from '../shared/vscode/commands2'
 
 /**
  * Activates Lambda components.
@@ -48,7 +49,7 @@ export async function activate(context: ExtContext): Promise<void> {
             'aws.downloadLambda',
             async (node: LambdaFunctionNode) => await downloadLambdaCommand(node)
         ),
-        vscode.commands.registerCommand('aws.uploadLambda', async arg => {
+        Commands.register({ id: 'aws.uploadLambda', autoconnect: true }, async (arg?: unknown) => {
             if (arg instanceof LambdaFunctionNode) {
                 await uploadLambdaCommand({
                     name: arg.functionName,


### PR DESCRIPTION
## Problem
The command doesn't auto-connect despite having entry-points outside of the AWS explorer

## Solution
Make it login prior to execution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
