### PR TITLE
feat(Schema): Decrease the amount of space SAM/CFN schemas take on the status bar

### DIFF
--- a/.changes/next-release/Feature-a61e0660-9f68-4e50-a0b1-b8a742075017.json
+++ b/.changes/next-release/Feature-a61e0660-9f68-4e50-a0b1-b8a742075017.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Decrease the amount of space SAM/CFN schemas take on the status bar"
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -96,7 +96,9 @@ export const INSIGHTS_TIMESTAMP_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSSZ'
 /**
  * URI scheme for CloudWatch Logs Virtual Documents
  */
+// TODO: change to a more conventional format like `aws-cloud-watch-logs` or `aws-cwl`
 export const CLOUDWATCH_LOGS_SCHEME = 'awsCloudWatchLogs'
+export const AWS_SCHEME = 'aws'
 
 export const LAMBDA_PACKAGE_TYPE_IMAGE = 'Image'
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -96,7 +96,6 @@ export const INSIGHTS_TIMESTAMP_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSSZ'
 /**
  * URI scheme for CloudWatch Logs Virtual Documents
  */
-// TODO: change to a more conventional format like `aws-cloud-watch-logs` or `aws-cwl`
 export const CLOUDWATCH_LOGS_SCHEME = 'awsCloudWatchLogs'
 export const AWS_SCHEME = 'aws'
 

--- a/src/shared/extensions/yaml.ts
+++ b/src/shared/extensions/yaml.ts
@@ -9,6 +9,7 @@ import { VSCODE_EXTENSION_ID } from '../extensions'
 import { getLogger } from '../logger/logger'
 import { getIdeProperties } from '../extensionUtilities'
 import { activateExtension } from '../utilities/vsCodeUtils'
+import { AWS_SCHEME } from '../constants'
 
 // sourced from https://github.com/redhat-developer/vscode-yaml/blob/3d82d61ea63d3e3a9848fe6b432f8f1f452c1bec/src/schema-extension-api.ts
 // removed everything that is not currently being used
@@ -20,8 +21,6 @@ interface YamlExtensionApi {
         label?: string
     ): boolean
 }
-
-const AWS_SCHEME = 'aws'
 
 function applyScheme(scheme: string, path: vscode.Uri): vscode.Uri {
     return path.with({ scheme })

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -19,7 +19,7 @@ import { writeFile } from 'fs-extra'
 import { SystemUtilities } from './systemUtilities'
 
 const GOFORMATION_MANIFEST_URL = 'https://api.github.com/repos/awslabs/goformation/releases/latest'
-const SCHEMA_PREFIX = `${AWS_SCHEME}://aws-toolkit-vscode/`
+const SCHEMA_PREFIX = `${AWS_SCHEME}://`
 
 export type Schemas = { [key: string]: vscode.Uri }
 export type SchemaType = 'yaml' | 'json'

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -3,12 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { mkdirSync, writeFileSync } from 'fs'
-import * as path from 'path'
 import * as vscode from 'vscode'
 import globals from './extensionGlobals'
 import { activateYamlExtension, YamlExtension } from './extensions/yaml'
-import * as filesystemUtilities from './filesystemUtilities'
 import * as pathutil from '../shared/utilities/pathUtils'
 import { getLogger } from './logger'
 import { FileResourceFetcher } from './resourcefetcher/fileResourceFetcher'
@@ -17,9 +14,12 @@ import { Settings } from './settings'
 import { once } from './utilities/functionUtils'
 import { normalizeSeparator } from './utilities/pathUtils'
 import { Any, ArrayConstructor } from './utilities/typeConstructors'
+import { AWS_SCHEME } from './constants'
+import { writeFile } from 'fs-extra'
+import { SystemUtilities } from './systemUtilities'
 
 const GOFORMATION_MANIFEST_URL = 'https://api.github.com/repos/awslabs/goformation/releases/latest'
-const SCHEMA_PREFIX = 'aws://aws-toolkit-vscode/'
+const SCHEMA_PREFIX = `${AWS_SCHEME}://aws-toolkit-vscode/`
 
 export type Schemas = { [key: string]: vscode.Uri }
 export type SchemaType = 'yaml' | 'json'
@@ -140,31 +140,28 @@ export class SchemaService {
  */
 export async function getDefaultSchemas(extensionContext: vscode.ExtensionContext): Promise<Schemas | undefined> {
     try {
-        // Convert the paths to URIs which is what the YAML extension expects
-        const cfnSchemaUri = vscode.Uri.file(
-            normalizeSeparator(path.join(extensionContext.globalStorageUri.fsPath, 'cloudformation.schema.json'))
-        )
-        const samSchemaUri = vscode.Uri.file(
-            normalizeSeparator(path.join(extensionContext.globalStorageUri.fsPath, 'sam.schema.json'))
-        )
+        const cfnSchemaUri = vscode.Uri.joinPath(extensionContext.globalStorageUri, 'cloudformation.schema.json')
+        const samSchemaUri = vscode.Uri.joinPath(extensionContext.globalStorageUri, 'sam.schema.json')
+
         const goformationSchemaVersion = await getPropertyFromJsonUrl(GOFORMATION_MANIFEST_URL, 'tag_name')
 
-        await getRemoteOrCachedFile({
-            filepath: cfnSchemaUri.fsPath,
+        await updateSchemaFromRemote({
+            destination: cfnSchemaUri,
             version: goformationSchemaVersion,
             url: `https://raw.githubusercontent.com/awslabs/goformation/${goformationSchemaVersion}/schema/cloudformation.schema.json`,
             cacheKey: 'cfnSchemaVersion',
             extensionContext,
             title: SCHEMA_PREFIX + 'cloudformation.schema.json',
         })
-        await getRemoteOrCachedFile({
-            filepath: samSchemaUri.fsPath,
+        await updateSchemaFromRemote({
+            destination: samSchemaUri,
             version: goformationSchemaVersion,
             url: `https://raw.githubusercontent.com/awslabs/goformation/${goformationSchemaVersion}/schema/sam.schema.json`,
             cacheKey: 'samSchemaVersion',
             extensionContext,
             title: SCHEMA_PREFIX + 'sam.schema.json',
         })
+
         return {
             cfn: cfnSchemaUri,
             sam: samSchemaUri,
@@ -186,46 +183,37 @@ export async function getDefaultSchemas(extensionContext: vscode.ExtensionContex
  * @param params.cacheKey Cache key to check version against
  * @param params.extensionContext VSCode extension context
  */
-export async function getRemoteOrCachedFile(params: {
-    filepath: string
+export async function updateSchemaFromRemote(params: {
+    destination: vscode.Uri
     version?: string
     url: string
     cacheKey: string
     extensionContext: vscode.ExtensionContext
     title: string
-}): Promise<string> {
-    const dir = path.parse(params.filepath).dir
-    if (!(await filesystemUtilities.fileExists(dir))) {
-        mkdirSync(dir, { recursive: true })
-    }
-
+}): Promise<void> {
     const cachedVersion = params.extensionContext.globalState.get<string>(params.cacheKey)
     const outdated = params.version && params.version !== cachedVersion
     if (!outdated) {
         // Check that the cached file actually can be fetched. Else we might
         // never update the cache.
-        const fileFetcher = new FileResourceFetcher(params.filepath)
+        const fileFetcher = new FileResourceFetcher(params.destination.fsPath)
         const content = await fileFetcher.get()
         if (content) {
-            return content
+            return
         }
     }
 
-    const httpFetcher = new HttpResourceFetcher(params.url, {
-        showUrl: true,
-        // updates curr version
-        onSuccess: contents => {
-            const parsedFile = JSON.parse(contents)
-            parsedFile.title = params.title
-            writeFileSync(params.filepath, JSON.stringify(parsedFile))
-            params.extensionContext.globalState.update(params.cacheKey, params.version)
-        },
-    })
+    const httpFetcher = new HttpResourceFetcher(params.url, { showUrl: true })
     const content = await httpFetcher.get()
     if (!content) {
-        throw new Error(`failed to resolve schema: ${params.filepath}`)
+        throw new Error(`failed to resolve schema: ${params.destination}`)
     }
-    return content
+
+    const parsedFile = { ...JSON.parse(content), title: params.title }
+    const dir = vscode.Uri.joinPath(params.destination, '..')
+    await SystemUtilities.createDirectory(dir)
+    await writeFile(params.destination.fsPath, JSON.stringify(parsedFile))
+    await params.extensionContext.globalState.update(params.cacheKey, params.version)
 }
 
 /**

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -213,7 +213,9 @@ export async function updateSchemaFromRemote(params: {
     const dir = vscode.Uri.joinPath(params.destination, '..')
     await SystemUtilities.createDirectory(dir)
     await writeFile(params.destination.fsPath, JSON.stringify(parsedFile))
-    await params.extensionContext.globalState.update(params.cacheKey, params.version)
+    await params.extensionContext.globalState.update(params.cacheKey, params.version).then(undefined, err => {
+        getLogger().warn(`schemas: failed to update cache key for "${params.title}": ${err?.message}`)
+    })
 }
 
 /**

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -221,7 +221,9 @@ export async function updateSchemaFromRemote(params: {
     } catch (err) {
         if (cachedContent) {
             getLogger().warn(
-                `schemas: failed to fetch the latest version for "${params.title}": ${(err as Error).message}`
+                `schemas: failed to fetch the latest version for "${params.title}": ${
+                    (err as Error).message
+                }. Using cached schema instead.`
             )
         } else {
             throw err


### PR DESCRIPTION
## Problem
- Currently SAM/CFN schema paths take up a lot of space on the status bar
 
## Solution
- Specify a title for the SAM/CFN schemas so VSCode-YAML will display that on the status bar instead of the full file path

Related issue: https://github.com/aws/aws-toolkit-vscode/issues/2704

The only annoying thing is when you have a title for the schema it automatically adds that everytime you hover something as shown in the after screenshot

## Screenshots
**Before:**
![Screen Shot 2022-06-20 at 9 14 24 AM](https://user-images.githubusercontent.com/103940141/174609739-58ebe7be-1bbc-4217-ba87-ebab96cb05d7.png)

**After:** 
![Screen Shot 2022-06-21 at 1 21 17 PM](https://user-images.githubusercontent.com/103940141/174860113-f1aaaa1e-6212-4e67-a285-2e729be0e91d.png)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
