### PR TITLE
fix(auth): use latest 'credential process provider' from the JS SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,14 +6,14 @@
     "packages": {
         "": {
             "name": "aws-toolkit-vscode",
-            "version": "1.40.0-SNAPSHOT",
+            "version": "1.41.0-SNAPSHOT",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/client-sso": "^3.54.0",
                 "@aws-sdk/client-sso-oidc": "^3.58.0",
                 "@aws-sdk/credential-provider-ini": "^3.46.0",
-                "@aws-sdk/credential-provider-process": "^3.15.0",
+                "@aws-sdk/credential-provider-process": "^3.110.0",
                 "@aws-sdk/credential-provider-sso": "^3.38.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
                 "adm-zip": "^0.5.9",
@@ -999,18 +999,17 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.37.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.37.0.tgz",
-            "integrity": "sha512-VOfWtUBbICb7xEHRFN7+fRA+move/3HT4mZt7C5KBXIaILT3b8hrK1mT/fRQ3dx9dF56PEGj/WkACOBjMzIcdg==",
+            "version": "3.110.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.110.0.tgz",
+            "integrity": "sha512-JJcZePvRTfQHYj/+EEY13yItnZH/e8exlARFUjN0L13UrgHpOJtDQBa+YBHXo6MbTFQh+re25z2kzc+zOYSMNQ==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.37.0",
-                "@aws-sdk/shared-ini-file-loader": "3.37.0",
-                "@aws-sdk/types": "3.37.0",
-                "@aws-sdk/util-credentials": "3.37.0",
-                "tslib": "^2.3.0"
+                "@aws-sdk/property-provider": "3.110.0",
+                "@aws-sdk/shared-ini-file-loader": "3.110.0",
+                "@aws-sdk/types": "3.110.0",
+                "tslib": "^2.3.1"
             },
             "engines": {
-                "node": ">= 10.0.0"
+                "node": ">= 12.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
@@ -1817,15 +1816,15 @@
             }
         },
         "node_modules/@aws-sdk/property-provider": {
-            "version": "3.37.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.37.0.tgz",
-            "integrity": "sha512-puXV4MIj+n9Pr4KbwpOz6+nK7gmJAgAOZW/yKXxyWH4fTcrCVe9xuo5kqaiI1gb5ojaNt2GuISBFR7bVLumh9Q==",
+            "version": "3.110.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.110.0.tgz",
+            "integrity": "sha512-7NkpmYeOkK3mhWBNU+/zSDqwzeaSPH1qrq4L//WV7WS/weYyE/jusQeZoOxVsuZQnQEXHt5O2hKVeUwShl12xA==",
             "dependencies": {
-                "@aws-sdk/types": "3.37.0",
-                "tslib": "^2.3.0"
+                "@aws-sdk/types": "3.110.0",
+                "tslib": "^2.3.1"
             },
             "engines": {
-                "node": ">= 10.0.0"
+                "node": ">= 12.0.0"
             }
         },
         "node_modules/@aws-sdk/protocol-http": {
@@ -1898,14 +1897,14 @@
             }
         },
         "node_modules/@aws-sdk/shared-ini-file-loader": {
-            "version": "3.37.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.37.0.tgz",
-            "integrity": "sha512-+vRBSlfa48R9KL7DpQt3dsu5/+5atjRgoCISblWo3SLpjrx41pKcjKneo7a1u0aP1Xc2oG2TfIyqTWZuOXsmEQ==",
+            "version": "3.110.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.110.0.tgz",
+            "integrity": "sha512-E1ERoqEoG206XNBYWCKLgHkzCbTxdpDEGbsLET2DnvjFsT0s9p2dPvVux3bYl7JVAhyGduE+qcqWk7MzhFCBNQ==",
             "dependencies": {
-                "tslib": "^2.3.0"
+                "tslib": "^2.3.1"
             },
             "engines": {
-                "node": ">= 10.0.0"
+                "node": ">= 12.0.0"
             }
         },
         "node_modules/@aws-sdk/signature-v4": {
@@ -1953,11 +1952,11 @@
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.37.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.37.0.tgz",
-            "integrity": "sha512-KwHB06E1uxof5ijfcQXYidyihoCRMnHEFvWCy/VlL+1S54FTlMZ27JOZzQhLiw8NqeNfO33aqpMkxR60TwUZzg==",
+            "version": "3.110.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.110.0.tgz",
+            "integrity": "sha512-dLVoqODU3laaqNFPyN1QLtlQnwX4gNPMXptEBIt/iJpuZf66IYJe6WCzVZGt4Zfa1CnUmrlA428AzdcA/KCr2A==",
             "engines": {
-                "node": ">= 10.0.0"
+                "node": ">= 12.0.0"
             }
         },
         "node_modules/@aws-sdk/url-parser": {
@@ -2049,18 +2048,6 @@
             },
             "engines": {
                 "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-credentials": {
-            "version": "3.37.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.37.0.tgz",
-            "integrity": "sha512-zcLhSZDKgBLhUjSU5HoQpuQiP3v8oE86NmV/tiZVPEaO6YVULEAB2Cfj1hpM/b/JXWzjSHfT06KXT7QUODKS+A==",
-            "dependencies": {
-                "@aws-sdk/shared-ini-file-loader": "3.37.0",
-                "tslib": "^2.3.0"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
             }
         },
         "node_modules/@aws-sdk/util-defaults-mode-browser": {
@@ -14387,15 +14374,14 @@
             }
         },
         "@aws-sdk/credential-provider-process": {
-            "version": "3.37.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.37.0.tgz",
-            "integrity": "sha512-VOfWtUBbICb7xEHRFN7+fRA+move/3HT4mZt7C5KBXIaILT3b8hrK1mT/fRQ3dx9dF56PEGj/WkACOBjMzIcdg==",
+            "version": "3.110.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.110.0.tgz",
+            "integrity": "sha512-JJcZePvRTfQHYj/+EEY13yItnZH/e8exlARFUjN0L13UrgHpOJtDQBa+YBHXo6MbTFQh+re25z2kzc+zOYSMNQ==",
             "requires": {
-                "@aws-sdk/property-provider": "3.37.0",
-                "@aws-sdk/shared-ini-file-loader": "3.37.0",
-                "@aws-sdk/types": "3.37.0",
-                "@aws-sdk/util-credentials": "3.37.0",
-                "tslib": "^2.3.0"
+                "@aws-sdk/property-provider": "3.110.0",
+                "@aws-sdk/shared-ini-file-loader": "3.110.0",
+                "@aws-sdk/types": "3.110.0",
+                "tslib": "^2.3.1"
             }
         },
         "@aws-sdk/credential-provider-sso": {
@@ -15048,12 +15034,12 @@
             }
         },
         "@aws-sdk/property-provider": {
-            "version": "3.37.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.37.0.tgz",
-            "integrity": "sha512-puXV4MIj+n9Pr4KbwpOz6+nK7gmJAgAOZW/yKXxyWH4fTcrCVe9xuo5kqaiI1gb5ojaNt2GuISBFR7bVLumh9Q==",
+            "version": "3.110.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.110.0.tgz",
+            "integrity": "sha512-7NkpmYeOkK3mhWBNU+/zSDqwzeaSPH1qrq4L//WV7WS/weYyE/jusQeZoOxVsuZQnQEXHt5O2hKVeUwShl12xA==",
             "requires": {
-                "@aws-sdk/types": "3.37.0",
-                "tslib": "^2.3.0"
+                "@aws-sdk/types": "3.110.0",
+                "tslib": "^2.3.1"
             }
         },
         "@aws-sdk/protocol-http": {
@@ -15111,11 +15097,11 @@
             "integrity": "sha512-XWANvjJJZNqsYhGmccSSuhsvINIUX1KckfDmvYtUR6cKM6nM6QWOg/QJeTFageTEpruJ5TqzW9vY414bIE883w=="
         },
         "@aws-sdk/shared-ini-file-loader": {
-            "version": "3.37.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.37.0.tgz",
-            "integrity": "sha512-+vRBSlfa48R9KL7DpQt3dsu5/+5atjRgoCISblWo3SLpjrx41pKcjKneo7a1u0aP1Xc2oG2TfIyqTWZuOXsmEQ==",
+            "version": "3.110.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.110.0.tgz",
+            "integrity": "sha512-E1ERoqEoG206XNBYWCKLgHkzCbTxdpDEGbsLET2DnvjFsT0s9p2dPvVux3bYl7JVAhyGduE+qcqWk7MzhFCBNQ==",
             "requires": {
-                "tslib": "^2.3.0"
+                "tslib": "^2.3.1"
             }
         },
         "@aws-sdk/signature-v4": {
@@ -15155,9 +15141,9 @@
             }
         },
         "@aws-sdk/types": {
-            "version": "3.37.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.37.0.tgz",
-            "integrity": "sha512-KwHB06E1uxof5ijfcQXYidyihoCRMnHEFvWCy/VlL+1S54FTlMZ27JOZzQhLiw8NqeNfO33aqpMkxR60TwUZzg=="
+            "version": "3.110.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.110.0.tgz",
+            "integrity": "sha512-dLVoqODU3laaqNFPyN1QLtlQnwX4gNPMXptEBIt/iJpuZf66IYJe6WCzVZGt4Zfa1CnUmrlA428AzdcA/KCr2A=="
         },
         "@aws-sdk/url-parser": {
             "version": "3.54.0",
@@ -15231,15 +15217,6 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.52.0.tgz",
             "integrity": "sha512-1wonBNkOOLJpMZnz2Kn69ToFgSoTTyGzJInir8WC5sME3zpkb5j41kTuEVbImNJhVv9MKjmGYrMeZbBVniLRPw==",
             "requires": {
-                "tslib": "^2.3.0"
-            }
-        },
-        "@aws-sdk/util-credentials": {
-            "version": "3.37.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.37.0.tgz",
-            "integrity": "sha512-zcLhSZDKgBLhUjSU5HoQpuQiP3v8oE86NmV/tiZVPEaO6YVULEAB2Cfj1hpM/b/JXWzjSHfT06KXT7QUODKS+A==",
-            "requires": {
-                "@aws-sdk/shared-ini-file-loader": "3.37.0",
                 "tslib": "^2.3.0"
             }
         },

--- a/package.json
+++ b/package.json
@@ -3001,7 +3001,7 @@
         "@aws-sdk/client-sso": "^3.54.0",
         "@aws-sdk/client-sso-oidc": "^3.58.0",
         "@aws-sdk/credential-provider-ini": "^3.46.0",
-        "@aws-sdk/credential-provider-process": "^3.15.0",
+        "@aws-sdk/credential-provider-process": "^3.110.0",
         "@aws-sdk/credential-provider-sso": "^3.38.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
         "adm-zip": "^0.5.9",


### PR DESCRIPTION
## Problem
Old versions did not return the expiration time.

## Solution
Update the package. The bug was (accidentally?) fixed in https://github.com/aws/aws-sdk-js-v3/pull/3287

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
