### PR TITLE
fix(css) webview style regression in cloud9

### DIFF
--- a/media/css/base-cloud9.css
+++ b/media/css/base-cloud9.css
@@ -97,6 +97,9 @@ option {
     color: var(--vscode-settings-dropdownForeground);
     background: var(--vscode-settings-dropdownBackground);
 }
+body.vscode-dark select:not([type='radio']) {
+    background: rgba(var(--shade), 0.1);
+}
 
 /* Header (for settings) (TODO: move to different sheet) */
 .header {

--- a/media/css/base-cloud9.css
+++ b/media/css/base-cloud9.css
@@ -65,8 +65,8 @@ input[type='number'] {
     padding: 4px 4px;
 }
 
-/* "Cloud9 gray" in input boxes (not buttons). */
-body.vscode-dark input:not([type='submit']) {
+/* "Cloud9 gray" in input boxes (not buttons/radios). */
+body.vscode-dark input:not([type='submit']):not([type='radio']) {
     background: rgba(var(--shade), 0.1);
 }
 
@@ -97,7 +97,7 @@ option {
     color: var(--vscode-settings-dropdownForeground);
     background: var(--vscode-settings-dropdownBackground);
 }
-body.vscode-dark select:not([type='radio']) {
+body.vscode-dark select {
     background: rgba(var(--shade), 0.1);
 }
 

--- a/media/css/base-cloud9.css
+++ b/media/css/base-cloud9.css
@@ -64,7 +64,9 @@ input[type='number'] {
     border: 1px solid var(--vscode-settings-textInputBorder);
     padding: 4px 4px;
 }
-body.vscode-dark input {
+
+/* "Cloud9 gray" in input boxes (not buttons). */
+body.vscode-dark input:not([type='submit']) {
     background: rgba(var(--shade), 0.1);
 }
 
@@ -95,9 +97,6 @@ option {
     color: var(--vscode-settings-dropdownForeground);
     background: var(--vscode-settings-dropdownBackground);
 }
-body.vscode-dark select {
-    background: rgba(var(--shade), 0.1);
-}
 
 /* Header (for settings) (TODO: move to different sheet) */
 .header {
@@ -122,16 +121,18 @@ button,
     padding: 8px;
 }
 button,
-.button-theme-primary:hover {
+.button-theme-primary:hover:not(:disabled) {
     background: var(--vscode-button-hoverBackground);
+    cursor: pointer;
 }
 .button-theme-secondary {
     color: var(--vscode-button-secondaryForeground);
     background: var(--vscode-button-secondaryBackground);
     border: 1px solid var(--vscode-button-border);
 }
-.button-theme-secondary:hover {
+.button-theme-secondary:hover:not(:disabled) {
     background: var(--vscode-button-secondaryHoverBackground);
+    cursor: pointer;
 }
 .button-theme-soft {
     color: var(--vscode-settings-textInputForeground);
@@ -162,14 +163,31 @@ body.vscode-dark textarea {
     display: contents;
 }
 
+.button-container {
+    display: flex;
+    align-items: flex-start;
+    flex-direction: row;
+    /* margin: 16px 0 0 0; */
+    padding: 10px;
+    position: sticky;
+    top: 10px;
+    justify-content: flex-end;
+    border-bottom: 1px solid var(--vscode-menu-separatorBackground);
+    /**
+     * HACK: Using background-color alpha as a workaround because "opacity" affects children.
+     * TODO: Is there a way to use alpha with var(--vscode-menu-background) ?
+     */
+    /* background-color: rgba(0, 0, 0, 0.1); */
+}
+
+.button-container h1 {
+    margin: 0px;
+}
+
 /* Overrides */
 body.vscode-dark .settings-panel {
     background: rgba(var(--tint), 0.02) !important;
 }
 body.vscode-light .settings-panel {
     background: rgba(var(--shade), 0.02) !important;
-}
-.button-container {
-    border: none !important;
-    background: none !important;
 }


### PR DESCRIPTION
## Problem:
After 0f86958823b5 #2691, buttons in cloud9 webviews are gray. And the
headers are not sticky.

## Solution:
Copy some of the base.css stuff to base-cloud9.css.
Remove some of the forced background-color items.

![image](https://user-images.githubusercontent.com/55561878/174918137-7a462313-67cb-4297-81d5-f6b2bc424cda.png)


![image](https://user-images.githubusercontent.com/55561878/174918103-423ba928-f004-4622-9209-a062829f9f54.png)

![image](https://user-images.githubusercontent.com/55561878/174918121-6957ae84-701e-488f-86b9-66ec604950ad.png)



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
