### PR TITLE
fix(auth): refresh credentials on certain API errors

### DIFF
--- a/.changes/next-release/Bug Fix-fd07b2a1-5c62-4402-9229-64149dfc5f12.json
+++ b/.changes/next-release/Bug Fix-fd07b2a1-5c62-4402-9229-64149dfc5f12.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Credentials are now automatically refreshed on certain AWS API errors"
+}

--- a/src/shared/awsClientBuilder.ts
+++ b/src/shared/awsClientBuilder.ts
@@ -104,13 +104,15 @@ export class DefaultAWSClientBuilder implements AWSClientBuilder {
                     shim.refresh()
                         .then(creds => {
                             this.loadCreds(creds)
+                            // The SDK V2 sets `expired` on certain errors so we should only
+                            // unset the flag after acquiring new credentials via `refresh`
+                            this.expired = false
                             callback()
                         })
                         .catch(callback)
                 }
 
                 private loadCreds(creds: CredentialsOptions & { expiration?: Date }) {
-                    this.expired = false
                     this.accessKeyId = creds.accessKeyId
                     this.secretAccessKey = creds.secretAccessKey
                     this.sessionToken = creds.sessionToken ?? this.sessionToken


### PR DESCRIPTION
## Problem
JS SDK v2 has built-in logic to 'refresh' credentials on certain API errors, but the way it works is that it directly mutates the credentials provider. 

## Solution
Align with the implementation. This should _finally_ resolve this fairly long-standing bug.

Related:
* #2664
* #2465
* #1226

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
