### PR TITLE
feat(cloud9): always add default region

### DIFF
--- a/src/awsexplorer/defaultRegion.ts
+++ b/src/awsexplorer/defaultRegion.ts
@@ -11,7 +11,7 @@ import { AwsContext } from '../shared/awsContext'
 import * as localizedText from '../shared/localizedText'
 import { createQuickPick, promptUser } from '../shared/ui/picker'
 import { AwsExplorer } from './awsExplorer'
-import { getIdeProperties } from '../shared/extensionUtilities'
+import { getIdeProperties, isCloud9 } from '../shared/extensionUtilities'
 import { PromptSettings } from '../shared/settings'
 
 class RegionMissingUI {
@@ -32,6 +32,12 @@ export async function checkExplorerForDefaultRegion(
 
     const explorerRegions = new Set(await awsContext.getExplorerRegions())
     if (explorerRegions.has(profileRegion)) {
+        return
+    }
+
+    if (isCloud9()) {
+        await awsContext.addExplorerRegion(profileRegion)
+        awsExplorer.refresh()
         return
     }
 


### PR DESCRIPTION
## Problem:
On Cloud9, changing credentials is uncommon, while _new_ environments
_are_ common. Showing a prompt to ask about adding a region to AWS
Explorer is noisy.

## Solution:
On Cloud9, add the credentials-default region to AWS Explorer without
prompting.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
