### PR TITLE
build(deps): update vscode-test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "aws-toolkit-vscode",
-            "version": "1.40.0-SNAPSHOT",
+            "version": "1.43.0-SNAPSHOT",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -76,7 +76,7 @@
                 "@types/xml2js": "^0.4.8",
                 "@typescript-eslint/eslint-plugin": "^5.15.0",
                 "@typescript-eslint/parser": "^5.15.0",
-                "@vscode/test-electron": "^2.1.4",
+                "@vscode/test-electron": "^2.1.5",
                 "@vue/compiler-sfc": "^3.2.26",
                 "circular-dependency-plugin": "^5.2.2",
                 "css-loader": "^6.5.1",
@@ -3613,9 +3613,9 @@
             "integrity": "sha512-AXhTv1nl3r4W5DqAfXXKiawQNW+tLBNlXn/GcsnFCL0j17sQ2AY+az9oB9K6wjkibq1fndNJvmT8RYN712Fdww=="
         },
         "node_modules/@vscode/test-electron": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.4.tgz",
-            "integrity": "sha512-tHHAWNVwl8C7nyezHAHdNPWkksdXWvmae6bt4k1tJ9hvMm6QIIk95Mkutl82XHcD60mdP46EHDGU+xFsAvygOQ==",
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.5.tgz",
+            "integrity": "sha512-O/ioqFpV+RvKbRykX2ItYPnbcZ4Hk5V0rY4uhQjQTLhGL9WZUvS7exzuYQCCI+ilSqJpctvxq2llTfGXf9UnnA==",
             "dev": true,
             "dependencies": {
                 "http-proxy-agent": "^4.0.1",
@@ -16505,9 +16505,9 @@
             "integrity": "sha512-AXhTv1nl3r4W5DqAfXXKiawQNW+tLBNlXn/GcsnFCL0j17sQ2AY+az9oB9K6wjkibq1fndNJvmT8RYN712Fdww=="
         },
         "@vscode/test-electron": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.4.tgz",
-            "integrity": "sha512-tHHAWNVwl8C7nyezHAHdNPWkksdXWvmae6bt4k1tJ9hvMm6QIIk95Mkutl82XHcD60mdP46EHDGU+xFsAvygOQ==",
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.5.tgz",
+            "integrity": "sha512-O/ioqFpV+RvKbRykX2ItYPnbcZ4Hk5V0rY4uhQjQTLhGL9WZUvS7exzuYQCCI+ilSqJpctvxq2llTfGXf9UnnA==",
             "dev": true,
             "requires": {
                 "http-proxy-agent": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -3085,7 +3085,7 @@
         "@types/xml2js": "^0.4.8",
         "@typescript-eslint/eslint-plugin": "^5.15.0",
         "@typescript-eslint/parser": "^5.15.0",
-        "@vscode/test-electron": "^2.1.4",
+        "@vscode/test-electron": "^2.1.5",
         "@vue/compiler-sfc": "^3.2.26",
         "circular-dependency-plugin": "^5.2.2",
         "css-loader": "^6.5.1",


### PR DESCRIPTION
vscode-test now retries failed vscode download, which should reduce
spurious CI failures. https://github.com/microsoft/vscode-test/pull/154


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
