### PR TITLE
feat(statusbar): merge codewhisperer status into toolkit status

### DIFF
--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -82,7 +82,11 @@ export async function activate(context: ExtContext): Promise<void> {
             }
             if (configurationChangeEvent.affectsConfiguration('aws.experiments')) {
                 const codewhispererEnabled = await codewhispererSettings.isEnabled()
-                if (!codewhispererEnabled) {
+                if (codewhispererEnabled) {
+                    if (!isCloud9()) {
+                        InlineCompletion.instance.setCodeWhispererStatusBarOk()
+                    }
+                } else {
                     set(CodeWhispererConstants.termsAcceptedKey, false, context)
                     set(CodeWhispererConstants.autoTriggerEnabledKey, false, context)
                     if (!isCloud9()) {

--- a/src/codewhisperer/service/inlineCompletion.ts
+++ b/src/codewhisperer/service/inlineCompletion.ts
@@ -44,7 +44,6 @@ export class InlineCompletion {
     public origin: Recommendation[]
     public position: number
     private typeAhead: string
-    private codewhispererStatusBar: vscode.StatusBarItem
     public isTypeaheadInProgress: boolean
     private _timer?: NodeJS.Timer
     private documentUri: vscode.Uri | undefined
@@ -58,7 +57,6 @@ export class InlineCompletion {
         this.origin = []
         this.position = 0
         this.typeAhead = ''
-        this.codewhispererStatusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1)
         this.isTypeaheadInProgress = false
         this.documentUri = undefined
     }
@@ -450,21 +448,19 @@ export class InlineCompletion {
     }
 
     setCodeWhispererStatusBarLoading() {
-        this.codewhispererStatusBar.text = ` $(loading~spin)CodeWhisperer`
-        this.codewhispererStatusBar.show()
+        globals.awsContext.setCodewhispererStatus('running')
     }
 
     setCodeWhispererStatusBarOk() {
-        this.codewhispererStatusBar.text = ` $(check)CodeWhisperer`
-        this.codewhispererStatusBar.show()
+        globals.awsContext.setCodewhispererStatus('enabled')
     }
 
     hideCodeWhispererStatusBar() {
-        this.codewhispererStatusBar.hide()
+        globals.awsContext.setCodewhispererStatus('disabled')
     }
 
     isPaginationRunning() {
-        return this.codewhispererStatusBar.text === ` $(loading~spin)CodeWhisperer`
+        return globals.awsContext.getCodewhispererStatus() === 'running'
     }
 
     get getIsActive() {

--- a/src/test/utilities/fakeAwsContext.ts
+++ b/src/test/utilities/fakeAwsContext.ts
@@ -65,6 +65,7 @@ export class FakeAwsContext implements AwsContext {
     public onDidChangeContext: vscode.Event<ContextChangeEventsArgs> =
         new vscode.EventEmitter<ContextChangeEventsArgs>().event
     private awsContextCredentials: AwsContextCredentials | undefined
+    private codewhispererStatus: 'enabled' | 'running' | 'disabled' = 'disabled'
 
     public constructor(params?: FakeAwsContextParams) {
         this.awsContextCredentials = params?.contextCredentials
@@ -113,6 +114,17 @@ export class FakeAwsContext implements AwsContext {
 
     public async removeExplorerRegion(...regions: string[]): Promise<void> {
         throw new Error('Method not implemented.')
+    }
+
+    public getCodewhispererStatus() {
+        return this.codewhispererStatus
+    }
+
+    public setCodewhispererStatus(status: 'enabled' | 'running' | 'disabled') {
+        if (this.codewhispererStatus === status) {
+            return
+        }
+        this.codewhispererStatus = status
     }
 }
 


### PR DESCRIPTION
## Todo: possible (additional) compromises

- show "CodeWhisperer" in the AWS status item when CW is actively making API requests?
- show an icon instead of full "CodeWhisperer" string?
- make it configurable (but we should have a "strong default" UI, not noisy)

## Problem

- cw status bar takes unnecessary space in the user's vscode statusbar

## Solution

- show cw status in toolkit status area with an icon
- also add tooltip info for cw in the toolkit status

<img width="400" alt="status-enabled" src="https://user-images.githubusercontent.com/55561878/186251957-fd647570-3bc6-47ea-91e0-8494eda118c1.png">
<img width="393" alt="status-running" src="https://user-images.githubusercontent.com/55561878/186251961-bc1f3fc4-90ce-49a2-9d91-fe6947727583.png">
<img width="226" alt="status-disabled" src="https://user-images.githubusercontent.com/55561878/186251965-8d4e43cf-3ae5-4258-9706-3dd9dfcab394.png">


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
