### PR TITLE
tests: reset `globalState` after each test

### DIFF
--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -18,7 +18,7 @@ import { getLogger, LogLevel } from '../shared/logger'
 import { setLogger } from '../shared/logger/logger'
 import { CodelensRootRegistry } from '../shared/sam/codelensRootRegistry'
 import { activateExtension } from '../shared/utilities/vsCodeUtils'
-import { FakeExtensionContext } from './fakeExtensionContext'
+import { FakeExtensionContext, FakeMemento } from './fakeExtensionContext'
 import { TestLogger } from './testLogger'
 import * as testUtil from './testUtil'
 
@@ -60,6 +60,7 @@ beforeEach(async function () {
     globals.telemetry.telemetryEnabled = true
     globals.telemetry.clearRecords()
     globals.telemetry.logger.clear()
+    ;(globals.context as FakeExtensionContext).globalState = new FakeMemento()
 
     await testUtil.closeAllEditors()
 })


### PR DESCRIPTION
We're still using `FakeExtensionContext` for some reason but not resetting the stateful bits.
This doesn't cover everything but it's most of what tests use.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
