### PR TITLE
fix(codewhisperer): Only enable intelliSense config in AWS C9

### DIFF
--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -457,13 +457,13 @@ export async function shutdown() {
 }
 
 export async function enableDefaultConfig() {
+    if (!isCloud9()) return
     const editorSettings = vscode.workspace.getConfiguration('editor')
     try {
         await editorSettings.update('suggest.showMethods', true, vscode.ConfigurationTarget.Global)
         // suggest.preview is available in vsc 1.57+
         await editorSettings.update('suggest.preview', true, vscode.ConfigurationTarget.Global)
         await editorSettings.update('acceptSuggestionOnEnter', 'on', vscode.ConfigurationTarget.Global)
-        await editorSettings.update('snippetSuggestions', 'top', vscode.ConfigurationTarget.Global)
     } catch (error) {
         getLogger().error('codewhisperer: Failed to update user settings', error)
     }

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -48,9 +48,11 @@ const performance = globalThis.performance ?? require('perf_hooks').performance
 
 export async function activate(context: ExtContext): Promise<void> {
     /**
-     * Enable essential intellisense default settings
+     * Enable essential intellisense default settings for AWS C9 IDE
      */
-    await enableDefaultConfig()
+    if (isCloud9()) {
+        await enableDefaultConfig()
+    }
 
     /**
      * CodeWhisperer security panel
@@ -457,13 +459,13 @@ export async function shutdown() {
 }
 
 export async function enableDefaultConfig() {
-    if (!isCloud9()) return
     const editorSettings = vscode.workspace.getConfiguration('editor')
     try {
         await editorSettings.update('suggest.showMethods', true, vscode.ConfigurationTarget.Global)
         // suggest.preview is available in vsc 1.57+
         await editorSettings.update('suggest.preview', true, vscode.ConfigurationTarget.Global)
         await editorSettings.update('acceptSuggestionOnEnter', 'on', vscode.ConfigurationTarget.Global)
+        await editorSettings.update('snippetSuggestions', 'top', vscode.ConfigurationTarget.Global)
     } catch (error) {
         getLogger().error('codewhisperer: Failed to update user settings', error)
     }


### PR DESCRIPTION
## Problem

https://github.com/aws/aws-toolkit-vscode/issues/2732

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
