### PR TITLE
fix(codewhisperer): Add missing userDecision events

### DIFF
--- a/src/codewhisperer/commands/invokeRecommendation.ts
+++ b/src/codewhisperer/commands/invokeRecommendation.ts
@@ -54,6 +54,7 @@ export async function invokeRecommendation(
             vsCodeState.isIntelliSenseActive = false
             RecommendationHandler.instance.isGenerateRecommendationInProgress = true
             try {
+                RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
                 RecommendationHandler.instance.clearRecommendations()
                 await RecommendationHandler.instance.getRecommendations(
                     client,

--- a/src/codewhisperer/service/inlineCompletion.ts
+++ b/src/codewhisperer/service/inlineCompletion.ts
@@ -322,6 +322,7 @@ export class InlineCompletion {
         config: ConfigurationEntry,
         autoTriggerType?: telemetry.CodewhispererAutomatedTriggerType
     ) {
+        RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
         RecommendationHandler.instance.clearRecommendations()
         this.setCodeWhispererStatusBarLoading()
         const isManualTrigger = triggerType === 'OnDemand'
@@ -347,6 +348,7 @@ export class InlineCompletion {
                 )
                 this.setCompletionItems(editor)
                 if (RecommendationHandler.instance.checkAndResetCancellationTokens()) {
+                    RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
                     RecommendationHandler.instance.clearRecommendations()
                     break
                 }

--- a/src/codewhisperer/service/keyStrokeHandler.ts
+++ b/src/codewhisperer/service/keyStrokeHandler.ts
@@ -178,6 +178,7 @@ export class KeyStrokeHandler {
                 vsCodeState.isIntelliSenseActive = false
                 RecommendationHandler.instance.isGenerateRecommendationInProgress = true
                 try {
+                    RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
                     RecommendationHandler.instance.clearRecommendations()
                     await RecommendationHandler.instance.getRecommendations(
                         client,


### PR DESCRIPTION
## Problem
When a suggestion is rejected and cleared from plugin in either intelliSense or VSC inline, sometimes a userDecision event is not fired in plugin telemetry.

## Solution

1. Always fire userDecision events before clearing the suggestions.
2. Do not send serviceInvocation events if genReco/listReco API is not called.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
