### PR TITLE
fix(codewhisperer): skip activation when disabled

### DIFF
--- a/.changes/next-release/Bug Fix-b99c68f5-b3fe-417d-ac9a-cd5b63697396.json
+++ b/.changes/next-release/Bug Fix-b99c68f5-b3fe-417d-ac9a-cd5b63697396.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeWhisperer features were not fully disabled if the experiment was disabled"
+}

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -47,6 +47,11 @@ import { RecommendationHandler } from './service/recommendationHandler'
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
 export async function activate(context: ExtContext): Promise<void> {
+    const codewhispererSettings = CodeWhispererSettings.instance
+    if (!codewhispererSettings.isEnabled()) {
+        return
+    }
+
     /**
      * Enable essential intellisense default settings for AWS C9 IDE
      */
@@ -63,7 +68,6 @@ export async function activate(context: ExtContext): Promise<void> {
     /**
      * Service control
      */
-    const codewhispererSettings = CodeWhispererSettings.instance
     const client = new codewhispererClient.DefaultCodeWhispererClient()
 
     const referenceHoverProvider = new ReferenceHoverProvider()


### PR DESCRIPTION
( won't be merged until after release)

## Problem
For troubleshooting issues potentially related to codewhisperer, it is
useful for users to be able to fully disable codewhisperer to rule it
out as a possible cause. But codewhisperer activate() is called even
when it is disabled in settings, and this creates various handlers for
numerous vscode events, which could be a potential source of performance
issues or other bugs.

## Solution
Skip codewhisperer activation entirely if it is disabled in
settings.



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
