### PR TITLE
refactor(commands): migrate to commands2

### DIFF
--- a/src/apigateway/activation.ts
+++ b/src/apigateway/activation.ts
@@ -8,6 +8,7 @@ import { RestApiNode } from './explorer/apiNodes'
 import { invokeRemoteRestApi } from './vue/invokeRemoteRestApi'
 import { copyUrlCommand } from './commands/copyUrl'
 import { ExtContext } from '../shared/extensions'
+import { Commands } from '../shared/vscode/commands2'
 
 /**
  * Activate API Gateway functionality for the extension.
@@ -19,14 +20,8 @@ export async function activate(activateArguments: {
     const extensionContext = activateArguments.extContext.extensionContext
     const regionProvider = activateArguments.extContext.regionProvider
     extensionContext.subscriptions.push(
-        vscode.commands.registerCommand(
-            'aws.apig.copyUrl',
-            async (node: RestApiNode) => await copyUrlCommand(node, regionProvider)
-        )
-    )
-
-    extensionContext.subscriptions.push(
-        vscode.commands.registerCommand(
+        Commands.register('aws.apig.copyUrl', async (node: RestApiNode) => await copyUrlCommand(node, regionProvider)),
+        Commands.register(
             'aws.apig.invokeRemoteRestApi',
             async (node: RestApiNode) =>
                 await invokeRemoteRestApi(activateArguments.extContext, {

--- a/src/apprunner/activation.ts
+++ b/src/apprunner/activation.ts
@@ -15,6 +15,7 @@ import { deleteService } from './commands/deleteService'
 import { createFromEcr } from './commands/createServiceFromEcr'
 import { ExtContext } from '../shared/extensions'
 import { copyToClipboard } from '../shared/utilities/messages'
+import { Commands } from '../shared/vscode/commands2'
 
 const localize = nls.loadMessageBundle()
 
@@ -79,7 +80,7 @@ commandMap.set(['aws.apprunner.deleteService', DELETE_SERVICE_FAILED], deleteSer
 export async function activate(context: ExtContext): Promise<void> {
     commandMap.forEach((command, tuple) => {
         context.extensionContext.subscriptions.push(
-            vscode.commands.registerCommand(tuple[0], async (...args: any) => {
+            Commands.register(tuple[0], async (...args: any) => {
                 try {
                     await command(...args)
                 } catch (err) {

--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -102,14 +102,11 @@ async function registerAwsExplorerCommands(
     )
 
     context.extensionContext.subscriptions.push(
-        vscode.commands.registerCommand(
+        Commands.register(
             'aws.executeStateMachine',
             async (node: StateMachineNode) => await executeStateMachine(context, node)
-        )
-    )
-
-    context.extensionContext.subscriptions.push(
-        vscode.commands.registerCommand(
+        ),
+        Commands.register(
             'aws.renderStateMachineGraph',
             async (node: StateMachineNode) =>
                 await downloadStateMachineDefinition({
@@ -117,25 +114,13 @@ async function registerAwsExplorerCommands(
                     outputChannel: toolkitOutputChannel,
                     isPreviewAndRender: true,
                 })
-        )
-    )
-
-    context.extensionContext.subscriptions.push(
-        vscode.commands.registerCommand('aws.copyArn', async (node: AWSResourceNode) => await copyArnCommand(node))
-    )
-
-    context.extensionContext.subscriptions.push(
-        vscode.commands.registerCommand('aws.copyName', async (node: AWSResourceNode) => await copyNameCommand(node))
-    )
-
-    context.extensionContext.subscriptions.push(
-        vscode.commands.registerCommand('aws.refreshAwsExplorerNode', async (element: AWSTreeNodeBase | undefined) => {
+        ),
+        Commands.register('aws.copyArn', async (node: AWSResourceNode) => await copyArnCommand(node)),
+        Commands.register('aws.copyName', async (node: AWSResourceNode) => await copyNameCommand(node)),
+        Commands.register('aws.refreshAwsExplorerNode', async (element: AWSTreeNodeBase | undefined) => {
             awsExplorer.refresh(element)
-        })
-    )
-
-    context.extensionContext.subscriptions.push(
-        vscode.commands.registerCommand('aws.loadMoreChildren', async (node: AWSTreeNodeBase & LoadMoreNode) => {
+        }),
+        Commands.register('aws.loadMoreChildren', async (node: AWSTreeNodeBase & LoadMoreNode) => {
             await loadMoreChildrenCommand(node, awsExplorer)
         })
     )

--- a/src/cloudWatchLogs/activation.ts
+++ b/src/cloudWatchLogs/activation.ts
@@ -15,6 +15,7 @@ import { LogStreamCodeLensProvider } from './document/logStreamCodeLensProvider'
 import { LogStreamDocumentProvider } from './document/logStreamDocumentProvider'
 import { LogGroupNode } from './explorer/logGroupNode'
 import { LogStreamRegistry } from './registry/logStreamRegistry'
+import { Commands } from '../shared/vscode/commands2'
 
 export async function activate(context: vscode.ExtensionContext, configuration: Settings): Promise<void> {
     const settings = new CloudWatchLogsSettings(configuration)
@@ -45,9 +46,9 @@ export async function activate(context: vscode.ExtensionContext, configuration: 
         )
     )
 
-    context.subscriptions.push(vscode.commands.registerCommand('aws.copyLogStreamName', copyLogStreamName))
+    context.subscriptions.push(Commands.register('aws.copyLogStreamName', copyLogStreamName))
     context.subscriptions.push(
-        vscode.commands.registerCommand(
+        Commands.register(
             'aws.addLogEvents',
             async (
                 document: vscode.TextDocument,
@@ -55,19 +56,14 @@ export async function activate(context: vscode.ExtensionContext, configuration: 
                 headOrTail: 'head' | 'tail',
                 onDidChangeCodeLensEvent: vscode.EventEmitter<void>
             ) => addLogEvents(document, registry, headOrTail, onDidChangeCodeLensEvent)
-        )
-    )
-    context.subscriptions.push(
-        vscode.commands.registerCommand(
+        ),
+        Commands.register(
             'aws.saveCurrentLogStreamContent',
             async (uri?: vscode.Uri) => await saveCurrentLogStreamContent(uri, registry)
-        )
-    )
-
-    // AWS Explorer right-click action
-    // Here instead of in ../awsexplorer/activation due to dependence on the registry.
-    context.subscriptions.push(
-        vscode.commands.registerCommand(
+        ),
+        // AWS Explorer right-click action
+        // Here instead of in ../awsexplorer/activation due to dependence on the registry.
+        Commands.register(
             'aws.cloudWatchLogs.viewLogStream',
             async (node: LogGroupNode) => await viewLogStream(node, registry)
         )

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -43,6 +43,7 @@ import { ReferenceInlineProvider } from './service/referenceInlineProvider'
 import { SecurityPanelViewProvider } from './views/securityPanelViewProvider'
 import { disposeSecurityDiagnostic } from './service/diagnosticsProvider'
 import { RecommendationHandler } from './service/recommendationHandler'
+import { Commands } from '../shared/vscode/commands2'
 
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
@@ -100,7 +101,7 @@ export async function activate(context: ExtContext): Promise<void> {
         /**
          * Accept terms of service
          */
-        vscode.commands.registerCommand('aws.codeWhisperer.acceptTermsOfService', async () => {
+        Commands.register('aws.codeWhisperer.acceptTermsOfService', async () => {
             set(CodeWhispererConstants.autoTriggerEnabledKey, true, context)
             set(CodeWhispererConstants.termsAcceptedKey, true, context)
             await vscode.commands.executeCommand('setContext', CodeWhispererConstants.termsAcceptedKey, true)
@@ -119,14 +120,14 @@ export async function activate(context: ExtContext): Promise<void> {
         /**
          * Cancel terms of service
          */
-        vscode.commands.registerCommand('aws.codeWhisperer.cancelTermsOfService', async () => {
+        Commands.register('aws.codeWhisperer.cancelTermsOfService', async () => {
             set(CodeWhispererConstants.autoTriggerEnabledKey, false, context)
             await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
         }),
         /**
          * Open Configuration
          */
-        vscode.commands.registerCommand('aws.codeWhisperer.configure', async id => {
+        Commands.register('aws.codeWhisperer.configure', async id => {
             if (id === 'codewhisperer') {
                 await vscode.commands.executeCommand(
                     'workbench.action.openSettings',
@@ -149,13 +150,13 @@ export async function activate(context: ExtContext): Promise<void> {
         // code scan
         showSecurityScan.register(context, securityPanelViewProvider, client),
         // manual trigger
-        vscode.commands.registerCommand('aws.codeWhisperer', async () => {
+        Commands.register({ id: 'aws.codeWhisperer', autoconnect: true }, async () => {
             invokeRecommendation(vscode.window.activeTextEditor as vscode.TextEditor, client, await getConfigEntry())
         }),
         /**
          * On recommendation acceptance
          */
-        vscode.commands.registerCommand(
+        Commands.register(
             'aws.codeWhisperer.accept',
             async (
                 range: vscode.Range,
@@ -329,25 +330,25 @@ export async function activate(context: ExtContext): Promise<void> {
                     await InlineCompletion.instance.rejectRecommendation(vscode.window.activeTextEditor)
                 }
             }),
-            vscode.commands.registerCommand('aws.codeWhisperer.rejectCodeSuggestion', async e => {
+            Commands.register('aws.codeWhisperer.rejectCodeSuggestion', async e => {
                 if (vscode.window.activeTextEditor)
                     await InlineCompletion.instance.rejectRecommendation(vscode.window.activeTextEditor)
             }),
             /**
              * Recommendation navigation
              */
-            vscode.commands.registerCommand('aws.codeWhisperer.nextCodeSuggestion', async () => {
+            Commands.register('aws.codeWhisperer.nextCodeSuggestion', async () => {
                 if (vscode.window.activeTextEditor)
                     InlineCompletion.instance.navigateRecommendation(vscode.window.activeTextEditor, true)
             }),
-            vscode.commands.registerCommand('aws.codeWhisperer.previousCodeSuggestion', async () => {
+            Commands.register('aws.codeWhisperer.previousCodeSuggestion', async () => {
                 if (vscode.window.activeTextEditor)
                     InlineCompletion.instance.navigateRecommendation(vscode.window.activeTextEditor, false)
             }),
             /**
              * Recommendation acceptance
              */
-            vscode.commands.registerCommand('aws.codeWhisperer.acceptCodeSuggestion', async () => {
+            Commands.register('aws.codeWhisperer.acceptCodeSuggestion', async () => {
                 if (vscode.window.activeTextEditor)
                     await InlineCompletion.instance.acceptRecommendation(vscode.window.activeTextEditor)
             })

--- a/src/dynamicResources/activation.ts
+++ b/src/dynamicResources/activation.ts
@@ -15,6 +15,7 @@ import { ResourcesNode } from './explorer/nodes/resourcesNode'
 import { ResourceNode } from './explorer/nodes/resourceNode'
 import { ResourceTypeNode } from './explorer/nodes/resourceTypeNode'
 import { RESOURCE_FILE_GLOB_PATTERN } from './awsResourceManager'
+import { Commands } from '../shared/vscode/commands2'
 import globals from '../shared/extensionGlobals'
 
 const localize = nls.loadMessageBundle()
@@ -30,7 +31,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     context.subscriptions.push(
         vscode.workspace.registerTextDocumentContentProvider('awsResource', new VirtualDocumentProvider()),
-        vscode.commands.registerCommand('aws.resources.openResourcePreview', async (node: ResourceNode) => {
+        Commands.register('aws.resources.openResourcePreview', async (node: ResourceNode) => {
             await openResource({
                 source: node,
                 preview: true,
@@ -38,25 +39,25 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                 diagnostics: resourceDiagnostics,
             })
         }),
-        vscode.commands.registerCommand('aws.resources.copyIdentifier', async (node: ResourceNode) => {
+        Commands.register('aws.resources.copyIdentifier', async (node: ResourceNode) => {
             await copyIdentifier(node.parent.typeName, node.identifier)
         }),
-        vscode.commands.registerCommand('aws.resources.configure', async (node: ResourcesNode) => {
+        Commands.register('aws.resources.configure', async (node: ResourcesNode) => {
             if (await configureResources()) {
                 node.refresh()
             }
         }),
-        vscode.commands.registerCommand('aws.resources.createResource', async (node: ResourceTypeNode) => {
+        Commands.register('aws.resources.createResource', async (node: ResourceTypeNode) => {
             await resourceManager.new(node)
         }),
-        vscode.commands.registerCommand('aws.resources.deleteResource', async (node: ResourceNode) => {
+        Commands.register('aws.resources.deleteResource', async (node: ResourceNode) => {
             if (await deleteResource(node.parent.cloudControl, node.parent.typeName, node.identifier)) {
                 await resourceManager.close(resourceManager.toUri(node)!)
                 node.parent.clearChildren()
                 node.parent.refresh()
             }
         }),
-        vscode.commands.registerCommand('aws.resources.updateResource', async (node: ResourceNode) => {
+        Commands.register('aws.resources.updateResource', async (node: ResourceNode) => {
             await openResource({
                 source: node,
                 preview: false,
@@ -64,7 +65,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                 diagnostics: resourceDiagnostics,
             })
         }),
-        vscode.commands.registerCommand('aws.resources.updateResourceInline', async (uri: vscode.Uri) => {
+        Commands.register('aws.resources.updateResourceInline', async (uri: vscode.Uri) => {
             await openResource({
                 source: uri,
                 preview: false,
@@ -75,11 +76,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         vscode.workspace.onDidSaveTextDocument(async (doc: vscode.TextDocument) => {
             return await saveResource(doc, resourceManager, resourceDiagnostics)
         }),
-        vscode.commands.registerCommand('aws.resources.saveResource', async (uri: vscode.Uri) => {
+        Commands.register('aws.resources.saveResource', async (uri: vscode.Uri) => {
             await vscode.window.showTextDocument(uri)
             await vscode.commands.executeCommand('workbench.action.files.save')
         }),
-        vscode.commands.registerCommand('aws.resources.closeResource', async (uri: vscode.Uri) => {
+        Commands.register('aws.resources.closeResource', async (uri: vscode.Uri) => {
             if (resourceManager.fromUri(uri) instanceof ResourceNode) {
                 await openResource({
                     source: uri,
@@ -92,7 +93,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                 await resourceManager.close(uri)
             }
         }),
-        vscode.commands.registerCommand('aws.resources.viewDocs', async (node: ResourceTypeNode) => {
+        Commands.register('aws.resources.viewDocs', async (node: ResourceTypeNode) => {
             await vscode.env.openExternal(vscode.Uri.parse(node.metadata.documentation))
         }),
         vscode.workspace.onDidChangeTextDocument(textDocumentEvent => {

--- a/src/ecr/activation.ts
+++ b/src/ecr/activation.ts
@@ -12,25 +12,26 @@ import { EcrNode } from './explorer/ecrNode'
 import { EcrRepositoryNode } from './explorer/ecrRepositoryNode'
 import { EcrTagNode } from './explorer/ecrTagNode'
 import { deleteTag } from './commands/deleteTag'
+import { Commands } from '../shared/vscode/commands2'
 
 /**
  * Activates ECR components.
  */
 export async function activate(extensionContext: vscode.ExtensionContext): Promise<void> {
     extensionContext.subscriptions.push(
-        vscode.commands.registerCommand('aws.ecr.createRepository', async (node: EcrNode) => {
+        Commands.register('aws.ecr.createRepository', async (node: EcrNode) => {
             await createRepository(node)
         }),
-        vscode.commands.registerCommand('aws.ecr.deleteRepository', async (node: EcrRepositoryNode) => {
+        Commands.register('aws.ecr.deleteRepository', async (node: EcrRepositoryNode) => {
             await deleteRepository(node)
         }),
-        vscode.commands.registerCommand('aws.ecr.copyRepositoryUri', async (node: EcrRepositoryNode) => {
+        Commands.register('aws.ecr.copyRepositoryUri', async (node: EcrRepositoryNode) => {
             await copyRepositoryUri(node)
         }),
-        vscode.commands.registerCommand('aws.ecr.copyTagUri', async (node: EcrTagNode) => {
+        Commands.register('aws.ecr.copyTagUri', async (node: EcrTagNode) => {
             await copyTagUri(node)
         }),
-        vscode.commands.registerCommand('aws.ecr.deleteTag', async (node: EcrTagNode) => {
+        Commands.register('aws.ecr.deleteTag', async (node: EcrTagNode) => {
             await deleteTag(node)
         })
     )

--- a/src/ecs/activation.ts
+++ b/src/ecs/activation.ts
@@ -13,10 +13,11 @@ import { EcsContainerNode } from './explorer/ecsContainerNode'
 import { EcsServiceNode } from './explorer/ecsServiceNode'
 import { ecsDocumentationUrl } from '../shared/constants'
 import { getLogger } from '../shared/logger'
+import { Commands } from '../shared/vscode/commands2'
 
 export async function activate(ctx: ExtContext): Promise<void> {
     ctx.extensionContext.subscriptions.push(
-        vscode.commands.registerCommand('aws.ecs.runCommandInContainer', async (node: EcsContainerNode) => {
+        Commands.register('aws.ecs.runCommandInContainer', async (node: EcsContainerNode) => {
             // VS Code will rarely call the command with `undefined` if the tree is still loading
             if (!(node instanceof EcsContainerNode)) {
                 getLogger().error('Cannot run command on node: %O', node)
@@ -33,19 +34,19 @@ export async function activate(ctx: ExtContext): Promise<void> {
     )
 
     ctx.extensionContext.subscriptions.push(
-        vscode.commands.registerCommand('aws.ecs.enableEcsExec', async (node: EcsServiceNode) => {
+        Commands.register('aws.ecs.enableEcsExec', async (node: EcsServiceNode) => {
             await updateEnableExecuteCommandFlag(node, true)
         })
     )
 
     ctx.extensionContext.subscriptions.push(
-        vscode.commands.registerCommand('aws.ecs.disableEcsExec', async (node: EcsServiceNode) => {
+        Commands.register('aws.ecs.disableEcsExec', async (node: EcsServiceNode) => {
             await updateEnableExecuteCommandFlag(node, false)
         })
     )
 
     ctx.extensionContext.subscriptions.push(
-        vscode.commands.registerCommand('aws.ecs.viewDocumentation', async () => {
+        Commands.register('aws.ecs.viewDocumentation', async () => {
             vscode.env.openExternal(vscode.Uri.parse(ecsDocumentationUrl))
         })
     )

--- a/src/eventSchemas/activation.ts
+++ b/src/eventSchemas/activation.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as vscode from 'vscode'
 import { downloadSchemaItemCode } from '../eventSchemas/commands/downloadSchemaItemCode'
 import { createSearchSchemasWebView } from './vue/searchSchemas'
 import { viewSchemaItem } from '../eventSchemas/commands/viewSchemaItem'

--- a/src/eventSchemas/activation.ts
+++ b/src/eventSchemas/activation.ts
@@ -11,6 +11,7 @@ import { RegistryItemNode } from '../eventSchemas/explorer/registryItemNode'
 import { SchemaItemNode } from '../eventSchemas/explorer/schemaItemNode'
 import { SchemasNode } from '../eventSchemas/explorer/schemasNode'
 import { ExtContext } from '../shared/extensions'
+import { Commands } from '../shared/vscode/commands2'
 
 /**
  * Activate Schemas functionality for the extension.
@@ -21,25 +22,16 @@ export async function activate(context: ExtContext): Promise<void> {
 
 async function registerSchemasCommands(context: ExtContext): Promise<void> {
     context.extensionContext.subscriptions.push(
-        vscode.commands.registerCommand(
-            'aws.viewSchemaItem',
-            async (node: SchemaItemNode) => await viewSchemaItem(node)
-        )
-    )
-    context.extensionContext.subscriptions.push(
-        vscode.commands.registerCommand(
+        Commands.register('aws.viewSchemaItem', async (node: SchemaItemNode) => await viewSchemaItem(node)),
+        Commands.register(
             'aws.downloadSchemaItemCode',
             async (node: SchemaItemNode) => await downloadSchemaItemCode(node, context.outputChannel)
-        )
-    )
-    context.extensionContext.subscriptions.push(
-        vscode.commands.registerCommand(
+        ),
+        Commands.register(
             'aws.searchSchema',
             async (node: SchemasNode) => await createSearchSchemasWebView(context, node)
-        )
-    )
-    context.extensionContext.subscriptions.push(
-        vscode.commands.registerCommand(
+        ),
+        Commands.register(
             'aws.searchSchemaPerRegistry',
             async (node: RegistryItemNode) => await createSearchSchemasWebView(context, node)
         )

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,7 +66,7 @@ import { join } from 'path'
 import { initializeIconPaths } from './shared/icons'
 import { Settings } from './shared/settings'
 import { isReleaseVersion } from './shared/vscode/env'
-import { Commands } from '../shared/vscode/commands2'
+import { Commands } from './shared/vscode/commands2'
 
 let localize: nls.LocalizeFunc
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,6 +66,7 @@ import { join } from 'path'
 import { initializeIconPaths } from './shared/icons'
 import { Settings } from './shared/settings'
 import { isReleaseVersion } from './shared/vscode/env'
+import { Commands } from '../shared/vscode/commands2'
 
 let localize: nls.LocalizeFunc
 
@@ -142,55 +143,40 @@ export async function activate(context: vscode.ExtensionContext) {
         context.subscriptions.push(
             // No-op command used for decoration-only codelenses.
             vscode.commands.registerCommand('aws.doNothingCommand', () => {}),
-            vscode.commands.registerCommand('aws.login', () => globals.awsContextCommands.onCommandLogin()),
-            vscode.commands.registerCommand('aws.logout', () => globals.awsContextCommands.onCommandLogout()),
+            Commands.register('aws.login', () => globals.awsContextCommands.onCommandLogin()),
+            Commands.register('aws.logout', () => globals.awsContextCommands.onCommandLogout()),
             // "Show AWS Commands..."
-            vscode.commands.registerCommand('aws.listCommands', () =>
+            Commands.register('aws.listCommands', () =>
                 vscode.commands.executeCommand('workbench.action.quickOpen', `> ${getIdeProperties().company}:`)
-            )
-        )
-
-        context.subscriptions.push(
-            vscode.commands.registerCommand('aws.credential.profile.create', async () => {
+            ),
+            Commands.register('aws.credential.profile.create', async () => {
                 try {
                     await globals.awsContextCommands.onCommandCreateCredentialsProfile()
                 } finally {
                     telemetry.recordAwsCreateCredentials()
                 }
-            })
-        )
-
-        // register URLs in extension menu
-        context.subscriptions.push(
-            vscode.commands.registerCommand('aws.help', async () => {
+            }),
+            // register URLs in extension menu
+            Commands.register('aws.help', async () => {
                 vscode.env.openExternal(vscode.Uri.parse(documentationUrl))
                 telemetry.recordAwsHelp()
-            })
-        )
-        context.subscriptions.push(
-            vscode.commands.registerCommand('aws.github', async () => {
+            }),
+            Commands.register('aws.github', async () => {
                 vscode.env.openExternal(vscode.Uri.parse(githubUrl))
                 telemetry.recordAwsShowExtensionSource()
-            })
-        )
-        context.subscriptions.push(
-            vscode.commands.registerCommand('aws.createIssueOnGitHub', async () => {
+            }),
+            Commands.register('aws.createIssueOnGitHub', async () => {
                 vscode.env.openExternal(vscode.Uri.parse(githubCreateIssueUrl))
                 telemetry.recordAwsReportPluginIssue()
-            })
-        )
-        context.subscriptions.push(
-            vscode.commands.registerCommand('aws.quickStart', async () => {
+            }),
+            Commands.register('aws.quickStart', async () => {
                 try {
                     await showQuickStartWebview(context)
                 } finally {
                     telemetry.recordAwsHelpQuickstart({ result: 'Succeeded' })
                 }
-            })
-        )
-
-        context.subscriptions.push(
-            vscode.commands.registerCommand('aws.aboutToolkit', async () => {
+            }),
+            Commands.register('aws.aboutToolkit', async () => {
                 await aboutToolkit()
             })
         )

--- a/src/iot/activation.ts
+++ b/src/iot/activation.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as vscode from 'vscode'
 import { IotThingNode } from './explorer/iotThingNode'
 import { ExtContext } from '../shared/extensions'
 import { IotThingFolderNode } from './explorer/iotThingFolderNode'
@@ -33,64 +32,65 @@ import { deletePolicyVersionCommand } from './commands/deletePolicyVersion'
 import { setDefaultPolicy } from './commands/setDefaultPolicy'
 import { createPolicyVersionCommand } from './commands/createPolicyVersion'
 import { viewPolicyVersionCommand } from './commands/viewPolicyVersion'
+import { Commands } from '../shared/vscode/commands2'
 
 /**
  * Activate IoT components.
  */
 export async function activate(context: ExtContext): Promise<void> {
     context.extensionContext.subscriptions.push(
-        vscode.commands.registerCommand('aws.iot.createThing', async (node: IotThingFolderNode) => {
+        Commands.register('aws.iot.createThing', async (node: IotThingFolderNode) => {
             await createThingCommand(node)
         }),
-        vscode.commands.registerCommand('aws.iot.deleteThing', async (node: IotThingNode) => {
+        Commands.register('aws.iot.deleteThing', async (node: IotThingNode) => {
             await deleteThingCommand(node)
         }),
-        vscode.commands.registerCommand('aws.iot.createCert', async (node: IotCertsFolderNode) => {
+        Commands.register('aws.iot.createCert', async (node: IotCertsFolderNode) => {
             await createCertificateCommand(node)
         }),
-        vscode.commands.registerCommand('aws.iot.deleteCert', async (node: IotCertWithPoliciesNode) => {
+        Commands.register('aws.iot.deleteCert', async (node: IotCertWithPoliciesNode) => {
             await deleteCertCommand(node)
         }),
-        vscode.commands.registerCommand('aws.iot.attachCert', async (node: IotThingNode) => {
+        Commands.register('aws.iot.attachCert', async (node: IotThingNode) => {
             await attachCertificateCommand(node)
         }),
-        vscode.commands.registerCommand('aws.iot.detachCert', async (node: IotThingCertNode) => {
+        Commands.register('aws.iot.detachCert', async (node: IotThingCertNode) => {
             await detachThingCertCommand(node)
         }),
-        vscode.commands.registerCommand('aws.iot.createPolicy', async (node: IotPolicyFolderNode) => {
+        Commands.register('aws.iot.createPolicy', async (node: IotPolicyFolderNode) => {
             await createPolicyCommand(node)
         }),
-        vscode.commands.registerCommand('aws.iot.deletePolicy', async (node: IotPolicyWithVersionsNode) => {
+        Commands.register('aws.iot.deletePolicy', async (node: IotPolicyWithVersionsNode) => {
             await deletePolicyCommand(node)
         }),
-        vscode.commands.registerCommand('aws.iot.attachPolicy', async (node: IotCertWithPoliciesNode) => {
+        Commands.register('aws.iot.attachPolicy', async (node: IotCertWithPoliciesNode) => {
             await attachPolicyCommand(node)
         }),
-        vscode.commands.registerCommand('aws.iot.detachPolicy', async (node: IotPolicyCertNode) => {
+        Commands.register('aws.iot.detachPolicy', async (node: IotPolicyCertNode) => {
             await detachPolicyCommand(node)
         }),
-        vscode.commands.registerCommand('aws.iot.activateCert', async (node: IotCertificateNode) => {
+        Commands.register('aws.iot.activateCert', async (node: IotCertificateNode) => {
             await activateCertificateCommand(node)
         }),
-        vscode.commands.registerCommand('aws.iot.deactivateCert', async (node: IotCertificateNode) => {
+        Commands.register('aws.iot.deactivateCert', async (node: IotCertificateNode) => {
             await deactivateCertificateCommand(node)
         }),
-        vscode.commands.registerCommand('aws.iot.revokeCert', async (node: IotCertificateNode) => {
+        Commands.register('aws.iot.revokeCert', async (node: IotCertificateNode) => {
             await revokeCertificateCommand(node)
         }),
-        vscode.commands.registerCommand('aws.iot.createPolicyVersion', async (node: IotPolicyWithVersionsNode) => {
+        Commands.register('aws.iot.createPolicyVersion', async (node: IotPolicyWithVersionsNode) => {
             await createPolicyVersionCommand(node)
         }),
-        vscode.commands.registerCommand('aws.iot.deletePolicyVersion', async (node: IotPolicyVersionNode) => {
+        Commands.register('aws.iot.deletePolicyVersion', async (node: IotPolicyVersionNode) => {
             await deletePolicyVersionCommand(node)
         }),
-        vscode.commands.registerCommand('aws.iot.setDefaultPolicy', async (node: IotPolicyVersionNode) => {
+        Commands.register('aws.iot.setDefaultPolicy', async (node: IotPolicyVersionNode) => {
             await setDefaultPolicy(node)
         }),
-        vscode.commands.registerCommand('aws.iot.viewPolicyVersion', async (node: IotPolicyVersionNode) => {
+        Commands.register('aws.iot.viewPolicyVersion', async (node: IotPolicyVersionNode) => {
             await viewPolicyVersionCommand(node)
         }),
-        vscode.commands.registerCommand('aws.iot.copyEndpoint', async (node: IotNode) => {
+        Commands.register('aws.iot.copyEndpoint', async (node: IotNode) => {
             await copyEndpointCommand(node)
         })
     )

--- a/src/lambda/activation.ts
+++ b/src/lambda/activation.ts
@@ -20,7 +20,7 @@ import { Commands } from '../shared/vscode/commands2'
  */
 export async function activate(context: ExtContext): Promise<void> {
     context.extensionContext.subscriptions.push(
-        vscode.commands.registerCommand(
+        Commands.register(
             'aws.deleteLambda',
             async (node: LambdaFunctionNode) =>
                 await deleteLambda({
@@ -31,7 +31,7 @@ export async function activate(context: ExtContext): Promise<void> {
                         await vscode.commands.executeCommand('aws.refreshAwsExplorerNode', node.parent),
                 })
         ),
-        vscode.commands.registerCommand(
+        Commands.register(
             'aws.invokeLambda',
             async (node: LambdaFunctionNode) =>
                 await invokeRemoteLambda(context, { outputChannel: context.outputChannel, functionNode: node })
@@ -45,10 +45,7 @@ export async function activate(context: ExtContext): Promise<void> {
                 await tryRemoveFolder(session.configuration.baseBuildDir)
             }
         }),
-        vscode.commands.registerCommand(
-            'aws.downloadLambda',
-            async (node: LambdaFunctionNode) => await downloadLambdaCommand(node)
-        ),
+        Commands.register('aws.downloadLambda', async (node: LambdaFunctionNode) => await downloadLambdaCommand(node)),
         Commands.register({ id: 'aws.uploadLambda', autoconnect: true }, async (arg?: unknown) => {
             if (arg instanceof LambdaFunctionNode) {
                 await uploadLambdaCommand({

--- a/src/lambda/vue/configEditor/samInvokeBackend.ts
+++ b/src/lambda/vue/configEditor/samInvokeBackend.ts
@@ -35,6 +35,7 @@ import { SamDebugConfigProvider } from '../../../shared/sam/debugger/awsSamDebug
 import { samLambdaCreatableRuntimes } from '../../models/samLambdaRuntime'
 import globals from '../../../shared/extensionGlobals'
 import { VueWebview } from '../../../webviews/main'
+import { Commands } from '../../../shared/vscode/commands2'
 
 const localize = nls.loadMessageBundle()
 
@@ -302,14 +303,11 @@ export class SamInvokeWebview extends VueWebview {
 const WebviewPanel = VueWebview.compilePanel(SamInvokeWebview)
 
 export function registerSamInvokeVueCommand(context: ExtContext): vscode.Disposable {
-    return vscode.commands.registerCommand(
-        'aws.launchConfigForm',
-        async (launchConfig?: AwsSamDebuggerConfiguration) => {
-            const webview = new WebviewPanel(context.extensionContext, context, launchConfig)
-            webview.show({ title: localize('AWS.command.launchConfigForm.title', 'Edit SAM Debug Configuration') })
-            recordSamOpenConfigUi()
-        }
-    )
+    return Commands.register('aws.launchConfigForm', async (launchConfig?: AwsSamDebuggerConfiguration) => {
+        const webview = new WebviewPanel(context.extensionContext, context, launchConfig)
+        webview.show({ title: localize('AWS.command.launchConfigForm.title', 'Edit SAM Debug Configuration') })
+        recordSamOpenConfigUi()
+    })
 }
 
 function getUriFromLaunchConfig(config: AwsSamDebuggerConfiguration): vscode.Uri | undefined {

--- a/src/s3/activation.ts
+++ b/src/s3/activation.ts
@@ -22,6 +22,7 @@ import { ExtContext } from '../shared/extensions'
 import { S3FileViewerManager, S3_EDIT_SCHEME, S3_READ_SCHEME } from './fileViewerManager'
 import { VirualFileSystem } from '../shared/virtualFilesystem'
 import globals from '../shared/extensionGlobals'
+import { Commands } from '../shared/vscode/commands2'
 
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
@@ -40,45 +41,48 @@ export async function activate(ctx: ExtContext): Promise<void> {
     ctx.extensionContext.subscriptions.push(
         vscode.workspace.registerFileSystemProvider(S3_EDIT_SCHEME, fs),
         vscode.workspace.registerFileSystemProvider(S3_READ_SCHEME, fs, { isReadonly: true }),
-        vscode.commands.registerCommand('aws.s3.copyPath', async (node: S3FolderNode | S3FileNode) => {
+        Commands.register('aws.s3.copyPath', async (node: S3FolderNode | S3FileNode) => {
             await copyPathCommand(node)
         }),
-        vscode.commands.registerCommand('aws.s3.presignedURL', async (node: S3FileNode) => {
+        Commands.register('aws.s3.presignedURL', async (node: S3FileNode) => {
             await presignedURLCommand(node)
         }),
-        vscode.commands.registerCommand('aws.s3.downloadFileAs', async (node: S3FileNode) => {
+        Commands.register('aws.s3.downloadFileAs', async (node: S3FileNode) => {
             await downloadFileAsCommand(node)
         }),
-        vscode.commands.registerCommand('aws.s3.openFile', async (node: S3FileNode) => {
+        Commands.register('aws.s3.openFile', async (node: S3FileNode) => {
             await openFileReadModeCommand(node, manager)
         }),
-        vscode.commands.registerCommand('aws.s3.editFile', async (uriOrNode: vscode.Uri | S3FileNode) => {
+        Commands.register('aws.s3.editFile', async (uriOrNode: vscode.Uri | S3FileNode) => {
             await editFileCommand(uriOrNode, manager)
         }),
-        vscode.commands.registerCommand('aws.s3.uploadFile', async (node?: S3BucketNode | S3FolderNode) => {
-            if (!node) {
-                const awsContext = ctx.awsContext
-                const regionCode = awsContext.getCredentialDefaultRegion()
-                const s3Client = globals.toolkitClientBuilder.createS3Client(regionCode)
-                const document = vscode.window.activeTextEditor?.document.uri
-                await uploadFileCommand(s3Client, document)
-            } else {
-                await uploadFileCommand(node.s3, node)
+        Commands.register(
+            { id: 'aws.s3.uploadFile', autoconnect: true },
+            async (node?: S3BucketNode | S3FolderNode) => {
+                if (!node) {
+                    const awsContext = ctx.awsContext
+                    const regionCode = awsContext.getCredentialDefaultRegion()
+                    const s3Client = globals.toolkitClientBuilder.createS3Client(regionCode)
+                    const document = vscode.window.activeTextEditor?.document.uri
+                    await uploadFileCommand(s3Client, document)
+                } else {
+                    await uploadFileCommand(node.s3, node)
+                }
             }
-        }),
-        vscode.commands.registerCommand('aws.s3.uploadFileToParent', async (node: S3FileNode) => {
+        ),
+        Commands.register('aws.s3.uploadFileToParent', async (node: S3FileNode) => {
             await uploadFileToParentCommand(node)
         }),
-        vscode.commands.registerCommand('aws.s3.createBucket', async (node: S3Node) => {
+        Commands.register('aws.s3.createBucket', async (node: S3Node) => {
             await createBucketCommand(node)
         }),
-        vscode.commands.registerCommand('aws.s3.createFolder', async (node: S3BucketNode | S3FolderNode) => {
+        Commands.register('aws.s3.createFolder', async (node: S3BucketNode | S3FolderNode) => {
             await createFolderCommand(node)
         }),
-        vscode.commands.registerCommand('aws.s3.deleteBucket', async (node: S3BucketNode) => {
+        Commands.register('aws.s3.deleteBucket', async (node: S3BucketNode) => {
             await deleteBucketCommand(node)
         }),
-        vscode.commands.registerCommand('aws.s3.deleteFile', async (node: S3FileNode) => {
+        Commands.register('aws.s3.deleteFile', async (node: S3FileNode) => {
             await deleteFileCommand(node)
         })
     )

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -11,6 +11,7 @@ import { CloudFormationTemplateRegistry } from './templateRegistry'
 import { getIdeProperties } from '../extensionUtilities'
 import { NoopWatcher } from '../watchedFiles'
 import { createStarterTemplateFile } from './cloudformation'
+import { Commands } from '../vscode/commands2'
 import globals from '../extensionGlobals'
 
 export const TEMPLATE_FILE_GLOB_PATTERN = '**/*.{yaml,yml}'
@@ -51,7 +52,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
     // If setting it up worked, add it to subscriptions so it is cleaned up at exit
     extensionContext.subscriptions.push(
         globals.templateRegistry,
-        vscode.commands.registerCommand('aws.cloudFormation.newTemplate', () => createStarterTemplateFile(false)),
-        vscode.commands.registerCommand('aws.sam.newTemplate', () => createStarterTemplateFile(true))
+        Commands.register('aws.cloudFormation.newTemplate', () => createStarterTemplateFile(false)),
+        Commands.register('aws.sam.newTemplate', () => createStarterTemplateFile(true))
     )
 }

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -206,14 +206,14 @@ async function activateCodeLensProviders(
     disposables.push(vscode.languages.registerCodeLensProvider(goLensProvider.GO_ALLFILES, goCodeLensProvider))
 
     disposables.push(
-        vscode.commands.registerCommand('aws.toggleSamCodeLenses', () => {
+        Commands.register({ id: 'aws.toggleSamCodeLenses', autoconnect: false }, async () => {
             const toggled = !configuration.get('enableCodeLenses', false)
             configuration.update('enableCodeLenses', toggled)
         })
     )
 
     disposables.push(
-        vscode.commands.registerCommand('aws.addSamDebugConfig', async () => {
+        Commands.register('aws.addSamDebugConfig', async () => {
             const activeEditor = vscode.window.activeTextEditor
             if (!activeEditor) {
                 getLogger().error(`aws.addSamDebugConfig was called without an active text editor`)

--- a/src/ssmDocument/activation.ts
+++ b/src/ssmDocument/activation.ts
@@ -15,6 +15,7 @@ import { DocumentItemNode } from './explorer/documentItemNode'
 import { deleteDocument } from './commands/deleteDocument'
 import { DocumentItemNodeWriteable } from './explorer/documentItemNodeWriteable'
 import { updateDocumentVersion } from './commands/updateDocumentVersion'
+import { Commands } from '../shared/vscode/commands2'
 
 // Activate SSM Document related functionality for the extension.
 export async function activate(
@@ -34,47 +35,26 @@ async function registerSsmDocumentCommands(
     outputChannel: vscode.OutputChannel
 ): Promise<void> {
     extensionContext.subscriptions.push(
-        vscode.commands.registerCommand('aws.ssmDocument.createLocalDocument', async () => {
+        Commands.register('aws.ssmDocument.createLocalDocument', async () => {
             await createSsmDocumentFromTemplate(extensionContext)
-        })
-    )
-
-    extensionContext.subscriptions.push(
-        vscode.commands.registerCommand('aws.ssmDocument.deleteDocument', async (node: DocumentItemNodeWriteable) => {
+        }),
+        Commands.register('aws.ssmDocument.deleteDocument', async (node: DocumentItemNodeWriteable) => {
             await deleteDocument(node)
-        })
-    )
-
-    extensionContext.subscriptions.push(
-        vscode.commands.registerCommand('aws.ssmDocument.openLocalDocument', async (node: DocumentItemNode) => {
+        }),
+        Commands.register('aws.ssmDocument.openLocalDocument', async (node: DocumentItemNode) => {
             await openDocumentItem(node, awsContext)
-        })
-    )
-
-    extensionContext.subscriptions.push(
-        vscode.commands.registerCommand('aws.ssmDocument.openLocalDocumentJson', async (node: DocumentItemNode) => {
+        }),
+        Commands.register('aws.ssmDocument.openLocalDocumentJson', async (node: DocumentItemNode) => {
             await openDocumentItemJson(node, awsContext)
-        })
-    )
-
-    extensionContext.subscriptions.push(
-        vscode.commands.registerCommand('aws.ssmDocument.openLocalDocumentYaml', async (node: DocumentItemNode) => {
+        }),
+        Commands.register('aws.ssmDocument.openLocalDocumentYaml', async (node: DocumentItemNode) => {
             await openDocumentItemYaml(node, awsContext)
-        })
-    )
-
-    extensionContext.subscriptions.push(
-        vscode.commands.registerCommand('aws.ssmDocument.publishDocument', async () => {
+        }),
+        Commands.register('aws.ssmDocument.publishDocument', async () => {
             await publishSSMDocument(awsContext, regionProvider)
+        }),
+        Commands.register('aws.ssmDocument.updateDocumentVersion', async (node: DocumentItemNodeWriteable) => {
+            await updateDocumentVersion(node, awsContext)
         })
-    )
-
-    extensionContext.subscriptions.push(
-        vscode.commands.registerCommand(
-            'aws.ssmDocument.updateDocumentVersion',
-            async (node: DocumentItemNodeWriteable) => {
-                await updateDocumentVersion(node, awsContext)
-            }
-        )
     )
 }

--- a/src/stepFunctions/activation.ts
+++ b/src/stepFunctions/activation.ts
@@ -11,6 +11,7 @@ import { activate as activateASL } from './asl/client'
 import { createStateMachineFromTemplate } from './commands/createStateMachineFromTemplate'
 import { publishStateMachine } from './commands/publishStateMachine'
 import { AslVisualizationManager } from './commands/visualizeStateMachine/aslVisualizationManager'
+import { Commands } from '../shared/vscode/commands2'
 
 import { ASL_FORMATS, YAML_ASL, JSON_ASL } from './constants/aslFormats'
 
@@ -50,7 +51,7 @@ async function registerStepFunctionCommands(
          * specifc subset of file types ( .json only, custom .states extension, etc...)
          * Ensure tests are written for this use case as well.
          */
-        vscode.commands.registerCommand('aws.previewStateMachine', async (arg?: vscode.TextEditor | vscode.Uri) => {
+        Commands.register('aws.previewStateMachine', async (arg?: vscode.TextEditor | vscode.Uri) => {
             try {
                 arg ??= vscode.window.activeTextEditor
                 const input = arg instanceof vscode.Uri ? arg : arg?.document
@@ -65,21 +66,15 @@ async function registerStepFunctionCommands(
                 telemetry.recordStepfunctionsPreviewstatemachine()
             }
         }),
-        renderCdkStateMachineGraph.register(extensionContext.globalState, cdkVisualizationManager)
-    )
-
-    extensionContext.subscriptions.push(
-        vscode.commands.registerCommand('aws.stepfunctions.createStateMachineFromTemplate', async () => {
+        renderCdkStateMachineGraph.register(extensionContext.globalState, cdkVisualizationManager),
+        Commands.register('aws.stepfunctions.createStateMachineFromTemplate', async () => {
             try {
                 await createStateMachineFromTemplate(extensionContext)
             } finally {
                 telemetry.recordStepfunctionsCreateStateMachineFromTemplate()
             }
-        })
-    )
-
-    extensionContext.subscriptions.push(
-        vscode.commands.registerCommand('aws.stepfunctions.publishStateMachine', async (node?: any) => {
+        }),
+        Commands.register('aws.stepfunctions.publishStateMachine', async (node?: any) => {
             const region: string | undefined = node?.regionCode
             await publishStateMachine(awsContext, outputChannel, region)
         })


### PR DESCRIPTION
- This is a step towards getting better telemetry about command usage, in particular "aws.toggleSamCodeLenses".
- Sets `autoconnect` on these commands:
    - 'aws.codeWhisperer'
    - 'aws.s3.uploadFile'


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
