### PR TITLE
fix(codewhisperer): Correctly stub API call in CodeWhisperer unit tests

### DIFF
--- a/src/test/codewhisperer/service/keyStrokeHandler.test.ts
+++ b/src/test/codewhisperer/service/keyStrokeHandler.test.ts
@@ -34,6 +34,8 @@ describe('keyStrokeHandler', function () {
             sinon.spy(RecommendationHandler.instance, 'getRecommendations')
             mockClient = new codewhispererSdkClient.DefaultCodeWhispererClient()
             resetCodeWhispererGlobalVariables()
+            sinon.stub(mockClient, 'listRecommendations')
+            sinon.stub(mockClient, 'generateRecommendations')
         })
         afterEach(function () {
             sinon.restore()
@@ -189,6 +191,8 @@ describe('keyStrokeHandler', function () {
             sinon.restore()
             mockClient = new codewhispererSdkClient.DefaultCodeWhispererClient()
             resetCodeWhispererGlobalVariables()
+            sinon.stub(mockClient, 'listRecommendations')
+            sinon.stub(mockClient, 'generateRecommendations')
         })
         afterEach(function () {
             sinon.restore()

--- a/src/test/codewhisperer/service/recommendationHandler.test.ts
+++ b/src/test/codewhisperer/service/recommendationHandler.test.ts
@@ -2,6 +2,7 @@
  * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import * as assert from 'assert'
 import * as vscode from 'vscode'
 import * as sinon from 'sinon'
@@ -34,6 +35,8 @@ describe('recommendationHandler', function () {
             sinon.restore()
             resetCodeWhispererGlobalVariables()
             sinon.stub(mockClient, 'listRecommendations')
+            sinon.stub(mockClient, 'generateRecommendations')
+            RecommendationHandler.instance.clearRecommendations()
         })
 
         afterEach(function () {
@@ -52,9 +55,8 @@ describe('recommendationHandler', function () {
                     },
                 },
             }
-            const recommendationHandler = new RecommendationHandler()
-            sinon.stub(recommendationHandler, 'getServerResponse').resolves(mockServerResult)
-            await recommendationHandler.getRecommendations(
+            sinon.stub(RecommendationHandler.instance, 'getServerResponse').resolves(mockServerResult)
+            await RecommendationHandler.instance.getRecommendations(
                 mockClient,
                 mockEditor,
                 'AutoTrigger',
@@ -62,7 +64,7 @@ describe('recommendationHandler', function () {
                 'Enter',
                 false
             )
-            const actual = recommendationHandler.recommendations
+            const actual = RecommendationHandler.instance.recommendations
             const expected: RecommendationsList = [{ content: "print('Hello World!')" }]
             assert.deepStrictEqual(actual, expected)
         })
@@ -79,9 +81,8 @@ describe('recommendationHandler', function () {
                     },
                 },
             }
-            const recommendationHandler = new RecommendationHandler()
-            sinon.stub(recommendationHandler, 'getServerResponse').resolves(mockServerResult)
-            await recommendationHandler.getRecommendations(
+            sinon.stub(RecommendationHandler.instance, 'getServerResponse').resolves(mockServerResult)
+            await RecommendationHandler.instance.getRecommendations(
                 mockClient,
                 mockEditor,
                 'AutoTrigger',
@@ -89,8 +90,8 @@ describe('recommendationHandler', function () {
                 'Enter',
                 false
             )
-            assert.strictEqual(recommendationHandler.requestId, 'test_request')
-            assert.strictEqual(recommendationHandler.sessionId, 'test_request')
+            assert.strictEqual(RecommendationHandler.instance.requestId, 'test_request')
+            assert.strictEqual(RecommendationHandler.instance.sessionId, 'test_request')
             assert.strictEqual(TelemetryHelper.instance.triggerType, 'AutoTrigger')
         })
 
@@ -106,12 +107,17 @@ describe('recommendationHandler', function () {
                     },
                 },
             }
-            const recommendationHandler = new RecommendationHandler()
-            sinon.stub(recommendationHandler, 'getServerResponse').resolves(mockServerResult)
+            sinon.stub(RecommendationHandler.instance, 'getServerResponse').resolves(mockServerResult)
             sinon.stub(performance, 'now').returns(0.0)
-            recommendationHandler.startPos = new vscode.Position(1, 0)
+            RecommendationHandler.instance.startPos = new vscode.Position(1, 0)
             TelemetryHelper.instance.cursorOffset = 2
-            await recommendationHandler.getRecommendations(mockClient, mockEditor, 'AutoTrigger', config, 'Enter')
+            await RecommendationHandler.instance.getRecommendations(
+                mockClient,
+                mockEditor,
+                'AutoTrigger',
+                config,
+                'Enter'
+            )
             const assertTelemetry = assertTelemetryCurried('codewhisperer_serviceInvocation')
             assertTelemetry({
                 codewhispererRequestId: 'test_request',


### PR DESCRIPTION
## Problem
There are unusual API calls in CodeWhisperer unit tests. These API calls should be stubbed. 

Errors like 

```
rejected promise not handled within 1 second: AccessDeniedException: User: arn:aws:sts::412837722354:assumed-role/AWSVectorConsolasCognito-AWSVectorConsolasCognito-1D8LCKDHOCXA1/CognitoIdentityCredentials is not authorized to perform: codewhisperer:GenerateRecommendations because no identity-based policy allows the codewhisperer:GenerateRecommendations action
stack trace: AccessDeniedException: User: arn:aws:sts::412837722354:assumed-role/AWSVectorConsolasCognito-AWSVectorConsolasCognito-1D8LCKDHOCXA1/CognitoIdentityCredentials is not authorized to perform: codewhisperer:GenerateRecommendations because no identity-based policy allows the codewhisperer:GenerateRecommendations action
```
 
```
rejected promise not handled within 1 second: ValidationException: Missing Amazon CodeWhisperer token.
stack trace: ValidationException: Missing Amazon CodeWhisperer token.
```

are caused by API calls in CodeWhisperer unit tests.

These errors are gone after this fix.

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
