### PR TITLE
refactor(ssm): clean-up create/update wizard

### DIFF
--- a/src/shared/wizards/wizard.ts
+++ b/src/shared/wizards/wizard.ts
@@ -103,6 +103,10 @@ export class Wizard<TState extends Partial<Record<keyof TState, unknown>>> {
         return this._form
     }
 
+    public get initialState(): Readonly<Partial<TState>> | undefined {
+        return this.options.initState
+    }
+
     private _estimator: ((state: TState) => number) | undefined
     public set parentEstimator(estimator: (state: TState) => number) {
         this._estimator = estimator

--- a/src/ssmDocument/commands/publishDocument.ts
+++ b/src/ssmDocument/commands/publishDocument.ts
@@ -14,12 +14,7 @@ import { ssmJson, ssmYaml } from '../../shared/constants'
 import * as localizedText from '../../shared/localizedText'
 import { getLogger, Logger } from '../../shared/logger'
 import { RegionProvider } from '../../shared/regions/regionProvider'
-import {
-    DefaultPublishSSMDocumentWizardContext,
-    PublishSSMDocumentWizard,
-    PublishSSMDocumentWizardContext,
-    PublishSSMDocumentWizardResponse,
-} from '../wizards/publishDocumentWizard'
+import { PublishSSMDocumentWizard, PublishSSMDocumentWizardResponse } from '../wizards/publishDocumentWizard'
 import * as telemetry from '../../shared/telemetry/telemetry'
 import { Window } from '../../shared/vscode/window'
 import { showConfirmationMessage } from '../util/util'
@@ -56,17 +51,11 @@ export async function publishSSMDocument(awsContext: AwsContext, regionProvider:
     }
 
     try {
-        const wizardContext: PublishSSMDocumentWizardContext = new DefaultPublishSSMDocumentWizardContext(
-            awsContext,
-            regionProvider
-        )
-        const wizardResponse: PublishSSMDocumentWizardResponse | undefined = await new PublishSSMDocumentWizard(
-            wizardContext
-        ).run()
-        if (wizardResponse?.PublishSsmDocAction == 'Create') {
-            await createDocument(wizardResponse, textDocument)
-        } else if (wizardResponse?.PublishSsmDocAction == 'Update') {
-            await updateDocument(wizardResponse, textDocument)
+        const response = await new PublishSSMDocumentWizard().run()
+        if (response?.action == 'Create') {
+            await createDocument(response, textDocument)
+        } else if (response?.action == 'Update') {
+            await updateDocument(response, textDocument)
         }
     } catch (err) {
         logger.error(err as Error)
@@ -79,7 +68,7 @@ export async function createDocument(
     client: SsmDocumentClient = globals.toolkitClientBuilder.createSsmClient(wizardResponse.region)
 ) {
     let result: telemetry.Result = 'Succeeded'
-    const ssmOperation: telemetry.SsmOperation = wizardResponse.PublishSsmDocAction as telemetry.SsmOperation
+    const ssmOperation = wizardResponse.action as telemetry.SsmOperation
 
     const logger: Logger = getLogger()
     logger.info(`Creating Systems Manager Document '${wizardResponse.name}'`)
@@ -114,7 +103,7 @@ export async function updateDocument(
     window = Window.vscode()
 ) {
     let result: telemetry.Result = 'Succeeded'
-    const ssmOperation: telemetry.SsmOperation = wizardResponse.PublishSsmDocAction as telemetry.SsmOperation
+    const ssmOperation = wizardResponse.action as telemetry.SsmOperation
 
     const logger: Logger = getLogger()
     logger.info(`Updating Systems Manager Document '${wizardResponse.name}'`)

--- a/src/ssmDocument/wizards/publishDocumentWizard.ts
+++ b/src/ssmDocument/wizards/publishDocumentWizard.ts
@@ -3,400 +3,140 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SSM } from 'aws-sdk'
 import globals from '../../shared/extensionGlobals'
-import * as vscode from 'vscode'
+
 import * as nls from 'vscode-nls'
-import { AwsContext } from '../../shared/awsContext'
-import { recentlyUsed } from '../../shared/localizedText'
-import { RegionProvider } from '../../shared/regions/regionProvider'
-import { getRegionsForActiveCredentials } from '../../shared/regions/regionUtilities'
-import * as input from '../../shared/ui/input'
-import * as picker from '../../shared/ui/picker'
-import { toArrayAsync } from '../../shared/utilities/collectionUtils'
-import {
-    MultiStepWizard,
-    WIZARD_GOBACK,
-    WIZARD_TERMINATE,
-    WizardContext,
-    wizardContinue,
-    WizardStep,
-} from '../../shared/wizards/multiStepWizard'
-import { validateDocumentName } from '../util/validateDocumentName'
-import { showViewLogsMessage } from '../../shared/utilities/messages'
 const localize = nls.loadMessageBundle()
 
+import { SSM } from 'aws-sdk'
+import { createCommonButtons } from '../../shared/ui/buttons'
+import { createRegionPrompter } from '../../shared/ui/common/region'
+import { createInputBox } from '../../shared/ui/inputPrompter'
+import { createQuickPick } from '../../shared/ui/pickerPrompter'
+import { Wizard, WIZARD_BACK } from '../../shared/wizards/wizard'
+import { validateDocumentName } from '../util/validateDocumentName'
+
 export interface PublishSSMDocumentWizardResponse {
-    PublishSsmDocAction: string
-    name: string
-    documentType?: SSM.DocumentType
-    region: string
+    readonly action: PublishSSMDocumentAction
+    readonly name: string
+    readonly documentType: 'Automation'
+    readonly region: string
 }
 
 export enum PublishSSMDocumentAction {
-    QuickCreate,
-    QuickUpdate,
+    QuickCreate = 'Create',
+    QuickUpdate = 'Update',
 }
 
-export interface PublishSSMDocumentWizardContext {
-    promptUserForPublishAction(
-        region: string,
-        publishAction: PublishSSMDocumentAction | undefined
-    ): Promise<PublishSSMDocumentAction | undefined>
-    promptUserForRegion(initialRegionCode?: string): Promise<string | undefined>
-    promptUserForDocumentName(): Promise<string | undefined>
-    promptUserForDocumentToUpdate(region: string): Promise<string | undefined>
-    promptUserForDocumentType(): Promise<SSM.DocumentType | undefined>
-    loadSSMDocument(region: string, documentType?: SSM.Types.DocumentType): Promise<void>
-}
-
-export class PublishSSMDocumentWizard extends MultiStepWizard<PublishSSMDocumentWizardResponse> {
-    private name?: string
-    private publishAction?: PublishSSMDocumentAction
-    private documentType?: SSM.DocumentType
-    private region: string | undefined
-
-    public constructor(private readonly context: PublishSSMDocumentWizardContext) {
-        super()
+async function* loadDocuments(region: string, documentType?: SSM.Types.DocumentType) {
+    const filters: SSM.Types.DocumentKeyValuesFilterList = [
+        {
+            Key: 'Owner',
+            Values: ['Self'],
+        },
+    ]
+    if (documentType !== undefined) {
+        filters.push({
+            Key: 'DocumentType',
+            Values: [documentType],
+        })
     }
+    const client = globals.toolkitClientBuilder.createSsmClient(region)
 
-    protected get startStep() {
-        return this.REGION
-    }
-
-    protected getResult(): PublishSSMDocumentWizardResponse | undefined {
-        if (!this.region) {
-            return undefined
-        }
-        switch (this.publishAction) {
-            case PublishSSMDocumentAction.QuickCreate: {
-                if (!this.name || !this.documentType) {
-                    return undefined
-                }
-
-                return {
-                    PublishSsmDocAction: 'Create',
-                    name: this.name,
-                    documentType: this.documentType,
-                    region: this.region,
-                }
-            }
-
-            case PublishSSMDocumentAction.QuickUpdate: {
-                if (!this.name) {
-                    return undefined
-                }
-
-                return {
-                    PublishSsmDocAction: 'Update',
-                    name: this.name,
-                    region: this.region,
-                }
-            }
-
-            default: {
-                return undefined
-            }
-        }
-    }
-
-    private readonly REGION: WizardStep = async () => {
-        this.region = await this.context.promptUserForRegion(this.region)
-
-        return this.region ? wizardContinue(this.PUBLISH_ACTION) : WIZARD_TERMINATE
-    }
-
-    private readonly PUBLISH_ACTION: WizardStep = async () => {
-        this.publishAction = await this.context.promptUserForPublishAction(this.region ?? '', this.publishAction)
-
-        switch (this.publishAction) {
-            case PublishSSMDocumentAction.QuickCreate: {
-                return wizardContinue(this.NEW_SSM_DOCUMENT_NAME)
-            }
-
-            case PublishSSMDocumentAction.QuickUpdate: {
-                return wizardContinue(this.EXISTING_SSM_DOCUMENT_NAME)
-            }
-
-            default: {
-                return WIZARD_GOBACK
-            }
-        }
-    }
-
-    private readonly NEW_SSM_DOCUMENT_TYPE: WizardStep = async () => {
-        this.documentType = await this.context.promptUserForDocumentType()
-
-        return this.documentType ? WIZARD_TERMINATE : WIZARD_GOBACK
-    }
-
-    private readonly NEW_SSM_DOCUMENT_NAME: WizardStep = async () => {
-        this.name = await this.context.promptUserForDocumentName()
-
-        return this.name ? wizardContinue(this.NEW_SSM_DOCUMENT_TYPE) : WIZARD_GOBACK
-    }
-
-    private readonly EXISTING_SSM_DOCUMENT_NAME: WizardStep = async () => {
-        this.documentType = await this.context.promptUserForDocumentType()
-        // TODO: make this return and pass the return value to the next step, otherwise the values here will never readjust.
-        await this.context.loadSSMDocument(this.region ?? '', this.documentType)
-        this.name = await this.context.promptUserForDocumentToUpdate(this.region ?? '')
-
-        return this.name ? WIZARD_TERMINATE : WIZARD_GOBACK
+    for await (const document of client.listDocuments({ Filters: filters })) {
+        yield [
+            {
+                label: document.Name!,
+                data: document.Name!,
+                description: `DocumentType: ${document.DocumentType}, DocumentVersion: ${document.DocumentVersion}`,
+            },
+        ]
     }
 }
 
-export interface PublishActionQuickPickItem {
-    label: string
-    description?: string
-    detail: string
-    action: PublishSSMDocumentAction
+function createNamePrompter() {
+    return createInputBox({
+        title: localize('AWS.ssmDocument.publishWizard.ssmDocumentName.title', 'Name your document'),
+        buttons: createCommonButtons(),
+        validateInput: validateDocumentName,
+    })
 }
 
-export interface DocumentTypeQuickPickItem {
-    label: string
-    description?: string
-    detail?: string
-    documentType: SSM.DocumentType
+function createUpdateDocumentPrompter(region: string, documentType?: string) {
+    return createQuickPick(loadDocuments(region, documentType), {
+        title: localize(
+            'AWS.ssmDocument.publishWizard.ssmDocumentToUpdate.title',
+            'Select a document to update ({0})',
+            region
+        ),
+        noItemsFoundItem: {
+            label: localize(
+                'AWS.ssmDocument.publishWizard.ssmDocumentToUpdate.noDocument',
+                'No self-owned documents could be found. Please create and upload a Systems Manager Document before updating.'
+            ),
+            data: WIZARD_BACK,
+        },
+        buttons: createCommonButtons(),
+    })
 }
 
-export interface UpdateDocumentQuickPickItem {
-    label: string
-    description?: string
-    detail?: string
-    alwaysShow: boolean
-    name?: string
+function createPublishPrompter(region: string) {
+    const publishItems = [
+        {
+            label: localize('AWS.ssmDocument.publishWizard.publishAction.quickCreate.label', 'Quick Create'),
+            detail: localize(
+                'AWS.ssmDocument.publishWizard.publishAction.quickCreate.detail',
+                'Create a Systems Manager Document'
+            ),
+            data: PublishSSMDocumentAction.QuickCreate,
+        },
+        {
+            label: localize('AWS.ssmDocument.publishWizard.publishAction.quickUpdate.label', 'Quick Update'),
+            detail: localize(
+                'AWS.ssmDocument.publishWizard.publishAction.quickUpdate.detail',
+                'Update an existing Systems Manager Document'
+            ),
+            data: PublishSSMDocumentAction.QuickUpdate,
+        },
+    ]
+
+    return createQuickPick(publishItems, {
+        title: localize(
+            'AWS.ssmDocument.publishWizard.publishAction.title',
+            'Publish to AWS Systems Manager Document ({0})',
+            region
+        ),
+        buttons: createCommonButtons(),
+    })
 }
 
-export class DefaultPublishSSMDocumentWizardContext extends WizardContext implements PublishSSMDocumentWizardContext {
-    private documents: SSM.Types.DocumentIdentifierList | undefined
+export class PublishSSMDocumentWizard extends Wizard<PublishSSMDocumentWizardResponse> {
+    public constructor(region?: string) {
+        super({ initState: { region } })
+        const form = this.form
 
-    private readonly totalSteps: number = 3
+        // TODO: add prompt when more types are supported
+        form.documentType.setDefault('Automation')
 
-    public constructor(private readonly awsContext: AwsContext, private readonly regionProvider: RegionProvider) {
-        super()
-    }
-
-    public async promptUserForRegion(initialRegionCode?: string): Promise<string | undefined> {
-        const partitionRegions = getRegionsForActiveCredentials(this.awsContext, this.regionProvider)
-
-        const quickPick = picker.createQuickPick<vscode.QuickPickItem>({
-            options: {
+        form.region.bindPrompter(() =>
+            createRegionPrompter(undefined, {
                 title: localize(
                     'AWS.message.prompt.ssmDocument.publishDocument.region',
                     'Which AWS Region would you like to publish to?'
                 ),
-                value: initialRegionCode,
-                matchOnDetail: true,
-                ignoreFocusOut: true,
-                step: 1,
-                totalSteps: this.totalSteps,
-            },
-            items: partitionRegions.map(region => ({
-                label: region.name,
-                detail: region.id,
-                // this is the only way to get this to show on going back
-                // this will make it so it always shows even when searching for something else
-                alwaysShow: region.id === initialRegionCode,
-                description: region.id === initialRegionCode ? recentlyUsed : '',
-            })),
-            buttons: [vscode.QuickInputButtons.Back],
-        })
+                serviceFilter: 'ssm',
+            }).transform(r => r.id)
+        )
 
-        const choices = await picker.promptUser<vscode.QuickPickItem>({
-            picker: quickPick,
-            onDidTriggerButton: (button, resolve, reject) => {
-                if (button === vscode.QuickInputButtons.Back) {
-                    resolve(undefined)
-                }
-            },
-        })
-        const val = picker.verifySinglePickerOutput(choices)
+        form.action.bindPrompter(state => createPublishPrompter(state.region!))
 
-        return val?.detail
-    }
-
-    public async loadSSMDocument(region: string, documentType?: SSM.Types.DocumentType): Promise<void> {
-        if (!this.documents) {
-            const filters: SSM.Types.DocumentKeyValuesFilterList = [
-                {
-                    Key: 'Owner',
-                    Values: ['Self'],
-                },
-            ]
-            if (documentType !== undefined) {
-                filters.push({
-                    Key: 'DocumentType',
-                    Values: [documentType],
-                })
+        form.name.bindPrompter(state => {
+            switch (state.action!) {
+                case PublishSSMDocumentAction.QuickCreate:
+                    return createNamePrompter()
+                case PublishSSMDocumentAction.QuickUpdate:
+                    return createUpdateDocumentPrompter(state.region!, state.documentType)
             }
-            const client = globals.toolkitClientBuilder.createSsmClient(region)
-            this.documents = await toArrayAsync(
-                client.listDocuments({
-                    Filters: filters,
-                })
-            )
-        }
-    }
-
-    // TODO: Uncomment code when supporting more document types in future
-    // TODO: Add step numbers and update this.totalSteps if this gets added back in!
-    //       Note: This will likely use the "this.additionalStep" pattern we're using elsewhere since this makes one branch longer than the other.
-    public async promptUserForDocumentType(): Promise<SSM.DocumentType | undefined> {
-        // const documentTypeItems: DocumentTypeQuickPickItem[] = [
-        //     {
-        //         label: localize('AWS.ssmDocument.publishWizard.documentType.automation.label', 'Automation'),
-        //         documentType: 'Automation',
-        //     },
-        // ]
-
-        // const quickPick = picker.createQuickPick<DocumentTypeQuickPickItem>({
-        //     options: {
-        //         ignoreFocusOut: true,
-        //         title: localize('AWS.ssmDocument.publishWizard.documentType.title', 'Select document type'),
-        //     },
-        //     buttons: [vscode.QuickInputButtons.Back],
-        //     items: documentTypeItems,
-        // })
-
-        // const choices = await picker.promptUser({
-        //     picker: quickPick,
-        //     onDidTriggerButton: (button, resolve, _reject) => {
-        //         if (button === vscode.QuickInputButtons.Back) {
-        //             resolve(undefined)
-        //         }
-        //     },
-        // })
-        // const picked = picker.verifySinglePickerOutput(choices)
-
-        // return picked ? picked.documentType : undefined
-        return 'Automation'
-    }
-
-    public async promptUserForDocumentName(): Promise<string | undefined> {
-        const inputBox = input.createInputBox({
-            options: {
-                title: localize('AWS.ssmDocument.publishWizard.ssmDocumentName.title', 'Name your document'),
-                ignoreFocusOut: true,
-                step: 3,
-                totalSteps: this.totalSteps,
-            },
-            buttons: [vscode.QuickInputButtons.Back],
         })
-
-        return await input.promptUser({
-            inputBox: inputBox,
-            onDidTriggerButton: (button, resolve, reject) => {
-                if (button === vscode.QuickInputButtons.Back) {
-                    resolve(undefined)
-                }
-            },
-            onValidateInput: validateDocumentName,
-        })
-    }
-
-    public async promptUserForDocumentToUpdate(region: string): Promise<string | undefined> {
-        let documentItems: UpdateDocumentQuickPickItem[]
-        if (!this.documents || !this.documents.length) {
-            showViewLogsMessage(
-                localize(
-                    'AWS.ssmDocument.publishWizard.ssmDocumentToUpdate.noDocument',
-                    'No self-owned documents could be found. Create and upload a Systems Manager Document before updating.'
-                ),
-                vscode.window
-            )
-            return undefined
-        } else {
-            documentItems = this.documents.map(doc => ({
-                label: doc.Name!,
-                alwaysShow: false,
-                name: doc.Name,
-                description: `DocumentType:${doc.DocumentType}, DocumentVersion:${doc.DocumentVersion}`,
-            }))
-        }
-
-        const quickPick = picker.createQuickPick<UpdateDocumentQuickPickItem>({
-            options: {
-                ignoreFocusOut: true,
-                title: localize(
-                    'AWS.ssmDocument.publishWizard.ssmDocumentToUpdate.title',
-                    'Select a document to update ({0})',
-                    region
-                ),
-                step: 3,
-                totalSteps: this.totalSteps,
-            },
-            buttons: [vscode.QuickInputButtons.Back],
-            items: documentItems,
-        })
-
-        const choices = await picker.promptUser({
-            picker: quickPick,
-            onDidTriggerButton: (button, resolve, _reject) => {
-                if (button === vscode.QuickInputButtons.Back) {
-                    resolve(undefined)
-                }
-            },
-        })
-        const picked = picker.verifySinglePickerOutput(choices)
-
-        return picked ? picked.name : undefined
-    }
-
-    public async promptUserForPublishAction(
-        region: string,
-        currentAction: PublishSSMDocumentAction | undefined
-    ): Promise<PublishSSMDocumentAction | undefined> {
-        const publishItems: PublishActionQuickPickItem[] = [
-            {
-                label: localize('AWS.ssmDocument.publishWizard.publishAction.quickCreate.label', 'Quick Create'),
-                detail: localize(
-                    'AWS.ssmDocument.publishWizard.publishAction.quickCreate.detail',
-                    'Create a Systems Manager Document'
-                ),
-                action: PublishSSMDocumentAction.QuickCreate,
-            },
-            {
-                label: localize('AWS.ssmDocument.publishWizard.publishAction.quickUpdate.label', 'Quick Update'),
-                detail: localize(
-                    'AWS.ssmDocument.publishWizard.publishAction.quickUpdate.detail',
-                    'Update an existing Systems Manager Document'
-                ),
-                action: PublishSSMDocumentAction.QuickUpdate,
-            },
-        ].map((item: PublishActionQuickPickItem) => {
-            if (item.action === currentAction) {
-                item.description = recentlyUsed
-            }
-
-            return item
-        })
-
-        const quickPick = picker.createQuickPick<PublishActionQuickPickItem>({
-            options: {
-                ignoreFocusOut: true,
-                title: localize(
-                    'AWS.ssmDocument.publishWizard.publishAction.title',
-                    'Publish to AWS Systems Manager Document ({0})',
-                    region
-                ),
-                step: 2,
-                totalSteps: this.totalSteps,
-            },
-            buttons: [vscode.QuickInputButtons.Back],
-            items: publishItems,
-        })
-
-        const choices = await picker.promptUser({
-            picker: quickPick,
-            onDidTriggerButton: (button, resolve, _reject) => {
-                if (button === vscode.QuickInputButtons.Back) {
-                    resolve(undefined)
-                }
-            },
-        })
-        const picked = picker.verifySinglePickerOutput(choices)
-
-        return picked ? picked.action : undefined
     }
 }

--- a/src/test/shared/wizards/wizardTestUtils.ts
+++ b/src/test/shared/wizards/wizardTestUtils.ts
@@ -59,7 +59,7 @@ function failIf(cond: boolean, message?: string): void {
 
 export function createWizardTester<T extends Partial<T>>(wizard: Wizard<T> | WizardForm<T>): WizardTester<T> {
     const form = wizard instanceof Wizard ? wizard.boundForm : wizard
-    const state = (wizard instanceof Wizard ? wizard.initialState : {}) as T
+    const state = (wizard instanceof Wizard ? JSON.parse(JSON.stringify(wizard.initialState ?? {})) : {}) as T
 
     function canShowPrompter(prop: string): boolean {
         const defaultState = form.applyDefaults(state)

--- a/src/test/shared/wizards/wizardTestUtils.ts
+++ b/src/test/shared/wizards/wizardTestUtils.ts
@@ -59,7 +59,7 @@ function failIf(cond: boolean, message?: string): void {
 
 export function createWizardTester<T extends Partial<T>>(wizard: Wizard<T> | WizardForm<T>): WizardTester<T> {
     const form = wizard instanceof Wizard ? wizard.boundForm : wizard
-    const state = {} as T
+    const state = (wizard instanceof Wizard ? wizard.initialState : {}) as T
 
     function canShowPrompter(prop: string): boolean {
         const defaultState = form.applyDefaults(state)

--- a/src/test/ssmDocument/commands/publishDocument.test.ts
+++ b/src/test/ssmDocument/commands/publishDocument.test.ts
@@ -12,7 +12,10 @@ import * as vscode from 'vscode'
 import { SsmDocumentClient } from '../../../shared/clients/ssmDocumentClient'
 import * as publish from '../../../ssmDocument/commands/publishDocument'
 import * as ssmUtils from '../../../ssmDocument/util/util'
-import { PublishSSMDocumentWizardResponse } from '../../../ssmDocument/wizards/publishDocumentWizard'
+import {
+    PublishSSMDocumentAction,
+    PublishSSMDocumentWizardResponse,
+} from '../../../ssmDocument/wizards/publishDocumentWizard'
 import { closeAllEditors } from '../../testUtil'
 
 describe('publishDocument', async function () {
@@ -44,7 +47,7 @@ describe('publishDocument', async function () {
 
     beforeEach(async function () {
         wizardResponse = {
-            PublishSsmDocAction: 'Update',
+            action: PublishSSMDocumentAction.QuickUpdate,
             name: 'test',
             documentType: 'Automation',
             region: '',
@@ -63,7 +66,7 @@ describe('publishDocument', async function () {
     describe('createDocument', async function () {
         it('createDocument API returns successfully', async function () {
             wizardResponse = {
-                PublishSsmDocAction: 'Create',
+                action: PublishSSMDocumentAction.QuickCreate,
                 name: 'test',
                 documentType: 'Automation',
                 region: '',

--- a/src/test/ssmDocument/wizards/publishDocumentWizard.test.ts
+++ b/src/test/ssmDocument/wizards/publishDocumentWizard.test.ts
@@ -1,0 +1,41 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createWizardTester, WizardTester } from '../../shared/wizards/wizardTestUtils'
+import {
+    PublishSSMDocumentWizard,
+    PublishSSMDocumentWizardResponse,
+} from '../../../ssmDocument/wizards/publishDocumentWizard'
+
+describe('AppRunnerCodeRepositoryWizard', function () {
+    let tester: WizardTester<PublishSSMDocumentWizardResponse>
+
+    beforeEach(function () {
+        const wizard = new PublishSSMDocumentWizard()
+        tester = createWizardTester(wizard)
+    })
+
+    it('has 3 steps by default', function () {
+        tester.assertShowCount(3)
+    })
+
+    it('never prompts for document type and uses a default value instead', function () {
+        tester.documentType.assertDoesNotShow()
+        tester.documentType.assertValue('Automation')
+    })
+
+    it('prompts for region, action, and a document name', function () {
+        tester.region.assertShowFirst()
+        tester.action.assertShowSecond()
+        tester.name.assertShowThird()
+    })
+
+    it('skips the region prompt if provided a region', function () {
+        const wizard = new PublishSSMDocumentWizard('us-west-2')
+        tester = createWizardTester(wizard)
+        tester.region.assertDoesNotShow()
+        tester.assertShowCount(2)
+    })
+})


### PR DESCRIPTION
## Problem
The old wizard code makes it hard to do other refactors, especially for things used by the wizard like `AwsContext`.

## Solution
Simplify the existing code and add test coverage.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
