### PR TITLE
fix(css): remove Cloud9 override for header

### DIFF
--- a/resources/css/base-cloud9.css
+++ b/resources/css/base-cloud9.css
@@ -55,11 +55,6 @@ body.vscode-light .settings-panel {
     background: rgba(var(--shade), 0.02) !important;
 }
 
-.button-container {
-    border: none !important;
-    background: none !important;
-}
-
 .button-container h1 {
     margin: 0px;
 }


### PR DESCRIPTION
## Problem
Accidentally added the override back in while merging the icons PR

## Solution
Remove the artifact

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
