### PR TITLE
feat(sam): do not show "Add Debug Config" codelenses by default

### DIFF
--- a/.changes/next-release/Bug Fix-30228c96-9b44-412f-9da7-9ab002c2be49.json
+++ b/.changes/next-release/Bug Fix-30228c96-9b44-412f-9da7-9ab002c2be49.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "`Add SAM Debug Configuration` codelenses in source files are now disabled by default. (To enable the codelenses, use the `AWS: Toggle SAM hints in source files` command or the `Enable SAM hints` setting.)"
+}

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
                 "aws.samcli.enableCodeLenses": {
                     "type": "boolean",
                     "description": "%AWS.configuration.enableCodeLenses%",
-                    "default": true
+                    "default": false
                 },
                 "aws.suppressPrompts": {
                     "type": "object",

--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -311,7 +311,7 @@ export async function makePythonCodeLensProvider(configuration: SamCliSettings):
             token: vscode.CancellationToken,
             forceProvide?: boolean
         ): Promise<vscode.CodeLens[]> => {
-            if (!forceProvide && !configuration.get('enableCodeLenses', true)) {
+            if (!forceProvide && !configuration.get('enableCodeLenses', false)) {
                 return []
             }
             // Try to activate the Python Extension before requesting symbols from a python file
@@ -338,7 +338,7 @@ export async function makeCSharpCodeLensProvider(configuration: SamCliSettings):
             token: vscode.CancellationToken,
             forceProvide?: boolean
         ): Promise<vscode.CodeLens[]> => {
-            if (!forceProvide && !configuration.get('enableCodeLenses', true)) {
+            if (!forceProvide && !configuration.get('enableCodeLenses', false)) {
                 return []
             }
             const handlers: LambdaHandlerCandidate[] = await csharpCodelens.getLambdaHandlerCandidates(document)
@@ -359,7 +359,7 @@ export function makeTypescriptCodeLensProvider(configuration: SamCliSettings): O
             token: vscode.CancellationToken,
             forceProvide?: boolean
         ): Promise<vscode.CodeLens[]> => {
-            if (!forceProvide && !configuration.get('enableCodeLenses', true)) {
+            if (!forceProvide && !configuration.get('enableCodeLenses', false)) {
                 return []
             }
             const handlers = await tsCodelens.getLambdaHandlerCandidates(document)
@@ -380,7 +380,7 @@ export async function makeGoCodeLensProvider(configuration: SamCliSettings): Pro
             token: vscode.CancellationToken,
             forceProvide?: boolean
         ): Promise<vscode.CodeLens[]> => {
-            if (!forceProvide && !configuration.get('enableCodeLenses', true)) {
+            if (!forceProvide && !configuration.get('enableCodeLenses', false)) {
                 return []
             }
             const handlers = await goCodelens.getLambdaHandlerCandidates(document)


### PR DESCRIPTION
## Problem:
The heuristic for deciding what is a lambda handler function is too
noisy, so the "AWS: ..." codelenses appear on almost any function for
untyped languages such javascript or python.

## Solution:
Disable the "aws.samcli.enableCodeLenses" setting by default. Customers
can reenable these codelenses with the `AWS: Toggle SAM hints` command
or the `Enable SAM hints` setting.



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
