### PR TITLE
fix(sam): set working directory for `sam build`

### DIFF
--- a/src/shared/sam/cli/samCliBuild.ts
+++ b/src/shared/sam/cli/samCliBuild.ts
@@ -10,6 +10,7 @@ import { pushIf } from '../../utilities/collectionUtils'
 import { localize } from '../../utilities/vsCodeUtils'
 import { Timeout, waitTimeout } from '../../utilities/timeoutUtils'
 import { ChildProcessResult } from '../../utilities/childProcess'
+import { dirname } from 'path'
 
 export interface SamCliBuildInvocationArguments {
     /**
@@ -133,7 +134,10 @@ export class SamCliBuildInvocation {
         }
 
         let childProcessResult: Promise<ChildProcessResult | void> = this.args.invoker.invoke({
-            spawnOptions: { env },
+            spawnOptions: {
+                env,
+                cwd: dirname(this.args.templatePath),
+            },
             arguments: invokeArgs,
             onStdout: onOutput,
             onStderr: onOutput,


### PR DESCRIPTION
## Problem
All of our SAM CLI invocations are ran without an explicit working directory. I believe node defaults to the current working directory of the process in this case i.e. the extension host. 

## Solution
Explicitly set a working directory for `sam build` as the template's directory. This is the behavior one would expect when running `sam build` in a fresh project. 

#### This now correctly creates a `.aws-sam` directory adjacent to the targeted template. The lack of an explicit working directory was (and is) a huge miss, creating tons of hard-to-diagnose problems.

Other `sam` commands are still affected although they are harder to change without breaking things due to the temporary directory :/ 

The way the Toolkit + SAM CLI interact is incredibly brittle and this 'solution' is mediocre at best.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
