### PR TITLE
fix(codewhisperer): Add await in each globalState.update

### DIFF
--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -90,8 +90,8 @@ export async function activate(context: ExtContext): Promise<void> {
             if (configurationChangeEvent.affectsConfiguration('aws.experiments')) {
                 const codewhispererEnabled = await codewhispererSettings.isEnabled()
                 if (!codewhispererEnabled) {
-                    set(CodeWhispererConstants.termsAcceptedKey, false, context)
-                    set(CodeWhispererConstants.autoTriggerEnabledKey, false, context)
+                    await set(CodeWhispererConstants.termsAcceptedKey, false, context)
+                    await set(CodeWhispererConstants.autoTriggerEnabledKey, false, context)
                     if (!isCloud9()) {
                         InlineCompletion.instance.hideCodeWhispererStatusBar()
                     }
@@ -106,15 +106,15 @@ export async function activate(context: ExtContext): Promise<void> {
          * Accept terms of service
          */
         Commands.register('aws.codeWhisperer.acceptTermsOfService', async () => {
-            set(CodeWhispererConstants.autoTriggerEnabledKey, true, context)
-            set(CodeWhispererConstants.termsAcceptedKey, true, context)
+            await set(CodeWhispererConstants.autoTriggerEnabledKey, true, context)
+            await set(CodeWhispererConstants.termsAcceptedKey, true, context)
             await vscode.commands.executeCommand('setContext', CodeWhispererConstants.termsAcceptedKey, true)
             await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
 
             const isShow = get(CodeWhispererConstants.welcomeMessageKey, context)
             if (!isShow) {
                 showCodeWhispererWelcomeMessage()
-                set(CodeWhispererConstants.welcomeMessageKey, true, context)
+                await set(CodeWhispererConstants.welcomeMessageKey, true, context)
             }
 
             if (!isCloud9()) {
@@ -125,7 +125,7 @@ export async function activate(context: ExtContext): Promise<void> {
          * Cancel terms of service
          */
         Commands.register('aws.codeWhisperer.cancelTermsOfService', async () => {
-            set(CodeWhispererConstants.autoTriggerEnabledKey, false, context)
+            await set(CodeWhispererConstants.autoTriggerEnabledKey, false, context)
             await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
         }),
         /**

--- a/src/codewhisperer/util/invalidateToken.ts
+++ b/src/codewhisperer/util/invalidateToken.ts
@@ -8,6 +8,6 @@ import globals from '../../shared/extensionGlobals'
 import { CodeWhispererConstants } from '../models/constants'
 
 export const invalidateAccessToken = async () => {
-    globals.context.globalState.update(CodeWhispererConstants.accessToken, undefined)
+    await globals.context.globalState.update(CodeWhispererConstants.accessToken, undefined)
     await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
 }


### PR DESCRIPTION
## Problem
When updating global state in CodeWhisperer, sometimes the update was not awaited and it might cause race conditions.


## Solution

await was added to each globalState.update call under CodeWhisperer.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
