### PR TITLE
fix(cloud9): omit "Show AWS Commands" in cloud9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1124,7 +1124,7 @@
                 },
                 {
                     "command": "aws.listCommands",
-                    "when": "view == aws.explorer",
+                    "when": "view == aws.explorer && !isCloud9",
                     "group": "1_account@3"
                 },
                 {


### PR DESCRIPTION
## Problem

"Show AWS Commands" should not appear in Cloud9, it's a vscode-ism.

## Solution

Add condition in package.json

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
