### PR TITLE
cwl: Cancel log group search 

### DIFF
--- a/src/cloudWatchLogs/commands/addLogEvents.ts
+++ b/src/cloudWatchLogs/commands/addLogEvents.ts
@@ -8,6 +8,7 @@ import * as AsyncLock from 'async-lock'
 import { getLogger } from '../../shared/logger/logger'
 import { LogStreamRegistry } from '../registry/logStreamRegistry'
 import { CancellationError } from '../../shared/utilities/timeoutUtils'
+import { localize } from 'vscode-nls'
 
 // TODO: Cut a PR to the async-lock package?...as of now, maxPending = 0 is theoretically ideal, but also falsy (which sets maxPending = 1000):
 // https://github.com/rogierschouten/async-lock/blob/78cb0c2441650d7bdc148548f99542ccc9c93fd7/lib/index.js#L19
@@ -42,10 +43,17 @@ export async function addLogEvents(
         if (CancellationError.isUserCancelled(e)) {
             getLogger().debug('cwl: User Cancelled Search')
         } else {
-            // TODO: We assume here that non-cancellation errors are always busty errors. This may not be true.
+            // What about busy errors here?
             // contingency in case lock isn't busy but still locked out. Don't want to accidentally trigger making codelens not busy
-            getLogger().debug(`addLogEvents already locked for lock: ${lockName}`)
-            return
+            const error = e as Error
+            vscode.window.showErrorMessage(
+                localize(
+                    'AWS.cwl.searchLogGroup.errorRetrievingLogs2',
+                    'Error retrieving logs for {0}: {1}',
+                    uri.path,
+                    error.message
+                )
+            )
         }
     } finally {
         registry.setBusyStatus(uri, false)

--- a/src/cloudWatchLogs/commands/addLogEvents.ts
+++ b/src/cloudWatchLogs/commands/addLogEvents.ts
@@ -43,7 +43,6 @@ export async function addLogEvents(
         if (CancellationError.isUserCancelled(e)) {
             getLogger().debug('cwl: User Cancelled Search')
         } else {
-            // What about busy errors here?
             // contingency in case lock isn't busy but still locked out. Don't want to accidentally trigger making codelens not busy
             const error = e as Error
             vscode.window.showErrorMessage(

--- a/src/cloudWatchLogs/commands/addLogEvents.ts
+++ b/src/cloudWatchLogs/commands/addLogEvents.ts
@@ -41,10 +41,10 @@ export async function addLogEvents(
         // contingency in case lock isn't busy but still locked out. Don't want to accidentally trigger making codelens not busy
         getLogger().debug(`addLogEvents already locked for lock: ${lockName}`)
         return
-    }
-
-    registry.setBusyStatus(uri, false)
-    if (onDidChangeCodeLensEvent) {
-        onDidChangeCodeLensEvent.fire()
+    } finally {
+        registry.setBusyStatus(uri, false)
+        if (onDidChangeCodeLensEvent) {
+            onDidChangeCodeLensEvent.fire()
+        }
     }
 }

--- a/src/cloudWatchLogs/commands/searchLogGroup.ts
+++ b/src/cloudWatchLogs/commands/searchLogGroup.ts
@@ -65,7 +65,7 @@ export async function searchLogGroup(registry: LogStreamRegistry): Promise<void>
         } catch (err) {
             if (CancellationError.isUserCancelled(err)) {
                 getLogger().debug('cwl: User Cancelled Search')
-                result = 'Cancelled'
+                result = 'Failed'
             } else {
                 const error = err as Error
                 vscode.window.showErrorMessage(

--- a/src/cloudWatchLogs/commands/searchLogGroup.ts
+++ b/src/cloudWatchLogs/commands/searchLogGroup.ts
@@ -46,9 +46,13 @@ export async function searchLogGroup(registry: LogStreamRegistry): Promise<void>
         }
 
         await registry.registerLog(uri, initialStreamData)
-        const doc = await vscode.workspace.openTextDocument(uri) // calls back into the provider
-        vscode.languages.setTextDocumentLanguage(doc, 'log')
-        await vscode.window.showTextDocument(doc, { preview: false })
+
+        if (registry.hasLog(uri)) {
+            // If the log recieved data i.e. wasn't cancelled.
+            const doc = await vscode.workspace.openTextDocument(uri) // calls back into the provider
+            vscode.languages.setTextDocumentLanguage(doc, 'log')
+            await vscode.window.showTextDocument(doc, { preview: false })
+        }
     } else {
         result = 'Cancelled'
     }

--- a/src/cloudWatchLogs/commands/searchLogGroup.ts
+++ b/src/cloudWatchLogs/commands/searchLogGroup.ts
@@ -45,7 +45,9 @@ export async function searchLogGroup(registry: LogStreamRegistry): Promise<void>
             logGroupInfo: logGroupInfo,
             retrieveLogsFunction: filterLogEventsFromUriComponents,
         }
+        // Currently displays nothing if update log fails in non-cancellationError. (don't want this)
 
+        // Catch error out here
         await registry.registerLog(uri, initialStreamData)
         const isLogCancelled = registry.getLogCancelled(uri)
         if (!isLogCancelled) {

--- a/src/cloudWatchLogs/commands/searchLogGroup.ts
+++ b/src/cloudWatchLogs/commands/searchLogGroup.ts
@@ -46,12 +46,14 @@ export async function searchLogGroup(registry: LogStreamRegistry): Promise<void>
         }
 
         await registry.registerLog(uri, initialStreamData)
-
-        if (registry.hasLog(uri)) {
+        const status = registry.getLogCancelled(uri)
+        if (status !== undefined && !status) {
             // If the log recieved data i.e. wasn't cancelled.
             const doc = await vscode.workspace.openTextDocument(uri) // calls back into the provider
             vscode.languages.setTextDocumentLanguage(doc, 'log')
             await vscode.window.showTextDocument(doc, { preview: false })
+        } else {
+            result = 'Cancelled'
         }
     } else {
         result = 'Cancelled'

--- a/src/cloudWatchLogs/commands/searchLogGroup.ts
+++ b/src/cloudWatchLogs/commands/searchLogGroup.ts
@@ -47,9 +47,8 @@ export async function searchLogGroup(registry: LogStreamRegistry): Promise<void>
         }
 
         await registry.registerLog(uri, initialStreamData)
-        const status = registry.getLogCancelled
-        if (status !== undefined && !status) {
-            // If the log recieved data i.e. wasn't cancelled.
+        const isLogCancelled = registry.getLogCancelled(uri)
+        if (!isLogCancelled) {
             const doc = await vscode.workspace.openTextDocument(uri) // calls back into the provider
             vscode.languages.setTextDocumentLanguage(doc, 'log')
             const textEditor = await vscode.window.showTextDocument(doc, { preview: false })

--- a/src/cloudWatchLogs/commands/viewLogStream.ts
+++ b/src/cloudWatchLogs/commands/viewLogStream.ts
@@ -55,12 +55,24 @@ export async function viewLogStream(node: LogGroupNode, registry: LogStreamRegis
             logGroupInfo: logGroupInfo,
             retrieveLogsFunction: getLogEventsFromUriComponents,
         }
-
-        await registry.registerLog(uri, initialStreamData)
-        const doc = await vscode.workspace.openTextDocument(uri) // calls back into the provider
-        vscode.languages.setTextDocumentLanguage(doc, 'log')
-        const textEditor = await vscode.window.showTextDocument(doc, { preview: false })
-        registry.setTextEditor(uri, textEditor) // For consistency, even though this isn't necessary (for now)
+        try {
+            await registry.registerLog(uri, initialStreamData)
+            const doc = await vscode.workspace.openTextDocument(uri) // calls back into the provider
+            vscode.languages.setTextDocumentLanguage(doc, 'log')
+            const textEditor = await vscode.window.showTextDocument(doc, { preview: false })
+            registry.setTextEditor(uri, textEditor) // For consistency, even though this isn't necessary (for now)
+        } catch (err) {
+            result = 'Cancelled'
+            const error = err as Error
+            vscode.window.showErrorMessage(
+                localize(
+                    'AWS.cwl.searchLogGroup.errorRetrievingLogs',
+                    'Error retrieving logs for Log Group {0} : {1}',
+                    logGroupInfo.groupName,
+                    error.message
+                )
+            )
+        }
     } else {
         result = 'Cancelled'
     }

--- a/src/cloudWatchLogs/commands/viewLogStream.ts
+++ b/src/cloudWatchLogs/commands/viewLogStream.ts
@@ -62,7 +62,7 @@ export async function viewLogStream(node: LogGroupNode, registry: LogStreamRegis
             const textEditor = await vscode.window.showTextDocument(doc, { preview: false })
             registry.setTextEditor(uri, textEditor) // For consistency, even though this isn't necessary (for now)
         } catch (err) {
-            result = 'Cancelled'
+            result = 'Failed'
             const error = err as Error
             vscode.window.showErrorMessage(
                 localize(

--- a/src/cloudWatchLogs/registry/logStreamRegistry.ts
+++ b/src/cloudWatchLogs/registry/logStreamRegistry.ts
@@ -13,7 +13,8 @@ import { CloudWatchLogsSettings, parseCloudWatchLogsUri, uriToKey } from '../clo
 import { getLogger } from '../../shared/logger'
 import { INSIGHTS_TIMESTAMP_FORMAT } from '../../shared/constants'
 import { DefaultCloudWatchLogsClient } from '../../shared/clients/cloudWatchLogsClient'
-
+import { Timeout } from '../../shared/utilities/timeoutUtils'
+import { showMessageWithCancel } from '../../shared/utilities/messages'
 // TODO: Add debug logging statements
 
 /**
@@ -193,6 +194,8 @@ export async function filterLogEventsFromUriComponents(
 ): Promise<CloudWatchLogsResponse> {
     const client = new DefaultCloudWatchLogsClient(logGroupInfo.regionName)
 
+    const timeout = new Timeout(1) // How should I set this?
+    showMessageWithCancel(`Loading log data from group ${logGroupInfo.groupName}`, timeout)
     const response = await client.filterLogEvents({
         logGroupName: logGroupInfo.groupName,
         filterPattern: parameters.filterPattern,

--- a/src/cloudWatchLogs/registry/logStreamRegistry.ts
+++ b/src/cloudWatchLogs/registry/logStreamRegistry.ts
@@ -136,13 +136,12 @@ export class LogStreamRegistry {
                     token: logEvents.nextForwardToken ?? '',
                 }
             }
-            if (!logEvents.cancelled) {
-                this.setLogData(uri, {
-                    ...stream,
-                    ...tokens,
-                    data: newData,
-                })
-            }
+            this.setLogData(uri, {
+                ...stream,
+                ...tokens,
+                data: newData,
+                cancelled: logEvents.cancelled,
+            })
 
             this._onDidChange.fire(uri)
         } catch (e) {
@@ -237,7 +236,6 @@ export async function filterLogEventsFromUriComponents(
                 events: response.events ? response.events : [],
                 nextForwardToken: response.nextToken,
                 nextBackwardToken: nextToken,
-                cancelled: false,
             }
         }
     } catch (err) {
@@ -277,7 +275,6 @@ export async function getLogEventsFromUriComponents(
         events: response.events ? response.events : [],
         nextForwardToken: response.nextForwardToken,
         nextBackwardToken: response.nextBackwardToken,
-        cancelled: false,
     }
 }
 

--- a/src/cloudWatchLogs/registry/logStreamRegistry.ts
+++ b/src/cloudWatchLogs/registry/logStreamRegistry.ts
@@ -198,7 +198,7 @@ export async function filterLogEventsFromUriComponents(
 ): Promise<CloudWatchLogsResponse | void> {
     const client = new DefaultCloudWatchLogsClient(logGroupInfo.regionName)
 
-    const timeout = new Timeout(10000) // How should I set this? This waits up to 5 seconds now
+    const timeout = new Timeout(10000)
     showMessageWithCancel(`Loading log data from group ${logGroupInfo.groupName}`, timeout)
     const responsePromise = client.filterLogEvents({
         logGroupName: logGroupInfo.groupName,

--- a/src/cloudWatchLogs/registry/logStreamRegistry.ts
+++ b/src/cloudWatchLogs/registry/logStreamRegistry.ts
@@ -225,27 +225,27 @@ export async function filterLogEventsFromUriComponents(
         nextToken,
         limit: parameters.limit,
     })
-    try {
-        const response = await waitTimeout(responsePromise, timeout, { allowUndefined: false })
+    // try {
+    const response = await waitTimeout(responsePromise, timeout, { allowUndefined: false })
 
-        // Use heuristic of last token as backward token and next token as forward to generalize token form.
-        // Note that this may become inconsistent if the contents of the calls are changing as they are being made.
-        // However, this fail wouldn't really impact customers.
-        if (response) {
-            return {
-                events: response.events ? response.events : [],
-                nextForwardToken: response.nextToken,
-                nextBackwardToken: nextToken,
-            }
-        }
-    } catch (err) {
-        if (CancellationError.isUserCancelled(err)) {
-            getLogger().info('cloudwatchlogs: user cancelled search')
-        } else {
-            getLogger().info('')
-            throw err
+    // Use heuristic of last token as backward token and next token as forward to generalize token form.
+    // Note that this may become inconsistent if the contents of the calls are changing as they are being made.
+    // However, this fail wouldn't really impact customers.
+    if (response) {
+        return {
+            events: response.events ? response.events : [],
+            nextForwardToken: response.nextToken,
+            nextBackwardToken: nextToken,
         }
     }
+    // } catch (err) {
+    //     if (CancellationError.isUserCancelled(err)) {
+    //         getLogger().info('cloudwatchlogs: user cancelled search')
+    //     } else {
+    //         getLogger().info('')
+    //         throw err
+    //     }
+    // }
     return {
         events: [],
         cancelled: true,

--- a/src/cloudWatchLogs/registry/logStreamRegistry.ts
+++ b/src/cloudWatchLogs/registry/logStreamRegistry.ts
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as nls from 'vscode-nls'
-const localize = nls.loadMessageBundle()
-
 import * as moment from 'moment'
 import * as vscode from 'vscode'
 import { CloudWatchLogs } from 'aws-sdk'

--- a/src/cloudWatchLogs/registry/logStreamRegistry.ts
+++ b/src/cloudWatchLogs/registry/logStreamRegistry.ts
@@ -194,7 +194,7 @@ export async function filterLogEventsFromUriComponents(
 ): Promise<CloudWatchLogsResponse> {
     const client = new DefaultCloudWatchLogsClient(logGroupInfo.regionName)
 
-    const timeout = new Timeout(10000)
+    const timeout = new Timeout(300000)
     showMessageWithCancel(`Loading log data from group ${logGroupInfo.groupName}`, timeout)
     const responsePromise = client.filterLogEvents({
         logGroupName: logGroupInfo.groupName,
@@ -214,9 +214,8 @@ export async function filterLogEventsFromUriComponents(
             nextForwardToken: response.nextToken,
             nextBackwardToken: nextToken,
         }
-    }
-    return {
-        events: [],
+    } else {
+        throw new Error('cwl:`filterLogEvents` did not return anything.')
     }
 }
 
@@ -238,6 +237,10 @@ export async function getLogEventsFromUriComponents(
         nextToken,
         limit: parameters.limit,
     })
+
+    if (!response) {
+        throw new Error('cwl:`getLogEvents` did not return anything.')
+    }
 
     return {
         events: response.events ? response.events : [],
@@ -267,7 +270,6 @@ export type CloudWatchLogsResponse = {
     events: CloudWatchLogs.FilteredLogEvents
     nextForwardToken?: CloudWatchLogs.NextToken
     nextBackwardToken?: CloudWatchLogs.NextToken
-    cancelled?: boolean
 }
 
 export type CloudWatchLogsAction = (
@@ -293,5 +295,4 @@ export class CloudWatchLogsData {
         token: CloudWatchLogs.NextToken
     }
     busy: boolean = false
-    cancelled?: boolean = false
 }


### PR DESCRIPTION
## Problem
If a search of log groups is taking too long or was accidental, the user has no way to cancel it. 
## Solution
Add a timeout that can be cancelled via user input. 

Note: This change involves using deprecated code from `waitTimeout` in `src/shared/utilities/timeoutUtils.ts`. 
Note: The `Timeout` object is currently set to auto cancel the search after 5 seconds. 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
