### PR TITLE
fix(codewhisperer): update security scan error message

### DIFF
--- a/src/codewhisperer/commands/basicCommands.ts
+++ b/src/codewhisperer/commands/basicCommands.ts
@@ -154,7 +154,7 @@ export const showSecurityScan = Commands.declare(
                     startSecurityScanWithProgress(securityPanelViewProvider, editor, client, context.extensionContext)
                 }
             } else {
-                vscode.window.showInformationMessage('Please open a file you want to scan to proceed.')
+                vscode.window.showInformationMessage('Please open a valid file you want to scan to proceed.')
             }
         }
 )


### PR DESCRIPTION
## Problem
If customer opens a non-text document, for example images, and hit security scan, they will see `Please open a file you want to scan to proceed`, which can be confusing.

## Solution
To update the error message to handle this case.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
