### PR TITLE
ux(auth): improve 'Create Credentials Profile' flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "aws-toolkit-vscode",
-            "version": "1.46.0-SNAPSHOT",
+            "version": "1.47.0-SNAPSHOT",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/src/credentials/wizards/createProfile.ts
+++ b/src/credentials/wizards/createProfile.ts
@@ -1,0 +1,102 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as nls from 'vscode-nls'
+const localize = nls.loadMessageBundle()
+
+import * as vscode from 'vscode'
+import { StepEstimator, Wizard, WIZARD_BACK } from '../../shared/wizards/wizard'
+import { Prompter, PromptResult } from '../../shared/ui/prompter'
+import { ParsedIniData, Profile } from '../../shared/credentials/credentialsFile'
+import { createInputBox } from '../../shared/ui/inputPrompter'
+import { DefaultStsClient } from '../../shared/clients/stsClient'
+import { ProfileKey } from './templates'
+
+function createProfileNamePrompter(profiles: ParsedIniData) {
+    return createInputBox({
+        title: localize('AWS.profileName.title', 'Enter a profile name'),
+        prompt: localize('AWS.profileName.prompt', 'Choose a unique name for the new profile'),
+        validateInput: name => {
+            if (name === '') {
+                return localize('AWS.credentials.error.emptyProfileName', 'Profile name must not be empty')
+            }
+
+            return Object.keys(profiles).find(k => k === name) ? 'Name is not unique' : undefined
+        },
+    })
+}
+
+export interface ProfileTemplateProvider<T extends Record<string, any> = any> {
+    readonly label: string
+    readonly description: string
+    readonly prompts: {
+        readonly [P in keyof T]: (name: string, profile: Partial<T>) => Prompter<T[P]>
+    }
+}
+
+export class CreateProfileWizard extends Wizard<CreateProfileState> {
+    public constructor(profiles: { readonly [name: string]: Profile }, template: ProfileTemplateProvider) {
+        super()
+
+        this.form.name.bindPrompter(() => createProfileNamePrompter(profiles))
+
+        for (const [k, v] of Object.entries(template.prompts)) {
+            this.form.profile[k].bindPrompter(({ name, profile }) => v(name!, profile ?? {}))
+        }
+
+        this.form.accountId.bindPrompter(({ name, profile }) => new ProfileChecker(name!, profile))
+    }
+}
+
+interface CreateProfileState {
+    readonly name: string
+    readonly profile: Profile
+    readonly accountId: string
+}
+
+class ProfileChecker<T extends Profile> extends Prompter<string> {
+    public constructor(private readonly name: string, private readonly profile: T) {
+        super()
+    }
+
+    protected async promptUser(): Promise<PromptResult<string>> {
+        // TODO(sijaden): de-dupe this and make it nicer
+        const loadingBar = vscode.window.createQuickPick()
+        loadingBar.title = `Checking profile ${this.name}`
+        loadingBar.enabled = false
+        loadingBar.busy = true
+        loadingBar.show()
+
+        try {
+            const region = this.profile['region'] ?? 'us-east-1' // De-dupe this pattern
+            const stsClient = new DefaultStsClient(region, {
+                accessKeyId: this.profile[ProfileKey.AccessKeyId]!,
+                secretAccessKey: this.profile[ProfileKey.SecretKey]!,
+            })
+
+            return (await stsClient.getCallerIdentity()).Account
+        } catch (err) {
+            vscode.window.showErrorMessage(
+                localize(
+                    'AWS.message.prompt.credentials.invalid',
+                    'Profile {0} is invalid: {1}',
+                    this.name,
+                    (err as any).message
+                )
+            )
+
+            return WIZARD_BACK
+        } finally {
+            loadingBar.dispose()
+        }
+    }
+
+    public setStepEstimator(estimator: StepEstimator<string>): void {}
+    public setSteps(current: number, total: number): void {}
+    public set recentItem(response: any) {}
+    public get recentItem(): any {
+        return
+    }
+}

--- a/src/credentials/wizards/createProfile.ts
+++ b/src/credentials/wizards/createProfile.ts
@@ -13,11 +13,14 @@ import { ParsedIniData, Profile } from '../../shared/credentials/credentialsFile
 import { createInputBox } from '../../shared/ui/inputPrompter'
 import { DefaultStsClient } from '../../shared/clients/stsClient'
 import { ProfileKey } from './templates'
+import { createCommonButtons } from '../../shared/ui/buttons'
+import { credentialHelpUrl } from '../../shared/constants'
 
 function createProfileNamePrompter(profiles: ParsedIniData) {
     return createInputBox({
         title: localize('AWS.profileName.title', 'Enter a profile name'),
         prompt: localize('AWS.profileName.prompt', 'Choose a unique name for the new profile'),
+        buttons: createCommonButtons(credentialHelpUrl),
         validateInput: name => {
             if (name === '') {
                 return localize('AWS.credentials.error.emptyProfileName', 'Profile name must not be empty')

--- a/src/credentials/wizards/templates.ts
+++ b/src/credentials/wizards/templates.ts
@@ -9,6 +9,8 @@ const localize = nls.loadMessageBundle()
 import { createInputBox } from '../../shared/ui/inputPrompter'
 import { getIdeProperties } from '../../shared/extensionUtilities'
 import { ProfileTemplateProvider } from './createProfile'
+import { createCommonButtons } from '../../shared/ui/buttons'
+import { credentialHelpUrl } from '../../shared/constants'
 
 // TODO: use this everywhere else
 export enum ProfileKey {
@@ -35,6 +37,7 @@ export const staticCredentialsTemplate: ProfileTemplateProvider<StaticProfile> =
         [ProfileKey.AccessKeyId]: name =>
             createInputBox({
                 title: getTitle(name),
+                buttons: createCommonButtons(credentialHelpUrl),
                 prompt: localize(
                     'AWS.placeHolder.inputAccessKey',
                     'Input the {0} Access Key',
@@ -55,6 +58,7 @@ export const staticCredentialsTemplate: ProfileTemplateProvider<StaticProfile> =
         [ProfileKey.SecretKey]: name =>
             createInputBox({
                 title: getTitle(name),
+                buttons: createCommonButtons(credentialHelpUrl),
                 prompt: localize(
                     'AWS.placeHolder.inputSecretKey',
                     'Input the {0} Secret Key',
@@ -82,6 +86,7 @@ export const processCredentialsTemplate: ProfileTemplateProvider<CredentialsProc
             createInputBox({
                 title: getTitle(name),
                 prompt: 'Enter a command to run',
+                buttons: createCommonButtons(credentialHelpUrl),
             }),
     },
 }

--- a/src/credentials/wizards/templates.ts
+++ b/src/credentials/wizards/templates.ts
@@ -1,0 +1,87 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as nls from 'vscode-nls'
+const localize = nls.loadMessageBundle()
+
+import { createInputBox } from '../../shared/ui/inputPrompter'
+import { getIdeProperties } from '../../shared/extensionUtilities'
+import { ProfileTemplateProvider } from './createProfile'
+
+// TODO: use this everywhere else
+export enum ProfileKey {
+    AccessKeyId = 'aws_access_key_id',
+    SecretKey = 'aws_secret_access_key',
+    Process = 'credential_process',
+}
+
+function getTitle(profileName: string): string {
+    return localize('AWS.title.createCredentialProfile', 'Creating new profile "{0}"', profileName)
+}
+
+interface StaticProfile {
+    [ProfileKey.AccessKeyId]: string
+    [ProfileKey.SecretKey]: string
+}
+
+const accessKeyPattern = /[\w]{16,128}/
+
+export const staticCredentialsTemplate: ProfileTemplateProvider<StaticProfile> = {
+    label: 'Static Credentials',
+    description: 'Use this for credentials that never expire',
+    prompts: {
+        [ProfileKey.AccessKeyId]: name =>
+            createInputBox({
+                title: getTitle(name),
+                prompt: localize(
+                    'AWS.placeHolder.inputAccessKey',
+                    'Input the {0} Access Key',
+                    getIdeProperties().company
+                ),
+                validateInput: accessKey => {
+                    if (accessKey === '') {
+                        return localize('AWS.credentials.error.emptyAccessKey', 'Access key must not be empty')
+                    }
+                    if (!accessKeyPattern.test(accessKey)) {
+                        return localize(
+                            'AWS.credentials.error.emptyAccessKey',
+                            'Access key must be alphanumeric and between 16 and 128 characters'
+                        )
+                    }
+                },
+            }),
+        [ProfileKey.SecretKey]: name =>
+            createInputBox({
+                title: getTitle(name),
+                prompt: localize(
+                    'AWS.placeHolder.inputSecretKey',
+                    'Input the {0} Secret Key',
+                    getIdeProperties().company
+                ),
+                validateInput: secretKey => {
+                    if (secretKey === '') {
+                        return localize('AWS.credentials.error.emptySecretKey', 'Secret key must not be empty')
+                    }
+                },
+                password: true,
+            }),
+    },
+}
+
+interface CredentialsProcessProfile {
+    [ProfileKey.Process]: string
+}
+
+export const processCredentialsTemplate: ProfileTemplateProvider<CredentialsProcessProfile> = {
+    label: 'External Process',
+    description: 'Creates a new profile that fetches credentials from a process',
+    prompts: {
+        [ProfileKey.Process]: name =>
+            createInputBox({
+                title: getTitle(name),
+                prompt: 'Enter a command to run',
+            }),
+    },
+}

--- a/src/credentials/wizards/templates.ts
+++ b/src/credentials/wizards/templates.ts
@@ -38,6 +38,8 @@ export const staticCredentialsTemplate: ProfileTemplateProvider<StaticProfile> =
             createInputBox({
                 title: getTitle(name),
                 buttons: createCommonButtons(credentialHelpUrl),
+                // Example comes from https://docs.aws.amazon.com/STS/latest/APIReference/API_GetAccessKeyInfo.html
+                placeholder: 'AKIAIOSFODNN7EXAMPLE',
                 prompt: localize(
                     'AWS.placeHolder.inputAccessKey',
                     'Input the {0} Access Key',
@@ -59,6 +61,8 @@ export const staticCredentialsTemplate: ProfileTemplateProvider<StaticProfile> =
             createInputBox({
                 title: getTitle(name),
                 buttons: createCommonButtons(credentialHelpUrl),
+                // Example comes from https://docs.aws.amazon.com/STS/latest/APIReference/API_GetAccessKeyInfo.html
+                placeholder: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
                 prompt: localize(
                     'AWS.placeHolder.inputSecretKey',
                     'Input the {0} Secret Key',

--- a/src/shared/awsContextCommands.ts
+++ b/src/shared/awsContextCommands.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import globals from './extensionGlobals'
+
 import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
@@ -13,24 +15,22 @@ import { CredentialsProviderManager } from '../credentials/providers/credentials
 import { AwsContext } from './awsContext'
 import { AwsContextTreeCollection } from './awsContextTreeCollection'
 import * as extensionConstants from './constants'
-import { CredentialSelectionState } from './credentials/credentialSelectionState'
 import {
     credentialProfileSelector,
     DefaultCredentialSelectionDataProvider,
-    promptToDefineCredentialsProfile,
 } from './credentials/defaultCredentialSelectionDataProvider'
 import { UserCredentialsUtils } from './credentials/userCredentialsUtils'
 import * as localizedText from './localizedText'
 import { RegionProvider } from './regions/regionProvider'
 import { getRegionsForActiveCredentials } from './regions/regionUtilities'
-import { SharedCredentialsProvider } from '../credentials/providers/sharedCredentialsProvider'
 import { getIdeProperties } from './extensionUtilities'
 import { credentialHelpUrl } from './constants'
-import { showViewLogsMessage } from './utilities/messages'
-import globals from './extensionGlobals'
-import { DefaultStsClient } from './clients/stsClient'
-import { getLogger } from './logger/logger'
 import { PromptSettings } from './settings'
+import { CreateProfileWizard } from '../credentials/wizards/createProfile'
+import { loadSharedCredentialsProfiles } from '../credentials/sharedCredentials'
+import { Profile } from './credentials/credentialsFile'
+import { ProfileKey, staticCredentialsTemplate } from '../credentials/wizards/templates'
+import { SharedCredentialsProvider } from '../credentials/providers/sharedCredentialsProvider'
 
 /**
  * @deprecated
@@ -154,63 +154,38 @@ export class AwsContextCommands {
      * @returns The profile name, or undefined if user cancelled
      */
     private async promptAndCreateNewCredentialsFile(): Promise<string | undefined> {
-        while (true) {
-            const dataProvider = new DefaultCredentialSelectionDataProvider([], globals.context)
-            const state: CredentialSelectionState = await promptToDefineCredentialsProfile(dataProvider)
+        const profiles = {} as Record<string, Profile>
+        for (const [k, v] of (await loadSharedCredentialsProfiles()).entries()) {
+            profiles[k] = v
+        }
 
-            if (!state.profileName || !state.accesskey || !state.secretKey) {
-                return undefined
-            }
+        const wizard = new CreateProfileWizard(profiles, staticCredentialsTemplate)
+        const resp = await wizard.run()
+        if (!resp) {
+            return
+        }
 
-            // TODO : Get a region relevant to the partition for these credentials -- https://github.com/aws/aws-toolkit-vscode/issues/188
-            const client = new DefaultStsClient('us-east-1', {
-                accessKeyId: state.accesskey,
-                secretAccessKey: state.secretKey,
-            })
-            const accountId = await client.getCallerIdentity().catch(err => {
-                getLogger().error(`credentials: failed to get account id: ${(err as Error).message}`)
-            })
+        await UserCredentialsUtils.generateCredentialsFile({
+            profileName: resp.name,
+            accessKey: resp.profile[ProfileKey.AccessKeyId]!,
+            secretKey: resp.profile[ProfileKey.SecretKey]!,
+        })
 
-            if (accountId) {
-                await UserCredentialsUtils.generateCredentialDirectoryIfNonexistent()
-                await UserCredentialsUtils.generateCredentialsFile({
-                    profileName: state.profileName,
-                    accessKey: state.accesskey,
-                    secretKey: state.secretKey,
-                })
+        const sharedProviderId: CredentialsId = {
+            credentialSource: SharedCredentialsProvider.getProviderType(),
+            credentialTypeId: resp.name,
+        }
 
-                const sharedProviderId: CredentialsId = {
-                    credentialSource: SharedCredentialsProvider.getProviderType(),
-                    credentialTypeId: state.profileName,
-                }
-
-                vscode.window.showInformationMessage(
-                    localize(
-                        'AWS.message.prompt.credentials.definition.done',
-                        'Created {0} credentials profile: {1}',
-                        getIdeProperties().company,
-                        state.profileName
-                    )
-                )
-
-                return asString(sharedProviderId)
-            }
-
-            const response = await showViewLogsMessage(
-                localize(
-                    'AWS.message.prompt.credentials.definition.tryAgain',
-                    '{0} credentials appear invalid. Try again?',
-                    getIdeProperties().company
-                ),
-                globals.window,
-                'warn',
-                [localizedText.yes, localizedText.no]
+        vscode.window.showInformationMessage(
+            localize(
+                'AWS.message.prompt.credentials.definition.done',
+                'Created {0} credentials profile: {1}',
+                getIdeProperties().company,
+                resp.name
             )
+        )
 
-            if (!response || response !== localizedText.yes) {
-                return undefined
-            }
-        } // Keep asking until cancel or valid credentials are entered
+        return asString(sharedProviderId)
     }
 
     /**

--- a/src/shared/credentials/userCredentialsUtils.ts
+++ b/src/shared/credentials/userCredentialsUtils.ts
@@ -84,6 +84,7 @@ export class UserCredentialsUtils {
      * @param credentialsContext the profile to create in the file
      */
     public static async generateCredentialsFile(credentialsContext?: CredentialsTemplateContext): Promise<void> {
+        await this.generateCredentialDirectoryIfNonexistent()
         const dest = getCredentialsFilename()
         const contents = credentialsContext ? ['', createNewCredentialsFile(credentialsContext)] : []
 

--- a/src/test/credentials/wizards/createProfile.test.ts
+++ b/src/test/credentials/wizards/createProfile.test.ts
@@ -1,0 +1,73 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { createWizardTester } from '../../shared/wizards/wizardTestUtils'
+import { CreateProfileWizard, ProfileTemplateProvider } from '../../../credentials/wizards/createProfile'
+import {
+    processCredentialsTemplate,
+    ProfileKey,
+    staticCredentialsTemplate,
+} from '../../../credentials/wizards/templates'
+import { Prompter, PromptResult } from '../../../shared/ui/prompter'
+import { StepEstimator } from '../../../shared/wizards/wizard'
+import { Profile } from '../../../shared/credentials/credentialsFile'
+
+class TestPrompter extends Prompter<string | undefined> {
+    public constructor(private readonly name: string, private readonly profile: Profile) {
+        super()
+    }
+
+    protected async promptUser(): Promise<PromptResult<string>> {
+        return JSON.stringify({ [this.name]: this.profile })
+    }
+
+    public setStepEstimator(estimator: StepEstimator<string>): void {}
+    public setSteps(current: number, total: number): void {}
+    public set recentItem(response: any) {}
+    public get recentItem(): any {
+        return
+    }
+}
+
+describe('CreateProfileWizard', function () {
+    it('prompts for profile name, access key, secret, and then validates (static)', function () {
+        const tester = createWizardTester(new CreateProfileWizard({}, staticCredentialsTemplate))
+        tester.name.assertShowFirst()
+        tester.profile[ProfileKey.AccessKeyId].assertShowSecond()
+        tester.profile[ProfileKey.SecretKey].assertShowThird()
+        tester.accountId.assertShow(4)
+    })
+
+    it('prompts for profile name, command, and then validates (process)', function () {
+        const tester = createWizardTester(new CreateProfileWizard({}, processCredentialsTemplate))
+        tester.name.assertShowFirst()
+        tester.profile[ProfileKey.Process].assertShowSecond()
+        tester.accountId.assertShowThird()
+    })
+
+    it('passes in the profile name + state to template prompts', async function () {
+        const template: ProfileTemplateProvider<Profile> = {
+            label: '',
+            description: '',
+            prompts: {
+                step1: (name, profile) => new TestPrompter(name, profile),
+                step2: (name, profile) => new TestPrompter(name, profile),
+            },
+        }
+
+        const wizard = new CreateProfileWizard({}, template)
+        wizard.form.name.bindPrompter(() => new TestPrompter('test', {}).transform(r => Object.keys(JSON.parse(r!))[0]))
+        wizard.form.accountId.bindPrompter(() => new TestPrompter('', {}).transform(r => r!))
+
+        const result = await wizard.run()
+        const step1 = result?.profile?.['step1']
+        const step2 = result?.profile?.['step2']
+        assert.ok(step1)
+        assert.ok(step2)
+        assert.deepStrictEqual(JSON.parse(step1), { test: {} })
+        assert.deepStrictEqual(JSON.parse(step2), { test: { step1 } })
+    })
+})


### PR DESCRIPTION
## Problem
Old flow is clunky. If the user provides bad credentials they need to start all over. 

## Solution
Use updated flow that goes back a step on failure.

This flow was pulled from a separate branch with more in-depth UX improvements which is why the implementation is split into a 'template' rather than a single wizard.

The validation step can be made nicer but that's for another time.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
