### PR TITLE
feat(filetypes): syntax highlighting for ~/.aws/ files

### DIFF
--- a/.changes/next-release/Feature-2d7e75e6-fd08-41fd-91d0-5e1a8c26759d.json
+++ b/.changes/next-release/Feature-2d7e75e6-fd08-41fd-91d0-5e1a8c26759d.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "basic syntax highlighting for ~/.aws/credentials and ~/.aws/config files"
+}

--- a/src/shared/awsFiletypes.ts
+++ b/src/shared/awsFiletypes.ts
@@ -73,6 +73,7 @@ export function activate(): void {
                 return
             }
 
+            const basename = path.basename(doc.fileName)
             let fileExt: string | undefined = path.extname(doc.fileName)
             fileExt = fileExt ? fileExt : undefined // Telemetry client will fail on empty string.
 
@@ -86,6 +87,11 @@ export function activate(): void {
             // HACK: for "~/.aws/foo" vscode sometimes _only_ emits "~/.aws/foo.git".
             if (telemKind === 'awsCredentials' && fileExt === '.git') {
                 fileExt = undefined
+            }
+
+            // Ensure nice syntax highlighting for ~/.aws/ files.
+            if (telemKind === 'awsCredentials' && (basename === 'credentials' || basename === 'config')) {
+                vscode.languages.setTextDocumentLanguage(doc, 'ini')
             }
 
             if (await isSameMetricPending(telemKind, fileExt)) {

--- a/src/shared/awsFiletypes.ts
+++ b/src/shared/awsFiletypes.ts
@@ -90,7 +90,11 @@ export function activate(): void {
             }
 
             // Ensure nice syntax highlighting for ~/.aws/ files.
-            if (telemKind === 'awsCredentials' && (basename === 'credentials' || basename === 'config')) {
+            if (
+                telemKind === 'awsCredentials' &&
+                doc.languageId !== 'ini' &&
+                (basename === 'credentials' || basename === 'config')
+            ) {
                 vscode.languages.setTextDocumentLanguage(doc, 'ini')
             }
 


### PR DESCRIPTION
## Problem:
Files ~/.aws/credentials and ~/.aws/config are highlighted incorrectly if vscode auto-detect is disabled or fails depending on the contents, then sets the language to "plaintext" or "markdown".

## Solution:
Set the language as "ini".


## Before

<img width="516" alt="image" src="https://user-images.githubusercontent.com/55561878/181621851-e0f1594a-49df-44f9-a303-f96fe58a9680.png">


## After

<img width="557" alt="image" src="https://user-images.githubusercontent.com/55561878/181621683-f9839efe-c672-4ac7-a8ec-a5d34dcd6bfb.png">


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
