### PR TITLE
feat(ui): decouple tree nodes from the UI representation

### DIFF
--- a/src/awsexplorer/localExplorer.ts
+++ b/src/awsexplorer/localExplorer.ts
@@ -5,10 +5,9 @@
 
 import * as vscode from 'vscode'
 import * as telemetry from '../shared/telemetry/telemetry'
-import { cdkNode } from '../cdk/explorer/rootNode'
+import { cdkNode, CdkRootNode } from '../cdk/explorer/rootNode'
 import { ResourceTreeDataProvider, TreeNode } from '../shared/treeview/resourceTreeDataProvider'
 import { once } from '../shared/utilities/functionUtils'
-import { AppNode } from '../cdk/explorer/nodes/appNode'
 import { isCloud9 } from '../shared/extensionUtilities'
 import { codewhispererNode } from '../codewhisperer/explorer/codewhispererNode'
 
@@ -49,7 +48,7 @@ export function createLocalExplorerView(): vscode.TreeView<TreeNode> {
     // Legacy CDK metric, remove this when we add something generic
     const recordExpandCdkOnce = once(telemetry.recordCdkAppExpanded)
     view.onDidExpandElement(e => {
-        if (e.element.resource instanceof AppNode) {
+        if (e.element.resource instanceof CdkRootNode) {
             recordExpandCdkOnce()
         }
     })

--- a/src/cdk/explorer/nodes/appNode.ts
+++ b/src/cdk/explorer/nodes/appNode.ts
@@ -21,11 +21,9 @@ import { getIcon } from '../../../shared/icons'
 export class AppNode implements TreeNode {
     public readonly id = this.location.cdkJsonUri.toString()
     public readonly resource = this.location
-    public readonly treeItem: vscode.TreeItem
+    public readonly label = vscode.workspace.asRelativePath(vscode.Uri.joinPath(this.location.cdkJsonUri, '..'))
 
-    public constructor(private readonly location: CdkAppLocation) {
-        this.treeItem = this.createTreeItem()
-    }
+    public constructor(private readonly location: CdkAppLocation) {}
 
     public async getChildren(): Promise<(ConstructNode | TreeNode)[]> {
         const constructs = []
@@ -59,9 +57,8 @@ export class AppNode implements TreeNode {
         }
     }
 
-    private createTreeItem() {
-        const label = vscode.workspace.asRelativePath(vscode.Uri.joinPath(this.location.cdkJsonUri, '..'))
-        const item = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.Collapsed)
+    public getTreeItem() {
+        const item = new vscode.TreeItem(this.label, vscode.TreeItemCollapsibleState.Collapsed)
 
         item.contextValue = 'awsCdkAppNode'
         item.iconPath = getIcon('aws-cdk-logo')

--- a/src/cdk/explorer/nodes/constructNode.ts
+++ b/src/cdk/explorer/nodes/constructNode.ts
@@ -13,13 +13,10 @@ import { generatePropertyNodes } from './propertyNode'
 
 export class ConstructNode implements TreeNode {
     public readonly id = this.construct.id
-    public readonly treeItem: vscode.TreeItem
     private readonly type = treeInspector.getTypeAttributeOrDefault(this.construct, '')
     private readonly properties = treeInspector.getProperties(this.construct)
 
-    public constructor(private readonly location: CdkAppLocation, private readonly construct: ConstructTreeEntity) {
-        this.treeItem = this.createTreeItem()
-    }
+    public constructor(private readonly location: CdkAppLocation, private readonly construct: ConstructTreeEntity) {}
 
     public get resource() {
         return {
@@ -36,7 +33,7 @@ export class ConstructNode implements TreeNode {
         return [...propertyNodes, ...constructNodes]
     }
 
-    private createTreeItem() {
+    public getTreeItem() {
         const collapsibleState =
             this.construct.children || this.construct.attributes
                 ? vscode.TreeItemCollapsibleState.Collapsed

--- a/src/cdk/explorer/nodes/propertyNode.ts
+++ b/src/cdk/explorer/nodes/propertyNode.ts
@@ -14,11 +14,8 @@ import { TreeNode } from '../../../shared/treeview/resourceTreeDataProvider'
 export class PropertyNode implements TreeNode {
     public readonly id = this.key
     public readonly resource = this.value
-    public readonly treeItem: vscode.TreeItem
 
-    public constructor(private readonly key: string, private readonly value: unknown) {
-        this.treeItem = this.createTreeItem()
-    }
+    public constructor(private readonly key: string, private readonly value: unknown) {}
 
     public async getChildren(): Promise<TreeNode[]> {
         if (this.value instanceof Array || this.value instanceof Object) {
@@ -28,7 +25,7 @@ export class PropertyNode implements TreeNode {
         }
     }
 
-    private createTreeItem() {
+    public getTreeItem() {
         const item = new vscode.TreeItem(`${this.key}: ${this.value}`)
 
         item.contextValue = 'awsCdkPropertyNode'

--- a/src/cdk/explorer/rootNode.ts
+++ b/src/cdk/explorer/rootNode.ts
@@ -20,25 +20,24 @@ export async function getAppNodes(): Promise<TreeNode[]> {
         return [createPlaceholderItem(localize('AWS.cdk.explorerNode.noApps', '[No CDK Apps found in Workspaces]'))]
     }
 
-    return appsFound.map(appLocation => new AppNode(appLocation))
+    return appsFound.map(appLocation => new AppNode(appLocation)).sort((a, b) => a.label.localeCompare(b.label) ?? 0)
 }
 
 export class CdkRootNode implements TreeNode {
     public readonly id = 'cdk'
-    public readonly treeItem = this.createTreeItem()
     public readonly resource = this
     private readonly onDidChangeChildrenEmitter = new vscode.EventEmitter<void>()
     public readonly onDidChangeChildren = this.onDidChangeChildrenEmitter.event
 
-    public async getChildren() {
-        return (await getAppNodes()).sort((a, b) => a.treeItem?.label?.localeCompare(b.treeItem?.label ?? '') ?? 0)
+    public getChildren() {
+        return getAppNodes()
     }
 
     public refresh(): void {
         this.onDidChangeChildrenEmitter.fire()
     }
 
-    private createTreeItem() {
+    public getTreeItem() {
         const item = new vscode.TreeItem('CDK')
         item.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed
         item.contextValue = 'awsCdkRootNode'

--- a/src/codewhisperer/explorer/codewhispererNode.ts
+++ b/src/codewhisperer/explorer/codewhispererNode.ts
@@ -24,7 +24,6 @@ import { isCloud9 } from '../../shared/extensionUtilities'
 import { Cloud9AccessState } from '../models/model'
 export class CodeWhispererNode implements RootNode {
     public readonly id = 'codewhisperer'
-    public readonly treeItem = this.createTreeItem()
     public readonly resource = this
     private readonly onDidChangeChildrenEmitter = new vscode.EventEmitter<void>()
     public readonly onDidChangeChildren = this.onDidChangeChildrenEmitter.event
@@ -45,7 +44,7 @@ export class CodeWhispererNode implements RootNode {
         })
     }
 
-    private createTreeItem() {
+    public getTreeItem() {
         const item = new vscode.TreeItem('CodeWhisperer (Preview)')
         item.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed
         item.contextValue = 'awsCodeWhispererNode'

--- a/src/shared/treeview/resource.ts
+++ b/src/shared/treeview/resource.ts
@@ -24,7 +24,6 @@ export interface ResourceProvider<T extends Resource = Resource> {
 
 export class ResourceTreeNode<T extends Resource> implements TreeNode<T> {
     public readonly id = this.resource.id
-    public readonly treeItem = this.createTreeItem()
 
     public constructor(
         public readonly resource: T,
@@ -40,7 +39,7 @@ export class ResourceTreeNode<T extends Resource> implements TreeNode<T> {
         return this.children?.listResources() ?? []
     }
 
-    private createTreeItem(): vscode.TreeItem {
+    public getTreeItem(): vscode.TreeItem {
         const collapsed =
             this.children !== undefined
                 ? vscode.TreeItemCollapsibleState.Collapsed

--- a/src/shared/treeview/resourceTreeDataProvider.ts
+++ b/src/shared/treeview/resourceTreeDataProvider.ts
@@ -25,14 +25,19 @@ export interface TreeNode<T = unknown> {
     readonly resource: T
 
     /**
-     * A tree item used to display the node in a tree view.
-     */
-    readonly treeItem: vscode.TreeItem
-
-    /**
-     * Optional event to signal that this node's children has changed.
+     * An optional event to signal that this node's children has changed.
      */
     readonly onDidChangeChildren?: vscode.Event<void>
+
+    /**
+     * An optional event to signal that this node's tree item has changed.
+     */
+    readonly onDidChangeTreeItem?: vscode.Event<void>
+
+    /**
+     * Returns a tree item used to display the node in a tree view.
+     */
+    getTreeItem(): Promise<vscode.TreeItem> | vscode.TreeItem
 
     /**
      * Optional method to provide child nodes.
@@ -46,7 +51,7 @@ export function isTreeNode(obj: unknown): obj is TreeNode {
         typeof obj === 'object' &&
         'resource' in obj &&
         typeof (obj as TreeNode).id === 'string' &&
-        (obj as TreeNode).treeItem instanceof vscode.TreeItem
+        typeof (obj as TreeNode).getTreeItem === 'function'
     )
 }
 
@@ -54,30 +59,44 @@ function copyNode<T>(id: string, node: Omit<TreeNode<T>, 'id'>): TreeNode<T> {
     return {
         id,
         resource: node.resource,
-        treeItem: node.treeItem,
         onDidChangeChildren: node.onDidChangeChildren,
+        onDidChangeTreeItem: node.onDidChangeTreeItem,
+        getTreeItem: node.getTreeItem?.bind(node),
         getChildren: node.getChildren?.bind(node),
     }
 }
 
 export class ResourceTreeDataProvider implements vscode.TreeDataProvider<TreeNode> {
-    private readonly children: Map<string, TreeNode[]> = new Map()
-    private readonly listeners: Map<string, vscode.Disposable> = new Map()
+    private readonly items = new Map<string, vscode.TreeItem>()
+    private readonly children = new Map<string, TreeNode[]>()
+    private readonly listeners = new Map<string, vscode.Disposable>()
     private readonly onDidChangeTreeDataEmitter = new vscode.EventEmitter<TreeNode | void>()
     public readonly onDidChangeTreeData = this.onDidChangeTreeDataEmitter.event
 
     public constructor(private readonly root: Required<Pick<TreeNode, 'getChildren'>>) {}
 
-    public getTreeItem(element: TreeNode): vscode.TreeItem {
-        const item = element.treeItem
+    public async getTreeItem(element: TreeNode): Promise<vscode.TreeItem> {
+        const previousItem = this.items.get(element.id)
+        if (previousItem) {
+            return previousItem
+        }
+
+        const item = await element.getTreeItem()
         item.id = element.id
+        this.items.set(element.id, item)
 
         return item
     }
 
     public async getChildren(element?: TreeNode): Promise<TreeNode[]> {
         if (element) {
-            this.children.get(element.id)?.forEach(n => this.clear(n))
+            const previousChildren = this.children.get(element.id)
+
+            if (previousChildren !== undefined) {
+                return previousChildren
+            } else {
+                this.children.get(element.id)?.forEach(n => this.clear(n))
+            }
         }
 
         const getId = (id: string) => (element ? `${element.id}/${id}` : id)
@@ -91,6 +110,7 @@ export class ResourceTreeDataProvider implements vscode.TreeDataProvider<TreeNod
     public refresh(): void {
         vscode.Disposable.from(...this.listeners.values()).dispose()
 
+        this.items.clear()
         this.children.clear()
         this.listeners.clear()
         this.onDidChangeTreeDataEmitter.fire()
@@ -99,6 +119,7 @@ export class ResourceTreeDataProvider implements vscode.TreeDataProvider<TreeNod
     private clear(node: TreeNode): void {
         const children = this.children.get(node.id)
 
+        this.items.delete(node.id)
         this.children.delete(node.id)
         this.listeners.get(node.id)?.dispose()
         this.listeners.delete(node.id)
@@ -108,14 +129,29 @@ export class ResourceTreeDataProvider implements vscode.TreeDataProvider<TreeNod
 
     private insert(id: string, resource: TreeNode): TreeNode {
         const node = copyNode(id, resource)
+        const listeners: vscode.Disposable[] = []
 
         if (node.onDidChangeChildren) {
-            const listener = node.onDidChangeChildren?.(() => {
-                this.children.get(node.id)?.forEach(n => this.clear(n))
-                this.onDidChangeTreeDataEmitter.fire(node)
-            })
+            listeners.push(
+                node.onDidChangeChildren?.(() => {
+                    this.children.get(node.id)?.forEach(n => this.clear(n))
+                    this.children.delete(node.id)
+                    this.onDidChangeTreeDataEmitter.fire(node)
+                })
+            )
+        }
 
-            this.listeners.set(id, listener)
+        if (node.onDidChangeTreeItem) {
+            listeners.push(
+                node.onDidChangeTreeItem?.(() => {
+                    this.items.delete(node.id)
+                    this.onDidChangeTreeDataEmitter.fire(node)
+                })
+            )
+        }
+
+        if (listeners.length !== 0) {
+            this.listeners.set(id, vscode.Disposable.from(...listeners))
         }
 
         return node

--- a/src/shared/vscode/commands2.ts
+++ b/src/shared/vscode/commands2.ts
@@ -286,12 +286,15 @@ class CommandResource<T extends Callback = Callback, U extends any[] = any[]> {
     private buildTreeNode(id: string, args: unknown[]) {
         return (content: PartialTreeItem) => {
             const treeItem = new vscode.TreeItem(content.label, vscode.TreeItemCollapsibleState.None)
-            treeItem.command = { command: id, arguments: args, title: content.label }
+            Object.assign(treeItem, {
+                ...content,
+                command: { command: id, arguments: args, title: content.label },
+            })
 
             return {
                 id: `${id}-${(this.idCounter += 1)}`,
-                treeItem: Object.assign(treeItem, content),
                 resource: this,
+                getTreeItem: () => treeItem,
             }
         }
     }

--- a/src/test/cdk/explorer/appNode.test.ts
+++ b/src/test/cdk/explorer/appNode.test.ts
@@ -31,11 +31,11 @@ describe('AppNode', function () {
     })
 
     it('initializes label, tooltip, and icon', async function () {
-        const testNode = getTestNode()
+        const testNode = getTestNode().getTreeItem()
 
-        assert.strictEqual(testNode.treeItem.label, path.relative(workspaceFolderPath, path.dirname(cdkJsonPath)))
-        assert.strictEqual(testNode.treeItem.tooltip, vscode.Uri.file(cdkJsonPath).path)
-        assert.strictEqual(testNode.treeItem.iconPath, getIcon('aws-cdk-logo'))
+        assert.strictEqual(testNode.label, path.relative(workspaceFolderPath, path.dirname(cdkJsonPath)))
+        assert.strictEqual(testNode.tooltip, vscode.Uri.file(cdkJsonPath).path)
+        assert.strictEqual(testNode.iconPath, getIcon('aws-cdk-logo'))
     })
 
     it('returns placeholder node when app contains no stacks', async function () {
@@ -48,7 +48,7 @@ describe('AppNode', function () {
         const childNodes = await testNode.getChildren()
 
         assert.strictEqual(childNodes.length, 1)
-        assert.ok(childNodes[0].treeItem.label?.includes('No stacks'))
+        assert.ok((await childNodes[0].getTreeItem()).label?.includes('No stacks'))
     })
 
     it('returns construct node when app has stacks', async function () {
@@ -71,7 +71,7 @@ describe('AppNode', function () {
         const childNodes = await testNode.getChildren()
 
         assert.strictEqual(childNodes.length, 1)
-        assert.ok(childNodes[0].treeItem.label?.includes('Unable to load construct tree'))
+        assert.ok((await childNodes[0].getTreeItem()).label?.includes('Unable to load construct tree'))
     })
 
     function getTestNode(): appNode.AppNode {

--- a/src/test/cdk/explorer/constructNode.test.ts
+++ b/src/test/cdk/explorer/constructNode.test.ts
@@ -24,12 +24,12 @@ describe('ConstructNode', function () {
     }
 
     it('initializes label, tooltip, and icon', async function () {
-        const testNode = generateTestNode(label)
+        const testNode = generateTestNode(label).getTreeItem()
 
-        assert.strictEqual(testNode.treeItem.label, label)
-        assert.strictEqual(testNode.treeItem.tooltip, constructTreePath)
-        assert.strictEqual(testNode.treeItem.iconPath, getIcon('aws-cdk-logo'))
-        assert.strictEqual(testNode.treeItem.collapsibleState, vscode.TreeItemCollapsibleState.Collapsed)
+        assert.strictEqual(testNode.label, label)
+        assert.strictEqual(testNode.tooltip, constructTreePath)
+        assert.strictEqual(testNode.iconPath, getIcon('aws-cdk-logo'))
+        assert.strictEqual(testNode.collapsibleState, vscode.TreeItemCollapsibleState.Collapsed)
     })
 
     it('returns a uri with a fragment pointing to the resource', async () => {
@@ -44,9 +44,9 @@ describe('ConstructNode', function () {
         const testNode = new ConstructNode(location, {
             ...treeUtils.generateConstructTreeEntity('', constructTreePath),
             attributes: treeUtils.generateAttributes(),
-        })
+        }).getTreeItem()
 
-        assert.strictEqual(testNode.treeItem.iconPath, getIcon('aws-cloudformation-stack'))
+        assert.strictEqual(testNode.iconPath, getIcon('aws-cloudformation-stack'))
     })
 
     it('returns no child nodes if construct does not have any', async function () {
@@ -66,7 +66,7 @@ describe('ConstructNode', function () {
 
         const childNodes = testNode.getChildren()
         assert.strictEqual(childNodes.length, 1)
-        assert.strictEqual(childNodes[0].treeItem.collapsibleState, vscode.TreeItemCollapsibleState.None)
+        assert.strictEqual((await childNodes[0].getTreeItem()).collapsibleState, vscode.TreeItemCollapsibleState.None)
     })
 
     it('child node is collapsed if construct has child with attributes', async function () {
@@ -83,7 +83,10 @@ describe('ConstructNode', function () {
 
         const childNodes = testNode.getChildren()
         assert.strictEqual(childNodes.length, 1, 'Expected child node with attributes to be collapsed')
-        assert.strictEqual(childNodes[0].treeItem.collapsibleState, vscode.TreeItemCollapsibleState.Collapsed)
+        assert.strictEqual(
+            (await childNodes[0].getTreeItem()).collapsibleState,
+            vscode.TreeItemCollapsibleState.Collapsed
+        )
     })
 
     it('returns child node of PropertyNode when construct has props', async function () {

--- a/src/test/cdk/explorer/propertyNode.test.ts
+++ b/src/test/cdk/explorer/propertyNode.test.ts
@@ -10,8 +10,8 @@ describe('PropertyNode', function () {
     const label = 'myProperty'
 
     it('initializes label', async function () {
-        const testNode = new PropertyNode(label, 'blue')
-        assert.strictEqual(testNode.treeItem.label, `${label}: blue`)
+        const testNode = new PropertyNode(label, 'blue').getTreeItem()
+        assert.strictEqual(testNode.label, `${label}: blue`)
     })
 
     it('returns no children when property does not have nested values', async function () {
@@ -30,7 +30,7 @@ describe('PropertyNode', function () {
         const childNodes = await testNode.getChildren()
 
         assert.strictEqual(childNodes.length, 1, 'Expected a single property node for a string property')
-        assert.strictEqual(childNodes[0].treeItem.label, `key: ${value}`)
+        assert.strictEqual((await childNodes[0].getTreeItem()).label, `key: ${value}`)
     })
 
     it('returns single child when property has a boolean value', async function () {
@@ -40,7 +40,7 @@ describe('PropertyNode', function () {
         const childNodes = await testNode.getChildren()
 
         assert.strictEqual(childNodes.length, 1, 'Expected a single property node for a boolean property')
-        assert.strictEqual(childNodes[0].treeItem.label, 'key: true')
+        assert.strictEqual((await childNodes[0].getTreeItem()).label, 'key: true')
     })
 
     it('returns single child when property has an int value', async function () {
@@ -51,7 +51,11 @@ describe('PropertyNode', function () {
         const childNodes = await testNode.getChildren()
 
         assert.strictEqual(childNodes.length, 1, 'Expected a single property node for an int property')
-        assert.strictEqual(childNodes[0].treeItem.label, `key: ${value}`, 'Unexpected label on PropertyNode')
+        assert.strictEqual(
+            (await childNodes[0].getTreeItem()).label,
+            `key: ${value}`,
+            'Unexpected label on PropertyNode'
+        )
     })
 
     it('returns a nested property node with a property node for each value in the array', async function () {
@@ -62,7 +66,7 @@ describe('PropertyNode', function () {
 
         const childNodes = await testNode.getChildren()
         assert.strictEqual(childNodes.length, 1, 'expected nested property to have a child node for array')
-        assert.strictEqual(childNodes[0].treeItem.label, 'key', 'Unexpected label on node')
+        assert.strictEqual((await childNodes[0].getTreeItem()).label, 'key', 'Unexpected label on node')
 
         const childPropertyNodes = await childNodes[0].getChildren?.()
         assert.strictEqual(childPropertyNodes?.length, 3, 'Expected each value in nested array to have a child node')
@@ -82,10 +86,10 @@ describe('PropertyNode', function () {
         const childNodes = await testNode.getChildren()
 
         assert.strictEqual(childNodes.length, 1, 'Expected nested property of object type to have child nodes')
-        assert.strictEqual(childNodes[0].treeItem.label, 'key')
+        assert.strictEqual((await childNodes[0].getTreeItem()).label, 'key')
 
         const grandChildren = await childNodes[0]?.getChildren?.()
         assert.strictEqual(grandChildren?.length, 1, 'Expected nested property of object type to have grandchild nodes')
-        assert.strictEqual(grandChildren[0].treeItem.label, 'nestedKey')
+        assert.strictEqual((await grandChildren[0].getTreeItem()).label, 'nestedKey')
     })
 })

--- a/src/test/shared/treeview/resourceTreeDataProvider.test.ts
+++ b/src/test/shared/treeview/resourceTreeDataProvider.test.ts
@@ -13,15 +13,24 @@ interface Tree {
 
 class TestNode implements TreeNode<TestNode> {
     private readonly onDidChangeChildrenEmitter = new EventEmitter<void>()
+    private readonly onDidChangeTreeItemEmitter = new EventEmitter<void>()
 
     public readonly resource = this
-    public readonly treeItem = new TreeItem(this.id)
     public readonly onDidChangeChildren = this.onDidChangeChildrenEmitter.event
+    public readonly onDidChangeTreeItem = this.onDidChangeTreeItemEmitter.event
 
     public constructor(public readonly id: string, private readonly tree: Tree) {}
 
-    public refresh() {
+    public refreshChildren() {
         this.onDidChangeChildrenEmitter.fire()
+    }
+
+    public refreshTreeItem() {
+        this.onDidChangeTreeItemEmitter.fire()
+    }
+
+    public getTreeItem() {
+        return new TreeItem(this.id)
     }
 
     public getChildren() {
@@ -37,8 +46,8 @@ function getRoot(tree: Tree) {
     return { getChildren: () => buildTree(tree) }
 }
 
-function getLabels(nodes: TreeNode[]): string[] {
-    return nodes.map(n => n.treeItem.label ?? 'not set')
+function getLabels(nodes: TreeNode[]): Promise<string[]> {
+    return Promise.all(nodes.map(async n => (await n.getTreeItem()).label ?? 'not set'))
 }
 
 function intoTestNode(node: TreeNode): TestNode | never {
@@ -57,13 +66,14 @@ function setupChanged(provider: ResourceTreeDataProvider): TreeNode[] {
 }
 
 describe('ResourceTreeDataProvider', function () {
+    const tree = { node0: { node1: {} } }
     const flatTree = { node0: {}, node1: {}, node2: {} }
 
     it('lists children from a root node', async function () {
         const provider = new ResourceTreeDataProvider(getRoot(flatTree))
         const children = await provider.getChildren()
 
-        assert.deepStrictEqual(getLabels(children), ['node0', 'node1', 'node2'])
+        assert.deepStrictEqual(await getLabels(children), ['node0', 'node1', 'node2'])
     })
 
     it('can refresh the provider', async function () {
@@ -71,37 +81,80 @@ describe('ResourceTreeDataProvider', function () {
         const changed = setupChanged(provider)
 
         const nodes = (await provider.getChildren()).map(intoTestNode)
-        nodes[0].refresh()
-        nodes[1].refresh()
+        nodes[0].refreshChildren()
+        nodes[1].refreshChildren()
         provider.refresh()
-        nodes[2].refresh()
+        nodes[2].refreshChildren()
 
-        assert.deepStrictEqual(getLabels(changed), ['node0', 'node1'])
+        assert.deepStrictEqual(await getLabels(changed), ['node0', 'node1'])
     })
 
-    describe('nested', function () {
-        const nested = { nested: flatTree }
+    it('clears tree items on refresh', async function () {
+        const provider = new ResourceTreeDataProvider(getRoot(tree))
+        const [node0] = await provider.getChildren()
+        const item0 = await provider.getTreeItem(node0)
+        provider.refresh()
+
+        const newItem0 = await provider.getTreeItem(node0)
+        assert.notStrictEqual(newItem0, item0)
+        assert.deepStrictEqual(newItem0, item0)
+    })
+
+    it("caches children, clearing the cache when a node's children change", async function () {
+        const provider = new ResourceTreeDataProvider(getRoot(tree))
+        const [node0] = await provider.getChildren()
+        const children = await provider.getChildren(node0)
+
+        assert.strictEqual(await provider.getChildren(node0), children)
+        intoTestNode(node0).refreshChildren()
+        assert.notStrictEqual(await provider.getChildren(node0), children)
+    })
+
+    it("caches tree items, clearing the cache when a node's tree item changes", async function () {
+        const provider = new ResourceTreeDataProvider(getRoot(tree))
+        const [node0] = await provider.getChildren()
+        const treeItem = await provider.getTreeItem(node0)
+
+        assert.strictEqual(await provider.getTreeItem(node0), treeItem)
+        intoTestNode(node0).refreshTreeItem()
+        assert.notStrictEqual(await provider.getTreeItem(node0), treeItem)
+    })
+
+    it('preserves event listeners of cached children after tree item changes', async function () {
+        const provider = new ResourceTreeDataProvider(getRoot(tree))
+        const [node0] = await provider.getChildren()
+        await provider.getChildren(node0)
+        intoTestNode(node0).refreshTreeItem()
+
+        const [node1] = await provider.getChildren(node0)
+        const changed = setupChanged(provider)
+        intoTestNode(node1).refreshTreeItem()
+        assert.deepStrictEqual(await getLabels(changed), ['node1'])
+    })
+
+    describe('nested tree', function () {
+        const nestedTree = { nested: flatTree }
 
         it('can list children from an element', async function () {
-            const provider = new ResourceTreeDataProvider(getRoot(nested))
+            const provider = new ResourceTreeDataProvider(getRoot(nestedTree))
             const children1 = await provider.getChildren()
             const children2 = await provider.getChildren(children1[0])
 
-            assert.deepStrictEqual(getLabels(children1), ['nested'])
-            assert.deepStrictEqual(getLabels(children2), ['node0', 'node1', 'node2'])
+            assert.deepStrictEqual(await getLabels(children1), ['nested'])
+            assert.deepStrictEqual(await getLabels(children2), ['node0', 'node1', 'node2'])
         })
 
         it('can get a tree item with a unique id', async function () {
-            const provider = new ResourceTreeDataProvider(getRoot(nested))
+            const provider = new ResourceTreeDataProvider(getRoot(nestedTree))
             const children = await provider.getChildren((await provider.getChildren())[0])
-            const item = provider.getTreeItem(children[0])
+            const item = await provider.getTreeItem(children[0])
 
             assert.strictEqual(item.id, 'nested/node0')
             assert.strictEqual(item.label, 'node0')
         })
 
         it('clears nested event listeners', async function () {
-            const provider = new ResourceTreeDataProvider(getRoot(nested))
+            const provider = new ResourceTreeDataProvider(getRoot(nestedTree))
             const changed = setupChanged(provider)
 
             const children1 = await provider.getChildren()
@@ -110,12 +163,39 @@ describe('ResourceTreeDataProvider', function () {
             const nodes1 = children1.map(intoTestNode)
             const nodes2 = children2.map(intoTestNode)
 
-            nodes2[0].refresh()
-            nodes2[1].refresh()
-            nodes1[0].refresh()
-            nodes2[0].refresh()
+            nodes2[0].refreshChildren()
+            nodes2[1].refreshChildren()
+            nodes1[0].refreshChildren()
+            nodes2[0].refreshChildren()
 
-            assert.deepStrictEqual(getLabels(changed), ['node0', 'node1', 'nested'])
+            assert.deepStrictEqual(await getLabels(changed), ['node0', 'node1', 'nested'])
+        })
+
+        it('can refresh only the tree item, preserving the children', async function () {
+            const provider = new ResourceTreeDataProvider(getRoot(nestedTree))
+            const changed = setupChanged(provider)
+
+            const [nested] = await provider.getChildren()
+            const testNode = intoTestNode(nested)
+            const children = await provider.getChildren(nested)
+            testNode.refreshTreeItem()
+
+            assert.deepStrictEqual(await getLabels(changed), ['nested'])
+            assert.strictEqual(children, await provider.getChildren(nested))
+        })
+
+        it('does not cache nested tree items if the parent node changes children', async function () {
+            const provider = new ResourceTreeDataProvider(getRoot(tree))
+            const [node0] = await provider.getChildren()
+            const [node1] = await provider.getChildren(node0)
+
+            const item1 = await provider.getTreeItem(node1)
+            assert.strictEqual(await provider.getTreeItem(node1), item1)
+            intoTestNode(node0).refreshChildren()
+
+            const newItem1 = await provider.getTreeItem(node1)
+            assert.notStrictEqual(newItem1, item1)
+            assert.deepStrictEqual(newItem1, item1)
         })
     })
 })

--- a/src/test/shared/vscode/commands.test.ts
+++ b/src/test/shared/vscode/commands.test.ts
@@ -134,7 +134,7 @@ describe('Commands', function () {
             it('can build a tree node', function () {
                 const registered = commands.register('sum', sum)
                 const built = registered.build(5, 4).asTreeNode({ label: 'Sum' })
-                const item = built.treeItem
+                const item = built.getTreeItem()
 
                 assert.ok(item instanceof vscode.TreeItem)
                 assert.strictEqual(item.label, 'Sum')


### PR DESCRIPTION
## Problem
While prototyping features, I kept running into the situation where I wanted to update how a node was rendered independently of the node's children. The current implementation does not easily support this use-case, forcing us to propagate events up to a parent node to get the desired behavior.

## Solution
Fully generalize the `TreeNode` interface. It was already very close to the general solution, it just needed a few tweaks to get it there. Of course, implementing this correctly with a tree data provider required more substantial changes which tests were added for.

I wouldn't recommend that _all_ tree node implementations use this pattern because it can quickly spiral out of control from a maintainability point of view. Still, I'd rather have the proper solution readily available than a bunch of one-off bespoke solutions. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
