### PR TITLE
feat(connect): "Edit Credentials" in profile quickpick; restore "Connect to AWS"; autoconnect max 1

### DIFF
--- a/.changes/next-release/Bug Fix-80a89464-b246-4ed8-bc7c-c58bdad7b508.json
+++ b/.changes/next-release/Bug Fix-80a89464-b246-4ed8-bc7c-c58bdad7b508.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "restored `Connect to AWS` command (alias to the `Choose AWS Profile` command)"
+}

--- a/.changes/next-release/Feature-aa840ab7-982f-4c52-a2c5-c6d1513129af.json
+++ b/.changes/next-release/Feature-aa840ab7-982f-4c52-a2c5-c6d1513129af.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "`Choose AWS Profile` quickpick now includes an `Edit Credentials` action"
+}

--- a/.changes/next-release/Feature-eae23041-03ad-4df1-92ab-908412b5f584.json
+++ b/.changes/next-release/Feature-eae23041-03ad-4df1-92ab-908412b5f584.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Auto-connect tries a maximum of one non-default profile instead of three"
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "onStartupFinished",
         "onDebugResolve:aws-sam",
         "onCommand:aws.login",
+        "onCommand:aws.login2",
         "onCommand:aws.credentials.profile.create",
         "onCommand:aws.credentials.edit",
         "onCommand:aws.logout",
@@ -1752,6 +1753,17 @@
                 "cloud9": {
                     "cn": {
                         "title": "%AWS.command.login.cn%",
+                        "category": "%AWS.title.cn%"
+                    }
+                }
+            },
+            {
+                "command": "aws.login2",
+                "title": "%AWS.command.login2%",
+                "category": "%AWS.title%",
+                "cloud9": {
+                    "cn": {
+                        "title": "%AWS.command.login2.cn%",
                         "category": "%AWS.title.cn%"
                     }
                 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -76,6 +76,8 @@
     "AWS.command.help": "View Toolkit Documentation",
     "AWS.command.login": "Choose AWS Profile...",
     "AWS.command.login.cn": "Choose Amazon Profile...",
+    "AWS.command.login2": "Connect to AWS",
+    "AWS.command.login2.cn": "Connect to Amazon",
     "AWS.command.logout": "Sign out",
     "AWS.command.createIssueOnGitHub": "Report Toolkit Issue",
     "AWS.command.createNewSamApp": "Create Lambda SAM Application",

--- a/src/credentials/loginManager.ts
+++ b/src/credentials/loginManager.ts
@@ -117,6 +117,8 @@ export class LoginManager {
 
     /**
      * Removes Credentials from the Toolkit. Essentially the Toolkit becomes "logged out".
+     *
+     * TODO: for SSO this should do a server-side logout.
      */
     public async logout(force?: boolean): Promise<void> {
         await this.awsContext.setCredentials(undefined, force)

--- a/src/credentials/loginManager.ts
+++ b/src/credentials/loginManager.ts
@@ -38,6 +38,7 @@ import { Credentials } from '@aws-sdk/types'
 import { ToolkitError } from '../shared/toolkitError'
 import * as localizedText from '../shared/localizedText'
 import { DefaultStsClient } from '../shared/clients/stsClient'
+import { findAsync } from '../shared/utilities/collectionUtils'
 
 export class LoginManager {
     private readonly defaultCredentialsRegion = 'us-east-1'
@@ -217,21 +218,21 @@ export async function loginWithMostRecentCredentials(
     }
 
     // Try to auto-connect the default profile.
-    if (defaultProfile) {
+    if (defaultProfile && defaultProfile !== previousCredentialsId) {
         getLogger().info('autoconnect: trying "%s"', defaultProfile)
         if (await tryConnect(providerMap[defaultProfile], !isCloud9())) {
             return
         }
     }
 
-    // Try to auto-connect up to 3 other profiles (useful for Cloud9, ECS, …).
-    for (let i = 0; i < 4 && i < profileNames.length; i++) {
-        const p = profileNames[i]
-        if (p === defaultName) {
-            continue
-        }
-        getLogger().info('autoconnect: trying "%s"', p)
-        if (await tryConnect(providerMap[p], !isCloud9())) {
+    // Try to auto-connect any other non-default profile (useful for env vars, IMDS, Cloud9, ECS, …).
+    const nonDefault = await findAsync(profileNames, async p => {
+        const provider = await manager.getCredentialsProvider(providerMap[p])
+        return p !== defaultName && !!provider?.canAutoConnect()
+    })
+    if (nonDefault) {
+        getLogger().info('autoconnect: trying "%s"', nonDefault)
+        if (await tryConnect(providerMap[nonDefault], !isCloud9())) {
             return
         }
     }

--- a/src/credentials/providers/credentialsProviderManager.ts
+++ b/src/credentials/providers/credentialsProviderManager.ts
@@ -51,7 +51,6 @@ export class CredentialsProviderManager {
             providers = providers.concat(refreshed)
         }
 
-        getLogger().verbose(`available credentials providers: ${providers}`)
         return providers
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -139,6 +139,8 @@ export async function activate(context: vscode.ExtensionContext) {
             // No-op command used for decoration-only codelenses.
             vscode.commands.registerCommand('aws.doNothingCommand', () => {}),
             Commands.register('aws.login', () => globals.awsContextCommands.onCommandLogin()),
+            // "Connect to AWS": redundant with "Choose AWS Profile", but kept to avoid confusion.
+            Commands.register('aws.login2', () => globals.awsContextCommands.onCommandLogin()),
             Commands.register('aws.logout', () => globals.awsContextCommands.onCommandLogout()),
             // "Show AWS Commands..."
             Commands.register('aws.listCommands', () =>

--- a/src/shared/awsContextCommands.ts
+++ b/src/shared/awsContextCommands.ts
@@ -189,8 +189,7 @@ export class AwsContextCommands {
     }
 
     /**
-     * @description Responsible for getting a profile from the user,
-     * working with them to define one if necessary.
+     * Gets a profile from the user, or runs "Create Credentials" command if there are no profiles.
      *
      * @returns User's selected Profile name, or undefined if none was selected.
      * undefined is also returned if we leave the user in a state where they are

--- a/src/shared/credentials/credentialSelectionDataProvider.ts
+++ b/src/shared/credentials/credentialSelectionDataProvider.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { QuickPickItem } from 'vscode'
+import * as vscode from 'vscode'
 import { MultiStepInputFlowController } from '../multiStepInputFlowController'
 import { CredentialSelectionState } from './credentialSelectionState'
 
@@ -12,8 +12,9 @@ export interface CredentialSelectionDataProvider {
 
     pickCredentialProfile(
         input: MultiStepInputFlowController,
+        actions: vscode.QuickPickItem[],
         state: Partial<CredentialSelectionState>
-    ): Promise<QuickPickItem>
+    ): Promise<vscode.QuickPickItem>
 
     inputProfileName(
         input: MultiStepInputFlowController,

--- a/src/shared/utilities/collectionUtils.ts
+++ b/src/shared/utilities/collectionUtils.ts
@@ -137,6 +137,21 @@ export function filter<T>(sequence: Iterable<T>, condition: (item: T) => boolean
     return result
 }
 
+/**
+ * Gets the first item matching predicate, or undefined.
+ */
+export async function findAsync<T>(
+    sequence: Iterable<T>,
+    predicate: (item: T) => Promise<boolean>
+): Promise<T | undefined> {
+    for (const item of sequence) {
+        if (await predicate(item)) {
+            return item
+        }
+    }
+    return undefined
+}
+
 export async function* filterAsync<T>(
     sequence: Iterable<T>,
     condition: (item: T) => Promise<boolean>

--- a/src/test/shared/credentials/defaultCredentialSelectionDataProvider.test.ts
+++ b/src/test/shared/credentials/defaultCredentialSelectionDataProvider.test.ts
@@ -22,6 +22,7 @@ describe('defaultCredentialSelectionDataProvider', function () {
 
                 public async pickCredentialProfile(
                     input: MultiStepInputFlowController,
+                    actions: QuickPickItem[],
                     partialState: Partial<CredentialSelectionState>
                 ): Promise<QuickPickItem> {
                     return new Promise<QuickPickItem>(resolve => {
@@ -75,6 +76,7 @@ describe('defaultCredentialSelectionDataProvider', function () {
 
                 public async pickCredentialProfile(
                     input: MultiStepInputFlowController,
+                    actions: QuickPickItem[],
                     partialState: Partial<CredentialSelectionState>
                 ): Promise<QuickPickItem> {
                     throw new Error('Should never get here')

--- a/src/test/techdebt.test.ts
+++ b/src/test/techdebt.test.ts
@@ -22,6 +22,8 @@ describe('tech debt', function () {
             semver.lt(minVscode, '1.51.0'),
             'remove filesystemUtilities.findFile(), use vscode.workspace.findFiles() instead'
         )
+
+        assert.ok(semver.lt(minVscode, '1.64.0'), 'remove QuickPickItemKind stub in pickCredentialProfile()')
     })
 
     it('nodejs minimum version', async function () {


### PR DESCRIPTION
- Problem 1:
    - Docs still mention the "Connect to AWS" command, though it was renamed.
    - Even if we update the docs, there is evidence that customers still expect a "Connect" command; "Choose AWS Profile" is not intuitive for the first connection.
    - **Solution:**
        - Restore "Connect to AWS" command.
- Problem 2:
    - Trying non-default profiles is useful when env vars or IMDS are present. But in other cases, arbitrarily trying 3 profiles can be annoying.
    - **Solution:**
        - Try only 1 other profile instead of 3.
        - ref https://github.com/aws/aws-toolkit-vscode/pull/2316 https://github.com/aws/aws-toolkit-vscode/commit/1f5b341301864fd273cec8ff6de6c168961e6d3c
- Problem 3:
    - "AWS" statusbar item and other entrypoints defer to the profile picker, and there's no obvious way to edit the profiles.
    - **Solution:**
        - Expose an `Edit Credentials` action as the top item of the profile picker.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
