### PR TITLE
Hkobew/fix cancel search

### DIFF
--- a/src/cloudWatchLogs/changeLogSearch.ts
+++ b/src/cloudWatchLogs/changeLogSearch.ts
@@ -5,7 +5,7 @@
 import * as telemetry from '../shared/telemetry/telemetry'
 import * as vscode from 'vscode'
 import { showInputBox } from '../shared/ui/inputPrompter'
-import { isLogStreamUri } from './cloudWatchLogsUtils'
+import { createURIFromArgs, isLogStreamUri } from './cloudWatchLogsUtils'
 import { prepareDocument } from './commands/searchLogGroup'
 import { getActiveDocumentUri } from './document/logStreamDocumentProvider'
 import { CloudWatchLogsData, filterLogEventsFromUriComponents, LogStreamRegistry } from './registry/logStreamRegistry'
@@ -82,9 +82,10 @@ export async function changeLogSearchParams(
         return
     }
 
-    const newUri = await registry.registerLogWithNewUri(oldUri, newData)
+    registry.deregisterLog(oldUri)
+    const newUri = createURIFromArgs(newData.logGroupInfo, newData.parameters)
 
-    result = await prepareDocument(newUri, registry)
+    result = await prepareDocument(newUri, newData, registry)
 
     console.log(result)
 }

--- a/src/cloudWatchLogs/commands/searchLogGroup.ts
+++ b/src/cloudWatchLogs/commands/searchLogGroup.ts
@@ -60,8 +60,13 @@ function handleWizardResponse(response: SearchLogGroupWizardResponse, registry: 
     return initialStreamData
 }
 
-export async function prepareDocument(uri: vscode.Uri, registry: LogStreamRegistry): Promise<telemetry.Result> {
+export async function prepareDocument(
+    uri: vscode.Uri,
+    initialLogData: CloudWatchLogsData,
+    registry: LogStreamRegistry
+): Promise<telemetry.Result> {
     try {
+        await registry.registerLog(uri, initialLogData)
         const doc = await vscode.workspace.openTextDocument(uri) // calls back into the provider
         vscode.languages.setTextDocumentLanguage(doc, 'log')
 
@@ -120,9 +125,7 @@ export async function searchLogGroup(node: LogGroupNode | undefined, registry: L
 
     const uri = createURIFromArgs(initialLogData.logGroupInfo, initialLogData.parameters)
 
-    await registry.registerLog(uri, initialLogData)
-
-    const result = await prepareDocument(uri, registry)
+    const result = await prepareDocument(uri, initialLogData, registry)
     telemetry.recordCloudwatchlogsOpenStream({ result })
 }
 

--- a/src/cloudWatchLogs/registry/logStreamRegistry.ts
+++ b/src/cloudWatchLogs/registry/logStreamRegistry.ts
@@ -6,7 +6,7 @@
 import * as moment from 'moment'
 import * as vscode from 'vscode'
 import { CloudWatchLogs } from 'aws-sdk'
-import { CloudWatchLogsSettings, parseCloudWatchLogsUri, uriToKey, createURIFromArgs } from '../cloudWatchLogsUtils'
+import { CloudWatchLogsSettings, parseCloudWatchLogsUri, uriToKey } from '../cloudWatchLogsUtils'
 import { getLogger } from '../../shared/logger'
 import { INSIGHTS_TIMESTAMP_FORMAT } from '../../shared/constants'
 import { DefaultCloudWatchLogsClient } from '../../shared/clients/cloudWatchLogsClient'

--- a/src/cloudWatchLogs/registry/logStreamRegistry.ts
+++ b/src/cloudWatchLogs/registry/logStreamRegistry.ts
@@ -185,18 +185,6 @@ export class LogStreamRegistry {
     public hasTextEditor(uri: vscode.Uri): boolean {
         return this.hasLog(uri) && this.getTextEditor(uri) !== undefined
     }
-    /**
-     * Deregisters log with oldUri and registers one with the content of newData.
-     * @param oldUri
-     * @param newData
-     * @returns new Uri associated with new Data
-     */
-    public async registerLogWithNewUri(oldUri: vscode.Uri, newData: CloudWatchLogsData): Promise<vscode.Uri> {
-        this.deregisterLog(oldUri)
-        const newUri = createURIFromArgs(newData.logGroupInfo, newData.parameters)
-        await this.registerLog(newUri, newData)
-        return newUri
-    }
 }
 
 export async function filterLogEventsFromUriComponents(

--- a/src/test/cloudWatchLogs/changeLogSearch.test.ts
+++ b/src/test/cloudWatchLogs/changeLogSearch.test.ts
@@ -44,7 +44,9 @@ describe('changeLogSearch', async function () {
 
     it('unregisters old log and registers a new one', async function () {
         assert.deepStrictEqual(testRegistry.hasLog(oldUri), true)
-        const newUri = await testRegistry.registerLogWithNewUri(oldUri, newData)
+        testRegistry.deregisterLog(oldUri)
+        const newUri = createURIFromArgs(newData.logGroupInfo, newData.parameters)
+        await testRegistry.registerLog(newUri, newData)
         assert.deepStrictEqual(testRegistry.hasLog(oldUri), false)
         assert.deepStrictEqual(testRegistry.getLogData(newUri)?.parameters.filterPattern, newText)
     })


### PR DESCRIPTION
## Problem
BUG: Cancelling a log group search would result in an error. 
## Solution
The `prepareDocument` function in `searchLogGroup.ts` did not contain that function(`registry.registerLog`) that it needed to contain in order to catch cancellation errors. 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
