### PR TITLE
CWL: don't show commands on commandPalette

### DIFF
--- a/package.json
+++ b/package.json
@@ -846,6 +846,14 @@
                     "when": "false"
                 },
                 {
+                    "command": "aws.cwl.changeFilterPattern",
+                    "when": "false"
+                },
+                {
+                    "command": "aws.cwl.changeTimeFilter",
+                    "when": "false"
+                },
+                {
                     "command": "aws.ecr.deleteRepository",
                     "when": "false"
                 },


### PR DESCRIPTION
## Problem
There are three cloudWatchLogs commands available when viewing a log group search or log stream. `aws.cwl.changeFilterPattern` and `aws.cwl.changeTimeFilter` don't offer anything `aws.cwl.searchLogGroup` doesn't. 
## Solution
We eliminate `aws.cwl.changeFilterPattern` and `aws.cwl.changeTimeFilter` from command Palette. 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
