### PR TITLE
fix(codewhisperer): block concurrent getAccessToken API call

### DIFF
--- a/src/codewhisperer/util/showAccessTokenPrompt.ts
+++ b/src/codewhisperer/util/showAccessTokenPrompt.ts
@@ -60,7 +60,7 @@ export const showAccessTokenPrompt = async (
     const validateInput = async (): Promise<void> => {
         if (!picker.value.length) {
             displayError(false)
-        } else {
+        } else if (!picker.busy) {
             picker.busy = true
             try {
                 const getAccessTokenPromise = client.getAccessToken({ identityToken: picker.value })


### PR DESCRIPTION
## Problem
Concurrent getAccessToken API calls are not blocked. They can cause a problem when same token is registered and returns token already claimed error to client.

## Solution
Use picker.busy flag to block concurrent getAccessToken API calls

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
