### PR TITLE
fix(codewhisperer): Add userDecision telemetry for empty recommendation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
                 "yaml-cfn": "^0.3.1"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.59",
+                "@aws-toolkits/telemetry": "^1.0.61",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^8.1.0",
                 "@types/adm-zip": "^0.4.34",

--- a/package.json
+++ b/package.json
@@ -3194,7 +3194,7 @@
         "report": "nyc report --reporter=html --reporter=json"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.59",
+        "@aws-toolkits/telemetry": "^1.0.61",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^8.1.0",
         "@types/adm-zip": "^0.4.34",

--- a/src/codewhisperer/service/completionProvider.ts
+++ b/src/codewhisperer/service/completionProvider.ts
@@ -17,7 +17,7 @@ export function getCompletionItems(document: vscode.TextDocument, position: vsco
     const completionItems: vscode.CompletionItem[] = []
     RecommendationHandler.instance.recommendations.forEach((recommendation, index) => {
         completionItems.push(getCompletionItem(document, position, recommendation, index))
-        RecommendationHandler.instance.recommendationSuggestionState.set(index, 'Showed')
+        RecommendationHandler.instance.setSuggestionState(index, 'Showed')
     })
     return completionItems
 }

--- a/src/codewhisperer/service/inlineCompletion.ts
+++ b/src/codewhisperer/service/inlineCompletion.ts
@@ -287,7 +287,7 @@ export class InlineCompletion {
                                 curItem,
                                 this.origin[curItem.index].references
                             )
-                            RecommendationHandler.instance.recommendationSuggestionState.set(curItem.index, 'Showed')
+                            RecommendationHandler.instance.setSuggestionState(curItem.index, 'Showed')
                         })
                 }
             })
@@ -431,7 +431,7 @@ export class InlineCompletion {
             this.origin.forEach((item, index) => {
                 if (
                     item.content.startsWith(this.typeAhead) &&
-                    RecommendationHandler.instance.recommendationSuggestionState.get(index) !== 'Filtered'
+                    RecommendationHandler.instance.getSuggestionState(index) !== 'Filtered'
                 ) {
                     this.items.push({
                         content: item.content.substring(this.typeAhead.length),
@@ -441,7 +441,7 @@ export class InlineCompletion {
             })
         } else {
             this.origin.forEach((item, index) => {
-                if (RecommendationHandler.instance.recommendationSuggestionState.get(index) !== 'Filtered') {
+                if (RecommendationHandler.instance.getSuggestionState(index) !== 'Filtered') {
                     this.items.push({
                         content: item.content,
                         index: index,

--- a/src/codewhisperer/util/telemetryHelper.ts
+++ b/src/codewhisperer/util/telemetryHelper.ts
@@ -109,13 +109,9 @@ export class TelemetryHelper {
         acceptIndex: number,
         recommendationSuggestionState?: Map<number, string>
     ): telemetry.CodewhispererSuggestionState {
-        if (recommendationSuggestionState?.get(i) === 'Empty') {
-            return 'Empty'
-        }
-        if (recommendationSuggestionState?.get(i) === 'Filter') {
-            return 'Filter'
-        } else if (recommendationSuggestionState?.get(i) === 'Discard') {
-            return 'Discard'
+        const state = recommendationSuggestionState?.get(i)
+        if (state && ['Empty', 'Filter', 'Discard'].includes(state)) {
+            return state as telemetry.CodewhispererSuggestionState
         } else if (recommendationSuggestionState !== undefined && recommendationSuggestionState.get(i) !== 'Showed') {
             return 'Unseen'
         }

--- a/src/codewhisperer/util/telemetryHelper.ts
+++ b/src/codewhisperer/util/telemetryHelper.ts
@@ -3,19 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as telemetry from '../../shared/telemetry/telemetry'
-import * as vscode from 'vscode'
 import { runtimeLanguageContext } from './runtimeLanguageContext'
 import { RecommendationsList } from '../client/codewhisperer'
-import { isCloud9 } from '../../shared/extensionUtilities'
 import { LicenseUtil } from './licenseUtil'
 
 export class TelemetryHelper {
-    /**
-     * to record each recommendation is prefix matched or not with
-     * left context before 'editor.action.triggerSuggest'
-     */
-    public isPrefixMatched: boolean[]
-
     /**
      * Trigger type for getting CodeWhisperer recommendation
      */
@@ -34,7 +26,6 @@ export class TelemetryHelper {
     public cursorOffset: number
 
     constructor() {
-        this.isPrefixMatched = []
         this.triggerType = 'OnDemand'
         this.CodeWhispererAutomatedtriggerType = 'KeyStrokeCount'
         this.completionType = 'Line'
@@ -47,49 +38,24 @@ export class TelemetryHelper {
         return (this.#instance ??= new this())
     }
 
-    /**
-     * VScode IntelliSense has native matching for recommendation.
-     * This is only to check if the recommendation match the updated left context when
-     * user keeps typing before getting CodeWhisperer response back.
-     * @param recommendations the recommendations of current invocation
-     * @param startPos the invocation position of current invocation
-     * @param newCodeWhispererRequest if newCodeWhispererRequest, then we need to reset the invocationContext.isPrefixMatched, which is used as
-     *                           part of user decision telemetry (see models.ts for more details)
-     * @param editor the current VSCode editor
-     *
-     * @returns
-     */
-    public updatePrefixMatchArray(
-        recommendations: RecommendationsList,
-        startPos: vscode.Position,
-        newCodeWhispererRequest: boolean,
-        editor: vscode.TextEditor | undefined
+    public recordUserDecisionTelemetryForEmptyList(
+        requestId: string,
+        sessionId: string,
+        paginationIndex: number,
+        languageId: string
     ) {
-        if (!editor || !newCodeWhispererRequest) {
-            return
-        }
-        // Only works for cloud9, as it works for completion items
-        if (isCloud9() && startPos.line !== editor.selection.active.line) {
-            return
-        }
-
-        let typedPrefix = ''
-        if (newCodeWhispererRequest) {
-            this.isPrefixMatched = []
-        }
-
-        typedPrefix = editor.document.getText(new vscode.Range(startPos, editor.selection.active))
-
-        recommendations.forEach(recommendation => {
-            if (recommendation.content.startsWith(typedPrefix)) {
-                if (newCodeWhispererRequest) {
-                    this.isPrefixMatched.push(true)
-                }
-            } else {
-                if (newCodeWhispererRequest) {
-                    this.isPrefixMatched.push(false)
-                }
-            }
+        const languageContext = runtimeLanguageContext.getLanguageContext(languageId)
+        telemetry.recordCodewhispererUserDecision({
+            codewhispererRequestId: requestId,
+            codewhispererSessionId: sessionId ? sessionId : undefined,
+            codewhispererPaginationProgress: paginationIndex,
+            codewhispererTriggerType: this.triggerType,
+            codewhispererSuggestionIndex: -1,
+            codewhispererSuggestionState: 'Empty',
+            codewhispererSuggestionReferences: undefined,
+            codewhispererSuggestionReferenceCount: 0,
+            codewhispererCompletionType: this.completionType,
+            codewhispererLanguage: languageContext.language,
         })
     }
 
@@ -99,10 +65,11 @@ export class TelemetryHelper {
      * @param acceptIndex the index of the accepted suggestion in the corresponding list of CodeWhisperer response.
      * If this function is not called on acceptance, then acceptIndex == -1
      * @param languageId the language ID of the current document in current active editor
-     * @param filtered whether this user decision is to filter the recommendation due to license
+     * @param paginationIndex the index of pagination calls
+     * @param recommendationSuggestionState the key-value mapping from index to suggestion state
      */
 
-    public async recordUserDecisionTelemetry(
+    public recordUserDecisionTelemetry(
         requestId: string,
         sessionId: string,
         recommendations: RecommendationsList,
@@ -114,20 +81,13 @@ export class TelemetryHelper {
         const languageContext = runtimeLanguageContext.getLanguageContext(languageId)
         // emit user decision telemetry
         recommendations.forEach((_elem, i) => {
-            let unseen = true
-            let filtered = false
-            if (recommendationSuggestionState !== undefined) {
-                if (recommendationSuggestionState.get(i) === 'Filtered') {
-                    filtered = true
-                }
-                if (recommendationSuggestionState.get(i) === 'Showed') {
-                    unseen = false
-                }
-            }
             let uniqueSuggestionReferences: string | undefined = undefined
             const uniqueLicenseSet = LicenseUtil.getUniqueLicenseNames(_elem.references)
             if (uniqueLicenseSet.size > 0) {
                 uniqueSuggestionReferences = JSON.stringify(Array.from(uniqueLicenseSet))
+            }
+            if (_elem.content.length === 0) {
+                recommendationSuggestionState?.set(i, 'Empty')
             }
             telemetry.recordCodewhispererUserDecision({
                 codewhispererRequestId: requestId,
@@ -135,7 +95,7 @@ export class TelemetryHelper {
                 codewhispererPaginationProgress: paginationIndex,
                 codewhispererTriggerType: this.triggerType,
                 codewhispererSuggestionIndex: i,
-                codewhispererSuggestionState: this.getSuggestionState(i, acceptIndex, filtered, unseen),
+                codewhispererSuggestionState: this.getSuggestionState(i, acceptIndex, recommendationSuggestionState),
                 codewhispererSuggestionReferences: uniqueSuggestionReferences,
                 codewhispererSuggestionReferenceCount: _elem.references ? _elem.references.length : 0,
                 codewhispererCompletionType: this.completionType,
@@ -147,22 +107,21 @@ export class TelemetryHelper {
     public getSuggestionState(
         i: number,
         acceptIndex: number,
-        filtered: boolean = false,
-        unseen: boolean = false
+        recommendationSuggestionState?: Map<number, string>
     ): telemetry.CodewhispererSuggestionState {
-        if (filtered) return 'Filter'
-        if (unseen) return 'Unseen'
-        if (acceptIndex == -1) {
-            return this.isPrefixMatched[i] ? 'Reject' : 'Discard'
+        if (recommendationSuggestionState?.get(i) === 'Empty') {
+            return 'Empty'
         }
-        if (!this.isPrefixMatched[i]) {
+        if (recommendationSuggestionState?.get(i) === 'Filter') {
+            return 'Filter'
+        } else if (recommendationSuggestionState?.get(i) === 'Discard') {
             return 'Discard'
-        } else {
-            if (i == acceptIndex) {
-                return 'Accept'
-            } else {
-                return 'Ignore'
-            }
+        } else if (recommendationSuggestionState !== undefined && recommendationSuggestionState.get(i) !== 'Showed') {
+            return 'Unseen'
         }
+        if (acceptIndex === -1) {
+            return 'Reject'
+        }
+        return i === acceptIndex ? 'Accept' : 'Ignore'
     }
 }

--- a/src/test/codewhisperer/commands/onAcceptance.test.ts
+++ b/src/test/codewhisperer/commands/onAcceptance.test.ts
@@ -132,7 +132,7 @@ describe('onAcceptance', function () {
             RecommendationHandler.instance.startPos = new vscode.Position(1, 0)
             mockEditor.selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 0))
             RecommendationHandler.instance.recommendations = [{ content: "print('Hello World!')" }]
-            RecommendationHandler.instance.recommendationSuggestionState = new Map([[0, 'Showed']])
+            RecommendationHandler.instance.setSuggestionState(0, 'Showed')
             TelemetryHelper.instance.triggerType = 'OnDemand'
             TelemetryHelper.instance.completionType = 'Line'
             const assertTelemetry = assertTelemetryCurried('codewhisperer_userDecision')

--- a/src/test/codewhisperer/service/recommendationHandler.test.ts
+++ b/src/test/codewhisperer/service/recommendationHandler.test.ts
@@ -66,7 +66,7 @@ describe('recommendationHandler', function () {
                 false
             )
             const actual = RecommendationHandler.instance.recommendations
-            const expected: RecommendationsList = [{ content: "print('Hello World!')" }]
+            const expected: RecommendationsList = [{ content: "print('Hello World!')" }, { content: '' }]
             assert.deepStrictEqual(actual, expected)
         })
 

--- a/src/test/codewhisperer/util/telemetryHelper.test.ts
+++ b/src/test/codewhisperer/util/telemetryHelper.test.ts
@@ -16,34 +16,41 @@ describe('telemetryHelper', function () {
             telemetryHelper = new TelemetryHelper()
         })
 
-        it('user event is discard when recommendation 0 with accept index = -1 & recommendation prefix 0 does not match current code', function () {
-            telemetryHelper.isPrefixMatched = [false, true]
-            const actual = telemetryHelper.getSuggestionState(0, -1)
+        it('user event is discard when recommendation state is Discarded with accept index = -1', function () {
+            const actual = telemetryHelper.getSuggestionState(0, -1, new Map([[0, 'Discard']]))
             assert.strictEqual(actual, 'Discard')
         })
 
-        it('user event is reject when recommendation 0 with accept index = -1 & recommendation prefix 0 matches current code', function () {
-            telemetryHelper.isPrefixMatched = [true, true]
-            const actual = telemetryHelper.getSuggestionState(0, -1)
+        it('user event is reject when recommendation state is Showed with accept index = -1', function () {
+            const actual = telemetryHelper.getSuggestionState(0, -1, new Map([[0, 'Showed']]))
             assert.strictEqual(actual, 'Reject')
         })
 
-        it('user event is discard when recommendation 1 with accept index = 1 & recommendation prefix 1 does not match code', function () {
-            telemetryHelper.isPrefixMatched = [true, false]
-            const actual = telemetryHelper.getSuggestionState(1, 1)
-            assert.strictEqual(actual, 'Discard')
-        })
-
-        it('user event is Accept when recommendation 0 with accept index = 1 & recommendation prefix 0 matches code', function () {
-            telemetryHelper.isPrefixMatched = [true, true]
-            const actual = telemetryHelper.getSuggestionState(0, 0)
+        it('user event is Accept when recommendation state is Showed with accept index matches', function () {
+            const actual = telemetryHelper.getSuggestionState(0, 0, new Map([[0, 'Showed']]))
             assert.strictEqual(actual, 'Accept')
         })
 
-        it('user event is Ignore when recommendation 0 with accept index = 1 & recommendation prefix 0 matches code', function () {
-            telemetryHelper.isPrefixMatched = [true, true]
-            const actual = telemetryHelper.getSuggestionState(0, 1)
+        it('user event is Ignore when recommendation state is Showed with accept index does not match', function () {
+            const actual = telemetryHelper.getSuggestionState(0, 1, new Map([[0, 'Showed']]))
             assert.strictEqual(actual, 'Ignore')
+        })
+
+        it('user event is Unseen when recommendation state is not Showed, is not Unseen when recommendation is showed', function () {
+            const actual0 = telemetryHelper.getSuggestionState(0, 1, new Map([[1, 'Showed']]))
+            assert.strictEqual(actual0, 'Unseen')
+            const actual1 = telemetryHelper.getSuggestionState(1, 1, new Map([[1, 'Showed']]))
+            assert.strictEqual(actual1, 'Accept')
+        })
+
+        it('user event is Filter when recommendation state is Filter', function () {
+            const actual = telemetryHelper.getSuggestionState(0, 1, new Map([[0, 'Filter']]))
+            assert.strictEqual(actual, 'Filter')
+        })
+
+        it('user event is Empty when recommendation state is Empty', function () {
+            const actual = telemetryHelper.getSuggestionState(0, 1, new Map([[0, 'Empty']]))
+            assert.strictEqual(actual, 'Empty')
         })
     })
 
@@ -57,22 +64,14 @@ describe('telemetryHelper', function () {
             telemetryHelper.triggerType = 'AutoTrigger'
             const assertTelemetry = assertTelemetryCurried('codewhisperer_userDecision')
             const suggestionState = new Map<number, string>([[0, 'Showed']])
-            await telemetryHelper.recordUserDecisionTelemetry(
-                requestId,
-                sessionId,
-                response,
-                0,
-                'python',
-                0,
-                suggestionState
-            )
+            telemetryHelper.recordUserDecisionTelemetry(requestId, sessionId, response, 0, 'python', 0, suggestionState)
             assertTelemetry({
                 codewhispererRequestId: 'test_x',
                 codewhispererSessionId: 'test_x',
                 codewhispererPaginationProgress: 0,
                 codewhispererTriggerType: 'AutoTrigger',
                 codewhispererSuggestionIndex: 0,
-                codewhispererSuggestionState: 'Discard',
+                codewhispererSuggestionState: 'Accept',
                 codewhispererSuggestionReferenceCount: 0,
                 codewhispererCompletionType: 'Line',
                 codewhispererLanguage: 'python',


### PR DESCRIPTION
## Problem
1. Recommendations of empty string or empty list are not reported in userDecision telemetry.
2. The type prefix matching for determining Discard event should only be performed when client gets the suggestion from server. 


## Solution
1. Report useDecision events for empty recommendations.
2. Do telemetry type prefix matching when suggestion first reaches client.
3. If a suggestion is marked as Discard but later it was showed to user, it won't be reported as Discard in userDecision telemetry.


Note:

This fix is not user facing so no changelog item is added.

This PR has been tested with below test cases:

1. With recommendation = [] at line 259 of recommendationHandler.ts that simulate a Empty List recommendations. userDecision event with Empty was sent.
2. With r.content = '' at line 266 of that simulate a Empty string recommendations.  userDecision event with Empty was sent. 
4. Trigger at `def ` in a python file and type `test_i` before first reco returns, the recos not starting with `test_i` was marked as Discard.



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
