### PR TITLE
fix(codewhisperer):  Fix up & down not moving cursor when suggestion active

### DIFF
--- a/.changes/next-release/Bug Fix-a8470482-60c4-4711-b967-e5b8c446a027.json
+++ b/.changes/next-release/Bug Fix-a8470482-60c4-4711-b967-e5b8c446a027.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Fix a bug when pressing up or down does not move cursor when suggestion is active"
+	"description": "CodeWhisperer: when pressing up or down does not move cursor when suggestion is active"
 }

--- a/.changes/next-release/Bug Fix-a8470482-60c4-4711-b967-e5b8c446a027.json
+++ b/.changes/next-release/Bug Fix-a8470482-60c4-4711-b967-e5b8c446a027.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix a bug when pressing up or down does not move cursor when suggestion is active"
+}

--- a/package.json
+++ b/package.json
@@ -2943,13 +2943,15 @@
                 "command": "aws.codeWhisperer.rejectCodeSuggestion",
                 "key": "up",
                 "mac": "up",
-                "when": "editorTextFocus && CODEWHISPERER_SERVICE_ACTIVE"
+                "when": "editorTextFocus && CODEWHISPERER_SERVICE_ACTIVE",
+                "args": "up"
             },
             {
                 "command": "aws.codeWhisperer.rejectCodeSuggestion",
                 "key": "down",
                 "mac": "down",
-                "when": "editorTextFocus && CODEWHISPERER_SERVICE_ACTIVE"
+                "when": "editorTextFocus && CODEWHISPERER_SERVICE_ACTIVE",
+                "args": "down"
             },
             {
                 "command": "aws.codeWhisperer.acceptCodeSuggestion",

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -341,6 +341,8 @@ export async function activate(context: ExtContext): Promise<void> {
                         await vscode.commands.executeCommand('cursorUp')
                     } else if (e === 'down') {
                         await vscode.commands.executeCommand('cursorDown')
+                    } else if (e !== undefined) {
+                        getLogger().warn(`Unexpected argument for rejectCodeSuggestion ${e}`)
                     }
                 }
             }),

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -335,8 +335,14 @@ export async function activate(context: ExtContext): Promise<void> {
                 }
             }),
             Commands.register('aws.codeWhisperer.rejectCodeSuggestion', async e => {
-                if (vscode.window.activeTextEditor)
+                if (vscode.window.activeTextEditor) {
                     await InlineCompletion.instance.rejectRecommendation(vscode.window.activeTextEditor)
+                    if (e === 'up') {
+                        await vscode.commands.executeCommand('cursorUp')
+                    } else if (e === 'down') {
+                        await vscode.commands.executeCommand('cursorDown')
+                    }
+                }
             }),
             /**
              * Recommendation navigation


### PR DESCRIPTION
## Problem
When pressing up or down when suggestion is active, the cursor won't go up or down.

## Solution
Let cursor go up or down after user pressing pressing up or down( meanwhile the suggestion is rejected).

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
