### PR TITLE
fix(tests): closeAllEditors() sometimes fails

### DIFF
--- a/src/test/testUtil.ts
+++ b/src/test/testUtil.ts
@@ -255,12 +255,13 @@ export async function closeAllEditors(): Promise<unknown> {
         return await vscode.commands.executeCommand('openEditors.closeAll')
     }
 
-    // Remove the below code (all of it) when `openEditors.closeAll` is available in all versions
-    await vscode.commands.executeCommand('workbench.action.closeAllEditors')
+    // TODO: Remove the below code (all of it) when `openEditors.closeAll` is available in all versions
 
     // The output channel counts as an editor, but you can't really close that...
     const noVisibleEditor: boolean | undefined = await waitUntil(
         async () => {
+            // Race: documents could appear after the call to closeAllEditors(), so retry.
+            await vscode.commands.executeCommand('workbench.action.closeAllEditors')
             const visibleEditors = vscode.window.visibleTextEditors.filter(
                 editor => !editor.document.fileName.includes('extension-output') // Output channels are named with the prefix 'extension-output'
             )

--- a/src/test/testUtil.ts
+++ b/src/test/testUtil.ts
@@ -243,25 +243,27 @@ export async function assertTextEditorContains(contents: string): Promise<void |
 }
 
 /**
- * Executes the close all editors command and waits for all visible editors to disappear
+ * Executes the "openEditors.closeAll" command and asserts that all visible
+ * editors were closed after waiting.
  */
-export async function closeAllEditors(): Promise<unknown> {
-    if ((await vscode.commands.getCommands()).includes('openEditors.closeAll')) {
+export async function closeAllEditors(): Promise<void> {
+    const hasCloseAll = (await vscode.commands.getCommands()).includes('openEditors.closeAll')
+    // Derived by inspecting 'Keyboard Shortcuts' via command `>Preferences: Open Keyboard Shortcuts`
+    // `workbench.action.closeAllEditors` is unreliable and should not be used if possible
+    const closeAllCmd = hasCloseAll ? 'openEditors.closeAll' : 'workbench.action.closeAllEditors'
+    if (hasCloseAll) {
         if (isMinimumVersion() && !isReleaseVersion()) {
-            throw Error('openEditors.closeAll is available in min version, remove me!')
+            throw Error(
+                '"openEditors.closeAll" is available in min version, remove use of "workbench.action.closeAllEditors"!'
+            )
         }
-        // Derived by inspecting 'Keyboard Shortcuts' via command `>Preferences: Open Keyboard Shortcuts`
-        // `workbench.action.closeAllEditors` is unreliable and should not be used if possible
-        return await vscode.commands.executeCommand('openEditors.closeAll')
     }
-
-    // TODO: Remove the below code (all of it) when `openEditors.closeAll` is available in all versions
 
     // The output channel counts as an editor, but you can't really close that...
     const noVisibleEditor: boolean | undefined = await waitUntil(
         async () => {
             // Race: documents could appear after the call to closeAllEditors(), so retry.
-            await vscode.commands.executeCommand('workbench.action.closeAllEditors')
+            await vscode.commands.executeCommand(closeAllCmd)
             const visibleEditors = vscode.window.visibleTextEditors.filter(
                 editor => !editor.document.fileName.includes('extension-output') // Output channels are named with the prefix 'extension-output'
             )
@@ -277,9 +279,7 @@ export async function closeAllEditors(): Promise<unknown> {
 
     if (!noVisibleEditor) {
         throw new Error(
-            `Editor "${
-                vscode.window.activeTextEditor!.document.fileName
-            }" was still open after executing "closeAllEditors"`
+            `Editor "${vscode.window.activeTextEditor!.document.fileName}" was still open after closeAllEditors()`
         )
     }
 }


### PR DESCRIPTION
## Problem:
Flaky CI failure (on "minimum" job):

    1 failing
    1) "before each" hook for "returns placeholder node if no resource types are enabled":
       Error: Editor "Untitled-1" was still open after executing "closeAllEditors"
        at Object.<anonymous> (src/test/testUtil.ts:278:15)

## Solution:
Retry the "closeAllEditors" command.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
