### PR TITLE
fix(SAM/Go): update Delve install script

### DIFF
--- a/.changes/next-release/Bug Fix-1859b589-4651-4fa5-9545-317fceaff3f1.json
+++ b/.changes/next-release/Bug Fix-1859b589-4651-4fa5-9545-317fceaff3f1.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Delve debugger installation failures for Go Lambdas on MacOS"
+	"description": "Delve debugger installation fails for Go Lambdas on MacOS"
 }

--- a/.changes/next-release/Bug Fix-1859b589-4651-4fa5-9545-317fceaff3f1.json
+++ b/.changes/next-release/Bug Fix-1859b589-4651-4fa5-9545-317fceaff3f1.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "fixed Delve debugger installation for Go Lambdas on MacOS"
+	"description": "Delve debugger installation failures for Go Lambdas on MacOS"
 }

--- a/.changes/next-release/Bug Fix-1859b589-4651-4fa5-9545-317fceaff3f1.json
+++ b/.changes/next-release/Bug Fix-1859b589-4651-4fa5-9545-317fceaff3f1.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "fixed Delve debugger installation for Go Lambdas on MacOS"
+}

--- a/src/shared/sam/debugger/goSamDebug.ts
+++ b/src/shared/sam/debugger/goSamDebug.ts
@@ -163,7 +163,7 @@ interface InstallScript {
  * @returns Path for the debugger install script, undefined if we already built the binary
  */
 async function makeInstallScript(debuggerPath: string, isWindows: boolean): Promise<InstallScript | undefined> {
-    let script: string = ''
+    let script: string = isWindows ? '' : '#!/bin/sh\n'
     const DELVE_REPO: string = 'github.com/go-delve/delve'
     const scriptExt: string = isWindows ? 'cmd' : 'sh'
     const delvePath: string = path.posix.join(debuggerPath, 'dlv')


### PR DESCRIPTION
## Problem
See #2797

This affects MacOS running Node 16+, presumably due to a change in libuv.
Same root cause as https://github.com/aws/aws-toolkit-vscode/pull/2666

## Solution
Add shebang line. I don't think we have any other places with shell scripts we create but could be wrong.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
