### PR TITLE
fix(tests): update `visualizeStateMachine` 

### DIFF
--- a/src/stepFunctions/commands/downloadStateMachineDefinition.ts
+++ b/src/stepFunctions/commands/downloadStateMachineDefinition.ts
@@ -16,6 +16,7 @@ import { DefaultStepFunctionsClient, StepFunctionsClient } from '../../shared/cl
 import { getLogger, Logger } from '../../shared/logger'
 import { recordStepfunctionsDownloadStateMachineDefinition, Result } from '../../shared/telemetry/telemetry'
 import { StateMachineNode } from '../explorer/stepFunctionsNodes'
+import { previewStateMachineCommand } from '../activation'
 
 export async function downloadStateMachineDefinition(params: {
     outputChannel: vscode.OutputChannel
@@ -38,7 +39,7 @@ export async function downloadStateMachineDefinition(params: {
             })
 
             const textEditor = await vscode.window.showTextDocument(doc)
-            await vscode.commands.executeCommand('aws.previewStateMachine', textEditor)
+            await previewStateMachineCommand.execute(textEditor)
         } else {
             const wsPath = vscode.workspace.workspaceFolders
                 ? vscode.workspace.workspaceFolders[0].uri.fsPath


### PR DESCRIPTION
## Problem
These tests execute extension commands, and one test specifically checks for an error. Commands now show an error message instead of bubbling it up so this test ended up stalling on the error message.

## Solution
Fix the test so it checks for an error message.

Need to figure out why Mocha timeouts don't work so these stalled tests are easier to find.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
