### PR TITLE
fix(codewhisperer): only get reference log if there is reference

### DIFF
--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -171,7 +171,7 @@ export async function activate(context: ExtContext): Promise<void> {
                 triggerType: telemetry.CodewhispererTriggerType,
                 completionType: telemetry.CodewhispererCompletionType,
                 language: telemetry.CodewhispererLanguage,
-                references: codewhispererClient.References
+                references?: codewhispererClient.References
             ) => {
                 const bracketConfiguration = vscode.workspace.getConfiguration('editor').get('autoClosingBrackets')
                 const isAutoClosingBracketsEnabled: boolean = bracketConfiguration !== 'never' ? true : false
@@ -192,7 +192,7 @@ export async function activate(context: ExtContext): Promise<void> {
                     isAutoClosingBracketsEnabled,
                     context.extensionContext.globalState
                 )
-                if (references != undefined && editor != undefined) {
+                if (references?.length && editor) {
                     const referenceLog = ReferenceLogViewProvider.getReferenceLog(recommendation, references, editor)
                     referenceLogViewProvider.addReferenceLog(referenceLog)
                     referenceHoverProvider.addCodeReferences(recommendation, references)


### PR DESCRIPTION
## Problem
`references` will be an empty array if there is no reference in VSC, therefore no need to get reference log
## Solution
add a check for the length of the array in this code path
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
