### PR TITLE
fix(cwl): update resourceScheme in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -832,11 +832,11 @@
                 },
                 {
                     "command": "aws.copyLogStreamName",
-                    "when": "resourceScheme == awsCloudWatchLogs"
+                    "when": "resourceScheme == aws-cwl"
                 },
                 {
                     "command": "aws.saveCurrentLogStreamContent",
-                    "when": "resourceScheme == awsCloudWatchLogs"
+                    "when": "resourceScheme == aws-cwl"
                 },
                 {
                     "command": "aws.s3.editFile",
@@ -1079,17 +1079,17 @@
                 },
                 {
                     "command": "aws.saveCurrentLogStreamContent",
-                    "when": "resourceScheme == awsCloudWatchLogs",
+                    "when": "resourceScheme == aws-cwl",
                     "group": "navigation"
                 },
                 {
                     "command": "aws.cwl.changeFilterPattern",
-                    "when": "resourceScheme == awsCloudWatchLogs",
+                    "when": "resourceScheme == aws-cwl",
                     "group": "navigation"
                 },
                 {
                     "command": "aws.cwl.changeTimeFilter",
-                    "when": "resourceScheme == awsCloudWatchLogs",
+                    "when": "resourceScheme == aws-cwl",
                     "group": "navigation"
                 },
                 {
@@ -1121,7 +1121,7 @@
             "editor/title/context": [
                 {
                     "command": "aws.copyLogStreamName",
-                    "when": "resourceScheme == awsCloudWatchLogs",
+                    "when": "resourceScheme == aws-cwl",
                     "group": "1_cutcopypaste@1"
                 }
             ],


### PR DESCRIPTION
## Problem
Escape Hatches were invisible and some other functionality was not emitting proper telemetry. 
## Solution
The source was that the `package.json` file was outdated. 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
