### PR TITLE
cwl: onDidCloseTextDocument() should be called exactly once for the lifetime of the Toolkit

### DIFF
--- a/src/cloudWatchLogs/activation.ts
+++ b/src/cloudWatchLogs/activation.ts
@@ -42,6 +42,7 @@ export async function activate(context: vscode.ExtensionContext, configuration: 
                 registry.disposeRegistryData(doc.uri)
             }
         }),
+        // Do highlight on text-changed event because we don't control when text is populated by vscode, also for "load more" codelens.
         vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => {
             const eventUri = event.document.uri
             if (registry.hasLog(eventUri) && !isLogStreamUri(eventUri)) {

--- a/src/cloudWatchLogs/activation.ts
+++ b/src/cloudWatchLogs/activation.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode'
 import { CLOUDWATCH_LOGS_SCHEME } from '../shared/constants'
 import { Settings } from '../shared/settings'
-import { CloudWatchLogsSettings } from './cloudWatchLogsUtils'
+import { CloudWatchLogsSettings, isLogStreamUri } from './cloudWatchLogsUtils'
 import { addLogEvents } from './commands/addLogEvents'
 import { copyLogStreamName } from './commands/copyLogStreamName'
 import { saveCurrentLogStreamContent } from './commands/saveCurrentLogStreamContent'
@@ -41,6 +41,15 @@ export async function activate(context: vscode.ExtensionContext, configuration: 
             if (doc.isClosed && doc.uri.scheme === CLOUDWATCH_LOGS_SCHEME) {
                 registry.disposeRegistryData(doc.uri)
                 registry.deregisterLog(doc.uri)
+            }
+        })
+    )
+
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => {
+            const eventUri = event.document.uri
+            if (registry.hasLog(eventUri) && !isLogStreamUri(eventUri)) {
+                registry.highlightDocument(eventUri)
             }
         })
     )

--- a/src/cloudWatchLogs/activation.ts
+++ b/src/cloudWatchLogs/activation.ts
@@ -39,6 +39,7 @@ export async function activate(context: vscode.ExtensionContext, configuration: 
     context.subscriptions.push(
         vscode.workspace.onDidCloseTextDocument(doc => {
             if (doc.isClosed && doc.uri.scheme === CLOUDWATCH_LOGS_SCHEME) {
+                registry.disposeRegistryData(doc.uri)
                 registry.deregisterLog(doc.uri)
             }
         })

--- a/src/cloudWatchLogs/activation.ts
+++ b/src/cloudWatchLogs/activation.ts
@@ -42,10 +42,7 @@ export async function activate(context: vscode.ExtensionContext, configuration: 
                 registry.disposeRegistryData(doc.uri)
                 registry.deregisterLog(doc.uri)
             }
-        })
-    )
-
-    context.subscriptions.push(
+        }),
         vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => {
             const eventUri = event.document.uri
             if (registry.hasLog(eventUri) && !isLogStreamUri(eventUri)) {

--- a/src/cloudWatchLogs/activation.ts
+++ b/src/cloudWatchLogs/activation.ts
@@ -40,7 +40,6 @@ export async function activate(context: vscode.ExtensionContext, configuration: 
         vscode.workspace.onDidCloseTextDocument(doc => {
             if (doc.isClosed && doc.uri.scheme === CLOUDWATCH_LOGS_SCHEME) {
                 registry.disposeRegistryData(doc.uri)
-                registry.deregisterLog(doc.uri)
             }
         }),
         vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => {

--- a/src/cloudWatchLogs/registry/logStreamRegistry.ts
+++ b/src/cloudWatchLogs/registry/logStreamRegistry.ts
@@ -33,10 +33,6 @@ export class LogStreamRegistry {
                 this.highlightDocument(eventUri)
             }
         })
-
-        vscode.workspace.onDidCloseTextDocument((document: vscode.TextDocument) => {
-            this.disposeRegistryData(document.uri)
-        })
     }
 
     /**

--- a/src/cloudWatchLogs/registry/logStreamRegistry.ts
+++ b/src/cloudWatchLogs/registry/logStreamRegistry.ts
@@ -54,6 +54,7 @@ export class LogStreamRegistry {
         if (this.hasLog(uri) && !isLogStreamUri(uri)) {
             this.clearStreamIdMap(uri)
         }
+        this.activeLogs.delete(uriToKey(uri))
     }
 
     /**
@@ -150,14 +151,6 @@ export class LogStreamRegistry {
         })
 
         this._onDidChange.fire(uri)
-    }
-
-    /**
-     * Deletes a stream from the registry.
-     * @param uri Document URI
-     */
-    public deregisterLog(uri: vscode.Uri): void {
-        this.activeLogs.delete(uriToKey(uri))
     }
 
     public setBusyStatus(uri: vscode.Uri, isBusy: boolean): void {

--- a/src/cloudWatchLogs/registry/logStreamRegistry.ts
+++ b/src/cloudWatchLogs/registry/logStreamRegistry.ts
@@ -26,14 +26,7 @@ export class LogStreamRegistry {
     public constructor(
         public readonly configuration: CloudWatchLogsSettings,
         private readonly activeLogs: Map<string, ActiveTab> = new Map<string, ActiveTab>()
-    ) {
-        vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => {
-            const eventUri = event.document.uri
-            if (this.hasLog(eventUri) && !isLogStreamUri(eventUri)) {
-                this.highlightDocument(eventUri)
-            }
-        })
-    }
+    ) {}
 
     /**
      * Event fired on log content change

--- a/src/test/cloudWatchLogs/changeLogSearch.test.ts
+++ b/src/test/cloudWatchLogs/changeLogSearch.test.ts
@@ -44,7 +44,7 @@ describe('changeLogSearch', async function () {
 
     it('unregisters old log and registers a new one', async function () {
         assert.deepStrictEqual(testRegistry.hasLog(oldUri), true)
-        testRegistry.deregisterLog(oldUri)
+        testRegistry.disposeRegistryData(oldUri)
         const newUri = createURIFromArgs(newData.logGroupInfo, newData.parameters)
         await testRegistry.registerLog(newUri, newData)
         assert.deepStrictEqual(testRegistry.hasLog(oldUri), false)

--- a/src/test/cloudWatchLogs/registry/logStreamRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logStreamRegistry.test.ts
@@ -159,6 +159,8 @@ describe('LogStreamRegistry', async function () {
             ])
             assert.deepStrictEqual(streamIDMap, expectedMap)
             registry.disposeRegistryData(doc.uri)
+            // We want to re-register log here otherwise this returns undefined.
+            registry.setLogData(searchLogGroupUri, logGroupsStream)
             streamIDMap = registry.getStreamIdMap(searchLogGroupUri)
             assert.deepStrictEqual(streamIDMap, new Map<number, string>())
         })
@@ -227,7 +229,7 @@ describe('LogStreamRegistry', async function () {
         })
     })
 
-    describe('deregisterLog', function () {
+    describe('disposeRegistryData', function () {
         it('deletes a log', function () {
             assert.strictEqual(registry.hasLog(registeredUri), true)
             registry.disposeRegistryData(registeredUri)

--- a/src/test/cloudWatchLogs/registry/logStreamRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logStreamRegistry.test.ts
@@ -230,13 +230,13 @@ describe('LogStreamRegistry', async function () {
     describe('deregisterLog', function () {
         it('deletes a log', function () {
             assert.strictEqual(registry.hasLog(registeredUri), true)
-            registry.deregisterLog(registeredUri)
+            registry.disposeRegistryData(registeredUri)
             assert.strictEqual(registry.hasLog(registeredUri), false)
         })
 
         it('does not error if the log does not exist in the registry', function () {
             assert.strictEqual(registry.hasLog(missingRegisteredUri), false)
-            registry.deregisterLog(missingRegisteredUri)
+            registry.disposeRegistryData(missingRegisteredUri)
             assert.strictEqual(registry.hasLog(missingRegisteredUri), false)
         })
     })


### PR DESCRIPTION
## Problem
`onDidCloseTextDocument` was being called anytime registry was initiated and was not being made a disposable.
## Solution
Move the event handlers out of the registry class and into subscriptions so that they are disposable and avoid any potential memory issues. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
