### PR TITLE
cwl: cancel view log stream + loading message. 

### DIFF
--- a/src/cloudWatchLogs/registry/logStreamRegistry.ts
+++ b/src/cloudWatchLogs/registry/logStreamRegistry.ts
@@ -333,14 +333,16 @@ export async function getLogEventsFromUriComponents(
             `Log Stream name not specified for log group ${logGroupInfo.groupName} on region ${logGroupInfo.regionName}`
         )
     }
-    const timeout = new Timeout(300000)
-    showMessageWithCancel(`Loading data from log stream ${logGroupInfo.streamName}`, timeout)
-    const responsePromise = client.getLogEvents({
+    const cwlParameters = {
         logGroupName: logGroupInfo.groupName,
         logStreamName: logGroupInfo.streamName,
         nextToken,
         limit: parameters.limit,
-    })
+    }
+
+    const timeout = new Timeout(300000)
+    showMessageWithCancel(`Loading data from log stream ${logGroupInfo.streamName}`, timeout)
+    const responsePromise = client.getLogEvents(cwlParameters)
     const response = await waitTimeout(responsePromise, timeout, { allowUndefined: false })
 
     if (!response) {

--- a/src/cloudWatchLogs/registry/logStreamRegistry.ts
+++ b/src/cloudWatchLogs/registry/logStreamRegistry.ts
@@ -333,12 +333,15 @@ export async function getLogEventsFromUriComponents(
             `Log Stream name not specified for log group ${logGroupInfo.groupName} on region ${logGroupInfo.regionName}`
         )
     }
-    const response = await client.getLogEvents({
+    const timeout = new Timeout(300000)
+    showMessageWithCancel(`Loading data from log stream ${logGroupInfo.streamName}`, timeout)
+    const responsePromise = client.getLogEvents({
         logGroupName: logGroupInfo.groupName,
         logStreamName: logGroupInfo.streamName,
         nextToken,
         limit: parameters.limit,
     })
+    const response = await waitTimeout(responsePromise, timeout, { allowUndefined: false })
 
     if (!response) {
         throw new Error('cwl:`getLogEvents` did not return anything.')


### PR DESCRIPTION
## Problem
`viewLogStream` could also take a long time to load and we already have to the code to improve this. 
## Solution
Implement the same logic as we have in `searchLogGroup`. 
TODO: Generalize this logic as a function `getResponseOrCancel`. Note: I tried to do this and it ended up much nastier than keeping them separate so didn't include in this PR. 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
