### PR TITLE
cwl: Update custom date range prompter

### DIFF
--- a/src/cloudWatchLogs/timeFilterSubmenu.ts
+++ b/src/cloudWatchLogs/timeFilterSubmenu.ts
@@ -95,9 +95,10 @@ export class TimeFilterSubmenu extends Prompter<TimeFilterResponse> {
         while (true) {
             switch (this.currentState) {
                 case 'recent-range': {
-                    this.steps && this.defaultPrompter.setSteps(this.steps[0], this.steps[1])
+                    const prompter = this.createMenuPrompter()
+                    this.steps && prompter.setSteps(this.steps[0], this.steps[1])
 
-                    const resp = await this.defaultPrompter.prompt()
+                    const resp = await prompter.prompt()
                     if (resp === customRange) {
                         this.switchState('custom-range')
                     } else if (isValidResponse(resp)) {
@@ -119,7 +120,6 @@ export class TimeFilterSubmenu extends Prompter<TimeFilterResponse> {
                         return { start: startTime.valueOf(), end: endTime.valueOf() }
                     }
 
-                    this.defaultPrompter = this.createMenuPrompter() //reload the defaultPrompter
                     this.switchState('recent-range')
 
                     break

--- a/src/cloudWatchLogs/timeFilterSubmenu.ts
+++ b/src/cloudWatchLogs/timeFilterSubmenu.ts
@@ -88,6 +88,7 @@ export class TimeFilterSubmenu extends Prompter<TimeFilterResponse> {
             title: 'Enter custom date range',
             placeholder: 'YYYY/MM/DD-YYYY/MM/DD',
             validateInput: input => this.validateDate(input),
+            buttons: createCommonButtons(),
         })
     }
 

--- a/src/cloudWatchLogs/timeFilterSubmenu.ts
+++ b/src/cloudWatchLogs/timeFilterSubmenu.ts
@@ -30,7 +30,6 @@ export class TimeFilterSubmenu extends Prompter<TimeFilterResponse> {
     private currentState: 'custom-range' | 'recent-range' = 'recent-range'
     private steps?: [current: number, total: number]
     public defaultPrompter: QuickPickPrompter<typeof customRange | number> = this.createMenuPrompter()
-    public customPrompter: InputBoxPrompter = this.createDateBox()
 
     public constructor() {
         super()
@@ -113,7 +112,7 @@ export class TimeFilterSubmenu extends Prompter<TimeFilterResponse> {
                     break
                 }
                 case 'custom-range': {
-                    const resp = await this.customPrompter.prompt()
+                    const resp = await this.createDateBox().prompt()
                     if (isValidResponse(resp)) {
                         const [startTime, endTime] = this.parseDate(resp)
 

--- a/src/test/cloudWatchLogs/commands/searchLogGroup.test.ts
+++ b/src/test/cloudWatchLogs/commands/searchLogGroup.test.ts
@@ -71,7 +71,7 @@ describe('searchLogGroup', async function () {
             let customTimeRangePrompter: InputBoxPrompter
 
             before(function () {
-                customTimeRangePrompter = testTimeRangeMenu.customPrompter
+                customTimeRangePrompter = testTimeRangeMenu.createDateBox()
                 testDateBox = exposeEmitters(customTimeRangePrompter.inputBox, [
                     'onDidAccept',
                     'onDidChangeValue',
@@ -84,7 +84,6 @@ describe('searchLogGroup', async function () {
                     testDateBox.value = value
                     testDateBox.fireOnDidAccept()
                 }
-                customTimeRangePrompter = testTimeRangeMenu.customPrompter
 
                 const validInput = '2000/10/06-2001/11/08'
                 const result = customTimeRangePrompter.prompt()


### PR DESCRIPTION
## Problem
The custom time range box did not have the same buttons/functionality as all other Wizard prompts. Additionally, there was an error when the custom time range box was cancelled and then reopened. 
## Solution
We can add the common buttons to custom time range box and not reuse a previous prompter to avoid the error. 

<img width="720" alt="image" src="https://user-images.githubusercontent.com/42325418/183717149-19f340b2-e100-4ae7-8d48-e2f8829bd527.png">

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
