### PR TITLE
fix(): "API proposal" error for older vscode

### DIFF
--- a/src/shared/credentials/defaultCredentialSelectionDataProvider.ts
+++ b/src/shared/credentials/defaultCredentialSelectionDataProvider.ts
@@ -12,6 +12,7 @@
 // Based on the multiStepInput code in the QuickInput VSCode extension sample.
 
 import * as vscode from 'vscode'
+import * as semver from 'semver'
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
@@ -51,7 +52,7 @@ export class DefaultCredentialSelectionDataProvider implements CredentialSelecti
         state: Partial<CredentialSelectionState>
     ): Promise<vscode.QuickPickItem> {
         // Remove this stub after we bump minimum to vscode 1.64
-        const QuickPickItemKind = (vscode as any).QuickPickItemKind
+        const QuickPickItemKind = semver.gte(vscode.version, '1.64.0') ? (vscode as any).QuickPickItemKind : undefined
         const menuTop: vscode.QuickPickItem[] = [
             // vscode 1.64 supports QuickPickItemKind.Separator.
             // https://github.com/microsoft/vscode/commit/eb416b4f9ebfda1c798aa7c8b2f4e81c6ce1984f


### PR DESCRIPTION
## Problem:
Error on vscode 1.63 or older:

    2022-08-10 18:29:21 [ERROR]: aws.login: Error: Extension 'amazonwebservices.aws-toolkit-vscode' CANNOT use API proposal: quickPickSeparators.
    Its package.json#enabledApiProposals-property declares: [] but NOT quickPickSeparators.
     The missing proposal MUST be added and you must start in extension development mode or use the following command line switch: --enable-proposed-api amazonwebservices.aws-toolkit-vscode

## Solution:
Check vscode version instead of relying on feature-detection.

ref #2820


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
