### PR TITLE
performance: optimize `Developer Tools` view

### DIFF
--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -12,7 +12,12 @@ import globals from '../shared/extensionGlobals'
 import { ExtContext } from '../shared/extensions'
 import { getLogger } from '../shared/logger'
 import { RegionProvider } from '../shared/regions/regionProvider'
-import { recordAwsRefreshExplorer, recordAwsShowRegion, recordVscodeActiveRegions } from '../shared/telemetry/telemetry'
+import {
+    recordAwsRefreshExplorer,
+    recordAwsShowRegion,
+    recordCdkAppExpanded,
+    recordVscodeActiveRegions,
+} from '../shared/telemetry/telemetry'
 import { AWSResourceNode } from '../shared/treeview/nodes/awsResourceNode'
 import { AWSTreeNodeBase } from '../shared/treeview/nodes/awsTreeNodeBase'
 import { Commands } from '../shared/vscode/commands2'
@@ -25,6 +30,9 @@ import { copyNameCommand } from './commands/copyName'
 import { loadMoreChildrenCommand } from './commands/loadMoreChildren'
 import { checkExplorerForDefaultRegion } from './defaultRegion'
 import { createLocalExplorerView } from './localExplorer'
+import { cdkNode, CdkRootNode } from '../cdk/explorer/rootNode'
+import { codewhispererNode } from '../codewhisperer/explorer/codewhispererNode'
+import { once } from '../shared/utilities/functionUtils'
 
 /**
  * Activates the AWS Explorer UI and related functionality.
@@ -69,6 +77,21 @@ export async function activate(args: {
             }
         })
     )
+
+    const nodes = [cdkNode, codewhispererNode]
+    const developerTools = createLocalExplorerView(nodes)
+    args.context.extensionContext.subscriptions.push(developerTools)
+
+    // Legacy CDK behavior. Mostly useful for C9 as they do not have inline buttons.
+    developerTools.onDidChangeVisibility(({ visible }) => visible && cdkNode.refresh())
+
+    // Legacy CDK metric, remove this when we add something generic
+    const recordExpandCdkOnce = once(recordCdkAppExpanded)
+    developerTools.onDidExpandElement(e => {
+        if (e.element.resource instanceof CdkRootNode) {
+            recordExpandCdkOnce()
+        }
+    })
 }
 
 async function registerAwsExplorerCommands(
@@ -131,7 +154,4 @@ async function registerAwsExplorerCommands(
         }),
         loadMoreChildrenCommand.register(awsExplorer)
     )
-
-    const developerTools = createLocalExplorerView()
-    context.extensionContext.subscriptions.push(developerTools)
 }

--- a/src/awsexplorer/localExplorer.ts
+++ b/src/awsexplorer/localExplorer.ts
@@ -4,30 +4,21 @@
  */
 
 import * as vscode from 'vscode'
-import * as telemetry from '../shared/telemetry/telemetry'
-import { cdkNode, CdkRootNode } from '../cdk/explorer/rootNode'
 import { ResourceTreeDataProvider, TreeNode } from '../shared/treeview/resourceTreeDataProvider'
-import { once } from '../shared/utilities/functionUtils'
 import { isCloud9 } from '../shared/extensionUtilities'
-import { codewhispererNode } from '../codewhisperer/explorer/codewhispererNode'
 
-export interface RootNode extends TreeNode {
-    canShow?(): Promise<boolean> | boolean
+export interface RootNode<T = unknown> extends TreeNode<T> {
+    /**
+     * An optional event to signal that this node's visibility has changed.
+     */
     readonly onDidChangeVisibility?: vscode.Event<void>
-}
 
-const roots: readonly RootNode[] = [cdkNode, codewhispererNode]
-
-async function getChildren(roots: readonly RootNode[]) {
-    const nodes: TreeNode[] = []
-
-    for (const node of roots) {
-        if (!node.canShow || (await node.canShow())) {
-            nodes.push(node)
-        }
-    }
-
-    return nodes
+    /**
+     * Determines whether this node should be rendered in the tree view.
+     *
+     * If not implemented, it is assumed that the node is always visible.
+     */
+    canShow?(): Promise<boolean> | boolean
 }
 
 /**
@@ -37,31 +28,28 @@ async function getChildren(roots: readonly RootNode[]) {
  * Components placed under this view do not strictly need to be 'local'. They just need to place greater
  * emphasis on the developer's local development environment.
  */
-export function createLocalExplorerView(): vscode.TreeView<TreeNode> {
-    const treeDataProvider = new ResourceTreeDataProvider({ getChildren: () => getChildren(roots) })
+export function createLocalExplorerView(rootNodes: RootNode[]): vscode.TreeView<TreeNode> {
+    const treeDataProvider = new ResourceTreeDataProvider({ getChildren: () => getChildren(rootNodes) })
     const view = vscode.window.createTreeView('aws.developerTools', { treeDataProvider })
 
-    roots.forEach(node => {
-        node.onDidChangeVisibility?.(() => treeDataProvider.refresh())
-    })
-
-    // Legacy CDK metric, remove this when we add something generic
-    const recordExpandCdkOnce = once(telemetry.recordCdkAppExpanded)
-    view.onDidExpandElement(e => {
-        if (e.element.resource instanceof CdkRootNode) {
-            recordExpandCdkOnce()
-        }
-    })
-
-    // Legacy CDK behavior. Mostly useful for C9 as they do not have inline buttons.
-    view.onDidChangeVisibility(({ visible }) => visible && cdkNode.refresh())
+    rootNodes.forEach(node => node.onDidChangeVisibility?.(() => treeDataProvider.refresh(node)))
 
     // Cloud9 will only refresh when refreshing the entire tree
     if (isCloud9()) {
-        roots.forEach(node => {
-            node.onDidChangeChildren?.(() => treeDataProvider.refresh())
-        })
+        rootNodes.forEach(node => node.onDidChangeChildren?.(() => treeDataProvider.refresh(node)))
     }
 
     return view
+}
+
+async function getChildren(roots: RootNode[]) {
+    const nodes: TreeNode[] = []
+
+    for (const node of roots) {
+        if (!node.canShow || (await node.canShow())) {
+            nodes.push(node)
+        }
+    }
+
+    return nodes
 }

--- a/src/shared/treeview/resourceTreeDataProvider.ts
+++ b/src/shared/treeview/resourceTreeDataProvider.ts
@@ -107,12 +107,17 @@ export class ResourceTreeDataProvider implements vscode.TreeDataProvider<TreeNod
         return tracked
     }
 
-    public refresh(): void {
-        vscode.Disposable.from(...this.listeners.values()).dispose()
+    public refresh(node?: TreeNode): void {
+        if (node === undefined) {
+            vscode.Disposable.from(...this.listeners.values()).dispose()
 
-        this.items.clear()
-        this.children.clear()
-        this.listeners.clear()
+            this.items.clear()
+            this.children.clear()
+            this.listeners.clear()
+        } else {
+            this.clear(node)
+        }
+
         this.onDidChangeTreeDataEmitter.fire()
     }
 

--- a/src/shared/utilities/functionUtils.ts
+++ b/src/shared/utilities/functionUtils.ts
@@ -35,8 +35,8 @@ export function shared<T, U extends any[]>(fn: (...args: U) => Promise<T>): (...
  * Special-case of `memoize`. Ensures a function is executed only once.
  */
 export function once<T>(fn: () => T): () => T {
-    let val: T,
-        ran = false
+    let val: T
+    let ran = false
 
     return () => (ran ? val : ((val = fn()), (ran = true), val))
 }

--- a/src/shared/utilities/functionUtils.ts
+++ b/src/shared/utilities/functionUtils.ts
@@ -35,9 +35,10 @@ export function shared<T, U extends any[]>(fn: (...args: U) => Promise<T>): (...
  * Special-case of `memoize`. Ensures a function is executed only once.
  */
 export function once<T>(fn: () => T): () => T {
-    let val: T
+    let val: T,
+        ran = false
 
-    return () => (val ??= fn())
+    return () => (ran ? val : ((val = fn()), (ran = true), val))
 }
 
 /**

--- a/src/test/shared/treeview/resourceTreeDataProvider.test.ts
+++ b/src/test/shared/treeview/resourceTreeDataProvider.test.ts
@@ -50,7 +50,7 @@ function getLabels(nodes: TreeNode[]): Promise<string[]> {
     return Promise.all(nodes.map(async n => (await n.getTreeItem()).label ?? 'not set'))
 }
 
-function intoTestNode(node: TreeNode): TestNode | never {
+function toTestNode(node: TreeNode): TestNode | never {
     if (!(node.resource instanceof TestNode)) {
         throw new TypeError(`Node "${node.id}" had an incorrect resource: ${node.resource}`)
     }
@@ -63,6 +63,11 @@ function setupChanged(provider: ResourceTreeDataProvider): TreeNode[] {
     provider.onDidChangeTreeData(node => node && changed.push(node))
 
     return changed
+}
+
+function assertNotCached(newItem: TreeItem, oldItem: TreeItem): void {
+    assert.notStrictEqual(newItem, oldItem)
+    assert.deepStrictEqual(newItem, oldItem)
 }
 
 describe('ResourceTreeDataProvider', function () {
@@ -80,7 +85,7 @@ describe('ResourceTreeDataProvider', function () {
         const provider = new ResourceTreeDataProvider(getRoot(flatTree))
         const changed = setupChanged(provider)
 
-        const nodes = (await provider.getChildren()).map(intoTestNode)
+        const nodes = (await provider.getChildren()).map(toTestNode)
         nodes[0].refreshChildren()
         nodes[1].refreshChildren()
         provider.refresh()
@@ -96,8 +101,7 @@ describe('ResourceTreeDataProvider', function () {
         provider.refresh()
 
         const newItem0 = await provider.getTreeItem(node0)
-        assert.notStrictEqual(newItem0, item0)
-        assert.deepStrictEqual(newItem0, item0)
+        assertNotCached(newItem0, item0)
     })
 
     it('can refresh a node independently of the rest of the tree', async function () {
@@ -110,8 +114,7 @@ describe('ResourceTreeDataProvider', function () {
         const newItem0 = await provider.getTreeItem(node0)
         const newItem1 = await provider.getTreeItem(node1)
         assert.strictEqual(newItem0, item0)
-        assert.notStrictEqual(newItem1, item1)
-        assert.deepStrictEqual(newItem1, item1)
+        assertNotCached(newItem1, item1)
     })
 
     it("caches children, clearing the cache when a node's children change", async function () {
@@ -120,7 +123,7 @@ describe('ResourceTreeDataProvider', function () {
         const children = await provider.getChildren(node0)
 
         assert.strictEqual(await provider.getChildren(node0), children)
-        intoTestNode(node0).refreshChildren()
+        toTestNode(node0).refreshChildren()
         assert.notStrictEqual(await provider.getChildren(node0), children)
     })
 
@@ -130,19 +133,19 @@ describe('ResourceTreeDataProvider', function () {
         const treeItem = await provider.getTreeItem(node0)
 
         assert.strictEqual(await provider.getTreeItem(node0), treeItem)
-        intoTestNode(node0).refreshTreeItem()
-        assert.notStrictEqual(await provider.getTreeItem(node0), treeItem)
+        toTestNode(node0).refreshTreeItem()
+        assertNotCached(await provider.getTreeItem(node0), treeItem)
     })
 
     it('preserves event listeners of cached children after tree item changes', async function () {
         const provider = new ResourceTreeDataProvider(getRoot(tree))
         const [node0] = await provider.getChildren()
         await provider.getChildren(node0)
-        intoTestNode(node0).refreshTreeItem()
+        toTestNode(node0).refreshTreeItem()
 
         const [node1] = await provider.getChildren(node0)
         const changed = setupChanged(provider)
-        intoTestNode(node1).refreshTreeItem()
+        toTestNode(node1).refreshTreeItem()
         assert.deepStrictEqual(await getLabels(changed), ['node1'])
     })
 
@@ -174,8 +177,8 @@ describe('ResourceTreeDataProvider', function () {
             const children1 = await provider.getChildren()
             const children2 = await provider.getChildren(children1[0])
 
-            const nodes1 = children1.map(intoTestNode)
-            const nodes2 = children2.map(intoTestNode)
+            const nodes1 = children1.map(toTestNode)
+            const nodes2 = children2.map(toTestNode)
 
             nodes2[0].refreshChildren()
             nodes2[1].refreshChildren()
@@ -190,7 +193,7 @@ describe('ResourceTreeDataProvider', function () {
             const changed = setupChanged(provider)
 
             const [nested] = await provider.getChildren()
-            const testNode = intoTestNode(nested)
+            const testNode = toTestNode(nested)
             const children = await provider.getChildren(nested)
             testNode.refreshTreeItem()
 
@@ -205,11 +208,8 @@ describe('ResourceTreeDataProvider', function () {
 
             const item1 = await provider.getTreeItem(node1)
             assert.strictEqual(await provider.getTreeItem(node1), item1)
-            intoTestNode(node0).refreshChildren()
-
-            const newItem1 = await provider.getTreeItem(node1)
-            assert.notStrictEqual(newItem1, item1)
-            assert.deepStrictEqual(newItem1, item1)
+            toTestNode(node0).refreshChildren()
+            assertNotCached(await provider.getTreeItem(node1), item1)
         })
     })
 })

--- a/src/test/shared/treeview/resourceTreeDataProvider.test.ts
+++ b/src/test/shared/treeview/resourceTreeDataProvider.test.ts
@@ -100,6 +100,20 @@ describe('ResourceTreeDataProvider', function () {
         assert.deepStrictEqual(newItem0, item0)
     })
 
+    it('can refresh a node independently of the rest of the tree', async function () {
+        const provider = new ResourceTreeDataProvider(getRoot(flatTree))
+        const [node0, node1] = await provider.getChildren()
+        const item0 = await provider.getTreeItem(node0)
+        const item1 = await provider.getTreeItem(node1)
+        provider.refresh(node1)
+
+        const newItem0 = await provider.getTreeItem(node0)
+        const newItem1 = await provider.getTreeItem(node1)
+        assert.strictEqual(newItem0, item0)
+        assert.notStrictEqual(newItem1, item1)
+        assert.deepStrictEqual(newItem1, item1)
+    })
+
     it("caches children, clearing the cache when a node's children change", async function () {
         const provider = new ResourceTreeDataProvider(getRoot(tree))
         const [node0] = await provider.getChildren()

--- a/src/test/shared/utilities/functionUtils.test.ts
+++ b/src/test/shared/utilities/functionUtils.test.ts
@@ -1,0 +1,20 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { once } from '../../../shared/utilities/functionUtils'
+
+describe('once', function () {
+    it('does not execute sync functions returning void more than once', function () {
+        let counter = 0
+        const fn = once(() => void counter++)
+
+        fn()
+        assert.strictEqual(counter, 1)
+
+        fn()
+        assert.strictEqual(counter, 1)
+    })
+})


### PR DESCRIPTION
## Problem
View is re-rendered when a node becomes "invisible".
This is a consequence of visibility being functionally different from a node's children changing.

## Solution
Externally refresh a specific node's child **without** changing the children array itself. 
This can also be implemented by increasing the scope of `onDidChangeChildren` and exposing it on the "root" node although I'll save that for another time.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
