### PR TITLE
feat(codewhisperer): handle extra brackets onAcceptance of recommendation

### DIFF
--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -173,8 +173,6 @@ export async function activate(context: ExtContext): Promise<void> {
                 language: telemetry.CodewhispererLanguage,
                 references: codewhispererClient.References
             ) => {
-                const bracketConfiguration = vscode.workspace.getConfiguration('editor').get('autoClosingBrackets')
-                const isAutoClosingBracketsEnabled: boolean = bracketConfiguration !== 'never' ? true : false
                 const editor = vscode.window.activeTextEditor
                 await onAcceptance(
                     {
@@ -189,7 +187,6 @@ export async function activate(context: ExtContext): Promise<void> {
                         language,
                         references,
                     },
-                    isAutoClosingBracketsEnabled,
                     context.extensionContext.globalState
                 )
                 if (references != undefined && editor != undefined) {

--- a/src/codewhisperer/commands/onAcceptance.ts
+++ b/src/codewhisperer/commands/onAcceptance.ts
@@ -13,19 +13,14 @@ import { TextEdit, WorkspaceEdit, workspace } from 'vscode'
 import { getTabSizeSetting } from '../../shared/utilities/editorUtilities'
 import { getLogger } from '../../shared/logger/logger'
 import { isCloud9 } from '../../shared/extensionUtilities'
-import { handleAutoClosingBrackets } from '../util/closingBracketUtil'
+import { handleExtraBrackets } from '../util/closingBracketUtil'
 import { RecommendationHandler } from '../service/recommendationHandler'
 import { InlineCompletion } from '../service/inlineCompletion'
-import { KeyStrokeHandler } from '../service/keyStrokeHandler'
 
 /**
  * This function is called when user accepts a intelliSense suggestion or an inline suggestion
  */
-export async function onAcceptance(
-    acceptanceEntry: OnRecommendationAcceptanceEntry,
-    isAutoClosingBracketsEnabled: boolean,
-    globalStorage: vscode.Memento
-) {
+export async function onAcceptance(acceptanceEntry: OnRecommendationAcceptanceEntry, globalStorage: vscode.Memento) {
     RecommendationHandler.instance.cancelPaginatedRequest()
     /**
      * Format document
@@ -45,15 +40,9 @@ export async function onAcceptance(
         /**
          * Mitigation to right context handling mainly for auto closing bracket use case
          */
-        if (isAutoClosingBracketsEnabled && !InlineCompletion.instance.isTypeaheadInProgress) {
+        if (!InlineCompletion.instance.isTypeaheadInProgress) {
             try {
-                await handleAutoClosingBrackets(
-                    acceptanceEntry.triggerType,
-                    acceptanceEntry.editor,
-                    acceptanceEntry.recommendation,
-                    end.line,
-                    KeyStrokeHandler.instance.specialChar
-                )
+                await handleExtraBrackets(acceptanceEntry.editor, acceptanceEntry.recommendation, end)
             } catch (error) {
                 getLogger().error(`${error} in handleAutoClosingBrackets`)
             }

--- a/src/codewhisperer/util/closingBracketUtil.ts
+++ b/src/codewhisperer/util/closingBracketUtil.ts
@@ -4,71 +4,123 @@
  */
 
 import * as vscode from 'vscode'
-import { TextEdit, workspace, WorkspaceEdit } from 'vscode'
+import { workspace, WorkspaceEdit } from 'vscode'
 import { isCloud9 } from '../../shared/extensionUtilities'
-import * as telemetry from '../../shared/telemetry/telemetry'
+import { CodeWhispererConstants } from '../models/constants'
 
-export async function handleAutoClosingBrackets(
-    triggerType: telemetry.CodewhispererTriggerType,
+interface bracketMapType {
+    [k: string]: string
+}
+
+const bracketMap: bracketMapType = {
+    ')': '(',
+    ']': '[',
+    '}': '{',
+}
+
+export const calculateBracketsLevel = (code: string) => {
+    const bracketCounts: Map<string, number> = new Map([
+        ['(', 0],
+        ['[', 0],
+        ['{', 0],
+    ])
+    const bracketsIndexLevel = []
+
+    for (let i = 0; i < code.length; i++) {
+        const char = code[i]
+        if (bracketCounts.has(char)) {
+            const count = bracketCounts.get(char) || 0
+            const newCount = count + 1
+            bracketCounts.set(char, newCount)
+            bracketsIndexLevel.push({
+                char,
+                count: newCount,
+                idx: i,
+            })
+        } else if (char in bracketMap) {
+            const correspondingBracket = bracketMap[char as keyof bracketMapType]
+            const count = bracketCounts.get(correspondingBracket) || 0
+            const newCount = count - 1
+            bracketCounts.set(bracketMap[char], newCount)
+            bracketsIndexLevel.push({
+                char: correspondingBracket,
+                count: newCount,
+                idx: i,
+            })
+        }
+    }
+    return bracketsIndexLevel
+}
+
+export const getBracketsToRemove = (recommendation: string, rightContext: string) => {
+    const recommendationBrackets = calculateBracketsLevel(recommendation)
+    const rightContextBrackets = calculateBracketsLevel(rightContext)
+    let i = 0
+    let j = 0
+    const toBeRemoved = []
+
+    while (i < recommendationBrackets.length && j < rightContextBrackets.length) {
+        const { char: char1, count: level1 } = recommendationBrackets[i]
+        const { char: char2, count: level2, idx: idx2 } = rightContextBrackets[j]
+        if (char1 !== char2 || level1 !== level2) {
+            i++
+            continue
+        }
+        toBeRemoved.push(idx2)
+        i++
+        j++
+    }
+    return toBeRemoved
+}
+
+export const removeBracketsFromRightContext = async (
     editor: vscode.TextEditor,
-    recommendation: string,
-    line: number,
-    specialChar: string
-) {
-    const openingBrackets = new Map<string, string>()
-    openingBrackets.set('{', '}')
-    openingBrackets.set('(', ')')
-    openingBrackets.set('[', ']')
-    const closingBracket = openingBrackets.get(specialChar)
-    if (
-        triggerType === 'AutoTrigger' &&
-        closingBracket !== undefined &&
-        hasExtraClosingBracket(recommendation, specialChar, closingBracket)
-    ) {
-        let curLine = line
-        let textLine = editor.document.lineAt(curLine).text
-        while (curLine > 0 && !textLine.includes(closingBracket)) {
-            curLine--
-            textLine = editor.document.lineAt(curLine).text
-        }
-        if (curLine >= 0) {
-            const pos = textLine.lastIndexOf(closingBracket)
-            const range = new vscode.Range(curLine, pos, curLine, pos + 1)
-            if (isCloud9()) {
-                const edit: TextEdit = {
-                    range: range,
-                    newText: '',
-                }
-                const wEdit = new WorkspaceEdit()
-                wEdit.set(editor.document.uri, [edit])
-                await workspace.applyEdit(wEdit)
-            } else {
-                await editor.edit(
-                    editBuilder => {
-                        editBuilder.delete(range)
-                    },
-                    { undoStopAfter: false, undoStopBefore: false }
-                )
-            }
-        }
+    idxToRemove: number[],
+    endPosition: vscode.Position
+) => {
+    const offset = editor.document.offsetAt(endPosition)
+
+    if (isCloud9()) {
+        const edits = idxToRemove.map(idx => ({
+            range: new vscode.Range(
+                editor.document.positionAt(offset + idx),
+                editor.document.positionAt(offset + idx + 1)
+            ),
+            newText: '',
+        }))
+        const wEdit = new WorkspaceEdit()
+        wEdit.set(editor.document.uri, [...edits])
+        await workspace.applyEdit(wEdit)
+    } else {
+        await editor.edit(
+            editBuilder => {
+                idxToRemove.forEach(idx => {
+                    const range = new vscode.Range(
+                        editor.document.positionAt(offset + idx),
+                        editor.document.positionAt(offset + idx + 1)
+                    )
+                    editBuilder.delete(range)
+                })
+            },
+            { undoStopAfter: false, undoStopBefore: false }
+        )
     }
 }
 
-export function hasExtraClosingBracket(
+export async function handleExtraBrackets(
+    editor: vscode.TextEditor,
     recommendation: string,
-    openingBracket: string,
-    closingBracket: string
-): boolean {
-    let count = 0
-    let pos = recommendation.indexOf(closingBracket)
-    while (pos > 0) {
-        count++
-        pos = recommendation.indexOf(closingBracket, pos + 1)
+    endPosition: vscode.Position
+) {
+    const end = editor.document.offsetAt(endPosition)
+    const rightContext = editor.document.getText(
+        new vscode.Range(
+            editor.document.positionAt(end),
+            editor.document.positionAt(end + CodeWhispererConstants.charactersLimit)
+        )
+    )
+    const bracketsToRemove = getBracketsToRemove(recommendation, rightContext)
+    if (bracketsToRemove.length) {
+        removeBracketsFromRightContext(editor, bracketsToRemove, endPosition)
     }
-    pos = recommendation.indexOf(openingBracket)
-    while (pos > 0) {
-        count--
-        pos = recommendation.indexOf(openingBracket, pos + 1)
-    }
-    return count === 1
 }

--- a/src/codewhisperer/util/closingBracketUtil.ts
+++ b/src/codewhisperer/util/closingBracketUtil.ts
@@ -18,7 +18,7 @@ const bracketMap: bracketMapType = {
     '}': '{',
 }
 
-export const calculateBracketsLevel = (code: string) => {
+export const calculateBracketsLevel = (code: string, isRightContext: boolean = false) => {
     const bracketCounts: Map<string, number> = new Map([
         ['(', 0],
         ['[', 0],
@@ -47,6 +47,9 @@ export const calculateBracketsLevel = (code: string) => {
                 count: newCount,
                 idx: i,
             })
+        } else if (isRightContext && !(char in bracketMap) && !bracketCounts.has(char) && !/\s/.test(char)) {
+            // we can stop processing right context when we encounter a char that is not a bracket nor white space
+            break
         }
     }
     return bracketsIndexLevel
@@ -54,7 +57,7 @@ export const calculateBracketsLevel = (code: string) => {
 
 export const getBracketsToRemove = (recommendation: string, rightContext: string) => {
     const recommendationBrackets = calculateBracketsLevel(recommendation)
-    const rightContextBrackets = calculateBracketsLevel(rightContext)
+    const rightContextBrackets = calculateBracketsLevel(rightContext, true)
     let i = 0
     let j = 0
     const toBeRemoved = []

--- a/src/test/codewhisperer/commands/onAcceptance.test.ts
+++ b/src/test/codewhisperer/commands/onAcceptance.test.ts
@@ -41,7 +41,6 @@ describe('onAcceptance', function () {
                     language: 'python',
                     references: undefined,
                 },
-                true,
                 extensionContext.globalState
             )
             assert.ok(commandSpy.calledWith('editor.action.format'))
@@ -75,7 +74,6 @@ describe('onAcceptance', function () {
                     language: 'javascript',
                     references: fakeReferences,
                 },
-                true,
                 extensionContext.globalState
             )
             assert.ok(commandStub.calledWith('vscode.executeFormatRangeProvider'))
@@ -109,7 +107,6 @@ describe('onAcceptance', function () {
                     language: 'python',
                     references: fakeReferences,
                 },
-                true,
                 extensionContext.globalState
             )
             const actualArg = trackerSpy.getCall(0).args[0]
@@ -150,7 +147,6 @@ describe('onAcceptance', function () {
                     language: 'python',
                     references: undefined,
                 },
-                true,
                 extensionContext.globalState
             )
             assertTelemetry({


### PR DESCRIPTION
## Problem
When customer invoke CodeWhisperer, they might already have matching brackets in the right context but our current implementation is not taking it into account.

## Solution
When customer accept a recommendation, we match the brackets that are in the accepted recommendation with user's right context, and remove the extra brackets if there is any:

in VSC:

https://user-images.githubusercontent.com/60411978/184037665-0c68da1a-d13c-4947-adb5-929435664a8e.mov

in C9:

https://user-images.githubusercontent.com/60411978/184037688-1615cad5-06f9-45ee-8dfc-4207d7634423.mov

with whitespace:


https://user-images.githubusercontent.com/60411978/184675900-ea83c202-53a5-4660-9831-2a57a234b52d.mov







<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
