### PR TITLE
Hkobew/clean up tests

### DIFF
--- a/src/test/cloudWatchLogs/changeLogSearch.test.ts
+++ b/src/test/cloudWatchLogs/changeLogSearch.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert'
 import { CloudWatchLogsSettings, createURIFromArgs } from '../../cloudWatchLogs/cloudWatchLogsUtils'
 import { LogStreamRegistry, ActiveTab, CloudWatchLogsData } from '../../cloudWatchLogs/registry/logStreamRegistry'
 import { Settings } from '../../shared/settings'
-import { fakeGetLogEvents, testComponents, testStreamData1 } from './utils.test'
+import { fakeGetLogEvents, testComponents, testStreamData } from './utils.test'
 
 describe('changeLogSearch', async function () {
     let testRegistry: LogStreamRegistry
@@ -39,7 +39,7 @@ describe('changeLogSearch', async function () {
     before(function () {
         testRegistry = new LogStreamRegistry(new CloudWatchLogsSettings(config), new Map<string, ActiveTab>())
 
-        testRegistry.registerLog(oldUri, testStreamData1)
+        testRegistry.registerLog(oldUri, testStreamData)
     })
 
     it('unregisters old log and registers a new one', async function () {

--- a/src/test/cloudWatchLogs/registry/logStreamRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logStreamRegistry.test.ts
@@ -6,12 +6,7 @@
 import * as assert from 'assert'
 import * as moment from 'moment'
 import * as vscode from 'vscode'
-import {
-    CloudWatchLogsData,
-    LogStreamRegistry,
-    ActiveTab,
-    CloudWatchLogsEvent,
-} from '../../../cloudWatchLogs/registry/logStreamRegistry'
+import { CloudWatchLogsData, LogStreamRegistry, ActiveTab } from '../../../cloudWatchLogs/registry/logStreamRegistry'
 import { INSIGHTS_TIMESTAMP_FORMAT } from '../../../shared/constants'
 import { Settings } from '../../../shared/settings'
 import { CloudWatchLogsSettings, createURIFromArgs } from '../../../cloudWatchLogs/cloudWatchLogsUtils'
@@ -24,22 +19,6 @@ describe('LogStreamRegistry', async function () {
     const config = new Settings(vscode.ConfigurationTarget.Workspace)
 
     const newText = 'a little longer now\n'
-
-    // const testData: CloudWatchLogsData = {
-    //     data: [
-    //         {
-    //             message: 'short and sweet\n',
-    //         },
-    //     ],
-    //     parameters: {},
-    //     logGroupInfo: {
-    //         groupName: 'Less',
-    //         regionName: 'Is',
-    //         streamName: 'More',
-    //     },
-    //     retrieveLogsFunction: fakeGetLogEvents,
-    //     busy: false,
-    // }
 
     const newLineData: CloudWatchLogsData = {
         data: [
@@ -82,7 +61,6 @@ describe('LogStreamRegistry', async function () {
     }
 
     const registeredUri = createURIFromArgs(testStreamData.logGroupInfo, testStreamData.parameters)
-    // const testDataUri = createURIFromArgs(testData.logGroupInfo, testData.parameters)
     const unregisteredUri = createURIFromArgs(unregisteredData.logGroupInfo, unregisteredData.parameters)
     const newLineUri = createURIFromArgs(newLineData.logGroupInfo, newLineData.parameters)
     const searchLogGroupUri = createURIFromArgs(logGroupsStream.logGroupInfo, logGroupsStream.parameters)
@@ -90,7 +68,6 @@ describe('LogStreamRegistry', async function () {
     beforeEach(function () {
         registry = new LogStreamRegistry(new CloudWatchLogsSettings(config), map)
         registry.setLogData(registeredUri, testStreamData)
-        // registry.setLogData(testDataUri, testData)
         registry.setLogData(newLineUri, newLineData)
         registry.setLogData(searchLogGroupUri, logGroupsStream)
 

--- a/src/test/cloudWatchLogs/registry/logStreamRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logStreamRegistry.test.ts
@@ -10,15 +10,13 @@ import { LogStreamRegistry, ActiveTab } from '../../../cloudWatchLogs/registry/l
 import { INSIGHTS_TIMESTAMP_FORMAT } from '../../../shared/constants'
 import { Settings } from '../../../shared/settings'
 import { CloudWatchLogsSettings, createURIFromArgs } from '../../../cloudWatchLogs/cloudWatchLogsUtils'
-import { logGroupsStream, newLineData, testStreamData, testStreamNames, unregisteredData } from '../utils.test'
+import { logGroupsStream, newLineData, newText, testStreamData, testStreamNames, unregisteredData } from '../utils.test'
 
 describe('LogStreamRegistry', async function () {
     let registry: LogStreamRegistry
     let map: Map<string, ActiveTab>
 
     const config = new Settings(vscode.ConfigurationTarget.Workspace)
-
-    const newText = 'a little longer now\n'
 
     const registeredUri = createURIFromArgs(testStreamData.logGroupInfo, testStreamData.parameters)
     const unregisteredUri = createURIFromArgs(unregisteredData.logGroupInfo, unregisteredData.parameters)

--- a/src/test/cloudWatchLogs/registry/logStreamRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logStreamRegistry.test.ts
@@ -88,69 +88,71 @@ describe('LogStreamRegistry', async function () {
             )
         })
 
-        it('registers stream ids to map and clears it on document close', async function () {
-            await registry.updateLog(searchLogGroupUri)
-            registry.getLogContent(searchLogGroupUri) // We run this to create the mappings
-            const doc = await vscode.workspace.openTextDocument(searchLogGroupUri)
-            let streamIDMap = registry.getStreamIdMap(searchLogGroupUri)
-            const expectedMap = new Map<number, string>([
-                [0, testStreamNames[0]],
-                [1, testStreamNames[1]],
-            ])
-            assert.deepStrictEqual(streamIDMap, expectedMap)
-            registry.disposeRegistryData(doc.uri)
-            // We want to re-register log here otherwise this returns undefined.
-            registry.setLogData(searchLogGroupUri, logGroupsStream)
-            streamIDMap = registry.getStreamIdMap(searchLogGroupUri)
-            assert.deepStrictEqual(streamIDMap, new Map<number, string>())
-        })
-
-        it('handles newlines within event messages', function () {
-            const oldData = registry.getLogData(searchLogGroupUri)
-            assert(oldData)
-            registry.setLogData(searchLogGroupUri, {
-                ...oldData,
-                data: [
-                    {
-                        message: 'This \n is \n a \n message \n spanning \n many \n lines',
-                        logStreamName: 'stream1',
-                    },
-                    {
-                        message: 'Here \n is \n another \n one.',
-                        logStreamName: 'stream2',
-                    },
-                    {
-                        message: 'and \n just \n one \n more',
-                        logStreamName: 'stream1',
-                    },
-                    {
-                        message: 'and thats it.',
-                        logStreamName: 'stream3',
-                    },
-                ],
+        describe('setStreamIds', function () {
+            it('registers stream ids to map and clears it on document close', async function () {
+                await registry.updateLog(searchLogGroupUri)
+                registry.getLogContent(searchLogGroupUri) // We run this to create the mappings
+                const doc = await vscode.workspace.openTextDocument(searchLogGroupUri)
+                let streamIDMap = registry.getStreamIdMap(searchLogGroupUri)
+                const expectedMap = new Map<number, string>([
+                    [0, testStreamNames[0]],
+                    [1, testStreamNames[1]],
+                ])
+                assert.deepStrictEqual(streamIDMap, expectedMap)
+                registry.disposeRegistryData(doc.uri)
+                // We want to re-register log here otherwise this returns undefined.
+                registry.setLogData(searchLogGroupUri, logGroupsStream)
+                streamIDMap = registry.getStreamIdMap(searchLogGroupUri)
+                assert.deepStrictEqual(streamIDMap, new Map<number, string>())
             })
-            registry.getLogContent(searchLogGroupUri)
-            const streamIDMap = registry.getStreamIdMap(searchLogGroupUri)
-            const expectedMap = new Map<number, string>([
-                [0, 'stream1'],
-                [1, 'stream1'],
-                [2, 'stream1'],
-                [3, 'stream1'],
-                [4, 'stream1'],
-                [5, 'stream1'],
-                [6, 'stream1'],
-                [7, 'stream2'],
-                [8, 'stream2'],
-                [9, 'stream2'],
-                [10, 'stream2'],
-                [11, 'stream1'],
-                [12, 'stream1'],
-                [13, 'stream1'],
-                [14, 'stream1'],
-                [15, 'stream3'],
-            ])
-            assert.deepStrictEqual(streamIDMap, expectedMap)
-            registry.setLogData(searchLogGroupUri, oldData)
+
+            it('handles newlines within event messages', function () {
+                const oldData = registry.getLogData(searchLogGroupUri)
+                assert(oldData)
+                registry.setLogData(searchLogGroupUri, {
+                    ...oldData,
+                    data: [
+                        {
+                            message: 'This \n is \n a \n message \n spanning \n many \n lines',
+                            logStreamName: 'stream1',
+                        },
+                        {
+                            message: 'Here \n is \n another \n one.',
+                            logStreamName: 'stream2',
+                        },
+                        {
+                            message: 'and \n just \n one \n more',
+                            logStreamName: 'stream1',
+                        },
+                        {
+                            message: 'and thats it.',
+                            logStreamName: 'stream3',
+                        },
+                    ],
+                })
+                registry.getLogContent(searchLogGroupUri)
+                const streamIDMap = registry.getStreamIdMap(searchLogGroupUri)
+                const expectedMap = new Map<number, string>([
+                    [0, 'stream1'],
+                    [1, 'stream1'],
+                    [2, 'stream1'],
+                    [3, 'stream1'],
+                    [4, 'stream1'],
+                    [5, 'stream1'],
+                    [6, 'stream1'],
+                    [7, 'stream2'],
+                    [8, 'stream2'],
+                    [9, 'stream2'],
+                    [10, 'stream2'],
+                    [11, 'stream1'],
+                    [12, 'stream1'],
+                    [13, 'stream1'],
+                    [14, 'stream1'],
+                    [15, 'stream3'],
+                ])
+                assert.deepStrictEqual(streamIDMap, expectedMap)
+                registry.setLogData(searchLogGroupUri, oldData)
+            })
         })
     })
 

--- a/src/test/cloudWatchLogs/registry/logStreamRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logStreamRegistry.test.ts
@@ -6,11 +6,11 @@
 import * as assert from 'assert'
 import * as moment from 'moment'
 import * as vscode from 'vscode'
-import { CloudWatchLogsData, LogStreamRegistry, ActiveTab } from '../../../cloudWatchLogs/registry/logStreamRegistry'
+import { LogStreamRegistry, ActiveTab } from '../../../cloudWatchLogs/registry/logStreamRegistry'
 import { INSIGHTS_TIMESTAMP_FORMAT } from '../../../shared/constants'
 import { Settings } from '../../../shared/settings'
 import { CloudWatchLogsSettings, createURIFromArgs } from '../../../cloudWatchLogs/cloudWatchLogsUtils'
-import { fakeGetLogEvents, fakeSearchLogGroup, testStreamData, testStreamNames } from '../utils.test'
+import { logGroupsStream, newLineData, testStreamData, testStreamNames, unregisteredData } from '../utils.test'
 
 describe('LogStreamRegistry', async function () {
     let registry: LogStreamRegistry
@@ -19,46 +19,6 @@ describe('LogStreamRegistry', async function () {
     const config = new Settings(vscode.ConfigurationTarget.Workspace)
 
     const newText = 'a little longer now\n'
-
-    const newLineData: CloudWatchLogsData = {
-        data: [
-            {
-                timestamp: 12745641600000,
-                message: 'the\nline\rmust\r\nbe\ndrawn\rHERE\nright\nhere\r\nno\nfurther\n',
-            },
-        ],
-        parameters: {},
-        logGroupInfo: {
-            groupName: 'Not',
-            regionName: 'Here',
-            streamName: 'Dude',
-        },
-        retrieveLogsFunction: fakeGetLogEvents,
-        busy: false,
-    }
-
-    const unregisteredData: CloudWatchLogsData = {
-        data: [],
-        parameters: {},
-        logGroupInfo: {
-            groupName: 'ANOTHER',
-            regionName: 'LINE',
-            streamName: 'PIEEEECCCEEEEEE',
-        },
-        retrieveLogsFunction: fakeGetLogEvents,
-        busy: false,
-    }
-
-    const logGroupsStream: CloudWatchLogsData = {
-        data: [],
-        parameters: {},
-        logGroupInfo: {
-            groupName: 'thisIsAGroupName',
-            regionName: 'thisIsARegionCode',
-        },
-        retrieveLogsFunction: fakeSearchLogGroup,
-        busy: false,
-    }
 
     const registeredUri = createURIFromArgs(testStreamData.logGroupInfo, testStreamData.parameters)
     const unregisteredUri = createURIFromArgs(unregisteredData.logGroupInfo, unregisteredData.parameters)

--- a/src/test/cloudWatchLogs/registry/logStreamRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logStreamRegistry.test.ts
@@ -28,8 +28,6 @@ describe('LogStreamRegistry', async function () {
         registry.setLogData(registeredUri, testStreamData)
         registry.setLogData(newLineUri, newLineData)
         registry.setLogData(searchLogGroupUri, logGroupsStream)
-
-        registry.updateLog(searchLogGroupUri)
     })
 
     describe('hasLog', function () {
@@ -91,6 +89,7 @@ describe('LogStreamRegistry', async function () {
         })
 
         it('registers stream ids to map and clears it on document close', async function () {
+            await registry.updateLog(searchLogGroupUri)
             registry.getLogContent(searchLogGroupUri) // We run this to create the mappings
             const doc = await vscode.workspace.openTextDocument(searchLogGroupUri)
             let streamIDMap = registry.getStreamIdMap(searchLogGroupUri)

--- a/src/test/cloudWatchLogs/utils.test.ts
+++ b/src/test/cloudWatchLogs/utils.test.ts
@@ -50,7 +50,7 @@ export const testComponents = {
     parameters: { filterPattern: 'this is a bad filter!' },
 }
 
-export const testStreamData1: CloudWatchLogsData = {
+export const testStreamData: CloudWatchLogsData = {
     data: [
         {
             timestamp: 1,

--- a/src/test/cloudWatchLogs/utils.test.ts
+++ b/src/test/cloudWatchLogs/utils.test.ts
@@ -77,7 +77,47 @@ export const testStreamData: CloudWatchLogsData = {
     retrieveLogsFunction: fakeGetLogEvents,
     busy: false,
 }
-const goodUri = createURIFromArgs(testComponents.logGroupInfo, testComponents.parameters)
+
+export const newLineData: CloudWatchLogsData = {
+    data: [
+        {
+            timestamp: 12745641600000,
+            message: 'the\nline\rmust\r\nbe\ndrawn\rHERE\nright\nhere\r\nno\nfurther\n',
+        },
+    ],
+    parameters: {},
+    logGroupInfo: {
+        groupName: 'Not',
+        regionName: 'Here',
+        streamName: 'Dude',
+    },
+    retrieveLogsFunction: fakeGetLogEvents,
+    busy: false,
+}
+
+export const unregisteredData: CloudWatchLogsData = {
+    data: [],
+    parameters: {},
+    logGroupInfo: {
+        groupName: 'ANOTHER',
+        regionName: 'LINE',
+        streamName: 'PIEEEECCCEEEEEE',
+    },
+    retrieveLogsFunction: fakeGetLogEvents,
+    busy: false,
+}
+
+export const logGroupsStream: CloudWatchLogsData = {
+    data: [],
+    parameters: {},
+    logGroupInfo: {
+        groupName: 'thisIsAGroupName',
+        regionName: 'thisIsARegionCode',
+    },
+    retrieveLogsFunction: fakeSearchLogGroup,
+    busy: false,
+}
+export const goodUri = createURIFromArgs(testComponents.logGroupInfo, testComponents.parameters)
 
 describe('parseCloudWatchLogsUri', async function () {
     it('converts a valid URI to components', function () {

--- a/src/test/cloudWatchLogs/utils.test.ts
+++ b/src/test/cloudWatchLogs/utils.test.ts
@@ -14,7 +14,7 @@ import {
 import { CLOUDWATCH_LOGS_SCHEME } from '../../shared/constants'
 import { findOccurencesOf } from '../../shared/utilities/textDocumentUtilities'
 
-const newText = 'a little longer now\n'
+export const newText = 'a little longer now\n'
 
 export async function fakeGetLogEvents(): Promise<CloudWatchLogsResponse> {
     return {


### PR DESCRIPTION
## Problem
The CloudWatchLogs tests have data spanned across many different files and have many different instances of test data. 
## Solution
Centralize the testing data in `utils.test.ts` and reuse previous testing data when possible to avoid a bloated amount of test data. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
