### PR TITLE
testing: add `testCommand` util

### DIFF
--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -143,6 +143,9 @@ that is a net cost.
 
     -   [Testing Refresh Button](https://github.com/aws/aws-toolkit-vscode/blob/b34c8f7650c862c388992781844695b014b5d974/src/test/shared/ui/prompters/rolePrompter.test.ts#L58-L65)
 
+-   Use [`testCommand`](../src/test/shared/vscode/testUtils.ts) for testing commands created by `Commands.declare`
+    -   Prefer executing the real command directly when possible
+
 ## Code guidelines
 
 -   Use maps to group variables, rather than ad-hoc/informal grouping.

--- a/src/test/shared/vscode/testUtils.ts
+++ b/src/test/shared/vscode/testUtils.ts
@@ -82,7 +82,8 @@ export function testCommand<T extends (...args: any[]) => unknown, U extends any
 ): Command<T> {
     const testCommands = new Commands()
     const testId = `test.${command.id}`
-    const resource = (command as any).resource as { id: string; factory: (...args: U) => any }
+    // `command` refers to the hidden 'CommandResource' class in 'commands2.ts'
+    const resource = (command as any).resource as { id: string; factory: (...args: U) => any; info: any }
 
-    return testCommands.register({ ...resource, id: testId }, resource.factory(...args))
+    return testCommands.register({ ...resource.info, id: testId }, resource.factory(...args))
 }

--- a/src/test/shared/vscode/testUtils.ts
+++ b/src/test/shared/vscode/testUtils.ts
@@ -79,7 +79,7 @@ export function exposeEmitters<T, K extends EventEmitters<T>>(obj: T, keys: K[])
 export function testCommand<T extends (...args: any[]) => unknown, U extends any[]>(
     command: ReturnType<typeof Commands.declare<T, U>>,
     ...args: U
-): Command<T> {
+): Command<T> & vscode.Disposable {
     const testCommands = new Commands()
     const testId = `test.${command.id}`
     // `command` refers to the hidden 'CommandResource' class in 'commands2.ts'

--- a/src/test/shared/vscode/testUtils.ts
+++ b/src/test/shared/vscode/testUtils.ts
@@ -71,6 +71,9 @@ export function exposeEmitters<T, K extends EventEmitters<T>>(obj: T, keys: K[])
  *
  * await testMemento.update('foo', 'bar')
  * assert.strictEqual(await testFoo.execute(), 'bar')
+ *
+ * // Clean-up the command afterwards
+ * testFoo.dispose()
  * ```
  */
 export function testCommand<T extends (...args: any[]) => unknown, U extends any[]>(


### PR DESCRIPTION
## Problem
Not obvious how to test commands without splitting up the logic. 
This is only applicable when the command itself requires fakes.

## Solution
Add util function to create testable versions of commands. It's not perfect because VS Code commands are meant to be global and unique whereas testing often requires test versions of things. The implementation is also fragile but acceptable for simple tests.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
