### PR TITLE
feat(codewhisperer): make the license name bold in reference log

### DIFF
--- a/src/codewhisperer/service/referenceLogViewProvider.ts
+++ b/src/codewhisperer/service/referenceLogViewProvider.ts
@@ -86,7 +86,7 @@ export class ReferenceLogViewProvider implements vscode.WebviewViewProvider {
             let repository = reference.repository?.length ? reference.repository : 'unknown'
             if (reference.url?.length) {
                 repository = `<a href=${reference.url}>${reference.repository}</a>`
-                license = `<b>${reference.licenseName || 'unknown'}</b>`
+                license = `<b><i>${reference.licenseName || 'unknown'}</i></b>`
             }
 
             text +=

--- a/src/codewhisperer/service/referenceLogViewProvider.ts
+++ b/src/codewhisperer/service/referenceLogViewProvider.ts
@@ -86,7 +86,7 @@ export class ReferenceLogViewProvider implements vscode.WebviewViewProvider {
             let repository = reference.repository?.length ? reference.repository : 'unknown'
             if (reference.url?.length) {
                 repository = `<a href=${reference.url}>${reference.repository}</a>`
-                license = reference.licenseName || 'unknown'
+                license = `<b>${reference.licenseName || 'unknown'}</b>`
             }
 
             text +=


### PR DESCRIPTION
## Problem
request from product to make the license name bold and italic in reference log so it stands out more
## Solution
![Screen Shot 2022-08-16 at 1 52 38 PM](https://user-images.githubusercontent.com/60411978/184983040-a6790d96-ac03-44a7-bdaa-02bca7cc921c.png)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
