### PR TITLE
cwl: Fix bug where empty results are returned with valid nextToken

### DIFF
--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -138,34 +138,6 @@ export class LogDataRegistry {
                   },
             request,
         })
-        // TODO: Consider getPaginatedAwsCallIter? Would need a way to differentiate between head/tail...
-        //let logDataGetter: AsyncIterator<CloudWatchLogsResponse>
-        // switch(logData.retrieveLogsFunction) {
-        //     case getLogEventsFromUriComponents:
-        //         logDataGetter = getPaginatedAwsCallIter({
-        //             awsCall: async request => await getLogEventsFromUriComponents(logData.logGroupInfo, logData.parameters, nextToken),
-        //             nextTokenNames: {
-        //                 request: 'nextForwardToken',
-        //                 response: 'nextForwardToken',
-        //             },
-        //             request,
-        //         })
-        //         break
-
-        //     case filterLogEventsFromUriComponents:
-        //         logDataGetter = getPaginatedAwsCallIter({
-        //         awsCall: async request => await filterLogEventsFromUriComponents(logData.logGroupInfo, logData.parameters, nextToken),
-        //         nextTokenNames: {
-        //             request: 'nextForwardToken',
-        //             response: 'nextForwardToken',
-        //         },
-        //         request,
-        //     })
-        //         break
-
-        //     default:
-        //         throw new Error(`cwl: unknown function passed into updateLog as retrieveLogsFunction`)
-        // }
         let newLogEvents: CloudWatchLogs.FilteredLogEvents = []
         let next: IteratorResult<CloudWatchLogsResponse> = await logDataGetter.next()
         newLogEvents = newLogEvents.concat(next.value.events)

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -128,19 +128,24 @@ export class LogDataRegistry {
             nextForwardToken: logData.next?.token,
             nextBackwardToken: logData.previous?.token,
         }
+
+        const isHead = headOrTail === 'head'
         const logDataGetter: AsyncIterator<CloudWatchLogsResponse> = getPaginatedAwsCallIter({
             awsCall: async request =>
-                await logData.retrieveLogsFunction(logData.logGroupInfo, logData.parameters, request.nextForwardToken),
-            nextTokenNames:
-                headOrTail === 'head'
-                    ? {
-                          request: 'nextForwardToken',
-                          response: 'nextForwardToken',
-                      }
-                    : {
-                          request: 'nextBackwardToken',
-                          response: 'nextBackwardToken',
-                      },
+                await logData.retrieveLogsFunction(
+                    logData.logGroupInfo,
+                    logData.parameters,
+                    isHead ? request.nextForwardToken : request.nextBackwardToken
+                ),
+            nextTokenNames: isHead
+                ? {
+                      request: 'nextForwardToken',
+                      response: 'nextForwardToken',
+                  }
+                : {
+                      request: 'nextBackwardToken',
+                      response: 'nextBackwardToken',
+                  },
             request,
         })
         let newLogEvents: CloudWatchLogs.FilteredLogEvents = []

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -127,10 +127,15 @@ export class LogDataRegistry {
         const logDataGetter: AsyncIterator<CloudWatchLogsResponse> = getPaginatedAwsCallIter({
             awsCall: async request =>
                 await logData.retrieveLogsFunction(logData.logGroupInfo, logData.parameters, request.nextForwardToken),
-            nextTokenNames: {
-                request: 'nextForwardToken',
-                response: 'nextForwardToken',
-            },
+            nextTokenNames: headOrTail
+                ? {
+                      request: 'nextForwardToken',
+                      response: 'nextForwardToken',
+                  }
+                : {
+                      request: 'nextBackwardToken',
+                      response: 'nextForwardToken',
+                  },
             request,
         })
         // TODO: Consider getPaginatedAwsCallIter? Would need a way to differentiate between head/tail...

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -123,7 +123,11 @@ export class LogDataRegistry {
             getLogger().debug(`No registry entry for ${uri.path}`)
             return
         }
-        const nextToken = headOrTail === 'head' ? logData.previous?.token : logData.next?.token
+        const request: CloudWatchLogsResponse = {
+            events: [],
+            nextForwardToken: logData.next?.token,
+            nextBackwardToken: logData.previous?.token,
+        }
         const logDataGetter: AsyncIterator<CloudWatchLogsResponse> = getPaginatedAwsCallIter({
             awsCall: async request =>
                 await logData.retrieveLogsFunction(logData.logGroupInfo, logData.parameters, request.nextForwardToken),
@@ -152,8 +156,6 @@ export class LogDataRegistry {
             nextForwardToken: next.value.nextForwardToken,
             nextBackwardToken: next.value.nextBackwardToken,
         }
-
-        //const logEvents = await logData.retrieveLogsFunction(logData.logGroupInfo, logData.parameters, nextToken)
 
         const newData =
             headOrTail === 'head'

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -135,16 +135,16 @@ export class LogDataRegistry {
                 await logData.retrieveLogsFunction(
                     logData.logGroupInfo,
                     logData.parameters,
-                    isHead ? request.nextForwardToken : request.nextBackwardToken
+                    isHead ? request.nextBackwardToken : request.nextForwardToken
                 ),
             nextTokenNames: isHead
                 ? {
-                      request: 'nextForwardToken',
-                      response: 'nextForwardToken',
-                  }
-                : {
                       request: 'nextBackwardToken',
                       response: 'nextBackwardToken',
+                  }
+                : {
+                      request: 'nextForwardToken',
+                      response: 'nextForwardToken',
                   },
             request,
         })

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -14,9 +14,6 @@ import { Timeout, waitTimeout } from '../../shared/utilities/timeoutUtils'
 import { showMessageWithCancel } from '../../shared/utilities/messages'
 import { findOccurencesOf } from '../../shared/utilities/textDocumentUtilities'
 import { getPaginatedAwsCallIter } from '../../shared/utilities/collectionUtils'
-import { request } from 'http'
-import { FilteredLogEvents } from 'aws-sdk/clients/cloudwatchlogs'
-import { nextTick } from 'process'
 // TODO: Add debug logging statements
 
 /**

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -131,15 +131,16 @@ export class LogDataRegistry {
         const logDataGetter: AsyncIterator<CloudWatchLogsResponse> = getPaginatedAwsCallIter({
             awsCall: async request =>
                 await logData.retrieveLogsFunction(logData.logGroupInfo, logData.parameters, request.nextForwardToken),
-            nextTokenNames: headOrTail
-                ? {
-                      request: 'nextForwardToken',
-                      response: 'nextForwardToken',
-                  }
-                : {
-                      request: 'nextBackwardToken',
-                      response: 'nextForwardToken',
-                  },
+            nextTokenNames:
+                headOrTail === 'head'
+                    ? {
+                          request: 'nextForwardToken',
+                          response: 'nextForwardToken',
+                      }
+                    : {
+                          request: 'nextBackwardToken',
+                          response: 'nextBackwardToken',
+                      },
             request,
         })
         let newLogEvents: CloudWatchLogs.FilteredLogEvents = []
@@ -400,7 +401,6 @@ export type CloudWatchLogsParameters = {
     endTime?: number
     limit?: number
     streamNameOptions?: string[]
-    nextForwardToken?: CloudWatchLogs.NextToken
 }
 
 export type CloudWatchLogsResponse = {

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -129,7 +129,7 @@ export class LogDataRegistry {
         const nextToken = headOrTail === 'head' ? logData.previous?.token : logData.next?.token
         const logDataGetter: AsyncIterator<CloudWatchLogsResponse> = getPaginatedAwsCallIter({
             awsCall: async request =>
-                await logData.retrieveLogsFunction(logData.logGroupInfo, logData.parameters, nextToken),
+                await logData.retrieveLogsFunction(logData.logGroupInfo, logData.parameters, request.nextForwardToken),
             nextTokenNames: {
                 request: 'nextForwardToken',
                 response: 'nextForwardToken',

--- a/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
@@ -45,7 +45,7 @@ describe('LogDataRegistry', async function () {
         // check that newData is changed to what it should be.
         const newData = registry.getLogData(paginatedUri)
         assert(newData)
-        const expected = headOrTail === 'head' ? (await fakeGetLogEvents()).events : (await fakeSearchLogGroup()).events
+        const expected = headOrTail === 'head' ? (await fakeSearchLogGroup()).events : (await fakeGetLogEvents()).events
         assert.deepStrictEqual(newData.data, expected)
     }
 

--- a/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
@@ -77,11 +77,11 @@ describe('LogDataRegistry', async function () {
 
     describe('updateLog', async function () {
         it("properply paginates the results with 'head'", async () => {
-            testUpdateLog('head')
+            await testUpdateLog('head')
         })
 
         it("properply paginates the results with 'tail'", async () => {
-            testUpdateLog('tail')
+            await testUpdateLog('tail')
         })
     })
 

--- a/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
@@ -11,6 +11,7 @@ import { INSIGHTS_TIMESTAMP_FORMAT } from '../../../shared/constants'
 import { Settings } from '../../../shared/settings'
 import { CloudWatchLogsSettings, createURIFromArgs } from '../../../cloudWatchLogs/cloudWatchLogsUtils'
 import {
+    fakeGetLogEvents,
     fakeSearchLogGroup,
     logGroupsData,
     newLineData,
@@ -37,14 +38,15 @@ describe('LogDataRegistry', async function () {
         const oldData = registry.getLogData(paginatedUri)
         // check that oldData is unchanged.
         assert(oldData)
-        assert.strictEqual(oldData.data, paginatedData.data)
+        assert.deepStrictEqual(oldData.data, paginatedData.data)
 
         await registry.updateLog(paginatedUri, headOrTail)
 
         // check that newData is changed to what it should be.
         const newData = registry.getLogData(paginatedUri)
         assert(newData)
-        assert.deepStrictEqual(newData.data, (await fakeSearchLogGroup()).events)
+        const expected = headOrTail === 'head' ? (await fakeGetLogEvents()).events : (await fakeSearchLogGroup()).events
+        assert.deepStrictEqual(newData.data, expected)
     }
 
     beforeEach(function () {

--- a/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
@@ -73,7 +73,7 @@ describe('LogDataRegistry', async function () {
             // check that newData is changed to what it should be.
             const newData = registry.getLogData(paginatedUri)
             assert(newData)
-            assert.strictEqual(newData.data, (await fakeGetLogEvents()).events)
+            assert.deepStrictEqual(newData.data, (await fakeGetLogEvents()).events)
         })
     })
 

--- a/src/test/cloudWatchLogs/utils.test.ts
+++ b/src/test/cloudWatchLogs/utils.test.ts
@@ -17,6 +17,11 @@ import { CLOUDWATCH_LOGS_SCHEME } from '../../shared/constants'
 import { findOccurencesOf } from '../../shared/utilities/textDocumentUtilities'
 
 export const newText = 'a little longer now\n'
+export const addedEvent = {
+    message: 'this is an additional event',
+}
+export const forwardToken = 'forward'
+export const backwardToken = 'backward'
 
 export async function returnPaginatedEvents(
     logGroupInfo: CloudWatchLogsGroupInfo,
@@ -24,17 +29,29 @@ export async function returnPaginatedEvents(
     nextToken?: CloudWatchLogs.NextToken
 ) {
     switch (nextToken) {
-        case 'forward':
+        case forwardToken:
             return fakeGetLogEvents()
-        case 'backward':
+        case backwardToken:
             return fakeSearchLogGroup()
         default:
             return {
                 events: [],
-                nextForwardToken: 'forward',
-                nextBackwardToken: 'backward',
+                nextForwardToken: forwardToken,
+                nextBackwardToken: backwardToken,
             }
     }
+}
+
+export async function returnNonEmptyPaginatedEvents(
+    logGroupInfo: CloudWatchLogsGroupInfo,
+    parameters: CloudWatchLogsParameters,
+    nextToken?: CloudWatchLogs.NextToken
+) {
+    const result = await returnPaginatedEvents(logGroupInfo, parameters, nextToken)
+    if (result.events.length === 0) {
+        result.events = [addedEvent]
+    }
+    return result
 }
 
 export async function fakeGetLogEvents(): Promise<CloudWatchLogsResponse> {

--- a/src/test/cloudWatchLogs/utils.test.ts
+++ b/src/test/cloudWatchLogs/utils.test.ts
@@ -23,12 +23,17 @@ export async function returnPaginatedEvents(
     parameters: CloudWatchLogsParameters,
     nextToken?: CloudWatchLogs.NextToken
 ) {
-    if (nextToken) {
-        return fakeGetLogEvents()
-    }
-    return {
-        events: [],
-        nextForwardToken: 'this-is-a-token',
+    switch (nextToken) {
+        case 'forward':
+            return fakeGetLogEvents()
+        case 'backward':
+            return fakeSearchLogGroup()
+        default:
+            return {
+                events: [],
+                nextForwardToken: 'forward',
+                nextBackwardToken: 'backward',
+            }
     }
 }
 

--- a/src/test/cloudWatchLogs/utils.test.ts
+++ b/src/test/cloudWatchLogs/utils.test.ts
@@ -4,17 +4,33 @@
  */
 
 import * as assert from 'assert'
+import { CloudWatchLogs } from 'aws-sdk'
 import * as vscode from 'vscode'
 import { createURIFromArgs, parseCloudWatchLogsUri, uriToKey } from '../../cloudWatchLogs/cloudWatchLogsUtils'
 import {
     CloudWatchLogsParameters,
     CloudWatchLogsData,
     CloudWatchLogsResponse,
+    CloudWatchLogsGroupInfo,
 } from '../../cloudWatchLogs/registry/logDataRegistry'
 import { CLOUDWATCH_LOGS_SCHEME } from '../../shared/constants'
 import { findOccurencesOf } from '../../shared/utilities/textDocumentUtilities'
 
 export const newText = 'a little longer now\n'
+
+export async function returnPaginatedEvents(
+    logGroupInfo: CloudWatchLogsGroupInfo,
+    parameters: CloudWatchLogsParameters,
+    nextToken?: CloudWatchLogs.NextToken
+) {
+    if (nextToken) {
+        return fakeGetLogEvents()
+    }
+    return {
+        events: [],
+        nextForwardToken: 'this-is-a-token',
+    }
+}
 
 export async function fakeGetLogEvents(): Promise<CloudWatchLogsResponse> {
     return {
@@ -115,6 +131,17 @@ export const logGroupsData: CloudWatchLogsData = {
         regionName: 'thisIsARegionCode',
     },
     retrieveLogsFunction: fakeSearchLogGroup,
+    busy: false,
+}
+
+export const paginatedData: CloudWatchLogsData = {
+    data: [],
+    parameters: {},
+    logGroupInfo: {
+        groupName: 'g',
+        regionName: 'r',
+    },
+    retrieveLogsFunction: returnPaginatedEvents,
     busy: false,
 }
 export const goodUri = createURIFromArgs(testComponents.logGroupInfo, testComponents.parameters)


### PR DESCRIPTION
## Problem
Sometimes the results from cwl API return empty, with a `nextToken`. We don't account for this case. 
## Solution
Implement `getPaginatedAwsCallIter` in order to handle this case. 

**Note**: DONT MERGE. Codelenses are currently not working so something is wrong. It passes tests, but doesn't work on realdata. 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
