### PR TITLE
fix(codewhisperer): Remove startTime in CodeWhisperer percentageCode metric

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "aws-toolkit-vscode",
-            "version": "1.47.0-SNAPSHOT",
+            "version": "1.49.0-SNAPSHOT",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -51,7 +51,7 @@
                 "yaml-cfn": "^0.3.1"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.61",
+                "@aws-toolkits/telemetry": "^1.0.64",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^8.1.0",
                 "@types/adm-zip": "^0.4.34",
@@ -2242,9 +2242,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.61",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.61.tgz",
-            "integrity": "sha512-o1j7nrUOfC+nGgQBmnfa8X2GTP0b3HZT5JWcm65tjBhfqgLL6nXa3br2+ZD2MOMx90Qxor8XgGLbcS8UMb4MeA==",
+            "version": "1.0.64",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.64.tgz",
+            "integrity": "sha512-CVfeeDT6W8kEtAMNABcIk45VA/nBjmHEygTwsFGMdOxWT2+8xaLUWl/jS6CYsFpePrix9imTX9qHMMJESD4EzQ==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",
@@ -16055,9 +16055,9 @@
             }
         },
         "@aws-toolkits/telemetry": {
-            "version": "1.0.61",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.61.tgz",
-            "integrity": "sha512-o1j7nrUOfC+nGgQBmnfa8X2GTP0b3HZT5JWcm65tjBhfqgLL6nXa3br2+ZD2MOMx90Qxor8XgGLbcS8UMb4MeA==",
+            "version": "1.0.64",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.64.tgz",
+            "integrity": "sha512-CVfeeDT6W8kEtAMNABcIk45VA/nBjmHEygTwsFGMdOxWT2+8xaLUWl/jS6CYsFpePrix9imTX9qHMMJESD4EzQ==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -3196,7 +3196,7 @@
         "report": "nyc report --reporter=html --reporter=json"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.61",
+        "@aws-toolkits/telemetry": "^1.0.64",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^8.1.0",
         "@types/adm-zip": "^0.4.34",

--- a/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
+++ b/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
@@ -69,10 +69,8 @@ export class CodeWhispererCodeCoverageTracker {
         const acceptedTokens = this._acceptedTokens
         const percentCount = ((acceptedTokens.length / totalTokens.length) * 100).toFixed(2)
         const percentage = Math.round(parseInt(percentCount))
-        const date = new globals.clock.Date(this._startTime)
         telemetry.recordCodewhispererCodePercentage({
             codewhispererTotalTokens: totalTokens.length ? totalTokens.length : 0,
-            codewhispererStartTime: date.toString(),
             codewhispererLanguage: this._language,
             codewhispererAcceptedTokens: acceptedTokens.length ? acceptedTokens.length : 0,
             codewhispererPercentage: percentage ? percentage : 0,

--- a/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
+++ b/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
@@ -71,7 +71,6 @@ describe('codewhispererCodecoverageTracker', function () {
             tracker.emitCodeWhispererCodeContribution()
             assertTelemetry({
                 codewhispererTotalTokens: 20,
-                codewhispererStartTime: 'Thu Jan 01 1970 00:00:00 GMT+0000 (Coordinated Universal Time)',
                 codewhispererLanguage: language,
                 codewhispererAcceptedTokens: 20,
                 codewhispererPercentage: 100,


### PR DESCRIPTION
## Problem
The startTime field in CodeWhisperer percentageCode metric is unused but it caused issue on the backend.

## Solution

Remove this startTime field.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
