### PR TITLE
fix(codewhisperer): Mark suggestions as Discard in some cases

### DIFF
--- a/src/codewhisperer/service/inlineCompletion.ts
+++ b/src/codewhisperer/service/inlineCompletion.ts
@@ -291,7 +291,6 @@ export class InlineCompletion {
                         })
                 }
             })
-
         vsCodeState.isCodeWhispererEditing = false
     }
 
@@ -389,6 +388,8 @@ export class InlineCompletion {
                     RecommendationHandler.instance.recommendations.forEach((r, i) => {
                         RecommendationHandler.instance.setSuggestionState(i, 'Discard')
                     })
+                    RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
+                    RecommendationHandler.instance.clearRecommendations()
                     if (this._timer !== undefined) {
                         clearTimeout(this._timer)
                         this._timer = undefined

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -265,8 +265,9 @@ export class RecommendationHandler {
             // these suggestions can be marked as Showed if typeahead can be removed with new inline API
             recommendation.forEach((r, i) => {
                 if (
-                    !r.content.startsWith(typedPrefix) &&
-                    this.getSuggestionState(i + this.recommendations.length) === undefined
+                    (!r.content.startsWith(typedPrefix) &&
+                        this.getSuggestionState(i + this.recommendations.length) === undefined) ||
+                    this.cancellationToken.token.isCancellationRequested
                 ) {
                     this.setSuggestionState(i + this.recommendations.length, 'Discard')
                 }
@@ -344,12 +345,17 @@ export class RecommendationHandler {
             return false
         }
         // do not show recommendation if cursor is before invocation position
+        // also mark as Discard
         if (editor.selection.active.isBefore(this.startPos)) {
+            this.recommendations.forEach((r, i) => {
+                this.setSuggestionState(i, 'Discard')
+            })
             reject()
             return false
         }
 
         // do not show recommendation if typeahead does not match
+        // also mark as Discard
         const typedPrefix = editor.document.getText(
             new vscode.Range(
                 this.startPos.line,
@@ -359,6 +365,9 @@ export class RecommendationHandler {
             )
         )
         if (!this.recommendations[0].content.startsWith(typedPrefix.trimStart())) {
+            this.recommendations.forEach((r, i) => {
+                this.setSuggestionState(i, 'Discard')
+            })
             reject()
             return false
         }


### PR DESCRIPTION
## Problem

By the time when plugin gets first paginated suggestion(s), 

1. If the cursor is behind invocation position, it is Discarded.
2. If the typeahead does not match, it is Discarded.
3. If the editor is changed or the invocation editor lost focus, it is Discarded.

## Solution

Mark suggestions as Discard in the above 3 cases. 


https://user-images.githubusercontent.com/97199248/186044661-5dd36cf3-3ac7-452a-92d8-07eb50cd643e.mov


https://user-images.githubusercontent.com/97199248/186044683-6f3a1aeb-1ffc-46ac-a4e7-f757cc1cc5bc.mov


https://user-images.githubusercontent.com/97199248/186044693-f2454786-c7c8-4e4c-9003-00916f5189bb.mov



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
