### PR TITLE
feat(telemetry): add execution spans

### DIFF
--- a/src/apigateway/commands/copyUrl.ts
+++ b/src/apigateway/commands/copyUrl.ts
@@ -16,7 +16,7 @@ import { Stage } from 'aws-sdk/clients/apigateway'
 import { DefaultApiGatewayClient } from '../../shared/clients/apiGatewayClient'
 import { DEFAULT_DNS_SUFFIX, RegionProvider } from '../../shared/regions/regionProvider'
 import { getLogger } from '../../shared/logger'
-import { recordApigatewayCopyUrl } from '../../shared/telemetry/telemetry'
+import { telemetry } from '../../shared/telemetry/spans'
 
 interface StageInvokeUrlQuickPick extends vscode.QuickPickItem {
     // override declaration so this can't be undefined
@@ -48,7 +48,7 @@ export async function copyUrlCommand(
         )
     } catch (e) {
         getLogger().error(`Failed to load stages: %O`, e)
-        recordApigatewayCopyUrl({ result: 'Failed' })
+        telemetry.apigateway_copyUrl.emit({ result: 'Failed' })
         return
     }
 
@@ -61,12 +61,12 @@ export async function copyUrlCommand(
         window.showInformationMessage(
             localize('AWS.apig.copyUrlNoStages', "Failed to copy URL because '{0}' has no stages", node.name)
         )
-        recordApigatewayCopyUrl({ result: 'Failed' })
+        telemetry.apigateway_copyUrl.emit({ result: 'Failed' })
         return
     } else if (quickPickItems.length === 1) {
         const url = quickPickItems[0].detail
         await copyToClipboard(url, 'URL')
-        recordApigatewayCopyUrl({ result: 'Succeeded' })
+        telemetry.apigateway_copyUrl.emit({ result: 'Succeeded' })
         return
     }
 
@@ -89,13 +89,13 @@ export async function copyUrlCommand(
     const pickerResponse = picker.verifySinglePickerOutput<StageInvokeUrlQuickPick>(choices)
 
     if (!pickerResponse) {
-        recordApigatewayCopyUrl({ result: 'Cancelled' })
+        telemetry.apigateway_copyUrl.emit({ result: 'Cancelled' })
         return
     }
 
     const url = pickerResponse.detail
     await copyToClipboard(url, 'URL')
-    recordApigatewayCopyUrl({ result: 'Succeeded' })
+    telemetry.apigateway_copyUrl.emit({ result: 'Succeeded' })
 }
 
 export function buildDefaultApiInvokeUrl(apiId: string, region: string, dnsSuffix: string, stage: string): string {

--- a/src/apigateway/vue/invokeRemoteRestApi.ts
+++ b/src/apigateway/vue/invokeRemoteRestApi.ts
@@ -10,10 +10,11 @@ import { getLogger, Logger } from '../../shared/logger'
 import { toArrayAsync } from '../../shared/utilities/collectionUtils'
 import { Resource } from 'aws-sdk/clients/apigateway'
 import { localize } from '../../shared/utilities/vsCodeUtils'
-import { recordApigatewayInvokeRemote, Result } from '../../shared/telemetry/telemetry'
+import { Result } from '../../shared/telemetry/telemetry'
 import { VueWebview } from '../../webviews/main'
 import { ExtContext } from '../../shared/extensions'
 import { DefaultApiGatewayClient } from '../../shared/clients/apiGatewayClient'
+import { telemetry } from '../../shared/telemetry/spans'
 
 interface InvokeApiMessage {
     region: string
@@ -94,7 +95,7 @@ export class RemoteRestInvokeWebview extends VueWebview {
         } finally {
             // only set method if it is not empty or undefined
             const method = message.selectedMethod ? message.selectedMethod.toUpperCase() : undefined
-            recordApigatewayInvokeRemote({
+            telemetry.apigateway_invokeRemote.emit({
                 result: result,
                 httpMethod: method,
             })

--- a/src/apprunner/activation.ts
+++ b/src/apprunner/activation.ts
@@ -4,7 +4,6 @@
  */
 
 import * as vscode from 'vscode'
-import * as telemetry from '../shared/telemetry/telemetry'
 import * as nls from 'vscode-nls'
 import { showViewLogsMessage } from '../shared/utilities/messages'
 import { AppRunnerServiceNode } from './explorer/apprunnerServiceNode'
@@ -16,6 +15,8 @@ import { createFromEcr } from './commands/createServiceFromEcr'
 import { ExtContext } from '../shared/extensions'
 import { copyToClipboard } from '../shared/utilities/messages'
 import { Commands } from '../shared/vscode/commands2'
+import { telemetry } from '../shared/telemetry/spans'
+import { Result } from '../shared/telemetry/telemetry'
 
 const localize = nls.loadMessageBundle()
 
@@ -38,30 +39,30 @@ const DELETE_SERVICE_FAILED = localize('aws.apprunner.deleteService.failed', 'Fa
 
 const copyUrl = async (node: AppRunnerServiceNode) => {
     copyToClipboard(node.url, 'URL')
-    telemetry.recordApprunnerCopyServiceUrl({ passive: false })
+    telemetry.apprunner_copyServiceUrl.emit({ passive: false })
 }
 const openUrl = async (node: AppRunnerServiceNode) => {
     await vscode.env.openExternal(vscode.Uri.parse(node.url))
-    telemetry.recordApprunnerOpenServiceUrl({ passive: false })
+    telemetry.apprunner_openServiceUrl.emit({ passive: false })
 }
 
 const resumeService = async (node: AppRunnerServiceNode) => {
-    let telemetryResult: telemetry.Result = 'Failed'
+    let telemetryResult: Result = 'Failed'
     try {
         await node.resume()
         telemetryResult = 'Succeeded'
     } finally {
-        telemetry.recordApprunnerResumeService({ result: telemetryResult, passive: false })
+        telemetry.apprunner_resumeService.emit({ result: telemetryResult, passive: false })
     }
 }
 
 const deployService = async (node: AppRunnerServiceNode) => {
-    let telemetryResult: telemetry.Result = 'Failed'
+    let telemetryResult: Result = 'Failed'
     try {
         await node.deploy()
         telemetryResult = 'Succeeded'
     } finally {
-        telemetry.recordApprunnerStartDeployment({ result: telemetryResult, passive: false })
+        telemetry.apprunner_startDeployment.emit({ result: telemetryResult, passive: false })
     }
 }
 

--- a/src/apprunner/commands/createService.ts
+++ b/src/apprunner/commands/createService.ts
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as telemetry from '../../shared/telemetry/telemetry'
+import { telemetry } from '../../shared/telemetry/spans'
+import { AppRunnerServiceSource, Result } from '../../shared/telemetry/telemetry'
 import { AppRunnerNode } from '../explorer/apprunnerNode'
 import { CreateAppRunnerServiceWizard } from '../wizards/apprunnerCreateServiceWizard'
 
 export async function createAppRunnerService(node: AppRunnerNode): Promise<void> {
-    let telemetryResult: telemetry.Result = 'Failed'
-    let source: telemetry.AppRunnerServiceSource | undefined = undefined
+    let telemetryResult: Result = 'Failed'
+    let source: AppRunnerServiceSource | undefined = undefined
 
     try {
         const wizard = new CreateAppRunnerServiceWizard(node.regionCode)
@@ -30,7 +31,7 @@ export async function createAppRunnerService(node: AppRunnerNode): Promise<void>
                 : undefined
         telemetryResult = 'Succeeded'
     } finally {
-        telemetry.recordApprunnerCreateService({
+        telemetry.apprunner_createService.emit({
             result: telemetryResult,
             // If we cancel there is no source type (so this should be optional)
             appRunnerServiceSource: source as any,

--- a/src/apprunner/commands/createServiceFromEcr.ts
+++ b/src/apprunner/commands/createServiceFromEcr.ts
@@ -3,19 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as telemetry from '../../shared/telemetry/telemetry'
 import * as vscode from 'vscode'
 import { EcrRepositoryNode } from '../../ecr/explorer/ecrRepositoryNode'
 import { EcrTagNode } from '../../ecr/explorer/ecrTagNode'
 
 import { CreateAppRunnerServiceWizard } from '../wizards/apprunnerCreateServiceWizard'
 import { DefaultAppRunnerClient } from '../../shared/clients/apprunnerClient'
+import { telemetry } from '../../shared/telemetry/spans'
+import { Result } from '../../shared/telemetry/telemetry'
 
 export async function createFromEcr(
     node: EcrTagNode | EcrRepositoryNode,
     client = new DefaultAppRunnerClient(node.regionCode)
 ): Promise<void> {
-    let telemetryResult: telemetry.Result = 'Failed'
+    let telemetryResult: Result = 'Failed'
 
     try {
         const ecrNode = (node as any).tag === undefined ? (node as EcrRepositoryNode) : (node as EcrTagNode).parent
@@ -40,7 +41,7 @@ export async function createFromEcr(
         vscode.commands.executeCommand('aws.refreshAwsExplorer', true)
         telemetryResult = 'Succeeded'
     } finally {
-        telemetry.recordApprunnerCreateService({
+        telemetry.apprunner_createService.emit({
             result: telemetryResult,
             appRunnerServiceSource: 'ecr',
             passive: false,

--- a/src/apprunner/commands/deleteService.ts
+++ b/src/apprunner/commands/deleteService.ts
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as telemetry from '../../shared/telemetry/telemetry'
 import { createHelpButton } from '../../shared/ui/buttons'
 import { createInputBox } from '../../shared/ui/inputPrompter'
 import { AppRunnerServiceNode } from '../explorer/apprunnerServiceNode'
 import * as nls from 'vscode-nls'
 import { isValidResponse } from '../../shared/wizards/wizard'
+import { telemetry } from '../../shared/telemetry/spans'
+import { AppRunnerServiceStatus, Result } from '../../shared/telemetry/telemetry'
 const localize = nls.loadMessageBundle()
 
 function validateName(name: string) {
@@ -20,8 +21,8 @@ function validateName(name: string) {
 }
 
 export async function deleteService(node: AppRunnerServiceNode): Promise<void> {
-    let telemetryResult: telemetry.Result = 'Failed'
-    const appRunnerServiceStatus = node.info.Status as telemetry.AppRunnerServiceStatus
+    let telemetryResult: Result = 'Failed'
+    const appRunnerServiceStatus = node.info.Status as AppRunnerServiceStatus
 
     try {
         const inputBox = createInputBox({
@@ -41,7 +42,7 @@ export async function deleteService(node: AppRunnerServiceNode): Promise<void> {
         await node.delete()
         telemetryResult = 'Succeeded'
     } finally {
-        telemetry.recordApprunnerDeleteService({
+        telemetry.apprunner_deleteService.emit({
             result: telemetryResult,
             appRunnerServiceStatus,
             passive: false,

--- a/src/apprunner/commands/pauseService.ts
+++ b/src/apprunner/commands/pauseService.ts
@@ -7,14 +7,15 @@ import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
 import * as vscode from 'vscode'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import * as localizedText from '../../shared/localizedText'
 import { showConfirmationMessage } from '../../shared/utilities/messages'
 import { AppRunnerServiceNode } from '../explorer/apprunnerServiceNode'
 import { PromptSettings } from '../../shared/settings'
+import { telemetry } from '../../shared/telemetry/spans'
+import { Result } from '../../shared/telemetry/telemetry'
 
 export async function pauseService(node: AppRunnerServiceNode): Promise<void> {
-    let telemetryResult: telemetry.Result = 'Failed'
+    let telemetryResult: Result = 'Failed'
 
     try {
         const prompts = PromptSettings.instance
@@ -34,7 +35,7 @@ export async function pauseService(node: AppRunnerServiceNode): Promise<void> {
         await node.pause()
         telemetryResult = 'Succeeded'
     } finally {
-        telemetry.recordApprunnerPauseService({
+        telemetry.apprunner_pauseService.emit({
             result: telemetryResult,
             passive: false,
         })

--- a/src/awsexplorer/commands/copyArn.ts
+++ b/src/awsexplorer/commands/copyArn.ts
@@ -5,7 +5,6 @@
 
 import * as nls from 'vscode-nls'
 import { showLogOutputChannel } from '../../shared/logger'
-import * as telemetry from '../../shared/telemetry/telemetry'
 const localize = nls.loadMessageBundle()
 
 import { AWSResourceNode } from '../../shared/treeview/nodes/awsResourceNode'
@@ -26,7 +25,6 @@ export async function copyArnCommand(
 ): Promise<void> {
     try {
         copyToClipboard(node.arn, 'ARN', window, env)
-        recordCopyArn({ result: 'Succeeded' })
     } catch (e) {
         const logsItem = localize('AWS.generic.message.viewLogs', 'View Logs...')
         window
@@ -43,9 +41,5 @@ export async function copyArnCommand(
                     showLogOutputChannel()
                 }
             })
-        recordCopyArn({ result: 'Failed' })
     }
 }
-
-// TODO add telemetry for copy arn
-function recordCopyArn({ result }: { result: telemetry.Result }): void {}

--- a/src/awsexplorer/localExplorer.ts
+++ b/src/awsexplorer/localExplorer.ts
@@ -4,12 +4,12 @@
  */
 
 import * as vscode from 'vscode'
-import * as telemetry from '../shared/telemetry/telemetry'
 import { cdkNode, CdkRootNode } from '../cdk/explorer/rootNode'
 import { ResourceTreeDataProvider, TreeNode } from '../shared/treeview/resourceTreeDataProvider'
 import { once } from '../shared/utilities/functionUtils'
 import { isCloud9 } from '../shared/extensionUtilities'
 import { codewhispererNode } from '../codewhisperer/explorer/codewhispererNode'
+import { telemetry } from '../shared/telemetry/spans'
 
 export interface RootNode extends TreeNode {
     canShow?(): Promise<boolean> | boolean
@@ -46,7 +46,7 @@ export function createLocalExplorerView(): vscode.TreeView<TreeNode> {
     })
 
     // Legacy CDK metric, remove this when we add something generic
-    const recordExpandCdkOnce = once(telemetry.recordCdkAppExpanded)
+    const recordExpandCdkOnce = once(() => telemetry.cdk_appExpanded.emit())
     view.onDidExpandElement(e => {
         if (e.element.resource instanceof CdkRootNode) {
             recordExpandCdkOnce()

--- a/src/cdk/explorer/rootNode.ts
+++ b/src/cdk/explorer/rootNode.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode'
 import { cdkDocumentationUrl } from '../../shared/constants'
-import { recordAwsHelp } from '../../shared/telemetry/telemetry.gen'
+import { telemetry } from '../../shared/telemetry/spans'
 import { TreeNode } from '../../shared/treeview/resourceTreeDataProvider'
 import { createPlaceholderItem } from '../../shared/treeview/utils'
 import { localize } from '../../shared/utilities/vsCodeUtils'
@@ -51,5 +51,5 @@ export const refreshCdkExplorer = Commands.register('aws.cdk.refresh', cdkNode.r
 
 Commands.register('aws.cdk.viewDocs', () => {
     vscode.env.openExternal(vscode.Uri.parse(cdkDocumentationUrl))
-    recordAwsHelp({ name: 'cdk' })
+    telemetry.aws_help.emit({ name: 'cdk' })
 })

--- a/src/cloudWatchLogs/commands/saveCurrentLogStreamContent.ts
+++ b/src/cloudWatchLogs/commands/saveCurrentLogStreamContent.ts
@@ -10,10 +10,11 @@ const localize = nls.loadMessageBundle()
 import * as fs from 'fs-extra'
 import * as path from 'path'
 import { SystemUtilities } from '../../shared/systemUtilities'
-import { recordCloudwatchlogsDownloadStreamToFile, Result } from '../../shared/telemetry/telemetry'
+import { Result } from '../../shared/telemetry/telemetry'
 import { Window } from '../../shared/vscode/window'
 import { parseCloudWatchLogsUri } from '../cloudWatchLogsUtils'
 import { LogStreamRegistry } from '../registry/logStreamRegistry'
+import { telemetry } from '../../shared/telemetry/spans'
 
 export async function saveCurrentLogStreamContent(
     uri: vscode.Uri | undefined,
@@ -75,7 +76,7 @@ export async function saveCurrentLogStreamContent(
         )
     }
 
-    recordCloudwatchlogsDownloadStreamToFile({
+    telemetry.cloudwatchlogs_downloadStreamToFile.emit({
         result: result,
     })
 }

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -17,7 +17,6 @@ import { resetIntelliSenseState } from './util/globalStateUtil'
 import { CodeWhispererSettings } from './util/codewhispererSettings'
 import { ExtContext } from '../shared/extensions'
 import { TextEditorSelectionChangeKind } from 'vscode'
-import * as telemetry from '../shared/telemetry/telemetry'
 import { CodeWhispererTracker } from './tracker/codewhispererTracker'
 import * as codewhispererClient from './client/codewhisperer'
 import { runtimeLanguageContext } from './util/runtimeLanguageContext'
@@ -44,6 +43,11 @@ import { SecurityPanelViewProvider } from './views/securityPanelViewProvider'
 import { disposeSecurityDiagnostic } from './service/diagnosticsProvider'
 import { RecommendationHandler } from './service/recommendationHandler'
 import { Commands } from '../shared/vscode/commands2'
+import {
+    CodewhispererCompletionType,
+    CodewhispererLanguage,
+    CodewhispererTriggerType,
+} from '../shared/telemetry/telemetry'
 
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
@@ -168,9 +172,9 @@ export async function activate(context: ExtContext): Promise<void> {
                 recommendation: string,
                 requestId: string,
                 sessionId: string,
-                triggerType: telemetry.CodewhispererTriggerType,
-                completionType: telemetry.CodewhispererCompletionType,
-                language: telemetry.CodewhispererLanguage,
+                triggerType: CodewhispererTriggerType,
+                completionType: CodewhispererCompletionType,
+                language: CodewhispererLanguage,
                 references: codewhispererClient.References
             ) => {
                 const bracketConfiguration = vscode.workspace.getConfiguration('editor').get('autoClosingBrackets')

--- a/src/codewhisperer/commands/startSecurityScan.ts
+++ b/src/codewhisperer/commands/startSecurityScan.ts
@@ -18,12 +18,12 @@ import {
     pollScanJobStatus,
     listScanResults,
 } from '../service/securityScanHandler'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import { runtimeLanguageContext } from '../util/runtimeLanguageContext'
 import { codeScanState, CodeScanTelemetryEntry } from '../models/model'
 import { openSettings } from '../../shared/settings'
 import { ok, viewSettings } from '../../shared/localizedText'
 import { statSync } from 'fs'
+import { telemetry } from '../../shared/telemetry/spans'
 
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
@@ -168,7 +168,7 @@ export async function startSecurityScan(
         await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
         codeScanTelemetryEntry.duration = performance.now() - codeScanStartTime
         codeScanTelemetryEntry.codeScanServiceInvocationsDuration = performance.now() - serviceInvocationStartTime
-        telemetry.recordCodewhispererSecurityScan(codeScanTelemetryEntry)
+        telemetry.codewhisperer_securityScan.emit(codeScanTelemetryEntry)
     }
 }
 

--- a/src/codewhisperer/explorer/codewhispererNode.ts
+++ b/src/codewhisperer/explorer/codewhispererNode.ts
@@ -4,7 +4,6 @@
  */
 
 import * as vscode from 'vscode'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import globals from '../../shared/extensionGlobals'
 import { CodeWhispererConstants } from '../models/constants'
 import {
@@ -22,6 +21,7 @@ import { RootNode } from '../../awsexplorer/localExplorer'
 import { Experiments } from '../../shared/settings'
 import { isCloud9 } from '../../shared/extensionUtilities'
 import { Cloud9AccessState } from '../models/model'
+import { telemetry } from '../../shared/telemetry/spans'
 export class CodeWhispererNode implements RootNode {
     public readonly id = 'codewhisperer'
     public readonly resource = this
@@ -35,7 +35,7 @@ export class CodeWhispererNode implements RootNode {
             if (key === 'CodeWhisperer') {
                 this.onDidChangeVisibilityEmitter.fire()
                 const codewhispererEnabled = await Experiments.instance.isExperimentEnabled('CodeWhisperer')
-                telemetry.recordAwsExperimentActivation({
+                telemetry.aws_experimentActivation.emit({
                     experimentId: CodeWhispererConstants.experimentId,
                     experimentState: codewhispererEnabled ? 'activated' : 'deactivated',
                     passive: false,

--- a/src/codewhisperer/models/model.ts
+++ b/src/codewhisperer/models/model.ts
@@ -2,8 +2,13 @@
  * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import * as telemetry from '../../shared/telemetry/telemetry'
 import * as vscode from 'vscode'
+import {
+    CodewhispererCompletionType,
+    CodewhispererLanguage,
+    CodewhispererTriggerType,
+    Result,
+} from '../../shared/telemetry/telemetry'
 import { References } from '../client/codewhisperer'
 
 // unavoidable global variables
@@ -38,9 +43,9 @@ export interface AcceptedSuggestionEntry {
     readonly requestId: string
     readonly sessionId: string
     readonly index: number
-    readonly triggerType: telemetry.CodewhispererTriggerType
-    readonly completionType: telemetry.CodewhispererCompletionType
-    readonly language: telemetry.CodewhispererLanguage
+    readonly triggerType: CodewhispererTriggerType
+    readonly completionType: CodewhispererCompletionType
+    readonly language: CodewhispererLanguage
 }
 
 export interface OnRecommendationAcceptanceEntry {
@@ -50,9 +55,9 @@ export interface OnRecommendationAcceptanceEntry {
     readonly recommendation: string
     readonly requestId: string
     readonly sessionId: string
-    readonly triggerType: telemetry.CodewhispererTriggerType
-    readonly completionType: telemetry.CodewhispererCompletionType
-    readonly language: telemetry.CodewhispererLanguage
+    readonly triggerType: CodewhispererTriggerType
+    readonly completionType: CodewhispererCompletionType
+    readonly language: CodewhispererLanguage
     readonly references: References | undefined
 }
 
@@ -82,7 +87,7 @@ export const codeScanState: CodeScanState = {
 
 export interface CodeScanTelemetryEntry {
     codewhispererCodeScanJobId?: string
-    codewhispererLanguage: telemetry.CodewhispererLanguage
+    codewhispererLanguage: CodewhispererLanguage
     codewhispererCodeScanSrcPayloadBytes: number
     codewhispererCodeScanBuildPayloadBytes?: number
     codewhispererCodeScanSrcZipFileBytes: number
@@ -92,7 +97,7 @@ export interface CodeScanTelemetryEntry {
     contextTruncationDuration: number
     artifactsUploadDuration: number
     codeScanServiceInvocationsDuration: number
-    result: telemetry.Result
+    result: Result
     reason?: string
     codewhispererCodeScanTotalIssues: number
 }

--- a/src/codewhisperer/service/inlineCompletion.ts
+++ b/src/codewhisperer/service/inlineCompletion.ts
@@ -11,10 +11,10 @@ import { TelemetryHelper } from '../util/telemetryHelper'
 import { ReferenceInlineProvider } from './referenceInlineProvider'
 import { DefaultCodeWhispererClient, Recommendation } from '../client/codewhisperer'
 import { RecommendationHandler } from './recommendationHandler'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import { showTimedMessage } from '../../shared/utilities/messages'
 import { getLogger } from '../../shared/logger/logger'
 import globals from '../../shared/extensionGlobals'
+import { CodewhispererAutomatedTriggerType, CodewhispererTriggerType } from '../../shared/telemetry/telemetry'
 
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
@@ -318,9 +318,9 @@ export class InlineCompletion {
     async getPaginatedRecommendation(
         client: DefaultCodeWhispererClient,
         editor: vscode.TextEditor,
-        triggerType: telemetry.CodewhispererTriggerType,
+        triggerType: CodewhispererTriggerType,
         config: ConfigurationEntry,
-        autoTriggerType?: telemetry.CodewhispererAutomatedTriggerType
+        autoTriggerType?: CodewhispererAutomatedTriggerType
     ) {
         RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
         RecommendationHandler.instance.clearRecommendations()

--- a/src/codewhisperer/service/keyStrokeHandler.ts
+++ b/src/codewhisperer/service/keyStrokeHandler.ts
@@ -4,7 +4,6 @@
  */
 
 import * as vscode from 'vscode'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import { DefaultCodeWhispererClient } from '../client/codewhisperer'
 import * as EditorContext from '../util/editorContext'
 import { CodeWhispererConstants } from '../models/constants'
@@ -16,6 +15,7 @@ import { CodeWhispererCodeCoverageTracker } from '../tracker/codewhispererCodeCo
 import globals from '../../shared/extensionGlobals'
 import { isCloud9 } from '../../shared/extensionUtilities'
 import { RecommendationHandler } from './recommendationHandler'
+import { CodewhispererAutomatedTriggerType } from '../../shared/telemetry/telemetry'
 
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
@@ -64,7 +64,7 @@ export class KeyStrokeHandler {
             if (autoTriggerType === '') {
                 return
             }
-            const triggerTtype = autoTriggerType as telemetry.CodewhispererAutomatedTriggerType
+            const triggerTtype = autoTriggerType as CodewhispererAutomatedTriggerType
             this.invokeAutomatedTrigger(triggerTtype, editor, client, config)
         } catch (error) {
             getLogger().error('Automated Trigger Exception : ', error)
@@ -166,7 +166,7 @@ export class KeyStrokeHandler {
         return changedText
     }
     async invokeAutomatedTrigger(
-        autoTriggerType: telemetry.CodewhispererAutomatedTriggerType,
+        autoTriggerType: CodewhispererAutomatedTriggerType,
         editor: vscode.TextEditor,
         client: DefaultCodeWhispererClient,
         config: ConfigurationEntry

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -4,7 +4,6 @@
  */
 
 import * as vscode from 'vscode'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import { extensionVersion } from '../../shared/vscode/env'
 import { RecommendationsList, DefaultCodeWhispererClient, Recommendation } from '../client/codewhisperer'
 import * as EditorContext from '../util/editorContext'
@@ -18,6 +17,13 @@ import { isCloud9 } from '../../shared/extensionUtilities'
 import { asyncCallWithTimeout, isAwsError } from '../util/commonUtil'
 import * as codewhispererClient from '../client/codewhisperer'
 import { showTimedMessage } from '../../shared/utilities/messages'
+import { telemetry } from '../../shared/telemetry/spans'
+import {
+    CodewhispererAutomatedTriggerType,
+    CodewhispererCompletionType,
+    CodewhispererTriggerType,
+    Result,
+} from '../../shared/telemetry/telemetry'
 
 /**
  * This class is for getRecommendation/listRecommendation API calls and its states
@@ -76,7 +82,7 @@ export class RecommendationHandler {
     }
 
     async getServerResponse(
-        triggerType: telemetry.CodewhispererTriggerType,
+        triggerType: CodewhispererTriggerType,
         isManualTriggerOn: boolean,
         isFirstPaginationCall: boolean,
         promise: Promise<any>
@@ -112,18 +118,18 @@ export class RecommendationHandler {
     async getRecommendations(
         client: DefaultCodeWhispererClient,
         editor: vscode.TextEditor,
-        triggerType: telemetry.CodewhispererTriggerType,
+        triggerType: CodewhispererTriggerType,
         config: ConfigurationEntry,
-        autoTriggerType?: telemetry.CodewhispererAutomatedTriggerType,
+        autoTriggerType?: CodewhispererAutomatedTriggerType,
         pagination: boolean = true,
         page: number = 0
     ) {
         let recommendation: RecommendationsList = []
         let requestId = ''
         let sessionId = ''
-        let invocationResult: telemetry.Result = 'Failed'
+        let invocationResult: Result = 'Failed'
         let reason = ''
-        let completionType: telemetry.CodewhispererCompletionType = 'Line'
+        let completionType: CodewhispererCompletionType = 'Line'
         let startTime = 0
         let latency = 0
         let nextToken = ''
@@ -228,7 +234,7 @@ export class RecommendationHandler {
                 getLogger().verbose(`[${index}]\n${item.content.trimRight()}`)
             })
             if (shouldRecordServiceInvocation) {
-                telemetry.recordCodewhispererServiceInvocation({
+                telemetry.codewhisperer_serviceInvocation.emit({
                     codewhispererRequestId: requestId ? requestId : undefined,
                     codewhispererSessionId: sessionId ? sessionId : undefined,
                     codewhispererLastSuggestionIndex: this.recommendations.length - 1,

--- a/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
+++ b/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
@@ -4,10 +4,11 @@
  */
 
 import * as vscode from 'vscode'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import { getLogger } from '../../shared/logger/logger'
 import { CodeWhispererConstants } from '../models/constants'
 import globals from '../../shared/extensionGlobals'
+import { telemetry } from '../../shared/telemetry/spans'
+import { CodewhispererLanguage } from '../../shared/telemetry/telemetry'
 /**
  * This singleton class is mainly used for calculating the percentage of user modification.
  * The current calculation method is (Levenshtein edit distance / acceptedSuggestion.length).
@@ -17,9 +18,9 @@ export class CodeWhispererCodeCoverageTracker {
     private _totalTokens: string[]
     private _timer?: NodeJS.Timer
     private _startTime: number
-    private _language: telemetry.CodewhispererLanguage
+    private _language: CodewhispererLanguage
 
-    private constructor(language: telemetry.CodewhispererLanguage, private readonly _globals: vscode.Memento) {
+    private constructor(language: CodewhispererLanguage, private readonly _globals: vscode.Memento) {
         this._acceptedTokens = []
         this._totalTokens = []
         this._startTime = 0
@@ -70,7 +71,7 @@ export class CodeWhispererCodeCoverageTracker {
         const percentCount = ((acceptedTokens.length / totalTokens.length) * 100).toFixed(2)
         const percentage = Math.round(parseInt(percentCount))
         const date = new globals.clock.Date(this._startTime)
-        telemetry.recordCodewhispererCodePercentage({
+        telemetry.codewhisperer_codePercentage.emit({
             codewhispererTotalTokens: totalTokens.length ? totalTokens.length : 0,
             codewhispererStartTime: date.toString(),
             codewhispererLanguage: this._language,
@@ -117,9 +118,9 @@ export class CodeWhispererCodeCoverageTracker {
         }
     }
 
-    public static readonly instances = new Map<telemetry.CodewhispererLanguage, CodeWhispererCodeCoverageTracker>()
+    public static readonly instances = new Map<CodewhispererLanguage, CodeWhispererCodeCoverageTracker>()
     public static getTracker(
-        language: telemetry.CodewhispererLanguage = 'plaintext',
+        language: CodewhispererLanguage = 'plaintext',
         memento: vscode.Memento
     ): CodeWhispererCodeCoverageTracker {
         const instance = this.instances.get(language) ?? new this(language, memento)

--- a/src/codewhisperer/tracker/codewhispererTracker.ts
+++ b/src/codewhisperer/tracker/codewhispererTracker.ts
@@ -5,10 +5,10 @@
 
 import * as vscode from 'vscode'
 import globals from '../../shared/extensionGlobals'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import { distance } from 'fastest-levenshtein'
 import { AcceptedSuggestionEntry } from '../models/model'
 import { getLogger } from '../../shared/logger/logger'
+import { telemetry } from '../../shared/telemetry/spans'
 
 /**
  * This singleton class is mainly used for calculating the percentage of user modification.
@@ -92,7 +92,7 @@ export class CodeWhispererTracker {
         } catch (e) {
             getLogger().verbose(`Exception Thrown from CodeWhispererTracker: ${e}`)
         } finally {
-            telemetry.recordCodewhispererUserModification({
+            telemetry.codewhisperer_userModification.emit({
                 codewhispererRequestId: suggestion.requestId ? suggestion.requestId : 'undefined',
                 codewhispererSessionId: suggestion.sessionId ? suggestion.sessionId : undefined,
                 codewhispererTriggerType: suggestion.triggerType,

--- a/src/codewhisperer/util/closingBracketUtil.ts
+++ b/src/codewhisperer/util/closingBracketUtil.ts
@@ -6,10 +6,10 @@
 import * as vscode from 'vscode'
 import { TextEdit, workspace, WorkspaceEdit } from 'vscode'
 import { isCloud9 } from '../../shared/extensionUtilities'
-import * as telemetry from '../../shared/telemetry/telemetry'
+import { CodewhispererTriggerType } from '../../shared/telemetry/telemetry'
 
 export async function handleAutoClosingBrackets(
-    triggerType: telemetry.CodewhispererTriggerType,
+    triggerType: CodewhispererTriggerType,
     editor: vscode.TextEditor,
     recommendation: string,
     line: number,

--- a/src/codewhisperer/util/telemetryHelper.ts
+++ b/src/codewhisperer/util/telemetryHelper.ts
@@ -2,24 +2,30 @@
  * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import * as telemetry from '../../shared/telemetry/telemetry'
 import { runtimeLanguageContext } from './runtimeLanguageContext'
 import { RecommendationsList } from '../client/codewhisperer'
 import { LicenseUtil } from './licenseUtil'
+import { telemetry } from '../../shared/telemetry/spans'
+import {
+    CodewhispererAutomatedTriggerType,
+    CodewhispererCompletionType,
+    CodewhispererSuggestionState,
+    CodewhispererTriggerType,
+} from '../../shared/telemetry/telemetry'
 
 export class TelemetryHelper {
     /**
      * Trigger type for getting CodeWhisperer recommendation
      */
-    public triggerType: telemetry.CodewhispererTriggerType
+    public triggerType: CodewhispererTriggerType
     /**
      * Auto Trigger Type for getting event of Automated Trigger
      */
-    public CodeWhispererAutomatedtriggerType: telemetry.CodewhispererAutomatedTriggerType
+    public CodeWhispererAutomatedtriggerType: CodewhispererAutomatedTriggerType
     /**
      * completion Type of the CodeWhisperer recommendation, line vs block
      */
-    public completionType: telemetry.CodewhispererCompletionType
+    public completionType: CodewhispererCompletionType
     /**
      * the cursor offset location at invocation time
      */
@@ -45,7 +51,7 @@ export class TelemetryHelper {
         languageId: string
     ) {
         const languageContext = runtimeLanguageContext.getLanguageContext(languageId)
-        telemetry.recordCodewhispererUserDecision({
+        telemetry.codewhisperer_userDecision.emit({
             codewhispererRequestId: requestId,
             codewhispererSessionId: sessionId ? sessionId : undefined,
             codewhispererPaginationProgress: paginationIndex,
@@ -89,7 +95,7 @@ export class TelemetryHelper {
             if (_elem.content.length === 0) {
                 recommendationSuggestionState?.set(i, 'Empty')
             }
-            telemetry.recordCodewhispererUserDecision({
+            telemetry.codewhisperer_userDecision.emit({
                 codewhispererRequestId: requestId,
                 codewhispererSessionId: sessionId ? sessionId : undefined,
                 codewhispererPaginationProgress: paginationIndex,
@@ -108,10 +114,10 @@ export class TelemetryHelper {
         i: number,
         acceptIndex: number,
         recommendationSuggestionState?: Map<number, string>
-    ): telemetry.CodewhispererSuggestionState {
+    ): CodewhispererSuggestionState {
         const state = recommendationSuggestionState?.get(i)
         if (state && ['Empty', 'Filter', 'Discard'].includes(state)) {
-            return state as telemetry.CodewhispererSuggestionState
+            return state as CodewhispererSuggestionState
         } else if (recommendationSuggestionState !== undefined && recommendationSuggestionState.get(i) !== 'Showed') {
             return 'Unseen'
         }

--- a/src/credentials/providers/credentials.ts
+++ b/src/credentials/providers/credentials.ts
@@ -4,7 +4,7 @@
  */
 
 import * as AWS from '@aws-sdk/types'
-import * as telemetry from '../../shared/telemetry/telemetry.gen'
+import { CredentialSourceId, CredentialType } from '../../shared/telemetry/telemetry'
 
 const CREDENTIALS_PROVIDER_ID_SEPARATOR = ':'
 
@@ -73,7 +73,7 @@ export const credentialsProviderType = ['profile', 'ec2', 'ecs', 'env'] as const
 /**
  * Lossy map of CredentialsProviderType to telemetry.CredentialSourceId
  */
-export function credentialsProviderToTelemetryType(o: CredentialsProviderType): telemetry.CredentialSourceId {
+export function credentialsProviderToTelemetryType(o: CredentialsProviderType): CredentialSourceId {
     switch (o) {
         case 'ec2':
             return 'ec2'
@@ -104,7 +104,7 @@ export interface CredentialsProvider {
      *
      * Compare getCredentialsProviderType() which is type of the _provider_.
      */
-    getTelemetryType(): telemetry.CredentialType
+    getTelemetryType(): CredentialType
     getDefaultRegion(): string | undefined
     getHashCode(): string
     getCredentials(): Promise<AWS.Credentials>

--- a/src/credentials/providers/credentialsProviderManager.ts
+++ b/src/credentials/providers/credentialsProviderManager.ts
@@ -4,7 +4,7 @@
  */
 
 import { getLogger } from '../../shared/logger'
-import { recordAwsLoadCredentials } from '../../shared/telemetry/telemetry'
+import { telemetry } from '../../shared/telemetry/spans'
 import {
     asString,
     CredentialsProvider,
@@ -30,7 +30,7 @@ export class CredentialsProviderManager {
         for (const provider of this.providers) {
             if (await provider.isAvailable()) {
                 const telemType = credentialsProviderToTelemetryType(provider.getCredentialsId().credentialSource)
-                recordAwsLoadCredentials({ credentialSourceId: telemType, value: 1 })
+                telemetry.aws_loadCredentials.emit({ credentialSourceId: telemType })
                 providers = providers.concat(provider)
             } else {
                 getLogger().verbose(
@@ -47,7 +47,7 @@ export class CredentialsProviderManager {
                 continue
             }
             const telemType = credentialsProviderToTelemetryType(providerType)
-            recordAwsLoadCredentials({ credentialSourceId: telemType, value: refreshed.length })
+            telemetry.aws_loadCredentials.emit({ credentialSourceId: telemType })
             providers = providers.concat(refreshed)
         }
 

--- a/src/dynamicResources/commands/configure.ts
+++ b/src/dynamicResources/commands/configure.ts
@@ -5,10 +5,10 @@
 
 import * as vscode from 'vscode'
 import { localize } from '../../shared/utilities/vsCodeUtils'
-import { recordDynamicresourceSelectResources } from '../../shared/telemetry/telemetry'
 import { memoizedGetResourceTypes } from '../model/resources'
 import { fromExtensionManifest } from '../../shared/settings'
 import { ArrayConstructor } from '../../shared/utilities/typeConstructors'
+import { telemetry } from '../../shared/telemetry/spans'
 
 export class ResourcesSettings extends fromExtensionManifest('aws.resources', {
     enabledResources: ArrayConstructor(String),
@@ -42,7 +42,7 @@ export async function configureResources(settings = new ResourcesSettings()): Pr
             'enabledResources',
             result.map(res => res.label)
         )
-        recordDynamicresourceSelectResources()
+        telemetry.dynamicresource_selectResources.emit()
         return true
     }
 

--- a/src/dynamicResources/commands/copyIdentifier.ts
+++ b/src/dynamicResources/commands/copyIdentifier.ts
@@ -6,7 +6,7 @@
 import { Window } from '../../shared/vscode/window'
 import { Env } from '../../shared/vscode/env'
 import { copyToClipboard } from '../../shared/utilities/messages'
-import { recordDynamicresourceCopyIdentifier } from '../../shared/telemetry/telemetry'
+import { telemetry } from '../../shared/telemetry/spans'
 
 export async function copyIdentifier(
     typeName: string,
@@ -15,5 +15,5 @@ export async function copyIdentifier(
     env = Env.vscode()
 ) {
     copyToClipboard(identifier, 'identifier', window, env)
-    recordDynamicresourceCopyIdentifier({ resourceType: typeName })
+    telemetry.dynamicresource_copyIdentifier.emit({ resourceType: typeName })
 }

--- a/src/dynamicResources/commands/deleteResource.ts
+++ b/src/dynamicResources/commands/deleteResource.ts
@@ -8,9 +8,10 @@ import * as nls from 'vscode-nls'
 import { Window } from '../../shared/vscode/window'
 import { getLogger } from '../../shared/logger/logger'
 import { showConfirmationMessage, showViewLogsMessage } from '../../shared/utilities/messages'
-import { millisecondsSince, recordDynamicresourceMutateResource, Result } from '../../shared/telemetry/telemetry'
 import { CloudControlClient } from '../../shared/clients/cloudControlClient'
 import globals from '../../shared/extensionGlobals'
+import { telemetry } from '../../shared/telemetry/spans'
+import { millisecondsSince, Result } from '../../shared/telemetry/telemetry'
 const localize = nls.loadMessageBundle()
 
 export async function deleteResource(
@@ -88,7 +89,7 @@ export async function deleteResource(
                 )
                 return false
             } finally {
-                recordDynamicresourceMutateResource({
+                telemetry.dynamicresource_mutateResource.emit({
                     dynamicResourceOperation: 'Delete',
                     duration: millisecondsSince(startTime),
                     resourceType: typeName,

--- a/src/dynamicResources/commands/openResource.ts
+++ b/src/dynamicResources/commands/openResource.ts
@@ -7,9 +7,10 @@ import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 import { Window } from '../../shared/vscode/window'
 import { getLogger } from '../../shared/logger/logger'
-import { recordDynamicresourceGetResource, Result } from '../../shared/telemetry/telemetry'
+import { Result } from '../../shared/telemetry/telemetry'
 import { ResourceNode } from '../explorer/nodes/resourceNode'
 import { AwsResourceManager, TypeSchema } from '../awsResourceManager'
+import { telemetry } from '../../shared/telemetry/spans'
 const localize = nls.loadMessageBundle()
 
 export async function openResource(
@@ -67,7 +68,7 @@ export async function openResource(
                 getLogger().error('Error opening resource: %O', error)
                 result = 'Failed'
             } finally {
-                recordDynamicresourceGetResource({
+                telemetry.dynamicresource_getResource.emit({
                     resourceType: resource.parent.typeName,
                     result: result,
                 })

--- a/src/dynamicResources/commands/saveResource.ts
+++ b/src/dynamicResources/commands/saveResource.ts
@@ -8,7 +8,7 @@ import * as nls from 'vscode-nls'
 import { Window } from '../../shared/vscode/window'
 import { getLogger } from '../../shared/logger/logger'
 import { showViewLogsMessage } from '../../shared/utilities/messages'
-import { millisecondsSince, recordDynamicresourceMutateResource, Result } from '../../shared/telemetry/telemetry'
+import { millisecondsSince, Result } from '../../shared/telemetry/telemetry'
 import { compare, Operation } from 'fast-json-patch'
 import { ResourceNode } from '../explorer/nodes/resourceNode'
 import { ResourceTypeNode } from '../explorer/nodes/resourceTypeNode'
@@ -16,6 +16,7 @@ import { AwsResourceManager } from '../awsResourceManager'
 import { CloudControlClient } from '../../shared/clients/cloudControlClient'
 import { CloudControl } from 'aws-sdk'
 import globals from '../../shared/extensionGlobals'
+import { telemetry } from '../../shared/telemetry/spans'
 
 const localize = nls.loadMessageBundle()
 
@@ -121,7 +122,7 @@ export async function createResource(
                     throw e
                 }
             } finally {
-                recordDynamicresourceMutateResource({
+                telemetry.dynamicresource_mutateResource.emit({
                     dynamicResourceOperation: 'Create',
                     duration: millisecondsSince(startTime),
                     resourceType: typeName,
@@ -217,7 +218,7 @@ export async function updateResource(
                     throw e
                 }
             } finally {
-                recordDynamicresourceMutateResource({
+                telemetry.dynamicresource_mutateResource.emit({
                     dynamicResourceOperation: 'Update',
                     duration: millisecondsSince(startTime),
                     resourceType: typeName,

--- a/src/dynamicResources/explorer/nodes/resourceTypeNode.ts
+++ b/src/dynamicResources/explorer/nodes/resourceTypeNode.ts
@@ -14,10 +14,11 @@ import { createErrorItem, makeChildrenNodes, TreeShim } from '../../../shared/tr
 import { localize } from '../../../shared/utilities/vsCodeUtils'
 import { ResourcesNode } from './resourcesNode'
 import { ResourceNode } from './resourceNode'
-import { recordDynamicresourceListResource, Result } from '../../../shared/telemetry/telemetry'
+import { Result } from '../../../shared/telemetry/telemetry'
 import { CloudControl } from 'aws-sdk'
 import { ResourceTypeMetadata } from '../../model/resources'
 import { DefaultS3Client } from '../../../shared/clients/s3Client'
+import { telemetry } from '../../../shared/telemetry/spans'
 
 export const CONTEXT_VALUE_RESOURCE_OPERATIONS: any = {
     CREATE: 'Creatable',
@@ -87,7 +88,7 @@ export class ResourceTypeNode extends AWSTreeNodeBase implements LoadMoreNode {
                 return 0
             },
         })
-        recordDynamicresourceListResource({
+        telemetry.dynamicresource_listResource.emit({
             resourceType: this.typeName,
             result: result,
         })

--- a/src/ecr/commands/copyRepositoryUri.ts
+++ b/src/ecr/commands/copyRepositoryUri.ts
@@ -7,7 +7,7 @@ import { Env } from '../../shared/vscode/env'
 import { copyToClipboard } from '../../shared/utilities/messages'
 import { Window } from '../../shared/vscode/window'
 import { EcrRepositoryNode } from '../explorer/ecrRepositoryNode'
-import { recordEcrCopyRepositoryUri } from '../../shared/telemetry/telemetry'
+import { telemetry } from '../../shared/telemetry/spans'
 
 export async function copyRepositoryUri(
     node: EcrRepositoryNode,
@@ -16,5 +16,5 @@ export async function copyRepositoryUri(
 ): Promise<void> {
     const uri = node.repository.repositoryUri
     copyToClipboard(uri, 'URI', window, env)
-    recordEcrCopyRepositoryUri()
+    telemetry.ecr_copyRepositoryUri.emit()
 }

--- a/src/ecr/commands/copyTagUri.ts
+++ b/src/ecr/commands/copyTagUri.ts
@@ -4,13 +4,13 @@
  */
 
 import { EcrTagNode } from '../explorer/ecrTagNode'
-import { recordEcrCopyTagUri } from '../../shared/telemetry/telemetry'
 import { Env } from '../../shared/vscode/env'
 import { copyToClipboard } from '../../shared/utilities/messages'
 import { Window } from '../../shared/vscode/window'
+import { telemetry } from '../../shared/telemetry/spans'
 
 export async function copyTagUri(node: EcrTagNode, window = Window.vscode(), env = Env.vscode()): Promise<void> {
     const uri = `${node.repository.repositoryUri}:${node.tag}`
     copyToClipboard(uri, 'URI', window, env)
-    recordEcrCopyTagUri()
+    telemetry.ecr_copyTagUri.emit()
 }

--- a/src/ecr/commands/createRepository.ts
+++ b/src/ecr/commands/createRepository.ts
@@ -10,7 +10,7 @@ import { Window } from '../../shared/vscode/window'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { showViewLogsMessage } from '../../shared/utilities/messages'
 import { validateRepositoryName } from '../utils'
-import { recordEcrCreateRepository } from '../../shared/telemetry/telemetry'
+import { telemetry } from '../../shared/telemetry/spans'
 
 export async function createRepository(
     node: EcrNode,
@@ -27,7 +27,7 @@ export async function createRepository(
 
     if (!repositoryName) {
         getLogger().info('createRepository cancelled')
-        recordEcrCreateRepository({ result: 'Cancelled' })
+        telemetry.ecr_createRepository.emit({ result: 'Cancelled' })
         return
     }
 
@@ -39,14 +39,14 @@ export async function createRepository(
         window.showInformationMessage(
             localize('AWS.ecr.createRepository.success', 'Created repository {0}', repositoryName)
         )
-        recordEcrCreateRepository({ result: 'Succeeded' })
+        telemetry.ecr_createRepository.emit({ result: 'Succeeded' })
     } catch (e) {
         getLogger().error(`Failed to create repository ${repositoryName}: %O`, e)
         showViewLogsMessage(
             localize('AWS.ecr.createRepository.failure', 'Failed to create repository {0}', repositoryName),
             window
         )
-        recordEcrCreateRepository({ result: 'Failed' })
+        telemetry.ecr_createRepository.emit({ result: 'Failed' })
     } finally {
         await commands.execute('aws.refreshAwsExplorerNode', node)
     }

--- a/src/ecr/commands/deleteRepository.ts
+++ b/src/ecr/commands/deleteRepository.ts
@@ -9,7 +9,7 @@ import { Commands } from '../../shared/vscode/commands'
 import { Window } from '../../shared/vscode/window'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { showViewLogsMessage } from '../../shared/utilities/messages'
-import { recordEcrDeleteRepository } from '../../shared/telemetry/telemetry'
+import { telemetry } from '../../shared/telemetry/spans'
 
 export async function deleteRepository(
     node: EcrRepositoryNode,
@@ -23,7 +23,7 @@ export async function deleteRepository(
     const isConfirmed = await showConfirmationDialog(repositoryName, window)
     if (!isConfirmed) {
         getLogger().info('DeleteRepository cancelled')
-        recordEcrDeleteRepository({ result: 'Cancelled' })
+        telemetry.ecr_deleteRepository.emit({ result: 'Cancelled' })
         return
     }
 
@@ -36,14 +36,14 @@ export async function deleteRepository(
         window.showInformationMessage(
             localize('AWS.ecr.deleteRepository.success', 'Deleted repository {0}', repositoryName)
         )
-        recordEcrDeleteRepository({ result: 'Succeeded' })
+        telemetry.ecr_deleteRepository.emit({ result: 'Succeeded' })
     } catch (e) {
         getLogger().error(`Failed to delete repository ${repositoryName}: %O`, e)
         showViewLogsMessage(
             localize('AWS.ecr.deleteRepository.failure', 'Failed to delete repository {0}', repositoryName),
             window
         )
-        recordEcrDeleteRepository({ result: 'Failed' })
+        telemetry.ecr_deleteRepository.emit({ result: 'Failed' })
     } finally {
         await commands.execute('aws.refreshAwsExplorerNode', node.parent)
     }

--- a/src/ecs/commands/runCommandInContainer.ts
+++ b/src/ecs/commands/runCommandInContainer.ts
@@ -11,7 +11,6 @@ import { Window } from '../../shared/vscode/window'
 import { getLogger } from '../../shared/logger'
 import { ChildProcess } from '../../shared/utilities/childProcess'
 import { EcsContainerNode } from '../explorer/ecsContainerNode'
-import { recordEcsRunExecuteCommand } from '../../shared/telemetry/telemetry.gen'
 import {
     ecsRequiredIamPermissionsUrl,
     ecsRequiredTaskPermissionsUrl,
@@ -27,6 +26,7 @@ import { isCloud9 } from '../../shared/extensionUtilities'
 import { PromptSettings } from '../../shared/settings'
 import { viewDocs } from '../../shared/localizedText'
 import { DefaultIamClient } from '../../shared/clients/iamClient'
+import { telemetry } from '../../shared/telemetry/spans'
 
 // Required SSM permissions for the task IAM role, see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html#ecs-exec-enabling-and-using
 const REQUIRED_SSM_PERMISSIONS = [
@@ -138,7 +138,7 @@ export async function runCommandInContainer(
             showViewLogsMessage(failedMessage)
         }
     } finally {
-        recordEcsRunExecuteCommand({ result: result, ecsExecuteCommandType: 'command' })
+        telemetry.ecs_runExecuteCommand.emit({ result: result, ecsExecuteCommandType: 'command' })
         status?.dispose()
     }
 }

--- a/src/ecs/commands/updateEnableExecuteCommandFlag.ts
+++ b/src/ecs/commands/updateEnableExecuteCommandFlag.ts
@@ -6,7 +6,7 @@ import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
 import { PromptSettings } from '../../shared/settings'
-import { recordEcsDisableExecuteCommand, recordEcsEnableExecuteCommand } from '../../shared/telemetry/telemetry.gen'
+import { telemetry } from '../../shared/telemetry/spans'
 import { Commands } from '../../shared/vscode/commands'
 import { Window } from '../../shared/vscode/window'
 import { EcsServiceNode } from '../explorer/ecsServiceNode'
@@ -50,7 +50,7 @@ export async function updateEnableExecuteCommandFlag(
     if (enable === hasExecEnabled) {
         result = 'Cancelled'
         window.showInformationMessage(redundantActionMessage)
-        recordEcsEnableExecuteCommand({ result: result, passive: false })
+        telemetry.ecs_enableExecuteCommand.emit({ result: result, passive: false })
         return
     }
     try {
@@ -72,9 +72,9 @@ export async function updateEnableExecuteCommandFlag(
         window.showErrorMessage((e as Error).message)
     } finally {
         if (enable) {
-            recordEcsEnableExecuteCommand({ result: result!, passive: false })
+            telemetry.ecs_enableExecuteCommand.emit({ result: result!, passive: false })
         } else {
-            recordEcsDisableExecuteCommand({ result: result!, passive: false })
+            telemetry.ecs_disableExecuteCommand.emit({ result: result!, passive: false })
         }
     }
 }

--- a/src/eventSchemas/commands/downloadSchemaItemCode.ts
+++ b/src/eventSchemas/commands/downloadSchemaItemCode.ts
@@ -13,7 +13,7 @@ import { SchemaClient } from '../../shared/clients/schemaClient'
 import { makeTemporaryToolkitFolder, tryRemoveFolder } from '../../shared/filesystemUtilities'
 import * as localizedText from '../../shared/localizedText'
 import { getLogger, Logger } from '../../shared/logger'
-import { recordSchemasDownload, Result } from '../../shared/telemetry/telemetry'
+import { Result } from '../../shared/telemetry/telemetry'
 import { SchemaItemNode } from '../explorer/schemaItemNode'
 import { getLanguageDetails } from '../models/schemaCodeLangs'
 
@@ -25,6 +25,7 @@ import {
 
 import * as admZip from 'adm-zip'
 import globals from '../../shared/extensionGlobals'
+import { telemetry } from '../../shared/telemetry/spans'
 
 enum CodeGenerationStatus {
     CREATE_COMPLETE = 'CREATE_COMPLETE',
@@ -91,7 +92,7 @@ export async function downloadSchemaItemCode(node: SchemaItemNode, outputChannel
         vscode.window.showErrorMessage(errorMessage)
         logger.error('Error downloading schema: %O', error)
     } finally {
-        recordSchemasDownload({ result: downloadResult })
+        telemetry.schemas_download.emit({ result: downloadResult })
     }
 }
 

--- a/src/eventSchemas/commands/viewSchemaItem.ts
+++ b/src/eventSchemas/commands/viewSchemaItem.ts
@@ -8,9 +8,10 @@ const localize = nls.loadMessageBundle()
 
 import * as vscode from 'vscode'
 import { getLogger, Logger } from '../../shared/logger'
-import { recordSchemasView, Result } from '../../shared/telemetry/telemetry'
+import { Result } from '../../shared/telemetry/telemetry'
 import { getTabSizeSetting } from '../../shared/utilities/editorUtilities'
 import { SchemaItemNode } from '../explorer/schemaItemNode'
+import { telemetry } from '../../shared/telemetry/spans'
 
 export async function viewSchemaItem(node: SchemaItemNode) {
     const logger: Logger = getLogger()
@@ -31,7 +32,7 @@ export async function viewSchemaItem(node: SchemaItemNode) {
         )
         logger.error('Error on schema preview: %O', error)
     } finally {
-        recordSchemasView({ result: viewResult })
+        telemetry.schemas_view.emit({ result: viewResult })
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,7 +40,6 @@ import { activate as activateSam } from './shared/sam/activation'
 import { activate as activateTelemetry } from './shared/telemetry/activation'
 import { activate as activateS3 } from './s3/activation'
 import * as awsFiletypes from './shared/awsFiletypes'
-import * as telemetry from './shared/telemetry/telemetry'
 import { activate as activateCodeWhisperer, shutdown as codewhispererShutdown } from './codewhisperer/activation'
 import { ExtContext } from './shared/extensions'
 import { activate as activateApiGateway } from './apigateway/activation'
@@ -66,6 +65,7 @@ import { isReleaseVersion } from './shared/vscode/env'
 import { Commands, registerErrorHandler } from './shared/vscode/commands2'
 import { formatError, isUserCancelledError, ToolkitError, UnknownError } from './shared/errors'
 import { Logging } from './shared/logger/commands'
+import { telemetry } from './shared/telemetry/spans'
 
 let localize: nls.LocalizeFunc
 
@@ -155,28 +155,28 @@ export async function activate(context: vscode.ExtensionContext) {
                 try {
                     await globals.awsContextCommands.onCommandCreateCredentialsProfile()
                 } finally {
-                    telemetry.recordAwsCreateCredentials()
+                    telemetry.aws_createCredentials.emit()
                 }
             }),
             Commands.register('aws.credentials.edit', () => globals.awsContextCommands.onCommandEditCredentials()),
             // register URLs in extension menu
             Commands.register('aws.help', async () => {
                 vscode.env.openExternal(vscode.Uri.parse(documentationUrl))
-                telemetry.recordAwsHelp()
+                telemetry.aws_help.emit()
             }),
             Commands.register('aws.github', async () => {
                 vscode.env.openExternal(vscode.Uri.parse(githubUrl))
-                telemetry.recordAwsShowExtensionSource()
+                telemetry.aws_showExtensionSource.emit()
             }),
             Commands.register('aws.createIssueOnGitHub', async () => {
                 vscode.env.openExternal(vscode.Uri.parse(githubCreateIssueUrl))
-                telemetry.recordAwsReportPluginIssue()
+                telemetry.aws_reportPluginIssue.emit()
             }),
             Commands.register('aws.quickStart', async () => {
                 try {
                     await showQuickStartWebview(context)
                 } finally {
-                    telemetry.recordAwsHelpQuickstart({ result: 'Succeeded' })
+                    telemetry.aws_helpQuickstart.emit({ result: 'Succeeded' })
                 }
             }),
             Commands.register('aws.aboutToolkit', async () => {
@@ -307,9 +307,7 @@ function recordToolkitInitialization(activationStartedOn: number, logger?: Logge
         const activationFinishedOn = Date.now()
         const duration = activationFinishedOn - activationStartedOn
 
-        telemetry.recordToolkitInit({
-            duration: duration,
-        })
+        telemetry.toolkit_init.emit({ duration })
     } catch (err) {
         logger?.error(err as Error)
     }

--- a/src/feedback/vue/submitFeedback.ts
+++ b/src/feedback/vue/submitFeedback.ts
@@ -7,11 +7,11 @@ import globals from '../../shared/extensionGlobals'
 import { ExtContext } from '../../shared/extensions'
 
 import { getLogger } from '../../shared/logger'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import * as vscode from 'vscode'
 import { TelemetryService } from '../../shared/telemetry/telemetryService'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { VueWebview, VueWebviewPanel } from '../../webviews/main'
+import { telemetry } from '../../shared/telemetry/spans'
 
 export interface FeedbackMessage {
     comment: string
@@ -42,14 +42,14 @@ export class FeedbackWebview extends VueWebview {
             const errorMessage = (err as Error).message || 'Failed to submit feedback'
             logger.error(`feedback failed: "${message.sentiment}": ${errorMessage}`)
 
-            telemetry.recordFeedbackResult({ result: 'Failed' })
+            telemetry.feedback_result.emit({ result: 'Failed' })
 
             return errorMessage
         }
 
         logger.info(`feedback sent: "${message.sentiment}"`)
 
-        telemetry.recordFeedbackResult({ result: 'Succeeded' })
+        telemetry.feedback_result.emit({ result: 'Succeeded' })
 
         this.dispose()
 

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -28,7 +28,6 @@ import { getSamCliVersion, getSamCliContext, SamCliContext } from '../../shared/
 import { runSamCliInit, SamCliInitArgs } from '../../shared/sam/cli/samCliInit'
 import { throwAndNotifyIfInvalid } from '../../shared/sam/cli/samCliValidationUtils'
 import { SamCliValidator } from '../../shared/sam/cli/samCliValidator'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import { addFolderToWorkspace, tryGetAbsolutePath } from '../../shared/utilities/workspaceUtils'
 import { goRuntimes } from '../models/samLambdaRuntime'
 import { eventBridgeStarterAppTemplate } from '../models/samTemplates'
@@ -41,12 +40,13 @@ import { TemplateTargetProperties } from '../../shared/sam/debugger/awsSamDebugC
 import { openLaunchJsonFile } from '../../shared/sam/debugger/commands/addSamDebugConfiguration'
 import { waitUntil } from '../../shared/utilities/timeoutUtils'
 import { debugNewSamAppUrl, launchConfigDocUrl } from '../../shared/constants'
-import { Runtime } from 'aws-sdk/clients/lambda'
 import { getIdeProperties, isCloud9 } from '../../shared/extensionUtilities'
 import { execSync } from 'child_process'
 import { writeFile } from 'fs-extra'
 import { checklogs } from '../../shared/localizedText'
 import globals from '../../shared/extensionGlobals'
+import { telemetry } from '../../shared/telemetry/spans'
+import { LambdaArchitecture, Result, Runtime } from '../../shared/telemetry/telemetry'
 
 type CreateReason = 'unknown' | 'userCancelled' | 'fileNotFound' | 'complete' | 'error'
 
@@ -58,7 +58,7 @@ export async function resumeCreateNewSamApp(
     extContext: ExtContext,
     activationReloadState: ActivationReloadState = new ActivationReloadState()
 ) {
-    let createResult: telemetry.Result = 'Succeeded'
+    let createResult: Result = 'Succeeded'
     let reason: CreateReason = 'complete'
     let samVersion: string | undefined
     const samInitState: SamInitState | undefined = activationReloadState.getSamInitState()
@@ -88,7 +88,7 @@ export async function resumeCreateNewSamApp(
             extContext,
             folder,
             templateUri,
-            samInitState?.isImage ? samInitState?.runtime : undefined
+            samInitState?.isImage ? (samInitState?.runtime as Runtime | undefined) : undefined
         )
         const tryOpenReadme = await writeToolkitReadme(readmeUri.fsPath, configs)
         if (tryOpenReadme) {
@@ -106,13 +106,13 @@ export async function resumeCreateNewSamApp(
         getLogger().error('Error resuming new SAM Application: %O', err as Error)
     } finally {
         activationReloadState.clearSamInitState()
-        const arch = samInitState?.architecture as telemetry.LambdaArchitecture
-        telemetry.recordSamInit({
+        const arch = samInitState?.architecture as LambdaArchitecture
+        telemetry.sam_init.emit({
             lambdaPackageType: samInitState?.isImage ? 'Image' : 'Zip',
             lambdaArchitecture: arch,
             result: createResult,
             reason: reason,
-            runtime: samInitState?.runtime as telemetry.Runtime,
+            runtime: samInitState?.runtime as Runtime,
             version: samVersion,
         })
     }
@@ -120,7 +120,7 @@ export async function resumeCreateNewSamApp(
 
 export interface CreateNewSamApplicationResults {
     runtime: string
-    result: telemetry.Result
+    result: Result
 }
 
 /**
@@ -133,7 +133,7 @@ export async function createNewSamApplication(
 ): Promise<void> {
     const awsContext: AwsContext = extContext.awsContext
     const regionProvider: RegionProvider = extContext.regionProvider
-    let createResult: telemetry.Result = 'Succeeded'
+    let createResult: Result = 'Succeeded'
     let reason: CreateReason = 'unknown'
     let lambdaPackageType: 'Zip' | 'Image' | undefined
     let createRuntime: Runtime | undefined
@@ -163,7 +163,7 @@ export async function createNewSamApplication(
             return
         }
 
-        createRuntime = config.runtimeAndPackage.runtime
+        createRuntime = config.runtimeAndPackage.runtime as Runtime
 
         initArguments = {
             name: config.name,
@@ -336,12 +336,12 @@ export async function createNewSamApplication(
         // An error occured, so do not try to continue during the next extension activation
         activationReloadState.clearSamInitState()
     } finally {
-        telemetry.recordSamInit({
+        telemetry.sam_init.emit({
             lambdaPackageType: lambdaPackageType,
             lambdaArchitecture: initArguments?.architecture,
             result: createResult,
             reason: reason,
-            runtime: createRuntime as telemetry.Runtime,
+            runtime: createRuntime,
             version: samVersion,
         })
     }

--- a/src/lambda/commands/deleteCloudFormation.ts
+++ b/src/lambda/commands/deleteCloudFormation.ts
@@ -11,11 +11,12 @@ import { DefaultCloudFormationClient } from '../../shared/clients/cloudFormation
 
 import * as localizedText from '../../shared/localizedText'
 import { getLogger, Logger } from '../../shared/logger'
-import { recordCloudformationDelete, Result } from '../../shared/telemetry/telemetry'
+import { Result } from '../../shared/telemetry/telemetry'
 import { CloudFormationStackNode } from '../explorer/cloudFormationNodes'
 import { showConfirmationMessage } from '../../shared/utilities/messages'
 import { Window } from '../../shared/vscode/window'
 import { getIdeProperties } from '../../shared/extensionUtilities'
+import { telemetry } from '../../shared/telemetry/spans'
 
 export async function deleteCloudFormation(refresh: () => void, node?: CloudFormationStackNode) {
     const logger: Logger = getLogger()
@@ -71,6 +72,6 @@ export async function deleteCloudFormation(refresh: () => void, node?: CloudForm
             )
         )
     } finally {
-        recordCloudformationDelete({ result: deleteResult })
+        telemetry.cloudformation_delete.emit({ result: deleteResult })
     }
 }

--- a/src/lambda/commands/deleteLambda.ts
+++ b/src/lambda/commands/deleteLambda.ts
@@ -3,18 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import globals from '../../shared/extensionGlobals'
-
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
 import * as vscode from 'vscode'
 import * as localizedText from '../../shared/localizedText'
 import { DefaultLambdaClient } from '../../shared/clients/lambdaClient'
-import { millisecondsSince, recordLambdaDelete, Result } from '../../shared/telemetry/telemetry'
+import { Result } from '../../shared/telemetry/telemetry'
 import { showConfirmationMessage, showViewLogsMessage } from '../../shared/utilities/messages'
 import { FunctionConfiguration } from 'aws-sdk/clients/lambda'
 import { getLogger } from '../../shared/logger/logger'
+import { telemetry } from '../../shared/telemetry/spans'
 
 async function confirmDeletion(functionName: string, window = vscode.window): Promise<boolean> {
     return showConfirmationMessage(
@@ -37,12 +36,11 @@ export async function deleteLambda(
     window = vscode.window
 ): Promise<void> {
     if (!lambda.FunctionName) {
-        recordLambdaDelete({ duration: 0, result: 'Failed' })
+        telemetry.lambda_delete.emit({ duration: 0, result: 'Failed' })
 
         throw new TypeError('Lambda does not have a function name')
     }
 
-    const startTime = new globals.clock.Date()
     let deleteResult: Result = 'Succeeded'
 
     try {
@@ -62,9 +60,7 @@ export async function deleteLambda(
 
         showViewLogsMessage(message, window)
     } finally {
-        recordLambdaDelete({
-            createTime: startTime,
-            duration: millisecondsSince(startTime),
+        telemetry.lambda_delete.emit({
             result: deleteResult,
         })
     }

--- a/src/lambda/commands/deploySamApplication.ts
+++ b/src/lambda/commands/deploySamApplication.ts
@@ -21,9 +21,10 @@ import { runSamCliDeploy } from '../../shared/sam/cli/samCliDeploy'
 import { SamCliProcessInvoker } from '../../shared/sam/cli/samCliInvokerUtils'
 import { runSamCliPackage } from '../../shared/sam/cli/samCliPackage'
 import { throwAndNotifyIfInvalid } from '../../shared/sam/cli/samCliValidationUtils'
-import { recordSamDeploy, Result } from '../../shared/telemetry/telemetry'
+import { Result } from '../../shared/telemetry/telemetry'
 import { addCodiconToString } from '../../shared/utilities/textUtilities'
 import { SamDeployWizardResponse } from '../wizards/samDeployWizard'
+import { telemetry } from '../../shared/telemetry/spans'
 
 const localize = nls.loadMessageBundle()
 
@@ -134,7 +135,7 @@ export async function deploySamApplication(
         )
     } finally {
         await tryRemoveFolder(deployFolder)
-        recordSamDeploy({ result: deployResult, version: samVersion })
+        telemetry.sam_deploy.emit({ result: deployResult, version: samVersion })
     }
 }
 

--- a/src/lambda/commands/downloadLambda.ts
+++ b/src/lambda/commands/downloadLambda.ts
@@ -17,7 +17,6 @@ import * as localizedText from '../../shared/localizedText'
 import { getLogger } from '../../shared/logger'
 import { HttpResourceFetcher } from '../../shared/resourcefetcher/httpResourceFetcher'
 import { createCodeAwsSamDebugConfig } from '../../shared/sam/debugger/awsSamDebugConfiguration'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import * as pathutils from '../../shared/utilities/pathUtils'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { addFolderToWorkspace } from '../../shared/utilities/workspaceUtils'
@@ -26,20 +25,19 @@ import { promptUserForLocation, WizardContext } from '../../shared/wizards/multi
 import { getLambdaDetails } from '../utils'
 import { Progress } from 'got/dist/source'
 import { DefaultLambdaClient } from '../../shared/clients/lambdaClient'
+import { telemetry } from '../../shared/telemetry/spans'
+import { Result, Runtime } from '../../shared/telemetry/telemetry'
 
 export async function downloadLambdaCommand(functionNode: LambdaFunctionNode) {
     const result = await runDownloadLambda(functionNode)
 
-    telemetry.recordLambdaImport({
+    telemetry.lambda_import.emit({
         result,
-        runtime: functionNode.configuration.Runtime as telemetry.Runtime | undefined,
+        runtime: functionNode.configuration.Runtime as Runtime | undefined,
     })
 }
 
-async function runDownloadLambda(
-    functionNode: LambdaFunctionNode,
-    window = Window.vscode()
-): Promise<telemetry.Result> {
+async function runDownloadLambda(functionNode: LambdaFunctionNode, window = Window.vscode()): Promise<Result> {
     const workspaceFolders = vscode.workspace.workspaceFolders || []
     const functionName = functionNode.configuration.FunctionName!
 
@@ -78,7 +76,7 @@ async function runDownloadLambda(
         }
     }
 
-    return await window.withProgress<telemetry.Result>(
+    return await window.withProgress<Result>(
         {
             location: vscode.ProgressLocation.Notification,
             cancellable: false,

--- a/src/lambda/commands/uploadLambda.ts
+++ b/src/lambda/commands/uploadLambda.ts
@@ -22,7 +22,6 @@ import * as localizedText from '../../shared/localizedText'
 import { getLogger } from '../../shared/logger'
 import { SamCliBuildInvocation } from '../../shared/sam/cli/samCliBuild'
 import { getSamCliContext } from '../../shared/sam/cli/samCliContext'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import { SamTemplateGenerator } from '../../shared/templates/sam/samTemplateGenerator'
 import { Window } from '../../shared/vscode/window'
 import { addCodiconToString } from '../../shared/utilities/textUtilities'
@@ -40,6 +39,8 @@ import { toArrayAsync } from '../../shared/utilities/collectionUtils'
 import { fromExtensionManifest } from '../../shared/settings'
 import { createRegionPrompter } from '../../shared/ui/common/region'
 import { DefaultLambdaClient } from '../../shared/clients/lambdaClient'
+import { telemetry } from '../../shared/telemetry/spans'
+import { Result, Runtime } from '../../shared/telemetry/telemetry'
 
 interface SavedLambdas {
     [profile: string]: { [region: string]: string }
@@ -90,7 +91,7 @@ export interface LambdaFunction {
  * @param path Uri to the template.yaml file or the directory the command was invoked from
  */
 export async function uploadLambdaCommand(lambdaArg?: LambdaFunction, path?: vscode.Uri) {
-    let result: telemetry.Result = 'Cancelled'
+    let result: Result = 'Cancelled'
     let lambda: LambdaFunction | undefined
 
     try {
@@ -118,9 +119,9 @@ export async function uploadLambdaCommand(lambdaArg?: LambdaFunction, path?: vsc
             getLogger().error(`Lambda upload failed: %O`, err)
         }
     } finally {
-        telemetry.recordLambdaUpdateFunctionCode({
+        telemetry.lambda_updateFunctionCode.emit({
             result,
-            runtime: lambda?.configuration?.Runtime as telemetry.Runtime | undefined,
+            runtime: lambda?.configuration?.Runtime as Runtime | undefined,
         })
         if (result === 'Succeeded') {
             const profile = globals.awsContext.getCredentialProfileName()

--- a/src/lambda/vue/configEditor/samInvokeBackend.ts
+++ b/src/lambda/vue/configEditor/samInvokeBackend.ts
@@ -28,7 +28,6 @@ import { sampleRequestPath } from '../../constants'
 import { tryGetAbsolutePath } from '../../../shared/utilities/workspaceUtils'
 import { CloudFormation } from '../../../shared/cloudformation/cloudformation'
 import { openLaunchJsonFile } from '../../../shared/sam/debugger/commands/addSamDebugConfiguration'
-import { recordSamOpenConfigUi } from '../../../shared/telemetry/telemetry.gen'
 import { getSampleLambdaPayloads } from '../../utils'
 import { isCloud9 } from '../../../shared/extensionUtilities'
 import { SamDebugConfigProvider } from '../../../shared/sam/debugger/awsSamDebugger'
@@ -36,6 +35,7 @@ import { samLambdaCreatableRuntimes } from '../../models/samLambdaRuntime'
 import globals from '../../../shared/extensionGlobals'
 import { VueWebview } from '../../../webviews/main'
 import { Commands } from '../../../shared/vscode/commands2'
+import { telemetry } from '../../../shared/telemetry/spans'
 
 const localize = nls.loadMessageBundle()
 
@@ -306,7 +306,7 @@ export function registerSamInvokeVueCommand(context: ExtContext): vscode.Disposa
     return Commands.register('aws.launchConfigForm', async (launchConfig?: AwsSamDebuggerConfiguration) => {
         const webview = new WebviewPanel(context.extensionContext, context, launchConfig)
         webview.show({ title: localize('AWS.command.launchConfigForm.title', 'Edit SAM Debug Configuration') })
-        recordSamOpenConfigUi()
+        telemetry.sam_openConfigUi.emit()
     })
 }
 

--- a/src/lambda/vue/remoteInvoke/invokeLambda.ts
+++ b/src/lambda/vue/remoteInvoke/invokeLambda.ts
@@ -18,7 +18,8 @@ import { getSampleLambdaPayloads, SampleRequest } from '../../utils'
 
 import * as nls from 'vscode-nls'
 import { VueWebview } from '../../../webviews/main'
-import * as telemetry from '../../../shared/telemetry/telemetry'
+import { telemetry } from '../../../shared/telemetry/spans'
+import { Result } from '../../../shared/telemetry/telemetry'
 
 const localize = nls.loadMessageBundle()
 
@@ -53,7 +54,7 @@ export class RemoteInvokeWebview extends VueWebview {
     }
 
     public async invokeLambda(input: string): Promise<void> {
-        let result: telemetry.Result = 'Succeeded'
+        let result: Result = 'Succeeded'
 
         this.channel.show()
         this.channel.appendLine('Loading response...')
@@ -77,7 +78,7 @@ export class RemoteInvokeWebview extends VueWebview {
             this.channel.appendLine('')
             result = 'Failed'
         } finally {
-            telemetry.recordLambdaInvokeRemote({ result, passive: false })
+            telemetry.lambda_invokeRemote.emit({ result, passive: false })
         }
     }
 

--- a/src/lambda/wizards/samDeployWizard.ts
+++ b/src/lambda/wizards/samDeployWizard.ts
@@ -16,7 +16,6 @@ import { getLogger } from '../../shared/logger'
 import { createHelpButton } from '../../shared/ui/buttons'
 import * as input from '../../shared/ui/input'
 import * as picker from '../../shared/ui/picker'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import { difference, filter, IteratorTransformer } from '../../shared/utilities/collectionUtils'
 import {
     MultiStepWizard,
@@ -42,6 +41,7 @@ import globals from '../../shared/extensionGlobals'
 import { SamCliSettings } from '../../shared/sam/cli/samCliSettings'
 import { getIcon } from '../../shared/icons'
 import { DefaultS3Client } from '../../shared/clients/s3Client'
+import { telemetry } from '../../shared/telemetry/spans'
 
 const CREATE_NEW_BUCKET = localize('AWS.command.s3.createBucket', 'Create Bucket...')
 const ENTER_BUCKET = localize('AWS.samcli.deploy.bucket.existingLabel', 'Enter Existing Bucket Name...')
@@ -800,13 +800,13 @@ export class SamDeployWizard extends MultiStepWizard<SamDeployWizardResponse> {
                 vscode.window.showInformationMessage(
                     localize('AWS.s3.createBucket.success', 'Created bucket: {0}', newBucketName)
                 )
-                telemetry.recordS3CreateBucket({ result: 'Succeeded' })
+                telemetry.s3_createBucket.emit({ result: 'Succeeded' })
             } catch (e) {
                 showViewLogsMessage(
                     localize('AWS.s3.createBucket.error.general', 'Failed to create bucket: {0}', newBucketRequest),
                     vscode.window
                 )
-                telemetry.recordS3CreateBucket({ result: 'Failed' })
+                telemetry.s3_createBucket.emit({ result: 'Failed' })
                 return WIZARD_RETRY
             }
         } else if (response === ENTER_BUCKET) {

--- a/src/s3/commands/copyPath.ts
+++ b/src/s3/commands/copyPath.ts
@@ -8,7 +8,7 @@ import { copyToClipboard } from '../../shared/utilities/messages'
 import { Window } from '../../shared/vscode/window'
 import { S3FolderNode } from '../explorer/s3FolderNode'
 import { S3FileNode } from '../explorer/s3FileNode'
-import * as telemetry from '../../shared/telemetry/telemetry'
+import { telemetry } from '../../shared/telemetry/spans'
 
 /**
  * Copies the path to the folder or file represented by the given node.
@@ -21,5 +21,5 @@ export async function copyPathCommand(
     env = Env.vscode()
 ): Promise<void> {
     copyToClipboard(node.path, 'path', window, env)
-    telemetry.recordS3CopyPath()
+    telemetry.s3_copyPath.emit()
 }

--- a/src/s3/commands/createBucket.ts
+++ b/src/s3/commands/createBucket.ts
@@ -4,7 +4,6 @@
  */
 
 import { getLogger } from '../../shared/logger'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { Commands } from '../../shared/vscode/commands'
 import { Window } from '../../shared/vscode/window'
@@ -12,6 +11,7 @@ import { S3Node } from '../explorer/s3Nodes'
 import { validateBucketName } from '../util'
 import { ToolkitError } from '../../shared/errors'
 import { CancellationError } from '../../shared/utilities/timeoutUtils'
+import { telemetry } from '../../shared/telemetry/spans'
 
 /**
  * Creates a bucket in the s3 region represented by the given node.
@@ -32,7 +32,7 @@ export async function createBucketCommand(
     })
 
     if (!bucketName) {
-        telemetry.recordS3CreateBucket({ result: 'Cancelled' })
+        telemetry.s3_createBucket.emit({ result: 'Cancelled' })
         throw new CancellationError('user')
     }
 
@@ -42,10 +42,10 @@ export async function createBucketCommand(
 
         getLogger().info('Created bucket: %O', bucket)
         window.showInformationMessage(localize('AWS.s3.createBucket.success', 'Created bucket: {0}', bucketName))
-        telemetry.recordS3CreateBucket({ result: 'Succeeded' })
+        telemetry.s3_createBucket.emit({ result: 'Succeeded' })
     } catch (e) {
         const message = localize('AWS.s3.createBucket.error.general', 'Failed to create bucket: {0}', bucketName)
-        telemetry.recordS3CreateBucket({ result: 'Failed' })
+        telemetry.s3_createBucket.emit({ result: 'Failed' })
         throw ToolkitError.chain(e, message)
     } finally {
         await refreshNode(node, commands)

--- a/src/s3/commands/createFolder.ts
+++ b/src/s3/commands/createFolder.ts
@@ -5,7 +5,6 @@
 
 import { DEFAULT_DELIMITER } from '../../shared/clients/s3Client'
 import { getLogger } from '../../shared/logger'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import { S3BucketNode } from '../explorer/s3BucketNode'
 import { S3FolderNode } from '../explorer/s3FolderNode'
 import { Commands } from '../../shared/vscode/commands'
@@ -13,6 +12,7 @@ import { Window } from '../../shared/vscode/window'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { readablePath } from '../util'
 import { showViewLogsMessage } from '../../shared/utilities/messages'
+import { telemetry } from '../../shared/telemetry/spans'
 
 /**
  * Creates a subfolder in the bucket or folder represented by the given node.
@@ -40,7 +40,7 @@ export async function createFolderCommand(
 
     if (!folderName) {
         getLogger().info('CreateFolder cancelled')
-        telemetry.recordS3CreateFolder({ result: 'Cancelled' })
+        telemetry.s3_createFolder.emit({ result: 'Cancelled' })
         return
     }
 
@@ -52,14 +52,14 @@ export async function createFolderCommand(
 
         getLogger().info('Successfully created folder %O', folder)
         window.showInformationMessage(localize('AWS.s3.createFolder.success', 'Created folder {0}', folderName))
-        telemetry.recordS3CreateFolder({ result: 'Succeeded' })
+        telemetry.s3_createFolder.emit({ result: 'Succeeded' })
     } catch (e) {
         getLogger().error(`Failed to create folder ${path} in bucket '${node.bucket.name}': %O`, e)
         showViewLogsMessage(
             localize('AWS.s3.createFolder.error.general', 'Failed to create folder {0}', folderName),
             window
         )
-        telemetry.recordS3CreateFolder({ result: 'Failed' })
+        telemetry.s3_createFolder.emit({ result: 'Failed' })
     }
 
     await refreshNode(node, commands)

--- a/src/s3/commands/deleteBucket.ts
+++ b/src/s3/commands/deleteBucket.ts
@@ -5,13 +5,13 @@
 
 import * as vscode from 'vscode'
 import { getLogger } from '../../shared/logger'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { Commands } from '../../shared/vscode/commands'
 import { Window } from '../../shared/vscode/window'
 import { S3BucketNode } from '../explorer/s3BucketNode'
 import { S3Node } from '../explorer/s3Nodes'
 import { showViewLogsMessage } from '../../shared/utilities/messages'
+import { telemetry } from '../../shared/telemetry/spans'
 
 /**
  * Deletes the bucket represented by the given node.
@@ -37,7 +37,7 @@ export async function deleteBucketCommand(
     const isConfirmed = await showConfirmationDialog(node.bucket.name, window)
     if (!isConfirmed) {
         getLogger().info('DeleteBucket cancelled')
-        telemetry.recordS3DeleteBucket({ result: 'Cancelled' })
+        telemetry.s3_deleteBucket.emit({ result: 'Cancelled' })
         return
     }
 
@@ -46,14 +46,14 @@ export async function deleteBucketCommand(
         await deleteWithProgress(node, window)
 
         getLogger().info(`Successfully deleted bucket ${node.bucket.name}`)
-        telemetry.recordS3DeleteBucket({ result: 'Succeeded' })
+        telemetry.s3_deleteBucket.emit({ result: 'Succeeded' })
     } catch (e) {
         getLogger().error(`Failed to delete bucket ${node.bucket.name}: %O`, e)
         showViewLogsMessage(
             localize('AWS.s3.deleteBucket.error.general', 'Failed to delete bucket {0}', node.bucket.name),
             window
         )
-        telemetry.recordS3DeleteBucket({ result: 'Failed' })
+        telemetry.s3_deleteBucket.emit({ result: 'Failed' })
     }
 
     await refreshNode(node.parent, commands)

--- a/src/s3/commands/deleteFile.ts
+++ b/src/s3/commands/deleteFile.ts
@@ -5,7 +5,6 @@
 
 import * as localizedText from '../../shared/localizedText'
 import { getLogger } from '../../shared/logger'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import { addCodiconToString } from '../../shared/utilities/textUtilities'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { Commands } from '../../shared/vscode/commands'
@@ -15,6 +14,7 @@ import { S3FileNode } from '../explorer/s3FileNode'
 import { S3FolderNode } from '../explorer/s3FolderNode'
 import { readablePath } from '../util'
 import { showViewLogsMessage, showConfirmationMessage } from '../../shared/utilities/messages'
+import { telemetry } from '../../shared/telemetry/spans'
 
 const DELETE_FILE_DISPLAY_TIMEOUT_MS = 2000
 
@@ -44,7 +44,7 @@ export async function deleteFileCommand(
     )
     if (!isConfirmed) {
         getLogger().info('DeleteFile cancelled')
-        telemetry.recordS3DeleteObject({ result: 'Cancelled' })
+        telemetry.s3_deleteObject.emit({ result: 'Cancelled' })
         return
     }
 
@@ -57,14 +57,14 @@ export async function deleteFileCommand(
             addCodiconToString('trash', localize('AWS.deleteFile.success', 'Deleted {0}', node.file.name)),
             DELETE_FILE_DISPLAY_TIMEOUT_MS
         )
-        telemetry.recordS3DeleteObject({ result: 'Succeeded' })
+        telemetry.s3_deleteObject.emit({ result: 'Succeeded' })
     } catch (e) {
         getLogger().error(`Failed to delete file ${filePath}: %O`, e)
         showViewLogsMessage(
             localize('AWS.s3.deleteFile.error.general', 'Failed to delete file {0}', node.file.name),
             window
         )
-        telemetry.recordS3DeleteObject({ result: 'Failed' })
+        telemetry.s3_deleteObject.emit({ result: 'Failed' })
     }
 
     await refreshNode(node.parent, commands)

--- a/src/s3/commands/downloadFileAs.ts
+++ b/src/s3/commands/downloadFileAs.ts
@@ -8,7 +8,6 @@ import * as vscode from 'vscode'
 
 import { downloadsDir } from '../../shared/filesystemUtilities'
 import { getLogger } from '../../shared/logger'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import { Window } from '../../shared/vscode/window'
 import { S3FileNode } from '../explorer/s3FileNode'
 import { readablePath } from '../util'
@@ -21,6 +20,7 @@ import { getTelemetryResult, ToolkitError } from '../../shared/errors'
 import { streamToBuffer, streamToFile } from '../../shared/utilities/streamUtilities'
 import { S3File } from '../fileViewerManager'
 import globals from '../../shared/extensionGlobals'
+import { telemetry } from '../../shared/telemetry/spans'
 
 interface DownloadFileOptions {
     /**
@@ -123,7 +123,7 @@ export async function downloadFileAsCommand(
     const saveLocation = await promptForSaveLocation(file.name, window)
     if (!saveLocation) {
         getLogger().info('DownloadFile cancelled')
-        telemetry.recordS3DownloadObject({ result: 'Cancelled' })
+        telemetry.s3_downloadObject.emit({ result: 'Cancelled' })
         return
     }
 
@@ -142,9 +142,9 @@ export async function downloadFileAsCommand(
         )
 
         showOutputMessage(`Successfully downloaded file ${saveLocation}`, outputChannel)
-        telemetry.recordS3DownloadObject({ result: 'Succeeded' })
+        telemetry.s3_downloadObject.emit({ result: 'Succeeded' })
     } catch (e) {
-        telemetry.recordS3DownloadObject({ result: getTelemetryResult(e) })
+        telemetry.s3_downloadObject.emit({ result: getTelemetryResult(e) })
         throw e
     }
 }

--- a/src/s3/commands/openFile.ts
+++ b/src/s3/commands/openFile.ts
@@ -4,13 +4,14 @@
  */
 
 import * as vscode from 'vscode'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import { getTelemetryResult } from '../../shared/errors'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { Window } from '../../shared/vscode/window'
 import { S3FileNode } from '../explorer/s3FileNode'
 import { S3FileViewerManager, TabMode } from '../fileViewerManager'
 import { downloadFileAsCommand } from './downloadFileAs'
+import { telemetry } from '../../shared/telemetry/spans'
+import { Result } from '../../shared/telemetry/telemetry'
 
 const SIZE_LIMIT = 50 * Math.pow(10, 6)
 
@@ -39,8 +40,8 @@ export async function editFileCommand(uriOrNode: vscode.Uri | S3FileNode, manage
 
 function runWithTelemetry(fn: () => Promise<void>, mode: TabMode): Promise<void> {
     // TODO: these metrics shouldn't be separate. A single one with a 'mode' field would work fine.
-    const recordMetric = (result: telemetry.Result) =>
-        mode === TabMode.Read ? telemetry.recordS3OpenEditor({ result }) : telemetry.recordS3EditObject({ result })
+    const recordMetric = (result: Result) =>
+        mode === TabMode.Read ? telemetry.s3_openEditor.emit({ result }) : telemetry.s3_editObject.emit({ result })
 
     return fn()
         .then(() => recordMetric('Succeeded'))

--- a/src/s3/commands/presignedURL.ts
+++ b/src/s3/commands/presignedURL.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as telemetry from '../../shared/telemetry/telemetry'
 import { SignedUrlRequest } from '../../shared/clients/s3Client'
 import { Env } from '../../shared/vscode/env'
 import { copyToClipboard } from '../../shared/utilities/messages'
@@ -12,6 +11,7 @@ import { Window } from '../../shared/vscode/window'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { invalidNumberWarning } from '../../shared/localizedText'
 import { getLogger } from '../../shared/logger/logger'
+import { telemetry } from '../../shared/telemetry/spans'
 
 export async function presignedURLCommand(
     node: S3FileNode,
@@ -23,7 +23,7 @@ export async function presignedURLCommand(
         validTime = await promptTime(node.file.key, window)
     } catch (e) {
         getLogger().error(e as Error)
-        telemetry.recordS3CopyUrl({ result: 'Cancelled', presigned: true })
+        telemetry.s3_copyUrl.emit({ result: 'Cancelled', presigned: true })
         return
     }
 
@@ -41,12 +41,12 @@ export async function presignedURLCommand(
         url = await s3Client.getSignedUrl(request)
     } catch (e) {
         window.showErrorMessage('Error creating the presigned URL. Make sure you have access to the requested file.')
-        telemetry.recordS3CopyUrl({ result: 'Failed', presigned: true })
+        telemetry.s3_copyUrl.emit({ result: 'Failed', presigned: true })
         return
     }
 
     await copyToClipboard(url, 'URL', window, env)
-    telemetry.recordS3CopyUrl({ result: 'Succeeded', presigned: true })
+    telemetry.s3_copyUrl.emit({ result: 'Succeeded', presigned: true })
 }
 
 export async function promptTime(fileName: string, window = Window.vscode()): Promise<number> {

--- a/src/s3/commands/uploadFile.ts
+++ b/src/s3/commands/uploadFile.ts
@@ -12,7 +12,6 @@ import { getLogger } from '../../shared/logger'
 import { S3Node } from '../explorer/s3Nodes'
 import { Commands } from '../../shared/vscode/commands'
 import { Window } from '../../shared/vscode/window'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import { readablePath } from '../util'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { showOutputMessage } from '../../shared/utilities/messages'
@@ -26,6 +25,7 @@ import * as localizedText from '../../shared/localizedText'
 import { CancellationError } from '../../shared/utilities/timeoutUtils'
 import { progressReporter } from '../progressReporter'
 import globals from '../../shared/extensionGlobals'
+import { telemetry } from '../../shared/telemetry/spans'
 
 export interface FileSizeBytes {
     /**
@@ -96,7 +96,7 @@ export async function uploadFileCommand(
                 outputChannel
             )
             getLogger().info('UploadFile cancelled')
-            telemetry.recordS3UploadObject({ result: 'Cancelled' })
+            telemetry.s3_uploadObject.emit({ result: 'Cancelled' })
             return
         }
 
@@ -121,14 +121,14 @@ export async function uploadFileCommand(
                     outputChannel
                 )
                 getLogger().info('UploadFile cancelled')
-                telemetry.recordS3UploadObject({ result: 'Cancelled' })
+                telemetry.s3_uploadObject.emit({ result: 'Cancelled' })
                 return
             }
 
             const bucketResponse = await getBucket(s3Client).catch(e => {})
 
             if (!bucketResponse) {
-                telemetry.recordS3UploadObject({ result: 'Failed' })
+                telemetry.s3_uploadObject.emit({ result: 'Failed' })
                 return
             }
 
@@ -145,7 +145,7 @@ export async function uploadFileCommand(
                     outputChannel
                 )
                 getLogger().info('No bucket selected, cancelling upload')
-                telemetry.recordS3UploadObject({ result: 'Cancelled' })
+                telemetry.s3_uploadObject.emit({ result: 'Cancelled' })
                 return
             }
 
@@ -332,9 +332,8 @@ async function uploadBatchOfFiles(
         }
     )
 
-    telemetry.recordS3UploadObject({
+    telemetry.s3_uploadObject.emit({
         result: response.length > 0 ? 'Failed' : 'Succeeded',
-        value: uploadRequests.length,
         failedCount: response.length,
         successCount: uploadRequests.length - response.length,
     })

--- a/src/shared/awsFiletypes.ts
+++ b/src/shared/awsFiletypes.ts
@@ -7,12 +7,13 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 import * as constants from '../shared/constants'
 import * as aslFormats from '../stepFunctions/constants/aslFormats'
-import * as telemetry from './telemetry/telemetry'
 import * as pathutil from '../shared/utilities/pathUtils'
 import * as fsutil from '../shared/filesystemUtilities'
 import * as sysutil from '../shared/systemUtilities'
 import * as collectionUtil from '../shared/utilities/collectionUtils'
 import globals from './extensionGlobals'
+import { telemetry } from './telemetry/spans'
+import { AwsFiletype } from './telemetry/telemetry'
 
 /** AWS filetypes: vscode language ids */
 export const awsFiletypeLangIds = {
@@ -25,7 +26,7 @@ export const awsFiletypeLangIds = {
 /**
  * Maps vscode language ids to AWS filetypes for telemetry.
  */
-export function langidToAwsFiletype(langId: string): telemetry.AwsFiletype {
+export function langidToAwsFiletype(langId: string): AwsFiletype {
     switch (langId) {
         case constants.ssmJson:
         case constants.ssmYaml:
@@ -102,7 +103,7 @@ export function activate(): void {
                 return // Avoid redundant/duplicate metrics.
             }
 
-            telemetry.recordFileEditAwsFile({
+            telemetry.file_editAwsFile.emit({
                 awsFiletype: telemKind,
                 passive: true,
                 result: 'Succeeded',

--- a/src/shared/logger/commands.ts
+++ b/src/shared/logger/commands.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode'
 import { Logger } from '.'
-import { recordVscodeViewLogs } from '../telemetry/telemetry'
+import { telemetry } from '../telemetry/spans'
 import { Commands } from '../vscode/commands2'
 
 function revealLines(editor: vscode.TextEditor, start: number, end: number): void {
@@ -31,7 +31,7 @@ export class Logging {
     public constructor(private readonly defaultLogUri: vscode.Uri, private readonly logger: Logger) {}
 
     public async openLogUri(logUri = this.defaultLogUri): Promise<vscode.TextEditor | undefined> {
-        recordVscodeViewLogs() // Perhaps add additional argument to know which log was viewed?
+        telemetry.vscode_viewLogs.emit() // Perhaps add additional argument to know which log was viewed?
 
         return vscode.window.showTextDocument(logUri)
     }

--- a/src/shared/sam/cli/samCliDetection.ts
+++ b/src/shared/sam/cli/samCliDetection.ts
@@ -5,8 +5,8 @@
 
 import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
-import { recordSamDetect } from '../../../shared/telemetry/telemetry'
 import { samAboutInstallUrl } from '../../constants'
+import { telemetry } from '../../telemetry/spans'
 import { SamCliSettings } from './samCliSettings'
 
 const localize = nls.loadMessageBundle()
@@ -54,7 +54,7 @@ export async function detectSamCli(args: { passive: boolean; showMessage: boolea
     }
 
     if (!args.passive) {
-        recordSamDetect({ result: sam.path ? 'Succeeded' : 'Failed' })
+        telemetry.sam_detect.emit({ result: sam.path ? 'Succeeded' : 'Failed' })
     }
 }
 

--- a/src/shared/telemetry/spans.ts
+++ b/src/shared/telemetry/spans.ts
@@ -1,0 +1,254 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import globals from '../extensionGlobals'
+
+import type { AsyncLocalStorage as AsyncLocalStorageClass } from 'async_hooks'
+import {
+    definitions,
+    Metadata,
+    Metric,
+    MetricBase,
+    MetricDefinition,
+    MetricName,
+    MetricShapes,
+    TelemetryBase,
+} from './telemetry'
+import { getTelemetryReason, getTelemetryResult } from '../errors'
+
+const AsyncLocalStorage: typeof AsyncLocalStorageClass =
+    require('async_hooks').AsyncLocalStorage ??
+    class<T> {
+        readonly #store: T[] = []
+        #disabled = false
+
+        public disable() {
+            this.#disabled = true
+        }
+
+        public getStore() {
+            return this.#disabled ? undefined : this.#store[0]
+        }
+
+        public run<R>(store: T, callback: (...args: any[]) => R, ...args: any[]): R {
+            this.#disabled = false
+            this.#store.unshift(store)
+
+            try {
+                const result = callback(...args)
+                if (result instanceof Promise) {
+                    return result.finally(() => this.#store.shift()) as unknown as R
+                }
+                this.#store.shift()
+                return result
+            } catch (err) {
+                this.#store.shift()
+                throw err
+            }
+        }
+
+        public exit<R>(callback: (...args: any[]) => R, ...args: any[]): R {
+            const saved = this.#store.shift()
+
+            try {
+                const result = callback(...args)
+                if (result instanceof Promise) {
+                    return result.finally(() => saved !== undefined && this.#store.unshift(saved)) as unknown as R
+                }
+                saved !== undefined && this.#store.unshift(saved)
+                return result
+            } catch (err) {
+                saved !== undefined && this.#store.unshift(saved)
+                throw err
+            }
+        }
+
+        public enterWith(store: T): void {
+            // XXX: you need hooks into async resource lifecycles to implement this correctly
+            this.#store.shift()
+            this.#store.unshift(store)
+        }
+    }
+
+function getValidatedState(state: Partial<MetricBase>, definition: MetricDefinition) {
+    const missingFields: string[] = []
+
+    for (const [k, v] of Object.entries(state)) {
+        if (definition.requiredMetadata.includes(k) && v === undefined) {
+            missingFields.push(k)
+        }
+    }
+
+    if (missingFields.length !== 0) {
+        return Object.assign({ missingFields }, state)
+    }
+
+    return { ...state }
+}
+
+export class TelemetrySpan {
+    #startTime: Date | undefined = undefined
+    private readonly state: Partial<MetricBase> = {}
+    private readonly definition = definitions[this.name] ?? {
+        unit: 'None',
+        passive: true,
+        requiredMetadata: [],
+    }
+
+    public constructor(public readonly name: string) {}
+
+    public get startTime(): Date | undefined {
+        return this.#startTime
+    }
+
+    public record(data: Partial<MetricBase>): this {
+        Object.assign(this.state, data)
+        return this
+    }
+
+    public emit(data?: MetricBase): void {
+        const state = Object.assign(getValidatedState(this.state, this.definition), data)
+        const metadata = Object.entries(state)
+            .filter(([k, v]) => v !== undefined && !['passive', 'value'].includes(k))
+            .map(([k, v]) => ({ Key: k, Value: String(v) }))
+
+        globals.telemetry.record({
+            Metadata: metadata,
+            MetricName: this.name,
+            Value: state.value ?? 1,
+            Unit: this.definition.unit,
+            Passive: state.passive ?? this.definition.passive,
+            EpochTimestamp: (this.startTime ?? new globals.clock.Date()).getTime(),
+        })
+    }
+
+    public start(): this {
+        this.#startTime = new globals.clock.Date()
+        return this
+    }
+
+    public stop(err?: unknown): void {
+        const duration = this.startTime !== undefined ? globals.clock.Date.now() - this.startTime.getTime() : undefined
+
+        this.emit({
+            duration,
+            result: getTelemetryResult(err),
+            reason: getTelemetryReason(err),
+        })
+
+        this.#startTime = undefined
+    }
+}
+
+interface TelemetryContext {
+    readonly spans: TelemetrySpan[]
+    readonly activeSpan?: TelemetrySpan
+}
+
+// This class is called 'Telemetry' but really it can be used for any kind of tracing
+// You would need to make `Span` a template type and reduce the interface to just create/start/stop
+export class TelemetryTracer extends TelemetryBase {
+    readonly #context = new AsyncLocalStorage<TelemetryContext>()
+
+    public get context() {
+        return this.#context
+    }
+
+    public get spans(): readonly TelemetrySpan[] {
+        return this.#context.getStore()?.spans ?? []
+    }
+
+    public get activeSpan(): TelemetrySpan | undefined {
+        return this.#context.getStore()?.activeSpan
+    }
+
+    public record(data: Partial<MetricShapes[MetricName]>): void {
+        this.activeSpan?.record(data)
+    }
+
+    public recordThrough(data: Partial<MetricShapes[MetricName]>): void {
+        for (const span of this.spans) {
+            span.record(data)
+        }
+    }
+
+    public run<T, U extends MetricName>(name: U, fn: (span: Metric<MetricShapes[U]>) => T, data: MetricBase = {}): T {
+        const span = this.getSpan(name).start().record(data)
+        const frame = this.switchContext(span)
+
+        try {
+            const result = this.#context.run(frame, fn, span)
+
+            if (result instanceof Promise) {
+                return result
+                    .then(v => (span.stop(), v))
+                    .catch(e => {
+                        span.stop(e)
+                        throw e
+                    }) as unknown as T
+            }
+
+            span.stop()
+            return result
+        } catch (e) {
+            span.stop(e)
+            throw e
+        }
+    }
+
+    public instrument<T extends any[], U, R>(
+        name: string,
+        fn: (this: U, ...args: T) => R,
+        data?: MetricBase
+    ): (this: U, ...args: T) => R {
+        const run = this.run.bind(this)
+
+        return function (...args) {
+            // Typescript's `bind` overloading doesn't work well for parameter types
+            return run(name as MetricName, (fn as (this: U, ...args: any[]) => R).bind(this, ...args), data)
+        }
+    }
+
+    protected getMetric(name: string): Metric {
+        const getSpan = () => {
+            const span = this.getSpan(name)
+            if (!this.spans.includes(span)) {
+                this.#context.enterWith({ ...this.#context.getStore(), spans: [span, ...this.spans] })
+            }
+
+            return span
+        }
+
+        return {
+            name,
+            emit: data => void getSpan().emit(data),
+            record: data => void getSpan().record(data),
+            run: fn => this.run(name as MetricName, fn),
+        }
+    }
+
+    private getSpan(name: string): TelemetrySpan {
+        const span = this.#context.getStore()?.spans.find(s => s.name === name)
+
+        return span ?? new TelemetrySpan(name)
+    }
+
+    private switchContext(span: TelemetrySpan): TelemetryContext {
+        const spans = [...(this.spans ?? [])]
+        if (!spans.includes(span)) {
+            spans.unshift(span)
+        }
+
+        return { spans, activeSpan: span }
+    }
+}
+
+export const telemetry = new TelemetryTracer()
+
+export function metric<T extends MetricName>(name: T, data?: Metadata<MetricShapes[T]>) {
+    return function (_target: unknown, _name: string, desc: TypedPropertyDescriptor<(...args: any[]) => any>) {
+        desc.value = telemetry.instrument(name, desc.value!, data)
+    }
+}

--- a/src/shared/telemetry/telemetry.ts
+++ b/src/shared/telemetry/telemetry.ts
@@ -5,3 +5,8 @@
 
 // This file makes it so you can import 'telemetry' and not 'telemetry.gen'
 export * from './telemetry.gen'
+export { telemetry } from './spans'
+
+export function millisecondsSince(date: Date): number {
+    return Date.now() - date.getTime()
+}

--- a/src/shared/telemetry/telemetryService.ts
+++ b/src/shared/telemetry/telemetryService.ts
@@ -13,7 +13,6 @@ import { getLogger } from '../logger'
 import { MetricDatum } from './clienttelemetry'
 import { DefaultTelemetryClient } from './telemetryClient'
 import { DefaultTelemetryPublisher } from './telemetryPublisher'
-import { recordSessionEnd, recordSessionStart } from './telemetry'
 import { TelemetryFeedback } from './telemetryClient'
 import { TelemetryPublisher } from './telemetryPublisher'
 import { ACCOUNT_METADATA_KEY, AccountStatus, COMPUTE_REGION_KEY } from './telemetryClient'
@@ -21,6 +20,7 @@ import { TelemetryLogger } from './telemetryLogger'
 import globals from '../extensionGlobals'
 import { ClassToInterfaceType } from '../utilities/tsUtils'
 import { getClientId } from './util'
+import { telemetry } from './spans'
 
 export type TelemetryService = ClassToInterfaceType<DefaultTelemetryService>
 
@@ -77,7 +77,7 @@ export class DefaultTelemetryService {
         // TODO: `readEventsFromCache` should be async
         this._eventQueue.push(...DefaultTelemetryService.readEventsFromCache(this.persistFilePath))
         this._endOfCache = this._eventQueue[this._eventQueue.length - 1]
-        recordSessionStart()
+        telemetry.session_start.emit()
         this.startTimer()
     }
 
@@ -93,7 +93,7 @@ export class DefaultTelemetryService {
         if (this.telemetryEnabled && !isAutomation()) {
             const currTime = new globals.clock.Date()
             // This is noisy when running tests in vscode.
-            recordSessionEnd({ value: currTime.getTime() - this.startTime.getTime() })
+            telemetry.session_end.emit({ duration: currTime.getTime() - this.startTime.getTime() })
 
             try {
                 await writeFile(this.persistFilePath, JSON.stringify(this._eventQueue))

--- a/src/shared/telemetry/vscodeTelemetry.json
+++ b/src/shared/telemetry/vscodeTelemetry.json
@@ -164,6 +164,75 @@
         {
             "name": "stepfunctions_previewstatemachine",
             "description": ""
+        },
+        {
+            "name": "vscode_activeRegions",
+            "description": "Record the number of active regions at startup and when regions are added/removed",
+            "unit": "Count",
+            "passive": true
+        },
+        {
+            "name": "vscode_viewLogs",
+            "description": "View the VSCode IDE logs"
+        },
+        {
+            "name": "aws_showExplorerErrorDetails",
+            "description": "Called when getting more details about errors thrown by the explorer",
+            "metadata": [{ "type": "result" }]
+        },
+        {
+            "name": "aws_showRegion",
+            "description": "Records a call to add a region to the explorer"
+        },
+        {
+            "name": "aws_hideRegion",
+            "description": "Records a call to remove a region from the explorer"
+        },
+        {
+            "name": "sam_detect",
+            "description": "Called when detecting the location of the SAM CLI",
+            "metadata": [{ "type": "result" }],
+            "passive": true
+        },
+        {
+            "name": "cdk_explorerDisabled",
+            "description": "Called when expanding the CDK explorer is disabled"
+        },
+        {
+            "name": "cdk_explorerEnabled",
+            "description": "Called when the CDK explorer is enabled"
+        },
+        {
+            "name": "cdk_appExpanded",
+            "description": "Called when the CDK explorer is expanded"
+        },
+        {
+            "name": "cdk_provideFeedback",
+            "description": "Called when providing feedback for CDK"
+        },
+        {
+            "name": "cdk_help",
+            "description": "Called when clicking on help for CDK"
+        },
+        {
+            "name": "cdk_refreshExplorer",
+            "description": "Called when refreshing the CDK explorer"
+        },
+        {
+            "name": "sam_attachDebugger",
+            "description": "Called after trying to attach a debugger to a local sam invoke",
+            "metadata": [
+                { "type": "result" },
+                { "type": "lambdaPackageType" },
+                { "type": "runtime" },
+                { "type": "attempts" },
+                { "type": "duration" },
+                { "type": "lambdaArchitecture", "required": false }
+            ]
+        },
+        {
+            "name": "sam_openConfigUi",
+            "description": "Called after opening the SAM Config UI"
         }
     ]
 }

--- a/src/shared/utilities/cliUtils.ts
+++ b/src/shared/utilities/cliUtils.ts
@@ -13,7 +13,6 @@ import { getIdeProperties } from '../extensionUtilities'
 import { makeTemporaryToolkitFolder, tryRemoveFolder } from '../filesystemUtilities'
 import { getLogger } from '../logger'
 import { HttpResourceFetcher } from '../resourcefetcher/httpResourceFetcher'
-import * as telemetry from '../telemetry/telemetry'
 import { ChildProcess } from '../utilities/childProcess'
 import { Window } from '../vscode/window'
 
@@ -21,6 +20,8 @@ import * as nls from 'vscode-nls'
 import { Timeout, CancellationError } from './timeoutUtils'
 import { showMessageWithCancel } from './messages'
 import { DevSettings } from '../settings'
+import { telemetry } from '../telemetry/spans'
+import { Result, ToolId } from '../telemetry/telemetry'
 const localize = nls.loadMessageBundle()
 
 const msgDownloading = localize('AWS.installProgress.downloading', 'downloading...')
@@ -43,7 +44,7 @@ interface Cli {
     name: string
 }
 
-type AwsClis = Extract<telemetry.ToolId, 'session-manager-plugin'>
+type AwsClis = Extract<ToolId, 'session-manager-plugin'>
 
 /**
  * CLIs and their full filenames and download paths for their respective OSes
@@ -79,7 +80,7 @@ export async function installCli(cli: AwsClis, confirm: boolean, window: Window 
     if (!cliToInstall) {
         throw new InstallerError(`Invalid not found for CLI: ${cli}`)
     }
-    let result: telemetry.Result = 'Succeeded'
+    let result: Result = 'Succeeded'
 
     let tempDir: string | undefined
     const manualInstall = localize('AWS.cli.manualInstall', 'Install manually...')
@@ -164,10 +165,7 @@ export async function installCli(cli: AwsClis, confirm: boolean, window: Window 
             })
         }
 
-        telemetry.recordAwsToolInstallation({
-            result,
-            toolId: cli,
-        })
+        telemetry.aws_toolInstallation.emit({ result, toolId: cli })
     }
 }
 

--- a/src/shared/vscode/commands2.ts
+++ b/src/shared/vscode/commands2.ts
@@ -11,8 +11,8 @@ import { getLogger, NullLogger } from '../logger/logger'
 import { LoginManager } from '../../credentials/loginManager'
 import { FunctionKeys, Functions, getFunctions } from '../utilities/classUtils'
 import { TreeItemContent, TreeNode } from '../treeview/resourceTreeDataProvider'
-import { recordVscodeExecuteCommand } from '../telemetry/telemetry'
 import { DefaultTelemetryService } from '../telemetry/telemetryService'
+import { telemetry } from '../telemetry/spans'
 
 type Callback = (...args: any[]) => any
 type CommandFactory<T extends Callback, U extends any[]> = (...parameters: U) => T
@@ -340,7 +340,7 @@ function endRecordCommand(id: string, token: number, err?: unknown) {
 
     emitInfo.set(id, { ...data, debounceCounter: 0 })
 
-    recordVscodeExecuteCommand({
+    telemetry.vscode_executeCommand.emit({
         command: id,
         debounceCount: data.debounceCounter,
         result: getTelemetryResult(err),

--- a/src/ssmDocument/commands/createDocumentFromTemplate.ts
+++ b/src/ssmDocument/commands/createDocumentFromTemplate.ts
@@ -10,10 +10,11 @@ import * as path from 'path'
 import * as vscode from 'vscode'
 import * as YAML from 'yaml'
 import { getLogger, Logger } from '../../shared/logger'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import * as picker from '../../shared/ui/picker'
 import { promptUserForDocumentFormat } from '../util/util'
 import { readFileAsString } from '../../shared/filesystemUtilities'
+import { Result, DocumentFormat } from '../../shared/telemetry/telemetry'
+import { telemetry } from '../../shared/telemetry/spans'
 
 export interface SsmDocumentTemplateQuickPickItem {
     label: string
@@ -47,8 +48,8 @@ const SSMDOCUMENT_TEMPLATES: SsmDocumentTemplateQuickPickItem[] = [
 ]
 
 export async function createSsmDocumentFromTemplate(extensionContext: vscode.ExtensionContext): Promise<void> {
-    let result: telemetry.Result = 'Succeeded'
-    let format: telemetry.DocumentFormat | undefined = undefined
+    let result: Result = 'Succeeded'
+    let format: DocumentFormat | undefined = undefined
     let templateName: string | undefined = undefined
     const logger: Logger = getLogger()
 
@@ -83,7 +84,7 @@ export async function createSsmDocumentFromTemplate(extensionContext: vscode.Ext
                 step: 2,
                 totalSteps: 2,
             })
-            format = selectedDocumentFormat ? (selectedDocumentFormat as telemetry.DocumentFormat) : format
+            format = selectedDocumentFormat ? (selectedDocumentFormat as DocumentFormat) : format
             const textDocument: vscode.TextDocument | undefined = await openTextDocumentFromSelection(
                 selection,
                 extensionContext.extensionPath,
@@ -105,7 +106,7 @@ export async function createSsmDocumentFromTemplate(extensionContext: vscode.Ext
             )
         )
     } finally {
-        telemetry.recordSsmCreateDocument({
+        telemetry.ssm_createDocument.emit({
             result: result,
             documentFormat: format,
             starterTemplate: templateName,

--- a/src/ssmDocument/commands/deleteDocument.ts
+++ b/src/ssmDocument/commands/deleteDocument.ts
@@ -12,10 +12,11 @@ import { DocumentItemNodeWriteable } from '../explorer/documentItemNodeWriteable
 import { RegistryItemNode } from '../explorer/registryItemNode'
 import { showConfirmationMessage } from '../util/util'
 import * as localizedText from '../../shared/localizedText'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import { Window } from '../../shared/vscode/window'
 import { Commands } from '../../shared/vscode/commands'
 import { showViewLogsMessage } from '../../shared/utilities/messages'
+import { telemetry } from '../../shared/telemetry/spans'
+import { Result } from '../../shared/telemetry/telemetry'
 
 export async function deleteDocument(
     node: DocumentItemNodeWriteable,
@@ -24,7 +25,7 @@ export async function deleteDocument(
 ) {
     const logger: Logger = getLogger()
 
-    let result: telemetry.Result = 'Succeeded'
+    let result: Result = 'Succeeded'
     const isConfirmed = await showConfirmationMessage(
         {
             prompt: localize(
@@ -39,7 +40,7 @@ export async function deleteDocument(
     )
     if (!isConfirmed) {
         logger.info('DeleteDocument cancelled')
-        telemetry.recordSsmDeleteDocument({ result: 'Cancelled' })
+        telemetry.ssm_deleteDocument.emit({ result: 'Cancelled' })
         return
     }
 
@@ -78,7 +79,7 @@ export async function deleteDocument(
             vscode.window
         )
     } finally {
-        telemetry.recordSsmDeleteDocument({ result: result })
+        telemetry.ssm_deleteDocument.emit({ result: result })
     }
 }
 

--- a/src/ssmDocument/commands/openDocumentItem.ts
+++ b/src/ssmDocument/commands/openDocumentItem.ts
@@ -11,14 +11,15 @@ import * as vscode from 'vscode'
 import { DocumentItemNode } from '../explorer/documentItemNode'
 import { AwsContext } from '../../shared/awsContext'
 import { getLogger, Logger } from '../../shared/logger'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import * as picker from '../../shared/ui/picker'
 import { showViewLogsMessage } from '../../shared/utilities/messages'
+import { telemetry } from '../../shared/telemetry/spans'
+import { Result } from '../../shared/telemetry/telemetry'
 
 export async function openDocumentItem(node: DocumentItemNode, awsContext: AwsContext, format?: string) {
     const logger: Logger = getLogger()
 
-    let result: telemetry.Result = 'Succeeded'
+    let result: Result = 'Succeeded'
 
     let documentVersion: string | undefined = undefined
 
@@ -53,7 +54,7 @@ export async function openDocumentItem(node: DocumentItemNode, awsContext: AwsCo
             vscode.window
         )
     } finally {
-        telemetry.recordSsmOpenDocument({ result: result })
+        telemetry.ssm_openDocument.emit({ result: result })
     }
 }
 

--- a/src/ssmDocument/commands/publishDocument.ts
+++ b/src/ssmDocument/commands/publishDocument.ts
@@ -15,9 +15,10 @@ import * as localizedText from '../../shared/localizedText'
 import { getLogger, Logger } from '../../shared/logger'
 import { RegionProvider } from '../../shared/regions/regionProvider'
 import { PublishSSMDocumentWizard, PublishSSMDocumentWizardResponse } from '../wizards/publishDocumentWizard'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import { Window } from '../../shared/vscode/window'
 import { showConfirmationMessage } from '../util/util'
+import { telemetry } from '../../shared/telemetry/spans'
+import { Result, SsmOperation } from '../../shared/telemetry/telemetry'
 
 export async function publishSSMDocument(awsContext: AwsContext, regionProvider: RegionProvider): Promise<void> {
     const logger: Logger = getLogger()
@@ -66,8 +67,8 @@ export async function createDocument(
     textDocument: vscode.TextDocument,
     client: SsmDocumentClient = new DefaultSsmDocumentClient(wizardResponse.region)
 ) {
-    let result: telemetry.Result = 'Succeeded'
-    const ssmOperation = wizardResponse.action as telemetry.SsmOperation
+    let result: Result = 'Succeeded'
+    const ssmOperation = wizardResponse.action as SsmOperation
 
     const logger: Logger = getLogger()
     logger.info(`Creating Systems Manager Document '${wizardResponse.name}'`)
@@ -91,7 +92,7 @@ export async function createDocument(
             `Failed to create Systems Manager Document '${wizardResponse.name}'. \n${error.message}`
         )
     } finally {
-        telemetry.recordSsmPublishDocument({ result: result, ssmOperation: ssmOperation })
+        telemetry.ssm_publishDocument.emit({ result, ssmOperation })
     }
 }
 
@@ -101,8 +102,8 @@ export async function updateDocument(
     client: SsmDocumentClient = new DefaultSsmDocumentClient(wizardResponse.region),
     window = Window.vscode()
 ) {
-    let result: telemetry.Result = 'Succeeded'
-    const ssmOperation = wizardResponse.action as telemetry.SsmOperation
+    let result: Result = 'Succeeded'
+    const ssmOperation = wizardResponse.action as SsmOperation
 
     const logger: Logger = getLogger()
     logger.info(`Updating Systems Manager Document '${wizardResponse.name}'`)
@@ -163,6 +164,6 @@ export async function updateDocument(
             `Failed to update Systems Manager Document '${wizardResponse.name}'. \n${error.message}`
         )
     } finally {
-        telemetry.recordSsmPublishDocument({ result: result, ssmOperation: ssmOperation })
+        telemetry.ssm_publishDocument.emit({ result, ssmOperation })
     }
 }

--- a/src/ssmDocument/commands/updateDocumentVersion.ts
+++ b/src/ssmDocument/commands/updateDocumentVersion.ts
@@ -10,15 +10,16 @@ import { SSM } from 'aws-sdk'
 import * as vscode from 'vscode'
 import { AwsContext } from '../../shared/awsContext'
 import { getLogger, Logger } from '../../shared/logger'
-import * as telemetry from '../../shared/telemetry/telemetry'
 import * as picker from '../../shared/ui/picker'
 import { DocumentItemNodeWriteable } from '../explorer/documentItemNodeWriteable'
 import { showViewLogsMessage } from '../../shared/utilities/messages'
+import { telemetry } from '../../shared/telemetry/spans'
+import { Result } from '../../shared/telemetry/telemetry'
 
 export async function updateDocumentVersion(node: DocumentItemNodeWriteable, awsContext: AwsContext) {
     const logger: Logger = getLogger()
 
-    let result: telemetry.Result = 'Succeeded'
+    let result: Result = 'Succeeded'
 
     try {
         if (node.documentOwner === awsContext.getCredentialAccountId()) {
@@ -72,7 +73,7 @@ export async function updateDocumentVersion(node: DocumentItemNodeWriteable, aws
         )
         logger.error('Error on updating document version: %0', error)
     } finally {
-        telemetry.recordSsmUpdateDocumentVersion({ result: result })
+        telemetry.ssm_updateDocumentVersion.emit({ result: result })
     }
 }
 

--- a/src/stepFunctions/activation.ts
+++ b/src/stepFunctions/activation.ts
@@ -11,7 +11,6 @@ const localize = nls.loadMessageBundle()
 import { join } from 'path'
 import * as vscode from 'vscode'
 import { AwsContext } from '../shared/awsContext'
-import * as telemetry from '../shared/telemetry/telemetry'
 import { activate as activateASL } from './asl/client'
 import { createStateMachineFromTemplate } from './commands/createStateMachineFromTemplate'
 import { publishStateMachine } from './commands/publishStateMachine'
@@ -22,6 +21,7 @@ import { ASL_FORMATS, YAML_ASL, JSON_ASL } from './constants/aslFormats'
 import { AslVisualizationCDKManager } from './commands/visualizeStateMachine/aslVisualizationCDKManager'
 import { renderCdkStateMachineGraph } from './commands/visualizeStateMachine/renderStateMachineGraphCDK'
 import { ToolkitError } from '../shared/errors'
+import { telemetry } from '../shared/telemetry/spans'
 
 /**
  * Activate Step Functions related functionality for the extension.
@@ -58,7 +58,7 @@ export const previewStateMachineCommand = Commands.declare(
             return await manager.visualizeStateMachine(globalState, input)
         } finally {
             // TODO: Consider making the metric reflect the success/failure of the above call
-            telemetry.recordStepfunctionsPreviewstatemachine()
+            telemetry.stepfunctions_previewstatemachine.emit()
         }
     }
 )
@@ -78,7 +78,7 @@ async function registerStepFunctionCommands(
             try {
                 await createStateMachineFromTemplate(extensionContext)
             } finally {
-                telemetry.recordStepfunctionsCreateStateMachineFromTemplate()
+                telemetry.stepfunctions_createStateMachineFromTemplate.emit()
             }
         }),
         Commands.register('aws.stepfunctions.publishStateMachine', async (node?: any) => {

--- a/src/stepFunctions/commands/downloadStateMachineDefinition.ts
+++ b/src/stepFunctions/commands/downloadStateMachineDefinition.ts
@@ -14,9 +14,10 @@ import * as vscode from 'vscode'
 import { DefaultStepFunctionsClient, StepFunctionsClient } from '../../shared/clients/stepFunctionsClient'
 
 import { getLogger, Logger } from '../../shared/logger'
-import { recordStepfunctionsDownloadStateMachineDefinition, Result } from '../../shared/telemetry/telemetry'
+import { Result } from '../../shared/telemetry/telemetry'
 import { StateMachineNode } from '../explorer/stepFunctionsNodes'
 import { previewStateMachineCommand } from '../activation'
+import { telemetry } from '../../shared/telemetry/spans'
 
 export async function downloadStateMachineDefinition(params: {
     outputChannel: vscode.OutputChannel
@@ -70,6 +71,6 @@ export async function downloadStateMachineDefinition(params: {
         params.outputChannel.appendLine(error.message)
         params.outputChannel.appendLine('')
     } finally {
-        recordStepfunctionsDownloadStateMachineDefinition({ result: downloadResult })
+        telemetry.stepfunctions_downloadStateMachineDefinition.emit({ result: downloadResult })
     }
 }

--- a/src/stepFunctions/vue/executeStateMachine/executeStateMachine.ts
+++ b/src/stepFunctions/vue/executeStateMachine/executeStateMachine.ts
@@ -9,15 +9,12 @@ const localize = nls.loadMessageBundle()
 import { DefaultStepFunctionsClient } from '../../../shared/clients/stepFunctionsClient'
 
 import { getLogger } from '../../../shared/logger'
-import {
-    recordStepfunctionsExecuteStateMachine,
-    recordStepfunctionsExecuteStateMachineView,
-    Result,
-} from '../../../shared/telemetry/telemetry'
+import { Result } from '../../../shared/telemetry/telemetry'
 import { StateMachineNode } from '../../explorer/stepFunctionsNodes'
 import { ExtContext } from '../../../shared/extensions'
 import { VueWebview } from '../../../webviews/main'
 import * as vscode from 'vscode'
+import { telemetry } from '../../../shared/telemetry/spans'
 
 interface StateMachine {
     arn: string
@@ -74,7 +71,7 @@ export class ExecuteStateMachineWebview extends VueWebview {
             )
             this.channel.appendLine('')
         } finally {
-            recordStepfunctionsExecuteStateMachine({ result: executeResult })
+            telemetry.stepfunctions_executeStateMachine.emit({ result: executeResult })
         }
     }
 }
@@ -92,5 +89,5 @@ export async function executeStateMachine(context: ExtContext, node: StateMachin
         title: localize('AWS.executeStateMachine.title', 'Start Execution'),
         cssFiles: ['executeStateMachine.css'],
     })
-    recordStepfunctionsExecuteStateMachineView()
+    telemetry.stepfunctions_executeStateMachineView.emit()
 }

--- a/src/test/lambda/commands/createNewSamApp.test.ts
+++ b/src/test/lambda/commands/createNewSamApp.test.ts
@@ -28,6 +28,7 @@ import {
 import { normalize } from '../../../shared/utilities/pathUtils'
 import { getIdeProperties, isCloud9 } from '../../../shared/extensionUtilities'
 import globals from '../../../shared/extensionGlobals'
+import { Runtime } from '../../../shared/telemetry/telemetry'
 
 const TEMPLATE_YAML = 'template.yaml'
 
@@ -148,7 +149,7 @@ describe('createNewSamApp', function () {
                 fakeContext,
                 fakeWorkspaceFolder,
                 tempTemplate,
-                'someruntime',
+                'someruntime' as Runtime,
                 instance(mockLaunchConfiguration)
             )) as AwsSamDebuggerConfiguration[]
 

--- a/src/test/shared/telemetry/spans.test.ts
+++ b/src/test/shared/telemetry/spans.test.ts
@@ -1,0 +1,111 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { TelemetryTracer } from '../../../shared/telemetry/spans'
+import { MetricName } from '../../../shared/telemetry/telemetry'
+import { assertTelemetryCurried } from '../../testUtil'
+
+describe('TelemetryTracer', function () {
+    const metricName = 'test_metric' as MetricName
+    const assertTelemetry = assertTelemetryCurried(metricName)
+
+    describe('metrics', function () {
+        it('creates a span when recording against a metric', function () {
+            const tracer = new TelemetryTracer()
+            tracer.vscode_executeCommand.record({ command: 'foo', debounceCount: 1 })
+            tracer.spans[0]?.emit()
+
+            assertTelemetryCurried('vscode_executeCommand')({ command: 'foo', debounceCount: 1 })
+        })
+    })
+
+    describe('run', function () {
+        it('returns the result of the function', function () {
+            const tracer = new TelemetryTracer()
+            const result = tracer.run(metricName, () => 'foo')
+
+            assert.strictEqual(result, 'foo')
+        })
+
+        it('sets the active span', function () {
+            const tracer = new TelemetryTracer()
+            const checkSpan = () => tracer.run(metricName, span => assert.strictEqual(tracer.activeSpan, span))
+
+            assert.doesNotThrow(checkSpan)
+        })
+
+        it('uses a span over a telemetry metric', function () {
+            const tracer = new TelemetryTracer()
+            tracer.run(metricName, span => span.record({ source: 'bar' }))
+
+            assertTelemetry({ result: 'Succeeded', source: 'bar' })
+        })
+
+        it('can record metadata in nested spans', function () {
+            const nestedName = 'nested_metric' as MetricName
+            const tracer = new TelemetryTracer()
+
+            tracer.run(metricName, span1 => {
+                span1.record({ source: 'bar' })
+
+                tracer.run(nestedName, span2 => {
+                    span1.record({ attempts: 1 })
+                    span2.record({ source: 'foo' })
+                })
+            })
+
+            assertTelemetry({ result: 'Succeeded', source: 'bar', attempts: 1 })
+            assertTelemetryCurried(nestedName)({ result: 'Succeeded', source: 'foo' })
+        })
+
+        it('removes spans when exiting an execution context', function () {
+            const nestedName = 'nested_metric' as MetricName
+            const tracer = new TelemetryTracer()
+
+            tracer.run(metricName, () => {
+                tracer.run(nestedName, () => {
+                    assert.strictEqual(tracer.spans.length, 2)
+                })
+
+                assert.strictEqual(tracer.spans.length, 1)
+            })
+        })
+
+        it('adds spans during a nested execution', function () {
+            const nestedName = 'nested_metric' as MetricName
+            const tracer = new TelemetryTracer()
+
+            tracer.run(metricName, () => {
+                tracer.run(nestedName, () => {
+                    assert.strictEqual(tracer.spans.length, 2)
+                    tracer.apigateway_copyUrl.record({})
+                    assert.strictEqual(tracer.spans.length, 3)
+                })
+
+                assert.strictEqual(tracer.spans.length, 1)
+            })
+        })
+
+        it('closes spans after exiting nested executions', function () {
+            const nestedName = 'nested_metric' as MetricName
+            const tracer = new TelemetryTracer()
+
+            tracer.run(metricName, () => {
+                tracer.apigateway_copyUrl.record({})
+
+                tracer.run(nestedName, () => {
+                    assert.strictEqual(tracer.spans.length, 3)
+                    tracer.apigateway_copyUrl.record({})
+                    assert.strictEqual(tracer.spans.length, 3)
+                })
+
+                assert.strictEqual(tracer.spans.length, 2)
+            })
+
+            assert.strictEqual(tracer.spans.length, 0)
+        })
+    })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
         "noUnusedLocals": true,
         "lib": ["dom", "es6", "esnext.asynciterable"],
         "skipLibCheck": true,
-        "jsx": "preserve"
+        "jsx": "preserve",
+        "experimentalDecorators": true
     },
     "exclude": ["node_modules", ".vscode-test", "src/testFixtures", "dist"]
 }


### PR DESCRIPTION
## Problem
Large amounts of code duplication for tracking `result`/`duration` with telemetry.

## Solution
Add execution spans that can instrument arbitrary functions. 

This PR is dependent on https://github.com/aws/aws-toolkit-common/pull/354

### TODO
* More tests
* Documentation/examples for contributors
* Rearrange things
* Remove decorator?


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
