### PR TITLE
fix(codewhisperer): update code coverage tracker to keep tracker of removed characters

### DIFF
--- a/src/codewhisperer/commands/onAcceptance.ts
+++ b/src/codewhisperer/commands/onAcceptance.ts
@@ -94,8 +94,11 @@ export async function onAcceptance(acceptanceEntry: OnRecommendationAcceptanceEn
             completionType: acceptanceEntry.completionType,
             language: languageContext.language,
         })
-        CodeWhispererCodeCoverageTracker.getTracker(languageContext.language, globalStorage).setAcceptedTokens(
-            acceptanceEntry.recommendation
+        const codeRangeAfterFormat = new vscode.Range(start, acceptanceEntry.editor.selection.active)
+        CodeWhispererCodeCoverageTracker.getTracker(languageContext.language, globalStorage)?.countAcceptedTokens(
+            codeRangeAfterFormat,
+            acceptanceEntry.editor.document.getText(codeRangeAfterFormat),
+            acceptanceEntry.editor.document.fileName
         )
     }
 

--- a/src/codewhisperer/service/keyStrokeHandler.ts
+++ b/src/codewhisperer/service/keyStrokeHandler.ts
@@ -9,11 +9,8 @@ import { DefaultCodeWhispererClient } from '../client/codewhisperer'
 import * as EditorContext from '../util/editorContext'
 import { CodeWhispererConstants } from '../models/constants'
 import { vsCodeState, ConfigurationEntry } from '../models/model'
-import { runtimeLanguageContext } from '../util/runtimeLanguageContext'
 import { getLogger } from '../../shared/logger'
 import { InlineCompletion } from './inlineCompletion'
-import { CodeWhispererCodeCoverageTracker } from '../tracker/codewhispererCodeCoverageTracker'
-import globals from '../../shared/extensionGlobals'
 import { isCloud9 } from '../../shared/extensionUtilities'
 import { RecommendationHandler } from './recommendationHandler'
 
@@ -50,12 +47,6 @@ export class KeyStrokeHandler {
         config: ConfigurationEntry
     ): Promise<void> {
         try {
-            const content = event.contentChanges[0].text
-            const languageContext = runtimeLanguageContext.getLanguageContext(editor.document.languageId)
-            CodeWhispererCodeCoverageTracker.getTracker(
-                languageContext.language,
-                globals.context.globalState
-            ).setTotalTokens(content)
             const changedText = this.getChangedText(event, config.isAutomatedTriggerEnabled, editor)
             if (changedText === '') {
                 return

--- a/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
+++ b/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
@@ -103,37 +103,36 @@ export class CodeWhispererCodeCoverageTracker {
     }
 
     private tryStartTimer() {
-        if (this._timer === undefined) {
-            const currentDate = new globals.clock.Date()
-            this._startTime = currentDate.getTime()
-            this._timer = setTimeout(() => {
-                try {
-                    const currentTime = new globals.clock.Date().getTime()
-                    const delay: number = CodeWhispererConstants.defaultCheckPeriodMillis
-                    const diffTime: number = this._startTime + delay
-                    if (diffTime <= currentTime) {
-                        let totalTokens = 0
-                        for (const filename in this._totalTokens) {
-                            totalTokens += this._totalTokens[filename]
-                        }
-                        if (totalTokens > 0) {
-                            this.flush()
-                        } else {
-                            getLogger().debug(
-                                `CodeWhispererCodeCoverageTracker: skipped telemetry due to empty tokens array`
-                            )
-                        }
+        if (this._timer !== undefined) return
+        const currentDate = new globals.clock.Date()
+        this._startTime = currentDate.getTime()
+        this._timer = setTimeout(() => {
+            try {
+                const currentTime = new globals.clock.Date().getTime()
+                const delay: number = CodeWhispererConstants.defaultCheckPeriodMillis
+                const diffTime: number = this._startTime + delay
+                if (diffTime <= currentTime) {
+                    let totalTokens = 0
+                    for (const filename in this._totalTokens) {
+                        totalTokens += this._totalTokens[filename]
                     }
-                } catch (e) {
-                    getLogger().verbose(`Exception Thrown from CodeWhispererCodeCoverageTracker: ${e}`)
-                } finally {
-                    this._totalTokens = {}
-                    this._acceptedTokens = {}
-                    this._startTime = 0
-                    this.closeTimer()
+                    if (totalTokens > 0) {
+                        this.flush()
+                    } else {
+                        getLogger().debug(
+                            `CodeWhispererCodeCoverageTracker: skipped telemetry due to empty tokens array`
+                        )
+                    }
                 }
-            }, CodeWhispererConstants.defaultCheckPeriodMillis)
-        }
+            } catch (e) {
+                getLogger().verbose(`Exception Thrown from CodeWhispererCodeCoverageTracker: ${e}`)
+            } finally {
+                this._totalTokens = {}
+                this._acceptedTokens = {}
+                this._startTime = 0
+                this.closeTimer()
+            }
+        }, CodeWhispererConstants.defaultCheckPeriodMillis)
     }
 
     private closeTimer() {

--- a/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
+++ b/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
@@ -8,120 +8,186 @@ import * as telemetry from '../../shared/telemetry/telemetry'
 import { getLogger } from '../../shared/logger/logger'
 import { CodeWhispererConstants } from '../models/constants'
 import globals from '../../shared/extensionGlobals'
+import { vsCodeState } from '../models/model'
+import { distance } from 'fastest-levenshtein'
+
+interface CodeWhispererToken {
+    range: vscode.Range
+    text: string
+    accepted: number
+}
+
 /**
- * This singleton class is mainly used for calculating the percentage of user modification.
- * The current calculation method is (Levenshtein edit distance / acceptedSuggestion.length).
+ * This singleton class is mainly used for calculating the code written by codeWhisperer
  */
 export class CodeWhispererCodeCoverageTracker {
-    private _acceptedTokens: string[]
-    private _totalTokens: string[]
+    private _acceptedTokens: { [key: string]: CodeWhispererToken[] }
+    private _totalTokens: { [key: string]: number }
     private _timer?: NodeJS.Timer
     private _startTime: number
     private _language: telemetry.CodewhispererLanguage
 
     private constructor(language: telemetry.CodewhispererLanguage, private readonly _globals: vscode.Memento) {
-        this._acceptedTokens = []
-        this._totalTokens = []
+        this._acceptedTokens = {}
+        this._totalTokens = {}
         this._startTime = 0
         this._language = language
     }
 
-    public setAcceptedTokens(recommendation: string) {
+    public get acceptedTokens(): { [key: string]: CodeWhispererToken[] } {
+        return this._acceptedTokens
+    }
+    public get totalTokens(): { [key: string]: number } {
+        return this._totalTokens
+    }
+
+    public countAcceptedTokens(range: vscode.Range, text: string, filename: string) {
         const terms = this._globals.get<boolean>(CodeWhispererConstants.termsAcceptedKey) || false
         if (!terms) return
-
-        // generate accepted recoomendation token and stored in collection
-        this._acceptedTokens.push(...recommendation)
-        this._totalTokens.push(...recommendation)
-    }
-
-    public get AcceptedTokensLength(): number {
-        return this._acceptedTokens.length
-    }
-
-    public setTotalTokens(content: string) {
-        if (this._totalTokens.length === 0 && this._timer == undefined) {
-            const currentDate = new globals.clock.Date()
-            this._startTime = currentDate.getTime()
-            this.startTimer()
-        }
-
-        if (content.length <= 2) {
-            this._totalTokens.push(content)
-        } else if (content.length > 2) {
-            this._totalTokens.push(...content)
-        }
+        // generate accepted recommendation token and stored in collection
+        this.addAcceptedTokens(filename, { range: range, text: text, accepted: text.length })
+        this.addTotalTokens(filename, text.length)
     }
 
     public flush() {
         const terms = this._globals.get<boolean>(CodeWhispererConstants.termsAcceptedKey) || false
         if (!terms) {
-            this._totalTokens = []
-            this._acceptedTokens = []
+            this._totalTokens = {}
+            this._acceptedTokens = {}
             this.closeTimer()
             return
         }
-        this.emitCodeWhispererCodeContribution()
+        try {
+            this.emitCodeWhispererCodeContribution()
+        } catch (error) {
+            getLogger().error(`Encountered ${error} when emitting code contribution metric`)
+        }
+    }
+
+    public updateAcceptedTokensCount(editor: vscode.TextEditor) {
+        const filename = editor.document.fileName
+        if (filename in this._acceptedTokens) {
+            for (let i = 0; i < this._acceptedTokens[filename].length; i++) {
+                const oldText = this._acceptedTokens[filename][i].text
+                const newText = editor.document.getText(this._acceptedTokens[filename][i].range)
+                this._acceptedTokens[filename][i].accepted =
+                    Math.max(oldText.length, newText.length) - distance(oldText, newText)
+            }
+        }
     }
 
     public emitCodeWhispererCodeContribution() {
-        const totalTokens = this._totalTokens
-        const acceptedTokens = this._acceptedTokens
-        const percentCount = ((acceptedTokens.length / totalTokens.length) * 100).toFixed(2)
+        let totalTokens = 0
+        for (const filename in this._totalTokens) {
+            totalTokens += this._totalTokens[filename]
+        }
+        if (vscode.window.activeTextEditor) {
+            this.updateAcceptedTokensCount(vscode.window.activeTextEditor)
+        }
+        let acceptedTokens = 0
+        for (const filename in this._acceptedTokens) {
+            this._acceptedTokens[filename].forEach(v => {
+                if (filename in this._totalTokens && this._totalTokens[filename] >= v.accepted) {
+                    acceptedTokens += v.accepted
+                }
+            })
+        }
+        const percentCount = ((acceptedTokens / totalTokens) * 100).toFixed(2)
         const percentage = Math.round(parseInt(percentCount))
         telemetry.recordCodewhispererCodePercentage({
-            codewhispererTotalTokens: totalTokens.length ? totalTokens.length : 0,
+            codewhispererTotalTokens: totalTokens,
             codewhispererLanguage: this._language,
-            codewhispererAcceptedTokens: acceptedTokens.length ? acceptedTokens.length : 0,
+            codewhispererAcceptedTokens: acceptedTokens,
             codewhispererPercentage: percentage ? percentage : 0,
         })
     }
 
-    public startTimer() {
-        if (this._timer !== undefined) {
-            return
-        }
-        this._timer = setTimeout(() => {
-            try {
-                const currentTime = new globals.clock.Date().getTime()
-                const delay: number = CodeWhispererConstants.defaultCheckPeriodMillis
-                const diffTime: number = this._startTime + delay
-                if (diffTime <= currentTime) {
-                    const totalTokens = this._totalTokens
-                    const acceptedTokens = this._acceptedTokens
-                    if (totalTokens.length > 0 && acceptedTokens.length > 0) {
-                        this.flush()
-                    } else {
-                        getLogger().debug(
-                            `CodeWhispererCodeCoverageTracker: skipped telemetry due to empty tokens array`
-                        )
+    private tryStartTimer() {
+        if (this._timer === undefined) {
+            const currentDate = new globals.clock.Date()
+            this._startTime = currentDate.getTime()
+            this._timer = setTimeout(() => {
+                try {
+                    const currentTime = new globals.clock.Date().getTime()
+                    const delay: number = CodeWhispererConstants.defaultCheckPeriodMillis
+                    const diffTime: number = this._startTime + delay
+                    if (diffTime <= currentTime) {
+                        let totalTokens = 0
+                        for (const filename in this._totalTokens) {
+                            totalTokens += this._totalTokens[filename]
+                        }
+                        if (totalTokens > 0) {
+                            this.flush()
+                        } else {
+                            getLogger().debug(
+                                `CodeWhispererCodeCoverageTracker: skipped telemetry due to empty tokens array`
+                            )
+                        }
                     }
+                } catch (e) {
+                    getLogger().verbose(`Exception Thrown from CodeWhispererCodeCoverageTracker: ${e}`)
+                } finally {
+                    this._totalTokens = {}
+                    this._acceptedTokens = {}
+                    this._startTime = 0
+                    this.closeTimer()
                 }
-            } catch (e) {
-                getLogger().verbose(`Exception Thrown from CodeWhispererCodeCoverageTracker: ${e}`)
-            } finally {
-                this._totalTokens = []
-                this._acceptedTokens = []
-                this._startTime = 0
-                this.closeTimer()
-            }
-        }, CodeWhispererConstants.defaultCheckPeriodMillis)
+            }, CodeWhispererConstants.defaultCheckPeriodMillis)
+        }
     }
 
-    public closeTimer() {
+    private closeTimer() {
         if (this._timer !== undefined) {
             clearTimeout(this._timer)
             this._timer = undefined
         }
     }
 
-    public static readonly instances = new Map<telemetry.CodewhispererLanguage, CodeWhispererCodeCoverageTracker>()
-    public static getTracker(
-        language: telemetry.CodewhispererLanguage = 'plaintext',
-        memento: vscode.Memento
-    ): CodeWhispererCodeCoverageTracker {
-        const instance = this.instances.get(language) ?? new this(language, memento)
-        this.instances.set(language, instance)
-        return instance
+    public addAcceptedTokens(filename: string, token: CodeWhispererToken) {
+        if (!(filename in this._acceptedTokens)) {
+            this._acceptedTokens[filename] = []
+        }
+        this._acceptedTokens[filename].push(token)
+    }
+
+    public addTotalTokens(filename: string, count: number) {
+        if (!(filename in this._totalTokens)) {
+            this._totalTokens[filename] = 0
+        }
+        this._totalTokens[filename] += count
+        if (this._totalTokens[filename] < 0) {
+            this._totalTokens[filename] = 0
+        }
+    }
+
+    public countTotalTokens(e: vscode.TextDocumentChangeEvent) {
+        // ignore no contentChanges. ignore contentChanges from other plugins (formatters)
+        // only include contentChanges from user action
+        if (
+            !CodeWhispererConstants.supportedLanguages.includes(e.document.languageId) ||
+            vsCodeState.isCodeWhispererEditing ||
+            e.contentChanges.length !== 1
+        )
+            return
+        const content = e.contentChanges[0]
+        // do not count user tokens if user copies large chunk of code
+        if (content.text.length > 20) return
+        this.tryStartTimer()
+        if (content.text.length === 0) {
+            this.addTotalTokens(e.document.fileName, -content.rangeLength)
+        } else {
+            this.addTotalTokens(e.document.fileName, content.text.length)
+        }
+    }
+
+    public static readonly instances = new Map<string, CodeWhispererCodeCoverageTracker>()
+    public static getTracker(language: string, memento: vscode.Memento): CodeWhispererCodeCoverageTracker | undefined {
+        if (CodeWhispererConstants.supportedLanguages.includes(language)) {
+            const instance =
+                this.instances.get(language) ?? new this(language as telemetry.CodewhispererLanguage, memento)
+            this.instances.set(language, instance)
+            return instance
+        }
+        return undefined
     }
 }

--- a/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
+++ b/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
@@ -7,28 +7,157 @@ import * as assert from 'assert'
 import * as sinon from 'sinon'
 import * as vscode from 'vscode'
 import { CodeWhispererCodeCoverageTracker } from '../../../codewhisperer/tracker/codewhispererCodeCoverageTracker'
-import { resetCodeWhispererGlobalVariables } from '../testUtil'
+import { createMockDocument, createMockTextEditor, resetCodeWhispererGlobalVariables } from '../testUtil'
 import globals from '../../../shared/extensionGlobals'
 import { assertTelemetryCurried } from '../../testUtil'
+import { vsCodeState } from '../../../codewhisperer/models/model'
 
 describe('codewhispererCodecoverageTracker', function () {
-    const language = 'plaintext'
+    const language = 'python'
     const mockGlobalStorage: vscode.Memento = {
         update: sinon.spy(),
         get: sinon.stub().returns(true),
     }
 
-    describe('setAcceptedTokens', function () {
+    describe('updateAcceptedTokensCount', function () {
         beforeEach(function () {
             resetCodeWhispererGlobalVariables()
             CodeWhispererCodeCoverageTracker.instances.delete(language)
         })
 
-        it('Should set Accepted Tokens when CodeWhisperer terms accepted', function () {
-            const suggestion = "print('Hello World!')"
+        it('Should compute edit distance to update the accepted tokens', function () {
+            const editor = createMockTextEditor('import math\ndef addTwoNumbers(a, b):\n')
             const tracker = CodeWhispererCodeCoverageTracker.getTracker(language, mockGlobalStorage)
-            tracker.setAcceptedTokens(suggestion)
-            assert.strictEqual(tracker.AcceptedTokensLength, 21)
+            tracker?.addAcceptedTokens(editor.document.fileName, {
+                range: new vscode.Range(0, 0, 0, 39),
+                text: `import math\ndef two_sum(nums, target):\n`,
+                accepted: 39,
+            })
+            tracker?.addTotalTokens(editor.document.fileName, 100)
+            tracker?.updateAcceptedTokensCount(editor)
+            assert.strictEqual(tracker?.acceptedTokens[editor.document.fileName][0].accepted, 12)
+        })
+        afterEach(function () {
+            sinon.restore()
+        })
+    })
+
+    describe('countAcceptedTokens', function () {
+        beforeEach(function () {
+            resetCodeWhispererGlobalVariables()
+            CodeWhispererCodeCoverageTracker.instances.delete(language)
+        })
+        afterEach(function () {
+            sinon.restore()
+        })
+        it('Should skip when codeWhisperer ToS is not accepted', function () {
+            const tracker = CodeWhispererCodeCoverageTracker.getTracker(language, {
+                update: sinon.spy(),
+                get: sinon.stub().returns(false),
+            })
+            tracker?.countAcceptedTokens(new vscode.Range(0, 0, 0, 1), 'a', 'test.py')
+            const spy = sinon.spy(CodeWhispererCodeCoverageTracker.prototype, 'addAcceptedTokens')
+            assert.ok(!spy.called)
+        })
+
+        it('Should increase both AcceptedTokens and TotalTokens', function () {
+            const tracker = CodeWhispererCodeCoverageTracker.getTracker(language, mockGlobalStorage)
+            if (tracker) {
+                tracker.countAcceptedTokens(new vscode.Range(0, 0, 0, 1), 'a', 'test.py')
+                assert.deepStrictEqual(tracker.acceptedTokens['test.py'][0], {
+                    range: new vscode.Range(0, 0, 0, 1),
+                    text: 'a',
+                    accepted: 1,
+                })
+                assert.strictEqual(tracker.totalTokens['test.py'], 1)
+            }
+        })
+    })
+
+    describe('countTotalTokens', function () {
+        beforeEach(function () {
+            resetCodeWhispererGlobalVariables()
+            CodeWhispererCodeCoverageTracker.instances.delete(language)
+        })
+        afterEach(function () {
+            sinon.restore()
+        })
+        it('Should skip when user copy large files', function () {
+            const tracker = CodeWhispererCodeCoverageTracker.getTracker(language, mockGlobalStorage)
+            tracker?.countTotalTokens({
+                document: createMockDocument(),
+                contentChanges: [
+                    {
+                        range: new vscode.Range(0, 0, 0, 30),
+                        rangeOffset: 0,
+                        rangeLength: 30,
+                        text: 'def twoSum(nums, target):\nfor',
+                    },
+                ],
+            })
+            const startedSpy = sinon.spy(CodeWhispererCodeCoverageTracker.prototype, 'addTotalTokens')
+            assert.ok(!startedSpy.called)
+        })
+
+        it('Should skip when CodeWhisperer is editing', function () {
+            const tracker = CodeWhispererCodeCoverageTracker.getTracker(language, mockGlobalStorage)
+            vsCodeState.isCodeWhispererEditing = true
+            tracker?.countTotalTokens({
+                document: createMockDocument(),
+                contentChanges: [
+                    {
+                        range: new vscode.Range(0, 0, 0, 30),
+                        rangeOffset: 0,
+                        rangeLength: 30,
+                        text: 'def twoSum(nums, target):\nfor',
+                    },
+                ],
+            })
+            const startedSpy = sinon.spy(CodeWhispererCodeCoverageTracker.prototype, 'addTotalTokens')
+            assert.ok(!startedSpy.called)
+        })
+
+        it('Should reduce tokens when delete', function () {
+            const tracker = CodeWhispererCodeCoverageTracker.getTracker(language, mockGlobalStorage)
+            tracker?.countTotalTokens({
+                document: createMockDocument(),
+                contentChanges: [
+                    {
+                        range: new vscode.Range(0, 0, 0, 3),
+                        rangeOffset: 0,
+                        rangeLength: 0,
+                        text: 'aaa',
+                    },
+                ],
+            })
+            tracker?.countTotalTokens({
+                document: createMockDocument(),
+                contentChanges: [
+                    {
+                        range: new vscode.Range(0, 0, 0, 1),
+                        rangeOffset: 1,
+                        rangeLength: 1,
+                        text: '',
+                    },
+                ],
+            })
+            assert.strictEqual(tracker?.totalTokens['/test.py'], 2)
+        })
+
+        it('Should add tokens when type', function () {
+            const tracker = CodeWhispererCodeCoverageTracker.getTracker(language, mockGlobalStorage)
+            tracker?.countTotalTokens({
+                document: createMockDocument(),
+                contentChanges: [
+                    {
+                        range: new vscode.Range(0, 0, 0, 1),
+                        rangeOffset: 0,
+                        rangeLength: 0,
+                        text: 'a',
+                    },
+                ],
+            })
+            assert.strictEqual(tracker?.totalTokens['/test.py'], 1)
         })
     })
 
@@ -41,14 +170,14 @@ describe('codewhispererCodecoverageTracker', function () {
             resetCodeWhispererGlobalVariables()
             CodeWhispererCodeCoverageTracker.instances.delete(language)
         })
-
+        afterEach(function () {
+            sinon.restore()
+        })
         it('Should not send codecoverage telemetry if CodeWhisperer is disabled', function () {
-            const suggestion1 = "print('Hello World!)"
-            const suggestion2 = "print('Hello World!)"
             const tracker = CodeWhispererCodeCoverageTracker.getTracker(language, mockGlobalStorage1)
-            tracker.setTotalTokens(suggestion1)
-            tracker.setAcceptedTokens(suggestion2)
-            tracker.flush()
+            tracker?.addAcceptedTokens(`test.py`, { range: new vscode.Range(0, 0, 0, 7), text: `print()`, accepted: 7 })
+            tracker?.addTotalTokens(`test.py`, 100)
+            tracker?.flush()
             const data = globals.telemetry.logger.query({
                 metricName: 'codewhisperer_codePercentage',
                 filters: ['awsAccount'],
@@ -62,18 +191,20 @@ describe('codewhispererCodecoverageTracker', function () {
             resetCodeWhispererGlobalVariables()
             CodeWhispererCodeCoverageTracker.instances.delete(language)
         })
-
+        afterEach(function () {
+            sinon.restore()
+        })
         it(' emits codecoverage telemetry ', function () {
-            const sample = "print('Hello World!)"
             const tracker = CodeWhispererCodeCoverageTracker.getTracker(language, mockGlobalStorage)
             const assertTelemetry = assertTelemetryCurried('codewhisperer_codePercentage')
-            tracker.setAcceptedTokens(sample)
-            tracker.emitCodeWhispererCodeContribution()
+            tracker?.addAcceptedTokens(`test.py`, { range: new vscode.Range(0, 0, 0, 7), text: `print()`, accepted: 7 })
+            tracker?.addTotalTokens(`test.py`, 100)
+            tracker?.emitCodeWhispererCodeContribution()
             assertTelemetry({
-                codewhispererTotalTokens: 20,
+                codewhispererTotalTokens: 100,
                 codewhispererLanguage: language,
-                codewhispererAcceptedTokens: 20,
-                codewhispererPercentage: 100,
+                codewhispererAcceptedTokens: 7,
+                codewhispererPercentage: 7,
             })
         })
     })

--- a/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
+++ b/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
@@ -26,16 +26,16 @@ describe('codewhispererCodecoverageTracker', function () {
         })
 
         it('Should compute edit distance to update the accepted tokens', function () {
-            const editor = createMockTextEditor('import math\ndef addTwoNumbers(a, b):\n')
+            const editor = createMockTextEditor('def addTwoNumbers(a, b):\n')
             const tracker = CodeWhispererCodeCoverageTracker.getTracker(language, mockGlobalStorage)
             tracker?.addAcceptedTokens(editor.document.fileName, {
-                range: new vscode.Range(0, 0, 0, 37),
-                text: `import math\ndef two_sum(nums, target):\n`,
-                accepted: 37,
+                range: new vscode.Range(0, 0, 0, 25),
+                text: `def addTwoNumbers(x, y):\n`,
+                accepted: 25,
             })
             tracker?.addTotalTokens(editor.document.fileName, 100)
             tracker?.updateAcceptedTokensCount(editor)
-            assert.strictEqual(tracker?.acceptedTokens[editor.document.fileName][0].accepted, 12)
+            assert.strictEqual(tracker?.acceptedTokens[editor.document.fileName][0].accepted, 23)
         })
 
         afterEach(function () {

--- a/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
+++ b/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
@@ -119,8 +119,9 @@ describe('codewhispererCodecoverageTracker', function () {
 
         it('Should reduce tokens when delete', function () {
             const tracker = CodeWhispererCodeCoverageTracker.getTracker(language, mockGlobalStorage)
+            const doc = createMockDocument('import math', 'test.py', 'python')
             tracker?.countTotalTokens({
-                document: createMockDocument(),
+                document: doc,
                 contentChanges: [
                     {
                         range: new vscode.Range(0, 0, 0, 3),
@@ -131,7 +132,7 @@ describe('codewhispererCodecoverageTracker', function () {
                 ],
             })
             tracker?.countTotalTokens({
-                document: createMockDocument(),
+                document: doc,
                 contentChanges: [
                     {
                         range: new vscode.Range(0, 0, 0, 1),
@@ -141,13 +142,14 @@ describe('codewhispererCodecoverageTracker', function () {
                     },
                 ],
             })
-            assert.strictEqual(tracker?.totalTokens['/test.py'], 2)
+            assert.strictEqual(tracker?.totalTokens[doc.fileName], 2)
         })
 
         it('Should add tokens when type', function () {
             const tracker = CodeWhispererCodeCoverageTracker.getTracker(language, mockGlobalStorage)
+            const doc = createMockDocument('import math', 'test.py', 'python')
             tracker?.countTotalTokens({
-                document: createMockDocument(),
+                document: doc,
                 contentChanges: [
                     {
                         range: new vscode.Range(0, 0, 0, 1),
@@ -157,7 +159,7 @@ describe('codewhispererCodecoverageTracker', function () {
                     },
                 ],
             })
-            assert.strictEqual(tracker?.totalTokens['/test.py'], 1)
+            assert.strictEqual(tracker?.totalTokens[doc.fileName], 1)
         })
     })
 


### PR DESCRIPTION
## Problem
Current code percentage written metric in CodeCoverageTracker does not count tokens removed by user, which makes this metric inaccurate.

## Solution

Similar to what was implemented in AWS Toolkit for JetBrains by @Will-ShaoHua , we make best effort to:

1. Estimate total user token by counting user inputs and deletions
2. Estimate total accepted tokens from CodeWhisperer suggestion by counting unmodified suggestions

Total user token is updated when there is a TextDocumentChange Event,
1. If  the event is not from human input (i.e. from plugins, formatters), this event is ignored.
2. If the event is when user copy large chunk of code, this event is ignored.

We only count the user manual keyboard input, intelliSense code acceptance and small chunk code copy as inserted total user token. For deletion events, we take the range from them and reduce the total tokens until total tokens reaches 0.

Total accepted tokens is updated when user accept a code whisperer suggestion. At that time, the formatted suggestion is counted as accepted tokens. At the time of emitting telemetry data, a edit distance comparision will be done over the remaining code in accepted suggestion range and the accepted suggesetion code to estimate how many characters user has deleted in the accepted suggestion.  This edit distance update will also happen when user changes active editor ( go to another file in VS Code).


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
