### PR TITLE
feat(codewhisperer): Update security scan telemetry to track overall project size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
                 "yaml-cfn": "^0.3.1"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.64",
+                "@aws-toolkits/telemetry": "^1.0.67",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^8.1.0",
                 "@types/adm-zip": "^0.4.34",
@@ -2242,9 +2242,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.64",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.64.tgz",
-            "integrity": "sha512-CVfeeDT6W8kEtAMNABcIk45VA/nBjmHEygTwsFGMdOxWT2+8xaLUWl/jS6CYsFpePrix9imTX9qHMMJESD4EzQ==",
+            "version": "1.0.67",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.67.tgz",
+            "integrity": "sha512-Dzhdc+lds65VwvWyWTKfM+ffxHirtPvwUPbiabuAWaiynwhV2PaEPpgxtFi5UtDQ8qFh/BTh88FJUGGcX+2Tgw==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",
@@ -16055,9 +16055,9 @@
             }
         },
         "@aws-toolkits/telemetry": {
-            "version": "1.0.64",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.64.tgz",
-            "integrity": "sha512-CVfeeDT6W8kEtAMNABcIk45VA/nBjmHEygTwsFGMdOxWT2+8xaLUWl/jS6CYsFpePrix9imTX9qHMMJESD4EzQ==",
+            "version": "1.0.67",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.67.tgz",
+            "integrity": "sha512-Dzhdc+lds65VwvWyWTKfM+ffxHirtPvwUPbiabuAWaiynwhV2PaEPpgxtFi5UtDQ8qFh/BTh88FJUGGcX+2Tgw==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -3196,7 +3196,7 @@
         "report": "nyc report --reporter=html --reporter=json"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.64",
+        "@aws-toolkits/telemetry": "^1.0.67",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^8.1.0",
         "@types/adm-zip": "^0.4.34",

--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -127,6 +127,7 @@ export const CodeWhispererConstants = {
     codeScanZipExt: '.zip',
     contextTruncationTimeoutSeconds: 10,
     codeScanJobTimeoutSeconds: 50,
+    projectSizeCalculateTimeoutSeconds: 10,
     codeScanJobPollingIntervalSeconds: 5,
     artifactTypeSource: 'SourceCode',
     artifactTypeBuild: 'BuiltJars',

--- a/src/codewhisperer/models/model.ts
+++ b/src/codewhisperer/models/model.ts
@@ -83,6 +83,7 @@ export const codeScanState: CodeScanState = {
 export interface CodeScanTelemetryEntry {
     codewhispererCodeScanJobId?: string
     codewhispererLanguage: telemetry.CodewhispererLanguage
+    codewhispererCodeScanProjectBytes?: number
     codewhispererCodeScanSrcPayloadBytes: number
     codewhispererCodeScanBuildPayloadBytes?: number
     codewhispererCodeScanSrcZipFileBytes: number

--- a/src/codewhisperer/util/commonUtil.ts
+++ b/src/codewhisperer/util/commonUtil.ts
@@ -2,7 +2,6 @@
  * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
 export function getLocalDatetime() {
     const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
     return new Date().toLocaleString([], { timeZone: timezone })
@@ -26,4 +25,16 @@ export function isAwsError(error: any): boolean {
         typeof error.code === 'string' &&
         error.time instanceof Date
     )
+}
+
+export function getFileExt(languageId: string) {
+    switch (languageId) {
+        case 'java':
+            return '.java'
+        case 'python':
+            return '.py'
+        default:
+            break
+    }
+    return undefined
 }

--- a/src/shared/filesystemUtilities.ts
+++ b/src/shared/filesystemUtilities.ts
@@ -6,6 +6,7 @@
 import { access, mkdtemp, mkdirp, readFile, remove, existsSync, readdir, stat } from 'fs-extra'
 import * as crypto from 'crypto'
 import * as fs from 'fs'
+import * as fsExtra from 'fs-extra'
 import * as os from 'os'
 import * as path from 'path'
 import * as vscode from 'vscode'
@@ -19,6 +20,30 @@ export const tempDirPath = path.join(
     os.type() === 'Darwin' ? '/tmp' : os.tmpdir(),
     'aws-toolkit-vscode'
 )
+
+export async function getDirSize(
+    dirPath: string,
+    startTime: number,
+    duration: number,
+    fileExt: string
+): Promise<number> {
+    if (performance.now() - startTime > duration) {
+        getLogger().warn('getDirSize: exceeds time limit')
+        return 0
+    }
+    const files = await fsExtra.readdir(dirPath, { withFileTypes: true })
+    const fileSizes = files.map(async file => {
+        const filePath = path.join(dirPath, file.name)
+        if (file.isSymbolicLink()) return 0
+        if (file.isDirectory()) return getDirSize(filePath, startTime, duration, fileExt)
+        if (file.isFile() && file.name.endsWith(fileExt)) {
+            const { size } = await fsExtra.stat(filePath)
+            return size
+        }
+        return 0
+    })
+    return (await Promise.all(fileSizes)).reduce((accumulator, size) => accumulator + size, 0)
+}
 
 export function downloadsDir(): string {
     const downloadPath = path.join(os.homedir(), 'Downloads')


### PR DESCRIPTION
## Problem
- Update security scan telemetry to track overall project size

## Solution
- Add util method to get working directory size;
- Update security scan command to emit project size field telemetry;
- Verification is as follow images

Size from Finder view:
![Screen Shot 2022-08-23 at 5 04 07 PM](https://user-images.githubusercontent.com/90796612/186265704-9cff7429-0fda-4504-8079-10a277c56f7d.png)

Telemetry log indicates successfully emit essential field:
![Screen Shot 2022-08-23 at 5 03 55 PM](https://user-images.githubusercontent.com/90796612/186265706-f1bb2f4a-f893-4a1d-aff5-128646fb9d32.png)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
