### PR TITLE
feat(sam): improve run/debug error handling and telemetry

### DIFF
--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -8,7 +8,7 @@ import { Result } from './telemetry/telemetry'
 import { CancellationError } from './utilities/timeoutUtils'
 import { isNonNullable } from './utilities/tsUtils'
 
-interface ErrorInformation {
+export interface ErrorInformation {
     /**
      * Error names are optional, but if provided they should be generic yet self-explanatory.
      *

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -214,7 +214,7 @@ export class SamCliLocalInvokeInvocation {
         this.args.skipPullImage = !!this.args.skipPullImage
     }
 
-    public async execute(timeout?: Timeout): Promise<void> {
+    public async execute(timeout?: Timeout): Promise<ChildProcess> {
         await this.validate()
 
         const sam = await this.config.getOrDetectSamCli()
@@ -251,7 +251,7 @@ export class SamCliLocalInvokeInvocation {
         )
         invokeArgs.push(...(this.args.extraArgs ?? []))
 
-        await this.args.invoker.invoke({
+        return await this.args.invoker.invoke({
             options: {
                 env: {
                     ...process.env,

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -7,7 +7,6 @@ import * as semver from 'semver'
 import * as vscode from 'vscode'
 import * as fs from 'fs-extra'
 import * as nls from 'vscode-nls'
-import { Runtime } from 'aws-sdk/clients/lambda'
 import {
     getCodeRoot,
     getHandlerName,
@@ -17,6 +16,7 @@ import {
     GoDebugConfiguration,
     getTemplate,
     getArchitecture,
+    isImageLambdaConfig,
 } from '../../../lambda/local/debugConfiguration'
 import {
     Architecture,
@@ -53,10 +53,9 @@ import { makeInputTemplate, makeJsonFiles } from '../localLambdaRunner'
 import { SamLocalInvokeCommand } from '../cli/samCliLocalInvoke'
 import { getCredentialsFromStore } from '../../../credentials/credentialsStore'
 import { fromString } from '../../../credentials/providers/credentials'
-import { notifyUserInvalidCredentials } from '../../../credentials/credentialsUtilities'
 import { Credentials } from '@aws-sdk/types'
 import { CloudFormation } from '../../cloudformation/cloudformation'
-import { getSamCliVersion } from '../cli/samCliContext'
+import { getSamCliContext, getSamCliVersion } from '../cli/samCliContext'
 import {
     MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_IMAGE_SUPPORT,
     MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_GO_SUPPORT,
@@ -65,8 +64,52 @@ import { getIdeProperties, isCloud9 } from '../../extensionUtilities'
 import { resolve } from 'path'
 import globals from '../../extensionGlobals'
 import { LoginManager } from '../../../credentials/loginManager'
+import { Runtime, telemetry } from '../../telemetry/telemetry'
+import { ErrorInformation, isUserCancelledError, ToolkitError } from '../../errors'
+import { openLaunchJsonFile } from './commands/addSamDebugConfiguration'
+import { Logging } from '../../logger/commands'
+import { credentialHelpUrl } from '../../constants'
 
 const localize = nls.loadMessageBundle()
+
+interface NotificationButton<T = unknown> {
+    readonly label: string
+    readonly onClick: () => Promise<T> | T
+}
+
+class SamLaunchRequestError extends ToolkitError.named('SamLaunchRequestError') {
+    private readonly buttons: NotificationButton[]
+
+    public constructor(message: string, info?: ErrorInformation & { readonly extraButtons?: NotificationButton[] }) {
+        super(message, info)
+        this.buttons = info?.extraButtons ?? [
+            {
+                label: localize('AWS.generic.message.openConfig', 'Open Launch Config'),
+                onClick: openLaunchJsonFile,
+            },
+        ]
+    }
+
+    public async showNotification(): Promise<void> {
+        if (isUserCancelledError(this)) {
+            getLogger().verbose(`SAM run/debug: user cancelled`)
+            return
+        }
+
+        const logId = getLogger().error(this.trace)
+
+        const viewLogsButton = {
+            label: localize('AWS.generic.message.viewLogs', 'View Logs...'),
+            onClick: () => Logging.declared.viewLogsAtMessage.execute(logId),
+        }
+
+        const buttonsWithLogs = [viewLogsButton, ...this.buttons]
+
+        await vscode.window.showErrorMessage(this.message, ...buttonsWithLogs.map(b => b.label)).then(resp => {
+            return buttonsWithLogs.find(({ label }) => label === resp)?.onClick()
+        })
+    }
+}
 
 /**
  * SAM-specific launch attributes (which are not part of the DAP).
@@ -310,12 +353,31 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         folder: vscode.WorkspaceFolder | undefined,
         config: AwsSamDebuggerConfiguration,
         token?: vscode.CancellationToken
-    ): Promise<undefined> {
-        const resolvedConfig = await this.makeConfig(folder, config, token)
-        if (!resolvedConfig) {
-            return undefined
+    ): Promise<void> {
+        try {
+            if (config.invokeTarget.target === 'api') {
+                await telemetry.apigateway_invokeLocal.run(async span => {
+                    const resolved = await this.makeConfig(folder, config, token)
+                    span.record({ httpMethod: resolved.api?.httpMethod })
+
+                    return this.invokeConfig(resolved)
+                })
+            } else {
+                await telemetry.lambda_invokeLocal.run(async () => {
+                    const resolved = await this.makeConfig(folder, config, token)
+
+                    return this.invokeConfig(resolved)
+                })
+            }
+        } catch (err) {
+            if (err instanceof SamLaunchRequestError) {
+                err.showNotification()
+            } else if (err instanceof ToolkitError) {
+                new SamLaunchRequestError(err.message, { ...err }).showNotification()
+            } else {
+                SamLaunchRequestError.chain(err, 'Failed to run launch configuration').showNotification()
+            }
         }
-        await this.invokeConfig(resolvedConfig)
     }
 
     /**
@@ -332,22 +394,21 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         folder: vscode.WorkspaceFolder | undefined,
         config: AwsSamDebuggerConfiguration,
         token?: vscode.CancellationToken
-    ): Promise<SamLaunchRequestArgs | undefined> {
+    ): Promise<SamLaunchRequestArgs> {
         if (token?.isCancellationRequested) {
-            return undefined
+            throw new ToolkitError('Cancellation requested', { cancelled: true })
         }
+
         folder =
             folder ?? (vscode.workspace.workspaceFolders?.length ? vscode.workspace.workspaceFolders[0] : undefined)
         if (!folder) {
-            getLogger().error(`SAM debug: no workspace folder`)
-            vscode.window.showErrorMessage(
-                localize(
-                    'AWS.sam.debugger.noWorkspace',
-                    '{0} SAM debug: choose a workspace, then try again',
-                    getIdeProperties().company
-                )
+            const message = localize(
+                'AWS.sam.debugger.noWorkspace',
+                'Choose a workspace, then try again',
+                getIdeProperties().company
             )
-            return undefined
+
+            throw new SamLaunchRequestError(message, { code: 'NoWorkspaceFolder', extraButtons: [] })
         }
 
         // If "request" field is missing this means launch.json does not exist.
@@ -356,28 +417,24 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         const configValidator: AwsSamDebugConfigurationValidator = new DefaultAwsSamDebugConfigurationValidator(folder)
 
         if (!hasLaunchJson) {
-            vscode.window
-                .showErrorMessage(
-                    localize(
-                        'AWS.sam.debugger.noLaunchJson',
-                        '{0} SAM: To debug a Lambda locally, create a launch.json from the Run panel, then select a configuration.',
-                        getIdeProperties().company
-                    ),
-                    localize('AWS.gotoRunPanel', 'Run panel')
-                )
-                .then(async result => {
-                    if (!result) {
-                        return
-                    }
-                    await vscode.commands.executeCommand('workbench.view.debug')
-                })
-            return undefined
+            const message = localize(
+                'AWS.sam.debugger.noLaunchJson',
+                'To debug a Lambda locally, create a launch.json from the Run panel, then select a configuration.'
+            )
+
+            throw new SamLaunchRequestError(message, {
+                code: 'NoLaunchConfig',
+                extraButtons: [
+                    {
+                        label: localize('AWS.gotoRunPanel', 'Run panel'),
+                        onClick: () => vscode.commands.executeCommand('workbench.view.debug'),
+                    },
+                ],
+            })
         } else {
             const rv = configValidator.validate(config)
             if (!rv.isValid) {
-                getLogger().error(`SAM debug: invalid config: ${rv.message!}`)
-                vscode.window.showErrorMessage(rv.message!)
-                return undefined
+                throw new ToolkitError(`Invalid launch configuration: ${rv.message}`, { code: 'BadLaunchConfig' })
             } else if (rv.message) {
                 vscode.window.showInformationMessage(rv.message)
             }
@@ -433,27 +490,23 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         if (!isZip) {
             const samCliVersion = await getSamCliVersion(this.ctx.samCliContext())
             if (semver.lt(samCliVersion, MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_IMAGE_SUPPORT)) {
-                getLogger().error(`SAM debug: version (${samCliVersion}) too low for Image lambdas: ${config})`)
-                vscode.window.showErrorMessage(
-                    localize(
-                        'AWS.output.sam.no.image.support',
-                        'Support for Image-based Lambdas requires a minimum SAM CLI version of 1.13.0.'
-                    )
+                const message = localize(
+                    'AWS.output.sam.no.image.support',
+                    'Support for Image-based Lambdas requires a minimum SAM CLI version of 1.13.0.'
                 )
-                return undefined
+
+                throw new SamLaunchRequestError(message, { code: 'UnsupportedSamVersion', details: { samCliVersion } })
             }
         }
 
         if (!runtime) {
-            getLogger().error(`SAM debug: failed to launch config (missing runtime): ${config})`)
-            vscode.window.showErrorMessage(
-                localize(
-                    'AWS.sam.debugger.failedLaunch.missingRuntime',
-                    'Toolkit could not infer a runtime for config: {0}. Add a "lambda.runtime" field to your launch configuration.',
-                    config.name
-                )
+            const message = localize(
+                'AWS.sam.debugger.failedLaunch.missingRuntime',
+                'Toolkit could not infer a runtime for config: {0}. Add a "lambda.runtime" field to your launch configuration.',
+                config.name
             )
-            return undefined
+
+            throw new SamLaunchRequestError(message, { code: 'MissingRuntime' })
         }
 
         // SAM CLI versions before 1.18.1 do not work correctly for Go debugging.
@@ -494,11 +547,22 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
             if (fromStore) {
                 awsCredentials = fromStore
             } else {
-                getLogger().error(
-                    `SAM debug: invalid "aws.credentials" value in launch config: ${config.aws.credentials}`
-                )
-                notifyUserInvalidCredentials(config.aws.credentials)
-                return undefined
+                const credentialsId = config.aws.credentials
+                const getHelp = localize('AWS.generic.message.getHelp', 'Get Help...')
+                // TODO: getHelp page for Cloud9.
+                const extraButtons = isCloud9()
+                    ? []
+                    : [
+                          {
+                              label: getHelp,
+                              onClick: () => vscode.env.openExternal(vscode.Uri.parse(credentialHelpUrl)),
+                          },
+                      ]
+
+                throw new SamLaunchRequestError(`Invalid credentials found in launch configuration: ${credentialsId}`, {
+                    code: 'InvalidCredentials',
+                    extraButtons,
+                })
             }
         }
 
@@ -527,7 +591,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
             request: 'attach',
             codeRoot: codeRoot ?? '',
             workspaceFolder: folder,
-            runtime: runtime,
+            runtime: runtime as Runtime,
             runtimeFamily: runtimeFamily,
             handlerName: handlerName,
             documentUri: documentUri,
@@ -581,16 +645,13 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
                 break
             }
             default: {
-                getLogger().error(`SAM debug: unknown runtime: ${runtime})`)
-                vscode.window.showErrorMessage(
-                    localize(
-                        'AWS.sam.debugger.invalidRuntime',
-                        '{0} SAM debug: unknown runtime: {1}',
-                        getIdeProperties().company,
-                        runtime
-                    )
+                const message = localize(
+                    'AWS.sam.debugger.invalidRuntime',
+                    'Unknown or unsupported runtime: {0}',
+                    runtime
                 )
-                return undefined
+
+                throw new ToolkitError(message, { code: 'UnsupportedRuntime' })
             }
         }
         await makeJsonFiles(launchConfig)
@@ -618,6 +679,14 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
      * Performs the EXECUTE phase of SAM run/debug.
      */
     public async invokeConfig(config: SamLaunchRequestArgs): Promise<SamLaunchRequestArgs> {
+        telemetry.record({
+            debug: !config.noDebug,
+            runtime: config.runtime as Runtime,
+            lambdaArchitecture: config.architecture,
+            lambdaPackageType: isImageLambdaConfig(config) ? 'Image' : 'Zip',
+            version: await getSamCliVersion(getSamCliContext()),
+        })
+
         await LoginManager.tryAutoConnect()
         switch (config.runtimeFamily) {
             case RuntimeFamily.NodeJS: {
@@ -642,7 +711,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
                 return await javaDebug.invokeJavaLambda(this.ctx, config)
             }
             default: {
-                throw Error(`unknown runtimeFamily: ${config.runtimeFamily}`)
+                throw new Error(`unknown runtimeFamily: ${config.runtimeFamily}`)
             }
         }
     }

--- a/src/shared/sam/debugger/goSamDebug.ts
+++ b/src/shared/sam/debugger/goSamDebug.ts
@@ -21,9 +21,9 @@ import { Timeout } from '../../utilities/timeoutUtils'
 import { SystemUtilities } from '../../../shared/systemUtilities'
 import { execFileSync, SpawnOptions } from 'child_process'
 import * as nls from 'vscode-nls'
-import { showViewLogsMessage } from '../../../shared/utilities/messages'
 import { sleep } from '../../utilities/timeoutUtils'
 import globals from '../../extensionGlobals'
+import { ToolkitError } from '../../errors'
 const localize = nls.loadMessageBundle()
 
 /**
@@ -56,12 +56,12 @@ export async function invokeGoLambda(ctx: ExtContext, config: GoDebugConfigurati
     config.onWillAttachDebugger = waitForDelve
 
     if (!config.noDebug && !(await installDebugger(config.debuggerPath!))) {
-        showViewLogsMessage(
-            localize('AWS.sam.debugger.godelve.failed', 'Failed to install Delve for the lambda container.')
+        throw new ToolkitError(
+            localize('AWS.sam.debugger.godelve.failed', 'Failed to install Delve for the lambda container.'),
+            {
+                code: 'NoDelveInstallation',
+            }
         )
-
-        // Terminates the debug session by sending up a dummy config
-        return {} as GoDebugConfiguration
     }
 
     const c = (await runLambdaFunction(ctx, config, async () => {})) as GoDebugConfiguration

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -317,7 +317,7 @@ export async function runLambdaFunction(
     // A failure from either is a failure for the whole invocation
     const [process] = await Promise.all([invokeLambdaHandler(timer, envVars, config, settings), apiRequest]).catch(
         err => {
-            timer.dispose()
+            timer.cancel()
             throw err
         }
     )

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -26,14 +26,10 @@ import { DefaultSamCliProcessInvoker } from './cli/samCliInvoker'
 import { APIGatewayProperties } from './debugger/awsSamDebugConfiguration.gen'
 import { ChildProcess } from '../utilities/childProcess'
 import { SamCliSettings } from './cli/samCliSettings'
-import { getSamCliContext, getSamCliVersion } from './cli/samCliContext'
 import { CloudFormation } from '../cloudformation/cloudformation'
-import { getIdeProperties } from '../extensionUtilities'
 import { sleep } from '../utilities/timeoutUtils'
-import globals from '../extensionGlobals'
 import { showMessageWithCancel } from '../utilities/messages'
-import { telemetry } from '../telemetry/telemetry'
-import { Result, Runtime } from '../telemetry/telemetry'
+import { ToolkitError, UnknownError } from '../errors'
 
 const localize = nls.loadMessageBundle()
 
@@ -80,10 +76,6 @@ function makeResourceName(config: SamLaunchRequestArgs): string {
 const SAM_LOCAL_PORT_CHECK_RETRY_INTERVAL_MILLIS: number = 125
 const ATTACH_DEBUGGER_RETRY_DELAY_MILLIS: number = 1000
 
-/** "sam local start-api" wrapper from the current debug-session. */
-let samStartApi: Promise<boolean>
-let samStartApiProc: ChildProcess | undefined
-
 export async function makeInputTemplate(
     config: SamLaunchRequestArgs & { invokeTarget: { target: 'code' } }
 ): Promise<string> {
@@ -125,7 +117,7 @@ async function buildLambdaHandler(
     env: NodeJS.ProcessEnv,
     config: SamLaunchRequestArgs,
     settings: SamCliSettings
-): Promise<boolean> {
+): Promise<string> {
     const processInvoker = new DefaultSamCliProcessInvoker(settings)
 
     getLogger('channel').info(localize('AWS.output.building.sam.application', 'Building SAM application...'))
@@ -155,26 +147,20 @@ async function buildLambdaHandler(
         }
     }
 
-    try {
-        const samBuild = new SamCliBuildInvocation(samCliArgs)
-        await samBuild.execute(timer)
-        if (samBuild.failure()) {
-            getLogger('debugConsole').error(samBuild.failure()!)
-            throw new Error(samBuild.failure())
-        }
-        // build successful: use output template path for invocation
-        // TODO: refactor `buildLambdaHandler` to not mutate the config
-        config.templatePath = path.join(samBuildOutputFolder, 'template.yaml')
-        getLogger('channel').info(localize('AWS.output.building.sam.application.complete', 'Build complete.'))
-        return true
-    } catch (err) {
-        // build unsuccessful: don't delete temp template and continue using it for invocation
-        // will be cleaned up in the last `finally` step
-        getLogger('channel').warn(
-            localize('AWS.samcli.build.failedBuild', '"sam build" failed: {0}', config.templatePath)
-        )
-        return false
+    const samBuild = new SamCliBuildInvocation(samCliArgs)
+    const err = await samBuild
+        .execute(timer)
+        .then(() => {})
+        .catch(e => UnknownError.cast(e))
+    const failureMessage = err?.message ?? samBuild.failure()
+    if (failureMessage) {
+        // TODO(sijaden): ask SAM CLI for a way to map exit codes to error codes
+        // We can also scrape the debug output though that won't be as reliable
+        throw new ToolkitError(failureMessage, { code: 'BuildFailure' })
     }
+    getLogger('channel').info(localize('AWS.output.building.sam.application.complete', 'Build complete.'))
+
+    return path.join(samBuildOutputFolder, 'template.yaml')
 }
 
 async function invokeLambdaHandler(
@@ -182,7 +168,7 @@ async function invokeLambdaHandler(
     env: NodeJS.ProcessEnv,
     config: SamLaunchRequestArgs,
     settings: SamCliSettings
-): Promise<boolean> {
+): Promise<ChildProcess> {
     getLogger('channel').info(localize('AWS.output.starting.sam.app.locally', 'Starting SAM application locally'))
     getLogger().debug(`localLambdaRunner.invokeLambdaFunction: ${config.name}`)
 
@@ -213,54 +199,26 @@ async function invokeLambdaHandler(
             name: config.name,
         })
 
-        const recordApigwTelemetry = (result: Result) => {
-            telemetry.apigateway_invokeLocal.emit({
-                result: result,
-                runtime: config.runtime as Runtime,
-                debug: !config.noDebug,
-                httpMethod: config.api?.httpMethod,
-                lambdaArchitecture: config.architecture,
-            })
-        }
-
-        // We want async behavior so `await` is intentionally not used here, we
-        // need to call requestLocalApi() while it is up.
-        samStartApi = new Promise(resolve => {
-            config
-                .samLocalInvokeCommand!.invoke({
-                    options: {
-                        env: {
-                            ...process.env,
-                            ...env,
-                        },
+        return config
+            .samLocalInvokeCommand!.invoke({
+                options: {
+                    env: {
+                        ...process.env,
+                        ...env,
                     },
-                    command: samCommand,
-                    args: samArgs,
-                    // "sam local start-api" produces "attach" messages similar to "sam local invoke".
-                    waitForCues: true,
-                    timeout: timer,
-                    name: config.name,
-                })
-                .then(sam => {
-                    recordApigwTelemetry('Succeeded')
-                    samStartApiProc = sam
-                    resolve(true)
-                })
-                .catch(e => {
-                    recordApigwTelemetry('Failed')
-                    getLogger().warn(e as Error)
-                    getLogger('channel').error(
-                        localize(
-                            'AWS.error.during.apig.local',
-                            'Failed to start local API Gateway: {0}',
-                            (e as Error).message
-                        )
-                    )
-                    resolve(false)
-                })
-        })
+                },
+                command: samCommand,
+                args: samArgs,
+                // "sam local start-api" produces "attach" messages similar to "sam local invoke".
+                waitForCues: true,
+                timeout: timer,
+                name: config.name,
+            })
+            .catch(e => {
+                const message = localize('AWS.error.during.apig.local', 'Failed to start local API Gateway')
 
-        return true
+                throw ToolkitError.chain(e, message)
+            })
     } else {
         // 'target=code' or 'target=template'
         const localInvokeArgs: SamCliLocalInvokeInvocationArguments = {
@@ -283,38 +241,19 @@ async function invokeLambdaHandler(
 
         // sam local invoke ...
         const command = new SamCliLocalInvokeInvocation(localInvokeArgs)
-        let samVersion: string | undefined
-        let invokeResult: Result = 'Failed'
 
         try {
-            samVersion = await getSamCliVersion(getSamCliContext())
-            await command.execute(timer)
-            invokeResult = 'Succeeded'
+            return await command.execute(timer)
         } catch (err) {
-            getLogger('channel').error(
-                localize(
-                    'AWS.error.during.sam.local',
-                    'Failed to run SAM application locally: {0}',
-                    (err as Error).message
-                )
+            throw ToolkitError.chain(
+                err,
+                localize('AWS.error.during.sam.local', 'Failed to run SAM application locally')
             )
-
-            return false
         } finally {
             if (config.sam?.buildDir === undefined) {
                 await remove(config.templatePath)
             }
-            telemetry.lambda_invokeLocal.emit({
-                lambdaPackageType: isImageLambdaConfig(config) ? 'Image' : 'Zip',
-                lambdaArchitecture: config.architecture,
-                result: invokeResult,
-                runtime: config.runtime as Runtime,
-                debug: !config.noDebug,
-                version: samVersion,
-            })
         }
-
-        return true
     }
 }
 
@@ -333,7 +272,9 @@ export async function runLambdaFunction(
     // Verify if Docker is running
     const dockerResponse = await new ChildProcess('docker', ['ps'], { logging: 'no' }).run()
     if (dockerResponse.exitCode !== 0 || dockerResponse.stdout.includes('error during connect')) {
-        throw new Error('Running AWS SAM projects locally requires Docker. Is it installed and running?')
+        throw new ToolkitError('Running AWS SAM projects locally requires Docker. Is it installed and running?', {
+            code: 'NoDocker',
+        })
     }
     // Switch over to the output channel so the user has feedback that we're getting things ready
     ctx.outputChannel.show(true)
@@ -356,35 +297,43 @@ export async function runLambdaFunction(
     const settings = SamCliSettings.instance
     const timer = new Timeout(settings.getLocalInvokeTimeout())
 
-    if (!(await buildLambdaHandler(timer, envVars, config, settings))) {
-        return config
-    }
+    // TODO: refactor things to not mutate the config
+    config.templatePath = await buildLambdaHandler(timer, envVars, config, settings)
 
     await onAfterBuild()
     timer.refresh()
 
-    if (!(await invokeLambdaHandler(timer, envVars, config, settings))) {
-        return config
+    let apiRequest: Promise<void> | undefined
+    if (config.invokeTarget.target === 'api') {
+        const payload =
+            config.eventPayloadFile === undefined
+                ? undefined
+                : JSON.parse(await readFile(config.eventPayloadFile, { encoding: 'utf-8' }))
+
+        apiRequest = requestLocalApi(timer, config.api!, config.apiPort!, payload)
     }
+
+    // SAM CLI and any API requests are executed in parallel
+    // A failure from either is a failure for the whole invocation
+    const [process] = await Promise.all([invokeLambdaHandler(timer, envVars, config, settings), apiRequest]).catch(
+        err => {
+            timer.dispose()
+            throw err
+        }
+    )
 
     if (config.noDebug) {
         return config
     }
 
-    async function attach() {
-        if (config.invokeTarget.target === 'api') {
-            const payload =
-                config.eventPayloadFile === undefined
-                    ? undefined
-                    : JSON.parse(await readFile(config.eventPayloadFile, { encoding: 'utf-8' }))
-            // Send the request to the local API server.
-            await requestLocalApi(timer, config.api!, config.apiPort!, payload)
-            // Wait for cue messages ("Starting debugger" etc.) before attach.
-            if (!(await samStartApi)) {
-                return config
-            }
+    const terminationListener = vscode.debug.onDidTerminateDebugSession(session => {
+        const config = session.configuration as SamLaunchRequestArgs
+        if (config.invokeTarget?.target === 'api') {
+            stopApi(process, config)
         }
+    })
 
+    async function attach() {
         if (config.onWillAttachDebugger) {
             getLogger('channel').info(
                 localize('AWS.output.sam.local.waiting', 'Waiting for SAM application to start...')
@@ -400,38 +349,21 @@ export async function runLambdaFunction(
         await attachDebugger({
             debugConfig: config,
             retryDelayMillis: ATTACH_DEBUGGER_RETRY_DELAY_MILLIS,
-            onRecordAttachDebuggerMetric: (attachResult: boolean | undefined, attempts: number): void => {
-                telemetry.sam_attachDebugger.emit({
-                    lambdaPackageType: isImageLambdaConfig(config) ? 'Image' : 'Zip',
-                    lambdaArchitecture: config.architecture,
-                    runtime: config.runtime as Runtime,
-                    result: attachResult ? 'Succeeded' : 'Failed',
-                    attempts: attempts,
-                    duration: timer.elapsedTime,
-                })
-            },
         })
-            .then(r => {
-                if (r.success) {
-                    showDebugConsole()
-                }
-            })
-            .catch(e => {
-                getLogger().error(`Failed to debug: ${e}`)
-                globals.outputChannel.appendLine(`Failed to debug: ${e}`)
-            })
+
+        showDebugConsole()
     }
 
     try {
         await attach()
     } finally {
-        timer.dispose()
+        vscode.Disposable.from(timer, terminationListener).dispose()
     }
 
     return config
 }
 
-function stopApi(config: vscode.DebugConfiguration) {
+function stopApi(samStartApiProc: ChildProcess, config: vscode.DebugConfiguration) {
     if (!samStartApiProc) {
         getLogger().error('SAM: unknown debug session: %s', config.name)
         return
@@ -442,17 +374,8 @@ function stopApi(config: vscode.DebugConfiguration) {
         samStartApiProc.stop(true, 'SIGHUP')
     } catch (e) {
         getLogger().warn('SAM: failed to stop sam process: pid %d: %O', samStartApiProc.pid(), e as Error)
-    } finally {
-        samStartApiProc = undefined
     }
 }
-
-vscode.debug.onDidTerminateDebugSession(session => {
-    const config = session.configuration as SamLaunchRequestArgs
-    if (config.invokeTarget?.target === 'api') {
-        stopApi(config)
-    }
-})
 
 /**
  * Sends an HTTP request to the local API webserver, which invokes the backing
@@ -512,8 +435,8 @@ async function requestLocalApi(
             err.response?.statusCode === 403
                 ? `Local API failed to respond to path: ${api?.path}`
                 : `Local API failed to respond (${err.code}) at path: ${api?.path}, error: ${err.message}`
-        getLogger('channel').error(msg)
-        throw new Error(msg)
+
+        throw ToolkitError.chain(err, msg)
     })
 }
 
@@ -521,7 +444,6 @@ export interface AttachDebuggerContext {
     debugConfig: SamLaunchRequestArgs
     retryDelayMillis?: number
     onStartDebugging?: typeof vscode.debug.startDebugging
-    onRecordAttachDebuggerMetric?(attachResult: boolean | undefined, attempts: number): void
     onWillRetry?(): Promise<void>
 }
 
@@ -533,7 +455,7 @@ export async function attachDebugger({
         await sleep(retryDelayMillis)
     },
     ...params
-}: AttachDebuggerContext): Promise<{ success: boolean }> {
+}: AttachDebuggerContext): Promise<void> {
     getLogger().debug(
         `localLambdaRunner.attachDebugger: startDebugging with config: ${JSON.stringify(
             params.debugConfig,
@@ -541,9 +463,6 @@ export async function attachDebugger({
             2
         )}`
     )
-
-    let isDebuggerAttached = false
-    let retries = 0
 
     getLogger('channel').info(localize('AWS.output.sam.local.attaching', 'Attaching debugger to SAM application...'))
 
@@ -555,48 +474,27 @@ export async function attachDebugger({
         return params.debugConfig.runtimeFamily === RuntimeFamily.Python ? 8 : 1
     }
 
-    do {
-        isDebuggerAttached = await onStartDebugging(undefined, params.debugConfig)
-        if (!isDebuggerAttached) {
-            if (retries < maxRetries()) {
-                if (onWillRetry) {
-                    await onWillRetry()
-                }
-                retries += 1
-            } else {
-                getLogger('channel').error(
-                    localize(
-                        'AWS.output.sam.local.attach.retry.limit.exceeded',
-                        'Retry limit reached while trying to attach the debugger.'
-                    )
-                )
-                break
+    let retries = 0
+    while (true) {
+        const isDebuggerAttached = await onStartDebugging(undefined, params.debugConfig)
+        if (isDebuggerAttached) {
+            break
+        } else if (retries < maxRetries()) {
+            if (onWillRetry) {
+                await onWillRetry()
             }
+            retries += 1
+        } else {
+            throw new ToolkitError(localize('AWS.output.sam.local.attach.failed', 'Failed to attach debugger'), {
+                code: 'DebuggerRetryLimit',
+            })
         }
-    } while (!isDebuggerAttached)
-
-    if (params.onRecordAttachDebuggerMetric) {
-        params.onRecordAttachDebuggerMetric(isDebuggerAttached, retries + 1)
     }
 
-    if (isDebuggerAttached) {
-        getLogger('channel').info(localize('AWS.output.sam.local.attach.success', 'Debugger attached'))
-        getLogger().verbose(
-            `SAM: debug session: "${vscode.debug.activeDebugSession?.name}" / ${vscode.debug.activeDebugSession?.id}`
-        )
-    } else {
-        getLogger('channel').error(
-            localize(
-                'AWS.output.sam.local.attach.failure',
-                'Unable to attach Debugger. Check {0} Toolkit logs. If it took longer than expected to start, you can still attach.',
-                getIdeProperties().company
-            )
-        )
-    }
-
-    return {
-        success: isDebuggerAttached,
-    }
+    getLogger('channel').info(localize('AWS.output.sam.local.attach.success', 'Debugger attached'))
+    getLogger().verbose(
+        `SAM: debug session: "${vscode.debug.activeDebugSession?.name}" / ${vscode.debug.activeDebugSession?.id}`
+    )
 }
 
 /**

--- a/src/shared/telemetry/spans.ts
+++ b/src/shared/telemetry/spans.ts
@@ -112,6 +112,7 @@ export class TelemetrySpan {
     public emit(data?: MetricBase): void {
         const state = getValidatedState({ ...this.state, ...data }, this.definition)
         const metadata = Object.entries(state)
+            .filter(([_, v]) => v !== '') // XXX: the telemetry service currently rejects empty strings :/
             .filter(([k, v]) => v !== undefined && !TelemetrySpan.#excludedFields.includes(k))
             .map(([k, v]) => ({ Key: k, Value: String(v) }))
 

--- a/src/test/lambda/local/debugConfiguration.test.ts
+++ b/src/test/lambda/local/debugConfiguration.test.ts
@@ -19,6 +19,7 @@ import { CloudFormationTemplateRegistry } from '../../../shared/cloudformation/t
 import { getArchitecture, isImageLambdaConfig } from '../../../lambda/local/debugConfiguration'
 import { CloudFormation } from '../../../shared/cloudformation/cloudformation'
 import globals from '../../../shared/extensionGlobals'
+import { Runtime } from '../../../shared/telemetry/telemetry'
 
 describe('makeCoreCLRDebugConfiguration', function () {
     let tempFolder: string
@@ -46,7 +47,7 @@ describe('makeCoreCLRDebugConfiguration', function () {
             type: 'coreclr',
             request: 'attach',
             // cfnTemplate?: CloudFormation.Template
-            runtime: 'fakedotnet',
+            runtime: 'fakedotnet' as Runtime,
             handlerName: 'fakehandlername',
             noDebug: false,
             apiPort: 4242,
@@ -146,7 +147,7 @@ describe('isImageLambdaConfig', function () {
             runtimeFamily: RuntimeFamily.DotNetCore,
             request: 'launch',
             type: 'launch',
-            runtime: 'fakedotnet',
+            runtime: 'fakedotnet' as Runtime,
             handlerName: 'fakehandlername',
             envFile: '/fake/build/dir/env-vars.json',
             eventPayloadFile: '/fake/build/dir/event.json',
@@ -175,7 +176,7 @@ describe('isImageLambdaConfig', function () {
             runtimeFamily: RuntimeFamily.DotNetCore,
             request: 'launch',
             type: 'launch',
-            runtime: 'fakedotnet',
+            runtime: 'fakedotnet' as Runtime,
             handlerName: 'fakehandlername',
             envFile: '/fake/build/dir/env-vars.json',
             eventPayloadFile: '/fake/build/dir/event.json',
@@ -201,7 +202,7 @@ describe('isImageLambdaConfig', function () {
             runtimeFamily: RuntimeFamily.DotNetCore,
             request: 'launch',
             type: 'launch',
-            runtime: 'fakedotnet',
+            runtime: 'fakedotnet' as Runtime,
             handlerName: 'fakehandlername',
             envFile: '/fake/build/dir/env-vars.json',
             eventPayloadFile: '/fake/build/dir/event.json',

--- a/src/test/shared/codelens/localLambdaRunner.test.ts
+++ b/src/test/shared/codelens/localLambdaRunner.test.ts
@@ -13,6 +13,7 @@ import { ChildProcessResult } from '../../../shared/utilities/childProcess'
 import { FakeExtensionContext } from '../../fakeExtensionContext'
 import { SamLaunchRequestArgs } from '../../../shared/sam/debugger/awsSamDebugger'
 import { assertLogsContain } from '../../globalSetup.test'
+import { ToolkitError } from '../../../shared/errors'
 
 describe('localLambdaRunner', async function () {
     let tempDir: string
@@ -74,85 +75,31 @@ describe('localLambdaRunner', async function () {
             assertLogsContain('Debugger attached', false, 'info')
         })
 
-        it('Successful attach records a success metric', async function () {
-            await localLambdaRunner.attachDebugger({
-                debugConfig: {} as any as SamLaunchRequestArgs,
-                onStartDebugging: startDebuggingReturnsTrue,
-                onWillRetry,
-                onRecordAttachDebuggerMetric: (attachResult: boolean | undefined, attempts: number) => {
-                    assert.ok(attachResult, 'Expected to be logging an attach success metric')
-                    assert.strictEqual(attempts, 1, 'Unexpected Attempt count')
-                },
-            })
-        })
-
-        it('Successful attach returns success', async function () {
-            const results = await localLambdaRunner.attachDebugger({
-                debugConfig: {} as any as SamLaunchRequestArgs,
-                onStartDebugging: startDebuggingReturnsTrue,
-                onWillRetry,
-            })
-
-            assert.ok(results.success, 'Expected attach results to be successful')
-        })
-
-        it('Failure to attach logs that the debugger did not attach', async function () {
-            await localLambdaRunner.attachDebugger({
+        it('Failure to attach throws an error', async function () {
+            const results = localLambdaRunner.attachDebugger({
                 debugConfig: {} as any as SamLaunchRequestArgs,
                 onStartDebugging: startDebuggingReturnsFalse,
                 onWillRetry,
             })
 
-            // match start of string 'AWS.output.sam.local.attach.failure'
-            assertLogsContain('Unable to attach Debugger', false, 'error')
+            await assert.rejects(results, /failed to attach debugger/i)
         })
 
-        it('Failure to attach records a fail metric', async function () {
+        it('Uses a code for exceeding the retry limit', async function () {
+            const results = await localLambdaRunner
+                .attachDebugger({
+                    debugConfig: {} as any as SamLaunchRequestArgs,
+                    onStartDebugging: startDebuggingReturnsFalse,
+                    onWillRetry,
+                })
+                .catch(e => e)
+
+            assert.ok(results instanceof ToolkitError)
+            assert.strictEqual(results.code, 'DebuggerRetryLimit')
+        })
+
+        it('Does not fail if attach succeeds during retries', async function () {
             await localLambdaRunner.attachDebugger({
-                debugConfig: {} as any as SamLaunchRequestArgs,
-                onStartDebugging: startDebuggingReturnsFalse,
-                onWillRetry,
-                onRecordAttachDebuggerMetric: (attachResult: boolean | undefined, attempts: number) => {
-                    assert.strictEqual(attachResult, false, 'Expected to be logging an attach failure metric')
-                },
-            })
-        })
-
-        it('Failure to attach returns failure', async function () {
-            const results = await localLambdaRunner.attachDebugger({
-                debugConfig: {} as any as SamLaunchRequestArgs,
-                onStartDebugging: startDebuggingReturnsFalse,
-                onWillRetry,
-            })
-
-            assert.strictEqual(results.success, false, 'Expected attach results to fail')
-        })
-
-        it('Logs about exceeding the retry limit', async function () {
-            await localLambdaRunner.attachDebugger({
-                debugConfig: {} as any as SamLaunchRequestArgs,
-                onStartDebugging: startDebuggingReturnsFalse,
-                onWillRetry,
-            })
-
-            // match string 'AWS.output.sam.local.attach.retry.limit.exceeded'
-            assertLogsContain('Retry limit reached', false, 'error')
-        })
-
-        it('Does not log metrics when startDebugging returns false', async function () {
-            await localLambdaRunner.attachDebugger({
-                debugConfig: {} as any as SamLaunchRequestArgs,
-                onStartDebugging: startDebuggingReturnsFalse,
-                onRecordAttachDebuggerMetric: (attachResult: boolean | undefined, attempts: number): void => {
-                    assert.strictEqual(actualRetries, 1, 'Metrics should only be recorded once')
-                    assert.notStrictEqual(attachResult, undefined, 'attachResult should not be undefined')
-                },
-                onWillRetry,
-            })
-        })
-
-        it('Returns true if attach succeeds during retries', async function () {
-            const results = await localLambdaRunner.attachDebugger({
                 debugConfig: {} as any as SamLaunchRequestArgs,
                 onStartDebugging: async (
                     folder: vscode.WorkspaceFolder | undefined,
@@ -164,18 +111,6 @@ describe('localLambdaRunner', async function () {
                 },
                 onWillRetry,
             })
-
-            assert.ok(results.success, 'Expected attach results to succeed')
-        })
-
-        it('Returns false if retry count exceeded', async function () {
-            const results = await localLambdaRunner.attachDebugger({
-                debugConfig: {} as any as SamLaunchRequestArgs,
-                onStartDebugging: startDebuggingReturnsFalse,
-                onWillRetry,
-            })
-
-            assert.strictEqual(results.success, false, 'Expected attach results to fail')
         })
     })
 

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -314,19 +314,16 @@ describe('SamDebugConfigurationProvider', async function () {
             )
 
             // No workspace folder:
-            assert.deepStrictEqual(await debugConfigProvider.makeConfig(undefined, config.config), undefined)
+            await assert.rejects(() => debugConfigProvider.makeConfig(undefined, config.config))
 
             // No launch.json (vscode will pass an empty config.request):
-            assert.deepStrictEqual(
-                await debugConfigProvider.makeConfig(undefined, { ...config.config, request: '' }),
-                undefined
-            )
+            await assert.rejects(() => debugConfigProvider.makeConfig(undefined, { ...config.config, request: '' }))
 
             // Unknown runtime:
             config.config.lambda = {
                 runtime: 'happy-runtime-42',
             }
-            assert.deepStrictEqual(await debugConfigProvider.makeConfig(config.folder, config.config), undefined)
+            await assert.rejects(() => debugConfigProvider.makeConfig(config.folder, config.config))
 
             // bad credentials
             const mockCredentialsStore: CredentialsStore = new CredentialsStore()
@@ -354,14 +351,14 @@ describe('SamDebugConfigurationProvider', async function () {
                 ...fakeContext,
                 credentialsStore: mockCredentialsStore,
             })
-            assert.deepStrictEqual(
-                await debugConfigProviderMockCredentials.makeConfig(config.folder, {
+
+            await assert.rejects(() =>
+                debugConfigProviderMockCredentials.makeConfig(config.folder, {
                     ...config.config,
                     aws: {
                         credentials: 'profile:error',
                     },
-                }),
-                undefined
+                })
             )
         })
 
@@ -399,92 +396,96 @@ describe('SamDebugConfigurationProvider', async function () {
             )
         })
 
-        it('returns undefined when resolving debug configurations with an invalid request type', async function () {
-            const resolved = await debugConfigProvider.makeConfig(undefined, {
-                type: AWS_SAM_DEBUG_TYPE,
-                name: 'whats in a name',
-                request: 'not-direct-invoke',
-                invokeTarget: {
-                    target: CODE_TARGET_TYPE,
-                    lambdaHandler: 'sick handles',
-                    projectRoot: 'root as in beer',
-                },
-            })
-            assert.strictEqual(resolved, undefined)
-        })
-
-        it('returns undefined when resolving debug configurations with an invalid target type', async function () {
-            const tgt = 'not-code' as 'code'
-            const resolved = await debugConfigProvider.makeConfig(undefined, {
-                type: AWS_SAM_DEBUG_TYPE,
-                name: 'whats in a name',
-                request: DIRECT_INVOKE_TYPE,
-                invokeTarget: {
-                    target: tgt,
-                    lambdaHandler: 'sick handles',
-                    projectRoot: 'root as in beer',
-                },
-            })
-            assert.strictEqual(resolved, undefined)
-        })
-
-        it("returns undefined when resolving template debug configurations with a template that isn't in the registry", async () => {
-            const resolved = await debugConfigProvider.makeConfig(undefined, createFakeConfig({}))
-            assert.strictEqual(resolved, undefined)
-        })
-
-        it("returns undefined when resolving template debug configurations with a template that doesn't have the set resource", async () => {
-            await createAndRegisterYaml({}, tempFile, globals.templateRegistry)
-            const resolved = await debugConfigProvider.makeConfig(
-                undefined,
-                createFakeConfig({ templatePath: tempFile.fsPath })
+        it('rejects when resolving debug configurations with an invalid request type', async function () {
+            await assert.rejects(() =>
+                debugConfigProvider.makeConfig(undefined, {
+                    type: AWS_SAM_DEBUG_TYPE,
+                    name: 'whats in a name',
+                    request: 'not-direct-invoke',
+                    invokeTarget: {
+                        target: CODE_TARGET_TYPE,
+                        lambdaHandler: 'sick handles',
+                        projectRoot: 'root as in beer',
+                    },
+                })
             )
-            assert.strictEqual(resolved, undefined)
         })
 
-        it('returns undefined when resolving template debug configurations with a resource that has an invalid runtime in template', async function () {
+        it('rejects when resolving debug configurations with an invalid target type', async function () {
+            const tgt = 'not-code' as 'code'
+            await assert.rejects(() =>
+                debugConfigProvider.makeConfig(undefined, {
+                    type: AWS_SAM_DEBUG_TYPE,
+                    name: 'whats in a name',
+                    request: DIRECT_INVOKE_TYPE,
+                    invokeTarget: {
+                        target: tgt,
+                        lambdaHandler: 'sick handles',
+                        projectRoot: 'root as in beer',
+                    },
+                })
+            )
+        })
+
+        it("rejects when resolving template debug configurations with a template that isn't in the registry", async () => {
+            await assert.rejects(() => debugConfigProvider.makeConfig(undefined, createFakeConfig({})))
+        })
+
+        it("rejects when resolving template debug configurations with a template that doesn't have the set resource", async () => {
+            await createAndRegisterYaml({}, tempFile, globals.templateRegistry)
+            await assert.rejects(() =>
+                debugConfigProvider.makeConfig(undefined, createFakeConfig({ templatePath: tempFile.fsPath }))
+            )
+        })
+
+        it('rejects when resolving template debug configurations with a resource that has an invalid runtime in template', async function () {
             await createAndRegisterYaml(
                 { resourceName, runtime: 'moreLikeRanOutOfTime' },
                 tempFile,
                 globals.templateRegistry
             )
-            const resolved = await debugConfigProvider.makeConfig(
-                undefined,
-                createFakeConfig({
-                    templatePath: tempFile.fsPath,
-                    logicalId: resourceName,
-                })
+            await assert.rejects(
+                () =>
+                    debugConfigProvider.makeConfig(
+                        undefined,
+                        createFakeConfig({
+                            templatePath: tempFile.fsPath,
+                            logicalId: resourceName,
+                        })
+                    ),
+                /runtime/i
             )
-            assert.strictEqual(resolved, undefined)
         })
 
-        it('returns undefined when resolving template debug configurations with a resource that has an invalid runtime in template', async function () {
+        it('rejects when resolving template debug configurations with a resource that has an invalid runtime in template', async function () {
             testutil.toFile(
                 makeSampleSamTemplateYaml(true, { resourceName, runtime: 'moreLikeRanOutOfTime' }),
                 tempFile.fsPath
             )
             await globals.templateRegistry.addItemToRegistry(tempFile)
-            const resolved = await debugConfigProvider.makeConfig(undefined, {
-                type: AWS_SAM_DEBUG_TYPE,
-                name: 'whats in a name',
-                request: DIRECT_INVOKE_TYPE,
-                invokeTarget: {
-                    target: TEMPLATE_TARGET_TYPE,
-                    templatePath: tempFile.fsPath,
-                    logicalId: resourceName,
-                },
-            })
-            assert.strictEqual(resolved, undefined)
+            await assert.rejects(() =>
+                debugConfigProvider.makeConfig(undefined, {
+                    type: AWS_SAM_DEBUG_TYPE,
+                    name: 'whats in a name',
+                    request: DIRECT_INVOKE_TYPE,
+                    invokeTarget: {
+                        target: TEMPLATE_TARGET_TYPE,
+                        templatePath: tempFile.fsPath,
+                        logicalId: resourceName,
+                    },
+                })
+            )
         })
 
-        it('returns undefined when resolving code debug configurations with invalid runtimes', async function () {
-            const resolved = await debugConfigProvider.makeConfig(undefined, {
-                ...createBaseCodeConfig({}),
-                lambda: {
-                    runtime: 'COBOL',
-                },
-            })
-            assert.strictEqual(resolved, undefined)
+        it('rejects when resolving code debug configurations with invalid runtimes', async function () {
+            await assert.rejects(() =>
+                debugConfigProvider.makeConfig(undefined, {
+                    ...createBaseCodeConfig({}),
+                    lambda: {
+                        runtime: 'COBOL',
+                    },
+                })
+            )
         })
 
         it('supports workspace-relative template path ("./foo.yaml")', async function () {


### PR DESCRIPTION
## Problem
Our SAM run/debug implementation has several problems with error handling:
* Inconsistent error message UX (some are placed in the logs, some are shown directly to the user)
* Telemetry only covers a portion of the relevant code paths and does not emit reasons for failure
* Some errors are swallowed while others are bubbled up to the VSC API

## Solution
* Bubble up all errors but use a single error handler to prevent the VSC error modal from showing
    * Added a button to open the launch config to preserve current UX 
* Use telemetry spans to cover almost the entire code path
* Remove `sam_attachDebugger` metric as it is redundant. Failures to attach counts as a failure for the whole execution.
* Add some basic error codes to better determine why a run/debug execution failed


![Screen Shot 2022-09-02 at 9 37 24 AM](https://user-images.githubusercontent.com/31319484/188207971-c0b669e9-4ecc-4a53-aa49-3d94b0f2c7df.png)



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
