### PR TITLE
fix(sam): use different debugger args for Python image lambdas on C9 

### DIFF
--- a/.changes/next-release/Bug Fix-6b246663-e029-4e55-9ecb-c392c38c8aa2.json
+++ b/.changes/next-release/Bug Fix-6b246663-e029-4e55-9ecb-c392c38c8aa2.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Debugging Python image-based lambdas fails with `Init failed error=exec: \"-m\": executable file not found`"
+}

--- a/src/shared/sam/cli/samCliInvokerUtils.ts
+++ b/src/shared/sam/cli/samCliInvokerUtils.ts
@@ -56,9 +56,5 @@ export function logAndThrowIfUnexpectedExitCode(processResult: ChildProcessResul
         }
     }
 
-    if (!message) {
-        message = processResult.stderr || processResult.stdout || 'No message available'
-    }
-
-    throw makeUnexpectedExitCodeError(message)
+    throw makeUnexpectedExitCodeError(message ?? 'no message available')
 }

--- a/src/shared/sam/debugger/pythonSamDebug.ts
+++ b/src/shared/sam/debugger/pythonSamDebug.ts
@@ -138,9 +138,14 @@ export async function makePythonDebugConfig(
             // --ikpdb-protocol=vscode:
             //           For https://github.com/cmorisse/vscode-ikp3db
             //           Requires ikp3db 1.5 (unreleased): https://github.com/cmorisse/ikp3db/pull/12
-            config.debugArgs = [
-                `-m ikp3db --ikpdb-address=0.0.0.0 --ikpdb-port=${config.debugPort} -ik_ccwd=${ccwd} -ik_cwd=/var/task ${logArg}`,
-            ]
+            const debugArgs = `-m ikp3db --ikpdb-address=0.0.0.0 --ikpdb-port=${config.debugPort} -ik_ccwd=${ccwd} -ik_cwd=/var/task ${logArg}`
+
+            if (isImageLambda) {
+                const params = getPythonExeAndBootstrap(config.runtime)
+                config.debugArgs = [`${params.python} ${debugArgs} ${params.bootstrap}`]
+            } else {
+                config.debugArgs = [debugArgs]
+            }
         }
 
         manifestPath = await makePythonDebugManifest({


### PR DESCRIPTION
## Problem
Debugging Python image lambdas does not work on C9

## Solution
Use the same pattern that we use for debugpy

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
