### PR TITLE
feat(sam): simplify "install yaml" verbiage

### DIFF
--- a/src/awsexplorer/defaultRegion.ts
+++ b/src/awsexplorer/defaultRegion.ts
@@ -16,10 +16,7 @@ import { RegionProvider } from '../shared/regions/regionProvider'
 
 class RegionMissingUI {
     public static readonly add: string = localizedText.yes
-    public static readonly alwaysIgnore: string = localize(
-        'AWS.message.prompt.noDontAskAgain',
-        "No, and don't ask again"
-    )
+    public static readonly alwaysIgnore: string = localize('AWS.message.prompt.noDontAskAgain', "No, don't ask again")
     public static readonly ignore: string = localizedText.no
 }
 

--- a/src/ecs/commands/updateEnableExecuteCommandFlag.ts
+++ b/src/ecs/commands/updateEnableExecuteCommandFlag.ts
@@ -24,7 +24,7 @@ export async function updateEnableExecuteCommandFlag(
     settings = PromptSettings.instance
 ): Promise<void> {
     const yes = localize('AWS.generic.response.yes', 'Yes')
-    const yesDontAskAgain = localize('AWS.message.prompt.yesDontAskAgain', "Yes, and don't ask again")
+    const yesDontAskAgain = localize('AWS.message.prompt.yesDontAskAgain', "Yes, don't ask again")
     const no = localize('AWS.generic.response.no', 'No')
 
     const prompt = enable ? EcsRunCommandPrompt.Enable : EcsRunCommandPrompt.Disable

--- a/src/s3/fileViewerManager.ts
+++ b/src/s3/fileViewerManager.ts
@@ -339,7 +339,7 @@ export class S3FileViewerManager {
             'You are now editing an S3 file. Saved changes will be uploaded to your S3 bucket.'
         )
 
-        const dontShow = localize('AWS.s3.fileViewer.button.dismiss', "Don't show this again")
+        const dontShow = localize('AWS.s3.fileViewer.button.dismiss', "Don't show again")
         const help = localize('AWS.generic.message.learnMore', 'Learn more')
 
         await this.window.showWarningMessage(message, dontShow, help).then<unknown>(selection => {

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -322,23 +322,21 @@ async function promptInstallYamlPlugin(fileName: string, disposables: vscode.Dis
         }
         const settings = PromptSettings.instance
 
-        const goToMarketplace = localize('AWS.message.info.yaml.goToMarketplace', 'Open Marketplace Page')
-        const dismiss = localize('AWS.generic.response.dismiss', 'Dismiss')
-        const permanentlySuppress = localize('AWS.message.info.yaml.suppressPrompt', "Dismiss, and don't show again")
+        const installBtn = localize('AWS.missingExtension.install', 'Install...')
+        const permanentlySuppress = localize('AWS.message.info.yaml.suppressPrompt', "Don't show again")
 
         const response = await vscode.window.showInformationMessage(
             localize(
                 'AWS.message.info.yaml.prompt',
-                'Install YAML extension for additional {0} features.',
+                'Install YAML extension for more {0} features in SAM template.yaml files.',
                 getIdeProperties().company
             ),
-            goToMarketplace,
-            dismiss,
+            installBtn,
             permanentlySuppress
         )
 
         switch (response) {
-            case goToMarketplace:
+            case installBtn:
                 // Available options are:
                 // extension.open: opens extension page in VS Code extension marketplace view
                 // workspace.extension.installPlugin: autoinstalls plugin with no additional feedback


### PR DESCRIPTION
## Problem

- The `promptInstallYamlPlugin` buttons are verbose, and get truncated on a laptop-sized screen.
- In other "Install X" dialogs we use "Install" as the action button. "Open Marketplace Page" might be confused with a website link.

## Solution

<img width="550" alt="image" src="https://user-images.githubusercontent.com/55561878/188892972-9326bf66-4a09-4615-a911-5147ca41d7e7.png">


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
