### PR TITLE
chore: bump telemetry version to be 1.69

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
                 "yaml-cfn": "^0.3.1"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.68",
+                "@aws-toolkits/telemetry": "^1.0.69",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^8.1.0",
                 "@types/adm-zip": "^0.4.34",
@@ -2242,9 +2242,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.68",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.68.tgz",
-            "integrity": "sha512-l81tbxnhjZ+MLKsKg3vwlk98HpakbG4Stp5Lkpko89mRLRMBqI9e5wanRgsBaGa/ocHGJJxDAxTfbHhazdT4zA==",
+            "version": "1.0.69",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.69.tgz",
+            "integrity": "sha512-8y8KINj6MYBDVuRKcX4AjTPYUO1/9Cwf161q/6C0I6VZ2sYSE720N80P0U9lpWTaOcbUVnL5BJI/WdceJzcD8Q==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",
@@ -16124,9 +16124,9 @@
             }
         },
         "@aws-toolkits/telemetry": {
-            "version": "1.0.68",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.68.tgz",
-            "integrity": "sha512-l81tbxnhjZ+MLKsKg3vwlk98HpakbG4Stp5Lkpko89mRLRMBqI9e5wanRgsBaGa/ocHGJJxDAxTfbHhazdT4zA==",
+            "version": "1.0.69",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.69.tgz",
+            "integrity": "sha512-8y8KINj6MYBDVuRKcX4AjTPYUO1/9Cwf161q/6C0I6VZ2sYSE720N80P0U9lpWTaOcbUVnL5BJI/WdceJzcD8Q==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -3196,7 +3196,7 @@
         "report": "nyc report --reporter=html --reporter=json"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.68",
+        "@aws-toolkits/telemetry": "^1.0.69",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^8.1.0",
         "@types/adm-zip": "^0.4.34",


### PR DESCRIPTION
## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
