### PR TITLE
tests: fix failing SAM CLI integration tests

### DIFF
--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -489,11 +489,7 @@ describe('SAM Integration Tests', async function () {
                 })
 
                 it('produces an error when creating a SAM Application to the same location', async function () {
-                    await assert.rejects(
-                        createSamApplication(testDir),
-                        /directory already exists/,
-                        'Promise was not rejected'
-                    )
+                    await assert.rejects(createSamApplication(testDir), 'Promise was not rejected')
                 })
 
                 it('produces an Add Debug Configuration codelens', async function () {


### PR DESCRIPTION
## Problem 
I was wrong, [this change](https://github.com/aws/aws-toolkit-vscode/pull/2870/files#diff-4dd1d1082508662f8f220333fa91583d5fc4abdfcacc30547c2309cdf9435a65L59-R59) actually did cause the test failures

## Solution
Remove the regexp. The test loses some specificity but I think it's acceptable for better UX.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
