### PR TITLE
[codewhisperer]: emit perceived latency telemetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
                 "yaml-cfn": "^0.3.1"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.69",
+                "@aws-toolkits/telemetry": "^1.0.70",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^8.1.0",
                 "@types/adm-zip": "^0.4.34",
@@ -2242,16 +2242,16 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.69",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.69.tgz",
-            "integrity": "sha512-8y8KINj6MYBDVuRKcX4AjTPYUO1/9Cwf161q/6C0I6VZ2sYSE720N80P0U9lpWTaOcbUVnL5BJI/WdceJzcD8Q==",
+            "version": "1.0.70",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.70.tgz",
+            "integrity": "sha512-R6tRo/S0ugiGj0tBcqeQ4voFbTySNfJUtbDD5VXvDQpOQKiELvwaLmjfsczwC50SBYcxLt1O4CexXpz13WLjWw==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",
                 "fs-extra": "^10.0.0",
                 "lodash": "^4.17.20",
                 "prettier": "^2.1.2",
-                "ts-morph": "^15.1.0",
+                "ts-morph": "^16.0.0",
                 "typescript": "^4.7.3",
                 "yargs": "^17.0.1"
             }
@@ -3064,9 +3064,9 @@
             }
         },
         "node_modules/@ts-morph/common": {
-            "version": "0.16.0",
-            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.16.0.tgz",
-            "integrity": "sha512-SgJpzkTgZKLKqQniCjLaE3c2L2sdL7UShvmTmPBejAKd2OKV/yfMpQ2IWpAuA+VY5wy7PkSUaEObIqEK6afFuw==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.17.0.tgz",
+            "integrity": "sha512-RMSSvSfs9kb0VzkvQ2NWobwnj7TxCA9vI/IjR9bDHqgAyVbu2T0DN4wiKVqomyDWqO7dPr/tErSfq7urQ1Q37g==",
             "dev": true,
             "dependencies": {
                 "fast-glob": "^3.2.11",
@@ -4965,7 +4965,7 @@
         "node_modules/call-me-maybe": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-            "integrity": "sha512-wCyFsDQkKPwwF8BDwOiWNx/9K45L/hvggQiDbve+viMNMQnWhrlYIuBk09offfwCRtCO9P6XwUttufzU11WCVw==",
+            "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
             "dev": true
         },
         "node_modules/caller-callsite": {
@@ -6360,7 +6360,7 @@
         "node_modules/es6-iterator": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-            "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
             "dev": true,
             "dependencies": {
                 "d": "1",
@@ -7027,7 +7027,7 @@
         "node_modules/event-emitter": {
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-            "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+            "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
             "dev": true,
             "dependencies": {
                 "d": "1",
@@ -9336,7 +9336,7 @@
         "node_modules/lru-queue": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-            "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+            "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
             "dev": true,
             "dependencies": {
                 "es5-ext": "~0.10.2"
@@ -12867,13 +12867,13 @@
             }
         },
         "node_modules/ts-morph": {
-            "version": "15.1.0",
-            "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-15.1.0.tgz",
-            "integrity": "sha512-RBsGE2sDzUXFTnv8Ba22QfeuKbgvAGJFuTN7HfmIRUkgT/NaVLfDM/8OFm2NlFkGlWEXdpW5OaFIp1jvqdDuOg==",
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-16.0.0.tgz",
+            "integrity": "sha512-jGNF0GVpFj0orFw55LTsQxVYEUOCWBAbR5Ls7fTYE5pQsbW18ssTb/6UXx/GYAEjS+DQTp8VoTw0vqYMiaaQuw==",
             "dev": true,
             "dependencies": {
-                "@ts-morph/common": "~0.16.0",
-                "code-block-writer": "^11.0.0"
+                "@ts-morph/common": "~0.17.0",
+                "code-block-writer": "^11.0.3"
             }
         },
         "node_modules/ts-node": {
@@ -14814,9 +14814,9 @@
             }
         },
         "node_modules/yargs/node_modules/yargs-parser": {
-            "version": "21.0.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-            "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
             "dev": true,
             "engines": {
                 "node": ">=12"
@@ -16605,16 +16605,16 @@
             }
         },
         "@aws-toolkits/telemetry": {
-            "version": "1.0.69",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.69.tgz",
-            "integrity": "sha512-8y8KINj6MYBDVuRKcX4AjTPYUO1/9Cwf161q/6C0I6VZ2sYSE720N80P0U9lpWTaOcbUVnL5BJI/WdceJzcD8Q==",
+            "version": "1.0.70",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.70.tgz",
+            "integrity": "sha512-R6tRo/S0ugiGj0tBcqeQ4voFbTySNfJUtbDD5VXvDQpOQKiELvwaLmjfsczwC50SBYcxLt1O4CexXpz13WLjWw==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.6",
                 "fs-extra": "^10.0.0",
                 "lodash": "^4.17.20",
                 "prettier": "^2.1.2",
-                "ts-morph": "^15.1.0",
+                "ts-morph": "^16.0.0",
                 "typescript": "^4.7.3",
                 "yargs": "^17.0.1"
             }
@@ -17262,9 +17262,9 @@
             "dev": true
         },
         "@ts-morph/common": {
-            "version": "0.16.0",
-            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.16.0.tgz",
-            "integrity": "sha512-SgJpzkTgZKLKqQniCjLaE3c2L2sdL7UShvmTmPBejAKd2OKV/yfMpQ2IWpAuA+VY5wy7PkSUaEObIqEK6afFuw==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.17.0.tgz",
+            "integrity": "sha512-RMSSvSfs9kb0VzkvQ2NWobwnj7TxCA9vI/IjR9bDHqgAyVbu2T0DN4wiKVqomyDWqO7dPr/tErSfq7urQ1Q37g==",
             "dev": true,
             "requires": {
                 "fast-glob": "^3.2.11",
@@ -18852,7 +18852,7 @@
         "call-me-maybe": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-            "integrity": "sha512-wCyFsDQkKPwwF8BDwOiWNx/9K45L/hvggQiDbve+viMNMQnWhrlYIuBk09offfwCRtCO9P6XwUttufzU11WCVw==",
+            "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
             "dev": true
         },
         "caller-callsite": {
@@ -19945,7 +19945,7 @@
         "es6-iterator": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-            "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
             "dev": true,
             "requires": {
                 "d": "1",
@@ -20402,7 +20402,7 @@
         "event-emitter": {
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-            "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+            "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
             "dev": true,
             "requires": {
                 "d": "1",
@@ -22143,7 +22143,7 @@
         "lru-queue": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-            "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+            "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
             "dev": true,
             "requires": {
                 "es5-ext": "~0.10.2"
@@ -24854,13 +24854,13 @@
             }
         },
         "ts-morph": {
-            "version": "15.1.0",
-            "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-15.1.0.tgz",
-            "integrity": "sha512-RBsGE2sDzUXFTnv8Ba22QfeuKbgvAGJFuTN7HfmIRUkgT/NaVLfDM/8OFm2NlFkGlWEXdpW5OaFIp1jvqdDuOg==",
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-16.0.0.tgz",
+            "integrity": "sha512-jGNF0GVpFj0orFw55LTsQxVYEUOCWBAbR5Ls7fTYE5pQsbW18ssTb/6UXx/GYAEjS+DQTp8VoTw0vqYMiaaQuw==",
             "dev": true,
             "requires": {
-                "@ts-morph/common": "~0.16.0",
-                "code-block-writer": "^11.0.0"
+                "@ts-morph/common": "~0.17.0",
+                "code-block-writer": "^11.0.3"
             }
         },
         "ts-node": {
@@ -26396,9 +26396,9 @@
             },
             "dependencies": {
                 "yargs-parser": {
-                    "version": "21.0.1",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-                    "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+                    "version": "21.1.1",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+                    "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
                     "dev": true
                 }
             }

--- a/package.json
+++ b/package.json
@@ -3196,7 +3196,7 @@
         "report": "nyc report --reporter=html --reporter=json"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.69",
+        "@aws-toolkits/telemetry": "^1.0.70",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^8.1.0",
         "@types/adm-zip": "^0.4.34",

--- a/src/codewhisperer/service/inlineCompletion.ts
+++ b/src/codewhisperer/service/inlineCompletion.ts
@@ -14,7 +14,11 @@ import { RecommendationHandler } from './recommendationHandler'
 import { showTimedMessage } from '../../shared/utilities/messages'
 import { getLogger } from '../../shared/logger/logger'
 import globals from '../../shared/extensionGlobals'
-import { CodewhispererAutomatedTriggerType, CodewhispererTriggerType } from '../../shared/telemetry/telemetry'
+import {
+    telemetry,
+    CodewhispererAutomatedTriggerType,
+    CodewhispererTriggerType,
+} from '../../shared/telemetry/telemetry'
 
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
@@ -401,6 +405,21 @@ export class InlineCompletion {
                     this.setRange(new vscode.Range(editor.selection.active, editor.selection.active))
                     try {
                         await this.showRecommendation(editor)
+                        let languageId = editor?.document?.languageId
+                        languageId =
+                            languageId === CodeWhispererConstants.typescript
+                                ? CodeWhispererConstants.javascript
+                                : languageId
+                        const languageContext = runtimeLanguageContext.getLanguageContext(languageId)
+                        telemetry.codewhisperer_perceivedLatency.emit({
+                            codewhispererRequestId: RecommendationHandler.instance.requestId,
+                            codewhispererSessionId: RecommendationHandler.instance.sessionId,
+                            codewhispererTriggerType: TelemetryHelper.instance.triggerType,
+                            codewhispererCompletionType: TelemetryHelper.instance.completionType,
+                            codewhispererLanguage: languageContext.language,
+                            duration: performance.now() - RecommendationHandler.instance.lastInvocationTime,
+                            passive: true,
+                        })
                     } catch (error) {
                         getLogger().error(`Failed to show suggestion ${error}`)
                         RecommendationHandler.instance.cancelPaginatedRequest()


### PR DESCRIPTION
## Problem
We need more visibility into user's perceived latency
## Solution
To emit telemetry on the new perceivedLatency event: the definition of this event is added in this [PR](https://github.com/aws/aws-toolkit-common/pull/366)
corresponding JB PR is [here](https://github.com/aws/aws-toolkit-jetbrains/pull/3298)
<img width="1314" alt="Screen Shot 2022-09-12 at 2 21 16 PM" src="https://user-images.githubusercontent.com/60411978/189765558-49080691-d40c-4eda-894c-fbe44f13c784.png">



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
