### PR TITLE
feat(YAML): Prompt users to install YAML plugin when AWSTemplateFormatVersion becomes available in their YAML document

### DIFF
--- a/.changes/next-release/Feature-a884bba4-5d48-4a0b-9b80-9549697f4f79.json
+++ b/.changes/next-release/Feature-a884bba4-5d48-4a0b-9b80-9549697f4f79.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Prompt users to install YAML plugin when AWSTemplateFormatVersion becomes available in their YAML document"
+}

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -377,7 +377,7 @@ async function promptInstallYamlPlugin(disposables: vscode.Disposable[]) {
     const response = await vscode.window.showInformationMessage(
         localize(
             'AWS.message.info.yaml.prompt',
-            'Install YAML extension for more {0} features in SAM template.yaml files.',
+            'Install YAML extension for more {0} features in CloudFormation templates',
             getIdeProperties().company
         ),
         installBtn,

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -272,7 +272,7 @@ async function createYamlExtensionPrompt(): Promise<void> {
         // user opens a template file
         vscode.workspace.onDidOpenTextDocument(
             async (doc: vscode.TextDocument) => {
-                promptInstallYamlPlugin(doc.fileName, yamlPromptDisposables)
+                promptInstallYamlPluginFromFilename(doc.fileName, yamlPromptDisposables)
             },
             undefined,
             yamlPromptDisposables
@@ -286,6 +286,46 @@ async function createYamlExtensionPrompt(): Promise<void> {
             undefined,
             yamlPromptDisposables
         )
+
+        /**
+         * Prompt the user to install the YAML plugin when AWSTemplateFormatVersion becomes available as a top level key
+         * in the document
+         * @param event An vscode text document change event
+         * @returns nothing
+         */
+        async function promptOnAWSTemplateFormatVersion(event: vscode.TextDocumentChangeEvent): Promise<void> {
+            for (const change of event.contentChanges) {
+                const changedLine = event.document.lineAt(change.range.start.line)
+                if (changedLine.text.includes('AWSTemplateFormatVersion')) {
+                    promptInstallYamlPlugin(yamlPromptDisposables)
+                    return
+                }
+            }
+            return
+        }
+
+        const promptNotifications = new Map<string, Promise<unknown>>()
+        vscode.workspace.onDidChangeTextDocument(
+            (event: vscode.TextDocumentChangeEvent) => {
+                const uri = event.document.uri.toString()
+                if (
+                    event.document.languageId === 'yaml' &&
+                    !vscode.extensions.getExtension(VSCODE_EXTENSION_ID.yaml) &&
+                    !promptNotifications.has(uri)
+                ) {
+                    promptNotifications.set(
+                        uri,
+                        promptOnAWSTemplateFormatVersion(event).finally(() => promptNotifications.delete(uri))
+                    )
+                }
+            },
+            undefined,
+            yamlPromptDisposables
+        )
+
+        vscode.workspace.onDidCloseTextDocument((event: vscode.TextDocument) => {
+            promptNotifications.delete(event.uri.toString())
+        })
 
         // user already has an open template with focus
         // prescreen if a template.yaml is current open so we only call once
@@ -305,54 +345,62 @@ async function promptInstallYamlPluginFromEditor(
     disposables: vscode.Disposable[]
 ): Promise<void> {
     if (editor) {
-        promptInstallYamlPlugin(editor.document.fileName, disposables)
+        promptInstallYamlPluginFromFilename(editor.document.fileName, disposables)
     }
 }
 
 /**
- * Looks for template.yaml and template.yml files and disp[oses prompts
+ * Prompt user to install YAML plugin for template.yaml and template.yml files
  * @param fileName File name to check against
  * @param disposables List of disposables to dispose of when the filename is a template YAML file
  */
-async function promptInstallYamlPlugin(fileName: string, disposables: vscode.Disposable[]): Promise<void> {
+async function promptInstallYamlPluginFromFilename(fileName: string, disposables: vscode.Disposable[]): Promise<void> {
     if (fileName.endsWith('template.yaml') || fileName.endsWith('template.yml')) {
-        // immediately dispose other triggers so it doesn't flash again
-        for (const prompt of disposables) {
-            prompt.dispose()
-        }
-        const settings = PromptSettings.instance
+        promptInstallYamlPlugin(disposables)
+    }
+}
 
-        const installBtn = localize('AWS.missingExtension.install', 'Install...')
-        const permanentlySuppress = localize('AWS.message.info.yaml.suppressPrompt', "Don't show again")
+/**
+ * Show the install YAML extension prompt and dispose other listeners
+ * @param disposables
+ */
+async function promptInstallYamlPlugin(disposables: vscode.Disposable[]) {
+    // immediately dispose other triggers so it doesn't flash again
+    for (const prompt of disposables) {
+        prompt.dispose()
+    }
+    const settings = PromptSettings.instance
 
-        const response = await vscode.window.showInformationMessage(
-            localize(
-                'AWS.message.info.yaml.prompt',
-                'Install YAML extension for more {0} features in SAM template.yaml files.',
-                getIdeProperties().company
-            ),
-            installBtn,
-            permanentlySuppress
-        )
+    const installBtn = localize('AWS.missingExtension.install', 'Install...')
+    const permanentlySuppress = localize('AWS.message.info.yaml.suppressPrompt', "Don't show again")
 
-        switch (response) {
-            case installBtn:
-                // Available options are:
-                // extension.open: opens extension page in VS Code extension marketplace view
-                // workspace.extension.installPlugin: autoinstalls plugin with no additional feedback
-                // workspace.extension.search: preloads and executes a search in the extension sidebar with the given term
+    const response = await vscode.window.showInformationMessage(
+        localize(
+            'AWS.message.info.yaml.prompt',
+            'Install YAML extension for more {0} features in SAM template.yaml files.',
+            getIdeProperties().company
+        ),
+        installBtn,
+        permanentlySuppress
+    )
 
-                // not sure if these are 100% stable.
-                // Opting for `extension.open` as this gives the user a good path forward to install while not doing anything potentially unexpected.
-                try {
-                    await vscode.commands.executeCommand('extension.open', VSCODE_EXTENSION_ID.yaml)
-                } catch (e) {
-                    const err = e as Error
-                    getLogger().error(`Extension ${VSCODE_EXTENSION_ID.yaml} could not be opened: `, err.message)
-                }
-                break
-            case permanentlySuppress:
-                settings.disablePrompt('yamlExtPrompt')
-        }
+    switch (response) {
+        case installBtn:
+            // Available options are:
+            // extension.open: opens extension page in VS Code extension marketplace view
+            // workspace.extension.installPlugin: autoinstalls plugin with no additional feedback
+            // workspace.extension.search: preloads and executes a search in the extension sidebar with the given term
+
+            // not sure if these are 100% stable.
+            // Opting for `extension.open` as this gives the user a good path forward to install while not doing anything potentially unexpected.
+            try {
+                await vscode.commands.executeCommand('extension.open', VSCODE_EXTENSION_ID.yaml)
+            } catch (e) {
+                const err = e as Error
+                getLogger().error(`Extension ${VSCODE_EXTENSION_ID.yaml} could not be opened: `, err.message)
+            }
+            break
+        case permanentlySuppress:
+            settings.disablePrompt('yamlExtPrompt')
     }
 }


### PR DESCRIPTION
## Problem
Right now, we are only prompting users to install the YAML plugin when AWSTemplateFormatVersion is in a document when it's opened/focused or the file is template.yaml/template.yml but it doesn't take into account when users type into the document

## Solution
If the YAML plugin is not installed then listen to onDidChangeEvents until AWSTemplateFormatVersion becomes available. This feature is currently configured to have a higher debounce rate since the prompt doesn't need to show particularly fast. Also not every yaml file they open will be an aws related file.

Tested against 40k line yaml files

Related issue: https://github.com/aws/aws-toolkit-vscode/issues/2677

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
