### PR TITLE
fix(CodeWhisperer): interference with react plugin

### DIFF
--- a/.changes/next-release/Bug Fix-6071a140-0b81-468b-bb9b-f481c9147a7f.json
+++ b/.changes/next-release/Bug Fix-6071a140-0b81-468b-bb9b-f481c9147a7f.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Fix CodeWhisperer get triggered by React plugin generated code snippets"
+	"description": "CodeWhisperer triggered by React plugin generated code snippets"
 }

--- a/.changes/next-release/Bug Fix-6071a140-0b81-468b-bb9b-f481c9147a7f.json
+++ b/.changes/next-release/Bug Fix-6071a140-0b81-468b-bb9b-f481c9147a7f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix CodeWhisperer get triggered by React plugin generated code snippets"
+}

--- a/.changes/next-release/Bug Fix-77142a2a-46de-420b-b17e-ffcdabf6d93c.json
+++ b/.changes/next-release/Bug Fix-77142a2a-46de-420b-b17e-ffcdabf6d93c.json
@@ -1,4 +1,0 @@
-{
-	"type": "Bug Fix",
-	"description": "0"
-}

--- a/.changes/next-release/Bug Fix-77142a2a-46de-420b-b17e-ffcdabf6d93c.json
+++ b/.changes/next-release/Bug Fix-77142a2a-46de-420b-b17e-ffcdabf6d93c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "0"
+}

--- a/src/codewhisperer/service/keyStrokeHandler.ts
+++ b/src/codewhisperer/service/keyStrokeHandler.ts
@@ -154,6 +154,9 @@ export class KeyStrokeHandler {
         if (!changedRange.isSingleLine || changedText === '') {
             return ''
         }
+        if (changedText.split('\n').length > 1) {
+            return ''
+        }
         return changedText
     }
     async invokeAutomatedTrigger(


### PR DESCRIPTION
## Problem
When cwspr working with https://marketplace.visualstudio.com/items?itemName=dsznajder.es7-react-js-snippets plugin, which call generate code templates, the code template from react plugin will trigger cwspr auto completion, which is supposed to be block by this logic https://github.com/aws/aws-toolkit-vscode/blob/master/src/codewhisperer/service/keyStrokeHandler.ts#L154.

<img width="858" alt="image" src="https://user-images.githubusercontent.com/96078566/190466020-dfebd027-786e-437b-905d-d489c0c161d7.png">



## Solution
The multiline code snippet generated from the plugin above is not captured by API `isSingle`, so the PR is a short term fix for this and will try other more solid solution.

<img width="898" alt="image" src="https://user-images.githubusercontent.com/96078566/190469110-f4f419e3-0c81-48dc-bc69-2f70707bccbe.png">


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
