### PR TITLE
icons: add source field

### DIFF
--- a/src/shared/icons.ts
+++ b/src/shared/icons.ts
@@ -64,7 +64,7 @@ export function codicon(parts: TemplateStringsArray, ...components: (string | Ic
  * Used to expose the icon identifier which is otherwise hidden.
  */
 export class Icon extends ThemeIcon {
-    public constructor(public readonly id: string) {
+    public constructor(public readonly id: string, public readonly source?: Uri) {
         super(id)
     }
 
@@ -98,7 +98,14 @@ function resolveIconId(
         }
     }
 
-    return new Icon(namespace === 'vscode' ? name.replace('codicons-', '') : id)
+    // TODO: potentially embed the icon source in `package.json` to avoid this messy mapping
+    // of course, doing that implies we must always bundle both the original icon files and the font file
+    const mappedId = namespace === 'vscode' ? name.replace('codicons-', '') : id
+    const source = !['cloud9', 'vscode'].includes(namespace)
+        ? Uri.joinPath(Uri.file(iconsPath), namespace, rest[0], `${rest.slice(1).join('-')}.svg`)
+        : undefined
+
+    return new Icon(mappedId, source)
 }
 
 function resolvePathsSync(rootDir: string, target: string): { light: Uri; dark: Uri } | undefined {

--- a/src/test/shared/icons.test.ts
+++ b/src/test/shared/icons.test.ts
@@ -81,6 +81,23 @@ describe('getIcon', function () {
             await tryRemoveFolder(tempDir)
         }
     })
+
+    it('provides the icon source if available', async function () {
+        const tempDir = await makeTemporaryToolkitFolder()
+        const logoPath = path.join(tempDir, 'aws', 'cdk', 'logo.svg')
+
+        try {
+            await fs.mkdirp(path.dirname(logoPath))
+            await fs.writeFile(logoPath, '<svg></svg>')
+
+            const icon = getIcon('aws-cdk-logo', false, tempDir)
+
+            assert.ok(icon instanceof ThemeIcon)
+            assert.strictEqual(icon.source?.fsPath, Uri.file(logoPath).fsPath)
+        } finally {
+            await tryRemoveFolder(tempDir)
+        }
+    })
 })
 
 describe('codicon', function () {


### PR DESCRIPTION
## Problem
No easy way to figure out where an icon came from (this is a good thing in most cases)

## Solution
Add a best-effort escape hatch. Icons can come from many places so `source` may not always exist.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
