### PR TITLE
fix(codewhisperer): bug in handling closing brackets

### DIFF
--- a/.changes/next-release/Bug Fix-301c5e9e-3c91-4044-90c1-f419336d2b96.json
+++ b/.changes/next-release/Bug Fix-301c5e9e-3c91-4044-90c1-f419336d2b96.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeWhisperer duplicate closing bracket when using recommendation inside brackets"
+}

--- a/src/codewhisperer/util/closingBracketUtil.ts
+++ b/src/codewhisperer/util/closingBracketUtil.ts
@@ -40,7 +40,7 @@ export const calculateBracketsLevel = (code: string, isRightContext: boolean = f
         } else if (char in bracketMap) {
             const correspondingBracket = bracketMap[char as keyof bracketMapType]
             const count = bracketCounts.get(correspondingBracket) || 0
-            const newCount = count - 1
+            const newCount = count === 0 ? 0 : count - 1
             bracketCounts.set(bracketMap[char], newCount)
             bracketsIndexLevel.push({
                 char: correspondingBracket,

--- a/src/test/codewhisperer/util/closingBracketUtil.test.ts
+++ b/src/test/codewhisperer/util/closingBracketUtil.test.ts
@@ -67,7 +67,7 @@ describe('closingBracketUtil', function () {
             assert.ok(actual.length === 0)
         })
         it('Should return expected bracket to remove', function () {
-            const actual = getBracketsToRemove('return a+b}', '}')
+            const actual = getBracketsToRemove('{return a+b}', '}')
             const expected = [0]
             assert.deepStrictEqual(actual, expected)
         })


### PR DESCRIPTION
## Problem
the level of bracket needs to be greater than or equal to 0. When auto-triggering at a position before the opening `(`, it should be matched up with the closing `)` from right context.
## Solution
before:
![Kapture 2022-09-16 at 11 01 24](https://user-images.githubusercontent.com/60411978/190810172-58633804-26a3-43e4-be9c-4ec14e3ef366.gif)

after:


https://user-images.githubusercontent.com/60411978/190811164-f66720c4-0ca2-460a-b612-c075d03ebb9f.mov




<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
