### PR TITLE
feat(YAML): Watch untitled yaml files for cloudformation/sam contents

### DIFF
--- a/.changes/next-release/Feature-a4f4b3f0-0449-4e29-a8d1-f7d2c452ebc1.json
+++ b/.changes/next-release/Feature-a4f4b3f0-0449-4e29-a8d1-f7d2c452ebc1.json
@@ -1,4 +1,4 @@
 {
 	"type": "Feature",
-	"description": "Watch untitled yaml files for cloudformation/sam contents"
+	"description": "Enable syntax features for untitled (unsaved) cloudformation/sam yaml files"
 }

--- a/.changes/next-release/Feature-a4f4b3f0-0449-4e29-a8d1-f7d2c452ebc1.json
+++ b/.changes/next-release/Feature-a4f4b3f0-0449-4e29-a8d1-f7d2c452ebc1.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Watch untitled yaml files for cloudformation/sam contents"
+}

--- a/src/dynamicResources/awsResourceManager.ts
+++ b/src/dynamicResources/awsResourceManager.ts
@@ -100,7 +100,7 @@ export class AwsResourceManager {
                 remove(uri.fsPath)
 
                 globals.schemaService.registerMapping({
-                    path: uri.fsPath,
+                    uri,
                     type: 'json',
                     schema: undefined,
                 })
@@ -170,7 +170,7 @@ export class AwsResourceManager {
 
     private async registerSchema(
         typeName: string,
-        file: vscode.Uri,
+        uri: vscode.Uri,
         cloudFormation: CloudFormationClient
     ): Promise<void> {
         await this.initialize()
@@ -199,7 +199,7 @@ export class AwsResourceManager {
 
         globals.schemaService.registerMapping(
             {
-                path: file.fsPath,
+                uri,
                 type: 'json',
                 schema: location,
             },

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -36,6 +36,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
         globals.templateRegistry = registry
         await registry.addExcludedPattern(TEMPLATE_FILE_EXCLUDE_PATTERN)
         await registry.addWatchPattern(TEMPLATE_FILE_GLOB_PATTERN)
+        await registry.watchUntitledFiles()
     } catch (e) {
         vscode.window.showErrorMessage(
             localize(

--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -371,14 +371,17 @@ export namespace CloudFormation {
         }
 
         const templateAsYaml: string = await filesystemUtilities.readFileAsString(filename)
-        const template = yaml.load(templateAsYaml, {
+        return loadByContents(templateAsYaml, validate)
+    }
+
+    export async function loadByContents(contents: string, validate: boolean = true): Promise<Template> {
+        const template = yaml.load(contents, {
             schema: schema as any,
         }) as Template
 
         if (validate) {
             validateTemplate(template)
         }
-
         return template
     }
 

--- a/src/shared/sam/codelensRootRegistry.ts
+++ b/src/shared/sam/codelensRootRegistry.ts
@@ -4,6 +4,8 @@
  */
 
 import * as path from 'path'
+import * as pathutils from '../utilities/pathUtils'
+import * as vscode from 'vscode'
 import { WatchedFiles } from '../watchedFiles'
 
 /**
@@ -17,7 +19,8 @@ import { WatchedFiles } from '../watchedFiles'
  */
 export class CodelensRootRegistry extends WatchedFiles<string> {
     protected name: string = 'CodelensRootRegistry'
-    protected async load(p: string): Promise<string> {
-        return path.basename(p)
+    protected async process(p: vscode.Uri): Promise<string> {
+        const normalizedPath = pathutils.normalize(p.fsPath)
+        return path.basename(normalizedPath)
     }
 }

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -12,11 +12,11 @@ import { FileResourceFetcher } from './resourcefetcher/fileResourceFetcher'
 import { getPropertyFromJsonUrl, HttpResourceFetcher } from './resourcefetcher/httpResourceFetcher'
 import { Settings } from './settings'
 import { once } from './utilities/functionUtils'
-import { normalizeSeparator } from './utilities/pathUtils'
 import { Any, ArrayConstructor } from './utilities/typeConstructors'
 import { AWS_SCHEME } from './constants'
 import { writeFile } from 'fs-extra'
 import { SystemUtilities } from './systemUtilities'
+import { normalizeVSCodeUri } from './utilities/vsCodeUtils'
 
 const GOFORMATION_MANIFEST_URL = 'https://api.github.com/repos/awslabs/goformation/releases/latest'
 const SCHEMA_PREFIX = `${AWS_SCHEME}://`
@@ -25,7 +25,7 @@ export type Schemas = { [key: string]: vscode.Uri }
 export type SchemaType = 'yaml' | 'json'
 
 export interface SchemaMapping {
-    path: string
+    uri: vscode.Uri
     type: SchemaType
     schema?: string | vscode.Uri
 }
@@ -103,7 +103,7 @@ export class SchemaService {
 
         const batch = this.updateQueue.splice(0, this.updateQueue.length)
         for (const mapping of batch) {
-            const { type, schema, path } = mapping
+            const { type, schema, uri } = mapping
             const handler = this.handlers.get(type)
             if (!handler) {
                 throw new Error(`no registered handler for type ${type}`)
@@ -112,7 +112,7 @@ export class SchemaService {
                 'schema service: handle %s mapping: %s -> %s',
                 type,
                 schema?.toString() ?? '[removed]',
-                path
+                uri
             )
             await handler.handleUpdate(mapping, this.schemas)
         }
@@ -309,11 +309,10 @@ export class YamlSchemaHandler implements SchemaHandler {
             this.yamlExtension = ext
         }
 
-        const path = vscode.Uri.file(normalizeSeparator(mapping.path))
         if (mapping.schema) {
-            this.yamlExtension.assignSchema(path, resolveSchema(mapping.schema, schemas))
+            this.yamlExtension.assignSchema(mapping.uri, resolveSchema(mapping.schema, schemas))
         } else {
-            this.yamlExtension.removeSchema(path)
+            this.yamlExtension.removeSchema(mapping.uri)
         }
     }
 }
@@ -356,6 +355,7 @@ export class JsonSchemaHandler implements SchemaHandler {
 
         let settings = this.getJsonSettings()
 
+        const path = normalizeVSCodeUri(mapping.uri)
         if (mapping.schema) {
             const uri = resolveSchema(mapping.schema, schemas).toString()
             const existing = this.getSettingBy({ schemaPath: uri })
@@ -364,16 +364,16 @@ export class JsonSchemaHandler implements SchemaHandler {
                 if (!existing.fileMatch) {
                     getLogger().debug(`JsonSchemaHandler: skipped setting schema '${uri}'`)
                 } else {
-                    existing.fileMatch.push(mapping.path)
+                    existing.fileMatch.push(path)
                 }
             } else {
                 settings.push({
-                    fileMatch: [mapping.path],
+                    fileMatch: [path],
                     url: uri,
                 })
             }
         } else {
-            settings = filterJsonSettings(settings, file => file !== mapping.path)
+            settings = filterJsonSettings(settings, file => file !== path)
         }
 
         await this.config.update('json.schemas', settings)

--- a/src/shared/utilities/vsCodeUtils.ts
+++ b/src/shared/utilities/vsCodeUtils.ts
@@ -76,7 +76,10 @@ export function isUntitledScheme(uri: vscode.Uri): boolean {
     return uri.scheme === 'untitled'
 }
 
-// If the VSCode URI is untitled then return the string representation, otherwise normalize the filesystem path
+// If the VSCode URI is not a file then return the string representation, otherwise normalize the filesystem path
 export function normalizeVSCodeUri(uri: vscode.Uri): string {
-    return isUntitledScheme(uri) ? uri.toString() : pathutils.normalize(uri.fsPath)
+    if (uri.scheme !== 'file') {
+        return uri.toString()
+    }
+    return pathutils.normalize(uri.fsPath)
 }

--- a/src/shared/utilities/vsCodeUtils.ts
+++ b/src/shared/utilities/vsCodeUtils.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
-
+import * as pathutils from './pathUtils'
 import { getLogger } from '../logger/logger'
 import { Timeout, waitTimeout } from './timeoutUtils'
 
@@ -70,4 +70,13 @@ export async function activateExtension<T>(
  */
 export function promisifyThenable<T>(thenable: Thenable<T>): Promise<T> {
     return new Promise((resolve, reject) => thenable.then(resolve, reject))
+}
+
+export function isUntitledScheme(uri: vscode.Uri): boolean {
+    return uri.scheme === 'untitled'
+}
+
+// If the VSCode URI is untitled then return the string representation, otherwise normalize the filesystem path
+export function normalizeVSCodeUri(uri: vscode.Uri): string {
+    return isUntitledScheme(uri) ? uri.toString() : pathutils.normalize(uri.fsPath)
 }

--- a/src/shared/watchedFiles.ts
+++ b/src/shared/watchedFiles.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode'
 import { getLogger } from './logger/logger'
 import * as pathutils from './utilities/pathUtils'
 import * as path from 'path'
+import { isUntitledScheme, normalizeVSCodeUri } from './utilities/vsCodeUtils'
 
 export interface WatchedItem<T> {
     /**
@@ -22,7 +23,7 @@ export interface WatchedItem<T> {
 /**
  * WatchedFiles lets us index files in the current registry. It is used
  * for CFN templates among other things. WatchedFiles holds a list of pairs of
- * the absolute path to the file along with a transform of it that is useful for
+ * the absolute path to the file or the path to an untitled file along with a transform of it that is useful for
  * where it is used. For example, for templates, it parses the template and stores it.
  */
 export abstract class WatchedFiles<T> implements vscode.Disposable {
@@ -33,10 +34,13 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
     private readonly registryData: Map<string, T> = new Map<string, T>()
 
     /**
-     * Load in filesystem items, doing any parsing/validaton as required. If it fails, throws
-     * @param path A string with the absolute path to the detected file
+     * Process any incoming URI/content, doing any parsing/validation as required.
+     * If the path does not point to a file on the local file system then contents should be defined.
+     * If it fails, throws
+     * @param path A uri with the absolute path to the detected file
      */
-    protected abstract load(path: string): Promise<T | undefined>
+    protected abstract process(path: vscode.Uri, contents?: string): Promise<T | undefined>
+
     /**
      * Name for logs
      */
@@ -94,6 +98,26 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
     }
 
     /**
+     * Create a special watcher that operates only on untitled files.
+     * VSCode does not make it easy to watch untitled files and globs won't work without knowing exactly
+     * where the untitled files are stored on disk
+     */
+    public async watchUntitledFiles() {
+        this.disposables.push(
+            vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => {
+                if (isUntitledScheme(event.document.uri)) {
+                    this.addItemToRegistry(event.document.uri, true, event.document.getText())
+                }
+            }),
+            vscode.workspace.onDidCloseTextDocument((event: vscode.TextDocument) => {
+                if (isUntitledScheme(event.uri)) {
+                    this.remove(event.uri)
+                }
+            })
+        )
+    }
+
+    /**
      * Adds a regex pattern to ignore paths containing the pattern
      */
     public async addExcludedPattern(pattern: RegExp): Promise<void> {
@@ -109,16 +133,16 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
      * Adds an item to registry. Wipes any existing item in its place with new copy of the data
      * @param uri vscode.Uri containing the item to load in
      */
-    public async addItemToRegistry(uri: vscode.Uri, quiet?: boolean): Promise<void> {
+    public async addItemToRegistry(uri: vscode.Uri, quiet?: boolean, contents?: string): Promise<void> {
         const excluded = this.excludedFilePatterns.find(pattern => uri.fsPath.match(pattern))
         if (excluded) {
             getLogger().verbose(`${this.name}: excluding path (matches "${excluded}"): ${uri.fsPath}`)
             return
         }
-        const pathAsString = pathutils.normalize(uri.fsPath)
-        this.assertAbsolute(pathAsString)
+        this.assertAbsolute(uri)
+        const pathAsString = normalizeVSCodeUri(uri)
         try {
-            const item = await this.load(pathAsString)
+            const item = await this.process(uri, contents)
             if (item) {
                 this.registryData.set(pathAsString, item)
             } else {
@@ -135,12 +159,12 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
 
     /**
      * Get a specific item's data
+     * Untitled files must be referred to by their URI
      * @param path Absolute path to item of interest or a vscode.Uri to the item
      */
     public getRegisteredItem(path: string | vscode.Uri): WatchedItem<T> | undefined {
         // fsPath is needed for Windows, it's equivalent to path on mac/linux
-        const absolutePath = typeof path === 'string' ? path : path.fsPath
-        const normalizedPath = pathutils.normalize(absolutePath)
+        const normalizedPath = typeof path === 'string' ? pathutils.normalize(path) : normalizeVSCodeUri(path)
         this.assertAbsolute(normalizedPath)
         const item = this.registryData.get(normalizedPath)
         if (!item) {
@@ -176,7 +200,7 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
         if (typeof path === 'string') {
             this.registryData.delete(path)
         } else {
-            const pathAsString = pathutils.normalize(path.fsPath)
+            const pathAsString = normalizeVSCodeUri(path)
             this.assertAbsolute(pathAsString)
             this.registryData.delete(pathAsString)
         }
@@ -240,16 +264,25 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
         )
     }
 
-    private assertAbsolute(p: string) {
-        if (!path.isAbsolute(p)) {
-            throw Error(`FileRegistry: path is relative when it should be absolute: ${p}`)
+    /**
+     * Assert if the path is absolute.
+     * Untitled URIs are considered absolute
+     * @param p The path to verify
+     */
+    private assertAbsolute(p: string | vscode.Uri) {
+        const pathAsString = typeof p === 'string' ? p : p.fsPath
+        if (
+            (typeof p === 'string' && !path.isAbsolute(pathAsString) && !pathAsString.startsWith('untitled:')) ||
+            (typeof p !== 'string' && !path.isAbsolute(pathAsString) && !isUntitledScheme(p))
+        ) {
+            throw new Error(`FileRegistry: path is relative when it should be absolute: ${pathAsString}`)
         }
     }
 }
 
 export class NoopWatcher extends WatchedFiles<any> {
-    protected async load(path: string): Promise<any> {
-        throw new Error(`Attempted to add a file to the NoopWatcher: ${path}`)
+    protected async process(uri: vscode.Uri): Promise<any> {
+        throw new Error(`Attempted to add a file to the NoopWatcher: ${uri.fsPath}`)
     }
     protected name: string = 'NoOp'
 }

--- a/src/shared/watchedFiles.ts
+++ b/src/shared/watchedFiles.ts
@@ -23,7 +23,7 @@ export interface WatchedItem<T> {
 /**
  * WatchedFiles lets us index files in the current registry. It is used
  * for CFN templates among other things. WatchedFiles holds a list of pairs of
- * the absolute path to the file or the path to an untitled file along with a transform of it that is useful for
+ * the absolute path to the file or "untitled:" URI along with a transform of it that is useful for
  * where it is used. For example, for templates, it parses the template and stores it.
  */
 export abstract class WatchedFiles<T> implements vscode.Disposable {
@@ -99,8 +99,7 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
 
     /**
      * Create a special watcher that operates only on untitled files.
-     * VSCode does not make it easy to watch untitled files and globs won't work without knowing exactly
-     * where the untitled files are stored on disk
+     * To "watch" the in-memory contents of an untitled:/ file we just subscribe to `onDidChangeTextDocument`
      */
     public async watchUntitledFiles() {
         this.disposables.push(

--- a/src/test/dynamicResources/awsResourceManager.test.ts
+++ b/src/test/dynamicResources/awsResourceManager.test.ts
@@ -6,6 +6,7 @@
 import * as assert from 'assert'
 import * as sinon from 'sinon'
 import * as path from 'path'
+import * as pathutils from '../../shared/utilities/pathUtils'
 import * as vscode from 'vscode'
 import { ResourcesNode } from '../../dynamicResources/explorer/nodes/resourcesNode'
 import { ResourceNode } from '../../dynamicResources/explorer/nodes/resourceNode'
@@ -192,7 +193,9 @@ describe('ResourceManager', function () {
         const expectedSchemaLocation = path.join(tempFolder, 'sometype.schema.json')
         assert.ok(existsSync(expectedSchemaLocation))
         assert.strictEqual(mapping.type, 'json')
-        assert.strictEqual(mapping.uri.fsPath.toLowerCase(), editor.document.uri.fsPath.toLowerCase())
+        assert.ok(
+            pathutils.areEqual(undefined, mapping.uri.fsPath.toLowerCase(), editor.document.uri.fsPath.toLowerCase())
+        )
         const schema = mapping.schema as vscode.Uri
         assert.strictEqual(schema.fsPath.toLowerCase(), expectedSchemaLocation.toLowerCase())
     })
@@ -217,7 +220,9 @@ describe('ResourceManager', function () {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         const [mapping] = capture(schemaService.registerMapping).last()
         assert.strictEqual(mapping.type, 'json')
-        assert.strictEqual(mapping.uri.fsPath.toString().toLowerCase(), editor.document.uri.fsPath.toLowerCase())
+        assert.ok(
+            pathutils.areEqual(undefined, mapping.uri.fsPath.toLowerCase(), editor.document.uri.fsPath.toLowerCase())
+        )
         assert.strictEqual(mapping.schema, undefined)
     })
 

--- a/src/test/dynamicResources/awsResourceManager.test.ts
+++ b/src/test/dynamicResources/awsResourceManager.test.ts
@@ -4,9 +4,9 @@
  */
 
 import * as assert from 'assert'
+import * as testutil from '../testUtil'
 import * as sinon from 'sinon'
 import * as path from 'path'
-import * as pathutils from '../../shared/utilities/pathUtils'
 import * as vscode from 'vscode'
 import { ResourcesNode } from '../../dynamicResources/explorer/nodes/resourcesNode'
 import { ResourceNode } from '../../dynamicResources/explorer/nodes/resourceNode'
@@ -193,9 +193,7 @@ describe('ResourceManager', function () {
         const expectedSchemaLocation = path.join(tempFolder, 'sometype.schema.json')
         assert.ok(existsSync(expectedSchemaLocation))
         assert.strictEqual(mapping.type, 'json')
-        assert.ok(
-            pathutils.areEqual(undefined, mapping.uri.fsPath.toLowerCase(), editor.document.uri.fsPath.toLowerCase())
-        )
+        testutil.assertEqualPaths(mapping.uri.fsPath.toLowerCase(), editor.document.uri.fsPath.toLowerCase())
         const schema = mapping.schema as vscode.Uri
         assert.strictEqual(schema.fsPath.toLowerCase(), expectedSchemaLocation.toLowerCase())
     })
@@ -220,9 +218,7 @@ describe('ResourceManager', function () {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         const [mapping] = capture(schemaService.registerMapping).last()
         assert.strictEqual(mapping.type, 'json')
-        assert.ok(
-            pathutils.areEqual(undefined, mapping.uri.fsPath.toLowerCase(), editor.document.uri.fsPath.toLowerCase())
-        )
+        testutil.assertEqualPaths(mapping.uri.fsPath.toLowerCase(), editor.document.uri.fsPath.toLowerCase())
         assert.strictEqual(mapping.schema, undefined)
     })
 

--- a/src/test/dynamicResources/awsResourceManager.test.ts
+++ b/src/test/dynamicResources/awsResourceManager.test.ts
@@ -192,7 +192,7 @@ describe('ResourceManager', function () {
         const expectedSchemaLocation = path.join(tempFolder, 'sometype.schema.json')
         assert.ok(existsSync(expectedSchemaLocation))
         assert.strictEqual(mapping.type, 'json')
-        assert.strictEqual(mapping.path.toLowerCase(), editor.document.uri.fsPath.toLowerCase())
+        assert.strictEqual(mapping.uri.fsPath.toLowerCase(), editor.document.uri.fsPath.toLowerCase())
         const schema = mapping.schema as vscode.Uri
         assert.strictEqual(schema.fsPath.toLowerCase(), expectedSchemaLocation.toLowerCase())
     })
@@ -217,7 +217,7 @@ describe('ResourceManager', function () {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         const [mapping] = capture(schemaService.registerMapping).last()
         assert.strictEqual(mapping.type, 'json')
-        assert.strictEqual(mapping.path.toLowerCase(), editor.document.uri.fsPath.toLowerCase())
+        assert.strictEqual(mapping.uri.fsPath.toString().toLowerCase(), editor.document.uri.fsPath.toLowerCase())
         assert.strictEqual(mapping.schema, undefined)
     })
 

--- a/src/test/dynamicResources/awsResourceManager.test.ts
+++ b/src/test/dynamicResources/awsResourceManager.test.ts
@@ -193,7 +193,7 @@ describe('ResourceManager', function () {
         const expectedSchemaLocation = path.join(tempFolder, 'sometype.schema.json')
         assert.ok(existsSync(expectedSchemaLocation))
         assert.strictEqual(mapping.type, 'json')
-        testutil.assertEqualPaths(mapping.uri.fsPath.toLowerCase(), editor.document.uri.fsPath.toLowerCase())
+        testutil.assertEqualPaths(mapping.uri.fsPath, editor.document.uri.fsPath)
         const schema = mapping.schema as vscode.Uri
         assert.strictEqual(schema.fsPath.toLowerCase(), expectedSchemaLocation.toLowerCase())
     })
@@ -218,7 +218,7 @@ describe('ResourceManager', function () {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         const [mapping] = capture(schemaService.registerMapping).last()
         assert.strictEqual(mapping.type, 'json')
-        testutil.assertEqualPaths(mapping.uri.fsPath.toLowerCase(), editor.document.uri.fsPath.toLowerCase())
+        testutil.assertEqualPaths(mapping.uri.fsPath, editor.document.uri.fsPath)
         assert.strictEqual(mapping.schema, undefined)
     })
 

--- a/src/test/shared/schemas.test.ts
+++ b/src/test/shared/schemas.test.ts
@@ -46,12 +46,12 @@ describe('SchemaService', function () {
 
     it('assigns schemas to the yaml extension', async function () {
         service.registerMapping({
-            path: '/foo',
+            uri: vscode.Uri.parse('/foo'),
             type: 'yaml',
             schema: 'cfn',
         })
         service.registerMapping({
-            path: '/bar',
+            uri: vscode.Uri.parse('/bar'),
             type: 'yaml',
             schema: 'sam',
         })
@@ -62,7 +62,7 @@ describe('SchemaService', function () {
 
     it('removes schemas from the yaml extension', async function () {
         service.registerMapping({
-            path: '/foo',
+            uri: vscode.Uri.parse('/foo'),
             type: 'yaml',
             schema: undefined,
         })
@@ -72,7 +72,7 @@ describe('SchemaService', function () {
 
     it('registers schemas to json configuration', async function () {
         service.registerMapping({
-            path: '/foo',
+            uri: vscode.Uri.parse('/foo'),
             type: 'json',
             schema: 'cfn',
         })
@@ -90,7 +90,7 @@ describe('SchemaService', function () {
 
     it('removes schemas from json configuration', async function () {
         service.registerMapping({
-            path: '/foo',
+            uri: vscode.Uri.parse('/foo'),
             type: 'json',
             schema: undefined,
         })
@@ -113,7 +113,7 @@ describe('SchemaService', function () {
         })
 
         service.registerMapping({
-            path: '/foo',
+            uri: vscode.Uri.parse('/foo'),
             type: 'yaml',
             schema: 'cfn',
         })
@@ -126,7 +126,7 @@ describe('SchemaService', function () {
         service = new SchemaService(fakeExtensionContext)
 
         service.registerMapping({
-            path: '/foo',
+            uri: vscode.Uri.parse('/foo'),
             type: 'yaml',
             schema: 'cfn',
         })


### PR DESCRIPTION
## Problem
- Currently, untitled yaml files for cloudformation/sam do not get a schema associated until the file is saved

## Solution
- Watch untitled yaml files for cloudformation/sam contents and apply the schema accordingly
- Allow the file watcher to be able to work with untitled yaml files

To test you can just create a new untitled file and make sure the language is yaml. Then add `AWSTemplateFormatVersion` and it should automatically start detecting the schema
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
