### PR TITLE
fix(auth): ec2/ecs credentials caching

### DIFF
--- a/.changes/next-release/Bug Fix-bfe16ba3-99a9-4953-80fe-792a666829b8.json
+++ b/.changes/next-release/Bug Fix-bfe16ba3-99a9-4953-80fe-792a666829b8.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "cached ECS/EC2 credentials not refreshed when expired"
+}

--- a/src/credentials/providers/ec2CredentialsProvider.ts
+++ b/src/credentials/providers/ec2CredentialsProvider.ts
@@ -19,9 +19,9 @@ import globals from '../../shared/extensionGlobals'
  * @see CredentialsProviderType
  */
 export class Ec2CredentialsProvider implements CredentialsProvider {
-    private credentials: Credentials | undefined
     private region: string | undefined
     private available: boolean | undefined
+    private readonly createTime = Date.now()
 
     public constructor(private metadata: Ec2MetadataClient = new DefaultEc2MetadataClient()) {}
 
@@ -80,7 +80,7 @@ export class Ec2CredentialsProvider implements CredentialsProvider {
     }
 
     public getHashCode(): string {
-        return getStringHash(JSON.stringify(this.credentials))
+        return getStringHash(this.getProviderType() + `-${this.createTime}`)
     }
 
     public canAutoConnect(): boolean {
@@ -88,9 +88,6 @@ export class Ec2CredentialsProvider implements CredentialsProvider {
     }
 
     public async getCredentials(): Promise<Credentials> {
-        if (!this.credentials) {
-            this.credentials = await fromInstanceMetadata()()
-        }
-        return this.credentials
+        return fromInstanceMetadata()()
     }
 }

--- a/src/credentials/providers/ecsCredentialsProvider.ts
+++ b/src/credentials/providers/ecsCredentialsProvider.ts
@@ -18,8 +18,8 @@ import globals from '../../shared/extensionGlobals'
  * @see CredentialsProviderType
  */
 export class EcsCredentialsProvider implements CredentialsProvider {
-    private credentials: Credentials | undefined
     private available: boolean | undefined
+    private readonly createTime = Date.now()
 
     public constructor(private provider: CredentialProvider = fromContainerMetadata()) {}
 
@@ -34,7 +34,7 @@ export class EcsCredentialsProvider implements CredentialsProvider {
         if (env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI || env.AWS_CONTAINER_CREDENTIALS_FULL_URI) {
             const start = globals.clock.Date.now()
             try {
-                this.credentials = await this.provider()
+                await this.provider()
                 getLogger().verbose(`credentials: retrieved ECS container credentials`)
 
                 this.available = true
@@ -73,7 +73,7 @@ export class EcsCredentialsProvider implements CredentialsProvider {
     }
 
     public getHashCode(): string {
-        return getStringHash(JSON.stringify(this.credentials))
+        return getStringHash(this.getProviderType() + `-${this.createTime}`)
     }
 
     public canAutoConnect(): boolean {
@@ -81,9 +81,6 @@ export class EcsCredentialsProvider implements CredentialsProvider {
     }
 
     public async getCredentials(): Promise<Credentials> {
-        if (!this.credentials) {
-            this.credentials = await this.provider()
-        }
-        return this.credentials
+        return this.provider()
     }
 }


### PR DESCRIPTION
## Problem
Credentials from ECS and EC2 are held past expiration

## Solution
Remove the memoization

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
