### PR TITLE
refactor(codewhisperer): onAccept command

### DIFF
--- a/src/codewhisperer/commands/onAcceptance.ts
+++ b/src/codewhisperer/commands/onAcceptance.ts
@@ -16,6 +16,8 @@ import { isCloud9 } from '../../shared/extensionUtilities'
 import { handleExtraBrackets } from '../util/closingBracketUtil'
 import { RecommendationHandler } from '../service/recommendationHandler'
 import { InlineCompletion } from '../service/inlineCompletion'
+import { ReferenceLogViewProvider } from '../service/referenceLogViewProvider'
+import { ReferenceHoverProvider } from '../service/referenceHoverProvider'
 
 /**
  * This function is called when user accepts a intelliSense suggestion or an inline suggestion
@@ -100,6 +102,18 @@ export async function onAcceptance(acceptanceEntry: OnRecommendationAcceptanceEn
             acceptanceEntry.editor.document.getText(codeRangeAfterFormat),
             acceptanceEntry.editor.document.fileName
         )
+        if (acceptanceEntry.references !== undefined) {
+            const referenceLog = ReferenceLogViewProvider.getReferenceLog(
+                acceptanceEntry.recommendation,
+                acceptanceEntry.references,
+                acceptanceEntry.editor
+            )
+            ReferenceLogViewProvider.instance.addReferenceLog(referenceLog)
+            ReferenceHoverProvider.instance.addCodeReferences(
+                acceptanceEntry.recommendation,
+                acceptanceEntry.references
+            )
+        }
     }
 
     // at the end of recommendation acceptance, clear recommendations.

--- a/src/codewhisperer/commands/onInlineAcceptance.ts
+++ b/src/codewhisperer/commands/onInlineAcceptance.ts
@@ -16,7 +16,52 @@ import { RecommendationHandler } from '../service/recommendationHandler'
 import { InlineCompletionService } from '../service/inlineCompletionService'
 import { sleep } from '../../shared/utilities/timeoutUtils'
 import { handleExtraBrackets } from '../util/closingBracketUtil'
+import { Commands } from '../../shared/vscode/commands2'
+import { isInlineCompletionEnabled } from '../util/commonUtil'
+import { ExtContext } from '../../shared/extensions'
+import { onAcceptance } from './onAcceptance'
+import * as codewhispererClient from '../client/codewhisperer'
+import {
+    CodewhispererCompletionType,
+    CodewhispererLanguage,
+    CodewhispererTriggerType,
+} from '../../shared/telemetry/telemetry.gen'
+import { ReferenceLogViewProvider } from '../service/referenceLogViewProvider'
+import { ReferenceHoverProvider } from '../service/referenceHoverProvider'
 
+export const acceptSuggestion = Commands.declare(
+    'aws.codeWhisperer.accept',
+    (context: ExtContext) =>
+        async (
+            range: vscode.Range,
+            acceptIndex: number,
+            recommendation: string,
+            requestId: string,
+            sessionId: string,
+            triggerType: CodewhispererTriggerType,
+            completionType: CodewhispererCompletionType,
+            language: CodewhispererLanguage,
+            references: codewhispererClient.References
+        ) => {
+            const editor = vscode.window.activeTextEditor
+            const onAcceptanceFunc = isInlineCompletionEnabled() ? onInlineAcceptance : onAcceptance
+            await onAcceptanceFunc(
+                {
+                    editor,
+                    range,
+                    acceptIndex,
+                    recommendation,
+                    requestId,
+                    sessionId,
+                    triggerType,
+                    completionType,
+                    language,
+                    references,
+                },
+                context.extensionContext.globalState
+            )
+        }
+)
 /**
  * This function is called when user accepts a intelliSense suggestion or an inline suggestion
  */
@@ -91,6 +136,18 @@ export async function onInlineAcceptance(
             acceptanceEntry.editor.document.getText(codeRangeAfterFormat),
             acceptanceEntry.editor.document.fileName
         )
+        if (acceptanceEntry.references !== undefined) {
+            const referenceLog = ReferenceLogViewProvider.getReferenceLog(
+                acceptanceEntry.recommendation,
+                acceptanceEntry.references,
+                acceptanceEntry.editor
+            )
+            ReferenceLogViewProvider.instance.addReferenceLog(referenceLog)
+            ReferenceHoverProvider.instance.addCodeReferences(
+                acceptanceEntry.recommendation,
+                acceptanceEntry.references
+            )
+        }
     }
 
     // at the end of recommendation acceptance, clear recommendations.

--- a/src/codewhisperer/service/referenceHoverProvider.ts
+++ b/src/codewhisperer/service/referenceHoverProvider.ts
@@ -15,7 +15,11 @@ interface CodeReference {
 
 export class ReferenceHoverProvider implements vscode.HoverProvider {
     private _codeReferenceCache: CodeReference[] = []
+    static #instance: ReferenceHoverProvider
 
+    public static get instance() {
+        return (this.#instance ??= new this())
+    }
     public provideHover(
         document: vscode.TextDocument,
         position: vscode.Position,

--- a/src/codewhisperer/service/referenceLogViewProvider.ts
+++ b/src/codewhisperer/service/referenceLogViewProvider.ts
@@ -8,6 +8,7 @@ import { References } from '../client/codewhisperer'
 import { LicenseUtil } from '../util/licenseUtil'
 import * as CodeWhispererConstants from '../models/constants'
 import { CodeWhispererSettings } from '../util/codewhispererSettings'
+import globals from '../../shared/extensionGlobals'
 import { isCloud9 } from '../../shared/extensionUtilities'
 import { TelemetryHelper } from '../util/telemetryHelper'
 
@@ -15,9 +16,12 @@ export class ReferenceLogViewProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = 'aws.codeWhisperer.referenceLog'
     private _view?: vscode.WebviewView
     private _referenceLogs: string[] = []
-    private _settings: CodeWhispererSettings
-    constructor(private readonly _extensionUri: vscode.Uri, settings: CodeWhispererSettings) {
-        this._settings = settings
+    private _extensionUri: vscode.Uri = globals.context.extensionUri
+    constructor() {}
+    static #instance: ReferenceLogViewProvider
+
+    public static get instance() {
+        return (this.#instance ??= new this())
     }
 
     public resolveWebviewView(
@@ -34,7 +38,7 @@ export class ReferenceLogViewProvider implements vscode.WebviewViewProvider {
         }
         this._view.webview.html = this.getHtml(
             webviewView.webview,
-            this._settings.isIncludeSuggestionsWithCodeReferencesEnabled()
+            CodeWhispererSettings.instance.isIncludeSuggestionsWithCodeReferencesEnabled()
         )
         this._view.webview.onDidReceiveMessage(data => {
             vscode.commands.executeCommand('aws.codeWhisperer.configure', 'codewhisperer')
@@ -43,7 +47,7 @@ export class ReferenceLogViewProvider implements vscode.WebviewViewProvider {
 
     public async update() {
         if (this._view) {
-            const showPrompt = this._settings.isIncludeSuggestionsWithCodeReferencesEnabled()
+            const showPrompt = CodeWhispererSettings.instance.isIncludeSuggestionsWithCodeReferencesEnabled()
             this._view.webview.html = this.getHtml(this._view.webview, showPrompt)
         }
     }


### PR DESCRIPTION
## Problem
The on acceptance command is chunky and prone to error. [https://github.com/aws/aws-toolkit-vscode/pull/2888#discussion_r973187466](https://github.com/aws/aws-toolkit-vscode/pull/2888)

## Solution

On acceptance is separated from activation.ts. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
