### PR TITLE
fix(codewhisperer): impove 'hover' override robustness for inline suggestions

### DIFF
--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -57,6 +57,11 @@ import {
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
 export async function activate(context: ExtContext): Promise<void> {
+    // No need to await. This can be removed once the 'hover.enabled' hack is no longer needed.
+    HoverConfigUtil.instance.restoreHoverConfig().catch(err => {
+        getLogger().warn('codewhisperer: failed to restore "editor.hover.enabled" setting: %O', err)
+    })
+
     const codewhispererSettings = CodeWhispererSettings.instance
     if (!codewhispererSettings.isEnabled()) {
         return

--- a/src/codewhisperer/util/hoverConfigUtil.ts
+++ b/src/codewhisperer/util/hoverConfigUtil.ts
@@ -3,13 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import globals from '../../shared/extensionGlobals'
 import { Settings } from '../../shared/settings'
 
 export class HoverConfigUtil extends Settings.define('editor', { 'hover.enabled': Boolean }) {
     // disable hover popup when inline suggestion is active
     // this is because native popup Next/Previous button have bug that removes active inline suggestion
     // this class can be removed once inlineCompletionAdditions API is available
-    private userHoverEnabled?: boolean
+
+    public constructor(private readonly globalState = globals.context.globalState, settings = Settings.instance) {
+        super(settings)
+    }
 
     static #instance: HoverConfigUtil
 
@@ -19,14 +23,15 @@ export class HoverConfigUtil extends Settings.define('editor', { 'hover.enabled'
 
     async overwriteHoverConfig() {
         if (this.get('hover.enabled', false)) {
+            await this.globalState.update('settings.editor.hover.enabled', true)
             await this.update('hover.enabled', false)
-            this.userHoverEnabled = true
         }
     }
 
     async restoreHoverConfig() {
-        if (this.userHoverEnabled) {
-            await this.update('hover.enabled', this.userHoverEnabled)
+        if (this.globalState.get('settings.editor.hover.enabled')) {
+            await this.update('hover.enabled', true)
+            await this.globalState.update('settings.editor.hover.enabled', undefined)
         }
     }
 }

--- a/src/test/codewhisperer/util/hoverConfigUtil.test.ts
+++ b/src/test/codewhisperer/util/hoverConfigUtil.test.ts
@@ -5,6 +5,7 @@
 
 import * as assert from 'assert'
 import { HoverConfigUtil } from '../../../codewhisperer/util/hoverConfigUtil'
+import { FakeMemento } from '../../fakeExtensionContext'
 
 describe('HoverConfigUtil', function () {
     describe('overwriteHoverConfig', async function () {
@@ -15,6 +16,7 @@ describe('HoverConfigUtil', function () {
             const actual = hoverConfigUtil.get('hover.enabled', false)
             assert.strictEqual(actual, false)
         })
+
         it('Should not set hover enabled to false if it is currently false', async function () {
             const hoverConfigUtil = new HoverConfigUtil()
             await hoverConfigUtil.update('hover.enabled', false)
@@ -33,6 +35,7 @@ describe('HoverConfigUtil', function () {
             const actual = hoverConfigUtil.get('hover.enabled', false)
             assert.strictEqual(actual, true)
         })
+
         it('Should not restore hover config it was not previously overwritten', async function () {
             const hoverConfigUtil = new HoverConfigUtil()
             await hoverConfigUtil.update('hover.enabled', false)
@@ -40,5 +43,20 @@ describe('HoverConfigUtil', function () {
             const actual = hoverConfigUtil.get('hover.enabled', false)
             assert.strictEqual(actual, false)
         })
+    })
+
+    it('stores the previous setting value in the provided memento', async function () {
+        const memento = new FakeMemento()
+
+        const util1 = new HoverConfigUtil(memento)
+        await util1.update('hover.enabled', true)
+        await util1.overwriteHoverConfig()
+
+        const util2 = new HoverConfigUtil(memento)
+        await util2.update('hover.enabled', false)
+        await util2.restoreHoverConfig()
+
+        const actual = util2.get('hover.enabled', false)
+        assert.strictEqual(actual, true)
     })
 })


### PR DESCRIPTION
## Problem
CodeWhisperer won't restore user settings if they reload/exit at certain times

## Solution
Use `globalState` + restore the setting on extension activation

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
