### PR TITLE
feat(codewhisperer): auto-trigger improvements

### DIFF
--- a/.changes/next-release/Feature-6590b13d-5693-4975-9f7f-bb08d9972d1c.json
+++ b/.changes/next-release/Feature-6590b13d-5693-4975-9f7f-bb08d9972d1c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "CodeWhisperer Auto-tigger improvements"
+}

--- a/src/codewhisperer/commands/invokeRecommendation.ts
+++ b/src/codewhisperer/commands/invokeRecommendation.ts
@@ -10,7 +10,6 @@ import { DefaultCodeWhispererClient } from '../client/codewhisperer'
 import { InlineCompletion } from '../service/inlineCompletion'
 import { isCloud9 } from '../../shared/extensionUtilities'
 import { RecommendationHandler } from '../service/recommendationHandler'
-import { KeyStrokeHandler } from '../service/keyStrokeHandler'
 import { isInlineCompletionEnabled } from '../util/commonUtil'
 import { InlineCompletionService } from '../service/inlineCompletionService'
 
@@ -50,7 +49,6 @@ export async function invokeRecommendation(
                 RecommendationHandler.instance.isValidResponse()
             )
         }
-        KeyStrokeHandler.instance.keyStrokeCount = 0
         if (isCloud9()) {
             if (RecommendationHandler.instance.isGenerateRecommendationInProgress) return
             vsCodeState.isIntelliSenseActive = false

--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -19,6 +19,8 @@ export const promiseTimeoutLimit = 15 // seconds
 
 export const invocationKeyThreshold = 15
 
+export const idleTimerPollPeriod = 25
+
 export const specialCharactersList = ['{', '[', '(', ':', '\t', '\n']
 
 export const normalTextChangeRegex = /[A-Za-z0-9]/g

--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -19,7 +19,7 @@ export const promiseTimeoutLimit = 15 // seconds
 
 export const invocationKeyThreshold = 15
 
-export const idleTimerPollPeriod = 25
+export const idleTimerPollPeriod = 25 // milliseconds
 
 export const specialCharactersList = ['{', '[', '(', ':', '\t', '\n']
 

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -365,6 +365,10 @@ export class InlineCompletionService {
         this.statusBar.hide()
     }
 
+    isPaginationRunning(): boolean {
+        return this._isPaginationRunning
+    }
+
     isSuggestionVisible(): boolean {
         return this.inlineCompletionProvider?.getActiveItemIndex !== undefined
     }

--- a/src/codewhisperer/service/keyStrokeHandler.ts
+++ b/src/codewhisperer/service/keyStrokeHandler.ts
@@ -79,8 +79,6 @@ export class KeyStrokeHandler {
             // Pause automated trigger when typed input matches recommendation prefix for inline suggestion
             if (InlineCompletion.instance.isTypeaheadInProgress) return
 
-            this.startIdleTimeTriggerTimer(event, editor, client, config)
-
             // Skip Cloud9 IntelliSense acceptance event
             if (
                 isCloud9() &&
@@ -94,6 +92,9 @@ export class KeyStrokeHandler {
 
             let triggerType: CodewhispererAutomatedTriggerType | undefined
             const changedSource = new DefaultDocumentChangedType(event.contentChanges).checkChangeSource()
+            if ([DocumentChangedSource.SpecialCharsKey, DocumentChangedSource.RegularKey].includes(changedSource)) {
+                this.startIdleTimeTriggerTimer(event, editor, client, config)
+            }
             switch (changedSource) {
                 case DocumentChangedSource.EnterKey: {
                     triggerType = 'Enter'

--- a/src/codewhisperer/service/keyStrokeHandler.ts
+++ b/src/codewhisperer/service/keyStrokeHandler.ts
@@ -55,11 +55,12 @@ export class KeyStrokeHandler {
         this.idleTriggerTimer = setInterval(() => {
             const duration = Math.floor((performance.now() - RecommendationHandler.instance.lastInvocationTime) / 1000)
             if (duration < CodeWhispererConstants.invocationTimeIntervalThreshold) return
+            if (isCloud9() && RecommendationHandler.instance.isGenerateRecommendationInProgress) return
+            if (isInlineCompletionEnabled() && InlineCompletionService.instance.isPaginationRunning()) return
+            if (InlineCompletion.instance.getIsActive || InlineCompletion.instance.isPaginationRunning()) return
             this.invokeAutomatedTrigger('IdleTime', editor, client, config)
-            if (this.idleTriggerTimer) {
-                clearInterval(this.idleTriggerTimer)
-                this.idleTriggerTimer = undefined
-            }
+            if (this.idleTriggerTimer) clearInterval(this.idleTriggerTimer)
+            this.idleTriggerTimer = undefined
         }, CodeWhispererConstants.idleTimerPollPeriod)
     }
 

--- a/src/test/codewhisperer/commands/invokeRecommendation.test.ts
+++ b/src/test/codewhisperer/commands/invokeRecommendation.test.ts
@@ -11,7 +11,6 @@ import { ConfigurationEntry } from '../../../codewhisperer/models/model'
 import { invokeRecommendation } from '../../../codewhisperer/commands/invokeRecommendation'
 import { InlineCompletion } from '../../../codewhisperer/service/inlineCompletion'
 import { InlineCompletionService } from '../../../codewhisperer/service/inlineCompletionService'
-import { KeyStrokeHandler } from '../../../codewhisperer/service/keyStrokeHandler'
 
 describe('invokeRecommendation', function () {
     describe('invokeRecommendation', function () {
@@ -39,19 +38,6 @@ describe('invokeRecommendation', function () {
             }
             await invokeRecommendation(mockEditor, mockClient, config)
             assert.ok(getRecommendationStub.called || oldGetRecommendationStub.called)
-        })
-
-        it('When called, keyStrokeCount should be set to 0', async function () {
-            const mockEditor = createMockTextEditor()
-            KeyStrokeHandler.instance.keyStrokeCount = 10
-            const config: ConfigurationEntry = {
-                isShowMethodsEnabled: true,
-                isManualTriggerEnabled: true,
-                isAutomatedTriggerEnabled: true,
-                isIncludeSuggestionsWithCodeReferencesEnabled: true,
-            }
-            await invokeRecommendation(mockEditor, mockClient, config)
-            assert.strictEqual(KeyStrokeHandler.instance.keyStrokeCount, 0)
         })
     })
 })


### PR DESCRIPTION
## Problem
to improve our auto-trigger heuristic to be more aggressive at showing recommendations
## Solution
- remove key stroke based auto-trigger
- add new triggering based on user's idle time, we will trigger if there has been 2s since the last invocation and the previous request has finished

Inline api not enabled:

https://user-images.githubusercontent.com/60411978/192033831-71d269f3-6bba-4118-b22f-d31a830a7e3c.mov

inline api enabled:

https://user-images.githubusercontent.com/60411978/192033900-73fb747a-b315-4a84-984b-88f6ad0ce9ca.mov

cloud9:

https://user-images.githubusercontent.com/60411978/192033930-53e6d8d0-2def-48a9-9144-f86690acb9c6.mov







<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
