### PR TITLE
feat(dev): "Show Global State"

### DIFF
--- a/.changes/next-release/Feature-66c53a81-650f-442b-ad0c-4ea71a3f1f3c.json
+++ b/.changes/next-release/Feature-66c53a81-650f-442b-ad0c-4ea71a3f1f3c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "\"AWS (Developer)\" menu now includes a \"Show Global State\" item"
+}

--- a/package.json
+++ b/package.json
@@ -1060,7 +1060,7 @@
                 },
                 {
                     "command": "aws.dev.openMenu",
-                    "when": "aws.isDevMode"
+                    "when": "aws.isDevMode || isCloud9"
                 }
             ],
             "editor/title": [

--- a/src/dev/activation.ts
+++ b/src/dev/activation.ts
@@ -21,10 +21,10 @@ interface MenuOption {
 }
 
 /**
- * Currently contains all known developer tools.
+ * Defines AWS Toolkit developer tools.
  *
  * Options are displayed as quick-pick items. The {@link MenuOption.executor} callback is ran
- * if the user selects an option. There is no support for name-spacing. Just add the relevant
+ * on selection. There is no support for name-spacing. Just add the relevant
  * feature/module as a description so it can be moved around easier.
  */
 const menuOptions: Record<string, MenuOption> = {
@@ -34,6 +34,22 @@ const menuOptions: Record<string, MenuOption> = {
         detail: 'Edit a key in global/secret storage as a JSON document',
         executor: openStorageFromInput,
     },
+    showGlobalState: {
+        label: 'Show Global State',
+        description: 'AWS Toolkit',
+        detail: 'Shows various state (including environment variables)',
+        executor: showGlobalState,
+    },
+}
+
+export class GlobalStateDocumentProvider implements vscode.TextDocumentContentProvider {
+    provideTextDocumentContent(uri: vscode.Uri): string {
+        let s = 'Environment variables known to AWS Toolkit:\n'
+        for (const [k, v] of Object.entries(process.env)) {
+            s += `${k}=${v}\n`
+        }
+        return s
+    }
 }
 
 /**
@@ -53,7 +69,8 @@ export function activate(ctx: ExtContext): void {
 
     ctx.extensionContext.subscriptions.push(
         devSettings.onDidChangeActiveSettings(updateMode),
-        vscode.commands.registerCommand('aws.dev.openMenu', () => openMenu(ctx, menuOptions))
+        vscode.commands.registerCommand('aws.dev.openMenu', () => openMenu(ctx, menuOptions)),
+        vscode.workspace.registerTextDocumentContentProvider('aws-dev2', new GlobalStateDocumentProvider())
     )
 
     updateMode()
@@ -226,6 +243,12 @@ async function openStorageFromInput() {
     if (response) {
         return openStorageCommand.execute(response.target, response.key)
     }
+}
+
+async function showGlobalState() {
+    const uri = vscode.Uri.parse('aws-dev2:global-state')
+    const doc = await vscode.workspace.openTextDocument(uri)
+    await vscode.window.showTextDocument(doc, { preview: false })
 }
 
 export const openStorageCommand = Commands.from(ObjectEditor).declareOpenStorage('_aws.dev.openStorage')


### PR DESCRIPTION
## Problem

Toolkit developers, and customers who are troubleshooting, need a way to see the various global state that Toolkit depends on.

## Solution

Introduce `Show Global State` item in the "AWS (Developer)" menu. Currently only shows env vars, but can be expanded later.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
