### PR TITLE
fix(codewhisperer): Sometimes not show recommendation bug in new inline code path

### DIFF
--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -174,21 +174,9 @@ export async function activate(context: ExtContext): Promise<void> {
         acceptSuggestion.register(context),
         // on text document close.
         vscode.workspace.onDidCloseTextDocument(e => {
-            if (isInlineCompletionEnabled()) {
-                if (e.uri.fsPath === InlineCompletionService.instance.filePath()) {
-                    RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(
-                        vscode.window.activeTextEditor,
-                        -1
-                    )
-                    RecommendationHandler.instance.clearRecommendations()
-                }
-            } else {
-                RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(
-                    vscode.window.activeTextEditor,
-                    -1
-                )
-                RecommendationHandler.instance.clearRecommendations()
-            }
+            if (isInlineCompletionEnabled() && e.uri.fsPath !== InlineCompletionService.instance.filePath()) return
+            RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(vscode.window.activeTextEditor, -1)
+            RecommendationHandler.instance.clearRecommendations()
         }),
 
         vscode.languages.registerHoverProvider(

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -174,8 +174,21 @@ export async function activate(context: ExtContext): Promise<void> {
         acceptSuggestion.register(context),
         // on text document close.
         vscode.workspace.onDidCloseTextDocument(e => {
-            RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(vscode.window.activeTextEditor, -1)
-            RecommendationHandler.instance.clearRecommendations()
+            if (isInlineCompletionEnabled()) {
+                if (e.uri.fsPath === InlineCompletionService.instance.filePath()) {
+                    RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(
+                        vscode.window.activeTextEditor,
+                        -1
+                    )
+                    RecommendationHandler.instance.clearRecommendations()
+                }
+            } else {
+                RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(
+                    vscode.window.activeTextEditor,
+                    -1
+                )
+                RecommendationHandler.instance.clearRecommendations()
+            }
         }),
 
         vscode.languages.registerHoverProvider(

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -191,6 +191,10 @@ export class InlineCompletionService {
         return (this.#instance ??= new this())
     }
 
+    filePath(): string | undefined {
+        return this.documentUri?.fsPath
+    }
+
     // These commands override the vs code inline completion commands
     // They are subscribed when suggestion starts and disposed when suggestion is accepted/rejected
     // to avoid impacting other plugins or user who uses this API


### PR DESCRIPTION
## Problem

Fix a critical bug that were introduced in https://github.com/aws/aws-toolkit-vscode/commit/f82944e81c155ef938ab2e264b6747b47d54fa34

When changing the hover config in inlineCompletionService, a document text close event will be sent and received by the listener in activation.ts, which removed the recommendations.

This bug will make new inline completion not showing the recommendation if there is only one recommendation in paginated response. 

No changelog item is needed for this fix.

## Solution

Let the doc close listener only remove recommendation when the closed file is the invocation file.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
