### PR TITLE
fix(ecs): update `Copy ARN` command and region node

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
                 },
                 "aws.ecs.openTerminalCommand": {
                     "type": "string",
-                    "default": "/usr/bin/env bash",
+                    "default": "/bin/sh",
                     "markdownDescription": "%AWS.configuration.description.ecs.openTerminalCommand%"
                 },
                 "aws.iot.maxItemsPerPage": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -102,7 +102,7 @@
     "AWS.ecs.enableEcsExec": "Enable Command Execution",
     "AWS.ecs.disableEcsExec": "Disable Command Execution",
     "AWS.ecs.runCommandInContainer": "Run Command in Container",
-    "AWS.ecs.openTaskInTerminal": "Open Task in Terminal",
+    "AWS.ecs.openTaskInTerminal": "Open Terminal...",
     "AWS.command.samcli.detect": "Detect SAM CLI",
     "AWS.command.deleteCloudFormation": "Delete CloudFormation Stack",
     "AWS.command.viewSchemaItem": "View Schema",

--- a/src/awsexplorer/commands/copyArn.ts
+++ b/src/awsexplorer/commands/copyArn.ts
@@ -13,16 +13,19 @@ import { copyToClipboard } from '../../shared/utilities/messages'
 import { Window } from '../../shared/vscode/window'
 import { Commands } from '../../shared/vscode/commands'
 import { getIdeProperties } from '../../shared/extensionUtilities'
+import { TreeShim } from '../../shared/treeview/utils'
 
 /**
  * Copies the arn of the resource represented by the given node.
  */
 export async function copyArnCommand(
-    node: AWSResourceNode,
+    node: AWSResourceNode | TreeShim<AWSResourceNode>,
     window = Window.vscode(),
     env = Env.vscode(),
     commands = Commands.vscode()
 ): Promise<void> {
+    node = node instanceof TreeShim ? node.node.resource : node
+
     try {
         copyToClipboard(node.arn, 'ARN', window, env)
     } catch (e) {

--- a/src/awsexplorer/commands/copyName.ts
+++ b/src/awsexplorer/commands/copyName.ts
@@ -7,18 +7,17 @@ import { Env } from '../../shared/vscode/env'
 import { copyToClipboard } from '../../shared/utilities/messages'
 import { Window } from '../../shared/vscode/window'
 import { AWSResourceNode } from '../../shared/treeview/nodes/awsResourceNode'
+import { TreeShim } from '../../shared/treeview/utils'
 
 /**
  * Copies the name of the resource represented by the given node.
  */
 export async function copyNameCommand(
-    node: AWSResourceNode,
+    node: AWSResourceNode | TreeShim<AWSResourceNode>,
     window = Window.vscode(),
     env = Env.vscode()
 ): Promise<void> {
-    copyToClipboard(node.name, 'name', window, env)
-    recordCopyName()
-}
+    node = node instanceof TreeShim ? node.node.resource : node
 
-// TODO add telemetry for copy name
-function recordCopyName(): void {}
+    await copyToClipboard(node.name, 'name', window, env)
+}

--- a/src/ecs/commands.ts
+++ b/src/ecs/commands.ts
@@ -173,10 +173,7 @@ export const openTaskInTerminal = Commands.register('aws.ecs.openTaskInTerminal'
                 terminal.show()
             })
         } catch (err) {
-            throw ToolkitError.chain(
-                err,
-                localize('AWS.ecs.openTaskInTerminal.error', 'Failed to open task in terminal.')
-            )
+            throw ToolkitError.chain(err, localize('AWS.ecs.openTaskInTerminal.error', 'Failed to open terminal.'))
         }
     })
 })

--- a/src/ecs/model.ts
+++ b/src/ecs/model.ts
@@ -68,6 +68,7 @@ export class Container {
 
 export class Service {
     public readonly id = this.description.serviceArn!
+    public readonly arn = this.description.serviceArn!
 
     private readonly onDidChangeEmitter = new vscode.EventEmitter<void>()
     public readonly onDidChangeTreeItem = this.onDidChangeEmitter.event

--- a/src/ecs/wizards/executeCommand.ts
+++ b/src/ecs/wizards/executeCommand.ts
@@ -22,6 +22,7 @@ function createTaskPrompter(node: Container) {
     const taskItems = (async () => {
         // Filter for only 'Running' tasks
         return (await node.listTasks()).map(task => {
+            // TODO: get task definition name and include it in the item detail
             // The last 32 digits of the task arn is the task identifier
             const taskId = task.taskArn.substring(task.taskArn.length - 32)
             const invalidSelection = task.lastStatus !== 'RUNNING'
@@ -31,7 +32,7 @@ function createTaskPrompter(node: Container) {
                 detail: `Status: ${task.lastStatus}  Desired status: ${task.desiredStatus}`,
                 description:
                     invalidSelection && task.desiredStatus === 'RUNNING'
-                        ? 'Task starting, try again later.'
+                        ? 'Container instance starting, try again later.'
                         : undefined,
                 data: taskId,
                 invalidSelection,
@@ -40,12 +41,15 @@ function createTaskPrompter(node: Container) {
     })()
 
     return createQuickPick(taskItems, {
-        title: localize('AWS.command.ecs.runCommandInContainer.chooseTask', 'Choose a task'),
+        title: localize('AWS.command.ecs.runCommandInContainer.chooseInstance', 'Choose a container instance'),
         buttons: createCommonButtons(ecsExecToolkitGuideUrl),
         noItemsFoundItem: {
-            label: localize('AWS.command.ecs.runCommandInContainer.noTasks', 'No valid tasks for this container'),
+            label: localize(
+                'AWS.command.ecs.runCommandInContainer.noInstances',
+                'No valid instances for this container'
+            ),
             detail: localize(
-                'AWS.command.ecs.runCommandInContainer.noTasks.description',
+                'AWS.command.ecs.runCommandInContainer.noInstances.description',
                 'If command execution was recently enabled, try again in a few minutes.'
             ),
             data: WIZARD_BACK,

--- a/src/shared/clients/ecsClient.ts
+++ b/src/shared/clients/ecsClient.ts
@@ -77,7 +77,7 @@ export class DefaultEcsClient {
                 return []
             }
 
-            const resp = await (await client).describeServices({ services }).promise()
+            const resp = await (await client).describeServices({ cluster: request.cluster, services }).promise()
             return resp.services!
         })
     }

--- a/src/shared/treeview/utils.ts
+++ b/src/shared/treeview/utils.ts
@@ -96,10 +96,10 @@ export function unboxTreeNode<T>(node: TreeNode, predicate: (resource: unknown) 
  * Any new or existing code needs to account for this additional layer as the shim
  * would be passed in as-is.
  */
-export class TreeShim extends AWSTreeNodeBase {
+export class TreeShim<T = unknown> extends AWSTreeNodeBase {
     private children?: AWSTreeNodeBase[]
 
-    public constructor(public readonly node: TreeNode) {
+    public constructor(public readonly node: TreeNode<T>) {
         super('Loading...')
         this.updateTreeItem()
 

--- a/src/test/awsExplorer/commands/copyArn.test.ts
+++ b/src/test/awsExplorer/commands/copyArn.test.ts
@@ -4,8 +4,10 @@
  */
 
 import * as assert from 'assert'
+import { TreeItem } from 'vscode'
 import { copyArnCommand } from '../../../awsexplorer/commands/copyArn'
 import { AWSResourceNode } from '../../../shared/treeview/nodes/awsResourceNode'
+import { TreeShim } from '../../../shared/treeview/utils'
 import { FakeEnv } from '../../shared/vscode/fakeEnv'
 import { FakeWindow } from '../../shared/vscode/fakeWindow'
 
@@ -36,6 +38,17 @@ describe('copyArnCommand', function () {
         assert.strictEqual(env.clipboard.text, undefined)
         assert.strictEqual(window.statusBar.message, undefined)
         assert.ok(window.message.error?.includes('Could not find an ARN'))
+    })
+
+    it('handles `TreeShim`', async function () {
+        const node = new TreeShim({
+            id: 'shim',
+            resource: { name: 'resource', arn: 'arn' },
+            getTreeItem: () => new TreeItem(''),
+        })
+
+        await copyArnCommand(node, window, env)
+        assert.strictEqual(env.clipboard.text, 'arn')
     })
 })
 

--- a/src/test/awsExplorer/commands/copyName.test.ts
+++ b/src/test/awsExplorer/commands/copyName.test.ts
@@ -4,8 +4,10 @@
  */
 
 import * as assert from 'assert'
+import { TreeItem } from 'vscode'
 import { copyNameCommand } from '../../../awsexplorer/commands/copyName'
 import { AWSResourceNode } from '../../../shared/treeview/nodes/awsResourceNode'
+import { TreeShim } from '../../../shared/treeview/utils'
 import { FakeEnv } from '../../shared/vscode/fakeEnv'
 import { FakeWindow } from '../../shared/vscode/fakeWindow'
 
@@ -21,5 +23,18 @@ describe('copyNameCommand', function () {
         await copyNameCommand(node, window, env)
 
         assert.strictEqual(env.clipboard.text, 'name')
+    })
+
+    it('handles `TreeShim`', async function () {
+        const node = new TreeShim({
+            id: 'shim',
+            resource: { name: 'resource', arn: 'arn' },
+            getTreeItem: () => new TreeItem(''),
+        })
+
+        const window = new FakeWindow()
+        const env = new FakeEnv()
+        await copyNameCommand(node, window, env)
+        assert.strictEqual(env.clipboard.text, 'resource')
     })
 })


### PR DESCRIPTION
## Problem
* The "Copy ARN" command doesn't work with `TreeShim`
* `RegionNode` caches all service nodes
* Can't list services for non-default ECS cluster (#2915)

## Solution
* Fix the copy name/ARN commands
    * Added tests for this
* Change `RegionNode` to lazily instantiate service nodes
* Add cluster ARN to `listServices` call

Also added more documentation for `ResourceTreeNode`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
