### PR TITLE
refactor(clients): decrease boilerplate with a new class factory function

### DIFF
--- a/src/ecs/client.ts
+++ b/src/ecs/client.ts
@@ -1,0 +1,69 @@
+/*!
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ECS } from 'aws-sdk'
+import { defineClient } from '../shared/clientBuilder'
+import { AsyncCollection } from '../shared/utilities/asyncCollection'
+import { isNonNullable } from '../shared/utilities/tsUtils'
+
+export class EcsClient extends defineClient(ECS) {
+    public constructor(public readonly regionCode: string) {
+        super({ region: regionCode })
+    }
+
+    public listAndDescribeClusters(request: ECS.ListClustersRequest = {}): AsyncCollection<ECS.Cluster[]> {
+        const collection = this.listClusters.paginate('nextToken', request)
+
+        return collection
+            .map(resp => resp.clusterArns)
+            .filter(isNonNullable)
+            .map(async clusters => {
+                if (clusters.length === 0) {
+                    return []
+                }
+
+                const resp = await this.describeClusters({ clusters })
+                return resp.clusters!
+            })
+    }
+
+    public listAndDescribeServices(request: ECS.ListServicesRequest = {}): AsyncCollection<ECS.Service[]> {
+        const collection = this.listServices.paginate('nextToken', request)
+
+        return collection
+            .map(resp => resp.serviceArns)
+            .filter(isNonNullable)
+            .map(async services => {
+                if (services.length === 0) {
+                    return []
+                }
+
+                const resp = await this.describeServices({ cluster: request.cluster, services })
+                return resp.services!
+            })
+    }
+
+    public listAndDescribeTasks(request: ECS.ListTasksRequest = {}): AsyncCollection<ECS.Task[]> {
+        const collection = this.listTasks.paginate('nextToken', request)
+
+        return collection
+            .map(resp => resp.taskArns)
+            .filter(isNonNullable)
+            .map(async tasks => {
+                if (tasks.length === 0) {
+                    return []
+                }
+
+                const resp = await this.describeTasks({ cluster: request.cluster, tasks })
+                return resp.tasks!
+            })
+    }
+
+    public executeInteractiveCommand(request: Omit<ECS.ExecuteCommandRequest, 'interactive'>) {
+        // Currently the 'interactive' flag is required and needs to be true for ExecuteCommand: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ExecuteCommand.html
+        // This may change 'in the near future' as explained here: https://aws.amazon.com/blogs/containers/new-using-amazon-ecs-exec-access-your-containers-fargate-ec2/
+        return this.executeCommand({ ...request, interactive: true })
+    }
+}

--- a/src/ecs/model.ts
+++ b/src/ecs/model.ts
@@ -8,11 +8,11 @@ const localize = nls.loadMessageBundle()
 
 import * as vscode from 'vscode'
 import { ECS } from 'aws-sdk'
-import { DefaultEcsClient } from '../shared/clients/ecsClient'
 import { ResourceTreeNode } from '../shared/treeview/resource'
 import { getIcon } from '../shared/icons'
 import { AsyncCollection } from '../shared/utilities/asyncCollection'
 import { prepareCommand } from './util'
+import { EcsClient } from './client'
 
 function createValidTaskFilter(containerName: string) {
     return function (t: ECS.Task): t is ECS.Task & { taskArn: string } {
@@ -33,11 +33,13 @@ interface ContainerDescription extends ECS.ContainerDefinition {
 export class Container {
     public readonly id = this.description.name!
 
-    public constructor(private readonly client: DefaultEcsClient, public readonly description: ContainerDescription) {}
+    public constructor(private readonly client: EcsClient, public readonly description: ContainerDescription) {}
 
     public async listTasks() {
-        const resp = await this.client.listTasks({ cluster: this.description.clusterArn })
-        const tasks = await this.client.describeTasks(this.description.clusterArn, resp)
+        const tasks = await this.client
+            .listAndDescribeTasks({ cluster: this.description.clusterArn })
+            .flatten()
+            .promise()
 
         return tasks.filter(createValidTaskFilter(this.description.name!))
     }
@@ -72,7 +74,7 @@ export class Service {
     private readonly onDidChangeEmitter = new vscode.EventEmitter<void>()
     public readonly onDidChangeTreeItem = this.onDidChangeEmitter.event
 
-    public constructor(private readonly client: DefaultEcsClient, public readonly description: ECS.Service) {}
+    public constructor(private readonly client: EcsClient, public readonly description: ECS.Service) {}
 
     public async listContainers(): Promise<Container[]> {
         const definition = await this.getDefinition()
@@ -94,7 +96,9 @@ export class Service {
             throw new Error(`No task definition found for ECS service ${this.id}`)
         }
 
-        const resp = await this.client.describeTaskDefinition(this.description.taskDefinition!)
+        const resp = await this.client.describeTaskDefinition({
+            taskDefinition: this.description.taskDefinition,
+        })
 
         return resp.taskDefinition!
     }
@@ -141,11 +145,11 @@ export class Service {
 class Cluster {
     public readonly id = this.cluster.clusterArn!
 
-    public constructor(private readonly client: DefaultEcsClient, private readonly cluster: ECS.Cluster) {}
+    public constructor(private readonly client: EcsClient, private readonly cluster: ECS.Cluster) {}
 
     public listServices(): AsyncCollection<Service[]> {
         return this.client
-            .listServices({ cluster: this.cluster.clusterArn! })
+            .listAndDescribeServices({ cluster: this.cluster.clusterArn! })
             .map(services => services.map(s => new Service(this.client, s)))
     }
 
@@ -171,7 +175,7 @@ class Cluster {
 
 class Ecs {
     public readonly id = 'ecs'
-    public constructor(private readonly client: DefaultEcsClient) {}
+    public constructor(private readonly client: EcsClient) {}
 
     public getTreeItem() {
         const item = new vscode.TreeItem('ECS')
@@ -181,12 +185,12 @@ class Ecs {
     }
 
     public listClusters(): AsyncCollection<Cluster[]> {
-        return this.client.listClusters().map(clusters => clusters.map(c => new Cluster(this.client, c)))
+        return this.client.listAndDescribeClusters().map(clusters => clusters.map(c => new Cluster(this.client, c)))
     }
 }
 
 export function getEcsRootNode(region: string) {
-    const controller = new Ecs(new DefaultEcsClient(region))
+    const controller = new Ecs(new EcsClient(region))
 
     return new ResourceTreeNode(controller, {
         placeholder: localize('AWS.explorerNode.ecs.noClusters', '[No Clusters found]'),

--- a/src/ecs/util.ts
+++ b/src/ecs/util.ts
@@ -9,7 +9,6 @@ import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
 import * as vscode from 'vscode'
-import { EcsClient } from '../shared/clients/ecsClient'
 import { IamClient } from '../shared/clients/iamClient'
 import { ToolkitError } from '../shared/errors'
 import { isCloud9 } from '../shared/extensionUtilities'
@@ -18,6 +17,7 @@ import { TaskDefinition } from 'aws-sdk/clients/ecs'
 import { getLogger } from '../shared/logger'
 import { SSM } from 'aws-sdk'
 import { fromExtensionManifest } from '../shared/settings'
+import { EcsClient } from './client'
 
 interface EcsTaskIdentifer {
     readonly task: string
@@ -71,7 +71,7 @@ export async function prepareCommand(
     task: EcsTaskIdentifer
 ): Promise<{ path: string; args: string[]; dispose: () => void }> {
     const ssmPlugin = await getOrInstallCli('session-manager-plugin', !isCloud9())
-    const { session } = await client.executeCommand({ ...task, command })
+    const { session } = await client.executeInteractiveCommand({ ...task, command })
     const args = [JSON.stringify(session), client.regionCode, 'StartSession']
 
     async function terminateSession() {

--- a/src/shared/clientBuilder.ts
+++ b/src/shared/clientBuilder.ts
@@ -1,0 +1,299 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import globals from './extensionGlobals'
+
+import { Request, Service, AWSError, Credentials as CredentialsClass } from 'aws-sdk'
+import { CredentialsOptions } from 'aws-sdk/lib/credentials'
+import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
+import { CredentialsShim } from '../credentials/loginManager'
+import { FunctionKeys, getFunctions } from './utilities/classUtils'
+import { SharedKeys } from './utilities/tsUtils'
+import { getClientId } from './telemetry/util'
+import { env, version } from 'vscode'
+import { extensionVersion, isReleaseVersion } from './vscode/env'
+import { AsyncCollection, toCollection } from './utilities/asyncCollection'
+import { getLogger } from './logger/logger'
+import { ToolkitError } from './errors'
+
+interface PromiseResult<T, E = unknown> extends Promise<T> {
+    catch<R, U>(onrejected?: (reason: E) => R | PromiseResult<R, U>): PromiseResult<T | R, U>
+    catch<R = never>(onrejected?: (reason: E) => R | PromiseLike<R>): PromiseResult<T | R>
+}
+
+type ShiftTuple<T> = T extends [infer _, ...infer U] ? U : never
+
+interface Operation<T extends any[], R, E = unknown> {
+    (...args: T): ServiceRequest<R, E>
+    send(...args: T): ServiceRequest<R, E>
+    paginate(mark: SharedKeys<T[0], R>, request: T[0], ...rest: ShiftTuple<T>): AsyncCollection<R>
+}
+
+interface ServiceRequest<T, E = unknown> extends PromiseResult<T, E> {
+    readonly operation: string
+    readonly headers: Record<string, string | undefined>
+    cancel(reason?: string): void
+
+    // should only be used for instrumentation
+    onResponse(listener: ResponseListener): this
+}
+
+interface ServiceResponse {
+    readonly requestId: string
+    readonly headers: Record<string, string | undefined>
+}
+
+type RequestListener = (request: ServiceRequest<unknown>) => void
+type ResponseListener = (response: ServiceResponse) => void
+
+interface Configuration {
+    readonly region?: string
+    readonly endpoint?: string
+    readonly sendUserAgent?: boolean
+    readonly credentials?: CredentialsOptions | (() => Promise<CredentialsOptions>)
+    readonly requestListeners?: RequestListener[]
+    readonly retryableErrorMatchers?: ((error: AWSError) => boolean)[]
+}
+
+type RemoveOverload<T> = T extends {
+    (...args: infer A1): infer R1
+    (...args: infer _A2): infer _R2
+}
+    ? { (...args: A1): R1 }
+    : T
+
+type RemoveCallback<T> = T extends (...args: [...params: infer U, callback?: (...args: any[]) => any]) => infer R
+    ? (...args: U) => R
+    : T
+type MapRequest<T> = T extends (...args: infer U) => Request<infer R, infer E> ? Operation<U, R, E> : T
+type MapSdkV2<T extends Service> = Pick<
+    { [P in keyof T]: MapRequest<RemoveCallback<RemoveOverload<T[P]>>> },
+    FunctionKeys<T>
+>
+
+interface ClientDefinition extends Configuration {
+    readonly apiConfig?: any
+    readonly logging?: boolean
+}
+
+interface SdkV2Service {
+    readonly [key: string]: (...args: any[]) => Request<unknown, unknown> | unknown
+}
+
+class SdkV2Wrapper {
+    private readonly serviceName: string
+
+    public constructor(private readonly service: Service, private readonly config: ClientDefinition = {}) {
+        const proto = Object.getPrototypeOf(this.service)
+        this.serviceName = proto.serviceIdentifier ?? proto.api?.serviceId ?? '[unknown service]'
+
+        // Prototype binding would be better but that's easily doable with bound functions
+        for (const [k, v] of Object.entries(getFunctions(proto.constructor as new () => SdkV2Service))) {
+            const operation = this.sendRequest.bind(this, k, v)
+
+            ;(this as any)[k] = Object.assign(operation, {
+                send: operation,
+                paginate: paginate.bind(undefined, operation),
+            })
+        }
+    }
+
+    private sendRequest<T extends any[], R, E>(
+        operation: string,
+        fn: (this: Service, ...args: T) => Request<R, E> | unknown,
+        ...args: T
+    ): ServiceRequest<R | unknown, E> {
+        const headers: Record<string, string | undefined> = {}
+        const responseListeners = [] as ResponseListener[]
+        let sdkRequest: Request<R, E>
+        let cancelReason: string | undefined
+
+        const requestPromise: PromiseResult<R | unknown, E> = new Promise(async resolve => {
+            this.service.config.update(await this.resolveOptions())
+
+            const val = fn.call(this.service, ...args)
+            if (!(val instanceof Request)) {
+                return resolve(val)
+            }
+
+            sdkRequest = val
+
+            if (this.config.logging) {
+                getLogger().debug(
+                    `${this.serviceName} (operation: ${request.operation}): called with %O`,
+                    (val as any).params
+                )
+            }
+
+            // The request can be cancelled before it exists
+            if (cancelReason !== undefined) {
+                val.abort()
+            }
+
+            this.config.requestListeners?.forEach(cb => cb(request))
+
+            val.on('build', req => {
+                for (const [k, v] of Object.entries(headers)) {
+                    if (v === undefined) {
+                        delete req.httpRequest.headers[k]
+                    } else {
+                        req.httpRequest.headers[k] = v
+                    }
+                }
+            })
+
+            val.on('retry', resp => {
+                if (!resp.error) {
+                    return
+                }
+
+                const canRetry = this.config.retryableErrorMatchers?.some(fn => fn(resp.error))
+                if (canRetry) {
+                    // add log?
+                    globals.awsContext.credentialsShim?.refresh()
+                    resp.error.retryable = true
+                }
+            })
+
+            val.on('complete', resp => {
+                const response: ServiceResponse = {
+                    requestId: resp.requestId,
+                    headers: resp.httpResponse.headers,
+                }
+
+                responseListeners.forEach(cb => cb(response))
+
+                if (
+                    resp.error !== undefined &&
+                    cancelReason !== undefined &&
+                    resp.error.name === 'RequestAbortedError'
+                ) {
+                    resp.error.originalError = new ToolkitError('Request cancelled', {
+                        cancelled: cancelReason === 'user',
+                        code: cancelReason,
+                    })
+                }
+
+                if (this.config.logging) {
+                    getLogger().debug(
+                        `${this.serviceName} (operation: ${request.operation}, requestId: ${resp.requestId}): returned %O`,
+                        resp.data ?? resp.error
+                    )
+                }
+            })
+
+            resolve(sdkRequest.promise())
+        })
+
+        const request = Object.assign(requestPromise, {
+            headers,
+            operation,
+            cancel: (reason: string) => ((cancelReason ??= reason ?? 'user'), sdkRequest?.abort()),
+            onResponse: (listener: ResponseListener) => (responseListeners.push(listener), request),
+        })
+
+        return request
+    }
+
+    private async resolveOptions() {
+        const credentials =
+            typeof this.config.credentials === 'function'
+                ? await this.config.credentials()
+                : this.config.credentials ?? SdkV2Credentials.getToolkitCredentials()
+
+        const customUserAgent = this.config.sendUserAgent ? await getUserAgent() : undefined
+
+        return { credentials, customUserAgent }
+    }
+}
+
+function paginate<T, R, U extends any[]>(
+    operation: Operation<[T, ...U], R>['send'],
+    tokenKey: SharedKeys<T, R>,
+    request: T,
+    ...rest: U
+): AsyncCollection<R> {
+    request = { ...request }
+
+    return toCollection(async function* () {
+        do {
+            const response = await operation(request, ...rest)
+            if (!response[tokenKey]) {
+                return response
+            }
+
+            yield response
+            request[tokenKey] = response[tokenKey] as T[typeof tokenKey]
+        } while (request[tokenKey])
+    })
+}
+
+export function defineClient<T extends Service>(
+    service: new (options?: ServiceConfigurationOptions) => T,
+    definition?: ClientDefinition
+): new (options?: Configuration & ServiceConfigurationOptions) => MapSdkV2<T> {
+    return class extends SdkV2Wrapper {
+        public constructor(config?: Configuration & ServiceConfigurationOptions) {
+            const mergedConfig = {
+                logging: !isReleaseVersion(true),
+                ...definition,
+                ...config,
+                credentials: undefined,
+            }
+
+            super(new service(mergedConfig), mergedConfig)
+        }
+    } as unknown as new (options?: Configuration & ServiceConfigurationOptions) => MapSdkV2<T>
+}
+
+class SdkV2Credentials extends CredentialsClass {
+    public constructor(private readonly shim: CredentialsShim) {
+        // The class doesn't like being instantiated with empty creds
+        super({ accessKeyId: '???', secretAccessKey: '???' })
+    }
+
+    public override get(callback: (err?: AWSError) => void): void {
+        // Always try to fetch the latest creds first, attempting a refresh if needed
+        // A 'passive' refresh is attempted first, before trying an 'active' one if certain criteria are met
+        this.shim
+            .get()
+            .then(creds => {
+                this.loadCreds(creds)
+                this.needsRefresh() ? this.refresh(callback) : callback()
+            })
+            .catch(callback)
+    }
+
+    public override refresh(callback: (err?: AWSError) => void): void {
+        this.shim
+            .refresh()
+            .then(creds => {
+                this.loadCreds(creds)
+                // The SDK V2 sets `expired` on certain errors so we should only
+                // unset the flag after acquiring new credentials via `refresh`
+                this.expired = false
+                callback()
+            })
+            .catch(callback)
+    }
+
+    private loadCreds(creds: CredentialsOptions & { expiration?: Date }) {
+        this.accessKeyId = creds.accessKeyId
+        this.secretAccessKey = creds.secretAccessKey
+        this.sessionToken = creds.sessionToken ?? this.sessionToken
+        this.expireTime = creds.expiration ?? this.expireTime
+    }
+
+    public static getToolkitCredentials(shim = globals.awsContext.credentialsShim) {
+        return shim ? new this(shim) : undefined
+    }
+}
+
+async function getUserAgent() {
+    const platformName = env.appName.replace(/\s/g, '-')
+    const clientId = await getClientId(globals.context.globalState)
+
+    return `AWS-Toolkit-For-VSCode/${extensionVersion} ${platformName}/${version} ClientId/${clientId}`
+}

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -287,5 +287,9 @@ function hasCode(error: Error): error is typeof error & { code: string } {
 }
 
 export function isUserCancelledError(error: unknown): boolean {
-    return CancellationError.isUserCancelled(error) || (error instanceof ToolkitError && error.cancelled)
+    return (
+        CancellationError.isUserCancelled(error) ||
+        (error instanceof ToolkitError && error.cancelled) ||
+        (isAwsError(error) && isUserCancelledError(error.originalError))
+    )
 }

--- a/src/shared/utilities/collectionUtils.ts
+++ b/src/shared/utilities/collectionUtils.ts
@@ -4,7 +4,7 @@
  */
 
 import { AsyncCollection, toCollection } from './asyncCollection'
-import { SharedProp, AccumulableKeys, Coalesce } from './tsUtils'
+import { SharedKeys, AccumulableKeys, Coalesce } from './tsUtils'
 
 export function union<T>(a: Iterable<T>, b: Iterable<T>): Set<T> {
     const result = new Set<T>()
@@ -319,7 +319,7 @@ export function isAsyncIterable(obj: any): obj is AsyncIterable<unknown> {
 export function pageableToCollection<
     TRequest,
     TResponse,
-    TTokenProp extends SharedProp<TRequest, TResponse>,
+    TTokenProp extends SharedKeys<TRequest, TResponse>,
     TTokenType extends TRequest[TTokenProp] & TResponse[TTokenProp],
     TResult extends AccumulableKeys<TResponse> = never
 >(

--- a/src/shared/utilities/tsUtils.ts
+++ b/src/shared/utilities/tsUtils.ts
@@ -69,7 +69,7 @@ export type SharedTypes<T1, T2> = {
 }
 
 /* All of the string keys of the shared type */
-export type SharedProp<T1, T2> = string & keyof SharedTypes<T1, T2>
+export type SharedKeys<T1, T2> = string & keyof SharedTypes<T1, T2>
 
 /* Any key that can be accumulated (i.e. an array) */
 export type AccumulableKeys<T> = NonNullable<


### PR DESCRIPTION
## Problem
Our SDK client wrappers have a lot of boilerplate. Very tedious to work with.

## Solution
De-dupe using a similar pattern used with `settings.ts` i.e. inheriting from an anonymous class. 

### Other notes
* Clients should be moved to the relevant module, not `src/shared/clients`
* The way I implemented things makes overriding inherited client methods not safe. Typescript will luckily complain if you try.
* Unsure if we should have logging enabled by default or not
* Some of the logic is for backwards compat with modules that use lower-level AWS SDK v2 APIs 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
