### PR TITLE
fix(codewhisperer): only send one empty user decision per pagination session

### DIFF
--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -283,7 +283,7 @@ export class RecommendationHandler {
             this.recommendations = isCloud9() ? recommendation : this.recommendations.concat(recommendation)
             this._onDidReceiveRecommendation.fire()
         }
-
+        // send Empty userDecision event only when all paginated request finishes
         if (this.recommendations.length === 0 && nextToken === '') {
             TelemetryHelper.instance.recordUserDecisionTelemetryForEmptyList(
                 requestId,

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -282,7 +282,9 @@ export class RecommendationHandler {
             })
             this.recommendations = isCloud9() ? recommendation : this.recommendations.concat(recommendation)
             this._onDidReceiveRecommendation.fire()
-        } else {
+        }
+
+        if (this.recommendations.length === 0 && nextToken === '') {
             TelemetryHelper.instance.recordUserDecisionTelemetryForEmptyList(
                 requestId,
                 sessionId,

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -283,7 +283,7 @@ export class RecommendationHandler {
             this.recommendations = isCloud9() ? recommendation : this.recommendations.concat(recommendation)
             this._onDidReceiveRecommendation.fire()
         }
-        // send Empty userDecision event only when all paginated request finishes
+        // send Empty userDecision event if user receives no recommendations in this session at all.
         if (this.recommendations.length === 0 && nextToken === '') {
             TelemetryHelper.instance.recordUserDecisionTelemetryForEmptyList(
                 requestId,

--- a/src/test/codewhisperer/service/recommendationHandler.test.ts
+++ b/src/test/codewhisperer/service/recommendationHandler.test.ts
@@ -130,6 +130,39 @@ describe('recommendationHandler', function () {
                 codewhispererLanguage: 'python',
             })
         })
+
+        it('should call telemetry function that records a Empty userDecision event', async function () {
+            const mockServerResult = {
+                recommendations: [],
+                nextToken: '',
+                $response: {
+                    requestId: 'test_request_empty',
+                    httpResponse: {
+                        headers: {
+                            'x-amzn-sessionid': 'test_request_empty',
+                        },
+                    },
+                },
+            }
+            const handler = new RecommendationHandler()
+            sinon.stub(handler, 'getServerResponse').resolves(mockServerResult)
+            sinon.stub(performance, 'now').returns(0.0)
+            handler.startPos = new vscode.Position(1, 0)
+            TelemetryHelper.instance.cursorOffset = 2
+            await handler.getRecommendations(mockClient, mockEditor, 'AutoTrigger', config, 'Enter')
+            const assertTelemetry = assertTelemetryCurried('codewhisperer_userDecision')
+            assertTelemetry({
+                codewhispererRequestId: 'test_request_empty',
+                codewhispererSessionId: 'test_request_empty',
+                codewhispererPaginationProgress: 0,
+                codewhispererTriggerType: 'AutoTrigger',
+                codewhispererSuggestionIndex: -1,
+                codewhispererSuggestionState: 'Empty',
+                codewhispererSuggestionReferenceCount: 0,
+                codewhispererCompletionType: 'Line',
+                codewhispererLanguage: 'python',
+            })
+        })
     })
 
     describe('isValidResponse', function () {


### PR DESCRIPTION
## Problem
userDecision events with Empty recommendation state in CodeWhisperer is sent more than expected. This event should only be sent when all paginated responses are Empty list of recommendation

## Solution
Only send one empty user decision per pagination session

No changelog item is needed for this PR.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
