### PR TITLE
tests(explorer): add utils and examples using ECS

### DIFF
--- a/src/ecs/model.ts
+++ b/src/ecs/model.ts
@@ -139,7 +139,7 @@ export class Service {
     }
 }
 
-class Cluster {
+export class Cluster {
     public readonly id = this.cluster.clusterArn!
 
     public constructor(private readonly client: DefaultEcsClient, private readonly cluster: ECS.Cluster) {}

--- a/src/test/ecs/model.test.ts
+++ b/src/test/ecs/model.test.ts
@@ -1,0 +1,88 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Cluster, Container, Service } from '../../ecs/model'
+import { DefaultEcsClient } from '../../shared/clients/ecsClient'
+import { assertChildren, assertTreeItem } from '../shared/treeview/testUtil'
+import { createCollectionFromPages } from '../utilities/collectionUtils'
+import { stub } from '../utilities/stubber'
+
+const clusterData = {
+    clusterArn: 'arn:aws:ecs:us-east-1:012345678910:cluster/my-cluster',
+    clusterName: 'my-cluster',
+}
+
+const serviceData = {
+    serviceArn: 'arn:aws:ecs:us-east-1:012345678910:service/my-cluster/my-service',
+    serviceName: 'my-service',
+    taskDefinition: 'arn:aws:ecs:us-east-1:012345678910:task-definition/my-task:1',
+}
+
+const containerData = {
+    name: 'my-container',
+    clusterArn: clusterData.clusterArn,
+    taskRoleArn: 'arn:aws:iam::012345678910:role/my-role',
+}
+
+const getClient = () => stub(DefaultEcsClient, { regionCode: 'us-east-1' })
+
+describe('Container', function () {
+    it('has a tree item', async function () {
+        const container = new Container(getClient(), containerData)
+
+        await assertTreeItem(container, {
+            label: containerData.name,
+            contextValue: 'awsEcsContainerNodeExecDisabled',
+        })
+    })
+
+    it('has a tree item when "enableExecuteCommand" is set', async function () {
+        const container = new Container(getClient(), { ...containerData, enableExecuteCommand: true })
+
+        await assertTreeItem(container, {
+            label: containerData.name,
+            contextValue: 'awsEcsContainerNodeExecEnabled',
+        })
+    })
+})
+
+describe('Service', function () {
+    it('has a tree item', async function () {
+        const service = new Service(getClient(), serviceData)
+
+        await assertTreeItem(service, {
+            label: serviceData.serviceName,
+            contextValue: 'awsEcsServiceNode.DISABLED',
+        })
+    })
+
+    it('lists containers', async function () {
+        const client = getClient()
+        client.describeTaskDefinition.resolves({ taskDefinition: { containerDefinitions: [containerData] } })
+
+        const cluster = new Service(client, serviceData)
+        await assertChildren(cluster, containerData.name)
+    })
+})
+
+describe('Cluster', function () {
+    it('has a tree item', async function () {
+        const cluster = new Cluster(getClient(), clusterData)
+
+        await assertTreeItem(cluster, {
+            label: clusterData.clusterName,
+            tooltip: clusterData.clusterArn,
+            contextValue: 'awsEcsClusterNode',
+        })
+    })
+
+    it('lists services', async function () {
+        const client = getClient()
+        client.listServices.returns(createCollectionFromPages([serviceData]))
+
+        const cluster = new Cluster(client, clusterData)
+        await assertChildren(cluster, serviceData.serviceName)
+    })
+})

--- a/src/test/shared/treeview/testUtil.ts
+++ b/src/test/shared/treeview/testUtil.ts
@@ -1,0 +1,43 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import * as assert from 'assert'
+import { selectFrom, keys } from '../../../shared/utilities/tsUtils'
+import { TreeNode } from '../../../shared/treeview/resourceTreeDataProvider'
+
+type Nodeable = { toTreeNode: () => TreeNode }
+type Node = TreeNode | Nodeable
+type Matcher = string | { [P in keyof vscode.TreeItem]: vscode.TreeItem[P] }
+
+const resolveNode = (node: Node) =>
+    (node as Nodeable).toTreeNode !== undefined ? (node as Nodeable).toTreeNode() : (node as TreeNode)
+
+const applyMatcher = (item: vscode.TreeItem, matcher: Matcher | undefined) =>
+    !!matcher && typeof matcher !== 'string' ? selectFrom(item, ...keys(matcher)) : item.label
+
+/**
+ * Checks if the explorer tree node produces an item that matches the expected properties.
+ *
+ * Only fields specified will be checked. Everything else on the item is ignored.
+ */
+export async function assertTreeItem(model: Node, expected: Exclude<Matcher, string>): Promise<void | never> {
+    const item = await resolveNode(model).getTreeItem()
+    assert.deepStrictEqual(applyMatcher(item, expected), expected)
+}
+
+/**
+ * Checks if the explorer tree node produces the expected children.
+ *
+ * Children can be matched either by their label or by an object of expected properties.
+ */
+export async function assertChildren(model: Node, ...expected: Matcher[]): Promise<void | never> {
+    const children = await resolveNode(model).getChildren?.()
+    assert.ok(children, 'Expected tree node to have children')
+
+    const items = await Promise.all(children.map(child => child.getTreeItem()))
+    const matched = items.map((item, i) => applyMatcher(item, expected[i]))
+    assert.deepStrictEqual(matched, expected)
+}

--- a/src/test/utilities/collectionUtils.ts
+++ b/src/test/utilities/collectionUtils.ts
@@ -3,7 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { AsyncCollection, toCollection } from '../../shared/utilities/asyncCollection'
+
 // TODO: what is the point of this? should it live in src/shared/utilities/collectionUtils.ts ?
 export async function* asyncGenerator<T>(items: T[]): AsyncIterableIterator<T> {
     yield* items
+}
+
+export function createCollectionFromPages<T>(...pages: T[]): AsyncCollection<T> {
+    return toCollection(async function* () {
+        for (let i = 0; i < pages.length - 1; i++) {
+            yield pages[i]
+        }
+
+        return pages[pages.length - 1]
+    })
 }


### PR DESCRIPTION
## Problem
* Current explorer tree tests are verbose and redundant
* No tests for ECS explorer tree

## Solution
* Add some utils
* Add simple tests

The tedious part for writing these tests is collecting example data. A follow-up PR will address that.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
