### PR TITLE
fix(ecs): gate "Open Terminal..." feature on Cloud9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1579,7 +1579,7 @@
                 {
                     "command": "aws.ecs.openTaskInTerminal",
                     "group": "0@2",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsEcsContainerNodeExec)(.*)$/"
+                    "when": "view == aws.explorer && viewItem =~ /^(awsEcsContainerNodeExec)(.*)$/ && !isCloud9"
                 },
                 {
                     "command": "aws.ecs.enableEcsExec",

--- a/src/ecs/commands.ts
+++ b/src/ecs/commands.ts
@@ -24,6 +24,7 @@ import { getResourceFromTreeNode } from '../shared/treeview/utils'
 import { Container, Service } from './model'
 import { Instance } from '../shared/utilities/typeConstructors'
 import { telemetry } from '../shared/telemetry/telemetry'
+import { isCloud9 } from '../shared/extensionUtilities'
 
 async function runCommandWizard(
     param?: unknown,
@@ -138,6 +139,10 @@ export const runCommandInContainer = Commands.register('aws.ecs.runCommandInCont
 
 // VSC is logging args to the PTY host log file if shell integration is enabled :(
 async function withoutShellIntegration<T>(cb: () => T | Promise<T>): Promise<T> {
+    if (isCloud9()) {
+        return cb()
+    }
+
     const userValue = Settings.instance.get('terminal.integrated.shellIntegration.enabled', Boolean)
 
     try {

--- a/src/ecs/commands.ts
+++ b/src/ecs/commands.ts
@@ -24,7 +24,6 @@ import { getResourceFromTreeNode } from '../shared/treeview/utils'
 import { Container, Service } from './model'
 import { Instance } from '../shared/utilities/typeConstructors'
 import { telemetry } from '../shared/telemetry/telemetry'
-import { isCloud9 } from '../shared/extensionUtilities'
 
 async function runCommandWizard(
     param?: unknown,
@@ -139,10 +138,6 @@ export const runCommandInContainer = Commands.register('aws.ecs.runCommandInCont
 
 // VSC is logging args to the PTY host log file if shell integration is enabled :(
 async function withoutShellIntegration<T>(cb: () => T | Promise<T>): Promise<T> {
-    if (isCloud9()) {
-        return cb()
-    }
-
     const userValue = Settings.instance.get('terminal.integrated.shellIntegration.enabled', Boolean)
 
     try {


### PR DESCRIPTION
See #2928
The VSC API does not work on C9,  the handler for `createTerminal` is not implemented.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
