### PR TITLE
fix(codewhisperer): Fix duplicate userDecision telemetry accept

### DIFF
--- a/src/codewhisperer/commands/onInlineAcceptance.ts
+++ b/src/codewhisperer/commands/onInlineAcceptance.ts
@@ -62,6 +62,7 @@ export const acceptSuggestion = Commands.declare(
             ).finally(async () => {
                 if (isInlineCompletionEnabled()) {
                     // at the end of recommendation acceptance, clear recommendations.
+                    RecommendationHandler.instance.clearRecommendations()
                     await InlineCompletionService.instance.clearInlineCompletionStates(editor)
                 }
             })
@@ -154,7 +155,4 @@ export async function onInlineAcceptance(
             )
         }
     }
-
-    // at the end of recommendation acceptance, clear recommendations.
-    RecommendationHandler.instance.clearRecommendations()
 }

--- a/src/codewhisperer/commands/onInlineAcceptance.ts
+++ b/src/codewhisperer/commands/onInlineAcceptance.ts
@@ -154,4 +154,7 @@ export async function onInlineAcceptance(
             )
         }
     }
+
+    // at the end of recommendation acceptance, clear recommendations.
+    RecommendationHandler.instance.clearRecommendations()
 }

--- a/src/test/codewhisperer/service/completionProvider.test.ts
+++ b/src/test/codewhisperer/service/completionProvider.test.ts
@@ -35,6 +35,8 @@ describe('completionProviderService', function () {
     describe('getCompletionItem', function () {
         it('should return targetCompletionItem given input', function () {
             RecommendationHandler.instance.startPos = new vscode.Position(0, 0)
+            RecommendationHandler.instance.requestId = 'mock_requestId_getCompletionItem'
+            RecommendationHandler.instance.sessionId = 'mock_sessionId_getCompletionItem'
             const mockPosition = new vscode.Position(0, 1)
             const mockRecommendationDetail: Recommendation = {
                 content: "\n\t\tconsole.log('Hello world!');\n\t}",
@@ -60,8 +62,8 @@ describe('completionProviderService', function () {
                         new vscode.Range(0, 0, 0, 0),
                         1,
                         "\n\t\tconsole.log('Hello world!');\n\t}",
-                        'test',
-                        'test',
+                        'mock_requestId_getCompletionItem',
+                        'mock_sessionId_getCompletionItem',
                         'OnDemand',
                         'Line',
                         'javascript',


### PR DESCRIPTION
## Problem
When accept a reco, userDecision telemetry was sent twice. In release 1.51.0, telemetry acceptance userDecision events will be sent twice. 


## Solution
Remove recommendations before they are sent twice.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
