### PR TITLE
telemetry: rename vscode_viewLogs => toolkit_viewLogs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
                 "yaml-cfn": "^0.3.1"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.72",
+                "@aws-toolkits/telemetry": "^1.0.76",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^8.1.0",
                 "@types/adm-zip": "^0.4.34",
@@ -1806,9 +1806,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.72",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.72.tgz",
-            "integrity": "sha512-IEXiN0/jWHK2zWX/hLTZTr+nmB9JVCmWSu/efgGSVIEP74yUMlwpAEH2WXjIGVl4SAfr9m0yBCpx9xJeXVYPWg==",
+            "version": "1.0.76",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.76.tgz",
+            "integrity": "sha512-vCoZ22iZssHefopZpxZoacsFTrfHIxcrGiiCiM0rHU/x6V2/D3YNnB7+9HidargVT1IyYF0fW+CslY2wlWBi1g==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",
@@ -15987,9 +15987,9 @@
             }
         },
         "@aws-toolkits/telemetry": {
-            "version": "1.0.72",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.72.tgz",
-            "integrity": "sha512-IEXiN0/jWHK2zWX/hLTZTr+nmB9JVCmWSu/efgGSVIEP74yUMlwpAEH2WXjIGVl4SAfr9m0yBCpx9xJeXVYPWg==",
+            "version": "1.0.76",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.76.tgz",
+            "integrity": "sha512-vCoZ22iZssHefopZpxZoacsFTrfHIxcrGiiCiM0rHU/x6V2/D3YNnB7+9HidargVT1IyYF0fW+CslY2wlWBi1g==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -3232,7 +3232,7 @@
         "report": "nyc report --reporter=html --reporter=json"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.72",
+        "@aws-toolkits/telemetry": "^1.0.76",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^8.1.0",
         "@types/adm-zip": "^0.4.34",

--- a/src/shared/logger/commands.ts
+++ b/src/shared/logger/commands.ts
@@ -31,7 +31,7 @@ export class Logging {
     public constructor(private readonly defaultLogUri: vscode.Uri, private readonly logger: Logger) {}
 
     public async openLogUri(logUri = this.defaultLogUri): Promise<vscode.TextEditor | undefined> {
-        telemetry.vscode_viewLogs.emit() // Perhaps add additional argument to know which log was viewed?
+        telemetry.toolkit_viewLogs.emit() // Perhaps add additional argument to know which log was viewed?
 
         return vscode.window.showTextDocument(logUri)
     }

--- a/src/shared/telemetry/vscodeTelemetry.json
+++ b/src/shared/telemetry/vscodeTelemetry.json
@@ -172,10 +172,6 @@
             "passive": true
         },
         {
-            "name": "vscode_viewLogs",
-            "description": "View the VSCode IDE logs"
-        },
-        {
             "name": "aws_showExplorerErrorDetails",
             "description": "Called when getting more details about errors thrown by the explorer",
             "metadata": [{ "type": "result" }]


### PR DESCRIPTION
There is now a common metric for "view logs", so we don't need a vscode-specific one:
https://github.com/aws/aws-toolkit-common/pull/377


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
