### PR TITLE
Add language intellisense when working with buildspec

### DIFF
--- a/.changes/next-release/Feature-3e2b9bd4-02cc-4e05-bac5-2a1f1551881c.json
+++ b/.changes/next-release/Feature-3e2b9bd4-02cc-4e05-bac5-2a1f1551881c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Add auto completion, validation, hover assistance for AWS CodeBuild [buildspec](https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html#build-spec-ref-syntax) files"
+}

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
         "onCommand:aws.addSamDebugConfig",
         "onCommand:aws.s3.uploadFile",
         "onCommand:aws.cloudFormation.newTemplate",
+        "onCommand:aws.buildspec.newTemplate",
         "onCommand:aws.sam.newTemplate",
         "onFileSystem:s3",
         "onFileSystem:s3-readonly",
@@ -2837,6 +2838,16 @@
             {
                 "command": "aws.sam.newTemplate",
                 "title": "%AWS.command.sam.newTemplate%",
+                "category": "%AWS.title%",
+                "cloud9": {
+                    "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
+            },
+            {
+                "command": "aws.buildspec.newTemplate",
+                "title": "%AWS.command.buildspec.newTemplate%",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -120,6 +120,7 @@
     "AWS.command.viewLogs": "View Toolkit Logs",
     "AWS.command.sam.newTemplate": "Create new SAM Template",
     "AWS.command.cloudFormation.newTemplate": "Create new CloudFormation Template",
+    "AWS.command.buildspec.newTemplate": "Create new Buildspec Template",
     "AWS.command.quickStart": "View Quick Start",
     "AWS.command.iot.createThing": "Create Thing...",
     "AWS.command.iot.createCert": "Create Certificate...",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import { activate as activateSchemas } from './eventSchemas/activation'
 import { activate as activateLambda } from './lambda/activation'
 import { DefaultAWSClientBuilder } from './shared/awsClientBuilder'
 import { activate as activateCloudFormationTemplateRegistry } from './shared/cloudformation/activation'
+import { activate as activateBuildspecTemplateRegistry } from './shared/buildspec/activation'
 import { documentationUrl, endpointsFileUrl, githubCreateIssueUrl, githubUrl } from './shared/constants'
 import { DefaultAwsContext } from './shared/awsContext'
 import { AwsContextCommands } from './shared/awsContextCommands'
@@ -188,6 +189,7 @@ export async function activate(context: vscode.ExtensionContext) {
         )
 
         await activateCloudFormationTemplateRegistry(context)
+        await activateBuildspecTemplateRegistry(context)
 
         await activateAwsExplorer({
             context: extContext,

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -615,7 +615,7 @@ describe('SAM Integration Tests', async function () {
                     }
 
                     // XXX: force load since template registry seems a bit flakey
-                    await globals.templateRegistry.addItemToRegistry(vscode.Uri.file(cfnTemplatePath))
+                    await globals.templateRegistry.cfn.addItemToRegistry(vscode.Uri.file(cfnTemplatePath))
 
                     await startDebugger(scenario, scenarioIndex, target, testConfig, testDisposables, sessionLog)
                 }

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -271,7 +271,7 @@ export async function createNewSamApplication(
         // Race condition where SAM app is created but template doesn't register in time.
         // Poll for 5 seconds, otherwise direct user to codelens.
         const isTemplateRegistered = await waitUntil(
-            async () => globals.templateRegistry.getRegisteredItem(templateUri),
+            async () => globals.templateRegistry.cfn.getRegisteredItem(templateUri),
             {
                 timeout: 5000,
                 interval: 500,

--- a/src/lambda/local/debugConfiguration.ts
+++ b/src/lambda/local/debugConfiguration.ts
@@ -193,7 +193,7 @@ export function getTemplate(
     }
     const templateInvoke = config.invokeTarget as TemplateTargetProperties
     const fullPath = tryGetAbsolutePath(folder, templateInvoke.templatePath)
-    const cfnTemplate = globals.templateRegistry.getRegisteredItem(fullPath)?.item
+    const cfnTemplate = globals.templateRegistry.cfn.getRegisteredItem(fullPath)?.item
     return cfnTemplate
 }
 

--- a/src/lambda/vue/configEditor/samInvokeBackend.ts
+++ b/src/lambda/vue/configEditor/samInvokeBackend.ts
@@ -161,7 +161,7 @@ export class SamInvokeWebview extends VueWebview {
     public async getTemplate() {
         const items: (vscode.QuickPickItem & { templatePath: string })[] = []
         const NO_TEMPLATE = 'NOTEMPLATEFOUND'
-        for (const template of globals.templateRegistry.registeredItems) {
+        for (const template of globals.templateRegistry.cfn.registeredItems) {
             const resources = template.item.Resources
             if (resources) {
                 for (const resource of Object.keys(resources)) {

--- a/src/lambda/wizards/samDeployWizard.ts
+++ b/src/lambda/wizards/samDeployWizard.ts
@@ -208,7 +208,7 @@ export class DefaultSamDeployWizardContext implements SamDeployWizardContext {
     }
 
     public async determineIfTemplateHasImages(templatePath: vscode.Uri): Promise<boolean> {
-        const template = globals.templateRegistry.getRegisteredItem(templatePath.fsPath)
+        const template = globals.templateRegistry.cfn.getRegisteredItem(templatePath.fsPath)
         const resources = template?.item?.Resources
         if (resources === undefined) {
             return false
@@ -931,7 +931,7 @@ function validateStackName(value: string): string | undefined {
 }
 
 async function getTemplateChoices(...workspaceFolders: vscode.Uri[]): Promise<SamTemplateQuickPickItem[]> {
-    const templateUris = globals.templateRegistry.registeredItems.map(o => vscode.Uri.file(o.path))
+    const templateUris = globals.templateRegistry.cfn.registeredItems.map(o => vscode.Uri.file(o.path))
     const uriToLabel: Map<vscode.Uri, string> = new Map<vscode.Uri, string>()
     const labelCounts: Map<string, number> = new Map()
 

--- a/src/shared/buildspec/activation.ts
+++ b/src/shared/buildspec/activation.ts
@@ -1,0 +1,45 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { Commands } from '../vscode/commands2'
+import { createStarterTemplateFile, localize } from '../utilities/vsCodeUtils'
+import { BuildspecTemplateRegistry } from './registry'
+import { getLogger } from '../logger'
+import globals from '../extensionGlobals'
+import { NoopWatcher } from '../watchedFiles'
+
+export const TEMPLATE_FILE_GLOB_PATTERN = '**/*.{yaml,yml}'
+
+/**
+ * Activate Buildspec related functionality for the extension.
+ */
+export async function activate(extensionContext: vscode.ExtensionContext): Promise<void> {
+    try {
+        const registry = new BuildspecTemplateRegistry()
+        globals.templateRegistry.buildspec = registry
+        await registry.addWatchPattern(TEMPLATE_FILE_GLOB_PATTERN)
+        await registry.watchUntitledFiles()
+    } catch (e) {
+        vscode.window.showErrorMessage(
+            localize(
+                'AWS.buildspec.failToInitialize',
+                'Failed to activate buildspec template registry. Language features will not appear on buildspec files.'
+            )
+        )
+        getLogger().error('Failed to activate buildspec template registry', e)
+        globals.templateRegistry.buildspec = new NoopWatcher() as unknown as BuildspecTemplateRegistry
+    }
+    extensionContext.subscriptions.push(
+        Commands.register('aws.buildspec.newTemplate', () => {
+            return createStarterTemplateFile(buildspecTemplate)
+        })
+    )
+}
+
+const buildspecTemplate = `version: 0.2
+phases:
+  
+`

--- a/src/shared/buildspec/registry.ts
+++ b/src/shared/buildspec/registry.ts
@@ -1,0 +1,55 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import * as yaml from 'js-yaml'
+import globals from '../extensionGlobals'
+import { WatchedFiles } from '../watchedFiles'
+import { isUntitledScheme } from '../utilities/vsCodeUtils'
+import { SystemUtilities } from '../systemUtilities'
+
+interface BuildspecTemplate {
+    version?: unknown
+    phases?: unknown
+}
+
+export class BuildspecTemplateRegistry extends WatchedFiles<BuildspecTemplate> {
+    protected name: string = 'BuildspecTemplateRegistry'
+    protected async process(uri: vscode.Uri, contents?: string): Promise<BuildspecTemplate | undefined> {
+        let template: BuildspecTemplate | undefined
+        try {
+            if (isUntitledScheme(uri)) {
+                if (!contents) {
+                    // this error technically just throw us into the catch so the error message isn't used
+                    throw new Error('Contents must be defined for untitled uris')
+                }
+                template = yaml.load(contents, {}) as BuildspecTemplate
+            } else {
+                const templateAsYaml: string = await SystemUtilities.readFile(uri)
+                template = yaml.load(templateAsYaml, {}) as BuildspecTemplate
+            }
+        } catch (e) {
+            globals.schemaService.registerMapping({ uri, type: 'yaml', schema: undefined })
+            return undefined
+        }
+
+        if (template.version && template.phases) {
+            globals.schemaService.registerMapping({ uri, type: 'yaml', schema: 'buildspec' })
+            return template
+        }
+
+        globals.schemaService.registerMapping({ uri, type: 'yaml', schema: undefined })
+        return undefined
+    }
+
+    public async remove(uri: vscode.Uri): Promise<void> {
+        globals.schemaService.registerMapping({
+            uri,
+            type: 'yaml',
+            schema: undefined,
+        })
+        await super.remove(uri)
+    }
+}

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -5,14 +5,14 @@
 
 import * as vscode from 'vscode'
 import { getLogger } from '../logger'
-import { localize } from '../utilities/vsCodeUtils'
+import { createStarterTemplateFile, localize } from '../utilities/vsCodeUtils'
 
 import { CloudFormationTemplateRegistry } from './templateRegistry'
 import { getIdeProperties } from '../extensionUtilities'
 import { NoopWatcher } from '../watchedFiles'
-import { createStarterTemplateFile } from './cloudformation'
 import { Commands } from '../vscode/commands2'
 import globals from '../extensionGlobals'
+import { createCloudFormationTemplateYaml } from './cloudformation'
 
 export const TEMPLATE_FILE_GLOB_PATTERN = '**/*.{yaml,yml}'
 
@@ -53,7 +53,13 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
     // If setting it up worked, add it to subscriptions so it is cleaned up at exit
     extensionContext.subscriptions.push(
         globals.templateRegistry.cfn,
-        Commands.register('aws.cloudFormation.newTemplate', () => createStarterTemplateFile(false)),
-        Commands.register('aws.sam.newTemplate', () => createStarterTemplateFile(true))
+        Commands.register('aws.cloudFormation.newTemplate', () => {
+            const contents = createCloudFormationTemplateYaml(false)
+            return createStarterTemplateFile(contents)
+        }),
+        Commands.register('aws.sam.newTemplate', () => {
+            const contents = createCloudFormationTemplateYaml(true)
+            return createStarterTemplateFile(contents)
+        })
     )
 }

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -33,7 +33,7 @@ export const TEMPLATE_FILE_EXCLUDE_PATTERN = /.*[/\\]\.aws-sam([/\\].*|$)/
 export async function activate(extensionContext: vscode.ExtensionContext): Promise<void> {
     try {
         const registry = new CloudFormationTemplateRegistry()
-        globals.templateRegistry = registry
+        globals.templateRegistry.cfn = registry
         await registry.addExcludedPattern(TEMPLATE_FILE_EXCLUDE_PATTERN)
         await registry.addWatchPattern(TEMPLATE_FILE_GLOB_PATTERN)
         await registry.watchUntitledFiles()
@@ -41,18 +41,18 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
         vscode.window.showErrorMessage(
             localize(
                 'AWS.codelens.failToInitialize',
-                'Failed to activate template registry. {0}} will not appear on SAM template files.',
+                'Failed to activate cloudformation template registry. {0} will not appear on SAM template files.',
                 getIdeProperties().codelenses
             )
         )
         getLogger().error('Failed to activate template registry', e)
         // This prevents us from breaking for any reason later if it fails to load. Since
         // Noop watcher is always empty, we will get back empty arrays with no issues.
-        globals.templateRegistry = new NoopWatcher() as unknown as CloudFormationTemplateRegistry
+        globals.templateRegistry.cfn = new NoopWatcher() as unknown as CloudFormationTemplateRegistry
     }
     // If setting it up worked, add it to subscriptions so it is cleaned up at exit
     extensionContext.subscriptions.push(
-        globals.templateRegistry,
+        globals.templateRegistry.cfn,
         Commands.register('aws.cloudFormation.newTemplate', () => createStarterTemplateFile(false)),
         Commands.register('aws.sam.newTemplate', () => createStarterTemplateFile(true))
     )

--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as fs from 'fs-extra'
-import * as vscode from 'vscode'
 import { writeFile } from 'fs-extra'
 import { schema } from 'yaml-cfn'
 import * as yaml from 'js-yaml'
@@ -13,7 +11,6 @@ import { SystemUtilities } from '../systemUtilities'
 import { getLogger } from '../logger'
 import { LAMBDA_PACKAGE_TYPE_IMAGE } from '../constants'
 import { isCloud9 } from '../extensionUtilities'
-import { Window } from '../vscode/window'
 
 export namespace CloudFormation {
     export const SERVERLESS_API_TYPE = 'AWS::Serverless::Api'
@@ -807,28 +804,11 @@ export namespace CloudFormation {
 }
 
 /**
- * Creates a starter YAML template file.
- * @param isSam: Create a SAM template instead of a CFN template
- */
-export async function createStarterTemplateFile(isSam?: boolean, window: Window = Window.vscode()): Promise<void> {
-    const content = createStarterTemplateYaml(isSam)
-    const wsFolder = vscode.workspace.workspaceFolders
-    const loc = await window.showSaveDialog({
-        filters: { YAML: ['yaml'] },
-        defaultUri: wsFolder && wsFolder[0] ? wsFolder[0].uri : undefined,
-    })
-    if (loc) {
-        fs.writeFileSync(loc.fsPath, content)
-        await vscode.commands.executeCommand('vscode.open', loc)
-    }
-}
-
-/**
  * Creates a boilerplate CFN or SAM template that is complete enough to be picked up for JSON schema assignment
  * TODO: Remove `isCloud9` when Cloud9 gets YAML code completion
  * @param isSam Create a SAM or CFN template
  */
-function createStarterTemplateYaml(isSam?: boolean): string {
+export function createCloudFormationTemplateYaml(isSam: boolean): string {
     return `AWSTemplateFormatVersion: '2010-09-09'
 ${isSam ? 'Transform: AWS::Serverless-2016-10-31\n' : ''}
 Description: <your stack description here>

--- a/src/shared/cloudformation/templateRegistry.ts
+++ b/src/shared/cloudformation/templateRegistry.ts
@@ -78,7 +78,7 @@ export class CloudFormationTemplateRegistry extends WatchedFiles<CloudFormation.
 export function getResourcesForHandler(
     filepath: string,
     handler: string,
-    unfilteredTemplates: WatchedItem<CloudFormation.Template>[] = globals.templateRegistry.registeredItems
+    unfilteredTemplates: WatchedItem<CloudFormation.Template>[] = globals.templateRegistry.cfn.registeredItems
 ): { templateDatum: WatchedItem<CloudFormation.Template>; name: string; resourceData: CloudFormation.Resource }[] {
     // TODO: Array.flat and Array.flatMap not introduced until >= Node11.x -- migrate when VS Code updates Node ver
     const o = unfilteredTemplates.map(templateDatum => {

--- a/src/shared/extensionGlobals.ts
+++ b/src/shared/extensionGlobals.ts
@@ -8,6 +8,7 @@ import { AwsResourceManager } from '../dynamicResources/awsResourceManager'
 import { AWSClientBuilder } from './awsClientBuilder'
 import { AwsContext } from './awsContext'
 import { AwsContextCommands } from './awsContextCommands'
+import { BuildspecTemplateRegistry } from './buildspec/registry'
 import { CloudFormationTemplateRegistry } from './cloudformation/templateRegistry'
 import { RegionProvider } from './regions/regionProvider'
 import { CodelensRootRegistry } from './sam/codelensRootRegistry'
@@ -43,7 +44,7 @@ export function initialize(context: ExtensionContext, window: Window): ToolkitGl
         didReload: checkDidReload(context),
         manifestPaths: {} as ToolkitGlobals['manifestPaths'],
         visualizationResourcePaths: {} as ToolkitGlobals['visualizationResourcePaths'],
-        templateRegistry: {} as ToolkitGlobals['templateRegistry']
+        templateRegistry: {} as ToolkitGlobals['templateRegistry'],
     })
 
     return globals
@@ -67,6 +68,7 @@ interface ToolkitGlobals {
     telemetry: TelemetryService & { logger: TelemetryLogger }
     templateRegistry: {
         cfn: CloudFormationTemplateRegistry
+        buildspec: BuildspecTemplateRegistry
     }
     schemaService: SchemaService
     codelensRootRegistry: CodelensRootRegistry

--- a/src/shared/extensionGlobals.ts
+++ b/src/shared/extensionGlobals.ts
@@ -43,6 +43,7 @@ export function initialize(context: ExtensionContext, window: Window): ToolkitGl
         didReload: checkDidReload(context),
         manifestPaths: {} as ToolkitGlobals['manifestPaths'],
         visualizationResourcePaths: {} as ToolkitGlobals['visualizationResourcePaths'],
+        templateRegistry: {} as ToolkitGlobals['templateRegistry']
     })
 
     return globals
@@ -64,7 +65,9 @@ interface ToolkitGlobals {
     regionProvider: RegionProvider
     sdkClientBuilder: AWSClientBuilder
     telemetry: TelemetryService & { logger: TelemetryLogger }
-    templateRegistry: CloudFormationTemplateRegistry
+    templateRegistry: {
+        cfn: CloudFormationTemplateRegistry
+    }
     schemaService: SchemaService
     codelensRootRegistry: CodelensRootRegistry
     resourceManager: AwsResourceManager

--- a/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
@@ -68,7 +68,7 @@ export class DefaultAwsSamDebugConfigurationValidator implements AwsSamDebugConf
                 const fullpath = tryGetAbsolutePath(this.workspaceFolder, config.invokeTarget.templatePath)
                 // Normalize to absolute path for use in the runner.
                 config.invokeTarget.templatePath = fullpath
-                cfnTemplate = globals.templateRegistry.getRegisteredItem(fullpath)?.item
+                cfnTemplate = globals.templateRegistry.cfn.getRegisteredItem(fullpath)?.item
             }
             rv = this.validateTemplateConfig(config, config.invokeTarget.templatePath, cfnTemplate)
         } else if (config.invokeTarget.target === CODE_TARGET_TYPE) {

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -249,7 +249,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         const configs: AwsSamDebuggerConfiguration[] = []
         if (folder) {
             const folderPath = folder.uri.fsPath
-            const templates = globals.templateRegistry.registeredItems
+            const templates = globals.templateRegistry.cfn.registeredItems
 
             for (const templateDatum of templates) {
                 if (isInDirectory(folderPath, templateDatum.path)) {

--- a/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
@@ -57,7 +57,7 @@ export async function addSamDebugConfiguration(
         let preloadedConfig = undefined
 
         if (workspaceFolder) {
-            const templateDatum = globals.templateRegistry.getRegisteredItem(rootUri)
+            const templateDatum = globals.templateRegistry.cfn.getRegisteredItem(rootUri)
             if (templateDatum) {
                 const resource = templateDatum.item.Resources![resourceName]
                 if (!resource) {

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -10,7 +10,7 @@ import * as pathutil from '../shared/utilities/pathUtils'
 import { getLogger } from './logger'
 import { FileResourceFetcher } from './resourcefetcher/fileResourceFetcher'
 import { getPropertyFromJsonUrl, HttpResourceFetcher } from './resourcefetcher/httpResourceFetcher'
-import { Settings } from './settings'
+import { DevSettings, Settings } from './settings'
 import { once } from './utilities/functionUtils'
 import { Any, ArrayConstructor } from './utilities/typeConstructors'
 import { AWS_SCHEME } from './constants'
@@ -142,7 +142,7 @@ export async function getDefaultSchemas(extensionContext: vscode.ExtensionContex
     try {
         const cfnSchemaUri = vscode.Uri.joinPath(extensionContext.globalStorageUri, 'cloudformation.schema.json')
         const samSchemaUri = vscode.Uri.joinPath(extensionContext.globalStorageUri, 'sam.schema.json')
-
+        const buildSpecSchemaUri = vscode.Uri.joinPath(extensionContext.globalStorageUri, 'buildspec.schema.json')
         const goformationSchemaVersion = await getPropertyFromJsonUrl(GOFORMATION_MANIFEST_URL, 'tag_name')
 
         await updateSchemaFromRemote({
@@ -161,7 +161,21 @@ export async function getDefaultSchemas(extensionContext: vscode.ExtensionContex
             extensionContext,
             title: SCHEMA_PREFIX + 'sam.schema.json',
         })
-
+        const buildSpecSchemaUrl = DevSettings.instance.get('buildspecSchemaUrl', '')
+        if (buildSpecSchemaUrl !== '') {
+            await updateSchemaFromRemote({
+                destination: buildSpecSchemaUri,
+                url: buildSpecSchemaUrl,
+                cacheKey: 'buildSpecSchemaVersion',
+                extensionContext,
+                title: SCHEMA_PREFIX + 'buildspec.schema.json',
+            })
+            return {
+                cfn: cfnSchemaUri,
+                sam: samSchemaUri,
+                buildspec: buildSpecSchemaUri,
+            }
+        }
         return {
             cfn: cfnSchemaUri,
             sam: samSchemaUri,

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -536,6 +536,7 @@ const DEV_SETTINGS = {
     forceInstallTools: Boolean,
     telemetryEndpoint: String,
     telemetryUserPool: String,
+    buildspecSchemaUrl: String,
 }
 
 type ResolvedDevSettings = FromDescriptor<typeof DEV_SETTINGS>

--- a/src/shared/utilities/vsCodeUtils.ts
+++ b/src/shared/utilities/vsCodeUtils.ts
@@ -3,11 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as fs from 'fs-extra'
 import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 import * as pathutils from './pathUtils'
 import { getLogger } from '../logger/logger'
 import { Timeout, waitTimeout } from './timeoutUtils'
+import { Window } from '../vscode/window'
 
 // TODO: Consider NLS initialization/configuration here & have packages to import localize from here
 export const localize = nls.loadMessageBundle()
@@ -82,4 +84,19 @@ export function normalizeVSCodeUri(uri: vscode.Uri): string {
         return uri.toString()
     }
     return pathutils.normalize(uri.fsPath)
+}
+
+/**
+ * Given some contents, create a starter YAML template file.
+ */
+export async function createStarterTemplateFile(content: string, window: Window = Window.vscode()): Promise<void> {
+    const wsFolder = vscode.workspace.workspaceFolders
+    const loc = await window.showSaveDialog({
+        filters: { YAML: ['yaml'] },
+        defaultUri: wsFolder && wsFolder[0] ? wsFolder[0].uri : undefined,
+    })
+    if (loc) {
+        fs.writeFileSync(loc.fsPath, content)
+        await vscode.commands.executeCommand('vscode.open', loc)
+    }
 }

--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -51,7 +51,7 @@ after(async function () {
 beforeEach(async function () {
     // Set every test up so that TestLogger is the logger used by toolkit code
     testLogger = setupTestLogger()
-    globals.templateRegistry = new CloudFormationTemplateRegistry()
+    globals.templateRegistry.cfn = new CloudFormationTemplateRegistry()
     globals.codelensRootRegistry = new CodelensRootRegistry()
 
     // Enable telemetry features for tests. The metrics won't actually be posted.
@@ -67,7 +67,7 @@ afterEach(function () {
     // Prevent other tests from using the same TestLogger instance
     teardownTestLogger(this.currentTest?.fullTitle() as string)
     testLogger = undefined
-    globals.templateRegistry.dispose()
+    globals.templateRegistry.cfn.dispose()
     globals.codelensRootRegistry.dispose()
 })
 

--- a/src/test/lambda/commands/createNewSamApp.test.ts
+++ b/src/test/lambda/commands/createNewSamApp.test.ts
@@ -75,7 +75,7 @@ describe('createNewSamApp', function () {
 
     afterEach(async function () {
         await fs.remove(tempFolder)
-        globals.templateRegistry.reset()
+        globals.templateRegistry.cfn.reset()
     })
 
     describe('getProjectUri', function () {
@@ -108,7 +108,7 @@ describe('createNewSamApp', function () {
             testutil.toFile(makeSampleSamTemplateYaml(true), tempTemplate.fsPath)
 
             // without runtime
-            await globals.templateRegistry.addItemToRegistry(tempTemplate)
+            await globals.templateRegistry.cfn.addItemToRegistry(tempTemplate)
             const launchConfigs = await addInitialLaunchConfiguration(
                 fakeContext,
                 fakeWorkspaceFolder,
@@ -144,7 +144,7 @@ describe('createNewSamApp', function () {
             testutil.toFile(makeSampleSamTemplateYaml(true), tempTemplate.fsPath)
 
             // without runtime
-            await globals.templateRegistry.addItemToRegistry(tempTemplate)
+            await globals.templateRegistry.cfn.addItemToRegistry(tempTemplate)
             const launchConfigs = (await addInitialLaunchConfiguration(
                 fakeContext,
                 fakeWorkspaceFolder,
@@ -181,7 +181,7 @@ describe('createNewSamApp', function () {
         it('returns a blank array if it does not match any launch configs', async function () {
             testutil.toFile(makeSampleSamTemplateYaml(true), tempTemplate.fsPath)
 
-            await globals.templateRegistry.addItemToRegistry(tempTemplate)
+            await globals.templateRegistry.cfn.addItemToRegistry(tempTemplate)
             const launchConfigs = await addInitialLaunchConfiguration(
                 fakeContext,
                 fakeWorkspaceFolder,
@@ -197,7 +197,7 @@ describe('createNewSamApp', function () {
 
             testutil.toFile(makeSampleSamTemplateYaml(true), tempTemplate.fsPath)
 
-            await globals.templateRegistry.addItemToRegistry(tempTemplate)
+            await globals.templateRegistry.cfn.addItemToRegistry(tempTemplate)
             const launchConfigs = await addInitialLaunchConfiguration(
                 fakeContext,
                 fakeWorkspaceFolder,
@@ -231,9 +231,9 @@ describe('createNewSamApp', function () {
             testutil.toFile(makeSampleSamTemplateYaml(true), otherTemplate2.fsPath)
             testutil.toFile('target file', path.join(otherFolder1, TEMPLATE_YAML))
 
-            await globals.templateRegistry.addItemToRegistry(tempTemplate)
-            await globals.templateRegistry.addItemToRegistry(otherTemplate1)
-            await globals.templateRegistry.addItemToRegistry(otherTemplate2)
+            await globals.templateRegistry.cfn.addItemToRegistry(tempTemplate)
+            await globals.templateRegistry.cfn.addItemToRegistry(otherTemplate1)
+            await globals.templateRegistry.cfn.addItemToRegistry(otherTemplate2)
 
             const launchConfigs1 = await addInitialLaunchConfiguration(
                 fakeContext,

--- a/src/test/lambda/config/templates.test.ts
+++ b/src/test/lambda/config/templates.test.ts
@@ -785,7 +785,7 @@ describe('getExistingConfiguration', async function () {
 
     afterEach(async function () {
         await remove(tempFolder)
-        globals.templateRegistry.reset()
+        globals.templateRegistry.cfn.reset()
     })
 
     it("returns undefined if the legacy config file doesn't exist", async () => {
@@ -796,7 +796,7 @@ describe('getExistingConfiguration', async function () {
     it('returns undefined if the legacy config file is not valid JSON', async function () {
         await writeFile(tempTemplateFile.fsPath, makeSampleSamTemplateYaml(true, { handler: matchedHandler }), 'utf8')
         await writeFile(tempConfigFile, makeSampleSamTemplateYaml(true, { handler: matchedHandler }), 'utf8')
-        await globals.templateRegistry.addItemToRegistry(tempTemplateFile)
+        await globals.templateRegistry.cfn.addItemToRegistry(tempTemplateFile)
         const val = await getExistingConfiguration(fakeWorkspaceFolder, matchedHandler, tempTemplateFile)
         assert.strictEqual(val, undefined)
     })
@@ -817,7 +817,7 @@ describe('getExistingConfiguration', async function () {
             },
         }
         await writeFile(tempConfigFile, JSON.stringify(configData), 'utf8')
-        await globals.templateRegistry.addItemToRegistry(tempTemplateFile)
+        await globals.templateRegistry.cfn.addItemToRegistry(tempTemplateFile)
         const val = await getExistingConfiguration(fakeWorkspaceFolder, matchedHandler, tempTemplateFile)
         assert.ok(val)
         if (val) {

--- a/src/test/lambda/local/debugConfiguration.test.ts
+++ b/src/test/lambda/local/debugConfiguration.test.ts
@@ -132,7 +132,7 @@ describe('isImageLambdaConfig', function () {
             name: 'It was me, fakeWorkspaceFolder!',
             index: 0,
         }
-        registry = globals.templateRegistry
+        registry = globals.templateRegistry.cfn
         appDir = pathutil.normalize(path.join(testutil.getProjectDir(), 'testFixtures/workspaceFolder/'))
     })
 

--- a/src/test/shared/awsFiletypes.test.ts
+++ b/src/test/shared/awsFiletypes.test.ts
@@ -16,6 +16,7 @@ import { waitUntil } from '../../shared/utilities/timeoutUtils'
 describe('awsFiletypes', function () {
     let awsConfigUri: vscode.Uri | undefined
     let cfnUri: vscode.Uri | undefined
+    let buildspecUri: vscode.Uri | undefined
 
     beforeEach(async function () {
         testUtil.closeAllEditors()
@@ -32,6 +33,12 @@ describe('awsFiletypes', function () {
             'python3.7-plain-sam-app/template.yaml'
         )
         cfnUri = vscode.Uri.file(cfnFile)
+
+        const buildspecFile = workspaceUtils.tryGetAbsolutePath(
+            vscode.workspace.workspaceFolders?.[0],
+            'buildspec/buildspec.yml'
+        )
+        buildspecUri = vscode.Uri.file(buildspecFile)
     })
 
     after(async function () {
@@ -40,7 +47,9 @@ describe('awsFiletypes', function () {
 
     it('emit telemetry when opened by user', async function () {
         await globals.templateRegistry.cfn.addItemToRegistry(cfnUri!)
+        await globals.templateRegistry.buildspec.addItemToRegistry(buildspecUri!)
         await vscode.commands.executeCommand('vscode.open', cfnUri)
+        await vscode.commands.executeCommand('vscode.open', buildspecUri)
         await vscode.commands.executeCommand('vscode.open', awsConfigUri)
         await vscode.workspace.openTextDocument({
             content: 'test content for SSM JSON',
@@ -60,13 +69,15 @@ describe('awsFiletypes', function () {
         )
 
         assert(r, 'did not emit expected telemetry')
-        assert(r.length === 3, 'emitted file_editAwsFile too many times')
+        assert(r.length === 4, 'emitted file_editAwsFile too many times')
         const m1filetype = r[0].Metadata?.find(o => o.Key === 'awsFiletype')?.Value
         const m2filetype = r[1].Metadata?.find(o => o.Key === 'awsFiletype')?.Value
         const m3filetype = r[2].Metadata?.find(o => o.Key === 'awsFiletype')?.Value
+        const m4filetype = r[3].Metadata?.find(o => o.Key === 'awsFiletype')?.Value
         assert.strictEqual(m1filetype, 'cloudformationSam')
-        assert.strictEqual(m2filetype, 'awsCredentials')
-        assert.strictEqual(m3filetype, 'ssmDocument')
+        assert.strictEqual(m2filetype, 'codebuildBuildspec')
+        assert.strictEqual(m3filetype, 'awsCredentials')
+        assert.strictEqual(m4filetype, 'ssmDocument')
     })
 
     it('emit telemetry exactly once per filetype in a given flush window', async function () {

--- a/src/test/shared/awsFiletypes.test.ts
+++ b/src/test/shared/awsFiletypes.test.ts
@@ -39,7 +39,7 @@ describe('awsFiletypes', function () {
     })
 
     it('emit telemetry when opened by user', async function () {
-        await globals.templateRegistry.addItemToRegistry(cfnUri!)
+        await globals.templateRegistry.cfn.addItemToRegistry(cfnUri!)
         await vscode.commands.executeCommand('vscode.open', cfnUri)
         await vscode.commands.executeCommand('vscode.open', awsConfigUri)
         await vscode.workspace.openTextDocument({
@@ -70,7 +70,7 @@ describe('awsFiletypes', function () {
     })
 
     it('emit telemetry exactly once per filetype in a given flush window', async function () {
-        await globals.templateRegistry.addItemToRegistry(cfnUri!)
+        await globals.templateRegistry.cfn.addItemToRegistry(cfnUri!)
         await vscode.commands.executeCommand('vscode.open', cfnUri)
         async function getMetrics() {
             return await waitUntil(

--- a/src/test/shared/debug/launchConfiguration.test.ts
+++ b/src/test/shared/debug/launchConfiguration.test.ts
@@ -105,7 +105,7 @@ describe('LaunchConfiguration', function () {
     const templateUriCsharp = vscode.Uri.file(path.join(workspace.uri.fsPath, 'csharp6-zip/template.yaml'))
 
     beforeEach(async function () {
-        await globals.templateRegistry.addWatchPattern(TEMPLATE_FILE_GLOB_PATTERN)
+        await globals.templateRegistry.cfn.addWatchPattern(TEMPLATE_FILE_GLOB_PATTERN)
 
         // TODO: remove mocks in favor of testing src/testFixtures/ data.
         mockConfigSource = mock()
@@ -115,7 +115,7 @@ describe('LaunchConfiguration', function () {
     })
 
     afterEach(function () {
-        globals.templateRegistry.reset()
+        globals.templateRegistry.cfn.reset()
     })
 
     it('getConfigsMappedToTemplates(type=api)', async function () {

--- a/src/test/shared/sam/debugger/awsSamDebugConfigurationValidator.test.ts
+++ b/src/test/shared/sam/debugger/awsSamDebugConfigurationValidator.test.ts
@@ -107,18 +107,18 @@ describe('DefaultAwsSamDebugConfigurationValidator', function () {
     let savedRegistry: CloudFormationTemplateRegistry
 
     before(function () {
-        savedRegistry = globals.templateRegistry
+        savedRegistry = globals.templateRegistry.cfn
     })
 
     after(function () {
-        globals.templateRegistry = savedRegistry
+        globals.templateRegistry.cfn = savedRegistry
     })
 
     beforeEach(function () {
         when(mockRegistry.getRegisteredItem('/')).thenReturn(templateData)
         when(mockRegistry.getRegisteredItem('/image')).thenReturn(imageTemplateData)
 
-        globals.templateRegistry = mockRegistry
+        globals.templateRegistry.cfn = mockRegistry
 
         validator = new DefaultAwsSamDebugConfigurationValidator(instance(mockFolder))
     })

--- a/src/testFixtures/workspaceFolder/buildspec/buildspec.yml
+++ b/src/testFixtures/workspaceFolder/buildspec/buildspec.yml
@@ -1,0 +1,5 @@
+version: 0.2
+phases:
+  install:
+    commands:
+      - ""


### PR DESCRIPTION
## Problem
Currently buildspec doesn't not have any language intellisense and doesn't provide any convenient way to create a starter template.

## Solution
Enable language intellisense features through a buildspec schema (yet to be published). Also, add `Create new buildspec template` in the command palette.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
