### PR TITLE
refactor: no string arg in watchedFiles.remove()

### DIFF
--- a/src/shared/cloudformation/templateRegistry.ts
+++ b/src/shared/cloudformation/templateRegistry.ts
@@ -64,8 +64,7 @@ export class CloudFormationTemplateRegistry extends WatchedFiles<CloudFormation.
             type: 'yaml',
             schema: undefined,
         })
-        const path = normalizeVSCodeUri(uri)
-        await super.remove(path)
+        await super.remove(uri)
     }
 }
 

--- a/src/shared/watchedFiles.ts
+++ b/src/shared/watchedFiles.ts
@@ -193,16 +193,13 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
 
     /**
      * Removes an item from the registry.
-     * @param absolutePath The absolute path to the item or a vscode.Uri to the item
+     *
+     * @param path Path to the item
      */
-    public async remove(path: string | vscode.Uri): Promise<void> {
-        if (typeof path === 'string') {
-            this.registryData.delete(path)
-        } else {
-            const pathAsString = normalizeVSCodeUri(path)
-            this.assertAbsolute(pathAsString)
-            this.registryData.delete(pathAsString)
-        }
+    public async remove(path: vscode.Uri): Promise<void> {
+        const pathAsString = normalizeVSCodeUri(path)
+        this.assertAbsolute(pathAsString)
+        this.registryData.delete(pathAsString)
     }
 
     /**

--- a/src/test/shared/cloudformation/templateRegistry.test.ts
+++ b/src/test/shared/cloudformation/templateRegistry.test.ts
@@ -96,7 +96,7 @@ describe('CloudFormation Template Registry', async function () {
                 await testRegistry.addItemToRegistry(vscode.Uri.file(filename.fsPath))
                 assert.strictEqual(testRegistry.registeredItems.length, 1)
 
-                await testRegistry.remove(vscode.Uri.file(filename.fsPath))
+                await testRegistry.remove(filename)
                 assert.strictEqual(testRegistry.registeredItems.length, 0)
             })
 


### PR DESCRIPTION

No need for remove() to accept a string anymore.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
