### PR TITLE
fix(codewhisperer): clear telemetry logger to avoid flaky test case

### DIFF
--- a/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -53,6 +53,10 @@ describe('CodeWhisperer-basicCommands', function () {
     })
 
     describe('toggleCodeSuggestion', function () {
+        beforeEach(function () {
+            resetCodeWhispererGlobalVariables()
+        })
+
         it('should emit aws_modifySetting event on user toggling autoSuggestion - deactivate', async function () {
             const fakeMemeto = new FakeMemento()
             targetCommand = testCommand(toggleCodeSuggestions, fakeMemeto)

--- a/src/test/codewhisperer/testUtil.ts
+++ b/src/test/codewhisperer/testUtil.ts
@@ -10,11 +10,13 @@ import { vsCodeState, AcceptedSuggestionEntry } from '../../codewhisperer/models
 import { MockDocument } from '../fake/fakeDocument'
 import { getLogger } from '../../shared/logger'
 import { CodeWhispererCodeCoverageTracker } from '../../codewhisperer/tracker/codewhispererCodeCoverageTracker'
+import globals from '../../shared/extensionGlobals'
 
 export function resetCodeWhispererGlobalVariables() {
     vsCodeState.isIntelliSenseActive = false
     vsCodeState.isCodeWhispererEditing = false
     CodeWhispererCodeCoverageTracker.instances.clear()
+    globals.telemetry.logger.clear()
 }
 
 export function createMockDocument(

--- a/src/test/codewhisperer/util/telemetryHelper.test.ts
+++ b/src/test/codewhisperer/util/telemetryHelper.test.ts
@@ -55,6 +55,9 @@ describe('telemetryHelper', function () {
     })
 
     describe('recordUserDecisionTelemetry', function () {
+        beforeEach(function () {
+            resetCodeWhispererGlobalVariables()
+        })
         it('Should call telemetry record for each recommendations with proper arguments', async function () {
             const telemetryHelper = new TelemetryHelper()
             const response = [{ content: "print('Hello')" }]


### PR DESCRIPTION
## Problem
In some situation telemetry test case in CodeWhisperer may fail. The assertTelemetry compares a deep equal of the first telemetry record it gets from the queries. 

## Solution
Clean the telemetry records before each telemetry test case.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
