### PR TITLE
fix(codewhisperer): fix auto-trigger regressions

### DIFF
--- a/.changes/next-release/Bug Fix-24b2f685-2010-4504-ace1-6bad1ca4b660.json
+++ b/.changes/next-release/Bug Fix-24b2f685-2010-4504-ace1-6bad1ca4b660.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix bug when CodeWhisperer auto trigger did not work as expected"
+}

--- a/.changes/next-release/Bug Fix-24b2f685-2010-4504-ace1-6bad1ca4b660.json
+++ b/.changes/next-release/Bug Fix-24b2f685-2010-4504-ace1-6bad1ca4b660.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Fix bug when CodeWhisperer auto trigger did not work as expected"
+	"description": "CodeWhisperer auto trigger not working correctly in certain circumstances"
 }

--- a/src/codewhisperer/service/keyStrokeHandler.ts
+++ b/src/codewhisperer/service/keyStrokeHandler.ts
@@ -99,6 +99,10 @@ export class KeyStrokeHandler {
                     break
                 }
             }
+            if (this.keyStrokeCount >= 15) {
+                triggerType = 'KeyStrokeCount'
+                this.keyStrokeCount = 0
+            }
             if (triggerType) {
                 this.invokeAutomatedTrigger(triggerType, editor, client, config)
             }

--- a/src/codewhisperer/service/keyStrokeHandler.ts
+++ b/src/codewhisperer/service/keyStrokeHandler.ts
@@ -71,7 +71,7 @@ export class KeyStrokeHandler {
             let triggerType: CodewhispererAutomatedTriggerType | undefined
             const changedSource = new DefaultDocumentChangedType(event.contentChanges).checkChangeSource()
             // Time duration between 2 invocations should be greater than the threshold
-            // This threshold does not applies to Enter | SpecialCharacters type auto trigger.
+            // This threshold does not applies to Enter | SpecialCharacters | IntelliSenseAcceptance type auto trigger.
             const duration = Math.floor((performance.now() - RecommendationHandler.instance.lastInvocationTime) / 1000)
             switch (changedSource) {
                 case DocumentChangedSource.EnterKey: {
@@ -86,9 +86,8 @@ export class KeyStrokeHandler {
                 }
                 case DocumentChangedSource.IntelliSense: {
                     this.keyStrokeCount += 1
-                    if (duration >= CodeWhispererConstants.invocationTimeIntervalThreshold) {
-                        triggerType = 'IntelliSenseAcceptance'
-                    }
+                    triggerType = 'IntelliSenseAcceptance'
+
                     break
                 }
                 case DocumentChangedSource.RegularKey: {

--- a/src/codewhisperer/service/keyStrokeHandler.ts
+++ b/src/codewhisperer/service/keyStrokeHandler.ts
@@ -93,16 +93,17 @@ export class KeyStrokeHandler {
                 }
                 case DocumentChangedSource.RegularKey: {
                     this.keyStrokeCount += 1
+                    if (this.keyStrokeCount >= 15) {
+                        triggerType = 'KeyStrokeCount'
+                        this.keyStrokeCount = 0
+                    }
                     break
                 }
                 default: {
                     break
                 }
             }
-            if (this.keyStrokeCount >= 15) {
-                triggerType = 'KeyStrokeCount'
-                this.keyStrokeCount = 0
-            }
+
             if (triggerType) {
                 this.invokeAutomatedTrigger(triggerType, editor, client, config)
             }

--- a/src/test/codewhisperer/service/keyStrokeHandler.test.ts
+++ b/src/test/codewhisperer/service/keyStrokeHandler.test.ts
@@ -113,12 +113,50 @@ describe('keyStrokeHandler', function () {
             assert.ok(!invokeSpy.called)
         })
 
+        it('Should call invokeAutomatedTrigger if previous text input is within 2 seconds but the new input is new line', async function () {
+            KeyStrokeHandler.instance.keyStrokeCount = 14
+            const mockEditor = createMockTextEditor()
+            const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
+                mockEditor.document,
+                new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)),
+                '\n'
+            )
+            RecommendationHandler.instance.lastInvocationTime = performance.now() - 1500
+            await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)
+            assert.ok(invokeSpy.called)
+        })
+
+        it('Should call invokeAutomatedTrigger if previous text input is within 2 seconds but the new input is a specialcharacter', async function () {
+            KeyStrokeHandler.instance.keyStrokeCount = 14
+            const mockEditor = createMockTextEditor()
+            const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
+                mockEditor.document,
+                new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)),
+                '('
+            )
+            RecommendationHandler.instance.lastInvocationTime = performance.now() - 1500
+            await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)
+            assert.ok(invokeSpy.called)
+        })
+
         it('Should call invokeAutomatedTrigger with Enter when inputing \n', async function () {
             const mockEditor = createMockTextEditor()
             const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
                 mockEditor.document,
                 new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)),
                 '\n'
+            )
+            await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)
+            invokeSpy('Enter', mockEditor, mockClient)
+            assert.ok(invokeSpy.called)
+        })
+
+        it('Should call invokeAutomatedTrigger with Enter when inputing \r\n', async function () {
+            const mockEditor = createMockTextEditor()
+            const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
+                mockEditor.document,
+                new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 2)),
+                '\r\n'
             )
             await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)
             invokeSpy('Enter', mockEditor, mockClient)


### PR DESCRIPTION
## Problem
1. The 15 character keystroke auto-trigger was accidentally removed in https://github.com/aws/aws-toolkit-vscode/pull/2899. 
2. Enter auto trigger by \r\n was removed in https://github.com/aws/aws-toolkit-vscode/pull/2899. 
3. Reverted the 2 second auto trigger limitation for Special characters | Enter |intelliSense auto triggers which was removed in https://github.com/aws/aws-toolkit-vscode/pull/2899. 

## Solution
Trigger auto trigger when there are more than 15 keystroke inputs.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
