### PR TITLE
fix(codewhisperer): additional cases for auto-trigger

### DIFF
--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -105,7 +105,7 @@ class CodeWhispererInlineCompletionItemProvider implements vscode.InlineCompleti
         const iteratingIndexes = this.getIteratingIndexes()
         for (const i of iteratingIndexes) {
             const r = RecommendationHandler.instance.recommendations[i]
-            if (r.content.startsWith(prefix)) {
+            if (r.content.startsWith(prefix) && r.content.length > 0) {
                 this.activeItemIndex = i
                 items.push({
                     insertText: this.getGhostText(prefix, r.content),

--- a/src/codewhisperer/service/keyStrokeHandler.ts
+++ b/src/codewhisperer/service/keyStrokeHandler.ts
@@ -87,11 +87,11 @@ export class KeyStrokeHandler {
                 case DocumentChangedSource.IntelliSense: {
                     this.keyStrokeCount += 1
                     triggerType = 'IntelliSenseAcceptance'
-
                     break
                 }
                 case DocumentChangedSource.RegularKey: {
-                    this.keyStrokeCount += 1
+                    // text length can be greater than 1 in Cloud9
+                    this.keyStrokeCount += event.contentChanges[0].text.length
                     if (
                         this.keyStrokeCount >= 15 &&
                         duration >= CodeWhispererConstants.invocationTimeIntervalThreshold
@@ -222,8 +222,8 @@ export class DefaultDocumentChangedType extends DocumentChangedType {
             return DocumentChangedSource.Unknown
         }
 
-        // Case when event.contentChanges.length > 1
-        if (this.contentChanges.length > 1) {
+        // event.contentChanges.length will be 2 when user press Enter key multiple times
+        if (this.contentChanges.length > 2) {
             return DocumentChangedSource.Reformatting
         }
 
@@ -244,12 +244,12 @@ export class DefaultDocumentChangedType extends DocumentChangedType {
             } else if (new RegExp('^[ ]+$').test(changedText)) {
                 // single line && single place reformat should consist of space chars only
                 return DocumentChangedSource.Reformatting
-            } else if (new RegExp('^[\\S]+$').test(changedText)) {
+            } else if (new RegExp('^[\\S]+$').test(changedText) && !isCloud9()) {
                 // match single word only, which is general case for intellisense suggestion, it's still possible intllisense suggest
                 // multi-words code snippets
                 return DocumentChangedSource.IntelliSense
             } else {
-                return DocumentChangedSource.Unknown
+                return isCloud9() ? DocumentChangedSource.RegularKey : DocumentChangedSource.Unknown
             }
         }
 


### PR DESCRIPTION
## Problem
2 additional regression cases found for auto-trigger after #2899 refactoring:
- it's not triggering when user press multiple Enter key
- In Cloud9, every document change is triggering recommendation as IntelliSenseAcceptance because the length of changedText for Cloud9 content change event is greater than 1

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
