### PR TITLE
test(buildspec/cfn): Add basic intellisense tests for cloudformation and buildspec

### DIFF
--- a/.changes/1.61.0.json
+++ b/.changes/1.61.0.json
@@ -1,0 +1,26 @@
+{
+	"date": "2023-01-12",
+	"version": "1.61.0",
+	"entries": [
+		{
+			"type": "Bug Fix",
+			"description": "AWS regions are not dynamically fetched by the Toolkit"
+		},
+		{
+			"type": "Bug Fix",
+			"description": "S3: saving files from the editor overwrites existing content types"
+		},
+		{
+			"type": "Bug Fix",
+			"description": "S3: file editor fails on binary files with no file extension"
+		},
+		{
+			"type": "Feature",
+			"description": "CodeWhisperer: more responsive Auto-Suggestions"
+		},
+		{
+			"type": "Feature",
+			"description": "Copy Lambda Function URL in AWS Explorer"
+		}
+	]
+}

--- a/.changes/next-release/Bug Fix-108e77f0-4ffa-4c67-9032-62f334fc84c7.json
+++ b/.changes/next-release/Bug Fix-108e77f0-4ffa-4c67-9032-62f334fc84c7.json
@@ -1,4 +1,0 @@
-{
-	"type": "Bug Fix",
-	"description": "AWS regions are not dynamically fetched by the Toolkit"
-}

--- a/.changes/next-release/Bug Fix-3e26f9c4-6479-4c79-8849-400914f3da90.json
+++ b/.changes/next-release/Bug Fix-3e26f9c4-6479-4c79-8849-400914f3da90.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "iam: ignore permission check when denial comes from organization csp policy"
+}

--- a/.changes/next-release/Bug Fix-7b9e7b89-463b-444d-99f3-d3f19d921dc2.json
+++ b/.changes/next-release/Bug Fix-7b9e7b89-463b-444d-99f3-d3f19d921dc2.json
@@ -1,4 +1,0 @@
-{
-	"type": "Bug Fix",
-	"description": "S3: saving files from the editor overwrites existing content types"
-}

--- a/.changes/next-release/Bug Fix-8cd5b4be-7da7-4c7b-982e-1d828f2387cc.json
+++ b/.changes/next-release/Bug Fix-8cd5b4be-7da7-4c7b-982e-1d828f2387cc.json
@@ -1,4 +1,0 @@
-{
-	"type": "Bug Fix",
-	"description": "S3: file editor fails on binary files with no file extension"
-}

--- a/.changes/next-release/Feature-778c35c9-3c44-40e0-a6b1-4e656c74eadf.json
+++ b/.changes/next-release/Feature-778c35c9-3c44-40e0-a6b1-4e656c74eadf.json
@@ -1,4 +1,0 @@
-{
-	"type": "Feature",
-	"description": "CodeWhisperer: more responsive Auto-Suggestions"
-}

--- a/.changes/next-release/Feature-9adfbb52-6012-4ddd-b1aa-d18a5e870961.json
+++ b/.changes/next-release/Feature-9adfbb52-6012-4ddd-b1aa-d18a5e870961.json
@@ -1,4 +1,0 @@
-{
-	"type": "Feature",
-	"description": "Copy Lambda Function URL in AWS Explorer"
-}

--- a/.changes/next-release/Feature-bf5e2a43-174d-4549-a914-a4bda5bce0c5.json
+++ b/.changes/next-release/Feature-bf5e2a43-174d-4549-a914-a4bda5bce0c5.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Upload Lambda wizard will skip prompts and auto select parent directory when invoked from a template file."
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,37 @@ module.exports = {
     ],
     rules: {
         curly: 2, // Enforce braces on "if"/"for"/etc.
+        'id-length': [
+            'error',
+            {
+                min: 1,
+                max: 40,
+                exceptionPatterns: [
+                    '^codecatalyst_', // CodeCatalyst telemetry names are verbose :(
+                ],
+            },
+        ],
+        // https://typescript-eslint.io/rules/naming-convention/
+        '@typescript-eslint/naming-convention': [
+            'error',
+            {
+                selector: 'default',
+                format: ['camelCase', 'PascalCase'],
+                // Allow underscores.
+                leadingUnderscore: 'allowSingleOrDouble',
+                trailingUnderscore: 'allowSingleOrDouble',
+            },
+            // Allow object properties, enums, and methods to have any format:
+            //   {
+            //     'foo-1-2-3': 42,
+            //   }
+            // https://github.com/typescript-eslint/typescript-eslint/issues/1483#issuecomment-733421303
+            {
+                selector: ['objectLiteralProperty', 'classMethod', 'enumMember'],
+                format: null,
+                // modifiers: ['requiresQuotes'],
+            },
+        ],
         // TODO reenable this rule (by removing this off)
         'no-async-promise-executor': 'off',
         // TODO reenable this rule (by removing this off)
@@ -40,8 +71,6 @@ module.exports = {
         // TODO rennable this rule (by removing this off)
         // this is another troublesome one, producing ~600 issues
         '@typescript-eslint/no-use-before-define': 'off',
-        // TODO rennable this rule (by removing this off)
-        '@typescript-eslint/camelcase': 'off',
         // TODO rennable this rule (by removing this off)
         'no-useless-escape': 'off',
         // TODO rennable this rule (by removing this off)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.61.0 2023-01-12
+
+- **Bug Fix** AWS regions are not dynamically fetched by the Toolkit
+- **Bug Fix** S3: saving files from the editor overwrites existing content types
+- **Bug Fix** S3: file editor fails on binary files with no file extension
+- **Feature** CodeWhisperer: more responsive Auto-Suggestions
+- **Feature** Copy Lambda Function URL in AWS Explorer
+
 ## 1.60.0 2022-12-16
 
 - **Bug Fix** CodeWhisperer: fix potential undefined reference

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "aws-toolkit-vscode",
-    "version": "1.61.0-SNAPSHOT",
+    "version": "1.62.0-SNAPSHOT",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "aws-toolkit-vscode",
     "displayName": "AWS Toolkit",
     "description": "Amazon Web Services toolkit for browsing and updating cloud resources",
-    "version": "1.61.0-SNAPSHOT",
+    "version": "1.62.0-SNAPSHOT",
     "extensionKind": [
         "workspace"
     ],

--- a/scripts/build/generateIcons.ts
+++ b/scripts/build/generateIcons.ts
@@ -136,10 +136,13 @@ async function generate(mappings: Record<string, number | undefined> = {}) {
             }
 
             if (!obj.name.startsWith('vscode')) {
+                // Normalize the font path regardless of platform
+                // See https://github.com/aws/aws-toolkit-vscode/pull/3066#discussion_r1063662657
+                const normalizedPath = relativeDest.split(path.sep).join(path.posix.sep)
                 icons.push({
                     name: obj.name,
                     path: filePath,
-                    data: createPackageIcon(`./${relativeDest}`, obj.unicode[0]),
+                    data: createPackageIcon(`./${normalizedPath}`, obj.unicode[0]),
                 })
             } else {
                 icons.push({ name: obj.name, path: filePath })

--- a/scripts/build/generateNonCodeFiles.ts
+++ b/scripts/build/generateNonCodeFiles.ts
@@ -9,7 +9,7 @@ import { marked } from 'marked'
 import * as path from 'path'
 
 // doesn't use path utils as this should be formatted for finding images with HTML markup
-const REPO_ROOT = process.cwd()
+const repoRoot = process.cwd()
 
 /**
  * replaces relative paths with an `!!EXTENSIONROOT!!` token.
@@ -45,10 +45,10 @@ function generateFileHash(root: string) {
 }
 
 try {
-    translateReadmeToHtml(REPO_ROOT, 'README.quickstart.vscode.md', 'quickStartVscode.html')
-    translateReadmeToHtml(REPO_ROOT, 'README.quickstart.cloud9.md', 'quickStartCloud9.html')
-    translateReadmeToHtml(REPO_ROOT, 'README.quickstart.cloud9.md', 'quickStartCloud9-cn.html', true)
-    generateFileHash(REPO_ROOT)
+    translateReadmeToHtml(repoRoot, 'README.quickstart.vscode.md', 'quickStartVscode.html')
+    translateReadmeToHtml(repoRoot, 'README.quickstart.cloud9.md', 'quickStartCloud9.html')
+    translateReadmeToHtml(repoRoot, 'README.quickstart.cloud9.md', 'quickStartCloud9-cn.html', true)
+    generateFileHash(repoRoot)
 } catch (error) {
     console.error(error)
     process.exit(100)

--- a/scripts/test/integrationTest.ts
+++ b/scripts/test/integrationTest.ts
@@ -8,7 +8,7 @@ import { runTests } from '@vscode/test-electron'
 import { VSCODE_EXTENSION_ID } from '../../src/shared/extensions'
 import { installVSCodeExtension, setupVSCodeTestInstance, getCliArgsToDisableExtensions } from './launchTestUtilities'
 
-const DISABLE_WORKSPACE_TRUST = '--disable-workspace-trust'
+const disableWorkspaceTrust = '--disable-workspace-trust'
 
 async function setupVSCode(): Promise<string> {
     console.log('Setting up VS Code Test instance...')
@@ -46,7 +46,7 @@ async function setupVSCode(): Promise<string> {
             vscodeExecutablePath: vsCodeExecutablePath,
             extensionDevelopmentPath: cwd,
             extensionTestsPath: testEntrypoint,
-            launchArgs: [...disableExtensions, workspacePath, DISABLE_WORKSPACE_TRUST],
+            launchArgs: [...disableExtensions, workspacePath, disableWorkspaceTrust],
             extensionTestsEnv: {
                 ['DEVELOPMENT_PATH']: cwd,
                 ['AWS_TOOLKIT_AUTOMATION']: 'integration',

--- a/scripts/test/launchTestUtilities.ts
+++ b/scripts/test/launchTestUtilities.ts
@@ -7,10 +7,10 @@ import * as child_process from 'child_process'
 import * as manifest from '../../package.json'
 import { downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath } from '@vscode/test-electron'
 
-const ENVVAR_VSCODE_TEST_VERSION = 'VSCODE_TEST_VERSION'
+const envvarVscodeTestVersion = 'VSCODE_TEST_VERSION'
 
-const STABLE = 'stable'
-const MINIMUM = 'minimum'
+const stable = 'stable'
+const minimum = 'minimum'
 
 /**
  * Downloads and unzips a copy of VS Code to run tests against.
@@ -23,10 +23,10 @@ const MINIMUM = 'minimum'
  * VSCODE_TEST_VERSION prior to running the tests.
  */
 export async function setupVSCodeTestInstance(): Promise<string> {
-    let vsCodeVersion = process.env[ENVVAR_VSCODE_TEST_VERSION]
+    let vsCodeVersion = process.env[envvarVscodeTestVersion]
     if (!vsCodeVersion) {
-        vsCodeVersion = STABLE
-    } else if (vsCodeVersion === MINIMUM) {
+        vsCodeVersion = stable
+    } else if (vsCodeVersion === minimum) {
         vsCodeVersion = getMinVsCodeVersion()
     }
 

--- a/src/apigateway/commands/copyUrl.ts
+++ b/src/apigateway/commands/copyUrl.ts
@@ -14,7 +14,7 @@ import { ProgressLocation } from 'vscode'
 
 import { Stage } from 'aws-sdk/clients/apigateway'
 import { DefaultApiGatewayClient } from '../../shared/clients/apiGatewayClient'
-import { DEFAULT_DNS_SUFFIX, RegionProvider } from '../../shared/regions/regionProvider'
+import { defaultDnsSuffix, RegionProvider } from '../../shared/regions/regionProvider'
 import { getLogger } from '../../shared/logger'
 import { telemetry } from '../../shared/telemetry/telemetry'
 
@@ -29,7 +29,7 @@ export async function copyUrlCommand(
     window = Window.vscode()
 ): Promise<void> {
     const region = node.regionCode
-    const dnsSuffix = regionProvider.getDnsSuffixForRegion(region) || DEFAULT_DNS_SUFFIX
+    const dnsSuffix = regionProvider.getDnsSuffixForRegion(region) || defaultDnsSuffix
     const client = new DefaultApiGatewayClient(region)
 
     let stages: Stage[]

--- a/src/apprunner/activation.ts
+++ b/src/apprunner/activation.ts
@@ -22,20 +22,20 @@ const localize = nls.loadMessageBundle()
 
 const commandMap = new Map<[command: string, errorMessage: string], (...args: any) => Promise<any>>()
 
-const CREATE_SERVICE_FAILED = localize('aws.apprunner.createService.failed', 'Failed to create App Runner service')
-const CREATE_SERVICE_ECR_FAILED = localize(
+const createServiceFailed = localize('aws.apprunner.createService.failed', 'Failed to create App Runner service')
+const createServiceEcrFailed = localize(
     'aws.apprunner.createServiceFromEcr.failed',
     'Failed to create App Runner service from ECR'
 )
-const PAUSE_SERVICE_FAILED = localize('aws.apprunner.pauseService.failed', 'Failed to pause App Runner service')
-const RESUME_SERVICE_FAILED = localize('aws.apprunner.resumeService.failed', 'Failed to resume App Runner service')
-const COPY_SERVICE_URL_FAILED = localize('aws.apprunner.copyServiceUrl.failed', 'Failed to copy App Runner service URL')
-const OPEN_SERVICE_FAILED = localize('aws.apprunner.open.failed', 'Failed to open App Runner service')
-const DEPLOY_SERVICE_FAILED = localize(
+const pauseServiceFailed = localize('aws.apprunner.pauseService.failed', 'Failed to pause App Runner service')
+const resumeServiceFailed = localize('aws.apprunner.resumeService.failed', 'Failed to resume App Runner service')
+const copyServiceUrlFailed = localize('aws.apprunner.copyServiceUrl.failed', 'Failed to copy App Runner service URL')
+const openServiceFailed = localize('aws.apprunner.open.failed', 'Failed to open App Runner service')
+const deployServiceFailed = localize(
     'aws.apprunner.startDeployment.failed',
     'Failed to start deployment of App Runner service'
 )
-const DELETE_SERVICE_FAILED = localize('aws.apprunner.deleteService.failed', 'Failed to delete App Runner service')
+const deleteServiceFailed = localize('aws.apprunner.deleteService.failed', 'Failed to delete App Runner service')
 
 const copyUrl = async (node: AppRunnerServiceNode) => {
     copyToClipboard(node.url, 'URL')
@@ -66,14 +66,14 @@ const deployService = async (node: AppRunnerServiceNode) => {
     }
 }
 
-commandMap.set(['aws.apprunner.createService', CREATE_SERVICE_FAILED], createAppRunnerService)
-commandMap.set(['aws.apprunner.createServiceFromEcr', CREATE_SERVICE_ECR_FAILED], createFromEcr)
-commandMap.set(['aws.apprunner.pauseService', PAUSE_SERVICE_FAILED], pauseService)
-commandMap.set(['aws.apprunner.resumeService', RESUME_SERVICE_FAILED], resumeService)
-commandMap.set(['aws.apprunner.copyServiceUrl', COPY_SERVICE_URL_FAILED], copyUrl)
-commandMap.set(['aws.apprunner.open', OPEN_SERVICE_FAILED], openUrl)
-commandMap.set(['aws.apprunner.startDeployment', DEPLOY_SERVICE_FAILED], deployService)
-commandMap.set(['aws.apprunner.deleteService', DELETE_SERVICE_FAILED], deleteService)
+commandMap.set(['aws.apprunner.createService', createServiceFailed], createAppRunnerService)
+commandMap.set(['aws.apprunner.createServiceFromEcr', createServiceEcrFailed], createFromEcr)
+commandMap.set(['aws.apprunner.pauseService', pauseServiceFailed], pauseService)
+commandMap.set(['aws.apprunner.resumeService', resumeServiceFailed], resumeService)
+commandMap.set(['aws.apprunner.copyServiceUrl', copyServiceUrlFailed], copyUrl)
+commandMap.set(['aws.apprunner.open', openServiceFailed], openUrl)
+commandMap.set(['aws.apprunner.startDeployment', deployServiceFailed], deployService)
+commandMap.set(['aws.apprunner.deleteService', deleteServiceFailed], deleteService)
 
 /**
  * Activates App Runner

--- a/src/apprunner/explorer/apprunnerNode.ts
+++ b/src/apprunner/explorer/apprunnerNode.ts
@@ -15,7 +15,7 @@ import globals from '../../shared/extensionGlobals'
 
 const localize = nls.loadMessageBundle()
 
-const POLLING_INTERVAL = 20000
+const pollingInterval = 20000
 export class AppRunnerNode extends AWSTreeNodeBase {
     private readonly serviceNodes: Map<AppRunner.ServiceId, AppRunnerServiceNode> = new Map()
     private readonly pollingNodes: Set<string> = new Set()
@@ -98,7 +98,7 @@ export class AppRunnerNode extends AWSTreeNodeBase {
 
     public startPolling(id: string): void {
         this.pollingNodes.add(id)
-        this.pollTimer = this.pollTimer ?? globals.clock.setInterval(this.refresh.bind(this), POLLING_INTERVAL)
+        this.pollTimer = this.pollTimer ?? globals.clock.setInterval(this.refresh.bind(this), pollingInterval)
     }
 
     public stopPolling(id: string): void {

--- a/src/apprunner/explorer/apprunnerServiceNode.ts
+++ b/src/apprunner/explorer/apprunnerServiceNode.ts
@@ -19,18 +19,18 @@ import { getIcon } from '../../shared/icons'
 import { DefaultCloudWatchLogsClient } from '../../shared/clients/cloudWatchLogsClient'
 const localize = nls.loadMessageBundle()
 
-const CONTEXT_BASE = 'awsAppRunnerServiceNode'
+const contextBase = 'awsAppRunnerServiceNode'
 
-const OPERATION_STATUS = {
-    START_DEPLOYMENT: localize('AWS.apprunner.operationStatus.deploy', 'Deploying...'),
-    CREATE_SERVICE: localize('AWS.apprunner.operationStatus.create', 'Creating...'),
-    PAUSE_SERVICE: localize('AWS.apprunner.operationStatus.pause', 'Pausing...'),
-    RESUME_SERVICE: localize('AWS.apprunner.operationStatus.resume', 'Resuming...'),
-    DELETE_SERVICE: localize('AWS.apprunner.operationStatus.delete', 'Deleting...'),
-    UPDATE_SERVICE: localize('AWS.apprunner.operationStatus.update', 'Updating...'),
+const operationStatus = {
+    START_DEPLOYMENT: localize('AWS.apprunner.operationStatus.deploy', 'Deploying...'), // eslint-disable-line @typescript-eslint/naming-convention
+    CREATE_SERVICE: localize('AWS.apprunner.operationStatus.create', 'Creating...'), // eslint-disable-line @typescript-eslint/naming-convention
+    PAUSE_SERVICE: localize('AWS.apprunner.operationStatus.pause', 'Pausing...'), // eslint-disable-line @typescript-eslint/naming-convention
+    RESUME_SERVICE: localize('AWS.apprunner.operationStatus.resume', 'Resuming...'), // eslint-disable-line @typescript-eslint/naming-convention
+    DELETE_SERVICE: localize('AWS.apprunner.operationStatus.delete', 'Deleting...'), // eslint-disable-line @typescript-eslint/naming-convention
+    UPDATE_SERVICE: localize('AWS.apprunner.operationStatus.update', 'Updating...'), // eslint-disable-line @typescript-eslint/naming-convention
 }
 
-type ServiceOperation = keyof typeof OPERATION_STATUS
+type ServiceOperation = keyof typeof operationStatus
 
 export class AppRunnerServiceNode extends CloudWatchLogsBase implements AWSResourceNode {
     public readonly name: string
@@ -76,7 +76,7 @@ export class AppRunnerServiceNode extends CloudWatchLogsBase implements AWSResou
 
     private setLabel(): void {
         const displayStatus = this.currentOperation.Type
-            ? OPERATION_STATUS[this.currentOperation.Type]
+            ? operationStatus[this.currentOperation.Type]
             : `${this._info.Status.charAt(0)}${this._info.Status.slice(1).toLowerCase().replace(/\_/g, ' ')}`
         this.label = `${this._info.ServiceName} [${displayStatus}]`
     }
@@ -138,7 +138,7 @@ export class AppRunnerServiceNode extends CloudWatchLogsBase implements AWSResou
         }
 
         this._info = Object.assign(this._info, info)
-        this.contextValue = `${CONTEXT_BASE}.${this._info.Status}`
+        this.contextValue = `${contextBase}.${this._info.Status}`
         this.setLabel()
     }
 

--- a/src/apprunner/wizards/imageRepositoryWizard.ts
+++ b/src/apprunner/wizards/imageRepositoryWizard.ts
@@ -27,8 +27,8 @@ import { createExitPrompter } from '../../shared/ui/common/exitPrompter'
 
 const localize = nls.loadMessageBundle()
 
-const PUBLIC_ECR = 'public.ecr.aws'
-const APP_RUNNER_ECR_ENTITY = 'build.apprunner.amazonaws'
+const publicEcr = 'public.ecr.aws'
+const appRunnerEcrEntity = 'build.apprunner.amazonaws'
 
 export type TaggedEcrRepository = EcrRepository & { tag?: string }
 
@@ -119,11 +119,11 @@ function createImagePrompter(
 
         const privateRegExp = /[0-9]+\.dkr\.ecr\.[a-zA-z0-9\-]+\.amazonaws\.com/
 
-        if (options.noPublicMessage && userInputParts[0].startsWith(PUBLIC_ECR)) {
+        if (options.noPublicMessage && userInputParts[0].startsWith(publicEcr)) {
             return options.noPublicMessage
         }
 
-        if (!userInputParts[0].startsWith(PUBLIC_ECR) && !userInputParts[0].match(privateRegExp)) {
+        if (!userInputParts[0].startsWith(publicEcr) && !userInputParts[0].match(privateRegExp)) {
             return 'not a valid ECR URL'
         }
     }
@@ -259,7 +259,7 @@ export class AppRunnerImageRepositoryWizard extends Wizard<AppRunner.SourceConfi
             return createRolePrompter(iamClient, {
                 title: localize('AWS.apprunner.createService.selectRole.title', 'Select a role to pull from ECR'),
                 helpUrl: vscode.Uri.parse(apprunnerCreateServiceDocsUrl),
-                roleFilter: role => (role.AssumeRolePolicyDocument ?? '').includes(APP_RUNNER_ECR_ENTITY),
+                roleFilter: role => (role.AssumeRolePolicyDocument ?? '').includes(appRunnerEcrEntity),
                 createRole: createEcrRole.bind(undefined, iamClient),
             }).transform(resp => resp.Arn)
         }

--- a/src/awsexplorer/awsExplorer.ts
+++ b/src/awsexplorer/awsExplorer.ts
@@ -25,7 +25,7 @@ export class AwsExplorer implements vscode.TreeDataProvider<AWSTreeNodeBase>, Re
     private readonly _onDidChangeTreeData: vscode.EventEmitter<AWSTreeNodeBase | undefined>
     private readonly regionNodes: Map<string, RegionNode>
 
-    private readonly ROOT_NODE_ADD_REGION = new AWSCommandTreeNode(
+    private readonly rootNodeAddRegion = new AWSCommandTreeNode(
         undefined,
         localize('AWS.explorerNode.addRegion', 'Add regions to {0} Explorer...', getIdeProperties().company),
         'aws.showRegion',
@@ -129,7 +129,7 @@ export class AwsExplorer implements vscode.TreeDataProvider<AWSTreeNodeBase>, Re
         )
 
         if (this.regionNodes.size === 0) {
-            return [this.getAuthNode(), this.ROOT_NODE_ADD_REGION]
+            return [this.getAuthNode(), this.rootNodeAddRegion]
         }
 
         return await makeChildrenNodes({

--- a/src/awsexplorer/childNodeLoader.ts
+++ b/src/awsexplorer/childNodeLoader.ts
@@ -9,7 +9,7 @@ import { MoreResultsNode } from './moreResultsNode'
 import { ChildNodeCache } from './childNodeCache'
 import * as AsyncLock from 'async-lock'
 
-const LOCK_KEY = 'ChildNodeLoader'
+const lockKey = 'ChildNodeLoader'
 
 export interface ChildNodePage<T extends AWSTreeNodeBase = AWSTreeNodeBase> {
     newChildren: T[]
@@ -56,7 +56,7 @@ export class ChildNodeLoader<T extends AWSTreeNodeBase = AWSTreeNodeBase> {
      * Returns true if a {@link loadMoreChildren} call is in progress.
      */
     public isLoadingMoreChildren(): boolean {
-        return this.loadChildrenLock.isBusy(LOCK_KEY)
+        return this.loadChildrenLock.isBusy(lockKey)
     }
 
     /**
@@ -92,7 +92,7 @@ export class ChildNodeLoader<T extends AWSTreeNodeBase = AWSTreeNodeBase> {
      */
     private async loadMoreChildrenIf(condition: () => boolean): Promise<void> {
         if (condition()) {
-            return this.loadChildrenLock.acquire(LOCK_KEY, async () => {
+            return this.loadChildrenLock.acquire(lockKey, async () => {
                 if (condition()) {
                     const newPage = await this.loadPage(this.cache.continuationToken)
                     this.cache.appendPage(newPage)

--- a/src/awsexplorer/regionNode.ts
+++ b/src/awsexplorer/regionNode.ts
@@ -13,7 +13,7 @@ import { S3Node } from '../s3/explorer/s3Nodes'
 import { EcrNode } from '../ecr/explorer/ecrNode'
 import { IotNode } from '../iot/explorer/iotNodes'
 import { Region } from '../shared/regions/endpoints'
-import { DEFAULT_PARTITION, RegionProvider } from '../shared/regions/regionProvider'
+import { defaultPartition, RegionProvider } from '../shared/regions/regionProvider'
 import { AWSTreeNodeBase } from '../shared/treeview/nodes/awsTreeNodeBase'
 import { StepFunctionsNode } from '../stepFunctions/explorer/stepFunctionsNodes'
 import { SsmDocumentNode } from '../ssmDocument/explorer/ssmDocumentNode'
@@ -104,7 +104,7 @@ export class RegionNode extends AWSTreeNodeBase {
         //  `serviceId`s are checked against ~/resources/endpoints.json to see whether or not the service is available in the given region.
         //  If the service is available, we use the `createFn` to generate the node for the region.
         //  This interface exists so we can add additional nodes to the array (otherwise Typescript types the array to what's already in the array at creation)
-        const partitionId = this.regionProvider.getPartitionId(this.regionCode) ?? DEFAULT_PARTITION
+        const partitionId = this.regionProvider.getPartitionId(this.regionCode) ?? defaultPartition
         const childNodes: AWSTreeNodeBase[] = []
         for (const { serviceId, createFn } of serviceCandidates) {
             if (this.regionProvider.isServiceInRegion(serviceId, this.regionCode)) {

--- a/src/cloudWatchLogs/commands/viewLogStream.ts
+++ b/src/cloudWatchLogs/commands/viewLogStream.ts
@@ -81,7 +81,7 @@ export class DefaultSelectLogStreamWizardContext implements SelectLogStreamWizar
                     },
                     request,
                 }),
-            response => convertDescribeLogStreamsToQuickPickItems(response)
+            response => convertDescribeLogToQuickPickItems(response)
         )
 
         const controller = new picker.IteratingQuickPickController(qp, populator)
@@ -112,7 +112,7 @@ export class DefaultSelectLogStreamWizardContext implements SelectLogStreamWizar
     }
 }
 
-export function convertDescribeLogStreamsToQuickPickItems(
+export function convertDescribeLogToQuickPickItems(
     response: CloudWatchLogs.DescribeLogStreamsResponse
 ): vscode.QuickPickItem[] {
     return (response.logStreams ?? []).map<vscode.QuickPickItem>(stream => ({
@@ -141,7 +141,7 @@ export class SelectLogStreamWizard extends MultiStepWizard<SelectLogStreamRespon
     }
 
     protected get startStep(): WizardStep {
-        return this.SELECT_STREAM
+        return this.selectStream
     }
 
     protected getResult(): SelectLogStreamResponse | undefined {
@@ -156,7 +156,7 @@ export class SelectLogStreamWizard extends MultiStepWizard<SelectLogStreamRespon
         }
     }
 
-    private readonly SELECT_STREAM: WizardStep = async () => {
+    private readonly selectStream: WizardStep = async () => {
         const returnVal = await this.context.pickLogStream()
 
         // retry on error

--- a/src/cloudWatchLogs/explorer/logGroupNode.ts
+++ b/src/cloudWatchLogs/explorer/logGroupNode.ts
@@ -9,14 +9,14 @@ import { AWSResourceNode } from '../../shared/treeview/nodes/awsResourceNode'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 import { getIcon } from '../../shared/icons'
 
-export const CONTEXT_VALUE_CLOUDWATCH_LOG = 'awsCloudWatchLogNode'
+export const contextValueCloudwatchLog = 'awsCloudWatchLogNode'
 
 export class LogGroupNode extends AWSTreeNodeBase implements AWSResourceNode {
     public constructor(public readonly regionCode: string, public logGroup: CloudWatchLogs.LogGroup) {
         super('')
         this.update(logGroup)
         this.iconPath = getIcon('aws-cloudwatch-log-group')
-        this.contextValue = CONTEXT_VALUE_CLOUDWATCH_LOG
+        this.contextValue = contextValueCloudwatchLog
     }
 
     public update(logGroup: CloudWatchLogs.LogGroup): void {

--- a/src/codecatalyst/auth.ts
+++ b/src/codecatalyst/auth.ts
@@ -96,7 +96,7 @@ export class CodeCatalystAuthenticationProvider {
 
     public async promptNotConnected(): Promise<SsoConnection> {
         type ConnectionFlowEvent = Partial<MetricShapes[MetricName]> & {
-            readonly codecatalyst_connectionFlow: 'Create' | 'Switch' | 'Upgrade'
+            readonly codecatalyst_connectionFlow: 'Create' | 'Switch' | 'Upgrade' // eslint-disable-line @typescript-eslint/naming-convention
         }
 
         const conn = (await this.auth.listConnections()).find(isBuilderIdConnection)

--- a/src/codecatalyst/devfile.ts
+++ b/src/codecatalyst/devfile.ts
@@ -9,7 +9,7 @@ const localize = nls.loadMessageBundle()
 import * as vscode from 'vscode'
 import * as path from 'path'
 import { DevEnvClient } from '../shared/clients/devenvClient'
-import { DevfileRegistry, DEVFILE_GLOB_PATTERN } from '../shared/fs/devfileRegistry'
+import { DevfileRegistry, devfileGlobPattern } from '../shared/fs/devfileRegistry'
 import { getLogger } from '../shared/logger'
 import { Commands } from '../shared/vscode/commands2'
 import { checkUnsavedChanges } from '../shared/utilities/workspaceUtils'
@@ -110,13 +110,13 @@ export class DevfileCodeLensProvider implements vscode.CodeLensProvider {
 export function registerDevfileWatcher(devenvClient: DevEnvClient): vscode.Disposable {
     const registry = new DevfileRegistry()
     const codelensProvider = new DevfileCodeLensProvider(registry, devenvClient)
-    registry.addWatchPattern(DEVFILE_GLOB_PATTERN)
+    registry.addWatchPattern(devfileGlobPattern)
 
     const codelensDisposable = vscode.languages.registerCodeLensProvider(
         {
             language: 'yaml',
             scheme: 'file',
-            pattern: DEVFILE_GLOB_PATTERN,
+            pattern: devfileGlobPattern,
         },
         codelensProvider
     )

--- a/src/codecatalyst/model.ts
+++ b/src/codecatalyst/model.ts
@@ -18,9 +18,9 @@ import { getLogger } from '../shared/logger'
 import { AsyncCollection, toCollection } from '../shared/utilities/asyncCollection'
 import { getCodeCatalystSpaceName, getCodeCatalystProjectName } from '../shared/vscode/env'
 import { writeFile } from 'fs-extra'
-import { SSH_AGENT_SOCKET_VARIABLE, startSshAgent, startVscodeRemote } from '../shared/extensions/ssh'
+import { sshAgentSocketVariable, startSshAgent, startVscodeRemote } from '../shared/extensions/ssh'
 import { ChildProcess } from '../shared/utilities/childProcess'
-import { ensureDependencies, HOST_NAME_PREFIX } from './tools'
+import { ensureDependencies, hostNamePrefix } from './tools'
 import { isCodeCatalystVSCode } from './utils'
 import { Timeout } from '../shared/utilities/timeoutUtils'
 import { Commands } from '../shared/vscode/commands2'
@@ -101,7 +101,7 @@ export function createCodeCatalystEnvProvider(
         await cacheBearerToken(await client.getBearerToken(), devenv.id)
         const vars = getCodeCatalystSsmEnv(client.regionCode, ssmPath, devenv)
 
-        return useSshAgent ? { [SSH_AGENT_SOCKET_VARIABLE]: await startSshAgent(), ...vars } : vars
+        return useSshAgent ? { [sshAgentSocketVariable]: await startSshAgent(), ...vars } : vars
     }
 }
 
@@ -140,7 +140,7 @@ export function sshLogFileLocation(devenvId: string): string {
 }
 
 export function getHostNameFromEnv(env: DevEnvironmentId): string {
-    return `${HOST_NAME_PREFIX}${env.id}`
+    return `${hostNamePrefix}${env.id}`
 }
 
 export interface ConnectedDevEnv {
@@ -344,4 +344,4 @@ export interface DevEnvMemento {
     alias: string | undefined
 }
 
-export const CODECATALYST_RECONNECT_KEY = 'CODECATALYST_RECONNECT'
+export const codecatalystReconnectKey = 'CODECATALYST_RECONNECT'

--- a/src/codecatalyst/tools.ts
+++ b/src/codecatalyst/tools.ts
@@ -36,7 +36,7 @@ interface MissingTool {
     readonly reason?: string
 }
 
-export const HOST_NAME_PREFIX = 'aws-devenv-'
+export const hostNamePrefix = 'aws-devenv-'
 
 export async function ensureDependencies(
     window = vscode.window
@@ -180,7 +180,7 @@ async function ensureCodeCatalystSshConfig(sshPath: string) {
     return Result.ok()
 }
 
-const configHostName = `${HOST_NAME_PREFIX}*`
+const configHostName = `${hostNamePrefix}*`
 function createSSHConfigSection(proxyCommand: string): string {
     // "AddKeysToAgent" will automatically add keys used on the server to the local agent. If not set, then `ssh-add`
     // must be done locally. It's mostly a convenience thing; private keys are _not_ shared with the server.
@@ -205,7 +205,7 @@ async function verifySSHHost({
     section: string
     proxyCommand: string
 }) {
-    const matchResult = await matchSshSection(sshPath, `${HOST_NAME_PREFIX}test`)
+    const matchResult = await matchSshSection(sshPath, `${hostNamePrefix}test`)
     if (matchResult.isErr()) {
         return matchResult
     }

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -186,7 +186,7 @@ export async function activate(context: ExtContext): Promise<void> {
             if (isInlineCompletionEnabled() && e.uri.fsPath !== InlineCompletionService.instance.filePath()) {
                 return
             }
-            RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(vscode.window.activeTextEditor, -1)
+            RecommendationHandler.instance.reportUserDecisionOfRecommendation(vscode.window.activeTextEditor, -1)
             RecommendationHandler.instance.clearRecommendations()
         }),
 
@@ -246,11 +246,11 @@ export async function activate(context: ExtContext): Promise<void> {
                 ) || false
             const notificationLastShown: number =
                 context.extensionContext.globalState.get<number | undefined>(
-                    CodeWhispererConstants.accessTokenMigrationDoNotShowAgainLastShown
+                    CodeWhispererConstants.accessTokenMigrationDoNotShowLastShown
                 ) || 1
 
             //Add 7 days to notificationLastShown to determine whether warn message should show
-            if (doNotShowAgain || notificationLastShown + (1000 * 60 * 60 * 24 * 7) >= Date.now()) {
+            if (doNotShowAgain || notificationLastShown + 1000 * 60 * 60 * 24 * 7 >= Date.now()) {
                 return
             } else if (t <= CodeWhispererConstants.accessTokenCutOffDate) {
                 vscode.window
@@ -275,7 +275,7 @@ export async function activate(context: ExtContext): Promise<void> {
                         }
                     })
                 context.extensionContext.globalState.update(
-                    CodeWhispererConstants.accessTokenMigrationDoNotShowAgainLastShown,
+                    CodeWhispererConstants.accessTokenMigrationDoNotShowLastShown,
                     Date.now()
                 )
             } else {
@@ -311,7 +311,7 @@ export async function activate(context: ExtContext): Promise<void> {
 
     async function showCodeWhispererWelcomeMessage(): Promise<void> {
         const filePath = isCloud9()
-            ? context.extensionContext.asAbsolutePath(CodeWhispererConstants.welcomeCodeWhispererCloud9ReadmeFileSource)
+            ? context.extensionContext.asAbsolutePath(CodeWhispererConstants.welcomeCodeWhispererCloud9Readme)
             : context.extensionContext.asAbsolutePath(CodeWhispererConstants.welcomeCodeWhispererReadmeFileSource)
         const readmeUri = vscode.Uri.file(filePath)
         await vscode.commands.executeCommand('markdown.showPreviewToSide', readmeUri)
@@ -330,13 +330,12 @@ export async function activate(context: ExtContext): Promise<void> {
             vscode.workspace.getConfiguration('editor').get('suggest.showMethods') || false
         const isAutomatedTriggerEnabled: boolean = getAutoTriggerStatus()
         const isManualTriggerEnabled: boolean = await getManualTriggerStatus()
-        const isIncludeSuggestionsWithCodeReferencesEnabled =
-            codewhispererSettings.isIncludeSuggestionsWithCodeReferencesEnabled()
+        const isSuggestionsWithCodeReferencesEnabled = codewhispererSettings.isSuggestionsWithCodeReferencesEnabled()
         return {
             isShowMethodsEnabled,
             isManualTriggerEnabled,
             isAutomatedTriggerEnabled,
-            isIncludeSuggestionsWithCodeReferencesEnabled,
+            isSuggestionsWithCodeReferencesEnabled,
         }
     }
 
@@ -617,7 +616,7 @@ export async function activate(context: ExtContext): Promise<void> {
 
 export async function shutdown() {
     if (isCloud9()) {
-        RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(vscode.window.activeTextEditor, -1)
+        RecommendationHandler.instance.reportUserDecisionOfRecommendation(vscode.window.activeTextEditor, -1)
         RecommendationHandler.instance.clearRecommendations()
     }
     if (isInlineCompletionEnabled()) {

--- a/src/codewhisperer/commands/invokeRecommendation.ts
+++ b/src/codewhisperer/commands/invokeRecommendation.ts
@@ -58,7 +58,7 @@ export async function invokeRecommendation(
             vsCodeState.isIntelliSenseActive = false
             RecommendationHandler.instance.isGenerateRecommendationInProgress = true
             try {
-                RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
+                RecommendationHandler.instance.reportUserDecisionOfRecommendation(editor, -1)
                 RecommendationHandler.instance.clearRecommendations()
                 await RecommendationHandler.instance.getRecommendations(
                     client,

--- a/src/codewhisperer/commands/onAcceptance.ts
+++ b/src/codewhisperer/commands/onAcceptance.ts
@@ -32,7 +32,7 @@ export async function onAcceptance(acceptanceEntry: OnRecommendationAcceptanceEn
         const start = acceptanceEntry.range.start
         const end = isCloud9() ? acceptanceEntry.editor.selection.active : acceptanceEntry.range.end
         const languageId = acceptanceEntry.editor.document.languageId
-        RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(
+        RecommendationHandler.instance.reportUserDecisionOfRecommendation(
             acceptanceEntry.editor,
             acceptanceEntry.acceptIndex
         )

--- a/src/codewhisperer/commands/onInlineAcceptance.ts
+++ b/src/codewhisperer/commands/onInlineAcceptance.ts
@@ -84,7 +84,7 @@ export async function onInlineAcceptance(
         const start = acceptanceEntry.range.start
         const end = acceptanceEntry.editor.selection.active
         const languageId = acceptanceEntry.editor.document.languageId
-        RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(
+        RecommendationHandler.instance.reportUserDecisionOfRecommendation(
             acceptanceEntry.editor,
             acceptanceEntry.acceptIndex
         )

--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -103,7 +103,7 @@ export const licenseFilter = 'CodeWhisperer suggestions were filtered due to ref
  */
 export const welcomeCodeWhispererReadmeFileSource = 'resources/markdown/WelcomeToCodeWhisperer.md'
 
-export const welcomeCodeWhispererCloud9ReadmeFileSource = 'resources/markdown/WelcomeToCodeWhispererCloud9.md'
+export const welcomeCodeWhispererCloud9Readme = 'resources/markdown/WelcomeToCodeWhispererCloud9.md'
 
 export const welcomeMessageKey = 'CODEWHISPERER_WELCOME_MESSAGE'
 
@@ -242,7 +242,7 @@ export const accessTokenMigrationDoNotShowAgain = `Don\'t Show Again`
 
 export const accessTokenMigrationDoNotShowAgainKey = 'CODEWHISPERER_ACCESS_TOKEN_MIGRATION_DO_NOT_SHOW_AGAIN'
 
-export const accessTokenMigrationDoNotShowAgainLastShown =
+export const accessTokenMigrationDoNotShowLastShown =
     'CODEWHISPERER_ACCESS_TOKEN_MIGRATION_DO_NOT_SHOW_AGAIN_LAST_SHOWN_TIME'
 
 export const accessTokenMigrationDoNotShowAgainInfo = `You will not receive this notification again. If you would like to continue using CodeWhisperer after January 31, 2023, you can still connect with AWS. [Learn More](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/codewhisper-setup-general.html).`

--- a/src/codewhisperer/models/model.ts
+++ b/src/codewhisperer/models/model.ts
@@ -65,7 +65,7 @@ export interface ConfigurationEntry {
     readonly isShowMethodsEnabled: boolean
     readonly isManualTriggerEnabled: boolean
     readonly isAutomatedTriggerEnabled: boolean
-    readonly isIncludeSuggestionsWithCodeReferencesEnabled: boolean
+    readonly isSuggestionsWithCodeReferencesEnabled: boolean
 }
 
 export interface InlineCompletionItem {

--- a/src/codewhisperer/service/inlineCompletion.ts
+++ b/src/codewhisperer/service/inlineCompletion.ts
@@ -136,7 +136,7 @@ export class InlineCompletion {
 
         RecommendationHandler.instance.cancelPaginatedRequest()
         // report all recommendation as rejected
-        RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
+        RecommendationHandler.instance.reportUserDecisionOfRecommendation(editor, -1)
     }
 
     async rejectRecommendation(
@@ -329,7 +329,7 @@ export class InlineCompletion {
         config: ConfigurationEntry,
         autoTriggerType?: CodewhispererAutomatedTriggerType
     ) {
-        RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
+        RecommendationHandler.instance.reportUserDecisionOfRecommendation(editor, -1)
         RecommendationHandler.instance.clearRecommendations()
         this.setCodeWhispererStatusBarLoading()
         const isManualTrigger = triggerType === 'OnDemand'
@@ -355,7 +355,7 @@ export class InlineCompletion {
                 )
                 this.setCompletionItems(editor)
                 if (RecommendationHandler.instance.checkAndResetCancellationTokens()) {
-                    RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
+                    RecommendationHandler.instance.reportUserDecisionOfRecommendation(editor, -1)
                     RecommendationHandler.instance.clearRecommendations()
                     break
                 }
@@ -397,7 +397,7 @@ export class InlineCompletion {
                     RecommendationHandler.instance.recommendations.forEach((r, i) => {
                         RecommendationHandler.instance.setSuggestionState(i, 'Discard')
                     })
-                    RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
+                    RecommendationHandler.instance.reportUserDecisionOfRecommendation(editor, -1)
                     RecommendationHandler.instance.clearRecommendations()
                     if (this._timer !== undefined) {
                         clearTimeout(this._timer)
@@ -427,7 +427,7 @@ export class InlineCompletion {
                         RecommendationHandler.instance.recommendations.forEach((r, i) => {
                             RecommendationHandler.instance.setSuggestionState(i, 'Discard')
                         })
-                        RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
+                        RecommendationHandler.instance.reportUserDecisionOfRecommendation(editor, -1)
                         RecommendationHandler.instance.clearRecommendations()
                     }
                     if (this._timer !== undefined) {
@@ -448,7 +448,7 @@ export class InlineCompletion {
                                     showTimedMessage(CodeWhispererConstants.noSuggestions, 2000)
                                 }
                             }
-                            RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
+                            RecommendationHandler.instance.reportUserDecisionOfRecommendation(editor, -1)
                             RecommendationHandler.instance.clearRecommendations()
                         }
                     }

--- a/src/codewhisperer/service/keyStrokeHandler.ts
+++ b/src/codewhisperer/service/keyStrokeHandler.ts
@@ -167,7 +167,7 @@ export class KeyStrokeHandler {
                 vsCodeState.isIntelliSenseActive = false
                 RecommendationHandler.instance.isGenerateRecommendationInProgress = true
                 try {
-                    RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
+                    RecommendationHandler.instance.reportUserDecisionOfRecommendation(editor, -1)
                     RecommendationHandler.instance.clearRecommendations()
                     await RecommendationHandler.instance.getRecommendations(
                         client,

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -151,7 +151,7 @@ export class RecommendationHandler {
             req = EditorContext.buildListRecommendationRequest(
                 editor as vscode.TextEditor,
                 this.nextToken,
-                accessToken ? undefined : config.isIncludeSuggestionsWithCodeReferencesEnabled
+                accessToken ? undefined : config.isSuggestionsWithCodeReferencesEnabled
             )
         } else {
             req = EditorContext.buildGenerateRecommendationRequest(editor as vscode.TextEditor)
@@ -341,7 +341,11 @@ export class RecommendationHandler {
         this.nextToken = ''
         this.errorMessagePrompt = ''
     }
-    reportUserDecisionOfCurrentRecommendation(editor: vscode.TextEditor | undefined, acceptIndex: number) {
+
+    /**
+     * Emits telemetry reflecting user decision for current recommendation.
+     */
+    reportUserDecisionOfRecommendation(editor: vscode.TextEditor | undefined, acceptIndex: number) {
         TelemetryHelper.instance.recordUserDecisionTelemetry(
             this.requestId,
             this.sessionId,
@@ -359,7 +363,7 @@ export class RecommendationHandler {
 
     canShowRecommendationInIntelliSense(editor: vscode.TextEditor, showPrompt: boolean = false): boolean {
         const reject = () => {
-            this.reportUserDecisionOfCurrentRecommendation(editor, -1)
+            this.reportUserDecisionOfRecommendation(editor, -1)
             this.clearRecommendations()
         }
         if (!this.isValidResponse()) {

--- a/src/codewhisperer/service/referenceLogViewProvider.ts
+++ b/src/codewhisperer/service/referenceLogViewProvider.ts
@@ -39,7 +39,7 @@ export class ReferenceLogViewProvider implements vscode.WebviewViewProvider {
         }
         this._view.webview.html = this.getHtml(
             webviewView.webview,
-            CodeWhispererSettings.instance.isIncludeSuggestionsWithCodeReferencesEnabled()
+            CodeWhispererSettings.instance.isSuggestionsWithCodeReferencesEnabled()
         )
         this._view.webview.onDidReceiveMessage(data => {
             vscode.commands.executeCommand('aws.codeWhisperer.configure', 'codewhisperer')
@@ -48,7 +48,7 @@ export class ReferenceLogViewProvider implements vscode.WebviewViewProvider {
 
     public async update() {
         if (this._view) {
-            const showPrompt = CodeWhispererSettings.instance.isIncludeSuggestionsWithCodeReferencesEnabled()
+            const showPrompt = CodeWhispererSettings.instance.isSuggestionsWithCodeReferencesEnabled()
             this._view.webview.html = this.getHtml(this._view.webview, showPrompt)
         }
     }

--- a/src/codewhisperer/tracker/codewhispererTracker.ts
+++ b/src/codewhisperer/tracker/codewhispererTracker.ts
@@ -23,16 +23,16 @@ export class CodeWhispererTracker {
     /**
      * the interval of the background thread invocation, which is triggered by the timer
      */
-    private static readonly DEFAULT_CHECK_PERIOD_MILLIS = 1000 * 60 * 1 // 1 minute in milliseconds
+    private static readonly defaultCheckPeriodMillis = 1000 * 60 * 1 // 1 minute in milliseconds
     /**
      * modification should be recorded at least 5 minutes after accepted into the editor
      */
-    private static readonly DEFAULT_MODIFICATION_INTERVAL_MILLIS = 1000 * 60 * 5 // 5 minutes in milliseconds
+    private static readonly defaultModificationIntervalMillis = 1000 * 60 * 5 // 5 minutes in milliseconds
 
     /**
      * This is to avoid user overflowing the eventQueue by spamming accepted suggestions
      */
-    private static readonly DEFAULT_MAX_QUEUE_SIZE = 10000
+    private static readonly defaultMaxQueueSize = 10000
 
     private constructor() {
         this._eventQueue = []
@@ -47,7 +47,7 @@ export class CodeWhispererTracker {
             this.startTimer()
         }
 
-        if (this._eventQueue.length >= CodeWhispererTracker.DEFAULT_MAX_QUEUE_SIZE) {
+        if (this._eventQueue.length >= CodeWhispererTracker.defaultMaxQueueSize) {
             this._eventQueue.shift()
         }
         this._eventQueue.push(suggestion)
@@ -65,7 +65,7 @@ export class CodeWhispererTracker {
         for (const suggestion of this._eventQueue) {
             if (
                 currentTime.getTime() - suggestion.time.getTime() >
-                CodeWhispererTracker.DEFAULT_MODIFICATION_INTERVAL_MILLIS
+                CodeWhispererTracker.defaultModificationIntervalMillis
             ) {
                 this.emitTelemetryOnSuggestion(suggestion)
             } else {
@@ -132,7 +132,7 @@ export class CodeWhispererTracker {
                         this._timer!.refresh()
                     }
                 }
-            }, CodeWhispererTracker.DEFAULT_CHECK_PERIOD_MILLIS)
+            }, CodeWhispererTracker.defaultCheckPeriodMillis)
         }
     }
 

--- a/src/codewhisperer/util/codewhispererSettings.ts
+++ b/src/codewhisperer/util/codewhispererSettings.ts
@@ -9,7 +9,7 @@ const description = {
     shareCodeWhispererContentWithAWS: Boolean,
 }
 export class CodeWhispererSettings extends fromExtensionManifest('aws.codeWhisperer', description) {
-    public isIncludeSuggestionsWithCodeReferencesEnabled(): boolean {
+    public isSuggestionsWithCodeReferencesEnabled(): boolean {
         return this.get(`includeSuggestionsWithCodeReferences`, false)
     }
 

--- a/src/codewhisperer/util/cognitoIdentity.ts
+++ b/src/codewhisperer/util/cognitoIdentity.ts
@@ -7,14 +7,14 @@ import * as CodeWhispererConstants from '../models/constants'
 import globals from '../../shared/extensionGlobals'
 import { getLogger } from '../../shared/logger'
 
-const COGNITO_ID_KEY = 'cognitoID'
+const cognitoIdKey = 'cognitoID'
 
 export const getCognitoCredentials = async (): Promise<CognitoIdentityCredentials> => {
     const region = CodeWhispererConstants.region
     try {
         // grab Cognito identityId
         const poolId = CodeWhispererConstants.identityPoolID
-        const identityMapJson = globals.context.globalState.get<string>(COGNITO_ID_KEY, '[]')
+        const identityMapJson = globals.context.globalState.get<string>(cognitoIdKey, '[]')
 
         const identityMap = new Map<string, string>(JSON.parse(identityMapJson) as Iterable<[string, string]>)
         let identityId = identityMap.get(poolId)
@@ -25,7 +25,7 @@ export const getCognitoCredentials = async (): Promise<CognitoIdentityCredential
 
             // save it
             identityMap.set(poolId, identityId)
-            await globals.context.globalState.update(COGNITO_ID_KEY, JSON.stringify(Array.from(identityMap.entries())))
+            await globals.context.globalState.update(cognitoIdKey, JSON.stringify(Array.from(identityMap.entries())))
         }
 
         const credentials = new CognitoIdentityCredentials({ IdentityId: identityId }, { region })

--- a/src/codewhisperer/util/dependencyGraph/javaDependencyGraph.ts
+++ b/src/codewhisperer/util/dependencyGraph/javaDependencyGraph.ts
@@ -21,8 +21,8 @@ export interface JavaStatement {
     packages: string[]
 }
 
-export const IMPORT_REGEX = /^import(\s+static\s*)?\s+([\w\.]+)\s*;/gm
-export const PACKAGE_REGEX = /^package\s+([\w\.]+)\s*;/gm
+export const importRegex = /^import(\s+static\s*)?\s+([\w\.]+)\s*;/gm
+export const packageRegex = /^package\s+([\w\.]+)\s*;/gm
 
 export class JavaDependencyGraph extends DependencyGraph {
     private _outputDirs: Set<string> = new Set<string>()
@@ -44,8 +44,8 @@ export class JavaDependencyGraph extends DependencyGraph {
 
     private extractStatement(content: string): JavaStatement {
         return {
-            imports: content.match(new RegExp(IMPORT_REGEX)) ?? [],
-            packages: content.match(new RegExp(PACKAGE_REGEX)) ?? [],
+            imports: content.match(new RegExp(importRegex)) ?? [],
+            packages: content.match(new RegExp(packageRegex)) ?? [],
         }
     }
 

--- a/src/codewhisperer/util/dependencyGraph/javascriptDependencyGraph.ts
+++ b/src/codewhisperer/util/dependencyGraph/javascriptDependencyGraph.ts
@@ -11,9 +11,9 @@ import * as CodeWhispererConstants from '../../models/constants'
 import path = require('path')
 import { sleep } from '../../../shared/utilities/timeoutUtils'
 
-export const IMPORT_REGEX = /^[ \t]*import[ \t]+.+;?$/gm
-export const REQUIRE_REGEX = /^[ \t]*.+require[ \t]*\([ \t]*['"][^'"]+['"][ \t]*\)[ \t]*;?/gm
-export const MODULE_REGEX = /["'][^"'\r\n]+["']/gm
+export const importRegex = /^[ \t]*import[ \t]+.+;?$/gm
+export const requireRegex = /^[ \t]*.+require[ \t]*\([ \t]*['"][^'"]+['"][ \t]*\)[ \t]*;?/gm
+export const moduleRegex = /["'][^"'\r\n]+["']/gm
 
 export class JavascriptDependencyGraph extends DependencyGraph {
     private _generatedDirs: Set<string> = new Set(['node_modules', 'dist', 'build', 'cdk.out'])
@@ -31,7 +31,7 @@ export class JavascriptDependencyGraph extends DependencyGraph {
     }
 
     getModulePath(modulePathStr: string) {
-        const matches = modulePathStr.match(MODULE_REGEX)
+        const matches = modulePathStr.match(moduleRegex)
         if (matches) {
             const extract = matches[0]
             modulePathStr = extract.substring(1, extract.length - 1)
@@ -105,8 +105,8 @@ export class JavascriptDependencyGraph extends DependencyGraph {
     async readImports(uri: vscode.Uri) {
         const content: string = await readFileAsString(uri.fsPath)
         this._totalLines += content.split(DependencyGraphConstants.newlineRegex).length
-        const importRegExp = new RegExp(IMPORT_REGEX)
-        const requireRegExp = new RegExp(REQUIRE_REGEX)
+        const importRegExp = new RegExp(importRegex)
+        const requireRegExp = new RegExp(requireRegex)
         const importMatches = content.match(importRegExp)
         const requireMatches = content.match(requireRegExp)
         const matches: Set<string> = new Set()

--- a/src/codewhisperer/util/dependencyGraph/pythonDependencyGraph.ts
+++ b/src/codewhisperer/util/dependencyGraph/pythonDependencyGraph.ts
@@ -11,7 +11,7 @@ import * as CodeWhispererConstants from '../../models/constants'
 import path = require('path')
 import { sleep } from '../../../shared/utilities/timeoutUtils'
 
-export const IMPORT_REGEX =
+export const importRegex =
     /^(?:from[ ]+(\S+)[ ]+)?import[ ]+(\S+)(?:[ ]+as[ ]+\S+)?[ ]*([,]*[ ]+(\S+)(?:[ ]+as[ ]+\S+)?[ ]*)*$/gm
 
 export class PythonDependencyGraph extends DependencyGraph {
@@ -30,7 +30,7 @@ export class PythonDependencyGraph extends DependencyGraph {
     private async readImports(uri: vscode.Uri) {
         const content: string = await readFileAsString(uri.fsPath)
         this._totalLines += content.split(DependencyGraphConstants.newlineRegex).length
-        const regExp = new RegExp(IMPORT_REGEX)
+        const regExp = new RegExp(importRegex)
         return content.match(regExp) ?? []
     }
 

--- a/src/codewhisperer/views/securityPanelViewProvider.ts
+++ b/src/codewhisperer/views/securityPanelViewProvider.ts
@@ -90,8 +90,8 @@ export class SecurityPanelViewProvider implements vscode.WebviewViewProvider {
                 this.packageName
             }</span> found <span class="total">${total}</span> issues</p>`
         )
-        this.panelSets.forEach((panel_set, index) => {
-            this.addLine(panel_set, index)
+        this.panelSets.forEach((panelSet, index) => {
+            this.addLine(panelSet, index)
         })
         this.update()
         if (editor) {
@@ -124,8 +124,8 @@ export class SecurityPanelViewProvider implements vscode.WebviewViewProvider {
     }
 
     private persistLines() {
-        this.panelSets.forEach((panel_set, index) => {
-            this.persistLine(panel_set, index)
+        this.panelSets.forEach((panelSet, index) => {
+            this.persistLine(panelSet, index)
         })
     }
 
@@ -284,8 +284,8 @@ export class SecurityPanelViewProvider implements vscode.WebviewViewProvider {
         })
         this.panelSets[index] = currentPanelSet
         this.dynamicLog = []
-        this.panelSets.forEach((panel_set, index) => {
-            this.addLine(panel_set, index)
+        this.panelSets.forEach((panelSet, index) => {
+            this.addLine(panelSet, index)
         })
         this.update()
         if (editor) {

--- a/src/credentials/awsCredentialsStatusBarItem.ts
+++ b/src/credentials/awsCredentialsStatusBarItem.ts
@@ -12,13 +12,13 @@ import { getIdeProperties } from '../shared/extensionUtilities'
 import { DevSettings } from '../shared/settings'
 import { Auth, login } from './auth'
 
-const STATUSBAR_PRIORITY = 1
+const statusbarPriority = 1
 
 export async function initializeAwsCredentialsStatusBarItem(
     awsContext: AwsContext,
     context: vscode.ExtensionContext
 ): Promise<void> {
-    const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, STATUSBAR_PRIORITY)
+    const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, statusbarPriority)
     statusBarItem.command = login.build().asCommand({ title: 'Login' })
     statusBarItem.show()
     updateCredentialsStatusBarItem(statusBarItem)

--- a/src/credentials/credentialsCreator.ts
+++ b/src/credentials/credentialsCreator.ts
@@ -8,10 +8,7 @@ const localize = nls.loadMessageBundle()
 
 import { createInputBox, promptUser } from '../shared/ui/input'
 
-const ERROR_MESSAGE_USER_CANCELLED = localize(
-    'AWS.error.mfa.userCancelled',
-    'User cancelled entering authentication code'
-)
+const errorMessageUserCancelled = localize('AWS.error.mfa.userCancelled', 'User cancelled entering authentication code')
 
 /**
  * @description Prompts user for MFA token
@@ -37,7 +34,7 @@ export async function getMfaTokenFromUser(mfaSerial: string, profileName: string
 
     // Distinguish user cancel vs code entry issues with the error message
     if (!token) {
-        throw new Error(ERROR_MESSAGE_USER_CANCELLED)
+        throw new Error(errorMessageUserCancelled)
     }
 
     return token

--- a/src/credentials/credentialsUtilities.ts
+++ b/src/credentials/credentialsUtilities.ts
@@ -16,8 +16,8 @@ import { messages, showMessageWithCancel, showViewLogsMessage } from '../shared/
 import { Timeout, waitTimeout } from '../shared/utilities/timeoutUtils'
 import { fromExtensionManifest } from '../shared/settings'
 
-const CREDENTIALS_TIMEOUT = 300000 // 5 minutes
-const CREDENTIALS_PROGRESS_DELAY = 1000
+const credentialsTimeout = 300000 // 5 minutes
+const credentialsProgressDelay = 1000
 
 export function asEnvironmentVariables(credentials: Credentials): NodeJS.ProcessEnv {
     const environmentVariables: NodeJS.ProcessEnv = {}
@@ -70,7 +70,7 @@ export function hasProfileProperty(profile: Profile, propertyName: string): bool
 export async function resolveProviderWithCancel(
     profile: string,
     provider: Promise<Credentials>,
-    timeout: Timeout | number = CREDENTIALS_TIMEOUT
+    timeout: Timeout | number = credentialsTimeout
 ): Promise<Credentials> {
     if (typeof timeout === 'number') {
         timeout = new Timeout(timeout)
@@ -84,7 +84,7 @@ export async function resolveProviderWithCancel(
                 timeout
             )
         }
-    }, CREDENTIALS_PROGRESS_DELAY)
+    }, credentialsProgressDelay)
 
     return await waitTimeout(provider, timeout, {
         allowUndefined: false,

--- a/src/credentials/providers/credentials.ts
+++ b/src/credentials/providers/credentials.ts
@@ -6,7 +6,7 @@
 import * as AWS from '@aws-sdk/types'
 import { CredentialSourceId, CredentialType } from '../../shared/telemetry/telemetry'
 
-const CREDENTIALS_PROVIDER_ID_SEPARATOR = ':'
+const credentialsProviderIdSeparator = ':'
 
 /**
  * "Fully-qualified" credentials structure (source + name).
@@ -28,11 +28,11 @@ export interface CredentialsId {
  * @param credentials  Value to be formatted.
  */
 export function asString(credentials: CredentialsId): string {
-    return [credentials.credentialSource, credentials.credentialTypeId].join(CREDENTIALS_PROVIDER_ID_SEPARATOR)
+    return [credentials.credentialSource, credentials.credentialTypeId].join(credentialsProviderIdSeparator)
 }
 
 export function fromString(credentials: string): CredentialsId {
-    const separatorPos = credentials.indexOf(CREDENTIALS_PROVIDER_ID_SEPARATOR)
+    const separatorPos = credentials.indexOf(credentialsProviderIdSeparator)
 
     if (separatorPos === -1) {
         throw new Error(`Unexpected credentialsId format: ${credentials}`)

--- a/src/credentials/providers/sharedCredentialsProviderFactory.ts
+++ b/src/credentials/providers/sharedCredentialsProviderFactory.ts
@@ -9,7 +9,7 @@ import {
     getConfigFilename,
     getCredentialsFilename,
     loadSharedCredentialsProfiles,
-    updateAwsSdkLoadConfigEnvironmentVariable,
+    updateAwsSdkLoadConfigEnvVar,
 } from '../sharedCredentials'
 import { CredentialsProviderType } from './credentials'
 import { BaseCredentialsProviderFactory } from './credentialsProviderFactory'
@@ -55,7 +55,7 @@ export class SharedCredentialsProviderFactory extends BaseCredentialsProviderFac
         const allCredentialProfiles = await loadSharedCredentialsProfiles()
         this.loadedCredentialsModificationMillis = await this.getLastModifiedMillis(getCredentialsFilename())
         this.loadedConfigModificationMillis = await this.getLastModifiedMillis(getConfigFilename())
-        await updateAwsSdkLoadConfigEnvironmentVariable()
+        await updateAwsSdkLoadConfigEnvVar()
 
         const profileNames = Array.from(allCredentialProfiles.keys())
         getLogger().verbose(`credentials: found profiles: ${profileNames}`)

--- a/src/credentials/sharedCredentials.ts
+++ b/src/credentials/sharedCredentials.ts
@@ -70,7 +70,7 @@ function mergeProfileProperties(credentialsProfile?: Profile, configProfile?: Pr
     return profile
 }
 
-export async function updateAwsSdkLoadConfigEnvironmentVariable(): Promise<void> {
+export async function updateAwsSdkLoadConfigEnvVar(): Promise<void> {
     const configFileExists = await SystemUtilities.fileExists(getConfigFilename())
     process.env.AWS_SDK_LOAD_CONFIG = configFileExists ? 'true' : ''
 }

--- a/src/credentials/sso/cache.ts
+++ b/src/credentials/sso/cache.ts
@@ -29,16 +29,16 @@ export interface SsoCache {
     readonly registration: KeyedCache<ClientRegistration, RegistrationKey>
 }
 
-const CACHE_DIR = join(homedir(), '.aws', 'sso', 'cache')
+const cacheDir = join(homedir(), '.aws', 'sso', 'cache')
 
-export function getCache(directory = CACHE_DIR): SsoCache {
+export function getCache(directory = cacheDir): SsoCache {
     return {
         token: getTokenCache(directory),
         registration: getRegistrationCache(directory),
     }
 }
 
-export function getRegistrationCache(directory = CACHE_DIR): KeyedCache<ClientRegistration, RegistrationKey> {
+export function getRegistrationCache(directory = cacheDir): KeyedCache<ClientRegistration, RegistrationKey> {
     const hashScopes = (scopes: string[]) => {
         const shasum = crypto.createHash('sha256')
         scopes.forEach(s => shasum.update(s))
@@ -61,7 +61,7 @@ export function getRegistrationCache(directory = CACHE_DIR): KeyedCache<ClientRe
     return mapCache(cache, read, write)
 }
 
-export function getTokenCache(directory = CACHE_DIR): KeyedCache<SsoAccess> {
+export function getTokenCache(directory = cacheDir): KeyedCache<SsoAccess> {
     // Older specs do not store the registration
     type MaybeRegistration = Partial<Omit<ClientRegistration, 'expiresAt'> & { readonly registrationExpiresAt: string }>
 

--- a/src/credentials/sso/clients.ts
+++ b/src/credentials/sso/clients.ts
@@ -38,7 +38,7 @@ import { sleep } from '../../shared/utilities/timeoutUtils'
 import { isClientFault } from '../../shared/errors'
 import { DevSettings } from '../../shared/settings'
 
-const BACKOFF_DELAY_MS = 5000
+const backoffDelayMs = 5000
 export class OidcClient {
     public constructor(private readonly client: SSOOIDC, private readonly clock: { Date: typeof Date }) {}
 
@@ -75,7 +75,7 @@ export class OidcClient {
         }
     }
 
-    public async pollForToken(request: CreateTokenRequest, timeout: number, interval = BACKOFF_DELAY_MS) {
+    public async pollForToken(request: CreateTokenRequest, timeout: number, interval = backoffDelayMs) {
         while (this.clock.Date.now() + interval <= timeout) {
             try {
                 return await this.createToken(request)
@@ -85,7 +85,7 @@ export class OidcClient {
                 }
 
                 if (err instanceof SlowDownException) {
-                    interval += BACKOFF_DELAY_MS
+                    interval += backoffDelayMs
                 } else if (!(err instanceof AuthorizationPendingException)) {
                     throw err
                 }

--- a/src/credentials/sso/model.ts
+++ b/src/credentials/sso/model.ts
@@ -71,7 +71,7 @@ export async function openSsoPortalLink(authorization: { readonly verificationUr
 }
 
 // Most SSO 'expirables' are fairly long lived, so a one minute buffer is plenty.
-const EXPIRATION_BUFFER_MS = 60000
+const expirationBufferMs = 60000
 export function isExpired(expirable: { expiresAt: Date }): boolean {
-    return globals.clock.Date.now() + EXPIRATION_BUFFER_MS >= expirable.expiresAt.getTime()
+    return globals.clock.Date.now() + expirationBufferMs >= expirable.expiresAt.getTime()
 }

--- a/src/credentials/sso/ssoAccessTokenProvider.ts
+++ b/src/credentials/sso/ssoAccessTokenProvider.ts
@@ -14,9 +14,9 @@ import { OidcClient } from './clients'
 import { loadOr } from '../../shared/utilities/cacheUtils'
 import { isClientFault } from '../../shared/errors'
 
-const CLIENT_REGISTRATION_TYPE = 'public'
-const DEVICE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code'
-const REFRESH_GRANT_TYPE = 'refresh_token'
+const clientRegistrationType = 'public'
+const deviceGrantType = 'urn:ietf:params:oauth:grant-type:device_code'
+const refreshGrantType = 'refresh_token'
 
 /**
  *  SSO flow (RFC: https://tools.ietf.org/html/rfc8628)
@@ -114,7 +114,7 @@ export class SsoAccessTokenProvider {
     private async refreshToken(token: RequiredProps<SsoToken, 'refreshToken'>, registration: ClientRegistration) {
         try {
             const clientInfo = selectFrom(registration, 'clientId', 'clientSecret')
-            const response = await this.oidc.createToken({ ...clientInfo, ...token, grantType: REFRESH_GRANT_TYPE })
+            const response = await this.oidc.createToken({ ...clientInfo, ...token, grantType: refreshGrantType })
 
             return this.formatToken(response, registration)
         } catch (err) {
@@ -153,7 +153,7 @@ export class SsoAccessTokenProvider {
             clientId: registration.clientId,
             clientSecret: registration.clientSecret,
             deviceCode: authorization.deviceCode,
-            grantType: DEVICE_GRANT_TYPE,
+            grantType: deviceGrantType,
         }
 
         const token = await this.oidc.pollForToken(
@@ -168,7 +168,7 @@ export class SsoAccessTokenProvider {
     private async registerClient(): Promise<ClientRegistration> {
         return this.oidc.registerClient({
             clientName: `aws-toolkit-vscode-${globals.clock.Date.now()}`,
-            clientType: CLIENT_REGISTRATION_TYPE,
+            clientType: clientRegistrationType,
             scopes: this.profile.scopes,
         })
     }

--- a/src/dev/codecatalyst.ts
+++ b/src/dev/codecatalyst.ts
@@ -214,8 +214,8 @@ async function installVsix(
     })
     const { hostname, vscPath, sshPath, SessionProcess } = connection
 
-    const EXT_ID = VSCODE_EXTENSION_ID.awstoolkit
-    const EXT_PATH = `/home/mde-user/.vscode-server/extensions`
+    const extId = VSCODE_EXTENSION_ID.awstoolkit
+    const extPath = `/home/mde-user/.vscode-server/extensions`
     const userWithHost = `mde-user@${hostname}`
 
     if (path.extname(resp) !== '.vsix') {
@@ -223,7 +223,7 @@ async function installVsix(
 
         const packageData = await fs.readFile(path.join(resp, 'package.json'), 'utf-8')
         const targetManfiest: typeof manifest = JSON.parse(packageData)
-        const destName = `${EXT_PATH}/${EXT_ID}-${targetManfiest.version}`
+        const destName = `${extPath}/${extId}-${targetManfiest.version}`
         const source = `${resp}${path.sep}`
 
         // Using `.vscodeignore` would be nice here but `rsync` doesn't understand glob patterns
@@ -248,14 +248,14 @@ async function installVsix(
             .reverse()
             .slice(0, 2)
             .map(s => s.replace('.vsix', ''))
-        const destName = [EXT_ID, ...suffixParts.reverse()].join('-')
+        const destName = [extId, ...suffixParts.reverse()].join('-')
 
         const installCmd = [
-            `rm ${EXT_PATH}/.obsolete || true`,
-            `find ${EXT_PATH} -type d -name '${EXT_ID}*' -exec rm -rf {} +`,
-            `unzip ${remoteVsix} "extension/*" "extension.vsixmanifest" -d ${EXT_PATH}`,
-            `mv ${EXT_PATH}/extension ${EXT_PATH}/${destName}`,
-            `mv ${EXT_PATH}/extension.vsixmanifest ${EXT_PATH}/${destName}/.vsixmanifest`,
+            `rm ${extPath}/.obsolete || true`,
+            `find ${extPath} -type d -name '${extId}*' -exec rm -rf {} +`,
+            `unzip ${remoteVsix} "extension/*" "extension.vsixmanifest" -d ${extPath}`,
+            `mv ${extPath}/extension ${extPath}/${destName}`,
+            `mv ${extPath}/extension.vsixmanifest ${extPath}/${destName}/.vsixmanifest`,
         ].join(' && ')
 
         progress.report({ message: 'Installing VSIX...' })

--- a/src/dynamicResources/activation.ts
+++ b/src/dynamicResources/activation.ts
@@ -14,7 +14,7 @@ import { saveResource } from './commands/saveResource'
 import { ResourcesNode } from './explorer/nodes/resourcesNode'
 import { ResourceNode } from './explorer/nodes/resourceNode'
 import { ResourceTypeNode } from './explorer/nodes/resourceTypeNode'
-import { RESOURCE_FILE_GLOB_PATTERN } from './awsResourceManager'
+import { resourceFileGlobPattern } from './awsResourceManager'
 import { Commands } from '../shared/vscode/commands2'
 import globals from '../shared/extensionGlobals'
 
@@ -116,7 +116,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             {
                 language: 'json',
                 scheme: 'file',
-                pattern: RESOURCE_FILE_GLOB_PATTERN,
+                pattern: resourceFileGlobPattern,
             },
             new ResourceCodeLensProvider(resourceManager)
         )

--- a/src/dynamicResources/awsResourceManager.ts
+++ b/src/dynamicResources/awsResourceManager.ts
@@ -21,7 +21,7 @@ import { ResourceTypeNode } from './explorer/nodes/resourceTypeNode'
 import { isCloud9 } from '../shared/extensionUtilities'
 import globals from '../shared/extensionGlobals'
 
-export const RESOURCE_FILE_GLOB_PATTERN = '**/*.awsResource.json'
+export const resourceFileGlobPattern = '**/*.awsResource.json'
 
 export class AwsResourceManager {
     private folder: string | undefined

--- a/src/dynamicResources/explorer/nodes/resourceTypeNode.ts
+++ b/src/dynamicResources/explorer/nodes/resourceTypeNode.ts
@@ -20,14 +20,14 @@ import { ResourceTypeMetadata } from '../../model/resources'
 import { DefaultS3Client } from '../../../shared/clients/s3Client'
 import { telemetry } from '../../../shared/telemetry/telemetry'
 
-export const CONTEXT_VALUE_RESOURCE_OPERATIONS: any = {
+export const contextValueResourceOperations: any = {
     CREATE: 'Creatable',
     DELETE: 'Deletable',
     UPDATE: 'Updatable',
 }
-export const CONTEXT_VALUE_RESOURCE = 'ResourceNode'
+export const contextValueResource = 'ResourceNode'
 
-const UNAVAILABLE_RESOURCE = localize('AWS.explorerNode.resources.unavailable', 'Unavailable in region')
+const unavailableResource = localize('AWS.explorerNode.resources.unavailable', 'Unavailable in region')
 
 export class ResourceTypeNode extends AWSTreeNodeBase implements LoadMoreNode {
     private readonly childLoader: ChildNodeLoader = new ChildNodeLoader(this, token => this.loadPage(token))
@@ -45,19 +45,19 @@ export class ResourceTypeNode extends AWSTreeNodeBase implements LoadMoreNode {
         )
         this.tooltip = typeName
         const supportedOperations = metadata.operations
-            ? metadata.operations.map(op => CONTEXT_VALUE_RESOURCE_OPERATIONS[op])
-            : Object.values(CONTEXT_VALUE_RESOURCE_OPERATIONS)
+            ? metadata.operations.map(op => contextValueResourceOperations[op])
+            : Object.values(contextValueResourceOperations)
 
         if (!metadata.available) {
             this.contextValue = 'UnavailableResourceTypeNode'
-            this.description = !metadata.available ? UNAVAILABLE_RESOURCE : ''
+            this.description = !metadata.available ? unavailableResource : ''
         } else {
             const documentedContextValue = metadata.documentation ? 'Documented' : ''
             const createContextValue = supportedOperations.includes('Creatable') ? 'Creatable' : ''
             this.contextValue = `${documentedContextValue}${createContextValue}ResourceTypeNode`
         }
 
-        this.childContextValue = supportedOperations.join('') + CONTEXT_VALUE_RESOURCE
+        this.childContextValue = supportedOperations.join('') + contextValueResource
     }
 
     public async getChildren(): Promise<AWSTreeNodeBase[]> {
@@ -73,7 +73,7 @@ export class ResourceTypeNode extends AWSTreeNodeBase implements LoadMoreNode {
                     getLogger().warn(
                         `Resource type ${this.typeName} does not support LIST action in ${this.parent.region}`
                     )
-                    return new PlaceholderNode(this, `[${UNAVAILABLE_RESOURCE}]`)
+                    return new PlaceholderNode(this, `[${unavailableResource}]`)
                 } else {
                     result = 'Failed'
                     return new TreeShim(createErrorItem(error, `Resources: unexpected error: ${error.message}`))

--- a/src/eventSchemas/commands/downloadSchemaItemCode.ts
+++ b/src/eventSchemas/commands/downloadSchemaItemCode.ts
@@ -32,8 +32,8 @@ enum CodeGenerationStatus {
     CREATE_IN_PROGRESS = 'CREATE_IN_PROGRESS',
 }
 
-const RETRY_INTERVAL_MS = 2000
-const MAX_RETRIES = 150 // p100 of Java code generation is 250 seconds. So retry for an even 5 minutes.
+const retryintervalms = 2000
+const _maxRetries = 150 // p100 of Java code generation is 250 seconds. So retry for an even 5 minutes.
 
 export async function downloadSchemaItemCode(node: SchemaItemNode, outputChannel: vscode.OutputChannel) {
     const logger: Logger = getLogger()
@@ -217,8 +217,8 @@ export class CodeGenerationStatusPoller {
 
     public async pollForCompletion(
         codeDownloadRequest: SchemaCodeDownloadRequestDetails,
-        retryInterval: number = RETRY_INTERVAL_MS,
-        maxRetries: number = MAX_RETRIES
+        retryInterval: number = retryintervalms,
+        maxRetries: number = _maxRetries
     ): Promise<string> {
         for (let i = 0; i < maxRetries; i++) {
             const codeGenerationStatus = await this.getCurrentStatus(codeDownloadRequest)

--- a/src/eventSchemas/models/schemaCodeGenUtils.ts
+++ b/src/eventSchemas/models/schemaCodeGenUtils.ts
@@ -6,15 +6,15 @@
 // TODO: This is fragile. Very fragile. But it is necessary to get Schemas service launched, and we've evaluated all other tradeoffs
 // This will be done on the server-side as soon as we can, but for now the client needs to do this
 export class SchemaCodeGenUtils {
-    private readonly SCHEMA_PACKAGE_PREFIX = 'schema'
+    private readonly schemaPackagePrefix = 'schema'
     private readonly AWS = 'aws'
     private readonly PARTNER = 'partner'
-    private readonly AWS_PARTNER_PREFIX = `${this.AWS}.${this.PARTNER}-` // dash suffix because of 3p partner registry name format
-    private readonly AWS_EVENTS_PREFIX = `${this.AWS}.` // . suffix because of 1p event registry schema format
+    private readonly awsPartnerPrefix = `${this.AWS}.${this.PARTNER}-` // dash suffix because of 3p partner registry name format
+    private readonly awsEventsPrefix = `${this.AWS}.` // . suffix because of 1p event registry schema format
 
     public buildSchemaPackageName(schemaName: string): string {
         const builder = new CodeGenPackageBuilder()
-        builder.append(this.SCHEMA_PACKAGE_PREFIX)
+        builder.append(this.schemaPackagePrefix)
         this.buildPackageName(builder, schemaName)
 
         return builder.build()
@@ -32,17 +32,17 @@ export class SchemaCodeGenUtils {
     }
 
     private isAwsPartnerEvent(schemaName: string): boolean {
-        return schemaName.startsWith(this.AWS_PARTNER_PREFIX)
+        return schemaName.startsWith(this.awsPartnerPrefix)
     }
 
     private buildPartnerEventPackageName(builder: CodeGenPackageBuilder, schemaName: string): void {
-        const partnerSchemaString = schemaName.substring(this.AWS_PARTNER_PREFIX.length)
+        const partnerSchemaString = schemaName.substring(this.awsPartnerPrefix.length)
 
         builder.append(this.AWS).append(this.PARTNER).append(partnerSchemaString)
     }
 
     private isAwsEvent(name: string): boolean {
-        return name.startsWith(this.AWS_EVENTS_PREFIX)
+        return name.startsWith(this.awsEventsPrefix)
     }
 
     private buildAwsEventPackageName(builder: CodeGenPackageBuilder, schemaName: string): void {
@@ -65,7 +65,7 @@ class CodeGenPackageBuilder {
 
     public append(segment: string): CodeGenPackageBuilder {
         if (this.builder.length > 0) {
-            this.builder = this.builder.concat(IdentifierFormatter.PACKAGE_SEPARATOR)
+            this.builder = this.builder.concat(IdentifierFormatter.packageSeparator)
         }
         this.builder = this.builder.concat(IdentifierFormatter.toValidIdentifier(segment.toLowerCase()))
 
@@ -74,15 +74,15 @@ class CodeGenPackageBuilder {
 }
 
 export namespace IdentifierFormatter {
-    export const PACKAGE_SEPARATOR = '.'
-    const POTENTIAL_PACKAGE_SEPARATOR = '@'
-    const NOT_VALID_IDENTIFIER_REGEX = new RegExp(`[^a-zA-Z0-9_${POTENTIAL_PACKAGE_SEPARATOR}]`, 'g')
-    const POTENTIAL_PACKAGE_SEPARATOR_REGEX = new RegExp(POTENTIAL_PACKAGE_SEPARATOR, 'g')
-    const UNDERSCORE = '_'
+    export const packageSeparator = '.'
+    const potentialPackageSeparator = '@'
+    const notValidIdentifierRegex = new RegExp(`[^a-zA-Z0-9_${potentialPackageSeparator}]`, 'g')
+    const potentialPackageSeparatorRegex = new RegExp(potentialPackageSeparator, 'g')
+    const underscore = '_'
 
     export function toValidIdentifier(name: string): string {
         return name
-            .replace(NOT_VALID_IDENTIFIER_REGEX, UNDERSCORE)
-            .replace(POTENTIAL_PACKAGE_SEPARATOR_REGEX, PACKAGE_SEPARATOR)
+            .replace(notValidIdentifierRegex, underscore)
+            .replace(potentialPackageSeparatorRegex, packageSeparator)
     }
 }

--- a/src/eventSchemas/models/schemaCodeLangs.ts
+++ b/src/eventSchemas/models/schemaCodeLangs.ts
@@ -7,10 +7,10 @@ import { Runtime } from 'aws-sdk/clients/lambda'
 import { Set as ImmutableSet } from 'immutable'
 import { goRuntimes } from '../../lambda/models/samLambdaRuntime'
 
-export const JAVA = 'Java 8+'
-export const PYTHON = 'Python 3.6+'
-export const TYPESCRIPT = 'Typescript 3+'
-export const GO = 'Go 1+'
+export const JAVA = 'Java 8+' // eslint-disable-line @typescript-eslint/naming-convention
+export const PYTHON = 'Python 3.6+' // eslint-disable-line @typescript-eslint/naming-convention
+export const TYPESCRIPT = 'Typescript 3+' // eslint-disable-line @typescript-eslint/naming-convention
+export const GO = 'Go 1+' // eslint-disable-line @typescript-eslint/naming-convention
 export type SchemaCodeLangs = 'Java 8+' | 'Python 3.6+' | 'Typescript 3+' | 'Go 1+'
 
 export const schemaCodeLangs: ImmutableSet<SchemaCodeLangs> = ImmutableSet([JAVA, PYTHON, TYPESCRIPT, GO])

--- a/src/eventSchemas/templates/schemasAppTemplateUtils.ts
+++ b/src/eventSchemas/templates/schemasAppTemplateUtils.ts
@@ -7,19 +7,19 @@ import _ = require('lodash')
 import { IdentifierFormatter, SchemaCodeGenUtils } from '../../eventSchemas/models/schemaCodeGenUtils'
 import { SchemaClient } from '../../shared/clients/schemaClient'
 
-const X_AMAZON_EVENT_SOURCE = 'x-amazon-events-source'
-const X_AMAZON_EVENT_DETAIL_TYPE = 'x-amazon-events-detail-type'
+const xAmazonEventSource = 'x-amazon-events-source'
+const xAmazonEventDetailType = 'x-amazon-events-detail-type'
 
-const COMPONENTS = 'components'
-const SCHEMAS = 'schemas'
-const COMPONENTS_SCHEMAS_PATH = '#/components/schemas/'
-const AWS_EVENT = 'AWSEvent'
-const PROPERTIES = 'properties'
-const DETAIL = 'detail'
-const REF = '$ref'
+const components = 'components'
+const schemas = 'schemas'
+const componentsSchemasPath = '#/components/schemas/'
+const awsEvent = 'AWSEvent'
+const properties = 'properties'
+const detail = 'detail'
+const ref = '$ref'
 
-const DEFAULT_EVENT_SOURCE = 'INSERT-YOUR-EVENT-SOURCE'
-const DEFAULT_EVENT_DETAIL_TYPE = 'INSERT-YOUR-DETAIL-TYPE'
+const defaultEventSource = 'INSERT-YOUR-EVENT-SOURCE'
+const defaultEventDetailType = 'INSERT-YOUR-DETAIL-TYPE'
 
 export interface SchemaTemplateParameters {
     SchemaVersion: string
@@ -28,12 +28,12 @@ export interface SchemaTemplateParameters {
 
 // This matches the extra_content parameters to Schema-based templates in both key and value names in cookiecutter.json in the templates used by SamEventBridgeSchemaAppPython
 export interface SchemaTemplateExtraContext {
-    AWS_Schema_registry: string
-    AWS_Schema_name: string
-    AWS_Schema_root: string
-    AWS_Schema_source: string
-    AWS_Schema_detail_type: string
-    user_agent: string
+    AWS_Schema_registry: string // eslint-disable-line @typescript-eslint/naming-convention
+    AWS_Schema_name: string // eslint-disable-line @typescript-eslint/naming-convention
+    AWS_Schema_root: string // eslint-disable-line @typescript-eslint/naming-convention
+    AWS_Schema_source: string // eslint-disable-line @typescript-eslint/naming-convention
+    AWS_Schema_detail_type: string // eslint-disable-line @typescript-eslint/naming-convention
+    user_agent: string // eslint-disable-line @typescript-eslint/naming-convention
 }
 
 export async function buildSchemaTemplateParameters(schemaName: string, registryName: string, client: SchemaClient) {
@@ -41,18 +41,18 @@ export async function buildSchemaTemplateParameters(schemaName: string, registry
     const schemaNode = JSON.parse(response.Content!)
     const latestSchemaVersion = response.SchemaVersion
     // Standard OpenAPI specification for AwsEventNode
-    const awsEventNode = _.get(schemaNode, COMPONENTS.concat('.', SCHEMAS, '.', AWS_EVENT))
+    const awsEventNode = _.get(schemaNode, components.concat('.', schemas, '.', awsEvent))
 
     // Derive source from custom OpenAPI metadata provided by Schemas service
-    let source = _.get(awsEventNode, X_AMAZON_EVENT_SOURCE)
+    let source = _.get(awsEventNode, xAmazonEventSource)
     if (!_.isString(source)) {
-        source = DEFAULT_EVENT_SOURCE
+        source = defaultEventSource
     }
 
     // Derive detail type from custom OpenAPI metadata provided by Schemas service
-    let detailType = _.get(awsEventNode, X_AMAZON_EVENT_DETAIL_TYPE)
+    let detailType = _.get(awsEventNode, xAmazonEventDetailType)
     if (!_.isString(detailType)) {
-        detailType = DEFAULT_EVENT_DETAIL_TYPE
+        detailType = defaultEventDetailType
     }
 
     // Generate schema root/package from the scheme name
@@ -63,11 +63,11 @@ export async function buildSchemaTemplateParameters(schemaName: string, registry
     const rootSchemaEventName = buildRootSchemaEventName(schemaNode, awsEventNode) || getCoreFileName(schemaName)
 
     const templateExtraContent: SchemaTemplateExtraContext = {
-        AWS_Schema_registry: registryName,
-        AWS_Schema_name: rootSchemaEventName!,
-        AWS_Schema_root: schemaPackageHierarchy,
-        AWS_Schema_source: source,
-        AWS_Schema_detail_type: detailType,
+        AWS_Schema_registry: registryName, // eslint-disable-line @typescript-eslint/naming-convention
+        AWS_Schema_name: rootSchemaEventName!, // eslint-disable-line @typescript-eslint/naming-convention
+        AWS_Schema_root: schemaPackageHierarchy, // eslint-disable-line @typescript-eslint/naming-convention
+        AWS_Schema_source: source, // eslint-disable-line @typescript-eslint/naming-convention
+        AWS_Schema_detail_type: detailType, // eslint-disable-line @typescript-eslint/naming-convention
         // Need to provide user agent to SAM CLI so that it will enable appTemplate-based
         user_agent: 'AWSToolkit',
     }
@@ -87,16 +87,16 @@ function buildSchemaPackageHierarchy(schemaName: string) {
 }
 
 function buildRootSchemaEventName(schemaNode: any, awsEventNode: any) {
-    const refValue = _.get(awsEventNode, PROPERTIES.concat('.', DETAIL, '.', REF))
+    const refValue = _.get(awsEventNode, properties.concat('.', detail, '.', ref))
 
-    if (_.isString(refValue) && refValue.includes(COMPONENTS_SCHEMAS_PATH)) {
-        const awsEventDetailRef = refValue.split(COMPONENTS_SCHEMAS_PATH).pop()
+    if (_.isString(refValue) && refValue.includes(componentsSchemasPath)) {
+        const awsEventDetailRef = refValue.split(componentsSchemasPath).pop()
         if (!_.isEmpty(awsEventDetailRef)) {
             return IdentifierFormatter.toValidIdentifier(awsEventDetailRef!)
         }
     }
 
-    const schemaRoots = _.keysIn(_.get(schemaNode, COMPONENTS.concat('.', SCHEMAS)))
+    const schemaRoots = _.keysIn(_.get(schemaNode, components.concat('.', schemas)))
     if (!_.isEmpty(schemaRoots)) {
         return IdentifierFormatter.toValidIdentifier(schemaRoots[0])
     }

--- a/src/integrationTest/codelens.js.test.ts
+++ b/src/integrationTest/codelens.js.test.ts
@@ -10,16 +10,16 @@ import { getAddConfigCodeLens, getTestWorkspaceFolder } from './integrationTests
 import { AddSamDebugConfigurationInput } from '../shared/sam/debugger/commands/addSamDebugConfiguration'
 import * as testUtils from './integrationTestsUtilities'
 
-const ACTIVATE_EXTENSION_TIMEOUT_MILLIS = 30000
-const CODELENS_TEST_TIMEOUT_MILLIS = 10000
-const CODELENS_RETRY_INTERVAL = 1000
+const activateExtensionTimeoutMillis = 30000
+const codelensTestTimeoutMillis = 10000
+const codelensRetryInterval = 1000
 
 const workspaceFolder = getTestWorkspaceFolder()
 
 describe('SAM Local CodeLenses (JS)', async function () {
     // TODO : Extend this test suite out to work for different projects with different file configurations
     before(async function () {
-        this.timeout(ACTIVATE_EXTENSION_TIMEOUT_MILLIS)
+        this.timeout(activateExtensionTimeoutMillis)
         await testUtils.configureAwsToolkitExtension()
     })
 
@@ -29,14 +29,10 @@ describe('SAM Local CodeLenses (JS)', async function () {
         const expectedHandlerName = 'app.handlerBesidePackageJson'
         const document = await vscode.workspace.openTextDocument(appCodePath)
 
-        const codeLenses = await getAddConfigCodeLens(
-            document.uri,
-            CODELENS_TEST_TIMEOUT_MILLIS,
-            CODELENS_RETRY_INTERVAL
-        )
+        const codeLenses = await getAddConfigCodeLens(document.uri, codelensTestTimeoutMillis, codelensRetryInterval)
 
         assertAddDebugConfigCodeLensExists(codeLenses, expectedHandlerName, dirname(appCodePath))
-    }).timeout(CODELENS_TEST_TIMEOUT_MILLIS)
+    }).timeout(codelensTestTimeoutMillis)
 
     it('appear when manifest in root', async function () {
         const appRoot = join(workspaceFolder, 'js-manifest-in-root')
@@ -44,14 +40,10 @@ describe('SAM Local CodeLenses (JS)', async function () {
         const expectedHandlerName = 'src/subfolder/app.handlerTwoFoldersDeep'
         const document = await vscode.workspace.openTextDocument(appCodePath)
 
-        const codeLenses = await getAddConfigCodeLens(
-            document.uri,
-            CODELENS_TEST_TIMEOUT_MILLIS,
-            CODELENS_RETRY_INTERVAL
-        )
+        const codeLenses = await getAddConfigCodeLens(document.uri, codelensTestTimeoutMillis, codelensRetryInterval)
 
         assertAddDebugConfigCodeLensExists(codeLenses, expectedHandlerName, join(dirname(appCodePath), '..', '..'))
-    }).timeout(CODELENS_TEST_TIMEOUT_MILLIS)
+    }).timeout(codelensTestTimeoutMillis)
 
     it('appear when manifest in subfolder and app in subfolder to manifest', async function () {
         const appRoot = join(workspaceFolder, 'js-manifest-in-subfolder')
@@ -59,14 +51,10 @@ describe('SAM Local CodeLenses (JS)', async function () {
         const expectedHandlerName = 'subfolder/app.handlerInManifestSubfolder'
         const document = await vscode.workspace.openTextDocument(appCodePath)
 
-        const codeLenses = await getAddConfigCodeLens(
-            document.uri,
-            CODELENS_TEST_TIMEOUT_MILLIS,
-            CODELENS_RETRY_INTERVAL
-        )
+        const codeLenses = await getAddConfigCodeLens(document.uri, codelensTestTimeoutMillis, codelensRetryInterval)
 
         assertAddDebugConfigCodeLensExists(codeLenses, expectedHandlerName, join(dirname(appCodePath), '..'))
-    }).timeout(CODELENS_TEST_TIMEOUT_MILLIS)
+    }).timeout(codelensTestTimeoutMillis)
 
     it('appear when project is a few folders deep in the workspace', async function () {
         const appRoot = join(workspaceFolder, 'deeper-projects', 'js-plain-sam-app')
@@ -74,11 +62,7 @@ describe('SAM Local CodeLenses (JS)', async function () {
         const expectedHandlerName = 'app.projectDeepInWorkspace'
         const document = await vscode.workspace.openTextDocument(appCodePath)
 
-        const codeLenses = await getAddConfigCodeLens(
-            document.uri,
-            CODELENS_TEST_TIMEOUT_MILLIS,
-            CODELENS_RETRY_INTERVAL
-        )
+        const codeLenses = await getAddConfigCodeLens(document.uri, codelensTestTimeoutMillis, codelensRetryInterval)
 
         assertAddDebugConfigCodeLensExists(codeLenses, expectedHandlerName, dirname(appCodePath))
     })

--- a/src/integrationTest/integrationTestsUtilities.ts
+++ b/src/integrationTest/integrationTestsUtilities.ts
@@ -8,7 +8,7 @@ import { waitUntil } from '../shared/utilities/timeoutUtils'
 import * as vscode from 'vscode'
 
 // java8.al2 image does a while to pull
-const LAMBDA_SESSION_TIMEOUT = 60000
+const lambdaSessionTimeout = 60000
 
 // Retrieves CodeLenses from VS Code
 export async function getCodeLenses(uri: vscode.Uri): Promise<vscode.CodeLens[] | undefined> {
@@ -29,7 +29,7 @@ export function getTestWorkspaceFolder(): string {
 export async function configureAwsToolkitExtension(): Promise<void> {
     const configAws = vscode.workspace.getConfiguration('aws')
     // How long the Toolkit will wait for SAM CLI output before ending a session.
-    await configAws.update('samcli.lambdaTimeout', LAMBDA_SESSION_TIMEOUT, false)
+    await configAws.update('samcli.lambdaTimeout', lambdaSessionTimeout, false)
     // Enable codelenses.
     await configAws.update('samcli.enableCodeLenses', true, false)
 }

--- a/src/integrationTest/integrationTestsUtilities.ts
+++ b/src/integrationTest/integrationTestsUtilities.ts
@@ -6,14 +6,10 @@
 import * as assert from 'assert'
 import { waitUntil } from '../shared/utilities/timeoutUtils'
 import * as vscode from 'vscode'
+import { getCodeLenses } from '../shared/utilities/vsCodeUtils'
 
 // java8.al2 image does a while to pull
-const lambdaSessionTimeout = 60000
-
-// Retrieves CodeLenses from VS Code
-export async function getCodeLenses(uri: vscode.Uri): Promise<vscode.CodeLens[] | undefined> {
-    return vscode.commands.executeCommand('vscode.executeCodeLensProvider', uri)
-}
+export const slowTestTimeout = 60000
 
 export function getTestWorkspaceFolder(): string {
     assert.ok(vscode.workspace.workspaceFolders, 'Integration Tests expect a workspace folder to be loaded')
@@ -29,7 +25,7 @@ export function getTestWorkspaceFolder(): string {
 export async function configureAwsToolkitExtension(): Promise<void> {
     const configAws = vscode.workspace.getConfiguration('aws')
     // How long the Toolkit will wait for SAM CLI output before ending a session.
-    await configAws.update('samcli.lambdaTimeout', lambdaSessionTimeout, false)
+    await configAws.update('samcli.lambdaTimeout', slowTestTimeout, false)
     // Enable codelenses.
     await configAws.update('samcli.enableCodeLenses', true, false)
 }

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -32,15 +32,15 @@ import { closeAllEditors } from '../test/testUtil'
 const projectFolder = testUtils.getTestWorkspaceFolder()
 
 /* Test constants go here */
-const CODELENS_TIMEOUT: number = 60000
-const CODELENS_RETRY_INTERVAL: number = 200
+const codelensTimeout: number = 60000
+const codelensRetryInterval: number = 200
 // note: this refers to the _test_ timeout, not the invocation timeout
-const DEBUG_TIMEOUT: number = 240000
-const NO_DEBUG_SESSION_TIMEOUT: number = 5000
-const NO_DEBUG_SESSION_INTERVAL: number = 100
+const debugTimeout: number = 240000
+const noDebugSessionTimeout: number = 5000
+const noDebugSessionInterval: number = 100
 
 /** Go can't handle API tests yet */
-const SKIP_LANGUAGES_ON_API = ['go']
+const skipLanguagesOnApi = ['go']
 
 interface TestScenario {
     displayName: string
@@ -495,8 +495,8 @@ describe('SAM Integration Tests', async function () {
 
                     const codeLenses = await testUtils.getAddConfigCodeLens(
                         samAppCodeUri,
-                        CODELENS_TIMEOUT,
-                        CODELENS_RETRY_INTERVAL
+                        codelensTimeout,
+                        codelensRetryInterval
                     )
                     assert.ok(codeLenses && codeLenses.length === 2)
 
@@ -536,11 +536,11 @@ describe('SAM Integration Tests', async function () {
                 })
 
                 it('target=api: invokes and attaches on debug request (F5)', async function () {
-                    if (SKIP_LANGUAGES_ON_API.includes(scenario.language)) {
+                    if (skipLanguagesOnApi.includes(scenario.language)) {
                         this.skip()
                     }
 
-                    setTestTimeout(this.test?.fullTitle(), DEBUG_TIMEOUT)
+                    setTestTimeout(this.test?.fullTitle(), debugTimeout)
                     await testTarget('api', {
                         api: {
                             path: '/hello',
@@ -551,15 +551,15 @@ describe('SAM Integration Tests', async function () {
                 })
 
                 it('target=template: invokes and attaches on debug request (F5)', async function () {
-                    setTestTimeout(this.test?.fullTitle(), DEBUG_TIMEOUT)
+                    setTestTimeout(this.test?.fullTitle(), debugTimeout)
                     await testTarget('template')
                 })
 
                 async function testTarget(target: AwsSamTargetType, extraConfig: any = {}) {
                     // Allow previous sessions to go away.
                     await waitUntil(async () => vscode.debug.activeDebugSession === undefined, {
-                        timeout: NO_DEBUG_SESSION_TIMEOUT,
-                        interval: NO_DEBUG_SESSION_INTERVAL,
+                        timeout: noDebugSessionTimeout,
+                        interval: noDebugSessionInterval,
                         truthy: true,
                     })
 

--- a/src/integrationTest/shared/extensions/git.test.ts
+++ b/src/integrationTest/shared/extensions/git.test.ts
@@ -15,17 +15,17 @@ import { sleep } from '../../../shared/utilities/timeoutUtils'
 import { getLogger } from '../../../shared/logger/logger'
 import { getMinVsCodeVersion } from '../../../../scripts/test/launchTestUtilities' // TODO: don't use stuff from 'scripts'
 
-const TEST_REMOTE_NAME = 'test-origin'
-const TEST_REMOTE_URL = 'https://github.com/aws/aws-toolkit-vscode'
-const TEST_REMOTE_BRANCH = 'master'
-const TEST_REMOTE_HEAD = 'v1.32.0'
-const TEST_TIMEOUT = 1000
+const testRemoteName = 'test-origin'
+const testRemoteUrl = 'https://github.com/aws/aws-toolkit-vscode'
+const testRemoteBranch = 'master'
+const testRemoteHead = 'v1.32.0'
+const testTimeout = 1000
 
-const CONFIG_KEY = 'aws.test'
+const configKey = 'aws.test'
 
 // performance benchmarks
-const LIST_REMOTE_TIMEOUT = 5000
-const LIST_REMOTE_MAX_SIZE = 100000
+const listRemoteTimeout = 5000
+const listRemoteMaxSize = 100000
 
 /**
  * Error emitted by the git extension. This is undocumented!
@@ -85,7 +85,7 @@ describe('GitExtension', function () {
         }
 
         testRepo = repo
-        await testRepo.addRemote(TEST_REMOTE_NAME, TEST_REMOTE_URL)
+        await testRepo.addRemote(testRemoteName, testRemoteUrl)
 
         // make a single commit on 'master' to refer back to
         await testRepo.commit('test', { empty: true }).catch(parseGitError)
@@ -93,9 +93,9 @@ describe('GitExtension', function () {
 
     after(function () {
         try {
-            execFileSync(git.$api.git.path, ['config', '--global', '--unset', CONFIG_KEY])
+            execFileSync(git.$api.git.path, ['config', '--global', '--unset', configKey])
         } catch (err) {
-            getLogger().warn(`Unable to unset test git config value ${CONFIG_KEY}: %s`, err)
+            getLogger().warn(`Unable to unset test git config value ${configKey}: %s`, err)
         }
     })
 
@@ -107,7 +107,7 @@ describe('GitExtension', function () {
                     resolve(repo)
                 }
             })
-            setTimeout(() => reject(new Error('Timed out waiting for repository to open')), TEST_TIMEOUT)
+            setTimeout(() => reject(new Error('Timed out waiting for repository to open')), testTimeout)
         })
         await git.$api.init(newRepoUri).catch(parseGitError)
         await git.$api.openRepository(newRepoUri).catch(parseGitError)
@@ -123,7 +123,7 @@ describe('GitExtension', function () {
             wrapped.onDidChangeBranch(branch => {
                 resolve(branch)
             })
-            setTimeout(() => reject(new Error('Timed out waiting for branch to change')), TEST_TIMEOUT)
+            setTimeout(() => reject(new Error('Timed out waiting for branch to change')), testTimeout)
         })
         await testRepo.createBranch('new', true).catch(parseGitError)
         assert.strictEqual((await checkBranch)?.name, 'new')
@@ -135,12 +135,12 @@ describe('GitExtension', function () {
     })
 
     it('can list remotes and branches', async function () {
-        const TARGET_BRANCH = `${TEST_REMOTE_NAME}/${TEST_REMOTE_BRANCH}`
-        const remote = (await git.getRemotes()).find(r => r.name === TEST_REMOTE_NAME)
-        assert.ok(remote, `Did not find "${TEST_REMOTE_NAME}" in list of remotes`)
-        await testRepo.fetch({ remote: TEST_REMOTE_NAME, ref: TEST_REMOTE_BRANCH }).catch(parseGitError)
-        const branch = (await git.getBranchesForRemote(remote)).find(branch => branch.name === TARGET_BRANCH)
-        assert.ok(branch, `Failed to find "${TARGET_BRANCH}" associated with remote`)
+        const targetBranch = `${testRemoteName}/${testRemoteBranch}`
+        const remote = (await git.getRemotes()).find(r => r.name === testRemoteName)
+        assert.ok(remote, `Did not find "${testRemoteName}" in list of remotes`)
+        await testRepo.fetch({ remote: testRemoteName, ref: testRemoteBranch }).catch(parseGitError)
+        const branch = (await git.getBranchesForRemote(remote)).find(branch => branch.name === targetBranch)
+        assert.ok(branch, `Failed to find "${targetBranch}" associated with remote`)
     })
 
     it('can get repository config', async function () {
@@ -159,8 +159,8 @@ describe('GitExtension', function () {
     })
 
     it('can list files from a remote', async function () {
-        this.timeout(LIST_REMOTE_TIMEOUT)
-        const result = await git.listAllRemoteFiles({ fetchUrl: TEST_REMOTE_URL, branch: TEST_REMOTE_HEAD })
+        this.timeout(listRemoteTimeout)
+        const result = await git.listAllRemoteFiles({ fetchUrl: testRemoteUrl, branch: testRemoteHead })
 
         const readme = result.files.find(f => f.name === 'NOTICE')
         assert.ok(readme, 'Expected to find NOTICE file in repository root')
@@ -173,7 +173,7 @@ describe('GitExtension', function () {
             throw new Error('Download size was unable to be determined.')
         }
 
-        assert.ok(bytes(result.stats.downloadSize) < LIST_REMOTE_MAX_SIZE)
+        assert.ok(bytes(result.stats.downloadSize) < listRemoteMaxSize)
         assert.ok(await result.dispose())
         await assert.rejects(extension.read)
     })

--- a/src/integrationTest/yaml/intellisense.test.ts
+++ b/src/integrationTest/yaml/intellisense.test.ts
@@ -1,0 +1,120 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import * as manifest from '../../../package.json'
+import * as path from 'path'
+import * as fs from 'fs-extra'
+import * as vscode from 'vscode'
+import * as sinon from 'sinon'
+import * as semver from 'semver'
+import { getTestWorkspaceFolder, slowTestTimeout } from '../integrationTestsUtilities'
+import { activateExtension, getCompletionItems, getHoverItems } from '../../shared/utilities/vsCodeUtils'
+import { waitUntil } from '../../shared/utilities/timeoutUtils'
+import globals from '../../shared/extensionGlobals'
+import { VSCODE_EXTENSION_ID } from '../../shared/extensions'
+import { YamlExtensionApi } from '../../shared/extensions/yaml'
+import { writeTestSchemas } from '../../test/shared/schema/testUtils'
+import { BuildspecTemplateRegistry } from '../../shared/buildspec/registry'
+import { CloudFormationTemplateRegistry } from '../../shared/fs/templateRegistry'
+
+interface TestScenario {
+    name: string
+    templateCommand: string
+    registry: () => CloudFormationTemplateRegistry | BuildspecTemplateRegistry
+}
+
+const scenarios: TestScenario[] = [
+    {
+        name: 'buildspec',
+        templateCommand: 'aws.buildspec.newTemplate',
+        registry: () => globals.templateRegistry.buildspec,
+    },
+    {
+        name: 'cloudformation',
+        templateCommand: 'aws.cloudFormation.newTemplate',
+        registry: () => globals.templateRegistry.cfn,
+    },
+    {
+        name: 'sam',
+        templateCommand: 'aws.sam.newTemplate',
+        registry: () => globals.templateRegistry.cfn,
+    },
+]
+
+describe('YAML intellisense', async function () {
+    before(async function () {
+        // vscode-yaml isn't supported on the minimum toolkit version
+        if (semver.minVersion(manifest.engines.vscode)?.compare(vscode.version) !== -1) {
+            this.skip()
+        }
+
+        await waitUntil(
+            async () => {
+                const yamlExt = await activateExtension<YamlExtensionApi>(VSCODE_EXTENSION_ID.yaml)
+                return yamlExt?.exports?.registerContributor !== undefined
+            },
+            { timeout: slowTestTimeout }
+        )
+
+        // Ensure that all schemas are pre-downloaded before the tests start to prevent rate limiting by github
+        await writeTestSchemas(globals.context.globalStorageUri)
+
+        // Re-setup the schema service so that all the locally cached schemas are used, just in case we are rate limited by github
+        await globals.schemaService.start()
+    })
+
+    for (const scenario of scenarios) {
+        describe(`${scenario.name} intellisense`, async function () {
+            let workspaceDir: string
+            let testDir: string
+            let testFileUri: vscode.Uri
+
+            before(async function () {
+                workspaceDir = getTestWorkspaceFolder()
+                testDir = path.join(workspaceDir, `${scenario.name}-intellisense`)
+                testFileUri = vscode.Uri.file(path.join(testDir, 'test.yaml'))
+                await fs.mkdirp(testDir)
+
+                sinon.stub(vscode.window, 'showSaveDialog').returns(Promise.resolve(testFileUri))
+
+                await vscode.commands.executeCommand(scenario.templateCommand)
+
+                // Add the test file to the registry right away so we don't have to wait
+                await scenario.registry().addItemToRegistry(testFileUri, false)
+
+                // Flush the schema assignments
+                await globals.schemaService.processUpdates()
+            })
+
+            after(async function () {
+                await fs.remove(testDir)
+                sinon.restore()
+            })
+
+            it(`autocompletes and hovers a ${scenario.name} file`, async function () {
+                waitUntil(
+                    async () => {
+                        return globals.schemaService.isMapped(testFileUri)
+                    },
+                    { timeout: slowTestTimeout }
+                )
+
+                const completions = await getCompletionItems(testFileUri, new vscode.Position(4, 0))
+                if (!completions) {
+                    assert.fail(`Expected completion items in ${scenario.name} file`)
+                }
+                const filterTags = completions.items.filter(completion => !completion.label.startsWith('!'))
+                assert.notStrictEqual(filterTags.length, 0, 'Expected more than 0 completion items')
+
+                const hovers = await getHoverItems(testFileUri, new vscode.Position(1, 3))
+                if (!hovers) {
+                    assert.fail(`Expected hover items in ${scenario.name} file`)
+                }
+                assert.notStrictEqual(hovers.length, 0, 'Expected more than 0 hover items')
+            })
+        })
+    }
+})

--- a/src/iot/commands/createCert.ts
+++ b/src/iot/commands/createCert.ts
@@ -15,7 +15,9 @@ import { IotCertsFolderNode } from '../explorer/iotCertFolderNode'
 import { fileExists } from '../../shared/filesystemUtilities'
 import { Iot } from 'aws-sdk'
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 const MODE_RW_R_R = 0o644 //File permission 0644 rw-r--r-- for PEM files.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 const PEM_FILE_ENCODING = 'ascii'
 
 /**

--- a/src/iot/commands/updateCert.ts
+++ b/src/iot/commands/updateCert.ts
@@ -14,9 +14,9 @@ import { IotThingNode } from '../explorer/iotThingNode'
 import { IotCertsFolderNode } from '../explorer/iotCertFolderNode'
 import { IotNode } from '../explorer/iotNodes'
 
-const STATUS_REVOKED = 'REVOKED'
-const STATUS_ACTIVE = 'ACTIVE'
-const STATUS_INACTIVE = 'INACTIVE'
+const statusRevoked = 'REVOKED'
+const statusActive = 'ACTIVE'
+const statusInactive = 'INACTIVE'
 
 /**
  * Deactivates an active certificate.
@@ -53,7 +53,7 @@ export async function deactivateCertificateCommand(
 
     getLogger().info(`Deactivating certificate ${certId}`)
     try {
-        await node.iot.updateCertificate({ certificateId: certId, newStatus: STATUS_INACTIVE })
+        await node.iot.updateCertificate({ certificateId: certId, newStatus: statusInactive })
 
         getLogger().info(`deactivated certificate: ${certId}`)
         window.showInformationMessage(
@@ -109,7 +109,7 @@ export async function activateCertificateCommand(
 
     getLogger().info(`Activating certificate ${certId}`)
     try {
-        await node.iot.updateCertificate({ certificateId: certId, newStatus: STATUS_ACTIVE })
+        await node.iot.updateCertificate({ certificateId: certId, newStatus: statusActive })
 
         getLogger().info(`activated certificate: ${certId}`)
         window.showInformationMessage(localize('AWS.iot.activateCert.success', 'Activated: {0}', node.certificate.id))
@@ -159,7 +159,7 @@ export async function revokeCertificateCommand(
 
     getLogger().info(`Revoking certificate: ${certId}`)
     try {
-        await node.iot.updateCertificate({ certificateId: certId, newStatus: STATUS_REVOKED })
+        await node.iot.updateCertificate({ certificateId: certId, newStatus: statusRevoked })
 
         getLogger().info(`revoked certificate: ${certId}`)
         window.showInformationMessage(localize('AWS.iot.revokeCert.success', 'Revoked: {0}', node.certificate.id))

--- a/src/iot/explorer/iotCertificateNode.ts
+++ b/src/iot/explorer/iotCertificateNode.ts
@@ -25,7 +25,7 @@ import { LOCALIZED_DATE_FORMAT } from '../../shared/constants'
 import { Commands } from '../../shared/vscode/commands'
 import { getIcon } from '../../shared/icons'
 
-const CONTEXT_BASE = 'awsIotCertificateNode'
+const contextBase = 'awsIotCertificateNode'
 /**
  * Represents an IoT Certificate that may have either a Thing Node or the
  * Certificate Folder Node as a parent.
@@ -54,7 +54,7 @@ export abstract class IotCertificateNode extends AWSTreeNodeBase implements AWSR
         )
         this.iconPath = getIcon('aws-iot-certificate')
         this.description = `\t[${this.certificate.activeStatus}]`
-        this.contextValue = `${CONTEXT_BASE}.${this.certificate.activeStatus}`
+        this.contextValue = `${contextBase}.${this.certificate.activeStatus}`
     }
 
     public update(): void {
@@ -135,7 +135,7 @@ export class IotThingCertNode extends IotCertificateNode {
         protected readonly workspace = Workspace.vscode()
     ) {
         super(certificate, parent, iot, vscode.TreeItemCollapsibleState.Collapsed, things, workspace)
-        this.contextValue = `${CONTEXT_BASE}.Things.${this.certificate.activeStatus}`
+        this.contextValue = `${contextBase}.Things.${this.certificate.activeStatus}`
     }
 }
 
@@ -151,6 +151,6 @@ export class IotCertWithPoliciesNode extends IotCertificateNode implements LoadM
         protected readonly workspace = Workspace.vscode()
     ) {
         super(certificate, parent, iot, vscode.TreeItemCollapsibleState.Collapsed, things, workspace)
-        this.contextValue = `${CONTEXT_BASE}.Policies.${this.certificate.activeStatus}`
+        this.contextValue = `${contextBase}.Policies.${this.certificate.activeStatus}`
     }
 }

--- a/src/iot/explorer/iotPolicyFolderNode.ts
+++ b/src/iot/explorer/iotPolicyFolderNode.ts
@@ -20,10 +20,10 @@ import { IotNode } from './iotNodes'
 import { Commands } from '../../shared/vscode/commands'
 
 //Length of certificate ID. The certificate ID is the last segment of the ARN.
-const CERT_ID_LENGTH = 64
+const certIdLength = 64
 
 //Number of digits of the certificate ID to show
-const CERT_PREVIEW_LENGTH = 8
+const certPreviewLength = 8
 
 /**
  * Represents the group of all IoT Policies.
@@ -77,7 +77,7 @@ export class IotPolicyFolderNode extends AWSTreeNodeBase implements LoadMoreNode
                             this,
                             this.iot,
                             (await this.iot.listPolicyTargets({ policyName: policy.policyName! })).map(certId =>
-                                certId.slice(-CERT_ID_LENGTH, -CERT_ID_LENGTH + CERT_PREVIEW_LENGTH)
+                                certId.slice(-certIdLength, -certIdLength + certPreviewLength)
                             )
                         )
                 ) ?? []

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -50,9 +50,9 @@ import { LambdaArchitecture, Result, Runtime } from '../../shared/telemetry/tele
 
 type CreateReason = 'unknown' | 'userCancelled' | 'fileNotFound' | 'complete' | 'error'
 
-export const SAM_INIT_TEMPLATE_FILES: string[] = ['template.yaml', 'template.yml']
-export const SAM_INIT_README_FILE: string = 'README.TOOLKIT.md'
-export const SAM_INIT_README_SOURCE: string = 'resources/markdown/samReadme.md'
+export const samInitTemplateFiles: string[] = ['template.yaml', 'template.yml']
+export const samInitReadmeFile: string = 'README.TOOLKIT.md'
+export const samInitReadmeSource: string = 'resources/markdown/samReadme.md'
 
 export async function resumeCreateNewSamApp(
     extContext: ExtContext,
@@ -199,14 +199,14 @@ export async function createNewSamApplication(
 
         await runSamCliInit(initArguments, samCliContext)
 
-        const templateUri = await getProjectUri(config, SAM_INIT_TEMPLATE_FILES)
+        const templateUri = await getProjectUri(config, samInitTemplateFiles)
         if (!templateUri) {
             reason = 'fileNotFound'
 
             return
         }
 
-        const readmeUri = vscode.Uri.file(path.join(path.dirname(templateUri.fsPath), SAM_INIT_README_FILE))
+        const readmeUri = vscode.Uri.file(path.join(path.dirname(templateUri.fsPath), samInitReadmeFile))
 
         // Needs to be done or else gopls won't start
         if (goRuntimes.includes(createRuntime)) {
@@ -453,7 +453,7 @@ export async function writeToolkitReadme(
 ): Promise<boolean> {
     try {
         const configString: string = configurations.reduce((acc, cur) => `${acc}\n* ${cur.name}`, '')
-        const readme = (await getText(globals.context.asAbsolutePath(SAM_INIT_README_SOURCE)))
+        const readme = (await getText(globals.context.asAbsolutePath(samInitReadmeSource)))
             .replace(/\$\{PRODUCTNAME\}/g, `${getIdeProperties().company} Toolkit For ${getIdeProperties().longName}`)
             .replace(/\$\{IDE\}/g, getIdeProperties().shortName)
             .replace(/\$\{CODELENS\}/g, getIdeProperties().codelens)

--- a/src/lambda/commands/uploadLambda.ts
+++ b/src/lambda/commands/uploadLambda.ts
@@ -212,9 +212,13 @@ export class UploadLambdaWizard extends Wizard<UploadLambdaWizardState> {
         super({ initState: { lambda } })
         this.form.lambda.region.bindPrompter(() => createRegionPrompter().transform(region => region.id))
 
-        if (invokePath && fs.statSync(invokePath.fsPath).isDirectory()) {
+        if (invokePath) {
             this.form.uploadType.setDefault('directory')
-            this.form.targetUri.setDefault(invokePath)
+            if (fs.statSync(invokePath.fsPath).isFile()) {
+                this.form.targetUri.setDefault(vscode.Uri.file(path.dirname(invokePath.fsPath)))
+            } else {
+                this.form.targetUri.setDefault(invokePath)
+            }
         } else {
             this.form.uploadType.bindPrompter(() => createUploadTypePrompter())
             this.form.targetUri.bindPrompter(({ uploadType }) => {

--- a/src/lambda/config/configureParameterOverrides.ts
+++ b/src/lambda/config/configureParameterOverrides.ts
@@ -23,7 +23,7 @@ export interface ConfigureParameterOverridesContext {
     executeCommand: typeof vscode.commands.executeCommand
 }
 
-class DefaultConfigureParameterOverridesContext implements ConfigureParameterOverridesContext {
+class DefaultConfigureParamOverridesContext implements ConfigureParameterOverridesContext {
     public readonly getWorkspaceFolder = vscode.workspace.getWorkspaceFolder
 
     public readonly showErrorMessage = vscode.window.showErrorMessage
@@ -41,7 +41,7 @@ export async function configureParameterOverrides(
         templateUri: vscode.Uri
         requiredParameterNames?: Iterable<string>
     },
-    context: ConfigureParameterOverridesContext = new DefaultConfigureParameterOverridesContext()
+    context: ConfigureParameterOverridesContext = new DefaultConfigureParamOverridesContext()
 ): Promise<void> {
     const workspaceFolder = context.getWorkspaceFolder(templateUri)
     if (!workspaceFolder) {

--- a/src/lambda/config/templates.ts
+++ b/src/lambda/config/templates.ts
@@ -321,7 +321,7 @@ export class TemplatesConfigPopulator {
         templateRelativePath: string,
         parameterName: string
     ): TemplatesConfigPopulator {
-        this.ensureTemplateParameterOverridesSectionExists(templateRelativePath)
+        this.ensureTemplateParamOverrideSectionExists(templateRelativePath)
 
         this.ensureJsonPropertyExists(['templates', templateRelativePath, 'parameterOverrides', parameterName], '', [
             'string',
@@ -383,7 +383,7 @@ export class TemplatesConfigPopulator {
         return this
     }
 
-    private ensureTemplateParameterOverridesSectionExists(templateRelativePath: string): TemplatesConfigPopulator {
+    private ensureTemplateParamOverrideSectionExists(templateRelativePath: string): TemplatesConfigPopulator {
         this.ensureTemplateSectionExists(templateRelativePath)
 
         this.ensureJsonPropertyExists(['templates', templateRelativePath, 'parameterOverrides'], {})

--- a/src/lambda/explorer/cloudFormationNodes.ts
+++ b/src/lambda/explorer/cloudFormationNodes.ts
@@ -21,7 +21,7 @@ import { listCloudFormationStacks, listLambdaFunctions } from '../utils'
 import { LambdaFunctionNode } from './lambdaFunctionNode'
 import { getIcon } from '../../shared/icons'
 
-export const CONTEXT_VALUE_CLOUDFORMATION_LAMBDA_FUNCTION = 'awsCloudFormationFunctionNode'
+export const contextValueCloudformationLambdaFunction = 'awsCloudFormationFunctionNode'
 
 export class CloudFormationNode extends AWSTreeNodeBase {
     private readonly stackNodes: Map<string, CloudFormationStackNode>
@@ -154,7 +154,7 @@ function makeCloudFormationLambdaFunctionNode(
     configuration: Lambda.FunctionConfiguration
 ): LambdaFunctionNode {
     const node = new LambdaFunctionNode(parent, regionCode, configuration)
-    node.contextValue = CONTEXT_VALUE_CLOUDFORMATION_LAMBDA_FUNCTION
+    node.contextValue = contextValueCloudformationLambdaFunction
 
     return node
 }

--- a/src/lambda/explorer/lambdaNodes.ts
+++ b/src/lambda/explorer/lambdaNodes.ts
@@ -18,8 +18,8 @@ import { listLambdaFunctions } from '../utils'
 import { LambdaFunctionNode } from './lambdaFunctionNode'
 import { samLambdaImportableRuntimes } from '../models/samLambdaRuntime'
 
-export const CONTEXT_VALUE_LAMBDA_FUNCTION = 'awsRegionFunctionNode'
-export const CONTEXT_VALUE_LAMBDA_FUNCTION_IMPORTABLE = 'awsRegionFunctionNodeDownloadable'
+export const contextValueLambdaFunction = 'awsRegionFunctionNode'
+export const contextValueLambdaFunctionImportable = 'awsRegionFunctionNodeDownloadable'
 
 /**
  * An AWS Explorer node representing the Lambda Service.
@@ -72,8 +72,8 @@ function makeLambdaFunctionNode(
 ): LambdaFunctionNode {
     const node = new LambdaFunctionNode(parent, regionCode, configuration)
     node.contextValue = samLambdaImportableRuntimes.contains(node.configuration.Runtime ?? '')
-        ? CONTEXT_VALUE_LAMBDA_FUNCTION_IMPORTABLE
-        : CONTEXT_VALUE_LAMBDA_FUNCTION
+        ? contextValueLambdaFunctionImportable
+        : contextValueLambdaFunction
 
     return node
 }

--- a/src/lambda/local/debugConfiguration.ts
+++ b/src/lambda/local/debugConfiguration.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode'
 import { CloudFormation } from '../../shared/cloudformation/cloudformation'
 import {
     AwsSamDebuggerConfiguration,
-    AWS_SAM_DEBUG_TARGET_TYPES,
+    awsSamDebugTargetTypes,
     CodeTargetProperties,
     TemplateTargetProperties,
 } from '../../shared/sam/debugger/awsSamDebugConfiguration'
@@ -25,8 +25,8 @@ import globals from '../../shared/extensionGlobals'
  * Magic path on the Docker image.
  * https://github.com/aws/aws-sam-cli/blob/2201b17bff0a438b934abbb53f6c76eff9ccfa6d/samcli/local/docker/lambda_container.py#L25
  */
-export const DOTNET_CORE_DEBUGGER_PATH = '/tmp/lambci_debug_files/vsdbg'
-export const GO_DEBUGGER_PATH = '/tmp/lambci_debug_files'
+export const dotnetCoreDebuggerPath = '/tmp/lambci_debug_files/vsdbg'
+export const goDebuggerPath = '/tmp/lambci_debug_files'
 
 export interface NodejsDebugConfiguration extends SamLaunchRequestArgs {
     readonly runtimeFamily: RuntimeFamily.NodeJS
@@ -90,7 +90,7 @@ export interface GoDebugConfiguration extends SamLaunchRequestArgs {
 export interface PipeTransport {
     pipeProgram: 'sh' | 'powershell'
     pipeArgs: string[]
-    debuggerPath: typeof DOTNET_CORE_DEBUGGER_PATH
+    debuggerPath: typeof dotnetCoreDebuggerPath
     pipeCwd: string
 }
 
@@ -175,7 +175,7 @@ export function getHandlerName(
                 localize(
                     'AWS.sam.debugger.invalidTarget',
                     'Debug Configuration has an unsupported target type. Supported types: {0}',
-                    AWS_SAM_DEBUG_TARGET_TYPES.join(', ')
+                    awsSamDebugTargetTypes.join(', ')
                 )
             )
             return ''

--- a/src/lambda/models/samLambdaRuntime.ts
+++ b/src/lambda/models/samLambdaRuntime.ts
@@ -55,7 +55,7 @@ export const deprecatedRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>([
     'nodejs8.10',
     'nodejs10.x',
 ])
-const DEFAULT_RUNTIMES = ImmutableMap<RuntimeFamily, Runtime>([
+const defaultRuntimes = ImmutableMap<RuntimeFamily, Runtime>([
     [RuntimeFamily.NodeJS, 'nodejs14.x'],
     [RuntimeFamily.Python, 'python3.9'],
     [RuntimeFamily.DotNetCore, 'dotnetcore3.1'],
@@ -191,7 +191,7 @@ export function getRuntimeFamily(langId: string): RuntimeFamily {
  * Provides the default runtime for a given `RuntimeFamily` or undefined if the runtime is invalid.
  */
 export function getDefaultRuntime(runtime: RuntimeFamily): string | undefined {
-    return DEFAULT_RUNTIMES.get(runtime)
+    return defaultRuntimes.get(runtime)
 }
 
 /**

--- a/src/lambda/models/samTemplates.ts
+++ b/src/lambda/models/samTemplates.ts
@@ -19,7 +19,7 @@ export let stepFunctionsSampleApp = 'stepFunctionsSampleAppUnintialized'
 export const typeScriptBackendTemplate = 'App Backend using TypeScript'
 export const repromptUserForTemplate = 'REQUIRES_AWS_CREDENTIALS_REPROMPT_USER_FOR_TEMPLATE'
 
-export const CLI_VERSION_STEP_FUNCTIONS_TEMPLATE = '0.52.0'
+export const cliVersionStepFunctionsTemplate = '0.52.0'
 
 export type SamTemplate = string
 
@@ -127,7 +127,7 @@ export function supportsStepFuntionsTemplate(samCliVersion: string): boolean {
     if (!samCliVersion) {
         return false
     }
-    return semver.gte(samCliVersion, CLI_VERSION_STEP_FUNCTIONS_TEMPLATE)
+    return semver.gte(samCliVersion, cliVersionStepFunctionsTemplate)
 }
 
 export function supportsTypeScriptBackendTemplate(runtime: Runtime): boolean {

--- a/src/lambda/vue/configEditor/samInvokeBackend.ts
+++ b/src/lambda/vue/configEditor/samInvokeBackend.ts
@@ -160,7 +160,7 @@ export class SamInvokeWebview extends VueWebview {
      */
     public async getTemplate() {
         const items: (vscode.QuickPickItem & { templatePath: string })[] = []
-        const NO_TEMPLATE = 'NOTEMPLATEFOUND'
+        const noTemplate = 'NOTEMPLATEFOUND'
         for (const template of globals.templateRegistry.cfn.registeredItems) {
             const resources = template.item.Resources
             if (resources) {
@@ -187,7 +187,7 @@ export class SamInvokeWebview extends VueWebview {
                     'No templates with valid SAM functions found.'
                 ),
                 detail: localize('AWS.picker.dynamic.noItemsFound.detail', 'Click here to go back'),
-                templatePath: NO_TEMPLATE,
+                templatePath: noTemplate,
             })
         }
 
@@ -203,7 +203,7 @@ export class SamInvokeWebview extends VueWebview {
         })
         const selectedTemplate = picker.verifySinglePickerOutput(choices)
 
-        if (!selectedTemplate || selectedTemplate.templatePath === NO_TEMPLATE) {
+        if (!selectedTemplate || selectedTemplate.templatePath === noTemplate) {
             return
         }
 

--- a/src/lambda/wizards/samDeployWizard.ts
+++ b/src/lambda/wizards/samDeployWizard.ts
@@ -31,7 +31,7 @@ import { getOverriddenParameters, getParameters } from '../config/parameterUtils
 import { DefaultEcrClient, EcrRepository } from '../../shared/clients/ecrClient'
 import { getSamCliVersion } from '../../shared/sam/cli/samCliContext'
 import * as semver from 'semver'
-import { MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_IMAGE_SUPPORT } from '../../shared/sam/cli/samCliValidator'
+import { minSamCliVersionForImageSupport } from '../../shared/sam/cli/samCliValidator'
 import { ExtContext } from '../../shared/extensions'
 import { validateBucketName } from '../../s3/util'
 import { showViewLogsMessage } from '../../shared/utilities/messages'
@@ -43,7 +43,9 @@ import { getIcon } from '../../shared/icons'
 import { DefaultS3Client } from '../../shared/clients/s3Client'
 import { telemetry } from '../../shared/telemetry/telemetry'
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 const CREATE_NEW_BUCKET = localize('AWS.command.s3.createBucket', 'Create Bucket...')
+// eslint-disable-next-line @typescript-eslint/naming-convention
 const ENTER_BUCKET = localize('AWS.samcli.deploy.bucket.existingLabel', 'Enter Existing Bucket Name...')
 
 export interface SamDeployWizardResponse {
@@ -706,7 +708,7 @@ export class SamDeployWizard extends MultiStepWizard<SamDeployWizardResponse> {
         if (this.hasImages) {
             // TODO: remove check when min version is high enough
             const samCliVersion = await getSamCliVersion(this.context.extContext.samCliContext())
-            if (semver.lt(samCliVersion, MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_IMAGE_SUPPORT)) {
+            if (semver.lt(samCliVersion, minSamCliVersionForImageSupport)) {
                 vscode.window.showErrorMessage(
                     localize(
                         'AWS.output.sam.no.image.support',

--- a/src/lambda/wizards/samInitWizard.ts
+++ b/src/lambda/wizards/samInitWizard.ts
@@ -27,10 +27,7 @@ import {
     SamTemplate,
 } from '../models/samTemplates'
 import * as semver from 'semver'
-import {
-    MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_ARM_SUPPORT,
-    MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_IMAGE_SUPPORT,
-} from '../../shared/sam/cli/samCliValidator'
+import { minSamCliVersionForArmSupport, minSamCliVersionForImageSupport } from '../../shared/sam/cli/samCliValidator'
 import * as fsutil from '../../shared/filesystemUtilities'
 import { Wizard } from '../../shared/wizards/wizard'
 import { createFolderPrompt } from '../../shared/ui/common/location'
@@ -57,7 +54,7 @@ export interface CreateNewSamAppWizardForm {
 
 function createRuntimePrompter(samCliVersion: string): QuickPickPrompter<RuntimeAndPackage> {
     return createRuntimeQuickPick({
-        showImageRuntimes: semver.gte(samCliVersion, MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_IMAGE_SUPPORT),
+        showImageRuntimes: semver.gte(samCliVersion, minSamCliVersionForImageSupport),
         buttons: createCommonButtons(samInitDocUrl),
     })
 }
@@ -226,7 +223,7 @@ export class CreateNewSamAppWizard extends Wizard<CreateNewSamAppWizardForm> {
                 return false
             }
 
-            if (semver.lt(context.samCliVersion, MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_ARM_SUPPORT)) {
+            if (semver.lt(context.samCliVersion, minSamCliVersionForArmSupport)) {
                 return false
             }
 

--- a/src/s3/activation.ts
+++ b/src/s3/activation.ts
@@ -19,7 +19,7 @@ import { S3FolderNode } from './explorer/s3FolderNode'
 import { S3Node } from './explorer/s3Nodes'
 import { S3FileNode } from './explorer/s3FileNode'
 import { ExtContext } from '../shared/extensions'
-import { S3FileViewerManager, S3_EDIT_SCHEME, S3_READ_SCHEME } from './fileViewerManager'
+import { S3FileViewerManager, s3EditScheme, s3ReadScheme } from './fileViewerManager'
 import { VirualFileSystem } from '../shared/virtualFilesystem'
 import { Commands } from '../shared/vscode/commands2'
 
@@ -39,8 +39,8 @@ export async function activate(ctx: ExtContext): Promise<void> {
 
     ctx.extensionContext.subscriptions.push(manager)
     ctx.extensionContext.subscriptions.push(
-        vscode.workspace.registerFileSystemProvider(S3_EDIT_SCHEME, fs),
-        vscode.workspace.registerFileSystemProvider(S3_READ_SCHEME, fs, { isReadonly: true }),
+        vscode.workspace.registerFileSystemProvider(s3EditScheme, fs),
+        vscode.workspace.registerFileSystemProvider(s3ReadScheme, fs, { isReadonly: true }),
         Commands.register('aws.s3.copyPath', async (node: S3FolderNode | S3FileNode) => {
             await copyPathCommand(node)
         }),

--- a/src/s3/commands/deleteFile.ts
+++ b/src/s3/commands/deleteFile.ts
@@ -18,7 +18,7 @@ import { telemetry } from '../../shared/telemetry/telemetry'
 import { CancellationError } from '../../shared/utilities/timeoutUtils'
 import { ToolkitError } from '../../shared/errors'
 
-const DELETE_FILE_DISPLAY_TIMEOUT_MS = 2000
+const deleteFileDisplayTimeoutMs = 2000
 
 /**
  * Deletes the file represented by the given node.
@@ -62,7 +62,7 @@ export async function deleteFileCommand(
         getLogger().info(`deleted file: ${filePath}`)
         window.setStatusBarMessage(
             addCodiconToString('trash', localize('AWS.deleteFile.success', 'Deleted: {0}', node.file.name)),
-            DELETE_FILE_DISPLAY_TIMEOUT_MS
+            deleteFileDisplayTimeoutMs
         )
     })
 }

--- a/src/s3/commands/openFile.ts
+++ b/src/s3/commands/openFile.ts
@@ -11,7 +11,7 @@ import { S3FileViewerManager } from '../fileViewerManager'
 import { downloadFileAsCommand } from './downloadFileAs'
 import { telemetry } from '../../shared/telemetry/telemetry'
 
-const SIZE_LIMIT = 50 * Math.pow(10, 6)
+const sizeLimit = 50 * Math.pow(10, 6)
 
 export async function openFileReadModeCommand(node: S3FileNode, manager: S3FileViewerManager): Promise<void> {
     if (await isFileSizeValid(node.file.sizeBytes, node)) {
@@ -40,7 +40,7 @@ async function isFileSizeValid(
     fileNode: S3FileNode,
     window = Window.vscode()
 ): Promise<boolean> {
-    if (size && size > SIZE_LIMIT) {
+    if (size && size > sizeLimit) {
         const downloadAs = localize('AWS.s3.button.downloadAs', 'Download as..')
         window
             .showErrorMessage(

--- a/src/s3/explorer/s3FileNode.ts
+++ b/src/s3/explorer/s3FileNode.ts
@@ -25,7 +25,7 @@ import { getIcon } from '../../shared/icons'
  * US: Jan 5, 2020 5:30:20 PM GMT-0700
  * GB: 5 Jan 2020 17:30:20 GMT+0100
  */
-export const S3_DATE_FORMAT = 'll LTS [GMT]ZZ'
+export const s3DateFormat = 'll LTS [GMT]ZZ'
 
 /**
  * Represents an object in an S3 bucket.
@@ -47,7 +47,7 @@ export class S3FileNode extends AWSTreeNodeBase implements AWSResourceNode {
                 '{0}\nSize: {1}\nLast Modified: {2}',
                 this.file.key,
                 readableSize,
-                moment(file.lastModified).format(S3_DATE_FORMAT)
+                moment(file.lastModified).format(s3DateFormat)
             )
             this.description = `${readableSize}, ${getRelativeDate(file.lastModified, now)}`
         }

--- a/src/s3/fileViewerManager.ts
+++ b/src/s3/fileViewerManager.ts
@@ -18,15 +18,15 @@ import { PromptSettings } from '../shared/settings'
 import { telemetry } from '../shared/telemetry/telemetry'
 import { ToolkitError } from '../shared/errors'
 
-export const S3_EDIT_SCHEME = 's3'
-export const S3_READ_SCHEME = 's3-readonly'
+export const s3EditScheme = 's3'
+export const s3ReadScheme = 's3-readonly'
 export const enum TabMode {
     Read = 'read',
     Edit = 'edit',
 }
 
-const SIZE_LIMIT = 4 * Math.pow(10, 6) // 4 MB
-const PROMPT_ON_EDIT_KEY = 'fileViewerEdit'
+const sizeLimit = 4 * Math.pow(10, 6) // 4 MB
+const promptOnEditKey = 'fileViewerEdit'
 
 export interface S3Tab {
     dispose(): Promise<void> | void
@@ -67,7 +67,7 @@ export class S3FileProvider implements FileProvider {
             const result = downloadFile(this._file, {
                 client: this.client,
                 progressLocation:
-                    (this._file.sizeBytes ?? 0) < SIZE_LIMIT
+                    (this._file.sizeBytes ?? 0) < sizeLimit
                         ? vscode.ProgressLocation.Window
                         : vscode.ProgressLocation.Notification,
             })
@@ -126,7 +126,7 @@ export class S3FileViewerManager {
         private readonly fs: VirualFileSystem,
         private readonly window: typeof vscode.window = vscode.window,
         private readonly settings = PromptSettings.instance,
-        private readonly schemes = { read: S3_READ_SCHEME, edit: S3_EDIT_SCHEME }
+        private readonly schemes = { read: s3ReadScheme, edit: s3EditScheme }
     ) {
         this.disposables.push(this.registerTabCleanup())
     }
@@ -305,7 +305,7 @@ export class S3FileViewerManager {
                     'AWS.s3.fileViewer.warning.noSize',
                     "File size couldn't be determined. Continue with download?"
                 )
-            } else if (fileSize > SIZE_LIMIT) {
+            } else if (fileSize > sizeLimit) {
                 getLogger().debug(`FileViewer: File size ${fileSize} is >4MB, prompting user`)
 
                 return localize('AWS.s3.fileViewer.warning.4mb', 'File size is more than 4MB. Continue with download?')
@@ -335,7 +335,7 @@ export class S3FileViewerManager {
     }
 
     private async showEditNotification(): Promise<void> {
-        if (!(await this.settings.isPromptEnabled(PROMPT_ON_EDIT_KEY))) {
+        if (!(await this.settings.isPromptEnabled(promptOnEditKey))) {
             return
         }
 
@@ -349,7 +349,7 @@ export class S3FileViewerManager {
 
         await this.window.showWarningMessage(message, dontShow, help).then<unknown>(selection => {
             if (selection === dontShow) {
-                return this.settings.disablePrompt(PROMPT_ON_EDIT_KEY)
+                return this.settings.disablePrompt(promptOnEditKey)
             }
 
             if (selection === help) {

--- a/src/s3/progressReporter.ts
+++ b/src/s3/progressReporter.ts
@@ -9,7 +9,7 @@ import { throttle } from 'lodash'
 import { getLogger } from '../shared/logger/logger'
 import * as bytes from 'bytes'
 
-const DEFAULT_REPORTING_INTERVAL_MILLIS = 250
+const defaultReportingIntervalMillis = 250
 
 interface ProgressReporterOptions {
     readonly totalBytes?: number
@@ -34,7 +34,7 @@ export function progressReporter(
     const reporter = new ProgressReporter(progress, { totalBytes, reportMessage })
     const reportProgressThrottled = throttle(
         () => reporter.report(),
-        minIntervalMillis ?? DEFAULT_REPORTING_INTERVAL_MILLIS,
+        minIntervalMillis ?? defaultReportingIntervalMillis,
         { leading: true, trailing: false }
     )
 

--- a/src/shared/activationReloadState.ts
+++ b/src/shared/activationReloadState.ts
@@ -7,11 +7,11 @@ import * as vscode from 'vscode'
 import { Runtime } from 'aws-sdk/clients/lambda'
 import globals from './extensionGlobals'
 
-export const ACTIVATION_TEMPLATE_PATH_KEY = 'ACTIVATION_TEMPLATE_PATH_KEY'
-export const ACTIVATION_LAUNCH_PATH_KEY = 'ACTIVATION_LAUNCH_PATH_KEY'
-export const SAM_INIT_RUNTIME_KEY = 'SAM_INIT_RUNTIME_KEY'
-export const SAM_INIT_IMAGE_BOOLEAN_KEY = 'SAM_INIT_IMAGE_BOOLEAN_KEY'
-export const SAM_INIT_ARCH_KEY = 'SAM_INIT_ARCH_KEY'
+export const activationTemplatePathKey = 'ACTIVATION_TEMPLATE_PATH_KEY'
+export const activationLaunchPathKey = 'ACTIVATION_LAUNCH_PATH_KEY'
+export const samInitRuntimeKey = 'SAM_INIT_RUNTIME_KEY'
+export const samInitImageBooleanKey = 'SAM_INIT_IMAGE_BOOLEAN_KEY'
+export const samInitArchKey = 'SAM_INIT_ARCH_KEY'
 
 export interface SamInitState {
     template: string | undefined
@@ -27,28 +27,28 @@ export interface SamInitState {
 export class ActivationReloadState {
     public getSamInitState(): SamInitState | undefined {
         return {
-            template: this.extensionContext.globalState.get<string>(ACTIVATION_TEMPLATE_PATH_KEY),
-            readme: this.extensionContext.globalState.get<string>(ACTIVATION_LAUNCH_PATH_KEY),
-            runtime: this.extensionContext.globalState.get<string>(SAM_INIT_RUNTIME_KEY),
-            architecture: this.extensionContext.globalState.get<string>(SAM_INIT_ARCH_KEY),
-            isImage: this.extensionContext.globalState.get<boolean>(SAM_INIT_IMAGE_BOOLEAN_KEY),
+            template: this.extensionContext.globalState.get<string>(activationTemplatePathKey),
+            readme: this.extensionContext.globalState.get<string>(activationLaunchPathKey),
+            runtime: this.extensionContext.globalState.get<string>(samInitRuntimeKey),
+            architecture: this.extensionContext.globalState.get<string>(samInitArchKey),
+            isImage: this.extensionContext.globalState.get<boolean>(samInitImageBooleanKey),
         }
     }
 
     public setSamInitState(state: SamInitState): void {
-        this.extensionContext.globalState.update(ACTIVATION_TEMPLATE_PATH_KEY, state.template)
-        this.extensionContext.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, state.readme)
-        this.extensionContext.globalState.update(SAM_INIT_RUNTIME_KEY, state.runtime)
-        this.extensionContext.globalState.update(SAM_INIT_ARCH_KEY, state.architecture)
-        this.extensionContext.globalState.update(SAM_INIT_IMAGE_BOOLEAN_KEY, state.isImage)
+        this.extensionContext.globalState.update(activationTemplatePathKey, state.template)
+        this.extensionContext.globalState.update(activationLaunchPathKey, state.readme)
+        this.extensionContext.globalState.update(samInitRuntimeKey, state.runtime)
+        this.extensionContext.globalState.update(samInitArchKey, state.architecture)
+        this.extensionContext.globalState.update(samInitImageBooleanKey, state.isImage)
     }
 
     public clearSamInitState(): void {
-        this.extensionContext.globalState.update(ACTIVATION_TEMPLATE_PATH_KEY, undefined)
-        this.extensionContext.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, undefined)
-        this.extensionContext.globalState.update(SAM_INIT_RUNTIME_KEY, undefined)
-        this.extensionContext.globalState.update(SAM_INIT_ARCH_KEY, undefined)
-        this.extensionContext.globalState.update(SAM_INIT_IMAGE_BOOLEAN_KEY, undefined)
+        this.extensionContext.globalState.update(activationTemplatePathKey, undefined)
+        this.extensionContext.globalState.update(activationLaunchPathKey, undefined)
+        this.extensionContext.globalState.update(samInitRuntimeKey, undefined)
+        this.extensionContext.globalState.update(samInitArchKey, undefined)
+        this.extensionContext.globalState.update(samInitImageBooleanKey, undefined)
     }
 
     protected get extensionContext(): vscode.ExtensionContext {

--- a/src/shared/awsContext.ts
+++ b/src/shared/awsContext.ts
@@ -29,7 +29,7 @@ export interface ContextChangeEventsArgs {
 export type AwsContext = ClassToInterfaceType<DefaultAwsContext>
 
 const logged = new Set<string>()
-const DEFAULT_REGION = 'us-east-1'
+const defaultRegion = 'us-east-1'
 
 /**
  * Wraps an AWS context in terms of credential profile and zero or more regions. The
@@ -99,11 +99,11 @@ export class DefaultAwsContext implements AwsContext {
         if (!logged.has(credId) && !this.currentCredentials?.defaultRegion) {
             logged.add(credId)
             getLogger().warn(
-                `AwsContext: no default region in credentials profile, falling back to ${DEFAULT_REGION}: ${credId}`
+                `AwsContext: no default region in credentials profile, falling back to ${defaultRegion}: ${credId}`
             )
         }
 
-        return this.currentCredentials?.defaultRegion ?? DEFAULT_REGION
+        return this.currentCredentials?.defaultRegion ?? defaultRegion
     }
 
     private emitEvent() {

--- a/src/shared/buildspec/activation.ts
+++ b/src/shared/buildspec/activation.ts
@@ -11,7 +11,7 @@ import { getLogger } from '../logger'
 import globals from '../extensionGlobals'
 import { NoopWatcher } from '../fs/watchedFiles'
 
-export const TEMPLATE_FILE_GLOB_PATTERN = '**/*.{yaml,yml}'
+export const templateFileGlobPattern = '**/*.{yaml,yml}'
 
 /**
  * Activate Buildspec related functionality for the extension.
@@ -20,7 +20,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
     try {
         const registry = new BuildspecTemplateRegistry()
         globals.templateRegistry.buildspec = registry
-        await registry.addWatchPattern(TEMPLATE_FILE_GLOB_PATTERN)
+        await registry.addWatchPattern(templateFileGlobPattern)
         await registry.watchUntitledFiles()
     } catch (e) {
         vscode.window.showErrorMessage(

--- a/src/shared/clients/devenvClient.ts
+++ b/src/shared/clients/devenvClient.ts
@@ -6,11 +6,11 @@
 import got from 'got'
 import { getCodeCatalystDevEnvId } from '../vscode/env'
 
-const ENVIRONMENT_AUTH_TOKEN = '__MDE_ENV_API_AUTHORIZATION_TOKEN'
-const ENVIRONMENT_ENDPOINT = 'http://127.0.0.1:1339'
+const environmentAuthToken = '__MDE_ENV_API_AUTHORIZATION_TOKEN'
+const environmentEndpoint = 'http://127.0.0.1:1339'
 
 export class DevEnvClient {
-    public constructor(private readonly endpoint: string = ENVIRONMENT_ENDPOINT) {}
+    public constructor(private readonly endpoint: string = environmentEndpoint) {}
 
     public get id(): string | undefined {
         return getCodeCatalystDevEnvId()
@@ -40,7 +40,7 @@ export class DevEnvClient {
     }
 
     private get authToken(): string | undefined {
-        return process.env[ENVIRONMENT_AUTH_TOKEN]
+        return process.env[environmentAuthToken]
     }
 
     private readonly got = got.extend({

--- a/src/shared/clients/ec2MetadataClient.ts
+++ b/src/shared/clients/ec2MetadataClient.ts
@@ -19,7 +19,7 @@ export interface InstanceIdentity {
 
 export type Ec2MetadataClient = ClassToInterfaceType<DefaultEc2MetadataClient>
 export class DefaultEc2MetadataClient {
-    private static readonly METADATA_SERVICE_TIMEOUT: number = 500
+    private static readonly metadataServiceTimeout: number = 500
 
     public constructor(private metadata: MetadataService = DefaultEc2MetadataClient.getMetadataService()) {}
 
@@ -51,8 +51,8 @@ export class DefaultEc2MetadataClient {
     private static getMetadataService() {
         return new MetadataService({
             httpOptions: {
-                timeout: DefaultEc2MetadataClient.METADATA_SERVICE_TIMEOUT,
-                connectTimeout: DefaultEc2MetadataClient.METADATA_SERVICE_TIMEOUT,
+                timeout: DefaultEc2MetadataClient.metadataServiceTimeout,
+                connectTimeout: DefaultEc2MetadataClient.metadataServiceTimeout,
             } as any,
             // workaround for known bug: https://github.com/aws/aws-sdk-js/issues/3029
         })

--- a/src/shared/clients/ecsClient.ts
+++ b/src/shared/clients/ecsClient.ts
@@ -16,15 +16,13 @@ export type EcsResourceAndToken = {
     nextToken?: string
 }
 
-const MAX_RESULTS_PER_RESPONSE = 10
+const maxResultsPerResponse = 10
 export class DefaultEcsClient {
     public constructor(public readonly regionCode: string) {}
 
     public async getClusters(nextToken?: string): Promise<EcsResourceAndToken> {
         const sdkClient = await this.createSdkClient()
-        const clusterArnList = await sdkClient
-            .listClusters({ maxResults: MAX_RESULTS_PER_RESPONSE, nextToken })
-            .promise()
+        const clusterArnList = await sdkClient.listClusters({ maxResults: maxResultsPerResponse, nextToken }).promise()
         if (clusterArnList.clusterArns?.length === 0) {
             return { resource: [] }
         }
@@ -54,7 +52,7 @@ export class DefaultEcsClient {
     public async getServices(cluster: string, nextToken?: string): Promise<EcsResourceAndToken> {
         const sdkClient = await this.createSdkClient()
         const serviceArnList = await sdkClient
-            .listServices({ cluster: cluster, maxResults: MAX_RESULTS_PER_RESPONSE, nextToken })
+            .listServices({ cluster: cluster, maxResults: maxResultsPerResponse, nextToken })
             .promise()
         if (serviceArnList.serviceArns?.length === 0) {
             return { resource: [] }

--- a/src/shared/clients/iamClient.ts
+++ b/src/shared/clients/iamClient.ts
@@ -58,7 +58,11 @@ export class DefaultIamClient {
             throw new Error('No evaluation results found')
         }
 
-        return permissionResponse.EvaluationResults.filter(r => r.EvalDecision !== 'allowed')
+        // Ignore deny from Organization SCP.  These can result in false negatives.
+        // See https://github.com/aws/aws-sdk/issues/102
+        return permissionResponse.EvaluationResults.filter(
+            r => r.EvalDecision !== 'allowed' && r.OrganizationsDecisionDetail?.AllowedByOrganizations !== false
+        )
     }
 
     private async createSdkClient(): Promise<IAM> {

--- a/src/shared/clients/iotClient.ts
+++ b/src/shared/clients/iotClient.ts
@@ -10,11 +10,10 @@ import { getLogger } from '../logger'
 import { InterfaceNoSymbol } from '../utilities/tsUtils'
 import globals from '../extensionGlobals'
 
-export const DEFAULT_MAX_THINGS = 250 // 250 is the maximum allowed by the API
-export const DEFAULT_DELIMITER = '/'
+const defaultMaxThings = 250 // 250 is the maximum allowed by the API
 
 /* ATS is recommended over the deprecated Verisign certificates */
-const IOT_ENDPOINT_TYPE = 'iot:Data-ATS'
+const iotEndpointType = 'iot:Data-ATS'
 
 export type IotThing = { readonly name: string; readonly arn: string }
 export type IotCertificate = {
@@ -26,9 +25,9 @@ export type IotCertificate = {
 export type IotPolicy = IotThing
 export type IotClient = InterfaceNoSymbol<DefaultIotClient>
 
-const IOT_SERVICE_ARN = 'iot'
+const iotServiceArn = 'iot'
 //Pattern to extract the certificate ID from the parsed ARN resource.
-const CERT_ARN_RESOURCE_PATTERN = /cert\/(\w+)/
+const certArnResourcePattern = /cert\/(\w+)/
 
 export interface ListThingCertificatesResponse {
     readonly certificates: Iot.CertificateDescription[]
@@ -52,7 +51,7 @@ export class DefaultIotClient {
 
         const output: Iot.ListThingsResponse = await iot
             .listThings({
-                maxResults: request?.maxResults ?? DEFAULT_MAX_THINGS,
+                maxResults: request?.maxResults ?? defaultMaxThings,
                 nextToken: request?.nextToken,
             })
             .promise()
@@ -101,7 +100,7 @@ export class DefaultIotClient {
 
         const output: Iot.ListCertificatesResponse = await iot
             .listCertificates({
-                pageSize: request.pageSize ?? DEFAULT_MAX_THINGS,
+                pageSize: request.pageSize ?? defaultMaxThings,
                 marker: request.marker,
                 ascendingOrder: request.ascendingOrder,
             })
@@ -127,7 +126,7 @@ export class DefaultIotClient {
         const output: Iot.ListThingPrincipalsResponse = await iot
             .listThingPrincipals({
                 thingName: request.thingName,
-                maxResults: request.maxResults ?? DEFAULT_MAX_THINGS,
+                maxResults: request.maxResults ?? defaultMaxThings,
                 nextToken: request.nextToken,
             })
             .promise()
@@ -170,8 +169,8 @@ export class DefaultIotClient {
 
         const describedCerts = iotPrincipals.map(async iotPrincipal => {
             const principalArn = parse(iotPrincipal)
-            const certIdFound = principalArn.resource.match(CERT_ARN_RESOURCE_PATTERN)
-            if (principalArn.service != IOT_SERVICE_ARN || !certIdFound) {
+            const certIdFound = principalArn.resource.match(certArnResourcePattern)
+            if (principalArn.service != iotServiceArn || !certIdFound) {
                 return undefined
             }
             const certId = certIdFound[1]
@@ -201,7 +200,7 @@ export class DefaultIotClient {
 
         const output = await iot
             .listPrincipalThings({
-                maxResults: request.maxResults ?? DEFAULT_MAX_THINGS,
+                maxResults: request.maxResults ?? defaultMaxThings,
                 nextToken: request.nextToken,
                 principal: request.principal,
             })
@@ -300,7 +299,7 @@ export class DefaultIotClient {
 
         const output: Iot.ListPoliciesResponse = await iot
             .listPolicies({
-                pageSize: request.pageSize ?? DEFAULT_MAX_THINGS,
+                pageSize: request.pageSize ?? defaultMaxThings,
                 marker: request.marker,
                 ascendingOrder: request.ascendingOrder,
             })
@@ -322,7 +321,7 @@ export class DefaultIotClient {
         const output: Iot.ListPrincipalPoliciesResponse = await iot
             .listPrincipalPolicies({
                 principal: request.principal,
-                pageSize: request.pageSize ?? DEFAULT_MAX_THINGS,
+                pageSize: request.pageSize ?? defaultMaxThings,
                 marker: request.marker,
                 ascendingOrder: request.ascendingOrder,
             })
@@ -346,7 +345,7 @@ export class DefaultIotClient {
 
         const output = await iot
             .listTargetsForPolicy({
-                pageSize: request.pageSize ?? DEFAULT_MAX_THINGS,
+                pageSize: request.pageSize ?? defaultMaxThings,
                 marker: request.marker,
                 policyName: request.policyName,
             })
@@ -427,7 +426,7 @@ export class DefaultIotClient {
         getLogger().debug('GetEndpoint called')
         const iot = await this.iotProvider(this.regionCode)
 
-        const output = await iot.describeEndpoint({ endpointType: IOT_ENDPOINT_TYPE }).promise()
+        const output = await iot.describeEndpoint({ endpointType: iotEndpointType }).promise()
         if (!output.endpointAddress) {
             throw new Error('Failed to retrieve endpoint')
         }

--- a/src/shared/clients/s3Client.ts
+++ b/src/shared/clients/s3Client.ts
@@ -12,12 +12,12 @@ import { bufferToStream, DefaultFileStreams, FileStreams, pipe } from '../utilit
 import { assertHasProps, InterfaceNoSymbol, isNonNullable, RequiredProps } from '../utilities/tsUtils'
 import { Readable } from 'stream'
 import globals from '../extensionGlobals'
-import { DEFAULT_PARTITION } from '../regions/regionProvider'
+import { defaultPartition } from '../regions/regionProvider'
 import { AsyncCollection, toCollection } from '../utilities/asyncCollection'
 import { toStream } from '../utilities/collectionUtils'
 
-export const DEFAULT_MAX_KEYS = 300
-export const DEFAULT_DELIMITER = '/'
+export const DEFAULT_MAX_KEYS = 300 // eslint-disable-line @typescript-eslint/naming-convention
+export const DEFAULT_DELIMITER = '/' // eslint-disable-line @typescript-eslint/naming-convention
 
 export type Bucket = InterfaceNoSymbol<DefaultBucket>
 export type Folder = InterfaceNoSymbol<DefaultFolder>
@@ -132,7 +132,7 @@ export interface DeleteBucketRequest {
 export class DefaultS3Client {
     public constructor(
         public readonly regionCode: string,
-        private readonly partitionId = globals.regionProvider.getPartitionId(regionCode) ?? DEFAULT_PARTITION,
+        private readonly partitionId = globals.regionProvider.getPartitionId(regionCode) ?? defaultPartition,
         private readonly s3Provider: (regionCode: string) => Promise<S3> = createSdkClient,
         private readonly fileStreams: FileStreams = new DefaultFileStreams()
     ) {}

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -14,7 +14,7 @@ import { Commands } from '../vscode/commands2'
 import globals from '../extensionGlobals'
 import { createCloudFormationTemplateYaml } from './cloudformation'
 
-export const TEMPLATE_FILE_GLOB_PATTERN = '**/*.{yaml,yml}'
+export const templateFileGlobPattern = '**/*.{yaml,yml}'
 
 /**
  * Match any file path that contains a .aws-sam folder. The way this works is:
@@ -22,9 +22,9 @@ export const TEMPLATE_FILE_GLOB_PATTERN = '**/*.{yaml,yml}'
  * a '/' or '\' followed by any number of characters or end of a string (so it
  * matches both /.aws-sam or /.aws-sam/<any number of characters>)
  */
-export const TEMPLATE_FILE_EXCLUDE_PATTERN = /.*[/\\]\.aws-sam([/\\].*|$)/
+export const templateFileExcludePattern = /.*[/\\]\.aws-sam([/\\].*|$)/
 
-export const DEVFILE_EXCLUDE_PATTERN = /.*devfile\.(yaml|yml)/i
+export const devfileExcludePattern = /.*devfile\.(yaml|yml)/i
 
 /**
  * Creates a CloudFormationTemplateRegistry which retains the state of CloudFormation templates in a workspace.
@@ -36,9 +36,9 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
     try {
         const registry = new CloudFormationTemplateRegistry()
         globals.templateRegistry.cfn = registry
-        await registry.addExcludedPattern(DEVFILE_EXCLUDE_PATTERN)
-        await registry.addExcludedPattern(TEMPLATE_FILE_EXCLUDE_PATTERN)
-        await registry.addWatchPattern(TEMPLATE_FILE_GLOB_PATTERN)
+        await registry.addExcludedPattern(devfileExcludePattern)
+        await registry.addExcludedPattern(templateFileExcludePattern)
+        await registry.addWatchPattern(templateFileGlobPattern)
         await registry.watchUntitledFiles()
     } catch (e) {
         vscode.window.showErrorMessage(

--- a/src/shared/cloudformation/cloudformation.ts
+++ b/src/shared/cloudformation/cloudformation.ts
@@ -9,13 +9,13 @@ import * as yaml from 'js-yaml'
 import * as filesystemUtilities from '../filesystemUtilities'
 import { SystemUtilities } from '../systemUtilities'
 import { getLogger } from '../logger'
-import { LAMBDA_PACKAGE_TYPE_IMAGE } from '../constants'
+import { lambdaPackageTypeImage } from '../constants'
 import { isCloud9 } from '../extensionUtilities'
 
 export namespace CloudFormation {
-    export const SERVERLESS_API_TYPE = 'AWS::Serverless::Api'
-    export const SERVERLESS_FUNCTION_TYPE = 'AWS::Serverless::Function'
-    export const LAMBDA_FUNCTION_TYPE = 'AWS::Lambda::Function'
+    export const SERVERLESS_API_TYPE = 'AWS::Serverless::Api' // eslint-disable-line @typescript-eslint/naming-convention
+    export const SERVERLESS_FUNCTION_TYPE = 'AWS::Serverless::Function' // eslint-disable-line @typescript-eslint/naming-convention
+    export const LAMBDA_FUNCTION_TYPE = 'AWS::Lambda::Function' // eslint-disable-line @typescript-eslint/naming-convention
 
     export function isZipLambdaResource(
         resource?: ZipResourceProperties | ImageResourceProperties
@@ -418,7 +418,7 @@ export namespace CloudFormation {
             throw new Error('Missing or invalid value in Template for key: Type')
         }
         if (resource.Properties) {
-            if (resource.Properties.PackageType === LAMBDA_PACKAGE_TYPE_IMAGE) {
+            if (resource.Properties.PackageType === lambdaPackageTypeImage) {
                 if (!validatePropertyType(resource.Metadata, 'Dockerfile', template, 'string')) {
                     throw new Error('Missing or invalid value in Template for key: Metadata.Dockerfile')
                 }

--- a/src/shared/codelens/csharpCodeLensProvider.ts
+++ b/src/shared/codelens/csharpCodeLensProvider.ts
@@ -8,16 +8,16 @@ import * as vscode from 'vscode'
 import { LambdaHandlerCandidate } from '../lambdaHandlerSearch'
 import { findParentProjectFile } from '../utilities/workspaceUtils'
 
-export const CSHARP_LANGUAGE = 'csharp'
-export const CSHARP_ALLFILES: vscode.DocumentFilter[] = [
+export const csharpLanguage = 'csharp'
+export const csharpAllfiles: vscode.DocumentFilter[] = [
     {
         scheme: 'file',
-        language: CSHARP_LANGUAGE,
+        language: csharpLanguage,
     },
 ]
-export const CSHARP_BASE_PATTERN = '**/*.csproj'
+export const csharpBasePattern = '**/*.csproj'
 
-const REGEXP_RESERVED_WORD_PUBLIC = /\bpublic\b/
+const regexpReservedWordPublic = /\bpublic\b/
 
 export interface DotNetLambdaHandlerComponents {
     assembly: string
@@ -120,7 +120,7 @@ export function isPublicClassSymbol(
         const classDeclarationBeforeNameRange = new vscode.Range(symbol.range.start, symbol.selectionRange.start)
         const classDeclarationBeforeName: string = document.getText(classDeclarationBeforeNameRange)
 
-        return REGEXP_RESERVED_WORD_PUBLIC.test(classDeclarationBeforeName)
+        return regexpReservedWordPublic.test(classDeclarationBeforeName)
     }
 
     return false
@@ -140,7 +140,7 @@ export function isValidLambdaHandler(
         const signatureBeforeMethodNameRange = new vscode.Range(symbol.range.start, symbol.selectionRange.start)
         const signatureBeforeMethodName: string = document.getText(signatureBeforeMethodNameRange)
 
-        if (REGEXP_RESERVED_WORD_PUBLIC.test(signatureBeforeMethodName)) {
+        if (regexpReservedWordPublic.test(signatureBeforeMethodName)) {
             return isValidMethodSignature(symbol)
         }
     }

--- a/src/shared/codelens/goCodeLensProvider.ts
+++ b/src/shared/codelens/goCodeLensProvider.ts
@@ -12,18 +12,18 @@ import { findParentProjectFile } from '../utilities/workspaceUtils'
 import { basename, dirname } from 'path'
 import { activateExtension } from '../utilities/vsCodeUtils'
 
-export const GO_LANGUAGE = 'go'
-export const GO_ALLFILES: vscode.DocumentFilter[] = [
+export const goLanguage = 'go'
+export const goAllfiles: vscode.DocumentFilter[] = [
     {
         scheme: 'file',
-        language: GO_LANGUAGE,
+        language: goLanguage,
     },
 ]
 
 // Go modules were introduced in Go 1.11
 // Before that, $GOPATH had to be set properly to find dependencies
 // We currently just ignore projects without a Go module file
-export const GO_BASE_PATTERN = '**/go.mod'
+export const goBasePattern = '**/go.mod'
 
 export async function getLambdaHandlerCandidates(document: vscode.TextDocument): Promise<LambdaHandlerCandidate[]> {
     const modFile = await findParentProjectFile(document.uri, /go\.mod$/)

--- a/src/shared/codelens/javaCodeLensProvider.ts
+++ b/src/shared/codelens/javaCodeLensProvider.ts
@@ -7,19 +7,19 @@ import * as vscode from 'vscode'
 import { LambdaHandlerCandidate } from '../lambdaHandlerSearch'
 import { findParentProjectFile } from '../utilities/workspaceUtils'
 
-export const JAVA_LANGUAGE = 'java'
-export const JAVA_ALLFILES: vscode.DocumentFilter[] = [
+export const javaLanguage = 'java'
+export const javaAllfiles: vscode.DocumentFilter[] = [
     {
         scheme: 'file',
-        language: JAVA_LANGUAGE,
+        language: javaLanguage,
     },
 ]
-export const GRADLE_BASE_PATTERN = '**/build.gradle'
-export const MAVEN_BASE_PATTERN = '**/pom.xml'
+export const gradleBasePattern = '**/build.gradle'
+export const mavenBasePattern = '**/pom.xml'
 
-const REGEXP_RESERVED_WORD_PUBLIC = /\bpublic \b/
-const REGEXP_RESERVED_WORD_ABSTRACT = /\b abstract \b/
-const REGEXP_PARAMETERS = /\(.*\)/
+const regexpReservedWordPublic = /\bpublic \b/
+const regexpReservedWordAbstract = /\b abstract \b/
+const regexpParameters = /\(.*\)/
 
 export interface JavaLambdaHandlerComponents {
     package: string
@@ -97,8 +97,8 @@ export function isValidClassSymbol(
         const classDeclarationBeforeName: string = document.getText(classDeclarationBeforeNameRange)
 
         return (
-            REGEXP_RESERVED_WORD_PUBLIC.test(classDeclarationBeforeName) &&
-            !REGEXP_RESERVED_WORD_ABSTRACT.test(classDeclarationBeforeName)
+            regexpReservedWordPublic.test(classDeclarationBeforeName) &&
+            !regexpReservedWordAbstract.test(classDeclarationBeforeName)
         )
     }
 
@@ -119,7 +119,7 @@ export function isValidLambdaHandler(
         const signatureBeforeMethodNameRange = new vscode.Range(symbol.range.start, symbol.selectionRange.start)
         const signatureBeforeMethodName: string = document.getText(signatureBeforeMethodNameRange)
 
-        if (REGEXP_RESERVED_WORD_PUBLIC.test(signatureBeforeMethodName)) {
+        if (regexpReservedWordPublic.test(signatureBeforeMethodName)) {
             return isValidMethodSignature(symbol)
         }
     }
@@ -140,7 +140,7 @@ export function isValidMethodSignature(symbol: vscode.DocumentSymbol): boolean {
         // The `redhat.java` extension appears to strip a fair amount from this signature:
         // from source function `public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent input, final Context context)`
         // redhat extension returns: symbol.name = `'handleRequest(APIGatewayProxyRequestEvent, Context)'`
-        const parametersArr = REGEXP_PARAMETERS.exec(symbol.name)
+        const parametersArr = regexpParameters.exec(symbol.name)
         // reject if there are no parameters
         if (!parametersArr) {
             return false

--- a/src/shared/codelens/pythonCodeLensProvider.ts
+++ b/src/shared/codelens/pythonCodeLensProvider.ts
@@ -8,15 +8,15 @@ import * as vscode from 'vscode'
 import { LambdaHandlerCandidate } from '../lambdaHandlerSearch'
 import { findParentProjectFile } from '../utilities/workspaceUtils'
 
-export const PYTHON_LANGUAGE = 'python'
-export const PYTHON_ALLFILES: vscode.DocumentFilter[] = [
+export const pythonLanguage = 'python'
+export const pythonAllfiles: vscode.DocumentFilter[] = [
     {
         scheme: 'file',
-        language: PYTHON_LANGUAGE,
+        language: pythonLanguage,
     },
 ]
 
-export const PYTHON_BASE_PATTERN = '**/requirements.txt'
+export const pythonBasePattern = '**/requirements.txt'
 
 export async function getLambdaHandlerCandidates(uri: vscode.Uri): Promise<LambdaHandlerCandidate[]> {
     const rootUri = (await findParentProjectFile(uri, /^requirements\.txt$/)) || uri

--- a/src/shared/codelens/typescriptCodeLensProvider.ts
+++ b/src/shared/codelens/typescriptCodeLensProvider.ts
@@ -10,22 +10,22 @@ import { TypescriptLambdaHandlerSearch } from '../typescriptLambdaHandlerSearch'
 import { normalizeSeparator } from '../utilities/pathUtils'
 import { findParentProjectFile } from '../utilities/workspaceUtils'
 
-export const JAVASCRIPT_LANGUAGE = 'javascript'
+export const javascriptLanguage = 'javascript'
 
-export const TYPESCRIPT_LANGUAGE = 'typescript'
+export const typescriptLanguage = 'typescript'
 
-export const TYPESCRIPT_ALL_FILES: vscode.DocumentFilter[] = [
+export const typescriptAllFiles: vscode.DocumentFilter[] = [
     {
-        language: JAVASCRIPT_LANGUAGE,
+        language: javascriptLanguage,
         scheme: 'file',
     },
     {
-        language: TYPESCRIPT_LANGUAGE,
+        language: typescriptLanguage,
         scheme: 'file',
     },
 ]
 
-export const JAVASCRIPT_BASE_PATTERN = '**/package.json'
+export const javascriptBasePattern = '**/package.json'
 
 export async function getLambdaHandlerCandidates(document: vscode.TextDocument): Promise<LambdaHandlerCandidate[]> {
     const rootUri = (await findParentProjectFile(document.uri, /^package\.json$/)) || document.uri

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -98,19 +98,19 @@ export const ecsRequiredIamPermissionsUrl: string =
  * US: Jan 5, 2020 5:30:20 PM GMT-0700
  * GB: 5 Jan 2020 17:30:20 GMT+0100
  */
-export const LOCALIZED_DATE_FORMAT = 'll LTS [GMT]ZZ'
+export const LOCALIZED_DATE_FORMAT = 'll LTS [GMT]ZZ' // eslint-disable-line @typescript-eslint/naming-convention
 
 // moment().format() matches Insights console timestamp, e.g.: 2019-03-04T11:40:08.781-08:00
 // TODO: Do we want this this verbose? Log stream just shows HH:mm:ss
-export const INSIGHTS_TIMESTAMP_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSSZ'
+export const INSIGHTS_TIMESTAMP_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSSZ' // eslint-disable-line @typescript-eslint/naming-convention
 
 /**
  * URI scheme for CloudWatch Logs Virtual Documents
  */
-export const CLOUDWATCH_LOGS_SCHEME = 'awsCloudWatchLogs'
-export const AWS_SCHEME = 'aws'
+export const CLOUDWATCH_LOGS_SCHEME = 'awsCloudWatchLogs' // eslint-disable-line @typescript-eslint/naming-convention
+export const AWS_SCHEME = 'aws' // eslint-disable-line @typescript-eslint/naming-convention
 
-export const LAMBDA_PACKAGE_TYPE_IMAGE = 'Image'
+export const lambdaPackageTypeImage = 'Image'
 
 // URLs for App Runner
 export const apprunnerConnectionHelpUrl =

--- a/src/shared/credentials/credentialsProfileMru.ts
+++ b/src/shared/credentials/credentialsProfileMru.ts
@@ -9,7 +9,7 @@ import * as vscode from 'vscode'
  * Tracks the credentials selected by the user, ordered by most recent.
  */
 export class CredentialsProfileMru {
-    public static readonly MAX_CREDENTIAL_MRU_SIZE = 5
+    public static readonly maxCredentialMruSize = 5
 
     private static readonly configurationStateName: string = 'recentCredentials'
 
@@ -36,7 +36,7 @@ export class CredentialsProfileMru {
 
         mru.splice(0, 0, profileName)
 
-        mru.splice(CredentialsProfileMru.MAX_CREDENTIAL_MRU_SIZE)
+        mru.splice(CredentialsProfileMru.maxCredentialMruSize)
 
         await this._context.globalState.update(CredentialsProfileMru.configurationStateName, mru)
     }

--- a/src/shared/environmentVariables.ts
+++ b/src/shared/environmentVariables.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* eslint @typescript-eslint/naming-convention: 0 */
 export interface EnvironmentVariables {
     HOME?: string
     USERPROFILE?: string

--- a/src/shared/extensionUtilities.ts
+++ b/src/shared/extensionUtilities.ts
@@ -10,7 +10,7 @@ import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 import { readFileAsString } from './filesystemUtilities'
 import { getLogger } from './logger'
-import { VSCODE_EXTENSION_ID, EXTENSION_ALPHA_VERSION } from './extensions'
+import { VSCODE_EXTENSION_ID, extensionAlphaVersion } from './extensions'
 import { BaseTemplates } from './templates/baseTemplates'
 import { Ec2MetadataClient } from './clients/ec2MetadataClient'
 import { DefaultEc2MetadataClient } from './clients/ec2MetadataClient'
@@ -19,10 +19,10 @@ import { DevSettings } from './settings'
 
 const localize = nls.loadMessageBundle()
 
-const VSCODE_APPNAME = 'Visual Studio Code'
-const CLOUD9_APPNAME = 'AWS Cloud9'
-const CLOUD9_CN_APPNAME = 'Amazon Cloud9'
-const NOT_INITIALIZED = 'notInitialized'
+const vscodeAppname = 'Visual Studio Code'
+const cloud9Appname = 'AWS Cloud9'
+const cloud9CnAppname = 'Amazon Cloud9'
+const notInitialized = 'notInitialized'
 
 export const mostRecentVersionKey: string = 'globalsMostRecentVersion'
 
@@ -32,13 +32,13 @@ export enum IDE {
     unknown,
 }
 
-let computeRegion: string | undefined = NOT_INITIALIZED
+let computeRegion: string | undefined = notInitialized
 
 export function getIdeType(): IDE {
     const settings = DevSettings.instance
     if (
-        vscode.env.appName === CLOUD9_APPNAME ||
-        vscode.env.appName === CLOUD9_CN_APPNAME ||
+        vscode.env.appName === cloud9Appname ||
+        vscode.env.appName === cloud9CnAppname ||
         settings.get('forceCloud9', false)
     ) {
         return IDE.cloud9
@@ -46,7 +46,7 @@ export function getIdeType(): IDE {
 
     // Theia doesn't necessarily have all env propertie
     // so we should be defensive and assume appName is nullable.
-    if (vscode.env.appName?.startsWith(VSCODE_APPNAME)) {
+    if (vscode.env.appName?.startsWith(vscodeAppname)) {
         return IDE.vscode
     }
 
@@ -180,7 +180,7 @@ export async function createQuickStartWebview(
         { enableScripts: true }
     )
 
-    const baseTemplateFn = _.template(BaseTemplates.SIMPLE_HTML)
+    const baseTemplateFn = _.template(BaseTemplates.simpleHtml)
 
     const htmlBody = convertExtensionRootTokensToPath(
         await readFileAsString(path.join(context.extensionPath, actualPage)),
@@ -274,7 +274,7 @@ export function showWelcomeMessage(context: vscode.ExtensionContext): void {
         return
     }
     const version = vscode.extensions.getExtension(VSCODE_EXTENSION_ID.awstoolkit)?.packageJSON.version
-    if (version === EXTENSION_ALPHA_VERSION) {
+    if (version === extensionAlphaVersion) {
         vscode.window.showWarningMessage(
             localize(
                 'AWS.startup.toastIfAlpha',
@@ -359,7 +359,7 @@ export async function initializeComputeRegion(
 }
 
 export function getComputeRegion(): string | undefined {
-    if (computeRegion === NOT_INITIALIZED) {
+    if (computeRegion === notInitialized) {
         throw new Error('Attempted to get compute region without initializing.')
     }
 

--- a/src/shared/extensions.ts
+++ b/src/shared/extensions.ts
@@ -11,6 +11,7 @@ import { CredentialsStore } from '../credentials/credentialsStore'
 import { SamCliContext } from './sam/cli/samCliContext'
 import { UriHandler } from './vscode/uriHandler'
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const VSCODE_EXTENSION_ID = {
     awstoolkit: 'amazonwebservices.aws-toolkit-vscode',
     python: 'ms-python.python',
@@ -41,4 +42,4 @@ export interface ExtContext {
 /**
  * Version of the .vsix produced by package.ts with the --debug option.
  */
-export const EXTENSION_ALPHA_VERSION = '1.99.0-SNAPSHOT'
+export const extensionAlphaVersion = '1.99.0-SNAPSHOT'

--- a/src/shared/extensions/git.ts
+++ b/src/shared/extensions/git.ts
@@ -48,7 +48,7 @@ interface GitConfig {
 }
 
 const execFileAsync = promisify(execFile)
-const MIN_GIT_FILTER_VERSION = new SemVer('2.27.0')
+const minGitFilterVersion = new SemVer('2.27.0')
 
 function formatBranch(branch?: GitTypes.Branch): string {
     return branch?.name ?? branch?.commit ?? 'unknown'
@@ -333,9 +333,9 @@ export class GitExtension {
         const api = await this.validateApi(new Error('Cannot list files when the git extension is disabled'))
         const version = await this.getVersion()
 
-        if (version === undefined || version.compare(MIN_GIT_FILTER_VERSION) === -1) {
+        if (version === undefined || version.compare(minGitFilterVersion) === -1) {
             throw new Error(
-                `Git version is too low or could not be determined (min=${MIN_GIT_FILTER_VERSION}): ${
+                `Git version is too low or could not be determined (min=${minGitFilterVersion}): ${
                     version ?? 'unknown'
                 }`
             )

--- a/src/shared/extensions/ssh.ts
+++ b/src/shared/extensions/ssh.ts
@@ -15,7 +15,7 @@ import { VSCODE_EXTENSION_ID } from '../extensions'
 
 const localize = nls.loadMessageBundle()
 
-export const SSH_AGENT_SOCKET_VARIABLE = 'SSH_AUTH_SOCK'
+export const sshAgentSocketVariable = 'SSH_AUTH_SOCK'
 
 export function getSshConfigPath(): string {
     const sshConfigDir = path.join(SystemUtilities.getHomeDirectory(), '.ssh')
@@ -28,8 +28,8 @@ export function getSshConfigPath(): string {
  * @returns `undefined` if agent is already running or on Windows, otherwise the SSH agent socket
  */
 export async function startSshAgent(): Promise<string | undefined> {
-    if (process.env[SSH_AGENT_SOCKET_VARIABLE] !== undefined) {
-        return process.env[SSH_AGENT_SOCKET_VARIABLE]
+    if (process.env[sshAgentSocketVariable] !== undefined) {
+        return process.env[sshAgentSocketVariable]
     }
 
     getLogger().info('Starting SSH agent...')

--- a/src/shared/extensions/yaml.ts
+++ b/src/shared/extensions/yaml.ts
@@ -14,7 +14,7 @@ import { activateYAMLLanguageService, configureLanguageService } from './yamlSer
 
 // sourced from https://github.com/redhat-developer/vscode-yaml/blob/3d82d61ea63d3e3a9848fe6b432f8f1f452c1bec/src/schema-extension-api.ts
 // removed everything that is not currently being used
-interface YamlExtensionApi {
+export interface YamlExtensionApi {
     registerContributor(
         schema: string,
         requestSchema: (resource: string) => string | undefined,

--- a/src/shared/extensions/yamlActivation.ts
+++ b/src/shared/extensions/yamlActivation.ts
@@ -177,9 +177,9 @@ async function promptInstallYamlPlugin(disposables: vscode.Disposable[], templat
     const response = await vscode.window.showInformationMessage(
         localize(
             'AWS.message.info.yaml.prompt',
-            'Install YAML extension for more {0} features in {1} files',
-            getIdeProperties().company,
-            template
+            'For inline {0} template support from {1}, install the YAML extension',
+            template,
+            getIdeProperties().company
         ),
         installBtn,
         dontShow

--- a/src/shared/filesystemUtilities.ts
+++ b/src/shared/filesystemUtilities.ts
@@ -14,7 +14,7 @@ import { getLogger } from './logger'
 import * as pathutils from './utilities/pathUtils'
 import globals from '../shared/extensionGlobals'
 
-const DEFAULT_ENCODING: BufferEncoding = 'utf8'
+const defaultEncoding: BufferEncoding = 'utf8'
 
 export const tempDirPath = path.join(
     // https://github.com/aws/aws-toolkit-vscode/issues/240
@@ -84,7 +84,7 @@ export async function fileExists(p: string): Promise<boolean> {
  */
 export async function readFileAsString(
     pathLike: string,
-    options: { encoding: BufferEncoding; flag?: string } = { encoding: DEFAULT_ENCODING }
+    options: { encoding: BufferEncoding; flag?: string } = { encoding: defaultEncoding }
 ): Promise<string> {
     return readFile(pathLike, options)
 }

--- a/src/shared/fs/devfileRegistry.ts
+++ b/src/shared/fs/devfileRegistry.ts
@@ -11,7 +11,7 @@ import { SystemUtilities } from '../systemUtilities'
 import { getLogger } from '../logger/logger'
 import globals from '../extensionGlobals'
 
-export const DEVFILE_GLOB_PATTERN = '**/devfile.{yaml,yml}'
+export const devfileGlobPattern = '**/devfile.{yaml,yml}'
 
 export class DevfileRegistry extends WatchedFiles<Devfile> {
     protected name = 'DevfileRegistry'

--- a/src/shared/logger/activation.ts
+++ b/src/shared/logger/activation.ts
@@ -11,7 +11,7 @@ import * as fs from 'fs-extra'
 import { Logger, LogLevel, getLogger } from '.'
 import { extensionSettingsPrefix } from '../constants'
 import { setLogger } from './logger'
-import { LOG_OUTPUT_CHANNEL } from './outputChannel'
+import { logOutputChannel } from './outputChannel'
 import { WinstonToolkitLogger } from './winstonToolkitLogger'
 import { waitUntil } from '../utilities/timeoutUtils'
 import { cleanLogFiles } from './util'
@@ -21,7 +21,7 @@ import { SystemUtilities } from '../systemUtilities'
 
 const localize = nls.loadMessageBundle()
 
-const DEFAULT_LOG_LEVEL: LogLevel = 'info'
+const defaultLogLevel: LogLevel = 'info'
 
 /**
  * Activate Logger functionality for the extension.
@@ -30,7 +30,7 @@ export async function activate(
     extensionContext: vscode.ExtensionContext,
     outputChannel: vscode.OutputChannel
 ): Promise<void> {
-    const logOutputChannel = LOG_OUTPUT_CHANNEL
+    const chan = logOutputChannel
     const logUri = vscode.Uri.joinPath(extensionContext.logUri, makeLogFilename())
 
     await SystemUtilities.createDirectory(extensionContext.logUri)
@@ -38,7 +38,7 @@ export async function activate(
     const mainLogger = makeLogger(
         {
             logPaths: [logUri.fsPath],
-            outputChannels: [logOutputChannel],
+            outputChannels: [chan],
         },
         extensionContext.subscriptions
     )
@@ -51,7 +51,7 @@ export async function activate(
         makeLogger(
             {
                 logPaths: [logUri.fsPath],
-                outputChannels: [outputChannel, logOutputChannel],
+                outputChannels: [outputChannel, chan],
             },
             extensionContext.subscriptions
         ),
@@ -63,7 +63,7 @@ export async function activate(
         makeLogger(
             {
                 staticLogLevel: 'verbose', // verbose will log anything
-                outputChannels: [outputChannel, logOutputChannel],
+                outputChannels: [outputChannel, chan],
                 useDebugConsole: true,
             },
             extensionContext.subscriptions
@@ -136,7 +136,7 @@ export function makeLogger(
 function getLogLevel(): LogLevel {
     const configuration = Settings.instance.getSection(extensionSettingsPrefix)
 
-    return configuration.get('logLevel', DEFAULT_LOG_LEVEL)
+    return configuration.get('logLevel', defaultLogLevel)
 }
 
 function makeLogFilename(): string {

--- a/src/shared/logger/consoleLogTransport.ts
+++ b/src/shared/logger/consoleLogTransport.ts
@@ -6,7 +6,7 @@
 import * as Transport from 'winston-transport'
 import globals from '../extensionGlobals'
 
-const MESSAGE = Symbol.for('message')
+const MESSAGE = Symbol.for('message') // eslint-disable-line @typescript-eslint/naming-convention
 
 interface LogEntry {
     level: string

--- a/src/shared/logger/debugConsoleTransport.ts
+++ b/src/shared/logger/debugConsoleTransport.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode'
 import * as Transport from 'winston-transport'
 import globals from '../extensionGlobals'
 
-export const MESSAGE = Symbol.for('message')
+export const MESSAGE = Symbol.for('message') // eslint-disable-line @typescript-eslint/naming-convention
 
 interface LogEntry {
     level: string

--- a/src/shared/logger/outputChannel.ts
+++ b/src/shared/logger/outputChannel.ts
@@ -5,11 +5,11 @@
 
 import * as vscode from 'vscode'
 
-export const LOG_OUTPUT_CHANNEL: vscode.OutputChannel = vscode.window.createOutputChannel('AWS Toolkit Logs')
+export const logOutputChannel: vscode.OutputChannel = vscode.window.createOutputChannel('AWS Toolkit Logs')
 
 /**
  * Shows the log output channel.
  */
 export function showLogOutputChannel({ preserveFocus = true }: { preserveFocus?: boolean } = {}): void {
-    LOG_OUTPUT_CHANNEL.show(preserveFocus)
+    logOutputChannel.show(preserveFocus)
 }

--- a/src/shared/logger/outputChannelTransport.ts
+++ b/src/shared/logger/outputChannelTransport.ts
@@ -8,7 +8,7 @@ import * as Transport from 'winston-transport'
 import globals from '../extensionGlobals'
 import { removeAnsi } from '../utilities/textUtilities'
 
-export const MESSAGE = Symbol.for('message')
+export const MESSAGE = Symbol.for('message') // eslint-disable-line @typescript-eslint/naming-convention
 
 interface LogEntry {
     level: string

--- a/src/shared/logger/util.ts
+++ b/src/shared/logger/util.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs-extra'
 import * as path from 'path'
 import { getLogger } from '.'
 
-const DEFAULT_CLEANUP_PARAMS = {
+const defaultCleanupParams = {
     maxLogs: 100,
     maxFileSize: 100000000, // 100 MB
     maxKeptLogs: 20,
@@ -17,7 +17,7 @@ const DEFAULT_CLEANUP_PARAMS = {
 /**
  * Deletes the older logs when there are too many or are using too much space.
  */
-export async function cleanLogFiles(logDir: string, params = DEFAULT_CLEANUP_PARAMS): Promise<void> {
+export async function cleanLogFiles(logDir: string, params = defaultCleanupParams): Promise<void> {
     let files = await fs.readdir(logDir)
 
     if (files.length > params.maxLogs) {

--- a/src/shared/logger/winstonToolkitLogger.ts
+++ b/src/shared/logger/winstonToolkitLogger.ts
@@ -15,7 +15,7 @@ import { formatError, ToolkitError, UnknownError } from '../errors'
 
 // Need to limit how many logs are actually tracked
 // LRU cache would work well, currently it just dumps the least recently added log
-const LOGMAP_SIZE: number = 1000
+const logmapSize: number = 1000
 export class WinstonToolkitLogger implements Logger, vscode.Disposable {
     private readonly logger: winston.Logger
     private disposed: boolean = false
@@ -139,7 +139,7 @@ export class WinstonToolkitLogger implements Logger, vscode.Disposable {
             this.logger.log(level, message, ...meta, { logID: this.idCounter })
         }
 
-        this.logMap[this.idCounter % LOGMAP_SIZE] = {}
+        this.logMap[this.idCounter % logmapSize] = {}
         return this.idCounter++
     }
 
@@ -159,12 +159,12 @@ export class WinstonToolkitLogger implements Logger, vscode.Disposable {
         }
 
         // This prevents callers from getting stale logs
-        if (this.idCounter - logID > LOGMAP_SIZE) {
+        if (this.idCounter - logID > logmapSize) {
             return undefined
         }
 
-        if (this.logMap[logID % LOGMAP_SIZE]) {
-            return this.logMap[logID % LOGMAP_SIZE][file.toString(true)]
+        if (this.logMap[logID % logmapSize]) {
+            return this.logMap[logID % logmapSize][file.toString(true)]
         }
     }
 
@@ -176,7 +176,7 @@ export class WinstonToolkitLogger implements Logger, vscode.Disposable {
      * @param obj  Object passed from the event
      */
     private parseLogObject(file: vscode.Uri, obj: any): void {
-        const logID: number = parseInt(obj.logID) % LOGMAP_SIZE
+        const logID: number = parseInt(obj.logID) % logmapSize
         const symbols: symbol[] = Object.getOwnPropertySymbols(obj)
         const messageSymbol: symbol | undefined = symbols.find((s: symbol) => s.toString() === 'Symbol(message)')
 

--- a/src/shared/regions/regionProvider.ts
+++ b/src/shared/regions/regionProvider.ts
@@ -17,9 +17,9 @@ import { regionSettingKey } from '../constants'
 import { AwsContext } from '../awsContext'
 import { getIdeProperties, isCloud9 } from '../extensionUtilities'
 
-export const DEFAULT_REGION = 'us-east-1'
-export const DEFAULT_PARTITION = 'aws'
-export const DEFAULT_DNS_SUFFIX = 'amazonaws.com'
+export const defaultRegion = 'us-east-1'
+export const defaultPartition = 'aws'
+export const defaultDnsSuffix = 'amazonaws.com'
 
 interface RegionData {
     dnsSuffix: string
@@ -44,7 +44,7 @@ export class RegionProvider {
     }
 
     public get defaultRegionId() {
-        return this.awsContext.getCredentialDefaultRegion() ?? DEFAULT_REGION
+        return this.awsContext.getCredentialDefaultRegion() ?? defaultRegion
     }
 
     public get defaultPartitionId() {

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -135,12 +135,12 @@ async function activateCodeLensRegistry(context: ExtContext) {
         // "**/…" string patterns watch recursively across _all_ workspace
         // folders (see documentation for addWatchPattern()).
         //
-        await registry.addWatchPattern(pyLensProvider.PYTHON_BASE_PATTERN)
-        await registry.addWatchPattern(jsLensProvider.JAVASCRIPT_BASE_PATTERN)
-        await registry.addWatchPattern(csLensProvider.CSHARP_BASE_PATTERN)
-        await registry.addWatchPattern(goLensProvider.GO_BASE_PATTERN)
-        await registry.addWatchPattern(javaLensProvider.GRADLE_BASE_PATTERN)
-        await registry.addWatchPattern(javaLensProvider.MAVEN_BASE_PATTERN)
+        await registry.addWatchPattern(pyLensProvider.pythonBasePattern)
+        await registry.addWatchPattern(jsLensProvider.javascriptBasePattern)
+        await registry.addWatchPattern(csLensProvider.csharpBasePattern)
+        await registry.addWatchPattern(goLensProvider.goBasePattern)
+        await registry.addWatchPattern(javaLensProvider.gradleBasePattern)
+        await registry.addWatchPattern(javaLensProvider.mavenBasePattern)
     } catch (e) {
         vscode.window.showErrorMessage(
             localize(
@@ -177,14 +177,14 @@ async function activateCodeLensProviders(
     const supportedLanguages: {
         [language: string]: codelensUtils.OverridableCodeLensProvider
     } = {
-        [jsLensProvider.JAVASCRIPT_LANGUAGE]: tsCodeLensProvider,
-        [pyLensProvider.PYTHON_LANGUAGE]: pyCodeLensProvider,
+        [jsLensProvider.javascriptLanguage]: tsCodeLensProvider,
+        [pyLensProvider.pythonLanguage]: pyCodeLensProvider,
     }
 
     if (!isCloud9()) {
-        supportedLanguages[javaLensProvider.JAVA_LANGUAGE] = javaCodeLensProvider
-        supportedLanguages[csLensProvider.CSHARP_LANGUAGE] = csCodeLensProvider
-        supportedLanguages[goLensProvider.GO_LANGUAGE] = goCodeLensProvider
+        supportedLanguages[javaLensProvider.javaLanguage] = javaCodeLensProvider
+        supportedLanguages[csLensProvider.csharpLanguage] = csCodeLensProvider
+        supportedLanguages[goLensProvider.goLanguage] = goCodeLensProvider
     }
 
     disposables.push(
@@ -200,11 +200,11 @@ async function activateCodeLensProviders(
         )
     )
 
-    disposables.push(vscode.languages.registerCodeLensProvider(jsLensProvider.TYPESCRIPT_ALL_FILES, tsCodeLensProvider))
-    disposables.push(vscode.languages.registerCodeLensProvider(pyLensProvider.PYTHON_ALLFILES, pyCodeLensProvider))
-    disposables.push(vscode.languages.registerCodeLensProvider(javaLensProvider.JAVA_ALLFILES, javaCodeLensProvider))
-    disposables.push(vscode.languages.registerCodeLensProvider(csLensProvider.CSHARP_ALLFILES, csCodeLensProvider))
-    disposables.push(vscode.languages.registerCodeLensProvider(goLensProvider.GO_ALLFILES, goCodeLensProvider))
+    disposables.push(vscode.languages.registerCodeLensProvider(jsLensProvider.typescriptAllFiles, tsCodeLensProvider))
+    disposables.push(vscode.languages.registerCodeLensProvider(pyLensProvider.pythonAllfiles, pyCodeLensProvider))
+    disposables.push(vscode.languages.registerCodeLensProvider(javaLensProvider.javaAllfiles, javaCodeLensProvider))
+    disposables.push(vscode.languages.registerCodeLensProvider(csLensProvider.csharpAllfiles, csCodeLensProvider))
+    disposables.push(vscode.languages.registerCodeLensProvider(goLensProvider.goAllfiles, goCodeLensProvider))
 
     disposables.push(
         Commands.register({ id: 'aws.toggleSamCodeLenses', autoconnect: false }, async () => {

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -17,7 +17,7 @@ import { SamCliSettings } from './samCliSettings'
 
 const localize = nls.loadMessageBundle()
 
-export const WAIT_FOR_DEBUGGER_MESSAGES = {
+export const waitForDebuggerMessages = {
     PYTHON: 'Debugger waiting for client...',
     PYTHON_IKPDB: 'IKP3db listening on',
     NODEJS: 'Debugger listening on',
@@ -54,10 +54,7 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
     private readonly logger: Logger = getLogger()
 
     public constructor(
-        private readonly debuggerAttachCues: string[] = [
-            WAIT_FOR_DEBUGGER_MESSAGES.PYTHON,
-            WAIT_FOR_DEBUGGER_MESSAGES.NODEJS,
-        ]
+        private readonly debuggerAttachCues: string[] = [waitForDebuggerMessages.PYTHON, waitForDebuggerMessages.NODEJS]
     ) {}
 
     public async invoke({ options, ...params }: SamLocalInvokeCommandArgs): Promise<ChildProcess> {

--- a/src/shared/sam/cli/samCliLocator.ts
+++ b/src/shared/sam/cli/samCliLocator.ts
@@ -15,22 +15,22 @@ export interface SamCliLocationProvider {
 }
 
 export class DefaultSamCliLocationProvider implements SamCliLocationProvider {
-    private static SAM_CLI_LOCATOR: BaseSamCliLocator | undefined
+    private static samCliLocator: BaseSamCliLocator | undefined
 
     public async getLocation() {
         return DefaultSamCliLocationProvider.getSamCliLocator().getLocation()
     }
 
     public static getSamCliLocator(): SamCliLocationProvider {
-        if (!DefaultSamCliLocationProvider.SAM_CLI_LOCATOR) {
+        if (!DefaultSamCliLocationProvider.samCliLocator) {
             if (process.platform === 'win32') {
-                DefaultSamCliLocationProvider.SAM_CLI_LOCATOR = new WindowsSamCliLocator()
+                DefaultSamCliLocationProvider.samCliLocator = new WindowsSamCliLocator()
             } else {
-                DefaultSamCliLocationProvider.SAM_CLI_LOCATOR = new UnixSamCliLocator()
+                DefaultSamCliLocationProvider.samCliLocator = new UnixSamCliLocator()
             }
         }
 
-        return DefaultSamCliLocationProvider.SAM_CLI_LOCATOR
+        return DefaultSamCliLocationProvider.samCliLocator
     }
 }
 
@@ -116,10 +116,10 @@ abstract class BaseSamCliLocator {
 }
 
 class WindowsSamCliLocator extends BaseSamCliLocator {
-    // Do not access LOCATION_PATHS directly. Use getExecutableFolders()
-    private static LOCATION_PATHS: string[] | undefined
+    // Do not access locationPaths directly. Use getExecutableFolders()
+    private static locationPaths: string[] | undefined
 
-    private static readonly EXECUTABLE_FILENAMES: string[] = ['sam.cmd', 'sam.exe']
+    private static readonly executableFilenames: string[] = ['sam.cmd', 'sam.exe']
 
     public constructor() {
         super()
@@ -132,32 +132,32 @@ class WindowsSamCliLocator extends BaseSamCliLocator {
     }
 
     protected getExecutableFilenames(): string[] {
-        return WindowsSamCliLocator.EXECUTABLE_FILENAMES
+        return WindowsSamCliLocator.executableFilenames
     }
 
     protected getExecutableFolders(): string[] {
-        if (!WindowsSamCliLocator.LOCATION_PATHS) {
-            WindowsSamCliLocator.LOCATION_PATHS = []
+        if (!WindowsSamCliLocator.locationPaths) {
+            WindowsSamCliLocator.locationPaths = []
 
             const envVars = process.env as EnvironmentVariables
 
             const programFiles = envVars.PROGRAMFILES
             if (programFiles) {
-                WindowsSamCliLocator.LOCATION_PATHS.push(String.raw`${programFiles}\Amazon\AWSSAMCLI\bin`)
+                WindowsSamCliLocator.locationPaths.push(String.raw`${programFiles}\Amazon\AWSSAMCLI\bin`)
             }
 
             const programFilesX86 = envVars['PROGRAMFILES(X86)']
             if (programFilesX86) {
-                WindowsSamCliLocator.LOCATION_PATHS.push(String.raw`${programFilesX86}\Amazon\AWSSAMCLI\bin`)
+                WindowsSamCliLocator.locationPaths.push(String.raw`${programFilesX86}\Amazon\AWSSAMCLI\bin`)
             }
         }
 
-        return WindowsSamCliLocator.LOCATION_PATHS
+        return WindowsSamCliLocator.locationPaths
     }
 }
 
 class UnixSamCliLocator extends BaseSamCliLocator {
-    private static readonly LOCATION_PATHS: string[] = [
+    private static readonly locationPaths: string[] = [
         '/usr/local/bin',
         '/usr/bin',
         // WEIRD BUT TRUE: brew installs to /home/linuxbrew/.linuxbrew if
@@ -166,7 +166,7 @@ class UnixSamCliLocator extends BaseSamCliLocator {
         `${process.env.HOME}/.linuxbrew/bin`,
     ]
 
-    private static readonly EXECUTABLE_FILENAMES: string[] = ['sam']
+    private static readonly executableFilenames: string[] = ['sam']
 
     public constructor() {
         super()
@@ -179,10 +179,10 @@ class UnixSamCliLocator extends BaseSamCliLocator {
     }
 
     protected getExecutableFilenames(): string[] {
-        return UnixSamCliLocator.EXECUTABLE_FILENAMES
+        return UnixSamCliLocator.executableFilenames
     }
 
     protected getExecutableFolders(): string[] {
-        return UnixSamCliLocator.LOCATION_PATHS
+        return UnixSamCliLocator.locationPaths
     }
 }

--- a/src/shared/sam/cli/samCliSettings.ts
+++ b/src/shared/sam/cli/samCliSettings.ts
@@ -36,7 +36,7 @@ export async function migrateLegacySettings() {
     )
 }
 
-const LOCAL_TIMEOUT_DEFAULT_MILLIS: number = 90000
+const localTimeoutDefaultMillis: number = 90000
 interface SavedBuckets {
     [profile: string]: { [region: string]: string }
 }
@@ -132,7 +132,7 @@ export class SamCliSettings extends fromExtensionManifest('aws.samcli', descript
     }
 
     public getLocalInvokeTimeout(): number {
-        return this.get('lambdaTimeout', LOCAL_TIMEOUT_DEFAULT_MILLIS)
+        return this.get('lambdaTimeout', localTimeoutDefaultMillis)
     }
 
     static #instance: SamCliSettings

--- a/src/shared/sam/cli/samCliValidationNotification.ts
+++ b/src/shared/sam/cli/samCliValidationNotification.ts
@@ -11,8 +11,8 @@ import { getIdeProperties } from '../../extensionUtilities'
 import {
     InvalidSamCliError,
     InvalidSamCliVersionError,
-    MAXIMUM_SAM_CLI_VERSION_EXCLUSIVE,
-    MINIMUM_SAM_CLI_VERSION_INCLUSIVE,
+    maxSamCliVersionExclusive,
+    minSamCliVersion,
     SamCliNotFoundError,
     SamCliVersionValidation,
     SamCliVersionValidatorResult,
@@ -112,25 +112,25 @@ export function makeSamCliValidationNotification(
 }
 
 function makeVersionValidationNotificationMessage(validationResult: SamCliVersionValidatorResult): string {
-    const RECOMMENDATION_UPDATE_TOOLKIT: string = localize(
+    const recommendationUpdateToolkit: string = localize(
         'AWS.samcli.recommend.update.toolkit',
         'Check the Marketplace for an updated {0} Toolkit.',
         getIdeProperties().company
     )
 
-    const RECOMMENDATION_UPDATE_SAM_CLI: string = localize('AWS.samcli.recommend.update.samcli', 'Update your SAM CLI.')
+    const recommendationUpdateSamCli: string = localize('AWS.samcli.recommend.update.samcli', 'Update your SAM CLI.')
 
     const recommendation: string =
         validationResult.validation === SamCliVersionValidation.VersionTooHigh
-            ? RECOMMENDATION_UPDATE_TOOLKIT
-            : RECOMMENDATION_UPDATE_SAM_CLI
+            ? recommendationUpdateToolkit
+            : recommendationUpdateSamCli
 
     return localize(
         'AWS.samcli.notification.version.invalid',
         'Your SAM CLI version {0} does not meet requirements ({1} ≤ version < {2}). {3}',
         validationResult.version,
-        MINIMUM_SAM_CLI_VERSION_INCLUSIVE,
-        MAXIMUM_SAM_CLI_VERSION_EXCLUSIVE,
+        minSamCliVersion,
+        maxSamCliVersionExclusive,
         recommendation
     )
 }

--- a/src/shared/sam/cli/samCliValidator.ts
+++ b/src/shared/sam/cli/samCliValidator.ts
@@ -9,12 +9,12 @@ import { ClassToInterfaceType } from '../../utilities/tsUtils'
 import { SamCliSettings } from './samCliSettings'
 import { SamCliInfoInvocation, SamCliInfoResponse } from './samCliInfo'
 
-export const MINIMUM_SAM_CLI_VERSION_INCLUSIVE = '0.47.0'
-export const MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_IMAGE_SUPPORT = '1.13.0'
-export const MAXIMUM_SAM_CLI_VERSION_EXCLUSIVE = '2.0.0'
-export const MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_GO_SUPPORT = '1.18.1'
-export const MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_ARM_SUPPORT = '1.33.0'
-export const MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_DOTNET_31_SUPPORT = '1.4.0'
+export const minSamCliVersion = '0.47.0'
+export const minSamCliVersionForImageSupport = '1.13.0'
+export const maxSamCliVersionExclusive = '2.0.0'
+export const minSamCliVersionForGoSupport = '1.18.1'
+export const minSamCliVersionForArmSupport = '1.33.0'
+export const minSamCliVersionForDotnet31Support = '1.4.0'
 
 // Errors
 export class InvalidSamCliError extends Error {
@@ -120,11 +120,11 @@ export class DefaultSamCliValidator implements SamCliValidator {
             return SamCliVersionValidation.VersionNotParseable
         }
 
-        if (semver.lt(version, MINIMUM_SAM_CLI_VERSION_INCLUSIVE)) {
+        if (semver.lt(version, minSamCliVersion)) {
             return SamCliVersionValidation.VersionTooLow
         }
 
-        if (semver.gte(version, MAXIMUM_SAM_CLI_VERSION_EXCLUSIVE)) {
+        if (semver.gte(version, maxSamCliVersionExclusive)) {
             return SamCliVersionValidation.VersionTooHigh
         }
 

--- a/src/shared/sam/debugger/awsSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfiguration.ts
@@ -18,13 +18,13 @@ import { isCloud9 } from '../../extensionUtilities'
 
 export * from './awsSamDebugConfiguration.gen'
 
-export const AWS_SAM_DEBUG_TYPE = 'aws-sam'
-export const DIRECT_INVOKE_TYPE = 'direct-invoke'
-export const TEMPLATE_TARGET_TYPE = 'template' as const
-export const CODE_TARGET_TYPE = 'code' as const
-export const API_TARGET_TYPE = 'api' as const
-export const AWS_SAM_DEBUG_REQUEST_TYPES = [DIRECT_INVOKE_TYPE]
-export const AWS_SAM_DEBUG_TARGET_TYPES = [TEMPLATE_TARGET_TYPE, CODE_TARGET_TYPE, API_TARGET_TYPE]
+export const AWS_SAM_DEBUG_TYPE = 'aws-sam' // eslint-disable-line @typescript-eslint/naming-convention
+export const DIRECT_INVOKE_TYPE = 'direct-invoke' // eslint-disable-line @typescript-eslint/naming-convention
+export const TEMPLATE_TARGET_TYPE = 'template' as const // eslint-disable-line @typescript-eslint/naming-convention
+export const CODE_TARGET_TYPE = 'code' as const // eslint-disable-line @typescript-eslint/naming-convention
+export const API_TARGET_TYPE = 'api' as const // eslint-disable-line @typescript-eslint/naming-convention
+export const awsSamDebugRequestTypes = [DIRECT_INVOKE_TYPE]
+export const awsSamDebugTargetTypes = [TEMPLATE_TARGET_TYPE, CODE_TARGET_TYPE, API_TARGET_TYPE]
 
 export type AwsSamTargetType = 'api' | 'code' | 'template'
 

--- a/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
@@ -10,8 +10,8 @@ import { samImageLambdaRuntimes, samZipLambdaRuntimes } from '../../../lambda/mo
 import { CloudFormation } from '../../cloudformation/cloudformation'
 import { localize } from '../../utilities/vsCodeUtils'
 import {
-    AWS_SAM_DEBUG_REQUEST_TYPES,
-    AWS_SAM_DEBUG_TARGET_TYPES,
+    awsSamDebugRequestTypes,
+    awsSamDebugTargetTypes,
     AwsSamDebuggerConfiguration,
     CODE_TARGET_TYPE,
     TemplateTargetProperties,
@@ -47,17 +47,17 @@ export class DefaultAwsSamDebugConfigurationValidator implements AwsSamDebugConf
                 'Missing required field "{0}" in debug config',
                 'request'
             )
-        } else if (!AWS_SAM_DEBUG_REQUEST_TYPES.includes(config.request)) {
+        } else if (!awsSamDebugRequestTypes.includes(config.request)) {
             rv.message = localize(
                 'AWS.sam.debugger.invalidRequest',
                 'Debug Configuration has an unsupported request type. Supported types: {0}',
-                AWS_SAM_DEBUG_REQUEST_TYPES.join(', ')
+                awsSamDebugRequestTypes.join(', ')
             )
-        } else if (!AWS_SAM_DEBUG_TARGET_TYPES.includes(config.invokeTarget.target)) {
+        } else if (!awsSamDebugTargetTypes.includes(config.invokeTarget.target)) {
             rv.message = localize(
                 'AWS.sam.debugger.invalidTarget',
                 'Debug Configuration has an unsupported target type. Supported types: {0}',
-                AWS_SAM_DEBUG_TARGET_TYPES.join(', ')
+                awsSamDebugTargetTypes.join(', ')
             )
         } else if (
             config.invokeTarget.target === TEMPLATE_TARGET_TYPE ||

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -56,10 +56,7 @@ import { fromString } from '../../../credentials/providers/credentials'
 import { Credentials } from '@aws-sdk/types'
 import { CloudFormation } from '../../cloudformation/cloudformation'
 import { getSamCliContext, getSamCliVersion } from '../cli/samCliContext'
-import {
-    MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_IMAGE_SUPPORT,
-    MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_GO_SUPPORT,
-} from '../cli/samCliValidator'
+import { minSamCliVersionForImageSupport, minSamCliVersionForGoSupport } from '../cli/samCliValidator'
 import { getIdeProperties, isCloud9 } from '../../extensionUtilities'
 import { resolve } from 'path'
 import globals from '../../extensionGlobals'
@@ -339,6 +336,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
      * @param config User-provided config (from launch.json)
      * @param token  Cancellation token
      */
+    // eslint-disable-next-line id-length
     public async resolveDebugConfigurationWithSubstitutedVariables(
         folder: vscode.WorkspaceFolder | undefined,
         config: AwsSamDebuggerConfiguration,
@@ -489,7 +487,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         // TODO: Remove this when min sam version is > 1.13.0
         if (!isZip) {
             const samCliVersion = await getSamCliVersion(this.ctx.samCliContext())
-            if (semver.lt(samCliVersion, MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_IMAGE_SUPPORT)) {
+            if (semver.lt(samCliVersion, minSamCliVersionForImageSupport)) {
                 const message = localize(
                     'AWS.output.sam.no.image.support',
                     'Support for Image-based Lambdas requires a minimum SAM CLI version of 1.13.0.'
@@ -513,12 +511,12 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         // TODO: remove this when min sam version is >= 1.18.1
         if (goRuntimes.includes(runtime) && !config.noDebug) {
             const samCliVersion = await getSamCliVersion(this.ctx.samCliContext())
-            if (semver.lt(samCliVersion, MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_GO_SUPPORT)) {
+            if (semver.lt(samCliVersion, minSamCliVersionForGoSupport)) {
                 vscode.window.showWarningMessage(
                     localize(
                         'AWS.output.sam.local.no.go.support',
                         'Debugging go1.x lambdas requires a minimum SAM CLI version of {0}. Function will run locally without debug.',
-                        MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_GO_SUPPORT
+                        minSamCliVersionForGoSupport
                     )
                 )
                 config.noDebug = true

--- a/src/shared/sam/debugger/csharpSamDebug.ts
+++ b/src/shared/sam/debugger/csharpSamDebug.ts
@@ -9,14 +9,14 @@ import * as path from 'path'
 import * as semver from 'semver'
 import {
     DotNetCoreDebugConfiguration,
-    DOTNET_CORE_DEBUGGER_PATH,
+    dotnetCoreDebuggerPath,
     getCodeRoot,
     isImageLambdaConfig,
 } from '../../../lambda/local/debugConfiguration'
 import { RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
 import * as pathutil from '../../../shared/utilities/pathUtils'
 import { ExtContext } from '../../extensions'
-import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
+import { DefaultSamLocalInvokeCommand, waitForDebuggerMessages } from '../cli/samCliLocalInvoke'
 import { runLambdaFunction, waitForPort } from '../localLambdaRunner'
 import { SamLaunchRequestArgs } from './awsSamDebugger'
 import { ChildProcess } from '../../utilities/childProcess'
@@ -26,7 +26,7 @@ import { Window } from '../../vscode/window'
 
 import * as nls from 'vscode-nls'
 import { getSamCliVersion } from '../cli/samCliContext'
-import { MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_DOTNET_31_SUPPORT } from '../cli/samCliValidator'
+import { minSamCliVersionForDotnet31Support } from '../cli/samCliValidator'
 import globals from '../../extensionGlobals'
 const localize = nls.loadMessageBundle()
 
@@ -72,14 +72,14 @@ export async function invokeCsharpLambda(
     config: SamLaunchRequestArgs,
     window: Window = Window.vscode()
 ): Promise<SamLaunchRequestArgs> {
-    config.samLocalInvokeCommand = new DefaultSamLocalInvokeCommand([WAIT_FOR_DEBUGGER_MESSAGES.DOTNET])
+    config.samLocalInvokeCommand = new DefaultSamLocalInvokeCommand([waitForDebuggerMessages.DOTNET])
     // eslint-disable-next-line @typescript-eslint/unbound-method
     config.onWillAttachDebugger = waitForPort
 
     if (!config.noDebug) {
         const samCliVersion = await getSamCliVersion(ctx.samCliContext())
         // TODO: Remove this when min sam version is >= 1.4.0
-        if (semver.lt(samCliVersion, MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_DOTNET_31_SUPPORT)) {
+        if (semver.lt(samCliVersion, minSamCliVersionForDotnet31Support)) {
             window.showWarningMessage(
                 localize(
                     'AWS.output.sam.local.no.net.3.1.debug',
@@ -243,7 +243,7 @@ export async function makeCoreCLRDebugConfiguration(
 
     if (os.platform() === 'win32') {
         // Coerce drive letter to uppercase. While Windows is case-insensitive, sourceFileMap is case-sensitive.
-        codeUri = codeUri.replace(pathutil.DRIVE_LETTER_REGEX, match => match.toUpperCase())
+        codeUri = codeUri.replace(pathutil.driveLetterRegex, match => match.toUpperCase())
     }
 
     if (isImageLambda) {
@@ -278,14 +278,14 @@ export async function makeCoreCLRDebugConfiguration(
         pipeTransport: {
             pipeProgram: 'sh',
             pipeArgs,
-            debuggerPath: DOTNET_CORE_DEBUGGER_PATH,
+            debuggerPath: dotnetCoreDebuggerPath,
             pipeCwd: codeUri,
         },
         windows: {
             pipeTransport: {
                 pipeProgram: 'powershell',
                 pipeArgs,
-                debuggerPath: DOTNET_CORE_DEBUGGER_PATH,
+                debuggerPath: dotnetCoreDebuggerPath,
                 pipeCwd: codeUri,
             },
         },

--- a/src/shared/sam/debugger/goSamDebug.ts
+++ b/src/shared/sam/debugger/goSamDebug.ts
@@ -6,12 +6,12 @@
 import * as os from 'os'
 import * as path from 'path'
 import * as vscode from 'vscode'
-import { GoDebugConfiguration, GO_DEBUGGER_PATH, isImageLambdaConfig } from '../../../lambda/local/debugConfiguration'
+import { GoDebugConfiguration, goDebuggerPath, isImageLambdaConfig } from '../../../lambda/local/debugConfiguration'
 import { RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
 import * as pathutil from '../../../shared/utilities/pathUtils'
 import { ExtContext } from '../../extensions'
 import { findParentProjectFile } from '../../utilities/workspaceUtils'
-import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
+import { DefaultSamLocalInvokeCommand, waitForDebuggerMessages } from '../cli/samCliLocalInvoke'
 import { runLambdaFunction } from '../localLambdaRunner'
 import { SamLaunchRequestArgs } from './awsSamDebugger'
 import { getLogger } from '../../logger'
@@ -51,7 +51,7 @@ const localize = nls.loadMessageBundle()
  *  [2] https://github.com/lambci/docker-lambda/blob/f6b4765a9b659ceb949c34b19390026820ddd462/go1.x/run/aws-lambda-mock.go
  */
 export async function invokeGoLambda(ctx: ExtContext, config: GoDebugConfiguration): Promise<GoDebugConfiguration> {
-    config.samLocalInvokeCommand = new DefaultSamLocalInvokeCommand([WAIT_FOR_DEBUGGER_MESSAGES.GO_DELVE])
+    config.samLocalInvokeCommand = new DefaultSamLocalInvokeCommand([waitForDebuggerMessages.GO_DELVE])
     // eslint-disable-next-line @typescript-eslint/unbound-method
     config.onWillAttachDebugger = waitForDelve
 
@@ -124,7 +124,7 @@ export async function makeGoConfig(config: SamLaunchRequestArgs): Promise<GoDebu
         config.containerEnvVars = {
             _AWS_LAMBDA_GO_DEBUGGING: '1',
             _AWS_LAMBDA_GO_DELVE_API_VERSION: '2',
-            _AWS_LAMBDA_GO_DELVE_PATH: path.posix.join(GO_DEBUGGER_PATH, 'dlv'),
+            _AWS_LAMBDA_GO_DELVE_PATH: path.posix.join(goDebuggerPath, 'dlv'),
             _AWS_LAMBDA_GO_DELVE_LISTEN_PORT: port.toString(),
         }
     }
@@ -164,7 +164,7 @@ interface InstallScript {
  */
 async function makeInstallScript(debuggerPath: string, isWindows: boolean): Promise<InstallScript | undefined> {
     let script: string = isWindows ? '' : '#!/bin/sh\n'
-    const DELVE_REPO: string = 'github.com/go-delve/delve'
+    const delveRepo: string = 'github.com/go-delve/delve'
     const scriptExt: string = isWindows ? 'cmd' : 'sh'
     const delvePath: string = path.posix.join(debuggerPath, 'dlv')
     const installOptions: SpawnOptions = { env: { ...process.env } }
@@ -178,7 +178,7 @@ async function makeInstallScript(debuggerPath: string, isWindows: boolean): Prom
     // It's fine if we can't get the latest Delve version, the Toolkit will use the last built one instead
     try {
         const goPath: string = JSON.parse(execFileSync('go', ['env', '-json']).toString()).GOPATH
-        let repoPath: string = path.join(goPath, 'src', DELVE_REPO)
+        let repoPath: string = path.join(goPath, 'src', delveRepo)
 
         function getDelveVersion(repo: string, silent: boolean): string {
             try {
@@ -199,8 +199,8 @@ async function makeInstallScript(debuggerPath: string, isWindows: boolean): Prom
                 )
             )
             installOptions.env!['GOPATH'] = debuggerPath
-            repoPath = path.join(debuggerPath, 'src', DELVE_REPO)
-            const args = ['get', '-d', `${DELVE_REPO}/cmd/dlv`]
+            repoPath = path.join(debuggerPath, 'src', delveRepo)
+            const args = ['get', '-d', `${delveRepo}/cmd/dlv`]
             const out = execFileSync('go', args, installOptions as any)
             getLogger().debug('"go %O": %s', args, out)
         }
@@ -221,7 +221,7 @@ async function makeInstallScript(debuggerPath: string, isWindows: boolean): Prom
     installOptions.env!['GOARCH'] = 'amd64'
     installOptions.env!['GOOS'] = 'linux'
 
-    script += `go build -o "${delvePath}" "${DELVE_REPO}/cmd/dlv"\n`
+    script += `go build -o "${delvePath}" "${delveRepo}/cmd/dlv"\n`
 
     await fs.writeFile(installScriptPath, script, 'utf8')
     await fs.chmod(installScriptPath, 0o755)

--- a/src/shared/sam/debugger/javaSamDebug.ts
+++ b/src/shared/sam/debugger/javaSamDebug.ts
@@ -7,7 +7,7 @@ import { getCodeRoot, isImageLambdaConfig } from '../../../lambda/local/debugCon
 import { RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
 import { ExtContext } from '../../extensions'
 import { sleep } from '../../utilities/timeoutUtils'
-import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
+import { DefaultSamLocalInvokeCommand, waitForDebuggerMessages } from '../cli/samCliLocalInvoke'
 import { runLambdaFunction, waitForPort } from '../localLambdaRunner'
 import { SamLaunchRequestArgs } from './awsSamDebugger'
 
@@ -44,7 +44,7 @@ export async function makeJavaConfig(config: SamLaunchRequestArgs): Promise<SamL
 }
 
 export async function invokeJavaLambda(ctx: ExtContext, config: SamLaunchRequestArgs): Promise<SamLaunchRequestArgs> {
-    config.samLocalInvokeCommand = new DefaultSamLocalInvokeCommand([WAIT_FOR_DEBUGGER_MESSAGES.JAVA])
+    config.samLocalInvokeCommand = new DefaultSamLocalInvokeCommand([waitForDebuggerMessages.JAVA])
     // eslint-disable-next-line @typescript-eslint/unbound-method
     config.onWillAttachDebugger = async (port, timeout) => {
         await waitForPort(port, timeout, true)

--- a/src/shared/sam/debugger/pythonSamDebug.ts
+++ b/src/shared/sam/debugger/pythonSamDebug.ts
@@ -23,12 +23,12 @@ import { getLocalRootVariants } from '../../utilities/pathUtils'
 import { sleep } from '../../utilities/timeoutUtils'
 import { Timeout } from '../../utilities/timeoutUtils'
 import { getWorkspaceRelativePath } from '../../utilities/workspaceUtils'
-import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
+import { DefaultSamLocalInvokeCommand, waitForDebuggerMessages } from '../cli/samCliLocalInvoke'
 import { runLambdaFunction } from '../localLambdaRunner'
 import { SamLaunchRequestArgs } from './awsSamDebugger'
 
 /** SAM will mount the --debugger-path to /tmp/lambci_debug_files */
-const DEBUGPY_WRAPPER_PATH = '/tmp/lambci_debug_files/py_debug_wrapper.py'
+const debugpyWrapperPath = '/tmp/lambci_debug_files/py_debug_wrapper.py'
 
 // TODO: Fix this! Implement a more robust/flexible solution. This is just a basic minimal proof of concept.
 export async function getSamProjectDirPathForFile(filepath: string): Promise<string> {
@@ -102,7 +102,7 @@ export async function makePythonDebugConfig(
             config.debuggerPath = globals.context.asAbsolutePath(path.join('resources', 'debugger'))
             // NOTE: SAM CLI splits on each *single* space in `--debug-args`!
             //       Extra spaces will be passed as spurious "empty" arguments :(
-            const debugArgs = `${DEBUGPY_WRAPPER_PATH} --listen 0.0.0.0:${config.debugPort} --wait-for-client --log-to-stderr`
+            const debugArgs = `${debugpyWrapperPath} --listen 0.0.0.0:${config.debugPort} --wait-for-client --log-to-stderr`
             if (isImageLambda) {
                 const params = getPythonExeAndBootstrap(config.runtime)
                 config.debugArgs = [`${params.python} ${debugArgs} ${params.bootstrap}`]
@@ -224,8 +224,8 @@ export async function invokePythonLambda(
     config: PythonDebugConfiguration
 ): Promise<PythonDebugConfiguration> {
     config.samLocalInvokeCommand = new DefaultSamLocalInvokeCommand([
-        WAIT_FOR_DEBUGGER_MESSAGES.PYTHON,
-        WAIT_FOR_DEBUGGER_MESSAGES.PYTHON_IKPDB,
+        waitForDebuggerMessages.PYTHON,
+        waitForDebuggerMessages.PYTHON_IKPDB,
     ])
 
     // Must not used waitForPort() for ikpdb: the socket consumes

--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -14,7 +14,7 @@ import * as pathutil from '../../../shared/utilities/pathUtils'
 import { ExtContext } from '../../extensions'
 import { getLogger } from '../../logger'
 import { findParentProjectFile } from '../../utilities/workspaceUtils'
-import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli/samCliLocalInvoke'
+import { DefaultSamLocalInvokeCommand, waitForDebuggerMessages } from '../cli/samCliLocalInvoke'
 import { runLambdaFunction, waitForPort } from '../localLambdaRunner'
 import { SamLaunchRequestArgs } from './awsSamDebugger'
 
@@ -25,7 +25,7 @@ export async function invokeTypescriptLambda(
     ctx: ExtContext,
     config: NodejsDebugConfiguration
 ): Promise<NodejsDebugConfiguration> {
-    config.samLocalInvokeCommand = new DefaultSamLocalInvokeCommand([WAIT_FOR_DEBUGGER_MESSAGES.NODEJS])
+    config.samLocalInvokeCommand = new DefaultSamLocalInvokeCommand([waitForDebuggerMessages.NODEJS])
     // eslint-disable-next-line @typescript-eslint/unbound-method
     config.onWillAttachDebugger = waitForPort
 

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -462,7 +462,10 @@ export async function attachDebugger({
 }: AttachDebuggerContext): Promise<void> {
     getLogger().debug(
         `localLambdaRunner.attachDebugger: startDebugging with config: ${JSON.stringify(
-            params.debugConfig,
+            {
+                name: params.debugConfig.name,
+                invokeTarget: params.debugConfig.invokeTarget,
+            },
             undefined,
             2
         )}`

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -73,8 +73,8 @@ function makeResourceName(config: SamLaunchRequestArgs): string {
     }
 }
 
-const SAM_LOCAL_PORT_CHECK_RETRY_INTERVAL_MILLIS: number = 125
-const ATTACH_DEBUGGER_RETRY_DELAY_MILLIS: number = 1000
+const samLocalPortCheckRetryIntervalMillis: number = 125
+const attachDebuggerRetryDelayMillis: number = 1000
 
 export async function makeInputTemplate(
     config: SamLaunchRequestArgs & { invokeTarget: { target: 'code' } }
@@ -352,7 +352,7 @@ export async function runLambdaFunction(
 
         await attachDebugger({
             debugConfig: config,
-            retryDelayMillis: ATTACH_DEBUGGER_RETRY_DELAY_MILLIS,
+            retryDelayMillis: attachDebuggerRetryDelayMillis,
         })
 
         showDebugConsole()
@@ -391,8 +391,8 @@ async function requestLocalApi(
     apiPort: number,
     payload: any
 ): Promise<void> {
-    const RETRY_LIMIT = 10 // Number of attempts before showing a 'cancel' notification
-    const RETRY_DELAY = 200
+    const retryLimit = 10 // Number of attempts before showing a 'cancel' notification
+    const retryDelay = 200
     const reqMethod = api?.httpMethod || 'GET'
     const qs = (api?.querystring?.startsWith('?') ? '' : '?') + (api?.querystring ?? '')
     const uri = `http://127.0.0.1:${apiPort}${api?.path}${qs}`
@@ -413,14 +413,14 @@ async function requestLocalApi(
                 }
                 if (obj.error.code === 'ETIMEDOUT' || obj.error.response?.statusCode === 403 || timeout.completed) {
                     return 0
-                } else if (!notificationShown && obj.attemptCount >= RETRY_LIMIT) {
+                } else if (!notificationShown && obj.attemptCount >= retryLimit) {
                     notificationShown = true
                     getLogger().debug('Local API: showing cancel notification')
                     showMessageWithCancel('Waiting for local API to start...', timeout)
                 }
 
                 getLogger().debug(`Local API: retry (${obj.attemptCount}): ${uri}: ${obj.error.message}`)
-                return RETRY_DELAY
+                return retryDelay
             },
         },
         // TODO: api?.stageVariables,
@@ -452,7 +452,7 @@ export interface AttachDebuggerContext {
 }
 
 export async function attachDebugger({
-    retryDelayMillis = ATTACH_DEBUGGER_RETRY_DELAY_MILLIS,
+    retryDelayMillis = attachDebuggerRetryDelayMillis,
     onStartDebugging = vscode.debug.startDebugging,
     onWillRetry = async (): Promise<void> => {
         getLogger().debug('attachDebugger: retrying...')
@@ -515,7 +515,7 @@ export async function waitForPort(port: number, timeout: Timeout, isDebugPort: b
     const time = timeout.remainingTime
     try {
         // this function always attempts once no matter the timeoutDuration
-        await tcpPortUsed.waitUntilUsed(port, SAM_LOCAL_PORT_CHECK_RETRY_INTERVAL_MILLIS, time)
+        await tcpPortUsed.waitUntilUsed(port, samLocalPortCheckRetryIntervalMillis, time)
     } catch (err) {
         getLogger().warn(`Timeout after ${time} ms: port was not used: ${port}`)
         if (isDebugPort) {
@@ -530,7 +530,7 @@ export async function waitForPort(port: number, timeout: Timeout, isDebugPort: b
     }
 }
 
-export function shouldAppendRelativePathToFunctionHandler(runtime: string): boolean {
+export function shouldAppendRelativePathToFuncHandler(runtime: string): boolean {
     // getFamily will throw an error if the runtime doesn't exist
     switch (getFamily(runtime)) {
         case RuntimeFamily.NodeJS:

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -48,7 +48,7 @@ export interface SchemaHandler {
  * Processes the update of schema mappings for files in the workspace
  */
 export class SchemaService {
-    private static readonly DEFAULT_UPDATE_PERIOD_MILLIS = 1000
+    private static readonly defaultUpdatePeriodMillis = 1000
 
     private updatePeriod: number
     private timer?: NodeJS.Timer
@@ -66,7 +66,7 @@ export class SchemaService {
             handlers?: Map<SchemaType, SchemaHandler>
         }
     ) {
-        this.updatePeriod = opts?.updatePeriod ?? SchemaService.DEFAULT_UPDATE_PERIOD_MILLIS
+        this.updatePeriod = opts?.updatePeriod ?? SchemaService.defaultUpdatePeriodMillis
         this.schemas = opts?.schemas
         this.handlers =
             opts?.handlers ??

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -23,9 +23,8 @@ import { getStringHash } from './utilities/textUtilities'
 const goformationManifestURL = 'https://api.github.com/repos/awslabs/goformation/releases/latest'
 const devfileManifestURL = 'https://api.github.com/repos/devfile/api/releases/latest'
 const schemaPrefix = `${AWS_SCHEME}://`
-const hostedFilesCloudFrontDistribution = 'https://d3rrggjwfhwld2.cloudfront.net'
-const hostedFilesS3Fallback = 'https://aws-vs-toolkit.s3.amazonaws.com'
-const buildSpecHostedFilesPath = '/CodeBuild/buildspec/buildspec-standalone.schema.json'
+export const buildspecCloudfrontURL =
+    'https://d3rrggjwfhwld2.cloudfront.net/CodeBuild/buildspec/buildspec-standalone.schema.json'
 
 export type Schemas = { [key: string]: vscode.Uri }
 export type SchemaType = 'yaml' | 'json'
@@ -43,6 +42,10 @@ export interface SchemaHandler {
     /** Returns true if the given file path is handled by this `SchemaHandler`. */
     isMapped(f: vscode.Uri | string): boolean
 }
+
+export const cfnSchemaUri = (path: vscode.Uri) => vscode.Uri.joinPath(path, 'cloudformation.schema.json')
+export const samSchemaUri = (path: vscode.Uri) => vscode.Uri.joinPath(path, 'sam.schema.json')
+export const buildSpecSchemaUri = (path: vscode.Uri) => vscode.Uri.joinPath(path, 'buildspec.schema.json')
 
 /**
  * Processes the update of schema mappings for files in the workspace
@@ -146,10 +149,10 @@ export class SchemaService {
  * @param extensionContext VSCode extension context
  */
 export async function getDefaultSchemas(extensionContext: vscode.ExtensionContext): Promise<Schemas | undefined> {
-    const cfnSchemaUri = vscode.Uri.joinPath(extensionContext.globalStorageUri, 'cloudformation.schema.json')
-    const samSchemaUri = vscode.Uri.joinPath(extensionContext.globalStorageUri, 'sam.schema.json')
+    const cfnSchemaLocation = cfnSchemaUri(extensionContext.globalStorageUri)
+    const samSchemaLocation = samSchemaUri(extensionContext.globalStorageUri)
     const devfileSchemaUri = vscode.Uri.joinPath(extensionContext.globalStorageUri, 'devfile.schema.json')
-    const buildSpecSchemaUri = vscode.Uri.joinPath(extensionContext.globalStorageUri, 'buildspec.schema.json')
+    const buildSpecSchemaLocation = buildSpecSchemaUri(extensionContext.globalStorageUri)
 
     const goformationSchemaVersion = await getPropertyFromJsonUrl(goformationManifestURL, 'tag_name')
     const devfileSchemaVersion = await getPropertyFromJsonUrl(devfileManifestURL, 'tag_name')
@@ -158,28 +161,28 @@ export async function getDefaultSchemas(extensionContext: vscode.ExtensionContex
 
     try {
         await updateSchemaFromRemote({
-            destination: cfnSchemaUri,
+            destination: cfnSchemaLocation,
             version: goformationSchemaVersion,
             url: `https://raw.githubusercontent.com/awslabs/goformation/${goformationSchemaVersion}/schema/cloudformation.schema.json`,
             cacheKey: 'cfnSchemaVersion',
             extensionContext,
             title: schemaPrefix + 'cloudformation.schema.json',
         })
-        schemas['cfn'] = cfnSchemaUri
+        schemas['cfn'] = cfnSchemaLocation
     } catch (e) {
         getLogger().verbose('Could not download cfn schema: %s', (e as Error).message)
     }
 
     try {
         await updateSchemaFromRemote({
-            destination: samSchemaUri,
+            destination: samSchemaLocation,
             version: goformationSchemaVersion,
             url: `https://raw.githubusercontent.com/awslabs/goformation/${goformationSchemaVersion}/schema/sam.schema.json`,
             cacheKey: 'samSchemaVersion',
             extensionContext,
             title: schemaPrefix + 'sam.schema.json',
         })
-        schemas['sam'] = samSchemaUri
+        schemas['sam'] = samSchemaLocation
     } catch (e) {
         getLogger().verbose('Could not download sam schema: %s', (e as Error).message)
     }
@@ -199,35 +202,17 @@ export async function getDefaultSchemas(extensionContext: vscode.ExtensionContex
     }
 
     try {
-        try {
-            const contents = await getFromUrl(hostedFilesCloudFrontDistribution + buildSpecHostedFilesPath)
-            const buildspecSchemaVersion = contents ? getStringHash(contents) : undefined
-            await updateSchemaFromRemote({
-                destination: buildSpecSchemaUri,
-                url: hostedFilesCloudFrontDistribution + buildSpecHostedFilesPath,
-                version: buildspecSchemaVersion,
-                cacheKey: 'buildSpecSchemaVersion',
-                extensionContext,
-                title: schemaPrefix + 'buildspec.schema.json',
-            })
-            schemas['buildspec'] = buildSpecSchemaUri
-        } catch (e) {
-            getLogger().verbose(
-                'Could not download buildspec schema from CloudFront: %s. Attempting to download buildspec schema from S3',
-                (e as Error).message
-            )
-            const contents = await getFromUrl(hostedFilesCloudFrontDistribution + buildSpecHostedFilesPath)
-            const buildspecSchemaVersion = contents ? getStringHash(contents) : undefined
-            await updateSchemaFromRemote({
-                destination: buildSpecSchemaUri,
-                url: hostedFilesS3Fallback + buildSpecHostedFilesPath,
-                version: buildspecSchemaVersion,
-                cacheKey: 'buildSpecSchemaVersion',
-                extensionContext,
-                title: schemaPrefix + 'buildspec.schema.json',
-            })
-            schemas['buildspec'] = buildSpecSchemaUri
-        }
+        const contents = await getFromUrl(buildspecCloudfrontURL)
+        const buildspecSchemaVersion = contents ? getStringHash(contents) : undefined
+        await updateSchemaFromRemote({
+            destination: buildSpecSchemaLocation,
+            url: buildspecCloudfrontURL,
+            version: buildspecSchemaVersion,
+            cacheKey: 'buildSpecSchemaVersion',
+            extensionContext,
+            title: schemaPrefix + 'buildspec.schema.json',
+        })
+        schemas['buildspec'] = buildSpecSchemaLocation
     } catch (e) {
         getLogger().verbose('Could not download buildspec schema: %s', (e as Error).message)
     }
@@ -344,7 +329,14 @@ export class YamlSchemaHandler implements SchemaHandler {
         }
 
         if (mapping.schema) {
-            this.yamlExtension.assignSchema(mapping.uri, mapping.registry, resolveSchema(mapping.schema, schemas))
+            const schema = resolveSchema(mapping.schema, schemas)
+            if (!schema) {
+                getLogger().debug(
+                    `YamlSchemaHandler: failed to assign schema to ${mapping.uri}. Failed to find schema locally: ${mapping.schema}`
+                )
+                return
+            }
+            this.yamlExtension.assignSchema(mapping.uri, mapping.registry, schema)
         } else {
             this.yamlExtension.removeSchema(mapping.uri, mapping.registry)
         }
@@ -391,19 +383,26 @@ export class JsonSchemaHandler implements SchemaHandler {
 
         const path = normalizeVSCodeUri(mapping.uri)
         if (mapping.schema) {
-            const uri = resolveSchema(mapping.schema, schemas).toString()
-            const existing = this.getSettingBy({ schemaPath: uri })
+            const schema = resolveSchema(mapping.schema, schemas)
+            if (!schema) {
+                getLogger().debug(
+                    `JsonSchemaHandler: failed to assign schema to ${mapping.uri}. Failed to find schema locally: ${mapping.schema}`
+                )
+                return
+            }
+            const schemaUri = schema.toString()
+            const existing = this.getSettingBy({ schemaPath: schemaUri })
 
             if (existing) {
                 if (!existing.fileMatch) {
-                    getLogger().debug(`JsonSchemaHandler: skipped setting schema '${uri}'`)
+                    getLogger().debug(`JsonSchemaHandler: skipped setting schema '${schemaUri}'`)
                 } else {
                     existing.fileMatch.push(path)
                 }
             } else {
                 settings.push({
                     fileMatch: [path],
-                    url: uri,
+                    url: schemaUri,
                 })
             }
         } else {
@@ -433,7 +432,7 @@ export class JsonSchemaHandler implements SchemaHandler {
     }
 }
 
-function resolveSchema(schema: string | vscode.Uri, schemas: Schemas): vscode.Uri {
+function resolveSchema(schema: string | vscode.Uri, schemas: Schemas): vscode.Uri | undefined {
     if (schema instanceof vscode.Uri) {
         return schema
     }

--- a/src/shared/telemetry/activation.ts
+++ b/src/shared/telemetry/activation.ts
@@ -20,6 +20,7 @@ import { isAutomation, isReleaseVersion } from '../vscode/env'
 export const noticeResponseViewSettings = localize('AWS.telemetry.notificationViewSettings', 'Settings')
 export const noticeResponseOk = localize('AWS.telemetry.notificationOk', 'OK')
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const TELEMETRY_NOTICE_VERSION_ACKNOWLEDGED = 'awsTelemetryNoticeVersionAck'
 
 // Telemetry Notice Versions
@@ -27,7 +28,7 @@ export const TELEMETRY_NOTICE_VERSION_ACKNOWLEDGED = 'awsTelemetryNoticeVersionA
 // track scenarios when we may need to re-prompt the user about telemetry.
 // Version 1 was the original notice, allowing users to enable/disable/defer telemetry
 // Version 2 states that there is metrics gathering, which can be adjusted in the options
-const CURRENT_TELEMETRY_NOTICE_VERSION = 2
+const CURRENT_TELEMETRY_NOTICE_VERSION = 2 // eslint-disable-line @typescript-eslint/naming-convention
 
 /**
  * Sets up the Metrics system and initializes globals.telemetry

--- a/src/shared/telemetry/service-2.json
+++ b/src/shared/telemetry/service-2.json
@@ -229,8 +229,7 @@
     },
     "Value":{
       "type":"string",
-      "max":200,
-      "min":1
+      "max":65536
     }
   }
 }

--- a/src/shared/telemetry/telemetryClient.ts
+++ b/src/shared/telemetry/telemetryClient.ts
@@ -18,9 +18,9 @@ import globals from '../extensionGlobals'
 import { DevSettings } from '../settings'
 import { ClassToInterfaceType } from '../utilities/tsUtils'
 
-export const ACCOUNT_METADATA_KEY = 'awsAccount'
-export const REGION_KEY = 'awsRegion'
-export const COMPUTE_REGION_KEY = 'computeRegion'
+export const accountMetadataKey = 'awsAccount'
+export const regionKey = 'awsRegion'
+export const computeRegionKey = 'computeRegion'
 
 export enum AccountStatus {
     NotApplicable = 'n/a',
@@ -28,7 +28,7 @@ export enum AccountStatus {
     Invalid = 'invalid',
 }
 
-export const METADATA_FIELD_NAME = {
+export const metadataFieldName = {
     RESULT: 'result',
     DURATION: 'duration',
     REASON: 'reason',
@@ -53,16 +53,16 @@ export interface TelemetryFeedback {
 export type TelemetryClient = ClassToInterfaceType<DefaultTelemetryClient>
 
 export class DefaultTelemetryClient implements TelemetryClient {
-    private static readonly DEFAULT_IDENTITY_POOL = 'us-east-1:820fd6d1-95c0-4ca4-bffb-3f01d32da842'
-    private static readonly DEFAULT_TELEMETRY_ENDPOINT = 'https://client-telemetry.us-east-1.amazonaws.com'
-    private static readonly PRODUCT_NAME = 'AWS Toolkit For VS Code'
+    private static readonly defaultIdentityPool = 'us-east-1:820fd6d1-95c0-4ca4-bffb-3f01d32da842'
+    private static readonly defaultTelemetryEndpoint = 'https://client-telemetry.us-east-1.amazonaws.com'
+    private static readonly productName = 'AWS Toolkit For VS Code'
 
     private static initializeConfig(): TelemetryConfiguration {
         const settings = DevSettings.instance
 
         return {
-            endpoint: settings.get('telemetryEndpoint', this.DEFAULT_TELEMETRY_ENDPOINT),
-            identityPool: settings.get('telemetryUserPool', this.DEFAULT_IDENTITY_POOL),
+            endpoint: settings.get('telemetryEndpoint', this.defaultTelemetryEndpoint),
+            identityPool: settings.get('telemetryUserPool', this.defaultIdentityPool),
         }
     }
 
@@ -86,7 +86,7 @@ export class DefaultTelemetryClient implements TelemetryClient {
             if (!isAutomation()) {
                 await this.client
                     .postMetrics({
-                        AWSProduct: DefaultTelemetryClient.PRODUCT_NAME,
+                        AWSProduct: DefaultTelemetryClient.productName,
                         AWSProductVersion: extensionVersion,
                         ClientID: this.clientId,
                         OS: os.platform(),
@@ -113,7 +113,7 @@ export class DefaultTelemetryClient implements TelemetryClient {
         try {
             await this.client
                 .postFeedback({
-                    AWSProduct: DefaultTelemetryClient.PRODUCT_NAME,
+                    AWSProduct: DefaultTelemetryClient.productName,
                     AWSProductVersion: extensionVersion,
                     OS: os.platform(),
                     OSVersion: os.release(),

--- a/src/shared/telemetry/telemetryPublisher.ts
+++ b/src/shared/telemetry/telemetryPublisher.ts
@@ -17,7 +17,7 @@ export interface IdentityPublisherTuple {
 export type TelemetryPublisher = ClassToInterfaceType<DefaultTelemetryPublisher>
 
 export class DefaultTelemetryPublisher implements TelemetryPublisher {
-    private static readonly DEFAULT_MAX_BATCH_SIZE = 20
+    private static readonly defaultMaxBatchSize = 20
 
     private readonly _eventQueue: MetricDatum[]
 
@@ -56,7 +56,7 @@ export class DefaultTelemetryPublisher implements TelemetryPublisher {
         }
 
         while (this._eventQueue.length !== 0) {
-            const batch = this._eventQueue.splice(0, DefaultTelemetryPublisher.DEFAULT_MAX_BATCH_SIZE)
+            const batch = this._eventQueue.splice(0, DefaultTelemetryPublisher.defaultMaxBatchSize)
 
             if (this.telemetryClient === undefined) {
                 return

--- a/src/shared/telemetry/telemetryService.ts
+++ b/src/shared/telemetry/telemetryService.ts
@@ -11,11 +11,11 @@ import { AwsContext } from '../awsContext'
 import { isReleaseVersion, isAutomation } from '../vscode/env'
 import { getLogger } from '../logger'
 import { MetricDatum } from './clienttelemetry'
-import { DefaultTelemetryClient, REGION_KEY } from './telemetryClient'
+import { DefaultTelemetryClient, regionKey } from './telemetryClient'
 import { DefaultTelemetryPublisher } from './telemetryPublisher'
 import { TelemetryFeedback } from './telemetryClient'
 import { TelemetryPublisher } from './telemetryPublisher'
-import { ACCOUNT_METADATA_KEY, AccountStatus, COMPUTE_REGION_KEY } from './telemetryClient'
+import { accountMetadataKey, AccountStatus, computeRegionKey } from './telemetryClient'
 import { TelemetryLogger } from './telemetryLogger'
 import globals from '../extensionGlobals'
 import { ClassToInterfaceType } from '../utilities/tsUtils'
@@ -25,8 +25,8 @@ import { telemetry } from './telemetry'
 export type TelemetryService = ClassToInterfaceType<DefaultTelemetryService>
 
 export class DefaultTelemetryService {
-    public static readonly TELEMETRY_COGNITO_ID_KEY = 'telemetryId'
-    public static readonly DEFAULT_FLUSH_PERIOD_MILLIS = 1000 * 60 * 5 // 5 minutes in milliseconds
+    public static readonly telemetryCognitoIdKey = 'telemetryId'
+    public static readonly defaultFlushPeriodMillis = 1000 * 60 * 5 // 5 minutes in milliseconds
 
     public startTime: Date
     public readonly persistFilePath: string
@@ -62,7 +62,7 @@ export class DefaultTelemetryService {
         this.startTime = new globals.clock.Date()
 
         this._eventQueue = []
-        this._flushPeriod = DefaultTelemetryService.DEFAULT_FLUSH_PERIOD_MILLIS
+        this._flushPeriod = DefaultTelemetryService.defaultFlushPeriodMillis
 
         if (publisher !== undefined) {
             this.publisher = publisher
@@ -177,7 +177,7 @@ export class DefaultTelemetryService {
             // grab our Cognito identityId
             const poolId = DefaultTelemetryClient.config.identityPool
             const identityMapJson = this.context.globalState.get<string>(
-                DefaultTelemetryService.TELEMETRY_COGNITO_ID_KEY,
+                DefaultTelemetryService.telemetryCognitoIdKey,
                 '[]'
             )
             // Maps don't cleanly de/serialize with JSON.parse/stringify so we need to do it ourselves
@@ -192,7 +192,7 @@ export class DefaultTelemetryService {
                 // save it
                 identityMap.set(poolId, identityPublisherTuple.cognitoIdentityId)
                 await this.context.globalState.update(
-                    DefaultTelemetryService.TELEMETRY_COGNITO_ID_KEY,
+                    DefaultTelemetryService.telemetryCognitoIdKey,
                     JSON.stringify(Array.from(identityMap.entries()))
                 )
 
@@ -237,12 +237,12 @@ export class DefaultTelemetryService {
             }
         }
 
-        const commonMetadata = [{ Key: ACCOUNT_METADATA_KEY, Value: accountValue }]
+        const commonMetadata = [{ Key: accountMetadataKey, Value: accountValue }]
         if (this.computeRegion) {
-            commonMetadata.push({ Key: COMPUTE_REGION_KEY, Value: this.computeRegion })
+            commonMetadata.push({ Key: computeRegionKey, Value: this.computeRegion })
         }
-        if (!event?.Metadata?.some((m: any) => m?.Key == REGION_KEY)) {
-            commonMetadata.push({ Key: REGION_KEY, Value: globals.regionProvider.guessDefaultRegion() })
+        if (!event?.Metadata?.some((m: any) => m?.Key == regionKey)) {
+            commonMetadata.push({ Key: regionKey, Value: globals.regionProvider.guessDefaultRegion() })
         }
 
         if (event.Metadata) {

--- a/src/shared/telemetry/util.ts
+++ b/src/shared/telemetry/util.ts
@@ -11,8 +11,8 @@ import { isAutomation } from '../vscode/env'
 import { v4 as uuidv4 } from 'uuid'
 import { addTypeName } from '../utilities/typeConstructors'
 
-const LEGACY_SETTINGS_TELEMETRY_VALUE_DISABLE = 'Disable'
-const LEGACY_SETTINGS_TELEMETRY_VALUE_ENABLE = 'Enable'
+const legacySettingsTelemetryValueDisable = 'Disable'
+const legacySettingsTelemetryValueEnable = 'Enable'
 
 const TelemetryFlag = addTypeName('boolean', convertLegacy)
 
@@ -28,9 +28,9 @@ export function convertLegacy(value: unknown): boolean {
     }
 
     // Set telemetry value to boolean if the current value matches the legacy value
-    if (value === LEGACY_SETTINGS_TELEMETRY_VALUE_DISABLE) {
+    if (value === legacySettingsTelemetryValueDisable) {
         return false
-    } else if (value === LEGACY_SETTINGS_TELEMETRY_VALUE_ENABLE) {
+    } else if (value === legacySettingsTelemetryValueEnable) {
         return true
     } else {
         throw new TypeError(`Unknown telemetry setting: ${value}`)

--- a/src/shared/templates/baseTemplates.ts
+++ b/src/shared/templates/baseTemplates.ts
@@ -4,7 +4,7 @@
  */
 
 export class BaseTemplates {
-    public static readonly SIMPLE_HTML = `
+    public static readonly simpleHtml = `
         <html>
         <head>
             <meta charset="UTF-8">

--- a/src/shared/typescriptLambdaHandlerSearch.ts
+++ b/src/shared/typescriptLambdaHandlerSearch.ts
@@ -16,7 +16,7 @@ const getRange = (node: ts.Node) => ({
  * Detects functions that could possibly be used as Lambda Function Handlers from a Typescript file.
  */
 export class TypescriptLambdaHandlerSearch implements LambdaHandlerSearch {
-    public static readonly MAXIMUM_FUNCTION_PARAMETERS: number = 3
+    public static readonly maximumFunctionParameters: number = 3
 
     private readonly _baseFilename: string
     // _candidateDeclaredFunctionNames - names of functions that could be lambda handlers
@@ -67,7 +67,7 @@ export class TypescriptLambdaHandlerSearch implements LambdaHandlerSearch {
 
         handlers.push(...this.findCandidateHandlersInModuleExports())
         handlers.push(...this.findCandidateHandlersInExportedFunctions())
-        handlers.push(...this.findCandidateHandlersInExportDeclarations())
+        handlers.push(...this.findCandidateHandlersInExportDecls())
 
         return handlers
     }
@@ -158,7 +158,7 @@ export class TypescriptLambdaHandlerSearch implements LambdaHandlerSearch {
     /**
      * @description Looks at "export { xyz }" statements to find candidate Lambda handlers
      */
-    private findCandidateHandlersInExportDeclarations(): RootlessLambdaHandlerCandidate[] {
+    private findCandidateHandlersInExportDecls(): RootlessLambdaHandlerCandidate[] {
         const handlers: RootlessLambdaHandlerCandidate[] = []
 
         this._candidateExportDeclarations.forEach(exportDeclaration => {
@@ -289,7 +289,7 @@ export class TypescriptLambdaHandlerSearch implements LambdaHandlerSearch {
      */
     private static isValidFunctionAssignment(expression: ts.Expression): boolean {
         if (ts.isFunctionLike(expression)) {
-            return expression.parameters.length <= TypescriptLambdaHandlerSearch.MAXIMUM_FUNCTION_PARAMETERS
+            return expression.parameters.length <= TypescriptLambdaHandlerSearch.maximumFunctionParameters
         }
 
         return false
@@ -317,6 +317,6 @@ export class TypescriptLambdaHandlerSearch implements LambdaHandlerSearch {
     ): boolean {
         const nameIsValid: boolean = !validateName || !!node.name
 
-        return node.parameters.length <= TypescriptLambdaHandlerSearch.MAXIMUM_FUNCTION_PARAMETERS && nameIsValid
+        return node.parameters.length <= TypescriptLambdaHandlerSearch.maximumFunctionParameters && nameIsValid
     }
 }

--- a/src/shared/ui/buttons.ts
+++ b/src/shared/ui/buttons.ts
@@ -10,7 +10,7 @@ import { getIcon } from '../icons'
 import { WizardControl, WIZARD_EXIT, WIZARD_RETRY } from '../wizards/wizard'
 
 const localize = nls.loadMessageBundle()
-const HELP_TOOLTIP = localize('AWS.command.help', 'View Toolkit Documentation')
+const helpTooltip = localize('AWS.command.help', 'View Toolkit Documentation')
 
 type WizardButton<T> = QuickInputButton<T | WizardControl> | QuickInputButton<void>
 export type PrompterButtons<T> = readonly WizardButton<T>[]
@@ -31,7 +31,7 @@ export interface QuickInputButton<T> extends vscode.QuickInputButton {
  */
 export function createHelpButton(
     uri: string | vscode.Uri = documentationUrl,
-    tooltip: string = HELP_TOOLTIP
+    tooltip: string = helpTooltip
 ): QuickInputLinkButton {
     const iconPath = getIcon('vscode-help')
 

--- a/src/shared/ui/inputPrompter.ts
+++ b/src/shared/ui/inputPrompter.ts
@@ -22,7 +22,7 @@ export type ExtendedInputBoxOptions = Omit<vscode.InputBoxOptions, 'validateInpu
 
 export type InputBox = Omit<vscode.InputBox, 'buttons'> & { buttons: PrompterButtons<string> }
 
-export const DEFAULT_INPUTBOX_OPTIONS: vscode.InputBoxOptions = {
+export const defaultInputboxOptions: vscode.InputBoxOptions = {
     ignoreFocusOut: true,
 }
 
@@ -34,7 +34,7 @@ export const DEFAULT_INPUTBOX_OPTIONS: vscode.InputBoxOptions = {
  */
 export function createInputBox(options?: ExtendedInputBoxOptions): InputBoxPrompter {
     const inputBox = vscode.window.createInputBox() as InputBox
-    assign({ ...DEFAULT_INPUTBOX_OPTIONS, ...options }, inputBox)
+    assign({ ...defaultInputboxOptions, ...options }, inputBox)
     inputBox.buttons = options?.buttons ?? []
 
     const prompter = new InputBoxPrompter(inputBox)

--- a/src/shared/ui/picker.ts
+++ b/src/shared/ui/picker.ts
@@ -174,11 +174,13 @@ export class IteratingQuickPickController<TResponse> {
 
     // Default constructs are public static so they can be validated aganist by other functions.
 
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     public static readonly NO_ITEMS_ITEM: vscode.QuickPickItem = {
         label: localize('AWS.picker.dynamic.noItemsFound.label', '[No items found]'),
         detail: localize('AWS.picker.dynamic.noItemsFound.detail', 'Click here to go back'),
         alwaysShow: true,
     }
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     public static readonly ERROR_ITEM: vscode.QuickPickItem = {
         label: localize('AWS.picker.dynamic.errorNode.label', 'There was an error retrieving more items.'),
         alwaysShow: true,

--- a/src/shared/ui/pickerPrompter.ts
+++ b/src/shared/ui/pickerPrompter.ts
@@ -64,7 +64,7 @@ export type ExtendedQuickPickOptions<T> = Omit<
 }
 
 /** See {@link ExtendedQuickPickOptions.noItemsFoundItem noItemsFoundItem} for setting a different item */
-const DEFAULT_NO_ITEMS_ITEM = {
+const defaultNoItemsItem = {
     label: localize('AWS.picker.dynamic.noItemsFound.label', '[No items found]'),
     detail: localize('AWS.picker.dynamic.noItemsFound.detail', 'Click here to go back'),
     alwaysShow: true,
@@ -72,17 +72,17 @@ const DEFAULT_NO_ITEMS_ITEM = {
 }
 
 /** See {@link ExtendedQuickPickOptions.errorItem errorItem} for setting a different error item */
-const DEFAULT_ERROR_ITEM = {
+const defaultErrorItem = {
     // TODO: add icon, check for C9
     label: localize('AWS.picker.dynamic.error.label', '[Error loading items]'),
     alwaysShow: true,
     data: WIZARD_BACK,
 }
 
-export const DEFAULT_QUICKPICK_OPTIONS: ExtendedQuickPickOptions<any> = {
+export const defaultQuickpickOptions: ExtendedQuickPickOptions<any> = {
     ignoreFocusOut: true,
-    noItemsFoundItem: DEFAULT_NO_ITEMS_ITEM,
-    errorItem: DEFAULT_ERROR_ITEM,
+    noItemsFoundItem: defaultNoItemsItem,
+    errorItem: defaultErrorItem,
 }
 
 type QuickPickData<T> = PromptResult<T> | (() => Promise<PromptResult<T>>)
@@ -103,7 +103,7 @@ export type DataQuickPickItem<T> = vscode.QuickPickItem & {
 
 export type DataQuickPick<T> = Omit<vscode.QuickPick<DataQuickPickItem<T>>, 'buttons'> & { buttons: PrompterButtons<T> }
 
-export const CUSTOM_USER_INPUT = Symbol()
+export const customUserInput = Symbol()
 
 export function isDataQuickPickItem(obj: any): obj is DataQuickPickItem<any> {
     return typeof obj === 'object' && typeof (obj as vscode.QuickPickItem).label === 'string' && 'data' in obj
@@ -131,7 +131,7 @@ export function createQuickPick<T>(
     options?: ExtendedQuickPickOptions<T>
 ): QuickPickPrompter<T> {
     const picker = vscode.window.createQuickPick<DataQuickPickItem<T>>() as DataQuickPick<T>
-    const mergedOptions = { ...DEFAULT_QUICKPICK_OPTIONS, ...options }
+    const mergedOptions = { ...defaultQuickpickOptions, ...options }
     assign(mergedOptions, picker)
     picker.buttons = mergedOptions.buttons ?? []
 
@@ -582,7 +582,7 @@ export class FilterBoxQuickPickPrompter<T> extends QuickPickPrompter<T> {
         super(quickPick)
 
         this.transform(selection => {
-            if ((selection as T | typeof CUSTOM_USER_INPUT) === CUSTOM_USER_INPUT) {
+            if ((selection as T | typeof customUserInput) === customUserInput) {
                 return settings.transform(quickPick.value) ?? selection
             }
             return selection
@@ -602,7 +602,7 @@ export class FilterBoxQuickPickPrompter<T> extends QuickPickPrompter<T> {
         const picker = this.quickPick as DataQuickPick<T | symbol>
         const validator = (input: string) =>
             this.settings.validator !== undefined ? this.settings.validator(input) : undefined
-        const items = picker.items.filter(item => item.data !== CUSTOM_USER_INPUT)
+        const items = picker.items.filter(item => item.data !== customUserInput)
         const { label } = this.settings
 
         function update(value: string = '') {
@@ -611,7 +611,7 @@ export class FilterBoxQuickPickPrompter<T> extends QuickPickPrompter<T> {
                     label,
                     description: value,
                     alwaysShow: true,
-                    data: CUSTOM_USER_INPUT,
+                    data: customUserInput,
                     invalidSelection: validator(value) !== undefined,
                     detail: validator(value),
                 } as DataQuickPickItem<T | symbol>
@@ -627,6 +627,6 @@ export class FilterBoxQuickPickPrompter<T> extends QuickPickPrompter<T> {
     }
 
     private isUserInput(picked: any): picked is DataQuickPickItem<symbol> {
-        return picked !== undefined && picked.data === CUSTOM_USER_INPUT
+        return picked !== undefined && picked.data === customUserInput
     }
 }

--- a/src/shared/utilities/childProcess.ts
+++ b/src/shared/utilities/childProcess.ts
@@ -57,7 +57,7 @@ export interface ChildProcessResult {
     signal?: string
 }
 
-export const EOF = Symbol('EOF')
+export const eof = Symbol('EOF')
 
 /**
  * Convenience class to manage a child process
@@ -315,7 +315,7 @@ export class ChildProcess {
      *
      * This throws if the process hasn't started or if the write fails.
      */
-    public async send(input: string | Buffer | typeof EOF) {
+    public async send(input: string | Buffer | typeof eof) {
         if (this.childProcess === undefined) {
             throw new Error('Cannot write to non-existent process')
         }
@@ -325,7 +325,7 @@ export class ChildProcess {
             throw new Error('Cannot write to non-existent stdin')
         }
 
-        if (input === EOF) {
+        if (input === eof) {
             return new Promise<void>(resolve => stdin.end('', resolve))
         }
 

--- a/src/shared/utilities/cliUtils.ts
+++ b/src/shared/utilities/cliUtils.ts
@@ -50,7 +50,7 @@ type AwsClis = Extract<ToolId, 'session-manager-plugin'>
  * CLIs and their full filenames and download paths for their respective OSes
  * TODO: Add SAM? Other CLIs?
  */
-export const AWS_CLIS: { [cli in AwsClis]: Cli } = {
+export const awsClis: { [cli in AwsClis]: Cli } = {
     'session-manager-plugin': {
         command: {
             unix: path.join('sessionmanagerplugin', 'bin', 'session-manager-plugin'),
@@ -80,7 +80,7 @@ export async function installCli(
     confirm: boolean,
     window: Window = Window.vscode()
 ): Promise<string | never> {
-    const cliToInstall = AWS_CLIS[cli]
+    const cliToInstall = awsClis[cli]
     if (!cliToInstall) {
         throw new InstallerError(`Invalid not found for CLI: ${cli}`)
     }
@@ -252,9 +252,9 @@ async function installSsmCli(
 ): Promise<string> {
     progress.report({ message: msgDownloading })
 
-    const ssmInstaller = await downloadCliSource(AWS_CLIS['session-manager-plugin'], tempDir, timeout)
+    const ssmInstaller = await downloadCliSource(awsClis['session-manager-plugin'], tempDir, timeout)
     const outDir = path.join(getToolkitLocalCliPath(), 'sessionmanagerplugin')
-    const finalPath = path.join(getToolkitLocalCliPath(), getOsCommand(AWS_CLIS['session-manager-plugin']))
+    const finalPath = path.join(getToolkitLocalCliPath(), getOsCommand(awsClis['session-manager-plugin']))
     const TimedProcess = ChildProcess.extend({ timeout, rejectOnError: true, rejectOnErrorCode: true })
 
     getLogger('channel').info(`Installing SSM CLI from ${ssmInstaller} to ${outDir}...`)
@@ -326,7 +326,7 @@ export async function getOrInstallCli(
     if (DevSettings.instance.get('forceInstallTools', false)) {
         return installCli(cli, confirm, window)
     } else {
-        return (await getCliCommand(AWS_CLIS[cli])) ?? installCli(cli, confirm, window)
+        return (await getCliCommand(awsClis[cli])) ?? installCli(cli, confirm, window)
     }
 }
 

--- a/src/shared/utilities/editorUtilities.ts
+++ b/src/shared/utilities/editorUtilities.ts
@@ -6,10 +6,10 @@
 import * as _path from 'path'
 import { Settings } from '../settings'
 
-const DEFAULT_TAB_SIZE = 4
+const defaultTabSize = 4
 
 export function getTabSizeSetting(): number {
-    return Settings.instance.getSection('editor').get('tabSize', DEFAULT_TAB_SIZE)
+    return Settings.instance.getSection('editor').get('tabSize', defaultTabSize)
 }
 
 export function getInlineSuggestEnabled(): boolean {

--- a/src/shared/utilities/pathUtils.ts
+++ b/src/shared/utilities/pathUtils.ts
@@ -6,7 +6,7 @@
 import * as os from 'os'
 import * as _path from 'path'
 
-export const DRIVE_LETTER_REGEX = /^[a-zA-Z]\:/
+export const driveLetterRegex = /^[a-zA-Z]\:/
 
 function isUncPath(path: string) {
     return /^\s*[\/\\]{2}[^\/\\]+/.test(path)
@@ -80,7 +80,7 @@ export function normalize(p: string): string {
         return p
     }
     const firstChar = p.substring(0, 1)
-    if (DRIVE_LETTER_REGEX.test(p.substring(0, 2))) {
+    if (driveLetterRegex.test(p.substring(0, 2))) {
         return normalizeSeparator(_path.normalize(firstChar.toUpperCase() + p.substring(1)))
     }
     if (isUncPath(p)) {
@@ -90,10 +90,10 @@ export function normalize(p: string): string {
 }
 
 export function getLocalRootVariants(filePath: string): string[] {
-    if (process.platform === 'win32' && DRIVE_LETTER_REGEX.test(filePath)) {
+    if (process.platform === 'win32' && driveLetterRegex.test(filePath)) {
         return [
-            filePath.replace(DRIVE_LETTER_REGEX, match => match.toLowerCase()),
-            filePath.replace(DRIVE_LETTER_REGEX, match => match.toUpperCase()),
+            filePath.replace(driveLetterRegex, match => match.toLowerCase()),
+            filePath.replace(driveLetterRegex, match => match.toUpperCase()),
         ]
     }
 
@@ -107,7 +107,7 @@ export function getLocalRootVariants(filePath: string): string[] {
  */
 export function getDriveLetter(path: string): string {
     const fullpath = _path.resolve(path)
-    if (!fullpath || fullpath.length < 2 || !DRIVE_LETTER_REGEX.test(fullpath.substring(0, 2))) {
+    if (!fullpath || fullpath.length < 2 || !driveLetterRegex.test(fullpath.substring(0, 2))) {
         return ''
     }
 

--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -6,14 +6,14 @@
 import globals from '../extensionGlobals'
 import { CancellationToken, EventEmitter, Event } from 'vscode'
 
-export const TIMEOUT_EXPIRED_MESSAGE = 'Timeout token expired'
-export const TIMEOUT_CANCELLED_MESSAGE = 'Timeout token cancelled'
-export const TIMEOUT_UNEXPECTED_RESOLVE = 'Promise resolved with an unexpected object'
+export const timeoutExpiredMessage = 'Timeout token expired'
+export const timeoutCancelledMessage = 'Timeout token cancelled'
+export const timeoutUnexpectedResolve = 'Promise resolved with an unexpected object'
 
 type CancellationAgent = 'user' | 'timeout'
 export class CancellationError extends Error {
     public constructor(public readonly agent: CancellationAgent) {
-        super(agent === 'user' ? TIMEOUT_CANCELLED_MESSAGE : TIMEOUT_EXPIRED_MESSAGE)
+        super(agent === 'user' ? timeoutCancelledMessage : timeoutExpiredMessage)
     }
 
     public static isUserCancelled(err: any): err is CancellationError & { agent: 'user' } {
@@ -263,7 +263,7 @@ export async function waitTimeout<T, R = void, B extends boolean = true>(
     }
 
     if (result === undefined && (opt.allowUndefined ?? true) !== true) {
-        throw new Error(TIMEOUT_UNEXPECTED_RESOLVE)
+        throw new Error(timeoutUnexpectedResolve)
     }
 
     return result as T

--- a/src/shared/utilities/vsCodeUtils.ts
+++ b/src/shared/utilities/vsCodeUtils.ts
@@ -181,3 +181,18 @@ export async function createStarterTemplateFile(content: string, window: Window 
         await vscode.commands.executeCommand('vscode.open', loc)
     }
 }
+
+export async function getCodeLenses(uri: vscode.Uri): Promise<vscode.CodeLens[] | undefined> {
+    return vscode.commands.executeCommand('vscode.executeCodeLensProvider', uri)
+}
+
+export async function getCompletionItems(
+    uri: vscode.Uri,
+    position: vscode.Position
+): Promise<vscode.CompletionList | undefined> {
+    return vscode.commands.executeCommand('vscode.executeCompletionItemProvider', uri, position)
+}
+
+export async function getHoverItems(uri: vscode.Uri, position: vscode.Position): Promise<vscode.Hover[] | undefined> {
+    return vscode.commands.executeCommand('vscode.executeHoverProvider', uri, position)
+}

--- a/src/shared/vscode/env.ts
+++ b/src/shared/vscode/env.ts
@@ -41,11 +41,11 @@ export function isCI(): boolean {
 }
 
 /** Variable added via webpack */
-declare let EXTENSION_VERSION: string
-const TEST_VERSION = 'testPluginVersion'
+declare let EXTENSION_VERSION: string // eslint-disable-line @typescript-eslint/naming-convention
+const testVersion = 'testPluginVersion'
 
-/** The current extension version. If not built via Webpack, this defaults to {@link TEST_VERSION}. */
-let extensionVersion = TEST_VERSION
+/** The current extension version. If not built via Webpack, this defaults to {@link testVersion}. */
+let extensionVersion = testVersion
 try {
     extensionVersion = EXTENSION_VERSION
 } catch (e) {} // Just a reference error
@@ -55,14 +55,14 @@ try {
  * prerelease/test/nightly build)
  */
 export function isReleaseVersion(prereleaseOk: boolean = false): boolean {
-    return (prereleaseOk || !semver.prerelease(extensionVersion)) && extensionVersion !== TEST_VERSION
+    return (prereleaseOk || !semver.prerelease(extensionVersion)) && extensionVersion !== testVersion
 }
 
 /**
  * Returns true when source mapping is available
  */
 export function isSourceMappingAvailable(): boolean {
-    return extensionVersion === TEST_VERSION
+    return extensionVersion === testVersion
 }
 
 /**

--- a/src/shared/wizards/multiStepWizard.ts
+++ b/src/shared/wizards/multiStepWizard.ts
@@ -33,14 +33,17 @@ export enum WizardNextState {
     TERMINATE,
 }
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const WIZARD_RETRY: Transition = {
     nextState: WizardNextState.RETRY,
 }
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const WIZARD_TERMINATE: Transition = {
     nextState: WizardNextState.TERMINATE,
 }
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const WIZARD_GOBACK: Transition = {
     nextState: WizardNextState.GO_BACK,
 }

--- a/src/shared/wizards/wizard.ts
+++ b/src/shared/wizards/wizard.ts
@@ -34,15 +34,18 @@ export type WizardState<T> = {
 }
 
 // We use a symbol to safe-guard against collisions (alternatively this can be a class and use 'instanceof')
-const WIZARD_CONTROL = Symbol()
+const WIZARD_CONTROL = Symbol() // eslint-disable-line @typescript-eslint/naming-convention
 const makeControlString = (type: string) => `[WIZARD_CONTROL] ${type}`
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const WIZARD_RETRY = {
     id: WIZARD_CONTROL,
     type: ControlSignal.Retry,
     toString: () => makeControlString('Retry'),
 }
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const WIZARD_BACK = { id: WIZARD_CONTROL, type: ControlSignal.Back, toString: () => makeControlString('Back') }
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const WIZARD_EXIT = { id: WIZARD_CONTROL, type: ControlSignal.Exit, toString: () => makeControlString('Exit') }
 
 /** Control signals allow for alterations of the normal wizard flow */

--- a/src/shared/wizards/wizardForm.ts
+++ b/src/shared/wizards/wizardForm.ts
@@ -81,9 +81,9 @@ function checkParent<TState>(prop: string, state: TState, options: FormDataEleme
 }
 
 type FormProperty = keyof (FormElement<any, any> & ParentFormElement<any, any>)
-const BIND_PROMPTER: FormProperty = 'bindPrompter'
-const APPLY_FORM: FormProperty = 'applyBoundForm'
-const SET_DEFAULT: FormProperty = 'setDefault'
+const BIND_PROMPTER: FormProperty = 'bindPrompter' // eslint-disable-line @typescript-eslint/naming-convention
+const APPLY_FORM: FormProperty = 'applyBoundForm' // eslint-disable-line @typescript-eslint/naming-convention
+const SET_DEFAULT: FormProperty = 'setDefault' // eslint-disable-line @typescript-eslint/naming-convention
 
 /**
  * Maps individual {@link Prompter prompters} to a desired property of the output interface as defined by

--- a/src/ssmDocument/commands/createDocumentFromTemplate.ts
+++ b/src/ssmDocument/commands/createDocumentFromTemplate.ts
@@ -23,7 +23,7 @@ export interface SsmDocumentTemplateQuickPickItem {
     docType: string
 }
 
-const SSMDOCUMENT_TEMPLATES: SsmDocumentTemplateQuickPickItem[] = [
+const ssmdocumentTemplates: SsmDocumentTemplateQuickPickItem[] = [
     {
         label: localize('AWS.ssmDocument.template.automationHelloWorldPython.label', 'Hello world using Python'),
         description: localize(
@@ -61,7 +61,7 @@ export async function createSsmDocumentFromTemplate(extensionContext: vscode.Ext
             totalSteps: 2,
         },
         buttons: [vscode.QuickInputButtons.Back],
-        items: SSMDOCUMENT_TEMPLATES,
+        items: ssmdocumentTemplates,
     })
 
     const choices = await picker.promptUser({

--- a/src/ssmDocument/ssm/ssmClient.ts
+++ b/src/ssmDocument/ssm/ssmClient.ts
@@ -41,14 +41,14 @@ const yamlLanguageConfiguration: LanguageConfiguration = {
     },
 }
 
-const SSMDOCUMENT_LANGUAGESERVER_DEFAULTPORT = 6010
+const ssmdocumentLanguageserverDefaultport = 6010
 
 async function getLanguageServerDebuggerPort(extensionContext: ExtensionContext): Promise<number> {
     // get the port from env variable or use 6010 as default if not set
     const env = process.env as EnvironmentVariables
     const port = env.SSMDOCUMENT_LANGUAGESERVER_PORT
         ? parseInt(env.SSMDOCUMENT_LANGUAGESERVER_PORT as string)
-        : SSMDOCUMENT_LANGUAGESERVER_DEFAULTPORT
+        : ssmdocumentLanguageserverDefaultport
 
     return getPortPromise({ port: port })
 }

--- a/src/stepFunctions/commands/visualizeStateMachine/aslVisualization.ts
+++ b/src/stepFunctions/commands/visualizeStateMachine/aslVisualization.ts
@@ -15,7 +15,7 @@ import * as yaml from 'yaml'
 import { YAML_FORMATS } from '../../constants/aslFormats'
 import globals from '../../../shared/extensionGlobals'
 
-const YAML_OPTIONS: yaml.Options = {
+const yamlOptions: yaml.Options = {
     merge: false,
     maxAliasCount: 0,
     schema: 'yaml-1.1',
@@ -70,7 +70,7 @@ export class AslVisualization {
         let yamlErrors: string[] = []
 
         if (isYaml) {
-            const parsed = yaml.parseDocument(text, YAML_OPTIONS)
+            const parsed = yaml.parseDocument(text, yamlOptions)
             yamlErrors = parsed.errors.map(error => error.message)
             let json: any
 

--- a/src/stepFunctions/commands/visualizeStateMachine/getStateMachineDefinitionFromCfnTemplate.ts
+++ b/src/stepFunctions/commands/visualizeStateMachine/getStateMachineDefinitionFromCfnTemplate.ts
@@ -59,7 +59,7 @@ export function toUnescapedAslJsonString(
     escapedAslJsonStr:
         | string
         | {
-              'Fn::Join': any[]
+              'Fn::Join': any[] // eslint-disable-line @typescript-eslint/naming-convention
           }
 ): string {
     if (typeof escapedAslJsonStr === 'string') {

--- a/src/stepFunctions/constants/aslFormats.ts
+++ b/src/stepFunctions/constants/aslFormats.ts
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export const JSON_ASL = 'asl'
-export const JSON_TYPE = 'json'
-export const YAML_ASL = 'asl-yaml'
-export const YAML_TYPE = 'yaml'
-export const YAML_FORMATS = [YAML_TYPE, YAML_ASL]
-export const JSON_FORMATS = [JSON_TYPE, JSON_ASL]
-export const VALID_SFN_PUBLISH_FORMATS = JSON_FORMATS.concat(YAML_FORMATS)
-export const ASL_FORMATS = [JSON_ASL, YAML_ASL]
+export const JSON_ASL = 'asl' // eslint-disable-line @typescript-eslint/naming-convention
+export const JSON_TYPE = 'json' // eslint-disable-line @typescript-eslint/naming-convention
+export const YAML_ASL = 'asl-yaml' // eslint-disable-line @typescript-eslint/naming-convention
+export const YAML_TYPE = 'yaml' // eslint-disable-line @typescript-eslint/naming-convention
+export const YAML_FORMATS = [YAML_TYPE, YAML_ASL] // eslint-disable-line @typescript-eslint/naming-convention
+export const JSON_FORMATS = [JSON_TYPE, JSON_ASL] // eslint-disable-line @typescript-eslint/naming-convention
+export const VALID_SFN_PUBLISH_FORMATS = JSON_FORMATS.concat(YAML_FORMATS) // eslint-disable-line @typescript-eslint/naming-convention
+export const ASL_FORMATS = [JSON_ASL, YAML_ASL] // eslint-disable-line @typescript-eslint/naming-convention

--- a/src/stepFunctions/explorer/stepFunctionsNodes.ts
+++ b/src/stepFunctions/explorer/stepFunctionsNodes.ts
@@ -20,7 +20,7 @@ import { listStateMachines } from '../../stepFunctions/utils'
 import { Commands } from '../../shared/vscode/commands'
 import { getIcon } from '../../shared/icons'
 
-export const CONTEXT_VALUE_STATE_MACHINE = 'awsStateMachineNode'
+export const contextValueStateMachine = 'awsStateMachineNode'
 
 const sfnNodeMap = new Map<string, StepFunctionsNode>()
 
@@ -120,7 +120,7 @@ function makeStateMachineNode(
     details: StepFunctions.StateMachineListItem
 ): StateMachineNode {
     const node = new StateMachineNode(parent, regionCode, details)
-    node.contextValue = CONTEXT_VALUE_STATE_MACHINE
+    node.contextValue = contextValueStateMachine
 
     return node
 }

--- a/src/stepFunctions/utils.ts
+++ b/src/stepFunctions/utils.ts
@@ -24,11 +24,11 @@ import { fromExtensionManifest } from '../shared/settings'
 const documentSettings: DocumentLanguageSettings = { comments: 'error', trailingCommas: 'error' }
 const languageService = getLanguageService({})
 
-export const VISUALIZATION_SCRIPT_URL = 'https://do0of8uwbahzz.cloudfront.net/sfn-0.1.5.js'
-export const VISUALIZATION_CSS_URL = 'https://do0of8uwbahzz.cloudfront.net/graph-0.1.5.css'
+const visualizationScriptUrl = 'https://do0of8uwbahzz.cloudfront.net/sfn-0.1.5.js'
+const visualizationCssUrl = 'https://do0of8uwbahzz.cloudfront.net/graph-0.1.5.css'
 
-export const SCRIPTS_LAST_DOWNLOADED_URL = 'SCRIPT_LAST_DOWNLOADED_URL'
-export const CSS_LAST_DOWNLOADED_URL = 'CSS_LAST_DOWNLOADED_URL'
+const scriptsLastDownloadedUrl = 'SCRIPT_LAST_DOWNLOADED_URL'
+const cssLastDownloadedUrl = 'CSS_LAST_DOWNLOADED_URL'
 
 export interface UpdateCachedScriptOptions {
     globalStorage: vscode.Memento
@@ -76,8 +76,8 @@ export class StateMachineGraphCache {
     public async updateCache(globalStorage: vscode.Memento): Promise<void> {
         const scriptUpdate = this.updateCachedFile({
             globalStorage,
-            lastDownloadedURLKey: SCRIPTS_LAST_DOWNLOADED_URL,
-            currentURL: VISUALIZATION_SCRIPT_URL,
+            lastDownloadedURLKey: scriptsLastDownloadedUrl,
+            currentURL: visualizationScriptUrl,
             filePath: this.jsFilePath,
         }).catch(error => {
             this.logger.error('Failed to update State Machine Graph script assets')
@@ -88,8 +88,8 @@ export class StateMachineGraphCache {
 
         const cssUpdate = this.updateCachedFile({
             globalStorage,
-            lastDownloadedURLKey: CSS_LAST_DOWNLOADED_URL,
-            currentURL: VISUALIZATION_CSS_URL,
+            lastDownloadedURLKey: cssLastDownloadedUrl,
+            currentURL: visualizationCssUrl,
             filePath: this.cssFilePath,
         }).catch(error => {
             this.logger.error('Failed to update State Machine Graph css assets')
@@ -183,10 +183,10 @@ export async function* listStateMachines(
  * @param role The IAM role to check
  */
 export function isStepFunctionsRole(role: IAM.Role): boolean {
-    const STEP_FUNCTIONS_SEVICE_PRINCIPAL: string = 'states.amazonaws.com'
+    const stepFunctionsSevicePrincipal: string = 'states.amazonaws.com'
     const assumeRolePolicyDocument: string | undefined = role.AssumeRolePolicyDocument
 
-    return !!assumeRolePolicyDocument?.includes(STEP_FUNCTIONS_SEVICE_PRINCIPAL)
+    return !!assumeRolePolicyDocument?.includes(stepFunctionsSevicePrincipal)
 }
 
 export async function isDocumentValid(text: string, textDocument?: vscode.TextDocument): Promise<boolean> {

--- a/src/stepFunctions/wizards/createStateMachineWizard.ts
+++ b/src/stepFunctions/wizards/createStateMachineWizard.ts
@@ -11,7 +11,7 @@ import { createCommonButtons } from '../../shared/ui/buttons'
 import { createQuickPick, DataQuickPickItem } from '../../shared/ui/pickerPrompter'
 import { sfnCreateStateMachineUrl } from '../../shared/constants'
 
-export const STARTER_TEMPLATES: DataQuickPickItem<string>[] = [
+export const starterTemplates: DataQuickPickItem<string>[] = [
     {
         label: localize('AWS.stepfunctions.template.helloWorld.label', 'Hello world'),
         description: localize(
@@ -85,7 +85,7 @@ export class CreateStateMachineWizard extends Wizard<CreateStateMachineWizardRes
         super()
 
         this.form.templateFile.bindPrompter(() =>
-            createQuickPick(STARTER_TEMPLATES, {
+            createQuickPick(starterTemplates, {
                 title: localize(
                     'AWS.message.prompt.selectStateMachineTemplate.placeholder',
                     'Select a starter template'

--- a/src/test/apigateway/explorer/apiGatewayNodes.test.ts
+++ b/src/test/apigateway/explorer/apiGatewayNodes.test.ts
@@ -5,8 +5,8 @@
 
 import * as assert from 'assert'
 import {
-    assertNodeListOnlyContainsErrorNode,
-    assertNodeListOnlyContainsPlaceholderNode,
+    assertNodeListOnlyHasErrorNode,
+    assertNodeListOnlyHasPlaceholderNode,
 } from '../../utilities/explorerNodeAssertions'
 import { asyncGenerator } from '../../utilities/collectionUtils'
 import { ApiGatewayNode } from '../../../apigateway/explorer/apiGatewayNodes'
@@ -14,16 +14,16 @@ import { RestApiNode } from '../../../apigateway/explorer/apiNodes'
 import { DefaultApiGatewayClient } from '../../../shared/clients/apiGatewayClient'
 import { stub } from '../../utilities/stubber'
 
-const FAKE_PARTITION_ID = 'aws'
-const FAKE_REGION_CODE = 'someregioncode'
-const UNSORTED_TEXT = [
+const fakePartitionId = 'aws'
+const fakeRegionCode = 'someregioncode'
+const unsortedText = [
     { name: 'zebra', id: "it's zee not zed" },
     { name: 'zebra', id: "it's actually zed" },
     { name: 'Antelope', id: 'anti-antelope' },
     { name: 'aardvark', id: 'a-a-r-d-vark' },
     { name: 'elephant', id: 'trunk capacity' },
 ]
-const SORTED_TEXT = [
+const sortedText = [
     'aardvark (a-a-r-d-vark)',
     'Antelope (anti-antelope)',
     'elephant (trunk capacity)',
@@ -37,7 +37,7 @@ describe('ApiGatewayNode', function () {
     let apiNames: { name: string; id: string }[]
 
     function createClient() {
-        const client = stub(DefaultApiGatewayClient, { regionCode: FAKE_REGION_CODE })
+        const client = stub(DefaultApiGatewayClient, { regionCode: fakeRegionCode })
         client.listApis.callsFake(() => asyncGenerator(apiNames))
 
         return client
@@ -49,7 +49,7 @@ describe('ApiGatewayNode', function () {
             { name: 'api2', id: '22222' },
         ]
 
-        testNode = new ApiGatewayNode(FAKE_PARTITION_ID, FAKE_REGION_CODE, createClient())
+        testNode = new ApiGatewayNode(fakePartitionId, fakeRegionCode, createClient())
     })
 
     it('returns placeholder node if no children are present', async function () {
@@ -57,7 +57,7 @@ describe('ApiGatewayNode', function () {
 
         const childNodes = await testNode.getChildren()
 
-        assertNodeListOnlyContainsPlaceholderNode(childNodes)
+        assertNodeListOnlyHasPlaceholderNode(childNodes)
     })
 
     it('has RestApi child nodes', async function () {
@@ -69,19 +69,19 @@ describe('ApiGatewayNode', function () {
     })
 
     it('sorts child nodes', async function () {
-        apiNames = UNSORTED_TEXT
+        apiNames = unsortedText
 
         const childNodes = await testNode.getChildren()
 
         const actualChildOrder = childNodes.map(node => node.label)
-        assert.deepStrictEqual(actualChildOrder, SORTED_TEXT, 'Unexpected child sort order')
+        assert.deepStrictEqual(actualChildOrder, sortedText, 'Unexpected child sort order')
     })
 
     it('has an error node for a child if an error happens during loading', async function () {
         const client = createClient()
         client.listApis.throws(new Error())
 
-        const node = new ApiGatewayNode(FAKE_PARTITION_ID, FAKE_REGION_CODE, client)
-        assertNodeListOnlyContainsErrorNode(await node.getChildren())
+        const node = new ApiGatewayNode(fakePartitionId, fakeRegionCode, client)
+        assertNodeListOnlyHasErrorNode(await node.getChildren())
     })
 })

--- a/src/test/cdk/detectCdkProjects.test.ts
+++ b/src/test/cdk/detectCdkProjects.test.ts
@@ -19,6 +19,7 @@ describe('detectCdkProjects', function () {
     const workspacePaths: string[] = []
     const workspaceFolders: vscode.WorkspaceFolder[] = []
 
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     async function detectCdkProjects_wait(dirs: any) {
         return (
             (await waitUntil(

--- a/src/test/cloudWatchLogs/commands/viewLogStream.test.ts
+++ b/src/test/cloudWatchLogs/commands/viewLogStream.test.ts
@@ -11,7 +11,7 @@ import * as moment from 'moment'
 import {
     SelectLogStreamWizardContext,
     SelectLogStreamWizard,
-    convertDescribeLogStreamsToQuickPickItems,
+    convertDescribeLogToQuickPickItems,
 } from '../../../cloudWatchLogs/commands/viewLogStream'
 import { LogGroupNode } from '../../../cloudWatchLogs/explorer/logGroupNode'
 import { LOCALIZED_DATE_FORMAT } from '../../../shared/constants'
@@ -64,10 +64,10 @@ describe('viewLogStreamWizard', async function () {
     })
 })
 
-describe('convertDescribeLogStreamsToQuickPickItems', function () {
+describe('convertDescribeLogToQuickPickItems', function () {
     it('converts things correctly', function () {
         const time = new globals.clock.Date().getTime()
-        const results = convertDescribeLogStreamsToQuickPickItems({
+        const results = convertDescribeLogToQuickPickItems({
             logStreams: [
                 {
                     logStreamName: 'streamWithoutTimestamp',
@@ -88,7 +88,7 @@ describe('convertDescribeLogStreamsToQuickPickItems', function () {
             label: 'streamWithTimestamp',
             detail: moment(time).format(LOCALIZED_DATE_FORMAT),
         })
-        const noResults = convertDescribeLogStreamsToQuickPickItems({})
+        const noResults = convertDescribeLogToQuickPickItems({})
         assert.strictEqual(noResults.length, 0)
     })
 })

--- a/src/test/codewhisperer/commands/invokeRecommendation.test.ts
+++ b/src/test/codewhisperer/commands/invokeRecommendation.test.ts
@@ -34,7 +34,7 @@ describe('invokeRecommendation', function () {
                 isShowMethodsEnabled: true,
                 isManualTriggerEnabled: true,
                 isAutomatedTriggerEnabled: true,
-                isIncludeSuggestionsWithCodeReferencesEnabled: true,
+                isSuggestionsWithCodeReferencesEnabled: true,
             }
             await invokeRecommendation(mockEditor, mockClient, config)
             assert.ok(getRecommendationStub.called || oldGetRecommendationStub.called)

--- a/src/test/codewhisperer/service/inlineCompletion.test.ts
+++ b/src/test/codewhisperer/service/inlineCompletion.test.ts
@@ -192,7 +192,7 @@ describe('inlineCompletion', function () {
             isShowMethodsEnabled: true,
             isManualTriggerEnabled: true,
             isAutomatedTriggerEnabled: true,
-            isIncludeSuggestionsWithCodeReferencesEnabled: true,
+            isSuggestionsWithCodeReferencesEnabled: true,
         }
         const invokeSpy = sinon.stub(RecommendationHandler.instance, 'getRecommendations')
         let mockClient: codewhispererSdkClient.DefaultCodeWhispererClient

--- a/src/test/codewhisperer/service/inlineCompletionService.test.ts
+++ b/src/test/codewhisperer/service/inlineCompletionService.test.ts
@@ -23,7 +23,7 @@ describe('inlineCompletionService', function () {
             isShowMethodsEnabled: true,
             isManualTriggerEnabled: true,
             isAutomatedTriggerEnabled: true,
-            isIncludeSuggestionsWithCodeReferencesEnabled: true,
+            isSuggestionsWithCodeReferencesEnabled: true,
         }
 
         let mockClient: codewhispererSdkClient.DefaultCodeWhispererClient

--- a/src/test/codewhisperer/service/keyStrokeHandler.test.ts
+++ b/src/test/codewhisperer/service/keyStrokeHandler.test.ts
@@ -26,7 +26,7 @@ describe('keyStrokeHandler', function () {
         isShowMethodsEnabled: true,
         isManualTriggerEnabled: true,
         isAutomatedTriggerEnabled: true,
-        isIncludeSuggestionsWithCodeReferencesEnabled: true,
+        isSuggestionsWithCodeReferencesEnabled: true,
     }
     beforeEach(function () {
         resetCodeWhispererGlobalVariables()
@@ -59,7 +59,7 @@ describe('keyStrokeHandler', function () {
                 isShowMethodsEnabled: true,
                 isManualTriggerEnabled: true,
                 isAutomatedTriggerEnabled: false,
-                isIncludeSuggestionsWithCodeReferencesEnabled: true,
+                isSuggestionsWithCodeReferencesEnabled: true,
             }
             const keyStrokeHandler = new KeyStrokeHandler()
             await keyStrokeHandler.processKeyStroke(mockEvent, mockEditor, mockClient, cfg)

--- a/src/test/codewhisperer/service/recommendationHandler.test.ts
+++ b/src/test/codewhisperer/service/recommendationHandler.test.ts
@@ -24,7 +24,7 @@ describe('recommendationHandler', function () {
         isShowMethodsEnabled: true,
         isManualTriggerEnabled: true,
         isAutomatedTriggerEnabled: true,
-        isIncludeSuggestionsWithCodeReferencesEnabled: true,
+        isSuggestionsWithCodeReferencesEnabled: true,
     }
     beforeEach(function () {
         resetCodeWhispererGlobalVariables()

--- a/src/test/credentials/provider/sharedCredentialsProvider.test.ts
+++ b/src/test/credentials/provider/sharedCredentialsProvider.test.ts
@@ -13,7 +13,7 @@ import * as process from '@aws-sdk/credential-provider-process'
 import { ParsedIniData } from '@aws-sdk/shared-ini-file-loader'
 import { installFakeClock } from '../../testUtil'
 
-const MISSING_PROPERTIES_FRAGMENT = 'missing properties'
+const missingPropertiesFragment = 'missing properties'
 
 describe('SharedCredentialsProvider', async function () {
     let clock: FakeTimers.InstalledClock
@@ -107,7 +107,7 @@ describe('SharedCredentialsProvider', async function () {
         )
 
         assert.notStrictEqual(sut.validate(), undefined)
-        assertSubstringsInText(sut.validate(), MISSING_PROPERTIES_FRAGMENT, 'aws_secret_access_key')
+        assertSubstringsInText(sut.validate(), missingPropertiesFragment, 'aws_secret_access_key')
     })
 
     it('validation identifies when session_token is missing a corresponding access key id', async function () {
@@ -117,7 +117,7 @@ describe('SharedCredentialsProvider', async function () {
         )
 
         assert.notStrictEqual(sut.validate(), undefined)
-        assertSubstringsInText(sut.validate(), MISSING_PROPERTIES_FRAGMENT, 'aws_access_key_id')
+        assertSubstringsInText(sut.validate(), missingPropertiesFragment, 'aws_access_key_id')
     })
 
     it('validation identifies when session_token is missing a corresponding secret key', async function () {
@@ -127,7 +127,7 @@ describe('SharedCredentialsProvider', async function () {
         )
 
         assert.notStrictEqual(sut.validate(), undefined)
-        assertSubstringsInText(sut.validate(), MISSING_PROPERTIES_FRAGMENT, 'aws_secret_access_key')
+        assertSubstringsInText(sut.validate(), missingPropertiesFragment, 'aws_secret_access_key')
     })
 
     it('validation identifies when the profile contains no supported properties', async function () {

--- a/src/test/credentials/sso/cache.test.ts
+++ b/src/test/credentials/sso/cache.test.ts
@@ -12,19 +12,19 @@ import { getRegistrationCache, getTokenCache } from '../../../credentials/sso/ca
 describe('SSO Cache', function () {
     const region = 'dummyRegion'
     const startUrl = 'https://123456.awsapps.com/start'
-    const HOUR_IN_MS = 3600000
+    const hourInMs = 3600000
 
     let testDir: string
 
     const validRegistration = {
         clientId: 'dummyId',
         clientSecret: 'dummySecret',
-        expiresAt: new Date(Date.now() + HOUR_IN_MS),
+        expiresAt: new Date(Date.now() + hourInMs),
     }
 
     const validToken = {
         accessToken: 'longstringofrandomcharacters',
-        expiresAt: new Date(Date.now() + HOUR_IN_MS),
+        expiresAt: new Date(Date.now() + hourInMs),
     }
 
     beforeEach(async function () {

--- a/src/test/dynamicResources/awsResourceManager.test.ts
+++ b/src/test/dynamicResources/awsResourceManager.test.ts
@@ -33,9 +33,9 @@ describe('ResourceManager', function () {
     let schemaService: SchemaService
     let tempFolder: string
 
-    const FAKE_TYPE_NAME = 'sometype'
-    const FAKE_IDENTIFIER = 'someidentifier'
-    const FAKE_REGION = 'someregion'
+    const fakeTypeName = 'sometype'
+    const fakeIdentifier = 'someidentifier'
+    const fakeRegion = 'someregion'
 
     const fakeResourceDescription = {
         Role: 'arn:aws:iam::1234:role/service-role/fooResource',
@@ -55,14 +55,14 @@ describe('ResourceManager', function () {
         mockClients()
         tempFolder = await makeTemporaryToolkitFolder()
 
-        const rootNode = new ResourcesNode(FAKE_REGION, instance(cloudFormation), cloudControl)
+        const rootNode = new ResourcesNode(fakeRegion, instance(cloudFormation), cloudControl)
         resourceTypeNode = new ResourceTypeNode(
             rootNode,
-            FAKE_TYPE_NAME,
+            fakeTypeName,
             instance(cloudControl),
             {} as ResourceTypeMetadata
         )
-        resourceNode = new ResourceNode(resourceTypeNode, FAKE_IDENTIFIER)
+        resourceNode = new ResourceNode(resourceTypeNode, fakeIdentifier)
         const fakeContext = await FakeExtensionContext.create()
         fakeContext.globalStorageUri = vscode.Uri.file(tempFolder)
         resourceManager = new AwsResourceManager(fakeContext)
@@ -86,7 +86,7 @@ describe('ResourceManager', function () {
         const capturedUri = openTextDocumentStub.getCall(0).args[0] as vscode.Uri
 
         assert.strictEqual(capturedUri.scheme, 'awsResource')
-        assert.strictEqual(capturedUri.fsPath, `${FAKE_IDENTIFIER}.${FAKE_TYPE_NAME}.preview.json`)
+        assert.strictEqual(capturedUri.fsPath, `${fakeIdentifier}.${fakeTypeName}.preview.json`)
         assert.strictEqual(capturedUri.query, formatResourceModel(JSON.stringify(fakeResourceDescription)))
 
         assert.strictEqual(showTextDocumentStub.getCall(0).args[0], mockTextDocument)
@@ -106,7 +106,7 @@ describe('ResourceManager', function () {
         const capturedUri = openTextDocumentStub.getCall(0).args[0] as vscode.Uri
 
         assert.strictEqual(capturedUri.scheme, 'file')
-        assert.strictEqual(capturedUri.fsPath.endsWith(`${FAKE_IDENTIFIER}.${FAKE_TYPE_NAME}.awsResource.json`), true)
+        assert.strictEqual(capturedUri.fsPath.endsWith(`${fakeIdentifier}.${fakeTypeName}.awsResource.json`), true)
 
         const fileContents = JSON.parse(await readFileAsString(capturedUri.fsPath))
         assert.deepStrictEqual(fileContents, fakeResourceDescription)
@@ -151,7 +151,7 @@ describe('ResourceManager', function () {
         const capturedUri = openTextDocumentStub.getCall(0).args[0] as vscode.Uri
 
         assert.strictEqual(capturedUri.scheme, 'file')
-        assert.strictEqual(capturedUri.fsPath.endsWith(`new.${FAKE_TYPE_NAME}.awsResource.json`), true)
+        assert.strictEqual(capturedUri.fsPath.endsWith(`new.${fakeTypeName}.awsResource.json`), true)
 
         const fileContents = JSON.parse(await readFileAsString(capturedUri.fsPath))
         assert.deepStrictEqual(fileContents, {})
@@ -226,8 +226,8 @@ describe('ResourceManager', function () {
         when(
             cloudControl.getResource(
                 deepEqual({
-                    TypeName: FAKE_TYPE_NAME,
-                    Identifier: FAKE_IDENTIFIER,
+                    TypeName: fakeTypeName,
+                    Identifier: fakeIdentifier,
                 })
             )
         ).thenResolve({
@@ -237,7 +237,7 @@ describe('ResourceManager', function () {
                 Properties: JSON.stringify(fakeResourceDescription),
             },
         })
-        when(cloudFormation.describeType(FAKE_TYPE_NAME)).thenResolve({
+        when(cloudFormation.describeType(fakeTypeName)).thenResolve({
             Schema: '{}',
         })
     }

--- a/src/test/dynamicResources/commands/deleteResource.test.ts
+++ b/src/test/dynamicResources/commands/deleteResource.test.ts
@@ -11,8 +11,8 @@ import { deleteResource } from '../../../dynamicResources/commands/deleteResourc
 import { DefaultCloudControlClient } from '../../../shared/clients/cloudControlClient'
 
 describe('deleteResource', function () {
-    const FAKE_TYPE = 'fakeType'
-    const FAKE_IDENTIFIER = 'fakeIdentifier'
+    const fakeType = 'fakeType'
+    const fakeIdentifier = 'fakeIdentifier'
     const cloudControl = new DefaultCloudControlClient('')
     let sandbox: sinon.SinonSandbox
 
@@ -29,30 +29,30 @@ describe('deleteResource', function () {
         const stub = sandbox
             .stub(cloudControl, 'deleteResource')
             .callsFake(async ({ TypeName: typeName, Identifier: identifier }) => {
-                assert.strictEqual(typeName, FAKE_TYPE)
-                assert.strictEqual(identifier, FAKE_IDENTIFIER)
+                assert.strictEqual(typeName, fakeType)
+                assert.strictEqual(identifier, fakeIdentifier)
             })
 
-        await deleteResource(cloudControl, FAKE_TYPE, FAKE_IDENTIFIER, window)
+        await deleteResource(cloudControl, fakeType, fakeIdentifier, window)
 
-        assert.strictEqual(window.message.warning, `Delete resource ${FAKE_IDENTIFIER} (${FAKE_TYPE})?`)
+        assert.strictEqual(window.message.warning, `Delete resource ${fakeIdentifier} (${fakeType})?`)
 
         assert.strictEqual(stub.calledOnce, true)
 
         assert.strictEqual(window.progress.options?.location, vscode.ProgressLocation.Notification)
         assert.strictEqual(window.progress.options?.cancellable, false)
         assert.deepStrictEqual(window.progress.reported, [
-            { message: `Deleting resource ${FAKE_IDENTIFIER} (${FAKE_TYPE})...` },
+            { message: `Deleting resource ${fakeIdentifier} (${fakeType})...` },
         ])
 
-        assert.ok(window.message.information?.startsWith(`Deleted resource ${FAKE_IDENTIFIER} (${FAKE_TYPE})`))
+        assert.ok(window.message.information?.startsWith(`Deleted resource ${fakeIdentifier} (${fakeType})`))
     })
 
     it('does nothing when deletion is cancelled', async function () {
         const window = new FakeWindow({ message: { warningSelection: 'Cancel' } })
         const spy = sandbox.spy(cloudControl, 'deleteResource')
 
-        await deleteResource(cloudControl, FAKE_TYPE, FAKE_IDENTIFIER, window)
+        await deleteResource(cloudControl, fakeType, fakeIdentifier, window)
 
         assert.strictEqual(spy.notCalled, true)
 
@@ -67,9 +67,9 @@ describe('deleteResource', function () {
 
         const window = new FakeWindow({ message: { warningSelection: 'Delete' } })
 
-        await deleteResource(cloudControl, FAKE_TYPE, FAKE_IDENTIFIER, window)
+        await deleteResource(cloudControl, fakeType, fakeIdentifier, window)
 
-        assert.ok(window.message.error?.startsWith(`Failed to delete resource ${FAKE_IDENTIFIER} (${FAKE_TYPE})`))
+        assert.ok(window.message.error?.startsWith(`Failed to delete resource ${fakeIdentifier} (${fakeType})`))
     })
 
     it('shows a warning if unsupported action', async function () {
@@ -81,8 +81,8 @@ describe('deleteResource', function () {
 
         const window = new FakeWindow({ message: { warningSelection: 'Delete' } })
 
-        await deleteResource(cloudControl, FAKE_TYPE, FAKE_IDENTIFIER, window)
+        await deleteResource(cloudControl, fakeType, fakeIdentifier, window)
 
-        assert.ok(window.message.warning?.startsWith(`Resource type ${FAKE_TYPE} does not currently support delete`))
+        assert.ok(window.message.warning?.startsWith(`Resource type ${fakeType} does not currently support delete`))
     })
 })

--- a/src/test/dynamicResources/commands/openResource.test.ts
+++ b/src/test/dynamicResources/commands/openResource.test.ts
@@ -14,11 +14,11 @@ import { ResourceTypeNode } from '../../../dynamicResources/explorer/nodes/resou
 import { getDiagnostics, openResource } from '../../../dynamicResources/commands/openResource'
 
 describe('openResource', function () {
-    const FAKE_TYPE = 'fakeType'
-    const FAKE_IDENTIFIER = 'fakeIdentifier'
+    const fakeType = 'fakeType'
+    const fakeIdentifier = 'fakeIdentifier'
     let mockResourceManager: AwsResourceManager
     let mockDiagnosticCollection: vscode.DiagnosticCollection
-    const fakeResourceNode = new ResourceNode({ typeName: FAKE_TYPE } as ResourceTypeNode, FAKE_IDENTIFIER)
+    const fakeResourceNode = new ResourceNode({ typeName: fakeType } as ResourceTypeNode, fakeIdentifier)
 
     beforeEach(function () {
         mockResourceManager = mock()
@@ -40,7 +40,7 @@ describe('openResource', function () {
         assert.strictEqual(window.progress.options?.location, vscode.ProgressLocation.Notification)
         assert.strictEqual(window.progress.options?.cancellable, false)
         assert.deepStrictEqual(window.progress.reported, [
-            { message: `Opening resource ${FAKE_IDENTIFIER} (${FAKE_TYPE})...` },
+            { message: `Opening resource ${fakeIdentifier} (${fakeType})...` },
         ])
     })
 
@@ -56,7 +56,7 @@ describe('openResource', function () {
             },
             window
         )
-        assert.ok(window.message.error?.startsWith(`Failed to open resource ${FAKE_IDENTIFIER} (${FAKE_TYPE})`))
+        assert.ok(window.message.error?.startsWith(`Failed to open resource ${fakeIdentifier} (${fakeType})`))
     })
 
     it('handles opening ResourceNodes', async function () {

--- a/src/test/dynamicResources/commands/saveResource.test.ts
+++ b/src/test/dynamicResources/commands/saveResource.test.ts
@@ -12,8 +12,8 @@ import { AddOperation } from 'fast-json-patch'
 import { CloudControlClient } from '../../../shared/clients/cloudControlClient'
 
 describe('createResource', function () {
-    const FAKE_TYPE = 'fakeType'
-    const FAKE_DEFINITION = '{}'
+    const fakeType = 'fakeType'
+    const fakeDefinition = '{}'
 
     let mockCloudControl: CloudControlClient
 
@@ -28,8 +28,8 @@ describe('createResource', function () {
         when(
             mockCloudControl.createResource(
                 deepEqual({
-                    TypeName: FAKE_TYPE,
-                    DesiredState: FAKE_DEFINITION,
+                    TypeName: fakeType,
+                    DesiredState: fakeDefinition,
                 })
             )
         ).thenResolve({
@@ -38,38 +38,38 @@ describe('createResource', function () {
             },
         })
 
-        await createResource(FAKE_TYPE, FAKE_DEFINITION, instance(mockCloudControl), window)
+        await createResource(fakeType, fakeDefinition, instance(mockCloudControl), window)
 
         verify(
             mockCloudControl.createResource(
                 deepEqual({
-                    TypeName: FAKE_TYPE,
-                    DesiredState: FAKE_DEFINITION,
+                    TypeName: fakeType,
+                    DesiredState: fakeDefinition,
                 })
             )
         ).once()
         assert.strictEqual(window.progress.options?.location, vscode.ProgressLocation.Notification)
         assert.strictEqual(window.progress.options?.cancellable, false)
-        assert.deepStrictEqual(window.progress.reported, [{ message: `Creating resource (${FAKE_TYPE})...` }])
+        assert.deepStrictEqual(window.progress.reported, [{ message: `Creating resource (${fakeType})...` }])
 
-        assert.ok(window.message.information?.startsWith(`Created resource ${newIdentifier} (${FAKE_TYPE})`))
+        assert.ok(window.message.information?.startsWith(`Created resource ${newIdentifier} (${fakeType})`))
     })
 
     it('shows an error message when resource creation fails', async function () {
         when(
             mockCloudControl.createResource(
                 deepEqual({
-                    TypeName: FAKE_TYPE,
-                    DesiredState: FAKE_DEFINITION,
+                    TypeName: fakeType,
+                    DesiredState: fakeDefinition,
                 })
             )
         ).thenReject(new Error())
         const window = new FakeWindow()
 
         try {
-            await createResource(FAKE_TYPE, FAKE_DEFINITION, instance(mockCloudControl), window)
+            await createResource(fakeType, fakeDefinition, instance(mockCloudControl), window)
         } catch (err) {
-            assert.ok(window.message.error?.startsWith(`Failed to create resource (${FAKE_TYPE})`))
+            assert.ok(window.message.error?.startsWith(`Failed to create resource (${fakeType})`))
             return
         }
         assert.fail('Expected exception, but none was thrown.')
@@ -78,10 +78,10 @@ describe('createResource', function () {
     it('shows an error message when definition is not valid json', async function () {
         const window = new FakeWindow()
         try {
-            await createResource(FAKE_TYPE, 'foo', instance(mockCloudControl), window)
+            await createResource(fakeType, 'foo', instance(mockCloudControl), window)
         } catch (err) {
             verify(mockCloudControl.createResource(anything())).never()
-            assert.ok(window.message.error?.startsWith(`Failed to create resource (${FAKE_TYPE})`))
+            assert.ok(window.message.error?.startsWith(`Failed to create resource (${fakeType})`))
             return
         }
         assert.fail('Expected exception, but none was thrown.')
@@ -93,25 +93,25 @@ describe('createResource', function () {
         when(
             mockCloudControl.createResource(
                 deepEqual({
-                    TypeName: FAKE_TYPE,
-                    DesiredState: FAKE_DEFINITION,
+                    TypeName: fakeType,
+                    DesiredState: fakeDefinition,
                 })
             )
         ).thenReject(error)
         const window = new FakeWindow()
 
-        await createResource(FAKE_TYPE, FAKE_DEFINITION, instance(mockCloudControl), window)
+        await createResource(fakeType, fakeDefinition, instance(mockCloudControl), window)
 
-        assert.ok(window.message.warning?.startsWith(`${FAKE_TYPE} does not currently support resource creation`))
+        assert.ok(window.message.warning?.startsWith(`${fakeType} does not currently support resource creation`))
     })
 })
 
 describe('updateResource', function () {
-    const FAKE_TYPE = 'fakeType'
-    const FAKE_IDENTIFIER = 'fakeIdentifier'
-    const FAKE_DEFINITION = '{}'
-    const FAKE_OPERATION = { op: 'add', value: 'Foo' } as AddOperation<string>
-    const FAKE_DIFF = [FAKE_OPERATION]
+    const fakeType = 'fakeType'
+    const fakeIdentifier = 'fakeIdentifier'
+    const fakeDefinition = '{}'
+    const fakeOperation = { op: 'add', value: 'Foo' } as AddOperation<string>
+    const fakeDiff = [fakeOperation]
 
     let mockCloudControl: CloudControlClient
 
@@ -121,25 +121,25 @@ describe('updateResource', function () {
 
     it('updates resources, shows progress and confirmation', async function () {
         const window = new FakeWindow()
-        const patchJson = JSON.stringify(FAKE_DIFF)
+        const patchJson = JSON.stringify(fakeDiff)
 
         when(
             mockCloudControl.updateResource(
                 deepEqual({
-                    TypeName: FAKE_TYPE,
-                    Identifier: FAKE_IDENTIFIER,
+                    TypeName: fakeType,
+                    Identifier: fakeIdentifier,
                     PatchDocument: patchJson,
                 })
             )
         ).thenResolve()
 
-        await updateResource(FAKE_TYPE, FAKE_IDENTIFIER, FAKE_DEFINITION, instance(mockCloudControl), window, FAKE_DIFF)
+        await updateResource(fakeType, fakeIdentifier, fakeDefinition, instance(mockCloudControl), window, fakeDiff)
 
         verify(
             mockCloudControl.updateResource(
                 deepEqual({
-                    TypeName: FAKE_TYPE,
-                    Identifier: FAKE_IDENTIFIER,
+                    TypeName: fakeType,
+                    Identifier: fakeIdentifier,
                     PatchDocument: patchJson,
                 })
             )
@@ -147,19 +147,19 @@ describe('updateResource', function () {
         assert.strictEqual(window.progress.options?.location, vscode.ProgressLocation.Notification)
         assert.strictEqual(window.progress.options?.cancellable, false)
         assert.deepStrictEqual(window.progress.reported, [
-            { message: `Updating resource ${FAKE_IDENTIFIER} (${FAKE_TYPE})...` },
+            { message: `Updating resource ${fakeIdentifier} (${fakeType})...` },
         ])
 
-        assert.ok(window.message.information?.startsWith(`Updated resource ${FAKE_IDENTIFIER} (${FAKE_TYPE})`))
+        assert.ok(window.message.information?.startsWith(`Updated resource ${fakeIdentifier} (${fakeType})`))
     })
 
     it('shows an error message when resource update fails', async function () {
-        const patchJson = JSON.stringify(FAKE_DIFF)
+        const patchJson = JSON.stringify(fakeDiff)
         when(
             mockCloudControl.updateResource(
                 deepEqual({
-                    TypeName: FAKE_TYPE,
-                    Identifier: FAKE_IDENTIFIER,
+                    TypeName: fakeType,
+                    Identifier: fakeIdentifier,
                     PatchDocument: patchJson,
                 })
             )
@@ -167,16 +167,9 @@ describe('updateResource', function () {
         const window = new FakeWindow()
 
         try {
-            await updateResource(
-                FAKE_TYPE,
-                FAKE_IDENTIFIER,
-                FAKE_DEFINITION,
-                instance(mockCloudControl),
-                window,
-                FAKE_DIFF
-            )
+            await updateResource(fakeType, fakeIdentifier, fakeDefinition, instance(mockCloudControl), window, fakeDiff)
         } catch (err) {
-            assert.ok(window.message.error?.startsWith(`Failed to update resource ${FAKE_IDENTIFIER} (${FAKE_TYPE})`))
+            assert.ok(window.message.error?.startsWith(`Failed to update resource ${fakeIdentifier} (${fakeType})`))
             return
         }
         assert.fail('Expected exception, but none was thrown.')
@@ -185,27 +178,27 @@ describe('updateResource', function () {
     it('shows a warning message when there is no diff', async function () {
         const window = new FakeWindow()
 
-        await updateResource(FAKE_TYPE, FAKE_IDENTIFIER, FAKE_DEFINITION, instance(mockCloudControl), window, [])
+        await updateResource(fakeType, fakeIdentifier, fakeDefinition, instance(mockCloudControl), window, [])
 
         verify(mockCloudControl.updateResource(anything())).never()
         assert.ok(window.message.warning?.startsWith(`Update cancelled`))
     })
 
     it('shows a warning if unsupported action', async function () {
-        const patchJson = JSON.stringify(FAKE_DIFF)
+        const patchJson = JSON.stringify(fakeDiff)
         const error = new Error('fake exception')
         error.name = 'UnsupportedActionException'
         when(
             mockCloudControl.updateResource(
                 deepEqual({
-                    TypeName: FAKE_TYPE,
-                    Identifier: FAKE_IDENTIFIER,
+                    TypeName: fakeType,
+                    Identifier: fakeIdentifier,
                     PatchDocument: patchJson,
                 })
             )
         ).thenReject(error)
         const window = new FakeWindow()
-        await updateResource(FAKE_TYPE, FAKE_IDENTIFIER, FAKE_DEFINITION, instance(mockCloudControl), window, FAKE_DIFF)
-        assert.ok(window.message.warning?.startsWith(`${FAKE_TYPE} does not currently support resource updating`))
+        await updateResource(fakeType, fakeIdentifier, fakeDefinition, instance(mockCloudControl), window, fakeDiff)
+        assert.ok(window.message.warning?.startsWith(`${fakeType} does not currently support resource updating`))
     })
 })

--- a/src/test/dynamicResources/explorer/moreResourcesNode.test.ts
+++ b/src/test/dynamicResources/explorer/moreResourcesNode.test.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode'
 import { ResourcesNode } from '../../../dynamicResources/explorer/nodes/resourcesNode'
 import { ResourceTypeNode } from '../../../dynamicResources/explorer/nodes/resourceTypeNode'
 import { CloudFormationClient } from '../../../shared/clients/cloudFormationClient'
-import { assertNodeListOnlyContainsPlaceholderNode } from '../../utilities/explorerNodeAssertions'
+import { assertNodeListOnlyHasPlaceholderNode } from '../../utilities/explorerNodeAssertions'
 import { asyncGenerator } from '../../utilities/collectionUtils'
 import { mock, instance, when } from 'ts-mockito'
 import { CloudFormation } from 'aws-sdk'
@@ -16,8 +16,8 @@ import { CloudControlClient } from '../../../shared/clients/cloudControlClient'
 import { Settings } from '../../../shared/settings'
 import { ResourcesSettings } from '../../../dynamicResources/commands/configure'
 
-const UNSORTED_TEXT = ['zebra', 'Antelope', 'aardvark', 'elephant']
-const SORTED_TEXT = ['aardvark', 'Antelope', 'elephant', 'zebra']
+const unsortedText = ['zebra', 'Antelope', 'aardvark', 'elephant']
+const sortedText = ['aardvark', 'Antelope', 'elephant', 'zebra']
 
 describe('ResourcesNode', function () {
     let settings: ResourcesSettings
@@ -53,7 +53,7 @@ describe('ResourcesNode', function () {
 
         const childNodes = await testNode.getChildren()
 
-        assertNodeListOnlyContainsPlaceholderNode(childNodes)
+        assertNodeListOnlyHasPlaceholderNode(childNodes)
     })
 
     it('has ResourceTypeNode child nodes', async function () {
@@ -79,14 +79,14 @@ describe('ResourcesNode', function () {
     })
 
     it('sorts child nodes', async function () {
-        resourceTypes = UNSORTED_TEXT
+        resourceTypes = unsortedText
 
         await setConfiguration(resourceTypes)
 
         const childNodes = await testNode.getChildren()
 
         const actualChildOrder = childNodes.map(node => node.label)
-        assert.deepStrictEqual(actualChildOrder, SORTED_TEXT, 'Unexpected child sort order')
+        assert.deepStrictEqual(actualChildOrder, sortedText, 'Unexpected child sort order')
     })
 
     async function setConfiguration(resourceTypes: string[]) {

--- a/src/test/dynamicResources/explorer/resourceNode.test.ts
+++ b/src/test/dynamicResources/explorer/resourceNode.test.ts
@@ -7,35 +7,35 @@ import * as assert from 'assert'
 import { ResourceTypeNode } from '../../../dynamicResources/explorer/nodes/resourceTypeNode'
 import { ResourceNode } from '../../../dynamicResources/explorer/nodes/resourceNode'
 
-const FAKE_IDENTIFIER = 'someidentifier'
-const FAKE_ARN = 'arn:fooPartion:fooService:fooRegion:1234:fooType/someidentifier'
-const FAKE_CONTEXT_VALUE = 'FooContext'
+const fakeIdentifier = 'someidentifier'
+const fakeArn = 'arn:fooPartion:fooService:fooRegion:1234:fooType/someidentifier'
+const fakeContextValue = 'FooContext'
 
 describe('ResourceNode', function () {
     it('initializes name and tooltip', async function () {
-        const testNode = new ResourceNode({} as ResourceTypeNode, FAKE_IDENTIFIER)
-        assert.strictEqual(testNode.label, FAKE_IDENTIFIER)
-        assert.strictEqual(testNode.tooltip, FAKE_IDENTIFIER)
-        assert.strictEqual(testNode.identifier, FAKE_IDENTIFIER)
+        const testNode = new ResourceNode({} as ResourceTypeNode, fakeIdentifier)
+        assert.strictEqual(testNode.label, fakeIdentifier)
+        assert.strictEqual(testNode.tooltip, fakeIdentifier)
+        assert.strictEqual(testNode.identifier, fakeIdentifier)
     })
 
     it('parses resource ARN to get friendly name for label', async function () {
-        const testNode = new ResourceNode({} as ResourceTypeNode, FAKE_ARN)
+        const testNode = new ResourceNode({} as ResourceTypeNode, fakeArn)
         assert.strictEqual(testNode.label, 'fooType/someidentifier')
     })
 
     it('uses full ARN for tooltip', async function () {
-        const testNode = new ResourceNode({} as ResourceTypeNode, FAKE_ARN)
-        assert.strictEqual(testNode.tooltip, FAKE_ARN)
+        const testNode = new ResourceNode({} as ResourceTypeNode, fakeArn)
+        assert.strictEqual(testNode.tooltip, fakeArn)
     })
 
     it('uses provided contextValue', async function () {
-        const testNode = new ResourceNode({} as ResourceTypeNode, FAKE_ARN, FAKE_CONTEXT_VALUE)
-        assert.strictEqual(testNode.contextValue, FAKE_CONTEXT_VALUE)
+        const testNode = new ResourceNode({} as ResourceTypeNode, fakeArn, fakeContextValue)
+        assert.strictEqual(testNode.contextValue, fakeContextValue)
     })
 
     it('uses default contextValue if none is provided', async function () {
-        const testNode = new ResourceNode({} as ResourceTypeNode, FAKE_ARN)
+        const testNode = new ResourceNode({} as ResourceTypeNode, fakeArn)
         assert.strictEqual(testNode.contextValue, 'ResourceNode')
     })
 })

--- a/src/test/dynamicResources/explorer/resourceTypeNode.test.ts
+++ b/src/test/dynamicResources/explorer/resourceTypeNode.test.ts
@@ -10,17 +10,17 @@ import { ResourcesNode } from '../../../dynamicResources/explorer/nodes/resource
 import { ResourceNode } from '../../../dynamicResources/explorer/nodes/resourceNode'
 import { ResourceTypeNode } from '../../../dynamicResources/explorer/nodes/resourceTypeNode'
 import {
-    assertNodeListOnlyContainsErrorNode,
-    assertNodeListOnlyContainsPlaceholderNode,
+    assertNodeListOnlyHasErrorNode,
+    assertNodeListOnlyHasPlaceholderNode,
 } from '../../utilities/explorerNodeAssertions'
 import { deepEqual, instance, mock, when } from '../../utilities/mockito'
 import { CloudControlClient } from '../../../shared/clients/cloudControlClient'
 import { CloudControl } from 'aws-sdk'
 import { ResourceTypeMetadata } from '../../../dynamicResources/model/resources'
 
-const FAKE_TYPE_NAME = 'sometype'
-const UNSORTED_TEXT = ['zebra', 'Antelope', 'aardvark', 'elephant']
-const SORTED_TEXT = ['aardvark', 'Antelope', 'elephant', 'zebra']
+const fakeTypeName = 'sometype'
+const unsortedText = ['zebra', 'Antelope', 'aardvark', 'elephant']
+const sortedText = ['aardvark', 'Antelope', 'elephant', 'zebra']
 
 describe('ResourceTypeNode', function () {
     let testNode: ResourceTypeNode
@@ -38,8 +38,8 @@ describe('ResourceTypeNode', function () {
     })
 
     it('initializes name and tooltip', async function () {
-        assert.strictEqual(testNode.label, FAKE_TYPE_NAME)
-        assert.strictEqual(testNode.tooltip, FAKE_TYPE_NAME)
+        assert.strictEqual(testNode.label, fakeTypeName)
+        assert.strictEqual(testNode.tooltip, fakeTypeName)
     })
 
     it('returns placeholder node if no resources are found', async function () {
@@ -50,7 +50,7 @@ describe('ResourceTypeNode', function () {
 
         const childNodes = await testNode.getChildren()
 
-        assertNodeListOnlyContainsPlaceholderNode(childNodes)
+        assertNodeListOnlyHasPlaceholderNode(childNodes)
     })
 
     it('has ResourceNode child nodes', async function () {
@@ -100,7 +100,7 @@ describe('ResourceTypeNode', function () {
     })
 
     it('sorts child nodes', async function () {
-        resourceIdentifiers = UNSORTED_TEXT
+        resourceIdentifiers = unsortedText
         mockCloudControlClient(resourceIdentifiers)
 
         testNode = generateTestNode(instance(cloudControl))
@@ -108,7 +108,7 @@ describe('ResourceTypeNode', function () {
         const childNodes = await testNode.getChildren()
 
         const actualChildOrder = childNodes.map(node => node.label)
-        assert.deepStrictEqual(actualChildOrder, SORTED_TEXT, 'Unexpected child sort order')
+        assert.deepStrictEqual(actualChildOrder, sortedText, 'Unexpected child sort order')
     })
 
     it('has an error node for a child if an error happens during loading', async function () {
@@ -117,7 +117,7 @@ describe('ResourceTypeNode', function () {
         testNode = generateTestNode(instance(cloudControl))
 
         const childNodes = await testNode.getChildren()
-        assertNodeListOnlyContainsErrorNode(childNodes)
+        assertNodeListOnlyHasErrorNode(childNodes)
     })
 
     it('has a placeholder node for a child if unsupported action', async function () {
@@ -128,7 +128,7 @@ describe('ResourceTypeNode', function () {
         testNode = generateTestNode(instance(cloudControl))
 
         const childNodes = await testNode.getChildren()
-        assertNodeListOnlyContainsPlaceholderNode(childNodes)
+        assertNodeListOnlyHasPlaceholderNode(childNodes)
     })
 
     it('has Documented contextValue if documentation available', function () {
@@ -177,19 +177,19 @@ describe('ResourceTypeNode', function () {
             documentation,
             available: available ?? true,
         } as ResourceTypeMetadata
-        return new ResourceTypeNode({} as ResourcesNode, FAKE_TYPE_NAME, client, metadata)
+        return new ResourceTypeNode({} as ResourcesNode, fakeTypeName, client, metadata)
     }
 
     function mockCloudControlClient(resourceIdentifiers: string[]): void {
         when(
             cloudControl.listResources(
                 deepEqual({
-                    TypeName: FAKE_TYPE_NAME,
+                    TypeName: fakeTypeName,
                     NextToken: anything(),
                 })
             )
         ).thenResolve({
-            TypeName: FAKE_TYPE_NAME,
+            TypeName: fakeTypeName,
             NextToken: undefined,
             ResourceDescriptions: resourceIdentifiers.map<CloudControl.ResourceDescription>(identifier => {
                 return {

--- a/src/test/dynamicResources/model/resources.test.ts
+++ b/src/test/dynamicResources/model/resources.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert'
 import { getResourceTypes } from '../../../dynamicResources/model/resources'
 
-const FAKE_RESOURCE_MODEL = {
+const fakeResourceModel = {
     Type1: {
         operations: ['CREATE', 'READ', 'DELETE', 'UPDATE'],
         documentation: 'foo',
@@ -23,14 +23,14 @@ const FAKE_RESOURCE_MODEL = {
 
 describe('getResourceTypes', function () {
     it('returns a map of resource types', function () {
-        const types = getResourceTypes(FAKE_RESOURCE_MODEL)
+        const types = getResourceTypes(fakeResourceModel)
         const fakeType = types.get('Type3')
         assert.deepStrictEqual(fakeType?.operations, ['READ', 'LIST'])
         assert.strictEqual(fakeType?.documentation, 'baz')
     })
 
     it('filters out types not supporting LIST operation', function () {
-        const types = getResourceTypes(FAKE_RESOURCE_MODEL)
+        const types = getResourceTypes(fakeResourceModel)
         assert.strictEqual(types.size, 2)
         assert.ok(!types.has('Type1'))
     })

--- a/src/test/ecr/explorer/EcrNode.test.ts
+++ b/src/test/ecr/explorer/EcrNode.test.ts
@@ -10,7 +10,7 @@ import { EcrNode } from '../../../ecr/explorer/ecrNode'
 import { EcrRepositoryNode } from '../../../ecr/explorer/ecrRepositoryNode'
 import { PlaceholderNode } from '../../../shared/treeview/nodes/placeholderNode'
 import { EcrTagNode } from '../../../ecr/explorer/ecrTagNode'
-import { assertNodeListOnlyContainsErrorNode } from '../../utilities/explorerNodeAssertions'
+import { assertNodeListOnlyHasErrorNode } from '../../utilities/explorerNodeAssertions'
 
 describe('EcrNode', function () {
     let ecr: EcrClient
@@ -65,7 +65,7 @@ describe('EcrNode', function () {
 
         const children = await new EcrNode(ecr).getChildren()
 
-        assertNodeListOnlyContainsErrorNode(children)
+        assertNodeListOnlyHasErrorNode(children)
         assert.ok(stub.calledOnce)
     })
 })
@@ -128,7 +128,7 @@ describe('EcrRepositoryNode', function () {
 
         const children = await new EcrRepositoryNode({} as EcrNode, ecr, repository).getChildren()
 
-        assertNodeListOnlyContainsErrorNode(children)
+        assertNodeListOnlyHasErrorNode(children)
         assert.ok(stub.calledOnce)
     })
 })

--- a/src/test/eventSchemas/commands/downloadSchemaItemCode.test.ts
+++ b/src/test/eventSchemas/commands/downloadSchemaItemCode.test.ts
@@ -207,8 +207,8 @@ describe('CodeGeneratorStatusPoller', function () {
     const language = 'Java8'
     const schemaVersion = 'testVersion'
 
-    const RETRY_INTERVAL_MS = 1
-    const MAX_RETRIES = 2
+    const retryIntervalMs = 1
+    const maxRetries = 2
 
     enum CodeGenerationStatus {
         CREATE_COMPLETE = 'CREATE_COMPLETE',
@@ -273,7 +273,7 @@ describe('CodeGeneratorStatusPoller', function () {
                 .returns(Promise.resolve(schemaResponse.Status))
 
             await assert.rejects(
-                statuspoller.pollForCompletion(request, RETRY_INTERVAL_MS, MAX_RETRIES),
+                statuspoller.pollForCompletion(request, retryIntervalMs, maxRetries),
                 new Error(
                     `Failed to download code for schema ${request.schemaName} before timeout. Please try again later`
                 ),
@@ -281,8 +281,8 @@ describe('CodeGeneratorStatusPoller', function () {
             )
             assert.strictEqual(
                 statusPoll.callCount,
-                MAX_RETRIES,
-                'getCurrentStatus should be called MAX_RETRIES times before timing out'
+                maxRetries,
+                'getCurrentStatus should be called maxRetries times before timing out'
             )
         })
 
@@ -295,7 +295,7 @@ describe('CodeGeneratorStatusPoller', function () {
                 .stub(statuspoller, 'getCurrentStatus')
                 .withArgs(request)
                 .returns(Promise.resolve(schemaResponse.Status))
-            const status = await statuspoller.pollForCompletion(request, RETRY_INTERVAL_MS, MAX_RETRIES)
+            const status = await statuspoller.pollForCompletion(request, retryIntervalMs, maxRetries)
             assert.strictEqual(
                 statusPoll.callCount,
                 1,
@@ -309,11 +309,11 @@ describe('CodeGeneratorStatusPoller', function () {
             statusPoll.onCall(0).returns(Promise.resolve(CodeGenerationStatus.CREATE_IN_PROGRESS))
             statusPoll.onCall(1).returns(Promise.resolve(CodeGenerationStatus.CREATE_COMPLETE)) // After maxAttempts
 
-            const status = await statuspoller.pollForCompletion(request, RETRY_INTERVAL_MS, MAX_RETRIES)
+            const status = await statuspoller.pollForCompletion(request, retryIntervalMs, maxRetries)
             assert.strictEqual(
                 statusPoll.callCount,
-                MAX_RETRIES,
-                'getCurrentStatus should be called MAX_RETRIES(2) times as it returns CREATE_COMPLETE on the 2nd call'
+                maxRetries,
+                'getCurrentStatus should be called maxRetries(2) times as it returns CREATE_COMPLETE on the 2nd call'
             )
             assert.strictEqual(status, CodeGenerationStatus.CREATE_COMPLETE, 'status should match')
         })

--- a/src/test/eventSchemas/commands/searchSchemas.test.ts
+++ b/src/test/eventSchemas/commands/searchSchemas.test.ts
@@ -36,10 +36,10 @@ describe('Search Schemas', function () {
     })
 
     const schemaClient = new DefaultSchemaClient('')
-    const TEST_REGISTRY = 'testRegistry'
-    const TEST_REGISTRY2 = 'testRegistry2'
-    const FAIL_REGISTRY = 'failRegistry'
-    const FAIL_REGISTRY2 = 'failRegistry2'
+    const testRegistry = 'testRegistry'
+    const testRegistry2 = 'testRegistry2'
+    const failRegistry = 'failRegistry'
+    const failRegistry2 = 'failRegistry2'
 
     const versionSummary1: Schemas.SearchSchemaVersionSummary = {
         SchemaVersion: '1',
@@ -48,19 +48,19 @@ describe('Search Schemas', function () {
         SchemaVersion: '2',
     }
     const searchSummary1: Schemas.SearchSchemaSummary = {
-        RegistryName: TEST_REGISTRY,
+        RegistryName: testRegistry,
         SchemaName: 'testSchema1',
         SchemaVersions: [versionSummary1, versionSummary2],
     }
 
     const searchSummary2: Schemas.SearchSchemaSummary = {
-        RegistryName: TEST_REGISTRY,
+        RegistryName: testRegistry,
         SchemaName: 'testSchema2',
         SchemaVersions: [versionSummary1],
     }
 
     const searchSummary3: Schemas.SearchSchemaSummary = {
-        RegistryName: TEST_REGISTRY2,
+        RegistryName: testRegistry2,
         SchemaName: 'testSchema3',
         SchemaVersions: [versionSummary1],
     }
@@ -86,7 +86,7 @@ describe('Search Schemas', function () {
             const client = stub(DefaultSchemaClient, { regionCode: 'region-1' })
             client.searchSchemas.returns(asyncGenerator([searchSummary1, searchSummary2]))
 
-            const results = await getSearchListForSingleRegistry(client, TEST_REGISTRY, 'searchText')
+            const results = await getSearchListForSingleRegistry(client, testRegistry, 'searchText')
 
             assert.strictEqual(results.length, 2, 'search should return 2 summaries')
 
@@ -107,17 +107,17 @@ describe('Search Schemas', function () {
                 'title should be same as schemaName, no prefix appended'
             )
 
-            assert.strictEqual(results[0].RegistryName, TEST_REGISTRY, 'summary should belong to requested registry')
-            assert.strictEqual(results[1].RegistryName, TEST_REGISTRY, 'summary should belong to requested registry')
+            assert.strictEqual(results[0].RegistryName, testRegistry, 'summary should belong to requested registry')
+            assert.strictEqual(results[1].RegistryName, testRegistry, 'summary should belong to requested registry')
         })
 
         it('should display an error message when search api call fails', async function () {
             const client = stub(DefaultSchemaClient, { regionCode: 'region-1' })
             const vscodeSpy = sandbox.spy(vscode.window, 'showErrorMessage')
-            const displayMessage = `Unable to search registry ${FAIL_REGISTRY}`
+            const displayMessage = `Unable to search registry ${failRegistry}`
 
             //make an api call with non existent registryName - should return empty results
-            const results = await getSearchListForSingleRegistry(client, FAIL_REGISTRY, 'randomText')
+            const results = await getSearchListForSingleRegistry(client, failRegistry, 'randomText')
 
             assert.strictEqual(results.length, 0, 'should return 0 summaries')
             assert.strictEqual(vscodeSpy.callCount, 1, ' error message should be shown exactly once')
@@ -128,21 +128,18 @@ describe('Search Schemas', function () {
     describe('getSearchResults', function () {
         it('should display error message for failed registries and return summaries for successful ones', async function () {
             const vscodeSpy = sandbox.spy(vscode.window, 'showErrorMessage')
-            const displayMessage = `Unable to search registry ${FAIL_REGISTRY}`
-            const displayMessage2 = `Unable to search registry ${FAIL_REGISTRY2}`
+            const displayMessage = `Unable to search registry ${failRegistry}`
+            const displayMessage2 = `Unable to search registry ${failRegistry2}`
 
             const searchSummaryList1 = [searchSummary1, searchSummary2]
             const searchSummaryList2 = [searchSummary3]
 
             const searchSchemaStub = sandbox.stub(schemaClient, 'searchSchemas')
-            searchSchemaStub.withArgs('randomText', TEST_REGISTRY).returns(asyncGenerator(searchSummaryList1)).onCall(0)
-            searchSchemaStub
-                .withArgs('randomText', TEST_REGISTRY2)
-                .returns(asyncGenerator(searchSummaryList2))
-                .onCall(1)
+            searchSchemaStub.withArgs('randomText', testRegistry).returns(asyncGenerator(searchSummaryList1)).onCall(0)
+            searchSchemaStub.withArgs('randomText', testRegistry2).returns(asyncGenerator(searchSummaryList2)).onCall(1)
             const results = await getSearchResults(
                 schemaClient,
-                [TEST_REGISTRY, TEST_REGISTRY2, FAIL_REGISTRY, FAIL_REGISTRY2],
+                [testRegistry, testRegistry2, failRegistry, failRegistry2],
                 'randomText'
             )
 
@@ -152,13 +149,13 @@ describe('Search Schemas', function () {
             results.sort(function (a, b) {
                 return a.RegistryName > b.RegistryName ? 1 : b.RegistryName > a.RegistryName ? -1 : 0
             })
-            const expectedTitle1 = TEST_REGISTRY.concat('/', searchSummary1.SchemaName!)
-            const expectedTitle2 = TEST_REGISTRY.concat('/', searchSummary2.SchemaName!)
-            const expectedTitle3 = TEST_REGISTRY2.concat('/', searchSummary3.SchemaName!)
+            const expectedTitle1 = testRegistry.concat('/', searchSummary1.SchemaName!)
+            const expectedTitle2 = testRegistry.concat('/', searchSummary2.SchemaName!)
+            const expectedTitle3 = testRegistry2.concat('/', searchSummary3.SchemaName!)
 
-            assert.strictEqual(results[0].RegistryName, TEST_REGISTRY, 'sumnmary should belong to requested registry')
-            assert.strictEqual(results[1].RegistryName, TEST_REGISTRY, 'sumnmary should belong to requested registry')
-            assert.strictEqual(results[2].RegistryName, TEST_REGISTRY2, 'sumnmary should belong to requested registry')
+            assert.strictEqual(results[0].RegistryName, testRegistry, 'sumnmary should belong to requested registry')
+            assert.strictEqual(results[1].RegistryName, testRegistry, 'sumnmary should belong to requested registry')
+            assert.strictEqual(results[2].RegistryName, testRegistry2, 'sumnmary should belong to requested registry')
 
             assert.strictEqual(results[0].Title, expectedTitle1, 'title should be prefixed with registryName')
             assert.strictEqual(results[1].Title, expectedTitle2, 'title should be prefixed with registryName')
@@ -176,17 +173,17 @@ describe('Search Schemas', function () {
     })
 
     describe('handleMessage', function () {
-        const singleRegistryName = [TEST_REGISTRY]
-        const multipleRegistryNames = [TEST_REGISTRY, TEST_REGISTRY2]
-        const AWS_EVENT_SCHEMA_RAW =
+        const singleRegistryName = [testRegistry]
+        const multipleRegistryNames = [testRegistry, testRegistry2]
+        const awsEventSchemaRaw =
             '{"openapi":"3.0.0","info":{"version":"1.0.0","title":"Event"},"paths":{},"components":{"schemas":{"Event":{"type":"object"}}}}'
         const schemaResponse: Schemas.DescribeSchemaResponse = {
-            Content: AWS_EVENT_SCHEMA_RAW,
+            Content: awsEventSchemaRaw,
         }
 
         it('shows schema content for latest matching schema version by default', async function () {
             const versionedSummary = {
-                RegistryName: TEST_REGISTRY,
+                RegistryName: testRegistry,
                 Title: getPageHeader(singleRegistryName),
                 VersionList: ['3', '2', '1'],
             }
@@ -206,7 +203,7 @@ describe('Search Schemas', function () {
 
         it('shows schema content for user selected version', async function () {
             const versionedSummary = {
-                RegistryName: TEST_REGISTRY,
+                RegistryName: testRegistry,
                 Title: getPageHeader(multipleRegistryNames),
                 VersionList: ['1'],
             }
@@ -225,23 +222,23 @@ describe('Search Schemas', function () {
 
         it('shows schema list when user makes a search', async function () {
             const expectResults1 = {
-                RegistryName: TEST_REGISTRY,
-                Title: TEST_REGISTRY + '/testSchema1',
+                RegistryName: testRegistry,
+                Title: testRegistry + '/testSchema1',
                 VersionList: ['2', '1'],
             }
             const expectResults2 = {
-                RegistryName: TEST_REGISTRY,
-                Title: TEST_REGISTRY + '/testSchema2',
+                RegistryName: testRegistry,
+                Title: testRegistry + '/testSchema2',
                 VersionList: ['1'],
             }
 
             const searchSummaryList = [searchSummary1, searchSummary2]
             sandbox
                 .stub(schemaClient, 'searchSchemas')
-                .withArgs('searchText', TEST_REGISTRY)
+                .withArgs('searchText', testRegistry)
                 .returns(asyncGenerator(searchSummaryList))
 
-            const webview = createWebview([TEST_REGISTRY, TEST_REGISTRY])
+            const webview = createWebview([testRegistry, testRegistry])
             const resp = await webview.searchSchemas('searchText')
 
             assert.deepStrictEqual(resp.results, [expectResults1, expectResults2])
@@ -252,25 +249,25 @@ describe('Search Schemas', function () {
     describe('getRegistryNameList', function () {
         it('should return list with single registry name for registryItemNode', async function () {
             const fakeRegistryNew = {
-                RegistryName: TEST_REGISTRY,
+                RegistryName: testRegistry,
                 RegistryArn: 'arn:aws:schemas:us-west-2:19930409:registry/testRegistry',
             }
 
             const registryItemNode = new RegistryItemNode(fakeRegistryNew, schemaClient)
 
             const result = await getRegistryNames(registryItemNode, schemaClient)
-            assert.deepStrictEqual(result, [TEST_REGISTRY], 'should have a single registry name in it')
+            assert.deepStrictEqual(result, [testRegistry], 'should have a single registry name in it')
         })
 
         it('should return list with multiple registry names for schemasNode', async function () {
             const schemasNode = new SchemasNode(schemaClient)
-            const registrySummary1 = { RegistryArn: 'arn:aws:registry/' + TEST_REGISTRY, RegistryName: TEST_REGISTRY }
-            const registrySummary2 = { RegistryArn: 'arn:aws:registry/' + TEST_REGISTRY2, RegistryName: TEST_REGISTRY2 }
+            const registrySummary1 = { RegistryArn: 'arn:aws:registry/' + testRegistry, RegistryName: testRegistry }
+            const registrySummary2 = { RegistryArn: 'arn:aws:registry/' + testRegistry2, RegistryName: testRegistry2 }
 
             sandbox.stub(schemaClient, 'listRegistries').returns(asyncGenerator([registrySummary1, registrySummary2]))
 
             const result = await getRegistryNames(schemasNode, schemaClient)
-            assert.deepStrictEqual(result, [TEST_REGISTRY, TEST_REGISTRY2], 'should have two registry names in it')
+            assert.deepStrictEqual(result, [testRegistry, testRegistry2], 'should have two registry names in it')
         })
 
         it('should return an empty list and display error message if schemas service not available in the region', async function () {

--- a/src/test/eventSchemas/commands/viewSchemaItem.test.ts
+++ b/src/test/eventSchemas/commands/viewSchemaItem.test.ts
@@ -13,11 +13,11 @@ import { SchemaItemNode } from '../../../eventSchemas/explorer/schemaItemNode'
 import { getTabSizeSetting } from '../../../shared/utilities/editorUtilities'
 import { DefaultSchemaClient } from '../../../shared/clients/schemaClient'
 
-const SCHEMA_TAB_SIZE = 2
-const AWS_EVENT_SCHEMA_RAW =
+const schemaTabSize = 2
+const awsEventSchemaRaw =
     '{"openapi":"3.0.0","info":{"version":"1.0.0","title":"Event"},"paths":{},"components":{"schemas":{"Event":{"type":"object","required":["result","cause","event","request-id"],"properties":{"cause":{"type":"string"},"event":{"type":"string"},"request-id":{"type":"string"},"result":{"type":"integer"}}}}}}'
 
-const AWS_EVENT_SCHEMA_PRETTY = `{
+const awsEventSchemaPretty = `{
   "openapi": "3.0.0",
   "info": {
     "version": "1.0.0",
@@ -65,18 +65,18 @@ describe('viewSchemaItem', async function () {
 
     describe('schemaFormatter', function () {
         it('can pretty print schema content', function () {
-            const formattedSchema = schemaFormatter(AWS_EVENT_SCHEMA_RAW, SCHEMA_TAB_SIZE)
-            assert.strictEqual(formattedSchema, AWS_EVENT_SCHEMA_PRETTY, 'Schema content not pretty printed')
+            const formattedSchema = schemaFormatter(awsEventSchemaRaw, schemaTabSize)
+            assert.strictEqual(formattedSchema, awsEventSchemaPretty, 'Schema content not pretty printed')
         })
     })
 
     describe('showSchemaContent', async function () {
         it('inserts pretty schema content into an editor', async function () {
             const insertStub = stubTextEditInsert()
-            await showSchemaContent(AWS_EVENT_SCHEMA_RAW, SCHEMA_TAB_SIZE)
+            await showSchemaContent(awsEventSchemaRaw, schemaTabSize)
 
             assert.strictEqual(insertStub.calledOnce, true, 'should be called once')
-            assert.strictEqual(insertStub.getCalls()[0].args[1], AWS_EVENT_SCHEMA_PRETTY, 'should insert pretty schema')
+            assert.strictEqual(insertStub.getCalls()[0].args[1], awsEventSchemaPretty, 'should insert pretty schema')
         })
     })
 
@@ -85,7 +85,7 @@ describe('viewSchemaItem', async function () {
     const fakeSchema = {
         SchemaName: testSchemaName,
     }
-    const expectedSchema = JSON.stringify(JSON.parse(AWS_EVENT_SCHEMA_RAW), undefined, getTabSizeSetting())
+    const expectedSchema = JSON.stringify(JSON.parse(awsEventSchemaRaw), undefined, getTabSizeSetting())
 
     it('prettifies schema content and inserts into the editor ', async function () {
         const schemaNode = generateSchemaItemNode()
@@ -118,7 +118,7 @@ describe('viewSchemaItem', async function () {
 
     function generateSchemaItemNode(): SchemaItemNode {
         const schemaResponse: Schemas.DescribeSchemaResponse = {
-            Content: AWS_EVENT_SCHEMA_RAW,
+            Content: awsEventSchemaRaw,
         }
         const schemaClient = new DefaultSchemaClient('')
         sandbox.stub(schemaClient, 'describeSchema').returns(Promise.resolve(schemaResponse))

--- a/src/test/eventSchemas/explorer/registryItemNode.test.ts
+++ b/src/test/eventSchemas/explorer/registryItemNode.test.ts
@@ -14,8 +14,8 @@ import { DefaultSchemaClient } from '../../../shared/clients/schemaClient'
 import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
 import { PlaceholderNode } from '../../../shared/treeview/nodes/placeholderNode'
 import {
-    assertNodeListOnlyContainsErrorNode,
-    assertNodeListOnlyContainsPlaceholderNode,
+    assertNodeListOnlyHasErrorNode,
+    assertNodeListOnlyHasPlaceholderNode,
 } from '../../utilities/explorerNodeAssertions'
 import { asyncGenerator } from '../../utilities/collectionUtils'
 import { getIcon } from '../../../shared/icons'
@@ -137,7 +137,7 @@ describe('DefaultRegistryNode', function () {
         const schemasNode = new SchemasNode(createSchemaClient())
         const childNodes = await schemasNode.getChildren()
 
-        assertNodeListOnlyContainsPlaceholderNode(childNodes)
+        assertNodeListOnlyHasPlaceholderNode(childNodes)
     })
 
     it('handles error', async function () {
@@ -155,6 +155,6 @@ describe('DefaultRegistryNode', function () {
         const testNode: ThrowErrorDefaultSchemaRegistrynNode = new ThrowErrorDefaultSchemaRegistrynNode()
 
         const childNodes = await testNode.getChildren()
-        assertNodeListOnlyContainsErrorNode(childNodes)
+        assertNodeListOnlyHasErrorNode(childNodes)
     })
 })

--- a/src/test/eventSchemas/providers/schemasDataProvider.test.ts
+++ b/src/test/eventSchemas/providers/schemasDataProvider.test.ts
@@ -14,16 +14,16 @@ import { asyncGenerator } from '../../utilities/collectionUtils'
 import { stub } from '../../utilities/stubber'
 
 describe('schemasDataProvider', function () {
-    const TEST_REGION = 'testRegion'
-    const TEST_REGION2 = 'testRegion2'
-    const TEST_REGISTRY = 'testRegistry'
-    const TEST_REGISTRY2 = 'testRegistry2'
-    const TEST_SCHEMA = 'testSchema'
-    const TEST_SCHEMA2 = 'testSchema2'
-    const registrySummary1 = { RegistryName: TEST_REGISTRY }
-    const registrySummary2 = { RegistryName: TEST_REGISTRY2 }
-    const schemaSummary = { SchemaName: TEST_SCHEMA }
-    const schemaSummary2 = { SchemaName: TEST_SCHEMA2 }
+    const testRegion = 'testRegion'
+    const testRegion2 = 'testRegion2'
+    const testRegistry = 'testRegistry'
+    const testRegistry2 = 'testRegistry2'
+    const testSchema = 'testSchema'
+    const testSchema2 = 'testSchema2'
+    const registrySummary1 = { RegistryName: testRegistry }
+    const registrySummary2 = { RegistryName: testRegistry2 }
+    const schemaSummary = { SchemaName: testSchema }
+    const schemaSummary2 = { SchemaName: testSchema2 }
     const testCredentials = {} as any as AWS.Credentials
     const testCredentials2 = {} as any as AWS.Credentials
 
@@ -54,19 +54,19 @@ describe('schemasDataProvider', function () {
     describe('getRegistries', function () {
         it('should return registries for given region', async function () {
             const registryNames = await dataProviderObject.getRegistries(
-                TEST_REGION,
+                testRegion,
                 createSchemaClient(),
                 testCredentials
             )
             assert.ok(registryNames!.length === 2, 'unexpected number of registries returned')
-            assert.strictEqual(registryNames![0], TEST_REGISTRY, 'TEST_REGISTRY name should match')
-            assert.strictEqual(registryNames![1], TEST_REGISTRY2, 'TEST_REGISTRY2 name should match')
+            assert.strictEqual(registryNames![0], testRegistry, 'testRegistry name should match')
+            assert.strictEqual(registryNames![1], testRegistry2, 'testRegistry2 name should match')
         })
 
         it('should retain results when it is queried with same credentials ', async function () {
             const client = createSchemaClient()
-            await dataProviderObject.getRegistries(TEST_REGION, client, testCredentials)
-            await dataProviderObject.getRegistries(TEST_REGION2, client, testCredentials)
+            await dataProviderObject.getRegistries(testRegion, client, testCredentials)
+            await dataProviderObject.getRegistries(testRegion2, client, testCredentials)
 
             assert.ok(
                 cacheData.credentialsRegionDataList.length === 1,
@@ -85,8 +85,8 @@ describe('schemasDataProvider', function () {
             const regionData1 = cacheData.credentialsRegionDataList[0].regionDataList[0]
             const regionData2 = cacheData.credentialsRegionDataList[0].regionDataList[1]
 
-            assert.strictEqual(regionData1.region, TEST_REGION)
-            assert.strictEqual(regionData2.region, TEST_REGION2)
+            assert.strictEqual(regionData1.region, testRegion)
+            assert.strictEqual(regionData2.region, testRegion2)
 
             assert.ok(regionData1.registryNames.length === 2, 'First region should have two registryNames')
             assert.ok(regionData2.registryNames.length === 1, 'Second region should have one registryName')
@@ -106,8 +106,8 @@ describe('schemasDataProvider', function () {
 
         it('should retain results when it is queried with different credentials ', async function () {
             const client = createSchemaClient()
-            await dataProviderObject.getRegistries(TEST_REGION, client, testCredentials)
-            await dataProviderObject.getRegistries(TEST_REGION, client, testCredentials2)
+            await dataProviderObject.getRegistries(testRegion, client, testCredentials)
+            await dataProviderObject.getRegistries(testRegion, client, testCredentials2)
 
             assert.ok(cacheData.credentialsRegionDataList.length === 2, 'Cache should contain data for two credentials')
             assert.strictEqual(
@@ -136,7 +136,7 @@ describe('schemasDataProvider', function () {
             client.listRegistries.reset()
             client.listRegistries.throws(new Error('Custom error'))
 
-            const result = await dataProviderObject.getRegistries(TEST_REGION, client, testCredentials)
+            const result = await dataProviderObject.getRegistries(testRegion, client, testCredentials)
 
             assert.strictEqual(result, undefined)
             assert.ok(
@@ -149,8 +149,8 @@ describe('schemasDataProvider', function () {
     describe('getSchemas', function () {
         it('should return schemas for given region', async function () {
             const schemas = await dataProviderObject.getSchemas(
-                TEST_REGION,
-                TEST_REGISTRY,
+                testRegion,
+                testRegistry,
                 createSchemaClient(),
                 testCredentials
             )
@@ -162,8 +162,8 @@ describe('schemasDataProvider', function () {
 
         it('should retain results when it is queried with same credentials ', async function () {
             const client = createSchemaClient()
-            await dataProviderObject.getSchemas(TEST_REGION, TEST_REGISTRY, client, testCredentials)
-            await dataProviderObject.getSchemas(TEST_REGION, TEST_REGISTRY2, client, testCredentials)
+            await dataProviderObject.getSchemas(testRegion, testRegistry, client, testCredentials)
+            await dataProviderObject.getSchemas(testRegion, testRegistry2, client, testCredentials)
 
             assert.ok(
                 cacheData.credentialsRegionDataList.length === 1,
@@ -200,8 +200,8 @@ describe('schemasDataProvider', function () {
 
         it('should retain results when it is queried with different credentials ', async function () {
             const client = createSchemaClient()
-            await dataProviderObject.getSchemas(TEST_REGION, TEST_REGISTRY, client, testCredentials)
-            await dataProviderObject.getSchemas(TEST_REGION, TEST_REGISTRY, client, testCredentials2)
+            await dataProviderObject.getSchemas(testRegion, testRegistry, client, testCredentials)
+            await dataProviderObject.getSchemas(testRegion, testRegistry, client, testCredentials2)
 
             assert.ok(cacheData.credentialsRegionDataList.length === 2, 'Cache should contain data for two credentials')
             assert.strictEqual(
@@ -230,7 +230,7 @@ describe('schemasDataProvider', function () {
             client.listSchemas.reset()
             client.listSchemas.throws(new Error('Custom error'))
 
-            const result = await dataProviderObject.getSchemas(TEST_REGION, TEST_REGISTRY, client, testCredentials)
+            const result = await dataProviderObject.getSchemas(testRegion, testRegistry, client, testCredentials)
 
             assert.strictEqual(result, undefined)
             assert.ok(

--- a/src/test/eventSchemas/templates/schemasAppTemplateUtils.test.ts
+++ b/src/test/eventSchemas/templates/schemasAppTemplateUtils.test.ts
@@ -8,42 +8,43 @@ import { buildSchemaTemplateParameters } from '../../../eventSchemas/templates/s
 import { DefaultSchemaClient } from '../../../shared/clients/schemaClient'
 import { stub } from '../../utilities/stubber'
 import {
-    AWS_EVENT_SCHEMA_CONTENT,
-    CUSTOMER_UPLOADED_SCHEMA,
-    CUSTOMER_UPLOADED_SCHEMA_MULTIPLE_TYPES,
-    PARTNER_SCHEMA_CONTENT,
+    awsEventSchemaContent,
+    customerUploadedSchema,
+    customerUploadedSchemaMultipleTypes,
+    partnerSchemaContent,
 } from './schemasExamples'
 
-const AWS_SCHEMA_NAME = 'aws.ec2@EC2InstanceStateChangeNotification'
-const AWS_SCHEMA_EXPECTED_PACKAGE_NAME = 'schema.aws.ec2.ec2instancestatechangenotification'
-const REGISTRY_NAME = 'Registry'
-const SCHEMA_VERSION = '1'
-const AWS_TOOLKIT_USER_AGENT = 'AWSToolkit'
+const awsSchemaName = 'aws.ec2@EC2InstanceStateChangeNotification'
+const awsSchemaExpectedPackageName = 'schema.aws.ec2.ec2instancestatechangenotification'
+const registryName = 'Registry'
+const schemaVersion = '1'
+const awsToolkitUserAgent = 'AWSToolkit'
 
-const PARTNER_SCHEMA_EXPECTED_PACKAGE_NAME = 'schema.aws.partner.mongodb_com_1234567_tickets.ticket_created'
-const PARTNER_SCHEMA_NAME = 'aws.partner-mongodb.com/1234567-tickets@Ticket.Created'
+const partnerSchemaExpectedPackageName = 'schema.aws.partner.mongodb_com_1234567_tickets.ticket_created'
+const partnerSchemaName = 'aws.partner-mongodb.com/1234567-tickets@Ticket.Created'
 
-const CUSTOMER_UPLOADED_SCHEMA_NAME = 'someCustomer.SomeAwesomeSchema'
-const CUSTOMER_UPLOADED_SCHEMA_EXPECTED_PACKAGE_NAME = 'schema.somecustomer_someawesomeschema'
-const DEFAULT_EVENT_SOURCE = 'INSERT-YOUR-EVENT-SOURCE'
-const DEFAULT_EVENT_DETAIL_TYPE = 'INSERT-YOUR-DETAIL-TYPE'
+const customerUploadedSchemaName = 'someCustomer.SomeAwesomeSchema'
+/** Expected package name. */
+const customerUploadedSchemaExpectedPackage = 'schema.somecustomer_someawesomeschema'
+const defaultEventSource = 'INSERT-YOUR-EVENT-SOURCE'
+const defaultEventDetailType = 'INSERT-YOUR-DETAIL-TYPE'
 
-const CUSTOMER_UPLOADED_SCHEMA_MULTIPLE_TYPES_NAME = 'someCustomer.multipleTypes@SomeOtherAwesomeSchema'
-const CUSTOMER_UPLOADED_SCHEMA_MULTIPLE_TYPES_EXPECTED_PACKAGE_NAME =
-    'schema.somecustomer_multipletypes.someotherawesomeschema'
+const customerUploadedSchemaMultipleTypesName = 'someCustomer.multipleTypes@SomeOtherAwesomeSchema'
+/** Expected package name. */
+const customerUploadedSchemaMultipleTypesPkg = 'schema.somecustomer_multipletypes.someotherawesomeschema'
 
 describe('Build template parameters for AwsEventSchema', async function () {
     it('should build correct template parameters for aws event schema', async function () {
         const schemaClient = stub(DefaultSchemaClient, { regionCode: 'region-1' })
         schemaClient.describeSchema.resolves({
-            Content: AWS_EVENT_SCHEMA_CONTENT,
-            SchemaVersion: SCHEMA_VERSION,
+            Content: awsEventSchemaContent,
+            SchemaVersion: schemaVersion,
         })
 
-        const result = await buildSchemaTemplateParameters(AWS_SCHEMA_NAME, REGISTRY_NAME, schemaClient)
+        const result = await buildSchemaTemplateParameters(awsSchemaName, registryName, schemaClient)
 
-        assert.strictEqual(result.SchemaVersion, SCHEMA_VERSION, 'Schema version not matching')
-        assert.strictEqual(result.templateExtraContent.AWS_Schema_registry, REGISTRY_NAME, 'Registry name not matching')
+        assert.strictEqual(result.SchemaVersion, schemaVersion, 'Schema version not matching')
+        assert.strictEqual(result.templateExtraContent.AWS_Schema_registry, registryName, 'Registry name not matching')
 
         assert.strictEqual(
             result.templateExtraContent.AWS_Schema_name,
@@ -52,7 +53,7 @@ describe('Build template parameters for AwsEventSchema', async function () {
         )
         assert.strictEqual(
             result.templateExtraContent.AWS_Schema_root,
-            AWS_SCHEMA_EXPECTED_PACKAGE_NAME,
+            awsSchemaExpectedPackageName,
             'schemaPackageHierarchy'
         )
 
@@ -68,7 +69,7 @@ describe('Build template parameters for AwsEventSchema', async function () {
         )
         assert.strictEqual(
             result.templateExtraContent.user_agent,
-            AWS_TOOLKIT_USER_AGENT,
+            awsToolkitUserAgent,
             'User agent should be hardcoded to AWSToolkit'
         )
     })
@@ -78,14 +79,14 @@ describe('Build template parameters for PartnerSchema', async function () {
     it('should build correct template parameters for partner schema', async function () {
         const schemaClient = stub(DefaultSchemaClient, { regionCode: 'region-1' })
         schemaClient.describeSchema.resolves({
-            Content: PARTNER_SCHEMA_CONTENT,
-            SchemaVersion: SCHEMA_VERSION,
+            Content: partnerSchemaContent,
+            SchemaVersion: schemaVersion,
         })
 
-        const result = await buildSchemaTemplateParameters(PARTNER_SCHEMA_NAME, REGISTRY_NAME, schemaClient)
+        const result = await buildSchemaTemplateParameters(partnerSchemaName, registryName, schemaClient)
 
-        assert.strictEqual(result.SchemaVersion, SCHEMA_VERSION, 'Schema version not matching')
-        assert.strictEqual(result.templateExtraContent.AWS_Schema_registry, REGISTRY_NAME, 'Registry name not matching')
+        assert.strictEqual(result.SchemaVersion, schemaVersion, 'Schema version not matching')
+        assert.strictEqual(result.templateExtraContent.AWS_Schema_registry, registryName, 'Registry name not matching')
 
         assert.strictEqual(
             result.templateExtraContent.AWS_Schema_name,
@@ -94,7 +95,7 @@ describe('Build template parameters for PartnerSchema', async function () {
         )
         assert.strictEqual(
             result.templateExtraContent.AWS_Schema_root,
-            PARTNER_SCHEMA_EXPECTED_PACKAGE_NAME,
+            partnerSchemaExpectedPackageName,
             'schemaPackageHierarchy'
         )
 
@@ -110,7 +111,7 @@ describe('Build template parameters for PartnerSchema', async function () {
         )
         assert.strictEqual(
             result.templateExtraContent.user_agent,
-            AWS_TOOLKIT_USER_AGENT,
+            awsToolkitUserAgent,
             'User agent should be hardcoded to AWSToolkit'
         )
     })
@@ -120,35 +121,35 @@ describe('Build template parameters for CustomerUploadedSchema', async function 
     it('should build correct template parameters for customer uploaded schema with single type', async function () {
         const schemaClient = stub(DefaultSchemaClient, { regionCode: 'region-1' })
         schemaClient.describeSchema.resolves({
-            Content: CUSTOMER_UPLOADED_SCHEMA,
-            SchemaVersion: SCHEMA_VERSION,
+            Content: customerUploadedSchema,
+            SchemaVersion: schemaVersion,
         })
 
-        const result = await buildSchemaTemplateParameters(CUSTOMER_UPLOADED_SCHEMA_NAME, REGISTRY_NAME, schemaClient)
+        const result = await buildSchemaTemplateParameters(customerUploadedSchemaName, registryName, schemaClient)
 
-        assert.strictEqual(result.SchemaVersion, SCHEMA_VERSION, 'Schema version not matching')
-        assert.strictEqual(result.templateExtraContent.AWS_Schema_registry, REGISTRY_NAME, 'Registry name not matching')
+        assert.strictEqual(result.SchemaVersion, schemaVersion, 'Schema version not matching')
+        assert.strictEqual(result.templateExtraContent.AWS_Schema_registry, registryName, 'Registry name not matching')
 
         assert.strictEqual(result.templateExtraContent.AWS_Schema_name, 'Some_Awesome_Schema', 'schemaRootEventName')
         assert.strictEqual(
             result.templateExtraContent.AWS_Schema_root,
-            CUSTOMER_UPLOADED_SCHEMA_EXPECTED_PACKAGE_NAME,
+            customerUploadedSchemaExpectedPackage,
             'schemaPackageHierarchy'
         )
 
         assert.strictEqual(
             result.templateExtraContent.AWS_Schema_source,
-            DEFAULT_EVENT_SOURCE,
+            defaultEventSource,
             'custom schemas should have default event source'
         )
         assert.strictEqual(
             result.templateExtraContent.AWS_Schema_detail_type,
-            DEFAULT_EVENT_DETAIL_TYPE,
+            defaultEventDetailType,
             'custom schemas should have default detail type'
         )
         assert.strictEqual(
             result.templateExtraContent.user_agent,
-            AWS_TOOLKIT_USER_AGENT,
+            awsToolkitUserAgent,
             'User agent should be hardcoded to AWSToolkit'
         )
     })
@@ -158,18 +159,18 @@ describe('Build template parameters for CustomerUploadedSchemaMultipleTypes', as
     it('should  build correct template parameters for customer uploaded schema with multiple types', async function () {
         const schemaClient = stub(DefaultSchemaClient, { regionCode: 'region-1' })
         schemaClient.describeSchema.resolves({
-            Content: CUSTOMER_UPLOADED_SCHEMA_MULTIPLE_TYPES,
-            SchemaVersion: SCHEMA_VERSION,
+            Content: customerUploadedSchemaMultipleTypes,
+            SchemaVersion: schemaVersion,
         })
 
         const result = await buildSchemaTemplateParameters(
-            CUSTOMER_UPLOADED_SCHEMA_MULTIPLE_TYPES_NAME,
-            REGISTRY_NAME,
+            customerUploadedSchemaMultipleTypesName,
+            registryName,
             schemaClient
         )
 
-        assert.strictEqual(result.SchemaVersion, SCHEMA_VERSION, 'Schema version not matching')
-        assert.strictEqual(result.templateExtraContent.AWS_Schema_registry, REGISTRY_NAME, 'Registry name not matching')
+        assert.strictEqual(result.SchemaVersion, schemaVersion, 'Schema version not matching')
+        assert.strictEqual(result.templateExtraContent.AWS_Schema_registry, registryName, 'Registry name not matching')
 
         assert.strictEqual(
             result.templateExtraContent.AWS_Schema_name,
@@ -178,23 +179,23 @@ describe('Build template parameters for CustomerUploadedSchemaMultipleTypes', as
         )
         assert.strictEqual(
             result.templateExtraContent.AWS_Schema_root,
-            CUSTOMER_UPLOADED_SCHEMA_MULTIPLE_TYPES_EXPECTED_PACKAGE_NAME,
+            customerUploadedSchemaMultipleTypesPkg,
             'schemaPackageHierarchy'
         )
 
         assert.strictEqual(
             result.templateExtraContent.AWS_Schema_source,
-            DEFAULT_EVENT_SOURCE,
+            defaultEventSource,
             'custom schemas should have default event source'
         )
         assert.strictEqual(
             result.templateExtraContent.AWS_Schema_detail_type,
-            DEFAULT_EVENT_DETAIL_TYPE,
+            defaultEventDetailType,
             'custom schemas should have default detail type'
         )
         assert.strictEqual(
             result.templateExtraContent.user_agent,
-            AWS_TOOLKIT_USER_AGENT,
+            awsToolkitUserAgent,
             'User agent should be hardcoded to AWSToolkit'
         )
     })

--- a/src/test/eventSchemas/templates/schemasExamples.ts
+++ b/src/test/eventSchemas/templates/schemasExamples.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export const AWS_EVENT_SCHEMA_CONTENT = `{
+export const awsEventSchemaContent = `{
     "openapi" : "3.0.0",
     "info" : {
       "version" : "1.0.0",
@@ -68,7 +68,7 @@ export const AWS_EVENT_SCHEMA_CONTENT = `{
     }
   }`
 
-export const PARTNER_SCHEMA_CONTENT = `{
+export const partnerSchemaContent = `{
     "openapi": "3.0.0",
     "info": {
       "version": "1.0.0",
@@ -136,7 +136,7 @@ export const PARTNER_SCHEMA_CONTENT = `{
     }
   }`
 
-export const CUSTOMER_UPLOADED_SCHEMA = `{
+export const customerUploadedSchema = `{
     "openapi": "3.0.0",
     "info": {
       "version": "1.0.0",
@@ -164,7 +164,7 @@ export const CUSTOMER_UPLOADED_SCHEMA = `{
     }
   }`
 
-export const CUSTOMER_UPLOADED_SCHEMA_MULTIPLE_TYPES = `{
+export const customerUploadedSchemaMultipleTypes = `{
     "openapi": "3.0.0",
     "info": {
       "version": "1.0.0",

--- a/src/test/fakeExtensionContext.ts
+++ b/src/test/fakeExtensionContext.ts
@@ -10,8 +10,8 @@ import { CredentialsStore } from '../credentials/credentialsStore'
 import { ExtContext } from '../shared/extensions'
 import { SamCliContext } from '../shared/sam/cli/samCliContext'
 import {
-    MINIMUM_SAM_CLI_VERSION_INCLUSIVE,
-    MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_GO_SUPPORT,
+    minSamCliVersion,
+    minSamCliVersionForGoSupport,
     SamCliValidator,
     SamCliValidatorResult,
     SamCliVersionValidation,
@@ -113,7 +113,7 @@ export class FakeExtensionContext implements vscode.ExtensionContext {
                 invoker: new TestSamCliProcessInvoker((spawnOptions, args: any[]): ChildProcessResult => {
                     return new FakeChildProcessResult({})
                 }),
-                validator: new FakeSamCliValidator(MINIMUM_SAM_CLI_VERSION_INCLUSIVE_FOR_GO_SUPPORT),
+                validator: new FakeSamCliValidator(minSamCliVersionForGoSupport),
             } as SamCliContext
         }
         const regionProvider = createTestRegionProvider({ globalState: ctx.globalState, awsContext })
@@ -173,7 +173,7 @@ class SecretStorage implements vscode.SecretStorage {
 
 export class FakeSamCliValidator implements SamCliValidator {
     private readonly version: string
-    public constructor(version: string = MINIMUM_SAM_CLI_VERSION_INCLUSIVE) {
+    public constructor(version: string = minSamCliVersion) {
         this.version = version
     }
     public async detectValidSamCli(): Promise<SamCliValidatorResult> {

--- a/src/test/feedback/commands/submitFeedbackListener.test.ts
+++ b/src/test/feedback/commands/submitFeedbackListener.test.ts
@@ -8,9 +8,9 @@ import { TelemetryService } from '../../../shared/telemetry/telemetryService'
 import * as assert from 'assert'
 import { FeedbackWebview } from '../../../feedback/vue/submitFeedback'
 
-const COMMENT = 'comment'
-const SENTIMENT = 'Positive'
-const message = { command: 'submitFeedback', comment: COMMENT, sentiment: SENTIMENT }
+const comment = 'comment'
+const sentiment = 'Positive'
+const message = { command: 'submitFeedback', comment: comment, sentiment: sentiment }
 
 describe('submitFeedbackListener', function () {
     let mockTelemetry: TelemetryService
@@ -23,7 +23,7 @@ describe('submitFeedbackListener', function () {
         const webview = new FeedbackWebview(instance(mockTelemetry))
         await webview.submit(message)
 
-        verify(mockTelemetry.postFeedback(deepEqual({ comment: COMMENT, sentiment: SENTIMENT }))).once()
+        verify(mockTelemetry.postFeedback(deepEqual({ comment: comment, sentiment: sentiment }))).once()
         assert.ok(webview.isDisposed)
     })
 

--- a/src/test/iot/commands/viewPolicyVersion.test.ts
+++ b/src/test/iot/commands/viewPolicyVersion.test.ts
@@ -14,10 +14,10 @@ import { IotClient } from '../../../shared/clients/iotClient'
 import { anything, mock, instance, when, deepEqual } from '../../utilities/mockito'
 import { getTabSizeSetting } from '../../../shared/utilities/editorUtilities'
 
-const AWS_IOT_EXAMPLE_POLICY =
+const awsIotExamplePolicy =
     '{ "Version": "2012-10-17", "Statement": [ {"Effect": "Allow", "Action": "*", "Resource": "*" } ] }'
 
-const expectedPolicy = JSON.stringify(JSON.parse(AWS_IOT_EXAMPLE_POLICY), undefined, getTabSizeSetting())
+const expectedPolicy = JSON.stringify(JSON.parse(awsIotExamplePolicy), undefined, getTabSizeSetting())
 
 describe('viewPolicyVersionCommand', function () {
     const policyName = 'test-policy'
@@ -55,7 +55,7 @@ describe('viewPolicyVersionCommand', function () {
         const showTextDocumentStub = sandbox.stub(vscode.window, 'showTextDocument').resolves({} as vscode.TextEditor)
 
         when(iot.getPolicyVersion(deepEqual({ policyName, policyVersionId: 'V1' }))).thenResolve({
-            policyDocument: AWS_IOT_EXAMPLE_POLICY,
+            policyDocument: awsIotExamplePolicy,
         })
         await viewPolicyVersionCommand(node)
 

--- a/src/test/lambda/commands/createNewSamApp.test.ts
+++ b/src/test/lambda/commands/createNewSamApp.test.ts
@@ -13,7 +13,7 @@ import { FakeExtensionContext } from '../../fakeExtensionContext'
 import {
     addInitialLaunchConfiguration,
     getProjectUri,
-    SAM_INIT_TEMPLATE_FILES,
+    samInitTemplateFiles,
     writeToolkitReadme,
 } from '../../../lambda/commands/createNewSamApp'
 import { LaunchConfiguration } from '../../../shared/debug/launchConfiguration'
@@ -30,7 +30,7 @@ import { getIdeProperties, isCloud9 } from '../../../shared/extensionUtilities'
 import globals from '../../../shared/extensionGlobals'
 import { Runtime } from '../../../shared/telemetry/telemetry'
 
-const TEMPLATE_YAML = 'template.yaml'
+const templateYaml = 'template.yaml'
 
 describe('createNewSamApp', function () {
     let mockLaunchConfiguration: LaunchConfiguration
@@ -47,7 +47,7 @@ describe('createNewSamApp', function () {
         fakeContext = await FakeExtensionContext.getFakeExtContext()
         tempFolder = await makeTemporaryToolkitFolder()
         tempTemplate = vscode.Uri.file(path.join(tempFolder, 'test.yaml'))
-        fakeTarget = path.join(tempFolder, TEMPLATE_YAML)
+        fakeTarget = path.join(tempFolder, templateYaml)
         testutil.toFile('target file', fakeTarget)
 
         fakeWorkspaceFolder = {
@@ -81,7 +81,7 @@ describe('createNewSamApp', function () {
     describe('getProjectUri', function () {
         it('returns the target file when it exists', async function () {
             assert.strictEqual(
-                normalize((await getProjectUri(fakeResponse, SAM_INIT_TEMPLATE_FILES))?.fsPath ?? ''),
+                normalize((await getProjectUri(fakeResponse, samInitTemplateFiles))?.fsPath ?? ''),
                 normalize(fakeTarget)
             )
         })
@@ -91,15 +91,15 @@ describe('createNewSamApp', function () {
             fakeTarget = path.join(tempFolder, 'template.yml')
             testutil.toFile('target file', fakeTarget)
             assert.strictEqual(
-                normalize((await getProjectUri(fakeResponse, SAM_INIT_TEMPLATE_FILES))?.fsPath ?? ''),
+                normalize((await getProjectUri(fakeResponse, samInitTemplateFiles))?.fsPath ?? ''),
                 normalize(fakeTarget)
             )
         })
         it('returns undefined when the target does not exist', async function () {
             const badResponse1 = { location: fakeResponse.location, name: 'notreal' }
             const badResponse2 = { location: vscode.Uri.parse('fake://notreal'), name: 'notafile' }
-            assert.strictEqual((await getProjectUri(badResponse1, SAM_INIT_TEMPLATE_FILES))?.fsPath, undefined)
-            assert.strictEqual((await getProjectUri(badResponse2, SAM_INIT_TEMPLATE_FILES))?.fsPath, undefined)
+            assert.strictEqual((await getProjectUri(badResponse1, samInitTemplateFiles))?.fsPath, undefined)
+            assert.strictEqual((await getProjectUri(badResponse2, samInitTemplateFiles))?.fsPath, undefined)
         })
     })
 
@@ -112,7 +112,7 @@ describe('createNewSamApp', function () {
             const launchConfigs = await addInitialLaunchConfiguration(
                 fakeContext,
                 fakeWorkspaceFolder,
-                (await getProjectUri(fakeResponse, SAM_INIT_TEMPLATE_FILES))!,
+                (await getProjectUri(fakeResponse, samInitTemplateFiles))!,
                 undefined,
                 instance(mockLaunchConfiguration)
             )
@@ -201,7 +201,7 @@ describe('createNewSamApp', function () {
             const launchConfigs = await addInitialLaunchConfiguration(
                 fakeContext,
                 fakeWorkspaceFolder,
-                (await getProjectUri(fakeResponse, SAM_INIT_TEMPLATE_FILES))!,
+                (await getProjectUri(fakeResponse, samInitTemplateFiles))!,
                 undefined,
                 instance(mockLaunchConfiguration)
             )
@@ -229,7 +229,7 @@ describe('createNewSamApp', function () {
             testutil.toFile(makeSampleSamTemplateYaml(true), tempTemplate.fsPath)
             testutil.toFile(makeSampleSamTemplateYaml(true), otherTemplate1.fsPath)
             testutil.toFile(makeSampleSamTemplateYaml(true), otherTemplate2.fsPath)
-            testutil.toFile('target file', path.join(otherFolder1, TEMPLATE_YAML))
+            testutil.toFile('target file', path.join(otherFolder1, templateYaml))
 
             await globals.templateRegistry.cfn.addItemToRegistry(tempTemplate)
             await globals.templateRegistry.cfn.addItemToRegistry(otherTemplate1)
@@ -238,7 +238,7 @@ describe('createNewSamApp', function () {
             const launchConfigs1 = await addInitialLaunchConfiguration(
                 fakeContext,
                 fakeWorkspaceFolder,
-                (await getProjectUri(fakeResponse, SAM_INIT_TEMPLATE_FILES))!,
+                (await getProjectUri(fakeResponse, samInitTemplateFiles))!,
                 undefined,
                 instance(mockLaunchConfiguration)
             )
@@ -248,7 +248,7 @@ describe('createNewSamApp', function () {
                 fakeWorkspaceFolder,
                 (await getProjectUri(
                     { location: fakeWorkspaceFolder.uri, name: 'otherFolder' },
-                    SAM_INIT_TEMPLATE_FILES
+                    samInitTemplateFiles
                 ))!,
                 undefined,
                 instance(mockLaunchConfiguration)

--- a/src/test/lambda/config/samParameterCompletionItemProvider.test.ts
+++ b/src/test/lambda/config/samParameterCompletionItemProvider.test.ts
@@ -72,7 +72,7 @@ function createTemplatesSymbol({
     return templatesSymbol
 }
 
-class MockSamParameterCompletionItemProviderContext implements SamParameterCompletionItemProviderContext {
+class MockSamParamComplItemProviderContext implements SamParameterCompletionItemProviderContext {
     public readonly logger: Pick<Logger, 'warn'>
     public readonly getWorkspaceFolder: typeof vscode.workspace.getWorkspaceFolder
     public readonly executeCommand: typeof vscode.commands.executeCommand
@@ -99,7 +99,7 @@ describe('SamParameterCompletionItemProvider', async function () {
     it('recovers gracefully if document is not in a workspace', async function () {
         const warnArgs: (Error | string)[][] = []
         const provider = new SamParameterCompletionItemProvider(
-            new MockSamParameterCompletionItemProviderContext({
+            new MockSamParamComplItemProviderContext({
                 logger: {
                     warn(...message: (Error | string)[]) {
                         warnArgs.push(message)
@@ -109,14 +109,14 @@ describe('SamParameterCompletionItemProvider', async function () {
             })
         )
 
-        const document: vscode.TextDocument = ({
+        const document: vscode.TextDocument = {
             uri: vscode.Uri.file(path.join('my', 'path')),
-        } as any) as vscode.TextDocument
+        } as any as vscode.TextDocument
         const actualItems = await provider.provideCompletionItems(
             document,
             new vscode.Position(0, 0),
-            ({} as any) as vscode.CancellationToken,
-            ({} as any) as vscode.CompletionContext
+            {} as any as vscode.CancellationToken,
+            {} as any as vscode.CompletionContext
         )
 
         assert.ok(actualItems)
@@ -131,20 +131,20 @@ describe('SamParameterCompletionItemProvider', async function () {
 
     it('does not provide suggestions if document symbols could not be loaded', async function () {
         const provider = new SamParameterCompletionItemProvider(
-            new MockSamParameterCompletionItemProviderContext({
+            new MockSamParamComplItemProviderContext({
                 executeCommand: async () => undefined,
-                getWorkspaceFolder: () => (({ uri: vscode.Uri.file('') } as any) as vscode.WorkspaceFolder),
+                getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
             })
         )
 
-        const document: vscode.TextDocument = ({
+        const document: vscode.TextDocument = {
             uri: vscode.Uri.file(path.join('my', 'path')),
-        } as any) as vscode.TextDocument
+        } as any as vscode.TextDocument
         const actualItems = await provider.provideCompletionItems(
             document,
             new vscode.Position(0, 0),
-            ({} as any) as vscode.CancellationToken,
-            ({} as any) as vscode.CompletionContext
+            {} as any as vscode.CancellationToken,
+            {} as any as vscode.CompletionContext
         )
 
         assert.ok(actualItems)
@@ -153,20 +153,20 @@ describe('SamParameterCompletionItemProvider', async function () {
 
     it('does not provide suggestions if no matching template is found', async function () {
         const provider = new SamParameterCompletionItemProvider(
-            new MockSamParameterCompletionItemProviderContext({
-                executeCommand: async <T>() => ([] as any) as T,
-                getWorkspaceFolder: () => (({ uri: vscode.Uri.file('') } as any) as vscode.WorkspaceFolder),
+            new MockSamParamComplItemProviderContext({
+                executeCommand: async <T>() => [] as any as T,
+                getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
             })
         )
 
-        const document: vscode.TextDocument = ({
+        const document: vscode.TextDocument = {
             uri: vscode.Uri.file(path.join('my', 'path')),
-        } as any) as vscode.TextDocument
+        } as any as vscode.TextDocument
         const actualItems = await provider.provideCompletionItems(
             document,
             new vscode.Position(0, 0),
-            ({} as any) as vscode.CancellationToken,
-            ({} as any) as vscode.CompletionContext
+            {} as any as vscode.CancellationToken,
+            {} as any as vscode.CompletionContext
         )
 
         assert.ok(actualItems)
@@ -180,9 +180,9 @@ describe('SamParameterCompletionItemProvider', async function () {
         })
 
         const provider = new SamParameterCompletionItemProvider(
-            new MockSamParameterCompletionItemProviderContext({
-                executeCommand: async <T>() => ([templatesSymbol] as any) as T,
-                getWorkspaceFolder: () => (({ uri: vscode.Uri.file('') } as any) as vscode.WorkspaceFolder),
+            new MockSamParamComplItemProviderContext({
+                executeCommand: async <T>() => [templatesSymbol] as any as T,
+                getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
                 loadTemplate: async () => ({
                     Parameters: {
                         MyParamName1: {
@@ -196,17 +196,17 @@ describe('SamParameterCompletionItemProvider', async function () {
             })
         )
 
-        const document: vscode.TextDocument = ({
+        const document: vscode.TextDocument = {
             uri: vscode.Uri.file(path.join('.aws', 'templates.json')),
             getWordRangeAtPosition: () => new vscode.Range(3, 0, 3, 10),
             getText: () => '',
-        } as any) as vscode.TextDocument
+        } as any as vscode.TextDocument
 
         const actualItems = await provider.provideCompletionItems(
             document,
             new vscode.Position(3, 0),
-            ({} as any) as vscode.CancellationToken,
-            ({} as any) as vscode.CompletionContext
+            {} as any as vscode.CancellationToken,
+            {} as any as vscode.CompletionContext
         )
 
         assert.ok(actualItems)
@@ -222,9 +222,9 @@ describe('SamParameterCompletionItemProvider', async function () {
         })
 
         const provider = new SamParameterCompletionItemProvider(
-            new MockSamParameterCompletionItemProviderContext({
-                executeCommand: async <T>() => ([templatesSymbol] as any) as T,
-                getWorkspaceFolder: () => (({ uri: vscode.Uri.file('') } as any) as vscode.WorkspaceFolder),
+            new MockSamParamComplItemProviderContext({
+                executeCommand: async <T>() => [templatesSymbol] as any as T,
+                getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
                 loadTemplate: async () => ({
                     Parameters: {
                         MyParamName1: {
@@ -241,17 +241,17 @@ describe('SamParameterCompletionItemProvider', async function () {
             })
         )
 
-        const document: vscode.TextDocument = ({
+        const document: vscode.TextDocument = {
             uri: vscode.Uri.file(path.join('.aws', 'templates.json')),
             getWordRangeAtPosition: () => new vscode.Range(3, 0, 3, 10),
             getText: () => 'MyParamName',
-        } as any) as vscode.TextDocument
+        } as any as vscode.TextDocument
 
         const actualItems = await provider.provideCompletionItems(
             document,
             new vscode.Position(3, 0),
-            ({} as any) as vscode.CancellationToken,
-            ({} as any) as vscode.CompletionContext
+            {} as any as vscode.CancellationToken,
+            {} as any as vscode.CompletionContext
         )
 
         assert.ok(actualItems)
@@ -262,17 +262,17 @@ describe('SamParameterCompletionItemProvider', async function () {
 
     it('recovers gracefully if templates.json is empty or invalid', async function () {
         const provider = new SamParameterCompletionItemProvider(
-            new MockSamParameterCompletionItemProviderContext({
+            new MockSamParamComplItemProviderContext({
                 executeCommand: async <T>() => undefined,
-                getWorkspaceFolder: () => (({ uri: vscode.Uri.file('') } as any) as vscode.WorkspaceFolder),
+                getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
             })
         )
 
         const actualItems = await provider.provideCompletionItems(
-            ({ uri: vscode.Uri.file(path.join('.aws', 'templates.json')) } as any) as vscode.TextDocument,
+            { uri: vscode.Uri.file(path.join('.aws', 'templates.json')) } as any as vscode.TextDocument,
             new vscode.Position(0, 0),
-            ({} as any) as vscode.CancellationToken,
-            ({} as any) as vscode.CompletionContext
+            {} as any as vscode.CancellationToken,
+            {} as any as vscode.CompletionContext
         )
 
         assert.ok(actualItems)
@@ -286,9 +286,9 @@ describe('SamParameterCompletionItemProvider', async function () {
         })
 
         const provider = new SamParameterCompletionItemProvider(
-            new MockSamParameterCompletionItemProviderContext({
-                executeCommand: async <T>() => ([templatesSymbol] as any) as T,
-                getWorkspaceFolder: () => (({ uri: vscode.Uri.file('') } as any) as vscode.WorkspaceFolder),
+            new MockSamParamComplItemProviderContext({
+                executeCommand: async <T>() => [templatesSymbol] as any as T,
+                getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
                 loadTemplate: async () => ({
                     Parameters: {
                         MyParamName1: {
@@ -305,17 +305,17 @@ describe('SamParameterCompletionItemProvider', async function () {
             })
         )
 
-        const document: vscode.TextDocument = ({
+        const document: vscode.TextDocument = {
             uri: vscode.Uri.file(path.join('.aws', 'templates.json')),
             getWordRangeAtPosition: () => new vscode.Range(3, 0, 3, 10),
             getText: () => 'MyParamName',
-        } as any) as vscode.TextDocument
+        } as any as vscode.TextDocument
 
         const actualItems = await provider.provideCompletionItems(
             document,
             new vscode.Position(11, 0),
-            ({} as any) as vscode.CancellationToken,
-            ({} as any) as vscode.CompletionContext
+            {} as any as vscode.CancellationToken,
+            {} as any as vscode.CompletionContext
         )
 
         assert.ok(actualItems)
@@ -325,9 +325,9 @@ describe('SamParameterCompletionItemProvider', async function () {
     it('recovers gracefully if `parameterOverrides` is not defined for this template', async function () {
         const templatesSymbol = createTemplatesSymbol({})
         const provider = new SamParameterCompletionItemProvider(
-            new MockSamParameterCompletionItemProviderContext({
-                executeCommand: async <T>() => ([templatesSymbol] as any) as T,
-                getWorkspaceFolder: () => (({ uri: vscode.Uri.file('') } as any) as vscode.WorkspaceFolder),
+            new MockSamParamComplItemProviderContext({
+                executeCommand: async <T>() => [templatesSymbol] as any as T,
+                getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
                 loadTemplate: async () => ({
                     Parameters: {
                         MyParamName1: {
@@ -344,17 +344,17 @@ describe('SamParameterCompletionItemProvider', async function () {
             })
         )
 
-        const document: vscode.TextDocument = ({
+        const document: vscode.TextDocument = {
             uri: vscode.Uri.file(path.join('.aws', 'templates.json')),
             getWordRangeAtPosition: () => new vscode.Range(3, 0, 3, 10),
             getText: () => 'MyParamName',
-        } as any) as vscode.TextDocument
+        } as any as vscode.TextDocument
 
         const actualItems = await provider.provideCompletionItems(
             document,
             new vscode.Position(11, 0),
-            ({} as any) as vscode.CancellationToken,
-            ({} as any) as vscode.CompletionContext
+            {} as any as vscode.CancellationToken,
+            {} as any as vscode.CompletionContext
         )
 
         assert.ok(actualItems)
@@ -368,9 +368,9 @@ describe('SamParameterCompletionItemProvider', async function () {
         })
 
         const provider = new SamParameterCompletionItemProvider(
-            new MockSamParameterCompletionItemProviderContext({
-                executeCommand: async <T>() => ([templatesSymbol] as any) as T,
-                getWorkspaceFolder: () => (({ uri: vscode.Uri.file('') } as any) as vscode.WorkspaceFolder),
+            new MockSamParamComplItemProviderContext({
+                executeCommand: async <T>() => [templatesSymbol] as any as T,
+                getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
                 loadTemplate: async () => ({
                     Parameters: {
                         MyParamName1: {
@@ -387,17 +387,17 @@ describe('SamParameterCompletionItemProvider', async function () {
             })
         )
 
-        const document: vscode.TextDocument = ({
+        const document: vscode.TextDocument = {
             uri: vscode.Uri.file(path.join('.aws', 'templates.json')),
             getWordRangeAtPosition: () => new vscode.Range(3, 0, 3, 10),
             getText: () => 'MyParamName',
-        } as any) as vscode.TextDocument
+        } as any as vscode.TextDocument
 
         const actualItems = await provider.provideCompletionItems(
             document,
             new vscode.Position(9, 0),
-            ({} as any) as vscode.CancellationToken,
-            ({} as any) as vscode.CompletionContext
+            {} as any as vscode.CancellationToken,
+            {} as any as vscode.CompletionContext
         )
 
         assert.ok(actualItems)
@@ -411,9 +411,9 @@ describe('SamParameterCompletionItemProvider', async function () {
         })
 
         const provider = new SamParameterCompletionItemProvider(
-            new MockSamParameterCompletionItemProviderContext({
-                executeCommand: async <T>() => ([templatesSymbol] as any) as T,
-                getWorkspaceFolder: () => (({ uri: vscode.Uri.file('') } as any) as vscode.WorkspaceFolder),
+            new MockSamParamComplItemProviderContext({
+                executeCommand: async <T>() => [templatesSymbol] as any as T,
+                getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
                 loadTemplate: async () => ({
                     Parameters: {
                         MyParamName1: {
@@ -430,17 +430,17 @@ describe('SamParameterCompletionItemProvider', async function () {
             })
         )
 
-        const document: vscode.TextDocument = ({
+        const document: vscode.TextDocument = {
             uri: vscode.Uri.file(path.join('.aws', 'templates.json')),
             getWordRangeAtPosition: () => new vscode.Range(3, 0, 3, 10),
             getText: () => 'MyParamName',
-        } as any) as vscode.TextDocument
+        } as any as vscode.TextDocument
 
         const actualItems = await provider.provideCompletionItems(
             document,
             new vscode.Position(4, 0),
-            ({} as any) as vscode.CancellationToken,
-            ({} as any) as vscode.CompletionContext
+            {} as any as vscode.CancellationToken,
+            {} as any as vscode.CompletionContext
         )
 
         assert.ok(actualItems)

--- a/src/test/lambda/explorer/cloudFormationNodes.test.ts
+++ b/src/test/lambda/explorer/cloudFormationNodes.test.ts
@@ -9,7 +9,7 @@ import * as os from 'os'
 import {
     CloudFormationNode,
     CloudFormationStackNode,
-    CONTEXT_VALUE_CLOUDFORMATION_LAMBDA_FUNCTION,
+    contextValueCloudformationLambdaFunction,
 } from '../../../lambda/explorer/cloudFormationNodes'
 import { LambdaFunctionNode } from '../../../lambda/explorer/lambdaFunctionNode'
 import { DefaultCloudFormationClient } from '../../../shared/clients/cloudFormationClient'
@@ -18,8 +18,8 @@ import globals from '../../../shared/extensionGlobals'
 import { TestAWSTreeNode } from '../../shared/treeview/nodes/testAWSTreeNode'
 import { asyncGenerator } from '../../utilities/collectionUtils'
 import {
-    assertNodeListOnlyContainsErrorNode,
-    assertNodeListOnlyContainsPlaceholderNode,
+    assertNodeListOnlyHasErrorNode,
+    assertNodeListOnlyHasPlaceholderNode,
 } from '../../utilities/explorerNodeAssertions'
 import { stub } from '../../utilities/stubber'
 
@@ -92,7 +92,7 @@ describe('CloudFormationStackNode', function () {
         const node = generateTestNode()
         const childNodes = await node.getChildren()
 
-        assertNodeListOnlyContainsPlaceholderNode(childNodes)
+        assertNodeListOnlyHasPlaceholderNode(childNodes)
     })
 
     it('has LambdaFunctionNode child nodes', async function () {
@@ -123,7 +123,7 @@ describe('CloudFormationStackNode', function () {
         childNodes.forEach(node =>
             assert.strictEqual(
                 node.contextValue,
-                CONTEXT_VALUE_CLOUDFORMATION_LAMBDA_FUNCTION,
+                contextValueCloudformationLambdaFunction,
                 'expected the node to have a CloudFormation contextValue'
             )
         )
@@ -152,7 +152,7 @@ describe('CloudFormationStackNode', function () {
         cloudFormationClient.describeStackResources.throws()
 
         const node = generateTestNode({ cloudFormationClient })
-        assertNodeListOnlyContainsErrorNode(await node.getChildren())
+        assertNodeListOnlyHasErrorNode(await node.getChildren())
     })
 })
 
@@ -181,7 +181,7 @@ describe('CloudFormationNode', function () {
         const cloudFormationNode = new CloudFormationNode(regionCode, client)
         const children = await cloudFormationNode.getChildren()
 
-        assertNodeListOnlyContainsPlaceholderNode(children)
+        assertNodeListOnlyHasPlaceholderNode(children)
     })
 
     it('has an error node for a child if an error happens during loading', async function () {
@@ -189,6 +189,6 @@ describe('CloudFormationNode', function () {
         client.listStacks.throws()
         const cloudFormationNode = new CloudFormationNode(regionCode, client)
 
-        assertNodeListOnlyContainsErrorNode(await cloudFormationNode.getChildren())
+        assertNodeListOnlyHasErrorNode(await cloudFormationNode.getChildren())
     })
 })

--- a/src/test/lambda/explorer/lambdaNodes.test.ts
+++ b/src/test/lambda/explorer/lambdaNodes.test.ts
@@ -5,11 +5,11 @@
 
 import * as assert from 'assert'
 import { LambdaFunctionNode } from '../../../lambda/explorer/lambdaFunctionNode'
-import { CONTEXT_VALUE_LAMBDA_FUNCTION, LambdaNode } from '../../../lambda/explorer/lambdaNodes'
+import { contextValueLambdaFunction, LambdaNode } from '../../../lambda/explorer/lambdaNodes'
 import { asyncGenerator } from '../../utilities/collectionUtils'
 import {
-    assertNodeListOnlyContainsErrorNode,
-    assertNodeListOnlyContainsPlaceholderNode,
+    assertNodeListOnlyHasErrorNode,
+    assertNodeListOnlyHasPlaceholderNode,
 } from '../../utilities/explorerNodeAssertions'
 import { stub } from '../../utilities/stubber'
 import { DefaultLambdaClient } from '../../../shared/clients/lambdaClient'
@@ -31,7 +31,7 @@ describe('LambdaNode', function () {
     it('returns placeholder node if no children are present', async function () {
         const childNodes = await createNode().getChildren()
 
-        assertNodeListOnlyContainsPlaceholderNode(childNodes)
+        assertNodeListOnlyHasPlaceholderNode(childNodes)
     })
 
     it('has LambdaFunctionNode child nodes', async function () {
@@ -50,7 +50,7 @@ describe('LambdaNode', function () {
         childNodes.forEach(node =>
             assert.strictEqual(
                 node.contextValue,
-                CONTEXT_VALUE_LAMBDA_FUNCTION,
+                contextValueLambdaFunction,
                 'expected the node to have a CloudFormation contextValue'
             )
         )
@@ -68,6 +68,6 @@ describe('LambdaNode', function () {
         client.listFunctions.throws()
         const node = new LambdaNode(regionCode, client)
 
-        assertNodeListOnlyContainsErrorNode(await node.getChildren())
+        assertNodeListOnlyHasErrorNode(await node.getChildren())
     })
 })

--- a/src/test/lambda/models/samTemplates.test.ts
+++ b/src/test/lambda/models/samTemplates.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert'
 import {
-    CLI_VERSION_STEP_FUNCTIONS_TEMPLATE,
+    cliVersionStepFunctionsTemplate,
     getSamCliTemplateParameter,
     getSamTemplateWizardOption,
     getTemplateDescription,
@@ -61,7 +61,7 @@ before(function () {
 describe('getSamTemplateWizardOption', function () {
     it('should successfully return available templates for specific runtime', function () {
         for (const runtime of samZipLambdaRuntimes.values()) {
-            const result = getSamTemplateWizardOption(runtime, 'Zip', CLI_VERSION_STEP_FUNCTIONS_TEMPLATE)
+            const result = getSamTemplateWizardOption(runtime, 'Zip', cliVersionStepFunctionsTemplate)
             switch (runtime) {
                 case 'python3.7':
                 case 'python3.8':

--- a/src/test/s3/explorer/s3FileNode.test.ts
+++ b/src/test/s3/explorer/s3FileNode.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert'
 import * as moment from 'moment'
 import { S3BucketNode } from '../../../s3/explorer/s3BucketNode'
-import { S3_DATE_FORMAT, S3FileNode } from '../../../s3/explorer/s3FileNode'
+import { s3DateFormat, S3FileNode } from '../../../s3/explorer/s3FileNode'
 import { S3Client } from '../../../shared/clients/s3Client'
 
 describe('S3FileNode', function () {
@@ -16,7 +16,7 @@ describe('S3FileNode', function () {
     const sizeBytes = 1024
     const lastModified = new Date(2020, 5, 4, 3, 2, 1)
     const now = new Date(2020, 6, 4)
-    const lastModifiedReadable = moment(lastModified).format(S3_DATE_FORMAT)
+    const lastModifiedReadable = moment(lastModified).format(s3DateFormat)
 
     it('creates an S3 File Node', async function () {
         const node = new S3FileNode(

--- a/src/test/samples/typescript/sampleFunctions.ts
+++ b/src/test/samples/typescript/sampleFunctions.ts
@@ -39,8 +39,8 @@ function exportedViaDeclaration(arg1: string) {}
 const exportedArrowViaDeclaration = (arg1: string) => {}
 const exportedArrowViaDeclarationAlt: (x: string) => void = arg1 => {}
 
-const exportedArrowViaDeclarationWithFourArgs = (arg1: string, arg2: string, arg3: string, arg4: string) => {}
-const exportedArrowViaDeclarationWithFourArgsAlt: (arg1: string, arg2: string, arg3: string, arg4: string) => void = (
+const exportedArrowViaDeclWithFourArgs = (arg1: string, arg2: string, arg3: string, arg4: string) => {}
+const exportedArrowViaDeclWithFourArgsAlt: (arg1: string, arg2: string, arg3: string, arg4: string) => void = (
     arg1,
     arg2,
     arg3,
@@ -48,4 +48,4 @@ const exportedArrowViaDeclarationWithFourArgsAlt: (arg1: string, arg2: string, a
 ) => {}
 
 export { exportedViaDeclaration, exportedArrowViaDeclaration, exportedArrowViaDeclarationAlt }
-export { functionWithFourArgs, exportedArrowViaDeclarationWithFourArgs, exportedArrowViaDeclarationWithFourArgsAlt }
+export { functionWithFourArgs, exportedArrowViaDeclWithFourArgs, exportedArrowViaDeclWithFourArgsAlt }

--- a/src/test/shared/activationReloadState.test.ts
+++ b/src/test/shared/activationReloadState.test.ts
@@ -7,11 +7,11 @@
 
 import * as assert from 'assert'
 import {
-    ACTIVATION_LAUNCH_PATH_KEY,
+    activationLaunchPathKey,
     ActivationReloadState,
-    SAM_INIT_RUNTIME_KEY,
-    SAM_INIT_IMAGE_BOOLEAN_KEY,
-    ACTIVATION_TEMPLATE_PATH_KEY,
+    samInitRuntimeKey,
+    samInitImageBooleanKey,
+    activationTemplatePathKey,
 } from '../../shared/activationReloadState'
 import globals, { checkDidReload } from '../../shared/extensionGlobals'
 
@@ -27,10 +27,10 @@ describe('ActivationReloadState', async function () {
     })
 
     it('decides globals.didReload', async function () {
-        await globals.context.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, undefined)
+        await globals.context.globalState.update(activationLaunchPathKey, undefined)
         assert.strictEqual(checkDidReload(globals.context), false)
 
-        await globals.context.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, '/some/path')
+        await globals.context.globalState.update(activationLaunchPathKey, '/some/path')
         assert.strictEqual(checkDidReload(globals.context), true)
     })
 
@@ -45,22 +45,22 @@ describe('ActivationReloadState', async function () {
             })
 
             assert.strictEqual(
-                globals.context.globalState.get(ACTIVATION_LAUNCH_PATH_KEY),
+                globals.context.globalState.get(activationLaunchPathKey),
                 'somepath',
                 'Unexpected Launch Path value was set'
             )
             assert.strictEqual(
-                globals.context.globalState.get(ACTIVATION_TEMPLATE_PATH_KEY),
+                globals.context.globalState.get(activationTemplatePathKey),
                 'sometemplate',
                 'Unexpected Template Path value was set'
             )
             assert.strictEqual(
-                globals.context.globalState.get(SAM_INIT_RUNTIME_KEY),
+                globals.context.globalState.get(samInitRuntimeKey),
                 undefined,
                 'Unexpected init runtime key value was set'
             )
             assert.strictEqual(
-                globals.context.globalState.get(SAM_INIT_IMAGE_BOOLEAN_KEY),
+                globals.context.globalState.get(samInitImageBooleanKey),
                 false,
                 'Unexpected init image boolean value was set'
             )
@@ -76,22 +76,22 @@ describe('ActivationReloadState', async function () {
             })
 
             assert.strictEqual(
-                globals.context.globalState.get(ACTIVATION_LAUNCH_PATH_KEY),
+                globals.context.globalState.get(activationLaunchPathKey),
                 'somepath',
                 'Unexpected Launch Path value was set'
             )
             assert.strictEqual(
-                globals.context.globalState.get(ACTIVATION_TEMPLATE_PATH_KEY),
+                globals.context.globalState.get(activationTemplatePathKey),
                 'sometemplate',
                 'Unexpected Template Path value was set'
             )
             assert.strictEqual(
-                globals.context.globalState.get(SAM_INIT_RUNTIME_KEY),
+                globals.context.globalState.get(samInitRuntimeKey),
                 'someruntime',
                 'Unexpected init runtime value was set'
             )
             assert.strictEqual(
-                globals.context.globalState.get(SAM_INIT_IMAGE_BOOLEAN_KEY),
+                globals.context.globalState.get(samInitImageBooleanKey),
                 false,
                 'Unexpected init image boolean value was set'
             )
@@ -107,22 +107,22 @@ describe('ActivationReloadState', async function () {
             })
 
             assert.strictEqual(
-                globals.context.globalState.get(ACTIVATION_LAUNCH_PATH_KEY),
+                globals.context.globalState.get(activationLaunchPathKey),
                 'somepath',
                 'Unexpected Launch Path value was set'
             )
             assert.strictEqual(
-                globals.context.globalState.get(ACTIVATION_TEMPLATE_PATH_KEY),
+                globals.context.globalState.get(activationTemplatePathKey),
                 'sometemplate',
                 'Unexpected Template Path value was set'
             )
             assert.strictEqual(
-                globals.context.globalState.get(SAM_INIT_RUNTIME_KEY),
+                globals.context.globalState.get(samInitRuntimeKey),
                 'someruntime',
                 'Unexpected init runtime value was set'
             )
             assert.strictEqual(
-                globals.context.globalState.get(SAM_INIT_IMAGE_BOOLEAN_KEY),
+                globals.context.globalState.get(samInitImageBooleanKey),
                 true,
                 'Unexpected init image boolean value was set'
             )
@@ -131,9 +131,9 @@ describe('ActivationReloadState', async function () {
 
     describe('getSamInitState', async function () {
         it('path defined, without runtime', async function () {
-            await globals.context.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, 'getsomepath')
-            await globals.context.globalState.update(ACTIVATION_TEMPLATE_PATH_KEY, 'gettemplatepath')
-            await globals.context.globalState.update(SAM_INIT_RUNTIME_KEY, undefined)
+            await globals.context.globalState.update(activationLaunchPathKey, 'getsomepath')
+            await globals.context.globalState.update(activationTemplatePathKey, 'gettemplatepath')
+            await globals.context.globalState.update(samInitRuntimeKey, undefined)
 
             assert.strictEqual(
                 activationReloadState.getSamInitState()?.readme,
@@ -158,9 +158,9 @@ describe('ActivationReloadState', async function () {
         })
 
         it('path defined, with runtime', async function () {
-            await globals.context.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, 'getsomepath')
-            await globals.context.globalState.update(ACTIVATION_TEMPLATE_PATH_KEY, 'gettemplatepath')
-            await globals.context.globalState.update(SAM_INIT_RUNTIME_KEY, 'getsomeruntime')
+            await globals.context.globalState.update(activationLaunchPathKey, 'getsomepath')
+            await globals.context.globalState.update(activationTemplatePathKey, 'gettemplatepath')
+            await globals.context.globalState.update(samInitRuntimeKey, 'getsomeruntime')
 
             assert.strictEqual(
                 activationReloadState.getSamInitState()?.readme,
@@ -185,10 +185,10 @@ describe('ActivationReloadState', async function () {
         })
 
         it('path defined, with runtime and isImage', async function () {
-            await globals.context.globalState.update(ACTIVATION_LAUNCH_PATH_KEY, 'getsomepath')
-            await globals.context.globalState.update(ACTIVATION_TEMPLATE_PATH_KEY, 'gettemplatepath')
-            await globals.context.globalState.update(SAM_INIT_RUNTIME_KEY, 'getsomeruntime')
-            await globals.context.globalState.update(SAM_INIT_IMAGE_BOOLEAN_KEY, true)
+            await globals.context.globalState.update(activationLaunchPathKey, 'getsomepath')
+            await globals.context.globalState.update(activationTemplatePathKey, 'gettemplatepath')
+            await globals.context.globalState.update(samInitRuntimeKey, 'getsomeruntime')
+            await globals.context.globalState.update(samInitImageBooleanKey, true)
 
             assert.strictEqual(
                 activationReloadState.getSamInitState()?.readme,
@@ -224,25 +224,25 @@ describe('ActivationReloadState', async function () {
         activationReloadState.clearSamInitState()
 
         assert.strictEqual(
-            globals.context.globalState.get(ACTIVATION_LAUNCH_PATH_KEY),
+            globals.context.globalState.get(activationLaunchPathKey),
             undefined,
             'Expected launch path to be cleared (undefined)'
         )
 
         assert.strictEqual(
-            globals.context.globalState.get(ACTIVATION_TEMPLATE_PATH_KEY),
+            globals.context.globalState.get(activationTemplatePathKey),
             undefined,
             'Expected template path to be cleared (undefined)'
         )
 
         assert.strictEqual(
-            globals.context.globalState.get(SAM_INIT_RUNTIME_KEY),
+            globals.context.globalState.get(samInitRuntimeKey),
             undefined,
             'Expected runtime key to be cleared (undefined)'
         )
 
         assert.strictEqual(
-            globals.context.globalState.get(SAM_INIT_IMAGE_BOOLEAN_KEY),
+            globals.context.globalState.get(samInitImageBooleanKey),
             undefined,
             'Expected isImage key to be cleared (undefined)'
         )

--- a/src/test/shared/clients/iamClient.test.ts
+++ b/src/test/shared/clients/iamClient.test.ts
@@ -21,6 +21,15 @@ describe('iamClient', function () {
         const incorrectPermissionsResponse = {
             EvaluationResults: [{ EvalActionName: 'example:permission', EvalDecision: 'denied' }],
         }
+        const organizationsDenyPermissionsResponse = {
+            EvaluationResults: [
+                {
+                    EvalActionName: 'example:permission',
+                    EvalDecision: 'implicitDeny',
+                    OrganizationsDecisionDetail: { AllowedByOrganizations: false },
+                },
+            ],
+        }
 
         afterEach(function () {
             sinon.restore()
@@ -36,6 +45,11 @@ describe('iamClient', function () {
 
         it('does not return correct task permissions', async function () {
             sinon.stub(iamClient, 'simulatePrincipalPolicy').resolves(correctPermissionsResponse)
+            assert.deepStrictEqual(await iamClient.getDeniedActions(request), [])
+        })
+
+        it('does not return possibly false organizational implicitDeny', async function () {
+            sinon.stub(iamClient, 'simulatePrincipalPolicy').resolves(organizationsDenyPermissionsResponse)
             assert.deepStrictEqual(await iamClient.getDeniedActions(request), [])
         })
     })

--- a/src/test/shared/credentials/credentialsProfileMru.test.ts
+++ b/src/test/shared/credentials/credentialsProfileMru.test.ts
@@ -63,11 +63,11 @@ describe('CredentialsProfileMru', function () {
     it('does not list more than MAX_CRENDTIAL_MRU_SIZE profiles', async function () {
         const credentialsMru = new CredentialsProfileMru(await FakeExtensionContext.create())
 
-        for (let i = 0; i < CredentialsProfileMru.MAX_CREDENTIAL_MRU_SIZE + 1; i++) {
+        for (let i = 0; i < CredentialsProfileMru.maxCredentialMruSize + 1; i++) {
             await credentialsMru.setMostRecentlyUsedProfile(`entry${i}`)
         }
 
         const mru = credentialsMru.getMruList()
-        assert.strictEqual(mru.length, CredentialsProfileMru.MAX_CREDENTIAL_MRU_SIZE)
+        assert.strictEqual(mru.length, CredentialsProfileMru.maxCredentialMruSize)
     })
 })

--- a/src/test/shared/credentials/userCredentialsUtils.test.ts
+++ b/src/test/shared/credentials/userCredentialsUtils.test.ts
@@ -8,6 +8,8 @@ import * as fs from 'fs-extra'
 import * as path from 'path'
 import * as sinon from 'sinon'
 
+/* eslint @typescript-eslint/naming-convention: 0 */
+
 import { Uri } from 'vscode'
 import { loadSharedConfigFiles } from '../../../shared/credentials/credentialsFile'
 import { UserCredentialsUtils } from '../../../shared/credentials/userCredentialsUtils'

--- a/src/test/shared/debug/launchConfiguration.test.ts
+++ b/src/test/shared/debug/launchConfiguration.test.ts
@@ -17,7 +17,7 @@ import { AwsSamDebuggerConfiguration } from '../../../shared/sam/debugger/awsSam
 import { AwsSamDebugConfigurationValidator } from '../../../shared/sam/debugger/awsSamDebugConfigurationValidator'
 import * as pathutils from '../../../shared/utilities/pathUtils'
 import * as testutil from '../../testUtil'
-import { TEMPLATE_FILE_GLOB_PATTERN } from '../../../shared/cloudformation/activation'
+import { templateFileGlobPattern } from '../../../shared/cloudformation/activation'
 import globals from '../../../shared/extensionGlobals'
 
 const samDebugConfiguration: AwsSamDebuggerConfiguration = {
@@ -105,7 +105,7 @@ describe('LaunchConfiguration', function () {
     const templateUriCsharp = vscode.Uri.file(path.join(workspace.uri.fsPath, 'csharp6-zip/template.yaml'))
 
     beforeEach(async function () {
-        await globals.templateRegistry.cfn.addWatchPattern(TEMPLATE_FILE_GLOB_PATTERN)
+        await globals.templateRegistry.cfn.addWatchPattern(templateFileGlobPattern)
 
         // TODO: remove mocks in favor of testing src/testFixtures/ data.
         mockConfigSource = mock()

--- a/src/test/shared/regions/testUtil.ts
+++ b/src/test/shared/regions/testUtil.ts
@@ -7,8 +7,8 @@ import { Memento } from 'vscode'
 import { AwsContext } from '../../../shared/awsContext'
 import { RegionProvider } from '../../../shared/regions/regionProvider'
 
-export const DEFAULT_TEST_REGION_CODE = 'someRegion'
-export const DEFAULT_TEST_REGION_NAME = 'Some Region'
+export const DEFAULT_TEST_REGION_CODE = 'someRegion' // eslint-disable-line @typescript-eslint/naming-convention
+export const DEFAULT_TEST_REGION_NAME = 'Some Region' // eslint-disable-line @typescript-eslint/naming-convention
 
 const endpoints = {
     partitions: [

--- a/src/test/shared/sam/cli/samCliInit.test.ts
+++ b/src/test/shared/sam/cli/samCliInit.test.ts
@@ -200,6 +200,7 @@ describe('runSamCliInit', async function () {
         before(function () {
             lazyLoadSamTemplateStrings()
 
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             extraContent = {
                 AWS_Schema_registry: 'testRegistry',
                 AWS_Schema_name: 'testSchema',

--- a/src/test/shared/sam/cli/samCliValidator.test.ts
+++ b/src/test/shared/sam/cli/samCliValidator.test.ts
@@ -8,8 +8,8 @@ import globals from '../../../../shared/extensionGlobals'
 import { SamCliInfoResponse } from '../../../../shared/sam/cli/samCliInfo'
 import {
     DefaultSamCliValidator,
-    MAXIMUM_SAM_CLI_VERSION_EXCLUSIVE,
-    MINIMUM_SAM_CLI_VERSION_INCLUSIVE,
+    maxSamCliVersionExclusive,
+    minSamCliVersion,
     SamCliValidatorContext,
     SamCliVersionValidation,
 } from '../../../../shared/sam/cli/samCliValidator'
@@ -41,7 +41,7 @@ describe('DefaultSamCliValidator', async function () {
     const samCliVersionTestScenarios = [
         {
             situation: 'SAM CLI Version is valid',
-            version: MINIMUM_SAM_CLI_VERSION_INCLUSIVE,
+            version: minSamCliVersion,
             expectedVersionValidation: SamCliVersionValidation.Valid,
         },
         {
@@ -51,7 +51,7 @@ describe('DefaultSamCliValidator', async function () {
         },
         {
             situation: 'SAM CLI Version is too high',
-            version: MAXIMUM_SAM_CLI_VERSION_EXCLUSIVE,
+            version: maxSamCliVersionExclusive,
             expectedVersionValidation: SamCliVersionValidation.VersionTooHigh,
         },
         {
@@ -118,7 +118,7 @@ describe('DefaultSamCliValidator', async function () {
         })
 
         it('Uses the cached validation result', async function () {
-            const validatorContext = new TestSamCliValidatorContext(MINIMUM_SAM_CLI_VERSION_INCLUSIVE)
+            const validatorContext = new TestSamCliValidatorContext(minSamCliVersion)
             const samCliValidator = new DefaultSamCliValidator(validatorContext)
 
             await samCliValidator.getVersionValidatorResult()
@@ -128,7 +128,7 @@ describe('DefaultSamCliValidator', async function () {
         })
 
         it('Does not use the cached validation result if the SAM CLI timestamp changed', async function () {
-            const validatorContext = new TestSamCliValidatorContext(MINIMUM_SAM_CLI_VERSION_INCLUSIVE)
+            const validatorContext = new TestSamCliValidatorContext(minSamCliVersion)
             const samCliValidator = new DefaultSamCliValidator(validatorContext)
 
             await samCliValidator.getVersionValidatorResult()

--- a/src/test/shared/schema/testUtils.ts
+++ b/src/test/shared/schema/testUtils.ts
@@ -4,8 +4,12 @@
  */
 
 import * as assert from 'assert'
+import got from 'got'
 import * as path from 'path'
+import * as vscode from 'vscode'
+import { writeFile } from 'fs-extra'
 import { GitExtension } from '../../../shared/extensions/git'
+import { cfnSchemaUri, samSchemaUri, buildSpecSchemaUri, buildspecCloudfrontURL } from '../../../shared/schemas'
 
 export type JSONValue = string | boolean | number | null | JSONValue[] | JSONObject
 
@@ -16,9 +20,10 @@ export interface JSONObject {
 export interface TestSchemas {
     samSchema: JSONObject
     cfnSchema: JSONObject
+    buildSpecSchema: JSONObject
 }
 
-export async function getCITestSchemas(): Promise<TestSchemas> {
+async function downloadCITestSchemas() {
     const fetchUrl = 'https://github.com/awslabs/goformation'
     const repo = await GitExtension.instance.listAllRemoteFiles({
         fetchUrl,
@@ -40,11 +45,31 @@ export async function getCITestSchemas(): Promise<TestSchemas> {
 
     repo.dispose()
 
-    const samSchema = JSON.parse(samSchemaFile)
-    const cfnSchema = JSON.parse(cfnSchemaFile)
+    const buildSpecSchemaFile = await got.get(buildspecCloudfrontURL).text()
+
+    return {
+        cfnSchemaFile,
+        samSchemaFile,
+        buildSpecSchemaFile,
+    }
+}
+
+export async function writeTestSchemas(storageLocation: vscode.Uri): Promise<void> {
+    const files = await downloadCITestSchemas()
+    await writeFile(cfnSchemaUri(storageLocation).fsPath, files.cfnSchemaFile)
+    await writeFile(samSchemaUri(storageLocation).fsPath, files.samSchemaFile)
+    await writeFile(buildSpecSchemaUri(storageLocation).fsPath, files.buildSpecSchemaFile)
+}
+
+export async function getCITestSchemas(): Promise<TestSchemas> {
+    const schemas = await downloadCITestSchemas()
+    const samSchema = JSON.parse(schemas.samSchemaFile)
+    const cfnSchema = JSON.parse(schemas.cfnSchemaFile)
+    const buildSpecSchema = JSON.parse(schemas.buildSpecSchemaFile)
     return {
         samSchema,
         cfnSchema,
+        buildSpecSchema,
     }
 }
 

--- a/src/test/shared/settingsConfiguration.test.ts
+++ b/src/test/shared/settingsConfiguration.test.ts
@@ -10,19 +10,19 @@ import { TestSettings } from '../utilities/testSettingsConfiguration'
 import { ClassToInterfaceType } from '../../shared/utilities/tsUtils'
 import { Optional } from '../../shared/utilities/typeConstructors'
 
-const SETTINGS_TARGET = vscode.ConfigurationTarget.Workspace
+const settingsTarget = vscode.ConfigurationTarget.Workspace
 
 describe('Settings', function () {
     // These tests use an actual extension setting, because vscode.WorkspaceConfiguration fails when
     // you attempt to update one that isn't defined in package.json. We will restore the setting value
     // at the end of the tests.
-    const SETTING_KEY = 'aws.samcli.lambdaTimeout'
+    const settingKey = 'aws.samcli.lambdaTimeout'
 
     let sut: Settings
 
     beforeEach(async function () {
-        sut = new Settings(SETTINGS_TARGET)
-        await sut.update(SETTING_KEY, undefined)
+        sut = new Settings(settingsTarget)
+        await sut.update(settingKey, undefined)
     })
 
     const scenarios = [
@@ -49,9 +49,9 @@ describe('Settings', function () {
 
         scenarios.forEach(scenario => {
             it(scenario.desc, async () => {
-                await settings.update(SETTING_KEY, scenario.testValue, SETTINGS_TARGET)
+                await settings.update(settingKey, scenario.testValue, settingsTarget)
 
-                const actualValue = sut.get(SETTING_KEY)
+                const actualValue = sut.get(settingKey)
                 assert.deepStrictEqual(actualValue, scenario.testValue)
             })
         })
@@ -68,21 +68,21 @@ describe('Settings', function () {
             //
             // Setting exists but has wrong type:
             //
-            await settings.update(SETTING_KEY, 123, SETTINGS_TARGET)
-            assert.throws(() => sut.get(SETTING_KEY, String))
-            assert.throws(() => sut.get(SETTING_KEY, Object))
-            assert.throws(() => sut.get(SETTING_KEY, Boolean))
+            await settings.update(settingKey, 123, settingsTarget)
+            assert.throws(() => sut.get(settingKey, String))
+            assert.throws(() => sut.get(settingKey, Object))
+            assert.throws(() => sut.get(settingKey, Boolean))
         })
     })
 
     describe('update', function () {
         scenarios.forEach(scenario => {
             it(scenario.desc, async () => {
-                await sut.update(SETTING_KEY, scenario.testValue)
+                await sut.update(settingKey, scenario.testValue)
 
                 // Write tests need to retrieve vscode.WorkspaceConfiguration after writing the value
                 // because they seem to cache values.
-                const savedValue = vscode.workspace.getConfiguration().get(SETTING_KEY)
+                const savedValue = vscode.workspace.getConfiguration().get(settingKey)
 
                 assert.deepStrictEqual(savedValue, scenario.testValue)
             })
@@ -90,7 +90,7 @@ describe('Settings', function () {
     })
 
     describe('onDidChangeSection', function () {
-        const rootSection = SETTING_KEY.split('.').shift() ?? ''
+        const rootSection = settingKey.split('.').shift() ?? ''
 
         it('fires after a section changes', async function () {
             let eventCount = 0
@@ -99,10 +99,10 @@ describe('Settings', function () {
             await sut.update('editor.tabSize', 4)
             assert.strictEqual(eventCount, 0)
 
-            await sut.update(SETTING_KEY, false)
+            await sut.update(settingKey, false)
             assert.strictEqual(eventCount, 1)
 
-            await sut.update(SETTING_KEY, true)
+            await sut.update(settingKey, true)
             assert.strictEqual(eventCount, 2)
         })
 
@@ -112,9 +112,9 @@ describe('Settings', function () {
                 sut.onDidChangeSection(rootSection, resolve)
             })
 
-            await sut.update(SETTING_KEY, true)
+            await sut.update(settingKey, true)
 
-            const subKey = SETTING_KEY.replace(`${rootSection}.`, '')
+            const subKey = settingKey.replace(`${rootSection}.`, '')
             const affectsConfiguration = await changedEvent.then(e => e.affectsConfiguration.bind(e))
 
             assert.strictEqual(affectsConfiguration('foo'), false)
@@ -173,7 +173,7 @@ describe('Settings', function () {
 })
 
 describe('DevSetting', function () {
-    const TEST_SETTING = 'forceCloud9'
+    const testSetting = 'forceCloud9'
 
     let settings: ClassToInterfaceType<Settings>
     let sut: DevSettings
@@ -184,19 +184,19 @@ describe('DevSetting', function () {
     })
 
     it('can read settings', async function () {
-        assert.strictEqual(sut.get(TEST_SETTING, false), false)
-        await settings.update(`aws.dev.${TEST_SETTING}`, true)
-        assert.strictEqual(sut.get(TEST_SETTING, false), true)
+        assert.strictEqual(sut.get(testSetting, false), false)
+        await settings.update(`aws.dev.${testSetting}`, true)
+        assert.strictEqual(sut.get(testSetting, false), true)
     })
 
     it('only changes active settings if a value exists', function () {
-        assert.strictEqual(sut.get(TEST_SETTING, true), true)
+        assert.strictEqual(sut.get(testSetting, true), true)
         assert.deepStrictEqual(sut.activeSettings, {})
     })
 
     it('only changes active settings if the value is not the default', async function () {
-        await settings.update(`aws.dev.${TEST_SETTING}`, false)
-        assert.strictEqual(sut.get(TEST_SETTING, false), false)
+        await settings.update(`aws.dev.${testSetting}`, false)
+        assert.strictEqual(sut.get(testSetting, false), false)
         assert.deepStrictEqual(sut.activeSettings, {})
     })
 
@@ -206,14 +206,14 @@ describe('DevSetting', function () {
             sut.onDidChangeActiveSettings(() => resolve(sut.activeSettings))
         })
 
-        await settings.update(`aws.dev.${TEST_SETTING}`, true)
-        assert.strictEqual(sut.get(TEST_SETTING, false), true)
-        assert.deepStrictEqual(await state, { [TEST_SETTING]: true })
+        await settings.update(`aws.dev.${testSetting}`, true)
+        assert.strictEqual(sut.get(testSetting, false), true)
+        assert.deepStrictEqual(await state, { [testSetting]: true })
     })
 })
 
 describe('PromptSetting', function () {
-    const PROMPT_SETTING_KEY = 'aws.suppressPrompts'
+    const promptSettingKey = 'aws.suppressPrompts'
     const target = vscode.ConfigurationTarget.Workspace
 
     let settings: Settings
@@ -242,10 +242,10 @@ describe('PromptSetting', function () {
         ]
         scenarios.forEach(scenario => {
             it(scenario.desc, async () => {
-                const defaultSetting = settings.get(PROMPT_SETTING_KEY, Object)
-                await settings.update(PROMPT_SETTING_KEY, scenario.testValue)
+                const defaultSetting = settings.get(promptSettingKey, Object)
+                await settings.update(promptSettingKey, scenario.testValue)
                 await sut.disablePrompt(promptName)
-                const actual = settings.get(PROMPT_SETTING_KEY)
+                const actual = settings.get(promptSettingKey)
                 const expected = { ...defaultSetting, ...scenario.expected }
                 assert.deepStrictEqual(actual, expected)
             })
@@ -284,13 +284,13 @@ describe('PromptSetting', function () {
 
         scenarios.forEach(scenario => {
             it(scenario.desc, async () => {
-                await settings.update(PROMPT_SETTING_KEY, scenario.testValue)
-                const before = settings.get(PROMPT_SETTING_KEY, Object, {})
+                await settings.update(promptSettingKey, scenario.testValue)
+                const before = settings.get(promptSettingKey, Object, {})
                 const result = await sut.isPromptEnabled(promptName)
 
                 assert.deepStrictEqual(result, scenario.expected)
                 assert.deepStrictEqual(
-                    { ...before, ...settings.get(PROMPT_SETTING_KEY, Object) },
+                    { ...before, ...settings.get(promptSettingKey, Object) },
                     { ...before, ...scenario.promptAfter }
                 )
             })

--- a/src/test/shared/telemetry/telemetryService.test.ts
+++ b/src/test/shared/telemetry/telemetryService.test.ts
@@ -12,7 +12,7 @@ import { AccountStatus } from '../../../shared/telemetry/telemetryClient'
 import { FakeExtensionContext } from '../../fakeExtensionContext'
 
 import {
-    DEFAULT_TEST_ACCOUNT_ID,
+    defaultTestAccountId,
     FakeAwsContext,
     makeFakeAwsContextWithPlaceholderIds,
 } from '../../utilities/fakeAwsContext'
@@ -177,7 +177,7 @@ describe('DefaultTelemetryService', function () {
         assert.strictEqual(logger.metricCount, 1)
 
         const metrics = logger.queryFull({ metricName: 'name' })
-        assertMetadataContainsTestAccount(metrics[0], DEFAULT_TEST_ACCOUNT_ID)
+        assertMetadataContainsTestAccount(metrics[0], defaultTestAccountId)
     })
 
     it('events with `session` namespace do not have an account tied to them', async function () {

--- a/src/test/shared/telemetry/util.test.ts
+++ b/src/test/shared/telemetry/util.test.ts
@@ -10,7 +10,7 @@ import { convertLegacy, getClientId, TelemetryConfig } from '../../../shared/tel
 import { FakeMemento } from '../../fakeExtensionContext'
 
 describe('TelemetryConfig', function () {
-    const SETTING_KEY = 'aws.telemetry'
+    const settingKey = 'aws.telemetry'
     const settings = new Settings(ConfigurationTarget.Workspace)
 
     let sut: TelemetryConfig
@@ -73,7 +73,7 @@ describe('TelemetryConfig', function () {
     describe('isTelemetryEnabled', function () {
         scenarios.forEach(scenario => {
             it(scenario.desc, async () => {
-                await settings.update(SETTING_KEY, scenario.initialSettingValue)
+                await settings.update(settingKey, scenario.initialSettingValue)
 
                 assert.strictEqual(sut.isEnabled(), scenario.expectedIsEnabledValue)
             })

--- a/src/test/shared/treeview/treeNodeUtilities.test.ts
+++ b/src/test/shared/treeview/treeNodeUtilities.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert'
 import { PlaceholderNode } from '../../../shared/treeview/nodes/placeholderNode'
 import { makeChildrenNodes } from '../../../shared/treeview/utils'
-import { assertNodeListOnlyContainsErrorNode } from '../../utilities/explorerNodeAssertions'
+import { assertNodeListOnlyHasErrorNode } from '../../utilities/explorerNodeAssertions'
 import { TestAWSTreeNode } from './nodes/testAWSTreeNode'
 
 describe('makeChildrenNodes', async function () {
@@ -33,7 +33,7 @@ describe('makeChildrenNodes', async function () {
             },
         })
 
-        assertNodeListOnlyContainsErrorNode(childNodes)
+        assertNodeListOnlyHasErrorNode(childNodes)
     })
 
     it('returns a placeholder node if there are no child nodes', async function () {

--- a/src/test/shared/ui/inputPrompter.test.ts
+++ b/src/test/shared/ui/inputPrompter.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert'
 import { createBackButton, QuickInputButton } from '../../../shared/ui/buttons'
 import { WIZARD_BACK } from '../../../shared/wizards/wizard'
 import * as vscode from 'vscode'
-import { createInputBox, DEFAULT_INPUTBOX_OPTIONS, InputBoxPrompter } from '../../../shared/ui/inputPrompter'
+import { createInputBox, defaultInputboxOptions, InputBoxPrompter } from '../../../shared/ui/inputPrompter'
 import { exposeEmitters, ExposeEmitters } from '../vscode/testUtils'
 
 describe('createInputBox', function () {
@@ -20,8 +20,8 @@ describe('createInputBox', function () {
         const prompter = createInputBox()
         const inputBox = prompter.inputBox
 
-        Object.keys(DEFAULT_INPUTBOX_OPTIONS).forEach(key => {
-            assert.strictEqual(inputBox[key as keyof vscode.InputBox], (DEFAULT_INPUTBOX_OPTIONS as any)[key])
+        Object.keys(defaultInputboxOptions).forEach(key => {
+            assert.strictEqual(inputBox[key as keyof vscode.InputBox], (defaultInputboxOptions as any)[key])
         })
     })
 })

--- a/src/test/shared/ui/pickerPrompter.test.ts
+++ b/src/test/shared/ui/pickerPrompter.test.ts
@@ -12,9 +12,9 @@ import {
     FilterBoxQuickPickPrompter,
     DataQuickPick,
     DataQuickPickItem,
-    DEFAULT_QUICKPICK_OPTIONS,
+    defaultQuickpickOptions,
     QuickPickPrompter,
-    CUSTOM_USER_INPUT,
+    customUserInput,
 } from '../../../shared/ui/pickerPrompter'
 import { WIZARD_BACK } from '../../../shared/wizards/wizard'
 import { exposeEmitters, ExposeEmitters } from '../vscode/testUtils'
@@ -30,7 +30,7 @@ describe('createQuickPick', function () {
         const picker = prompter.quickPick
 
         Object.keys(picker).forEach(key => {
-            const defaultValue = (DEFAULT_QUICKPICK_OPTIONS as Record<string, any>)[key]
+            const defaultValue = (defaultQuickpickOptions as Record<string, any>)[key]
             if (defaultValue !== undefined) {
                 assert.strictEqual(picker[key as keyof vscode.QuickPick<any>], defaultValue)
             }
@@ -286,7 +286,7 @@ describe('QuickPickPrompter', function () {
 })
 
 describe('FilterBoxQuickPickPrompter', function () {
-    const TEST_TIMEOUT = 5000
+    const testTimeout = 5000
     const testItems = [
         { label: 'item1', data: 0 },
         { label: 'item2', data: 1 },
@@ -302,7 +302,7 @@ describe('FilterBoxQuickPickPrompter', function () {
     let testPrompter: FilterBoxQuickPickPrompter<number>
 
     function addTimeout(): void {
-        setTimeout(picker.dispose.bind(picker), TEST_TIMEOUT)
+        setTimeout(picker.dispose.bind(picker), testTimeout)
     }
 
     function loadAndPrompt(): ReturnType<typeof testPrompter.prompt> {
@@ -369,7 +369,7 @@ describe('FilterBoxQuickPickPrompter', function () {
                 }
             })
 
-            testPrompter.recentItem = { data: CUSTOM_USER_INPUT, description: input } as any
+            testPrompter.recentItem = { data: customUserInput, description: input } as any
             picker.fireOnDidChangeValue(input)
         })
 

--- a/src/test/shared/ui/testUtils.ts
+++ b/src/test/shared/ui/testUtils.ts
@@ -82,7 +82,7 @@ interface TestOptions {
     // TODO: add formatting options?
 }
 
-const TEST_DEFAULTS: Required<TestOptions> = {
+const testDefaults: Required<TestOptions> = {
     timeout: 5000,
 }
 
@@ -108,7 +108,7 @@ export function createQuickPickTester<T>(
     const errors: Error[] = []
     const traces: AssertionParams[] = []
     const testPicker = exposeEmitters(prompter.quickPick, ['onDidAccept', 'onDidTriggerButton'])
-    const resolvedOptions = { ...TEST_DEFAULTS, ...options }
+    const resolvedOptions = { ...testDefaults, ...options }
 
     /* Waits until the picker is both enabled and not busy. */
     function whenReady(): Promise<void[]> {

--- a/src/test/shared/utilities/childProcess.test.ts
+++ b/src/test/shared/utilities/childProcess.test.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs-extra'
 import * as os from 'os'
 import * as path from 'path'
 import { makeTemporaryToolkitFolder, tryRemoveFolder } from '../../../shared/filesystemUtilities'
-import { ChildProcess, EOF } from '../../../shared/utilities/childProcess'
+import { ChildProcess, eof } from '../../../shared/utilities/childProcess'
 import { sleep } from '../../../shared/utilities/timeoutUtils'
 import { Timeout, waitUntil } from '../../../shared/utilities/timeoutUtils'
 
@@ -300,7 +300,7 @@ describe('ChildProcess', async function () {
                 const childProcess = new ChildProcess('cat')
                 const result = childProcess.run()
                 await childProcess.send('foo')
-                await childProcess.send(EOF)
+                await childProcess.send(eof)
                 const { stdout } = await result
                 assert.strictEqual(stdout, 'foo')
             })

--- a/src/test/shared/utilities/timeoutUtils.test.ts
+++ b/src/test/shared/utilities/timeoutUtils.test.ts
@@ -51,7 +51,7 @@ describe('timeoutUtils', async function () {
             clock.tick(timerLengthMs + 1)
             await assert.rejects(
                 shortTimer.promisify(),
-                new Error(timeoutUtils.TIMEOUT_EXPIRED_MESSAGE),
+                new Error(timeoutUtils.timeoutExpiredMessage),
                 'Timer did not reject due to timeout'
             )
         })
@@ -391,7 +391,7 @@ describe('timeoutUtils', async function () {
             clock.tick(300)
             timeout.dispose() // Promise now resolves undefined
             clock.tick(200)
-            await assert.rejects(timedPromise, new Error(timeoutUtils.TIMEOUT_UNEXPECTED_RESOLVE))
+            await assert.rejects(timedPromise, new Error(timeoutUtils.timeoutUnexpectedResolve))
         })
 
         it('"completeTimeout" option set to false throws expired error', async function () {
@@ -400,7 +400,7 @@ describe('timeoutUtils', async function () {
             clock.tick(600)
             await timedPromise
             clock.tick(300)
-            await assert.rejects(timeout.promisify(), new Error(timeoutUtils.TIMEOUT_EXPIRED_MESSAGE))
+            await assert.rejects(timeout.promisify(), new Error(timeoutUtils.timeoutExpiredMessage))
         })
     })
 })

--- a/src/test/shared/vscode/uriHandler.test.ts
+++ b/src/test/shared/vscode/uriHandler.test.ts
@@ -8,11 +8,11 @@ import * as vscode from 'vscode'
 import { SearchParams, UriHandler } from '../../../shared/vscode/uriHandler'
 
 describe('UriHandler', function () {
-    const TEST_PATH = '/my/path'
+    const testPath = '/my/path'
     let uriHandler: UriHandler
 
     function makeUri(query?: string): vscode.Uri {
-        return vscode.Uri.parse(`scheme://authority${TEST_PATH}${query !== undefined ? `?${query}` : ''}`)
+        return vscode.Uri.parse(`scheme://authority${testPath}${query !== undefined ? `?${query}` : ''}`)
     }
 
     beforeEach(function () {
@@ -20,13 +20,13 @@ describe('UriHandler', function () {
     })
 
     it('can register a handler', async function () {
-        uriHandler.registerHandler(TEST_PATH, q => assert.strictEqual(q.get('key'), 'value'))
+        uriHandler.registerHandler(testPath, q => assert.strictEqual(q.get('key'), 'value'))
         return uriHandler.handleUri(makeUri('key=value'))
     })
 
     it('uses parser if available', async function () {
         uriHandler.registerHandler(
-            TEST_PATH,
+            testPath,
             q => assert.strictEqual(q.myNumber, 123),
             (q: SearchParams) => ({ myNumber: Number(q.get('myString')) })
         )
@@ -34,20 +34,20 @@ describe('UriHandler', function () {
     })
 
     it('can handle lists', async function () {
-        uriHandler.registerHandler(TEST_PATH, q => assert.deepStrictEqual(q.get('list'), ['1', '2', '3']))
+        uriHandler.registerHandler(testPath, q => assert.deepStrictEqual(q.get('list'), ['1', '2', '3']))
         return uriHandler.handleUri(makeUri('list=1&list=2&list=3'))
     })
 
     it('can dispose handlers', async function () {
         return new Promise((resolve, reject) => {
-            uriHandler.registerHandler(TEST_PATH, () => reject(new Error('this should not be called'))).dispose()
+            uriHandler.registerHandler(testPath, () => reject(new Error('this should not be called'))).dispose()
             uriHandler.handleUri(makeUri()).then(resolve)
         })
     })
 
     it('throws when registering handler for same path', function () {
-        uriHandler.registerHandler(TEST_PATH, () => {})
-        assert.throws(() => uriHandler.registerHandler(TEST_PATH, () => {}))
+        uriHandler.registerHandler(testPath, () => {})
+        assert.throws(() => uriHandler.registerHandler(testPath, () => {}))
     })
 
     it('catches errors thrown by the parser', function (done) {
@@ -56,7 +56,7 @@ describe('UriHandler', function () {
             throw new Error()
         }
 
-        uriHandler.registerHandler(TEST_PATH, handler, parser)
+        uriHandler.registerHandler(testPath, handler, parser)
         assert.doesNotReject(uriHandler.handleUri(makeUri('key=value'))).then(done, done)
     })
 
@@ -65,7 +65,7 @@ describe('UriHandler', function () {
             throw new Error()
         }
 
-        uriHandler.registerHandler(TEST_PATH, handler)
+        uriHandler.registerHandler(testPath, handler)
         return assert.doesNotReject(uriHandler.handleUri(makeUri()))
     })
 })

--- a/src/test/shared/wizards/wizardTestUtils.ts
+++ b/src/test/shared/wizards/wizardTestUtils.ts
@@ -39,18 +39,18 @@ type MockForm<T, TState = T> = {
 }
 
 type FormTesterMethodKey = keyof MockWizardFormElement<any>
-const VALUE: FormTesterMethodKey = 'value'
-const APPLY_INPUT: FormTesterMethodKey = 'applyInput'
-const CLEAR_INPUT: FormTesterMethodKey = 'clearInput'
-const ASSERT_SHOW: FormTesterMethodKey = 'assertShow'
-const ASSERT_SHOW_FIRST: FormTesterMethodKey = 'assertShowFirst'
-const ASSERT_SHOW_SECOND: FormTesterMethodKey = 'assertShowSecond'
-const ASSERT_SHOW_THIRD: FormTesterMethodKey = 'assertShowThird'
-const ASSERT_SHOW_ANY: FormTesterMethodKey = 'assertShowAny'
-const NOT_ASSERT_SHOW: FormTesterMethodKey = 'assertDoesNotShow'
-const NOT_ASSERT_SHOW_ANY: FormTesterMethodKey = 'assertDoesNotShowAny'
-const ASSERT_VALUE: FormTesterMethodKey = 'assertValue'
-const SHOW_COUNT: FormTesterMethodKey = 'assertShowCount'
+const VALUE: FormTesterMethodKey = 'value' // eslint-disable-line @typescript-eslint/naming-convention
+const APPLY_INPUT: FormTesterMethodKey = 'applyInput' // eslint-disable-line @typescript-eslint/naming-convention
+const CLEAR_INPUT: FormTesterMethodKey = 'clearInput' // eslint-disable-line @typescript-eslint/naming-convention
+const ASSERT_SHOW: FormTesterMethodKey = 'assertShow' // eslint-disable-line @typescript-eslint/naming-convention
+const ASSERT_SHOW_FIRST: FormTesterMethodKey = 'assertShowFirst' // eslint-disable-line @typescript-eslint/naming-convention
+const ASSERT_SHOW_SECOND: FormTesterMethodKey = 'assertShowSecond' // eslint-disable-line @typescript-eslint/naming-convention
+const ASSERT_SHOW_THIRD: FormTesterMethodKey = 'assertShowThird' // eslint-disable-line @typescript-eslint/naming-convention
+const ASSERT_SHOW_ANY: FormTesterMethodKey = 'assertShowAny' // eslint-disable-line @typescript-eslint/naming-convention
+const NOT_ASSERT_SHOW: FormTesterMethodKey = 'assertDoesNotShow' // eslint-disable-line @typescript-eslint/naming-convention
+const NOT_ASSERT_SHOW_ANY: FormTesterMethodKey = 'assertDoesNotShowAny' // eslint-disable-line @typescript-eslint/naming-convention
+const ASSERT_VALUE: FormTesterMethodKey = 'assertValue' // eslint-disable-line @typescript-eslint/naming-convention
+const SHOW_COUNT: FormTesterMethodKey = 'assertShowCount' // eslint-disable-line @typescript-eslint/naming-convention
 
 type Tester<T> = MockForm<Required<T>> & Pick<MockWizardFormElement<any>, typeof SHOW_COUNT>
 export type WizardTester<T> = T extends Wizard<infer U> ? Tester<U> : Tester<T>

--- a/src/test/ssmDocument/explorer/documentTypeNode.test.ts
+++ b/src/test/ssmDocument/explorer/documentTypeNode.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert'
 import * as sinon from 'sinon'
 import { DocumentTypeNode } from '../../../ssmDocument/explorer/documentTypeNode'
 
-import { assertNodeListOnlyContainsErrorNode } from '../../utilities/explorerNodeAssertions'
+import { assertNodeListOnlyHasErrorNode } from '../../utilities/explorerNodeAssertions'
 
 describe('DocumentTypeNode', function () {
     let sandbox: sinon.SinonSandbox
@@ -41,6 +41,6 @@ describe('DocumentTypeNode', function () {
         })
         const childNodes = await testNode.getChildren()
 
-        assertNodeListOnlyContainsErrorNode(childNodes)
+        assertNodeListOnlyHasErrorNode(childNodes)
     })
 })

--- a/src/test/ssmDocument/explorer/registryItemNode.test.ts
+++ b/src/test/ssmDocument/explorer/registryItemNode.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert'
 import { RegistryItemNode } from '../../../ssmDocument/explorer/registryItemNode'
-import { assertNodeListOnlyContainsErrorNode } from '../../utilities/explorerNodeAssertions'
+import { assertNodeListOnlyHasErrorNode } from '../../utilities/explorerNodeAssertions'
 import { asyncGenerator } from '../../utilities/collectionUtils'
 import { DefaultSsmDocumentClient } from '../../../shared/clients/ssmDocumentClient'
 import { stub } from '../../utilities/stubber'
@@ -22,7 +22,7 @@ describe('RegistryItemNode', function () {
         const testNode = new RegistryItemNode(regionCode, 'Owned by me', documentType, client)
         const childNodes = await testNode.getChildren()
 
-        assertNodeListOnlyContainsErrorNode(childNodes)
+        assertNodeListOnlyHasErrorNode(childNodes)
     })
 
     it('puts documents into right registry', async function () {

--- a/src/test/stepFunctions/explorer/stepFunctionNodes.test.ts
+++ b/src/test/stepFunctions/explorer/stepFunctionNodes.test.ts
@@ -5,13 +5,13 @@
 
 import * as assert from 'assert'
 import {
-    CONTEXT_VALUE_STATE_MACHINE,
+    contextValueStateMachine,
     StateMachineNode,
     StepFunctionsNode,
 } from '../../../stepFunctions/explorer/stepFunctionsNodes'
 import {
-    assertNodeListOnlyContainsErrorNode,
-    assertNodeListOnlyContainsPlaceholderNode,
+    assertNodeListOnlyHasErrorNode,
+    assertNodeListOnlyHasPlaceholderNode,
 } from '../../utilities/explorerNodeAssertions'
 import { asyncGenerator } from '../../utilities/collectionUtils'
 import globals from '../../../shared/extensionGlobals'
@@ -42,7 +42,7 @@ describe('StepFunctionsNode', function () {
     it('returns placeholder node if no children are present', async function () {
         const node = new StepFunctionsNode(regionCode, createStatesClient())
 
-        assertNodeListOnlyContainsPlaceholderNode(await node.getChildren())
+        assertNodeListOnlyHasPlaceholderNode(await node.getChildren())
     })
 
     it('has StateMachineNode child nodes', async function () {
@@ -56,7 +56,7 @@ describe('StepFunctionsNode', function () {
             assert.ok(node instanceof StateMachineNode, 'Expected child node to be StateMachineNode')
             assert.strictEqual(
                 node.contextValue,
-                CONTEXT_VALUE_STATE_MACHINE,
+                contextValueStateMachine,
                 'expected the node to have a State Machine contextValue'
             )
         })
@@ -76,6 +76,6 @@ describe('StepFunctionsNode', function () {
         client.listStateMachines.throws()
         const testNode = new StepFunctionsNode(regionCode, client)
 
-        assertNodeListOnlyContainsErrorNode(await testNode.getChildren())
+        assertNodeListOnlyHasErrorNode(await testNode.getChildren())
     })
 })

--- a/src/test/stepFunctions/utils.test.ts
+++ b/src/test/stepFunctions/utils.test.ts
@@ -11,10 +11,10 @@ import * as vscode from 'vscode'
 import { makeTemporaryToolkitFolder } from '../../shared/filesystemUtilities'
 import { isDocumentValid, isStepFunctionsRole, StateMachineGraphCache } from '../../stepFunctions/utils'
 
-const REQUEST_BODY = 'request body string'
-const ASSET_URL = 'https://something'
-const FILE_PATH = '/some/path'
-const STORAGE_KEY = 'KEY'
+const requestBody = 'request body string'
+const assetUrl = 'https://something'
+const filePath = '/some/path'
+const storageKey = 'KEY'
 let tempFolder = ''
 
 describe('StateMachineGraphCache', function () {
@@ -33,7 +33,7 @@ describe('StateMachineGraphCache', function () {
                 get: sinon.stub().returns(undefined),
             }
 
-            const getFileData = sinon.stub().resolves(REQUEST_BODY)
+            const getFileData = sinon.stub().resolves(requestBody)
             const fileExists = sinon.stub().onFirstCall().resolves(false).onSecondCall().resolves(true)
 
             const writeFile = sinon.spy()
@@ -49,13 +49,13 @@ describe('StateMachineGraphCache', function () {
 
             await cache.updateCachedFile({
                 globalStorage,
-                lastDownloadedURLKey: STORAGE_KEY,
-                currentURL: ASSET_URL,
-                filePath: FILE_PATH,
+                lastDownloadedURLKey: storageKey,
+                currentURL: assetUrl,
+                filePath: filePath,
             })
 
-            assert.ok(globalStorage.update.calledWith(STORAGE_KEY, ASSET_URL))
-            assert.ok(writeFile.calledWith(FILE_PATH, REQUEST_BODY))
+            assert.ok(globalStorage.update.calledWith(storageKey, assetUrl))
+            assert.ok(writeFile.calledWith(filePath, requestBody))
         })
 
         it('downloads and stores a file when cached file exists but url has been updated', async function () {
@@ -64,7 +64,7 @@ describe('StateMachineGraphCache', function () {
                 get: sinon.stub().returns('https://old-url'),
             }
 
-            const getFileData = sinon.stub().resolves(REQUEST_BODY)
+            const getFileData = sinon.stub().resolves(requestBody)
             const fileExists = sinon.stub().onFirstCall().resolves(true).onSecondCall().resolves(true)
 
             const writeFile = sinon.spy()
@@ -80,22 +80,22 @@ describe('StateMachineGraphCache', function () {
 
             await cache.updateCachedFile({
                 globalStorage,
-                lastDownloadedURLKey: STORAGE_KEY,
-                currentURL: ASSET_URL,
-                filePath: FILE_PATH,
+                lastDownloadedURLKey: storageKey,
+                currentURL: assetUrl,
+                filePath: filePath,
             })
 
-            assert.ok(globalStorage.update.calledWith(STORAGE_KEY, ASSET_URL))
-            assert.ok(writeFile.calledWith(FILE_PATH, REQUEST_BODY))
+            assert.ok(globalStorage.update.calledWith(storageKey, assetUrl))
+            assert.ok(writeFile.calledWith(filePath, requestBody))
         })
 
         it('it does not store data when file exists and url for it is same', async function () {
             const globalStorage = {
                 update: sinon.spy(),
-                get: sinon.stub().returns(ASSET_URL),
+                get: sinon.stub().returns(assetUrl),
             }
 
-            const getFileData = sinon.stub().resolves(REQUEST_BODY)
+            const getFileData = sinon.stub().resolves(requestBody)
             const fileExists = sinon.stub().onFirstCall().resolves(true).onSecondCall().resolves(true)
 
             const writeFile = sinon.spy()
@@ -111,9 +111,9 @@ describe('StateMachineGraphCache', function () {
 
             await cache.updateCachedFile({
                 globalStorage,
-                lastDownloadedURLKey: STORAGE_KEY,
-                currentURL: ASSET_URL,
-                filePath: FILE_PATH,
+                lastDownloadedURLKey: storageKey,
+                currentURL: assetUrl,
+                filePath: filePath,
             })
 
             assert.ok(globalStorage.update.notCalled)
@@ -126,7 +126,7 @@ describe('StateMachineGraphCache', function () {
                 get: sinon.stub().returns(undefined),
             }
 
-            const getFileData = sinon.stub().resolves(REQUEST_BODY)
+            const getFileData = sinon.stub().resolves(requestBody)
             const fileExists = sinon.stub().onFirstCall().resolves(false).onSecondCall().resolves(false)
 
             const writeFile = sinon.spy()
@@ -146,13 +146,13 @@ describe('StateMachineGraphCache', function () {
 
             await cache.updateCachedFile({
                 globalStorage,
-                lastDownloadedURLKey: STORAGE_KEY,
-                currentURL: ASSET_URL,
-                filePath: FILE_PATH,
+                lastDownloadedURLKey: storageKey,
+                currentURL: assetUrl,
+                filePath: filePath,
             })
 
-            assert.ok(globalStorage.update.calledWith(STORAGE_KEY, ASSET_URL))
-            assert.ok(writeFile.calledWith(FILE_PATH, REQUEST_BODY))
+            assert.ok(globalStorage.update.calledWith(storageKey, assetUrl))
+            assert.ok(writeFile.calledWith(filePath, requestBody))
             assert.ok(makeDir.calledWith(dirPath))
         })
     })

--- a/src/test/utilities/explorerNodeAssertions.ts
+++ b/src/test/utilities/explorerNodeAssertions.ts
@@ -7,13 +7,13 @@ import * as assert from 'assert'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 import { PlaceholderNode } from '../../shared/treeview/nodes/placeholderNode'
 
-export function assertNodeListOnlyContainsErrorNode(nodes: AWSTreeNodeBase[]) {
+export function assertNodeListOnlyHasErrorNode(nodes: AWSTreeNodeBase[]) {
     assert(nodes !== undefined)
     assert.strictEqual(nodes.length, 1, 'Unexpected node count')
     assert.strictEqual(nodes[0].contextValue, 'awsErrorNode', 'Expected ErrorNode in the list')
 }
 
-export function assertNodeListOnlyContainsPlaceholderNode(nodes: AWSTreeNodeBase[]) {
+export function assertNodeListOnlyHasPlaceholderNode(nodes: AWSTreeNodeBase[]) {
     assert(nodes !== undefined)
     assert.strictEqual(nodes.length, 1, 'Unexpected node count')
     assert.ok(nodes[0] instanceof PlaceholderNode, 'Expected placeholder node in the list')

--- a/src/test/utilities/fakeAwsContext.ts
+++ b/src/test/utilities/fakeAwsContext.ts
@@ -8,14 +8,14 @@ import * as AWS from '@aws-sdk/types'
 import { AwsContext, AwsContextCredentials, ContextChangeEventsArgs } from '../../shared/awsContext'
 import { DEFAULT_TEST_REGION_CODE } from '../shared/regions/testUtil'
 
-export const DEFAULT_TEST_PROFILE_NAME = 'qwerty'
-export const DEFAULT_TEST_ACCOUNT_ID = '123456789012'
+export const defaultTestProfileName = 'qwerty'
+export const defaultTestAccountId = '123456789012'
+const defaultRegion = 'us-east-1'
 
 export interface FakeAwsContextParams {
     contextCredentials?: AwsContextCredentials
 }
 
-const DEFAULT_REGION = 'us-east-1'
 export class FakeAwsContext implements AwsContext {
     public onDidChangeContext: vscode.Event<ContextChangeEventsArgs> =
         new vscode.EventEmitter<ContextChangeEventsArgs>().event
@@ -55,7 +55,7 @@ export class FakeAwsContext implements AwsContext {
     }
 
     public getCredentialDefaultRegion(): string {
-        return this.awsContextCredentials?.defaultRegion ?? DEFAULT_REGION
+        return this.awsContextCredentials?.defaultRegion ?? defaultRegion
     }
 }
 
@@ -63,8 +63,8 @@ export function makeFakeAwsContextWithPlaceholderIds(credentials: AWS.Credential
     return new FakeAwsContext({
         contextCredentials: {
             credentials: credentials,
-            credentialsId: DEFAULT_TEST_PROFILE_NAME,
-            accountId: DEFAULT_TEST_ACCOUNT_ID,
+            credentialsId: defaultTestProfileName,
+            accountId: defaultTestAccountId,
             defaultRegion: DEFAULT_TEST_REGION_CODE,
         },
     })

--- a/src/webviews/main.ts
+++ b/src/webviews/main.ts
@@ -397,10 +397,10 @@ function resolveWebviewHtml(params: {
     main: vscode.Uri
 }): string {
     const resolvedParams = { ...params, connectSource: `'none'` }
-    const LOCAL_SERVER = process.env.WEBPACK_DEVELOPER_SERVER
+    const localServer = process.env.WEBPACK_DEVELOPER_SERVER
 
-    if (LOCAL_SERVER) {
-        const local = vscode.Uri.parse(LOCAL_SERVER)
+    if (localServer) {
+        const local = vscode.Uri.parse(localServer)
         resolvedParams.cspSource = `${params.cspSource} ${local.toString()}`
         resolvedParams.main = local.with({ path: `/${params.webviewJs}` })
         resolvedParams.connectSource = `'self' ws:`


### PR DESCRIPTION
## Problem:
- We don't have any intellisense level tests (hover, completion) for cloudformation or buildspec
    
## Solution:
- Add completion and hover tests for both cloudformation and buildspec
- The test schemas must be downloaded through the vscode git extension otherwise we risk getting rate limited on the tests. We can either do this upfront (like in this commit), which forces us to re-start the schema service to pick up the new schemas during the tests. Alternatively, we can use the git extension to download github related schemas everytime, but then we have to download an entire repo every single time we want to update the schema
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
