### PR TITLE
fix(schemas): Allow template registries to "own" a file path to fix race conditions in JSON Schema assignment

### DIFF
--- a/src/shared/buildspec/registry.ts
+++ b/src/shared/buildspec/registry.ts
@@ -31,16 +31,16 @@ export class BuildspecTemplateRegistry extends WatchedFiles<BuildspecTemplate> {
                 template = yaml.load(templateAsYaml, {}) as BuildspecTemplate
             }
         } catch (e) {
-            globals.schemaService.registerMapping({ uri, type: 'yaml', schema: undefined })
+            globals.schemaService.registerMapping({ uri, type: 'yaml', schema: undefined, owner: this.name })
             return undefined
         }
 
-        if (template.version && template.phases) {
-            globals.schemaService.registerMapping({ uri, type: 'yaml', schema: 'buildspec' })
+        if (template && template.version && template.phases) {
+            globals.schemaService.registerMapping({ uri, type: 'yaml', schema: 'buildspec', owner: this.name })
             return template
         }
 
-        globals.schemaService.registerMapping({ uri, type: 'yaml', schema: undefined })
+        globals.schemaService.registerMapping({ uri, type: 'yaml', schema: undefined, owner: this.name })
         return undefined
     }
 
@@ -49,6 +49,7 @@ export class BuildspecTemplateRegistry extends WatchedFiles<BuildspecTemplate> {
             uri,
             type: 'yaml',
             schema: undefined,
+            owner: this.name,
         })
         await super.remove(uri)
     }

--- a/src/shared/cloudformation/templateRegistry.ts
+++ b/src/shared/cloudformation/templateRegistry.ts
@@ -35,7 +35,7 @@ export class CloudFormationTemplateRegistry extends WatchedFiles<CloudFormation.
                 template = await CloudFormation.load(path, false)
             }
         } catch (e) {
-            globals.schemaService.registerMapping({ uri, type: 'yaml', schema: undefined })
+            globals.schemaService.registerMapping({ uri, type: 'yaml', schema: undefined, owner: this.name })
             return undefined
         }
 
@@ -44,16 +44,16 @@ export class CloudFormationTemplateRegistry extends WatchedFiles<CloudFormation.
         if (template.AWSTemplateFormatVersion || template.Resources) {
             if (template.Transform && template.Transform.toString().startsWith('AWS::Serverless')) {
                 // apply serverless schema
-                globals.schemaService.registerMapping({ uri, type: 'yaml', schema: 'sam' })
+                globals.schemaService.registerMapping({ uri, type: 'yaml', schema: 'sam', owner: this.name })
             } else {
                 // apply cfn schema
-                globals.schemaService.registerMapping({ uri, type: 'yaml', schema: 'cfn' })
+                globals.schemaService.registerMapping({ uri, type: 'yaml', schema: 'cfn', owner: this.name })
             }
 
             return template
         }
 
-        globals.schemaService.registerMapping({ uri, type: 'yaml', schema: undefined })
+        globals.schemaService.registerMapping({ uri, type: 'yaml', schema: undefined, owner: this.name })
         return undefined
     }
 
@@ -63,6 +63,7 @@ export class CloudFormationTemplateRegistry extends WatchedFiles<CloudFormation.
             uri,
             type: 'yaml',
             schema: undefined,
+            owner: this.name,
         })
         await super.remove(uri)
     }

--- a/src/test/shared/schemas.test.ts
+++ b/src/test/shared/schemas.test.ts
@@ -133,4 +133,127 @@ describe('SchemaService', function () {
         await service.processUpdates()
         verify(fakeYamlExtension.assignSchema(anything(), anything())).never()
     })
+
+    it('processes no updates if owner is different', async function () {
+        const testUri = vscode.Uri.parse('/foo')
+        service.registerMapping(
+            {
+                uri: testUri,
+                type: 'yaml',
+                schema: 'cfn',
+                owner: 'test_registry',
+            },
+            true
+        )
+        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), cfnSchema)).once()
+
+        service.registerMapping(
+            {
+                uri: testUri,
+                type: 'yaml',
+                schema: 'cfn',
+                owner: 'different_test_registry',
+            },
+            true
+        )
+        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), cfnSchema)).once()
+    })
+
+    it('processes updates if owner is the same', async function () {
+        const testUri = vscode.Uri.parse('/foo')
+        service.registerMapping(
+            {
+                uri: testUri,
+                type: 'yaml',
+                schema: 'cfn',
+                owner: 'test_registry',
+            },
+            true
+        )
+        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), cfnSchema)).once()
+
+        service.registerMapping(
+            {
+                uri: testUri,
+                type: 'yaml',
+                schema: 'sam',
+                owner: 'test_registry',
+            },
+            true
+        )
+        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), samSchema)).once()
+    })
+
+    it('processes updates if schema type changed', async function () {
+        const testUri = vscode.Uri.parse('/foo')
+        service.registerMapping(
+            {
+                uri: testUri,
+                type: 'yaml',
+                schema: 'cfn',
+                owner: 'test_registry',
+            },
+            true
+        )
+        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), cfnSchema)).once()
+
+        service.registerMapping(
+            {
+                uri: testUri,
+                type: 'yaml',
+                schema: 'sam',
+                owner: 'different_test_registry',
+            },
+            true
+        )
+        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), samSchema)).once()
+    })
+
+    it('processes updates if file becomes owned', async function () {
+        const testUri = vscode.Uri.parse('/foo')
+        service.registerMapping(
+            {
+                uri: testUri,
+                type: 'yaml',
+                schema: 'cfn',
+            },
+            true
+        )
+        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), cfnSchema)).once()
+
+        service.registerMapping(
+            {
+                uri: testUri,
+                type: 'yaml',
+                schema: 'sam',
+                owner: 'test_registry',
+            },
+            true
+        )
+        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), samSchema)).once()
+    })
+
+    it('processes no updates if non owner tries to change file', async function () {
+        const testUri = vscode.Uri.parse('/foo')
+        service.registerMapping(
+            {
+                uri: testUri,
+                type: 'yaml',
+                schema: 'cfn',
+                owner: 'test_registry',
+            },
+            true
+        )
+        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), cfnSchema)).once()
+
+        service.registerMapping(
+            {
+                uri: testUri,
+                type: 'yaml',
+                schema: 'sam',
+            },
+            true
+        )
+        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), samSchema)).never()
+    })
 })


### PR DESCRIPTION
## Problem
- Currently buildspec and cloudformation are watching all yaml files and trying to race to see evaluate whether the current yaml file is buildspec or cloudformation. This means that sometimes schemas won't be set for valid buildspec or cloudformation files. This is due to an issue in the watchedfile registry, where having multiple template registries watch one file type wasn't really considered.

## Solution
- Introduce the concept of "owned" files in the template registries, where only owners of a file can update the schema for a file unless the type of the schema changes. E.g. cloudformation <-> buildspec. Since each registry is considered seperate and the implementation for the buildspec/cloudformation registries in other parts of the code require only their file types to be available, this choice may be easier than having to refactor everything. This is a temporary solution until we are able to remove the template registries completely.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
