### PR TITLE
feat(auth): add initial unified auth implementation

### DIFF
--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -28,7 +28,7 @@ import { telemetry } from '../shared/telemetry/telemetry'
 import { cdkNode, CdkRootNode } from '../cdk/explorer/rootNode'
 import { codewhispererNode } from '../codewhisperer/explorer/codewhispererNode'
 import { once } from '../shared/utilities/functionUtils'
-import { Auth, AuthNode, ProfileStore } from '../credentials/auth'
+import { Auth, AuthNode } from '../credentials/auth'
 import { DevSettings } from '../shared/settings'
 
 /**
@@ -75,10 +75,8 @@ export async function activate(args: {
         })
     )
 
-    const auth = new Auth(new ProfileStore(args.context.extensionContext.globalState))
-    const authNode = new AuthNode(auth)
     const nodes = DevSettings.instance.get('showAuthNode', false)
-        ? [authNode, cdkNode, codewhispererNode]
+        ? [new AuthNode(Auth.instance), cdkNode, codewhispererNode]
         : [cdkNode, codewhispererNode]
 
     const developerTools = createLocalExplorerView(nodes)

--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -28,6 +28,8 @@ import { telemetry } from '../shared/telemetry/telemetry'
 import { cdkNode, CdkRootNode } from '../cdk/explorer/rootNode'
 import { codewhispererNode } from '../codewhisperer/explorer/codewhispererNode'
 import { once } from '../shared/utilities/functionUtils'
+import { Auth, AuthNode, ProfileStore } from '../credentials/auth'
+import { DevSettings } from '../shared/settings'
 
 /**
  * Activates the AWS Explorer UI and related functionality.
@@ -73,7 +75,12 @@ export async function activate(args: {
         })
     )
 
-    const nodes = [cdkNode, codewhispererNode]
+    const auth = new Auth(new ProfileStore(args.context.extensionContext.globalState))
+    const authNode = new AuthNode(auth)
+    const nodes = DevSettings.instance.get('showAuthNode', false)
+        ? [authNode, cdkNode, codewhispererNode]
+        : [cdkNode, codewhispererNode]
+
     const developerTools = createLocalExplorerView(nodes)
     args.context.extensionContext.subscriptions.push(developerTools)
 

--- a/src/credentials/auth.ts
+++ b/src/credentials/auth.ts
@@ -1,0 +1,384 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { Credentials } from '@aws-sdk/types'
+import { SsoAccessTokenProvider } from './sso/ssoAccessTokenProvider'
+import { getIcon } from '../shared/icons'
+import { Commands } from '../shared/vscode/commands2'
+import { showQuickPick } from '../shared/ui/pickerPrompter'
+import { isValidResponse } from '../shared/wizards/wizard'
+import { CancellationError } from '../shared/utilities/timeoutUtils'
+import { ToolkitError } from '../shared/errors'
+import { getCache } from './sso/cache'
+import { createFactoryFunction, Mutable } from '../shared/utilities/tsUtils'
+import { SsoToken } from './sso/model'
+
+interface SsoConnection {
+    readonly type: 'sso'
+    readonly id: string
+    readonly label: string
+    readonly scopes?: string[]
+    getToken(): Promise<Pick<SsoToken, 'accessToken' | 'expiresAt'>>
+}
+
+interface IamConnection {
+    readonly type: 'iam'
+    readonly id: string
+    readonly label: string
+    getCredentials(): Promise<Credentials>
+}
+
+export type Connection = IamConnection | SsoConnection
+
+export interface SsoProfile {
+    readonly type: 'sso'
+    readonly ssoRegion: string
+    readonly startUrl: string
+    readonly scopes?: string[]
+}
+
+// Placeholder type.
+// Would be expanded over time to support
+// https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
+type Profile = SsoProfile
+
+interface AuthService {
+    listConnections(): Promise<Connection[]>
+    createConnection(profile: Profile): Promise<Connection>
+    deleteConnection(connection: Pick<Connection, 'id'>): void
+    getConnection(connection: Pick<Connection, 'id'>): Promise<Connection | undefined>
+}
+
+interface LoginManager {
+    readonly activeConnection: Connection | undefined
+    readonly onDidChangeActiveConnection: vscode.Event<Connection | undefined>
+    login(connection: Pick<Connection, 'id'>): Promise<Connection>
+    logout(): void
+}
+
+interface ProfileMetadata {
+    readonly label?: string
+    readonly connectionState: 'valid' | 'invalid' | 'unauthenticated' | 'authenticating'
+    readonly canShowExpirationMessage: boolean
+}
+
+type StoredProfile<T extends Profile = Profile> = T & { readonly metadata: ProfileMetadata }
+
+export class ProfileStore {
+    public constructor(private readonly memento: vscode.Memento) {}
+
+    public getProfile(id: string): StoredProfile | undefined {
+        return this.getData()[id]
+    }
+
+    public listProfiles(): [id: string, profile: StoredProfile][] {
+        return Object.entries(this.getData())
+    }
+
+    public async addProfile(id: string, profile: Profile): Promise<StoredProfile> {
+        if (this.getProfile(id) !== undefined) {
+            throw new Error(`Profile already exists: ${id}`)
+        }
+
+        return this.putProfile(id, this.initMetadata(profile))
+    }
+
+    public async updateProfile(id: string, metadata: Partial<ProfileMetadata>): Promise<StoredProfile> {
+        const profile = this.getProfile(id)
+        if (profile === undefined) {
+            throw new Error(`Profile does not exist: ${id}`)
+        }
+
+        return this.putProfile(id, { ...profile, metadata: { ...profile.metadata, ...metadata } })
+    }
+
+    public async deleteProfile(id: string): Promise<void> {
+        const data = this.getData()
+        delete (data as Mutable<typeof data>)[id]
+
+        await this.updateData(data)
+    }
+
+    private getData() {
+        return this.memento.get<{ readonly [id: string]: StoredProfile }>('auth.profiles', {})
+    }
+
+    private async updateData(state: { readonly [id: string]: StoredProfile | undefined }) {
+        await this.memento.update('auth.profiles', state)
+    }
+
+    private async putProfile(id: string, profile: StoredProfile) {
+        await this.updateData({ ...this.getData(), [id]: profile })
+
+        return profile
+    }
+
+    private initMetadata(profile: Profile): StoredProfile {
+        return {
+            ...profile,
+            metadata: {
+                canShowExpirationMessage: false,
+                connectionState: 'unauthenticated',
+            },
+        }
+    }
+}
+
+function keyedDebounce<T, U extends any[], K extends string = string>(
+    fn: (key: K, ...args: U) => Promise<T>
+): typeof fn {
+    const pending = new Map<K, Promise<T>>()
+
+    return (key, ...args) => {
+        if (pending.has(key)) {
+            return pending.get(key)!
+        }
+
+        const promise = fn(key, ...args).finally(() => pending.delete(key))
+        pending.set(key, promise)
+
+        return promise
+    }
+}
+
+// TODO: replace this with `idToken` when available
+export function getSsoProfileKey(profile: Pick<SsoProfile, 'startUrl' | 'scopes'>): string {
+    const scopesFragment = profile.scopes ? `?scopes=${profile.scopes.sort()}` : ''
+
+    return `${profile.startUrl}${scopesFragment}`
+}
+
+function sortProfilesByScope(profiles: StoredProfile<Profile>[]): StoredProfile<SsoProfile>[] {
+    return profiles
+        .filter((c): c is StoredProfile<SsoProfile> => c.type === 'sso')
+        .sort((a, b) => (a.scopes?.length ?? 0) - (b.scopes?.length ?? 0))
+}
+
+// The true connection state can only be known after trying to use the connection
+// So it is not exposed on the `Connection` interface
+type StatefulConnection = Connection & { readonly state: ProfileMetadata['connectionState'] }
+
+export class Auth implements AuthService, LoginManager {
+    private readonly ssoCache = getCache()
+    private readonly onDidChangeActiveConnectionEmitter = new vscode.EventEmitter<StatefulConnection | undefined>()
+    public readonly onDidChangeActiveConnection = this.onDidChangeActiveConnectionEmitter.event
+
+    public constructor(
+        private readonly store: ProfileStore,
+        private readonly createTokenProvider = createFactoryFunction(SsoAccessTokenProvider)
+    ) {}
+
+    #activeConnection: Mutable<StatefulConnection> | undefined
+    public get activeConnection(): StatefulConnection | undefined {
+        return this.#activeConnection
+    }
+
+    public async login({ id }: Pick<Connection, 'id'>): Promise<Connection> {
+        const profile = this.store.getProfile(id)
+        if (profile === undefined) {
+            throw new Error(`Connection does not exist: ${id}`)
+        }
+
+        const conn = this.createSsoConnection(id, profile)
+        this.#activeConnection = conn
+
+        if (conn.state !== 'valid') {
+            await this.updateState(id, 'unauthenticated')
+            await conn.getToken()
+        } else {
+            this.onDidChangeActiveConnectionEmitter.fire(conn)
+        }
+
+        return conn
+    }
+
+    public logout(): void {
+        this.#activeConnection = undefined
+        this.onDidChangeActiveConnectionEmitter.fire(undefined)
+    }
+
+    public async listConnections(): Promise<Connection[]> {
+        return this.store.listProfiles().map(([id, profile]) => this.createSsoConnection(id, profile))
+    }
+
+    // XXX: Used to combined scoped connections with the same startUrl into a single one
+    public async listMergedConnections(): Promise<Connection[]> {
+        return Array.from(
+            this.store
+                .listProfiles()
+                .filter((data): data is [string, StoredProfile<SsoProfile>] => data[1].type === 'sso')
+                .sort((a, b) => (a[1].scopes?.length ?? 0) - (b[1].scopes?.length ?? 0))
+                .reduce(
+                    (r, [id, profile]) => (r.set(profile.startUrl, this.createSsoConnection(id, profile)), r),
+                    new Map<string, Connection>()
+                )
+                .values()
+        )
+    }
+
+    public async createConnection(profile: SsoProfile): Promise<SsoConnection>
+    public async createConnection(profile: Profile): Promise<Connection> {
+        // XXX: Scoped connections must be shared as a workaround
+        if (profile.scopes) {
+            const sharedProfile = sortProfilesByScope(this.store.listProfiles().map(p => p[1])).find(
+                p => p.startUrl === profile.startUrl
+            )
+            const scopes = Array.from(new Set([...profile.scopes, ...(sharedProfile?.scopes ?? [])]))
+            profile = sharedProfile ? { ...profile, scopes } : profile
+        }
+
+        // XXX: `id` should be based off the resolved `idToken`, _not_ the source profile
+        const id = getSsoProfileKey(profile)
+        const storedProfile = await this.store.addProfile(id, profile)
+        const conn = this.createSsoConnection(id, storedProfile)
+
+        try {
+            await conn.getToken()
+        } catch (err) {
+            await this.store.deleteProfile(id)
+            throw err
+        }
+
+        return conn
+    }
+
+    public async deleteConnection(connection: Pick<Connection, 'id'>): Promise<void> {
+        await this.store.deleteProfile(connection.id)
+        if (connection.id === this.#activeConnection?.id) {
+            this.logout()
+        }
+    }
+
+    public async getConnection(connection: Pick<Connection, 'id'>): Promise<Connection | undefined> {
+        const connections = await this.listConnections()
+
+        return connections.find(c => c.id === connection.id)
+    }
+
+    private async updateState(id: Connection['id'], connectionState: ProfileMetadata['connectionState']) {
+        const metadata: Partial<ProfileMetadata> =
+            connectionState !== 'invalid' ? { connectionState, canShowExpirationMessage: false } : { connectionState }
+
+        const profile = await this.store.updateProfile(id, metadata)
+
+        if (this.#activeConnection) {
+            this.#activeConnection.state = connectionState
+            this.onDidChangeActiveConnectionEmitter.fire(this.#activeConnection)
+        }
+
+        return profile
+    }
+
+    private createSsoConnection(
+        id: Connection['id'],
+        profile: StoredProfile<SsoProfile>
+    ): SsoConnection & StatefulConnection {
+        const provider = this.createTokenProvider(
+            {
+                identifier: id,
+                startUrl: profile.startUrl,
+                scopes: profile.scopes,
+                region: profile.ssoRegion,
+            },
+            this.ssoCache
+        )
+
+        return {
+            id,
+            type: profile.type,
+            scopes: profile.scopes,
+            state: profile.metadata.connectionState,
+            label: profile.metadata?.label ?? `SSO (${profile.startUrl})`,
+            getToken: () => this.debouncedGetToken(id, provider),
+        }
+    }
+
+    private readonly debouncedGetToken = keyedDebounce(Auth.prototype.getToken.bind(this))
+    private async getToken(id: Connection['id'], provider: SsoAccessTokenProvider): Promise<SsoToken> {
+        const token = await provider.getToken()
+
+        return token ?? this.handleInvalidCredentials(id, () => provider.createToken())
+    }
+
+    private async handleInvalidCredentials<T>(id: Connection['id'], refresh: () => Promise<T>): Promise<T> {
+        const previousState = this.store.getProfile(id)?.metadata.connectionState
+        const { metadata } = await this.updateState(id, 'invalid')
+
+        if (metadata.canShowExpirationMessage) {
+            throw new ToolkitError('Credentials are invalid or expired. Try logging in again.', {
+                code: 'InvalidCredentials',
+            })
+        }
+
+        if (previousState !== 'unauthenticated') {
+            await this.store.updateProfile(id, { canShowExpirationMessage: true })
+
+            const message = 'Credentials are expired or invalid, login again?'
+            const resp = await vscode.window.showInformationMessage(message, 'Yes', 'No')
+            if (resp !== 'Yes') {
+                throw new ToolkitError('User cancelled login', {
+                    cancelled: true,
+                    code: 'InvalidCredentials',
+                })
+            }
+        }
+
+        const refreshed = await refresh()
+        await this.updateState(id, 'valid')
+
+        return refreshed
+    }
+}
+
+const loginCommand = Commands.register('aws.auth.login', async (auth: Auth) => {
+    const items = (async function () {
+        const connections = await auth.listMergedConnections()
+
+        return [...connections.map(c => ({ label: c.label, data: c }))]
+    })()
+
+    const resp = await showQuickPick(items, { title: 'Select a connection' })
+    if (!isValidResponse(resp)) {
+        throw new CancellationError('user')
+    }
+
+    await auth.login(resp)
+})
+
+function mapEventType<T, U = void>(event: vscode.Event<T>, fn?: (val: T) => U): vscode.Event<U> {
+    const emitter = new vscode.EventEmitter<U>()
+    event(val => (fn ? emitter.fire(fn(val)) : emitter.fire(undefined as U)))
+
+    return emitter.event
+}
+
+export class AuthNode {
+    public readonly id = 'auth'
+    public readonly onDidChangeTreeItem = mapEventType(this.resource.onDidChangeActiveConnection)
+
+    public constructor(public readonly resource: Auth) {}
+
+    public getTreeItem() {
+        if (this.resource.activeConnection?.state === 'invalid') {
+            return this.createBadConnectionItem()
+        }
+
+        const label = this.resource.activeConnection?.label
+        const item = new vscode.TreeItem(label ? `Connected to ${label}` : 'Select a connection...')
+        item.iconPath = getIcon('vscode-account')
+        item.command = loginCommand.build(this.resource).asCommand({ title: 'Login' })
+
+        return item
+    }
+
+    private createBadConnectionItem() {
+        const item = new vscode.TreeItem('Connection is invalid or expired')
+        item.iconPath = getIcon('vscode-error')
+        item.command = loginCommand.build(this.resource).asCommand({ title: 'Login' })
+
+        return item
+    }
+}

--- a/src/credentials/auth.ts
+++ b/src/credentials/auth.ts
@@ -15,6 +15,7 @@ import { ToolkitError } from '../shared/errors'
 import { getCache } from './sso/cache'
 import { createFactoryFunction, Mutable } from '../shared/utilities/tsUtils'
 import { SsoToken } from './sso/model'
+import globals from '../shared/extensionGlobals'
 
 interface SsoConnection {
     readonly type: 'sso'
@@ -330,6 +331,11 @@ export class Auth implements AuthService, LoginManager {
         await this.updateState(id, 'valid')
 
         return refreshed
+    }
+
+    static #instance: Auth | undefined
+    public static get instance() {
+        return (this.#instance ??= new Auth(new ProfileStore(globals.context.globalState)))
     }
 }
 

--- a/src/credentials/sdkV2Compat.ts
+++ b/src/credentials/sdkV2Compat.ts
@@ -1,0 +1,33 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AWSError } from 'aws-sdk'
+import { Token } from 'aws-sdk/lib/token'
+import { Connection } from './auth'
+
+export class TokenProvider extends Token {
+    public constructor(private readonly connection: Connection & { type: 'sso' }) {
+        super({ token: '', expireTime: new Date(0) })
+    }
+
+    public override get(cb: (err?: AWSError | undefined) => void): void {
+        if (!this.token || this.needsRefresh()) {
+            this.refresh(cb)
+        }
+
+        cb()
+    }
+
+    public override refresh(cb: (err?: AWSError | undefined) => void): void {
+        this.connection
+            .getToken()
+            .then(({ accessToken, expiresAt }) => {
+                this.token = accessToken
+                this.expireTime = expiresAt
+                this.expired = false
+            })
+            .catch(cb)
+    }
+}

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -536,6 +536,7 @@ const DEV_SETTINGS = {
     forceInstallTools: Boolean,
     telemetryEndpoint: String,
     telemetryUserPool: String,
+    showAuthNode: Boolean,
 }
 
 type ResolvedDevSettings = FromDescriptor<typeof DEV_SETTINGS>

--- a/src/shared/utilities/tsUtils.ts
+++ b/src/shared/utilities/tsUtils.ts
@@ -65,6 +65,10 @@ export function createConstantMap<T extends PropertyKey, U extends PropertyKey>(
     return new Map<T, U>(Object.entries(obj) as [T, U][]) as unknown as ConstantMap<T, U>
 }
 
+export function createFactoryFunction<T extends new (...args: any[]) => any>(ctor: T): FactoryFunction<T> {
+    return (...args) => new ctor(...args)
+}
+
 type NoSymbols<T> = { [Property in keyof T]: Property extends symbol ? never : Property }[keyof T]
 export type InterfaceNoSymbol<T> = Pick<T, NoSymbols<T>>
 /**
@@ -112,3 +116,10 @@ export type RequiredProps<T, K extends keyof T> = T & { [P in K]-?: NonNullable<
 
 /** Analagous to shifting an array but for tuples */
 export type Shift<T extends any[]> = T extends [infer _, ...infer U] ? U : []
+
+/** Transforms a type into a mutable version */
+export type Mutable<T> = { -readonly [P in keyof T]: T[P] }
+
+export type FactoryFunction<T extends abstract new (...args: any[]) => any> = (
+    ...args: ConstructorParameters<T>
+) => InstanceType<T>

--- a/src/test/credentials/auth.test.ts
+++ b/src/test/credentials/auth.test.ts
@@ -1,0 +1,148 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import * as sinon from 'sinon'
+import * as vscode from 'vscode'
+import { Auth, getSsoProfileKey, ProfileStore, SsoProfile } from '../../credentials/auth'
+import { SsoToken } from '../../credentials/sso/model'
+import { SsoAccessTokenProvider } from '../../credentials/sso/ssoAccessTokenProvider'
+import { FakeMemento } from '../fakeExtensionContext'
+import { createTestWindow } from '../shared/vscode/window'
+import { captureEvent } from '../testUtil'
+import { stub } from '../utilities/stubber'
+
+function createStore() {
+    return new ProfileStore(new FakeMemento())
+}
+
+function createSsoProfile(props?: Partial<Omit<SsoProfile, 'type'>>): SsoProfile {
+    return {
+        type: 'sso',
+        ssoRegion: 'us-east-1',
+        startUrl: 'https://d-0123456789.awsapps.com/start',
+        ...props,
+    }
+}
+
+const ssoProfile = createSsoProfile()
+const scopedSsoProfile = createSsoProfile({ scopes: ['foo'] })
+
+describe('Auth', function () {
+    const tokenProviders = new Map<string, ReturnType<typeof createTestTokenProvider>>()
+
+    function createTestTokenProvider(...[profile]: ConstructorParameters<typeof SsoAccessTokenProvider>) {
+        let token: SsoToken | undefined
+        const provider = stub(SsoAccessTokenProvider)
+        tokenProviders.set(getSsoProfileKey(profile), provider)
+        provider.getToken.callsFake(async () => token)
+        provider.createToken.callsFake(
+            async () => (token = { accessToken: '123', expiresAt: new Date(Date.now() + 100000) })
+        )
+        provider.invalidate.callsFake(async () => (token = undefined))
+
+        return provider
+    }
+
+    let auth: Auth
+
+    beforeEach(function () {
+        tokenProviders.clear()
+        sinon.restore()
+        auth = new Auth(createStore(), createTestTokenProvider)
+    })
+
+    it('can create a new sso connection', async function () {
+        const conn = await auth.createConnection(ssoProfile)
+        assert.strictEqual(conn.type, 'sso')
+    })
+
+    it('can list connections', async function () {
+        const conn1 = await auth.createConnection(ssoProfile)
+        const conn2 = await auth.createConnection(scopedSsoProfile)
+        assert.deepStrictEqual(
+            (await auth.listConnections()).map(c => c.id),
+            [conn1.id, conn2.id]
+        )
+    })
+
+    it('can get a connection', async function () {
+        const conn = await auth.createConnection(ssoProfile)
+        assert.ok(await auth.getConnection({ id: conn.id }))
+    })
+
+    it('can delete a connection', async function () {
+        const conn = await auth.createConnection(ssoProfile)
+        await auth.deleteConnection({ id: conn.id })
+        assert.strictEqual((await auth.listConnections()).length, 0)
+    })
+
+    it('can delete an active connection', async function () {
+        const conn = await auth.createConnection(ssoProfile)
+        await auth.login(conn)
+        assert.ok(auth.activeConnection)
+        await auth.deleteConnection(auth.activeConnection)
+        assert.strictEqual((await auth.listConnections()).length, 0)
+        assert.strictEqual(auth.activeConnection, undefined)
+    })
+
+    it('throws when creating a duplicate connection', async function () {
+        await auth.createConnection(ssoProfile)
+        await assert.rejects(() => auth.createConnection(ssoProfile))
+    })
+
+    it('throws when using an invalid connection that was deleted', async function () {
+        const conn = await auth.createConnection(ssoProfile)
+        const provider = tokenProviders.get(getSsoProfileKey(ssoProfile))
+        await provider?.invalidate()
+        await auth.deleteConnection(conn)
+        await assert.rejects(() => conn.getToken())
+    })
+
+    it('can login and fires an event', async function () {
+        const conn = await auth.createConnection(ssoProfile)
+
+        const events = captureEvent(auth.onDidChangeActiveConnection)
+        await auth.login(conn)
+        assert.strictEqual(auth.activeConnection?.id, conn.id)
+        assert.strictEqual(auth.activeConnection.state, 'valid')
+        assert.strictEqual(events.emits[0]?.id, conn.id)
+    })
+
+    it('can logout and fires an event', async function () {
+        const conn = await auth.createConnection(ssoProfile)
+
+        const events = captureEvent(auth.onDidChangeActiveConnection)
+        await auth.login(conn)
+        assert.strictEqual(auth.activeConnection?.id, conn.id)
+        auth.logout()
+        assert.strictEqual(auth.activeConnection, undefined)
+        assert.strictEqual(events.last, undefined)
+    })
+
+    describe('SSO Connections', function () {
+        it('creates a new token if one does not exist', async function () {
+            const conn = await auth.createConnection(ssoProfile)
+            const provider = tokenProviders.get(getSsoProfileKey(ssoProfile))
+            assert.deepStrictEqual(await provider?.getToken(), await conn.getToken())
+        })
+
+        it('prompts the user if the token is invalid or expired', async function () {
+            const conn = await auth.createConnection(ssoProfile)
+            const provider = tokenProviders.get(getSsoProfileKey(ssoProfile))
+            assert.ok(provider)
+
+            const testWindow = createTestWindow()
+            sinon.replace(vscode, 'window', testWindow)
+
+            await conn.getToken()
+            await provider.invalidate()
+            const token = conn.getToken()
+            const message = await testWindow.waitForMessage(/credentials are expired or invalid,/i)
+            message.selectItem(/yes/i)
+            assert.notStrictEqual(await token, undefined)
+        })
+    })
+})

--- a/src/test/fakeExtensionContext.ts
+++ b/src/test/fakeExtensionContext.ts
@@ -134,15 +134,8 @@ export class FakeMemento implements vscode.Memento {
     public constructor(private readonly _storage: FakeMementoStorage = {}) {}
     public get<T>(key: string): T | undefined
     public get<T>(key: string, defaultValue: T): T
-    public get(key: any, defaultValue?: any) {
-        if (Object.prototype.hasOwnProperty.call(this._storage, String(key))) {
-            return this._storage[key]
-        }
-        if (defaultValue) {
-            return defaultValue
-        }
-
-        return undefined
+    public get(key: string, defaultValue?: unknown) {
+        return this._storage[key] ?? defaultValue
     }
     public update(key: string, value: any): Thenable<void> {
         this._storage[key] = value

--- a/src/test/shared/vscode/message.ts
+++ b/src/test/shared/vscode/message.ts
@@ -40,6 +40,10 @@ export class TestMessage<T extends vscode.MessageItem = vscode.MessageItem> {
         this.onDidSelectItem = this._onDidSelectItem.event
     }
 
+    public get visible() {
+        return this._showing
+    }
+
     public assertMessage(expected: string): void {
         assert.strictEqual(this.message, expected)
     }

--- a/src/test/shared/vscode/window.ts
+++ b/src/test/shared/vscode/window.ts
@@ -13,11 +13,6 @@ export interface TestWindow {
     waitForMessage(expected: string | RegExp, timeout?: number): Promise<ShownMessage>
 }
 
-// TODO: it's better to just buffer event emitters until they have a listener
-function fireNext<T>(emitter: vscode.EventEmitter<T>, data: T): void {
-    setTimeout(() => emitter.fire(data))
-}
-
 /**
  * A test window proxies {@link vscode.window}, intercepting calls whilst
  * allowing for introspection and mocking as-needed.
@@ -25,6 +20,12 @@ function fireNext<T>(emitter: vscode.EventEmitter<T>, data: T): void {
 export function createTestWindow(): Window & TestWindow {
     // TODO: write mix-in Proxy factory function
     const onDidShowMessageEmitter = new vscode.EventEmitter<ShownMessage>()
+    const shownMessages: ShownMessage[] = []
+
+    function fireOnDidShowMessage(message: ShownMessage) {
+        shownMessages.push(message)
+        onDidShowMessageEmitter.fire(message)
+    }
 
     return new Proxy(vscode.window, {
         get: (target, prop, recv) => {
@@ -34,6 +35,11 @@ export function createTestWindow(): Window & TestWindow {
             if (prop === 'waitForMessage') {
                 return (expected: string | RegExp, timeout: number = 5000) => {
                     return new Promise<ShownMessage>((resolve, reject) => {
+                        const alreadyShown = shownMessages.find(m => m.visible && m.message.match(expected))
+                        if (alreadyShown) {
+                            return resolve(alreadyShown)
+                        }
+
                         const d = onDidShowMessageEmitter.event(shownMessage => {
                             if (shownMessage.message.match(expected)) {
                                 d.dispose()
@@ -48,15 +54,13 @@ export function createTestWindow(): Window & TestWindow {
                 }
             }
             if (prop === 'showInformationMessage') {
-                return TestMessage.create(SeverityLevel.Information, message =>
-                    fireNext(onDidShowMessageEmitter, message)
-                )
+                return TestMessage.create(SeverityLevel.Information, fireOnDidShowMessage)
             }
             if (prop === 'showWarningMessage') {
-                return TestMessage.create(SeverityLevel.Warning, message => fireNext(onDidShowMessageEmitter, message))
+                return TestMessage.create(SeverityLevel.Warning, fireOnDidShowMessage)
             }
             if (prop === 'showErrorMessage') {
-                return TestMessage.create(SeverityLevel.Error, message => fireNext(onDidShowMessageEmitter, message))
+                return TestMessage.create(SeverityLevel.Error, fireOnDidShowMessage)
             }
             return Reflect.get(target, prop, recv)
         },


### PR DESCRIPTION
## Problem
No easy way to manipulate SSO configurations separate from traditional AWS credentials

## Solution
* Add a shared auth service
* Gate any UI behind a feature flag
    * Add the setting `"aws.dev.showAuthNode": true` to see the UI

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
