### PR TITLE
feat(s3): "Copy Path" now gets the full "s3://…" path

### DIFF
--- a/src/s3/commands/createFolder.ts
+++ b/src/s3/commands/createFolder.ts
@@ -10,7 +10,6 @@ import { S3FolderNode } from '../explorer/s3FolderNode'
 import { Commands } from '../../shared/vscode/commands'
 import { Window } from '../../shared/vscode/window'
 import { localize } from '../../shared/utilities/vsCodeUtils'
-import { readablePath } from '../util'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { CancellationError } from '../../shared/utilities/timeoutUtils'
 import { ToolkitError } from '../../shared/errors'
@@ -35,7 +34,7 @@ export async function createFolderCommand(
 
     await telemetry.s3_createFolder.run(async () => {
         const folderName = await window.showInputBox({
-            prompt: localize('AWS.s3.createFolder.prompt', 'Enter a folder to create in {0}', readablePath(node)),
+            prompt: localize('AWS.s3.createFolder.prompt', 'Enter a folder to create in {0}', node.bucket.uri),
             placeHolder: localize('AWS.s3.createFolder.placeHolder', 'Folder Name'),
             validateInput: validateFolderName,
         })

--- a/src/s3/commands/deleteFile.ts
+++ b/src/s3/commands/deleteFile.ts
@@ -12,7 +12,6 @@ import { Window } from '../../shared/vscode/window'
 import { S3BucketNode } from '../explorer/s3BucketNode'
 import { S3FileNode } from '../explorer/s3FileNode'
 import { S3FolderNode } from '../explorer/s3FolderNode'
-import { readablePath } from '../util'
 import { showConfirmationMessage } from '../../shared/utilities/messages'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { CancellationError } from '../../shared/utilities/timeoutUtils'
@@ -33,13 +32,13 @@ export async function deleteFileCommand(
     window = Window.vscode(),
     commands = Commands.vscode()
 ): Promise<void> {
-    const filePath = readablePath(node)
+    const filePath = node.file.uri
     getLogger().debug('DeleteFile called for %O', node)
 
     await telemetry.s3_deleteObject.run(async () => {
         const isConfirmed = await showConfirmationMessage(
             {
-                prompt: localize('AWS.s3.deleteFile.prompt', 'Are you sure you want to delete file {0}?', filePath),
+                prompt: localize('AWS.s3.deleteFile.prompt', 'Delete file {0}?', filePath),
                 confirm: localizedText.localizedDelete,
                 cancel: localizedText.cancel,
             },
@@ -48,8 +47,6 @@ export async function deleteFileCommand(
         if (!isConfirmed) {
             throw new CancellationError('user')
         }
-
-        getLogger().info(`Deleting file ${filePath}`)
 
         await node
             .deleteFile()

--- a/src/s3/commands/downloadFileAs.ts
+++ b/src/s3/commands/downloadFileAs.ts
@@ -9,7 +9,6 @@ import * as vscode from 'vscode'
 import { downloadsDir } from '../../shared/filesystemUtilities'
 import { Window } from '../../shared/vscode/window'
 import { S3FileNode } from '../explorer/s3FileNode'
-import { readablePath } from '../util'
 import { progressReporter } from '../progressReporter'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { showOutputMessage } from '../../shared/utilities/messages'
@@ -116,7 +115,7 @@ export async function downloadFileAsCommand(
     outputChannel = globals.outputChannel
 ): Promise<void> {
     const { bucket, file } = node
-    const sourcePath = readablePath(node)
+    const sourcePath = node.file.uri
 
     await telemetry.s3_downloadObject.run(async () => {
         const saveLocation = await promptForSaveLocation(file.name, window)

--- a/src/s3/commands/uploadFile.ts
+++ b/src/s3/commands/uploadFile.ts
@@ -284,7 +284,7 @@ async function uploadBatchOfFiles(
             while (!token.isCancellationRequested && requestIdx < uploadRequests.length) {
                 const request = uploadRequests[requestIdx]
                 const fileName = path.basename(request.key)
-                const destinationPath = readablePath({ bucket: { name: request.bucketName }, path: request.key })
+                const destinationPath = readablePath({ bucket: request.bucketName, path: request.key })
                 showOutputMessage(
                     localize('AWS.s3.uploadFile.startUpload', 'Uploading file {0} to {1}', fileName, destinationPath),
                     outputChannel

--- a/src/s3/explorer/s3BucketNode.ts
+++ b/src/s3/explorer/s3BucketNode.ts
@@ -115,8 +115,7 @@ export class S3BucketNode extends AWSTreeNodeBase implements AWSResourceNode, Lo
     }
 
     public get path(): string {
-        // Even though the bucket is the "root", there is no '/' prefix on objects inside
-        return ''
+        return this.bucket.uri
     }
 
     public [inspect.custom](): string {

--- a/src/s3/explorer/s3FileNode.ts
+++ b/src/s3/explorer/s3FileNode.ts
@@ -87,7 +87,7 @@ export class S3FileNode extends AWSTreeNodeBase implements AWSResourceNode {
     }
 
     public get path(): string {
-        return this.file.key
+        return this.file.uri
     }
 
     public [inspect.custom](): string {

--- a/src/s3/explorer/s3FolderNode.ts
+++ b/src/s3/explorer/s3FolderNode.ts
@@ -107,7 +107,7 @@ export class S3FolderNode extends AWSTreeNodeBase implements AWSResourceNode, Lo
     }
 
     public get path(): string {
-        return this.folder.path
+        return this.folder.uri
     }
 
     public [inspect.custom](): string {

--- a/src/s3/util.ts
+++ b/src/s3/util.ts
@@ -4,18 +4,15 @@
  */
 
 import { localize } from '../shared/utilities/vsCodeUtils'
+
 /**
- * Creates a readable path to an s3 bucket or object (e.g. s3://...).
+ * Builds an "s3://…" path.
  *
  * This is the format used by AWS CLI.
  * @see https://docs.aws.amazon.com/cli/latest/reference/s3/#path-argument-type
- *
- * @param bucket contains the name of the bucket.
- * @param path to the object, or an empty string if this is the root of the bucket.
- * @returns the readable path to the s3 bucket or object (e.g. s3://...).
  */
-export function readablePath({ bucket, path }: { bucket: { name: string }; path: string }): string {
-    return path ? `s3://${bucket.name}/${path}` : `s3://${bucket.name}`
+export function readablePath({ bucket, path }: { bucket: string; path: string | undefined }): string {
+    return path ? `s3://${bucket}/${path}` : `s3://${bucket}`
 }
 
 /**

--- a/src/shared/clients/s3Client.ts
+++ b/src/shared/clients/s3Client.ts
@@ -15,6 +15,7 @@ import { InterfaceNoSymbol } from '../utilities/tsUtils'
 import { Readable } from 'stream'
 import globals from '../extensionGlobals'
 import { DEFAULT_PARTITION } from '../regions/regionProvider'
+import { readablePath } from '../../s3/util'
 
 export const DEFAULT_MAX_KEYS = 300
 export const DEFAULT_DELIMITER = '/'
@@ -618,11 +619,14 @@ export class DefaultBucket {
     public readonly name: string
     public readonly region: string
     public readonly arn: string
+    /** s3://… URI */
+    public readonly uri: string
 
     public constructor({ partitionId, region, name }: { partitionId: string; region: string; name: string }) {
         this.name = name
         this.region = region
         this.arn = buildArn({ partitionId, bucketName: name })
+        this.uri = readablePath({ bucket: name, path: undefined })
     }
 
     public [inspect.custom](): string {
@@ -634,10 +638,13 @@ export class DefaultFolder {
     public readonly name: string
     public readonly path: string
     public readonly arn: string
+    /** s3://… URI */
+    public readonly uri: string
 
     public constructor({ partitionId, bucketName, path }: { partitionId: string; bucketName: string; path: string }) {
         this.path = path
         this.arn = buildArn({ partitionId, bucketName, key: path })
+        this.uri = readablePath({ bucket: bucketName, path: path })
         this.name = _(this.path).split(DEFAULT_DELIMITER).dropRight()!.last()!
     }
 
@@ -650,6 +657,8 @@ export class DefaultFile {
     public readonly name: string
     public readonly key: string
     public readonly arn: string
+    /** s3://… URI */
+    public readonly uri: string
     public readonly lastModified?: Date
     public readonly sizeBytes?: number
     public readonly eTag?: string
@@ -672,6 +681,7 @@ export class DefaultFile {
         this.name = _(key).split(DEFAULT_DELIMITER).last()!
         this.key = key
         this.arn = buildArn({ partitionId, bucketName, key })
+        this.uri = readablePath({ bucket: bucketName, path: key })
         this.lastModified = lastModified
         this.sizeBytes = sizeBytes
         this.eTag = eTag

--- a/src/test/s3/commands/copyPath.test.ts
+++ b/src/test/s3/commands/copyPath.test.ts
@@ -24,8 +24,8 @@ describe('copyPathCommand', function () {
 
 function createS3FolderNode(): S3FolderNode {
     return new S3FolderNode(
-        { name: 'name', region: 'region', arn: 'arn' },
-        { name: 'name', path: 'path', arn: 'arn ' },
+        { name: 'name', region: 'region', arn: 'arn', uri: 's3://foo' },
+        { name: 'name', path: 'path', arn: 'arn ', uri: 's3://foo' },
         {} as S3Client
     )
 }

--- a/src/test/s3/commands/createBucket.test.ts
+++ b/src/test/s3/commands/createBucket.test.ts
@@ -24,7 +24,7 @@ describe('createBucketCommand', function () {
 
     it('prompts for bucket name, creates bucket, shows success, and refreshes node', async function () {
         when(s3.createBucket(deepEqual({ bucketName }))).thenResolve({
-            bucket: { name: bucketName, region: 'region', arn: 'arn' },
+            bucket: { name: bucketName, region: 'region', arn: 'arn', uri: 's3://foo' },
         })
 
         const window = new FakeWindow({ inputBox: { input: bucketName } })

--- a/src/test/s3/commands/createFolder.test.ts
+++ b/src/test/s3/commands/createFolder.test.ts
@@ -28,7 +28,7 @@ describe('createFolderCommand', function () {
     beforeEach(function () {
         s3 = mock()
         node = new S3BucketNode(
-            { name: bucketName, region: 'region', arn: 'arn' },
+            { name: bucketName, region: 'region', arn: 'arn', uri: 's3://foo' },
             new S3Node(instance(s3)),
             instance(s3)
         )
@@ -36,7 +36,7 @@ describe('createFolderCommand', function () {
 
     it('prompts for folder name, creates folder, shows success, and refreshes node', async function () {
         when(s3.createFolder(deepEqual({ path: folderPath, bucketName }))).thenResolve({
-            folder: { name: folderName, path: folderPath, arn: 'arn' },
+            folder: { name: folderName, path: folderPath, arn: 'arn', uri: 's3://foo' },
         })
 
         const window = new FakeWindow({ inputBox: { input: folderName } })

--- a/src/test/s3/commands/deleteBucket.test.ts
+++ b/src/test/s3/commands/deleteBucket.test.ts
@@ -23,7 +23,11 @@ describe('deleteBucketCommand', function () {
     beforeEach(function () {
         s3 = mock()
         parentNode = new S3Node(instance(s3))
-        node = new S3BucketNode({ name: bucketName, region: 'region', arn: 'arn' }, parentNode, instance(s3))
+        node = new S3BucketNode(
+            { name: bucketName, region: 'region', arn: 'arn', uri: 's3://foo' },
+            parentNode,
+            instance(s3)
+        )
     })
 
     it('confirms deletion, deletes bucket, shows progress bar, and refreshes parent node', async function () {

--- a/src/test/s3/commands/deleteFile.test.ts
+++ b/src/test/s3/commands/deleteFile.test.ts
@@ -17,7 +17,7 @@ describe('deleteFileCommand', function () {
     const key = 'foo/bar.jpg'
     const name = 'bar.jpg'
     const bucketName = 'bucket-name'
-    const bucket: Bucket = { name: bucketName, region: 'region', arn: 'arn' }
+    const bucket: Bucket = { name: bucketName, region: 'region', arn: 'arn', uri: 's3://foo' }
 
     let s3: S3Client
     let parentNode: S3BucketNode
@@ -26,7 +26,7 @@ describe('deleteFileCommand', function () {
     beforeEach(function () {
         s3 = mock()
         parentNode = new S3BucketNode(bucket, {} as S3Node, instance(s3))
-        node = new S3FileNode(bucket, { name, key, arn: 'arn' }, parentNode, instance(s3))
+        node = new S3FileNode(bucket, { name, key, arn: 'arn', uri: 's3://foo' }, parentNode, instance(s3))
     })
 
     it('confirms deletion, deletes file, shows status bar confirmation, and refreshes parent node', async function () {

--- a/src/test/s3/commands/downloadFileAs.test.ts
+++ b/src/test/s3/commands/downloadFileAs.test.ts
@@ -39,11 +39,11 @@ describe('downloadFileAsCommand', function () {
     beforeEach(function () {
         s3 = mock()
 
-        const bucket: Bucket = { name: bucketName, region: 'region', arn: 'arn' }
+        const bucket: Bucket = { name: bucketName, region: 'region', arn: 'arn', uri: 's3://foo' }
         bucketNode = new S3BucketNode(bucket, {} as S3Node, instance(s3))
         node = new S3FileNode(
             bucket,
-            { name: fileName, key: key, arn: 'arn', lastModified, sizeBytes },
+            { name: fileName, key: key, arn: 'arn', lastModified, sizeBytes, uri: 's3://foo' },
             bucketNode,
             instance(s3)
         )

--- a/src/test/s3/commands/presignedURL.test.ts
+++ b/src/test/s3/commands/presignedURL.test.ts
@@ -31,9 +31,9 @@ describe('presignedURLCommand', function () {
         window = mock()
         env = new FakeEnv()
 
-        const bucket: Bucket = { name: bucketName, region: 'region', arn: 'arn' }
+        const bucket: Bucket = { name: bucketName, region: 'region', arn: 'arn', uri: 's3://foo' }
         bucketNode = new S3BucketNode(bucket, {} as S3Node, instance(s3))
-        node = new S3FileNode(bucket, { name: key, key: key, arn: 'arn' }, bucketNode, instance(s3))
+        node = new S3FileNode(bucket, { name: key, key: key, arn: 'arn', uri: 's3://foo' }, bucketNode, instance(s3))
     })
 
     it('calls S3 to get the URL', async function () {

--- a/src/test/s3/commands/uploadFile.test.ts
+++ b/src/test/s3/commands/uploadFile.test.ts
@@ -42,7 +42,7 @@ describe('uploadFileCommand', function () {
         s3 = mock()
         commands = new FakeCommands()
         bucketNode = new S3BucketNode(
-            { name: bucketName, region: 'region', arn: 'arn' },
+            { name: bucketName, region: 'region', arn: 'arn', uri: 's3://foo' },
             new S3Node(instance(s3)),
             instance(s3)
         )
@@ -55,7 +55,7 @@ describe('uploadFileCommand', function () {
             s3 = mock()
             commands = new FakeCommands()
             bucketNode = new S3BucketNode(
-                { name: bucketName, region: 'region', arn: 'arn' },
+                { name: bucketName, region: 'region', arn: 'arn', uri: 's3://foo' },
                 new S3Node(instance(s3)),
                 instance(s3)
             )

--- a/src/test/s3/explorer/s3BucketNode.test.ts
+++ b/src/test/s3/explorer/s3BucketNode.test.ts
@@ -18,9 +18,9 @@ import { FakeWorkspace } from '../../shared/vscode/fakeWorkspace'
 describe('S3BucketNode', function () {
     const name = 'bucket-name'
     const continuationToken = 'continuationToken'
-    const bucket: Bucket = { name, region: 'region', arn: 'arn' }
-    const file: File = { name: 'name', key: 'key', arn: 'arn' }
-    const folder: Folder = { name: 'folder', path: 'path', arn: 'arn' }
+    const bucket: Bucket = { name, region: 'region', arn: 'arn', uri: 's3://foo' }
+    const file: File = { name: 'name', key: 'key', arn: 'arn', uri: 's3://foo' }
+    const folder: Folder = { name: 'folder', path: 'path', arn: 'arn', uri: 's3://foo' }
     const maxResults = 200
     let s3: S3Client
 

--- a/src/test/s3/explorer/s3FileNode.test.ts
+++ b/src/test/s3/explorer/s3FileNode.test.ts
@@ -20,8 +20,8 @@ describe('S3FileNode', function () {
 
     it('creates an S3 File Node', async function () {
         const node = new S3FileNode(
-            { name: 'bucket-name', region: 'region', arn: 'arn' },
-            { name, key, arn, sizeBytes, lastModified },
+            { name: 'bucket-name', region: 'region', arn: 'arn', uri: 's3://foo' },
+            { name, key, arn, sizeBytes, lastModified, uri: 's3://foo' },
             {} as S3BucketNode,
             {} as S3Client,
             now

--- a/src/test/s3/explorer/s3FolderNode.test.ts
+++ b/src/test/s3/explorer/s3FolderNode.test.ts
@@ -17,10 +17,10 @@ describe('S3FolderNode', function () {
     const bucketName = 'bucket-name'
     const path = 'folder/path'
     const continuationToken = 'continuationToken'
-    const bucket: Bucket = { name: bucketName, region: 'region', arn: 'arn' }
-    const file: File = { name: 'name', key: 'key', arn: 'arn' }
-    const folder: Folder = { name: 'folder', path, arn: 'arn' }
-    const subFolder: Folder = { name: 'subFolder', path: 'subPath', arn: 'subArn' }
+    const bucket: Bucket = { name: bucketName, region: 'region', arn: 'arn', uri: 's3://foo' }
+    const file: File = { name: 'name', key: 'key', arn: 'arn', uri: 's3://foo' }
+    const folder: Folder = { name: 'folder', path, arn: 'arn', uri: 's3://foo' }
+    const subFolder: Folder = { name: 'subFolder', path: 'subPath', arn: 'subArn', uri: 's3://foo' }
     const maxResults = 200
     const workspace = new FakeWorkspace({
         section: 'aws',

--- a/src/test/s3/explorer/s3Nodes.test.ts
+++ b/src/test/s3/explorer/s3Nodes.test.ts
@@ -11,8 +11,13 @@ import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
 import { instance, mock, when } from '../../utilities/mockito'
 
 describe('S3Node', function () {
-    const firstBucket: Bucket = { name: 'first-bucket-name', region: 'firstRegion', arn: 'firstArn' }
-    const secondBucket: Bucket = { name: 'second-bucket-name', region: 'secondRegion', arn: 'secondArn' }
+    const firstBucket: Bucket = { name: 'first-bucket-name', region: 'firstRegion', arn: 'firstArn', uri: 's3://foo' }
+    const secondBucket: Bucket = {
+        name: 'second-bucket-name',
+        region: 'secondRegion',
+        arn: 'secondArn',
+        uri: 's3://foo',
+    }
 
     let s3: S3Client
 

--- a/src/test/s3/util/util.test.ts
+++ b/src/test/s3/util/util.test.ts
@@ -13,13 +13,13 @@ describe('messages', function () {
         const objectPath = 'path/to/object'
 
         it('creates a readable path for an S3 bucket', function () {
-            const path = readablePath({ bucket: { name: bucketName }, path: bucketPath })
+            const path = readablePath({ bucket: bucketName, path: bucketPath })
 
             assert.strictEqual(path, 's3://bucket-name')
         })
 
         it('creates a readable path for an object in an S3 bucket', function () {
-            const path = readablePath({ bucket: { name: bucketName }, path: objectPath })
+            const path = readablePath({ bucket: bucketName, path: objectPath })
 
             assert.strictEqual(path, 's3://bucket-name/path/to/object')
         })


### PR DESCRIPTION
## Problem
- `Copy Path` isn't very useful. #2953
- S3 ARNs don't work with AWS CLI `aws s3` command: https://docs.aws.amazon.com/cli/latest/reference/s3/

## Solution
Change the behavior of `Copy Path` to return `s3://` URLs instead of just the "key".


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
