### PR TITLE
feat(dev): add endpoints override

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,6 +244,18 @@ Toolkit for testing and development purposes. To use a setting just add it to
 your `settings.json`. At runtime, if the Toolkit reads any of these settings,
 the "AWS" statusbar item will [change its color](https://github.com/aws/aws-toolkit-vscode/blob/479b9d45b5f5ad30fc10567e649b59801053aeba/src/credentials/awsCredentialsStatusBarItem.ts#L45). Use the setting `aws.dev.forceDevMode` to trigger this effect on start-up.
 
+### Service Endpoints
+
+Endpoint overrides can be set per-service using the `aws.dev.endpoints` settings. This is a JSON object where each key is the service ID (case-insensitive) and each value is the endpoint. Refer to the SDK [API models](https://github.com/aws/aws-sdk-js/tree/master/apis) to find relevant service IDs.
+
+Example:
+
+```json
+"aws.dev.endpoints": {
+    "s3": "http://example.com"
+}
+```
+
 ### Telemetry and Automation
 
 Metrics are only emitted if the extension is assumed to be ran from an actual user rather than automation scripts.

--- a/src/credentials/sso/clients.ts
+++ b/src/credentials/sso/clients.ts
@@ -35,6 +35,7 @@ import { getLogger } from '../../shared/logger'
 import { SsoAccessTokenProvider } from './ssoAccessTokenProvider'
 import { sleep } from '../../shared/utilities/timeoutUtils'
 import { isClientFault } from '../../shared/errors'
+import { DevSettings } from '../../shared/settings'
 
 const BACKOFF_DELAY_MS = 5000
 
@@ -97,7 +98,13 @@ export class OidcClient {
     }
 
     public static create(region: string) {
-        return new this(new SSOOIDC({ region: region }), globals.clock)
+        return new this(
+            new SSOOIDC({
+                region,
+                endpoint: DevSettings.instance.get('endpoints', {})['ssooidc'],
+            }),
+            globals.clock
+        )
     }
 }
 
@@ -183,6 +190,12 @@ export class SsoClient {
     }
 
     public static create(region: string, provider: SsoAccessTokenProvider) {
-        return new this(new SSO({ region }), provider)
+        return new this(
+            new SSO({
+                region,
+                endpoint: DevSettings.instance.get('endpoints', {})['sso'],
+            }),
+            provider
+        )
     }
 }

--- a/src/shared/awsClientBuilder.ts
+++ b/src/shared/awsClientBuilder.ts
@@ -59,7 +59,8 @@ export interface AWSClientBuilder {
         type: new (o: ServiceConfigurationOptions) => T,
         options?: ServiceOptions,
         region?: string,
-        userAgent?: boolean
+        userAgent?: boolean,
+        settings?: DevSettings
     ): Promise<T>
 }
 
@@ -70,7 +71,8 @@ export class DefaultAWSClientBuilder implements AWSClientBuilder {
         type: new (o: ServiceConfigurationOptions) => T,
         options?: ServiceOptions,
         region?: string,
-        userAgent: boolean = true
+        userAgent: boolean = true,
+        settings = DevSettings.instance
     ): Promise<T> {
         const onRequest = options?.onRequestSetup ?? []
         const listeners = Array.isArray(onRequest) ? onRequest : [onRequest]
@@ -134,8 +136,10 @@ export class DefaultAWSClientBuilder implements AWSClientBuilder {
 
         const apiConfig = (opt as { apiConfig?: { metadata?: Record<string, string> } } | undefined)?.apiConfig
         const serviceName =
-            apiConfig?.metadata?.serviceId ?? (type as unknown as { serviceIdentifier: string }).serviceIdentifier
-        opt.endpoint = DevSettings.instance.get('endpoints', {})[serviceName.toLowerCase()]
+            apiConfig?.metadata?.serviceId ?? (type as unknown as { serviceIdentifier?: string }).serviceIdentifier
+        if (serviceName) {
+            opt.endpoint = settings.get('endpoints', {})[serviceName.toLowerCase()]
+        }
 
         const service = new type(opt)
         const originalSetup = service.setupRequestListeners.bind(service)

--- a/src/shared/awsClientBuilder.ts
+++ b/src/shared/awsClientBuilder.ts
@@ -9,6 +9,7 @@ import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
 import { env, version } from 'vscode'
 import { AwsContext } from './awsContext'
 import globals from './extensionGlobals'
+import { DevSettings } from './settings'
 import { getClientId } from './telemetry/util'
 import { extensionVersion } from './vscode/env'
 
@@ -130,6 +131,11 @@ export class DefaultAWSClientBuilder implements AWSClientBuilder {
             const clientId = await getClientId(globals.context.globalState)
             opt.customUserAgent = `AWS-Toolkit-For-VSCode/${extensionVersion} ${platformName}/${version} ClientId/${clientId}`
         }
+
+        const apiConfig = (opt as { apiConfig?: { metadata?: Record<string, string> } } | undefined)?.apiConfig
+        const serviceName =
+            apiConfig?.metadata?.serviceId ?? (type as unknown as { serviceIdentifier: string }).serviceIdentifier
+        opt.endpoint = DevSettings.instance.get('endpoints', {})[serviceName.toLowerCase()]
 
         const service = new type(opt)
         const originalSetup = service.setupRequestListeners.bind(service)

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode'
 import * as packageJson from '../../package.json'
 import { getLogger } from './logger'
-import { cast, FromDescriptor, TypeConstructor, TypeDescriptor } from './utilities/typeConstructors'
+import { cast, FromDescriptor, Record, TypeConstructor, TypeDescriptor } from './utilities/typeConstructors'
 import { ClassToInterfaceType, keys } from './utilities/tsUtils'
 import { toRecord } from './utilities/collectionUtils'
 import { isNameMangled } from './vscode/env'
@@ -536,6 +536,7 @@ const DEV_SETTINGS = {
     forceInstallTools: Boolean,
     telemetryEndpoint: String,
     telemetryUserPool: String,
+    endpoints: Record(String, String),
 }
 
 type ResolvedDevSettings = FromDescriptor<typeof DEV_SETTINGS>

--- a/src/shared/utilities/typeConstructors.ts
+++ b/src/shared/utilities/typeConstructors.ts
@@ -125,6 +125,24 @@ function InstanceConstructor<T>(type: new (...args: any[]) => T): TypeConstructo
     }
 }
 
+export function Record<T extends PropertyKey, U>(
+    key: TypeConstructor<T>,
+    value: TypeConstructor<U>
+): TypeConstructor<Record<T, U>> {
+    return input => {
+        if (!(typeof input === 'object') || !input) {
+            throw new TypeError('Value is not a non-nullable object')
+        }
+
+        const result = {} as Record<T, U>
+        for (const [k, v] of Object.entries(input)) {
+            result[cast(k, key)] = cast(v, value)
+        }
+
+        return result
+    }
+}
+
 export type Optional<T> = TypeConstructor<T | undefined>
 export const Optional = OptionalConstructor
 

--- a/src/test/shared/defaultAwsClientBuilder.test.ts
+++ b/src/test/shared/defaultAwsClientBuilder.test.ts
@@ -7,9 +7,11 @@ import * as assert from 'assert'
 import { AWSError, Request, Service } from 'aws-sdk'
 import { version } from 'vscode'
 import { AWSClientBuilder, DefaultAWSClientBuilder } from '../../shared/awsClientBuilder'
+import { DevSettings } from '../../shared/settings'
 import { getClientId } from '../../shared/telemetry/util'
 import { FakeMemento } from '../fakeExtensionContext'
 import { FakeAwsContext } from '../utilities/fakeAwsContext'
+import { TestSettings } from '../utilities/testSettingsConfiguration'
 
 describe('DefaultAwsClientBuilder', function () {
     let builder: AWSClientBuilder
@@ -43,6 +45,24 @@ describe('DefaultAwsClientBuilder', function () {
             })
 
             assert.strictEqual(service.config.customUserAgent, 'CUSTOM USER AGENT')
+        })
+
+        it('can use endpoint override', async function () {
+            const settings = new TestSettings()
+            await settings.update('aws.dev.endpoints', { foo: 'http://example.com' })
+
+            const service = await builder.createAwsService(
+                Service,
+                {
+                    customUserAgent: 'CUSTOM USER AGENT',
+                    apiConfig: { metadata: { serviceId: 'foo' } },
+                } as any,
+                undefined,
+                undefined,
+                new DevSettings(settings)
+            )
+
+            assert.strictEqual(service.config.endpoint, 'http://example.com')
         })
 
         describe('request listeners', function () {


### PR DESCRIPTION
## Problem
No easy way for us to change service endpoints

## Solution
Add `aws.dev.endpoints` setting. This could be exposed to extension users in a later release.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
