### PR TITLE
build: also generate CHANGELOG.md in prereleases

### DIFF
--- a/.changes/next-release/Bug Fix-e4cfd29a-bc4e-4aab-809d-08b44991d139.json
+++ b/.changes/next-release/Bug Fix-e4cfd29a-bc4e-4aab-809d-08b44991d139.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "JSON-schemas download logic is brittle #2957"
+}

--- a/buildspec/packageTestVsix.yml
+++ b/buildspec/packageTestVsix.yml
@@ -28,6 +28,8 @@ phases:
 
     build:
         commands:
+            # Generate CHANGELOG.md
+            - npm run createRelease
             - npm run generateNonCodeFiles
             - cp ./README.quickstart.vscode.md ./README.md
             - npm run package

--- a/scripts/build/createRelease.ts
+++ b/scripts/build/createRelease.ts
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+//
+// Generates CHANGELOG.md
+//
+
 import * as child_process from 'child_process'
 import * as fs from 'fs-extra'
 import * as path from 'path'
@@ -17,12 +21,12 @@ fs.mkdirpSync(nextReleaseDirectory)
 
 const changeFiles = fs.readdirSync(nextReleaseDirectory)
 if (changeFiles.length === 0) {
-    console.log('Error! no changes to release!')
-    process.exit(-1)
+    console.warn('no changes to release (missing .changes/ directory)')
+    process.exit()
 }
 try {
     fs.accessSync(changesFile)
-    console.log(`Error! changelog file ${changesFile} already exists for version ${version}!`)
+    console.log(`error: changelog data file already exists: ${changesFile}`)
     process.exit(-1)
 } catch (err) {
     // This is what we want to happen, the file should not exist


### PR DESCRIPTION
## Problem

changelog is not generated for prerelease builds.

## Solution

generate the changelog in CI "package test" job.

![image](https://user-images.githubusercontent.com/55561878/198738803-67aede62-0429-47bb-8168-f57aca216b42.png)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
