### PR TITLE
fix(dev): preserve hard-coded endpoint override if it exists

### DIFF
--- a/src/shared/awsClientBuilder.ts
+++ b/src/shared/awsClientBuilder.ts
@@ -138,7 +138,7 @@ export class DefaultAWSClientBuilder implements AWSClientBuilder {
         const serviceName =
             apiConfig?.metadata?.serviceId ?? (type as unknown as { serviceIdentifier?: string }).serviceIdentifier
         if (serviceName) {
-            opt.endpoint = settings.get('endpoints', {})[serviceName.toLowerCase()]
+            opt.endpoint = settings.get('endpoints', {})[serviceName.toLowerCase()] ?? opt.endpoint
         }
 
         const service = new type(opt)

--- a/src/test/shared/defaultAwsClientBuilder.test.ts
+++ b/src/test/shared/defaultAwsClientBuilder.test.ts
@@ -65,6 +65,24 @@ describe('DefaultAwsClientBuilder', function () {
             assert.strictEqual(service.config.endpoint, 'http://example.com')
         })
 
+        it('does not clobber endpoint setting if no override is present', async function () {
+            const settings = new TestSettings()
+
+            const service = await builder.createAwsService(
+                Service,
+                {
+                    customUserAgent: 'CUSTOM USER AGENT',
+                    apiConfig: { metadata: { serviceId: 'foo' } },
+                    endpoint: 'http://example.com',
+                } as any,
+                undefined,
+                undefined,
+                new DevSettings(settings)
+            )
+
+            assert.strictEqual(service.config.endpoint, 'http://example.com')
+        })
+
         describe('request listeners', function () {
             type WithConfig = Parameters<typeof builder['createAwsService']>[1] & { apiConfig: Record<string, any> }
 


### PR DESCRIPTION
## Problem
Endpoint override doesn't play nicely with hard-coded variant

## Solution
Don't clobber it

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
