### PR TITLE
fix(credentials): "Connect" and "Choose Profile" open create credentials wizard/profile selector when credentials aren't present in aws configs

### DIFF
--- a/.changes/next-release/Bug Fix-f3f310a4-ee52-4c4a-8c91-3ca9b4b670c6.json
+++ b/.changes/next-release/Bug Fix-f3f310a4-ee52-4c4a-8c91-3ca9b4b670c6.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "\"Connect\" and \"Choose Profile\" open create credentials wizard/profile selector when credentials aren't present in aws configs"
+}

--- a/src/shared/awsContextCommands.ts
+++ b/src/shared/awsContextCommands.ts
@@ -170,7 +170,7 @@ export class AwsContextCommands {
      * editing their credentials file.
      */
     private async getProfileNameFromUser(): Promise<string | undefined> {
-        const credentialsFiles: string[] = await UserCredentialsUtils.findExistingCredentialsFilenames()
+        const credentialsFiles: string[] = await UserCredentialsUtils.findExistingCredentialsFilenames(true)
         const providerMap = await CredentialsProviderManager.getInstance().getCredentialProviderNames()
         const profileNames = Object.keys(providerMap)
         if (profileNames.length > 0) {

--- a/src/test/shared/credentials/userCredentialsUtils.test.ts
+++ b/src/test/shared/credentials/userCredentialsUtils.test.ts
@@ -6,6 +6,7 @@
 import * as assert from 'assert'
 import * as fs from 'fs-extra'
 import * as path from 'path'
+import * as sinon from 'sinon'
 
 import { Uri } from 'vscode'
 import { loadSharedConfigFiles } from '../../../shared/credentials/credentialsFile'
@@ -23,9 +24,7 @@ describe('UserCredentialsUtils', function () {
     })
 
     afterEach(async function () {
-        const env = process.env as EnvironmentVariables
-        delete env.AWS_SHARED_CREDENTIALS_FILE
-        delete env.AWS_CONFIG_FILE
+        sinon.restore()
     })
 
     after(async function () {
@@ -37,15 +36,15 @@ describe('UserCredentialsUtils', function () {
             const credentialsFilename = path.join(tempFolder, 'credentials-both-exist-test')
             const configFilename = path.join(tempFolder, 'config-both-exist-test')
 
-            const env = process.env as EnvironmentVariables
-            env.AWS_SHARED_CREDENTIALS_FILE = credentialsFilename
-            env.AWS_CONFIG_FILE = configFilename
+            sinon.stub(process, 'env').value({
+                AWS_SHARED_CREDENTIALS_FILE: credentialsFilename,
+                AWS_CONFIG_FILE: configFilename,
+            } as EnvironmentVariables)
 
             createCredentialsFile(credentialsFilename, ['default'])
             createCredentialsFile(configFilename, ['default'])
 
             const foundFiles: string[] = await UserCredentialsUtils.findExistingCredentialsFilenames()
-            assert(foundFiles)
             assert.strictEqual(foundFiles.length, 2)
         })
 
@@ -53,14 +52,14 @@ describe('UserCredentialsUtils', function () {
             const credentialsFilename = path.join(tempFolder, 'credentials-exist-test')
             const configFilename = path.join(tempFolder, 'config-not-exist-test')
 
-            const env = process.env as EnvironmentVariables
-            env.AWS_SHARED_CREDENTIALS_FILE = credentialsFilename
-            env.AWS_CONFIG_FILE = configFilename
+            sinon.stub(process, 'env').value({
+                AWS_SHARED_CREDENTIALS_FILE: credentialsFilename,
+                AWS_CONFIG_FILE: configFilename,
+            } as EnvironmentVariables)
 
             createCredentialsFile(credentialsFilename, ['default'])
 
             const foundFiles: string[] = await UserCredentialsUtils.findExistingCredentialsFilenames()
-            assert(foundFiles)
             assert.strictEqual(foundFiles.length, 1)
             assert.strictEqual(foundFiles[0], credentialsFilename)
         })
@@ -69,14 +68,14 @@ describe('UserCredentialsUtils', function () {
             const credentialsFilename = path.join(tempFolder, 'credentials-not-exist-test')
             const configFilename = path.join(tempFolder, 'config-exist-test')
 
-            const env = process.env as EnvironmentVariables
-            env.AWS_SHARED_CREDENTIALS_FILE = credentialsFilename
-            env.AWS_CONFIG_FILE = configFilename
+            sinon.stub(process, 'env').value({
+                AWS_SHARED_CREDENTIALS_FILE: credentialsFilename,
+                AWS_CONFIG_FILE: configFilename,
+            } as EnvironmentVariables)
 
             createCredentialsFile(configFilename, ['default'])
 
             const foundFiles: string[] = await UserCredentialsUtils.findExistingCredentialsFilenames()
-            assert(foundFiles)
             assert.strictEqual(foundFiles.length, 1)
             assert.strictEqual(foundFiles[0], configFilename)
         })
@@ -85,12 +84,12 @@ describe('UserCredentialsUtils', function () {
             const credentialsFilename = path.join(tempFolder, 'credentials-not-exist-test')
             const configFilename = path.join(tempFolder, 'config-not-exist-test')
 
-            const env = process.env as EnvironmentVariables
-            env.AWS_SHARED_CREDENTIALS_FILE = credentialsFilename
-            env.AWS_CONFIG_FILE = configFilename
+            sinon.stub(process, 'env').value({
+                AWS_SHARED_CREDENTIALS_FILE: credentialsFilename,
+                AWS_CONFIG_FILE: configFilename,
+            } as EnvironmentVariables)
 
             const foundFiles: string[] = await UserCredentialsUtils.findExistingCredentialsFilenames()
-            assert(foundFiles)
             assert.strictEqual(foundFiles.length, 0)
         })
 
@@ -98,15 +97,15 @@ describe('UserCredentialsUtils', function () {
             const credentialsFilename = path.join(tempFolder, 'credentials-both-exist-but-no-credentials-test')
             const configFilename = path.join(tempFolder, 'config-both-exist-but-no-credentials-test')
 
-            const env = process.env as EnvironmentVariables
-            env.AWS_SHARED_CREDENTIALS_FILE = credentialsFilename
-            env.AWS_CONFIG_FILE = configFilename
+            sinon.stub(process, 'env').value({
+                AWS_SHARED_CREDENTIALS_FILE: credentialsFilename,
+                AWS_CONFIG_FILE: configFilename,
+            } as EnvironmentVariables)
 
             createCredentialsFile(credentialsFilename, [])
             createCredentialsFile(configFilename, [])
 
             const foundFiles: string[] = await UserCredentialsUtils.findExistingCredentialsFilenames(true)
-            assert(foundFiles)
             assert.strictEqual(foundFiles.length, 0)
         })
     })
@@ -116,8 +115,9 @@ describe('UserCredentialsUtils', function () {
             const credentialsFilename = path.join(tempFolder, 'credentials-generation-test')
             const profileName = 'someRandomProfileName'
 
-            const env = process.env as EnvironmentVariables
-            env.AWS_SHARED_CREDENTIALS_FILE = credentialsFilename
+            sinon.stub(process, 'env').value({
+                AWS_SHARED_CREDENTIALS_FILE: credentialsFilename,
+            } as EnvironmentVariables)
             const creds = {
                 accessKey: '123',
                 profileName: profileName,

--- a/src/test/shared/credentials/userCredentialsUtils.test.ts
+++ b/src/test/shared/credentials/userCredentialsUtils.test.ts
@@ -93,6 +93,22 @@ describe('UserCredentialsUtils', function () {
             assert(foundFiles)
             assert.strictEqual(foundFiles.length, 0)
         })
+
+        it('returns empty result if files dont contain credentials', async function () {
+            const credentialsFilename = path.join(tempFolder, 'credentials-both-exist-but-no-credentials-test')
+            const configFilename = path.join(tempFolder, 'config-both-exist-but-no-credentials-test')
+
+            const env = process.env as EnvironmentVariables
+            env.AWS_SHARED_CREDENTIALS_FILE = credentialsFilename
+            env.AWS_CONFIG_FILE = configFilename
+
+            createCredentialsFile(credentialsFilename, [])
+            createCredentialsFile(configFilename, [])
+
+            const foundFiles: string[] = await UserCredentialsUtils.findExistingCredentialsFilenames(true)
+            assert(foundFiles)
+            assert.strictEqual(foundFiles.length, 0)
+        })
     })
 
     describe('generateCredentialsFile', function () {


### PR DESCRIPTION
## Problem
- If ~/.aws/config exists but doesn't have a usable credentials profile, the Connect to AWS and Choose AWS Profile actions open ~/.aws/config immediately instead of starting the Create Credentials Profile wizard.

## Solution
- When using "Connect" and "Choose profile", open the create credentials wizard or the profile selector when credentials aren't actually present in the ~/.aws/config and ~/.aws/credentials files

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
