### PR TITLE
feat(auth): persist active connection and add more docs

### DIFF
--- a/src/credentials/auth.ts
+++ b/src/credentials/auth.ts
@@ -275,8 +275,8 @@ export class Auth implements AuthService, ConnectionManager {
             throw new Error(`Connection does not exist: ${id}`)
         }
 
-        await this.validateConnection(id, profile)
-        const conn = (this.#activeConnection = this.getSsoConnection(id, profile))
+        const validated = await this.validateConnection(id, profile)
+        const conn = (this.#activeConnection = this.getSsoConnection(id, validated))
         this.onDidChangeActiveConnectionEmitter.fire(conn)
         await this.store.setCurrentProfileId(id)
 

--- a/src/credentials/auth.ts
+++ b/src/credentials/auth.ts
@@ -28,6 +28,7 @@ export interface SsoConnection {
     readonly type: 'sso'
     readonly id: string
     readonly label: string
+    readonly startUrl: string
     readonly scopes?: string[]
 
     /**
@@ -414,6 +415,7 @@ export class Auth implements AuthService, ConnectionManager {
             id,
             type: profile.type,
             scopes: profile.scopes,
+            startUrl: profile.startUrl,
             state: profile.metadata.connectionState,
             label: profile.metadata?.label ?? `SSO (${profile.startUrl})`,
             getToken: () => this.debouncedGetToken(id, provider),

--- a/src/credentials/sso/clients.ts
+++ b/src/credentials/sso/clients.ts
@@ -10,6 +10,7 @@ import {
     GetRoleCredentialsRequest,
     ListAccountRolesRequest,
     ListAccountsRequest,
+    LogoutRequest,
     RoleInfo,
     SSO,
     SSOServiceException,
@@ -159,6 +160,11 @@ export class SsoClient {
             ...response.roleCredentials,
             expiration: expiration ? new globals.clock.Date(expiration) : undefined,
         }
+    }
+
+    public async logout(request: Omit<LogoutRequest, OmittedProps> = {}) {
+        const method = this.client.logout.bind(this.client)
+        await this.call(method as ExtractOverload<typeof method>, request)
     }
 
     private call<T extends { accessToken: string | undefined }, U>(

--- a/src/test/credentials/auth.test.ts
+++ b/src/test/credentials/auth.test.ts
@@ -171,6 +171,7 @@ describe('Auth', function () {
 
     it('uses the persisted connection if available (invalid)', async function () {
         const conn = await setupInvalidSsoConnection(auth, ssoProfile)
+        tokenProviders.get(getSsoProfileKey(ssoProfile))?.getToken.resolves(undefined)
         await store.setCurrentProfileId(conn.id)
         await auth.restorePreviousSession()
         assert.strictEqual(auth.activeConnection?.state, 'invalid')
@@ -228,6 +229,7 @@ describe('Auth', function () {
         it('shows an error if the connection is invalid', async function () {
             const node = new AuthNode(auth)
             const conn = await setupInvalidSsoConnection(auth, ssoProfile)
+            tokenProviders.get(getSsoProfileKey(ssoProfile))?.getToken.resolves(undefined)
             await store.setCurrentProfileId(conn.id)
             await auth.restorePreviousSession()
             await assertTreeItem(node, { label: 'Connection is invalid or expired' })

--- a/src/test/credentials/auth.test.ts
+++ b/src/test/credentials/auth.test.ts
@@ -6,10 +6,12 @@
 import * as assert from 'assert'
 import * as sinon from 'sinon'
 import * as vscode from 'vscode'
-import { Auth, getSsoProfileKey, ProfileStore, SsoProfile } from '../../credentials/auth'
+import { Auth, AuthNode, getSsoProfileKey, ProfileStore, SsoConnection, SsoProfile } from '../../credentials/auth'
 import { SsoToken } from '../../credentials/sso/model'
 import { SsoAccessTokenProvider } from '../../credentials/sso/ssoAccessTokenProvider'
+import { ToolkitError } from '../../shared/errors'
 import { FakeMemento } from '../fakeExtensionContext'
+import { assertTreeItem } from '../shared/treeview/testUtil'
 import { createTestWindow } from '../shared/vscode/window'
 import { captureEvent } from '../testUtil'
 import { stub } from '../utilities/stubber'
@@ -29,10 +31,9 @@ const scopedSsoProfile = createSsoProfile({ scopes: ['foo'] })
 describe('Auth', function () {
     const tokenProviders = new Map<string, ReturnType<typeof createTestTokenProvider>>()
 
-    function createTestTokenProvider(...[profile]: ConstructorParameters<typeof SsoAccessTokenProvider>) {
+    function createTestTokenProvider() {
         let token: SsoToken | undefined
         const provider = stub(SsoAccessTokenProvider)
-        tokenProviders.set(getSsoProfileKey(profile), provider)
         provider.getToken.callsFake(async () => token)
         provider.createToken.callsFake(
             async () => (token = { accessToken: '123', expiresAt: new Date(Date.now() + 1000000) })
@@ -42,14 +43,44 @@ describe('Auth', function () {
         return provider
     }
 
-    let auth: Auth
+    function getTestTokenProvider(...[profile]: ConstructorParameters<typeof SsoAccessTokenProvider>) {
+        const key = getSsoProfileKey(profile)
+        const cachedProvider = tokenProviders.get(key)
+        if (cachedProvider !== undefined) {
+            return cachedProvider
+        }
 
-    beforeEach(function () {
+        const provider = createTestTokenProvider()
+        tokenProviders.set(key, provider)
+
+        return provider
+    }
+
+    async function invalidateConnection(profile: SsoProfile) {
+        const provider = tokenProviders.get(getSsoProfileKey(profile))
+        await provider?.invalidate()
+
+        return provider
+    }
+
+    async function setupInvalidSsoConnection(auth: Auth, profile: SsoProfile) {
+        const conn = await auth.createConnection(profile)
+        await invalidateConnection(profile)
+
+        return conn
+    }
+
+    let auth: Auth
+    let store: ProfileStore
+
+    afterEach(function () {
         tokenProviders.clear()
         sinon.restore()
+    })
 
-        const store = new ProfileStore(new FakeMemento())
-        auth = new Auth(store, createTestTokenProvider)
+    beforeEach(function () {
+        store = new ProfileStore(new FakeMemento())
+        auth = new Auth(store, getTestTokenProvider)
     })
 
     it('can create a new sso connection', async function () {
@@ -92,16 +123,38 @@ describe('Auth', function () {
     })
 
     it('throws when using an invalid connection that was deleted', async function () {
-        const conn = await auth.createConnection(ssoProfile)
-        const provider = tokenProviders.get(getSsoProfileKey(ssoProfile))
-        await provider?.invalidate()
+        const conn = await setupInvalidSsoConnection(auth, ssoProfile)
         await auth.deleteConnection(conn)
         await assert.rejects(() => conn.getToken())
     })
 
+    it('can logout and fires an event', async function () {
+        const conn = await auth.createConnection(ssoProfile)
+        const events = captureEvent(auth.onDidChangeActiveConnection)
+        await auth.useConnection(conn)
+        assert.strictEqual(auth.activeConnection?.id, conn.id)
+        await auth.logout()
+        assert.strictEqual(auth.activeConnection, undefined)
+        assert.strictEqual(events.last, undefined)
+    })
+
+    describe('useConnection', function () {
+        it('re-authenticates if the connection is invalid', async function () {
+            const conn = await setupInvalidSsoConnection(auth, ssoProfile)
+            await auth.useConnection(conn)
+            assert.strictEqual(auth.activeConnection?.state, 'valid')
+        })
+
+        it('fires an event', async function () {
+            const conn = await auth.createConnection(ssoProfile)
+            const events = captureEvent(auth.onDidChangeActiveConnection)
+            await auth.useConnection(conn)
+            assert.strictEqual(events.emits[0]?.id, conn.id)
+        })
+    })
+
     it('can login and fires an event', async function () {
         const conn = await auth.createConnection(ssoProfile)
-
         const events = captureEvent(auth.onDidChangeActiveConnection)
         await auth.useConnection(conn)
         assert.strictEqual(auth.activeConnection?.id, conn.id)
@@ -109,18 +162,32 @@ describe('Auth', function () {
         assert.strictEqual(events.emits[0]?.id, conn.id)
     })
 
-    it('can logout and fires an event', async function () {
+    it('uses the persisted connection if available (valid)', async function () {
         const conn = await auth.createConnection(ssoProfile)
+        await store.setCurrentProfileId(conn.id)
+        await auth.restorePreviousSession()
+        assert.strictEqual(auth.activeConnection?.state, 'valid')
+    })
 
-        const events = captureEvent(auth.onDidChangeActiveConnection)
-        await auth.useConnection(conn)
-        assert.strictEqual(auth.activeConnection?.id, conn.id)
-        auth.logout()
-        assert.strictEqual(auth.activeConnection, undefined)
-        assert.strictEqual(events.last, undefined)
+    it('uses the persisted connection if available (invalid)', async function () {
+        const conn = await setupInvalidSsoConnection(auth, ssoProfile)
+        await store.setCurrentProfileId(conn.id)
+        await auth.restorePreviousSession()
+        assert.strictEqual(auth.activeConnection?.state, 'invalid')
     })
 
     describe('SSO Connections', function () {
+        async function runExpiredGetTokenFlow(conn: SsoConnection, selection: string | RegExp) {
+            const testWindow = createTestWindow()
+            sinon.replace(vscode, 'window', testWindow)
+
+            const token = conn.getToken()
+            const message = await testWindow.waitForMessage(/credentials are expired or invalid,/i)
+            message.selectItem(selection)
+
+            return token
+        }
+
         it('creates a new token if one does not exist', async function () {
             const conn = await auth.createConnection(ssoProfile)
             const provider = tokenProviders.get(getSsoProfileKey(ssoProfile))
@@ -128,19 +195,42 @@ describe('Auth', function () {
         })
 
         it('prompts the user if the token is invalid or expired', async function () {
+            const conn = await setupInvalidSsoConnection(auth, ssoProfile)
+            const token = await runExpiredGetTokenFlow(conn, /yes/i)
+            assert.notStrictEqual(token, undefined)
+        })
+
+        it('using the connection lazily updates the state', async function () {
             const conn = await auth.createConnection(ssoProfile)
-            const provider = tokenProviders.get(getSsoProfileKey(ssoProfile))
-            assert.ok(provider)
+            await auth.useConnection(conn)
+            await invalidateConnection(ssoProfile)
 
-            const testWindow = createTestWindow()
-            sinon.replace(vscode, 'window', testWindow)
+            const token = runExpiredGetTokenFlow(conn, /no/i)
+            await assert.rejects(token, ToolkitError)
 
-            await conn.getToken()
-            await provider.invalidate()
-            const token = conn.getToken()
-            const message = await testWindow.waitForMessage(/credentials are expired or invalid,/i)
-            message.selectItem(/yes/i)
-            assert.notStrictEqual(await token, undefined)
+            assert.strictEqual(auth.activeConnection?.state, 'invalid')
+        })
+    })
+
+    describe('AuthNode', function () {
+        it('shows a login message if not connected', async function () {
+            const node = new AuthNode(auth)
+            await assertTreeItem(node, { label: 'Select a connection...' })
+        })
+
+        it('shows the connection if valid', async function () {
+            const node = new AuthNode(auth)
+            const conn = await auth.createConnection(ssoProfile)
+            await auth.useConnection(conn)
+            await assertTreeItem(node, { label: `Connected to ${conn.label}` })
+        })
+
+        it('shows an error if the connection is invalid', async function () {
+            const node = new AuthNode(auth)
+            const conn = await setupInvalidSsoConnection(auth, ssoProfile)
+            await store.setCurrentProfileId(conn.id)
+            await auth.restorePreviousSession()
+            await assertTreeItem(node, { label: 'Connection is invalid or expired' })
         })
     })
 })

--- a/src/test/utilities/stubber.ts
+++ b/src/test/utilities/stubber.ts
@@ -21,6 +21,11 @@ export function stub<T>(ctor: new (...args: any[]) => T, fields?: Fields<T>): St
                 return Reflect.get(target, prop, receiver)
             }
 
+            // For `Promise` support
+            if (prop === 'then') {
+                return undefined
+            }
+
             const previous = stubs.get(prop)
             if (previous !== undefined) {
                 return previous


### PR DESCRIPTION
## Problem
The Auth service doesn't remember the active connection across sessions

## Solution
Persist the connection id and restore it later.

Originally I was going to implement something similar to `canAutoConnect` but just persisting the current connection is simpler and more user-friendly for the case of expired connections

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
