### PR TITLE
fix(credentials): Make finding existing credential filenames more robust

### DIFF
--- a/src/shared/credentials/userCredentialsUtils.ts
+++ b/src/shared/credentials/userCredentialsUtils.ts
@@ -4,11 +4,13 @@
  */
 
 import * as path from 'path'
-
+import * as vscode from 'vscode'
 import { mkdirp, writeFile } from 'fs-extra'
 import { getConfigFilename, getCredentialsFilename } from '../../credentials/sharedCredentials'
 import { fileExists } from '../filesystemUtilities'
 import { SystemUtilities } from '../systemUtilities'
+import { loadSharedConfigFiles, Profile } from './credentialsFile'
+import { SharedCredentialsProvider } from '../../credentials/providers/sharedCredentialsProvider'
 
 const header = `
 # AWS credentials file used by AWS CLI, SDKs, and tools.
@@ -58,20 +60,49 @@ export class UserCredentialsUtils {
      * @returns array of filenames for files found.
      */
     public static async findExistingCredentialsFilenames(isCredentialsRequired = false): Promise<string[]> {
-        const candidateFiles: string[] = [getCredentialsFilename(), getConfigFilename()]
+        const configFilename = getConfigFilename()
+        const credentialsFileName = getCredentialsFilename()
 
-        const existsResults: boolean[] = await Promise.all(
-            candidateFiles.map(async filename => {
-                const exists = await SystemUtilities.fileExists(filename)
-                if (!exists || !isCredentialsRequired) {
-                    return exists
+        const configs = await loadSharedConfigFiles({
+            config: vscode.Uri.file(configFilename),
+            credentials: vscode.Uri.file(credentialsFileName),
+        })
+        const credentials = new Map([
+            [credentialsFileName, configs.credentialsFile],
+            [configFilename, configs.configFile],
+        ])
+
+        const credentialFiles = []
+        for (const [filename, profiles] of credentials.entries()) {
+            const exists = await SystemUtilities.fileExists(filename)
+            if (!exists) {
+                continue
+            }
+
+            if (!isCredentialsRequired) {
+                credentialFiles.push(filename)
+                continue
+            }
+
+            // ensure that the given filename has at least one valid profile
+            const validProfiles = []
+            const allProfiles = new Map(Object.entries(profiles).filter(item => item[1] !== undefined)) as Map<
+                string,
+                Profile
+            >
+            for (const profile of Object.keys(profiles)) {
+                const credProvider = new SharedCredentialsProvider(profile, allProfiles)
+                if (await credProvider.isAvailable()) {
+                    validProfiles.push(profile)
                 }
-                const contents = await SystemUtilities.readFile(filename)
-                return /aws_access_key_id|aws_secret_access_key|aws_session_token/i.test(contents)
-            })
-        )
+            }
 
-        return candidateFiles.filter((filename, index) => existsResults[index])
+            if (validProfiles.length !== 0) {
+                credentialFiles.push(filename)
+            }
+        }
+
+        return credentialFiles
     }
 
     /**

--- a/src/test/shared/credentials/userCredentialsUtils.test.ts
+++ b/src/test/shared/credentials/userCredentialsUtils.test.ts
@@ -93,6 +93,39 @@ describe('UserCredentialsUtils', function () {
             assert.strictEqual(foundFiles.length, 0)
         })
 
+        it('returns credentials files if profiles are required and config does not exist', async function () {
+            const credentialsFilename = path.join(tempFolder, 'credentials-exists-profiles-required-no-config-test')
+            const configFilename = path.join(tempFolder, 'config-not-exist-profiles-required-but-no-config-test')
+
+            sinon.stub(process, 'env').value({
+                AWS_SHARED_CREDENTIALS_FILE: credentialsFilename,
+                AWS_CONFIG_FILE: configFilename,
+            } as EnvironmentVariables)
+
+            createCredentialsFile(credentialsFilename, ['default'])
+
+            const foundFiles: string[] = await UserCredentialsUtils.findExistingCredentialsFilenames(true)
+            assert.strictEqual(foundFiles.length, 1)
+        })
+
+        it('returns config files if profiles are required and credentials does not exist', async function () {
+            const credentialsFilename = path.join(
+                tempFolder,
+                'credentials-exists-profiles-required-no-credentials-test'
+            )
+            const configFilename = path.join(tempFolder, 'config-not-exist-profiles-required-but-no-credentials-test')
+
+            sinon.stub(process, 'env').value({
+                AWS_SHARED_CREDENTIALS_FILE: credentialsFilename,
+                AWS_CONFIG_FILE: configFilename,
+            } as EnvironmentVariables)
+
+            createCredentialsFile(configFilename, ['default'])
+
+            const foundFiles: string[] = await UserCredentialsUtils.findExistingCredentialsFilenames(true)
+            assert.strictEqual(foundFiles.length, 1)
+        })
+
         it('returns empty result if files dont contain credentials', async function () {
             const credentialsFilename = path.join(tempFolder, 'credentials-both-exist-but-no-credentials-test')
             const configFilename = path.join(tempFolder, 'config-both-exist-but-no-credentials-test')
@@ -104,6 +137,22 @@ describe('UserCredentialsUtils', function () {
 
             createCredentialsFile(credentialsFilename, [])
             createCredentialsFile(configFilename, [])
+
+            const foundFiles: string[] = await UserCredentialsUtils.findExistingCredentialsFilenames(true)
+            assert.strictEqual(foundFiles.length, 0)
+        })
+
+        it('returns empty result if files contains nonsense', async function () {
+            const credentialsFilename = path.join(tempFolder, 'credentials-both-exist-but-contain-nonsense-test')
+            const configFilename = path.join(tempFolder, 'config-both-exist-but-contain-nonsense-test')
+
+            sinon.stub(process, 'env').value({
+                AWS_SHARED_CREDENTIALS_FILE: credentialsFilename,
+                AWS_CONFIG_FILE: configFilename,
+            } as EnvironmentVariables)
+
+            fs.writeFileSync(credentialsFilename, 'adfadfgwergsdfgsdfgjsdifgsdfugi')
+            fs.writeFileSync(configFilename, 'adfadfgwergsdfgsdfgjsdifgsdfugi')
 
             const foundFiles: string[] = await UserCredentialsUtils.findExistingCredentialsFilenames(true)
             assert.strictEqual(foundFiles.length, 0)


### PR DESCRIPTION
## Problem
- Currently the way we find existing credential filenames is by seeing if a few keys are in the credentials document. This isn't really robust and breaks down for different profile types.

## Solution
- Re-use the sharedCredentialsProvider to provide validation when trying to find existing credential filenames. This will ensure that if we find a credentials file, it has at least one valid profile name
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
