### PR TITLE
Use hosted files for buildspec schema

### DIFF
--- a/src/shared/resourcefetcher/httpResourceFetcher.ts
+++ b/src/shared/resourcefetcher/httpResourceFetcher.ts
@@ -154,15 +154,10 @@ export class HttpResourceFetcher implements ResourceFetcher {
  * Retrieves JSON property value from a remote resource
  * @param property property to retrieve
  * @param url url of JSON resource
- * @param fetcher optional HTTP resource fetcher to use
  * @returns property value if available or undefined
  */
-export async function getPropertyFromJsonUrl(
-    url: string,
-    property: string,
-    fetcher?: HttpResourceFetcher
-): Promise<any | undefined> {
-    const resourceFetcher = fetcher ?? new HttpResourceFetcher(url, { showUrl: true })
+export async function getPropertyFromJsonUrl(url: string, property: string): Promise<any | undefined> {
+    const resourceFetcher = new HttpResourceFetcher(url, { showUrl: true })
     const result = await resourceFetcher.get()
     if (result) {
         try {
@@ -174,4 +169,14 @@ export async function getPropertyFromJsonUrl(
             getLogger().error(`JSON parsing failed for "${url}": ${(err as Error).message}`)
         }
     }
+}
+
+/**
+ * Gets contents from a remote resource
+ * @param url url of the resource
+ * @returns contents from the url if available or undefined
+ */
+export async function getFromUrl(url: string): Promise<string | undefined> {
+    const resourceFetcher = new HttpResourceFetcher(url, { showUrl: true })
+    return resourceFetcher.get()
 }

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -9,7 +9,7 @@ import { activateYamlExtension, YamlExtension } from './extensions/yaml'
 import * as pathutil from '../shared/utilities/pathUtils'
 import { getLogger } from './logger'
 import { FileResourceFetcher } from './resourcefetcher/fileResourceFetcher'
-import { getPropertyFromJsonUrl, HttpResourceFetcher } from './resourcefetcher/httpResourceFetcher'
+import { getFromUrl, getPropertyFromJsonUrl, HttpResourceFetcher } from './resourcefetcher/httpResourceFetcher'
 import { Settings } from './settings'
 import { once } from './utilities/functionUtils'
 import { Any, ArrayConstructor } from './utilities/typeConstructors'
@@ -18,12 +18,13 @@ import { writeFile } from 'fs-extra'
 import { SystemUtilities } from './systemUtilities'
 import { normalizeVSCodeUri } from './utilities/vsCodeUtils'
 import { CloudFormation } from './cloudformation/cloudformation'
+import { getStringHash } from './utilities/textUtilities'
 
-const GOFORMATION_MANIFEST_URL = 'https://api.github.com/repos/awslabs/goformation/releases/latest'
-const SCHEMA_PREFIX = `${AWS_SCHEME}://`
-const HOSTED_FILES_CLOUD_FRONT_DISTRIBUTION = 'https://d3rrggjwfhwld2.cloudfront.net/'
-const HOSTED_FILES_S3_FALLBACK = 'https://aws-vs-toolkit.s3.amazonaws.com/'
-const BUILD_SPEC_HOSTED_FILES_PATH = '/CodeBuild/buildspec/buildspec-standalone.schema.json'
+const goformationManifestURL = 'https://api.github.com/repos/awslabs/goformation/releases/latest'
+const schemaPrefix = `${AWS_SCHEME}://`
+const buildspecHostedFilesPath = '/CodeBuild/buildspec/buildspec-standalone.schema.json'
+const buildspecCloudfrontURL = 'https://d3rrggjwfhwld2.cloudfront.net' + buildspecHostedFilesPath
+const buildspecS3FallbackURL = 'https://aws-vs-toolkit.s3.amazonaws.com' + buildspecHostedFilesPath
 
 export type Schemas = { [key: string]: vscode.Uri }
 export type SchemaType = 'yaml' | 'json'
@@ -168,20 +169,17 @@ export async function getDefaultSchemas(extensionContext: vscode.ExtensionContex
     const samSchemaUri = vscode.Uri.joinPath(extensionContext.globalStorageUri, 'sam.schema.json')
     const buildSpecSchemaUri = vscode.Uri.joinPath(extensionContext.globalStorageUri, 'buildspec.schema.json')
 
-    const goformationSchemaVersion = await getPropertyFromJsonUrl(GOFORMATION_MANIFEST_URL, 'tag_name')
-
+    const goformationSchemaVersion = await getPropertyFromJsonUrl(goformationManifestURL, 'tag_name')
     const schemas: Schemas = {}
 
     try {
-        const goformationSchemaVersion = await getPropertyFromJsonUrl(GOFORMATION_MANIFEST_URL, 'tag_name')
-
         await updateSchemaFromRemote({
             destination: cfnSchemaUri,
             version: goformationSchemaVersion,
             url: `https://raw.githubusercontent.com/awslabs/goformation/${goformationSchemaVersion}/schema/cloudformation.schema.json`,
             cacheKey: 'cfnSchemaVersion',
             extensionContext,
-            title: SCHEMA_PREFIX + 'cloudformation.schema.json',
+            title: schemaPrefix + 'cloudformation.schema.json',
         })
         schemas['cfn'] = cfnSchemaUri
     } catch (e) {
@@ -195,7 +193,7 @@ export async function getDefaultSchemas(extensionContext: vscode.ExtensionContex
             url: `https://raw.githubusercontent.com/awslabs/goformation/${goformationSchemaVersion}/schema/sam.schema.json`,
             cacheKey: 'samSchemaVersion',
             extensionContext,
-            title: SCHEMA_PREFIX + 'sam.schema.json',
+            title: schemaPrefix + 'sam.schema.json',
         })
         schemas['sam'] = samSchemaUri
     } catch (e) {
@@ -204,21 +202,31 @@ export async function getDefaultSchemas(extensionContext: vscode.ExtensionContex
 
     try {
         try {
+            const contents = await getFromUrl(buildspecCloudfrontURL)
+            const buildspecSchemaVersion = contents ? getStringHash(contents) : undefined
             await updateSchemaFromRemote({
                 destination: buildSpecSchemaUri,
-                url: HOSTED_FILES_CLOUD_FRONT_DISTRIBUTION + BUILD_SPEC_HOSTED_FILES_PATH,
+                version: buildspecSchemaVersion,
+                url: buildspecCloudfrontURL,
                 cacheKey: 'buildSpecSchemaVersion',
                 extensionContext,
-                title: SCHEMA_PREFIX + 'buildspec.schema.json',
+                title: schemaPrefix + 'buildspec.schema.json',
             })
             schemas['buildspec'] = buildSpecSchemaUri
         } catch (e) {
+            getLogger().verbose(
+                'Could not download buildspec schema from CloudFront: %s. Attempting to download buildspec schema from S3',
+                (e as Error).message
+            )
+            const contents = await getFromUrl(buildspecS3FallbackURL)
+            const buildspecSchemaVersion = contents ? getStringHash(contents) : undefined
             await updateSchemaFromRemote({
                 destination: buildSpecSchemaUri,
-                url: HOSTED_FILES_S3_FALLBACK + BUILD_SPEC_HOSTED_FILES_PATH,
+                version: buildspecSchemaVersion,
+                url: buildspecS3FallbackURL,
                 cacheKey: 'buildSpecSchemaVersion',
                 extensionContext,
-                title: SCHEMA_PREFIX + 'buildspec.schema.json',
+                title: schemaPrefix + 'buildspec.schema.json',
             })
             schemas['buildspec'] = buildSpecSchemaUri
         }


### PR DESCRIPTION
## Problem
- Currently you need to configure the buildspec schema location through a setting

## Solution
- Use the hosted files cloudfront distribution for getting the buildspec schema
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
