### PR TITLE
build: eslint "curly" rule

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ src/codewhisperer/client/codewhispererclient.d.ts
 **/*.gen.ts
 src/testFixtures/workspaceFolder/ts-plain-sam-app/
 dist/**
+types/*.d.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
         'prettier',
     ],
     rules: {
+        curly: 2, // Enforce braces on "if"/"for"/etc.
         // TODO reenable this rule (by removing this off)
         'no-async-promise-executor': 'off',
         // TODO reenable this rule (by removing this off)

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -175,7 +175,9 @@ export async function activate(context: ExtContext): Promise<void> {
         acceptSuggestion.register(context),
         // on text document close.
         vscode.workspace.onDidCloseTextDocument(e => {
-            if (isInlineCompletionEnabled() && e.uri.fsPath !== InlineCompletionService.instance.filePath()) return
+            if (isInlineCompletionEnabled() && e.uri.fsPath !== InlineCompletionService.instance.filePath()) {
+                return
+            }
             RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(vscode.window.activeTextEditor, -1)
             RecommendationHandler.instance.clearRecommendations()
         }),
@@ -413,19 +415,22 @@ export async function activate(context: ExtContext): Promise<void> {
              * Recommendation navigation
              */
             Commands.register('aws.codeWhisperer.nextCodeSuggestion', async () => {
-                if (vscode.window.activeTextEditor)
+                if (vscode.window.activeTextEditor) {
                     InlineCompletion.instance.navigateRecommendation(vscode.window.activeTextEditor, true)
+                }
             }),
             Commands.register('aws.codeWhisperer.previousCodeSuggestion', async () => {
-                if (vscode.window.activeTextEditor)
+                if (vscode.window.activeTextEditor) {
                     InlineCompletion.instance.navigateRecommendation(vscode.window.activeTextEditor, false)
+                }
             }),
             /**
              * Recommendation acceptance
              */
             Commands.register('aws.codeWhisperer.acceptCodeSuggestion', async () => {
-                if (vscode.window.activeTextEditor)
+                if (vscode.window.activeTextEditor) {
                     await InlineCompletion.instance.acceptRecommendation(vscode.window.activeTextEditor)
+                }
             })
         )
         // If the vscode is refreshed we need to maintain the status bar
@@ -540,8 +545,9 @@ export async function shutdown() {
         await InlineCompletionService.instance.clearInlineCompletionStates(vscode.window.activeTextEditor)
         await HoverConfigUtil.instance.restoreHoverConfig()
     } else {
-        if (vscode.window.activeTextEditor)
+        if (vscode.window.activeTextEditor) {
             await InlineCompletion.instance.resetInlineStates(vscode.window.activeTextEditor)
+        }
     }
     CodeWhispererTracker.getTracker().shutdown()
 }

--- a/src/codewhisperer/commands/invokeRecommendation.ts
+++ b/src/codewhisperer/commands/invokeRecommendation.ts
@@ -52,7 +52,9 @@ export async function invokeRecommendation(
         }
         KeyStrokeHandler.instance.keyStrokeCount = 0
         if (isCloud9()) {
-            if (RecommendationHandler.instance.isGenerateRecommendationInProgress) return
+            if (RecommendationHandler.instance.isGenerateRecommendationInProgress) {
+                return
+            }
             vsCodeState.isIntelliSenseActive = false
             RecommendationHandler.instance.isGenerateRecommendationInProgress = true
             try {

--- a/src/codewhisperer/commands/startSecurityScan.ts
+++ b/src/codewhisperer/commands/startSecurityScan.ts
@@ -131,7 +131,9 @@ export async function startSecurityScan(
          * Step 4:  Polling mechanism on scan job status
          */
         const jobStatus = await pollScanJobStatus(client, scanJob.jobId)
-        if (jobStatus === 'Failed') throw new Error('Security scan job failed.')
+        if (jobStatus === 'Failed') {
+            throw new Error('Security scan job failed.')
+        }
 
         /**
          * Step 5: Process and render scan results

--- a/src/codewhisperer/service/diagnosticsProvider.ts
+++ b/src/codewhisperer/service/diagnosticsProvider.ts
@@ -60,7 +60,9 @@ export function createSecurityDiagnosticCollection() {
 
 export function disposeSecurityDiagnostic(event: vscode.TextDocumentChangeEvent) {
     const uri = event.document.uri
-    if (!securityScanRender.initialized || !securityScanRender.securityDiagnosticCollection?.has(uri)) return
+    if (!securityScanRender.initialized || !securityScanRender.securityDiagnosticCollection?.has(uri)) {
+        return
+    }
     const currentSecurityDiagnostics = securityScanRender.securityDiagnosticCollection?.get(uri)
     const newSecurityDiagnostics: vscode.Diagnostic[] = []
     const changedRange = event.contentChanges[0].range

--- a/src/codewhisperer/service/inlineCompletion.ts
+++ b/src/codewhisperer/service/inlineCompletion.ts
@@ -99,7 +99,9 @@ export class InlineCompletion {
     }
 
     async acceptRecommendation(editor: vscode.TextEditor) {
-        if (vsCodeState.isCodeWhispererEditing) return
+        if (vsCodeState.isCodeWhispererEditing) {
+            return
+        }
         vsCodeState.isCodeWhispererEditing = true
         await editor
             ?.edit(
@@ -142,8 +144,12 @@ export class InlineCompletion {
         isTypeAheadRejection: boolean = false,
         onDidChangeVisibleTextEditors: boolean = false
     ) {
-        if (!editor || vsCodeState.isCodeWhispererEditing) return
-        if (!isTypeAheadRejection && this.items.length === 0) return
+        if (!editor || vsCodeState.isCodeWhispererEditing) {
+            return
+        }
+        if (!isTypeAheadRejection && this.items.length === 0) {
+            return
+        }
         vsCodeState.isCodeWhispererEditing = true
         ReferenceInlineProvider.instance.removeInlineReference()
         if (onDidChangeVisibleTextEditors && this.documentUri && this.documentUri.fsPath.length > 0) {
@@ -261,8 +267,11 @@ export class InlineCompletion {
                              * When typeAhead is involved we set the position of character with one more character to net let
                              * last bracket of recommendation to be removed
                              */
-                            if (this.isTypeaheadInProgress) this.setRange(new vscode.Range(this._range.start, pos))
-                            else this.setRange(new vscode.Range(this._range.start, editor.selection.active))
+                            if (this.isTypeaheadInProgress) {
+                                this.setRange(new vscode.Range(this._range.start, pos))
+                            } else {
+                                this.setRange(new vscode.Range(this._range.start, editor.selection.active))
+                            }
                             editor.setDecorations(this.dimDecoration, [this._range])
                             // cursor position
                             const position = editor.selection.active
@@ -291,7 +300,9 @@ export class InlineCompletion {
     }
 
     async navigateRecommendation(editor: vscode.TextEditor, next: boolean) {
-        if (!this.items?.length || this.items.length === 1 || vsCodeState.isCodeWhispererEditing || !editor) return
+        if (!this.items?.length || this.items.length === 1 || vsCodeState.isCodeWhispererEditing || !editor) {
+            return
+        }
         vsCodeState.isCodeWhispererEditing = true
         if (next) {
             if (this.position === this.items.length - 1) {
@@ -348,7 +359,9 @@ export class InlineCompletion {
                     RecommendationHandler.instance.clearRecommendations()
                     break
                 }
-                if (!RecommendationHandler.instance.hasNextToken()) break
+                if (!RecommendationHandler.instance.hasNextToken()) {
+                    break
+                }
                 page++
             }
         } catch (error) {

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -40,7 +40,9 @@ class CodeWhispererInlineCompletionItemProvider implements vscode.InlineCompleti
     private getGhostText(prefix: string, suggestion: string): string {
         const prefixLines = prefix.split(/\r\n|\r|\n/)
         const n = prefixLines.length
-        if (n <= 1) return suggestion
+        if (n <= 1) {
+            return suggestion
+        }
         let count = 1
         for (let i = 0; i < suggestion.length; i++) {
             if (suggestion[i] === '\n') {
@@ -257,7 +259,9 @@ export class InlineCompletionService {
 
     async tryShowRecommendation() {
         const editor = vscode.window.activeTextEditor
-        if (this.isSuggestionVisible() || editor === undefined) return
+        if (this.isSuggestionVisible() || editor === undefined) {
+            return
+        }
         if (
             editor.selection.active.isBefore(RecommendationHandler.instance.startPos) ||
             editor.document.uri.fsPath !== this.documentUri?.fsPath
@@ -283,7 +287,9 @@ export class InlineCompletionService {
         config: ConfigurationEntry,
         autoTriggerType?: CodewhispererAutomatedTriggerType
     ) {
-        if (vsCodeState.isCodeWhispererEditing || this._isPaginationRunning) return
+        if (vsCodeState.isCodeWhispererEditing || this._isPaginationRunning) {
+            return
+        }
         await this.clearInlineCompletionStates(editor)
         this.setCodeWhispererStatusBarLoading()
         RecommendationHandler.instance.checkAndResetCancellationTokens()
@@ -306,7 +312,9 @@ export class InlineCompletionService {
                     this.setCodeWhispererStatusBarOk()
                     return
                 }
-                if (!RecommendationHandler.instance.hasNextToken()) break
+                if (!RecommendationHandler.instance.hasNextToken()) {
+                    break
+                }
                 page++
             }
         } catch (error) {

--- a/src/codewhisperer/service/keyStrokeHandler.ts
+++ b/src/codewhisperer/service/keyStrokeHandler.ts
@@ -49,13 +49,19 @@ export class KeyStrokeHandler {
         config: ConfigurationEntry
     ): Promise<void> {
         try {
-            if (!config.isAutomatedTriggerEnabled) return
+            if (!config.isAutomatedTriggerEnabled) {
+                return
+            }
 
             // Skip when output channel gains focus and invoke
-            if (editor.document.languageId === 'Log') return
+            if (editor.document.languageId === 'Log') {
+                return
+            }
 
             // Pause automated trigger when typed input matches recommendation prefix for inline suggestion
-            if (InlineCompletion.instance.isTypeaheadInProgress) return
+            if (InlineCompletion.instance.isTypeaheadInProgress) {
+                return
+            }
 
             // Skip Cloud9 IntelliSense acceptance event
             if (
@@ -124,7 +130,9 @@ export class KeyStrokeHandler {
         if (editor) {
             this.keyStrokeCount = 0
             if (isCloud9()) {
-                if (RecommendationHandler.instance.isGenerateRecommendationInProgress) return
+                if (RecommendationHandler.instance.isGenerateRecommendationInProgress) {
+                    return
+                }
                 vsCodeState.isIntelliSenseActive = false
                 RecommendationHandler.instance.isGenerateRecommendationInProgress = true
                 try {
@@ -179,7 +187,9 @@ export abstract class DocumentChangedType {
 
     // Enter key should always start with ONE '\n' or '\r\n' and potentially following spaces due to IDE reformat
     protected isEnterKey(str: string): boolean {
-        if (str.length === 0) return false
+        if (str.length === 0) {
+            return false
+        }
         return (
             (str.startsWith('\r\n') && str.substring(2).trim() === '') ||
             (str[0] === '\n' && str.substring(1).trim() === '')
@@ -202,12 +212,18 @@ export abstract class DocumentChangedType {
     protected isSingleLine(str: string): boolean {
         let newLineCounts = 0
         for (const ch of str) {
-            if (ch === '\n') newLineCounts += 1
+            if (ch === '\n') {
+                newLineCounts += 1
+            }
         }
 
         // since pressing Enter key possibly will generate string like '\n        ' due to indention
-        if (this.isEnterKey(str)) return true
-        if (newLineCounts >= 1) return false
+        if (this.isEnterKey(str)) {
+            return true
+        }
+        if (newLineCounts >= 1) {
+            return false
+        }
         return true
     }
 }

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -155,7 +155,9 @@ export class RecommendationHandler {
             startTime = performance.now()
             this.lastInvocationTime = startTime
             // set start pos for non pagination call or first pagination call
-            if (!pagination || (pagination && page === 0)) this.startPos = editor.selection.active
+            if (!pagination || (pagination && page === 0)) {
+                this.startPos = editor.selection.active
+            }
 
             /**
              * Validate request

--- a/src/codewhisperer/service/referenceLogViewProvider.ts
+++ b/src/codewhisperer/service/referenceLogViewProvider.ts
@@ -102,12 +102,16 @@ export class ReferenceLogViewProvider implements vscode.WebviewViewProvider {
                     lineInfo
                 ) + ' <br>'
         }
-        if (text === ``) return ''
+        if (text === ``) {
+            return ''
+        }
         return `[${time}] Accepted recommendation ${text}<br>`
     }
 
     public addReferenceLog(referenceLog: string) {
-        if (referenceLog !== '') this._referenceLogs.push(referenceLog)
+        if (referenceLog !== '') {
+            this._referenceLogs.push(referenceLog)
+        }
         this.update()
     }
     private getHtml(webview: vscode.Webview, showPrompt: boolean): string {

--- a/src/codewhisperer/service/securityScanHandler.ts
+++ b/src/codewhisperer/service/securityScanHandler.ts
@@ -129,7 +129,9 @@ export async function createScanJob(
 }
 
 export async function getPresignedUrlAndUpload(client: DefaultCodeWhispererClient, truncPaths: TruncPaths) {
-    if (truncPaths.src.zip === '') throw new Error("Truncation failure: can't find valid source zip.")
+    if (truncPaths.src.zip === '') {
+        throw new Error("Truncation failure: can't find valid source zip.")
+    }
     const srcReq: codewhispererClient.CreateUploadUrlRequest = {
         artifactType: CodeWhispererConstants.artifactTypeSource,
         contentMd5: getMd5(truncPaths.src.zip),

--- a/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
+++ b/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
@@ -56,7 +56,9 @@ export class CodeWhispererCodeCoverageTracker {
     }
 
     public countAcceptedTokens(range: vscode.Range, text: string, filename: string) {
-        if (!this.isActive()) return
+        if (!this.isActive()) {
+            return
+        }
         // generate accepted recommendation token and stored in collection
         this.addAcceptedTokens(filename, { range: range, text: text, accepted: text.length })
         this.addTotalTokens(filename, text.length)
@@ -127,7 +129,9 @@ export class CodeWhispererCodeCoverageTracker {
     }
 
     private tryStartTimer() {
-        if (this._timer !== undefined) return
+        if (this._timer !== undefined) {
+            return
+        }
         const currentDate = new globals.clock.Date()
         this._startTime = currentDate.getTime()
         this._timer = setTimeout(() => {
@@ -195,11 +199,14 @@ export class CodeWhispererCodeCoverageTracker {
             !runtimeLanguageContext.isLanguageSupported(e.document.languageId) ||
             vsCodeState.isCodeWhispererEditing ||
             e.contentChanges.length !== 1
-        )
+        ) {
             return
+        }
         const content = e.contentChanges[0]
         // do not count user tokens if user copies large chunk of code
-        if (content.text.length > 20) return
+        if (content.text.length > 20) {
+            return
+        }
         this.tryStartTimer()
         // deletion events has no text.
         if (content.text.length === 0) {

--- a/src/codewhisperer/tracker/codewhispererTracker.ts
+++ b/src/codewhisperer/tracker/codewhispererTracker.ts
@@ -38,7 +38,9 @@ export class CodeWhispererTracker {
     }
 
     public enqueue(suggestion: AcceptedSuggestionEntry) {
-        if (!globals.telemetry.telemetryEnabled) return
+        if (!globals.telemetry.telemetryEnabled) {
+            return
+        }
 
         if (this._eventQueue.length >= 0) {
             this.startTimer()

--- a/src/codewhisperer/util/dependencyGraph/dependencyGraph.ts
+++ b/src/codewhisperer/util/dependencyGraph/dependencyGraph.ts
@@ -86,11 +86,15 @@ export abstract class DependencyGraph {
     }
 
     protected removeDir(dir: string) {
-        if (existsSync(dir)) fs.removeSync(dir)
+        if (existsSync(dir)) {
+            fs.removeSync(dir)
+        }
     }
 
     protected removeZip(zipFilePath: string) {
-        if (existsSync(zipFilePath)) fs.unlinkSync(zipFilePath)
+        if (existsSync(zipFilePath)) {
+            fs.unlinkSync(zipFilePath)
+        }
     }
 
     protected getTruncDirPath(uri: vscode.Uri) {

--- a/src/codewhisperer/util/dependencyGraph/javaDependencyGraph.ts
+++ b/src/codewhisperer/util/dependencyGraph/javaDependencyGraph.ts
@@ -62,7 +62,9 @@ export class JavaDependencyGraph extends DependencyGraph {
     }
 
     private generateSourceFilePathsOfAsterisk(dirPath: string, importPath: string) {
-        if (!importPath.endsWith('*')) throw new Error('Asterisk is not found in import statement.')
+        if (!importPath.endsWith('*')) {
+            throw new Error('Asterisk is not found in import statement.')
+        }
         const targetDir = path.join(dirPath, importPath.substring(0, importPath.length - 1))
         const filePaths: string[] = []
         readdirSync(targetDir, { encoding: ENCODE, withFileTypes: true }).forEach(file => {
@@ -107,8 +109,9 @@ export class JavaDependencyGraph extends DependencyGraph {
     private generateBuildFileRelativePath(uri: vscode.Uri, projectPath: string, pacakges: RegExpMatchArray) {
         const packagePath = pacakges.length > 0 ? this.generatePackagePath(pacakges[0]) : ''
         const sourceFilePath = uri.fsPath
-        if (!sourceFilePath.startsWith(projectPath))
+        if (!sourceFilePath.startsWith(projectPath)) {
             throw new Error("Invalid source file path which doesn't contain valid workspace.")
+        }
         let buildFileRelativePath
         if (packagePath === '') {
             buildFileRelativePath = path.parse(sourceFilePath).base
@@ -132,7 +135,9 @@ export class JavaDependencyGraph extends DependencyGraph {
     }
 
     parseImport(importStr: string, dirPaths: string[]) {
-        if (this._parsedStatements.has(importStr)) return []
+        if (this._parsedStatements.has(importStr)) {
+            return []
+        }
         this._parsedStatements.add(importStr)
         const importPath = this.getImportPath(importStr)
         const dependencies = this.generateSourceFilePaths(dirPaths, importPath)
@@ -181,11 +186,17 @@ export class JavaDependencyGraph extends DependencyGraph {
         while (q.length > 0) {
             let count: number = q.length
             while (count > 0) {
-                if (this.reachSizeLimit(this._totalSize)) return
+                if (this.reachSizeLimit(this._totalSize)) {
+                    return
+                }
                 count -= 1
                 const currentFilePath = q.shift()
-                if (currentFilePath === undefined) throw new Error('"undefined" is invalid for queued file.')
-                if (!existsSync(currentFilePath)) continue
+                if (currentFilePath === undefined) {
+                    throw new Error('"undefined" is invalid for queued file.')
+                }
+                if (!existsSync(currentFilePath)) {
+                    continue
+                }
                 this._pickedSourceFiles.add(currentFilePath)
                 this._totalSize += statSync(currentFilePath).size
                 const uri = vscode.Uri.file(currentFilePath)
@@ -207,7 +218,9 @@ export class JavaDependencyGraph extends DependencyGraph {
     }
 
     async traverseDir(dirPath: string) {
-        if (!existsSync(dirPath) || this.reachSizeLimit(this._totalSize) || this._fetchedDirs.has(dirPath)) return
+        if (!existsSync(dirPath) || this.reachSizeLimit(this._totalSize) || this._fetchedDirs.has(dirPath)) {
+            return
+        }
         readdirSync(dirPath, { encoding: ENCODE, withFileTypes: true }).forEach(async file => {
             const fileAbsPath = path.join(dirPath, file.name)
             if (existsSync(fileAbsPath) && file.name.charAt(0) !== '.') {
@@ -290,7 +303,9 @@ export class JavaDependencyGraph extends DependencyGraph {
     }
 
     private detectClasspath(dirPath: string, dirName: string, projectName: string, extension: string): PackageNode {
-        if (!existsSync(dirPath) || dirPath.indexOf(projectName) === -1) return { paths: [], valid: false }
+        if (!existsSync(dirPath) || dirPath.indexOf(projectName) === -1) {
+            return { paths: [], valid: false }
+        }
 
         const packageNode: PackageNode = { paths: [], valid: true }
         let hasBuildFile: boolean = false

--- a/src/codewhisperer/util/dependencyGraph/pythonDependencyGraph.ts
+++ b/src/codewhisperer/util/dependencyGraph/pythonDependencyGraph.ts
@@ -86,7 +86,9 @@ export class PythonDependencyGraph extends DependencyGraph {
 
     private getModulePath(modulePathStr: string) {
         const pos = modulePathStr.indexOf(' ' + AS + ' ')
-        if (pos !== -1) modulePathStr = modulePathStr.substring(0, pos)
+        if (pos !== -1) {
+            modulePathStr = modulePathStr.substring(0, pos)
+        }
         return modulePathStr.trim()
     }
 
@@ -108,7 +110,9 @@ export class PythonDependencyGraph extends DependencyGraph {
     }
 
     parseImport(importStr: string, dirPaths: string[]) {
-        if (this._parsedStatements.has(importStr)) return []
+        if (this._parsedStatements.has(importStr)) {
+            return []
+        }
         this._parsedStatements.add(importStr)
         const modulePaths = this.extractModulePaths(importStr)
         const importPaths = this.getImportPaths(importStr)
@@ -144,10 +148,14 @@ export class PythonDependencyGraph extends DependencyGraph {
         while (q.length > 0) {
             let count: number = q.length
             while (count > 0) {
-                if (this.reachSizeLimit(this._totalSize)) return
+                if (this.reachSizeLimit(this._totalSize)) {
+                    return
+                }
                 count -= 1
                 const currentFilePath = q.shift()
-                if (currentFilePath === undefined) throw new Error('"undefined" is invalid for queued file.')
+                if (currentFilePath === undefined) {
+                    throw new Error('"undefined" is invalid for queued file.')
+                }
                 this._pickedSourceFiles.add(currentFilePath)
                 this._totalSize += statSync(currentFilePath).size
                 const uri = vscode.Uri.file(currentFilePath)
@@ -161,10 +169,14 @@ export class PythonDependencyGraph extends DependencyGraph {
     }
 
     async traverseDir(dirPath: string) {
-        if (this.reachSizeLimit(this._totalSize)) return
+        if (this.reachSizeLimit(this._totalSize)) {
+            return
+        }
         readdirSync(dirPath, { encoding: ENCODE, withFileTypes: true }).forEach(async file => {
             const absPath = path.join(dirPath, file.name)
-            if (!existsSync(absPath)) return
+            if (!existsSync(absPath)) {
+                return
+            }
             if (file.isDirectory()) {
                 await this.traverseDir(absPath)
             } else if (file.isFile()) {

--- a/src/codewhisperer/views/securityPanelViewProvider.ts
+++ b/src/codewhisperer/views/securityPanelViewProvider.ts
@@ -221,7 +221,9 @@ export class SecurityPanelViewProvider implements vscode.WebviewViewProvider {
     }
 
     private getHtmlContent(): string {
-        if (this.persistLog.length == 0) return 'No security issues have been detected in the workspace.'
+        if (this.persistLog.length == 0) {
+            return 'No security issues have been detected in the workspace.'
+        }
         return this.persistLog.join('') + this.dynamicLog.join('')
     }
 
@@ -254,9 +256,13 @@ export class SecurityPanelViewProvider implements vscode.WebviewViewProvider {
 
     public disposeSecurityPanelItem(event: vscode.TextDocumentChangeEvent, editor: vscode.TextEditor | undefined) {
         const uri = event.document.uri
-        if (this.panelSets.length === 0) return
+        if (this.panelSets.length === 0) {
+            return
+        }
         const index = this.panelSets.findIndex(panelSet => panelSet.uri.fsPath === uri.fsPath)
-        if (index === -1) return
+        if (index === -1) {
+            return
+        }
 
         const currentPanelSet = this.panelSets[index]
         const changedRange = event.contentChanges[0].range

--- a/src/eventSchemas/commands/downloadSchemaItemCode.ts
+++ b/src/eventSchemas/commands/downloadSchemaItemCode.ts
@@ -371,10 +371,11 @@ export class CodeExtractor {
             localizedText.no
         )
 
-        if (!userResponse)
+        if (!userResponse) {
             throw new UserNotifiedError(
                 localize('AWS.message.error.schemas.downloadCodeBindings.cancelled', 'Download code bindings cancelled')
             )
+        }
 
         return userResponse === localizedText.yes
     }

--- a/src/shared/filesystemUtilities.ts
+++ b/src/shared/filesystemUtilities.ts
@@ -34,8 +34,12 @@ export async function getDirSize(
     const files = await fsExtra.readdir(dirPath, { withFileTypes: true })
     const fileSizes = files.map(async file => {
         const filePath = path.join(dirPath, file.name)
-        if (file.isSymbolicLink()) return 0
-        if (file.isDirectory()) return getDirSize(filePath, startTime, duration, fileExt)
+        if (file.isSymbolicLink()) {
+            return 0
+        }
+        if (file.isDirectory()) {
+            return getDirSize(filePath, startTime, duration, fileExt)
+        }
         if (file.isFile() && file.name.endsWith(fileExt)) {
             const { size } = await fsExtra.stat(filePath)
             return size

--- a/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
+++ b/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
@@ -72,7 +72,9 @@ describe('codewhispererCodecoverageTracker', function () {
             sinon.stub(TelemetryHelper.instance, 'isTelemetryEnabled').returns(true)
 
             tracker = CodeWhispererCodeCoverageTracker.getTracker('python', fakeMemeto)
-            if (!tracker) assert.fail()
+            if (!tracker) {
+                assert.fail()
+            }
             assert.strictEqual(tracker.isActive(), false)
 
             fakeMemeto.update(CodeWhispererConstants.termsAcceptedKey, false)
@@ -83,7 +85,9 @@ describe('codewhispererCodecoverageTracker', function () {
             sinon.stub(TelemetryHelper.instance, 'isTelemetryEnabled').returns(false)
 
             tracker = CodeWhispererCodeCoverageTracker.getTracker('java', fakeMemeto)
-            if (!tracker) assert.fail()
+            if (!tracker) {
+                assert.fail()
+            }
             assert.strictEqual(tracker.isActive(), false)
 
             fakeMemeto.update(CodeWhispererConstants.termsAcceptedKey, false)
@@ -95,7 +99,9 @@ describe('codewhispererCodecoverageTracker', function () {
             sinon.stub(TelemetryHelper.instance, 'isTelemetryEnabled').returns(true)
 
             tracker = CodeWhispererCodeCoverageTracker.getTracker('javascript', fakeMemeto)
-            if (!tracker) assert.fail()
+            if (!tracker) {
+                assert.fail()
+            }
             assert.strictEqual(tracker.isActive(), true)
         })
     })
@@ -117,7 +123,9 @@ describe('codewhispererCodecoverageTracker', function () {
         })
 
         it('Should compute edit distance to update the accepted tokens', function () {
-            if (!tracker) assert.fail()
+            if (!tracker) {
+                assert.fail()
+            }
             const editor = createMockTextEditor('def addTwoNumbers(a, b):\n')
 
             tracker.addAcceptedTokens(editor.document.fileName, {
@@ -176,14 +184,18 @@ describe('codewhispererCodecoverageTracker', function () {
         })
 
         it('Should skip when tracker is not active', function () {
-            if (!tracker) assert.fail()
+            if (!tracker) {
+                assert.fail()
+            }
             tracker.countAcceptedTokens(new vscode.Range(0, 0, 0, 1), 'a', 'test.py')
             const spy = sinon.spy(CodeWhispererCodeCoverageTracker.prototype, 'addAcceptedTokens')
             assert.ok(!spy.called)
         })
 
         it('Should increase both AcceptedTokens and TotalTokens', function () {
-            if (!tracker) assert.fail()
+            if (!tracker) {
+                assert.fail()
+            }
             tracker.countAcceptedTokens(new vscode.Range(0, 0, 0, 1), 'a', 'test.py')
             assert.deepStrictEqual(tracker.acceptedTokens['test.py'][0], {
                 range: new vscode.Range(0, 0, 0, 1),
@@ -211,7 +223,9 @@ describe('codewhispererCodecoverageTracker', function () {
         })
 
         it('Should skip when user copy large files', function () {
-            if (!tracker) assert.fail()
+            if (!tracker) {
+                assert.fail()
+            }
             tracker.countTotalTokens({
                 document: createMockDocument(),
                 contentChanges: [
@@ -229,7 +243,9 @@ describe('codewhispererCodecoverageTracker', function () {
         })
 
         it('Should skip when CodeWhisperer is editing', function () {
-            if (!tracker) assert.fail()
+            if (!tracker) {
+                assert.fail()
+            }
             vsCodeState.isCodeWhispererEditing = true
             tracker.countTotalTokens({
                 document: createMockDocument(),
@@ -247,7 +263,9 @@ describe('codewhispererCodecoverageTracker', function () {
         })
 
         it('Should reduce tokens when delete', function () {
-            if (!tracker) assert.fail()
+            if (!tracker) {
+                assert.fail()
+            }
             const doc = createMockDocument('import math', 'test.py', 'python')
             tracker.countTotalTokens({
                 document: doc,
@@ -275,7 +293,9 @@ describe('codewhispererCodecoverageTracker', function () {
         })
 
         it('Should add tokens when type', function () {
-            if (!tracker) assert.fail()
+            if (!tracker) {
+                assert.fail()
+            }
             const doc = createMockDocument('import math', 'test.py', 'python')
             tracker.countTotalTokens({
                 document: doc,
@@ -309,7 +329,9 @@ describe('codewhispererCodecoverageTracker', function () {
         })
 
         it('Should not send codecoverage telemetry if tracker is not active', function () {
-            if (!tracker) assert.fail()
+            if (!tracker) {
+                assert.fail()
+            }
             sinon.restore()
             sinon.stub(tracker, 'isActive').returns(false)
 


### PR DESCRIPTION
## Problem

Control flow statements are inconsistently formatted, e.g. there is some code like this:

    if (this._timer !== undefined) return

## Solution

Configure eslint to enforce braces:

    if (this._timer !== undefined) {
        return
    }

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
