### PR TITLE
fix(auth): update status bar color; use SSO connection as a fallback

### DIFF
--- a/src/credentials/auth.ts
+++ b/src/credentials/auth.ts
@@ -725,6 +725,11 @@ async function signout(auth: Auth) {
         }
     } else {
         await auth.logout()
+
+        const fallbackConn = (await auth.listConnections()).find(c => c.type === 'sso')
+        if (fallbackConn !== undefined) {
+            await auth.useConnection(fallbackConn)
+        }
     }
 }
 

--- a/src/credentials/awsCredentialsStatusBarItem.ts
+++ b/src/credentials/awsCredentialsStatusBarItem.ts
@@ -30,7 +30,8 @@ export async function initializeAwsCredentialsStatusBarItem(
 
     context.subscriptions.push(
         Auth.instance.onDidChangeActiveConnection(conn => {
-            updateCredentialsStatusBarItem(statusBarItem, conn?.label)
+            const color = conn?.state === 'invalid' ? new vscode.ThemeColor('statusBarItem.errorBackground') : undefined
+            updateCredentialsStatusBarItem(statusBarItem, conn?.label, color)
             handleDevSettings(devSettings, statusBarItem)
         }),
         devSettings.onDidChangeActiveSettings(() => handleDevSettings(devSettings, statusBarItem))
@@ -41,19 +42,18 @@ function handleDevSettings(devSettings: DevSettings, statusBarItem: vscode.Statu
     const developerMode = Object.keys(devSettings.activeSettings)
 
     if (developerMode.length > 0) {
-        ;(statusBarItem as any).backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground')
+        ;(statusBarItem as any).backgroundColor ??= new vscode.ThemeColor('statusBarItem.warningBackground')
 
         const devSettingsStr = developerMode.join('  \n')
         statusBarItem.tooltip = `Toolkit developer settings:\n${devSettingsStr}`
-    } else {
-        ;(statusBarItem as any).backgroundColor = undefined
     }
 }
 
 // Resolves when the status bar reaches its final state
 export async function updateCredentialsStatusBarItem(
     statusBarItem: vscode.StatusBarItem,
-    credentialsId?: string
+    credentialsId?: string,
+    color?: vscode.ThemeColor
 ): Promise<void> {
     const connectedMsg = localize(
         'AWS.credentials.statusbar.connected',
@@ -70,4 +70,5 @@ export async function updateCredentialsStatusBarItem(
     const company = getIdeProperties().company
     statusBarItem.tooltip = credentialsId ? connectedMsg : disconnectedMsg
     statusBarItem.text = credentialsId ? `${company}: ${credentialsId}` : company
+    ;(statusBarItem as any).backgroundColor = color
 }


### PR DESCRIPTION
## Problem
* Statusbar should be in an error state for expired credentials 
* Signout out of IAM connection puts users in a fully logged-out state

## Solution
* Update statusbar color depending on connection state
    * Use different color in dev mode 
* Fallback to an SSO connection when signing out of an IAM connection

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
