### PR TITLE
fix(auth): ensure token exists before persisting connection

### DIFF
--- a/src/credentials/auth.ts
+++ b/src/credentials/auth.ts
@@ -380,17 +380,21 @@ export class Auth implements AuthService, ConnectionManager {
 
         // XXX: `id` should be based off the resolved `idToken`, _not_ the source profile
         const id = getSsoProfileKey(profile)
-        const storedProfile = await this.store.addProfile(id, profile)
-        const conn = this.getSsoConnection(id, storedProfile)
+        const tokenProvider = this.getTokenProvider(id, {
+            ...profile,
+            metadata: { connectionState: 'unauthenticated' },
+        })
 
         try {
-            await conn.getToken()
+            ;(await tokenProvider.getToken()) ?? (await tokenProvider.createToken())
+            const storedProfile = await this.store.addProfile(id, profile)
+            await this.updateConnectionState(id, 'valid')
+
+            return this.getSsoConnection(id, storedProfile)
         } catch (err) {
             await this.store.deleteProfile(id)
             throw err
         }
-
-        return this.getSsoConnection(id, storedProfile)
     }
 
     public async deleteConnection(connection: Pick<Connection, 'id'>): Promise<void> {


### PR DESCRIPTION
## Problem
Connections are created _before_ the user finishes the auth flow. This can be confusing because the connections aren't marked as 'pending'. 

## Solution
Don't persist the connection until we get a token.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
