### PR TITLE
fix(auth): more improvements

### DIFF
--- a/src/credentials/auth.ts
+++ b/src/credentials/auth.ts
@@ -518,7 +518,8 @@ export class Auth implements AuthService, ConnectionManager {
         profile: StoredProfile<SsoProfile>
     ): SsoConnection & StatefulConnection {
         const provider = this.getTokenProvider(id, profile)
-        const label = `SSO (${profile.startUrl})`
+        const truncatedUrl = profile.startUrl.match(/https?:\/\/(.*).awsapps.com\/start/)?.[1] ?? profile.startUrl
+        const label = `IAM Identity Center (${truncatedUrl})`
 
         return {
             id,
@@ -785,7 +786,7 @@ export async function createStartUrlPrompter(title: string) {
 
     return createInputBox({
         title: `${title}: Enter Start URL`,
-        placeholder: "Enter start URL for your organization's SSO",
+        placeholder: "Enter start URL for your organization's AWS access portal",
         buttons: createCommonButtons(),
         validateInput: validateSsoUrl,
     })
@@ -808,7 +809,7 @@ const addConnection = Commands.register('aws.auth.addConnection', async () => {
         case 'iam':
             return await globals.awsContextCommands.onCommandCreateCredentialsProfile()
         case 'sso': {
-            const startUrlPrompter = await createStartUrlPrompter('SSO Connection')
+            const startUrlPrompter = await createStartUrlPrompter('IAM Identity Center')
             const startUrl = await startUrlPrompter.prompt()
             if (!isValidResponse(startUrl)) {
                 throw new CancellationError('user')

--- a/src/credentials/auth.ts
+++ b/src/credentials/auth.ts
@@ -518,7 +518,7 @@ export class Auth implements AuthService, ConnectionManager {
         profile: StoredProfile<SsoProfile>
     ): SsoConnection & StatefulConnection {
         const provider = this.getTokenProvider(id, profile)
-        const truncatedUrl = profile.startUrl.match(/https?:\/\/(.*).awsapps.com\/start/)?.[1] ?? profile.startUrl
+        const truncatedUrl = profile.startUrl.match(/https?:\/\/(.*)\.awsapps\.com\/start/)?.[1] ?? profile.startUrl
         const label = `IAM Identity Center (${truncatedUrl})`
 
         return {

--- a/src/credentials/auth.ts
+++ b/src/credentials/auth.ts
@@ -434,7 +434,7 @@ export class Auth implements AuthService, ConnectionManager {
 
             return provider.invalidate()
         } else if (profile.type === 'iam') {
-            globals.credentialsStore.invalidateCredentials(fromString(id))
+            globals.loginManager.store.invalidateCredentials(fromString(id))
         }
     }
 
@@ -547,14 +547,15 @@ export class Auth implements AuthService, ConnectionManager {
 
     private async createCachedCredentials(provider: CredentialsProvider) {
         const providerId = provider.getCredentialsId()
-        globals.credentialsStore.invalidateCredentials(providerId)
-        const { credentials } = await globals.credentialsStore.upsertCredentials(providerId, provider)
+        globals.loginManager.store.invalidateCredentials(providerId)
+        const { credentials } = await globals.loginManager.store.upsertCredentials(providerId, provider)
+        await globals.loginManager.validateCredentials(credentials, provider.getDefaultRegion())
 
         return credentials
     }
 
     private async getCachedCredentials(provider: CredentialsProvider) {
-        const creds = await globals.credentialsStore.getCredentials(provider.getCredentialsId())
+        const creds = await globals.loginManager.store.getCredentials(provider.getCredentialsId())
         if (creds !== undefined && creds.credentialsHashCode === provider.getHashCode()) {
             return creds.credentials
         }

--- a/src/credentials/sso/ssoAccessTokenProvider.ts
+++ b/src/credentials/sso/ssoAccessTokenProvider.ts
@@ -62,7 +62,10 @@ export class SsoAccessTokenProvider {
     ) {}
 
     public async invalidate(): Promise<void> {
-        await this.cache.token.clear(this.tokenCacheKey)
+        await Promise.all([
+            this.cache.token.clear(this.tokenCacheKey),
+            this.cache.registration.clear(this.registrationCacheKey),
+        ])
     }
 
     public async getToken(): Promise<SsoToken | undefined> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,7 +112,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
         await initializeAwsCredentialsStatusBarItem(awsContext, context)
         globals.regionProvider = regionProvider
-        globals.credentialsStore = credentialsStore
+        globals.loginManager = loginManager
         globals.awsContextCommands = new AwsContextCommands(regionProvider, Auth.instance)
         globals.sdkClientBuilder = new DefaultAWSClientBuilder(awsContext)
         globals.schemaService = new SchemaService(context)

--- a/src/shared/extensionGlobals.ts
+++ b/src/shared/extensionGlobals.ts
@@ -4,7 +4,7 @@
  */
 
 import { ExtensionContext, OutputChannel, Uri } from 'vscode'
-import { CredentialsStore } from '../credentials/credentialsStore'
+import { LoginManager } from '../credentials/loginManager'
 import { AwsResourceManager } from '../dynamicResources/awsResourceManager'
 import { AWSClientBuilder } from './awsClientBuilder'
 import { AwsContext } from './awsContext'
@@ -60,7 +60,7 @@ interface ToolkitGlobals {
     readonly window: Window
     // TODO: make the rest of these readonly (or delete them)
     outputChannel: OutputChannel
-    credentialsStore: CredentialsStore
+    loginManager: LoginManager
     awsContextCommands: AwsContextCommands
     awsContext: AwsContext
     regionProvider: RegionProvider

--- a/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
+++ b/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
@@ -78,6 +78,18 @@ describe('SsoAccessTokenProvider', function () {
         await tryRemoveFolder(tempDir)
     })
 
+    describe('invalidate', function () {
+        it('removes cached tokens and registrations', async function () {
+            const validToken = createToken(HOUR_IN_MS)
+            await cache.token.save(startUrl, { region, startUrl, token: validToken })
+            await cache.registration.save({ region }, createRegistration(HOUR_IN_MS))
+            await sut.invalidate()
+
+            assert.strictEqual(await cache.token.load(startUrl), undefined)
+            assert.strictEqual(await cache.registration.load({ region }), undefined)
+        })
+    })
+
     describe('getToken', function () {
         it('returns a cached token', async function () {
             const validToken = createToken(HOUR_IN_MS)


### PR DESCRIPTION
## Problem
* `invalidate` doesn't drop the cached registration
* Users can switch to invalid static credentials

## Solution
* Use `LoginManager` to validate profiles
* Update `invalidate`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
