### PR TITLE
feat(auth): add `SecondaryAuth`

### DIFF
--- a/src/credentials/secondaryAuth.ts
+++ b/src/credentials/secondaryAuth.ts
@@ -16,7 +16,9 @@ import { UnknownError } from '../shared/errors'
 async function promptUseNewConnection(newConn: Connection, oldConn: Connection, tools: string[]) {
     // Multi-select picker would be better ?
     const saveConnectionItem = {
-        label: `Yes, use ${newConn.label} with ${tools.join(', ')} while using ${oldConn.label} with other services.`,
+        label: `Yes, keep using ${newConn.label} with ${tools.join(', ')} while using ${
+            oldConn.label
+        } with other services.`,
         detail: `To remove later, select "Remove Connection from Tool" from the tool's context (right-click) menu.`,
         data: 'yes',
     } as const

--- a/src/credentials/secondaryAuth.ts
+++ b/src/credentials/secondaryAuth.ts
@@ -1,0 +1,191 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import globals from '../shared/extensionGlobals'
+
+import * as vscode from 'vscode'
+import { getLogger } from '../shared/logger'
+import { showQuickPick } from '../shared/ui/pickerPrompter'
+import { cast, Optional } from '../shared/utilities/typeConstructors'
+import { Auth, Connection } from './auth'
+import { once } from '../shared/utilities/functionUtils'
+import { UnknownError } from '../shared/errors'
+
+async function promptSaveConnection(newConn: Connection, oldConn: Connection, tools: string[]) {
+    // Multi-select picker would be better ?
+    const saveConnectionItem = {
+        label: `Keep using ${oldConn.label} with these tools: ${tools.join(', ')}.`,
+        detail: 'This can be removed by selecting "Remove Connection from Tool" on a tool node.',
+        data: 'yes',
+    } as const
+
+    const useConnectionItem = {
+        label: `Switch everything to authenticate with ${newConn.label}.`,
+        detail: 'This will not log you out; you can switch back at any point by selecting the connection.',
+        data: 'no',
+    } as const
+
+    const resp = await showQuickPick([saveConnectionItem, useConnectionItem], {
+        title: `Some tools do not work with ${newConn.label}`,
+        placeholder: 'Confirm choice',
+    })
+
+    return resp
+}
+
+async function promptUseNewConnection(conn: Connection, tool: string) {
+    const saveConnectionItem = {
+        label: `Save ${conn.label} to ${tool}`,
+        detail: `This can be removed by selecting "Remove Connection from Tool" on the ${tool} node.`,
+        data: 'yes',
+    } as const
+
+    const useConnectionItem = {
+        label: `Use ${conn.label} for everything`,
+        detail: 'This will not log you out; you can switch back at any point by selecting the connection.',
+        data: 'no',
+    } as const
+
+    return showQuickPick([saveConnectionItem, useConnectionItem], {
+        title: `Use ${conn.label} for ${tool}?`,
+    })
+}
+
+let oldConn: Auth['activeConnection']
+const auths = new Map<string, SecondaryAuth>()
+const registerAuthListener = once(() => {
+    Auth.instance.onDidChangeActiveConnection(async conn => {
+        const potentialConn = oldConn
+        if (conn !== undefined && potentialConn?.state === 'valid') {
+            const saveableAuths = Array.from(auths.values()).filter(
+                a => !a.isUsingSavedConnection && a.isUsable(potentialConn) && !a.isUsable(conn)
+            )
+            const toolNames = saveableAuths.map(a => a.toolLabel)
+            if (saveableAuths.length > 0 && (await promptSaveConnection(conn, potentialConn, toolNames)) === 'yes') {
+                await Promise.all(saveableAuths.map(a => a.saveConnection(potentialConn)))
+            }
+        }
+
+        oldConn = conn
+    })
+})
+
+export function getSecondaryAuth<T extends Connection>(
+    toolId: string,
+    toolLabel: string,
+    isValid: (conn: Connection) => conn is T
+): SecondaryAuth<T> {
+    const auth = new SecondaryAuth(toolId, toolLabel, isValid)
+    auths.set(toolId, auth)
+    registerAuthListener()
+
+    return auth
+}
+
+/**
+ * Enables a tool to bind to a connection independently from the global {@link Auth} service.
+ *
+ * Not all connections are usable by every tool, so callers of this class must provide a function
+ * that can identify usable connections. Toolkit users are notified whenever a loss of functionality
+ * would occur after switching connections. Users can then choose to save the usable connection to
+ * the tool, allowing the global connection to move freely.
+ */
+export class SecondaryAuth<T extends Connection = Connection> {
+    #activeConnection: Connection | undefined
+    #savedConnection: T | undefined
+
+    private readonly key = `${this.toolId}.savedConnectionId`
+    private readonly onDidChangeActiveConnectionEmitter = new vscode.EventEmitter<T | undefined>()
+    public readonly onDidChangeActiveConnection = this.onDidChangeActiveConnectionEmitter.event
+
+    public constructor(
+        public readonly toolId: string,
+        public readonly toolLabel: string,
+        public readonly isUsable: (conn: Connection) => conn is T,
+        private readonly auth = Auth.instance,
+        private readonly memento = globals.context.globalState
+    ) {
+        this.auth.onDidChangeActiveConnection(async conn => {
+            if (
+                conn === undefined &&
+                this.#savedConnection &&
+                this.#savedConnection.id === this.#activeConnection?.id
+            ) {
+                await this.removeConnection()
+            } else {
+                this.#activeConnection = conn
+                this.onDidChangeActiveConnectionEmitter.fire(this.activeConnection)
+            }
+        })
+    }
+
+    public get activeConnection(): T | undefined {
+        return (
+            this.#savedConnection ??
+            (this.#activeConnection && this.isUsable(this.#activeConnection) ? this.#activeConnection : undefined)
+        )
+    }
+
+    public get isUsingSavedConnection() {
+        return this.#savedConnection !== undefined
+    }
+
+    public get isConnectionExpired() {
+        return !!this.activeConnection && this.auth.getConnectionState(this.activeConnection) === 'invalid'
+    }
+
+    public async saveConnection(conn: T) {
+        await this.memento.update(this.key, conn.id)
+        this.#savedConnection = conn
+        this.onDidChangeActiveConnectionEmitter.fire(this.activeConnection)
+    }
+
+    public async removeConnection() {
+        await this.memento.update(this.key, undefined)
+        this.#savedConnection = undefined
+        this.onDidChangeActiveConnectionEmitter.fire(this.activeConnection)
+    }
+
+    public async useNewConnection(conn: T) {
+        if (this.auth.activeConnection !== undefined && !this.isUsable(this.auth.activeConnection)) {
+            if ((await promptUseNewConnection(conn, this.toolLabel)) === 'yes') {
+                await this.saveConnection(conn)
+            } else {
+                await this.auth.useConnection(conn)
+            }
+        } else {
+            await this.auth.useConnection(conn)
+        }
+    }
+
+    // Used to lazily restore persisted connections.
+    // Kind of clunky. We need an async module loader layer to make things ergonomic.
+    public readonly restoreConnection: () => Promise<T | undefined> = once(async () => {
+        try {
+            await this.auth.tryAutoConnect()
+            this.#savedConnection = await this.loadSavedConnection()
+            this.onDidChangeActiveConnectionEmitter.fire(this.activeConnection)
+
+            return this.#savedConnection
+        } catch (err) {
+            getLogger().warn(`auth (${this.toolId}): failed to restore connection: ${UnknownError.cast(err).message}`)
+        }
+    })
+
+    private async loadSavedConnection() {
+        const id = cast(this.memento.get(this.key), Optional(String))
+        const conn = id !== undefined ? await this.auth.getConnection({ id }) : undefined
+
+        if (conn === undefined) {
+            getLogger().warn(`auth (${this.toolId}): removing saved connection "${this.key}" as it no longer exists`)
+            await this.memento.update(this.key, undefined)
+        } else if (!this.isUsable(conn)) {
+            getLogger().warn(`auth (${this.toolId}): saved connection "${this.key}" is not valid`)
+            await this.memento.update(this.key, undefined)
+        } else {
+            return conn
+        }
+    }
+}

--- a/src/credentials/secondaryAuth.ts
+++ b/src/credentials/secondaryAuth.ts
@@ -35,21 +35,21 @@ async function promptSaveConnection(newConn: Connection, oldConn: Connection, to
     return resp
 }
 
-async function promptUseNewConnection(conn: Connection, tool: string) {
+async function promptUseNewConnection(newConn: Connection, oldConn: Connection, tool: string) {
     const saveConnectionItem = {
-        label: `Save ${conn.label} to ${tool}`,
-        detail: `This can be removed by selecting "Remove Connection from Tool" on the ${tool} node.`,
+        label: `Yes, use ${tool} with ${newConn.label} while using ${oldConn.label} with other services.`,
+        detail: `You can disconnect from ${tool} later.`,
         data: 'yes',
     } as const
 
     const useConnectionItem = {
-        label: `Use ${conn.label} for everything`,
-        detail: 'This will not log you out; you can switch back at any point by selecting the connection.',
+        label: `No, disconnect from ${tool} and use ${oldConn.label} for other services.`,
+        detail: `You can reconnect to ${tool} later.`,
         data: 'no',
     } as const
 
     return showQuickPick([saveConnectionItem, useConnectionItem], {
-        title: `Use ${conn.label} for ${tool}?`,
+        title: `Stay connected to ${tool} with ${newConn.label}?`,
     })
 }
 
@@ -150,7 +150,7 @@ export class SecondaryAuth<T extends Connection = Connection> {
 
     public async useNewConnection(conn: T) {
         if (this.auth.activeConnection !== undefined && !this.isUsable(this.auth.activeConnection)) {
-            if ((await promptUseNewConnection(conn, this.toolLabel)) === 'yes') {
+            if ((await promptUseNewConnection(conn, this.auth.activeConnection, this.toolLabel)) === 'yes') {
                 await this.saveConnection(conn)
             } else {
                 await this.auth.useConnection(conn)


### PR DESCRIPTION
## Problem
* No "Edit Credentials" button when switching connections
* Persisting connections is not cohesive

## Solution
* Add "Edit Credentials" button
* Add `SecondaryAuth` class (dead code)
 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
