### PR TITLE
feat(explorer): enable EventBridge Schemas in Cloud9

### DIFF
--- a/.changes/next-release/Feature-ddf9caaa-fa93-4d67-bd4c-817447ae6e68.json
+++ b/.changes/next-release/Feature-ddf9caaa-fa93-4d67-bd4c-817447ae6e68.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Cloud9: browse and generate code for EventBridge Schemas from AWS Explorer"
+}

--- a/package.json
+++ b/package.json
@@ -1485,17 +1485,17 @@
                 },
                 {
                     "command": "aws.searchSchema",
-                    "when": "view == aws.explorer && viewItem == awsSchemasNode && !isCloud9",
+                    "when": "view == aws.explorer && viewItem == awsSchemasNode",
                     "group": "0@1"
                 },
                 {
                     "command": "aws.searchSchemaPerRegistry",
-                    "when": "view == aws.explorer && viewItem == awsRegistryItemNode && !isCloud9",
+                    "when": "view == aws.explorer && viewItem == awsRegistryItemNode",
                     "group": "0@1"
                 },
                 {
                     "command": "aws.viewSchemaItem",
-                    "when": "view == aws.explorer && viewItem == awsSchemaItemNode && !isCloud9",
+                    "when": "view == aws.explorer && viewItem == awsSchemaItemNode",
                     "group": "0@1"
                 },
                 {
@@ -1680,7 +1680,7 @@
                 },
                 {
                     "command": "aws.downloadSchemaItemCode",
-                    "when": "view == aws.explorer && viewItem == awsSchemaItemNode && !isCloud9",
+                    "when": "view == aws.explorer && viewItem == awsSchemaItemNode",
                     "group": "1@1"
                 },
                 {

--- a/scripts/build/generateIcons.ts
+++ b/scripts/build/generateIcons.ts
@@ -81,7 +81,7 @@ async function generateCloud9Icons(targets: { name: string; path: string }[], de
 
     async function replaceColor(file: string, color: string, dst: string): Promise<void> {
         const contents = await fs.readFile(file, 'utf-8')
-        const replaced = contents.replace('currentColor', color)
+        const replaced = contents.replace(/currentColor/g, color)
         await fs.writeFile(dst, replaced)
     }
 

--- a/src/awsexplorer/regionNode.ts
+++ b/src/awsexplorer/regionNode.ts
@@ -12,7 +12,6 @@ import { LambdaNode } from '../lambda/explorer/lambdaNodes'
 import { S3Node } from '../s3/explorer/s3Nodes'
 import { EcrNode } from '../ecr/explorer/ecrNode'
 import { IotNode } from '../iot/explorer/iotNodes'
-import { isCloud9 } from '../shared/extensionUtilities'
 import { Region } from '../shared/regions/endpoints'
 import { DEFAULT_PARTITION, RegionProvider } from '../shared/regions/regionProvider'
 import { AWSTreeNodeBase } from '../shared/treeview/nodes/awsTreeNodeBase'
@@ -67,8 +66,7 @@ const serviceCandidates = [
     },
     {
         serviceId: 'schemas',
-        createFn: (regionCode: string) =>
-            !isCloud9() ? new SchemasNode(new DefaultSchemaClient(regionCode)) : undefined,
+        createFn: (regionCode: string) => new SchemasNode(new DefaultSchemaClient(regionCode)),
     },
     {
         serviceId: 'states',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,6 @@ import {
     getIdeProperties,
     getToolkitEnvironmentDetails,
     initializeComputeRegion,
-    isCloud9,
     showQuickStartWebview,
     showWelcomeMessage,
 } from './shared/extensionUtilities'
@@ -229,10 +228,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
         await activateEcs(extContext)
 
-        // Features which aren't currently functional in Cloud9
-        if (!isCloud9()) {
-            await activateSchemas(extContext)
-        }
+        await activateSchemas(extContext)
 
         await activateStepFunctions(context, awsContext, toolkitOutputChannel)
 


### PR DESCRIPTION
## Problem

Schemas feature of AWS Explorer not available in Cloud9.

## Solution

Enable it.

<img width="543" alt="image" src="https://user-images.githubusercontent.com/55561878/202770411-78d10659-0034-4088-bd30-b7a1512da0e8.png">


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
