### PR TITLE
sam: throw error when no templates are found

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -114,3 +114,7 @@ export const apprunnerCreateServiceDocsUrl: string = isCloud9()
 // URLs for S3
 // TODO: update docs to add the file viewer feature
 export const s3FileViewerHelpUrl = 'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/s3.html'
+
+// URL for SAM docs
+export const samDocsUrl =
+    'https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html'

--- a/src/test/lambda/commands/deploySamApplication.test.ts
+++ b/src/test/lambda/commands/deploySamApplication.test.ts
@@ -137,7 +137,8 @@ describe('deploySamApplication', async function () {
         profile = 'testAcct'
         tempToolkitFolder = await makeTemporaryToolkitFolder()
         templatePath = path.join(tempToolkitFolder, 'template.yaml')
-        writeFile(templatePath)
+        fs.writeFileSync(templatePath, "AWSTemplateFormatVersion: '2010-09-09'")
+        await globals.templateRegistry.addItemToRegistry(vscode.Uri.file(templatePath))
 
         // TODO: is this safe? will add output channel across all tests
         // we are using this pattern in other tests...
@@ -584,8 +585,4 @@ function assertErrorLogsSwallowed(text: string, exactMatch: boolean) {
             .some(e => !(e instanceof Error) && (exactMatch ? e === text : e.includes(text))),
         `Expected to find "${text}" in the error logs, but not as a thrown error`
     )
-}
-
-function writeFile(filename: string): void {
-    fs.writeFileSync(filename, '')
 }


### PR DESCRIPTION
## Problem
When running "Deploy SAM Application" command, if there are no SAM applications found, the menu is empty without any further feedback. This is confusing for new users or users just trying things out.
## Solution
Throw an error and provide the user with options to learn more via a link to the SAM docs and an option to create a new SAM application.

## Screenshot
![image](https://user-images.githubusercontent.com/25124281/203212633-3fb15c24-b6f3-4026-b6bd-2fd39f5393fb.png)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
