### PR TITLE
fix(logs): improve error logging

### DIFF
--- a/.changes/next-release/Bug Fix-2aac5758-8208-4124-83a8-3e347446e66c.json
+++ b/.changes/next-release/Bug Fix-2aac5758-8208-4124-83a8-3e347446e66c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "logging: `aws.viewLogsAtMessage` no longer fails when the log message cannot be found"
+}

--- a/src/apigateway/commands/copyUrl.ts
+++ b/src/apigateway/commands/copyUrl.ts
@@ -47,7 +47,7 @@ export async function copyUrlCommand(
             }
         )
     } catch (e) {
-        getLogger().error(`Failed to load stages: %O`, e)
+        getLogger().error(`Failed to load stages: %s`, e)
         telemetry.apigateway_copyUrl.emit({ result: 'Failed' })
         return
     }

--- a/src/apprunner/activation.ts
+++ b/src/apprunner/activation.ts
@@ -85,7 +85,7 @@ export async function activate(context: ExtContext): Promise<void> {
                 try {
                     await command(...args)
                 } catch (err) {
-                    getLogger().error(`${tuple[1]}: %O`, err)
+                    getLogger().error(`${tuple[1]}: %s`, err)
                     showViewLogsMessage(tuple[1])
                 }
             })

--- a/src/apprunner/explorer/apprunnerServiceNode.ts
+++ b/src/apprunner/explorer/apprunnerServiceNode.ts
@@ -127,7 +127,7 @@ export class AppRunnerServiceNode extends CloudWatchLogsBase implements AWSResou
                 getLogger().warn(
                     `Failed to list operations for service "${this._info.ServiceName}", service may be in an unstable state.`
                 )
-                getLogger().debug(`Failed to list operations for service "${this.arn}": %O`, err)
+                getLogger().debug(`Failed to list operations for service "${this.arn}": %s`, err)
             })
     }
 

--- a/src/apprunner/wizards/imageRepositoryWizard.ts
+++ b/src/apprunner/wizards/imageRepositoryWizard.ts
@@ -81,7 +81,7 @@ function createImagePrompter(
                 return repos
             })
             .catch(err => {
-                getLogger().error(`Unabled to list repositories: %O`, err)
+                getLogger().error(`Unabled to list repositories: %s`, err)
                 return [
                     {
                         label: localize(
@@ -187,7 +187,7 @@ function createTagPrompter(
                 return tagT
             })
             .catch(err => {
-                getLogger().error(`Unabled to list tags for repository "${imageRepo.repositoryName}": %O`, err)
+                getLogger().error(`Unabled to list tags for repository "${imageRepo.repositoryName}": %s`, err)
                 return [
                     {
                         label: localize(

--- a/src/awsexplorer/awsExplorer.ts
+++ b/src/awsexplorer/awsExplorer.ts
@@ -74,7 +74,7 @@ export class AwsExplorer implements vscode.TreeDataProvider<AWSTreeNodeBase>, Re
             }
         } catch (err) {
             const error = err as Error
-            this.logger.error(`Error getting children for node ${element?.label ?? 'Root Node'}: %O`, error)
+            this.logger.error(`Error getting children for node ${element?.label ?? 'Root Node'}: %s`, error)
 
             childNodes.splice(
                 0,

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -53,7 +53,7 @@ const performance = globalThis.performance ?? require('perf_hooks').performance
 export async function activate(context: ExtContext): Promise<void> {
     // No need to await. This can be removed once the 'hover.enabled' hack is no longer needed.
     HoverConfigUtil.instance.restoreHoverConfig().catch(err => {
-        getLogger().warn('codewhisperer: failed to restore "editor.hover.enabled" setting: %O', err)
+        getLogger().warn('codewhisperer: failed to restore "editor.hover.enabled" setting: %s', err)
     })
 
     const codewhispererSettings = CodeWhispererSettings.instance

--- a/src/credentials/auth.ts
+++ b/src/credentials/auth.ts
@@ -297,7 +297,7 @@ export class Auth implements AuthService, ConnectionManager {
         try {
             return await this.useConnection({ id })
         } catch (err) {
-            getLogger().warn(`auth: failed to restore previous session: ${UnknownError.cast(err).message}`)
+            getLogger().warn(`auth: failed to restore previous session: %s`, err)
         }
     }
 
@@ -433,7 +433,7 @@ export class Auth implements AuthService, ConnectionManager {
             // TODO: this seems to fail on the backend for scoped tokens
             await client.logout().catch(err => {
                 const name = profile.metadata.label ?? id
-                getLogger().warn(`auth: failed to logout of connection "${name}": ${UnknownError.cast(err)}`)
+                getLogger().warn(`auth: failed to logout of connection "${name}": %s`, err)
             })
 
             return provider.invalidate()
@@ -628,7 +628,7 @@ export class Auth implements AuthService, ConnectionManager {
                 await this.useConnection({ id })
                 return true
             } catch (err) {
-                getLogger().warn(`auth: failed to auto-connect using "${id}": ${UnknownError.cast(err).message}`)
+                getLogger().warn(`auth: failed to auto-connect using "${id}": %s`, err)
                 return false
             }
         }

--- a/src/credentials/loginManager.ts
+++ b/src/credentials/loginManager.ts
@@ -147,7 +147,7 @@ export class LoginManager {
             const loginManager = new LoginManager(awsContext, new CredentialsStore())
             await loginWithMostRecentCredentials(new CredentialsSettings(), loginManager)
         } catch (err) {
-            getLogger().error('credentials: failed to auto-connect: %O', err)
+            getLogger().error('credentials: failed to auto-connect: %s', err)
             showViewLogsMessage(localize('AWS.credentials.autoconnect.fatal', 'Exception occurred while connecting'))
         }
         return !!(await awsContext.getCredentials())

--- a/src/credentials/secondaryAuth.ts
+++ b/src/credentials/secondaryAuth.ts
@@ -11,7 +11,6 @@ import { showQuickPick } from '../shared/ui/pickerPrompter'
 import { cast, Optional } from '../shared/utilities/typeConstructors'
 import { Auth, Connection } from './auth'
 import { once } from '../shared/utilities/functionUtils'
-import { UnknownError } from '../shared/errors'
 
 async function promptUseNewConnection(newConn: Connection, oldConn: Connection, tools: string[]) {
     // Multi-select picker would be better ?
@@ -154,7 +153,7 @@ export class SecondaryAuth<T extends Connection = Connection> {
 
             return this.#savedConnection
         } catch (err) {
-            getLogger().warn(`auth (${this.toolId}): failed to restore connection: ${UnknownError.cast(err).message}`)
+            getLogger().warn(`auth (${this.toolId}): failed to restore connection: %s`, err)
         }
     })
 

--- a/src/dynamicResources/commands/deleteResource.ts
+++ b/src/dynamicResources/commands/deleteResource.ts
@@ -77,7 +77,7 @@ export async function deleteResource(
                     return false
                 }
                 result = 'Failed'
-                getLogger().error(`Failed to delete resource type ${typeName} identifier ${identifier}: %O`, e)
+                getLogger().error(`Failed to delete resource type ${typeName} identifier ${identifier}: %s`, e)
                 showViewLogsMessage(
                     localize(
                         'aws.resources.deleteResource.failure',

--- a/src/dynamicResources/commands/openResource.ts
+++ b/src/dynamicResources/commands/openResource.ts
@@ -65,7 +65,7 @@ export async function openResource(
                 )
 
                 window.showErrorMessage(errorMessage)
-                getLogger().error('Error opening resource: %O', error)
+                getLogger().error('Error opening resource: %s', error)
                 result = 'Failed'
             } finally {
                 telemetry.dynamicresource_getResource.emit({

--- a/src/ecr/commands/createRepository.ts
+++ b/src/ecr/commands/createRepository.ts
@@ -41,7 +41,7 @@ export async function createRepository(
         )
         telemetry.ecr_createRepository.emit({ result: 'Succeeded' })
     } catch (e) {
-        getLogger().error(`Failed to create repository ${repositoryName}: %O`, e)
+        getLogger().error(`Failed to create repository ${repositoryName}: %s`, e)
         showViewLogsMessage(
             localize('AWS.ecr.createRepository.failure', 'Failed to create repository: {0}', repositoryName),
             window

--- a/src/ecr/commands/deleteRepository.ts
+++ b/src/ecr/commands/deleteRepository.ts
@@ -38,7 +38,7 @@ export async function deleteRepository(
         )
         telemetry.ecr_deleteRepository.emit({ result: 'Succeeded' })
     } catch (e) {
-        getLogger().error(`Failed to delete repository ${repositoryName}: %O`, e)
+        getLogger().error(`Failed to delete repository ${repositoryName}: %s`, e)
         showViewLogsMessage(
             localize('AWS.ecr.deleteRepository.failure', 'Failed to delete repository: {0}', repositoryName),
             window

--- a/src/ecr/commands/deleteTag.ts
+++ b/src/ecr/commands/deleteTag.ts
@@ -50,7 +50,7 @@ export async function deleteTag(
         )
         telemetry.ecr_deleteTags.emit({ result: 'Succeeded', value: 1 })
     } catch (e) {
-        getLogger().error(`Failed to delete tag ${node.tag} from repository ${node.repository.repositoryName}: %O`, e)
+        getLogger().error(`Failed to delete tag ${node.tag} from repository ${node.repository.repositoryName}: %s`, e)
         showViewLogsMessage(
             localize(
                 'AWS.ecr.deleteTag.failure',

--- a/src/ecs/util.ts
+++ b/src/ecs/util.ts
@@ -80,7 +80,7 @@ export async function prepareCommand(
         ssm.terminateSession({ SessionId: sessionId })
             .promise()
             .catch(err => {
-                getLogger().warn(`ecs: failed to terminate session "${sessionId}": %O`, err)
+                getLogger().warn(`ecs: failed to terminate session "${sessionId}": %s`, err)
             })
     }
 

--- a/src/eventSchemas/commands/downloadSchemaItemCode.ts
+++ b/src/eventSchemas/commands/downloadSchemaItemCode.ts
@@ -90,7 +90,7 @@ export async function downloadSchemaItemCode(node: SchemaItemNode, outputChannel
             errorMessage = error.message
         }
         vscode.window.showErrorMessage(errorMessage)
-        logger.error('Error downloading schema: %O', error)
+        logger.error('Error downloading schema: %s', error)
     } finally {
         telemetry.schemas_download.emit({ result: downloadResult })
     }

--- a/src/eventSchemas/commands/viewSchemaItem.ts
+++ b/src/eventSchemas/commands/viewSchemaItem.ts
@@ -30,7 +30,7 @@ export async function viewSchemaItem(node: SchemaItemNode) {
                 node.schemaName
             )
         )
-        logger.error('Error on schema preview: %O', error)
+        logger.error('Error on schema preview: %s', error)
     } finally {
         telemetry.schemas_view.emit({ result: viewResult })
     }

--- a/src/eventSchemas/providers/schemasDataProvider.ts
+++ b/src/eventSchemas/providers/schemasDataProvider.ts
@@ -56,7 +56,7 @@ export class SchemasDataProvider {
             }
         } catch (err) {
             const error = err as Error
-            this.logger.error('Error retrieving registries: %O', error)
+            this.logger.error('Error retrieving registries: %s', error)
 
             return undefined
         }
@@ -87,7 +87,7 @@ export class SchemasDataProvider {
             }
         } catch (err) {
             const error = err as Error
-            this.logger.error('Error retrieving schemas: %O', error)
+            this.logger.error('Error retrieving schemas: %s', error)
 
             return undefined
         }

--- a/src/eventSchemas/vue/searchSchemas.ts
+++ b/src/eventSchemas/vue/searchSchemas.ts
@@ -137,7 +137,7 @@ export async function createSearchSchemasWebView(context: ExtContext, node: Regi
     } catch (err) {
         webviewResult = 'Failed'
         const error = err as Error
-        logger.error('Error searching schemas: %O', error)
+        logger.error('Error searching schemas: %s', error)
     } finally {
         telemetry.schemas_search.emit({ result: webviewResult })
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,7 +63,7 @@ import { join } from 'path'
 import { Settings } from './shared/settings'
 import { isReleaseVersion } from './shared/vscode/env'
 import { Commands, registerErrorHandler } from './shared/vscode/commands2'
-import { formatError, isUserCancelledError, ToolkitError, UnknownError } from './shared/errors'
+import { isUserCancelledError, ToolkitError } from './shared/errors'
 import { Logging } from './shared/logger/commands'
 import { UriHandler } from './shared/vscode/uriHandler'
 import { telemetry } from './shared/telemetry/telemetry'
@@ -256,8 +256,7 @@ async function handleError(error: unknown, topic: string, defaultMessage: string
     }
 
     const logsItem = localize('AWS.generic.message.viewLogs', 'View Logs...')
-    const logMessage = error instanceof ToolkitError ? error.trace : formatError(UnknownError.cast(error))
-    const logId = getLogger().error(`${topic}: ${logMessage}`)
+    const logId = getLogger().error(`${topic}: %s`, error)
     const message = error instanceof ToolkitError ? error.message : defaultMessage
 
     await vscode.window.showErrorMessage(message, logsItem).then(async resp => {

--- a/src/integrationTest/shared/extensions/git.test.ts
+++ b/src/integrationTest/shared/extensions/git.test.ts
@@ -95,7 +95,7 @@ describe('GitExtension', function () {
         try {
             execFileSync(git.$api.git.path, ['config', '--global', '--unset', CONFIG_KEY])
         } catch (err) {
-            getLogger().warn(`Unable to unset test git config value ${CONFIG_KEY}: %O`, err)
+            getLogger().warn(`Unable to unset test git config value ${CONFIG_KEY}: %s`, err)
         }
     })
 

--- a/src/iot/commands/attachCertificate.ts
+++ b/src/iot/commands/attachCertificate.ts
@@ -44,7 +44,7 @@ export async function attachCertificateCommand(
     try {
         await node.iot.attachThingPrincipal({ thingName, principal: cert.certificateArn! })
     } catch (e) {
-        getLogger().error(`Failed to attach certificate ${cert.certificateId}: %O`, e)
+        getLogger().error(`Failed to attach certificate ${cert.certificateId}: %s`, e)
         showViewLogsMessage(
             localize('AWS.iot.attachCert.error', 'Failed to attach certificate {0}', cert.certificateId),
             window
@@ -96,7 +96,7 @@ async function* getCertList(iot: IotClient, window?: Window) {
                     cert => cert.certificateArn && cert.certificateId && cert.status && cert.creationDate
                 ) ?? []
         } catch (e) {
-            getLogger().error(`Failed to retrieve certificates: %O`, e)
+            getLogger().error(`Failed to retrieve certificates: %s`, e)
             showViewLogsMessage(localize('AWS.iot.attachCert.error', 'Failed to retrieve certificates'), window)
             return
         }

--- a/src/iot/commands/attachPolicy.ts
+++ b/src/iot/commands/attachPolicy.ts
@@ -45,7 +45,7 @@ export async function attachPolicyCommand(
     try {
         await node.iot.attachPolicy({ policyName: policy.policyName!, target: certArn })
     } catch (e) {
-        getLogger().error(`Failed to attach policy ${policy.policyName}: %O`, e)
+        getLogger().error(`Failed to attach policy ${policy.policyName}: %s`, e)
         showViewLogsMessage(
             localize('AWS.iot.attachCert.error', 'Failed to attach policy {0}', policy.policyName),
             window
@@ -108,7 +108,7 @@ async function* getPolicyList(iot: IotClient, window?: Window) {
              * above API, but we filter here anyway for when we use ! later. */
             filteredPolicies = policyResponse.policies?.filter(policy => policy.policyArn && policy.policyName) ?? []
         } catch (e) {
-            getLogger().error(`Failed to retrieve policies: %O`, e)
+            getLogger().error(`Failed to retrieve policies: %s`, e)
             showViewLogsMessage(localize('AWS.iot.attachPolicy.error', 'Failed to retrieve policies'), window)
             return
         }

--- a/src/iot/commands/copyEndpoint.ts
+++ b/src/iot/commands/copyEndpoint.ts
@@ -23,7 +23,7 @@ export async function copyEndpointCommand(node: IotNode, window = Window.vscode(
     try {
         endpoint = await node.getEndpoint()
     } catch (e) {
-        getLogger().error('Failed to retrieve endpoint: %O', e)
+        getLogger().error('Failed to retrieve endpoint: %s', e)
         showViewLogsMessage(localize('AWS.iot.copyEndpoint.error', 'Failed to retrieve endpoint'), window)
         return
     }

--- a/src/iot/commands/createCert.ts
+++ b/src/iot/commands/createCert.ts
@@ -43,7 +43,7 @@ export async function createCertificateCommand(
             setAsActive: false,
         })
     } catch (e) {
-        getLogger().error('Failed to create certificate: %O', e)
+        getLogger().error('Failed to create certificate: %s', e)
         showViewLogsMessage(localize('AWS.iot.createCert.error', 'Failed to create certificate'), window)
         return undefined
     }
@@ -69,7 +69,7 @@ export async function createCertificateCommand(
         try {
             await node.iot.deleteCertificate({ certificateId: certId! })
         } catch (e) {
-            getLogger().error(`Failed to delete Certificate ${certId}: %O`, e)
+            getLogger().error(`Failed to delete Certificate ${certId}: %s`, e)
             showViewLogsMessage(
                 localize('AWS.iot.deleteCert.error', 'Failed to delete Certificate {0}', certId),
                 window
@@ -154,7 +154,7 @@ async function saveCredentials(
         await fs.writeFile(privateKeyPath, privateKey, { encoding: PEM_FILE_ENCODING, mode: MODE_RW_R_R })
         await fs.writeFile(publicKeyPath, publicKey, { encoding: PEM_FILE_ENCODING, mode: MODE_RW_R_R })
     } catch (e) {
-        getLogger().error('Could not save certificate: %O', e)
+        getLogger().error('Could not save certificate: %s', e)
         showViewLogsMessage(localize('AWS.iot.createCert.saveError', 'Failed to save certificate'), window)
         return false
     }

--- a/src/iot/commands/createPolicy.ts
+++ b/src/iot/commands/createPolicy.ts
@@ -44,7 +44,7 @@ export async function createPolicyCommand(
         await node.iot.createPolicy({ policyName, policyDocument: JSON.stringify(policyJSON) })
         window.showInformationMessage(localize('AWS.iot.createPolicy.success', 'Created Policy {0}', policyName))
     } catch (e) {
-        getLogger().error('Failed to create policy document: %O', e)
+        getLogger().error('Failed to create policy document: %s', e)
         showViewLogsMessage(localize('AWS.iot.createPolicy.error', 'Failed to create policy {0}', policyName), window)
         return
     }
@@ -72,7 +72,7 @@ export async function getPolicyDocument(window: Window): Promise<Buffer | undefi
     try {
         data = await fs.readFile(policyLocation.fsPath)
     } catch (e) {
-        getLogger().error('Failed to read policy document: %O', e)
+        getLogger().error('Failed to read policy document: %s', e)
         showViewLogsMessage(localize('AWS.iot.createPolicy.error', 'Failed to read policy document'), window)
         return undefined
     }

--- a/src/iot/commands/createPolicyVersion.ts
+++ b/src/iot/commands/createPolicyVersion.ts
@@ -41,7 +41,7 @@ export async function createPolicyVersionCommand(
             localize('AWS.iot.createPolicy.success', 'Created new version of {0}', policyName)
         )
     } catch (e) {
-        getLogger().error('Failed to create new policy version: %O', e)
+        getLogger().error('Failed to create new policy version: %s', e)
         showViewLogsMessage(
             localize('AWS.iot.createPolicyVersion.error', 'Failed to create new version of {0}', policyName),
             window

--- a/src/iot/commands/createThing.ts
+++ b/src/iot/commands/createThing.ts
@@ -42,7 +42,7 @@ export async function createThingCommand(
         getLogger().info('Created thing: %O', thing)
         window.showInformationMessage(localize('AWS.iot.createThing.success', 'Created Thing {0}', thingName))
     } catch (e) {
-        getLogger().error(`Failed to create Thing ${thingName}: %O`, e)
+        getLogger().error(`Failed to create Thing ${thingName}: %s`, e)
         showViewLogsMessage(localize('AWS.iot.createThing.error', 'Failed to create Thing: {0}', thingName), window)
     }
 

--- a/src/iot/commands/deleteCert.ts
+++ b/src/iot/commands/deleteCert.ts
@@ -48,7 +48,7 @@ export async function deleteCertCommand(
             return
         }
     } catch (e) {
-        getLogger().error(`Failed to retrieve Things attached to cert ${node.certificate.id}: %O`, e)
+        getLogger().error(`Failed to retrieve Things attached to cert ${node.certificate.id}: %s`, e)
         showViewLogsMessage(
             localize('AWS.iot.deleteCert.retrieveError', 'Failed to retrieve {0} attached to certificate', 'Things'),
             window
@@ -95,7 +95,7 @@ export async function deleteCertCommand(
             }
         }
     } catch (e) {
-        getLogger().error(`Failed to retrieve Policies attached to cert ${node.certificate.id}: %O`, e)
+        getLogger().error(`Failed to retrieve Policies attached to cert ${node.certificate.id}: %s`, e)
         showViewLogsMessage(
             localize('AWS.iot.deleteCert.retrieveError', 'Failed to retrieve {0} attached to certificate', 'policies'),
             window
@@ -111,7 +111,7 @@ export async function deleteCertCommand(
             localize('AWS.iot.deleteCert.success', 'Deleted certificate: {0}', node.certificate.id)
         )
     } catch (e) {
-        getLogger().error(`Failed to delete Certificate ${node.certificate.id}: %O`, e)
+        getLogger().error(`Failed to delete Certificate ${node.certificate.id}: %s`, e)
         showViewLogsMessage(
             localize('AWS.iot.deleteCert.error', 'Failed to delete certificate: {0}', node.certificate.id),
             window

--- a/src/iot/commands/deletePolicy.ts
+++ b/src/iot/commands/deletePolicy.ts
@@ -73,7 +73,7 @@ export async function deletePolicyCommand(
         getLogger().info(`deleted Policy: ${policyName}`)
         window.showInformationMessage(localize('AWS.iot.deletePolicy.success', 'Deleted Policy: {0}', node.policy.name))
     } catch (e) {
-        getLogger().error(`Failed to delete Policy: ${policyName}: %O`, e)
+        getLogger().error(`Failed to delete Policy: ${policyName}: %s`, e)
         showViewLogsMessage(
             localize('AWS.iot.deletePolicy.error', 'Failed to delete Policy: {0}', node.policy.name),
             window

--- a/src/iot/commands/deletePolicyVersion.ts
+++ b/src/iot/commands/deletePolicyVersion.ts
@@ -60,7 +60,7 @@ export async function deletePolicyVersionCommand(
             )
         )
     } catch (e) {
-        getLogger().error(`Failed to delete Policy Version: ${policyVersionId}: %O`, e)
+        getLogger().error(`Failed to delete Policy Version: ${policyVersionId}: %s`, e)
         showViewLogsMessage(
             localize(
                 'AWS.iot.deletePolicyVersion.error',

--- a/src/iot/commands/deleteThing.ts
+++ b/src/iot/commands/deleteThing.ts
@@ -60,7 +60,7 @@ export async function deleteThingCommand(
         getLogger().info(`deleted Thing: ${thingName}`)
         window.showInformationMessage(localize('AWS.iot.deleteThing.success', 'Deleted Thing: {0}', thingName))
     } catch (e) {
-        getLogger().error(`Failed to delete Thing: ${thingName}: %O`, e)
+        getLogger().error(`Failed to delete Thing: ${thingName}: %s`, e)
         showViewLogsMessage(localize('AWS.iot.deleteThing.error', 'Failed to delete Thing: {0}', thingName), window)
     }
 

--- a/src/iot/commands/detachCert.ts
+++ b/src/iot/commands/detachCert.ts
@@ -53,7 +53,7 @@ export async function detachThingCertCommand(
         getLogger().info(`detached certificate from Thing: ${thingName}`)
         window.showInformationMessage(localize('AWS.iot.detachCert.success', 'Detached: {0}', certId))
     } catch (e) {
-        getLogger().error(`Failed to detach certificate: ${certId}: %O`, e)
+        getLogger().error(`Failed to detach certificate: ${certId}: %s`, e)
         showViewLogsMessage(localize('AWS.iot.detachCert.error', 'Failed to detach: {0}', certId), window)
     }
 

--- a/src/iot/commands/detachPolicy.ts
+++ b/src/iot/commands/detachPolicy.ts
@@ -55,7 +55,7 @@ export async function detachPolicyCommand(
         getLogger().info(`detached policy: ${policyName}`)
         window.showInformationMessage(localize('AWS.iot.detachPolicy.success', 'Detached: {0}', policyName))
     } catch (e) {
-        getLogger().error(`Failed to detach certificate: ${certId}: %O`, e)
+        getLogger().error(`Failed to detach certificate: ${certId}: %s`, e)
         showViewLogsMessage(localize('AWS.iot.detachPolicy.error', 'Failed to detach: {0}', policyName), window)
     }
 

--- a/src/iot/commands/setDefaultPolicy.ts
+++ b/src/iot/commands/setDefaultPolicy.ts
@@ -37,7 +37,7 @@ export async function setDefaultPolicy(
             )
         )
     } catch (e) {
-        getLogger().error('Failed to set default policy version: %O', e)
+        getLogger().error('Failed to set default policy version: %s', e)
         showViewLogsMessage(localize('AWS.iot.setDefaultPolicy.error', 'Failed to set default policy version'), window)
     }
 

--- a/src/iot/commands/updateCert.ts
+++ b/src/iot/commands/updateCert.ts
@@ -60,7 +60,7 @@ export async function deactivateCertificateCommand(
             localize('AWS.iot.deactivateCert.success', 'Deactivated: {0}', node.certificate.id)
         )
     } catch (e) {
-        getLogger().error(`Failed to deactivate certificate ${certId}: %O`, e)
+        getLogger().error(`Failed to deactivate certificate ${certId}: %s`, e)
         showViewLogsMessage(
             localize('AWS.iot.deactivateCert.error', 'Failed to deactivate: {0}', node.certificate.id),
             window
@@ -114,7 +114,7 @@ export async function activateCertificateCommand(
         getLogger().info(`activated certificate: ${certId}`)
         window.showInformationMessage(localize('AWS.iot.activateCert.success', 'Activated: {0}', node.certificate.id))
     } catch (e) {
-        getLogger().error(`Failed to activate certificate ${certId}: %O`, e)
+        getLogger().error(`Failed to activate certificate ${certId}: %s`, e)
         showViewLogsMessage(
             localize('AWS.iot.activateCert.error', 'Failed to activate: {0}', node.certificate.id),
             window
@@ -164,7 +164,7 @@ export async function revokeCertificateCommand(
         getLogger().info(`revoked certificate: ${certId}`)
         window.showInformationMessage(localize('AWS.iot.revokeCert.success', 'Revoked: {0}', node.certificate.id))
     } catch (e) {
-        getLogger().error(`Failed to revoke certificate ${certId}: %O`, e)
+        getLogger().error(`Failed to revoke certificate ${certId}: %s`, e)
         showViewLogsMessage(localize('AWS.iot.revokeCert.error', 'Failed to revoke: {0}', node.certificate.id), window)
     }
 

--- a/src/lambda/commands/deleteLambda.ts
+++ b/src/lambda/commands/deleteLambda.ts
@@ -51,7 +51,7 @@ export async function deleteLambda(
         }
     } catch (err) {
         deleteResult = 'Failed'
-        getLogger().error(`Failed to delete lambda function "${lambda.FunctionName}": %O`, err)
+        getLogger().error(`Failed to delete lambda function "${lambda.FunctionName}": %s`, err)
         const message = localize(
             'AWS.command.deleteLambda.error',
             "There was an error deleting lambda function '{0}'",

--- a/src/lambda/commands/uploadLambda.ts
+++ b/src/lambda/commands/uploadLambda.ts
@@ -116,7 +116,7 @@ export async function uploadLambdaCommand(lambdaArg?: LambdaFunction, path?: vsc
             getLogger().error(`Lambda upload failed: %O`, err.cause ?? err)
         } else {
             showViewLogsMessage(`Could not upload lambda (unexpected exception)`)
-            getLogger().error(`Lambda upload failed: %O`, err)
+            getLogger().error(`Lambda upload failed: %s`, err)
         }
     } finally {
         telemetry.lambda_updateFunctionCode.emit({

--- a/src/shared/clients/lambdaClient.ts
+++ b/src/shared/clients/lambdaClient.ts
@@ -69,7 +69,7 @@ export class DefaultLambdaClient {
             })
             return response
         } catch (e) {
-            getLogger().error('Failed to get function: %O', e)
+            getLogger().error('Failed to get function: %s', e)
             throw e
         }
     }
@@ -91,7 +91,7 @@ export class DefaultLambdaClient {
 
             return response
         } catch (e) {
-            getLogger().error('Failed to run updateFunctionCode: %O', e)
+            getLogger().error('Failed to run updateFunctionCode: %s', e)
             throw e
         }
     }

--- a/src/shared/extensions/git.ts
+++ b/src/shared/extensions/git.ts
@@ -268,7 +268,7 @@ export class GitExtension {
                     }))
                     .filter(branch => !!branch.name)
             } catch (err) {
-                getLogger().verbose(`git: failed to get branches for remote "${remote.fetchUrl}": %O`, err)
+                getLogger().verbose(`git: failed to get branches for remote "${remote.fetchUrl}": %s`, err)
                 return []
             }
         }
@@ -286,7 +286,7 @@ export class GitExtension {
             ;(await repository.getConfigs()).forEach(({ key, value }) => (config[key] = value))
         } else {
             const { stdout } = await execFileAsync(api.git.path, ['config', '--list', `--global`]).catch(err => {
-                getLogger().verbose(`git: failed to read config: %O`, err)
+                getLogger().verbose(`git: failed to read config: %s`, err)
                 return { stdout: '' }
             })
 
@@ -314,7 +314,7 @@ export class GitExtension {
             }
             return semverParse(match[0]) as SemVer | undefined
         } catch (err) {
-            getLogger().verbose('git: failed to retrieve version: %O', err)
+            getLogger().verbose('git: failed to retrieve version: %s', err)
         }
     }
 

--- a/src/shared/icons.ts
+++ b/src/shared/icons.ts
@@ -12,7 +12,6 @@ import { Uri, ThemeIcon } from 'vscode'
 import { isCloud9 } from './extensionUtilities'
 import { memoize } from './utilities/functionUtils'
 import { getLogger } from './logger/logger'
-import { UnknownError } from './errors'
 
 // Animation:
 // https://code.visualstudio.com/api/references/icons-in-labels#animation

--- a/src/shared/icons.ts
+++ b/src/shared/icons.ts
@@ -116,7 +116,6 @@ function resolvePathsSync(rootDir: string, target: string): { light: Uri; dark: 
             return { dark: Uri.file(darkPath), light: Uri.file(lightPath) }
         }
     } catch (error) {
-        const message = UnknownError.cast(error).message
-        getLogger().warn(`icons: path resolution failed for "${target}": ${message}`)
+        getLogger().warn(`icons: path resolution failed for "${target}": %s`, error)
     }
 }

--- a/src/shared/logger/commands.ts
+++ b/src/shared/logger/commands.ts
@@ -47,7 +47,7 @@ export class Logging {
         const text = editor.document.getText()
         const textStart = text.indexOf(msg)
         if (textStart === -1) {
-            this.logger.warn(`logging: unable to find message with id "${logId}"`)
+            this.logger.debug(`logging: unable to find message with id "${logId}"`)
             return
         }
 

--- a/src/shared/logger/commands.ts
+++ b/src/shared/logger/commands.ts
@@ -39,20 +39,25 @@ export class Logging {
     public async openLogId(logId: number, logUri = this.defaultLogUri) {
         const msg = this.logger.getLogById(logId, logUri)
         const editor = await this.openLogUri(logUri)
-
         if (!msg || !editor) {
             return
         }
 
         // Retrieve where the message starts by counting number of newlines
         const text = editor.document.getText()
+        const textStart = text.indexOf(msg)
+        if (textStart === -1) {
+            this.logger.warn(`logging: unable to find message with id "${logId}"`)
+            return
+        }
+
         const lineStart = text
-            .slice(0, text.indexOf(msg))
+            .slice(0, textStart)
             .split(/\r?\n/)
             .filter(x => x).length
 
         if (lineStart > 0) {
-            const lineEnd = lineStart + msg.split(/\r?\n/).filter(x => x).length
+            const lineEnd = Math.min(editor.document.lineCount, lineStart + msg.split(/\r?\n/).filter(x => x).length)
             revealLines(editor, lineStart, lineEnd)
         } else {
             clearSelection(editor)

--- a/src/shared/regions/regionProvider.ts
+++ b/src/shared/regions/regionProvider.ts
@@ -153,7 +153,7 @@ export class RegionProvider {
                 instance.onDidChangeEmitter.fire()
             })
             .catch(err => {
-                getLogger().error('Failure while loading Endpoints Manifest: %O', err)
+                getLogger().error('Failure while loading Endpoints Manifest: %s', err)
 
                 vscode.window.showErrorMessage(
                     `${localize(

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -152,11 +152,15 @@ async function buildLambdaHandler(
         .execute(timer)
         .then(() => {})
         .catch(e => UnknownError.cast(e))
-    const failureMessage = err?.message ?? samBuild.failure()
-    if (failureMessage) {
+    const failure = err ?? samBuild.failure()
+    if (failure) {
         // TODO(sijaden): ask SAM CLI for a way to map exit codes to error codes
         // We can also scrape the debug output though that won't be as reliable
-        throw new ToolkitError(failureMessage, { code: 'BuildFailure' })
+        if (typeof failure === 'string') {
+            throw new ToolkitError(failure, { code: 'BuildFailure' })
+        } else {
+            throw ToolkitError.chain(failure, 'Failed to build SAM application', { code: 'BuildFailure' })
+        }
     }
     getLogger('channel').info(localize('AWS.output.building.sam.application.complete', 'Build complete.'))
 

--- a/src/shared/telemetry/activation.ts
+++ b/src/shared/telemetry/activation.ts
@@ -16,7 +16,6 @@ import { getComputeRegion, getIdeProperties, isCloud9 } from '../extensionUtilit
 import { openSettings, Settings } from '../settings'
 import { TelemetryConfig } from './util'
 import { isAutomation, isReleaseVersion } from '../vscode/env'
-import { UnknownError } from '../errors'
 
 export const noticeResponseViewSettings = localize('AWS.telemetry.notificationViewSettings', 'Settings')
 export const noticeResponseOk = localize('AWS.telemetry.notificationOk', 'OK')
@@ -62,7 +61,7 @@ export async function activate(extensionContext: vscode.ExtensionContext, awsCon
             throw e
         }
 
-        getLogger().error(`telemetry: failed to activate: ${UnknownError.cast(e).message}`)
+        getLogger().error(`telemetry: failed to activate: %s`, e)
     }
 }
 

--- a/src/shared/treeview/utils.ts
+++ b/src/shared/treeview/utils.ts
@@ -64,7 +64,7 @@ export function createThemeIcon(id: string, color?: string) {
 
 export function createErrorItem(error: Error, message?: string): TreeNode {
     const command = Logging.declared.viewLogsAtMessage
-    const logId = message ? getLogger().error(message) : getLogger().error(error)
+    const logId = message ? getLogger().error(`${message}: %s`, error) : getLogger().error(error)
 
     return command.build(logId).asTreeNode({
         label: localize('AWS.explorerNode.error.label', 'Failed to load resources (click for logs)'),

--- a/src/shared/ui/common/roles.ts
+++ b/src/shared/ui/common/roles.ts
@@ -73,7 +73,7 @@ function addCreateRoleButton(
         const items = createRole()
             .then(role => [{ label: role.RoleName, data: role }])
             .catch(err => {
-                getLogger().error('role prompter: Failed to create new role: %O', err)
+                getLogger().error('role prompter: Failed to create new role: %s', err)
                 showViewLogsMessage(localize('AWS.rolePrompter.createRole.failed', 'Failed to create new role'))
                 return []
             })

--- a/src/shared/ui/pickerPrompter.ts
+++ b/src/shared/ui/pickerPrompter.ts
@@ -411,7 +411,7 @@ export class QuickPickPrompter<T> extends Prompter<T> {
                         break
                     }
                 } catch (err) {
-                    getLogger().error('QuickPickPrompter: loading items from AsyncIterable failed: %O', err)
+                    getLogger().error('QuickPickPrompter: loading items from AsyncIterable failed: %s', err)
                     addErrorItem(err as Error)
                     break
                 }
@@ -421,7 +421,7 @@ export class QuickPickPrompter<T> extends Prompter<T> {
             try {
                 this.appendItems(await items)
             } catch (err) {
-                getLogger().error('QuickPickPrompter: loading items from Promise failed: %O', err)
+                getLogger().error('QuickPickPrompter: loading items from Promise failed: %s', err)
                 addErrorItem(err as Error)
             }
         } else {

--- a/src/shared/utilities/cliUtils.ts
+++ b/src/shared/utilities/cliUtils.ts
@@ -454,7 +454,7 @@ export async function getOrInstallCli(
 //         fs.link(existingPath, newPath, err => {
 //             if (err) {
 //                 const message = `Toolkit could not create a hard link for ${existingPath} to ${newPath}`
-//                 getLogger().error(`${message}: %O`, err)
+//                 getLogger().error(`${message}: %s`, err)
 //                 reject(new InstallerError(message))
 //             }
 //             resolve()

--- a/src/shared/utilities/typeConstructors.ts
+++ b/src/shared/utilities/typeConstructors.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ToolkitError } from '../errors'
 import { isNameMangled } from '../vscode/env'
 import { isNonNullable } from './tsUtils'
 
@@ -93,7 +94,7 @@ export function cast<T>(input: any, type: TypeConstructor<T>): T {
     try {
         return type(input) ?? input
     } catch (error) {
-        throw new TypeError(`Failed to cast type "${typeof input}" to ${typeName}: ${error}`)
+        throw ToolkitError.chain(error, `Failed to cast type "${typeof input}" to ${typeName}`)
     }
 }
 

--- a/src/shared/utilities/typeConstructors.ts
+++ b/src/shared/utilities/typeConstructors.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ToolkitError } from '../errors'
 import { isNameMangled } from '../vscode/env'
 import { isNonNullable } from './tsUtils'
 
@@ -94,7 +93,8 @@ export function cast<T>(input: any, type: TypeConstructor<T>): T {
     try {
         return type(input) ?? input
     } catch (error) {
-        throw ToolkitError.chain(error, `Failed to cast type "${typeof input}" to ${typeName}`)
+        // TODO: add chainable error that isn't `ToolkitError`
+        throw new TypeError(`Failed to cast type "${typeof input}" to ${typeName}`)
     }
 }
 

--- a/src/shared/vscode/commands2.ts
+++ b/src/shared/vscode/commands2.ts
@@ -371,7 +371,7 @@ async function runCommand<T extends Callback>(fn: T, info: CommandInfo<T>): Prom
         if (errorHandler !== undefined) {
             await errorHandler(info, error)
         } else {
-            logger.error(`command: ${label} failed without error handler: %O`, error)
+            logger.error(`command: ${label} failed without error handler: %s`, error)
             throw error
         }
     }

--- a/src/shared/vscode/env.ts
+++ b/src/shared/vscode/env.ts
@@ -59,6 +59,13 @@ export function isReleaseVersion(prereleaseOk: boolean = false): boolean {
 }
 
 /**
+ * Returns true when source mapping is available
+ */
+export function isSourceMappingAvailable(): boolean {
+    return extensionVersion === TEST_VERSION
+}
+
+/**
  * Returns true if the extension is being ran from automation.
  */
 export function isAutomation(): boolean {

--- a/src/stepFunctions/commands/visualizeStateMachine/abstractAslVisualizationManager.ts
+++ b/src/stepFunctions/commands/visualizeStateMachine/abstractAslVisualizationManager.ts
@@ -37,7 +37,7 @@ export abstract class AbstractAslVisualizationManager<T extends AslVisualization
         )
 
         logger.debug(`${this.name}: Unable to setup webview panel.`)
-        logger.error(`${this.name}: unexpected exception: %O`, err)
+        logger.error(`${this.name}: unexpected exception: %s`, err)
     }
 
     public getManagedVisualizations(): Map<string, T> {

--- a/src/stepFunctions/vue/executeStateMachine/executeStateMachine.ts
+++ b/src/stepFunctions/vue/executeStateMachine/executeStateMachine.ts
@@ -61,7 +61,7 @@ export class ExecuteStateMachineWebview extends VueWebview {
         } catch (e) {
             executeResult = 'Failed'
             const error = e as Error
-            this.logger.error('Error starting execution for Step Functions State Machine: %O', error)
+            this.logger.error('Error starting execution for Step Functions State Machine: %s', error)
             this.channel.appendLine(
                 localize(
                     'AWS.message.error.stepFunctions.executeStateMachine.failed_to_start',

--- a/src/test/codewhisperer/util/hoverConfigUtil.test.ts
+++ b/src/test/codewhisperer/util/hoverConfigUtil.test.ts
@@ -8,6 +8,11 @@ import { HoverConfigUtil } from '../../../codewhisperer/util/hoverConfigUtil'
 import { FakeMemento } from '../../fakeExtensionContext'
 
 describe('HoverConfigUtil', function () {
+    after(async function () {
+        // Restore the setting after running tests
+        await new HoverConfigUtil().update('hover.enabled', true)
+    })
+
     describe('overwriteHoverConfig', async function () {
         it('Should set hover enabled to false if it is currently true', async function () {
             const hoverConfigUtil = new HoverConfigUtil()


### PR DESCRIPTION
## Problem
* Inconsistent pattern for error logging
* Stack traces aren't emitted even when source maps are available
* `aws.viewLogsAtMessage` would show an extra error in certain situations

## Solution
* Use `%s` for error substitution so the entire object isn't printed
* Add logic to map errors in the logs depending on context
    * Source maps available and we log at error level -> output stack trace
    * Otherwise format the error in a nicer way
* Handle more edge cases in `aws.viewLogsAtMessage`

I have a follow-up to this PR but it can wait.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
