### PR TITLE
feat(telemetry): instrument experimental flags

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,7 +60,7 @@ import { SchemaService } from './shared/schemas'
 import { AwsResourceManager } from './dynamicResources/awsResourceManager'
 import globals, { initialize } from './shared/extensionGlobals'
 import { join } from 'path'
-import { Settings } from './shared/settings'
+import { Experiments, Settings } from './shared/settings'
 import { isReleaseVersion } from './shared/vscode/env'
 import { Commands, registerErrorHandler } from './shared/vscode/commands2'
 import { formatError, isUserCancelledError, ToolkitError, UnknownError } from './shared/errors'
@@ -119,9 +119,18 @@ export async function activate(context: vscode.ExtensionContext) {
         globals.resourceManager = new AwsResourceManager(context)
 
         const settings = Settings.instance
+        const experiments = Experiments.instance
 
         await initializeCredentials(context, awsContext, settings, loginManager)
         await activateTelemetry(context, awsContext, settings)
+
+        experiments.onDidChange(({ key }) => {
+            telemetry.aws_experimentActivation.run(span => {
+                // Record the key prior to reading the setting as `get` may throw
+                span.record({ experimentId: key })
+                span.record({ experimentState: experiments.get(key) ? 'activated' : 'deactivated' })
+            })
+        })
 
         await globals.schemaService.start()
         awsFiletypes.activate()


### PR DESCRIPTION
## Problem
No telemetry for when experiments are enabled/disabled

## Solution
Emit events when experiments change. The settings key is used directly as the experiment ID.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
