### PR TITLE
fix(tests): sso token cache race condition

### DIFF
--- a/src/credentials/sso/ssoAccessTokenProvider.ts
+++ b/src/credentials/sso/ssoAccessTokenProvider.ts
@@ -104,7 +104,7 @@ export class SsoAccessTokenProvider {
             return await this.authorize(registration)
         } catch (err) {
             if (err instanceof SSOOIDCServiceException && isClientFault(err)) {
-                this.cache.registration.clear(cacheKey)
+                await this.cache.registration.clear(cacheKey)
             }
 
             throw err
@@ -119,7 +119,7 @@ export class SsoAccessTokenProvider {
             return this.formatToken(response, registration)
         } catch (err) {
             if (err instanceof SSOOIDCServiceException && isClientFault(err)) {
-                this.cache.token.clear(this.tokenCacheKey)
+                await this.cache.token.clear(this.tokenCacheKey)
             }
 
             throw err


### PR DESCRIPTION
## Problem
Unit tests would sporadically fail due
to cache not being cleared when expected.
Certain methods called async clear() without
waiting, and the checks in the test executed before the clear() could complete.

Example test is `"drops expired tokens if failure was a client-fault"`
where `sut.getToken()` > `await this.refreshToken(data.token, data.registration)` > `this.cache.token.clear(this.tokenCacheKey)`

## Solution
Add 'await' to the impacted clear() calls.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
