### PR TITLE
fix(tests): decrease occurences of unreliable CDK tests

### DIFF
--- a/src/test/cdk/detectCdkProjects.test.ts
+++ b/src/test/cdk/detectCdkProjects.test.ts
@@ -26,7 +26,7 @@ describe('detectCdkProjects', function () {
                     return await detectCdkProjects(dirs)
                 },
                 {
-                    timeout: 3000,
+                    timeout: 10000,
                     interval: 250,
                     truthy: true,
                 }


### PR DESCRIPTION
## Problem
CDK tests sometimes fail

## Solution
Increase timeout time from 3000 -> 10000 ms

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
