### PR TITLE
fix(samcli): support legacy `templates.json` parameter overrides

### DIFF
--- a/src/shared/sam/sync.ts
+++ b/src/shared/sam/sync.ts
@@ -341,9 +341,9 @@ export async function runSamSync(args: SyncParams) {
     const { boundArgs } = await saveAndBindArgs(args)
     const overrides = await loadLegacyParameterOverrides(args.template)
     if (overrides !== undefined) {
-        // Undocumented attribute: `legacyFeatures` is a comma-delimited array of strings describing
-        // which legacy features are being supported for backwards compatability
-        telemetry.record({ legacyFeatures: 'templates.json' } as any)
+        // Leaving this out of the definitions file as this is _very_ niche and specific to the
+        // implementation. Plus we would have to redefine `sam_sync` to add it.
+        telemetry.record({ isUsingTemplatesJson: true } as any)
         boundArgs.push('--parameter-overrides', ...overrides)
     }
 


### PR DESCRIPTION
## Problem
`templates.json` still exists and is probably being used. The new experience doesn't support it.

## Solution
Read from `templates.json` if it exists and add the overrides to the command. Also, we record a telemetry attribute so we can track legacy usage.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
