### PR TITLE
fix(auth): stop race condition when auto-connecting with IAM credentials

### DIFF
--- a/.changes/next-release/Bug Fix-e4654073-0235-4976-a121-5a8263a07751.json
+++ b/.changes/next-release/Bug Fix-e4654073-0235-4976-a121-5a8263a07751.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "auth: auto-connecting using IAM credential profiles now succeeds when running commands outside of the AWS Explorer."
+}


### PR DESCRIPTION
## Problem
Some commands may fail on the first execution if the following conditions are true:
* The user has not connected yet, either automatically or manually
* The command or its dependencies use `AwsContext` early in its execution

The easiest way to reproduce this bug is by running `Sync SAM Application` on a template after reloading the window **without** opening the AWS view.

## Solution
Ensure `LoginManager` is logged-in before returning from `tryAutoConnect`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
