### PR TITLE
bug(yaml): Allow modelines to override default vscode-yaml registerContributor behaviour

### DIFF
--- a/.changes/next-release/Bug Fix-25801377-bfca-4c93-8707-6fe95c0f440c.json
+++ b/.changes/next-release/Bug Fix-25801377-bfca-4c93-8707-6fe95c0f440c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Allow modeline to override yaml schemas"
+}

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -20,6 +20,7 @@ import { normalizeVSCodeUri } from './utilities/vsCodeUtils'
 
 const GOFORMATION_MANIFEST_URL = 'https://api.github.com/repos/awslabs/goformation/releases/latest'
 const SCHEMA_PREFIX = `${AWS_SCHEME}://`
+export const samSchemaUri = () => vscode.Uri.joinPath(globals.context.globalStorageUri, 'sam.schema.json')
 
 export type Schemas = { [key: string]: vscode.Uri }
 export type SchemaType = 'yaml' | 'json'
@@ -140,7 +141,7 @@ export class SchemaService {
  */
 export async function getDefaultSchemas(extensionContext: vscode.ExtensionContext): Promise<Schemas | undefined> {
     const cfnSchemaUri = vscode.Uri.joinPath(extensionContext.globalStorageUri, 'cloudformation.schema.json')
-    const samSchemaUri = vscode.Uri.joinPath(extensionContext.globalStorageUri, 'sam.schema.json')
+    const samUri = samSchemaUri()
 
     const goformationSchemaVersion = await getPropertyFromJsonUrl(GOFORMATION_MANIFEST_URL, 'tag_name')
 
@@ -162,14 +163,14 @@ export async function getDefaultSchemas(extensionContext: vscode.ExtensionContex
 
     try {
         await updateSchemaFromRemote({
-            destination: samSchemaUri,
+            destination: samUri,
             version: goformationSchemaVersion,
             url: `https://raw.githubusercontent.com/awslabs/goformation/${goformationSchemaVersion}/schema/sam.schema.json`,
             cacheKey: 'samSchemaVersion',
             extensionContext,
             title: SCHEMA_PREFIX + 'sam.schema.json',
         })
-        schemas['sam'] = samSchemaUri
+        schemas['sam'] = samUri
     } catch (e) {
         getLogger().verbose('Could not download sam schema: %s', (e as Error).message)
     }


### PR DESCRIPTION
## Problem
Currently users have no way of overriding what schema gets applied to their SAM document

## Solution
This PR makes it so that SAM documents can be overriden by applying the modeline from https://github.com/aws/serverless-application-model/discussions/2645

This isn't an ideal implementation, but the registerContributor API from VSCode-YAML essentially enforces that when an extension "owns" a filetype, they are responsible for telling VSCode-YAML which schema should be used at all times. In order to circumvent this API we basically have to error out so it uses the best available backup schema it can find. In this case, the schema from the modeline. The consequence of this PR is that if the user has a SAM file that's decently large, then the intellisense will be slower because it has to read the user files on every single request.

fixes: https://github.com/aws/aws-toolkit-vscode/issues/3012

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
