### PR TITLE
test(GH-2090): Optimize SAM integration test

### DIFF
--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -647,5 +647,9 @@ describe('SAM Integration Tests', async function () {
         }
         const samCliContext = getSamCliContext()
         await runSamCliInit(initArguments, samCliContext)
+        // XXX: Fixes flakiness. Ensures the files from creation of sam
+        // app are processed by code lens file watcher. Otherwise, potential
+        // issues of file not in registry before it is found.
+        await globals.codelensRootRegistry.rebuild()
     }
 })

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -421,33 +421,6 @@ describe('SAM Integration Tests', async function () {
             }
 
             /**
-             * This suite cleans up at the end of each test.
-             */
-            describe('Starting from scratch', async function () {
-                let testDir: string
-
-                beforeEach(async function () {
-                    testDir = await mkdtemp(path.join(runtimeTestRoot, 'test-'))
-                    log(`testDir: ${testDir}`)
-                })
-
-                afterEach(async function () {
-                    // don't clean up after java tests so the java language server doesn't freak out
-                    if (scenario.language !== 'java') {
-                        await tryRemoveFolder(testDir)
-                    }
-                })
-
-                it('creates a new SAM Application (happy path)', async function () {
-                    await createSamApplication(testDir)
-
-                    // Check for readme file
-                    const readmePath = path.join(testDir, samApplicationName, 'README.md')
-                    assert.ok(await fileExists(readmePath), `Expected SAM App readme to exist at ${readmePath}`)
-                })
-            })
-
-            /**
              * This suite makes a sam app that all tests operate on.
              * Cleanup happens at the end of the suite.
              */
@@ -465,8 +438,11 @@ describe('SAM Integration Tests', async function () {
 
                     await createSamApplication(testDir)
                     appPath = path.join(testDir, samApplicationName, scenario.path)
+
                     cfnTemplatePath = path.join(testDir, samApplicationName, 'template.yaml')
+                    const readmePath = path.join(testDir, samApplicationName, 'README.md')
                     assert.ok(await fileExists(cfnTemplatePath), `Expected SAM template to exist at ${cfnTemplatePath}`)
+                    assert.ok(await fileExists(readmePath), `Expected SAM App readme to exist at ${readmePath}`)
 
                     samAppCodeUri = await openSamAppFile(appPath)
                 })

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -397,6 +397,30 @@ describe('SAM Integration Tests', async function () {
         console.log(`DebugSessions seen in this run:\n${sessionReport}`)
     })
 
+    describe('SAM install test', async () => {
+        let runtimeTestRoot: string
+        let randomTestScenario: TestScenario
+
+        before(async function () {
+            if (scenarios.length == 0) {
+                throw new Error('There are no scenarios available.')
+            }
+            randomTestScenario = scenarios[0]
+
+            runtimeTestRoot = path.join(testSuiteRoot, 'randomScenario')
+            mkdirpSync(runtimeTestRoot)
+        })
+
+        after(async function () {
+            await tryRemoveFolder(runtimeTestRoot)
+        })
+
+        it('produces an error when creating a SAM Application to the same location', async function () {
+            await createSamApplication(runtimeTestRoot, randomTestScenario)
+            await assert.rejects(createSamApplication(runtimeTestRoot, randomTestScenario), 'Promise was not rejected')
+        })
+    })
+
     for (let scenarioIndex = 0; scenarioIndex < scenarios.length; scenarioIndex++) {
         const scenario = scenarios[scenarioIndex]
 
@@ -436,7 +460,7 @@ describe('SAM Integration Tests', async function () {
                     testDir = await mkdtemp(path.join(runtimeTestRoot, 'samapp-'))
                     log(`testDir: ${testDir}`)
 
-                    await createSamApplication(testDir)
+                    await createSamApplication(testDir, scenario)
                     appPath = path.join(testDir, samApplicationName, scenario.path)
 
                     cfnTemplatePath = path.join(testDir, samApplicationName, 'template.yaml')
@@ -462,10 +486,6 @@ describe('SAM Integration Tests', async function () {
                     if (scenario.language !== 'java') {
                         await tryRemoveFolder(testDir)
                     }
-                })
-
-                it('produces an error when creating a SAM Application to the same location', async function () {
-                    await assert.rejects(createSamApplication(testDir), 'Promise was not rejected')
                 })
 
                 it('produces an Add Debug Configuration codelens', async function () {
@@ -598,22 +618,6 @@ describe('SAM Integration Tests', async function () {
             })
         })
 
-        async function createSamApplication(location: string): Promise<void> {
-            const initArguments: SamCliInitArgs = {
-                name: samApplicationName,
-                location: location,
-                dependencyManager: scenario.dependencyManager,
-            }
-            if (scenario.baseImage) {
-                initArguments.baseImage = scenario.baseImage
-            } else {
-                initArguments.runtime = scenario.runtime
-                initArguments.template = helloWorldTemplate
-            }
-            const samCliContext = getSamCliContext()
-            await runSamCliInit(initArguments, samCliContext)
-        }
-
         function assertCodeLensReferencesHasSameRoot(codeLens: vscode.CodeLens, expectedUri: vscode.Uri) {
             assert.ok(codeLens.command, 'CodeLens did not have a command')
             const command = codeLens.command!
@@ -627,5 +631,21 @@ describe('SAM Integration Tests', async function () {
 
             assert.strictEqual(path.dirname(params.rootUri.fsPath), path.dirname(expectedUri.fsPath))
         }
+    }
+
+    async function createSamApplication(location: string, scenario: TestScenario): Promise<void> {
+        const initArguments: SamCliInitArgs = {
+            name: samApplicationName,
+            location: location,
+            dependencyManager: scenario.dependencyManager,
+        }
+        if (scenario.baseImage) {
+            initArguments.baseImage = scenario.baseImage
+        } else {
+            initArguments.runtime = scenario.runtime
+            initArguments.template = helloWorldTemplate
+        }
+        const samCliContext = getSamCliContext()
+        await runSamCliInit(initArguments, samCliContext)
     }
 })

--- a/src/shared/fs/watchedFiles.ts
+++ b/src/shared/fs/watchedFiles.ts
@@ -221,7 +221,7 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
      * Rebuilds registry using current glob and exclusion patterns.
      * All functionality is currently internal to class, but can be made public if we want a manual "refresh" button
      */
-    public async rebuild(): Promise<void> {
+    private async rebuild(): Promise<void> {
         this.reset()
         for (const glob of this.globs) {
             const itemUris = await vscode.workspace.findFiles(glob)

--- a/src/shared/fs/watchedFiles.ts
+++ b/src/shared/fs/watchedFiles.ts
@@ -221,7 +221,7 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
      * Rebuilds registry using current glob and exclusion patterns.
      * All functionality is currently internal to class, but can be made public if we want a manual "refresh" button
      */
-    private async rebuild(): Promise<void> {
+    public async rebuild(): Promise<void> {
         this.reset()
         for (const glob of this.globs) {
             const itemUris = await vscode.workspace.findFiles(glob)


### PR DESCRIPTION
The `sam init` integration tests took an
average of 7 minutes to complete. This commit
reduces them to an average of 2 minutes 30 seconds.

## Problem

The current sam cli implementation clones the entire template repo each call of sam.test.ts#createSamApplication(). This function is called more than it needs to be for the same test coverage.

## Solution
Remove redundant calls to the createSamApplication() method. Test a certain scenario only once because it does not change for each iteration of SAM project type.

Additional:
I looked in to the `sam init --location` flag and it doesn't assist in trying to test the current logic this test aims to validate. Use of `--location` is a different way to do do a `sam init`, but we are only testing Scenario 1
Initializes a new SAM project with required parameters passed as parameters:
```
//Scenario 1
$ sam init --runtime python3.7 --dependency-manager pip --app-template hello-world --name sam-app
// Scenario 2
$ sam init --location /path/to/template/folder
```
from: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-init.html

Resolves #2090

Signed-off-by: Nikolas Komonen <nkomonen@amazon.com>





<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
