### PR TITLE
feat(codecatalyst): guide users to connect if not already connected

### DIFF
--- a/.changes/next-release/Feature-f5541d37-7638-4d1c-9347-fb565b379973.json
+++ b/.changes/next-release/Feature-f5541d37-7638-4d1c-9347-fb565b379973.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Amazon CodeCatalyst: UConnecting to AWS Builder ID when coming from the browser has been made easier"
+}

--- a/.changes/next-release/Feature-f5541d37-7638-4d1c-9347-fb565b379973.json
+++ b/.changes/next-release/Feature-f5541d37-7638-4d1c-9347-fb565b379973.json
@@ -1,4 +1,4 @@
 {
 	"type": "Feature",
-	"description": "Amazon CodeCatalyst: UConnecting to AWS Builder ID when coming from the browser has been made easier"
+	"description": "Amazon CodeCatalyst: Connecting to AWS Builder ID when coming from the browser has been made easier"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "aws-toolkit-vscode",
-            "version": "1.57.0-SNAPSHOT",
+            "version": "1.58.0-SNAPSHOT",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/src/codecatalyst/auth.ts
+++ b/src/codecatalyst/auth.ts
@@ -103,7 +103,8 @@ export class CodeCatalystAuthenticationProvider {
 
         if (conn === undefined || !isValidCodeCatalystConnection(conn)) {
             const isNewUser = conn === undefined
-            telemetry.record({ codecatalyst_connectionFlow: isNewUser ? 'New' : 'Upgrade' } as ConnectionFlowEvent)
+            // TODO: change to `satisfies` on TS 4.9
+            telemetry.record({ codecatalyst_connectionFlow: isNewUser ? 'Create' : 'Upgrade' } as ConnectionFlowEvent)
 
             const message = isNewUser
                 ? 'CodeCatalyst requires an AWS Builder ID connection. Set one up now?'
@@ -122,6 +123,7 @@ export class CodeCatalystAuthenticationProvider {
         }
 
         if (this.auth.activeConnection?.id !== conn.id) {
+            // TODO: change to `satisfies` on TS 4.9
             telemetry.record({ codecatalyst_connectionFlow: 'Switch' } as ConnectionFlowEvent)
 
             const resp = await vscode.window.showInformationMessage(

--- a/src/codecatalyst/auth.ts
+++ b/src/codecatalyst/auth.ts
@@ -100,15 +100,15 @@ export class CodeCatalystAuthenticationProvider {
         }
 
         const conn = (await this.auth.listConnections()).find(isBuilderIdConnection)
+        const isNewUser = conn === undefined
 
-        if (conn === undefined || !isValidCodeCatalystConnection(conn)) {
-            const isNewUser = conn === undefined
+        if (isNewUser || !isValidCodeCatalystConnection(conn)) {
             // TODO: change to `satisfies` on TS 4.9
             telemetry.record({ codecatalyst_connectionFlow: isNewUser ? 'Create' : 'Upgrade' } as ConnectionFlowEvent)
 
             const message = isNewUser
-                ? 'CodeCatalyst requires an AWS Builder ID connection. Set one up now?'
-                : 'Your AWS Builder ID connection does not have access to CodeCatalyst. You will need to reauthenticate in the browser. Reauthenticate now?'
+                ? 'CodeCatalyst requires an AWS Builder ID connection. Creating a connection opens your browser to login. Create one now?'
+                : 'Your AWS Builder ID connection does not have access to CodeCatalyst. Upgrading the connection requires another login. Upgrade now?'
             const resp = await vscode.window.showInformationMessage(message, localizedText.yes, localizedText.no)
             if (resp !== localizedText.yes) {
                 throw new ToolkitError('Not connected to CodeCatalyst', { code: 'NoConnection', cancelled: true })

--- a/src/codecatalyst/auth.ts
+++ b/src/codecatalyst/auth.ts
@@ -101,16 +101,18 @@ export class CodeCatalystAuthenticationProvider {
 
         const conn = (await this.auth.listConnections()).find(isBuilderIdConnection)
         const isNewUser = conn === undefined
+        const okItem: vscode.MessageItem = { title: localizedText.ok }
+        const cancelItem: vscode.MessageItem = { title: localizedText.cancel, isCloseAffordance: true }
 
         if (isNewUser || !isValidCodeCatalystConnection(conn)) {
             // TODO: change to `satisfies` on TS 4.9
             telemetry.record({ codecatalyst_connectionFlow: isNewUser ? 'Create' : 'Upgrade' } as ConnectionFlowEvent)
 
             const message = isNewUser
-                ? 'CodeCatalyst requires an AWS Builder ID connection. Creating a connection opens your browser to login. Create one now?'
-                : 'Your AWS Builder ID connection does not have access to CodeCatalyst. Upgrading the connection requires another login. Upgrade now?'
-            const resp = await vscode.window.showInformationMessage(message, localizedText.yes, localizedText.no)
-            if (resp !== localizedText.yes) {
+                ? 'CodeCatalyst requires an AWS Builder ID connection. Creating a connection opens your browser to login.\n\n Create one now?'
+                : 'Your AWS Builder ID connection does not have access to CodeCatalyst. Upgrading the connection requires another login.\n\n Upgrade now?'
+            const resp = await vscode.window.showInformationMessage(message, { modal: true }, okItem, cancelItem)
+            if (resp !== okItem) {
                 throw new ToolkitError('Not connected to CodeCatalyst', { code: 'NoConnection', cancelled: true })
             }
 
@@ -127,11 +129,12 @@ export class CodeCatalystAuthenticationProvider {
             telemetry.record({ codecatalyst_connectionFlow: 'Switch' } as ConnectionFlowEvent)
 
             const resp = await vscode.window.showInformationMessage(
-                'CodeCatalyst requires an AWS Builder ID connection. Switch to it now?',
-                localizedText.yes,
-                localizedText.no
+                'CodeCatalyst requires an AWS Builder ID connection.\n\n Switch to it now?',
+                { modal: true },
+                okItem,
+                cancelItem
             )
-            if (resp !== localizedText.yes) {
+            if (resp !== okItem) {
                 throw new ToolkitError('Not connected to CodeCatalyst', { code: 'NoConnection', cancelled: true })
             }
 

--- a/src/codecatalyst/commands.ts
+++ b/src/codecatalyst/commands.ts
@@ -133,12 +133,12 @@ function createClientInjector(
     clientFactory: () => Promise<CodeCatalystClient>
 ): ClientInjector {
     return async (command, ...args) => {
-        const client = await clientFactory()
+        let client = await clientFactory()
 
         try {
             if (!client.connected) {
                 const conn = await authProvider.promptNotConnected()
-                await client.setCredentials(async () => (await conn.getToken()).accessToken)
+                client = await client.setCredentials(async () => (await conn.getToken()).accessToken)
             }
 
             return await command(client, ...args)

--- a/src/codecatalyst/commands.ts
+++ b/src/codecatalyst/commands.ts
@@ -137,7 +137,8 @@ function createClientInjector(
 
         try {
             if (!client.connected) {
-                throw new ToolkitError('Not connected to CodeCatalyst', { code: 'NoConnection' })
+                const conn = await authProvider.promptNotConnected()
+                await client.setCredentials(async () => (await conn.getToken()).accessToken)
             }
 
             return await command(client, ...args)

--- a/src/codecatalyst/reconnect.ts
+++ b/src/codecatalyst/reconnect.ts
@@ -30,8 +30,8 @@ const MAX_RECONNECT_TIME = 10 * 60 * 1000
 
 export function watchRestartingDevEnvs(ctx: ExtContext, authProvider: CodeCatalystAuthenticationProvider) {
     let restartHandled = false
-    authProvider.onDidChangeActiveConnection(async () => {
-        if (restartHandled) {
+    authProvider.onDidChangeActiveConnection(async conn => {
+        if (restartHandled || conn === undefined) {
             return
         }
 


### PR DESCRIPTION
## Problem
Users trying to use CodeCatalyst features might not have an AWS Builder ID connection configured yet. This especially affects users coming from https://codecatalyst.aws

## Solution
Make it easier to set up a connection by asking the user to create/upgrade one.

![Screen Shot 2022-12-01 at 12 54 20 PM](https://user-images.githubusercontent.com/31319484/205157538-bc74bf12-787d-4a41-a6f7-d78501c4d5da.png)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
