### PR TITLE
feat(dev): add logic to download beta artifacts from a URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -333,6 +333,10 @@ As a simple example, let's say I wanted to add a new icon for CloudWatch log str
     getIcon('aws-cloudwatch-log-stream')
     ```
 
+### Beta artifacts
+
+The Toolkit codebase contains logic in `src/dev/beta.ts` to support development during private betas. Creating a beta artifact requires a _stable_ URL to source Toolkit builds from. This URL should be added to `src/dev/config.ts`. Subsequent Toolkit artifacts will have their version set to `1.999.0` with a commit hash. Builds will automatically query the URL to check for a new build once a day + on every reload.
+
 ## Importing icons from other open source repos
 
 If you are contribuing visual assets from other open source repos, the source repo must have a compatible license (such as MIT), and we need to document the source of the images. Follow these steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -335,7 +335,7 @@ As a simple example, let's say I wanted to add a new icon for CloudWatch log str
 
 ### Beta artifacts
 
-The Toolkit codebase contains logic in `src/dev/beta.ts` to support development during private betas. Creating a beta artifact requires a _stable_ URL to source Toolkit builds from. This URL should be added to `src/dev/config.ts`. Subsequent Toolkit artifacts will have their version set to `1.999.0` with a commit hash. Builds will automatically query the URL to check for a new build once a day + on every reload.
+The Toolkit codebase contains logic in `src/dev/beta.ts` to support development during private betas. Creating a beta artifact requires a _stable_ URL to source Toolkit builds from. This URL should be added to `src/dev/config.ts`. Subsequent Toolkit artifacts will have their version set to `1.999.0` with a commit hash. Builds will automatically query the URL to check for a new build once a day and on every reload.
 
 ## Importing icons from other open source repos
 

--- a/scripts/build/package.ts
+++ b/scripts/build/package.ts
@@ -4,9 +4,11 @@
  */
 
 //
-// Creates an artifact that can be given to users for testing alpha builds:
+// Creates an artifact that can be given to users for testing alpha/beta builds:
 //
-//     aws-toolkit-vscode-1.99.0-SNAPSHOT.vsix
+//     aws-toolkit-vscode-1.999.0-xxxxxxxxxxxx.vsix
+//
+// Where `xxxxxxxxxxxx` is the first 12 characters of the commit hash that produced the artifact
 //
 // The script works like this:
 // 1. temporarily change `version` in package.json
@@ -101,13 +103,12 @@ function main() {
             const packageJson: typeof manifest = JSON.parse(fs.readFileSync(packageJsonFile, { encoding: 'utf-8' }))
             const versionSuffix = getVersionSuffix()
             const version = packageJson.version
-            if (isBeta()) {
-                // Setting the version to an arbitrarily high number stops VSC from auto-updating the beta extension
-                packageJson.version = `1.999.0${versionSuffix}`
+            // Setting the version to an arbitrarily high number stops VSC from auto-updating the beta extension
+            const betaOrDebugVersion = `1.999.0${versionSuffix}`
+            if (isBeta() || args.debug) {
+                packageJson.version = betaOrDebugVersion
             } else {
-                packageJson.version = args.debug
-                    ? `1.99.0${versionSuffix}`
-                    : version.replace('-SNAPSHOT', versionSuffix)
+                packageJson.version = version.replace('-SNAPSHOT', versionSuffix)
             }
 
             if (args.skipClean) {

--- a/src/dev/activation.ts
+++ b/src/dev/activation.ts
@@ -4,6 +4,7 @@
  */
 
 import * as vscode from 'vscode'
+import * as config from './config'
 import { ExtContext } from '../shared/extensions'
 import { createCommonButtons } from '../shared/ui/buttons'
 import { createQuickPick } from '../shared/ui/pickerPrompter'
@@ -115,7 +116,7 @@ export function activate(ctx: ExtContext): void {
 
 let vsixWatchSubscription: vscode.Disposable | undefined
 function watchVsixUrl(settings: DevSettings): vscode.Disposable {
-    const vsixUrl = settings.get('betaUrl', '')
+    const vsixUrl = settings.get('betaUrl', config.betaUrl)
     vsixWatchSubscription?.dispose()
 
     if (vsixUrl) {

--- a/src/dev/activation.ts
+++ b/src/dev/activation.ts
@@ -102,28 +102,9 @@ export function activate(ctx: ExtContext): void {
     const editor = new ObjectEditor(ctx.extensionContext)
     ctx.extensionContext.subscriptions.push(openStorageCommand.register(editor))
 
-    if (!isCloud9() && !isReleaseVersion()) {
-        ctx.extensionContext.subscriptions.push(
-            watchVsixUrl(devSettings),
-            devSettings.onDidChange(({ key }) => {
-                if (key === 'betaUrl') {
-                    watchVsixUrl(devSettings)
-                }
-            })
-        )
+    if (!isCloud9() && !isReleaseVersion() && config.betaUrl) {
+        ctx.extensionContext.subscriptions.push(watchBetaVSIX(config.betaUrl))
     }
-}
-
-let vsixWatchSubscription: vscode.Disposable | undefined
-function watchVsixUrl(settings: DevSettings): vscode.Disposable {
-    const vsixUrl = settings.get('betaUrl', config.betaUrl)
-    vsixWatchSubscription?.dispose()
-
-    if (vsixUrl) {
-        vsixWatchSubscription = watchBetaVSIX(vsixUrl)
-    }
-
-    return { dispose: () => vsixWatchSubscription?.dispose() }
 }
 
 async function openMenu(ctx: ExtContext, options: typeof menuOptions): Promise<void> {

--- a/src/dev/activation.ts
+++ b/src/dev/activation.ts
@@ -15,6 +15,8 @@ import { Wizard } from '../shared/wizards/wizard'
 import { deleteDevEnvCommand, installVsixCommand, openTerminalCommand } from './codecatalyst'
 import { watchBetaVSIX } from './beta'
 import { isCloud9 } from '../shared/extensionUtilities'
+import { entries } from '../shared/utilities/tsUtils'
+import { isReleaseVersion } from '../shared/vscode/env'
 
 interface MenuOption {
     readonly label: string
@@ -99,7 +101,7 @@ export function activate(ctx: ExtContext): void {
     const editor = new ObjectEditor(ctx.extensionContext)
     ctx.extensionContext.subscriptions.push(openStorageCommand.register(editor))
 
-    if (!isCloud9()) {
+    if (!isCloud9() && !isReleaseVersion()) {
         ctx.extensionContext.subscriptions.push(
             watchVsixUrl(devSettings),
             devSettings.onDidChange(({ key }) => {
@@ -121,10 +123,6 @@ function watchVsixUrl(settings: DevSettings): vscode.Disposable {
     }
 
     return { dispose: () => vsixWatchSubscription?.dispose() }
-}
-
-function entries<T extends Record<string, U>, U>(obj: T): { [P in keyof T]: [P, T[P]] }[keyof T][] {
-    return Object.entries(obj) as { [P in keyof T]: [P, T[P]] }[keyof T][]
 }
 
 async function openMenu(ctx: ExtContext, options: typeof menuOptions): Promise<void> {

--- a/src/dev/beta.ts
+++ b/src/dev/beta.ts
@@ -126,7 +126,8 @@ async function promptInstallToolkit(pluginPath: vscode.Uri, newVersion: string, 
     const response = await vscode.window.showInformationMessage(
         localize(
             'AWS.dev.beta.updatePrompt',
-            `New version of AWS Toolkit is available at the beta URL (${vsixUrl}). Install the new version "{0}" to continue using the beta.`,
+            `New version of AWS Toolkit is available at the beta URL ({0}). Install the new version "{1}" to continue using the beta.`,
+            vsixUrl,
             newVersion
         ),
         installBtn

--- a/src/dev/beta.ts
+++ b/src/dev/beta.ts
@@ -1,0 +1,156 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as path from 'path'
+import * as nls from 'vscode-nls'
+import * as vscode from 'vscode'
+import * as AdmZip from 'adm-zip'
+import got from 'got'
+import globals from '../shared/extensionGlobals'
+import { getLogger } from '../shared/logger'
+import { VSCODE_EXTENSION_ID } from '../shared/extensions'
+import { makeTemporaryToolkitFolder } from '../shared/filesystemUtilities'
+import { reloadWindowPrompt } from '../shared/utilities/vsCodeUtils'
+import { ToolkitError } from '../shared/errors'
+import { SystemUtilities } from '../shared/systemUtilities'
+import { telemetry } from '../shared/telemetry/telemetry'
+import { cast } from '../shared/utilities/typeConstructors'
+import { CancellationError } from '../shared/utilities/timeoutUtils'
+
+const localize = nls.loadMessageBundle()
+
+const downloadIntervalMs = 1000 * 60 * 60 * 24 // A day in milliseconds
+const betaToolkitKey = 'dev.beta'
+
+interface BetaToolkit {
+    readonly needUpdate: boolean
+    readonly lastCheck: number
+}
+
+function getBetaToolkitData(vsixUrl: string): BetaToolkit | undefined {
+    return globals.context.globalState.get<Record<string, BetaToolkit>>(betaToolkitKey, {})[vsixUrl]
+}
+
+async function updateBetaToolkitData(vsixUrl: string, data: BetaToolkit) {
+    await globals.context.globalState.update(betaToolkitKey, {
+        ...globals.context.globalState.get<Record<string, BetaToolkit>>(betaToolkitKey, {}),
+        [vsixUrl]: data,
+    })
+}
+
+/**
+ * Watch the beta VSIX daily for changes.
+ * If this is the first time we are watching the beta version or if its been 24 hours since it was last checked then try to prompt for update
+ */
+export function watchBetaVSIX(vsixUrl: string): vscode.Disposable {
+    const toolkit = getBetaToolkitData(vsixUrl)
+    if (!toolkit || toolkit.needUpdate || Date.now() - toolkit.lastCheck > downloadIntervalMs) {
+        runCheck(vsixUrl)
+    }
+
+    const interval = globals.clock.setInterval(() => runCheck(vsixUrl), downloadIntervalMs)
+    return { dispose: () => clearInterval(interval) }
+}
+
+const runCheck = telemetry.instrument('vscode_checkBeta', checkBetaUrl)
+
+/**
+ * Prompt to update the beta extension when required
+ */
+async function checkBetaUrl(vsixUrl: string): Promise<void> {
+    const resp = await got(vsixUrl).buffer()
+    const latestBetaInfo = await getExtensionVersion(resp)
+    if (!VSCODE_EXTENSION_ID.awstoolkit.endsWith(latestBetaInfo.name)) {
+        throw new ToolkitError('URL does not point to an AWS Toolkit artifact', { code: 'InvalidExtensionName' })
+    }
+
+    const currentVersion = vscode.extensions.getExtension(VSCODE_EXTENSION_ID.awstoolkit)?.packageJSON.version
+    if (latestBetaInfo.version !== currentVersion) {
+        const tmpFolder = await makeTemporaryToolkitFolder()
+        const betaPath = vscode.Uri.joinPath(vscode.Uri.file(tmpFolder), path.basename(vsixUrl))
+        await SystemUtilities.writeFile(betaPath, resp)
+
+        try {
+            await promptInstallToolkit(betaPath, latestBetaInfo.version, vsixUrl)
+        } finally {
+            await SystemUtilities.remove(tmpFolder)
+        }
+    } else {
+        await updateBetaToolkitData(vsixUrl, {
+            lastCheck: Date.now(),
+            needUpdate: false,
+        })
+    }
+}
+
+interface ExtensionInfo {
+    readonly name: string
+    readonly version: string
+}
+
+/**
+ * Get the version of the extension or error if no version could be found
+ *
+ * @param extension The URI of the extension on disk or the raw data
+ * @returns The version of the extension
+ * @throws Error if the version could not be found
+ */
+async function getExtensionVersion(extension: Buffer): Promise<ExtensionInfo>
+async function getExtensionVersion(extensionLocation: vscode.Uri): Promise<ExtensionInfo>
+async function getExtensionVersion(extensionOrLocation: vscode.Uri | Buffer): Promise<ExtensionInfo> {
+    const fileNameOrData = extensionOrLocation instanceof vscode.Uri ? extensionOrLocation.fsPath : extensionOrLocation
+    const packageFile = new AdmZip(fileNameOrData).getEntry('extension/package.json')
+    const packageJSON = packageFile?.getData().toString()
+    if (!packageJSON) {
+        throw new ToolkitError('Extension does not have a `package.json`', { code: 'NoPackageJson' })
+    }
+
+    try {
+        const data = JSON.parse(packageJSON)
+
+        return {
+            name: cast(data.name, String),
+            version: cast(data.version, String),
+        }
+    } catch (e) {
+        throw ToolkitError.chain(e, 'Unable to parse extension data', { code: 'BadParse' })
+    }
+}
+
+async function promptInstallToolkit(pluginPath: vscode.Uri, newVersion: string, vsixUrl: string): Promise<void> {
+    const vsixName = path.basename(pluginPath.fsPath)
+    const installBtn = localize('AWS.missingExtension.install', 'Install...')
+
+    const response = await vscode.window.showInformationMessage(
+        localize(
+            'AWS.dev.beta.updatePrompt',
+            `New version of AWS Toolkit is available at the beta URL (${vsixUrl}). Install the new version "{0}" to continue using the beta.`,
+            newVersion
+        ),
+        installBtn
+    )
+
+    switch (response) {
+        case installBtn:
+            try {
+                getLogger().info(`dev: installing artifact ${vsixName}`)
+                await vscode.commands.executeCommand('workbench.extensions.installExtension', pluginPath)
+                await updateBetaToolkitData(vsixUrl, {
+                    lastCheck: Date.now(),
+                    needUpdate: false,
+                })
+                reloadWindowPrompt(localize('AWS.dev.beta.reloadPrompt', 'Reload now to use the new beta AWS Toolkit.'))
+            } catch (e) {
+                getLogger().error(`dev: extension ${vsixName} could not be installed: %s`, e)
+            }
+            break
+        case undefined:
+            await updateBetaToolkitData(vsixUrl, {
+                lastCheck: Date.now(),
+                needUpdate: true,
+            })
+            throw new CancellationError('user')
+    }
+}

--- a/src/dev/beta.ts
+++ b/src/dev/beta.ts
@@ -45,6 +45,8 @@ async function updateBetaToolkitData(vsixUrl: string, data: BetaToolkit) {
  * If this is the first time we are watching the beta version or if its been 24 hours since it was last checked then try to prompt for update
  */
 export function watchBetaVSIX(vsixUrl: string): vscode.Disposable {
+    getLogger().info(`dev: watching ${vsixUrl} for beta artifacts`)
+
     const toolkit = getBetaToolkitData(vsixUrl)
     if (!toolkit || toolkit.needUpdate || Date.now() - toolkit.lastCheck > downloadIntervalMs) {
         runAutoUpdate(vsixUrl)
@@ -58,7 +60,7 @@ async function runAutoUpdate(vsixUrl: string) {
     getLogger().debug(`dev: checking ${vsixUrl} for a new version`)
 
     try {
-        await telemetry.vscode_autoUpdateBeta.run(() => checkBetaUrl(vsixUrl))
+        await telemetry.aws_autoUpdateBeta.run(() => checkBetaUrl(vsixUrl))
     } catch (e) {
         if (!isUserCancelledError(e)) {
             getLogger().warn(`dev: beta extension auto-update failed: %s`, e)

--- a/src/dev/config.ts
+++ b/src/dev/config.ts
@@ -1,0 +1,9 @@
+/*!
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// This file is strictly used for private development
+// Nothing in this file should have a truthy value on mainline
+
+export const betaUrl = ''

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -546,7 +546,6 @@ const devSettings = {
     telemetryUserPool: String,
     endpoints: Record(String, String),
     cawsStage: String,
-    betaUrl: String,
 }
 type ResolvedDevSettings = FromDescriptor<typeof devSettings>
 type AwsDevSetting = keyof ResolvedDevSettings

--- a/src/shared/telemetry/vscodeTelemetry.json
+++ b/src/shared/telemetry/vscodeTelemetry.json
@@ -50,7 +50,7 @@
             ]
         },
         {
-            "name": "vscode_autoUpdateBeta",
+            "name": "aws_autoUpdateBeta",
             "description": "Emitted whenever the Toolkit checks, and potentially installs, a beta version",
             "passive": true
         },

--- a/src/shared/telemetry/vscodeTelemetry.json
+++ b/src/shared/telemetry/vscodeTelemetry.json
@@ -50,6 +50,11 @@
             ]
         },
         {
+            "name": "vscode_autoUpdateBeta",
+            "description": "Emitted whenever the Toolkit checks, and potentially installs, a beta version",
+            "passive": true
+        },
+        {
             "name": "aws_installCli",
             "description": "Called after attempting to install a local copy of a missing CLI",
             "metadata": [{ "type": "result" }, { "type": "cli" }]

--- a/src/shared/utilities/tsUtils.ts
+++ b/src/shared/utilities/tsUtils.ts
@@ -49,6 +49,13 @@ export function keys<T extends Record<string, any>>(obj: T): [keyof T & string] 
     return Object.keys(obj) as [keyof T & string]
 }
 
+/**
+ * Stricter form of {@link Object.entries} that gives slightly better types for object literals.
+ */
+export function entries<T extends Record<string, U>, U>(obj: T): { [P in keyof T]: [P, T[P]] }[keyof T][] {
+    return Object.entries(obj) as { [P in keyof T]: [P, T[P]] }[keyof T][]
+}
+
 export function isThenable<T>(obj: unknown): obj is Thenable<T> {
     return isNonNullable(obj) && typeof (obj as Thenable<T>).then === 'function'
 }


### PR DESCRIPTION
## Problem
We have no easy way to share beta builds with users

## Solution
Add codepath to download artifact from a URL. The user is prompted to install the new artifact if it is different from the currently installed extension.

**This codepath is never accessible in a release version**
~The dev setting `aws.dev.betaUrl` can be used to test this logic assuming the currently installed VSIX is a pre-release~
Only `src/dev/config.ts` is used to specify the beta URL to ensure that this behavior is dependent on compilation.

### Packaging
A 'config' file has been added to specify development constants. Keeping this as a separate file makes it easier to catch potential leaks and clean the git history of possibly sensitive information. If `betaUrl` is specified then the VSIX will be built with an artificially high version to stop auto-updates e.g. `1.999.0-xxxxxxxx`.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
