### PR TITLE
cwl: Fix bug where empty results are returned with valid nextToken

### DIFF
--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -129,15 +129,16 @@ export class LogDataRegistry {
         const logDataGetter: AsyncIterator<CloudWatchLogsResponse> = getPaginatedAwsCallIter({
             awsCall: async request =>
                 await logData.retrieveLogsFunction(logData.logGroupInfo, logData.parameters, request.nextForwardToken),
-            nextTokenNames: headOrTail
-                ? {
-                      request: 'nextForwardToken',
-                      response: 'nextForwardToken',
-                  }
-                : {
-                      request: 'nextBackwardToken',
-                      response: 'nextForwardToken',
-                  },
+            nextTokenNames:
+                headOrTail === 'head'
+                    ? {
+                          request: 'nextForwardToken',
+                          response: 'nextForwardToken',
+                      }
+                    : {
+                          request: 'nextBackwardToken',
+                          response: 'nextBackwardToken',
+                      },
             request,
         })
         let newLogEvents: CloudWatchLogs.FilteredLogEvents = []
@@ -398,7 +399,6 @@ export type CloudWatchLogsParameters = {
     endTime?: number
     limit?: number
     streamNameOptions?: string[]
-    nextForwardToken?: CloudWatchLogs.NextToken
 }
 
 export type CloudWatchLogsResponse = {

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -125,10 +125,15 @@ export class LogDataRegistry {
         const logDataGetter: AsyncIterator<CloudWatchLogsResponse> = getPaginatedAwsCallIter({
             awsCall: async request =>
                 await logData.retrieveLogsFunction(logData.logGroupInfo, logData.parameters, request.nextForwardToken),
-            nextTokenNames: {
-                request: 'nextForwardToken',
-                response: 'nextForwardToken',
-            },
+            nextTokenNames: headOrTail
+                ? {
+                      request: 'nextForwardToken',
+                      response: 'nextForwardToken',
+                  }
+                : {
+                      request: 'nextBackwardToken',
+                      response: 'nextForwardToken',
+                  },
             request,
         })
         // TODO: Consider getPaginatedAwsCallIter? Would need a way to differentiate between head/tail...

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -166,8 +166,9 @@ export class LogDataRegistry {
         const tokens: Pick<CloudWatchLogsData, 'next' | 'previous'> = {}
         // update if no token exists or if the token is updated in the correct direction.
         if (!logData.previous || headOrTail === 'head') {
-            tokens.previous = {
-                token: responseData.nextBackwardToken ?? '',
+            const token = responseData.nextBackwardToken
+            if (token) {
+                tokens.previous = { token }
             }
         }
         if (!logData.next || headOrTail === 'tail') {

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -133,16 +133,16 @@ export class LogDataRegistry {
                 await logData.retrieveLogsFunction(
                     logData.logGroupInfo,
                     logData.parameters,
-                    isHead ? request.nextForwardToken : request.nextBackwardToken
+                    isHead ? request.nextBackwardToken : request.nextForwardToken
                 ),
             nextTokenNames: isHead
                 ? {
-                      request: 'nextForwardToken',
-                      response: 'nextForwardToken',
-                  }
-                : {
                       request: 'nextBackwardToken',
                       response: 'nextBackwardToken',
+                  }
+                : {
+                      request: 'nextForwardToken',
+                      response: 'nextForwardToken',
                   },
             request,
         })

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -174,8 +174,9 @@ export class LogDataRegistry {
             }
         }
         if (!logData.next || headOrTail === 'tail') {
-            tokens.next = {
-                token: responseData.nextForwardToken ?? '',
+            const token = responseData.nextForwardToken ?? request.nextForwardToken
+            if (token) {
+                tokens.next = { token }
             }
         }
         this.setLogData(uri, {

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -136,34 +136,6 @@ export class LogDataRegistry {
                   },
             request,
         })
-        // TODO: Consider getPaginatedAwsCallIter? Would need a way to differentiate between head/tail...
-        //let logDataGetter: AsyncIterator<CloudWatchLogsResponse>
-        // switch(logData.retrieveLogsFunction) {
-        //     case getLogEventsFromUriComponents:
-        //         logDataGetter = getPaginatedAwsCallIter({
-        //             awsCall: async request => await getLogEventsFromUriComponents(logData.logGroupInfo, logData.parameters, nextToken),
-        //             nextTokenNames: {
-        //                 request: 'nextForwardToken',
-        //                 response: 'nextForwardToken',
-        //             },
-        //             request,
-        //         })
-        //         break
-
-        //     case filterLogEventsFromUriComponents:
-        //         logDataGetter = getPaginatedAwsCallIter({
-        //         awsCall: async request => await filterLogEventsFromUriComponents(logData.logGroupInfo, logData.parameters, nextToken),
-        //         nextTokenNames: {
-        //             request: 'nextForwardToken',
-        //             response: 'nextForwardToken',
-        //         },
-        //         request,
-        //     })
-        //         break
-
-        //     default:
-        //         throw new Error(`cwl: unknown function passed into updateLog as retrieveLogsFunction`)
-        // }
         let newLogEvents: CloudWatchLogs.FilteredLogEvents = []
         let next: IteratorResult<CloudWatchLogsResponse> = await logDataGetter.next()
         newLogEvents = newLogEvents.concat(next.value.events)

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -121,7 +121,11 @@ export class LogDataRegistry {
             getLogger().debug(`No registry entry for ${uri.path}`)
             return
         }
-        const nextToken = headOrTail === 'head' ? logData.previous?.token : logData.next?.token
+        const request: CloudWatchLogsResponse = {
+            events: [],
+            nextForwardToken: logData.next?.token,
+            nextBackwardToken: logData.previous?.token,
+        }
         const logDataGetter: AsyncIterator<CloudWatchLogsResponse> = getPaginatedAwsCallIter({
             awsCall: async request =>
                 await logData.retrieveLogsFunction(logData.logGroupInfo, logData.parameters, request.nextForwardToken),
@@ -150,8 +154,6 @@ export class LogDataRegistry {
             nextForwardToken: next.value.nextForwardToken,
             nextBackwardToken: next.value.nextBackwardToken,
         }
-
-        //const logEvents = await logData.retrieveLogsFunction(logData.logGroupInfo, logData.parameters, nextToken)
 
         const newData =
             headOrTail === 'head'

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -14,9 +14,6 @@ import { Timeout, waitTimeout } from '../../shared/utilities/timeoutUtils'
 import { showMessageWithCancel } from '../../shared/utilities/messages'
 import { findOccurencesOf } from '../../shared/utilities/textDocumentUtilities'
 import { getPaginatedAwsCallIter } from '../../shared/utilities/collectionUtils'
-import { request } from 'http'
-import { FilteredLogEvents } from 'aws-sdk/clients/cloudwatchlogs'
-import { nextTick } from 'process'
 // TODO: Add debug logging statements
 
 /**

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -13,6 +13,10 @@ import { DefaultCloudWatchLogsClient } from '../../shared/clients/cloudWatchLogs
 import { Timeout, waitTimeout } from '../../shared/utilities/timeoutUtils'
 import { showMessageWithCancel } from '../../shared/utilities/messages'
 import { findOccurencesOf } from '../../shared/utilities/textDocumentUtilities'
+import { getPaginatedAwsCallIter } from '../../shared/utilities/collectionUtils'
+import { request } from 'http'
+import { FilteredLogEvents } from 'aws-sdk/clients/cloudwatchlogs'
+import { nextTick } from 'process'
 // TODO: Add debug logging statements
 
 /**
@@ -121,25 +125,75 @@ export class LogDataRegistry {
             return
         }
         const nextToken = headOrTail === 'head' ? logData.previous?.token : logData.next?.token
-
+        const logDataGetter: AsyncIterator<CloudWatchLogsResponse> = getPaginatedAwsCallIter({
+            awsCall: async request =>
+                await logData.retrieveLogsFunction(logData.logGroupInfo, logData.parameters, nextToken),
+            nextTokenNames: {
+                request: 'nextForwardToken',
+                response: 'nextForwardToken',
+            },
+            request,
+        })
         // TODO: Consider getPaginatedAwsCallIter? Would need a way to differentiate between head/tail...
-        const logEvents = await logData.retrieveLogsFunction(logData.logGroupInfo, logData.parameters, nextToken)
+        //let logDataGetter: AsyncIterator<CloudWatchLogsResponse>
+        // switch(logData.retrieveLogsFunction) {
+        //     case getLogEventsFromUriComponents:
+        //         logDataGetter = getPaginatedAwsCallIter({
+        //             awsCall: async request => await getLogEventsFromUriComponents(logData.logGroupInfo, logData.parameters, nextToken),
+        //             nextTokenNames: {
+        //                 request: 'nextForwardToken',
+        //                 response: 'nextForwardToken',
+        //             },
+        //             request,
+        //         })
+        //         break
+
+        //     case filterLogEventsFromUriComponents:
+        //         logDataGetter = getPaginatedAwsCallIter({
+        //         awsCall: async request => await filterLogEventsFromUriComponents(logData.logGroupInfo, logData.parameters, nextToken),
+        //         nextTokenNames: {
+        //             request: 'nextForwardToken',
+        //             response: 'nextForwardToken',
+        //         },
+        //         request,
+        //     })
+        //         break
+
+        //     default:
+        //         throw new Error(`cwl: unknown function passed into updateLog as retrieveLogsFunction`)
+        // }
+        let newLogEvents: CloudWatchLogs.FilteredLogEvents = []
+        let next: IteratorResult<CloudWatchLogsResponse> = await logDataGetter.next()
+        newLogEvents = newLogEvents.concat(next.value.events)
+
+        while (newLogEvents.length === 0 && !next.done) {
+            next = await logDataGetter.next()
+            newLogEvents = newLogEvents.concat(next.value.events)
+        }
+
+        const responseData: CloudWatchLogsResponse = {
+            events: newLogEvents,
+            nextForwardToken: next.value.nextForwardToken,
+            nextBackwardToken: next.value.nextBackwardToken,
+        }
+
+        //const logEvents = await logData.retrieveLogsFunction(logData.logGroupInfo, logData.parameters, nextToken)
 
         const newData =
             headOrTail === 'head'
-                ? (logEvents.events ?? []).concat(logData.data)
-                : logData.data.concat(logEvents.events ?? [])
+                ? (responseData.events ?? []).concat(logData.data)
+                : logData.data.concat(responseData.events ?? [])
 
         const tokens: Pick<CloudWatchLogsData, 'next' | 'previous'> = {}
         // update if no token exists or if the token is updated in the correct direction.
         if (!logData.previous || headOrTail === 'head') {
             tokens.previous = {
-                token: logEvents.nextBackwardToken ?? '',
+                token: responseData.nextBackwardToken ?? '',
             }
         }
         if (!logData.next || headOrTail === 'tail') {
             tokens.next = {
-                token: logEvents.nextForwardToken ?? '',
+                token: responseData.nextForwardToken ?? '',
             }
         }
         this.setLogData(uri, {
@@ -368,6 +422,7 @@ export type CloudWatchLogsParameters = {
     endTime?: number
     limit?: number
     streamNameOptions?: string[]
+    nextForwardToken?: CloudWatchLogs.NextToken
 }
 
 export type CloudWatchLogsResponse = {

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -127,7 +127,7 @@ export class LogDataRegistry {
         const nextToken = headOrTail === 'head' ? logData.previous?.token : logData.next?.token
         const logDataGetter: AsyncIterator<CloudWatchLogsResponse> = getPaginatedAwsCallIter({
             awsCall: async request =>
-                await logData.retrieveLogsFunction(logData.logGroupInfo, logData.parameters, nextToken),
+                await logData.retrieveLogsFunction(logData.logGroupInfo, logData.parameters, request.nextForwardToken),
             nextTokenNames: {
                 request: 'nextForwardToken',
                 response: 'nextForwardToken',

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -126,19 +126,24 @@ export class LogDataRegistry {
             nextForwardToken: logData.next?.token,
             nextBackwardToken: logData.previous?.token,
         }
+
+        const isHead = headOrTail === 'head'
         const logDataGetter: AsyncIterator<CloudWatchLogsResponse> = getPaginatedAwsCallIter({
             awsCall: async request =>
-                await logData.retrieveLogsFunction(logData.logGroupInfo, logData.parameters, request.nextForwardToken),
-            nextTokenNames:
-                headOrTail === 'head'
-                    ? {
-                          request: 'nextForwardToken',
-                          response: 'nextForwardToken',
-                      }
-                    : {
-                          request: 'nextBackwardToken',
-                          response: 'nextBackwardToken',
-                      },
+                await logData.retrieveLogsFunction(
+                    logData.logGroupInfo,
+                    logData.parameters,
+                    isHead ? request.nextForwardToken : request.nextBackwardToken
+                ),
+            nextTokenNames: isHead
+                ? {
+                      request: 'nextForwardToken',
+                      response: 'nextForwardToken',
+                  }
+                : {
+                      request: 'nextBackwardToken',
+                      response: 'nextBackwardToken',
+                  },
             request,
         })
         let newLogEvents: CloudWatchLogs.FilteredLogEvents = []

--- a/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
@@ -45,7 +45,7 @@ describe('LogDataRegistry', async function () {
         // check that newData is changed to what it should be.
         const newData = registry.getLogData(paginatedUri)
         assert(newData)
-        const expected = headOrTail === 'head' ? (await fakeGetLogEvents()).events : (await fakeSearchLogGroup()).events
+        const expected = headOrTail === 'head' ? (await fakeSearchLogGroup()).events : (await fakeGetLogEvents()).events
         assert.deepStrictEqual(newData.data, expected)
     }
 

--- a/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
@@ -77,11 +77,11 @@ describe('LogDataRegistry', async function () {
 
     describe('updateLog', async function () {
         it("properply paginates the results with 'head'", async () => {
-            testUpdateLog('head')
+            await testUpdateLog('head')
         })
 
         it("properply paginates the results with 'tail'", async () => {
-            testUpdateLog('tail')
+            await testUpdateLog('tail')
         })
     })
 

--- a/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
@@ -6,25 +6,31 @@
 import * as assert from 'assert'
 import * as moment from 'moment'
 import * as vscode from 'vscode'
-import { LogDataRegistry, ActiveTab } from '../../../cloudWatchLogs/registry/logDataRegistry'
+import {
+    LogDataRegistry,
+    ActiveTab,
+    CloudWatchLogsAction,
+    CloudWatchLogsGroupInfo,
+    CloudWatchLogsParameters,
+    CloudWatchLogsResponse,
+    CloudWatchLogsData,
+} from '../../../cloudWatchLogs/registry/logDataRegistry'
 import { INSIGHTS_TIMESTAMP_FORMAT } from '../../../shared/constants'
 import { Settings } from '../../../shared/settings'
 import { CloudWatchLogsSettings, createURIFromArgs } from '../../../cloudWatchLogs/cloudWatchLogsUtils'
 import {
-    addedEvent,
-    backwardToken,
     fakeGetLogEvents,
     fakeSearchLogGroup,
-    forwardToken,
     logGroupsData,
     newLineData,
     newText,
     paginatedData,
-    returnNonEmptyPaginatedEvents,
     testLogData,
     testStreamNames,
     unregisteredData,
 } from '../utils.test'
+import { CloudWatchLogs } from 'aws-sdk'
+import { FilteredLogEvents } from 'aws-sdk/clients/cloudwatchlogs'
 
 describe('LogDataRegistry', async function () {
     let registry: LogDataRegistry
@@ -38,17 +44,30 @@ describe('LogDataRegistry', async function () {
     const searchLogGroupUri = createURIFromArgs(logGroupsData.logGroupInfo, logGroupsData.parameters)
     const paginatedUri = createURIFromArgs(paginatedData.logGroupInfo, paginatedData.parameters)
 
+    /**
+     * Convenience method to update a log and then
+     * get the data so that it can be verified by
+     * the test.
+     */
+    async function updateLogAndGetResult(
+        uri: vscode.Uri = paginatedUri,
+        headOrTail: 'head' | 'tail' = 'tail'
+    ): Promise<CloudWatchLogsData> {
+        await registry.updateLog(uri, headOrTail)
+        const data = registry.getLogData(uri)
+        assert(data)
+        return data
+    }
+
     async function testUpdateLog(headOrTail: 'head' | 'tail') {
         const oldData = registry.getLogData(paginatedUri)
         // check that oldData is unchanged.
         assert(oldData)
         assert.deepStrictEqual(oldData.data, paginatedData.data)
 
-        await registry.updateLog(paginatedUri, headOrTail)
+        const newData = await updateLogAndGetResult(paginatedUri, headOrTail)
 
         // check that newData is changed to what it should be.
-        const newData = registry.getLogData(paginatedUri)
-        assert(newData)
         const expected = headOrTail === 'head' ? (await fakeSearchLogGroup()).events : (await fakeGetLogEvents()).events
         assert.deepStrictEqual(newData.data, expected)
     }
@@ -82,59 +101,113 @@ describe('LogDataRegistry', async function () {
     })
 
     describe('updateLog', async function () {
-        it("properply paginates the results with 'head'", async () => {
+        it("properly paginates the results with 'head'", async () => {
             await testUpdateLog('head')
         })
 
-        it("properply paginates the results with 'tail'", async () => {
+        it("properly paginates the results with 'tail'", async () => {
             await testUpdateLog('tail')
         })
+    })
 
-        it('handles case of updating multiple times with new tokens', async () => {
-            const oldData = registry.getLogData(paginatedUri)
-            // check that oldData is unchanged.
-            assert(oldData)
-            assert.deepStrictEqual(oldData.data, paginatedData.data)
+    describe('updateLog pagination test', async function () {
+        const pageToken0 = undefined // Absence of token implies inital page
+        const pageToken1 = 'page1Token'
+        const pageToken2 = 'page2Token'
 
-            // Swap to use other paginate testing function
-            paginatedData.retrieveLogsFunction = returnNonEmptyPaginatedEvents
-
-            // Make first call.
-            await registry.updateLog(paginatedUri)
-            const firstUpdatedData = registry.getLogData(paginatedUri)
-            assert(firstUpdatedData)
-
-            const firstExpected = {
-                events: [addedEvent],
-                nextForwardToken: forwardToken,
-                nextBackwardToken: backwardToken,
+        function createCwlEvents(id: string, count: number): FilteredLogEvents {
+            let events: CloudWatchLogs.FilteredLogEvents = []
+            for (let i = 0; i < count; i++) {
+                events = events.concat({ message: `message-${id}`, logStreamName: `stream-${id}` })
             }
+            return events
+        }
+
+        async function buildCwlAction(isPage1Empty: boolean): Promise<CloudWatchLogsAction> {
+            return async function (
+                logGroupInfo: CloudWatchLogsGroupInfo,
+                parameters: CloudWatchLogsParameters,
+                nextToken?: CloudWatchLogs.NextToken
+            ) {
+                return getSimulatedCwlResponse(nextToken, isPage1Empty)
+            }
+        }
+
+        /**
+         * This function returns a simulated cloud watch logs reponse for a given token.
+         * @param token The page token
+         * @param isPage1Empty A flag to indicate if Page 1 should have data/isn't the tail.
+         * @returns
+         */
+        function getSimulatedCwlResponse(
+            token: CloudWatchLogs.NextToken | undefined,
+            isPage1Empty: boolean
+        ): CloudWatchLogsResponse {
+            switch (token) {
+                case pageToken1:
+                    if (isPage1Empty) {
+                        return { events: [], nextForwardToken: undefined, nextBackwardToken: pageToken0 }
+                    }
+                    return {
+                        events: createCwlEvents('P1', 1),
+                        nextForwardToken: pageToken2,
+                        nextBackwardToken: pageToken0,
+                    }
+                case pageToken2:
+                    return { events: [], nextForwardToken: undefined, nextBackwardToken: pageToken1 }
+                default: // pageToken0
+                    return {
+                        events: createCwlEvents('P0', 1),
+                        nextForwardToken: pageToken1,
+                        nextBackwardToken: undefined,
+                    }
+            }
+        }
+
+        it('can retrieve new logs when a page is updated', async () => {
+            // Swap to use other paginate testing function
+            const page1IsEmpty = true
+            paginatedData.retrieveLogsFunction = await buildCwlAction(page1IsEmpty)
+
+            // -- Make first call.
+            const firstUpdatedData = await updateLogAndGetResult(paginatedUri)
 
             const firstActual = {
                 events: firstUpdatedData.data,
                 nextForwardToken: firstUpdatedData.next?.token,
                 nextBackwardToken: firstUpdatedData.previous?.token,
             }
-
+            const firstExpected = getSimulatedCwlResponse(pageToken0, page1IsEmpty)
             assert.deepStrictEqual(firstActual, firstExpected)
 
-            // Make second call.
-            await registry.updateLog(paginatedUri)
-            const secondUpdatedData = registry.getLogData(paginatedUri)
-            assert(secondUpdatedData)
+            // -- Make second call.
+            const secondUpdatedData = await updateLogAndGetResult(paginatedUri)
 
-            const secondExpected = {
-                events: firstUpdatedData.data.concat((await fakeGetLogEvents()).events),
-                nextForwardToken: '',
-                nextBackwardToken: '',
-            }
             const secondActual = {
                 events: secondUpdatedData.data,
                 nextForwardToken: secondUpdatedData.next?.token,
                 nextBackwardToken: secondUpdatedData.previous?.token,
             }
+            // Expect the output to equal the first call since page 1 'does not exist yet'
+            assert.deepStrictEqual(secondActual, firstExpected)
 
-            assert.deepStrictEqual(secondActual, secondExpected)
+            // Simulate page 1 now getting data
+            secondUpdatedData.retrieveLogsFunction = await buildCwlAction(!page1IsEmpty)
+            registry.setLogData(paginatedUri, secondUpdatedData)
+
+            // -- Make third call.
+            const thirdUpdatedData = await updateLogAndGetResult(paginatedUri)
+
+            const thirdExpected = getSimulatedCwlResponse(pageToken1, !page1IsEmpty)
+            thirdExpected.events = firstExpected.events.concat(thirdExpected.events)
+
+            const thirdActual = {
+                events: thirdUpdatedData.data,
+                nextForwardToken: thirdUpdatedData.next?.token,
+                nextBackwardToken: thirdUpdatedData.previous?.token,
+            }
+
+            assert.deepStrictEqual(thirdActual, thirdExpected)
         })
     })
 

--- a/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
@@ -11,6 +11,7 @@ import { INSIGHTS_TIMESTAMP_FORMAT } from '../../../shared/constants'
 import { Settings } from '../../../shared/settings'
 import { CloudWatchLogsSettings, createURIFromArgs } from '../../../cloudWatchLogs/cloudWatchLogsUtils'
 import {
+    fakeGetLogEvents,
     fakeSearchLogGroup,
     logGroupsData,
     newLineData,
@@ -37,14 +38,15 @@ describe('LogDataRegistry', async function () {
         const oldData = registry.getLogData(paginatedUri)
         // check that oldData is unchanged.
         assert(oldData)
-        assert.strictEqual(oldData.data, paginatedData.data)
+        assert.deepStrictEqual(oldData.data, paginatedData.data)
 
         await registry.updateLog(paginatedUri, headOrTail)
 
         // check that newData is changed to what it should be.
         const newData = registry.getLogData(paginatedUri)
         assert(newData)
-        assert.deepStrictEqual(newData.data, (await fakeSearchLogGroup()).events)
+        const expected = headOrTail === 'head' ? (await fakeGetLogEvents()).events : (await fakeSearchLogGroup()).events
+        assert.deepStrictEqual(newData.data, expected)
     }
 
     beforeEach(function () {

--- a/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
@@ -73,7 +73,7 @@ describe('LogDataRegistry', async function () {
             // check that newData is changed to what it should be.
             const newData = registry.getLogData(paginatedUri)
             assert(newData)
-            assert.strictEqual(newData.data, (await fakeGetLogEvents()).events)
+            assert.deepStrictEqual(newData.data, (await fakeGetLogEvents()).events)
         })
     })
 

--- a/src/test/cloudWatchLogs/utils.test.ts
+++ b/src/test/cloudWatchLogs/utils.test.ts
@@ -17,6 +17,11 @@ import { CLOUDWATCH_LOGS_SCHEME } from '../../shared/constants'
 import { findOccurencesOf } from '../../shared/utilities/textDocumentUtilities'
 
 export const newText = 'a little longer now\n'
+export const addedEvent = {
+    message: 'this is an additional event',
+}
+export const forwardToken = 'forward'
+export const backwardToken = 'backward'
 
 export async function returnPaginatedEvents(
     logGroupInfo: CloudWatchLogsGroupInfo,
@@ -24,17 +29,29 @@ export async function returnPaginatedEvents(
     nextToken?: CloudWatchLogs.NextToken
 ) {
     switch (nextToken) {
-        case 'forward':
+        case forwardToken:
             return fakeGetLogEvents()
-        case 'backward':
+        case backwardToken:
             return fakeSearchLogGroup()
         default:
             return {
                 events: [],
-                nextForwardToken: 'forward',
-                nextBackwardToken: 'backward',
+                nextForwardToken: forwardToken,
+                nextBackwardToken: backwardToken,
             }
     }
+}
+
+export async function returnNonEmptyPaginatedEvents(
+    logGroupInfo: CloudWatchLogsGroupInfo,
+    parameters: CloudWatchLogsParameters,
+    nextToken?: CloudWatchLogs.NextToken
+) {
+    const result = await returnPaginatedEvents(logGroupInfo, parameters, nextToken)
+    if (result.events.length === 0) {
+        result.events = [addedEvent]
+    }
+    return result
 }
 
 export async function fakeGetLogEvents(): Promise<CloudWatchLogsResponse> {

--- a/src/test/cloudWatchLogs/utils.test.ts
+++ b/src/test/cloudWatchLogs/utils.test.ts
@@ -23,12 +23,17 @@ export async function returnPaginatedEvents(
     parameters: CloudWatchLogsParameters,
     nextToken?: CloudWatchLogs.NextToken
 ) {
-    if (nextToken) {
-        return fakeGetLogEvents()
-    }
-    return {
-        events: [],
-        nextForwardToken: 'this-is-a-token',
+    switch (nextToken) {
+        case 'forward':
+            return fakeGetLogEvents()
+        case 'backward':
+            return fakeSearchLogGroup()
+        default:
+            return {
+                events: [],
+                nextForwardToken: 'forward',
+                nextBackwardToken: 'backward',
+            }
     }
 }
 

--- a/src/test/cloudWatchLogs/utils.test.ts
+++ b/src/test/cloudWatchLogs/utils.test.ts
@@ -4,17 +4,33 @@
  */
 
 import * as assert from 'assert'
+import { CloudWatchLogs } from 'aws-sdk'
 import * as vscode from 'vscode'
 import { createURIFromArgs, parseCloudWatchLogsUri, uriToKey } from '../../cloudWatchLogs/cloudWatchLogsUtils'
 import {
     CloudWatchLogsParameters,
     CloudWatchLogsData,
     CloudWatchLogsResponse,
+    CloudWatchLogsGroupInfo,
 } from '../../cloudWatchLogs/registry/logDataRegistry'
 import { CLOUDWATCH_LOGS_SCHEME } from '../../shared/constants'
 import { findOccurencesOf } from '../../shared/utilities/textDocumentUtilities'
 
 export const newText = 'a little longer now\n'
+
+export async function returnPaginatedEvents(
+    logGroupInfo: CloudWatchLogsGroupInfo,
+    parameters: CloudWatchLogsParameters,
+    nextToken?: CloudWatchLogs.NextToken
+) {
+    if (nextToken) {
+        return fakeGetLogEvents()
+    }
+    return {
+        events: [],
+        nextForwardToken: 'this-is-a-token',
+    }
+}
 
 export async function fakeGetLogEvents(): Promise<CloudWatchLogsResponse> {
     return {
@@ -115,6 +131,17 @@ export const logGroupsData: CloudWatchLogsData = {
         regionName: 'thisIsARegionCode',
     },
     retrieveLogsFunction: fakeSearchLogGroup,
+    busy: false,
+}
+
+export const paginatedData: CloudWatchLogsData = {
+    data: [],
+    parameters: {},
+    logGroupInfo: {
+        groupName: 'g',
+        regionName: 'r',
+    },
+    retrieveLogsFunction: returnPaginatedEvents,
     busy: false,
 }
 export const goodUri = createURIFromArgs(testComponents.logGroupInfo, testComponents.parameters)


### PR DESCRIPTION
## Problem
Sometimes the results from cwl API return empty, with a `nextToken`. We don't account for this case. 
## Solution
Implement `getPaginatedAwsCallIter` in order to handle this case. 

**Note**: This is an addition to #2839 since it was not completed due to a failing unit test. This unit test is now resolved along with some other minor changes.

![Kapture 2022-12-13 at 14 33 37](https://user-images.githubusercontent.com/118216176/207428298-e1c3cbe7-d3ef-46a9-a0d1-976c3dbd898c.gif)



## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
