### PR TITLE
Gsweet/upload lambda skip prompt

### DIFF
--- a/.changes/next-release/Feature-bf5e2a43-174d-4549-a914-a4bda5bce0c5.json
+++ b/.changes/next-release/Feature-bf5e2a43-174d-4549-a914-a4bda5bce0c5.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Upload Lambda wizard will skip prompts and auto select parent directory when invoked from a template file."
+}

--- a/src/lambda/commands/uploadLambda.ts
+++ b/src/lambda/commands/uploadLambda.ts
@@ -212,9 +212,16 @@ export class UploadLambdaWizard extends Wizard<UploadLambdaWizardState> {
         super({ initState: { lambda } })
         this.form.lambda.region.bindPrompter(() => createRegionPrompter().transform(region => region.id))
 
-        if (invokePath && fs.statSync(invokePath.fsPath).isDirectory()) {
+        if (
+            (invokePath && fs.statSync(invokePath.fsPath).isDirectory()) ||
+            invokePath?.fsPath.endsWith('template.yaml')
+        ) {
             this.form.uploadType.setDefault('directory')
-            this.form.targetUri.setDefault(invokePath)
+            if (invokePath?.fsPath.endsWith('template.yaml')) {
+                this.form.targetUri.setDefault(vscode.Uri.file(path.dirname(invokePath.fsPath)))
+            } else {
+                this.form.targetUri.setDefault(invokePath)
+            }
         } else {
             this.form.uploadType.bindPrompter(() => createUploadTypePrompter())
             this.form.targetUri.bindPrompter(({ uploadType }) => {

--- a/src/lambda/commands/uploadLambda.ts
+++ b/src/lambda/commands/uploadLambda.ts
@@ -212,12 +212,9 @@ export class UploadLambdaWizard extends Wizard<UploadLambdaWizardState> {
         super({ initState: { lambda } })
         this.form.lambda.region.bindPrompter(() => createRegionPrompter().transform(region => region.id))
 
-        if (
-            (invokePath && fs.statSync(invokePath.fsPath).isDirectory()) ||
-            invokePath?.fsPath.endsWith('template.yaml')
-        ) {
+        if (invokePath) {
             this.form.uploadType.setDefault('directory')
-            if (invokePath?.fsPath.endsWith('template.yaml')) {
+            if (fs.statSync(invokePath.fsPath).isFile()) {
                 this.form.targetUri.setDefault(vscode.Uri.file(path.dirname(invokePath.fsPath)))
             } else {
                 this.form.targetUri.setDefault(invokePath)

--- a/src/test/lambda/wizards/uploadLambdaWizard.test.ts
+++ b/src/test/lambda/wizards/uploadLambdaWizard.test.ts
@@ -4,9 +4,11 @@
  */
 
 import * as vscode from 'vscode'
+import { writeFileSync } from 'fs-extra'
 import { createWizardTester, WizardTester } from '../../shared/wizards/wizardTestUtils'
 import { UploadLambdaWizard, UploadLambdaWizardState, LambdaFunction } from '../../../lambda/commands/uploadLambda'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
+import path = require('path')
 
 describe('UploadLambdaWizard', function () {
     let tester: WizardTester<UploadLambdaWizardState>
@@ -61,6 +63,29 @@ describe('UploadLambdaWizard', function () {
             tester.uploadType.assertValue('directory')
             tester.targetUri.assertDoesNotShow()
             tester.targetUri.assertValue(invokePath)
+            tester.lambda.name.assertShow(2)
+            tester.confirmedDeploy.assertShow(3)
+        })
+    })
+
+    describe('invoked from template', function () {
+        let tempDir: string
+        let tempDirUri: vscode.Uri
+        let invokePath: vscode.Uri
+        beforeEach(async function () {
+            tempDir = await makeTemporaryToolkitFolder()
+            tempDirUri = vscode.Uri.file(tempDir)
+            writeFileSync(path.join(tempDir, 'template.yaml'), '')
+            invokePath = vscode.Uri.file(path.join(tempDir, 'template.yaml'))
+            tester = createWizardTester(new UploadLambdaWizard(undefined, invokePath))
+        })
+
+        it('skip select directory, auto selected', function () {
+            tester.lambda.region.assertShow(1)
+            tester.uploadType.assertDoesNotShow()
+            tester.uploadType.assertValue('directory')
+            tester.targetUri.assertDoesNotShow()
+            tester.targetUri.assertValue(tempDirUri)
             tester.lambda.name.assertShow(2)
             tester.confirmedDeploy.assertShow(3)
         })

--- a/src/test/lambda/wizards/uploadLambdaWizard.test.ts
+++ b/src/test/lambda/wizards/uploadLambdaWizard.test.ts
@@ -4,11 +4,13 @@
  */
 
 import * as vscode from 'vscode'
+import * as path from 'path'
+import * as assert from 'assert'
+import * as fs from 'fs-extra'
 import { writeFileSync } from 'fs-extra'
 import { createWizardTester, WizardTester } from '../../shared/wizards/wizardTestUtils'
 import { UploadLambdaWizard, UploadLambdaWizardState, LambdaFunction } from '../../../lambda/commands/uploadLambda'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
-import path = require('path')
 
 describe('UploadLambdaWizard', function () {
     let tester: WizardTester<UploadLambdaWizardState>
@@ -56,6 +58,9 @@ describe('UploadLambdaWizard', function () {
             invokePath = vscode.Uri.file(tempDir)
             tester = createWizardTester(new UploadLambdaWizard(undefined, invokePath))
         })
+        afterEach(async function () {
+            await fs.remove(tempDir)
+        })
 
         it('skip select directory, auto selected', function () {
             tester.lambda.region.assertShow(1)
@@ -79,13 +84,16 @@ describe('UploadLambdaWizard', function () {
             invokePath = vscode.Uri.file(path.join(tempDir, 'template.yaml'))
             tester = createWizardTester(new UploadLambdaWizard(undefined, invokePath))
         })
+        afterEach(async function () {
+            await fs.remove(tempDir)
+        })
 
         it('skip select directory, auto selected', function () {
             tester.lambda.region.assertShow(1)
             tester.uploadType.assertDoesNotShow()
             tester.uploadType.assertValue('directory')
             tester.targetUri.assertDoesNotShow()
-            tester.targetUri.assertValue(tempDirUri)
+            assert.strictEqual(tester.targetUri.value?.fsPath, tempDirUri.fsPath)
             tester.lambda.name.assertShow(2)
             tester.confirmedDeploy.assertShow(3)
         })


### PR DESCRIPTION
## Problem
Invoking the context menu 'Upload Lambda...' on a `template.yaml` file prompts for directory when it isn't necessary.
## Solution
Auto select the parent directory of the `template.yaml` file as the target directory.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
