### PR TITLE
fix(auth): help button in "save connection" prompt does nothing

### DIFF
--- a/.changes/next-release/Bug Fix-1c8e7c12-027a-47d4-a6ed-30fdf16c0cb7.json
+++ b/.changes/next-release/Bug Fix-1c8e7c12-027a-47d4-a6ed-30fdf16c0cb7.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Help button on the \"save connection\" prompt does nothing"
+}

--- a/src/credentials/secondaryAuth.ts
+++ b/src/credentials/secondaryAuth.ts
@@ -31,7 +31,7 @@ async function promptUseNewConnection(newConn: Connection, oldConn: Connection, 
     } as const
 
     const helpButton = createHelpButton()
-    const openLink = () => helpButton.onClick()
+    const openLink = helpButton.onClick.bind(helpButton)
     helpButton.onClick = () => {
         telemetry.ui_click.emit({ elementId: 'connection_multiple_auths_help' })
         openLink()


### PR DESCRIPTION
## Problem
Help button doesn't work

## Solution
Fix the callback by binding instead of using an arrow function

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
