### PR TITLE
tests: add `value` to wizard tester

### DIFF
--- a/src/test/shared/wizards/wizardTestUtils.ts
+++ b/src/test/shared/wizards/wizardTestUtils.ts
@@ -10,6 +10,8 @@ import { Wizard } from '../../../shared/wizards/wizard'
 import { WizardForm } from '../../../shared/wizards/wizardForm'
 
 interface MockWizardFormElement<TProp> {
+    readonly value: TProp | undefined
+
     applyInput(input: TProp): void
     clearInput(): void
     /**
@@ -37,6 +39,7 @@ type MockForm<T, TState = T> = {
 }
 
 type FormTesterMethodKey = keyof MockWizardFormElement<any>
+const VALUE: FormTesterMethodKey = 'value'
 const APPLY_INPUT: FormTesterMethodKey = 'applyInput'
 const CLEAR_INPUT: FormTesterMethodKey = 'clearInput'
 const ASSERT_SHOW: FormTesterMethodKey = 'assertShow'
@@ -124,6 +127,8 @@ export function createWizardTester<T extends Partial<T>>(wizard: Wizard<T> | Wiz
 
                     // Using a switch rather than a map since a generic index signature is not yet possible
                     switch (prop) {
+                        case VALUE:
+                            return _.get(form.applyDefaults(state), path)
                         case APPLY_INPUT:
                             return <TProp>(input: TProp) => _.set(state, path, input)
                         case CLEAR_INPUT:


### PR DESCRIPTION
## Problem
The wizard tester is too rigid. `assertValue` always does a strict equal which doesn't work well for non-primitive types.
See https://github.com/aws/aws-toolkit-vscode/pull/3043

## Solution
Expose a `value` field so callers can make their own assertions.
Example usage:
```ts
assert.strictEqual(tester.someUriField.value?.fsPath, expectedUri.fsPath)
```

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
