### PR TITLE
fix(buildspec): Add install phase into buildspec template

### DIFF
--- a/src/shared/buildspec/activation.ts
+++ b/src/shared/buildspec/activation.ts
@@ -41,5 +41,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 
 const buildspecTemplate = `version: 0.2
 phases:
-  
+  install:
+    commands:
+      - ""
 `


### PR DESCRIPTION
## Problem
- Currently the buildspec template is pretty bare and technically invalid according to the schema

## Solution
- Introduce the install phase and commands to the buildspec template to make it valid

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
