### PR TITLE
fix(schemas): Improve template registry ownership model 

### DIFF
--- a/src/dynamicResources/awsResourceManager.ts
+++ b/src/dynamicResources/awsResourceManager.ts
@@ -27,6 +27,7 @@ export class AwsResourceManager {
     private folder: string | undefined
     private schemas: Map<string, Schema>
     private openResources: Map<string, ResourceNode | ResourceTypeNode>
+    private name = 'AwsResourceMananger'
 
     public constructor(private readonly extensionContext: vscode.ExtensionContext) {
         this.schemas = new Map<string, Schema>()
@@ -103,6 +104,7 @@ export class AwsResourceManager {
                     uri,
                     type: 'json',
                     schema: undefined,
+                    registry: this.name,
                 })
             }
 
@@ -202,6 +204,7 @@ export class AwsResourceManager {
                 uri,
                 type: 'json',
                 schema: location,
+                registry: this.name,
             },
             // Flush immediately so the onDidOpenTextDocument handler can work.
             true

--- a/src/shared/buildspec/registry.ts
+++ b/src/shared/buildspec/registry.ts
@@ -31,16 +31,16 @@ export class BuildspecTemplateRegistry extends WatchedFiles<BuildspecTemplate> {
                 template = yaml.load(templateAsYaml, {}) as BuildspecTemplate
             }
         } catch (e) {
-            globals.schemaService.registerMapping({ uri, type: 'yaml', schema: undefined, owner: this.name })
+            globals.schemaService.registerMapping({ uri, type: 'yaml', schema: undefined, registry: this.name })
             return undefined
         }
 
         if (template && template.version && template.phases) {
-            globals.schemaService.registerMapping({ uri, type: 'yaml', schema: 'buildspec', owner: this.name })
+            globals.schemaService.registerMapping({ uri, type: 'yaml', schema: 'buildspec', registry: this.name })
             return template
         }
 
-        globals.schemaService.registerMapping({ uri, type: 'yaml', schema: undefined, owner: this.name })
+        globals.schemaService.registerMapping({ uri, type: 'yaml', schema: undefined, registry: this.name })
         return undefined
     }
 
@@ -49,7 +49,7 @@ export class BuildspecTemplateRegistry extends WatchedFiles<BuildspecTemplate> {
             uri,
             type: 'yaml',
             schema: undefined,
-            owner: this.name,
+            registry: this.name,
         })
         await super.remove(uri)
     }

--- a/src/shared/extensions/yaml.ts
+++ b/src/shared/extensions/yaml.ts
@@ -32,28 +32,67 @@ function evaluate(schema: vscode.Uri | (() => vscode.Uri)): vscode.Uri {
 }
 
 export interface YamlExtension {
-    assignSchema(path: vscode.Uri, schema: vscode.Uri | (() => vscode.Uri)): void
-    removeSchema(path: vscode.Uri): void
-    getSchema(path: vscode.Uri): vscode.Uri | undefined
+    assignSchema(uri: vscode.Uri, registry: string, schema: vscode.Uri | (() => vscode.Uri)): void
+    removeSchema(uri: vscode.Uri, registry: string): void
+    getSchema(uri: vscode.Uri): string | undefined
+}
+
+// helper for declaring support for a schema for both cloud 9 and vscode
+function registerSchema(
+    path: string,
+    registry: string,
+    schema: vscode.Uri | (() => vscode.Uri),
+    schemaMap: Map<string, Map<string, vscode.Uri>>
+) {
+    const schemas = schemaMap.get(path)
+    if (!schemas) {
+        schemaMap.set(path, new Map())
+    }
+    schemaMap.set(path, schemaMap.get(path)!.set(registry, applyScheme(AWS_SCHEME, evaluate(schema))))
+}
+
+// helper for removing support for a schema for both cloud 9 and vscode
+function unregisterSchema(path: string, registry: string, schemaMap: Map<string, Map<string, vscode.Uri>>) {
+    const schemas = schemaMap.get(path)
+    if (!schemas) {
+        return
+    }
+    const removed = schemas.delete(registry)
+    if (removed) {
+        schemaMap.set(path, schemas)
+    }
+}
+
+// Get the schema that should be associated with the given path, if there are multiple then choose the first
+function getSchemas(path: string, schemaMap: Map<string, Map<string, vscode.Uri>>): string | undefined {
+    const schema = schemaMap.get(path)
+    if (!schema) {
+        return undefined
+    }
+    const possibleSchemas = Array.from(schema.values()).filter(schema => schema !== undefined)
+    if (possibleSchemas.length > 0) {
+        return possibleSchemas[0].toString()
+    }
+    return undefined
 }
 
 export async function activateYamlExtension(): Promise<YamlExtension | undefined> {
-    const schemaMap = new Map<string, vscode.Uri>()
+    const schemaMap = new Map<string, Map<string, vscode.Uri>>()
 
     if (isCloud9()) {
         // Until Cloud 9 supports VSCode-YAML out of the box, start the yaml-language-service
         // inside of the toolkit so that users can still have cfn/sam support
         const languageService = await activateYAMLLanguageService()
         return {
-            assignSchema: async (path, schema) => {
-                schemaMap.set(path.toString(), evaluate(schema))
+            assignSchema: (path, registry, schema) => {
+                registerSchema(path.fsPath, registry, schema, schemaMap)
                 configureLanguageService(languageService, schemaMap)
             },
-            removeSchema: path => {
-                schemaMap.delete(path.toString())
+            removeSchema: (path, registry) => {
+                unregisterSchema(path.fsPath, registry, schemaMap)
                 configureLanguageService(languageService, schemaMap)
             },
-            getSchema: path => schemaMap.get(path.toString()),
+            getSchema: path => getSchemas(path.fsPath, schemaMap),
         }
     }
 
@@ -64,7 +103,7 @@ export async function activateYamlExtension(): Promise<YamlExtension | undefined
     yamlExt.exports.registerContributor(
         AWS_SCHEME,
         resource => {
-            return schemaMap.get(resource)?.toString()
+            return getSchemas(vscode.Uri.parse(resource).fsPath, schemaMap)
         },
         uri => {
             try {
@@ -76,8 +115,10 @@ export async function activateYamlExtension(): Promise<YamlExtension | undefined
         }
     )
     return {
-        assignSchema: (path, schema) => schemaMap.set(path.toString(), applyScheme(AWS_SCHEME, evaluate(schema))),
-        removeSchema: path => schemaMap.delete(path.toString()),
-        getSchema: path => schemaMap.get(path.toString()),
+        assignSchema: (path, registry, schema) => {
+            registerSchema(path.fsPath, registry, schema, schemaMap)
+        },
+        removeSchema: (path, registry) => unregisterSchema(path.fsPath, registry, schemaMap),
+        getSchema: path => getSchemas(path.fsPath, schemaMap),
     }
 }

--- a/src/shared/extensions/yamlService.ts
+++ b/src/shared/extensions/yamlService.ts
@@ -91,13 +91,20 @@ export async function activateYAMLLanguageService(): Promise<LanguageService> {
     return yamlService
 }
 
-export function configureLanguageService(languageService: LanguageService, schemaMap: Map<string, vscode.Uri>): void {
+export function configureLanguageService(
+    languageService: LanguageService,
+    schemaMap: Map<string, Map<string, vscode.Uri>>
+): void {
     const schemaSettings: SchemasSettings[] = []
-    for (const [filePath, schemaUri] of schemaMap) {
-        schemaSettings.push({
-            fileMatch: [filePath],
-            uri: 'file://' + encodeURI(schemaUri.fsPath), // the file system path is encoded because os x has a space in the path and markdown will fail
-        })
+    for (const [filePath, schemas] of schemaMap) {
+        for (const [_, schemaUri] of schemas) {
+            if (schemaUri) {
+                schemaSettings.push({
+                    fileMatch: [filePath],
+                    uri: 'file://' + encodeURI(schemaUri.fsPath), // the file system path is encoded because os x has a space in the path and markdown will fail
+                })
+            }
+        }
     }
     languageService.configure({
         completion: true,

--- a/src/shared/fs/devfileRegistry.ts
+++ b/src/shared/fs/devfileRegistry.ts
@@ -26,13 +26,13 @@ export class DevfileRegistry extends WatchedFiles<Devfile> {
             const devfile = yaml.load(templateAsYaml) as Devfile
             // legacy (1.x) Devfiles do not contain a schemaVersion
             if (devfile.schemaVersion) {
-                globals.schemaService.registerMapping({ uri, type: 'yaml', schema: 'devfile' })
+                globals.schemaService.registerMapping({ uri, type: 'yaml', schema: 'devfile', registry: this.name })
                 return devfile
             }
         } catch (e) {
             getLogger().warn(`could not load Devfile "${uri.fsPath}": ${e}`)
         }
-        globals.schemaService.registerMapping({ uri, type: 'yaml', schema: undefined })
+        globals.schemaService.registerMapping({ uri, type: 'yaml', schema: undefined, registry: this.name })
         return undefined
     }
 
@@ -42,6 +42,7 @@ export class DevfileRegistry extends WatchedFiles<Devfile> {
             uri: uri,
             type: 'yaml',
             schema: undefined,
+            registry: this.name,
         })
         await super.remove(path)
     }

--- a/src/shared/fs/templateRegistry.ts
+++ b/src/shared/fs/templateRegistry.ts
@@ -35,7 +35,7 @@ export class CloudFormationTemplateRegistry extends WatchedFiles<CloudFormation.
                 template = await CloudFormation.load(path, false)
             }
         } catch (e) {
-            globals.schemaService.registerMapping({ uri, type: 'yaml', schema: undefined, owner: this.name })
+            globals.schemaService.registerMapping({ uri, type: 'yaml', schema: undefined, registry: this.name })
             return undefined
         }
 
@@ -44,16 +44,16 @@ export class CloudFormationTemplateRegistry extends WatchedFiles<CloudFormation.
         if (template.AWSTemplateFormatVersion || template.Resources) {
             if (template.Transform && template.Transform.toString().startsWith('AWS::Serverless')) {
                 // apply serverless schema
-                globals.schemaService.registerMapping({ uri, type: 'yaml', schema: 'sam', owner: this.name })
+                globals.schemaService.registerMapping({ uri, type: 'yaml', schema: 'sam', registry: this.name })
             } else {
                 // apply cfn schema
-                globals.schemaService.registerMapping({ uri, type: 'yaml', schema: 'cfn', owner: this.name })
+                globals.schemaService.registerMapping({ uri, type: 'yaml', schema: 'cfn', registry: this.name })
             }
 
             return template
         }
 
-        globals.schemaService.registerMapping({ uri, type: 'yaml', schema: undefined, owner: this.name })
+        globals.schemaService.registerMapping({ uri, type: 'yaml', schema: undefined, registry: this.name })
         return undefined
     }
 
@@ -63,7 +63,7 @@ export class CloudFormationTemplateRegistry extends WatchedFiles<CloudFormation.
             uri,
             type: 'yaml',
             schema: undefined,
-            owner: this.name,
+            registry: this.name,
         })
         await super.remove(uri)
     }

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -33,7 +33,7 @@ export type SchemaType = 'yaml' | 'json'
 export interface SchemaMapping {
     uri: vscode.Uri
     type: SchemaType
-    owner?: string
+    registry: string
     schema?: string | vscode.Uri
 }
 
@@ -56,7 +56,6 @@ export class SchemaService {
     private updateQueue: SchemaMapping[] = []
     private schemas?: Schemas
     private handlers: Map<SchemaType, SchemaHandler>
-    private owned: Map<vscode.Uri, SchemaMapping>
 
     public constructor(
         private readonly extensionContext: vscode.ExtensionContext,
@@ -75,7 +74,6 @@ export class SchemaService {
                 ['json', new JsonSchemaHandler()],
                 ['yaml', new YamlSchemaHandler()],
             ])
-        this.owned = new Map()
     }
 
     public isMapped(uri: vscode.Uri): boolean {
@@ -93,33 +91,15 @@ export class SchemaService {
     }
 
     /**
-     * Registers a schema mapping in the schema service. If the incoming mapping has an owner, then the mapping will be considered "owned".
-     * If the URI is owned (in the owners map), the update will only be processed if the incoming mapping owner is the same as the owned user OR
-     * the type of the schema changed
+     * Registers a schema mapping in the schema service
      *
      * @param mapping
      * @param flush Flush immediately instead of waiting for timer.
      */
     public registerMapping(mapping: SchemaMapping, flush?: boolean): void {
-        // The owner is undefined and needs to be set
-        const isOwnerUndefined =
-            !this.owned.has(mapping.uri) && mapping.owner !== undefined && mapping.schema !== undefined
-
-        // The owner and the incoming owner are defined but the schema changed
-        const isSchemaChanged =
-            this.owned.has(mapping.uri) &&
-            mapping.owner !== undefined &&
-            this.owned.get(mapping.uri)?.schema !== mapping.schema
-
-        if (isOwnerUndefined || isSchemaChanged) {
-            this.owned.set(mapping.uri, mapping)
-        }
-
-        if (mapping.owner === this.owned.get(mapping.uri)?.owner) {
-            this.updateQueue.push(mapping)
-            if (flush === true) {
-                this.processUpdates()
-            }
+        this.updateQueue.push(mapping)
+        if (flush === true) {
+            this.processUpdates()
         }
     }
 
@@ -351,6 +331,8 @@ export class YamlSchemaHandler implements SchemaHandler {
         return exists
     }
 
+    // Update which schemas should be assigned and removed.
+    // If multiple schemas are assigned to a single uri then use the first one is used
     async handleUpdate(mapping: SchemaMapping, schemas: Schemas): Promise<void> {
         if (!this.yamlExtension) {
             const ext = await activateYamlExtension()
@@ -362,9 +344,9 @@ export class YamlSchemaHandler implements SchemaHandler {
         }
 
         if (mapping.schema) {
-            this.yamlExtension.assignSchema(mapping.uri, resolveSchema(mapping.schema, schemas))
+            this.yamlExtension.assignSchema(mapping.uri, mapping.registry, resolveSchema(mapping.schema, schemas))
         } else {
-            this.yamlExtension.removeSchema(mapping.uri)
+            this.yamlExtension.removeSchema(mapping.uri, mapping.registry)
         }
     }
 }

--- a/src/test/shared/schemas.test.ts
+++ b/src/test/shared/schemas.test.ts
@@ -25,7 +25,9 @@ describe('SchemaService', function () {
     let config: Settings
     let fakeYamlExtension: YamlExtension
     const cfnSchema = vscode.Uri.file('cfn')
+    const cfnRegistry = 'cloudformation'
     const samSchema = vscode.Uri.file('sam')
+    const samRegistry = 'sam'
 
     beforeEach(async function () {
         fakeExtensionContext = await FakeExtensionContext.create()
@@ -49,15 +51,17 @@ describe('SchemaService', function () {
             uri: vscode.Uri.parse('/foo'),
             type: 'yaml',
             schema: 'cfn',
+            registry: cfnRegistry,
         })
         service.registerMapping({
             uri: vscode.Uri.parse('/bar'),
             type: 'yaml',
             schema: 'sam',
+            registry: samRegistry,
         })
         await service.processUpdates()
-        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), cfnSchema)).once()
-        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/bar')), samSchema)).once()
+        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), cfnRegistry, cfnSchema)).once()
+        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/bar')), samRegistry, samSchema)).once()
     })
 
     it('removes schemas from the yaml extension', async function () {
@@ -65,9 +69,10 @@ describe('SchemaService', function () {
             uri: vscode.Uri.parse('/foo'),
             type: 'yaml',
             schema: undefined,
+            registry: samRegistry,
         })
         await service.processUpdates()
-        verify(fakeYamlExtension.removeSchema(deepEqual(vscode.Uri.file('/foo')))).once()
+        verify(fakeYamlExtension.removeSchema(deepEqual(vscode.Uri.file('/foo')), samRegistry)).once()
     })
 
     it('registers schemas to json configuration', async function () {
@@ -75,6 +80,7 @@ describe('SchemaService', function () {
             uri: vscode.Uri.parse('/foo'),
             type: 'json',
             schema: 'cfn',
+            registry: cfnRegistry,
         })
         await service.processUpdates()
 
@@ -93,6 +99,7 @@ describe('SchemaService', function () {
             uri: vscode.Uri.parse('/foo'),
             type: 'json',
             schema: undefined,
+            registry: cfnRegistry,
         })
         await service.processUpdates()
 
@@ -116,9 +123,10 @@ describe('SchemaService', function () {
             uri: vscode.Uri.parse('/foo'),
             type: 'yaml',
             schema: 'cfn',
+            registry: cfnRegistry,
         })
         await service.processUpdates()
-        verify(fakeYamlExtension.assignSchema(anything(), anything())).never()
+        verify(fakeYamlExtension.assignSchema(anything(), anything(), anything())).never()
     })
 
     it('processes no updates if yaml extension unavailable', async function () {
@@ -129,131 +137,9 @@ describe('SchemaService', function () {
             uri: vscode.Uri.parse('/foo'),
             type: 'yaml',
             schema: 'cfn',
+            registry: cfnRegistry,
         })
         await service.processUpdates()
-        verify(fakeYamlExtension.assignSchema(anything(), anything())).never()
-    })
-
-    it('processes no updates if owner is different', async function () {
-        const testUri = vscode.Uri.parse('/foo')
-        service.registerMapping(
-            {
-                uri: testUri,
-                type: 'yaml',
-                schema: 'cfn',
-                owner: 'test_registry',
-            },
-            true
-        )
-        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), cfnSchema)).once()
-
-        service.registerMapping(
-            {
-                uri: testUri,
-                type: 'yaml',
-                schema: 'cfn',
-                owner: 'different_test_registry',
-            },
-            true
-        )
-        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), cfnSchema)).once()
-    })
-
-    it('processes updates if owner is the same', async function () {
-        const testUri = vscode.Uri.parse('/foo')
-        service.registerMapping(
-            {
-                uri: testUri,
-                type: 'yaml',
-                schema: 'cfn',
-                owner: 'test_registry',
-            },
-            true
-        )
-        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), cfnSchema)).once()
-
-        service.registerMapping(
-            {
-                uri: testUri,
-                type: 'yaml',
-                schema: 'sam',
-                owner: 'test_registry',
-            },
-            true
-        )
-        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), samSchema)).once()
-    })
-
-    it('processes updates if schema type changed', async function () {
-        const testUri = vscode.Uri.parse('/foo')
-        service.registerMapping(
-            {
-                uri: testUri,
-                type: 'yaml',
-                schema: 'cfn',
-                owner: 'test_registry',
-            },
-            true
-        )
-        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), cfnSchema)).once()
-
-        service.registerMapping(
-            {
-                uri: testUri,
-                type: 'yaml',
-                schema: 'sam',
-                owner: 'different_test_registry',
-            },
-            true
-        )
-        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), samSchema)).once()
-    })
-
-    it('processes updates if file becomes owned', async function () {
-        const testUri = vscode.Uri.parse('/foo')
-        service.registerMapping(
-            {
-                uri: testUri,
-                type: 'yaml',
-                schema: 'cfn',
-            },
-            true
-        )
-        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), cfnSchema)).once()
-
-        service.registerMapping(
-            {
-                uri: testUri,
-                type: 'yaml',
-                schema: 'sam',
-                owner: 'test_registry',
-            },
-            true
-        )
-        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), samSchema)).once()
-    })
-
-    it('processes no updates if non owner tries to change file', async function () {
-        const testUri = vscode.Uri.parse('/foo')
-        service.registerMapping(
-            {
-                uri: testUri,
-                type: 'yaml',
-                schema: 'cfn',
-                owner: 'test_registry',
-            },
-            true
-        )
-        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), cfnSchema)).once()
-
-        service.registerMapping(
-            {
-                uri: testUri,
-                type: 'yaml',
-                schema: 'sam',
-            },
-            true
-        )
-        verify(fakeYamlExtension.assignSchema(deepEqual(vscode.Uri.file('/foo')), samSchema)).never()
+        verify(fakeYamlExtension.assignSchema(anything(), anything(), anything())).never()
     })
 })


### PR DESCRIPTION
## Problem
- We currently have a concept of ownership in the template registry where a registry can declare that they "own" a uri. This is too fragile to work in practice and comes with too many edge cases (what happens if the owner isnt defined, etc, etc). This can lead to issues where the schema isn't getting correctly define for valid aws filetypes

## Solution
- Allow any template registry that defines a registry name to add a schema to a file uri. Then, when potential schemas are being evaluated use the first one that is defined. Since cfn/sam/buildspec are all distinct, we won't have any issues of them accidentally recognizing files that they shouldn't and it simplies the problem a lot

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
