### PR TITLE
codewhisperer: fix var assign error and move timestamp save

### DIFF
--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -244,14 +244,13 @@ export async function activate(context: ExtContext): Promise<void> {
                 context.extensionContext.globalState.get<boolean>(
                     CodeWhispererConstants.accessTokenMigrationDoNotShowAgainKey
                 ) || false
-            const notificationLastShown =
-                context.extensionContext.globalState.get<Date>(
+            const notificationLastShown: number =
+                context.extensionContext.globalState.get<number | undefined>(
                     CodeWhispererConstants.accessTokenMigrationDoNotShowAgainLastShown
-                ) || new Date()
+                ) || 1
 
             //Add 7 days to notificationLastShown to determine whether warn message should show
-            notificationLastShown.setDate(notificationLastShown.getDate() + 7)
-            if (doNotShowAgain || notificationLastShown <= t) {
+            if (doNotShowAgain || notificationLastShown + 1000 * 60 * 60 * 24 * 7 >= Date.now()) {
                 return
             } else if (t <= CodeWhispererConstants.accessTokenCutOffDate) {
                 vscode.window
@@ -277,7 +276,7 @@ export async function activate(context: ExtContext): Promise<void> {
                     })
                 context.extensionContext.globalState.update(
                     CodeWhispererConstants.accessTokenMigrationDoNotShowAgainLastShown,
-                    t
+                    Date.now()
                 )
             } else {
                 await globals.context.globalState.update(CodeWhispererConstants.accessToken, undefined)

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -247,14 +247,13 @@ export async function activate(context: ExtContext): Promise<void> {
             const notificationLastShown =
                 context.extensionContext.globalState.get<Date>(
                     CodeWhispererConstants.accessTokenMigrationDoNotShowAgainLastShown
-                ) || t
+                ) || new Date()
 
             //Add 7 days to notificationLastShown to determine whether warn message should show
             notificationLastShown.setDate(notificationLastShown.getDate() + 7)
             if (doNotShowAgain || notificationLastShown <= t) {
                 return
-            }
-            if (t <= CodeWhispererConstants.accessTokenCutOffDate) {
+            } else if (t <= CodeWhispererConstants.accessTokenCutOffDate) {
                 vscode.window
                     .showWarningMessage(
                         CodeWhispererConstants.accessTokenMigrationWarningMessage,
@@ -274,12 +273,12 @@ export async function activate(context: ExtContext): Promise<void> {
                                 CodeWhispererConstants.accessTokenMigrationDoNotShowAgainKey,
                                 true
                             )
-                            await context.extensionContext.globalState.update(
-                                CodeWhispererConstants.accessTokenMigrationDoNotShowAgainLastShown,
-                                t
-                            )
                         }
                     })
+                context.extensionContext.globalState.update(
+                    CodeWhispererConstants.accessTokenMigrationDoNotShowAgainLastShown,
+                    t
+                )
             } else {
                 await globals.context.globalState.update(CodeWhispererConstants.accessToken, undefined)
                 await vscode.commands.executeCommand('aws.codeWhisperer.refreshRootNode')

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -250,7 +250,7 @@ export async function activate(context: ExtContext): Promise<void> {
                 ) || 1
 
             //Add 7 days to notificationLastShown to determine whether warn message should show
-            if (doNotShowAgain || notificationLastShown + 1000 * 60 * 60 * 24 * 7 >= Date.now()) {
+            if (doNotShowAgain || notificationLastShown + (1000 * 60 * 60 * 24 * 7) >= Date.now()) {
                 return
             } else if (t <= CodeWhispererConstants.accessTokenCutOffDate) {
                 vscode.window

--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -241,6 +241,6 @@ export const accessTokenMigrationDoNotShowAgain = `Don\'t Show Again`
 export const accessTokenMigrationDoNotShowAgainKey = 'CODEWHISPERER_ACCESS_TOKEN_MIGRATION_DO_NOT_SHOW_AGAIN'
 
 export const accessTokenMigrationDoNotShowAgainLastShown =
-    'CODEWHISPERER_ACCESS_TOKEN_MIGRATION_DO_NOT_SHOW_AGAIN_LAST_SHOWN_TIMESTAMP'
+    'CODEWHISPERER_ACCESS_TOKEN_MIGRATION_DO_NOT_SHOW_AGAIN_LAST_SHOWN_TIME'
 
 export const accessTokenMigrationDoNotShowAgainInfo = `You will not receive this notification again. If you would like to continue using CodeWhisperer after January 31, 2023, you can still connect with AWS. [Learn More](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/codewhisper-setup-general.html).`

--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -241,6 +241,6 @@ export const accessTokenMigrationDoNotShowAgain = `Don\'t Show Again`
 export const accessTokenMigrationDoNotShowAgainKey = 'CODEWHISPERER_ACCESS_TOKEN_MIGRATION_DO_NOT_SHOW_AGAIN'
 
 export const accessTokenMigrationDoNotShowAgainLastShown =
-    'CODEWHISPERER_ACCESS_TOKEN_MIGRATION_DO_NOT_SHOW_AGAIN_LAST_SHOWN'
+    'CODEWHISPERER_ACCESS_TOKEN_MIGRATION_DO_NOT_SHOW_AGAIN_LAST_SHOWN_TIMESTAMP'
 
 export const accessTokenMigrationDoNotShowAgainInfo = `You will not receive this notification again. If you would like to continue using CodeWhisperer after January 31, 2023, you can still connect with AWS. [Learn More](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/codewhisper-setup-general.html).`


### PR DESCRIPTION
Fixes variable assignment error and moves warning message last seen timestamp so that timestamp is saved regardless of user action on popup.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
