### PR TITLE
fix(s3): handle content types more gracefully

### DIFF
--- a/.changes/next-release/Bug Fix-7b9e7b89-463b-444d-99f3-d3f19d921dc2.json
+++ b/.changes/next-release/Bug Fix-7b9e7b89-463b-444d-99f3-d3f19d921dc2.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "S3: uploading files overwrites existing content types"
+}

--- a/.changes/next-release/Bug Fix-7b9e7b89-463b-444d-99f3-d3f19d921dc2.json
+++ b/.changes/next-release/Bug Fix-7b9e7b89-463b-444d-99f3-d3f19d921dc2.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "S3: uploading files overwrites existing content types"
+	"description": "S3: saving files from the editor overwrites existing content types"
 }

--- a/.changes/next-release/Bug Fix-8cd5b4be-7da7-4c7b-982e-1d828f2387cc.json
+++ b/.changes/next-release/Bug Fix-8cd5b4be-7da7-4c7b-982e-1d828f2387cc.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "S3: file editor fails on binary files with no file extension"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "aws-toolkit-vscode",
-            "version": "1.58.0-SNAPSHOT",
+            "version": "1.61.0-SNAPSHOT",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/src/s3/commands/uploadFile.ts
+++ b/src/s3/commands/uploadFile.ts
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { S3 } from 'aws-sdk'
 import * as path from 'path'
-import { statSync } from 'fs'
+import * as mime from 'mime-types'
 import * as vscode from 'vscode'
-
+import { statSync } from 'fs'
+import { S3 } from 'aws-sdk'
 import { getLogger } from '../../shared/logger'
 import { S3Node } from '../explorer/s3Nodes'
 import { Commands } from '../../shared/vscode/commands'
@@ -365,6 +365,7 @@ async function uploadWithProgress(
         key: request.key,
         content: request.fileLocation,
         progressListener,
+        contentType: mime.contentType(path.extname(request.key)) || undefined,
     })
 
     progressListener(0)

--- a/src/s3/commands/uploadFile.ts
+++ b/src/s3/commands/uploadFile.ts
@@ -365,7 +365,7 @@ async function uploadWithProgress(
         key: request.key,
         content: request.fileLocation,
         progressListener,
-        contentType: mime.contentType(path.extname(request.key)) || undefined,
+        contentType: mime.contentType(path.extname(request.fileLocation.fsPath)) || undefined,
     })
 
     progressListener(0)

--- a/src/s3/explorer/s3BucketNode.ts
+++ b/src/s3/explorer/s3BucketNode.ts
@@ -5,13 +5,7 @@
 
 import * as vscode from 'vscode'
 import { ChildNodePage } from '../../awsexplorer/childNodeLoader'
-import {
-    Bucket,
-    CreateFolderRequest,
-    CreateFolderResponse,
-    S3Client,
-    UploadFileRequest,
-} from '../../shared/clients/s3Client'
+import { Bucket, CreateFolderRequest, CreateFolderResponse, S3Client } from '../../shared/clients/s3Client'
 
 import { AWSResourceNode } from '../../shared/treeview/nodes/awsResourceNode'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
@@ -89,14 +83,6 @@ export class S3BucketNode extends AWSTreeNodeBase implements AWSResourceNode, Lo
      */
     public async createFolder(request: CreateFolderRequest): Promise<CreateFolderResponse> {
         return this.s3.createFolder(request)
-    }
-
-    /**
-     * See {@link S3Client.uploadFile}.
-     */
-    public async uploadFile(request: UploadFileRequest): Promise<void> {
-        const managedUpload = await this.s3.uploadFile(request)
-        await managedUpload.promise()
     }
 
     /**

--- a/src/s3/explorer/s3FolderNode.ts
+++ b/src/s3/explorer/s3FolderNode.ts
@@ -4,14 +4,7 @@
  */
 
 import * as vscode from 'vscode'
-import {
-    Bucket,
-    CreateFolderRequest,
-    CreateFolderResponse,
-    Folder,
-    S3Client,
-    UploadFileRequest,
-} from '../../shared/clients/s3Client'
+import { Bucket, CreateFolderRequest, CreateFolderResponse, Folder, S3Client } from '../../shared/clients/s3Client'
 import { AWSResourceNode } from '../../shared/treeview/nodes/awsResourceNode'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 import { LoadMoreNode } from '../../shared/treeview/nodes/loadMoreNode'
@@ -88,14 +81,6 @@ export class S3FolderNode extends AWSTreeNodeBase implements AWSResourceNode, Lo
      */
     public async createFolder(request: CreateFolderRequest): Promise<CreateFolderResponse> {
         return this.s3.createFolder(request)
-    }
-
-    /**
-     * See {@link S3Client.uploadFile}.
-     */
-    public async uploadFile(request: UploadFileRequest): Promise<void> {
-        const managedUpload = await this.s3.uploadFile(request)
-        await managedUpload.promise()
     }
 
     public get arn(): string {

--- a/src/s3/fileViewerManager.ts
+++ b/src/s3/fileViewerManager.ts
@@ -215,7 +215,7 @@ export class S3FileViewerManager {
         const isTextDocument = contentType && mime.charset(contentType) == 'UTF-8'
 
         const uri = this.fileToUri(file, TabMode.Read)
-        if (await this.tryFocusTab(uri, uri.with({ scheme: this.schemes.read }))) {
+        if (await this.tryFocusTab(uri, uri.with({ scheme: this.schemes.edit }))) {
             return
         }
 
@@ -235,7 +235,7 @@ export class S3FileViewerManager {
      */
     public async openInEditMode(uriOrFile: vscode.Uri | S3File): Promise<void> {
         const uri = uriOrFile instanceof vscode.Uri ? uriOrFile : this.fileToUri(uriOrFile, TabMode.Edit)
-        const activeTab = await this.tryFocusTab(uri, uri.with({ scheme: this.schemes.edit }))
+        const activeTab = await this.tryFocusTab(uri, uri.with({ scheme: this.schemes.read }))
         const file = activeTab?.file ?? uriOrFile
 
         if (activeTab?.mode === TabMode.Edit) {

--- a/src/s3/fileViewerManager.ts
+++ b/src/s3/fileViewerManager.ts
@@ -16,6 +16,7 @@ import { s3FileViewerHelpUrl } from '../shared/constants'
 import { FileProvider, VirualFileSystem } from '../shared/virtualFilesystem'
 import { PromptSettings } from '../shared/settings'
 import { telemetry } from '../shared/telemetry/telemetry'
+import { UnknownError } from '../shared/errors'
 
 export const S3_EDIT_SCHEME = 's3'
 export const S3_READ_SCHEME = 's3-readonly'
@@ -54,8 +55,9 @@ export class S3FileProvider implements FileProvider {
         const stats = await this.client.headObject({ bucketName: bucket.name, key })
 
         this.updateETag(stats.ETag)
-        this._file.sizeBytes = stats.ContentLength
+        this._file.sizeBytes = stats.ContentLength ?? this._file.sizeBytes
         this._file.lastModified = stats.LastModified
+        this._file.ContentType = stats.ContentType
     }
 
     public async read(): Promise<Uint8Array> {
@@ -88,12 +90,13 @@ export class S3FileProvider implements FileProvider {
         return telemetry.s3_uploadObject.run(async span => {
             span.record({ component: 'viewer' })
 
+            const mimeType = mime.contentType(path.extname(this._file.name)) || undefined
             const result = await this.client
                 .uploadFile({
                     content,
                     key: this._file.key,
                     bucketName: this._file.bucket.name,
-                    contentType: mime.contentType(path.extname(this._file.name)) || undefined,
+                    contentType: this._file.ContentType ?? mimeType,
                 })
                 .then(u => u.promise())
 
@@ -123,8 +126,7 @@ export class S3FileViewerManager {
         private readonly fs: VirualFileSystem,
         private readonly window: typeof vscode.window = vscode.window,
         private readonly settings = PromptSettings.instance,
-        private readonly commands: typeof vscode.commands = vscode.commands,
-        private readonly workspace: typeof vscode.workspace = vscode.workspace
+        private readonly schemes = { read: S3_READ_SCHEME, edit: S3_EDIT_SCHEME }
     ) {
         this.disposables.push(this.registerTabCleanup())
     }
@@ -141,10 +143,15 @@ export class S3FileViewerManager {
     }
 
     private registerTabCleanup(): vscode.Disposable {
-        return this.workspace.onDidCloseTextDocument(async doc => {
+        return vscode.workspace.onDidCloseTextDocument(async doc => {
             const key = this.fs.uriToKey(doc.uri)
             await this.activeTabs[key]?.dispose()
         })
+    }
+
+    private async openUnknownDocument(fileUri: vscode.Uri): Promise<vscode.TextEditor | undefined> {
+        await vscode.commands.executeCommand('vscode.open', fileUri)
+        return this.window.visibleTextEditors.find(e => this.fs.uriToKey(e.document.uri) === this.fs.uriToKey(fileUri))
     }
 
     /**
@@ -160,21 +167,27 @@ export class S3FileViewerManager {
 
         // Defer to `vscode.open` for non-text files
         const contentType = mime.contentType(path.extname(fsPath))
-        if (contentType && mime.charset(contentType) != 'UTF-8') {
-            await this.commands.executeCommand('vscode.open', fileUri)
-            return this.window.visibleTextEditors.find(
-                e => this.fs.uriToKey(e.document.uri) === this.fs.uriToKey(fileUri)
-            )
+        if (!contentType || mime.charset(contentType) !== 'UTF-8') {
+            return this.openUnknownDocument(fileUri)
         }
 
-        const document = await this.workspace.openTextDocument(fileUri)
-        return await this.window.showTextDocument(document, options)
+        try {
+            const document = await vscode.workspace.openTextDocument(fileUri)
+            return await this.window.showTextDocument(document, options)
+        } catch (err) {
+            if (UnknownError.cast(err).message.match(/binary/)) {
+                getLogger().verbose(`S3FileViewer: unable to open "${fileUri.fsPath}" as text document: %s`, err)
+                return this.openUnknownDocument(fileUri)
+            }
+
+            throw err
+        }
     }
 
     private async closeEditor(editor: vscode.TextEditor | undefined): Promise<void> {
         if (editor && !editor.document.isClosed) {
             await this.window.showTextDocument(editor.document, { preserveFocus: false })
-            await this.commands.executeCommand('workbench.action.closeActiveEditor')
+            await vscode.commands.executeCommand('workbench.action.closeActiveEditor')
         }
     }
 
@@ -192,7 +205,7 @@ export class S3FileViewerManager {
                 await this.window.showTextDocument(activeTab.editor.document)
             } else {
                 getLogger().verbose(`S3FileViewer: Reopening non-text document`)
-                await this.commands.executeCommand('vscode.open', uri)
+                await vscode.commands.executeCommand('vscode.open', uri)
             }
 
             return activeTab
@@ -209,8 +222,8 @@ export class S3FileViewerManager {
         const contentType = mime.contentType(path.extname(file.name))
         const isTextDocument = contentType && mime.charset(contentType) == 'UTF-8'
 
-        const uri = S3FileViewerManager.fileToUri(file, TabMode.Read)
-        if (await this.tryFocusTab(uri, uri.with({ scheme: S3_EDIT_SCHEME }))) {
+        const uri = this.fileToUri(file, TabMode.Read)
+        if (await this.tryFocusTab(uri, uri.with({ scheme: this.schemes.read }))) {
             return
         }
 
@@ -224,13 +237,13 @@ export class S3FileViewerManager {
 
     /**
      * Opens the tab in edit mode with the use of an S3Tab, or shifts focus to an edit tab if any.
-     * Exiting read-only tabs are closed as they cannot be converted to edit tabs.
+     * Existing read-only tabs are closed as they cannot be converted to edit tabs.
      *
      * @param uriOrFile to be opened
      */
     public async openInEditMode(uriOrFile: vscode.Uri | S3File): Promise<void> {
-        const uri = uriOrFile instanceof vscode.Uri ? uriOrFile : S3FileViewerManager.fileToUri(uriOrFile, TabMode.Edit)
-        const activeTab = await this.tryFocusTab(uri, uri.with({ scheme: S3_READ_SCHEME }))
+        const uri = uriOrFile instanceof vscode.Uri ? uriOrFile : this.fileToUri(uriOrFile, TabMode.Edit)
+        const activeTab = await this.tryFocusTab(uri, uri.with({ scheme: this.schemes.edit }))
         const file = activeTab?.file ?? uriOrFile
 
         if (activeTab?.mode === TabMode.Edit) {
@@ -254,7 +267,7 @@ export class S3FileViewerManager {
             this.fs.registerProvider(uri, provider),
             provider.onDidChange(() => {
                 // TODO: find the correct node instead of refreshing it all
-                this.commands.executeCommand('aws.refreshAwsExplorer', true)
+                vscode.commands.executeCommand('aws.refreshAwsExplorer', true)
             })
         )
     }
@@ -267,7 +280,7 @@ export class S3FileViewerManager {
             throw new CancellationError('user')
         }
 
-        const uri = S3FileViewerManager.fileToUri(file, mode)
+        const uri = this.fileToUri(file, mode)
         const key = this.fs.uriToKey(uri)
         const provider = (this.providers[key] ??= this.registerProvider(file, uri))
         const editor = await this.openEditor(uri, { preview: mode === TabMode.Read })
@@ -353,8 +366,8 @@ export class S3FileViewerManager {
         })
     }
 
-    private static fileToUri(file: S3File, mode: TabMode): vscode.Uri {
-        const scheme = mode === TabMode.Read ? S3_READ_SCHEME : S3_EDIT_SCHEME
+    private fileToUri(file: S3File, mode: TabMode): vscode.Uri {
+        const scheme = mode === TabMode.Read ? this.schemes.read : this.schemes.edit
 
         return vscode.Uri.parse(`${scheme}:`, true).with({
             path: ['', file.bucket.region, file.bucket.name, file.key].join('/'),

--- a/src/shared/clients/s3Client.ts
+++ b/src/shared/clients/s3Client.ts
@@ -678,7 +678,7 @@ export interface File extends S3.Object, S3.HeadObjectOutput {
 export function toFile(bucket: Bucket, resp: RequiredProps<S3.Object, 'Key'>, delimiter = DEFAULT_DELIMITER): File {
     return {
         key: resp.Key,
-        arn: `${bucket.arn}${delimiter}${resp.Key}`,
+        arn: `${bucket.arn}/${resp.Key}`,
         name: resp.Key.split(delimiter).pop()!,
         eTag: resp.ETag,
         lastModified: resp.LastModified,

--- a/src/test/s3/util/fileViewerManager.test.ts
+++ b/src/test/s3/util/fileViewerManager.test.ts
@@ -244,6 +244,14 @@ describe('FileViewerManager', function () {
             assert.strictEqual(findEditors(textFile1.name)[0]?.document.uri.scheme, editScheme)
         })
 
+        it('re-uses tabs in edit mode when opening as read-only', async function () {
+            await fileViewerManager.openInEditMode({ ...textFile1, bucket })
+            await fileViewerManager.openInReadMode({ ...textFile1, bucket })
+            const editors = findEditors(textFile1.name)
+            assert.strictEqual(editors.length, 1)
+            assert.strictEqual(findEditors(textFile1.name)[0]?.document.uri.scheme, editScheme)
+        })
+
         it('can open in edit mode, showing a warning with two options', async function () {
             const shownMessage = testWindow.waitForMessage(/You are now editing an S3 file./).then(message => {
                 message.assertSeverity(SeverityLevel.Warning)

--- a/src/test/s3/util/fileViewerManager.test.ts
+++ b/src/test/s3/util/fileViewerManager.test.ts
@@ -6,23 +6,18 @@
 import * as assert from 'assert'
 import { ManagedUpload } from 'aws-sdk/clients/s3'
 import * as vscode from 'vscode'
-import { S3FileProvider, S3FileViewerManager, S3_EDIT_SCHEME, S3_READ_SCHEME } from '../../../s3/fileViewerManager'
-import {
-    DefaultBucket,
-    DefaultFile,
-    DefaultS3Client,
-    S3Client,
-    UploadFileRequest,
-} from '../../../shared/clients/s3Client'
+import { S3FileProvider, S3FileViewerManager } from '../../../s3/fileViewerManager'
+import { DefaultBucket, DefaultS3Client, File, toFile } from '../../../shared/clients/s3Client'
 import globals from '../../../shared/extensionGlobals'
 import { VirualFileSystem } from '../../../shared/virtualFilesystem'
 import { bufferToStream } from '../../../shared/utilities/streamUtilities'
 import { createTestWindow, TestWindow } from '../../shared/vscode/window'
-import { anything, instance, mock, when, resetCalls, verify } from '../../utilities/mockito'
 import { MockOutputChannel } from '../../mockOutputChannel'
 import { SeverityLevel } from '../../shared/vscode/message'
 import { assertTextEditorContains, closeAllEditors } from '../../testUtil'
 import { PromptSettings } from '../../../shared/settings'
+import { stub } from '../../utilities/stubber'
+import { assertHasProps } from '../../../shared/utilities/tsUtils'
 
 const bucket = new DefaultBucket({
     name: 'bucket-name',
@@ -30,36 +25,75 @@ const bucket = new DefaultBucket({
     partitionId: 'aws',
 })
 
-const bigImage = new DefaultFile({
-    bucketName: bucket.name,
-    eTag: '12345',
-    key: 'big-image.jpg',
-    sizeBytes: 5 * Math.pow(10, 6),
-    partitionId: 'aws',
+const bigImage = toFile(bucket, {
+    ETag: '12345',
+    Key: 'big-image.jpg',
+    Size: 5 * Math.pow(10, 6),
 })
 
 const computeTag = (content: Buffer) => content.toString()
 const makeFile = (key: string, content: Buffer) => {
     return Object.assign(
-        new DefaultFile({
-            key,
-            partitionId: 'aws',
-            bucketName: bucket.name,
-            eTag: computeTag(content),
-            sizeBytes: content.byteLength,
+        toFile(bucket, {
+            Key: key,
+            ETag: computeTag(content),
+            Size: content.byteLength,
+            LastModified: new Date(),
         }),
         { content }
     )
 }
 
+type DataFile = File & { readonly content: Buffer }
+function createS3() {
+    const files = new Map<string, DataFile>()
+    const client = stub(DefaultS3Client, { regionCode: bucket.region })
+    client.downloadFileStream.callsFake(async (_, key) => bufferToStream(getFile(key).content))
+    client.headObject.callsFake(async req => getFile(req.key))
+    client.uploadFile.callsFake(async req => {
+        if (req.content instanceof vscode.Uri) {
+            throw new Error('Did not expect a URI, expected a Buffer')
+        }
+        const newFile = {
+            ...makeFile(req.key, Buffer.from(req.content)),
+            ContentType: req.contentType,
+        }
+        assertHasProps(newFile, 'Key', 'ETag')
+        files.set(newFile.key, newFile)
+
+        const upload = stub(ManagedUpload)
+        upload.promise.resolves({
+            ...newFile,
+            Bucket: bucket.name,
+            Location: newFile.key,
+        })
+
+        return upload
+    })
+
+    function getFile(key: string) {
+        const file = files.get(key)
+        assert.ok(file, `No file found for key "${key}"`)
+
+        return file
+    }
+
+    function addFile(file: DataFile) {
+        assert.strictEqual(files.get(file.key), undefined, `File "${file.key}" already exists`)
+        files.set(file.key, file)
+    }
+
+    return { client, addFile, getFile }
+}
+
 describe('S3FileProvider', function () {
-    let s3: DefaultS3Client
+    const textFile = makeFile('file.txt', Buffer.from('content', 'utf-8'))
     let provider: S3FileProvider
-    let textFileContent: Buffer
-    let textFile: DefaultFile
-    let lastModified: Date
-    // We can just stub the `uploadFile` function instead, though this executes more code paths
-    let mockedUpload: ManagedUpload
+    let s3: ReturnType<typeof createS3>
+
+    function createProvider(file: DataFile) {
+        return new S3FileProvider(s3.client, { ...file, bucket })
+    }
 
     before(function () {
         // TODO: fix this dependency
@@ -67,45 +101,14 @@ describe('S3FileProvider', function () {
     })
 
     beforeEach(function () {
-        s3 = mock()
-        mockedUpload = mock()
-
-        textFileContent = Buffer.from('content', 'utf-8')
-        textFile = makeFile('file.txt', textFileContent)
-        lastModified = new Date()
-        provider = new S3FileProvider(instance(s3), { ...textFile, bucket })
-
-        when(s3.downloadFileStream(bucket.name, textFile.key)).thenCall(async () => bufferToStream(textFileContent))
-
-        when(s3.uploadFile(anything())).thenCall(async (request: UploadFileRequest) => {
-            // assumed that key + bucket is the same for all calls
-            if (request.content instanceof vscode.Uri) {
-                throw new Error('Did not expect a URI, expected a Buffer')
-            }
-            textFileContent = Buffer.from(request.content)
-            textFile = makeFile('file.txt', textFileContent)
-            lastModified = new Date()
-
-            return instance(mockedUpload)
-        })
-
-        when(s3.headObject(anything())).thenCall(async () => ({
-            ETag: computeTag(textFileContent),
-            ContentLength: textFile.sizeBytes,
-            LastModified: lastModified,
-        }))
-
-        when(mockedUpload.promise()).thenCall(async () => ({
-            ETag: computeTag(textFileContent),
-            Key: textFile.key,
-            Bucket: bucket.name,
-            Location: textFile.key, // not correct, needs to be a URI but doesn't matter here
-        }))
+        s3 = createS3()
+        s3.addFile(textFile)
+        provider = createProvider(textFile)
     })
 
     it('can read contents from s3', async function () {
         const content = await provider.read()
-        assert.deepStrictEqual(content, textFileContent)
+        assert.deepStrictEqual(content, s3.getFile(textFile.key).content)
     })
 
     it('can upload to s3', async function () {
@@ -119,7 +122,7 @@ describe('S3FileProvider', function () {
         assert.deepStrictEqual(stats, {
             ctime: 0,
             size: textFile.sizeBytes,
-            mtime: lastModified.getTime(),
+            mtime: textFile.lastModified?.getTime(),
         })
     })
 
@@ -131,35 +134,62 @@ describe('S3FileProvider', function () {
         await provider.write(Buffer.from('some text'))
         await changed
     })
+
+    it('uses mime type if no content type exists', async function () {
+        await provider.refresh()
+        await provider.write(Buffer.from('some text'))
+        assert.strictEqual(s3.getFile(textFile.key).ContentType, 'text/plain; charset=utf-8')
+    })
+
+    it('preserves content types if present', async function () {
+        const jsonFile = {
+            ...makeFile('json-blob', Buffer.from('{}')),
+            ContentType: 'application/json',
+        }
+        s3.addFile(jsonFile)
+        const newData = Buffer.from(JSON.stringify({ foo: 'bar' }))
+        const provider = createProvider(jsonFile)
+        await provider.refresh()
+        await provider.write(newData)
+
+        const result = s3.getFile(jsonFile.key)
+        assert.deepStrictEqual(result.content, newData)
+        assert.deepStrictEqual(result.ContentType, jsonFile.ContentType)
+    })
 })
 
 describe('FileViewerManager', function () {
-    let s3: S3Client
+    const readScheme = 's3-read-test'
+    const editScheme = 's3-edit-test'
+    let s3: ReturnType<typeof createS3>
     let fs: VirualFileSystem
     let fileViewerManager: S3FileViewerManager
     let testWindow: TestWindow
-    let workspace: typeof vscode.workspace
-    let commands: typeof vscode.commands
+    let disposables: vscode.Disposable[]
+
+    function findEditors(documentName: string, window = vscode.window) {
+        return window.visibleTextEditors.filter(e => e.document.fileName.endsWith(documentName))
+    }
 
     beforeEach(function () {
-        s3 = mock()
+        s3 = createS3()
         fs = new VirualFileSystem()
-        workspace = mock()
-        commands = mock()
         const window = (testWindow = createTestWindow())
 
-        fileViewerManager = new S3FileViewerManager(
-            () => instance(s3),
-            fs,
-            window,
-            new PromptSettings(),
-            instance(commands),
-            instance(workspace)
-        )
+        fileViewerManager = new S3FileViewerManager(() => s3.client, fs, window, new PromptSettings(), {
+            read: readScheme,
+            edit: editScheme,
+        })
+
+        disposables = [
+            vscode.workspace.registerFileSystemProvider(editScheme, fs),
+            vscode.workspace.registerFileSystemProvider(readScheme, fs, { isReadonly: true }),
+        ]
     })
 
     afterEach(async function () {
         await closeAllEditors()
+        vscode.Disposable.from(...disposables).dispose()
     })
 
     it('prompts if file size is greater than 4MB', async function () {
@@ -179,37 +209,22 @@ describe('FileViewerManager', function () {
         const textFile2Contents = Buffer.from('test2 contents', 'utf-8')
         const textFile2 = makeFile('test2.txt', textFile2Contents)
 
-        function mockOpen(file: ReturnType<typeof makeFile>, scheme: string = S3_READ_SCHEME) {
-            const expectedPath = `/${bucket.region}/${bucket.name}/${file.key}`
-
-            when(workspace.openTextDocument(anything())).thenCall(async (uri: vscode.Uri) => {
-                assert.strictEqual(uri.scheme, scheme)
-                assert.strictEqual(uri.path, expectedPath)
-                // Currently easier to open a new document, though this isn't _exactly_ what the user would see
-                return vscode.workspace.openTextDocument({ content: file.content.toString() })
-            })
-        }
-
         beforeEach(function () {
-            resetCalls(workspace)
+            s3.addFile(textFile1)
+            s3.addFile(textFile2)
         })
 
         it('opens a new editor if no document exists', async function () {
-            mockOpen(textFile1)
             await fileViewerManager.openInReadMode({ ...textFile1, bucket })
             await assertTextEditorContains(textFile1.content.toString())
         })
 
         it('closes the read-only tab when opening in edit mode', async function () {
-            mockOpen(textFile1)
             await fileViewerManager.openInReadMode({ ...textFile1, bucket })
-
-            when(commands.executeCommand('workbench.action.closeActiveEditor')).thenResolve()
-
-            mockOpen(textFile1, S3_EDIT_SCHEME)
             await fileViewerManager.openInEditMode({ ...textFile1, bucket })
-
-            verify(commands.executeCommand('workbench.action.closeActiveEditor')).once()
+            const editors = findEditors(textFile1.name)
+            assert.strictEqual(editors.length, 1)
+            assert.strictEqual(findEditors(textFile1.name)[0]?.document.uri.scheme, editScheme)
         })
 
         it('can open in edit mode, showing a warning with two options', async function () {
@@ -219,7 +234,6 @@ describe('FileViewerManager', function () {
                 return message
             })
 
-            mockOpen(textFile1, S3_EDIT_SCHEME)
             await fileViewerManager.openInEditMode({ ...textFile1, bucket })
 
             await assertTextEditorContains(textFile1.content.toString())
@@ -227,25 +241,30 @@ describe('FileViewerManager', function () {
         })
 
         it('re-uses an editor if already opened, focusing it', async function () {
-            mockOpen(textFile1)
             await fileViewerManager.openInReadMode({ ...textFile1, bucket })
-            mockOpen(textFile2)
             await fileViewerManager.openInReadMode({ ...textFile2, bucket })
 
             await assertTextEditorContains(textFile2.content.toString())
 
-            mockOpen(textFile1)
             await fileViewerManager.openInReadMode({ ...textFile1, bucket })
-
-            verify(workspace.openTextDocument(anything())).twice()
             await assertTextEditorContains(textFile1.content.toString())
+            assert.strictEqual(findEditors(textFile1.name).length, 1)
         })
 
         it('can open an S3 file with reserved URI characters', async function () {
             const contents = Buffer.from('text', 'utf-8')
             const file = makeFile('us-west-2:3cff280c/file.txt', contents)
+            s3.addFile(file)
 
-            mockOpen(file)
+            await fileViewerManager.openInReadMode({ ...file, bucket })
+            await assertTextEditorContains(contents.toString())
+        })
+
+        it('can open files with no file extension', async function () {
+            const contents = Buffer.from('text', 'utf-8')
+            const file = makeFile('us-west-2:3cff280c/file', contents)
+            s3.addFile(file)
+
             await fileViewerManager.openInReadMode({ ...file, bucket })
             await assertTextEditorContains(contents.toString())
         })

--- a/src/test/shared/clients/defaultS3Client.test.ts
+++ b/src/test/shared/clients/defaultS3Client.test.ts
@@ -305,6 +305,7 @@ describe('DefaultS3Client', function () {
                 key: fileKey,
                 content: fileLocation,
                 progressListener: progressCaptor.listener(),
+                contentType: 'image/jpeg',
             })
 
             verify(mockS3.upload(anything())).once()


### PR DESCRIPTION
## Problem
* Uploading files from the file editor overwrites the existing content type
    * #3055
* Non-text files without a file extension throw an error


## Solution
* Shift the `ContentType` parameter up so callers have to be explicit
* Treat files with no mime type as binary files

I also refactored `fileViewerManager.ts` a bit so it could be tested with significantly less mocks

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
