### PR TITLE
feat(sam): collect sam cli errors

### DIFF
--- a/src/shared/sam/cli/samCliInvokerUtils.ts
+++ b/src/shared/sam/cli/samCliInvokerUtils.ts
@@ -55,6 +55,42 @@ export function logAndThrowIfUnexpectedExitCode(processResult: ChildProcessResul
             message = processResult.error.message
         }
     }
+    const usefulErrors = collectAcceptedErrorMessages(processResult.stderr).join('\n')
+    throw makeUnexpectedExitCodeError(message ?? usefulErrors)
+}
 
-    throw makeUnexpectedExitCodeError(message ?? 'no message available')
+/**
+ * Collect known errors messages from a sam error message
+ * that may have multiple errors in one message.
+ * @param errors A string that can have multiple error messages
+ */
+export function collectAcceptedErrorMessages(errorMessage: string): string[] {
+    const errors = errorMessage.split('\n')
+    const shouldCollectFuncs = [_startsWithEscapeSequence, _startsWithError]
+    return errors.filter(error => {
+        return shouldCollectFuncs.some(shouldCollect => {
+            return shouldCollect(error)
+        })
+    })
+}
+
+/**
+ * Returns true if text starts with an escape
+ * sequence with one of the accepted sequences.
+ */
+function _startsWithEscapeSequence(text: string): boolean {
+    const escapeInDecimal = 27
+    if (text.charCodeAt(0) !== escapeInDecimal) {
+        return false
+    }
+
+    const remainingText = text.substring(1)
+    const acceptedSequences = ['[33m']
+    return acceptedSequences.some(code => {
+        return remainingText.startsWith(code)
+    })
+}
+
+function _startsWithError(text: string): boolean {
+    return text.startsWith('Error:')
 }

--- a/src/shared/sam/cli/samCliInvokerUtils.ts
+++ b/src/shared/sam/cli/samCliInvokerUtils.ts
@@ -66,7 +66,7 @@ export function logAndThrowIfUnexpectedExitCode(processResult: ChildProcessResul
  */
 export function collectAcceptedErrorMessages(errorMessage: string): string[] {
     const errors = errorMessage.split('\n')
-    const shouldCollectFuncs = [_startsWithEscapeSequence, _startsWithError]
+    const shouldCollectFuncs = [startsWithEscapeSequence, startsWithError]
     return errors.filter(error => {
         return shouldCollectFuncs.some(shouldCollect => {
             return shouldCollect(error)
@@ -75,22 +75,27 @@ export function collectAcceptedErrorMessages(errorMessage: string): string[] {
 }
 
 /**
+ * All accepted escape sequences.
+ */
+const yellowForeground = '[33m'
+const acceptedSequences = [yellowForeground]
+
+/**
  * Returns true if text starts with an escape
  * sequence with one of the accepted sequences.
  */
-function _startsWithEscapeSequence(text: string): boolean {
+function startsWithEscapeSequence(text: string, sequences = acceptedSequences): boolean {
     const escapeInDecimal = 27
     if (text.charCodeAt(0) !== escapeInDecimal) {
         return false
     }
 
     const remainingText = text.substring(1)
-    const acceptedSequences = ['[33m']
-    return acceptedSequences.some(code => {
+    return sequences.some(code => {
         return remainingText.startsWith(code)
     })
 }
 
-function _startsWithError(text: string): boolean {
+function startsWithError(text: string): boolean {
     return text.startsWith('Error:')
 }

--- a/src/test/shared/sam/cli/samCliInvokerUtils.test.ts
+++ b/src/test/shared/sam/cli/samCliInvokerUtils.test.ts
@@ -5,6 +5,7 @@
 
 import * as assert from 'assert'
 import {
+    collectAcceptedErrorMessages,
     logAndThrowIfUnexpectedExitCode,
     makeUnexpectedExitCodeError,
 } from '../../../../shared/sam/cli/samCliInvokerUtils'
@@ -40,5 +41,43 @@ describe('logAndThrowIfUnexpectedExitCode', async function () {
             'Correct error was not thrown'
         )
         await assertLogContainsBadExitInformation(getTestLogger(), childProcessResult, 456)
+    })
+})
+
+/**
+ * Returns a string with the 'Escape' character
+ * prepended to the given text.
+ *
+ * This exists because using '\e' does not
+ * work.
+ */
+function prependEscapeCode(text: string): string {
+    return String.fromCharCode(27) + text
+}
+
+describe('collectAcceptedErrorMessages()', async () => {
+    let result: string[]
+
+    before(async () => {
+        const input = [
+            prependEscapeCode('[33m This is an accepted escape sequence'),
+            prependEscapeCode('[100m This is not an accepted escape sequence'),
+            'This will be ignored',
+            'Error: This is accepted due to the prefix',
+        ].join('\n')
+        result = collectAcceptedErrorMessages(input)
+    })
+
+    it('has the expected amount of messages', async () => {
+        assert.strictEqual(result.length, 2)
+    })
+    it('collects the "Error:" prefix', async () => {
+        assert(result.includes('Error: This is accepted due to the prefix'))
+    })
+    it('collects accepted escape sequence prefixes', async () => {
+        assert(result.includes(prependEscapeCode('[33m This is an accepted escape sequence')))
+    })
+    it('ignores non-accepted escape sequence prefixes', async () => {
+        assert(!result.includes(prependEscapeCode('[100m This is not an accepted escape sequence')))
     })
 })


### PR DESCRIPTION
## Problem

The sam cli may fail when executing operations
internally. An example is trying to debug a
lambda using python, but a specific python
version does not exist.

## Solution

This commit now has the sam cli invoker collect
accepted errors (based off certain prefixes)
and throws them instead of indicating
'no message available'

You can test this by:
- Running the 'Extenstion' debugger
- Creating a python3.7 SAM lambda application
- Run and debug the lambda function
- This will induce an error telling you it could not find the python3.7 runtime (assuming you don't have it locally)

Signed-off-by: Nikolas Komonen <nkomonen@amazon.com>





<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
