### PR TITLE
fix(codewhisperer): Fix reject userDecision event reported as Discard

### DIFF
--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -110,7 +110,9 @@ class CodeWhispererInlineCompletionItemProvider implements vscode.InlineCompleti
         const truncatedSuggestion = this.truncateSuggestionOverlapWithRightContext(document, r.content)
         if (!r.content.startsWith(prefix) || truncatedSuggestion.length === 0) {
             //mark suggestion as Discard when it does not fit into the context
-            RecommendationHandler.instance.setSuggestionState(index, 'Discard')
+            if (RecommendationHandler.instance.getSuggestionState(index) !== 'Showed') {
+                RecommendationHandler.instance.setSuggestionState(index, 'Discard')
+            }
             return undefined
         }
         return {

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -104,12 +104,14 @@ class CodeWhispererInlineCompletionItemProvider implements vscode.InlineCompleti
         r: Recommendation,
         start: vscode.Position,
         end: vscode.Position,
-        index: number
+        index: number,
+        prefix: string
     ): vscode.InlineCompletionItem | undefined {
-        const prefix = document.getText(new vscode.Range(start, end)).replace(/\r\n/g, '\n')
+        if (!r.content.startsWith(prefix)) {
+            return undefined
+        }
         const truncatedSuggestion = this.truncateSuggestionOverlapWithRightContext(document, r.content)
-        if (!r.content.startsWith(prefix) || truncatedSuggestion.length === 0) {
-            //mark suggestion as Discard when it does not fit into the context
+        if (truncatedSuggestion.length === 0) {
             if (RecommendationHandler.instance.getSuggestionState(index) !== 'Showed') {
                 RecommendationHandler.instance.setSuggestionState(index, 'Discard')
             }
@@ -160,7 +162,7 @@ class CodeWhispererInlineCompletionItemProvider implements vscode.InlineCompleti
         ).length
         for (const i of iteratingIndexes) {
             const r = RecommendationHandler.instance.recommendations[i]
-            const item = this.getInlineCompletionItem(document, r, start, end, i)
+            const item = this.getInlineCompletionItem(document, r, start, end, i, prefix)
             if (item === undefined) {
                 continue
             }


### PR DESCRIPTION
## Problem
Reject userDecision event is misreported as Discard in below case:

When user saw a recommendation and keeps typing recommendation that does not match the prefix, the recommendation should be reported as Reject instead of Discard.

No changelog item is needed because this fix is not customer facing.

## Solution

This fix is verified against below test cases:
Test case 1: Accept a recommendation with no typeahead. Expect to see Accept, Unseen/Ignore (Depending on 2nd reco is seen or not) 
Test case 2: Reject a recommendation with no typeahead. Expect to see Reject, Unseen
Test case 3: Create typeahead not matching response before response arrives, continue typing, expect to see Discard, Unseen
Test case 4: Create typeahead not matching response after response arrives, continue typing, expect to see Reject, Unseen
Test case 5: When right context 100% match the recommendation, expect to see Discard.
Test case 6: Create typeahead not matching response before response arrives, continue typing, remove typeahead, see recommendation, then reject recommendation, expect to see Reject

A automated UX test is next step of this fix.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
