### PR TITLE
upload lambda: disable for image based lambdas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1460,22 +1460,22 @@
                 },
                 {
                     "command": "aws.invokeLambda",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsCloudFormationFunctionNode)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsCloudFormationFunctionNode|awsRegionFunctionNodeUploadable|awsRegionFunctionNodeDownloadableUploadable)$/",
                     "group": "0@1"
                 },
                 {
                     "command": "aws.downloadLambda",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsRegionFunctionNodeUploadable|awsRegionFunctionNodeDownloadableUploadable)$/",
                     "group": "0@2"
                 },
                 {
                     "command": "aws.uploadLambda",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsRegionFunctionNodeUploadable|awsRegionFunctionNodeDownloadableUploadable)$/",
                     "group": "1@1"
                 },
                 {
                     "command": "aws.deleteLambda",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsRegionFunctionNodeUploadable|awsRegionFunctionNodeDownloadableUploadable)$/",
                     "group": "4@1"
                 },
                 {
@@ -1615,12 +1615,12 @@
                 },
                 {
                     "command": "aws.copyName",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsCloudFormationFunctionNode|awsStateMachineNode|awsCloudFormationNode|awsS3BucketNode|awsS3FolderNode|awsS3FileNode|awsApiGatewayNode|awsIotThingNode)$|^(awsAppRunnerServiceNode|awsIotCertificateNode|awsIotPolicyNode|awsIotPolicyVersionNode)/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsCloudFormationFunctionNode|awsStateMachineNode|awsCloudFormationNode|awsS3BucketNode|awsS3FolderNode|awsS3FileNode|awsApiGatewayNode|awsIotThingNode)$|^(awsAppRunnerServiceNode|awsIotCertificateNode|awsIotPolicyNode|awsIotPolicyVersionNode|awsRegionFunctionNodeUploadable|awsRegionFunctionNodeDownloadableUploadable)/",
                     "group": "2@1"
                 },
                 {
                     "command": "aws.copyArn",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsCloudFormationFunctionNode|awsStateMachineNode|awsCloudFormationNode|awsCloudWatchLogNode|awsS3BucketNode|awsS3FolderNode|awsS3FileNode|awsApiGatewayNode|awsEcrRepositoryNode|awsIotThingNode)$|^(awsAppRunnerServiceNode|awsEcsServiceNode|awsIotCertificateNode|awsIotPolicyNode|awsIotPolicyVersionNode|awsMdeInstanceNode)/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsCloudFormationFunctionNode|awsStateMachineNode|awsCloudFormationNode|awsCloudWatchLogNode|awsS3BucketNode|awsS3FolderNode|awsS3FileNode|awsApiGatewayNode|awsEcrRepositoryNode|awsIotThingNode)$|^(awsAppRunnerServiceNode|awsEcsServiceNode|awsIotCertificateNode|awsIotPolicyNode|awsIotPolicyVersionNode|awsMdeInstanceNode|awsRegionFunctionNodeUploadable|awsRegionFunctionNodeDownloadableUploadable)/",
                     "group": "2@2"
                 },
                 {
@@ -2427,7 +2427,7 @@
                 "command": "aws.downloadLambda",
                 "title": "%AWS.command.downloadLambda%",
                 "category": "%AWS.title%",
-                "enablement": "viewItem == awsRegionFunctionNodeDownloadable",
+                "enablement": "viewItem =~ /^(awsRegionFunctionNodeDownloadable|awsRegionFunctionNodeDownloadableUploadable)$/",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2438,6 +2438,7 @@
                 "command": "aws.uploadLambda",
                 "title": "%AWS.command.uploadLambda%",
                 "category": "%AWS.title%",
+                "enablement": "viewItem =~ /^(awsRegionFunctionNodeUploadable|awsRegionFunctionNodeDownloadableUploadable)$/ || explorerResourceIsFolder || isFileSystemResource && resourceFilename =~ /^template\\.(json|yml|yaml)$/",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3464,7 +3465,7 @@
             "aws-stepfunctions-preview": {
                 "description": "AWS Contributed Icon",
                 "default": {
-                    "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
+                    "fontPath": "./resources\\fonts\\aws-toolkit-icons.woff",
                     "fontCharacter": "\\e1b7"
                 }
             }

--- a/src/lambda/commands/uploadLambda.ts
+++ b/src/lambda/commands/uploadLambda.ts
@@ -569,8 +569,23 @@ async function listAllLambdaNames(region: string, path?: vscode.Uri) {
     try {
         const foundLambdas = await toArrayAsync(listLambdaFunctions(lambdaClient))
         for (const l of foundLambdas) {
-            lambdaFunctionNames.push({ label: l.FunctionName!, data: l.FunctionName })
+            const item: DataQuickPickItem<string> = { label: l.FunctionName!, data: l.FunctionName }
+            if (l.PackageType === 'Image') {
+                item.invalidSelection = true
+                item.description = 'Cannot upload to this lambda'
+            }
+            lambdaFunctionNames.push(item)
         }
+        // sort invalid selections to the end
+        lambdaFunctionNames.sort((a, b) => {
+            if (a.invalidSelection && !b.invalidSelection) {
+                return 1
+            }
+            if (!a.invalidSelection && b.invalidSelection) {
+                return -1
+            }
+            return 0
+        })
     } catch (error) {
         getLogger().error('lambda: failed to list Lambda functions: %s', (error as Error).message)
     }

--- a/src/lambda/explorer/lambdaNodes.ts
+++ b/src/lambda/explorer/lambdaNodes.ts
@@ -20,6 +20,8 @@ import { samLambdaImportableRuntimes } from '../models/samLambdaRuntime'
 
 export const CONTEXT_VALUE_LAMBDA_FUNCTION = 'awsRegionFunctionNode'
 export const CONTEXT_VALUE_LAMBDA_FUNCTION_IMPORTABLE = 'awsRegionFunctionNodeDownloadable'
+export const CONTEXT_VALUE_LAMBDA_FUNCTION_UPLOADABLE = 'awsRegionFunctionNodeUploadable'
+export const CONTEXT_VALUE_LAMBDA_FUNCTION_IMPORTABLE_UPLOADABLE = 'awsRegionFunctionNodeDownloadableUploadable'
 
 /**
  * An AWS Explorer node representing the Lambda Service.
@@ -71,9 +73,17 @@ function makeLambdaFunctionNode(
     configuration: Lambda.FunctionConfiguration
 ): LambdaFunctionNode {
     const node = new LambdaFunctionNode(parent, regionCode, configuration)
-    node.contextValue = samLambdaImportableRuntimes.contains(node.configuration.Runtime ?? '')
-        ? CONTEXT_VALUE_LAMBDA_FUNCTION_IMPORTABLE
-        : CONTEXT_VALUE_LAMBDA_FUNCTION
 
+    if (samLambdaImportableRuntimes.contains(node.configuration.Runtime ?? '')) {
+        node.contextValue =
+            node.configuration.PackageType !== 'Image'
+                ? CONTEXT_VALUE_LAMBDA_FUNCTION_IMPORTABLE_UPLOADABLE
+                : CONTEXT_VALUE_LAMBDA_FUNCTION_IMPORTABLE
+    } else {
+        node.contextValue =
+            node.configuration.PackageType !== 'Image'
+                ? CONTEXT_VALUE_LAMBDA_FUNCTION_UPLOADABLE
+                : CONTEXT_VALUE_LAMBDA_FUNCTION
+    }
     return node
 }


### PR DESCRIPTION
## Problem
 The toolkit only supports 'Upload Lambda' when lambdas have a package type of 'zip'. Attempting to upload to an image based lambda results in an error.

## Solution
 Continue to show but disable the command on lambda nodes that have a package type of 'image'. The lambdas listed in the UploadLambdaWizard with this package type will be invalid (the user will not be able to select it) and a description has been added.

## Screenshot

![upload disabled](https://user-images.githubusercontent.com/25124281/208555302-8e380743-b5f2-4da3-87c2-7989dafd27ef.PNG)

![invalid seletion upload lambda](https://user-images.githubusercontent.com/25124281/208555783-7f796aa5-78d5-45c3-bbcf-153dabea9e0f.PNG)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
