### PR TITLE
fix(tests): Increase git buffer size so cfn/sam schema can be downloaded

### DIFF
--- a/src/shared/extensions/git.ts
+++ b/src/shared/extensions/git.ts
@@ -369,7 +369,7 @@ export class GitExtension {
 
                         return execFileAsync(api.git.path, ['cat-file', type, hash], {
                             cwd: tmpDir,
-                            maxBuffer: 1024 * 1024 * 5,
+                            maxBuffer: 1024 * 1024 * 6,
                         }).then(({ stdout }) => stdout)
                     },
                 }))


### PR DESCRIPTION
## Problem
Currently the integration tests in https://github.com/aws/aws-toolkit-vscode/pull/3042 are failing because the SAM schema fails to download with ```stdout maxBuffer length exceeded```

## Solution
Increase git buffer size

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
