### PR TITLE
fix(regions): prefer remote source over local source

### DIFF
--- a/.changes/next-release/Bug Fix-108e77f0-4ffa-4c67-9032-62f334fc84c7.json
+++ b/.changes/next-release/Bug Fix-108e77f0-4ffa-4c67-9032-62f334fc84c7.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "AWS regions are not dynamically fetched by the Toolkit"
+}

--- a/src/shared/regions/endpointsProvider.ts
+++ b/src/shared/regions/endpointsProvider.ts
@@ -21,19 +21,19 @@ export class EndpointsProvider {
 
     public async load(): Promise<Endpoints> {
         getLogger().info('Retrieving AWS endpoint data')
-        const localEndpointsJson = await this.localFetcher.get()
-        if (localEndpointsJson) {
-            const localEndpoints = loadEndpoints(localEndpointsJson)
-            if (localEndpoints) {
-                return localEndpoints
-            }
-        }
-
         const remoteEndpointsJson = await this.remoteFetcher.get()
         if (remoteEndpointsJson) {
             const remoteEndpoints = loadEndpoints(remoteEndpointsJson)
             if (remoteEndpoints) {
                 return remoteEndpoints
+            }
+        }
+
+        const localEndpointsJson = await this.localFetcher.get()
+        if (localEndpointsJson) {
+            const localEndpoints = loadEndpoints(localEndpointsJson)
+            if (localEndpoints) {
+                return localEndpoints
             }
         }
 

--- a/src/test/shared/regions/endpointsProvider.test.ts
+++ b/src/test/shared/regions/endpointsProvider.test.ts
@@ -43,4 +43,11 @@ describe('EndpointsProvider', async function () {
 
         assert.strictEqual(endpoints.partitions.length, 1)
     })
+
+    it('prefers remote fetcher over local fetcher', async function () {
+        const provider = new EndpointsProvider(fetcher1, fetcher2)
+        const endpoints = await provider.load()
+
+        assert.strictEqual(endpoints.partitions.length, 1)
+    })
 })


### PR DESCRIPTION
## Problem
`endpointsProvider.ts` is not using the remote endpoints file

## Solution
Rearrange the logic and add a test

### Notes
* `endpointsProvider.ts` is still flawed in that it never caches the remote manifest. **This PR is not a complete solution.**
* We should consider replacing our custom endpoints solution with public parameters: https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-public-parameters-global-infrastructure.html

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
