### PR TITLE
feat(codewhisperer): Add Client component latency telemetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
                 "yaml-cfn": "^0.3.1"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.82",
+                "@aws-toolkits/telemetry": "^1.0.87",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^8.1.0",
                 "@types/adm-zip": "^0.4.34",
@@ -1807,9 +1807,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.82",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.82.tgz",
-            "integrity": "sha512-TAjKR0pbN251PQecnvTcXb597lJZjIYBPjhbm5t/BX5nbHO1lJoMROZt8VxjkkK87YE4SHjNxF5l/0v+vhdhGw==",
+            "version": "1.0.87",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.87.tgz",
+            "integrity": "sha512-rN0s9YhU+SEIVTEojwuVm+Be3CXsTdIsg75PijVM9LdPqwNxzcSY2X/yU4K5R4QNMU160g4/qQ00BI9SdTJxKw==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",
@@ -16040,9 +16040,9 @@
             }
         },
         "@aws-toolkits/telemetry": {
-            "version": "1.0.82",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.82.tgz",
-            "integrity": "sha512-TAjKR0pbN251PQecnvTcXb597lJZjIYBPjhbm5t/BX5nbHO1lJoMROZt8VxjkkK87YE4SHjNxF5l/0v+vhdhGw==",
+            "version": "1.0.87",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.87.tgz",
+            "integrity": "sha512-rN0s9YhU+SEIVTEojwuVm+Be3CXsTdIsg75PijVM9LdPqwNxzcSY2X/yU4K5R4QNMU160g4/qQ00BI9SdTJxKw==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -3499,7 +3499,7 @@
         "report": "nyc report --reporter=html --reporter=json"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.82",
+        "@aws-toolkits/telemetry": "^1.0.87",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^8.1.0",
         "@types/adm-zip": "^0.4.34",

--- a/src/codewhisperer/client/codewhisperer.ts
+++ b/src/codewhisperer/client/codewhisperer.ts
@@ -20,6 +20,7 @@ import { getLogger } from '../../shared/logger'
 import { throttle } from 'lodash'
 import { Credentials } from 'aws-sdk'
 import { AuthUtil } from '../util/authUtil'
+import { TelemetryHelper } from '../util/telemetryHelper'
 
 const refreshCredentials = throttle(() => {
     getLogger().verbose('codewhisperer: invalidating expired credentials')
@@ -135,7 +136,9 @@ export class DefaultCodeWhispererClient {
 
     async createUserSdkClient(): Promise<CodeWhispererUserClient> {
         const isOptedOut = CodeWhispererSettings.instance.isOptoutEnabled()
+        TelemetryHelper.instance.setFetchCredentialStartTime()
         const bearerToken = await AuthUtil.instance.getBearerToken()
+        TelemetryHelper.instance.setSdkApiCallStartTime()
         return (await globals.sdkClientBuilder.createAwsService(
             Service,
             {

--- a/src/codewhisperer/commands/invokeRecommendation.ts
+++ b/src/codewhisperer/commands/invokeRecommendation.ts
@@ -14,6 +14,7 @@ import { KeyStrokeHandler } from '../service/keyStrokeHandler'
 import { isInlineCompletionEnabled } from '../util/commonUtil'
 import { InlineCompletionService } from '../service/inlineCompletionService'
 import { AuthUtil } from '../util/authUtil'
+import { TelemetryHelper } from '../util/telemetryHelper'
 
 /**
  * This function is for manual trigger CodeWhisperer
@@ -81,7 +82,8 @@ export async function invokeRecommendation(
             if (AuthUtil.instance.isConnectionExpired()) {
                 await AuthUtil.instance.showReauthenticatePrompt()
             }
-            InlineCompletionService.instance.getPaginatedRecommendation(client, editor, 'OnDemand', config)
+            TelemetryHelper.instance.setInvokeSuggestionStartTime()
+            await InlineCompletionService.instance.getPaginatedRecommendation(client, editor, 'OnDemand', config)
         } else {
             if (
                 !vsCodeState.isCodeWhispererEditing &&

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -171,6 +171,7 @@ class CodeWhispererInlineCompletionItemProvider implements vscode.InlineCompleti
             )
             this.nextMove = 0
             TelemetryHelper.instance.setFirstSuggestionShowTime()
+            TelemetryHelper.instance.tryRecordClientComponentLatency(document.languageId)
             this._onDidShow.fire()
             if (matchedCount >= 2 || RecommendationHandler.instance.hasNextToken()) {
                 return [item, { insertText: 'x' }]
@@ -365,6 +366,7 @@ export class InlineCompletionService {
                 showTimedMessage(CodeWhispererConstants.noSuggestions, 2000)
             }
         }
+        TelemetryHelper.instance.tryRecordClientComponentLatency(editor.document.languageId)
     }
 
     async showRecommendation(indexShift: number, isFirstRecommendation: boolean = false) {

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -170,6 +170,7 @@ class CodeWhispererInlineCompletionItemProvider implements vscode.InlineCompleti
                 r.references
             )
             this.nextMove = 0
+            TelemetryHelper.instance.setFirstSuggestionShowTime()
             this._onDidShow.fire()
             if (matchedCount >= 2 || RecommendationHandler.instance.hasNextToken()) {
                 return [item, { insertText: 'x' }]

--- a/src/codewhisperer/service/keyStrokeHandler.ts
+++ b/src/codewhisperer/service/keyStrokeHandler.ts
@@ -15,6 +15,7 @@ import { CodewhispererAutomatedTriggerType } from '../../shared/telemetry/teleme
 import { getTabSizeSetting } from '../../shared/utilities/editorUtilities'
 import { isInlineCompletionEnabled } from '../util/commonUtil'
 import { InlineCompletionService } from './inlineCompletionService'
+import { TelemetryHelper } from '../util/telemetryHelper'
 
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
@@ -155,7 +156,8 @@ export class KeyStrokeHandler {
                     RecommendationHandler.instance.isGenerateRecommendationInProgress = false
                 }
             } else if (isInlineCompletionEnabled()) {
-                InlineCompletionService.instance.getPaginatedRecommendation(
+                TelemetryHelper.instance.setInvokeSuggestionStartTime()
+                await InlineCompletionService.instance.getPaginatedRecommendation(
                     client,
                     editor,
                     'AutoTrigger',

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -201,6 +201,10 @@ export class RecommendationHandler {
                 nextToken = resp?.nextToken ? resp?.nextToken : ''
                 sessionId = resp?.$response?.httpResponse?.headers['x-amzn-sessionid']
                 TelemetryHelper.instance.setFirstResponseRequestId(requestId)
+                TelemetryHelper.instance.setSessionId(sessionId)
+                if (nextToken === '') {
+                    TelemetryHelper.instance.setAllPaginationEndTime()
+                }
             } else {
                 getLogger().info('Invalid Request : ', JSON.stringify(req, undefined, EditorContext.getTabSize()))
                 getLogger().verbose(`Invalid Request : ${JSON.stringify(req, undefined, EditorContext.getTabSize())}`)
@@ -309,11 +313,6 @@ export class RecommendationHandler {
         this.sessionId = sessionId
         this.nextToken = nextToken
         this.errorCode = errorCode
-
-        if (this.nextToken === '') {
-            TelemetryHelper.instance.setAllPaginationEndTime()
-            TelemetryHelper.instance.recordClientComponentLatency(sessionId, editor.document.languageId)
-        }
     }
 
     cancelPaginatedRequest() {

--- a/src/codewhisperer/util/telemetryHelper.ts
+++ b/src/codewhisperer/util/telemetryHelper.ts
@@ -160,10 +160,10 @@ export class TelemetryHelper {
         this.sessionId = ''
     }
 
+    /** This method is assumed to be invoked first at the start of execution **/
     public setInvokeSuggestionStartTime() {
-        if (this.invokeSuggestionStartTime === 0) {
-            this.invokeSuggestionStartTime = performance.now()
-        }
+         this.resetClientComponentLatencyTime()
+         this.invokeSuggestionStartTime = performance.now()
     }
 
     public setFetchCredentialStartTime() {

--- a/src/codewhisperer/util/telemetryHelper.ts
+++ b/src/codewhisperer/util/telemetryHelper.ts
@@ -35,6 +35,15 @@ export class TelemetryHelper {
 
     public startUrl: string | undefined
 
+    // timestamps to compute client component latency
+    private invokeSuggestionStartTime = 0
+    private fetchCredentialStartTime = 0
+    private sdkApiCallStartTime = 0
+    private sdkApiCallEndTime = 0
+    private firstSuggestionShowTime = 0
+    private allPaginationEndTime = 0
+    private firstResponseRequestId = ''
+
     constructor() {
         this.triggerType = 'OnDemand'
         this.CodeWhispererAutomatedtriggerType = 'KeyStrokeCount'
@@ -136,5 +145,75 @@ export class TelemetryHelper {
 
     public isTelemetryEnabled(): boolean {
         return globals.telemetry.telemetryEnabled
+    }
+
+    public resetClientComponentLatencyTime() {
+        this.invokeSuggestionStartTime = 0
+        this.sdkApiCallStartTime = 0
+        this.sdkApiCallEndTime = 0
+        this.fetchCredentialStartTime = 0
+        this.firstSuggestionShowTime = 0
+        this.allPaginationEndTime = 0
+        this.firstResponseRequestId = ''
+    }
+
+    public setInvokeSuggestionStartTime() {
+        if (this.invokeSuggestionStartTime === 0) {
+            this.invokeSuggestionStartTime = performance.now()
+        }
+    }
+
+    public setSdkApiCallStartTime() {
+        if (this.sdkApiCallStartTime === 0) {
+            this.sdkApiCallStartTime = performance.now()
+        }
+    }
+
+    public setSdkApiCallEndTime() {
+        if (this.sdkApiCallEndTime === 0) {
+            this.sdkApiCallEndTime = performance.now()
+        }
+    }
+
+    public setFetchCredentialStartTime() {
+        if (this.fetchCredentialStartTime === 0) {
+            this.fetchCredentialStartTime = performance.now()
+        }
+    }
+
+    public setFirstSuggestionShowTime() {
+        if (this.firstSuggestionShowTime === 0) {
+            this.firstSuggestionShowTime = performance.now()
+        }
+    }
+
+    public setFirstResponseRequestId(requestId: string) {
+        if (this.firstResponseRequestId === '') {
+            this.firstResponseRequestId = requestId
+        }
+    }
+
+    public setAllPaginationEndTime() {
+        if (this.allPaginationEndTime === 0) {
+            this.allPaginationEndTime = performance.now()
+        }
+    }
+
+    public recordClientComponentLatency(sessionId: string, languageId: string) {
+        telemetry.codewhisperer_clientComponentLatency.emit({
+            codewhispererRequestId: this.firstResponseRequestId,
+            codewhispererSessionId: sessionId,
+            codewhispererFirstCompletionLatency: this.sdkApiCallEndTime - this.invokeSuggestionStartTime,
+            codewhispererEndToEndLatency: this.firstSuggestionShowTime - this.invokeSuggestionStartTime,
+            codewhispererAllCompletionsLatency: this.allPaginationEndTime - this.invokeSuggestionStartTime,
+            codewhispererPostprocessingLatency: this.firstSuggestionShowTime - this.sdkApiCallEndTime,
+            codewhispererCredentialFetchingLatency: this.sdkApiCallStartTime - this.fetchCredentialStartTime,
+            codewhispererPreprocessingLatency: this.fetchCredentialStartTime - this.invokeSuggestionStartTime,
+            codewhispererCompletionType: this.completionType,
+            codewhispererTriggerType: this.triggerType,
+            codewhispererLanguage: runtimeLanguageContext.getLanguageContext(languageId).language,
+            credentialStartUrl: this.startUrl,
+        })
+        this.resetClientComponentLatencyTime()
     }
 }


### PR DESCRIPTION
## Problem

Adding a new telemetry : Client component latency for codewhisperer.

This telemetry's definition in https://github.com/aws/aws-toolkit-common/commit/618a9fb1585d0e7131901a9c4f3ac60ff4a3111f. 

A client component latency metric is emitted only once for each complete GenerationRecommendation pagination session if the suggestion is shown to the user.

```

{
            "name": "codewhispererFirstCompletionLatency",
            "type": "double",
            "description": "The time it takes for the response to be received after the plugin makes a first GenerateCompletions API call."
        },
        {
            "name": "codewhispererEndToEndLatency",
            "type": "double",
            "description": "The time it takes for the first completion to be shown in the IDE after the user performs the CW trigger action."
        },
        {
            "name": "codewhispererAllCompletionsLatency",
            "type": "double",
            "description": "The time it takes for the last GenerateCompletions response to be received after plugin makes a first call to GenerateCompletions API."
        },
        {
            "name": "codewhispererPostprocessingLatency",
            "type": "double",
            "description": "The time it takes for the first completions to be displayed in the IDE after the plugin receives the initial Completions object."
        },
        {
            "name": "codewhispererPreprocessingLatency",
            "type": "double",
            "description": "The time it takes for the plugin to make the first GenerateCompletions API call after the user performs the CW trigger action."
        },
        {
            "name": "codewhispererCredentialFetchingLatency",
            "type": "double",
            "description": "The time it takes to get the Sono/SSO credential for the invocation."
        },

```

This change is not customer facing, no change log is needed. 

## Solution

Record timestamp and compare the timestamp to build the Client component latency metric and report it to service.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
