### PR TITLE
ux(yaml): Improve install YAML extension prompt message

### DIFF
--- a/src/shared/extensions/yamlActivation.ts
+++ b/src/shared/extensions/yamlActivation.ts
@@ -177,9 +177,9 @@ async function promptInstallYamlPlugin(disposables: vscode.Disposable[], templat
     const response = await vscode.window.showInformationMessage(
         localize(
             'AWS.message.info.yaml.prompt',
-            'Install YAML extension for more {0} features in {1} files',
-            getIdeProperties().company,
-            template
+            'For inline {0} template support from {1}, install the YAML extension',
+            template,
+            getIdeProperties().company
         ),
         installBtn,
         dontShow


### PR DESCRIPTION
This was a UX suggestion from Jo

## Problem
- install YAML extension text should be more clear about what installing the extension does and why users should install it

## Solution
- Update the install the YAML extension text to say what installing the extension actually does

![Screen Shot 2023-01-11 at 10 14 05 AM](https://user-images.githubusercontent.com/103940141/211846224-d4e867e6-917a-4df5-af3f-5720008e2732.png)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
