### PR TITLE
Fix/asl visualizer no internet

### DIFF
--- a/.changes/next-release/Bug Fix-5dd44ab8-9083-4dd8-ac28-585d99895aca.json
+++ b/.changes/next-release/Bug Fix-5dd44ab8-9083-4dd8-ac28-585d99895aca.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Add fallback to local cached files for Step Function Visualizations where host doesn't have internet."
+}

--- a/src/stepFunctions/commands/visualizeStateMachine/aslVisualizationManager.ts
+++ b/src/stepFunctions/commands/visualizeStateMachine/aslVisualizationManager.ts
@@ -33,7 +33,20 @@ export class AslVisualizationManager extends AbstractAslVisualizationManager {
 
         // Existing visualization does not exist, construct new visualization
         try {
-            await this.cache.updateCache(globalStorage)
+            try {
+                await this.cache.updateCache(globalStorage)
+            } catch (err) {
+                // So we can't update the cache, but can we use an existing on disk version.
+                try {
+                    logger.warn(
+                        'Updating State Machine Graph Visualisation assets failed, checking for fallback local cache.'
+                    )
+                    await this.cache.confirmCacheExists()
+                } catch (err) {
+                    logger.error('No local cached State Machine Graph Visualization assets found.')
+                    throw err
+                }
+            }
 
             const newVisualization = new AslVisualization(document)
             this.handleNewVisualization(document.uri.fsPath, newVisualization)

--- a/src/test/stepFunctions/utils.test.ts
+++ b/src/test/stepFunctions/utils.test.ts
@@ -119,6 +119,42 @@ describe('StateMachineGraphCache', function () {
             assert.ok(globalStorage.update.notCalled)
             assert.ok(writeFile.notCalled)
         })
+        it('it passes if both files required exist', async function () {
+            const getFileData = sinon.stub().resolves(true)
+            const fileExists = sinon.stub().resolves(true)
+
+            const writeFile = sinon.spy()
+
+            const cache = new StateMachineGraphCache({
+                getFileData,
+                fileExists,
+                writeFile,
+                cssFilePath: '',
+                jsFilePath: '',
+                dirPath: '',
+            })
+
+            await cache.confirmCacheExists()
+
+            assert.ok(fileExists.calledTwice)
+        })
+        it('it rejects if both files required do not exist on filesystem', async function () {
+            const getFileData = sinon.stub()
+            const fileExists = sinon.stub().onFirstCall().resolves(true).onSecondCall().resolves(false)
+
+            const writeFile = sinon.spy()
+
+            const cache = new StateMachineGraphCache({
+                getFileData,
+                fileExists,
+                writeFile,
+                cssFilePath: 'one',
+                jsFilePath: 'two',
+                dirPath: '',
+            })
+
+            assert.rejects(cache.confirmCacheExists())
+        })
 
         it('creates assets directory when it does not exist', async function () {
             const globalStorage = {


### PR DESCRIPTION
PR for #2922 - sfn render fails if host has no internet connectivity, even with cached files present locally.

## Problem
Step Function Visualizer fails to render graph due to trying to source the graph.js and graph.css files from the internet on an disconnected c9/code instance - even when those files are available locally.
## Solution
On failure of network connectivity, falls back to local files where they both exist.

- [x] Tests added
- [x] Changelog updated
- [ ] Open to futher feedback on implementation from maintainers.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
