### PR TITLE
feat(sam): improved TypeScript support

### DIFF
--- a/.changes/next-release/Feature-46a93a97-f979-4c7a-9a8d-f241a30987b6.json
+++ b/.changes/next-release/Feature-46a93a97-f979-4c7a-9a8d-f241a30987b6.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Improved typescript support to match jetbrains plugin"
+}

--- a/.changes/next-release/Feature-46a93a97-f979-4c7a-9a8d-f241a30987b6.json
+++ b/.changes/next-release/Feature-46a93a97-f979-4c7a-9a8d-f241a30987b6.json
@@ -1,4 +1,4 @@
 {
 	"type": "Feature",
-	"description": "Improved typescript support to match jetbrains plugin"
+	"description": "SAM: run/debug now works for a larger variety of TypeScript projects"
 }

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -187,6 +187,7 @@ async function activateCodeLensProviders(
         supportedLanguages[javaLensProvider.JAVA_LANGUAGE] = javaCodeLensProvider
         supportedLanguages[csLensProvider.CSHARP_LANGUAGE] = csCodeLensProvider
         supportedLanguages[goLensProvider.GO_LANGUAGE] = goCodeLensProvider
+        supportedLanguages[jsLensProvider.TYPESCRIPT_LANGUAGE] = tsCodeLensProvider
     }
 
     disposables.push(

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -49,7 +49,7 @@ import {
     AwsSamDebugConfigurationValidator,
     DefaultAwsSamDebugConfigurationValidator,
 } from './awsSamDebugConfigurationValidator'
-import { makeInputTemplate, makeJsonFiles } from '../localLambdaRunner'
+import { getInputTemplatePath, makeInputTemplate, makeJsonFiles } from '../localLambdaRunner'
 import { SamLocalInvokeCommand } from '../cli/samCliLocalInvoke'
 import { getCredentialsFromStore } from '../../../credentials/credentialsStore'
 import { fromString } from '../../../credentials/providers/credentials'
@@ -466,7 +466,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
             codeConfig.invokeTarget.projectRoot = pathutil.normalize(
                 resolve(folder.uri.fsPath, config.invokeTarget.projectRoot)
             )
-            templateInvoke.templatePath = await makeInputTemplate(codeConfig)
+            templateInvoke.templatePath = getInputTemplatePath(codeConfig)
         }
 
         const isZip = CloudFormation.isZipLambdaResource(templateResource?.Properties)
@@ -600,6 +600,9 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
             envFile: '', // Populated by makeConfig().
             apiPort: apiPort,
             debugPort: debugPort,
+            invokeTarget: {
+                ...config.invokeTarget,
+            },
             lambda: {
                 ...config.lambda,
                 memoryMb: lambdaMemory,
@@ -654,6 +657,13 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
                 throw new ToolkitError(message, { code: 'UnsupportedRuntime' })
             }
         }
+
+        // generate template for target=code
+        if (launchConfig.invokeTarget.target === 'code') {
+            const codeConfig = launchConfig as SamLaunchRequestArgs & { invokeTarget: { target: 'code' } }
+            await makeInputTemplate(codeConfig)
+        }
+
         await makeJsonFiles(launchConfig)
 
         // Set the type, then vscode will pass the config to SamDebugSession.attachRequest().

--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -152,7 +152,7 @@ async function compileTypeScript(config: SamLaunchRequestArgs): Promise<void> {
 
     const loadBaseConfig = (tsConfigPath: PathLike) => {
         if (!existsSync(tsConfigPath)) {
-            return null
+            return undefined
         }
 
         try {
@@ -163,13 +163,13 @@ async function compileTypeScript(config: SamLaunchRequestArgs): Promise<void> {
             getLogger('channel').error(`Unable to use TypeScript base: ${tsConfigPath}`)
         }
 
-        return null
+        return undefined
     }
 
     const tsConfigPath = path.join(config.codeRoot, TS_CONFIG_FILE)
     const tsOutputPath = path.join(config.codeRoot, TS_BUILD_DIR)
 
-    let tsConfig =
+    const tsConfig =
         loadBaseConfig(tsConfigPath) || loadBaseConfig(path.join(config.codeRoot, TS_CONFIG_INITIAL_BASE_FILE)) || {}
 
     if (Object.keys(tsConfig).length === 0) {

--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { existsSync, PathLike, readFileSync } from 'fs'
 import { writeFileSync } from 'fs-extra'
 import * as path from 'path'
 import * as vscode from 'vscode'
@@ -18,6 +19,12 @@ import { DefaultSamLocalInvokeCommand, WAIT_FOR_DEBUGGER_MESSAGES } from '../cli
 import { runLambdaFunction, waitForPort } from '../localLambdaRunner'
 import { SamLaunchRequestArgs } from './awsSamDebugger'
 
+const TS_BUILD_DIR = 'aws-toolkit-ts-output'
+const TS_CONFIG_FILE = 'aws-toolkit-tsconfig.json'
+
+// use project tsconfig.json as initial base - if unable to parse existing config
+const TS_CONFIG_INITIAL_BASE_FILE = 'tsconfig.json'
+
 /**
  * Launches and attaches debugger to a SAM Node project.
  */
@@ -29,8 +36,7 @@ export async function invokeTypescriptLambda(
     // eslint-disable-next-line @typescript-eslint/unbound-method
     config.onWillAttachDebugger = waitForPort
 
-    const onAfterBuild = () => compileTypeScript(config)
-    const c = (await runLambdaFunction(ctx, config, onAfterBuild)) as NodejsDebugConfiguration
+    const c = (await runLambdaFunction(ctx, config, async () => {})) as NodejsDebugConfiguration
     return c
 }
 
@@ -67,6 +73,9 @@ export async function makeTypescriptConfig(config: SamLaunchRequestArgs): Promis
     let localRoot: string | undefined
     let remoteRoot: string | undefined
     config.codeRoot = pathutil.normalize(config.codeRoot)
+
+    // compile typescript code and convert lambda handler if necessary
+    await compileTypeScript(config)
 
     const isImageLambda = isImageLambdaConfig(config)
 
@@ -113,9 +122,9 @@ export async function makeTypescriptConfig(config: SamLaunchRequestArgs): Promis
  * Compiles non-template (target=code) debug configs, using a temporary default
  * tsconfig.json file.
  *
- * Assumes that `sam build` was already performed.
+ * Assumes that `sam build` was not already performed.
  */
-async function compileTypeScript(config: NodejsDebugConfiguration): Promise<void> {
+async function compileTypeScript(config: SamLaunchRequestArgs): Promise<void> {
     if (!config.baseBuildDir) {
         throw Error('invalid state: config.baseBuildDir was not set')
     }
@@ -134,46 +143,71 @@ async function compileTypeScript(config: NodejsDebugConfiguration): Promise<void
 
     // Require tsconfig.json or *.ts in the top-level of the source app, to
     // indicate a typescript Lambda. #2086
-    // Note: we don't use this tsconfig.json for compiling the target=code
-    // Lambda app below, instead we generate a minimal one.
+    // Note: we use this tsconfig.json as a base for compiling the target=code
+    // Lambda app below. If it does not exist, we generate a minimal one.
     const isTsApp = (await findTsOrTsConfig(config.codeRoot, false)) !== undefined
     if (!isTsApp) {
         return
     }
 
-    const buildOutputDir = path.join(config.baseBuildDir, 'output')
-    const buildDirTsFile = await findTsOrTsConfig(buildOutputDir, true)
-    if (!buildDirTsFile) {
-        // Should never happen: `sam build` should have copied the tsconfig.json from the source app dir.
-        throw new Error(`tsconfig.json or *.ts not found in: "${buildOutputDir}/*"`)
+    const loadBaseConfig = (tsConfigPath: PathLike) => {
+        if (!existsSync(tsConfigPath)) {
+            return null
+        }
+
+        try {
+            const tsConfig = JSON.parse(readFileSync(tsConfigPath).toString())
+            getLogger('channel').info(`Using base TypeScript config: ${tsConfigPath}`)
+            return tsConfig
+        } catch (err) {
+            getLogger('channel').error(`Unable to use TypeScript base: ${tsConfigPath}`)
+        }
+
+        return null
     }
-    // XXX: `sam` may rename the CodeUri (and thus "output/<app>/" dir) if the
-    // original "<app>/" dir contains special chars, so get it this way. #2086
-    const buildDirApp = path.dirname(buildDirTsFile)
-    const buildDirTsConfig = path.join(buildDirApp, 'tsconfig.json')
+
+    const tsConfigPath = path.join(config.codeRoot, TS_CONFIG_FILE)
+    const tsOutputPath = path.join(config.codeRoot, TS_BUILD_DIR)
+
+    let tsConfig =
+        loadBaseConfig(tsConfigPath) || loadBaseConfig(path.join(config.codeRoot, TS_CONFIG_INITIAL_BASE_FILE)) || {}
+
+    if (Object.keys(tsConfig).length === 0) {
+        getLogger('channel').info('Creating TypeScript config')
+    }
+
+    const compilerOptions = tsConfig.compilerOptions || {
+        target: 'es6',
+        module: 'commonjs',
+        inlineSourceMap: true,
+    }
+    tsConfig.compilerOptions = compilerOptions
+
+    // overwrite outDir, rootDir, sourceRoot
+    compilerOptions.outDir = tsOutputPath
+    compilerOptions.rootDir = '.'
+    compilerOptions.sourceRoot = config.codeRoot
+
+    const typeRoots: string[] = Array.isArray(compilerOptions.typeRoots) ? compilerOptions.typeRoots : []
+    typeRoots.push('node_modules/@types')
+    compilerOptions.typeRoots = [...new Set(typeRoots)]
+
+    const types: string[] = Array.isArray(compilerOptions.types) ? compilerOptions.types : []
+    types.push('node')
+    compilerOptions.types = [...new Set(types)]
+
+    writeFileSync(tsConfigPath, JSON.stringify(tsConfig, undefined, 4))
 
     const tsc = await systemutil.SystemUtilities.findTypescriptCompiler()
     if (!tsc) {
         throw new Error('TypeScript compiler "tsc" not found in node_modules/ or the system.')
     }
 
-    // Default config.
-    // Adapted from: https://github.com/aws/aws-toolkit-jetbrains/blob/911c54252d6a4271ee6cacf0ea1023506c4b504a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsLambdaBuilder.kt#L60
-    const defaultTsconfig = {
-        compilerOptions: {
-            target: 'es6',
-            module: 'commonjs',
-            typeRoots: ['node_modules/@types'],
-            types: ['node'],
-            rootDir: '.',
-            inlineSourceMap: true,
-        },
-    }
     try {
-        // Overwrite the tsconfig.json copied by `sam build`.
-        writeFileSync(buildDirTsConfig, JSON.stringify(defaultTsconfig, undefined, 4))
         getLogger('channel').info(`Compiling TypeScript app with: "${tsc}"`)
-        await new ChildProcess(tsc, ['--project', buildDirApp]).run()
+        await new ChildProcess(tsc, ['--project', tsConfigPath]).run()
+
+        config.invokeTarget.lambdaHandler = `${TS_BUILD_DIR}/${config.invokeTarget.lambdaHandler}`
     } catch (error) {
         getLogger('channel').error(`TypeScript compile error: ${error}`)
         throw Error('Failed to compile TypeScript app')

--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -200,7 +200,7 @@ async function compileTypeScript(config: SamLaunchRequestArgs): Promise<void> {
     writeFileSync(tsConfigPath, JSON.stringify(tsConfig, undefined, 4))
 
     // resolve ts lambda handler to point into build directory relative to codeRoot
-    const tsLambdaHandler = path.relative(config.codeRoot, `${tsBuildDir}/${config.invokeTarget.lambdaHandler}`)
+    const tsLambdaHandler = path.relative(config.codeRoot, path.join(tsBuildDir, config.invokeTarget.lambdaHandler))
     config.invokeTarget.lambdaHandler = tsLambdaHandler
     getLogger('channel').info(`Resolved compiled lambda handler to ${tsLambdaHandler}`)
 

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -718,7 +718,10 @@ describe('SamDebugConfigurationProvider', async function () {
                 debugPort: actual.debugPort,
                 documentUri: vscode.Uri.file(''), // TODO: remove or test.
                 handlerName: 'app.handler',
-                invokeTarget: { ...input.invokeTarget },
+                invokeTarget: {
+                    ...input.invokeTarget,
+                    lambdaHandler: `aws-toolkit-ts-output/${input.invokeTarget.lambdaHandler}`,
+                },
                 lambda: {
                     ...input.lambda,
                 },
@@ -752,7 +755,7 @@ describe('SamDebugConfigurationProvider', async function () {
   src:
     Type: AWS::Serverless::Function
     Properties:
-      Handler: app.handler
+      Handler: aws-toolkit-ts-output/app.handler
       CodeUri: >-
         ${expected.codeRoot}
       Runtime: nodejs12.x

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -720,7 +720,6 @@ describe('SamDebugConfigurationProvider', async function () {
                 handlerName: 'app.handler',
                 invokeTarget: {
                     ...input.invokeTarget,
-                    lambdaHandler: `aws-toolkit-ts-output/${input.invokeTarget.lambdaHandler}`,
                 },
                 lambda: {
                     ...input.lambda,
@@ -755,7 +754,7 @@ describe('SamDebugConfigurationProvider', async function () {
   src:
     Type: AWS::Serverless::Function
     Properties:
-      Handler: aws-toolkit-ts-output/app.handler
+      Handler: app.handler
       CodeUri: >-
         ${expected.codeRoot}
       Runtime: nodejs12.x


### PR DESCRIPTION
## Problem
TypeScript debugger has a race condition that breaks debugging much of the time. Hard-coded tsconfig also is used which breaks anything more than a very basic typescript lambda.

## Solution
Updated toolkit to generate tsconfig that attempts to match project tsconfig as close as possible, code is compiled into a ts build directory, sam deploys from there on an updated handler path (pointing to build dir). This eliminates the debugger race condition, and much more closely resembles a standard project build eliminating all of our errors. It also matches jetbrains approach [here](https://github.com/aws/aws-toolkit-jetbrains/blob/main/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsLambdaBuilder.kt).

Code updated:

- src/shared/sam/activation.ts: allow typescript code to be recognized
- src/shared/sam/debugger/awsSamDebugger.ts: code template generation after individual runtime configs are made so ts can update handler path
- src/shared/sam/debugger/typescriptSamDebug.ts: updated build directory process matching jetbrains (most of the updates)
- src/shared/sam/localLambdaRunner.ts: split getting template path and creating the template to facilitate awsSamDebugger.ts changes
- src/test/shared/sam/debugger/samDebugConfigProvider.test.ts: update ts tests

Tested with unit tests, and with several typescript projects including large and small lambdas. New code lines are covered with code coverage.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
