### PR TITLE
fix(icons): normalize font path regardless of platform

### DIFF
--- a/scripts/build/generateIcons.ts
+++ b/scripts/build/generateIcons.ts
@@ -136,10 +136,13 @@ async function generate(mappings: Record<string, number | undefined> = {}) {
             }
 
             if (!obj.name.startsWith('vscode')) {
+                // Normalize the font path regardless of platform
+                // See https://github.com/aws/aws-toolkit-vscode/pull/3066#discussion_r1063662657
+                const normalizedPath = relativeDest.split(path.sep).join(path.posix.sep)
                 icons.push({
                     name: obj.name,
                     path: filePath,
-                    data: createPackageIcon(`./${relativeDest}`, obj.unicode[0]),
+                    data: createPackageIcon(`./${normalizedPath}`, obj.unicode[0]),
                 })
             } else {
                 icons.push({ name: obj.name, path: filePath })


### PR DESCRIPTION
## Problem
Running the script on different platforms creates noise

## Solution
Normalize the emitted path

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
