### PR TITLE
lint: maximum name length

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,16 @@ module.exports = {
     ],
     rules: {
         curly: 2, // Enforce braces on "if"/"for"/etc.
+        'id-length': [
+            'error',
+            {
+                min: 1,
+                max: 40,
+                exceptionPatterns: [
+                    '^codecatalyst_', // CodeCatalyst telemetry names are verbose :(
+                ],
+            },
+        ],
         // https://typescript-eslint.io/rules/naming-convention/
         '@typescript-eslint/naming-convention': [
             'error',

--- a/src/cloudWatchLogs/commands/viewLogStream.ts
+++ b/src/cloudWatchLogs/commands/viewLogStream.ts
@@ -81,7 +81,7 @@ export class DefaultSelectLogStreamWizardContext implements SelectLogStreamWizar
                     },
                     request,
                 }),
-            response => convertDescribeLogStreamsToQuickPickItems(response)
+            response => convertDescribeLogToQuickPickItems(response)
         )
 
         const controller = new picker.IteratingQuickPickController(qp, populator)
@@ -112,7 +112,7 @@ export class DefaultSelectLogStreamWizardContext implements SelectLogStreamWizar
     }
 }
 
-export function convertDescribeLogStreamsToQuickPickItems(
+export function convertDescribeLogToQuickPickItems(
     response: CloudWatchLogs.DescribeLogStreamsResponse
 ): vscode.QuickPickItem[] {
     return (response.logStreams ?? []).map<vscode.QuickPickItem>(stream => ({

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -186,7 +186,7 @@ export async function activate(context: ExtContext): Promise<void> {
             if (isInlineCompletionEnabled() && e.uri.fsPath !== InlineCompletionService.instance.filePath()) {
                 return
             }
-            RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(vscode.window.activeTextEditor, -1)
+            RecommendationHandler.instance.reportUserDecisionOfRecommendation(vscode.window.activeTextEditor, -1)
             RecommendationHandler.instance.clearRecommendations()
         }),
 
@@ -246,11 +246,11 @@ export async function activate(context: ExtContext): Promise<void> {
                 ) || false
             const notificationLastShown: number =
                 context.extensionContext.globalState.get<number | undefined>(
-                    CodeWhispererConstants.accessTokenMigrationDoNotShowAgainLastShown
+                    CodeWhispererConstants.accessTokenMigrationDoNotShowLastShown
                 ) || 1
 
             //Add 7 days to notificationLastShown to determine whether warn message should show
-            if (doNotShowAgain || notificationLastShown + (1000 * 60 * 60 * 24 * 7) >= Date.now()) {
+            if (doNotShowAgain || notificationLastShown + 1000 * 60 * 60 * 24 * 7 >= Date.now()) {
                 return
             } else if (t <= CodeWhispererConstants.accessTokenCutOffDate) {
                 vscode.window
@@ -311,7 +311,7 @@ export async function activate(context: ExtContext): Promise<void> {
 
     async function showCodeWhispererWelcomeMessage(): Promise<void> {
         const filePath = isCloud9()
-            ? context.extensionContext.asAbsolutePath(CodeWhispererConstants.welcomeCodeWhispererCloud9ReadmeFileSource)
+            ? context.extensionContext.asAbsolutePath(CodeWhispererConstants.welcomeCodeWhispererCloud9Readme)
             : context.extensionContext.asAbsolutePath(CodeWhispererConstants.welcomeCodeWhispererReadmeFileSource)
         const readmeUri = vscode.Uri.file(filePath)
         await vscode.commands.executeCommand('markdown.showPreviewToSide', readmeUri)
@@ -330,13 +330,12 @@ export async function activate(context: ExtContext): Promise<void> {
             vscode.workspace.getConfiguration('editor').get('suggest.showMethods') || false
         const isAutomatedTriggerEnabled: boolean = getAutoTriggerStatus()
         const isManualTriggerEnabled: boolean = await getManualTriggerStatus()
-        const isIncludeSuggestionsWithCodeReferencesEnabled =
-            codewhispererSettings.isIncludeSuggestionsWithCodeReferencesEnabled()
+        const isWithCodeReferencesEnabled = codewhispererSettings.isWithCodeReferencesEnabled()
         return {
             isShowMethodsEnabled,
             isManualTriggerEnabled,
             isAutomatedTriggerEnabled,
-            isIncludeSuggestionsWithCodeReferencesEnabled,
+            isWithCodeReferencesEnabled,
         }
     }
 
@@ -617,7 +616,7 @@ export async function activate(context: ExtContext): Promise<void> {
 
 export async function shutdown() {
     if (isCloud9()) {
-        RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(vscode.window.activeTextEditor, -1)
+        RecommendationHandler.instance.reportUserDecisionOfRecommendation(vscode.window.activeTextEditor, -1)
         RecommendationHandler.instance.clearRecommendations()
     }
     if (isInlineCompletionEnabled()) {

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -275,7 +275,7 @@ export async function activate(context: ExtContext): Promise<void> {
                         }
                     })
                 context.extensionContext.globalState.update(
-                    CodeWhispererConstants.accessTokenMigrationDoNotShowAgainLastShown,
+                    CodeWhispererConstants.accessTokenMigrationDoNotShowLastShown,
                     Date.now()
                 )
             } else {
@@ -330,12 +330,12 @@ export async function activate(context: ExtContext): Promise<void> {
             vscode.workspace.getConfiguration('editor').get('suggest.showMethods') || false
         const isAutomatedTriggerEnabled: boolean = getAutoTriggerStatus()
         const isManualTriggerEnabled: boolean = await getManualTriggerStatus()
-        const isWithCodeReferencesEnabled = codewhispererSettings.isWithCodeReferencesEnabled()
+        const isSuggestionsWithCodeReferencesEnabled = codewhispererSettings.isSuggestionsWithCodeReferencesEnabled()
         return {
             isShowMethodsEnabled,
             isManualTriggerEnabled,
             isAutomatedTriggerEnabled,
-            isWithCodeReferencesEnabled,
+            isSuggestionsWithCodeReferencesEnabled,
         }
     }
 

--- a/src/codewhisperer/commands/invokeRecommendation.ts
+++ b/src/codewhisperer/commands/invokeRecommendation.ts
@@ -58,7 +58,7 @@ export async function invokeRecommendation(
             vsCodeState.isIntelliSenseActive = false
             RecommendationHandler.instance.isGenerateRecommendationInProgress = true
             try {
-                RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
+                RecommendationHandler.instance.reportUserDecisionOfRecommendation(editor, -1)
                 RecommendationHandler.instance.clearRecommendations()
                 await RecommendationHandler.instance.getRecommendations(
                     client,

--- a/src/codewhisperer/commands/onAcceptance.ts
+++ b/src/codewhisperer/commands/onAcceptance.ts
@@ -32,7 +32,7 @@ export async function onAcceptance(acceptanceEntry: OnRecommendationAcceptanceEn
         const start = acceptanceEntry.range.start
         const end = isCloud9() ? acceptanceEntry.editor.selection.active : acceptanceEntry.range.end
         const languageId = acceptanceEntry.editor.document.languageId
-        RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(
+        RecommendationHandler.instance.reportUserDecisionOfRecommendation(
             acceptanceEntry.editor,
             acceptanceEntry.acceptIndex
         )

--- a/src/codewhisperer/commands/onInlineAcceptance.ts
+++ b/src/codewhisperer/commands/onInlineAcceptance.ts
@@ -84,7 +84,7 @@ export async function onInlineAcceptance(
         const start = acceptanceEntry.range.start
         const end = acceptanceEntry.editor.selection.active
         const languageId = acceptanceEntry.editor.document.languageId
-        RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(
+        RecommendationHandler.instance.reportUserDecisionOfRecommendation(
             acceptanceEntry.editor,
             acceptanceEntry.acceptIndex
         )

--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -103,7 +103,7 @@ export const licenseFilter = 'CodeWhisperer suggestions were filtered due to ref
  */
 export const welcomeCodeWhispererReadmeFileSource = 'resources/markdown/WelcomeToCodeWhisperer.md'
 
-export const welcomeCodeWhispererCloud9ReadmeFileSource = 'resources/markdown/WelcomeToCodeWhispererCloud9.md'
+export const welcomeCodeWhispererCloud9Readme = 'resources/markdown/WelcomeToCodeWhispererCloud9.md'
 
 export const welcomeMessageKey = 'CODEWHISPERER_WELCOME_MESSAGE'
 
@@ -242,7 +242,7 @@ export const accessTokenMigrationDoNotShowAgain = `Don\'t Show Again`
 
 export const accessTokenMigrationDoNotShowAgainKey = 'CODEWHISPERER_ACCESS_TOKEN_MIGRATION_DO_NOT_SHOW_AGAIN'
 
-export const accessTokenMigrationDoNotShowAgainLastShown =
+export const accessTokenMigrationDoNotShowLastShown =
     'CODEWHISPERER_ACCESS_TOKEN_MIGRATION_DO_NOT_SHOW_AGAIN_LAST_SHOWN_TIME'
 
 export const accessTokenMigrationDoNotShowAgainInfo = `You will not receive this notification again. If you would like to continue using CodeWhisperer after January 31, 2023, you can still connect with AWS. [Learn More](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/codewhisper-setup-general.html).`

--- a/src/codewhisperer/models/model.ts
+++ b/src/codewhisperer/models/model.ts
@@ -65,7 +65,7 @@ export interface ConfigurationEntry {
     readonly isShowMethodsEnabled: boolean
     readonly isManualTriggerEnabled: boolean
     readonly isAutomatedTriggerEnabled: boolean
-    readonly isIncludeSuggestionsWithCodeReferencesEnabled: boolean
+    readonly isSuggestionsWithCodeReferencesEnabled: boolean
 }
 
 export interface InlineCompletionItem {

--- a/src/codewhisperer/service/inlineCompletion.ts
+++ b/src/codewhisperer/service/inlineCompletion.ts
@@ -136,7 +136,7 @@ export class InlineCompletion {
 
         RecommendationHandler.instance.cancelPaginatedRequest()
         // report all recommendation as rejected
-        RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
+        RecommendationHandler.instance.reportUserDecisionOfRecommendation(editor, -1)
     }
 
     async rejectRecommendation(
@@ -329,7 +329,7 @@ export class InlineCompletion {
         config: ConfigurationEntry,
         autoTriggerType?: CodewhispererAutomatedTriggerType
     ) {
-        RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
+        RecommendationHandler.instance.reportUserDecisionOfRecommendation(editor, -1)
         RecommendationHandler.instance.clearRecommendations()
         this.setCodeWhispererStatusBarLoading()
         const isManualTrigger = triggerType === 'OnDemand'
@@ -355,7 +355,7 @@ export class InlineCompletion {
                 )
                 this.setCompletionItems(editor)
                 if (RecommendationHandler.instance.checkAndResetCancellationTokens()) {
-                    RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
+                    RecommendationHandler.instance.reportUserDecisionOfRecommendation(editor, -1)
                     RecommendationHandler.instance.clearRecommendations()
                     break
                 }
@@ -397,7 +397,7 @@ export class InlineCompletion {
                     RecommendationHandler.instance.recommendations.forEach((r, i) => {
                         RecommendationHandler.instance.setSuggestionState(i, 'Discard')
                     })
-                    RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
+                    RecommendationHandler.instance.reportUserDecisionOfRecommendation(editor, -1)
                     RecommendationHandler.instance.clearRecommendations()
                     if (this._timer !== undefined) {
                         clearTimeout(this._timer)
@@ -427,7 +427,7 @@ export class InlineCompletion {
                         RecommendationHandler.instance.recommendations.forEach((r, i) => {
                             RecommendationHandler.instance.setSuggestionState(i, 'Discard')
                         })
-                        RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
+                        RecommendationHandler.instance.reportUserDecisionOfRecommendation(editor, -1)
                         RecommendationHandler.instance.clearRecommendations()
                     }
                     if (this._timer !== undefined) {
@@ -448,7 +448,7 @@ export class InlineCompletion {
                                     showTimedMessage(CodeWhispererConstants.noSuggestions, 2000)
                                 }
                             }
-                            RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
+                            RecommendationHandler.instance.reportUserDecisionOfRecommendation(editor, -1)
                             RecommendationHandler.instance.clearRecommendations()
                         }
                     }

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -22,8 +22,7 @@ import { getPrefixSuffixOverlap } from '../util/commonUtil'
 import globals from '../../shared/extensionGlobals'
 import { AuthUtil } from '../util/authUtil'
 
-// eslint-disable-next-line id-length
-class CodeWhispererInlineCompletionItemProvider implements vscode.InlineCompletionItemProvider {
+class CWInlineCompletionItemProvider implements vscode.InlineCompletionItemProvider {
     private activeItemIndex: number | undefined
     public nextMove: number
 
@@ -211,7 +210,7 @@ const hideCommand = Commands.declare(
 )
 
 export class InlineCompletionService {
-    private inlineCompletionProvider?: CodeWhispererInlineCompletionItemProvider
+    private inlineCompletionProvider?: CWInlineCompletionItemProvider
     private inlineCompletionProviderDisposable?: vscode.Disposable
     private maxPage = 100
     private statusBar: vscode.StatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1)
@@ -378,7 +377,7 @@ export class InlineCompletionService {
         if (vscode.window.activeTextEditor) {
             vscode.window.showTextDocument(vscode.window.activeTextEditor.document)
         }
-        this.inlineCompletionProvider = new CodeWhispererInlineCompletionItemProvider(
+        this.inlineCompletionProvider = new CWInlineCompletionItemProvider(
             this.inlineCompletionProvider?.getActiveItemIndex,
             indexShift
         )

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -22,6 +22,7 @@ import { getPrefixSuffixOverlap } from '../util/commonUtil'
 import globals from '../../shared/extensionGlobals'
 import { AuthUtil } from '../util/authUtil'
 
+// eslint-disable-next-line id-length
 class CodeWhispererInlineCompletionItemProvider implements vscode.InlineCompletionItemProvider {
     private activeItemIndex: number | undefined
     public nextMove: number
@@ -86,7 +87,7 @@ class CodeWhispererInlineCompletionItemProvider implements vscode.InlineCompleti
         return index
     }
 
-    truncateSuggestionOverlapWithRightContext(document: vscode.TextDocument, suggestion: string): string {
+    truncateOverlapWithRightContext(document: vscode.TextDocument, suggestion: string): string {
         let rightContextRange: vscode.Range | undefined = undefined
         const pos = RecommendationHandler.instance.startPos
         if (suggestion.split(/\r?\n/).length > 1) {
@@ -110,7 +111,7 @@ class CodeWhispererInlineCompletionItemProvider implements vscode.InlineCompleti
         if (!r.content.startsWith(prefix)) {
             return undefined
         }
-        const truncatedSuggestion = this.truncateSuggestionOverlapWithRightContext(document, r.content)
+        const truncatedSuggestion = this.truncateOverlapWithRightContext(document, r.content)
         if (truncatedSuggestion.length === 0) {
             if (RecommendationHandler.instance.getSuggestionState(index) !== 'Showed') {
                 RecommendationHandler.instance.setSuggestionState(index, 'Discard')
@@ -289,7 +290,7 @@ export class InlineCompletionService {
             vsCodeState.isCodeWhispererEditing = false
             ReferenceInlineProvider.instance.removeInlineReference()
             RecommendationHandler.instance.cancelPaginatedRequest()
-            RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
+            RecommendationHandler.instance.reportUserDecisionOfRecommendation(editor, -1)
             RecommendationHandler.instance.clearRecommendations()
             this.disposeInlineCompletion()
             this.setCodeWhispererStatusBarOk()
@@ -312,7 +313,7 @@ export class InlineCompletionService {
             RecommendationHandler.instance.recommendations.forEach((r, i) => {
                 RecommendationHandler.instance.setSuggestionState(i, 'Discard')
             })
-            RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
+            RecommendationHandler.instance.reportUserDecisionOfRecommendation(editor, -1)
             RecommendationHandler.instance.clearRecommendations()
         } else if (RecommendationHandler.instance.recommendations.length > 0) {
             RecommendationHandler.instance.moveStartPositionToSkipSpaces(editor)
@@ -349,7 +350,7 @@ export class InlineCompletionService {
                     page
                 )
                 if (RecommendationHandler.instance.checkAndResetCancellationTokens()) {
-                    RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
+                    RecommendationHandler.instance.reportUserDecisionOfRecommendation(editor, -1)
                     RecommendationHandler.instance.clearRecommendations()
                     this.setCodeWhispererStatusBarOk()
                     return

--- a/src/codewhisperer/service/keyStrokeHandler.ts
+++ b/src/codewhisperer/service/keyStrokeHandler.ts
@@ -167,7 +167,7 @@ export class KeyStrokeHandler {
                 vsCodeState.isIntelliSenseActive = false
                 RecommendationHandler.instance.isGenerateRecommendationInProgress = true
                 try {
-                    RecommendationHandler.instance.reportUserDecisionOfCurrentRecommendation(editor, -1)
+                    RecommendationHandler.instance.reportUserDecisionOfRecommendation(editor, -1)
                     RecommendationHandler.instance.clearRecommendations()
                     await RecommendationHandler.instance.getRecommendations(
                         client,

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -341,7 +341,11 @@ export class RecommendationHandler {
         this.nextToken = ''
         this.errorMessagePrompt = ''
     }
-    reportUserDecisionOfCurrentRecommendation(editor: vscode.TextEditor | undefined, acceptIndex: number) {
+
+    /**
+     * Emits telemetry reflecting user decision for current recommendation.
+     */
+    reportUserDecisionOfRecommendation(editor: vscode.TextEditor | undefined, acceptIndex: number) {
         TelemetryHelper.instance.recordUserDecisionTelemetry(
             this.requestId,
             this.sessionId,
@@ -359,7 +363,7 @@ export class RecommendationHandler {
 
     canShowRecommendationInIntelliSense(editor: vscode.TextEditor, showPrompt: boolean = false): boolean {
         const reject = () => {
-            this.reportUserDecisionOfCurrentRecommendation(editor, -1)
+            this.reportUserDecisionOfRecommendation(editor, -1)
             this.clearRecommendations()
         }
         if (!this.isValidResponse()) {

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -151,7 +151,7 @@ export class RecommendationHandler {
             req = EditorContext.buildListRecommendationRequest(
                 editor as vscode.TextEditor,
                 this.nextToken,
-                accessToken ? undefined : config.isIncludeSuggestionsWithCodeReferencesEnabled
+                accessToken ? undefined : config.isSuggestionsWithCodeReferencesEnabled
             )
         } else {
             req = EditorContext.buildGenerateRecommendationRequest(editor as vscode.TextEditor)

--- a/src/codewhisperer/service/referenceLogViewProvider.ts
+++ b/src/codewhisperer/service/referenceLogViewProvider.ts
@@ -39,7 +39,7 @@ export class ReferenceLogViewProvider implements vscode.WebviewViewProvider {
         }
         this._view.webview.html = this.getHtml(
             webviewView.webview,
-            CodeWhispererSettings.instance.isIncludeSuggestionsWithCodeReferencesEnabled()
+            CodeWhispererSettings.instance.isWithCodeReferencesEnabled()
         )
         this._view.webview.onDidReceiveMessage(data => {
             vscode.commands.executeCommand('aws.codeWhisperer.configure', 'codewhisperer')
@@ -48,7 +48,7 @@ export class ReferenceLogViewProvider implements vscode.WebviewViewProvider {
 
     public async update() {
         if (this._view) {
-            const showPrompt = CodeWhispererSettings.instance.isIncludeSuggestionsWithCodeReferencesEnabled()
+            const showPrompt = CodeWhispererSettings.instance.isWithCodeReferencesEnabled()
             this._view.webview.html = this.getHtml(this._view.webview, showPrompt)
         }
     }

--- a/src/codewhisperer/service/referenceLogViewProvider.ts
+++ b/src/codewhisperer/service/referenceLogViewProvider.ts
@@ -39,7 +39,7 @@ export class ReferenceLogViewProvider implements vscode.WebviewViewProvider {
         }
         this._view.webview.html = this.getHtml(
             webviewView.webview,
-            CodeWhispererSettings.instance.isWithCodeReferencesEnabled()
+            CodeWhispererSettings.instance.isSuggestionsWithCodeReferencesEnabled()
         )
         this._view.webview.onDidReceiveMessage(data => {
             vscode.commands.executeCommand('aws.codeWhisperer.configure', 'codewhisperer')
@@ -48,7 +48,7 @@ export class ReferenceLogViewProvider implements vscode.WebviewViewProvider {
 
     public async update() {
         if (this._view) {
-            const showPrompt = CodeWhispererSettings.instance.isWithCodeReferencesEnabled()
+            const showPrompt = CodeWhispererSettings.instance.isSuggestionsWithCodeReferencesEnabled()
             this._view.webview.html = this.getHtml(this._view.webview, showPrompt)
         }
     }

--- a/src/codewhisperer/util/codewhispererSettings.ts
+++ b/src/codewhisperer/util/codewhispererSettings.ts
@@ -9,7 +9,7 @@ const description = {
     shareCodeWhispererContentWithAWS: Boolean,
 }
 export class CodeWhispererSettings extends fromExtensionManifest('aws.codeWhisperer', description) {
-    public isWithCodeReferencesEnabled(): boolean {
+    public isSuggestionsWithCodeReferencesEnabled(): boolean {
         return this.get(`includeSuggestionsWithCodeReferences`, false)
     }
 

--- a/src/codewhisperer/util/codewhispererSettings.ts
+++ b/src/codewhisperer/util/codewhispererSettings.ts
@@ -9,7 +9,7 @@ const description = {
     shareCodeWhispererContentWithAWS: Boolean,
 }
 export class CodeWhispererSettings extends fromExtensionManifest('aws.codeWhisperer', description) {
-    public isIncludeSuggestionsWithCodeReferencesEnabled(): boolean {
+    public isWithCodeReferencesEnabled(): boolean {
         return this.get(`includeSuggestionsWithCodeReferences`, false)
     }
 

--- a/src/credentials/providers/sharedCredentialsProviderFactory.ts
+++ b/src/credentials/providers/sharedCredentialsProviderFactory.ts
@@ -9,7 +9,7 @@ import {
     getConfigFilename,
     getCredentialsFilename,
     loadSharedCredentialsProfiles,
-    updateAwsSdkLoadConfigEnvironmentVariable,
+    updateAwsSdkLoadConfigEnvVar,
 } from '../sharedCredentials'
 import { CredentialsProviderType } from './credentials'
 import { BaseCredentialsProviderFactory } from './credentialsProviderFactory'
@@ -55,7 +55,7 @@ export class SharedCredentialsProviderFactory extends BaseCredentialsProviderFac
         const allCredentialProfiles = await loadSharedCredentialsProfiles()
         this.loadedCredentialsModificationMillis = await this.getLastModifiedMillis(getCredentialsFilename())
         this.loadedConfigModificationMillis = await this.getLastModifiedMillis(getConfigFilename())
-        await updateAwsSdkLoadConfigEnvironmentVariable()
+        await updateAwsSdkLoadConfigEnvVar()
 
         const profileNames = Array.from(allCredentialProfiles.keys())
         getLogger().verbose(`credentials: found profiles: ${profileNames}`)

--- a/src/credentials/sharedCredentials.ts
+++ b/src/credentials/sharedCredentials.ts
@@ -70,7 +70,7 @@ function mergeProfileProperties(credentialsProfile?: Profile, configProfile?: Pr
     return profile
 }
 
-export async function updateAwsSdkLoadConfigEnvironmentVariable(): Promise<void> {
+export async function updateAwsSdkLoadConfigEnvVar(): Promise<void> {
     const configFileExists = await SystemUtilities.fileExists(getConfigFilename())
     process.env.AWS_SDK_LOAD_CONFIG = configFileExists ? 'true' : ''
 }

--- a/src/lambda/config/configureParameterOverrides.ts
+++ b/src/lambda/config/configureParameterOverrides.ts
@@ -23,7 +23,7 @@ export interface ConfigureParameterOverridesContext {
     executeCommand: typeof vscode.commands.executeCommand
 }
 
-class DefaultConfigureParameterOverridesContext implements ConfigureParameterOverridesContext {
+class DefaultConfigureParamOverridesContext implements ConfigureParameterOverridesContext {
     public readonly getWorkspaceFolder = vscode.workspace.getWorkspaceFolder
 
     public readonly showErrorMessage = vscode.window.showErrorMessage
@@ -41,7 +41,7 @@ export async function configureParameterOverrides(
         templateUri: vscode.Uri
         requiredParameterNames?: Iterable<string>
     },
-    context: ConfigureParameterOverridesContext = new DefaultConfigureParameterOverridesContext()
+    context: ConfigureParameterOverridesContext = new DefaultConfigureParamOverridesContext()
 ): Promise<void> {
     const workspaceFolder = context.getWorkspaceFolder(templateUri)
     if (!workspaceFolder) {

--- a/src/lambda/config/templates.ts
+++ b/src/lambda/config/templates.ts
@@ -321,7 +321,7 @@ export class TemplatesConfigPopulator {
         templateRelativePath: string,
         parameterName: string
     ): TemplatesConfigPopulator {
-        this.ensureTemplateParameterOverridesSectionExists(templateRelativePath)
+        this.ensureTemplateParamOverrideSectionExists(templateRelativePath)
 
         this.ensureJsonPropertyExists(['templates', templateRelativePath, 'parameterOverrides', parameterName], '', [
             'string',
@@ -383,7 +383,7 @@ export class TemplatesConfigPopulator {
         return this
     }
 
-    private ensureTemplateParameterOverridesSectionExists(templateRelativePath: string): TemplatesConfigPopulator {
+    private ensureTemplateParamOverrideSectionExists(templateRelativePath: string): TemplatesConfigPopulator {
         this.ensureTemplateSectionExists(templateRelativePath)
 
         this.ensureJsonPropertyExists(['templates', templateRelativePath, 'parameterOverrides'], {})

--- a/src/lambda/wizards/samDeployWizard.ts
+++ b/src/lambda/wizards/samDeployWizard.ts
@@ -31,7 +31,7 @@ import { getOverriddenParameters, getParameters } from '../config/parameterUtils
 import { DefaultEcrClient, EcrRepository } from '../../shared/clients/ecrClient'
 import { getSamCliVersion } from '../../shared/sam/cli/samCliContext'
 import * as semver from 'semver'
-import { minSamCliVersionInclusiveForImageSupport } from '../../shared/sam/cli/samCliValidator'
+import { minSamCliVersionForImageSupport } from '../../shared/sam/cli/samCliValidator'
 import { ExtContext } from '../../shared/extensions'
 import { validateBucketName } from '../../s3/util'
 import { showViewLogsMessage } from '../../shared/utilities/messages'
@@ -708,7 +708,7 @@ export class SamDeployWizard extends MultiStepWizard<SamDeployWizardResponse> {
         if (this.hasImages) {
             // TODO: remove check when min version is high enough
             const samCliVersion = await getSamCliVersion(this.context.extContext.samCliContext())
-            if (semver.lt(samCliVersion, minSamCliVersionInclusiveForImageSupport)) {
+            if (semver.lt(samCliVersion, minSamCliVersionForImageSupport)) {
                 vscode.window.showErrorMessage(
                     localize(
                         'AWS.output.sam.no.image.support',

--- a/src/lambda/wizards/samDeployWizard.ts
+++ b/src/lambda/wizards/samDeployWizard.ts
@@ -31,7 +31,7 @@ import { getOverriddenParameters, getParameters } from '../config/parameterUtils
 import { DefaultEcrClient, EcrRepository } from '../../shared/clients/ecrClient'
 import { getSamCliVersion } from '../../shared/sam/cli/samCliContext'
 import * as semver from 'semver'
-import { minimumSamCliVersionInclusiveForImageSupport } from '../../shared/sam/cli/samCliValidator'
+import { minSamCliVersionInclusiveForImageSupport } from '../../shared/sam/cli/samCliValidator'
 import { ExtContext } from '../../shared/extensions'
 import { validateBucketName } from '../../s3/util'
 import { showViewLogsMessage } from '../../shared/utilities/messages'
@@ -708,7 +708,7 @@ export class SamDeployWizard extends MultiStepWizard<SamDeployWizardResponse> {
         if (this.hasImages) {
             // TODO: remove check when min version is high enough
             const samCliVersion = await getSamCliVersion(this.context.extContext.samCliContext())
-            if (semver.lt(samCliVersion, minimumSamCliVersionInclusiveForImageSupport)) {
+            if (semver.lt(samCliVersion, minSamCliVersionInclusiveForImageSupport)) {
                 vscode.window.showErrorMessage(
                     localize(
                         'AWS.output.sam.no.image.support',

--- a/src/lambda/wizards/samInitWizard.ts
+++ b/src/lambda/wizards/samInitWizard.ts
@@ -27,10 +27,7 @@ import {
     SamTemplate,
 } from '../models/samTemplates'
 import * as semver from 'semver'
-import {
-    minSamCliVersionInclusiveForArmSupport,
-    minSamCliVersionInclusiveForImageSupport,
-} from '../../shared/sam/cli/samCliValidator'
+import { minSamCliVersionForArmSupport, minSamCliVersionForImageSupport } from '../../shared/sam/cli/samCliValidator'
 import * as fsutil from '../../shared/filesystemUtilities'
 import { Wizard } from '../../shared/wizards/wizard'
 import { createFolderPrompt } from '../../shared/ui/common/location'
@@ -57,7 +54,7 @@ export interface CreateNewSamAppWizardForm {
 
 function createRuntimePrompter(samCliVersion: string): QuickPickPrompter<RuntimeAndPackage> {
     return createRuntimeQuickPick({
-        showImageRuntimes: semver.gte(samCliVersion, minSamCliVersionInclusiveForImageSupport),
+        showImageRuntimes: semver.gte(samCliVersion, minSamCliVersionForImageSupport),
         buttons: createCommonButtons(samInitDocUrl),
     })
 }
@@ -226,7 +223,7 @@ export class CreateNewSamAppWizard extends Wizard<CreateNewSamAppWizardForm> {
                 return false
             }
 
-            if (semver.lt(context.samCliVersion, minSamCliVersionInclusiveForArmSupport)) {
+            if (semver.lt(context.samCliVersion, minSamCliVersionForArmSupport)) {
                 return false
             }
 

--- a/src/lambda/wizards/samInitWizard.ts
+++ b/src/lambda/wizards/samInitWizard.ts
@@ -28,8 +28,8 @@ import {
 } from '../models/samTemplates'
 import * as semver from 'semver'
 import {
-    minimumSamCliVersionInclusiveForArmSupport,
-    minimumSamCliVersionInclusiveForImageSupport,
+    minSamCliVersionInclusiveForArmSupport,
+    minSamCliVersionInclusiveForImageSupport,
 } from '../../shared/sam/cli/samCliValidator'
 import * as fsutil from '../../shared/filesystemUtilities'
 import { Wizard } from '../../shared/wizards/wizard'
@@ -57,7 +57,7 @@ export interface CreateNewSamAppWizardForm {
 
 function createRuntimePrompter(samCliVersion: string): QuickPickPrompter<RuntimeAndPackage> {
     return createRuntimeQuickPick({
-        showImageRuntimes: semver.gte(samCliVersion, minimumSamCliVersionInclusiveForImageSupport),
+        showImageRuntimes: semver.gte(samCliVersion, minSamCliVersionInclusiveForImageSupport),
         buttons: createCommonButtons(samInitDocUrl),
     })
 }
@@ -226,7 +226,7 @@ export class CreateNewSamAppWizard extends Wizard<CreateNewSamAppWizardForm> {
                 return false
             }
 
-            if (semver.lt(context.samCliVersion, minimumSamCliVersionInclusiveForArmSupport)) {
+            if (semver.lt(context.samCliVersion, minSamCliVersionInclusiveForArmSupport)) {
                 return false
             }
 

--- a/src/shared/sam/cli/samCliValidationNotification.ts
+++ b/src/shared/sam/cli/samCliValidationNotification.ts
@@ -11,7 +11,7 @@ import { getIdeProperties } from '../../extensionUtilities'
 import {
     InvalidSamCliError,
     InvalidSamCliVersionError,
-    maximumSamCliVersionExclusive,
+    maxSamCliVersionExclusive,
     minimumSamCliVersionInclusive,
     SamCliNotFoundError,
     SamCliVersionValidation,
@@ -130,7 +130,7 @@ function makeVersionValidationNotificationMessage(validationResult: SamCliVersio
         'Your SAM CLI version {0} does not meet requirements ({1} ≤ version < {2}). {3}',
         validationResult.version,
         minimumSamCliVersionInclusive,
-        maximumSamCliVersionExclusive,
+        maxSamCliVersionExclusive,
         recommendation
     )
 }

--- a/src/shared/sam/cli/samCliValidationNotification.ts
+++ b/src/shared/sam/cli/samCliValidationNotification.ts
@@ -12,7 +12,7 @@ import {
     InvalidSamCliError,
     InvalidSamCliVersionError,
     maxSamCliVersionExclusive,
-    minimumSamCliVersionInclusive,
+    minSamCliVersion,
     SamCliNotFoundError,
     SamCliVersionValidation,
     SamCliVersionValidatorResult,
@@ -129,7 +129,7 @@ function makeVersionValidationNotificationMessage(validationResult: SamCliVersio
         'AWS.samcli.notification.version.invalid',
         'Your SAM CLI version {0} does not meet requirements ({1} ≤ version < {2}). {3}',
         validationResult.version,
-        minimumSamCliVersionInclusive,
+        minSamCliVersion,
         maxSamCliVersionExclusive,
         recommendation
     )

--- a/src/shared/sam/cli/samCliValidator.ts
+++ b/src/shared/sam/cli/samCliValidator.ts
@@ -9,12 +9,12 @@ import { ClassToInterfaceType } from '../../utilities/tsUtils'
 import { SamCliSettings } from './samCliSettings'
 import { SamCliInfoInvocation, SamCliInfoResponse } from './samCliInfo'
 
-export const minimumSamCliVersionInclusive = '0.47.0'
-export const minSamCliVersionInclusiveForImageSupport = '1.13.0'
+export const minSamCliVersion = '0.47.0'
+export const minSamCliVersionForImageSupport = '1.13.0'
 export const maxSamCliVersionExclusive = '2.0.0'
-export const minSamCliVersionInclusiveForGoSupport = '1.18.1'
-export const minSamCliVersionInclusiveForArmSupport = '1.33.0'
-export const minSamCliVersionInclusiveForDotnet31Support = '1.4.0'
+export const minSamCliVersionForGoSupport = '1.18.1'
+export const minSamCliVersionForArmSupport = '1.33.0'
+export const minSamCliVersionForDotnet31Support = '1.4.0'
 
 // Errors
 export class InvalidSamCliError extends Error {
@@ -120,7 +120,7 @@ export class DefaultSamCliValidator implements SamCliValidator {
             return SamCliVersionValidation.VersionNotParseable
         }
 
-        if (semver.lt(version, minimumSamCliVersionInclusive)) {
+        if (semver.lt(version, minSamCliVersion)) {
             return SamCliVersionValidation.VersionTooLow
         }
 

--- a/src/shared/sam/cli/samCliValidator.ts
+++ b/src/shared/sam/cli/samCliValidator.ts
@@ -10,11 +10,11 @@ import { SamCliSettings } from './samCliSettings'
 import { SamCliInfoInvocation, SamCliInfoResponse } from './samCliInfo'
 
 export const minimumSamCliVersionInclusive = '0.47.0'
-export const minimumSamCliVersionInclusiveForImageSupport = '1.13.0'
-export const maximumSamCliVersionExclusive = '2.0.0'
-export const minimumSamCliVersionInclusiveForGoSupport = '1.18.1'
-export const minimumSamCliVersionInclusiveForArmSupport = '1.33.0'
-export const minimumSamCliVersionInclusiveForDotnet31Support = '1.4.0'
+export const minSamCliVersionInclusiveForImageSupport = '1.13.0'
+export const maxSamCliVersionExclusive = '2.0.0'
+export const minSamCliVersionInclusiveForGoSupport = '1.18.1'
+export const minSamCliVersionInclusiveForArmSupport = '1.33.0'
+export const minSamCliVersionInclusiveForDotnet31Support = '1.4.0'
 
 // Errors
 export class InvalidSamCliError extends Error {
@@ -124,7 +124,7 @@ export class DefaultSamCliValidator implements SamCliValidator {
             return SamCliVersionValidation.VersionTooLow
         }
 
-        if (semver.gte(version, maximumSamCliVersionExclusive)) {
+        if (semver.gte(version, maxSamCliVersionExclusive)) {
             return SamCliVersionValidation.VersionTooHigh
         }
 

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -56,10 +56,7 @@ import { fromString } from '../../../credentials/providers/credentials'
 import { Credentials } from '@aws-sdk/types'
 import { CloudFormation } from '../../cloudformation/cloudformation'
 import { getSamCliContext, getSamCliVersion } from '../cli/samCliContext'
-import {
-    minimumSamCliVersionInclusiveForImageSupport,
-    minimumSamCliVersionInclusiveForGoSupport,
-} from '../cli/samCliValidator'
+import { minSamCliVersionInclusiveForImageSupport, minSamCliVersionInclusiveForGoSupport } from '../cli/samCliValidator'
 import { getIdeProperties, isCloud9 } from '../../extensionUtilities'
 import { resolve } from 'path'
 import globals from '../../extensionGlobals'
@@ -489,7 +486,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         // TODO: Remove this when min sam version is > 1.13.0
         if (!isZip) {
             const samCliVersion = await getSamCliVersion(this.ctx.samCliContext())
-            if (semver.lt(samCliVersion, minimumSamCliVersionInclusiveForImageSupport)) {
+            if (semver.lt(samCliVersion, minSamCliVersionInclusiveForImageSupport)) {
                 const message = localize(
                     'AWS.output.sam.no.image.support',
                     'Support for Image-based Lambdas requires a minimum SAM CLI version of 1.13.0.'
@@ -513,12 +510,12 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         // TODO: remove this when min sam version is >= 1.18.1
         if (goRuntimes.includes(runtime) && !config.noDebug) {
             const samCliVersion = await getSamCliVersion(this.ctx.samCliContext())
-            if (semver.lt(samCliVersion, minimumSamCliVersionInclusiveForGoSupport)) {
+            if (semver.lt(samCliVersion, minSamCliVersionInclusiveForGoSupport)) {
                 vscode.window.showWarningMessage(
                     localize(
                         'AWS.output.sam.local.no.go.support',
                         'Debugging go1.x lambdas requires a minimum SAM CLI version of {0}. Function will run locally without debug.',
-                        minimumSamCliVersionInclusiveForGoSupport
+                        minSamCliVersionInclusiveForGoSupport
                     )
                 )
                 config.noDebug = true

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -56,7 +56,7 @@ import { fromString } from '../../../credentials/providers/credentials'
 import { Credentials } from '@aws-sdk/types'
 import { CloudFormation } from '../../cloudformation/cloudformation'
 import { getSamCliContext, getSamCliVersion } from '../cli/samCliContext'
-import { minSamCliVersionInclusiveForImageSupport, minSamCliVersionInclusiveForGoSupport } from '../cli/samCliValidator'
+import { minSamCliVersionForImageSupport, minSamCliVersionForGoSupport } from '../cli/samCliValidator'
 import { getIdeProperties, isCloud9 } from '../../extensionUtilities'
 import { resolve } from 'path'
 import globals from '../../extensionGlobals'
@@ -337,6 +337,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
      * @param token  Cancellation token
      */
     public async resolveDebugConfigurationWithSubstitutedVariables(
+        // eslint-disable-line id-length
         folder: vscode.WorkspaceFolder | undefined,
         config: AwsSamDebuggerConfiguration,
         token?: vscode.CancellationToken
@@ -486,7 +487,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         // TODO: Remove this when min sam version is > 1.13.0
         if (!isZip) {
             const samCliVersion = await getSamCliVersion(this.ctx.samCliContext())
-            if (semver.lt(samCliVersion, minSamCliVersionInclusiveForImageSupport)) {
+            if (semver.lt(samCliVersion, minSamCliVersionForImageSupport)) {
                 const message = localize(
                     'AWS.output.sam.no.image.support',
                     'Support for Image-based Lambdas requires a minimum SAM CLI version of 1.13.0.'
@@ -510,12 +511,12 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         // TODO: remove this when min sam version is >= 1.18.1
         if (goRuntimes.includes(runtime) && !config.noDebug) {
             const samCliVersion = await getSamCliVersion(this.ctx.samCliContext())
-            if (semver.lt(samCliVersion, minSamCliVersionInclusiveForGoSupport)) {
+            if (semver.lt(samCliVersion, minSamCliVersionForGoSupport)) {
                 vscode.window.showWarningMessage(
                     localize(
                         'AWS.output.sam.local.no.go.support',
                         'Debugging go1.x lambdas requires a minimum SAM CLI version of {0}. Function will run locally without debug.',
-                        minSamCliVersionInclusiveForGoSupport
+                        minSamCliVersionForGoSupport
                     )
                 )
                 config.noDebug = true

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -336,8 +336,8 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
      * @param config User-provided config (from launch.json)
      * @param token  Cancellation token
      */
+    // eslint-disable-next-line id-length
     public async resolveDebugConfigurationWithSubstitutedVariables(
-        // eslint-disable-line id-length
         folder: vscode.WorkspaceFolder | undefined,
         config: AwsSamDebuggerConfiguration,
         token?: vscode.CancellationToken

--- a/src/shared/sam/debugger/csharpSamDebug.ts
+++ b/src/shared/sam/debugger/csharpSamDebug.ts
@@ -26,7 +26,7 @@ import { Window } from '../../vscode/window'
 
 import * as nls from 'vscode-nls'
 import { getSamCliVersion } from '../cli/samCliContext'
-import { minSamCliVersionInclusiveForDotnet31Support } from '../cli/samCliValidator'
+import { minSamCliVersionForDotnet31Support } from '../cli/samCliValidator'
 import globals from '../../extensionGlobals'
 const localize = nls.loadMessageBundle()
 
@@ -79,7 +79,7 @@ export async function invokeCsharpLambda(
     if (!config.noDebug) {
         const samCliVersion = await getSamCliVersion(ctx.samCliContext())
         // TODO: Remove this when min sam version is >= 1.4.0
-        if (semver.lt(samCliVersion, minSamCliVersionInclusiveForDotnet31Support)) {
+        if (semver.lt(samCliVersion, minSamCliVersionForDotnet31Support)) {
             window.showWarningMessage(
                 localize(
                     'AWS.output.sam.local.no.net.3.1.debug',

--- a/src/shared/sam/debugger/csharpSamDebug.ts
+++ b/src/shared/sam/debugger/csharpSamDebug.ts
@@ -26,7 +26,7 @@ import { Window } from '../../vscode/window'
 
 import * as nls from 'vscode-nls'
 import { getSamCliVersion } from '../cli/samCliContext'
-import { minimumSamCliVersionInclusiveForDotnet31Support } from '../cli/samCliValidator'
+import { minSamCliVersionInclusiveForDotnet31Support } from '../cli/samCliValidator'
 import globals from '../../extensionGlobals'
 const localize = nls.loadMessageBundle()
 
@@ -79,7 +79,7 @@ export async function invokeCsharpLambda(
     if (!config.noDebug) {
         const samCliVersion = await getSamCliVersion(ctx.samCliContext())
         // TODO: Remove this when min sam version is >= 1.4.0
-        if (semver.lt(samCliVersion, minimumSamCliVersionInclusiveForDotnet31Support)) {
+        if (semver.lt(samCliVersion, minSamCliVersionInclusiveForDotnet31Support)) {
             window.showWarningMessage(
                 localize(
                     'AWS.output.sam.local.no.net.3.1.debug',

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -530,7 +530,7 @@ export async function waitForPort(port: number, timeout: Timeout, isDebugPort: b
     }
 }
 
-export function shouldAppendRelativePathToFunctionHandler(runtime: string): boolean {
+export function shouldAppendRelativePathToFuncHandler(runtime: string): boolean {
     // getFamily will throw an error if the runtime doesn't exist
     switch (getFamily(runtime)) {
         case RuntimeFamily.NodeJS:

--- a/src/shared/typescriptLambdaHandlerSearch.ts
+++ b/src/shared/typescriptLambdaHandlerSearch.ts
@@ -67,7 +67,7 @@ export class TypescriptLambdaHandlerSearch implements LambdaHandlerSearch {
 
         handlers.push(...this.findCandidateHandlersInModuleExports())
         handlers.push(...this.findCandidateHandlersInExportedFunctions())
-        handlers.push(...this.findCandidateHandlersInExportDeclarations())
+        handlers.push(...this.findCandidateHandlersInExportDecls())
 
         return handlers
     }
@@ -158,7 +158,7 @@ export class TypescriptLambdaHandlerSearch implements LambdaHandlerSearch {
     /**
      * @description Looks at "export { xyz }" statements to find candidate Lambda handlers
      */
-    private findCandidateHandlersInExportDeclarations(): RootlessLambdaHandlerCandidate[] {
+    private findCandidateHandlersInExportDecls(): RootlessLambdaHandlerCandidate[] {
         const handlers: RootlessLambdaHandlerCandidate[] = []
 
         this._candidateExportDeclarations.forEach(exportDeclaration => {

--- a/src/test/apigateway/explorer/apiGatewayNodes.test.ts
+++ b/src/test/apigateway/explorer/apiGatewayNodes.test.ts
@@ -5,8 +5,8 @@
 
 import * as assert from 'assert'
 import {
-    assertNodeListOnlyContainsErrorNode,
-    assertNodeListOnlyContainsPlaceholderNode,
+    assertNodeListOnlyHasErrorNode,
+    assertNodeListOnlyHasPlaceholderNode,
 } from '../../utilities/explorerNodeAssertions'
 import { asyncGenerator } from '../../utilities/collectionUtils'
 import { ApiGatewayNode } from '../../../apigateway/explorer/apiGatewayNodes'
@@ -57,7 +57,7 @@ describe('ApiGatewayNode', function () {
 
         const childNodes = await testNode.getChildren()
 
-        assertNodeListOnlyContainsPlaceholderNode(childNodes)
+        assertNodeListOnlyHasPlaceholderNode(childNodes)
     })
 
     it('has RestApi child nodes', async function () {
@@ -82,6 +82,6 @@ describe('ApiGatewayNode', function () {
         client.listApis.throws(new Error())
 
         const node = new ApiGatewayNode(fakePartitionId, fakeRegionCode, client)
-        assertNodeListOnlyContainsErrorNode(await node.getChildren())
+        assertNodeListOnlyHasErrorNode(await node.getChildren())
     })
 })

--- a/src/test/cloudWatchLogs/commands/viewLogStream.test.ts
+++ b/src/test/cloudWatchLogs/commands/viewLogStream.test.ts
@@ -11,7 +11,7 @@ import * as moment from 'moment'
 import {
     SelectLogStreamWizardContext,
     SelectLogStreamWizard,
-    convertDescribeLogStreamsToQuickPickItems,
+    convertDescribeLogToQuickPickItems,
 } from '../../../cloudWatchLogs/commands/viewLogStream'
 import { LogGroupNode } from '../../../cloudWatchLogs/explorer/logGroupNode'
 import { LOCALIZED_DATE_FORMAT } from '../../../shared/constants'
@@ -64,10 +64,10 @@ describe('viewLogStreamWizard', async function () {
     })
 })
 
-describe('convertDescribeLogStreamsToQuickPickItems', function () {
+describe('convertDescribeLogToQuickPickItems', function () {
     it('converts things correctly', function () {
         const time = new globals.clock.Date().getTime()
-        const results = convertDescribeLogStreamsToQuickPickItems({
+        const results = convertDescribeLogToQuickPickItems({
             logStreams: [
                 {
                     logStreamName: 'streamWithoutTimestamp',
@@ -88,7 +88,7 @@ describe('convertDescribeLogStreamsToQuickPickItems', function () {
             label: 'streamWithTimestamp',
             detail: moment(time).format(LOCALIZED_DATE_FORMAT),
         })
-        const noResults = convertDescribeLogStreamsToQuickPickItems({})
+        const noResults = convertDescribeLogToQuickPickItems({})
         assert.strictEqual(noResults.length, 0)
     })
 })

--- a/src/test/cloudWatchLogs/explorer/cloudWatchLogsNode.test.ts
+++ b/src/test/cloudWatchLogs/explorer/cloudWatchLogsNode.test.ts
@@ -8,8 +8,8 @@ import { contextValueCloudwatchLog, LogGroupNode } from '../../../cloudWatchLogs
 import { CloudWatchLogsNode } from '../../../cloudWatchLogs/explorer/cloudWatchLogsNode'
 import { asyncGenerator } from '../../utilities/collectionUtils'
 import {
-    assertNodeListOnlyContainsErrorNode,
-    assertNodeListOnlyContainsPlaceholderNode,
+    assertNodeListOnlyHasErrorNode,
+    assertNodeListOnlyHasPlaceholderNode,
 } from '../../utilities/explorerNodeAssertions'
 import { DefaultCloudWatchLogsClient } from '../../../shared/clients/cloudWatchLogsClient'
 import { stub } from '../../utilities/stubber'
@@ -41,7 +41,7 @@ describe('CloudWatchLogsNode', function () {
 
         const childNodes = await testNode.getChildren()
 
-        assertNodeListOnlyContainsPlaceholderNode(childNodes)
+        assertNodeListOnlyHasPlaceholderNode(childNodes)
     })
 
     it('has LogGroupNode child nodes', async function () {
@@ -78,6 +78,6 @@ describe('CloudWatchLogsNode', function () {
         client.describeLogGroups.throws(new Error())
 
         const node = new CloudWatchLogsNode(fakeRegionCode, client)
-        assertNodeListOnlyContainsErrorNode(await node.getChildren())
+        assertNodeListOnlyHasErrorNode(await node.getChildren())
     })
 })

--- a/src/test/codewhisperer/commands/invokeRecommendation.test.ts
+++ b/src/test/codewhisperer/commands/invokeRecommendation.test.ts
@@ -34,7 +34,7 @@ describe('invokeRecommendation', function () {
                 isShowMethodsEnabled: true,
                 isManualTriggerEnabled: true,
                 isAutomatedTriggerEnabled: true,
-                isIncludeSuggestionsWithCodeReferencesEnabled: true, // eslint-disable-line id-length
+                isSuggestionsWithCodeReferencesEnabled: true,
             }
             await invokeRecommendation(mockEditor, mockClient, config)
             assert.ok(getRecommendationStub.called || oldGetRecommendationStub.called)

--- a/src/test/codewhisperer/commands/invokeRecommendation.test.ts
+++ b/src/test/codewhisperer/commands/invokeRecommendation.test.ts
@@ -34,7 +34,7 @@ describe('invokeRecommendation', function () {
                 isShowMethodsEnabled: true,
                 isManualTriggerEnabled: true,
                 isAutomatedTriggerEnabled: true,
-                isIncludeSuggestionsWithCodeReferencesEnabled: true,
+                isIncludeSuggestionsWithCodeReferencesEnabled: true, // eslint-disable-line id-length
             }
             await invokeRecommendation(mockEditor, mockClient, config)
             assert.ok(getRecommendationStub.called || oldGetRecommendationStub.called)

--- a/src/test/codewhisperer/service/inlineCompletion.test.ts
+++ b/src/test/codewhisperer/service/inlineCompletion.test.ts
@@ -192,7 +192,7 @@ describe('inlineCompletion', function () {
             isShowMethodsEnabled: true,
             isManualTriggerEnabled: true,
             isAutomatedTriggerEnabled: true,
-            isIncludeSuggestionsWithCodeReferencesEnabled: true,
+            isIncludeSuggestionsWithCodeReferencesEnabled: true, // eslint-disable-line id-length
         }
         const invokeSpy = sinon.stub(RecommendationHandler.instance, 'getRecommendations')
         let mockClient: codewhispererSdkClient.DefaultCodeWhispererClient

--- a/src/test/codewhisperer/service/inlineCompletion.test.ts
+++ b/src/test/codewhisperer/service/inlineCompletion.test.ts
@@ -192,7 +192,7 @@ describe('inlineCompletion', function () {
             isShowMethodsEnabled: true,
             isManualTriggerEnabled: true,
             isAutomatedTriggerEnabled: true,
-            isIncludeSuggestionsWithCodeReferencesEnabled: true, // eslint-disable-line id-length
+            isSuggestionsWithCodeReferencesEnabled: true,
         }
         const invokeSpy = sinon.stub(RecommendationHandler.instance, 'getRecommendations')
         let mockClient: codewhispererSdkClient.DefaultCodeWhispererClient

--- a/src/test/codewhisperer/service/inlineCompletionService.test.ts
+++ b/src/test/codewhisperer/service/inlineCompletionService.test.ts
@@ -23,7 +23,7 @@ describe('inlineCompletionService', function () {
             isShowMethodsEnabled: true,
             isManualTriggerEnabled: true,
             isAutomatedTriggerEnabled: true,
-            isIncludeSuggestionsWithCodeReferencesEnabled: true, // eslint-disable-line id-length
+            isSuggestionsWithCodeReferencesEnabled: true,
         }
 
         let mockClient: codewhispererSdkClient.DefaultCodeWhispererClient

--- a/src/test/codewhisperer/service/inlineCompletionService.test.ts
+++ b/src/test/codewhisperer/service/inlineCompletionService.test.ts
@@ -23,7 +23,7 @@ describe('inlineCompletionService', function () {
             isShowMethodsEnabled: true,
             isManualTriggerEnabled: true,
             isAutomatedTriggerEnabled: true,
-            isIncludeSuggestionsWithCodeReferencesEnabled: true,
+            isIncludeSuggestionsWithCodeReferencesEnabled: true, // eslint-disable-line id-length
         }
 
         let mockClient: codewhispererSdkClient.DefaultCodeWhispererClient

--- a/src/test/codewhisperer/service/keyStrokeHandler.test.ts
+++ b/src/test/codewhisperer/service/keyStrokeHandler.test.ts
@@ -26,7 +26,7 @@ describe('keyStrokeHandler', function () {
         isShowMethodsEnabled: true,
         isManualTriggerEnabled: true,
         isAutomatedTriggerEnabled: true,
-        isIncludeSuggestionsWithCodeReferencesEnabled: true,
+        isIncludeSuggestionsWithCodeReferencesEnabled: true, // eslint-disable-line id-length
     }
     beforeEach(function () {
         resetCodeWhispererGlobalVariables()
@@ -59,7 +59,7 @@ describe('keyStrokeHandler', function () {
                 isShowMethodsEnabled: true,
                 isManualTriggerEnabled: true,
                 isAutomatedTriggerEnabled: false,
-                isIncludeSuggestionsWithCodeReferencesEnabled: true,
+                isIncludeSuggestionsWithCodeReferencesEnabled: true, // eslint-disable-line id-length
             }
             const keyStrokeHandler = new KeyStrokeHandler()
             await keyStrokeHandler.processKeyStroke(mockEvent, mockEditor, mockClient, cfg)

--- a/src/test/codewhisperer/service/keyStrokeHandler.test.ts
+++ b/src/test/codewhisperer/service/keyStrokeHandler.test.ts
@@ -26,7 +26,7 @@ describe('keyStrokeHandler', function () {
         isShowMethodsEnabled: true,
         isManualTriggerEnabled: true,
         isAutomatedTriggerEnabled: true,
-        isIncludeSuggestionsWithCodeReferencesEnabled: true, // eslint-disable-line id-length
+        isSuggestionsWithCodeReferencesEnabled: true,
     }
     beforeEach(function () {
         resetCodeWhispererGlobalVariables()
@@ -59,7 +59,7 @@ describe('keyStrokeHandler', function () {
                 isShowMethodsEnabled: true,
                 isManualTriggerEnabled: true,
                 isAutomatedTriggerEnabled: false,
-                isIncludeSuggestionsWithCodeReferencesEnabled: true, // eslint-disable-line id-length
+                isSuggestionsWithCodeReferencesEnabled: true,
             }
             const keyStrokeHandler = new KeyStrokeHandler()
             await keyStrokeHandler.processKeyStroke(mockEvent, mockEditor, mockClient, cfg)

--- a/src/test/codewhisperer/service/recommendationHandler.test.ts
+++ b/src/test/codewhisperer/service/recommendationHandler.test.ts
@@ -24,7 +24,7 @@ describe('recommendationHandler', function () {
         isShowMethodsEnabled: true,
         isManualTriggerEnabled: true,
         isAutomatedTriggerEnabled: true,
-        isIncludeSuggestionsWithCodeReferencesEnabled: true, // eslint-disable-line id-length
+        isSuggestionsWithCodeReferencesEnabled: true,
     }
     beforeEach(function () {
         resetCodeWhispererGlobalVariables()

--- a/src/test/codewhisperer/service/recommendationHandler.test.ts
+++ b/src/test/codewhisperer/service/recommendationHandler.test.ts
@@ -24,7 +24,7 @@ describe('recommendationHandler', function () {
         isShowMethodsEnabled: true,
         isManualTriggerEnabled: true,
         isAutomatedTriggerEnabled: true,
-        isIncludeSuggestionsWithCodeReferencesEnabled: true,
+        isIncludeSuggestionsWithCodeReferencesEnabled: true, // eslint-disable-line id-length
     }
     beforeEach(function () {
         resetCodeWhispererGlobalVariables()

--- a/src/test/dynamicResources/explorer/moreResourcesNode.test.ts
+++ b/src/test/dynamicResources/explorer/moreResourcesNode.test.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode'
 import { ResourcesNode } from '../../../dynamicResources/explorer/nodes/resourcesNode'
 import { ResourceTypeNode } from '../../../dynamicResources/explorer/nodes/resourceTypeNode'
 import { CloudFormationClient } from '../../../shared/clients/cloudFormationClient'
-import { assertNodeListOnlyContainsPlaceholderNode } from '../../utilities/explorerNodeAssertions'
+import { assertNodeListOnlyHasPlaceholderNode } from '../../utilities/explorerNodeAssertions'
 import { asyncGenerator } from '../../utilities/collectionUtils'
 import { mock, instance, when } from 'ts-mockito'
 import { CloudFormation } from 'aws-sdk'
@@ -53,7 +53,7 @@ describe('ResourcesNode', function () {
 
         const childNodes = await testNode.getChildren()
 
-        assertNodeListOnlyContainsPlaceholderNode(childNodes)
+        assertNodeListOnlyHasPlaceholderNode(childNodes)
     })
 
     it('has ResourceTypeNode child nodes', async function () {

--- a/src/test/dynamicResources/explorer/resourceTypeNode.test.ts
+++ b/src/test/dynamicResources/explorer/resourceTypeNode.test.ts
@@ -10,8 +10,8 @@ import { ResourcesNode } from '../../../dynamicResources/explorer/nodes/resource
 import { ResourceNode } from '../../../dynamicResources/explorer/nodes/resourceNode'
 import { ResourceTypeNode } from '../../../dynamicResources/explorer/nodes/resourceTypeNode'
 import {
-    assertNodeListOnlyContainsErrorNode,
-    assertNodeListOnlyContainsPlaceholderNode,
+    assertNodeListOnlyHasErrorNode,
+    assertNodeListOnlyHasPlaceholderNode,
 } from '../../utilities/explorerNodeAssertions'
 import { deepEqual, instance, mock, when } from '../../utilities/mockito'
 import { CloudControlClient } from '../../../shared/clients/cloudControlClient'
@@ -50,7 +50,7 @@ describe('ResourceTypeNode', function () {
 
         const childNodes = await testNode.getChildren()
 
-        assertNodeListOnlyContainsPlaceholderNode(childNodes)
+        assertNodeListOnlyHasPlaceholderNode(childNodes)
     })
 
     it('has ResourceNode child nodes', async function () {
@@ -117,7 +117,7 @@ describe('ResourceTypeNode', function () {
         testNode = generateTestNode(instance(cloudControl))
 
         const childNodes = await testNode.getChildren()
-        assertNodeListOnlyContainsErrorNode(childNodes)
+        assertNodeListOnlyHasErrorNode(childNodes)
     })
 
     it('has a placeholder node for a child if unsupported action', async function () {
@@ -128,7 +128,7 @@ describe('ResourceTypeNode', function () {
         testNode = generateTestNode(instance(cloudControl))
 
         const childNodes = await testNode.getChildren()
-        assertNodeListOnlyContainsPlaceholderNode(childNodes)
+        assertNodeListOnlyHasPlaceholderNode(childNodes)
     })
 
     it('has Documented contextValue if documentation available', function () {

--- a/src/test/ecr/explorer/EcrNode.test.ts
+++ b/src/test/ecr/explorer/EcrNode.test.ts
@@ -10,7 +10,7 @@ import { EcrNode } from '../../../ecr/explorer/ecrNode'
 import { EcrRepositoryNode } from '../../../ecr/explorer/ecrRepositoryNode'
 import { PlaceholderNode } from '../../../shared/treeview/nodes/placeholderNode'
 import { EcrTagNode } from '../../../ecr/explorer/ecrTagNode'
-import { assertNodeListOnlyContainsErrorNode } from '../../utilities/explorerNodeAssertions'
+import { assertNodeListOnlyHasErrorNode } from '../../utilities/explorerNodeAssertions'
 
 describe('EcrNode', function () {
     let ecr: EcrClient
@@ -65,7 +65,7 @@ describe('EcrNode', function () {
 
         const children = await new EcrNode(ecr).getChildren()
 
-        assertNodeListOnlyContainsErrorNode(children)
+        assertNodeListOnlyHasErrorNode(children)
         assert.ok(stub.calledOnce)
     })
 })
@@ -128,7 +128,7 @@ describe('EcrRepositoryNode', function () {
 
         const children = await new EcrRepositoryNode({} as EcrNode, ecr, repository).getChildren()
 
-        assertNodeListOnlyContainsErrorNode(children)
+        assertNodeListOnlyHasErrorNode(children)
         assert.ok(stub.calledOnce)
     })
 })

--- a/src/test/eventSchemas/explorer/registryItemNode.test.ts
+++ b/src/test/eventSchemas/explorer/registryItemNode.test.ts
@@ -14,8 +14,8 @@ import { DefaultSchemaClient } from '../../../shared/clients/schemaClient'
 import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
 import { PlaceholderNode } from '../../../shared/treeview/nodes/placeholderNode'
 import {
-    assertNodeListOnlyContainsErrorNode,
-    assertNodeListOnlyContainsPlaceholderNode,
+    assertNodeListOnlyHasErrorNode,
+    assertNodeListOnlyHasPlaceholderNode,
 } from '../../utilities/explorerNodeAssertions'
 import { asyncGenerator } from '../../utilities/collectionUtils'
 import { getIcon } from '../../../shared/icons'
@@ -137,7 +137,7 @@ describe('DefaultRegistryNode', function () {
         const schemasNode = new SchemasNode(createSchemaClient())
         const childNodes = await schemasNode.getChildren()
 
-        assertNodeListOnlyContainsPlaceholderNode(childNodes)
+        assertNodeListOnlyHasPlaceholderNode(childNodes)
     })
 
     it('handles error', async function () {
@@ -155,6 +155,6 @@ describe('DefaultRegistryNode', function () {
         const testNode: ThrowErrorDefaultSchemaRegistrynNode = new ThrowErrorDefaultSchemaRegistrynNode()
 
         const childNodes = await testNode.getChildren()
-        assertNodeListOnlyContainsErrorNode(childNodes)
+        assertNodeListOnlyHasErrorNode(childNodes)
     })
 })

--- a/src/test/eventSchemas/templates/schemasAppTemplateUtils.test.ts
+++ b/src/test/eventSchemas/templates/schemasAppTemplateUtils.test.ts
@@ -24,7 +24,8 @@ const partnerSchemaExpectedPackageName = 'schema.aws.partner.mongodb_com_1234567
 const partnerSchemaName = 'aws.partner-mongodb.com/1234567-tickets@Ticket.Created'
 
 const customerUploadedSchemaName = 'someCustomer.SomeAwesomeSchema'
-const customerUploadedSchemaExpectedPackageName = 'schema.somecustomer_someawesomeschema'
+/** Expected package name. */
+const customerUploadedSchemaExpectedPackage = 'schema.somecustomer_someawesomeschema'
 const defaultEventSource = 'INSERT-YOUR-EVENT-SOURCE'
 const defaultEventDetailType = 'INSERT-YOUR-DETAIL-TYPE'
 
@@ -132,7 +133,7 @@ describe('Build template parameters for CustomerUploadedSchema', async function 
         assert.strictEqual(result.templateExtraContent.AWS_Schema_name, 'Some_Awesome_Schema', 'schemaRootEventName')
         assert.strictEqual(
             result.templateExtraContent.AWS_Schema_root,
-            customerUploadedSchemaExpectedPackageName,
+            customerUploadedSchemaExpectedPackage,
             'schemaPackageHierarchy'
         )
 

--- a/src/test/eventSchemas/templates/schemasAppTemplateUtils.test.ts
+++ b/src/test/eventSchemas/templates/schemasAppTemplateUtils.test.ts
@@ -28,11 +28,9 @@ const customerUploadedSchemaExpectedPackageName = 'schema.somecustomer_someaweso
 const defaultEventSource = 'INSERT-YOUR-EVENT-SOURCE'
 const defaultEventDetailType = 'INSERT-YOUR-DETAIL-TYPE'
 
-// eslint-disable-next-line id-length
 const customerUploadedSchemaMultipleTypesName = 'someCustomer.multipleTypes@SomeOtherAwesomeSchema'
-// eslint-disable-next-line id-length
-const customerUploadedSchemaMultipleTypesExpectedPackageName =
-    'schema.somecustomer_multipletypes.someotherawesomeschema'
+/** Expected package name. */
+const customerUploadedSchemaMultipleTypesPkg = 'schema.somecustomer_multipletypes.someotherawesomeschema'
 
 describe('Build template parameters for AwsEventSchema', async function () {
     it('should build correct template parameters for aws event schema', async function () {
@@ -180,7 +178,7 @@ describe('Build template parameters for CustomerUploadedSchemaMultipleTypes', as
         )
         assert.strictEqual(
             result.templateExtraContent.AWS_Schema_root,
-            customerUploadedSchemaMultipleTypesExpectedPackageName,
+            customerUploadedSchemaMultipleTypesPkg,
             'schemaPackageHierarchy'
         )
 

--- a/src/test/eventSchemas/templates/schemasAppTemplateUtils.test.ts
+++ b/src/test/eventSchemas/templates/schemasAppTemplateUtils.test.ts
@@ -28,7 +28,9 @@ const customerUploadedSchemaExpectedPackageName = 'schema.somecustomer_someaweso
 const defaultEventSource = 'INSERT-YOUR-EVENT-SOURCE'
 const defaultEventDetailType = 'INSERT-YOUR-DETAIL-TYPE'
 
+// eslint-disable-next-line id-length
 const customerUploadedSchemaMultipleTypesName = 'someCustomer.multipleTypes@SomeOtherAwesomeSchema'
+// eslint-disable-next-line id-length
 const customerUploadedSchemaMultipleTypesExpectedPackageName =
     'schema.somecustomer_multipletypes.someotherawesomeschema'
 

--- a/src/test/fakeExtensionContext.ts
+++ b/src/test/fakeExtensionContext.ts
@@ -11,7 +11,7 @@ import { ExtContext } from '../shared/extensions'
 import { SamCliContext } from '../shared/sam/cli/samCliContext'
 import {
     minimumSamCliVersionInclusive,
-    minimumSamCliVersionInclusiveForGoSupport,
+    minSamCliVersionInclusiveForGoSupport,
     SamCliValidator,
     SamCliValidatorResult,
     SamCliVersionValidation,
@@ -113,7 +113,7 @@ export class FakeExtensionContext implements vscode.ExtensionContext {
                 invoker: new TestSamCliProcessInvoker((spawnOptions, args: any[]): ChildProcessResult => {
                     return new FakeChildProcessResult({})
                 }),
-                validator: new FakeSamCliValidator(minimumSamCliVersionInclusiveForGoSupport),
+                validator: new FakeSamCliValidator(minSamCliVersionInclusiveForGoSupport),
             } as SamCliContext
         }
         const regionProvider = createTestRegionProvider({ globalState: ctx.globalState, awsContext })

--- a/src/test/fakeExtensionContext.ts
+++ b/src/test/fakeExtensionContext.ts
@@ -10,8 +10,8 @@ import { CredentialsStore } from '../credentials/credentialsStore'
 import { ExtContext } from '../shared/extensions'
 import { SamCliContext } from '../shared/sam/cli/samCliContext'
 import {
-    minimumSamCliVersionInclusive,
-    minSamCliVersionInclusiveForGoSupport,
+    minSamCliVersion,
+    minSamCliVersionForGoSupport,
     SamCliValidator,
     SamCliValidatorResult,
     SamCliVersionValidation,
@@ -113,7 +113,7 @@ export class FakeExtensionContext implements vscode.ExtensionContext {
                 invoker: new TestSamCliProcessInvoker((spawnOptions, args: any[]): ChildProcessResult => {
                     return new FakeChildProcessResult({})
                 }),
-                validator: new FakeSamCliValidator(minSamCliVersionInclusiveForGoSupport),
+                validator: new FakeSamCliValidator(minSamCliVersionForGoSupport),
             } as SamCliContext
         }
         const regionProvider = createTestRegionProvider({ globalState: ctx.globalState, awsContext })
@@ -173,7 +173,7 @@ class SecretStorage implements vscode.SecretStorage {
 
 export class FakeSamCliValidator implements SamCliValidator {
     private readonly version: string
-    public constructor(version: string = minimumSamCliVersionInclusive) {
+    public constructor(version: string = minSamCliVersion) {
         this.version = version
     }
     public async detectValidSamCli(): Promise<SamCliValidatorResult> {

--- a/src/test/lambda/config/samParameterCompletionItemProvider.test.ts
+++ b/src/test/lambda/config/samParameterCompletionItemProvider.test.ts
@@ -72,8 +72,7 @@ function createTemplatesSymbol({
     return templatesSymbol
 }
 
-// eslint-disable-next-line id-length
-class MockSamParameterCompletionItemProviderContext implements SamParameterCompletionItemProviderContext {
+class MockSamParamComplItemProviderContext implements SamParameterCompletionItemProviderContext {
     public readonly logger: Pick<Logger, 'warn'>
     public readonly getWorkspaceFolder: typeof vscode.workspace.getWorkspaceFolder
     public readonly executeCommand: typeof vscode.commands.executeCommand
@@ -100,7 +99,7 @@ describe('SamParameterCompletionItemProvider', async function () {
     it('recovers gracefully if document is not in a workspace', async function () {
         const warnArgs: (Error | string)[][] = []
         const provider = new SamParameterCompletionItemProvider(
-            new MockSamParameterCompletionItemProviderContext({
+            new MockSamParamComplItemProviderContext({
                 logger: {
                     warn(...message: (Error | string)[]) {
                         warnArgs.push(message)
@@ -132,7 +131,7 @@ describe('SamParameterCompletionItemProvider', async function () {
 
     it('does not provide suggestions if document symbols could not be loaded', async function () {
         const provider = new SamParameterCompletionItemProvider(
-            new MockSamParameterCompletionItemProviderContext({
+            new MockSamParamComplItemProviderContext({
                 executeCommand: async () => undefined,
                 getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
             })
@@ -154,7 +153,7 @@ describe('SamParameterCompletionItemProvider', async function () {
 
     it('does not provide suggestions if no matching template is found', async function () {
         const provider = new SamParameterCompletionItemProvider(
-            new MockSamParameterCompletionItemProviderContext({
+            new MockSamParamComplItemProviderContext({
                 executeCommand: async <T>() => [] as any as T,
                 getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
             })
@@ -181,7 +180,7 @@ describe('SamParameterCompletionItemProvider', async function () {
         })
 
         const provider = new SamParameterCompletionItemProvider(
-            new MockSamParameterCompletionItemProviderContext({
+            new MockSamParamComplItemProviderContext({
                 executeCommand: async <T>() => [templatesSymbol] as any as T,
                 getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
                 loadTemplate: async () => ({
@@ -223,7 +222,7 @@ describe('SamParameterCompletionItemProvider', async function () {
         })
 
         const provider = new SamParameterCompletionItemProvider(
-            new MockSamParameterCompletionItemProviderContext({
+            new MockSamParamComplItemProviderContext({
                 executeCommand: async <T>() => [templatesSymbol] as any as T,
                 getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
                 loadTemplate: async () => ({
@@ -263,7 +262,7 @@ describe('SamParameterCompletionItemProvider', async function () {
 
     it('recovers gracefully if templates.json is empty or invalid', async function () {
         const provider = new SamParameterCompletionItemProvider(
-            new MockSamParameterCompletionItemProviderContext({
+            new MockSamParamComplItemProviderContext({
                 executeCommand: async <T>() => undefined,
                 getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
             })
@@ -287,7 +286,7 @@ describe('SamParameterCompletionItemProvider', async function () {
         })
 
         const provider = new SamParameterCompletionItemProvider(
-            new MockSamParameterCompletionItemProviderContext({
+            new MockSamParamComplItemProviderContext({
                 executeCommand: async <T>() => [templatesSymbol] as any as T,
                 getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
                 loadTemplate: async () => ({
@@ -326,7 +325,7 @@ describe('SamParameterCompletionItemProvider', async function () {
     it('recovers gracefully if `parameterOverrides` is not defined for this template', async function () {
         const templatesSymbol = createTemplatesSymbol({})
         const provider = new SamParameterCompletionItemProvider(
-            new MockSamParameterCompletionItemProviderContext({
+            new MockSamParamComplItemProviderContext({
                 executeCommand: async <T>() => [templatesSymbol] as any as T,
                 getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
                 loadTemplate: async () => ({
@@ -369,7 +368,7 @@ describe('SamParameterCompletionItemProvider', async function () {
         })
 
         const provider = new SamParameterCompletionItemProvider(
-            new MockSamParameterCompletionItemProviderContext({
+            new MockSamParamComplItemProviderContext({
                 executeCommand: async <T>() => [templatesSymbol] as any as T,
                 getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
                 loadTemplate: async () => ({
@@ -412,7 +411,7 @@ describe('SamParameterCompletionItemProvider', async function () {
         })
 
         const provider = new SamParameterCompletionItemProvider(
-            new MockSamParameterCompletionItemProviderContext({
+            new MockSamParamComplItemProviderContext({
                 executeCommand: async <T>() => [templatesSymbol] as any as T,
                 getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
                 loadTemplate: async () => ({

--- a/src/test/lambda/config/samParameterCompletionItemProvider.test.ts
+++ b/src/test/lambda/config/samParameterCompletionItemProvider.test.ts
@@ -72,6 +72,7 @@ function createTemplatesSymbol({
     return templatesSymbol
 }
 
+// eslint-disable-next-line id-length
 class MockSamParameterCompletionItemProviderContext implements SamParameterCompletionItemProviderContext {
     public readonly logger: Pick<Logger, 'warn'>
     public readonly getWorkspaceFolder: typeof vscode.workspace.getWorkspaceFolder
@@ -109,14 +110,14 @@ describe('SamParameterCompletionItemProvider', async function () {
             })
         )
 
-        const document: vscode.TextDocument = ({
+        const document: vscode.TextDocument = {
             uri: vscode.Uri.file(path.join('my', 'path')),
-        } as any) as vscode.TextDocument
+        } as any as vscode.TextDocument
         const actualItems = await provider.provideCompletionItems(
             document,
             new vscode.Position(0, 0),
-            ({} as any) as vscode.CancellationToken,
-            ({} as any) as vscode.CompletionContext
+            {} as any as vscode.CancellationToken,
+            {} as any as vscode.CompletionContext
         )
 
         assert.ok(actualItems)
@@ -133,18 +134,18 @@ describe('SamParameterCompletionItemProvider', async function () {
         const provider = new SamParameterCompletionItemProvider(
             new MockSamParameterCompletionItemProviderContext({
                 executeCommand: async () => undefined,
-                getWorkspaceFolder: () => (({ uri: vscode.Uri.file('') } as any) as vscode.WorkspaceFolder),
+                getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
             })
         )
 
-        const document: vscode.TextDocument = ({
+        const document: vscode.TextDocument = {
             uri: vscode.Uri.file(path.join('my', 'path')),
-        } as any) as vscode.TextDocument
+        } as any as vscode.TextDocument
         const actualItems = await provider.provideCompletionItems(
             document,
             new vscode.Position(0, 0),
-            ({} as any) as vscode.CancellationToken,
-            ({} as any) as vscode.CompletionContext
+            {} as any as vscode.CancellationToken,
+            {} as any as vscode.CompletionContext
         )
 
         assert.ok(actualItems)
@@ -154,19 +155,19 @@ describe('SamParameterCompletionItemProvider', async function () {
     it('does not provide suggestions if no matching template is found', async function () {
         const provider = new SamParameterCompletionItemProvider(
             new MockSamParameterCompletionItemProviderContext({
-                executeCommand: async <T>() => ([] as any) as T,
-                getWorkspaceFolder: () => (({ uri: vscode.Uri.file('') } as any) as vscode.WorkspaceFolder),
+                executeCommand: async <T>() => [] as any as T,
+                getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
             })
         )
 
-        const document: vscode.TextDocument = ({
+        const document: vscode.TextDocument = {
             uri: vscode.Uri.file(path.join('my', 'path')),
-        } as any) as vscode.TextDocument
+        } as any as vscode.TextDocument
         const actualItems = await provider.provideCompletionItems(
             document,
             new vscode.Position(0, 0),
-            ({} as any) as vscode.CancellationToken,
-            ({} as any) as vscode.CompletionContext
+            {} as any as vscode.CancellationToken,
+            {} as any as vscode.CompletionContext
         )
 
         assert.ok(actualItems)
@@ -181,8 +182,8 @@ describe('SamParameterCompletionItemProvider', async function () {
 
         const provider = new SamParameterCompletionItemProvider(
             new MockSamParameterCompletionItemProviderContext({
-                executeCommand: async <T>() => ([templatesSymbol] as any) as T,
-                getWorkspaceFolder: () => (({ uri: vscode.Uri.file('') } as any) as vscode.WorkspaceFolder),
+                executeCommand: async <T>() => [templatesSymbol] as any as T,
+                getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
                 loadTemplate: async () => ({
                     Parameters: {
                         MyParamName1: {
@@ -196,17 +197,17 @@ describe('SamParameterCompletionItemProvider', async function () {
             })
         )
 
-        const document: vscode.TextDocument = ({
+        const document: vscode.TextDocument = {
             uri: vscode.Uri.file(path.join('.aws', 'templates.json')),
             getWordRangeAtPosition: () => new vscode.Range(3, 0, 3, 10),
             getText: () => '',
-        } as any) as vscode.TextDocument
+        } as any as vscode.TextDocument
 
         const actualItems = await provider.provideCompletionItems(
             document,
             new vscode.Position(3, 0),
-            ({} as any) as vscode.CancellationToken,
-            ({} as any) as vscode.CompletionContext
+            {} as any as vscode.CancellationToken,
+            {} as any as vscode.CompletionContext
         )
 
         assert.ok(actualItems)
@@ -223,8 +224,8 @@ describe('SamParameterCompletionItemProvider', async function () {
 
         const provider = new SamParameterCompletionItemProvider(
             new MockSamParameterCompletionItemProviderContext({
-                executeCommand: async <T>() => ([templatesSymbol] as any) as T,
-                getWorkspaceFolder: () => (({ uri: vscode.Uri.file('') } as any) as vscode.WorkspaceFolder),
+                executeCommand: async <T>() => [templatesSymbol] as any as T,
+                getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
                 loadTemplate: async () => ({
                     Parameters: {
                         MyParamName1: {
@@ -241,17 +242,17 @@ describe('SamParameterCompletionItemProvider', async function () {
             })
         )
 
-        const document: vscode.TextDocument = ({
+        const document: vscode.TextDocument = {
             uri: vscode.Uri.file(path.join('.aws', 'templates.json')),
             getWordRangeAtPosition: () => new vscode.Range(3, 0, 3, 10),
             getText: () => 'MyParamName',
-        } as any) as vscode.TextDocument
+        } as any as vscode.TextDocument
 
         const actualItems = await provider.provideCompletionItems(
             document,
             new vscode.Position(3, 0),
-            ({} as any) as vscode.CancellationToken,
-            ({} as any) as vscode.CompletionContext
+            {} as any as vscode.CancellationToken,
+            {} as any as vscode.CompletionContext
         )
 
         assert.ok(actualItems)
@@ -264,15 +265,15 @@ describe('SamParameterCompletionItemProvider', async function () {
         const provider = new SamParameterCompletionItemProvider(
             new MockSamParameterCompletionItemProviderContext({
                 executeCommand: async <T>() => undefined,
-                getWorkspaceFolder: () => (({ uri: vscode.Uri.file('') } as any) as vscode.WorkspaceFolder),
+                getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
             })
         )
 
         const actualItems = await provider.provideCompletionItems(
-            ({ uri: vscode.Uri.file(path.join('.aws', 'templates.json')) } as any) as vscode.TextDocument,
+            { uri: vscode.Uri.file(path.join('.aws', 'templates.json')) } as any as vscode.TextDocument,
             new vscode.Position(0, 0),
-            ({} as any) as vscode.CancellationToken,
-            ({} as any) as vscode.CompletionContext
+            {} as any as vscode.CancellationToken,
+            {} as any as vscode.CompletionContext
         )
 
         assert.ok(actualItems)
@@ -287,8 +288,8 @@ describe('SamParameterCompletionItemProvider', async function () {
 
         const provider = new SamParameterCompletionItemProvider(
             new MockSamParameterCompletionItemProviderContext({
-                executeCommand: async <T>() => ([templatesSymbol] as any) as T,
-                getWorkspaceFolder: () => (({ uri: vscode.Uri.file('') } as any) as vscode.WorkspaceFolder),
+                executeCommand: async <T>() => [templatesSymbol] as any as T,
+                getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
                 loadTemplate: async () => ({
                     Parameters: {
                         MyParamName1: {
@@ -305,17 +306,17 @@ describe('SamParameterCompletionItemProvider', async function () {
             })
         )
 
-        const document: vscode.TextDocument = ({
+        const document: vscode.TextDocument = {
             uri: vscode.Uri.file(path.join('.aws', 'templates.json')),
             getWordRangeAtPosition: () => new vscode.Range(3, 0, 3, 10),
             getText: () => 'MyParamName',
-        } as any) as vscode.TextDocument
+        } as any as vscode.TextDocument
 
         const actualItems = await provider.provideCompletionItems(
             document,
             new vscode.Position(11, 0),
-            ({} as any) as vscode.CancellationToken,
-            ({} as any) as vscode.CompletionContext
+            {} as any as vscode.CancellationToken,
+            {} as any as vscode.CompletionContext
         )
 
         assert.ok(actualItems)
@@ -326,8 +327,8 @@ describe('SamParameterCompletionItemProvider', async function () {
         const templatesSymbol = createTemplatesSymbol({})
         const provider = new SamParameterCompletionItemProvider(
             new MockSamParameterCompletionItemProviderContext({
-                executeCommand: async <T>() => ([templatesSymbol] as any) as T,
-                getWorkspaceFolder: () => (({ uri: vscode.Uri.file('') } as any) as vscode.WorkspaceFolder),
+                executeCommand: async <T>() => [templatesSymbol] as any as T,
+                getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
                 loadTemplate: async () => ({
                     Parameters: {
                         MyParamName1: {
@@ -344,17 +345,17 @@ describe('SamParameterCompletionItemProvider', async function () {
             })
         )
 
-        const document: vscode.TextDocument = ({
+        const document: vscode.TextDocument = {
             uri: vscode.Uri.file(path.join('.aws', 'templates.json')),
             getWordRangeAtPosition: () => new vscode.Range(3, 0, 3, 10),
             getText: () => 'MyParamName',
-        } as any) as vscode.TextDocument
+        } as any as vscode.TextDocument
 
         const actualItems = await provider.provideCompletionItems(
             document,
             new vscode.Position(11, 0),
-            ({} as any) as vscode.CancellationToken,
-            ({} as any) as vscode.CompletionContext
+            {} as any as vscode.CancellationToken,
+            {} as any as vscode.CompletionContext
         )
 
         assert.ok(actualItems)
@@ -369,8 +370,8 @@ describe('SamParameterCompletionItemProvider', async function () {
 
         const provider = new SamParameterCompletionItemProvider(
             new MockSamParameterCompletionItemProviderContext({
-                executeCommand: async <T>() => ([templatesSymbol] as any) as T,
-                getWorkspaceFolder: () => (({ uri: vscode.Uri.file('') } as any) as vscode.WorkspaceFolder),
+                executeCommand: async <T>() => [templatesSymbol] as any as T,
+                getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
                 loadTemplate: async () => ({
                     Parameters: {
                         MyParamName1: {
@@ -387,17 +388,17 @@ describe('SamParameterCompletionItemProvider', async function () {
             })
         )
 
-        const document: vscode.TextDocument = ({
+        const document: vscode.TextDocument = {
             uri: vscode.Uri.file(path.join('.aws', 'templates.json')),
             getWordRangeAtPosition: () => new vscode.Range(3, 0, 3, 10),
             getText: () => 'MyParamName',
-        } as any) as vscode.TextDocument
+        } as any as vscode.TextDocument
 
         const actualItems = await provider.provideCompletionItems(
             document,
             new vscode.Position(9, 0),
-            ({} as any) as vscode.CancellationToken,
-            ({} as any) as vscode.CompletionContext
+            {} as any as vscode.CancellationToken,
+            {} as any as vscode.CompletionContext
         )
 
         assert.ok(actualItems)
@@ -412,8 +413,8 @@ describe('SamParameterCompletionItemProvider', async function () {
 
         const provider = new SamParameterCompletionItemProvider(
             new MockSamParameterCompletionItemProviderContext({
-                executeCommand: async <T>() => ([templatesSymbol] as any) as T,
-                getWorkspaceFolder: () => (({ uri: vscode.Uri.file('') } as any) as vscode.WorkspaceFolder),
+                executeCommand: async <T>() => [templatesSymbol] as any as T,
+                getWorkspaceFolder: () => ({ uri: vscode.Uri.file('') } as any as vscode.WorkspaceFolder),
                 loadTemplate: async () => ({
                     Parameters: {
                         MyParamName1: {
@@ -430,17 +431,17 @@ describe('SamParameterCompletionItemProvider', async function () {
             })
         )
 
-        const document: vscode.TextDocument = ({
+        const document: vscode.TextDocument = {
             uri: vscode.Uri.file(path.join('.aws', 'templates.json')),
             getWordRangeAtPosition: () => new vscode.Range(3, 0, 3, 10),
             getText: () => 'MyParamName',
-        } as any) as vscode.TextDocument
+        } as any as vscode.TextDocument
 
         const actualItems = await provider.provideCompletionItems(
             document,
             new vscode.Position(4, 0),
-            ({} as any) as vscode.CancellationToken,
-            ({} as any) as vscode.CompletionContext
+            {} as any as vscode.CancellationToken,
+            {} as any as vscode.CompletionContext
         )
 
         assert.ok(actualItems)

--- a/src/test/lambda/explorer/cloudFormationNodes.test.ts
+++ b/src/test/lambda/explorer/cloudFormationNodes.test.ts
@@ -18,8 +18,8 @@ import globals from '../../../shared/extensionGlobals'
 import { TestAWSTreeNode } from '../../shared/treeview/nodes/testAWSTreeNode'
 import { asyncGenerator } from '../../utilities/collectionUtils'
 import {
-    assertNodeListOnlyContainsErrorNode,
-    assertNodeListOnlyContainsPlaceholderNode,
+    assertNodeListOnlyHasErrorNode,
+    assertNodeListOnlyHasPlaceholderNode,
 } from '../../utilities/explorerNodeAssertions'
 import { stub } from '../../utilities/stubber'
 
@@ -92,7 +92,7 @@ describe('CloudFormationStackNode', function () {
         const node = generateTestNode()
         const childNodes = await node.getChildren()
 
-        assertNodeListOnlyContainsPlaceholderNode(childNodes)
+        assertNodeListOnlyHasPlaceholderNode(childNodes)
     })
 
     it('has LambdaFunctionNode child nodes', async function () {
@@ -152,7 +152,7 @@ describe('CloudFormationStackNode', function () {
         cloudFormationClient.describeStackResources.throws()
 
         const node = generateTestNode({ cloudFormationClient })
-        assertNodeListOnlyContainsErrorNode(await node.getChildren())
+        assertNodeListOnlyHasErrorNode(await node.getChildren())
     })
 })
 
@@ -181,7 +181,7 @@ describe('CloudFormationNode', function () {
         const cloudFormationNode = new CloudFormationNode(regionCode, client)
         const children = await cloudFormationNode.getChildren()
 
-        assertNodeListOnlyContainsPlaceholderNode(children)
+        assertNodeListOnlyHasPlaceholderNode(children)
     })
 
     it('has an error node for a child if an error happens during loading', async function () {
@@ -189,6 +189,6 @@ describe('CloudFormationNode', function () {
         client.listStacks.throws()
         const cloudFormationNode = new CloudFormationNode(regionCode, client)
 
-        assertNodeListOnlyContainsErrorNode(await cloudFormationNode.getChildren())
+        assertNodeListOnlyHasErrorNode(await cloudFormationNode.getChildren())
     })
 })

--- a/src/test/lambda/explorer/lambdaNodes.test.ts
+++ b/src/test/lambda/explorer/lambdaNodes.test.ts
@@ -8,8 +8,8 @@ import { LambdaFunctionNode } from '../../../lambda/explorer/lambdaFunctionNode'
 import { contextValueLambdaFunction, LambdaNode } from '../../../lambda/explorer/lambdaNodes'
 import { asyncGenerator } from '../../utilities/collectionUtils'
 import {
-    assertNodeListOnlyContainsErrorNode,
-    assertNodeListOnlyContainsPlaceholderNode,
+    assertNodeListOnlyHasErrorNode,
+    assertNodeListOnlyHasPlaceholderNode,
 } from '../../utilities/explorerNodeAssertions'
 import { stub } from '../../utilities/stubber'
 import { DefaultLambdaClient } from '../../../shared/clients/lambdaClient'
@@ -31,7 +31,7 @@ describe('LambdaNode', function () {
     it('returns placeholder node if no children are present', async function () {
         const childNodes = await createNode().getChildren()
 
-        assertNodeListOnlyContainsPlaceholderNode(childNodes)
+        assertNodeListOnlyHasPlaceholderNode(childNodes)
     })
 
     it('has LambdaFunctionNode child nodes', async function () {
@@ -68,6 +68,6 @@ describe('LambdaNode', function () {
         client.listFunctions.throws()
         const node = new LambdaNode(regionCode, client)
 
-        assertNodeListOnlyContainsErrorNode(await node.getChildren())
+        assertNodeListOnlyHasErrorNode(await node.getChildren())
     })
 })

--- a/src/test/samples/typescript/sampleFunctions.ts
+++ b/src/test/samples/typescript/sampleFunctions.ts
@@ -39,9 +39,9 @@ function exportedViaDeclaration(arg1: string) {}
 const exportedArrowViaDeclaration = (arg1: string) => {}
 const exportedArrowViaDeclarationAlt: (x: string) => void = arg1 => {}
 
-const exportedArrowViaDeclarationWithFourArgs = (arg1: string, arg2: string, arg3: string, arg4: string) => {}
+const exportedArrowViaDeclWithFourArgs = (arg1: string, arg2: string, arg3: string, arg4: string) => {}
 // eslint-disable-next-line id-length
-const exportedArrowViaDeclarationWithFourArgsAlt: (arg1: string, arg2: string, arg3: string, arg4: string) => void = (
+const exportedArrowViaDeclWithFourArgsAlt: (arg1: string, arg2: string, arg3: string, arg4: string) => void = (
     arg1,
     arg2,
     arg3,
@@ -49,4 +49,4 @@ const exportedArrowViaDeclarationWithFourArgsAlt: (arg1: string, arg2: string, a
 ) => {}
 
 export { exportedViaDeclaration, exportedArrowViaDeclaration, exportedArrowViaDeclarationAlt }
-export { functionWithFourArgs, exportedArrowViaDeclarationWithFourArgs, exportedArrowViaDeclarationWithFourArgsAlt }
+export { functionWithFourArgs, exportedArrowViaDeclWithFourArgs, exportedArrowViaDeclWithFourArgsAlt }

--- a/src/test/samples/typescript/sampleFunctions.ts
+++ b/src/test/samples/typescript/sampleFunctions.ts
@@ -40,6 +40,7 @@ const exportedArrowViaDeclaration = (arg1: string) => {}
 const exportedArrowViaDeclarationAlt: (x: string) => void = arg1 => {}
 
 const exportedArrowViaDeclarationWithFourArgs = (arg1: string, arg2: string, arg3: string, arg4: string) => {}
+// eslint-disable-next-line id-length
 const exportedArrowViaDeclarationWithFourArgsAlt: (arg1: string, arg2: string, arg3: string, arg4: string) => void = (
     arg1,
     arg2,

--- a/src/test/samples/typescript/sampleFunctions.ts
+++ b/src/test/samples/typescript/sampleFunctions.ts
@@ -40,7 +40,6 @@ const exportedArrowViaDeclaration = (arg1: string) => {}
 const exportedArrowViaDeclarationAlt: (x: string) => void = arg1 => {}
 
 const exportedArrowViaDeclWithFourArgs = (arg1: string, arg2: string, arg3: string, arg4: string) => {}
-// eslint-disable-next-line id-length
 const exportedArrowViaDeclWithFourArgsAlt: (arg1: string, arg2: string, arg3: string, arg4: string) => void = (
     arg1,
     arg2,

--- a/src/test/shared/sam/cli/samCliValidator.test.ts
+++ b/src/test/shared/sam/cli/samCliValidator.test.ts
@@ -9,7 +9,7 @@ import { SamCliInfoResponse } from '../../../../shared/sam/cli/samCliInfo'
 import {
     DefaultSamCliValidator,
     maxSamCliVersionExclusive,
-    minimumSamCliVersionInclusive,
+    minSamCliVersion,
     SamCliValidatorContext,
     SamCliVersionValidation,
 } from '../../../../shared/sam/cli/samCliValidator'
@@ -41,7 +41,7 @@ describe('DefaultSamCliValidator', async function () {
     const samCliVersionTestScenarios = [
         {
             situation: 'SAM CLI Version is valid',
-            version: minimumSamCliVersionInclusive,
+            version: minSamCliVersion,
             expectedVersionValidation: SamCliVersionValidation.Valid,
         },
         {
@@ -118,7 +118,7 @@ describe('DefaultSamCliValidator', async function () {
         })
 
         it('Uses the cached validation result', async function () {
-            const validatorContext = new TestSamCliValidatorContext(minimumSamCliVersionInclusive)
+            const validatorContext = new TestSamCliValidatorContext(minSamCliVersion)
             const samCliValidator = new DefaultSamCliValidator(validatorContext)
 
             await samCliValidator.getVersionValidatorResult()
@@ -128,7 +128,7 @@ describe('DefaultSamCliValidator', async function () {
         })
 
         it('Does not use the cached validation result if the SAM CLI timestamp changed', async function () {
-            const validatorContext = new TestSamCliValidatorContext(minimumSamCliVersionInclusive)
+            const validatorContext = new TestSamCliValidatorContext(minSamCliVersion)
             const samCliValidator = new DefaultSamCliValidator(validatorContext)
 
             await samCliValidator.getVersionValidatorResult()

--- a/src/test/shared/sam/cli/samCliValidator.test.ts
+++ b/src/test/shared/sam/cli/samCliValidator.test.ts
@@ -8,7 +8,7 @@ import globals from '../../../../shared/extensionGlobals'
 import { SamCliInfoResponse } from '../../../../shared/sam/cli/samCliInfo'
 import {
     DefaultSamCliValidator,
-    maximumSamCliVersionExclusive,
+    maxSamCliVersionExclusive,
     minimumSamCliVersionInclusive,
     SamCliValidatorContext,
     SamCliVersionValidation,
@@ -51,7 +51,7 @@ describe('DefaultSamCliValidator', async function () {
         },
         {
             situation: 'SAM CLI Version is too high',
-            version: maximumSamCliVersionExclusive,
+            version: maxSamCliVersionExclusive,
             expectedVersionValidation: SamCliVersionValidation.VersionTooHigh,
         },
         {

--- a/src/test/shared/treeview/treeNodeUtilities.test.ts
+++ b/src/test/shared/treeview/treeNodeUtilities.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert'
 import { PlaceholderNode } from '../../../shared/treeview/nodes/placeholderNode'
 import { makeChildrenNodes } from '../../../shared/treeview/utils'
-import { assertNodeListOnlyContainsErrorNode } from '../../utilities/explorerNodeAssertions'
+import { assertNodeListOnlyHasErrorNode } from '../../utilities/explorerNodeAssertions'
 import { TestAWSTreeNode } from './nodes/testAWSTreeNode'
 
 describe('makeChildrenNodes', async function () {
@@ -33,7 +33,7 @@ describe('makeChildrenNodes', async function () {
             },
         })
 
-        assertNodeListOnlyContainsErrorNode(childNodes)
+        assertNodeListOnlyHasErrorNode(childNodes)
     })
 
     it('returns a placeholder node if there are no child nodes', async function () {

--- a/src/test/ssmDocument/explorer/documentTypeNode.test.ts
+++ b/src/test/ssmDocument/explorer/documentTypeNode.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert'
 import * as sinon from 'sinon'
 import { DocumentTypeNode } from '../../../ssmDocument/explorer/documentTypeNode'
 
-import { assertNodeListOnlyContainsErrorNode } from '../../utilities/explorerNodeAssertions'
+import { assertNodeListOnlyHasErrorNode } from '../../utilities/explorerNodeAssertions'
 
 describe('DocumentTypeNode', function () {
     let sandbox: sinon.SinonSandbox
@@ -41,6 +41,6 @@ describe('DocumentTypeNode', function () {
         })
         const childNodes = await testNode.getChildren()
 
-        assertNodeListOnlyContainsErrorNode(childNodes)
+        assertNodeListOnlyHasErrorNode(childNodes)
     })
 })

--- a/src/test/ssmDocument/explorer/registryItemNode.test.ts
+++ b/src/test/ssmDocument/explorer/registryItemNode.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert'
 import { RegistryItemNode } from '../../../ssmDocument/explorer/registryItemNode'
-import { assertNodeListOnlyContainsErrorNode } from '../../utilities/explorerNodeAssertions'
+import { assertNodeListOnlyHasErrorNode } from '../../utilities/explorerNodeAssertions'
 import { asyncGenerator } from '../../utilities/collectionUtils'
 import { DefaultSsmDocumentClient } from '../../../shared/clients/ssmDocumentClient'
 import { stub } from '../../utilities/stubber'
@@ -22,7 +22,7 @@ describe('RegistryItemNode', function () {
         const testNode = new RegistryItemNode(regionCode, 'Owned by me', documentType, client)
         const childNodes = await testNode.getChildren()
 
-        assertNodeListOnlyContainsErrorNode(childNodes)
+        assertNodeListOnlyHasErrorNode(childNodes)
     })
 
     it('puts documents into right registry', async function () {

--- a/src/test/stepFunctions/explorer/stepFunctionNodes.test.ts
+++ b/src/test/stepFunctions/explorer/stepFunctionNodes.test.ts
@@ -10,8 +10,8 @@ import {
     StepFunctionsNode,
 } from '../../../stepFunctions/explorer/stepFunctionsNodes'
 import {
-    assertNodeListOnlyContainsErrorNode,
-    assertNodeListOnlyContainsPlaceholderNode,
+    assertNodeListOnlyHasErrorNode,
+    assertNodeListOnlyHasPlaceholderNode,
 } from '../../utilities/explorerNodeAssertions'
 import { asyncGenerator } from '../../utilities/collectionUtils'
 import globals from '../../../shared/extensionGlobals'
@@ -42,7 +42,7 @@ describe('StepFunctionsNode', function () {
     it('returns placeholder node if no children are present', async function () {
         const node = new StepFunctionsNode(regionCode, createStatesClient())
 
-        assertNodeListOnlyContainsPlaceholderNode(await node.getChildren())
+        assertNodeListOnlyHasPlaceholderNode(await node.getChildren())
     })
 
     it('has StateMachineNode child nodes', async function () {
@@ -76,6 +76,6 @@ describe('StepFunctionsNode', function () {
         client.listStateMachines.throws()
         const testNode = new StepFunctionsNode(regionCode, client)
 
-        assertNodeListOnlyContainsErrorNode(await testNode.getChildren())
+        assertNodeListOnlyHasErrorNode(await testNode.getChildren())
     })
 })

--- a/src/test/utilities/explorerNodeAssertions.ts
+++ b/src/test/utilities/explorerNodeAssertions.ts
@@ -7,14 +7,14 @@ import * as assert from 'assert'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 import { PlaceholderNode } from '../../shared/treeview/nodes/placeholderNode'
 
-export function assertNodeListOnlyContainsErrorNode(nodes: AWSTreeNodeBase[]) {
+export function assertNodeListOnlyHasErrorNode(nodes: AWSTreeNodeBase[]) {
     assert(nodes !== undefined)
     assert.strictEqual(nodes.length, 1, 'Unexpected node count')
     assert.strictEqual(nodes[0].contextValue, 'awsErrorNode', 'Expected ErrorNode in the list')
 }
 
 // eslint-disable-next-line id-length
-export function assertNodeListOnlyContainsPlaceholderNode(nodes: AWSTreeNodeBase[]) {
+export function assertNodeListOnlyHasPlaceholderNode(nodes: AWSTreeNodeBase[]) {
     assert(nodes !== undefined)
     assert.strictEqual(nodes.length, 1, 'Unexpected node count')
     assert.ok(nodes[0] instanceof PlaceholderNode, 'Expected placeholder node in the list')

--- a/src/test/utilities/explorerNodeAssertions.ts
+++ b/src/test/utilities/explorerNodeAssertions.ts
@@ -13,7 +13,6 @@ export function assertNodeListOnlyHasErrorNode(nodes: AWSTreeNodeBase[]) {
     assert.strictEqual(nodes[0].contextValue, 'awsErrorNode', 'Expected ErrorNode in the list')
 }
 
-// eslint-disable-next-line id-length
 export function assertNodeListOnlyHasPlaceholderNode(nodes: AWSTreeNodeBase[]) {
     assert(nodes !== undefined)
     assert.strictEqual(nodes.length, 1, 'Unexpected node count')

--- a/src/test/utilities/explorerNodeAssertions.ts
+++ b/src/test/utilities/explorerNodeAssertions.ts
@@ -13,6 +13,7 @@ export function assertNodeListOnlyContainsErrorNode(nodes: AWSTreeNodeBase[]) {
     assert.strictEqual(nodes[0].contextValue, 'awsErrorNode', 'Expected ErrorNode in the list')
 }
 
+// eslint-disable-next-line id-length
 export function assertNodeListOnlyContainsPlaceholderNode(nodes: AWSTreeNodeBase[]) {
     assert(nodes !== undefined)
     assert.strictEqual(nodes.length, 1, 'Unexpected node count')


### PR DESCRIPTION
Problem:

    extrememlyLongNamesThatExplainTooMuchShouldLiveInTheDocstringNotTheName()

Solution:
- Enforce lessLongName by lint rule. https://eslint.org/docs/latest/rules/id-length


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
