### PR TITLE
fix(codecatalyst): cache results of `verifySession`

### DIFF
--- a/src/shared/clients/codecatalystClient.ts
+++ b/src/shared/clients/codecatalystClient.ts
@@ -320,6 +320,7 @@ class CodeCatalystClientInternal {
         const resp = await this.call(this.sdkClient.verifySession(), false)
         assertHasProps(resp, 'identity')
 
+        CodeCatalystClientInternal.identityCache.set(accessToken, resp.identity)
         setTimeout(() => CodeCatalystClientInternal.identityCache.delete(accessToken), expiresAt.getTime() - Date.now())
 
         return resp.identity


### PR DESCRIPTION
## Problem
`verifySession` is called every time a new client is created

## Solution
Cache `verifySession` based off the access token

### Testing
The way the CodeCatalyst client is written makes it difficult to test in a sustainable way. Something similar to https://github.com/aws/aws-toolkit-vscode/pull/2917 needs to be done to reduce the amount of custom logic in each service client.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
