### PR TITLE
cwl: validate search input

### DIFF
--- a/src/cloudWatchLogs/changeLogSearch.ts
+++ b/src/cloudWatchLogs/changeLogSearch.ts
@@ -7,7 +7,7 @@ import { showInputBox } from '../shared/ui/inputPrompter'
 import { createURIFromArgs, isLogStreamUri, recordTelemetryFilter } from './cloudWatchLogsUtils'
 import { prepareDocument } from './commands/searchLogGroup'
 import { getActiveDocumentUri } from './document/logDataDocumentProvider'
-import { CloudWatchLogsData, filterLogEventsFromUriComponents, LogDataRegistry } from './registry/logDataRegistry'
+import { CloudWatchLogsData, filterLogEventsFromUri, LogDataRegistry } from './registry/logDataRegistry'
 import { isViewAllEvents, TimeFilterResponse, TimeFilterSubmenu } from './timeFilterSubmenu'
 
 /**
@@ -58,7 +58,7 @@ export async function getNewData(
     let resourceType: CloudWatchResourceType = 'logGroup'
 
     if (newData.logGroupInfo.streamName) {
-        newData.retrieveLogsFunction = filterLogEventsFromUriComponents
+        newData.retrieveLogsFunction = filterLogEventsFromUri
         newData.parameters.streamNameOptions = [newData.logGroupInfo.streamName]
         newData.logGroupInfo.streamName = undefined
         resourceType = 'logStream'

--- a/src/cloudWatchLogs/commands/addLogEvents.ts
+++ b/src/cloudWatchLogs/commands/addLogEvents.ts
@@ -48,7 +48,7 @@ export async function addLogEvents(
             vscode.window.showErrorMessage(
                 localize(
                     'AWS.cwl.searchLogGroup.errorRetrievingLogs2',
-                    'Error retrieving logs for {0}: {1}',
+                    'Failed to get logs for {0}: {1}',
                     uri.path,
                     error.message
                 )

--- a/src/cloudWatchLogs/commands/searchLogGroup.ts
+++ b/src/cloudWatchLogs/commands/searchLogGroup.ts
@@ -10,7 +10,7 @@ import {
     CloudWatchLogsData,
     CloudWatchLogsGroupInfo,
     LogDataRegistry,
-    filterLogEventsFromUriComponents,
+    filterLogEventsFromUri,
     CloudWatchLogsParameters,
     initLogData,
 } from '../registry/logDataRegistry'
@@ -53,7 +53,7 @@ function handleWizardResponse(response: SearchLogGroupWizardResponse, registry: 
         }
     }
 
-    const logData = initLogData(logGroupInfo, parameters, filterLogEventsFromUriComponents)
+    const logData = initLogData(logGroupInfo, parameters, filterLogEventsFromUri)
 
     if (logData.parameters.startTime || logData.parameters.filterPattern) {
         recordTelemetryFilter(logData, 'logGroup', 'Command')
@@ -172,7 +172,7 @@ export function createFilterpatternPrompter(
             endTime: 9999,
         }
         try {
-            await filterLogEventsFromUriComponents(logGroupInfo, parameters)
+            await filterLogEventsFromUri(logGroupInfo, parameters)
         } catch (e) {
             return (e as Error).message
         }

--- a/src/cloudWatchLogs/commands/searchLogGroup.ts
+++ b/src/cloudWatchLogs/commands/searchLogGroup.ts
@@ -103,8 +103,8 @@ export async function searchLogGroup(node: LogGroupNode | undefined, registry: L
     }
 
     const wizard = node?.logGroup.logGroupName
-        ? new SearchLogGroupWizard({ groupName: node.logGroup.logGroupName, regionName: node.regionCode })
-        : new SearchLogGroupWizard()
+        ? new SearchLogGroupWizard(registry, { groupName: node.logGroup.logGroupName, regionName: node.regionCode })
+        : new SearchLogGroupWizard(registry)
     const response = await wizard.run()
 
     if (!response) {
@@ -139,7 +139,12 @@ async function logGroupsToArray(logGroups: AsyncIterableIterator<CloudWatchLogs.
     return logGroupsArray
 }
 
-export function createFilterpatternPrompter(logGroupName: string, isFirst: boolean): InputBoxPrompter {
+/** Prompts the user for a search query, and validates it. */
+export function createFilterpatternPrompter(
+    registry: LogDataRegistry,
+    logGroupName: string,
+    isFirst: boolean
+): InputBoxPrompter {
     const helpUri =
         'https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html#matching-terms-events'
     const titleText = localize(
@@ -151,10 +156,34 @@ export function createFilterpatternPrompter(logGroupName: string, isFirst: boole
         'AWS.cwl.searchLogGroup.filterPatternPlaceholder',
         'search pattern (case sensitive; empty matches all)'
     )
+
+    async function validateSearchPattern(searchPattern: string, isFinalInput: boolean): Promise<string | undefined> {
+        if (!isFinalInput) {
+            return undefined // Skip validation while user is typing.
+        }
+        const logGroupInfo: CloudWatchLogsGroupInfo = {
+            groupName: '/aws/apprunner/aaaaaaa/5d2870895ec34e7d810fb316cd9c9bf0',
+            regionName: 'us-west-2',
+        }
+        const parameters: CloudWatchLogsParameters = {
+            limit: 1,
+            filterPattern: searchPattern,
+            startTime: 1,
+            endTime: 9999,
+        }
+        try {
+            await filterLogEventsFromUriComponents(logGroupInfo, parameters)
+        } catch (e) {
+            return (e as Error).message
+        }
+        return undefined
+    }
+
     const options = {
         title: titleText,
         placeholder: placeHolderText,
         buttons: [createHelpButton(helpUri), createExitButton()],
+        validateInput: validateSearchPattern,
     }
 
     if (!isFirst) {
@@ -179,7 +208,7 @@ export interface SearchLogGroupWizardResponse {
 }
 
 export class SearchLogGroupWizard extends Wizard<SearchLogGroupWizardResponse> {
-    public constructor(logGroupInfo?: CloudWatchLogsGroupInfo) {
+    public constructor(registry: LogDataRegistry, logGroupInfo?: CloudWatchLogsGroupInfo) {
         super({
             initState: {
                 submenuResponse: logGroupInfo
@@ -194,7 +223,7 @@ export class SearchLogGroupWizard extends Wizard<SearchLogGroupWizardResponse> {
         this.form.submenuResponse.bindPrompter(createRegionSubmenu)
         this.form.timeRange.bindPrompter(() => new TimeFilterSubmenu())
         this.form.filterPattern.bindPrompter(({ submenuResponse }) =>
-            createFilterpatternPrompter(submenuResponse!.data, logGroupInfo ? true : false)
+            createFilterpatternPrompter(registry, submenuResponse!.data, logGroupInfo ? true : false)
         )
     }
 }

--- a/src/cloudWatchLogs/commands/viewLogStream.ts
+++ b/src/cloudWatchLogs/commands/viewLogStream.ts
@@ -20,8 +20,8 @@ import {
     CloudWatchLogsGroupInfo,
     CloudWatchLogsParameters,
     LogDataRegistry,
-    getLogEventsFromUriComponents,
-    getInitialLogData,
+    getLogEventsFromUriComponents as getLogEventsFromUri,
+    initLogData as initLogData,
 } from '../registry/logDataRegistry'
 import { createURIFromArgs } from '../cloudWatchLogsUtils'
 import { prepareDocument } from './searchLogGroup'
@@ -57,9 +57,9 @@ export async function viewLogStream(node: LogGroupNode, registry: LogDataRegistr
 
     const uri = createURIFromArgs(logGroupInfo, parameters)
 
-    const initialStreamData = getInitialLogData(logGroupInfo, parameters, getLogEventsFromUriComponents)
+    const logData = initLogData(logGroupInfo, parameters, getLogEventsFromUri)
 
-    result = await prepareDocument(uri, initialStreamData, registry)
+    result = await prepareDocument(uri, logData, registry)
     telemetry.cloudwatchlogs_open.emit({ result: result, cloudWatchResourceType: 'logStream', source: 'Explorer' })
 }
 

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -211,7 +211,7 @@ export async function filterLogEventsFromUriComponents(
     }
 
     const timeout = new Timeout(300000)
-    showMessageWithCancel(`Loading data from log group ${logGroupInfo.groupName}`, timeout)
+    showMessageWithCancel(`Searching log group: ${logGroupInfo.groupName}`, timeout)
     const responsePromise = client.filterLogEvents(cwlParameters)
     const response = await waitTimeout(responsePromise, timeout, { allowUndefined: false })
 
@@ -225,7 +225,7 @@ export async function filterLogEventsFromUriComponents(
             nextBackwardToken: nextToken,
         }
     } else {
-        throw new Error('cwl:`filterLogEvents` did not return anything.')
+        throw new Error('cwl: filterLogEvents returned null')
     }
 }
 
@@ -249,7 +249,7 @@ export async function getLogEventsFromUriComponents(
     }
 
     const timeout = new Timeout(300000)
-    showMessageWithCancel(`Loading data from log stream ${logGroupInfo.streamName}`, timeout)
+    showMessageWithCancel(`Fetching logs: ${logGroupInfo.streamName}`, timeout)
     const responsePromise = client.getLogEvents(cwlParameters)
     const response = await waitTimeout(responsePromise, timeout, { allowUndefined: false })
 
@@ -264,7 +264,8 @@ export async function getLogEventsFromUriComponents(
     }
 }
 
-export function getInitialLogData(
+/** Creates a log data container including a log fetcher which will populate the data if called. */
+export function initLogData(
     logGroupInfo: CloudWatchLogsGroupInfo,
     parameters: CloudWatchLogsParameters,
     retrieveLogsFunction: CloudWatchLogsAction

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -176,7 +176,7 @@ export class LogDataRegistry {
     }
 }
 
-export async function filterLogEventsFromUriComponents(
+export async function filterLogEventsFromUri(
     logGroupInfo: CloudWatchLogsGroupInfo,
     parameters: CloudWatchLogsParameters,
     nextToken?: string

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -158,13 +158,13 @@ export class LogDataRegistry {
 
     public registerInitialLog(
         uri: vscode.Uri,
-        retrieveLogsFunction: CloudWatchLogsAction = filterLogEventsFromUriComponents
+        retrieveLogsFunction: CloudWatchLogsAction = filterLogEventsFromUri
     ): void {
         if (this.isRegistered(uri)) {
             throw new Error(`Already registered: ${uri.toString()}`)
         }
         const data = parseCloudWatchLogsUri(uri)
-        this.setLogData(uri, getInitialLogData(data.logGroupInfo, data.parameters, retrieveLogsFunction))
+        this.setLogData(uri, initLogData(data.logGroupInfo, data.parameters, retrieveLogsFunction))
     }
 
     public getRegisteredLog(uri: vscode.Uri): CloudWatchLogsData {

--- a/src/cloudWatchLogs/timeFilterSubmenu.ts
+++ b/src/cloudWatchLogs/timeFilterSubmenu.ts
@@ -38,7 +38,7 @@ export class TimeFilterSubmenu extends Prompter<TimeFilterResponse> {
     private get recentTimeItems(): ItemLoadTypes<number> {
         const options: DataQuickPickItem<number>[] = []
         options.push({
-            label: 'View all events',
+            label: 'Any time',
             data: 0,
         })
         options.push({

--- a/src/eventSchemas/providers/schemasDataProvider.ts
+++ b/src/eventSchemas/providers/schemasDataProvider.ts
@@ -56,7 +56,7 @@ export class SchemasDataProvider {
             }
         } catch (err) {
             const error = err as Error
-            this.logger.error('Error retrieving registries: %s', error)
+            this.logger.error('Failed to get registries: %s', error)
 
             return undefined
         }
@@ -87,7 +87,7 @@ export class SchemasDataProvider {
             }
         } catch (err) {
             const error = err as Error
-            this.logger.error('Error retrieving schemas: %s', error)
+            this.logger.error('Failed to get schemas: %s', error)
 
             return undefined
         }

--- a/src/shared/extensionUtilities.ts
+++ b/src/shared/extensionUtilities.ts
@@ -147,9 +147,7 @@ export async function showQuickStartWebview(context: vscode.ExtensionContext): P
         const view = await createQuickStartWebview(context)
         view.reveal()
     } catch {
-        vscode.window.showErrorMessage(
-            localize('AWS.command.quickStart.error', 'There was an error retrieving the Quick Start page')
-        )
+        vscode.window.showErrorMessage(localize('AWS.command.quickStart.error', 'Error while loading Quick Start page'))
     }
 }
 

--- a/src/shared/ui/common/regionSubmenu.ts
+++ b/src/shared/ui/common/regionSubmenu.ts
@@ -42,7 +42,7 @@ export class RegionSubmenu<T> extends Prompter<RegionSubmenuResponse<T>> {
             {
                 label: 'Switch region',
                 data: switchRegion,
-                detail: `Showing options for ${this.currentRegion}`,
+                description: `current region: ${this.currentRegion}`,
             },
             ...prompter.quickPick.items,
         ]

--- a/src/shared/ui/picker.ts
+++ b/src/shared/ui/picker.ts
@@ -182,7 +182,7 @@ export class IteratingQuickPickController<TResponse> {
     }
     // eslint-disable-next-line @typescript-eslint/naming-convention
     public static readonly ERROR_ITEM: vscode.QuickPickItem = {
-        label: localize('AWS.picker.dynamic.errorNode.label', 'There was an error retrieving more items.'),
+        label: localize('AWS.picker.dynamic.errorNode.label', 'Failed to load more items.'),
         alwaysShow: true,
     }
 

--- a/src/test/cloudWatchLogs/commands/searchLogGroup.test.ts
+++ b/src/test/cloudWatchLogs/commands/searchLogGroup.test.ts
@@ -5,12 +5,13 @@
 
 import * as vscode from 'vscode'
 import * as assert from 'assert'
-import { SearchLogGroupWizard, createFilterpatternPrompter } from '../../../cloudWatchLogs/commands/searchLogGroup'
+import { SearchLogGroupWizard, createSearchPatternPrompter } from '../../../cloudWatchLogs/commands/searchLogGroup'
 import { TimeFilterSubmenu } from '../../../cloudWatchLogs/timeFilterSubmenu'
 import { exposeEmitters, ExposeEmitters } from '../../../../src/test/shared/vscode/testUtils'
 import { InputBoxPrompter } from '../../../shared/ui/inputPrompter'
 import { createWizardTester, WizardTester } from '../../shared/wizards/wizardTestUtils'
 import { createQuickPickTester, QuickPickTester } from '../../shared/ui/testUtils'
+import { CloudWatchLogsGroupInfo, CloudWatchLogsParameters } from '../../../cloudWatchLogs/registry/logDataRegistry'
 
 describe('searchLogGroup', async function () {
     describe('Wizard', async function () {
@@ -22,7 +23,13 @@ describe('searchLogGroup', async function () {
         let filterPatternPrompter: InputBoxPrompter
 
         before(function () {
-            filterPatternPrompter = createFilterpatternPrompter('test-loggroup', false)
+            const logGroup: CloudWatchLogsGroupInfo = {
+                groupName: 'est-loggroup',
+                regionName: 'us-east-1',
+            }
+            const logParams: CloudWatchLogsParameters = {}
+
+            filterPatternPrompter = createSearchPatternPrompter(logGroup, logParams, {}, false, true)
             testWizard = createWizardTester(new SearchLogGroupWizard())
             filterPatternInputBox = exposeEmitters(filterPatternPrompter.inputBox, [
                 'onDidAccept',
@@ -33,8 +40,8 @@ describe('searchLogGroup', async function () {
         it('shows logGroup prompt first and filterPattern second, then timerange submenu', function () {
             testWizard = createWizardTester(new SearchLogGroupWizard())
             testWizard.submenuResponse.assertShowFirst()
-            testWizard.filterPattern.assertShowSecond()
-            testWizard.timeRange.assertShowThird()
+            testWizard.timeRange.assertShowSecond()
+            testWizard.filterPattern.assertShowThird()
         })
 
         it('prompts for filterPattern and accepts input', async function () {
@@ -115,7 +122,7 @@ describe('searchLogGroup', async function () {
                 regionName: 'region-test',
             })
         )
-        nodeTestWizard.filterPattern.assertShowFirst()
+        nodeTestWizard.filterPattern.assertShowSecond()
         nodeTestWizard.submenuResponse.assertDoesNotShow()
     })
 
@@ -126,7 +133,7 @@ describe('searchLogGroup', async function () {
                 regionName: 'region-test',
             })
         )
-        nodeTestWizard.filterPattern.assertShowFirst()
+        nodeTestWizard.timeRange.assertShowFirst()
         nodeTestWizard.submenuResponse.assertDoesNotShow()
     })
 })

--- a/src/test/shared/ui/inputPrompter.test.ts
+++ b/src/test/shared/ui/inputPrompter.test.ts
@@ -132,5 +132,24 @@ describe('InputBoxPrompter', function () {
             accept('200')
             assert.strictEqual(await result, '200')
         })
+
+        it('passes isFinalInput', async function () {
+            function validateInput(resp: string, isFinalInput?: boolean) {
+                if (!isFinalInput) {
+                    return 'user is typing'
+                }
+                return undefined
+            }
+            testPrompter.setValidation(validateInput)
+            const result = testPrompter.prompt()
+
+            // NOT final input.
+            inputBox.fireOnDidChangeValue('hello')
+            assert.strictEqual(inputBox.validationMessage, 'user is typing')
+            // Final input (user confirmed / hit Enter).
+            accept('hello')
+            assert.strictEqual(inputBox.validationMessage, undefined)
+            assert.strictEqual(await result, 'hello')
+        })
     })
 })


### PR DESCRIPTION
## Problem

The "filter pattern" step is not validated until after the wizard closes, so customer must start the wizard again if CloudWatch logs API rejects the filter (search) pattern.

Because of current limitations of vscode and/or our Wizard framework, we can't dynamically make a service call because _async_ `onDidAccept` event handler is not await'd.

## Solution

<img width="544" alt="image" src="https://user-images.githubusercontent.com/55561878/214407106-87db2fdb-2d3f-4689-941b-89bfb00a0e5c.png">

- Change "Search Pattern" step to be the last step.
- Use a workaround similar to:
https://github.com/aws/aws-toolkit-vscode/blob/183dd3ae4bf14196962c242e9236092ae509e3b0/src/credentials/wizards/createProfile.ts#L69-L104
    - Subclass `InputBoxPrompter`
    - Override `promptUser()`. If validation fails,
        - return `WIZARD_RETRY`
        - restore state in a hacky way (the `retryState` object)




<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
