### PR TITLE
fix(inputPrompter): misplaced disposables argument

### DIFF
--- a/src/shared/ui/inputPrompter.ts
+++ b/src/shared/ui/inputPrompter.ts
@@ -92,10 +92,12 @@ export class InputBoxPrompter extends Prompter<string> {
 
         this.inputBox.onDidChangeValue(
             value => (this.inputBox.validationMessage = validate(value)),
+            undefined,
             this.validateEvents
         )
         this.inputBox.onDidAccept(
             () => (this.inputBox.validationMessage = validate(this.inputBox.value)),
+            undefined,
             this.validateEvents
         )
     }


### PR DESCRIPTION
Problem:
`this.validateEvents` is passed as the `thisArgs` parameter.

Solution:
pass `undefined` to `thisArgs` parameter, pass `this.validateEvents` to `disposables` parameter.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
