### PR TITLE
fix(sam): normalize function handler path for TS 'code' invokes

### DIFF
--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -201,7 +201,7 @@ async function compileTypeScript(config: SamLaunchRequestArgs): Promise<void> {
 
     // resolve ts lambda handler to point into build directory relative to codeRoot
     const tsLambdaHandler = path.relative(config.codeRoot, path.join(tsBuildDir, config.invokeTarget.lambdaHandler))
-    config.invokeTarget.lambdaHandler = tsLambdaHandler
+    config.invokeTarget.lambdaHandler = pathutil.normalizeSeparator(tsLambdaHandler)
     getLogger('channel').info(`Resolved compiled lambda handler to ${tsLambdaHandler}`)
 
     const tsc = await systemutil.SystemUtilities.findTypescriptCompiler()


### PR DESCRIPTION
## Problem
TS "code" configs do not work correctly on Windows. Minor bug from https://github.com/aws/aws-toolkit-vscode/pull/3099

## Solution
Normalize the handler path

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
