### PR TITLE
fix(codewhisperer): update error popup for access token migration

### DIFF
--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -251,8 +251,9 @@ export async function activate(context: ExtContext): Promise<void> {
             if (t <= CodeWhispererConstants.accessTokenCutOffDate) {
                 maybeShowTokenMigrationWarning()
             } else {
-                globals.context.globalState.update(CodeWhispererConstants.accessToken, undefined)
-                globals.context.globalState.update(CodeWhispererConstants.accessTokenExpriedKey, true)
+                await globals.context.globalState.update(CodeWhispererConstants.accessToken, undefined)
+                await globals.context.globalState.update(CodeWhispererConstants.accessTokenExpriedKey, true)
+                await vscode.commands.executeCommand('aws.codeWhisperer.refreshRootNode')
                 maybeShowTokenMigrationError()
             }
         } else if (accessTokenExpired) {

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -34,6 +34,7 @@ import {
     showFreeTierLimit,
     updateReferenceLog,
     showIntroduction,
+    showAccessTokenErrorLearnMore,
 } from './commands/basicCommands'
 import { sleep } from '../shared/utilities/timeoutUtils'
 import { ReferenceLogViewProvider } from './service/referenceLogViewProvider'
@@ -167,6 +168,8 @@ export async function activate(context: ExtContext): Promise<void> {
         showSsoSignIn.register(),
         // learn more about CodeWhisperer
         showLearnMore.register(),
+        // learn more about CodeWhisperer access token migration
+        showAccessTokenErrorLearnMore.register(),
         // show free tier limit
         showFreeTierLimit.register(),
         // update reference log instance
@@ -284,7 +287,9 @@ export async function activate(context: ExtContext): Promise<void> {
                 vscode.window
                     .showErrorMessage(
                         CodeWhispererConstants.accessTokenMigrationErrorMessage,
-                        CodeWhispererConstants.accessTokenMigrationErrorButtonMessage
+                        CodeWhispererConstants.accessTokenMigrationErrorButtonMessage,
+                        CodeWhispererConstants.accessTokenMigrationLearnMore,
+                        CodeWhispererConstants.accessTokenMigrationDoNotShowAgain
                     )
                     .then(async resp => {
                         if (resp === CodeWhispererConstants.accessTokenMigrationErrorButtonMessage) {
@@ -295,8 +300,14 @@ export async function activate(context: ExtContext): Promise<void> {
                                 CodeWhispererConstants.accessTokenMigrationDoNotShowAgainKey,
                                 true
                             )
+                        } else if (resp === CodeWhispererConstants.accessTokenMigrationLearnMore) {
+                            await vscode.commands.executeCommand('aws.codeWhisperer.accessTokenErrorLearnMore')
                         }
                     })
+                context.extensionContext.globalState.update(
+                    CodeWhispererConstants.accessTokenMigrationDoNotShowLastShown,
+                    Date.now()
+                )
             }
         }
     }

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -48,7 +48,6 @@ import { InlineCompletionService, refreshStatusBar } from './service/inlineCompl
 import { isInlineCompletionEnabled } from './util/commonUtil'
 import { CodeWhispererCodeCoverageTracker } from './tracker/codewhispererCodeCoverageTracker'
 import { AuthUtil, isUpgradeableConnection } from './util/authUtil'
-import globals from '../shared/extensionGlobals'
 import { Auth } from '../credentials/auth'
 import { isUserCancelledError } from '../shared/errors'
 import { showViewLogsMessage } from '../shared/utilities/messages'
@@ -62,6 +61,7 @@ export async function activate(context: ExtContext): Promise<void> {
     /**
      * Enable essential intellisense default settings for AWS C9 IDE
      */
+
     if (isCloud9()) {
         await enableDefaultConfigCloud9()
     }
@@ -243,73 +243,96 @@ export async function activate(context: ExtContext): Promise<void> {
 
             await vscode.commands.executeCommand('aws.codeWhisperer.refreshRootNode')
             const t = new Date()
-            const doNotShowAgain =
-                context.extensionContext.globalState.get<boolean>(
-                    CodeWhispererConstants.accessTokenMigrationDoNotShowAgainKey
-                ) || false
-            const notificationLastShown: number =
-                context.extensionContext.globalState.get<number | undefined>(
-                    CodeWhispererConstants.accessTokenMigrationDoNotShowLastShown
-                ) || 1
 
-            //Add 7 days to notificationLastShown to determine whether warn message should show
-            if (doNotShowAgain || notificationLastShown + 1000 * 60 * 60 * 24 * 7 >= Date.now()) {
-                return
-            } else if (t <= CodeWhispererConstants.accessTokenCutOffDate) {
-                vscode.window
-                    .showWarningMessage(
-                        CodeWhispererConstants.accessTokenMigrationWarningMessage,
-                        CodeWhispererConstants.accessTokenMigrationWarningButtonMessage,
-                        CodeWhispererConstants.accessTokenMigrationDoNotShowAgain
-                    )
-                    .then(async resp => {
-                        if (resp === CodeWhispererConstants.accessTokenMigrationWarningButtonMessage) {
-                            await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
-                            await showSsoSignIn.execute()
-                        } else if (resp === CodeWhispererConstants.accessTokenMigrationDoNotShowAgain) {
-                            await vscode.window.showInformationMessage(
-                                CodeWhispererConstants.accessTokenMigrationDoNotShowAgainInfo,
-                                'OK'
-                            )
-                            await context.extensionContext.globalState.update(
-                                CodeWhispererConstants.accessTokenMigrationDoNotShowAgainKey,
-                                true
-                            )
-                        }
-                    })
-                context.extensionContext.globalState.update(
-                    CodeWhispererConstants.accessTokenMigrationDoNotShowLastShown,
-                    Date.now()
-                )
+            if (t <= CodeWhispererConstants.accessTokenCutOffDate) {
+                maybeShowTokenMigrationWarning()
             } else {
-                await globals.context.globalState.update(CodeWhispererConstants.accessToken, undefined)
-                await vscode.commands.executeCommand('aws.codeWhisperer.refreshRootNode')
-                vscode.window
-                    .showErrorMessage(
-                        CodeWhispererConstants.accessTokenMigrationErrorMessage,
-                        CodeWhispererConstants.accessTokenMigrationErrorButtonMessage,
-                        CodeWhispererConstants.accessTokenMigrationLearnMore,
-                        CodeWhispererConstants.accessTokenMigrationDoNotShowAgain
-                    )
-                    .then(async resp => {
-                        if (resp === CodeWhispererConstants.accessTokenMigrationErrorButtonMessage) {
-                            await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
-                            await showSsoSignIn.execute()
-                        } else if (resp === CodeWhispererConstants.accessTokenMigrationDoNotShowAgain) {
-                            await context.extensionContext.globalState.update(
-                                CodeWhispererConstants.accessTokenMigrationDoNotShowAgainKey,
-                                true
-                            )
-                        } else if (resp === CodeWhispererConstants.accessTokenMigrationLearnMore) {
-                            await vscode.commands.executeCommand('aws.codeWhisperer.accessTokenErrorLearnMore')
-                        }
-                    })
-                context.extensionContext.globalState.update(
-                    CodeWhispererConstants.accessTokenMigrationDoNotShowLastShown,
-                    Date.now()
-                )
+                maybeShowTokenMigrationError()
             }
         }
+    }
+
+    function maybeShowTokenMigrationWarning() {
+        const doNotShowAgain =
+            context.extensionContext.globalState.get<boolean>(
+                CodeWhispererConstants.accessTokenMigrationDoNotShowAgainKey
+            ) || false
+        const notificationLastShown: number =
+            context.extensionContext.globalState.get<number | undefined>(
+                CodeWhispererConstants.accessTokenMigrationDoNotShowLastShown
+            ) || 1
+
+        //Add 7 days to notificationLastShown to determine whether warn message should show
+        if (doNotShowAgain || notificationLastShown + 1000 * 60 * 60 * 24 * 7 >= Date.now()) {
+            return
+        }
+
+        vscode.window
+            .showWarningMessage(
+                CodeWhispererConstants.accessTokenMigrationWarningMessage,
+                CodeWhispererConstants.accessTokenMigrationWarningButtonMessage,
+                CodeWhispererConstants.accessTokenMigrationDoNotShowAgain
+            )
+            .then(async resp => {
+                if (resp === CodeWhispererConstants.accessTokenMigrationWarningButtonMessage) {
+                    await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
+                    await showSsoSignIn.execute()
+                } else if (resp === CodeWhispererConstants.accessTokenMigrationDoNotShowAgain) {
+                    await vscode.window.showInformationMessage(
+                        CodeWhispererConstants.accessTokenMigrationDoNotShowAgainInfo,
+                        'OK'
+                    )
+                    await context.extensionContext.globalState.update(
+                        CodeWhispererConstants.accessTokenMigrationDoNotShowAgainKey,
+                        true
+                    )
+                }
+            })
+        context.extensionContext.globalState.update(
+            CodeWhispererConstants.accessTokenMigrationDoNotShowLastShown,
+            Date.now()
+        )
+    }
+
+    function maybeShowTokenMigrationError() {
+        const migrationErrordoNotShowAgain =
+            context.extensionContext.globalState.get<boolean>(
+                CodeWhispererConstants.accessTokenExpiredDoNotShowAgainKey
+            ) || false
+        const migrationErrorLastShown: number =
+            context.extensionContext.globalState.get<number | undefined>(
+                CodeWhispererConstants.accessTokenExpiredDoNotShowLastShown
+            ) || 1
+
+        //Add 7 days to notificationLastShown to determine whether warn message should show
+        if (migrationErrordoNotShowAgain || migrationErrorLastShown + 1000 * 60 * 60 * 24 * 7 >= Date.now()) {
+            return
+        }
+
+        vscode.window
+            .showErrorMessage(
+                CodeWhispererConstants.accessTokenMigrationErrorMessage,
+                CodeWhispererConstants.accessTokenMigrationErrorButtonMessage,
+                CodeWhispererConstants.accessTokenMigrationLearnMore,
+                CodeWhispererConstants.accessTokenMigrationDoNotShowAgain
+            )
+            .then(async resp => {
+                if (resp === CodeWhispererConstants.accessTokenMigrationErrorButtonMessage) {
+                    await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
+                    await showSsoSignIn.execute()
+                } else if (resp === CodeWhispererConstants.accessTokenMigrationDoNotShowAgain) {
+                    await context.extensionContext.globalState.update(
+                        CodeWhispererConstants.accessTokenExpiredDoNotShowAgainKey,
+                        true
+                    )
+                } else if (resp === CodeWhispererConstants.accessTokenMigrationLearnMore) {
+                    await vscode.commands.executeCommand('aws.codeWhisperer.accessTokenErrorLearnMore')
+                }
+            })
+        context.extensionContext.globalState.update(
+            CodeWhispererConstants.accessTokenExpiredDoNotShowLastShown,
+            Date.now()
+        )
     }
 
     function setStatusBarOK() {

--- a/src/codewhisperer/commands/basicCommands.ts
+++ b/src/codewhisperer/commands/basicCommands.ts
@@ -97,6 +97,13 @@ export const showLearnMore = Commands.declare('aws.codeWhisperer.learnMore', () 
     vscode.env.openExternal(vscode.Uri.parse(CodeWhispererConstants.learnMoreUriGeneral))
 })
 
+export const showAccessTokenErrorLearnMore = Commands.declare(
+    'aws.codeWhisperer.accessTokenErrorLearnMore',
+    () => async () => {
+        vscode.env.openExternal(vscode.Uri.parse(CodeWhispererConstants.accessTokenMigrationLearnMoreUri))
+    }
+)
+
 // TODO: Use a different URI
 export const showFreeTierLimit = Commands.declare('aws.codeWhisperer.freeTierLimit', () => async () => {
     vscode.env.openExternal(vscode.Uri.parse(CodeWhispererConstants.learnMoreUri))

--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -140,6 +140,9 @@ export const learnMoreUriGeneral = 'https://aws.amazon.com/codewhisperer/'
 
 export const learnMoreUri = 'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/codewhisperer.html'
 
+export const accessTokenMigrationLearnMoreUri =
+    'https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/codewhisperer-auth.html'
+
 export const identityPoolID = 'us-east-1:70717e99-906f-4add-908c-bd9074a2f5b9'
 
 /**
@@ -215,7 +218,7 @@ export const accessTokenCutOffDate = new Date(2023, 0, 31)
 
 export const accessTokenMigrationWarningMessage = `To continue using CodeWhisperer, you must add an AWS Builder ID or AWS IAM Identity Center connection by January 31, 2023.`
 
-export const accessTokenMigrationErrorMessage = `To continue using CodeWhisperer, you must add an AWS Builder ID or AWS IAM Identity Center connection.`
+export const accessTokenMigrationErrorMessage = `Your Preview Access Code has expired. To continue using CodeWhisperer, connect with AWS Builder ID or AWS IAM Identity center.`
 
 export const accessTokenMigrationWarningButtonMessage = `Connect with AWS to Continue`
 
@@ -237,6 +240,8 @@ export const failedToConnectAwsBuilderId = `Failed to connect to AWS Builder ID`
 export const failedToConnectIamIdentityCenter = `Failed to connect to IAM Identity Center`
 
 export const connectionExpired = `AWS Toolkit: Connection expired. Reauthenticate to continue.`
+
+export const accessTokenMigrationLearnMore = `Learn More`
 
 export const accessTokenMigrationDoNotShowAgain = `Don\'t Show Again`
 

--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -247,7 +247,12 @@ export const accessTokenMigrationDoNotShowAgain = `Don\'t Show Again`
 
 export const accessTokenMigrationDoNotShowAgainKey = 'CODEWHISPERER_ACCESS_TOKEN_MIGRATION_DO_NOT_SHOW_AGAIN'
 
+export const accessTokenExpiredDoNotShowAgainKey = 'CODEWHISPERER_ACCESS_TOKEN_EXPIRED_DO_NOT_SHOW_AGAIN'
+
 export const accessTokenMigrationDoNotShowLastShown =
     'CODEWHISPERER_ACCESS_TOKEN_MIGRATION_DO_NOT_SHOW_AGAIN_LAST_SHOWN_TIME'
+
+export const accessTokenExpiredDoNotShowLastShown =
+    'CODEWHISPERER_ACCESS_TOKEN_EXPIRED_DO_NOT_SHOW_AGAIN_LAST_SHOWN_TIME'
 
 export const accessTokenMigrationDoNotShowAgainInfo = `You will not receive this notification again. If you would like to continue using CodeWhisperer after January 31, 2023, you can still connect with AWS. [Learn More](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/codewhisper-setup-general.html).`

--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -249,6 +249,8 @@ export const accessTokenMigrationDoNotShowAgainKey = 'CODEWHISPERER_ACCESS_TOKEN
 
 export const accessTokenExpiredDoNotShowAgainKey = 'CODEWHISPERER_ACCESS_TOKEN_EXPIRED_DO_NOT_SHOW_AGAIN'
 
+export const accessTokenExpriedKey = 'CODEWHISPERER_ACCESS_TOKEN_EXPIRED'
+
 export const accessTokenMigrationDoNotShowLastShown =
     'CODEWHISPERER_ACCESS_TOKEN_MIGRATION_DO_NOT_SHOW_AGAIN_LAST_SHOWN_TIME'
 


### PR DESCRIPTION
## Problem
to update the error popup shown to users with access code after 1/31 cutoff date based on product decisions

- update the message shown on popup
- add "Don't show again" button
- add "Learn more" button with link to documentation

## Solution
before:

<img width="686" alt="Screen Shot 2023-01-24 at 1 49 42 PM" src="https://user-images.githubusercontent.com/60411978/214638507-4bbf2fec-ee71-4988-912a-934f2f8540eb.png">

after:

<img width="364" alt="Screen Shot 2023-01-24 at 1 57 25 PM" src="https://user-images.githubusercontent.com/60411978/214638615-d7ff9e2d-09fb-493b-a181-64b6a84268af.png">


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
