### PR TITLE
upload lambda: sort regions from appJson to top

### DIFF
--- a/src/shared/ui/common/region.ts
+++ b/src/shared/ui/common/region.ts
@@ -20,7 +20,10 @@ interface RegionPrompterOptions {
     readonly buttons?: PrompterButtons<Region>
     readonly serviceFilter?: string
     readonly helpUrl?: string | vscode.Uri
+    readonly fromAppJson?: string[]
 }
+
+const fromAppJsonDescription = 'from application.json'
 
 export function createRegionPrompter(
     regions = globals.regionProvider.getRegions(),
@@ -38,7 +41,7 @@ export function createRegionPrompter(
         detail: region.id,
         data: region,
         skipEstimate: true,
-        description: '',
+        description: options.fromAppJson?.includes(region.id) ? fromAppJsonDescription : '',
         recentlyUsed: region.id === lastRegion?.id,
     }))
 
@@ -53,7 +56,11 @@ export function createRegionPrompter(
         buttons: options.buttons ?? createCommonButtons(options.helpUrl),
         matchOnDetail: true,
         compare: (a, b) => {
-            return a.detail === defaultRegion ? -1 : b.detail === defaultRegion ? 1 : 0
+            return a.detail === defaultRegion || b.description === fromAppJsonDescription
+                ? -1
+                : b.detail === defaultRegion || b.description === fromAppJsonDescription
+                ? 1
+                : 0
         },
     })
 


### PR DESCRIPTION
## Problem
 We have metadata information about downloaded lambdas stored in an application.json file, but in the upload lambda flow we do not see a connection for region.
## Solution
 Add a description to the regions that are found in the application.json file and move those regions to the top of the list.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
