### PR TITLE
fix(codewhisperer): add additional delay time before showing recommen…

### DIFF
--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -22,6 +22,8 @@ export const invocationKeyThreshold = 15
 
 export const idleTimerPollPeriod = 25 // milliseconds
 
+export const showRecommendationTimerPollPeriod = 25
+
 export const specialCharactersList = ['{', '[', '(', ':', '\t', '\n']
 
 export const normalTextChangeRegex = /[A-Za-z0-9]/g
@@ -152,6 +154,9 @@ export const defaultCheckPeriodMillis = 1000 * 60 * 5
 
 // suggestion show delay, in milliseconds
 export const suggestionShowDelay = 250
+
+// add 200ms more delay on top of inline default 30-50ms
+export const inlineSuggestionShowDelay = 200
 
 export const referenceLog = 'CodeWhisperer Reference Log'
 

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -228,7 +228,7 @@ export class InlineCompletionService {
         this.next = nextCommand.register(this)
         this.hide = hideCommand.register(this)
         RecommendationHandler.instance.onDidReceiveRecommendation(e => {
-            this.sharedStartShowRecommendationTimer()
+            this.startShowRecommendationTimer()
         })
     }
 
@@ -242,9 +242,9 @@ export class InlineCompletionService {
         return this.documentUri?.fsPath
     }
 
-    private sharedStartShowRecommendationTimer = shared(this.startShowRecommendationTimer.bind(this))
+    private sharedTryShowRecommendation = shared(this.tryShowRecommendation.bind(this))
 
-    private async startShowRecommendationTimer() {
+    private startShowRecommendationTimer() {
         if (this._showRecommendationTimer) {
             clearInterval(this._showRecommendationTimer)
             this._showRecommendationTimer = undefined
@@ -255,7 +255,7 @@ export class InlineCompletionService {
                 return
             }
             try {
-                this.tryShowRecommendation()
+                this.sharedTryShowRecommendation()
             } finally {
                 if (this._showRecommendationTimer) {
                     clearInterval(this._showRecommendationTimer)

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -228,7 +228,7 @@ export class InlineCompletionService {
         this.next = nextCommand.register(this)
         this.hide = hideCommand.register(this)
         RecommendationHandler.instance.onDidReceiveRecommendation(e => {
-            this.startShowRecommendationTimer()
+            this.sharedStartShowRecommendationTimer()
         })
     }
 
@@ -242,21 +242,20 @@ export class InlineCompletionService {
         return this.documentUri?.fsPath
     }
 
-    private sharedTryShowRecommendation = shared(this.tryShowRecommendation.bind(this))
+    private sharedStartShowRecommendationTimer = shared(this.startShowRecommendationTimer.bind(this))
 
-    private startShowRecommendationTimer() {
+    private async startShowRecommendationTimer() {
         if (this._showRecommendationTimer) {
             clearInterval(this._showRecommendationTimer)
             this._showRecommendationTimer = undefined
         }
-
         this._showRecommendationTimer = setInterval(() => {
             const delay = performance.now() - vsCodeState.lastUserModificationTime
             if (delay < CodeWhispererConstants.inlineSuggestionShowDelay) {
                 return
             }
             try {
-                this.sharedTryShowRecommendation()
+                this.tryShowRecommendation()
             } finally {
                 if (this._showRecommendationTimer) {
                     clearInterval(this._showRecommendationTimer)


### PR DESCRIPTION
…dation

## Problem
the default delay time before showing recommendation in VSC inline api is around 30-50ms, which is too short. This often result in recommendation being shown to users when they are still typing.
## Solution
Add additional 200ms to get the number close to 250ms which matches the JB behavior
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
