### PR TITLE
fix(cwl): loading new log stream stuck in loop

### DIFF
--- a/src/cloudWatchLogs/commands/searchLogGroup.ts
+++ b/src/cloudWatchLogs/commands/searchLogGroup.ts
@@ -197,11 +197,16 @@ export class SearchPatternPrompter extends InputBoxPrompter {
         }
         getLogger().debug('cwl: validateSearchPattern: %O', searchPattern)
         try {
-            await filterLogEventsFromUri(this.logGroup, {
-                ...this.logParams,
-                filterPattern: searchPattern,
-                limit: 1,
-            })
+            await filterLogEventsFromUri(
+                this.logGroup,
+                {
+                    ...this.logParams,
+                    filterPattern: searchPattern,
+                    limit: 1,
+                },
+                undefined,
+                true
+            )
         } catch (e) {
             return (e as Error).message
         }

--- a/src/cloudWatchLogs/commands/viewLogStream.ts
+++ b/src/cloudWatchLogs/commands/viewLogStream.ts
@@ -20,8 +20,8 @@ import {
     CloudWatchLogsGroupInfo,
     CloudWatchLogsParameters,
     LogDataRegistry,
-    getLogEventsFromUriComponents as getLogEventsFromUri,
     initLogData as initLogData,
+    filterLogEventsFromUri,
 } from '../registry/logDataRegistry'
 import { createURIFromArgs } from '../cloudWatchLogsUtils'
 import { prepareDocument } from './searchLogGroup'
@@ -57,7 +57,7 @@ export async function viewLogStream(node: LogGroupNode, registry: LogDataRegistr
 
     const uri = createURIFromArgs(logGroupInfo, parameters)
 
-    const logData = initLogData(logGroupInfo, parameters, getLogEventsFromUri)
+    const logData = initLogData(logGroupInfo, parameters, filterLogEventsFromUri)
 
     result = await prepareDocument(uri, logData, registry)
     telemetry.cloudwatchlogs_open.emit({ result: result, cloudWatchResourceType: 'logStream', source: 'Explorer' })

--- a/src/cloudWatchLogs/document/logDataCodeLensProvider.ts
+++ b/src/cloudWatchLogs/document/logDataCodeLensProvider.ts
@@ -58,7 +58,8 @@ export class LogDataCodeLensProvider implements vscode.CodeLensProvider {
                   },
         }
 
-        if (isLogStreamUri(uri)) {
+        // log stream documents always start at the oldest log event, so no need to get older events
+        if (!isLogStreamUri(uri)) {
             codelenses.push(oldCodeLense)
         }
         codelenses.push(newerCodelense)

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -199,12 +199,13 @@ export class LogDataRegistry {
 }
 
 /**
- * @see getLogEventsFromUriComponents
+ * @param completeTimeout True to close the vscode cancel window when request is completed.
  */
 export async function filterLogEventsFromUri(
     logGroupInfo: CloudWatchLogsGroupInfo,
     parameters: CloudWatchLogsParameters,
-    nextToken?: string
+    nextToken?: string,
+    completeTimeout = false
 ): Promise<CloudWatchLogsResponse> {
     const client = new DefaultCloudWatchLogsClient(logGroupInfo.regionName)
 
@@ -245,7 +246,7 @@ export async function filterLogEventsFromUri(
     })
 
     const responsePromise = client.filterLogEvents(cwlParameters)
-    const response = await waitTimeout(responsePromise, msgTimeout, { allowUndefined: false })
+    const response = await waitTimeout(responsePromise, msgTimeout, { allowUndefined: false, completeTimeout })
 
     // Use heuristic of last token as backward token and next token as forward to generalize token form.
     // Note that this may become inconsistent if the contents of the calls are changing as they are being made.

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -193,6 +193,10 @@ export async function filterLogEventsFromUri(
         limit: parameters.limit,
     }
 
+    if (logGroupInfo.streamName !== undefined) {
+        cwlParameters.logStreamNames = [logGroupInfo.streamName]
+    }
+
     if (parameters.startTime && parameters.endTime) {
         cwlParameters.startTime = parameters.startTime
         cwlParameters.endTime = parameters.endTime
@@ -229,44 +233,6 @@ export async function filterLogEventsFromUri(
         }
     } else {
         throw new Error('cwl: filterLogEvents returned null')
-    }
-}
-
-/**
- * @see filterLogEventsFromUri
- */
-export async function getLogEventsFromUriComponents(
-    logGroupInfo: CloudWatchLogsGroupInfo,
-    parameters: CloudWatchLogsParameters,
-    nextToken?: string
-): Promise<CloudWatchLogsResponse> {
-    const client = new DefaultCloudWatchLogsClient(logGroupInfo.regionName)
-
-    if (!logGroupInfo.streamName) {
-        throw new Error(
-            `Log Stream name not specified for log group ${logGroupInfo.groupName} on region ${logGroupInfo.regionName}`
-        )
-    }
-    const cwlParameters = {
-        logGroupName: logGroupInfo.groupName,
-        logStreamName: logGroupInfo.streamName,
-        nextToken,
-        limit: parameters.limit,
-    }
-
-    const timeout = new Timeout(300000)
-    showMessageWithCancel(`Fetching logs: ${logGroupInfo.streamName}`, timeout, 1200)
-    const responsePromise = client.getLogEvents(cwlParameters)
-    const response = await waitTimeout(responsePromise, timeout, { allowUndefined: false })
-
-    if (!response) {
-        throw new Error('cwl:`getLogEvents` did not return anything.')
-    }
-
-    return {
-        events: response.events ? response.events : [],
-        nextForwardToken: response.nextForwardToken,
-        nextBackwardToken: response.nextBackwardToken,
     }
 }
 

--- a/src/shared/vscode/window.ts
+++ b/src/shared/vscode/window.ts
@@ -1,0 +1,182 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import globals from '../extensionGlobals'
+
+/**
+ * Type for arguments needed to update a progress window
+ * {@link vscode.window.withProgress}
+ */
+export interface ProgressEntry {
+    message?: string
+    increment?: number
+}
+
+/**
+ * Components associated with {@link module:vscode.window}.
+ */
+export interface Window {
+    /**
+     * See {@link module:vscode.window.setStatusBarMessage}.
+     */
+    setStatusBarMessage(message: string, hideAfterTimeout: number): vscode.Disposable
+
+    /**
+     * See {@link module:vscode.window.showInputBox}.
+     */
+    showInputBox(options?: vscode.InputBoxOptions, token?: vscode.CancellationToken): Thenable<string | undefined>
+
+    /**
+     * See {@link module:vscode.window.showInformationMessage}.
+     */
+    showInformationMessage(message: string, ...items: string[]): Thenable<string | undefined>
+    showInformationMessage(
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: string[]
+    ): Thenable<string | undefined>
+    showInformationMessage<T extends vscode.MessageItem>(message: string, ...items: T[]): Thenable<T | undefined>
+    showInformationMessage<T extends vscode.MessageItem>(
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: T[]
+    ): Thenable<T | undefined>
+
+    /**
+     * See {@link module:vscode.window.showWarningMessage}.
+     */
+    showWarningMessage(message: string, ...items: string[]): Thenable<string | undefined>
+    showWarningMessage(
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: string[]
+    ): Thenable<string | undefined>
+    showWarningMessage<T extends vscode.MessageItem>(message: string, ...items: T[]): Thenable<T | undefined>
+    showWarningMessage<T extends vscode.MessageItem>(
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: T[]
+    ): Thenable<T | undefined>
+
+    /**
+     * See {@link module:vscode.window.showErrorMessage}.
+     */
+    showErrorMessage(message: string, ...items: string[]): Thenable<string | undefined>
+    showErrorMessage(message: string, options: vscode.MessageOptions, ...items: string[]): Thenable<string | undefined>
+    showErrorMessage<T extends vscode.MessageItem>(message: string, ...items: T[]): Thenable<T | undefined>
+    showErrorMessage<T extends vscode.MessageItem>(
+        message: string,
+        options: vscode.MessageOptions,
+        ...items: T[]
+    ): Thenable<T | undefined>
+
+    /**
+     * See {@link module:vscode.window.withProgress}.
+     */
+    withProgress<R>(
+        options: vscode.ProgressOptions,
+        task: (progress: vscode.Progress<ProgressEntry>, token: vscode.CancellationToken) => Thenable<R>
+    ): Thenable<R>
+
+    /**
+     * See {@link module:vscode.window.showOpenDialog}.
+     */
+    showOpenDialog(options: vscode.OpenDialogOptions): Thenable<vscode.Uri[] | undefined>
+
+    /**
+     * See {@link module:vscode.window.showSaveDialog}.
+     */
+    showSaveDialog(options: vscode.SaveDialogOptions): Thenable<vscode.Uri | undefined>
+}
+
+/**
+ * @deprecated use `vscode.window` directly. Unit tests should use `getTestWindow()` to inspect/manipulate UI.
+ */
+export namespace Window {
+    export function vscode(): Window {
+        return new DefaultWindow()
+    }
+}
+
+class DefaultWindow implements Window {
+    public setStatusBarMessage(message: string, hideAfterTimeout: number): vscode.Disposable {
+        return vscode.window.setStatusBarMessage(message, hideAfterTimeout)
+    }
+
+    public showInputBox(
+        options?: vscode.InputBoxOptions,
+        token?: vscode.CancellationToken
+    ): Thenable<string | undefined> {
+        return vscode.window.showInputBox(options, token)
+    }
+
+    public showInformationMessage(...args: any[]): Thenable<any | undefined> {
+        // @ts-ignore
+        return vscode.window.showInformationMessage(...args)
+    }
+
+    public showWarningMessage(...args: any[]): Thenable<any | undefined> {
+        // @ts-ignore
+        return vscode.window.showWarningMessage(...args)
+    }
+
+    public showErrorMessage(...args: any[]): Thenable<any | undefined> {
+        // @ts-ignore
+        return vscode.window.showErrorMessage(...args)
+    }
+
+    /**
+     * Wraps the `vscode.window.withProgress` functionality with functionality that also writes to the output channel.
+     * Params match `vscode.window.withProgress` API; documentation follows:
+     *
+     * Show progress in the editor. Progress is shown while running the given callback and while the promise it returned isn't resolved nor rejected. The location at which progress should show (and other details) is defined via the passed ProgressOptions.
+     *
+     *  @param task
+     *  A callback returning a promise. Progress state can be reported with the provided progress-object.
+     *
+     *  To report discrete progress, use increment to indicate how much work has been completed. Each call with a increment value will be summed up and reflected as overall progress until 100% is reached (a value of e.g. 10 accounts for 10% of work done). Note that currently only ProgressLocation.Notification is capable of showing discrete progress.
+     *
+     *  To monitor if the operation has been cancelled by the user, use the provided CancellationToken. Note that currently only ProgressLocation.Notification is supporting to show a cancel button to cancel the long running operation.
+     *
+     *  @return — The thenable the task-callback returned.
+     */
+    public withProgress<R>(
+        options: vscode.ProgressOptions,
+        task: (progress: vscode.Progress<ProgressEntry>, token: vscode.CancellationToken) => Thenable<R>
+    ): Thenable<R> {
+        if (options.title) {
+            globals.outputChannel.appendLine(options.title)
+        }
+
+        // hijack the returned task to wrap progress with an output channel adapter
+        const newTask: (progress: vscode.Progress<ProgressEntry>, token: vscode.CancellationToken) => Thenable<R> = (
+            progress: vscode.Progress<ProgressEntry>,
+            token: vscode.CancellationToken
+        ) => {
+            const newProgress: vscode.Progress<ProgressEntry> = {
+                ...progress,
+                report: (value: ProgressEntry) => {
+                    if (value.message) {
+                        globals.outputChannel.appendLine(value.message)
+                    }
+                    progress.report(value)
+                },
+            }
+
+            return task(newProgress, token)
+        }
+
+        return vscode.window.withProgress(options, newTask)
+    }
+
+    public showOpenDialog(options: vscode.OpenDialogOptions): Thenable<vscode.Uri[] | undefined> {
+        return vscode.window.showOpenDialog(options)
+    }
+
+    public showSaveDialog(options: vscode.SaveDialogOptions): Thenable<vscode.Uri | undefined> {
+        return vscode.window.showSaveDialog(options)
+    }
+}

--- a/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
@@ -18,6 +18,7 @@ import { INSIGHTS_TIMESTAMP_FORMAT } from '../../../shared/constants'
 import { Settings } from '../../../shared/settings'
 import { CloudWatchLogsSettings, createURIFromArgs } from '../../../cloudWatchLogs/cloudWatchLogsUtils'
 import {
+    backwardToken,
     fakeGetLogEvents,
     fakeSearchLogGroup,
     logGroupsData,
@@ -84,6 +85,9 @@ describe('LogDataRegistry', async function () {
         })
 
         it("properly paginates the results with 'head'", async () => {
+            // Manually set a backwards token to exist
+            registry.setLogData(paginatedUri, { ...paginatedData, previous: { token: backwardToken } })
+
             const newEvents = await registry.fetchNextLogEvents(paginatedUri, 'head')
 
             // // check that newData is changed to what it should be.
@@ -97,6 +101,12 @@ describe('LogDataRegistry', async function () {
             // // check that newData is changed to what it should be.
             const expected = (await fakeGetLogEvents()).events
             assert.deepStrictEqual(newEvents, expected)
+        })
+
+        it("returns empty list if no 'head' token", async () => {
+            const newEvents = await registry.fetchNextLogEvents(paginatedUri, 'head')
+            // // check that newData is changed to what it should be.
+            assert.deepStrictEqual(newEvents, [])
         })
     })
 


### PR DESCRIPTION
# Problem

When using the load new events codelens on a non-filtered
log stream, we would get stuck in an endless loading loop.

When loading a non-filtered logstream, explicitly using
the GetLogEvents api, we assumed that there were
no more results if the next token was undefined.

The problem with this is that the GetLogEvents
api returns the SAME token if there are no more
results. This mistake was made since the
FilterLogEvents api does return undefined if there are no more results.

# Solution

Handle the scenario where the same token is returned and convert the result of the function that uses it in to undefined. We need to do this since the rest of the code expects the token to be undefined if
there are no more results.

# Steps

On a Log Group in the explorer, choose 'View Log Stream' and select a random one. Then click the load new log stream codelens. It will now be able to complete, while before it was stuck in an endless loop.

# Additional

A CancellableMessageManager was added, this allows for easy management of
the cancellable window for scenarios where duplicate windows may be called.
See the class documenation for more information.

Signed-off-by: Nikolas Komonen <nkomonen@amazon.com>

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
