### PR TITLE
add telemetry: sam cli not installed

### DIFF
--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -47,8 +47,7 @@ import { checklogs } from '../../shared/localizedText'
 import globals from '../../shared/extensionGlobals'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { LambdaArchitecture, Result, Runtime } from '../../shared/telemetry/telemetry'
-
-type CreateReason = 'unknown' | 'userCancelled' | 'fileNotFound' | 'complete' | 'error'
+import { getTelemetryReason, getTelemetryResult } from '../../shared/errors'
 
 export const samInitTemplateFiles: string[] = ['template.yaml', 'template.yml']
 export const samInitReadmeFile: string = 'README.TOOLKIT.md'
@@ -59,7 +58,7 @@ export async function resumeCreateNewSamApp(
     activationReloadState: ActivationReloadState = new ActivationReloadState()
 ) {
     let createResult: Result = 'Succeeded'
-    let reason: CreateReason = 'complete'
+    let reason: string | undefined
     let samVersion: string | undefined
     const samInitState: SamInitState | undefined = activationReloadState.getSamInitState()
     try {
@@ -134,7 +133,7 @@ export async function createNewSamApplication(
     const awsContext: AwsContext = extContext.awsContext
     const regionProvider: RegionProvider = extContext.regionProvider
     let createResult: Result = 'Succeeded'
-    let reason: CreateReason = 'unknown'
+    let reason: string | undefined
     let lambdaPackageType: 'Zip' | 'Image' | undefined
     let createRuntime: Runtime | undefined
     let samVersion: string | undefined
@@ -323,8 +322,8 @@ export async function createNewSamApplication(
             await vscode.workspace.openTextDocument(templateUri)
         }
     } catch (err) {
-        createResult = 'Failed'
-        reason = 'error'
+        createResult = getTelemetryResult(err)
+        reason = getTelemetryReason(err)
 
         globals.outputChannel.show(true)
         getLogger('channel').error(

--- a/src/shared/sam/cli/samCliValidationNotification.ts
+++ b/src/shared/sam/cli/samCliValidationNotification.ts
@@ -8,6 +8,8 @@ import * as nls from 'vscode-nls'
 
 import { samAboutInstallUrl, vscodeMarketplaceUrl } from '../../constants'
 import { getIdeProperties } from '../../extensionUtilities'
+import { telemetry } from '../../telemetry/telemetry'
+import { CancellationError } from '../../utilities/timeoutUtils'
 import {
     InvalidSamCliError,
     InvalidSamCliVersionError,
@@ -29,7 +31,13 @@ export interface SamCliValidationNotificationAction {
 const actionGoToSamCli: SamCliValidationNotificationAction = {
     label: localize('AWS.samcli.userChoice.visit.install.url', 'Get SAM CLI'),
     invoke: async () => {
-        await vscode.env.openExternal(vscode.Uri.parse(samAboutInstallUrl))
+        telemetry.aws_openUrl.run(async span => {
+            span.record({ url: samAboutInstallUrl })
+            const didOpen = await vscode.env.openExternal(vscode.Uri.parse(samAboutInstallUrl))
+            if (!didOpen) {
+                throw new CancellationError('user')
+            }
+        })
     },
 }
 

--- a/src/shared/sam/cli/samCliValidator.ts
+++ b/src/shared/sam/cli/samCliValidator.ts
@@ -8,6 +8,7 @@ import * as semver from 'semver'
 import { ClassToInterfaceType } from '../../utilities/tsUtils'
 import { SamCliSettings } from './samCliSettings'
 import { SamCliInfoInvocation, SamCliInfoResponse } from './samCliInfo'
+import { ToolkitError } from '../../errors'
 
 export const minSamCliVersion = '0.47.0'
 export const minSamCliVersionForImageSupport = '1.13.0'
@@ -17,21 +18,17 @@ export const minSamCliVersionForArmSupport = '1.33.0'
 export const minSamCliVersionForDotnet31Support = '1.4.0'
 
 // Errors
-export class InvalidSamCliError extends Error {
-    public constructor(message?: string | undefined) {
-        super(message)
-    }
-}
+export class InvalidSamCliError extends ToolkitError {}
 
 export class SamCliNotFoundError extends InvalidSamCliError {
     public constructor() {
-        super('SAM CLI was not found')
+        super('SAM CLI was not found', { code: 'MissingSamCli' })
     }
 }
 
 export class InvalidSamCliVersionError extends InvalidSamCliError {
     public constructor(public versionValidation: SamCliVersionValidatorResult) {
-        super('SAM CLI has an invalid version')
+        super('SAM CLI has an invalid version', { code: 'InvalidSamCliVersion' })
     }
 }
 


### PR DESCRIPTION
## Problem
 We have a number of commands that require the SAM CLI. We are not tracking how often users fail these commands because they do not have SAM CLI installed.

## Solution
 Add telemetry to track when this error is invoked.



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
