### PR TITLE
fix(resources): handle duplicate resource type definitions

### DIFF
--- a/.changes/next-release/Bug Fix-9f0b52be-3f38-41eb-92e8-f01a45281441.json
+++ b/.changes/next-release/Bug Fix-9f0b52be-3f38-41eb-92e8-f01a45281441.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Duplicate resource type definitions break the \"Resources\" node (#3132)"
+}

--- a/src/dynamicResources/explorer/nodes/resourcesNode.ts
+++ b/src/dynamicResources/explorer/nodes/resourcesNode.ts
@@ -9,7 +9,7 @@ import { CloudFormationClient, DefaultCloudFormationClient } from '../../../shar
 import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
 import { PlaceholderNode } from '../../../shared/treeview/nodes/placeholderNode'
 import { makeChildrenNodes } from '../../../shared/treeview/utils'
-import { toArrayAsync, toMap, updateInPlace } from '../../../shared/utilities/collectionUtils'
+import { toArrayAsync, updateInPlace } from '../../../shared/utilities/collectionUtils'
 import { ResourceTypeNode } from './resourceTypeNode'
 import { CloudFormation } from 'aws-sdk'
 import { CloudControlClient, DefaultCloudControlClient } from '../../../shared/clients/cloudControlClient'
@@ -60,10 +60,17 @@ export class ResourcesNode extends AWSTreeNodeBase {
         const defaultResources = isCloud9() ? Array.from(resourceTypes.keys()) : []
         const enabledResources = this.settings.get('enabledResources', defaultResources)
 
-        const availableTypes: Map<string, CloudFormation.TypeSummary> = toMap(
-            await toArrayAsync(this.cloudFormation.listTypes()),
-            type => type.TypeName
-        )
+        // Use the most recently update type definition per-type
+        const types = await toArrayAsync(this.cloudFormation.listTypes())
+        types.sort((a, b) => (a.LastUpdated?.getTime() ?? 0) - (b.LastUpdated?.getTime() ?? 0))
+
+        const availableTypes: Map<string, CloudFormation.TypeSummary> = new Map()
+        for (const type of types) {
+            if (type.TypeName) {
+                availableTypes.set(type.TypeName!, type)
+            }
+        }
+
         updateInPlace(
             this.resourceTypeNodes,
             enabledResources,

--- a/src/test/dynamicResources/explorer/moreResourcesNode.test.ts
+++ b/src/test/dynamicResources/explorer/moreResourcesNode.test.ts
@@ -89,6 +89,12 @@ describe('ResourcesNode', function () {
         assert.deepStrictEqual(actualChildOrder, sortedText, 'Unexpected child sort order')
     })
 
+    it('handles duplicate type entries without failing', async function () {
+        prepareMock(['type1', 'type2', 'type1'])
+        const childNodes = await testNode.getChildren()
+        assert.strictEqual(childNodes.length, 2, 'Unexpected child count')
+    })
+
     async function setConfiguration(resourceTypes: string[]) {
         await settings.update('enabledResources', resourceTypes)
     }


### PR DESCRIPTION
## Problem
Duplicate type definitions are not handled (#3132)

## Solution
Use the most recently updated definition

The CloudFormation service should clarify this behavior in their API documentation. Duplicated, undifferentiated type definitions is unexpected. This may be a bug with the service itself.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
