### PR TITLE
feat(terminal): "Connected Execution"

### DIFF
--- a/.changes/next-release/Feature-11c2d748-f5bf-4ed9-ad83-768d21c90275.json
+++ b/.changes/next-release/Feature-11c2d748-f5bf-4ed9-ad83-768d21c90275.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Selecting credentials sets AWS_* environment variables in new and existing Terminals #3139"
+}

--- a/src/credentials/auth.ts
+++ b/src/credentials/auth.ts
@@ -760,8 +760,14 @@ export async function promptForConnection(auth: Auth, type?: 'iam' | 'sso') {
 
     const placeholder =
         type === 'iam'
-            ? localize('aws.auth.promptConnection.iam.placeholder', 'Select an IAM credential')
-            : localize('aws.auth.promptConnection.all.placeholder', 'Select a connection')
+            ? localize(
+                  'aws.auth.promptConnection.iam.placeholder',
+                  'Select an IAM credential (also sets AWS_* environment variables)'
+              )
+            : localize(
+                  'aws.auth.promptConnection.all.placeholder',
+                  'Select a connection (also sets AWS_* environment variables)'
+              )
 
     const resp = await showQuickPick<Connection | 'addNewConnection' | 'editCredentials'>(items, {
         placeholder,

--- a/src/credentials/loginManager.ts
+++ b/src/credentials/loginManager.ts
@@ -78,6 +78,19 @@ export class LoginManager {
                 defaultRegion: provider.getDefaultRegion(),
             })
 
+            globals.context.environmentVariableCollection.replace('AWS_PROFILE', args.providerId.credentialTypeId)
+            const region = provider.getDefaultRegion()
+            if (region) {
+                globals.context.environmentVariableCollection.replace('AWS_REGION', region)
+            }
+            globals.context.environmentVariableCollection.replace('AWS_ACCESS_KEY_ID', credentials.accessKeyId)
+            globals.context.environmentVariableCollection.replace('AWS_SECRET_ACCESS_KEY', credentials.secretAccessKey)
+            if (credentials.sessionToken) {
+                globals.context.environmentVariableCollection.replace('AWS_SESSION_TOKEN', credentials.sessionToken)
+            } else {
+                globals.context.environmentVariableCollection.delete('AWS_SESSION_TOKEN')
+            }
+
             telemetryResult = 'Succeeded'
             return true
         } catch (err) {
@@ -328,6 +341,20 @@ function createCredentialsShim(
 
             const credentials = await provider.getCredentials()
             store.setCredentials(credentials, provider)
+
+            globals.context.environmentVariableCollection.replace('AWS_PROFILE', providerId.credentialTypeId)
+            const region = provider.getDefaultRegion()
+            if (region) {
+                globals.context.environmentVariableCollection.replace('AWS_REGION', region)
+            }
+            globals.context.environmentVariableCollection.replace('AWS_ACCESS_KEY_ID', credentials.accessKeyId)
+            globals.context.environmentVariableCollection.replace('AWS_SECRET_ACCESS_KEY', credentials.secretAccessKey)
+            if (credentials.sessionToken) {
+                globals.context.environmentVariableCollection.replace('AWS_SESSION_TOKEN', credentials.sessionToken)
+            } else {
+                globals.context.environmentVariableCollection.delete('AWS_SESSION_TOKEN')
+            }
+
             getLogger().debug(`credentials: refresh succeeded for: ${formatProviderId()}`)
             result = 'Succeeded'
 


### PR DESCRIPTION
# ( will be closed in favor of https://github.com/aws/aws-toolkit-vscode/pull/3040 )

# Problem:
Toolkit credentials selection does not propagate to Terminal.

# Solution:
Set `AWS_*` env vars in `ExtensionContext.environmentVariableCollection` when AWS credentials are selected or refreshed. This affects both new and _existing_ terminals created with the vscode `Terminal: Create New Terminal` command.

closes #1351

![image](https://user-images.githubusercontent.com/55561878/215938665-ef3f6eea-5343-450d-bead-c7d6c2aee2f3.png)

![image](https://user-images.githubusercontent.com/55561878/215938598-00907c4c-d3f2-4348-af27-04fd22ab9fe2.png)

![image](https://user-images.githubusercontent.com/55561878/215938711-6c9eab7b-3c0d-4948-a4ce-2d5f790a6120.png)


# todo: 

- document which env vars are updated and when:
    - when:
        1. credentials selection
        2. refresh event
    - which:
      ```
      AWS_PROFILE
      AWS_REGION
      AWS_ACCESS_KEY_ID
      AWS_SECRET_ACCESS_KEY
      AWS_SESSION_TOKEN
      AWS_SESSION_TOKEN
      ```


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
