### PR TITLE
cwl: Fix document highlight range + async content loading

### DIFF
--- a/src/cloudWatchLogs/document/logDataDocumentProvider.ts
+++ b/src/cloudWatchLogs/document/logDataDocumentProvider.ts
@@ -69,7 +69,9 @@ export class LogDataDocumentProvider implements vscode.TextDocumentContentProvid
             const initialStreamData = getInitialLogData(logGroupInfo, parameters, getLogEventsFromUriComponents)
             const streamUri = createURIFromArgs(logGroupInfo, parameters)
 
-            await this.registry.registerLog(streamUri, initialStreamData)
+            // dont await so doc content is loaded asynchronously, prevents stuttering on hover
+            this.registry.registerLog(streamUri, initialStreamData)
+
             const doc = await vscode.workspace.openTextDocument(streamUri)
             vscode.languages.setTextDocumentLanguage(doc, 'log')
 

--- a/src/cloudWatchLogs/document/logDataDocumentProvider.ts
+++ b/src/cloudWatchLogs/document/logDataDocumentProvider.ts
@@ -83,7 +83,7 @@ export class LogDataDocumentProvider implements vscode.TextDocumentContentProvid
             // Highlights the whole line on hover
             const locationLink: vscode.LocationLink = {
                 originSelectionRange: new vscode.Range(
-                    position.with(undefined, 0),
+                    position.with(undefined, curLine.firstNonWhitespaceCharacterIndex),
                     position.with(undefined, curLine.range.end.character)
                 ),
                 targetUri: streamUri,


### PR DESCRIPTION
## Problem 1
Previously a document highlight on a cwl would
highlight the entire line, even leading whitespace.

## Solution 1
The highlighting starts at the
first non whitespace character.

![Screen Shot 2023-02-01 at 12 22 50 PM](https://user-images.githubusercontent.com/118216176/216117194-ce91c37d-ef78-48fb-b21e-3c8868bd57e4.png)

---
## Problem 2
Previously, when we did ctrl + hover on a cwl
line in a log stream it would synchronously load
data before returning a definition highlight.

## Solution 2
Now we will return the definition highlight immediately
while loading the data async. This should improve
UX slightly.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
