### PR TITLE
lint: enable `noImplicitOverride` in `tsc`

### DIFF
--- a/src/apigateway/explorer/apiGatewayNodes.ts
+++ b/src/apigateway/explorer/apiGatewayNodes.ts
@@ -24,14 +24,14 @@ export class ApiGatewayNode extends AWSTreeNodeBase {
 
     public constructor(
         private readonly partitionId: string,
-        public readonly regionCode: string,
+        public override readonly regionCode: string,
         private readonly client = new DefaultApiGatewayClient(regionCode)
     ) {
         super('API Gateway', vscode.TreeItemCollapsibleState.Collapsed)
         this.apiNodes = new Map<string, RestApiNode>()
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => {
                 await this.updateChildren()

--- a/src/apigateway/explorer/apiNodes.ts
+++ b/src/apigateway/explorer/apiNodes.ts
@@ -8,12 +8,12 @@ import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 import { RestApi } from 'aws-sdk/clients/apigateway'
 
 export class RestApiNode extends AWSTreeNodeBase implements AWSResourceNode {
-    public id!: string
+    public override id!: string
 
     public constructor(
         public readonly parent: AWSTreeNodeBase,
         public readonly partitionId: string,
-        public readonly regionCode: string,
+        public override readonly regionCode: string,
         private api: RestApi
     ) {
         super('')

--- a/src/apprunner/explorer/apprunnerNode.ts
+++ b/src/apprunner/explorer/apprunnerNode.ts
@@ -21,12 +21,12 @@ export class AppRunnerNode extends AWSTreeNodeBase {
     private readonly pollingNodes: Set<string> = new Set()
     private pollTimer?: NodeJS.Timeout
 
-    public constructor(public readonly regionCode: string, public readonly client: AppRunnerClient) {
+    public constructor(public override readonly regionCode: string, public readonly client: AppRunnerClient) {
         super('App Runner', vscode.TreeItemCollapsibleState.Collapsed)
         this.contextValue = 'awsAppRunnerNode'
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => {
                 await this.updateChildren()

--- a/src/awsexplorer/regionNode.ts
+++ b/src/awsexplorer/regionNode.ts
@@ -85,7 +85,7 @@ const serviceCandidates = [
  */
 export class RegionNode extends AWSTreeNodeBase {
     private region: Region
-    public readonly regionCode: string
+    public override readonly regionCode: string
 
     public get regionName(): string {
         return this.region.name
@@ -99,7 +99,7 @@ export class RegionNode extends AWSTreeNodeBase {
         this.update(region)
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         //  Services that are candidates to add to the region explorer.
         //  `serviceId`s are checked against ~/resources/endpoints.json to see whether or not the service is available in the given region.
         //  If the service is available, we use the `createFn` to generate the node for the region.

--- a/src/cloudWatchLogs/explorer/cloudWatchLogsNode.ts
+++ b/src/cloudWatchLogs/explorer/cloudWatchLogsNode.ts
@@ -23,7 +23,7 @@ export abstract class CloudWatchLogsBase extends AWSTreeNodeBase {
 
     public constructor(
         label: string,
-        public readonly regionCode: string,
+        public override readonly regionCode: string,
         protected readonly cloudwatchClient: DefaultCloudWatchLogsClient
     ) {
         super(label, vscode.TreeItemCollapsibleState.Collapsed)
@@ -32,7 +32,7 @@ export abstract class CloudWatchLogsBase extends AWSTreeNodeBase {
 
     protected abstract getLogGroups(): Promise<Map<string, CloudWatchLogs.LogGroup>>
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => {
                 await this.updateChildren()

--- a/src/cloudWatchLogs/explorer/logGroupNode.ts
+++ b/src/cloudWatchLogs/explorer/logGroupNode.ts
@@ -12,7 +12,7 @@ import { getIcon } from '../../shared/icons'
 export const contextValueCloudwatchLog = 'awsCloudWatchLogNode'
 
 export class LogGroupNode extends AWSTreeNodeBase implements AWSResourceNode {
-    public constructor(public readonly regionCode: string, public logGroup: CloudWatchLogs.LogGroup) {
+    public constructor(public override readonly regionCode: string, public logGroup: CloudWatchLogs.LogGroup) {
         super('')
         this.update(logGroup)
         this.iconPath = getIcon('aws-cloudwatch-log-group')

--- a/src/credentials/providers/sharedCredentialsProviderFactory.ts
+++ b/src/credentials/providers/sharedCredentialsProviderFactory.ts
@@ -27,11 +27,11 @@ export class SharedCredentialsProviderFactory extends BaseCredentialsProviderFac
         }
     }
 
-    public getProviderType(): CredentialsProviderType | undefined {
+    public override getProviderType(): CredentialsProviderType | undefined {
         return SharedCredentialsProvider.getProviderType()
     }
 
-    protected resetProviders() {
+    protected override resetProviders() {
         this.loadedCredentialsModificationMillis = undefined
         this.loadedConfigModificationMillis = undefined
 

--- a/src/dynamicResources/explorer/nodes/resourceNode.ts
+++ b/src/dynamicResources/explorer/nodes/resourceNode.ts
@@ -15,7 +15,7 @@ export class ResourceNode extends AWSTreeNodeBase {
     public constructor(
         public readonly parent: ResourceTypeNode,
         public readonly identifier: string,
-        public contextValue?: string
+        public override contextValue?: string
     ) {
         super('')
         this.contextValue = contextValue ?? 'ResourceNode'

--- a/src/dynamicResources/explorer/nodes/resourceTypeNode.ts
+++ b/src/dynamicResources/explorer/nodes/resourceTypeNode.ts
@@ -60,7 +60,7 @@ export class ResourceTypeNode extends AWSTreeNodeBase implements LoadMoreNode {
         this.childContextValue = supportedOperations.join('') + contextValueResource
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         if (!this.metadata.available) {
             return []
         }

--- a/src/dynamicResources/explorer/nodes/resourcesNode.ts
+++ b/src/dynamicResources/explorer/nodes/resourcesNode.ts
@@ -33,7 +33,7 @@ export class ResourcesNode extends AWSTreeNodeBase {
         this.contextValue = 'resourcesRootNode'
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => {
                 await this.updateChildren()

--- a/src/ecr/explorer/ecrNode.ts
+++ b/src/ecr/explorer/ecrNode.ts
@@ -24,7 +24,7 @@ export class EcrNode extends AWSTreeNodeBase {
         this.contextValue = 'awsEcrNode'
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => {
                 const response = await toArrayAsync(this.ecr.describeRepositories())

--- a/src/ecr/explorer/ecrRepositoryNode.ts
+++ b/src/ecr/explorer/ecrRepositoryNode.ts
@@ -19,7 +19,7 @@ import { getIcon } from '../../shared/icons'
 export class EcrRepositoryNode extends AWSTreeNodeBase implements AWSResourceNode {
     name: string = this.repository.repositoryName
     arn: string = this.repository.repositoryArn
-    public readonly regionCode: string
+    public override readonly regionCode: string
 
     constructor(
         public readonly parent: EcrNode,
@@ -32,7 +32,7 @@ export class EcrRepositoryNode extends AWSTreeNodeBase implements AWSResourceNod
         this.regionCode = ecr.regionCode
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => {
                 const response = await toArrayAsync(this.ecr.describeTags(this.repository.repositoryName))

--- a/src/ecr/explorer/ecrTagNode.ts
+++ b/src/ecr/explorer/ecrTagNode.ts
@@ -9,7 +9,7 @@ import { EcrClient, EcrRepository } from '../../shared/clients/ecrClient'
 import { EcrRepositoryNode } from './ecrRepositoryNode'
 
 export class EcrTagNode extends AWSTreeNodeBase {
-    public readonly regionCode = this.parent.regionCode
+    public override readonly regionCode = this.parent.regionCode
 
     public constructor(
         public readonly parent: EcrRepositoryNode,

--- a/src/eventSchemas/explorer/registryItemNode.ts
+++ b/src/eventSchemas/explorer/registryItemNode.ts
@@ -22,7 +22,7 @@ import { SchemaClient } from '../../shared/clients/schemaClient'
 
 export class RegistryItemNode extends AWSTreeNodeBase {
     private readonly schemaNodes: Map<string, SchemaItemNode>
-    public readonly regionCode: string = this.client.regionCode
+    public override readonly regionCode: string = this.client.regionCode
 
     public constructor(private registryItemOutput: Schemas.RegistrySummary, private readonly client: SchemaClient) {
         super('', vscode.TreeItemCollapsibleState.Collapsed)
@@ -40,7 +40,7 @@ export class RegistryItemNode extends AWSTreeNodeBase {
         )
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => {
                 await this.updateChildren()

--- a/src/eventSchemas/explorer/schemasNode.ts
+++ b/src/eventSchemas/explorer/schemasNode.ts
@@ -18,7 +18,7 @@ import { SchemaClient } from '../../shared/clients/schemaClient'
 
 export class SchemasNode extends AWSTreeNodeBase {
     private readonly registryNodes: Map<string, RegistryItemNode>
-    public readonly regionCode = this.client.regionCode
+    public override readonly regionCode = this.client.regionCode
 
     public constructor(private readonly client: SchemaClient) {
         super('Schemas', vscode.TreeItemCollapsibleState.Collapsed)
@@ -26,7 +26,7 @@ export class SchemasNode extends AWSTreeNodeBase {
         this.contextValue = 'awsSchemasNode'
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => {
                 await this.updateChildren()

--- a/src/iot/explorer/iotCertFolderNode.ts
+++ b/src/iot/explorer/iotCertFolderNode.ts
@@ -35,7 +35,7 @@ export class IotCertsFolderNode extends AWSTreeNodeBase implements LoadMoreNode 
         this.contextValue = 'awsIotCertsNode'
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => this.childLoader.getChildren(),
             getNoChildrenPlaceholderNode: async () =>

--- a/src/iot/explorer/iotCertificateNode.ts
+++ b/src/iot/explorer/iotCertificateNode.ts
@@ -61,7 +61,7 @@ export abstract class IotCertificateNode extends AWSTreeNodeBase implements AWSR
         return undefined
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => this.childLoader.getChildren(),
             getNoChildrenPlaceholderNode: async () =>
@@ -128,11 +128,11 @@ export abstract class IotCertificateNode extends AWSTreeNodeBase implements AWSR
 
 export class IotThingCertNode extends IotCertificateNode {
     public constructor(
-        public readonly certificate: IotCertificate,
-        public readonly parent: IotThingNode,
-        public readonly iot: IotClient,
-        public readonly things?: string[],
-        protected readonly workspace = Workspace.vscode()
+        public override readonly certificate: IotCertificate,
+        public override readonly parent: IotThingNode,
+        public override readonly iot: IotClient,
+        public override readonly things?: string[],
+        protected override readonly workspace = Workspace.vscode()
     ) {
         super(certificate, parent, iot, vscode.TreeItemCollapsibleState.Collapsed, things, workspace)
         this.contextValue = `${contextBase}.Things.${this.certificate.activeStatus}`
@@ -144,11 +144,11 @@ export class IotThingCertNode extends IotCertificateNode {
  */
 export class IotCertWithPoliciesNode extends IotCertificateNode implements LoadMoreNode {
     public constructor(
-        public readonly certificate: IotCertificate,
-        public readonly parent: IotCertsFolderNode,
-        public readonly iot: IotClient,
-        public readonly things?: string[],
-        protected readonly workspace = Workspace.vscode()
+        public override readonly certificate: IotCertificate,
+        public override readonly parent: IotCertsFolderNode,
+        public override readonly iot: IotClient,
+        public override readonly things?: string[],
+        protected override readonly workspace = Workspace.vscode()
     ) {
         super(certificate, parent, iot, vscode.TreeItemCollapsibleState.Collapsed, things, workspace)
         this.contextValue = `${contextBase}.Policies.${this.certificate.activeStatus}`

--- a/src/iot/explorer/iotNodes.ts
+++ b/src/iot/explorer/iotNodes.ts
@@ -34,7 +34,7 @@ export class IotNode extends AWSTreeNodeBase {
         this.contextValue = 'awsIotNode'
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => {
                 const thingFolderNode = new IotThingFolderNode(this.iot, this)

--- a/src/iot/explorer/iotPolicyFolderNode.ts
+++ b/src/iot/explorer/iotPolicyFolderNode.ts
@@ -41,7 +41,7 @@ export class IotPolicyFolderNode extends AWSTreeNodeBase implements LoadMoreNode
         this.contextValue = 'awsIotPoliciesNode'
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => this.childLoader.getChildren(),
             getNoChildrenPlaceholderNode: async () =>

--- a/src/iot/explorer/iotPolicyNode.ts
+++ b/src/iot/explorer/iotPolicyNode.ts
@@ -60,10 +60,10 @@ export class IotPolicyNode extends AWSTreeNodeBase implements AWSResourceNode {
 
 export class IotPolicyCertNode extends IotPolicyNode {
     public constructor(
-        public readonly policy: IotPolicy,
-        public readonly parent: IotCertificateNode,
-        public readonly iot: IotClient,
-        protected readonly workspace = Workspace.vscode()
+        public override readonly policy: IotPolicy,
+        public override readonly parent: IotCertificateNode,
+        public override readonly iot: IotClient,
+        protected override readonly workspace = Workspace.vscode()
     ) {
         super(policy, parent, iot, vscode.TreeItemCollapsibleState.None, undefined, workspace)
         this.contextValue = 'awsIotPolicyNode.Certificates'
@@ -74,18 +74,18 @@ export class IotPolicyWithVersionsNode extends IotPolicyNode {
     private readonly versionNodes: Map<string, IotPolicyVersionNode>
 
     public constructor(
-        public readonly policy: IotPolicy,
-        public readonly parent: IotPolicyFolderNode,
-        public readonly iot: IotClient,
+        public override readonly policy: IotPolicy,
+        public override readonly parent: IotPolicyFolderNode,
+        public override readonly iot: IotClient,
         certs?: string[],
-        protected readonly workspace = Workspace.vscode()
+        protected override readonly workspace = Workspace.vscode()
     ) {
         super(policy, parent, iot, vscode.TreeItemCollapsibleState.Collapsed, certs, workspace)
         this.contextValue = 'awsIotPolicyNode.WithVersions'
         this.versionNodes = new Map<string, IotPolicyVersionNode>()
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => {
                 await this.updateChildren()

--- a/src/iot/explorer/iotThingFolderNode.ts
+++ b/src/iot/explorer/iotThingFolderNode.ts
@@ -35,7 +35,7 @@ export class IotThingFolderNode extends AWSTreeNodeBase implements LoadMoreNode 
         this.contextValue = 'awsIotThingsNode'
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => this.childLoader.getChildren(),
             getNoChildrenPlaceholderNode: async () =>

--- a/src/iot/explorer/iotThingNode.ts
+++ b/src/iot/explorer/iotThingNode.ts
@@ -40,7 +40,7 @@ export class IotThingNode extends AWSTreeNodeBase implements AWSResourceNode, Lo
         this.contextValue = 'awsIotThingNode'
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => this.childLoader.getChildren(),
             getNoChildrenPlaceholderNode: async () =>

--- a/src/lambda/explorer/cloudFormationNodes.ts
+++ b/src/lambda/explorer/cloudFormationNodes.ts
@@ -27,7 +27,7 @@ export class CloudFormationNode extends AWSTreeNodeBase {
     private readonly stackNodes: Map<string, CloudFormationStackNode>
 
     public constructor(
-        public readonly regionCode: string,
+        public override readonly regionCode: string,
         private readonly client = new DefaultCloudFormationClient(regionCode)
     ) {
         super('CloudFormation', vscode.TreeItemCollapsibleState.Collapsed)
@@ -35,7 +35,7 @@ export class CloudFormationNode extends AWSTreeNodeBase {
         this.contextValue = 'awsCloudFormationRootNode'
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => {
                 await this.updateChildren()
@@ -65,7 +65,7 @@ export class CloudFormationStackNode extends AWSTreeNodeBase implements AWSResou
 
     public constructor(
         public readonly parent: AWSTreeNodeBase,
-        public readonly regionCode: string,
+        public override readonly regionCode: string,
         private stackSummary: CloudFormation.StackSummary,
         private readonly lambdaClient = new DefaultLambdaClient(regionCode),
         private readonly cloudformationClient = new DefaultCloudFormationClient(regionCode)
@@ -98,7 +98,7 @@ export class CloudFormationStackNode extends AWSTreeNodeBase implements AWSResou
         return this.stackSummary.StackName
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => {
                 await this.updateChildren()

--- a/src/lambda/explorer/lambdaFunctionNode.ts
+++ b/src/lambda/explorer/lambdaFunctionNode.ts
@@ -13,7 +13,7 @@ import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 export class LambdaFunctionNode extends AWSTreeNodeBase implements AWSResourceNode {
     public constructor(
         public readonly parent: AWSTreeNodeBase,
-        public readonly regionCode: string,
+        public override readonly regionCode: string,
         public configuration: Lambda.FunctionConfiguration
     ) {
         super('')

--- a/src/lambda/explorer/lambdaNodes.ts
+++ b/src/lambda/explorer/lambdaNodes.ts
@@ -29,7 +29,7 @@ export class LambdaNode extends AWSTreeNodeBase {
     private readonly functionNodes: Map<string, LambdaFunctionNode>
 
     public constructor(
-        public readonly regionCode: string,
+        public override readonly regionCode: string,
         private readonly client = new DefaultLambdaClient(regionCode)
     ) {
         super('Lambda', vscode.TreeItemCollapsibleState.Collapsed)
@@ -37,7 +37,7 @@ export class LambdaNode extends AWSTreeNodeBase {
         this.contextValue = 'awsLambdaNode'
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => {
                 await this.updateChildren()

--- a/src/s3/explorer/s3BucketNode.ts
+++ b/src/s3/explorer/s3BucketNode.ts
@@ -40,7 +40,7 @@ export class S3BucketNode extends AWSTreeNodeBase implements AWSResourceNode, Lo
         this.contextValue = 'awsS3BucketNode'
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => this.childLoader.getChildren(),
             getNoChildrenPlaceholderNode: async () =>

--- a/src/s3/explorer/s3FolderNode.ts
+++ b/src/s3/explorer/s3FolderNode.ts
@@ -37,7 +37,7 @@ export class S3FolderNode extends AWSTreeNodeBase implements AWSResourceNode, Lo
         this.contextValue = 'awsS3FolderNode'
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => this.childLoader.getChildren(),
             getNoChildrenPlaceholderNode: async () =>

--- a/src/s3/explorer/s3Nodes.ts
+++ b/src/s3/explorer/s3Nodes.ts
@@ -23,7 +23,7 @@ export class S3Node extends AWSTreeNodeBase {
         this.contextValue = 'awsS3Node'
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => {
                 const response = await this.s3.listBuckets()

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -108,7 +108,7 @@ export class ToolkitError extends Error implements ErrorInformation {
      * A message that could potentially be shown to the user. This should not contain any
      * sensitive information and should be limited in technical detail.
      */
-    public readonly message: string
+    public override readonly message: string
     public readonly code = this.info.code
     public readonly details = this.info.details
 
@@ -135,7 +135,7 @@ export class ToolkitError extends Error implements ErrorInformation {
     /**
      * The name of the error. This is not necessarily the same as the class name.
      */
-    public get name(): string {
+    public override get name(): string {
         return this.#name
     }
 
@@ -194,10 +194,9 @@ export class ToolkitError extends Error implements ErrorInformation {
 
             // TypeScript does not allow the use of `this` types for generic prototype methods unfortunately
             // This implementation is equivalent to re-assignment i.e. an unbound method on the prototype
-            public static chain<T extends new (...args: ConstructorParameters<NamedErrorConstructor>) => ToolkitError>(
-                this: T,
-                ...args: Parameters<NamedErrorConstructor['chain']>
-            ): InstanceType<T> {
+            public static override chain<
+                T extends new (...args: ConstructorParameters<NamedErrorConstructor>) => ToolkitError
+            >(this: T, ...args: Parameters<NamedErrorConstructor['chain']>): InstanceType<T> {
                 return ToolkitError.chain.call(this, ...args) as InstanceType<T>
             }
         }
@@ -237,7 +236,7 @@ function formatDetails(err: Error): string | undefined {
 }
 
 export class UnknownError extends Error {
-    public readonly name = 'UnknownError'
+    public override readonly name = 'UnknownError'
 
     public constructor(public readonly cause: unknown) {
         super(String(cause))

--- a/src/shared/fs/devfileRegistry.ts
+++ b/src/shared/fs/devfileRegistry.ts
@@ -36,7 +36,7 @@ export class DevfileRegistry extends WatchedFiles<Devfile> {
         return undefined
     }
 
-    public async remove(path: vscode.Uri): Promise<void> {
+    public override async remove(path: vscode.Uri): Promise<void> {
         const uri = typeof path === 'string' ? vscode.Uri.parse(path, true) : path
         globals.schemaService.registerMapping({
             uri: uri,

--- a/src/shared/fs/templateRegistry.ts
+++ b/src/shared/fs/templateRegistry.ts
@@ -58,7 +58,7 @@ export class CloudFormationTemplateRegistry extends WatchedFiles<CloudFormation.
     }
 
     // handles delete case
-    public async remove(uri: vscode.Uri): Promise<void> {
+    public override async remove(uri: vscode.Uri): Promise<void> {
         globals.schemaService.registerMapping({
             uri,
             type: 'yaml',

--- a/src/shared/icons.ts
+++ b/src/shared/icons.ts
@@ -64,7 +64,7 @@ export class Icon extends ThemeIcon {
         super(id)
     }
 
-    public toString() {
+    public override toString() {
         return `$(${this.id})`
     }
 }

--- a/src/shared/logger/consoleLogTransport.ts
+++ b/src/shared/logger/consoleLogTransport.ts
@@ -23,7 +23,7 @@ export class ConsoleLogTransport extends Transport {
         super(options)
     }
 
-    public log(info: LogEntry, next: () => void): void {
+    public override log(info: LogEntry, next: () => void): void {
         globals.clock.setImmediate(() => {
             this.emit('logged', info)
             console.log(info[MESSAGE])

--- a/src/shared/logger/debugConsoleTransport.ts
+++ b/src/shared/logger/debugConsoleTransport.ts
@@ -24,7 +24,7 @@ export class DebugConsoleTransport extends Transport {
         super(options)
     }
 
-    public log(info: LogEntry, next: () => void): void {
+    public override log(info: LogEntry, next: () => void): void {
         globals.clock.setImmediate(() => {
             vscode.debug.activeDebugConsole.append(info[MESSAGE])
             this.emit('logged', info)

--- a/src/shared/logger/outputChannelTransport.ts
+++ b/src/shared/logger/outputChannelTransport.ts
@@ -34,7 +34,7 @@ export class OutputChannelTransport extends Transport {
         this.stripAnsi = options.stripAnsi
     }
 
-    public log(info: LogEntry, next: () => void): void {
+    public override log(info: LogEntry, next: () => void): void {
         globals.clock.setImmediate(() => {
             const msg: string = this.stripAnsi ? removeAnsi(info[MESSAGE]) : info[MESSAGE]
 

--- a/src/shared/ui/pickerPrompter.ts
+++ b/src/shared/ui/pickerPrompter.ts
@@ -301,7 +301,7 @@ export class QuickPickPrompter<T> extends Prompter<T> {
         super()
     }
 
-    public transform<R>(callback: Transform<T, R>): QuickPickPrompter<R> {
+    public override transform<R>(callback: Transform<T, R>): QuickPickPrompter<R> {
         return super.transform(callback) as QuickPickPrompter<R>
     }
 
@@ -570,7 +570,7 @@ export class QuickPickPrompter<T> extends Prompter<T> {
 export class FilterBoxQuickPickPrompter<T> extends QuickPickPrompter<T> {
     private onChangeValue?: vscode.Disposable
 
-    public set recentItem(response: T | DataQuickPickItem<T> | undefined) {
+    public override set recentItem(response: T | DataQuickPickItem<T> | undefined) {
         if (this.isUserInput(response)) {
             this.quickPick.value = response.description ?? ''
         } else {
@@ -589,7 +589,7 @@ export class FilterBoxQuickPickPrompter<T> extends QuickPickPrompter<T> {
         })
     }
 
-    public async loadItems(items: ItemLoadTypes<T>): Promise<void> {
+    public override async loadItems(items: ItemLoadTypes<T>): Promise<void> {
         if (this.onChangeValue) {
             this.onChangeValue.dispose()
         }

--- a/src/shared/ui/wizardPrompter.ts
+++ b/src/shared/ui/wizardPrompter.ts
@@ -31,7 +31,7 @@ export class WizardPrompter<T> extends Prompter<T> {
         this.stepOffset = total - 1
     }
 
-    public get totalSteps(): number {
+    public override get totalSteps(): number {
         return this.wizard.totalSteps - this.stepOffset
     }
 

--- a/src/ssmDocument/explorer/documentItemNode.ts
+++ b/src/ssmDocument/explorer/documentItemNode.ts
@@ -15,7 +15,7 @@ export class DocumentItemNode extends AWSTreeNodeBase {
     public constructor(
         private documentItem: SSM.Types.DocumentIdentifier,
         public readonly client: SsmDocumentClient,
-        public readonly regionCode: string
+        public override readonly regionCode: string
     ) {
         super('')
         this.update(documentItem)

--- a/src/ssmDocument/explorer/documentItemNodeWriteable.ts
+++ b/src/ssmDocument/explorer/documentItemNodeWriteable.ts
@@ -11,8 +11,8 @@ import { DocumentItemNode } from './documentItemNode'
 export class DocumentItemNodeWriteable extends DocumentItemNode {
     public constructor(
         documentItem: SSM.Types.DocumentIdentifier,
-        public readonly client: SsmDocumentClient,
-        public readonly regionCode: string,
+        public override readonly client: SsmDocumentClient,
+        public override readonly regionCode: string,
         public readonly parent: RegistryItemNode
     ) {
         super(documentItem, client, regionCode)

--- a/src/ssmDocument/explorer/documentTypeNode.ts
+++ b/src/ssmDocument/explorer/documentTypeNode.ts
@@ -20,7 +20,7 @@ export class DocumentTypeNode extends AWSTreeNodeBase {
     private readonly childRegistryNames = [amazonRegistryName, userRegistryName, sharedRegistryName]
 
     public constructor(
-        public readonly regionCode: string,
+        public override readonly regionCode: string,
         public documentType: string,
         private readonly client = new DefaultSsmDocumentClient(regionCode)
     ) {
@@ -40,7 +40,7 @@ export class DocumentTypeNode extends AWSTreeNodeBase {
         this.setLabel()
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => {
                 await this.updateChildren()

--- a/src/ssmDocument/explorer/registryItemNode.ts
+++ b/src/ssmDocument/explorer/registryItemNode.ts
@@ -26,7 +26,7 @@ export class RegistryItemNode extends AWSTreeNodeBase {
     private readonly documentNodes: Map<string, DocumentItemNode>
 
     public constructor(
-        public readonly regionCode: string,
+        public override readonly regionCode: string,
         public registryName: string,
         readonly documentType: string,
         private readonly client = new DefaultSsmDocumentClient(regionCode)
@@ -48,7 +48,7 @@ export class RegistryItemNode extends AWSTreeNodeBase {
         this.setLabel()
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => {
                 await this.updateChildren()

--- a/src/ssmDocument/explorer/ssmDocumentNode.ts
+++ b/src/ssmDocument/explorer/ssmDocumentNode.ts
@@ -19,7 +19,7 @@ export class SsmDocumentNode extends AWSTreeNodeBase {
     private readonly documentTypeNodes: Map<string, DocumentTypeNode>
 
     public constructor(
-        public readonly regionCode: string,
+        public override readonly regionCode: string,
         private readonly client = new DefaultSsmDocumentClient(regionCode)
     ) {
         super('Systems Manager', vscode.TreeItemCollapsibleState.Collapsed)
@@ -27,7 +27,7 @@ export class SsmDocumentNode extends AWSTreeNodeBase {
         this.contextValue = 'awsSsmDocumentNode'
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => {
                 await this.updateChildren()

--- a/src/stepFunctions/commands/visualizeStateMachine/aslVisualizationCDK.ts
+++ b/src/stepFunctions/commands/visualizeStateMachine/aslVisualizationCDK.ts
@@ -21,7 +21,7 @@ export class AslVisualizationCDK extends AslVisualization {
         this.stateMachineName = stateMachineName
     }
 
-    protected getText(textDocument: vscode.TextDocument): string {
+    protected override getText(textDocument: vscode.TextDocument): string {
         this.updateWebviewTitle()
         const definitionString = getStateMachineDefinitionFromCfnTemplate(this.stateMachineName, this.templatePath)
         return toUnescapedAslJsonString(definitionString ? definitionString : '')

--- a/src/stepFunctions/explorer/stepFunctionsNodes.ts
+++ b/src/stepFunctions/explorer/stepFunctionsNodes.ts
@@ -40,7 +40,7 @@ export class StepFunctionsNode extends AWSTreeNodeBase {
     private readonly stateMachineNodes: Map<string, StateMachineNode>
 
     public constructor(
-        public readonly regionCode: string,
+        public override readonly regionCode: string,
         private readonly client = new DefaultStepFunctionsClient(regionCode)
     ) {
         super('Step Functions', vscode.TreeItemCollapsibleState.Collapsed)
@@ -49,7 +49,7 @@ export class StepFunctionsNode extends AWSTreeNodeBase {
         sfnNodeMap.set(regionCode, this)
     }
 
-    public async getChildren(): Promise<AWSTreeNodeBase[]> {
+    public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
             getChildNodes: async () => {
                 await this.updateChildren()
@@ -83,7 +83,7 @@ export class StepFunctionsNode extends AWSTreeNodeBase {
 export class StateMachineNode extends AWSTreeNodeBase implements AWSResourceNode {
     public constructor(
         public readonly parent: AWSTreeNodeBase,
-        public readonly regionCode: string,
+        public override readonly regionCode: string,
         public details: StepFunctions.StateMachineListItem
     ) {
         super('')

--- a/src/test/credentials/provider/credentialsProviderFactory.test.ts
+++ b/src/test/credentials/provider/credentialsProviderFactory.test.ts
@@ -12,7 +12,7 @@ describe('BaseCredentialsProviderFactory', async function () {
      * This class exposes abstract class functionality for the purpose of testing it.
      */
     class TestCredentialsProviderFactory extends BaseCredentialsProviderFactory<CredentialsProvider> {
-        public getProviderType(): CredentialsProviderType {
+        public override getProviderType(): CredentialsProviderType {
             return 'profile'
         }
 
@@ -22,15 +22,15 @@ describe('BaseCredentialsProviderFactory', async function () {
 
         public async refresh(): Promise<void> {}
 
-        public addProvider(provider: CredentialsProvider) {
+        public override addProvider(provider: CredentialsProvider) {
             super.addProvider(provider)
         }
 
-        public removeProvider(provider: CredentialsProvider) {
+        public override removeProvider(provider: CredentialsProvider) {
             super.removeProvider(provider)
         }
 
-        public resetProviders() {
+        public override resetProviders() {
             super.resetProviders()
         }
     }

--- a/src/test/eventSchemas/explorer/registryItemNode.test.ts
+++ b/src/test/eventSchemas/explorer/registryItemNode.test.ts
@@ -147,7 +147,7 @@ describe('DefaultRegistryNode', function () {
                 super(createSchemaClient())
             }
 
-            public async updateChildren(): Promise<void> {
+            public override async updateChildren(): Promise<void> {
                 throw new Error('Hello there!')
             }
         }

--- a/src/test/shared/regions/regionProvider.test.ts
+++ b/src/test/shared/regions/regionProvider.test.ts
@@ -186,7 +186,7 @@ describe('RegionProvider', async function () {
             regionProvider.setLastTouchedRegion('us-west-1')
 
             const node = new (class extends AWSTreeNodeBase {
-                public readonly regionCode = 'us-west-2'
+                public override readonly regionCode = 'us-west-2'
                 public constructor() {
                     super('')
                 }

--- a/src/test/shared/sam/cli/samCliInfo.test.ts
+++ b/src/test/shared/sam/cli/samCliInfo.test.ts
@@ -8,7 +8,7 @@ import { SamCliInfoInvocation, SamCliInfoResponse } from '../../../../shared/sam
 
 describe('SamCliInfoInvocation', async function () {
     class TestSamCliInfoCommand extends SamCliInfoInvocation {
-        public convertOutput(text: string): SamCliInfoResponse | undefined {
+        public override convertOutput(text: string): SamCliInfoResponse | undefined {
             return super.convertOutput(text)
         }
     }

--- a/src/test/shared/sam/sync.test.ts
+++ b/src/test/shared/sam/sync.test.ts
@@ -66,7 +66,7 @@ describe('prepareSyncParams', function () {
     it('uses region if given a tree node', async function () {
         const params = await prepareSyncParams(
             new (class extends AWSTreeNodeBase {
-                public readonly regionCode = 'foo'
+                public override readonly regionCode = 'foo'
             })('')
         )
 

--- a/src/test/shared/ui/picker.test.ts
+++ b/src/test/shared/ui/picker.test.ts
@@ -680,7 +680,7 @@ describe('IteratingQuickPickController', async function () {
                     callback
                 )
             }
-            public async reset(): Promise<void> {
+            public override async reset(): Promise<void> {
                 this.spy()
             }
         }

--- a/src/test/shared/wizards/wizard.test.ts
+++ b/src/test/shared/wizards/wizard.test.ts
@@ -78,7 +78,7 @@ class TestPrompter<T, S = any> extends Prompter<T> {
         }
     }
 
-    public get totalSteps(): number {
+    public override get totalSteps(): number {
         return this._totalSteps
     }
 
@@ -87,7 +87,7 @@ class TestPrompter<T, S = any> extends Prompter<T> {
         this.responses = responses
     }
 
-    public async prompt(): Promise<PromptResult<T>> {
+    public override async prompt(): Promise<PromptResult<T>> {
         if (this.responses.length === this.promptCount) {
             this.fail('Ran out of responses')
         }

--- a/src/test/stepFunctions/commands/visualizeStateMachine.test.ts
+++ b/src/test/stepFunctions/commands/visualizeStateMachine.test.ts
@@ -195,7 +195,7 @@ describe('StepFunctions VisualizeStateMachine', async function () {
         const yamlDoc = await getYamlDoc()
         const postMessage = sinon.spy()
         class MockAslVisualizationYaml extends AslVisualization {
-            public getWebview(): vscode.Webview | undefined {
+            public override getWebview(): vscode.Webview | undefined {
                 return { postMessage } as unknown as vscode.Webview
             }
         }
@@ -219,7 +219,7 @@ describe('StepFunctions VisualizeStateMachine', async function () {
         const jsonDoc = await getJsonDoc()
         const postMessage = sinon.spy()
         class MockAslVisualizationJson extends AslVisualization {
-            public getWebview(): vscode.Webview | undefined {
+            public override getWebview(): vscode.Webview | undefined {
                 return { postMessage } as unknown as vscode.Webview
             }
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
         "resolveJsonModule": true,
         "strict": true,
         "noUnusedLocals": true,
+        "noImplicitOverride": true,
         "lib": ["dom", "es6", "esnext.asynciterable"],
         "skipLibCheck": true,
         "jsx": "preserve"


### PR DESCRIPTION
## Problem
It's not always obvious that classes are overriding methods in a base class

## Solution
Enforce usage of the `override` keyword

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
