### PR TITLE
cwl: single-click on log group shows stream select

### DIFF
--- a/.changes/next-release/Feature-3082756c-79f7-4341-88be-d2f583a93686.json
+++ b/.changes/next-release/Feature-3082756c-79f7-4341-88be-d2f583a93686.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Reveal the log stream prompt when selecting a log group from the explorer."
+}

--- a/.changes/next-release/Feature-3082756c-79f7-4341-88be-d2f583a93686.json
+++ b/.changes/next-release/Feature-3082756c-79f7-4341-88be-d2f583a93686.json
@@ -1,4 +1,4 @@
 {
 	"type": "Feature",
-	"description": "Reveal the log stream prompt when selecting a log group from the explorer."
+	"description": "CloudWatch Logs: one click to list log streams for a log group"
 }

--- a/src/cloudWatchLogs/explorer/logGroupNode.ts
+++ b/src/cloudWatchLogs/explorer/logGroupNode.ts
@@ -8,6 +8,7 @@ import * as os from 'os'
 import { AWSResourceNode } from '../../shared/treeview/nodes/awsResourceNode'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 import { getIcon } from '../../shared/icons'
+import { localize } from '../../shared/utilities/vsCodeUtils'
 
 export const contextValueCloudwatchLog = 'awsCloudWatchLogNode'
 
@@ -17,6 +18,11 @@ export class LogGroupNode extends AWSTreeNodeBase implements AWSResourceNode {
         this.update(logGroup)
         this.iconPath = getIcon('aws-cloudwatch-log-group')
         this.contextValue = contextValueCloudwatchLog
+        this.command = {
+            command: 'aws.cloudWatchLogs.viewLogStream',
+            title: localize('AWS.command.cloudWatchLogs.viewLogStream', 'View Log Stream'),
+            arguments: [this],
+        }
     }
 
     public update(logGroup: CloudWatchLogs.LogGroup): void {


### PR DESCRIPTION
Problem: There is only a single action associated with CW log groups and it is only available through the context menu.

Solution: Execute the view log stream selector when the log group node is selected.

## Problem
Currently the toolkit requires the user to right-click and then choose `View Log Stream` to start the selection prompt. 
## Solution
Start the prompt immediately when the node is left-clicked.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
