### PR TITLE
fix(ci): "git commit" fails in CI jobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -3490,7 +3490,6 @@
         }
     },
     "scripts": {
-        "prepare": "husky install",
         "vscode:prepublish": "npm run clean && npm run buildScripts && npm run lint && webpack --mode production && npm run copyFiles -- --webpacked",
         "clean": "ts-node ./scripts/clean.ts dist",
         "reset": "npm run clean -- node_modules && npm install",


### PR DESCRIPTION
# Problem:
"git commit" fails in "PushToGithub" CI job:

    .husky/pre-commit: 2: .: cannot open .husky/_/husky.sh: No such file

# Solution:
For now, just remove this npm "prepare" script. This is only wanted for developers, should not be used in CI.

Related: 0abd9199e53e0dbe01f99fe53e4510cf03f41056


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
