### PR TITLE
fix(ci): eslint fails with "out of memory"

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,6 +19,7 @@ jobs:
                 vscode-version: [minimum, stable, insiders]
         env:
             VSCODE_TEST_VERSION: ${{ matrix.vscode-version }}
+            NODE_OPTIONS: '--max-old-space-size=8192'
         steps:
             - uses: actions/checkout@v2
             - name: Use Node.js ${{ matrix.node-version }}
@@ -29,12 +30,12 @@ jobs:
             - run: npm run vscode:prepublish
             - name: Tests
               uses: GabrielBB/xvfb-action@v1
-              # `NODE_OPTIONS` should be isolated because of https://github.com/codecov/uploader/issues/475
-              env:
-                  NODE_OPTIONS: '--max-old-space-size=8192'
               with:
                   run: npm test
             - name: Code coverage
+              env:
+                  # Unset NODE_OPTIONS because of https://github.com/codecov/uploader/issues/475
+                  NODE_OPTIONS: ''
               if: ${{ github.repository == 'aws/aws-toolkit-vscode' && ( github.ref == 'master' || github.event_name == 'pull_request' ) }}
               uses: codecov/codecov-action@v2
               with:
@@ -51,6 +52,7 @@ jobs:
                 vscode-version: [stable, insiders]
         env:
             VSCODE_TEST_VERSION: ${{ matrix.vscode-version }}
+            NODE_OPTIONS: '--max-old-space-size=8192'
         steps:
             - uses: actions/checkout@v2
             - name: Use Node.js ${{ matrix.node-version }}
@@ -60,11 +62,11 @@ jobs:
             - run: npm ci
             - run: npm run vscode:prepublish
             - name: Tests
-              # `NODE_OPTIONS` should be isolated because of https://github.com/codecov/uploader/issues/475
-              env:
-                  NODE_OPTIONS: '--max-old-space-size=8192'
               run: npm test
             - name: Code coverage
+              env:
+                  # Unset NODE_OPTIONS because of https://github.com/codecov/uploader/issues/475
+                  NODE_OPTIONS: ''
               if: ${{ github.repository == 'aws/aws-toolkit-vscode' && ( github.ref == 'master' || github.event_name == 'pull_request' ) }}
               uses: codecov/codecov-action@v2
               with:


### PR DESCRIPTION
Problem:
eslint fails with "out of memory":

    > eslint -c .eslintrc.js --ext .ts .
    <--- Last few GCs --->
    [3880:0000021FE7348970]    58049 ms: Mark-sweep 2019.3 (2094.8) …
    [3880:0000021FE7348970]    60283 ms: Mark-sweep 2023.0 (2098.5) …
    <--- JS stacktrace --->
    FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory

Solution:
Set `--max-old-space-size` for all steps except codecov.



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
