### PR TITLE
Bump amazon-states-language-service dependency to ^1.8.0

### DIFF
--- a/.changes/next-release/Bug Fix-19fd655d-6194-4ec1-954a-1a0124a8de36.json
+++ b/.changes/next-release/Bug Fix-19fd655d-6194-4ec1-954a-1a0124a8de36.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Bump amazon-states-language-service dependency to ^1.8.0 to allow state machines to be created with the new intrinsic functions and Map state"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "@aws-sdk/util-arn-parser": "^3.46.0",
                 "@iarna/toml": "^2.2.5",
                 "adm-zip": "^0.5.9",
-                "amazon-states-language-service": "^1.7.2",
+                "amazon-states-language-service": "^1.8.0",
                 "async-lock": "^1.3.0",
                 "aws-sdk": "^2.1267.0",
                 "aws-ssm-document-language-service": "^1.0.0",
@@ -3851,9 +3851,9 @@
             }
         },
         "node_modules/amazon-states-language-service": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.7.2.tgz",
-            "integrity": "sha512-TUCv5/Z/NAqhBUmwS/0oFRFvXmd/8yyNW48Qu/9MRud0GK0k9c5Kdf2vdL0azOl7qIXDi82Emc89MBJEZuydkQ==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.8.0.tgz",
+            "integrity": "sha512-F5hTDQqAVOYEJCm4PTBf6ZjLQYqzLfnGfyNqxNMTYqilbZk/3T0GQManc0pgt5CbtFw62DB6ovBcEUQQa9xsvA==",
             "dependencies": {
                 "js-yaml": "^3.14.0",
                 "vscode-json-languageservice": "3.4.9",
@@ -17739,9 +17739,9 @@
             "requires": {}
         },
         "amazon-states-language-service": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.7.2.tgz",
-            "integrity": "sha512-TUCv5/Z/NAqhBUmwS/0oFRFvXmd/8yyNW48Qu/9MRud0GK0k9c5Kdf2vdL0azOl7qIXDi82Emc89MBJEZuydkQ==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.8.0.tgz",
+            "integrity": "sha512-F5hTDQqAVOYEJCm4PTBf6ZjLQYqzLfnGfyNqxNMTYqilbZk/3T0GQManc0pgt5CbtFw62DB6ovBcEUQQa9xsvA==",
             "requires": {
                 "js-yaml": "^3.14.0",
                 "vscode-json-languageservice": "3.4.9",

--- a/package.json
+++ b/package.json
@@ -3587,7 +3587,7 @@
         "@aws-sdk/util-arn-parser": "^3.46.0",
         "@iarna/toml": "^2.2.5",
         "adm-zip": "^0.5.9",
-        "amazon-states-language-service": "^1.7.2",
+        "amazon-states-language-service": "^1.8.0",
         "async-lock": "^1.3.0",
         "aws-sdk": "^2.1267.0",
         "aws-ssm-document-language-service": "^1.0.0",


### PR DESCRIPTION
## Problem

Customers are not able to validate their state machines definition with new intrinsic functions and new Map state attributes. This behaviour is not consistent with the launch of the new distributed Map state, and new intrinsic functions

## Solution

https://github.com/aws/amazon-states-language-service/pull/90 and https://github.com/aws/amazon-states-language-service/pull/86 added validation for both distributed Map fields and new intrinsic functions. Bumping the package version to `^1.8.0` to pull in this change.

## Testing
Confirmed that Map field values and new intrinsic functions were correctly validated when creating a new state machine, when bumping the version to `^1.8.0`.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
