### PR TITLE
fix(codewhisperer): do not clear recommendation if it is visible

### DIFF
--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -354,7 +354,7 @@ export class InlineCompletionService {
         config: ConfigurationEntry,
         autoTriggerType?: CodewhispererAutomatedTriggerType
     ) {
-        if (vsCodeState.isCodeWhispererEditing || this._isPaginationRunning) {
+        if (vsCodeState.isCodeWhispererEditing || this._isPaginationRunning || this.isSuggestionVisible()) {
             return
         }
         await this.clearInlineCompletionStates(editor)


### PR DESCRIPTION
## Problem
user will sometimes see recommendations disappear and show up again in 1-2 seconds
## Solution
don't call getPaginatedRecommendations if current recommendations are still being displayed
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
