### PR TITLE
s3: add download folder and multiple files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1029,6 +1029,10 @@
                     "when": "false"
                 },
                 {
+                    "command": "aws.s3.downloadFolder",
+                    "when": "false"
+                },
+                {
                     "command": "aws.s3.openFile",
                     "when": "false"
                 },
@@ -1388,6 +1392,11 @@
                     "group": "inline@2"
                 },
                 {
+                    "command": "aws.s3.downloadFolder",
+                    "when": "view == aws.explorer && viewItem == awsS3FolderNode",
+                    "group": "inline@1"
+                },
+                {
                     "command": "aws.s3.createBucket",
                     "when": "view == aws.explorer && viewItem == awsS3Node",
                     "group": "inline@1"
@@ -1581,6 +1590,11 @@
                     "command": "aws.s3.downloadFileAs",
                     "when": "view == aws.explorer && viewItem == awsS3FileNode",
                     "group": "0@1"
+                },
+                {
+                    "command": "aws.s3.downloadFolder",
+                    "when": "view == aws.explorer && viewItem == awsS3FolderNode",
+                    "group": "0@2"
                 },
                 {
                     "command": "aws.s3.uploadFile",
@@ -2345,6 +2359,11 @@
                         "category": "%AWS.title.cn%"
                     }
                 }
+            },
+            {
+                "command": "aws.s3.downloadFolder",
+                "title": "%AWS.command.s3.downloadFolder%",
+                "category": "%AWS.title%"
             },
             {
                 "command": "aws.s3.openFile",

--- a/package.nls.json
+++ b/package.nls.json
@@ -149,6 +149,7 @@
     "AWS.command.samcli.sync": "Sync SAM Application",
     "AWS.command.samcli.syncCode": "Sync SAM Application (code only)",
     "AWS.command.s3.downloadFileAs": "Download As...",
+    "AWS.command.s3.downloadFolder": "Download Folder...",
     "AWS.command.s3.editFile": "Edit File",
     "AWS.command.s3.openFile": "Open File",
     "AWS.command.s3.copyPath": "Copy Path",

--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -46,6 +46,7 @@ export async function activate(args: {
     const view = vscode.window.createTreeView(awsExplorer.viewProviderId, {
         treeDataProvider: awsExplorer,
         showCollapseAll: true,
+        canSelectMany: true,
     })
     globals.context.subscriptions.push(view)
 

--- a/src/s3/activation.ts
+++ b/src/s3/activation.ts
@@ -9,7 +9,7 @@ import { createBucketCommand } from './commands/createBucket'
 import { createFolderCommand } from './commands/createFolder'
 import { deleteBucketCommand } from './commands/deleteBucket'
 import { deleteFileCommand } from './commands/deleteFile'
-import { downloadFileAsCommand } from './commands/downloadFileAs'
+import { downloadFileAsCommand, downloadFolderCommand } from './commands/downloadFileAs'
 import { presignedURLCommand } from './commands/presignedURL'
 import { editFileCommand, openFileReadModeCommand } from './commands/openFile'
 import { uploadFileCommand } from './commands/uploadFile'
@@ -49,6 +49,9 @@ export async function activate(ctx: ExtContext): Promise<void> {
         }),
         Commands.register('aws.s3.downloadFileAs', async (node: S3FileNode) => {
             await downloadFileAsCommand(node)
+        }),
+        Commands.register('aws.s3.downloadFolder', async (node: S3FolderNode) => {
+            await downloadFolderCommand(node)
         }),
         Commands.register('aws.s3.openFile', async (node: S3FileNode) => {
             await openFileReadModeCommand(node, manager)


### PR DESCRIPTION
## Problem
Users can only download a single file at a time.
## Solution
Add multiselect to the AWS Explorer. Add the ability to download an S3 folder or multi-selected S3 files.

S3 designs https://github.com/aws/aws-toolkit-vscode/blob/master/designs/s3/design-vscode-s3.md
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
