### PR TITLE
CWL: Code lenses on 'Search Log Stream' document

### DIFF
--- a/src/cloudWatchLogs/commands/searchLogGroup.ts
+++ b/src/cloudWatchLogs/commands/searchLogGroup.ts
@@ -68,7 +68,7 @@ export async function prepareDocument(
     registry: LogDataRegistry
 ): Promise<Result> {
     try {
-        registry.fetchNextLogEvents(uri)
+        await registry.fetchNextLogEvents(uri)
         const textDocument = await vscode.workspace.openTextDocument(uri)
         await vscode.window.showTextDocument(textDocument, { preview: false })
         vscode.languages.setTextDocumentLanguage(textDocument, 'log')

--- a/src/cloudWatchLogs/document/logDataDocumentProvider.ts
+++ b/src/cloudWatchLogs/document/logDataDocumentProvider.ts
@@ -2,15 +2,15 @@
  * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { telemetry } from '../../shared/telemetry/telemetry'
 import * as vscode from 'vscode'
-import { CloudWatchLogsParameters, LogDataRegistry } from '../registry/logDataRegistry'
+import { CloudWatchLogsGroupInfo, LogDataRegistry, UriString } from '../registry/logDataRegistry'
 import { getLogger } from '../../shared/logger'
-import { parseCloudWatchLogsUri, createURIFromArgs, isCwlUri } from '../cloudWatchLogsUtils'
-import { generateTextFromLogEvents, StreamIdMap } from './textContent'
+import { isCwlUri } from '../cloudWatchLogsUtils'
+import { generateTextFromLogEvents, LineToLogStreamMap } from './textContent'
 
-export class LogDataDocumentProvider implements vscode.TextDocumentContentProvider, vscode.DefinitionProvider {
-    readonly uriToStreamIdMap: Map<string, StreamIdMap> = new Map()
+export class LogDataDocumentProvider implements vscode.TextDocumentContentProvider {
+    /** Resolves the correct {@link LineToLogStreamMap} instance for a given URI */
+    readonly lineToLogStreamMapResolver: Map<UriString, LineToLogStreamMap> = new Map()
     // Expose an event to signal changes of _virtual_ documents
     // to the editor
     private _onDidChange = new vscode.EventEmitter<vscode.Uri>()
@@ -31,72 +31,37 @@ export class LogDataDocumentProvider implements vscode.TextDocumentContentProvid
         }
         const events = this.registry.fetchCachedLogEvents(uri)
         const { text, streamIdMap } = generateTextFromLogEvents(events, { timestamps: true })
-        this.uriToStreamIdMap.set(uri.toString(), streamIdMap)
+        this.lineToLogStreamMapResolver.set(uri.toString(), streamIdMap)
         return text
     }
 
-    async provideDefinition(
-        document: vscode.TextDocument,
-        position: vscode.Position,
-        token: vscode.CancellationToken
-    ): Promise<vscode.Definition | vscode.LocationLink[] | undefined> {
-        const activeUri = document.uri
-        const logGroupInfo = parseCloudWatchLogsUri(activeUri).logGroupInfo
-
-        if (logGroupInfo.streamName) {
-            // This means we have a stream file not a log search.
-            return
+    /**
+     * Gives the Log Stream ID at a given line of a given document.
+     *
+     * The given document uri must have already been processed by this
+     * class, otherwise an error will be thrown.
+     *
+     * * @param lineNumber The line number of the document. Starts at 0, NOT 1!
+     */
+    public getLogStreamNameAtLine(
+        uri: vscode.Uri,
+        lineNumber: number
+    ): NonNullable<CloudWatchLogsGroupInfo['streamName']> {
+        let lineToLogStreamMap = this.lineToLogStreamMapResolver.get(uri.toString())
+        if (lineToLogStreamMap === undefined) {
+            // Document was not initialized yet, we will initialize and try again.
+            this.provideTextDocumentContent(uri)
+            lineToLogStreamMap = this.lineToLogStreamMapResolver.get(uri.toString())
+            if (lineToLogStreamMap === undefined) {
+                throw new Error(`${this.provideTextDocumentContent.name}() should have prevented this error.`)
+            }
         }
-        const curLine = document.lineAt(position.line)
-        try {
-            const streamIDMap = this.uriToStreamIdMap.get(activeUri.toString())
-            if (!streamIDMap || streamIDMap.size === 0) {
-                throw new Error(`cwl: No streamIDMap found for stream with uri ${activeUri.path}`)
-            }
-            const streamID = streamIDMap.get(curLine.lineNumber)
 
-            if (!streamID) {
-                throw new Error(
-                    `cwl: current line number ${curLine.lineNumber} is unregistered in streamIDMap for ${activeUri}`
-                )
-            }
-            const parameters: CloudWatchLogsParameters = {
-                limit: this.registry.configuration.get('limit', 10000),
-            }
-            logGroupInfo.streamName = streamID
-
-            const streamUri = createURIFromArgs(logGroupInfo, parameters)
-            this.registry.fetchNextLogEvents(streamUri)
-
-            const doc = await vscode.workspace.openTextDocument(streamUri)
-            vscode.languages.setTextDocumentLanguage(doc, 'log')
-
-            telemetry.cloudwatchlogs_open.emit({
-                result: 'Succeeded',
-                cloudWatchResourceType: 'logStream',
-                source: 'GoTo',
-            })
-
-            const startPosition = new vscode.Position(0, 0)
-            // Highlights the whole line on hover
-            const locationLink: vscode.LocationLink = {
-                originSelectionRange: new vscode.Range(
-                    position.with(undefined, curLine.firstNonWhitespaceCharacterIndex),
-                    position.with(undefined, curLine.range.end.character)
-                ),
-                targetUri: streamUri,
-                targetRange: new vscode.Range(startPosition, startPosition),
-            }
-            return [locationLink]
-        } catch (err) {
-            telemetry.cloudwatchlogs_open.emit({
-                result: 'Failed',
-                cloudWatchResourceType: 'logStream',
-                source: 'GoTo',
-            })
-
-            throw new Error(`cwl: Error determining definition for content in ${document.fileName}`)
+        const logStreamName = lineToLogStreamMap.get(lineNumber)
+        if (logStreamName === undefined) {
+            throw new Error(`Line number was not set in LineToLogStreamMap: ${lineNumber}`)
         }
+        return logStreamName
     }
 }
 

--- a/src/cloudWatchLogs/document/logStreamsCodeLensProvider.ts
+++ b/src/cloudWatchLogs/document/logStreamsCodeLensProvider.ts
@@ -1,0 +1,105 @@
+/*!
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { CLOUDWATCH_LOGS_SCHEME } from '../../shared/constants'
+import { CloudWatchLogsGroupInfo, LogDataRegistry } from '../registry/logDataRegistry'
+import { createURIFromArgs, isLogStreamUri, parseCloudWatchLogsUri } from '../cloudWatchLogsUtils'
+import { LogDataDocumentProvider } from './logDataDocumentProvider'
+
+type IdWithLine = { streamId: string; lineNum: number }
+
+export class LogStreamCodeLensProvider implements vscode.CodeLensProvider {
+    /**
+     * Constructor
+     *
+     * @param documentProvider We specifically want {@link LogDataDocumentProvider} since it manages the stream
+     *                         id map which this class will read data from.
+     */
+    public constructor(
+        private readonly registry: LogDataRegistry,
+        private readonly documentProvider: LogDataDocumentProvider
+    ) {}
+
+    private _onDidChangeCodeLenses = new vscode.EventEmitter<void>()
+    public get onDidChangeCodeLenses(): vscode.Event<void> {
+        return this._onDidChangeCodeLenses.event
+    }
+
+    public async provideCodeLenses(
+        document: vscode.TextDocument,
+        token: vscode.CancellationToken
+    ): Promise<vscode.CodeLens[] | null | undefined> {
+        const uri = document.uri
+
+        if (uri.scheme !== CLOUDWATCH_LOGS_SCHEME || isLogStreamUri(uri)) {
+            return []
+        }
+
+        const logGroupInfo = parseCloudWatchLogsUri(uri).logGroupInfo
+
+        if (logGroupInfo.streamName) {
+            // This means we have a stream file not a log search.
+            return
+        }
+
+        const codelenses: vscode.CodeLens[] = []
+
+        const linesToGenerateCodeLens = await this.getStartingLineOfEachStreamId(document)
+
+        // Create a code lens at the start of each Log Stream in the document
+        linesToGenerateCodeLens.forEach(idWithLine => {
+            codelenses.push(this.createLogStreamCodeLens(logGroupInfo, idWithLine))
+        })
+        return codelenses
+    }
+
+    createLogStreamCodeLens(logGroupInfo: CloudWatchLogsGroupInfo, idWithLine: IdWithLine): vscode.CodeLens {
+        const streamUri = createURIFromArgs({ ...logGroupInfo, streamName: idWithLine.streamId }, { limit: 1000 })
+        const cmd: vscode.Command = {
+            command: 'aws.loadLogStreamFile',
+            arguments: [streamUri, this.registry],
+            title: 'Load following Log Stream...',
+        }
+        const codeLensLocation = new vscode.Range(idWithLine.lineNum, 0, idWithLine.lineNum, 0)
+        return new vscode.CodeLens(codeLensLocation, cmd)
+    }
+
+    /**
+     * Gets the Log Stream Id + Line number it starts at for each Log Stream
+     * in the given document.
+     */
+    private async getStartingLineOfEachStreamId(document: vscode.TextDocument): Promise<IdWithLine[]> {
+        const result: IdWithLine[] = []
+
+        let currLine = 0
+        let lastStreamId = ''
+        while (currLine < document.lineCount - 1) {
+            const currStreamId = this.documentProvider.getLogStreamNameAtLine(document.uri, currLine)
+
+            if (currStreamId === undefined) {
+                throw new Error(`uriToStreamIdMap does not reflect the latest content of: ${document.uri.toString()}`)
+            }
+
+            if (currStreamId === lastStreamId) {
+                currLine++
+                continue
+            }
+            result.push({ streamId: currStreamId, lineNum: currLine })
+            currLine++
+            lastStreamId = currStreamId
+        }
+        return result
+    }
+}
+
+export async function loadAndOpenInitialLogStreamFile(uri: vscode.Uri, registry: LogDataRegistry): Promise<void> {
+    const td = await vscode.workspace.openTextDocument(uri)
+    await Promise.all([
+        vscode.window.showTextDocument(td),
+        vscode.languages.setTextDocumentLanguage(td, 'log'),
+        registry.fetchNextLogEvents(uri),
+    ])
+}

--- a/src/cloudWatchLogs/document/textContent.ts
+++ b/src/cloudWatchLogs/document/textContent.ts
@@ -5,19 +5,25 @@
 
 import * as moment from 'moment'
 import { INSIGHTS_TIMESTAMP_FORMAT } from '../../shared/constants'
-import { CloudWatchLogsEvent } from '../registry/logDataRegistry'
+import { CloudWatchLogsEvent, CloudWatchLogsGroupInfo } from '../registry/logDataRegistry'
 
-export type StreamIdMap = Map<number, string>
 export const timestampSpaceEquivalent = '                             '
+
+/**
+ * CWL output text can consist of Log Events from multiple different
+ * Log Streams. This map type is intended to map a specific line to
+ * its respective Log Stream
+ */
+export type LineToLogStreamMap = Map<number, NonNullable<CloudWatchLogsGroupInfo['streamName']>>
 
 export function generateTextFromLogEvents(
     events: CloudWatchLogsEvent[],
     formatting?: { timestamps?: boolean }
-): { text: string; streamIdMap: StreamIdMap } {
+): { text: string; streamIdMap: LineToLogStreamMap } {
     const inlineNewLineRegex = /((\r\n)|\n|\r)(?!$)/g
     // if no timestamp for some reason, entering a blank of equal length (29 characters long)
 
-    const streamIdMap: StreamIdMap = new Map()
+    const streamIdMap: LineToLogStreamMap = new Map()
     let text: string = ''
     let lineNumber = 0
     for (const event of events) {

--- a/src/test/cloudWatchLogs/document/logStreamsCodeLensProvider.test.ts
+++ b/src/test/cloudWatchLogs/document/logStreamsCodeLensProvider.test.ts
@@ -1,0 +1,62 @@
+/*!
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe } from 'mocha'
+import { LogStreamCodeLensProvider } from '../../../cloudWatchLogs/document/logStreamsCodeLensProvider'
+import { LogDataRegistry } from '../../../cloudWatchLogs/registry/logDataRegistry'
+import { LogDataDocumentProvider } from '../../../cloudWatchLogs/document/logDataDocumentProvider'
+import { CancellationToken, CodeLens, TextDocument } from 'vscode'
+import assert = require('assert')
+import { createURIFromArgs } from '../../../cloudWatchLogs/cloudWatchLogsUtils'
+import { createStubInstance, SinonStubbedInstance } from 'sinon'
+
+describe('LogStreamCodeLensProvider', async () => {
+    describe('provideCodeLenses()', async () => {
+        let codeLensProvider: LogStreamCodeLensProvider
+        let documentProvider: SinonStubbedInstance<LogDataDocumentProvider>
+
+        const logGroupInfo = { groupName: 'MyGroupName', regionName: 'MyRegionName' }
+        const logUri = createURIFromArgs(logGroupInfo, {})
+
+        before(async () => {
+            const registry: LogDataRegistry = {} as LogDataRegistry
+            documentProvider = createStubInstance(LogDataDocumentProvider)
+
+            codeLensProvider = new LogStreamCodeLensProvider(registry, documentProvider as any)
+        })
+        it('gets codelenses from a typical file', async () => {
+            const logStreamIdAtLine = ['streamId0', 'streamId0', 'streamId0', 'streamId1', 'streamId1', 'streamId2']
+            // Stub method which provides the log stream ID at a given line
+            for (let i = 0; i < logStreamIdAtLine.length; i++) {
+                documentProvider.getLogStreamNameAtLine.onCall(i).returns(logStreamIdAtLine[i])
+            }
+
+            const result = await codeLensProvider.provideCodeLenses(
+                { uri: logUri, lineCount: logStreamIdAtLine.length + 1 } as TextDocument,
+                {} as CancellationToken
+            )
+
+            // Create code lenses at the first occurence of each Log Stream
+            const expected = [
+                createCodeLensAtFirstOccurence('streamId0', logStreamIdAtLine),
+                createCodeLensAtFirstOccurence('streamId1', logStreamIdAtLine),
+                createCodeLensAtFirstOccurence('streamId2', logStreamIdAtLine),
+            ]
+            assert.deepStrictEqual(result, expected)
+        })
+
+        /**
+         * Creates a code lens at the first occurence of a stream id in the
+         * given string array.
+         */
+        function createCodeLensAtFirstOccurence(streamId: string, logStreamIdAtLine: string[]): CodeLens {
+            const firstOccurenceIndex = logStreamIdAtLine.findIndex(value => value == streamId)
+            return codeLensProvider.createLogStreamCodeLens(logGroupInfo, {
+                streamId: logStreamIdAtLine[firstOccurenceIndex],
+                lineNum: firstOccurenceIndex,
+            })
+        }
+    })
+})


### PR DESCRIPTION
## Problem

Previously, we used an inefficient implementation of Go To Definition (Ctrl + Click) to go to
open a specific Log Stream document from a document that had many Log Streams.

It was inefficient since we could not lazily load the Go To Definition objects and
it caused performance issues due to Go To Definition pre-loading pages
as the user hovered over the lines while holding Ctrl.

Additionally it was not obvious that we had this functionality available.

## Solution

- Drop the Go To Definition feature
- Replace it with Code Lenses that will appear at the beginning of
  each Log Stream. When clicked they will load the specific events
  of that log stream and open a new document

## Steps to Reproduce

1. Open the AWS Explorer
2. Drop down `CloudWatch Logs`
3. Right click one of them and select `Search Log Group`
4. Once fully loaded AND if you have multiple Log Streams, you will be able to see multiple Code Lenses that say `Load following Log Stream...`

<img width="640" alt="Screen Shot 2023-02-06 at 11 19 39 AM" src="https://user-images.githubusercontent.com/118216176/219506573-4ddf07cd-381a-48f9-8cef-e425d8439196.png">

## 160,000 Lines Gif
The following is a 160,000 line log file with ~10,000 code lenses. The gif is 10 fps so it wont look as good.
Also with pagination, we can only load 10,000 events max per page. So it will take a good amount of loads to start impacting performance.

![Kapture 2023-02-16 at 23 53 47](https://user-images.githubusercontent.com/118216176/219553256-bcbbe717-0d4f-4805-9c88-ff7530feaad2.gif)

From some quick testing once I get around 400k lines, scrolling isn't as smooth as if there were no code lenses but it is still completely usable.

## Future performance optimizations

The vscode API allows us to see where the user currently is in the document. This can allow us to load code lenses in the surrounding of where the user currently is in the document. This should give a big performance increase if we find users need it.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
