### PR TITLE
fix(cwl): avoid Progress message while validating search input

### DIFF
--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -176,6 +176,9 @@ export class LogDataRegistry {
     }
 }
 
+/**
+ * @see getLogEventsFromUriComponents
+ */
 export async function filterLogEventsFromUri(
     logGroupInfo: CloudWatchLogsGroupInfo,
     parameters: CloudWatchLogsParameters,
@@ -211,7 +214,7 @@ export async function filterLogEventsFromUri(
     }
 
     const timeout = new Timeout(300000)
-    showMessageWithCancel(`Searching log group: ${logGroupInfo.groupName}`, timeout)
+    showMessageWithCancel(`Searching log group: ${logGroupInfo.groupName}`, timeout, 1200)
     const responsePromise = client.filterLogEvents(cwlParameters)
     const response = await waitTimeout(responsePromise, timeout, { allowUndefined: false })
 
@@ -229,6 +232,9 @@ export async function filterLogEventsFromUri(
     }
 }
 
+/**
+ * @see filterLogEventsFromUri
+ */
 export async function getLogEventsFromUriComponents(
     logGroupInfo: CloudWatchLogsGroupInfo,
     parameters: CloudWatchLogsParameters,
@@ -249,7 +255,7 @@ export async function getLogEventsFromUriComponents(
     }
 
     const timeout = new Timeout(300000)
-    showMessageWithCancel(`Fetching logs: ${logGroupInfo.streamName}`, timeout)
+    showMessageWithCancel(`Fetching logs: ${logGroupInfo.streamName}`, timeout, 1200)
     const responsePromise = client.getLogEvents(cwlParameters)
     const response = await waitTimeout(responsePromise, timeout, { allowUndefined: false })
 

--- a/src/dev/codecatalyst.ts
+++ b/src/dev/codecatalyst.ts
@@ -25,6 +25,9 @@ import { createCommonButtons } from '../shared/ui/buttons'
 
 type LazyProgress<T> = vscode.Progress<T> & vscode.Disposable & { getToken(): Timeout }
 
+/**
+ * Progress dialog that does not show until `report()` is called.
+ */
 function lazyProgress<T extends Record<string, any>>(timeout: Timeout): LazyProgress<T> {
     let dispose!: () => void
     let progress: vscode.Progress<T>

--- a/src/shared/utilities/messages.ts
+++ b/src/shared/utilities/messages.ts
@@ -148,25 +148,49 @@ export function showOutputMessage(message: string, outputChannel: vscode.OutputC
 
 /**
  * Attaches a Timeout object to VS Code's Progress notification system.
- * Not exported since it isn't used (yet)
+ *
  * @see showMessageWithCancel for an example usage
  */
 async function showProgressWithTimeout(
     options: vscode.ProgressOptions,
-    timeout: Timeout
+    timeout: Timeout,
+    showAfterMs: number,
 ): Promise<vscode.Progress<{ message?: string; increment?: number }>> {
-    // Cloud9 doesn't support Progress notifications. User won't be able to cancel.
+    if (showAfterMs < 0) {
+        throw Error('invalid "showAfterMs" value')
+    }
+    if (showAfterMs === 0) {
+        showAfterMs = 1 // Show immediately.
+    }
+    // Cloud9 doesn't support `ProgressLocation.Notification`. User won't be able to cancel.
     if (isCloud9()) {
         options.location = vscode.ProgressLocation.Window
     }
 
-    const progressPromise: Promise<vscode.Progress<{ message?: string; increment?: number }>> = new Promise(resolve => {
-        vscode.window.withProgress(options, function (progress, token) {
-            token.onCancellationRequested(() => timeout.cancel())
-            resolve(progress)
-            return new Promise(timeout.onCompletion)
-        })
-    })
+    // See also: codecatalyst.ts:LazyProgress
+    const progressPromise: Promise<vscode.Progress<{ message?: string; increment?: number }>> = new Promise(
+        (resolve, reject) => {
+            setTimeout(async () => {
+                try {
+                    if (timeout.completed) {
+                        getLogger().debug('showProgressWithTimeout: completed before "showAfterMs"')
+                        resolve({
+                            report: () => undefined, // no-op.
+                        })
+                        return
+                    }
+                    vscode.window.withProgress(options, function (progress, token) {
+                        token.onCancellationRequested(() => timeout.cancel())
+                        resolve(progress)
+                        return new Promise(timeout.onCompletion)
+                    })
+                } catch (e) {
+                    getLogger().error('report(): progressPromise failed', e)
+                    reject(e)
+                }
+            }, showAfterMs)
+        }
+    )
 
     return progressPromise
 }
@@ -176,16 +200,18 @@ async function showProgressWithTimeout(
  *
  * @param message Message to display
  * @param timeout Timeout object that will be killed if the user clicks 'Cancel'
- * @param window Window to display the message on (default: vscode.window)
+ * @param showAfterMs Do not show the progress message until `showAfterMs` milliseconds.
  *
  * @returns Progress object allowing the caller to update progress status
  */
 export async function showMessageWithCancel(
     message: string,
-    timeout: Timeout
+    timeout: Timeout,
+    showAfterMs: number = 0,
+    window: Window = globals.window
 ): Promise<vscode.Progress<{ message?: string; increment?: number }>> {
     const progressOptions = { location: vscode.ProgressLocation.Notification, title: message, cancellable: true }
-    return showProgressWithTimeout(progressOptions, timeout)
+    return showProgressWithTimeout(progressOptions, timeout, showAfterMs)
 }
 
 /**

--- a/src/shared/utilities/messages.ts
+++ b/src/shared/utilities/messages.ts
@@ -196,7 +196,7 @@ async function showProgressWithTimeout(
 }
 
 /**
- * Presents the user with a notification to cancel a pending process.
+ * Shows a Progress message which allows the user to cancel a pending `timeout` task.
  *
  * @param message Message to display
  * @param timeout Timeout object that will be killed if the user clicks 'Cancel'
@@ -208,7 +208,6 @@ export async function showMessageWithCancel(
     message: string,
     timeout: Timeout,
     showAfterMs: number = 0,
-    window: Window = globals.window
 ): Promise<vscode.Progress<{ message?: string; increment?: number }>> {
     const progressOptions = { location: vscode.ProgressLocation.Notification, title: message, cancellable: true }
     return showProgressWithTimeout(progressOptions, timeout, showAfterMs)

--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -37,8 +37,6 @@ interface TypedCancellationToken extends CancellationToken {
 /**
  * Timeout that can handle both cancellation token-style and time limit-style timeout situations. Timeouts
  * cannot be used after 'complete' has been called or if the Timeout expired.
- *
- * @param timeoutLength Length of timeout duration (in ms)
  */
 export class Timeout {
     private _startTime: number
@@ -51,6 +49,9 @@ export class Timeout {
     private readonly _onCompletionEmitter = new EventEmitter<void>()
     public readonly onCompletion = this._onCompletionEmitter.event
 
+    /**
+     * @param timeoutLength Length of timeout duration (in ms)
+     */
     public constructor(timeoutLength: number) {
         this._startTime = globals.clock.Date.now()
         this._endTime = this._startTime + timeoutLength


### PR DESCRIPTION
Problem:
Search pattern is validated by making a service call 45cba189e6fe. This triggers the "Searching..." progress dialog, which is noisy.

Solution:
Don't show the "Searching..." progress dialog until after ~1 second.



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
