### PR TITLE
refactor(package.json): viewItem format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1280,42 +1280,42 @@
             "view/item/context": [
                 {
                     "command": "aws.apig.invokeRemoteRestApi",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsApiGatewayNode)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsApiGatewayNode)[-ANU]*$/",
                     "group": "0@1"
                 },
                 {
                     "command": "aws.codecatalyst.removeConnection",
-                    "when": "viewItem == awsCodeCatalystNodeSaved",
+                    "when": "viewItem =~ /^awsCodeCatalystNodeSaved[-ANU]*$/",
                     "group": "0@1"
                 },
                 {
                     "command": "aws.codecatalyst.removeConnection",
-                    "when": "viewItem == awsCodeCatalystNodeSaved",
+                    "when": "viewItem =~ /^awsCodeCatalystNodeSaved[-ANU]*$/",
                     "group": "inline@1"
                 },
                 {
                     "command": "aws.ecr.createRepository",
-                    "when": "view == aws.explorer && viewItem == awsEcrNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsEcrNode[-ANU]*$/",
                     "group": "inline@1"
                 },
                 {
                     "command": "aws.iot.createThing",
-                    "when": "view == aws.explorer && viewItem == awsIotThingsNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsIotThingsNode[-ANU]*$/",
                     "group": "inline@1"
                 },
                 {
                     "command": "aws.iot.createCert",
-                    "when": "view == aws.explorer && viewItem == awsIotCertsNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsIotCertsNode[-ANU]*$/",
                     "group": "inline@1"
                 },
                 {
                     "command": "aws.iot.createPolicy",
-                    "when": "view == aws.explorer && viewItem == awsIotPoliciesNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsIotPoliciesNode[-ANU]*$/",
                     "group": "inline@1"
                 },
                 {
                     "command": "aws.iot.attachCert",
-                    "when": "view == aws.explorer && viewItem == awsIotThingNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsIotThingNode[-ANU]*$/",
                     "group": "inline@1"
                 },
                 {
@@ -1325,187 +1325,187 @@
                 },
                 {
                     "command": "aws.s3.openFile",
-                    "when": "view == aws.explorer && viewItem == awsS3FileNode && !isCloud9",
+                    "when": "view == aws.explorer && viewItem =~ /^awsS3FileNode[-ANU]*$/ && !isCloud9",
                     "group": "0@1"
                 },
                 {
                     "command": "aws.s3.editFile",
-                    "when": "view == aws.explorer && viewItem == awsS3FileNode && !isCloud9",
+                    "when": "view == aws.explorer && viewItem =~ /^awsS3FileNode[-ANU]*$/ && !isCloud9",
                     "group": "inline@1"
                 },
                 {
                     "command": "aws.s3.downloadFileAs",
-                    "when": "view == aws.explorer && viewItem == awsS3FileNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsS3FileNode[-ANU]*$/",
                     "group": "inline@2"
                 },
                 {
                     "command": "aws.s3.createBucket",
-                    "when": "view == aws.explorer && viewItem == awsS3Node",
+                    "when": "view == aws.explorer && viewItem =~ /^awsS3Node[-ANU]*$/",
                     "group": "inline@1"
                 },
                 {
                     "command": "aws.s3.createFolder",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsS3BucketNode|awsS3FolderNode)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsS3BucketNode|awsS3FolderNode)[-ANU]*$/",
                     "group": "inline@1"
                 },
                 {
                     "command": "aws.ssmDocument.openLocalDocument",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsDocumentItemNode|awsDocumentItemNodeWriteable)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsDocumentItemNode|awsDocumentItemNodeWriteable)[-ANU]*$/",
                     "group": "inline@1"
                 },
                 {
                     "command": "aws.s3.uploadFile",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsS3BucketNode|awsS3FolderNode)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsS3BucketNode|awsS3FolderNode)[-ANU]*$/",
                     "group": "inline@2"
                 },
                 {
                     "command": "aws.showRegion",
-                    "when": "view == aws.explorer && viewItem == awsRegionNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsRegionNode[-ANU]*$/",
                     "group": "0@1"
                 },
                 {
                     "command": "aws.lambda.createNewSamApp",
-                    "when": "view == aws.explorer && viewItem == awsLambdaNode || viewItem == awsRegionNode",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsLambdaNode|awsRegionNode)[-ANU]*$/",
                     "group": "1@1"
                 },
                 {
                     "command": "aws.launchConfigForm",
-                    "when": "view == aws.explorer && viewItem == awsLambdaNode || viewItem == awsRegionNode || viewItem == awsCloudFormationRootNode",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsLambdaNode|awsRegionNode|awsCloudFormationRootNode)[-ANU]*$/",
                     "group": "1@1"
                 },
                 {
                     "command": "aws.deploySamApplication",
-                    "when": "config.aws.samcli.legacyDeploy && view == aws.explorer && viewItem =~ /^(awsLambdaNode|awsRegionNode|awsCloudFormationRootNode)$/",
+                    "when": "config.aws.samcli.legacyDeploy && view == aws.explorer && viewItem =~ /^(awsLambdaNode|awsRegionNode|awsCloudFormationRootNode)[-ANU]*$/",
                     "group": "1@2"
                 },
                 {
                     "command": "aws.samcli.sync",
-                    "when": "!config.aws.samcli.legacyDeploy && view == aws.explorer && viewItem =~ /^(awsLambdaNode|awsRegionNode|awsCloudFormationRootNode)$/",
+                    "when": "!config.aws.samcli.legacyDeploy && view == aws.explorer && viewItem =~ /^(awsLambdaNode|awsRegionNode|awsCloudFormationRootNode)[-ANU]*$/",
                     "group": "1@2"
                 },
                 {
                     "command": "aws.samcli.syncCode",
-                    "when": "config.aws.experiments.samSyncCode && !config.aws.samcli.legacyDeploy && view == aws.explorer && viewItem =~ /^(awsLambdaNode|awsRegionNode|awsCloudFormationRootNode)$/",
+                    "when": "config.aws.experiments.samSyncCode && !config.aws.samcli.legacyDeploy && view == aws.explorer && viewItem =~ /^(awsLambdaNode|awsRegionNode|awsCloudFormationRootNode)[-ANU]*$/",
                     "group": "1@3"
                 },
                 {
                     "command": "aws.ecr.copyTagUri",
-                    "when": "view == aws.explorer && viewItem == awsEcrTagNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsEcrTagNode[-ANU]*$/",
                     "group": "2@1"
                 },
                 {
                     "command": "aws.ecr.deleteTag",
-                    "when": "view == aws.explorer && viewItem == awsEcrTagNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsEcrTagNode[-ANU]*$/",
                     "group": "3@1"
                 },
                 {
                     "command": "aws.ecr.copyRepositoryUri",
-                    "when": "view == aws.explorer && viewItem == awsEcrRepositoryNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsEcrRepositoryNode[-ANU]*$/",
                     "group": "2@1"
                 },
                 {
                     "command": "aws.ecr.createRepository",
-                    "when": "view == aws.explorer && viewItem == awsEcrNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsEcrNode[-ANU]*$/",
                     "group": "0@1"
                 },
                 {
                     "command": "aws.ecr.deleteRepository",
-                    "when": "view == aws.explorer && viewItem == awsEcrRepositoryNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsEcrRepositoryNode[-ANU]*$/",
                     "group": "3@1"
                 },
                 {
                     "command": "aws.invokeLambda",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsCloudFormationFunctionNode)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsCloudFormationFunctionNode)[-ANU]*$/",
                     "group": "0@1"
                 },
                 {
                     "command": "aws.downloadLambda",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable)[-ANU]*$/",
                     "group": "0@2"
                 },
                 {
                     "command": "aws.uploadLambda",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable)[-ANU]*$/",
                     "group": "1@1"
                 },
                 {
                     "command": "aws.deleteLambda",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable)[-ANU]*$/",
                     "group": "4@1"
                 },
                 {
                     "command": "aws.copyLambdaUrl",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable)[-ANU]*$/",
                     "group": "2@0"
                 },
                 {
                     "command": "aws.deleteCloudFormation",
-                    "when": "view == aws.explorer && viewItem == awsCloudFormationNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsCloudFormationNode[-ANU]*$/",
                     "group": "3@5"
                 },
                 {
                     "command": "aws.searchSchema",
-                    "when": "view == aws.explorer && viewItem == awsSchemasNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsSchemasNode[-ANU]*$/",
                     "group": "0@1"
                 },
                 {
                     "command": "aws.searchSchemaPerRegistry",
-                    "when": "view == aws.explorer && viewItem == awsRegistryItemNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsRegistryItemNode[-ANU]*$/",
                     "group": "0@1"
                 },
                 {
                     "command": "aws.viewSchemaItem",
-                    "when": "view == aws.explorer && viewItem == awsSchemaItemNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsSchemaItemNode[-ANU]*$/",
                     "group": "0@1"
                 },
                 {
                     "command": "aws.stepfunctions.createStateMachineFromTemplate",
-                    "when": "view == aws.explorer && viewItem == awsStepFunctionsNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsStepFunctionsNode[-ANU]*$/",
                     "group": "0@1"
                 },
                 {
                     "command": "aws.downloadStateMachineDefinition",
-                    "when": "view == aws.explorer && viewItem == awsStateMachineNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsStateMachineNode[-ANU]*$/",
                     "group": "0@1"
                 },
                 {
                     "command": "aws.renderStateMachineGraph",
-                    "when": "view == aws.explorer && viewItem == awsStateMachineNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsStateMachineNode[-ANU]*$/",
                     "group": "0@2"
                 },
                 {
                     "command": "aws.cdk.renderStateMachineGraph",
-                    "when": "viewItem == awsCdkStateMachineNode",
+                    "when": "viewItem =~ /^awsCdkStateMachineNode[-ANU]*$/",
                     "group": "inline@1"
                 },
                 {
                     "command": "aws.cdk.renderStateMachineGraph",
-                    "when": "viewItem == awsCdkStateMachineNode",
+                    "when": "viewItem =~ /^awsCdkStateMachineNode[-ANU]*$/",
                     "group": "0@1"
                 },
                 {
                     "command": "aws.executeStateMachine",
-                    "when": "view == aws.explorer && viewItem == awsStateMachineNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsStateMachineNode[-ANU]*$/",
                     "group": "0@3"
                 },
                 {
                     "command": "aws.iot.createThing",
-                    "when": "view == aws.explorer && viewItem == awsIotThingsNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsIotThingsNode[-ANU]*$/",
                     "group": "0@1"
                 },
                 {
                     "command": "aws.iot.createCert",
-                    "when": "view == aws.explorer && viewItem == awsIotCertsNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsIotCertsNode[-ANU]*$/",
                     "group": "0@1"
                 },
                 {
                     "command": "aws.iot.createPolicy",
-                    "when": "view == aws.explorer && viewItem == awsIotPoliciesNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsIotPoliciesNode[-ANU]*$/",
                     "group": "0@1"
                 },
                 {
                     "command": "aws.iot.createPolicyVersion",
-                    "when": "view == aws.explorer && viewItem == awsIotPolicyNode.WithVersions",
+                    "when": "view == aws.explorer && viewItem =~ /^awsIotPolicyNode[-ANU]*.WithVersions$/",
                     "group": "0@1"
                 },
                 {
@@ -1515,7 +1515,7 @@
                 },
                 {
                     "command": "aws.iot.attachCert",
-                    "when": "view == aws.explorer && viewItem == awsIotThingNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsIotThingNode[-ANU]*$/",
                     "group": "0@1"
                 },
                 {
@@ -1525,62 +1525,62 @@
                 },
                 {
                     "command": "aws.s3.createBucket",
-                    "when": "view == aws.explorer && viewItem == awsS3Node",
+                    "when": "view == aws.explorer && viewItem =~ /^awsS3Node[-ANU]*$/",
                     "group": "0@1"
                 },
                 {
                     "command": "aws.s3.downloadFileAs",
-                    "when": "view == aws.explorer && viewItem == awsS3FileNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsS3FileNode[-ANU]*$/",
                     "group": "0@1"
                 },
                 {
                     "command": "aws.s3.uploadFile",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsS3BucketNode|awsS3FolderNode)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsS3BucketNode|awsS3FolderNode)[-ANU]*$/",
                     "group": "0@1"
                 },
                 {
                     "command": "aws.s3.uploadFileToParent",
-                    "when": "view == aws.explorer && viewItem == awsS3FileNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsS3FileNode[-ANU]*$/",
                     "group": "1@1"
                 },
                 {
                     "command": "aws.s3.createFolder",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsS3BucketNode|awsS3FolderNode)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsS3BucketNode|awsS3FolderNode)[-ANU]*$/",
                     "group": "1@1"
                 },
                 {
                     "command": "aws.iot.deactivateCert",
-                    "when": "view == aws.explorer && viewItem =~ /^awsIotCertificateNode.(Things|Policies).ACTIVE$/",
+                    "when": "view == aws.explorer && viewItem =~ /^awsIotCertificateNode[-ANU]*.(Things|Policies).ACTIVE$/",
                     "group": "1@1"
                 },
                 {
                     "command": "aws.iot.activateCert",
-                    "when": "view == aws.explorer && viewItem =~ /^awsIotCertificateNode.(Things|Policies).INACTIVE$/",
+                    "when": "view == aws.explorer && viewItem =~ /^awsIotCertificateNode[-ANU]*.(Things|Policies).INACTIVE$/",
                     "group": "1@1"
                 },
                 {
                     "command": "aws.iot.revokeCert",
-                    "when": "view == aws.explorer && viewItem =~ /^awsIotCertificateNode.(Things|Policies).(ACTIVE|INACTIVE)$/",
+                    "when": "view == aws.explorer && viewItem =~ /^awsIotCertificateNode[-ANU]*.(Things|Policies).(ACTIVE|INACTIVE)$/",
                     "group": "1@2"
                 },
                 {
                     "command": "aws.iot.setDefaultPolicy",
-                    "when": "view == aws.explorer && viewItem == awsIotPolicyVersionNode.NONDEFAULT",
+                    "when": "view == aws.explorer && viewItem =~ /^awsIotPolicyVersionNode[-ANU]*.NONDEFAULT$/",
                     "group": "1@1"
                 },
                 {
                     "command": "aws.iot.copyEndpoint",
-                    "when": "view == aws.explorer && viewItem == awsIotNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsIotNode[-ANU]*$/",
                     "group": "2@1"
                 },
                 {
                     "command": "aws.copyName",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsCloudFormationFunctionNode|awsStateMachineNode|awsCloudFormationNode|awsS3BucketNode|awsS3FolderNode|awsS3FileNode|awsApiGatewayNode|awsIotThingNode)$|^(awsAppRunnerServiceNode|awsIotCertificateNode|awsIotPolicyNode|awsIotPolicyVersionNode)/",
+                    "when": "view == aws.explorer && viewItem =~ /^aws[^-]*-([AU]*N)/",
                     "group": "2@1"
                 },
                 {
                     "command": "aws.copyArn",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsCloudFormationFunctionNode|awsStateMachineNode|awsCloudFormationNode|awsCloudWatchLogNode|awsS3BucketNode|awsS3FolderNode|awsS3FileNode|awsApiGatewayNode|awsEcrRepositoryNode|awsIotThingNode)$|^(awsAppRunnerServiceNode|awsEcsServiceNode|awsIotCertificateNode|awsIotPolicyNode|awsIotPolicyVersionNode|awsMdeInstanceNode)/",
+                    "when": "view == aws.explorer && viewItem =~ /^aws[^-]*-([NU]*A)/",
                     "group": "2@2"
                 },
                 {
@@ -1605,12 +1605,12 @@
                 },
                 {
                     "command": "aws.iot.detachPolicy",
-                    "when": "view == aws.explorer && viewItem == awsIotPolicyNode.Certificates",
+                    "when": "view == aws.explorer && viewItem =~ /^awsIotPolicyNode.Certificates[-ANU]*$/",
                     "group": "3@1"
                 },
                 {
                     "command": "aws.iot.deleteThing",
-                    "when": "view == aws.explorer && viewItem == awsIotThingNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsIotThingNode[-ANU]*$/",
                     "group": "3@1"
                 },
                 {
@@ -1620,33 +1620,33 @@
                 },
                 {
                     "command": "aws.iot.deletePolicy",
-                    "when": "view == aws.explorer && viewItem == awsIotPolicyNode.WithVersions",
+                    "when": "view == aws.explorer && viewItem =~ /^awsIotPolicyNode.WithVersions[-ANU]*$/",
                     "group": "3@1"
                 },
                 {
                     "command": "aws.iot.deletePolicyVersion",
-                    "when": "view == aws.explorer && viewItem == awsIotPolicyVersionNode.NONDEFAULT",
+                    "when": "view == aws.explorer && viewItem =~ /^awsIotPolicyVersionNode.NONDEFAULT[-ANU]*$/",
                     "group": "3@1"
                 },
                 {
                     "command": "aws.s3.deleteBucket",
-                    "when": "view == aws.explorer && viewItem == awsS3BucketNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsS3BucketNode[-ANU]*$/",
                     "group": "3@1"
                 },
                 {
                     "command": "aws.s3.deleteFile",
-                    "when": "view == aws.explorer && viewItem == awsS3FileNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsS3FileNode[-ANU]*$/",
                     "group": "3@1"
                 },
                 {
                     "command": "aws.downloadSchemaItemCode",
-                    "when": "view == aws.explorer && viewItem == awsSchemaItemNode",
+                    "when": "view == aws.explorer && viewItem =~ /^awsSchemaItemNode[-ANU]*$/",
                     "group": "1@1"
                 },
                 {
                     "command": "aws.cloudWatchLogs.viewLogStream",
                     "group": "0@1",
-                    "when": "view == aws.explorer && viewItem == awsCloudWatchLogNode"
+                    "when": "view == aws.explorer && viewItem =~ /^awsCloudWatchLogNode[-ANU]*$/"
                 },
                 {
                     "command": "aws.ssmDocument.openLocalDocumentYaml",
@@ -1661,12 +1661,12 @@
                 {
                     "command": "aws.ssmDocument.updateDocumentVersion",
                     "group": "2@1",
-                    "when": "view == aws.explorer && viewItem == awsDocumentItemNodeWriteable"
+                    "when": "view == aws.explorer && viewItem =~ /^awsDocumentItemNodeWriteable[-ANU]*$/"
                 },
                 {
                     "command": "aws.ssmDocument.deleteDocument",
                     "group": "3@2",
-                    "when": "view == aws.explorer && viewItem == awsDocumentItemNodeWriteable"
+                    "when": "view == aws.explorer && viewItem =~ /^awsDocumentItemNodeWriteable[-ANU]*$/"
                 },
                 {
                     "command": "aws.ecs.runCommandInContainer",
@@ -1681,26 +1681,26 @@
                 {
                     "command": "aws.ecs.enableEcsExec",
                     "group": "0@2",
-                    "when": "view == aws.explorer && viewItem == awsEcsServiceNode.DISABLED"
+                    "when": "view == aws.explorer && viewItem =~ /^awsEcsServiceNode.DISABLED[-ANU]*$/"
                 },
                 {
                     "command": "aws.ecs.disableEcsExec",
                     "group": "0@2",
-                    "when": "view == aws.explorer && viewItem == awsEcsServiceNode.ENABLED"
+                    "when": "view == aws.explorer && viewItem =~ /^awsEcsServiceNode.ENABLED[-ANU]*$/"
                 },
                 {
                     "command": "aws.ecs.viewDocumentation",
                     "group": "1@3",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsEcsClusterNode|awsEcsContainerNode)$|^awsEcsServiceNode/"
+                    "when": "view == aws.explorer && viewItem =~ /^((awsEcsClusterNode|awsEcsContainerNode)[-ANU]*)$|^awsEcsServiceNode/"
                 },
                 {
                     "command": "aws.resources.configure",
-                    "when": "view == aws.explorer && viewItem == resourcesRootNode",
+                    "when": "view == aws.explorer && viewItem =~ /^resourcesRootNode[-ANU]*$/",
                     "group": "1@1"
                 },
                 {
                     "command": "aws.resources.configure",
-                    "when": "view == aws.explorer && viewItem == resourcesRootNode",
+                    "when": "view == aws.explorer && viewItem =~ /^resourcesRootNode[-ANU]*$/",
                     "group": "inline@1"
                 },
                 {

--- a/src/apigateway/explorer/apiNodes.ts
+++ b/src/apigateway/explorer/apiNodes.ts
@@ -18,7 +18,7 @@ export class RestApiNode extends AWSTreeNodeBase implements AWSResourceNode {
     ) {
         super('')
         this.update(api)
-        this.contextValue = 'awsApiGatewayNode'
+        this.contextValue = 'awsApiGatewayNode-AN'
     }
 
     public update(api: RestApi): void {

--- a/src/apprunner/explorer/apprunnerServiceNode.ts
+++ b/src/apprunner/explorer/apprunnerServiceNode.ts
@@ -19,7 +19,7 @@ import { getIcon } from '../../shared/icons'
 import { DefaultCloudWatchLogsClient } from '../../shared/clients/cloudWatchLogsClient'
 const localize = nls.loadMessageBundle()
 
-const contextBase = 'awsAppRunnerServiceNode'
+const contextBase = 'awsAppRunnerServiceNode-AN'
 
 const operationStatus = {
     START_DEPLOYMENT: localize('AWS.apprunner.operationStatus.deploy', 'Deploying...'), // eslint-disable-line @typescript-eslint/naming-convention

--- a/src/cloudWatchLogs/explorer/logGroupNode.ts
+++ b/src/cloudWatchLogs/explorer/logGroupNode.ts
@@ -10,7 +10,7 @@ import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 import { getIcon } from '../../shared/icons'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 
-export const contextValueCloudwatchLog = 'awsCloudWatchLogNode'
+export const contextValueCloudwatchLog = 'awsCloudWatchLogNode-A'
 
 export class LogGroupNode extends AWSTreeNodeBase implements AWSResourceNode {
     public constructor(public override readonly regionCode: string, public logGroup: CloudWatchLogs.LogGroup) {

--- a/src/ecr/explorer/ecrRepositoryNode.ts
+++ b/src/ecr/explorer/ecrRepositoryNode.ts
@@ -28,7 +28,7 @@ export class EcrRepositoryNode extends AWSTreeNodeBase implements AWSResourceNod
     ) {
         super(repository.repositoryName, vscode.TreeItemCollapsibleState.Collapsed)
         this.iconPath = getIcon('aws-ecr-registry')
-        this.contextValue = 'awsEcrRepositoryNode'
+        this.contextValue = 'awsEcrRepositoryNode-A'
         this.regionCode = ecr.regionCode
     }
 

--- a/src/ecs/model.ts
+++ b/src/ecs/model.ts
@@ -106,8 +106,8 @@ export class Service {
         item.iconPath = getIcon('aws-ecs-service')
         item.tooltip = `${this.description.serviceArn}\nTask Definition: ${this.description.taskDefinition}`
         item.contextValue = this.description.enableExecuteCommand
-            ? 'awsEcsServiceNode.ENABLED'
-            : 'awsEcsServiceNode.DISABLED'
+            ? 'awsEcsServiceNode-A.ENABLED'
+            : 'awsEcsServiceNode-A.DISABLED'
 
         return item
     }

--- a/src/iot/explorer/iotCertificateNode.ts
+++ b/src/iot/explorer/iotCertificateNode.ts
@@ -25,7 +25,7 @@ import { LOCALIZED_DATE_FORMAT } from '../../shared/constants'
 import { Commands } from '../../shared/vscode/commands'
 import { getIcon } from '../../shared/icons'
 
-const contextBase = 'awsIotCertificateNode'
+const contextBase = 'awsIotCertificateNode-AN'
 /**
  * Represents an IoT Certificate that may have either a Thing Node or the
  * Certificate Folder Node as a parent.

--- a/src/iot/explorer/iotPolicyNode.ts
+++ b/src/iot/explorer/iotPolicyNode.ts
@@ -42,7 +42,7 @@ export class IotPolicyNode extends AWSTreeNodeBase implements AWSResourceNode {
             certs?.length ?? 0 > 0 ? `\nAttached to: ${certs?.join(', ')}` : ''
         )
         this.iconPath = getIcon('aws-iot-policy')
-        this.contextValue = 'awsIotPolicyNode.Certificates'
+        this.contextValue = 'awsIotPolicyNode-AN.Certificates'
     }
 
     public get arn(): string {
@@ -66,7 +66,7 @@ export class IotPolicyCertNode extends IotPolicyNode {
         protected override readonly workspace = Workspace.vscode()
     ) {
         super(policy, parent, iot, vscode.TreeItemCollapsibleState.None, undefined, workspace)
-        this.contextValue = 'awsIotPolicyNode.Certificates'
+        this.contextValue = 'awsIotPolicyNode-AN.Certificates'
     }
 }
 
@@ -81,7 +81,7 @@ export class IotPolicyWithVersionsNode extends IotPolicyNode {
         protected override readonly workspace = Workspace.vscode()
     ) {
         super(policy, parent, iot, vscode.TreeItemCollapsibleState.Collapsed, certs, workspace)
-        this.contextValue = 'awsIotPolicyNode.WithVersions'
+        this.contextValue = 'awsIotPolicyNode-AN.WithVersions'
         this.versionNodes = new Map<string, IotPolicyVersionNode>()
     }
 

--- a/src/iot/explorer/iotPolicyVersionNode.ts
+++ b/src/iot/explorer/iotPolicyVersionNode.ts
@@ -55,7 +55,7 @@ export class IotPolicyVersionNode extends AWSTreeNodeBase implements AWSResource
             version.versionId,
             version.isDefaultVersion ? '*' : ''
         )
-        this.contextValue = 'awsIotPolicyVersionNode.' + (this.isDefault ? 'DEFAULT' : 'NONDEFAULT')
+        this.contextValue = 'awsIotPolicyVersionNode-AN.' + (this.isDefault ? 'DEFAULT' : 'NONDEFAULT')
     }
 
     public get arn(): string {

--- a/src/iot/explorer/iotThingNode.ts
+++ b/src/iot/explorer/iotThingNode.ts
@@ -37,7 +37,7 @@ export class IotThingNode extends AWSTreeNodeBase implements AWSResourceNode, Lo
         super(thing.name, vscode.TreeItemCollapsibleState.Collapsed)
         this.tooltip = thing.name
         this.iconPath = getIcon('aws-iot-thing')
-        this.contextValue = 'awsIotThingNode'
+        this.contextValue = 'awsIotThingNode-AN'
     }
 
     public override async getChildren(): Promise<AWSTreeNodeBase[]> {

--- a/src/lambda/explorer/cloudFormationNodes.ts
+++ b/src/lambda/explorer/cloudFormationNodes.ts
@@ -21,7 +21,7 @@ import { listCloudFormationStacks, listLambdaFunctions } from '../utils'
 import { LambdaFunctionNode } from './lambdaFunctionNode'
 import { getIcon } from '../../shared/icons'
 
-export const contextValueCloudformationLambdaFunction = 'awsCloudFormationFunctionNode'
+export const contextValueCloudformationLambdaFunction = 'awsCloudFormationFunctionNode-AN'
 
 export class CloudFormationNode extends AWSTreeNodeBase {
     private readonly stackNodes: Map<string, CloudFormationStackNode>
@@ -73,7 +73,7 @@ export class CloudFormationStackNode extends AWSTreeNodeBase implements AWSResou
         super('', vscode.TreeItemCollapsibleState.Collapsed)
 
         this.update(stackSummary)
-        this.contextValue = 'awsCloudFormationNode'
+        this.contextValue = 'awsCloudFormationNode-AN'
         this.functionNodes = new Map<string, LambdaFunctionNode>()
         this.iconPath = getIcon('aws-cloudformation-stack')
     }

--- a/src/lambda/explorer/lambdaNodes.ts
+++ b/src/lambda/explorer/lambdaNodes.ts
@@ -18,8 +18,8 @@ import { listLambdaFunctions } from '../utils'
 import { LambdaFunctionNode } from './lambdaFunctionNode'
 import { samLambdaImportableRuntimes } from '../models/samLambdaRuntime'
 
-export const contextValueLambdaFunction = 'awsRegionFunctionNode'
-export const contextValueLambdaFunctionImportable = 'awsRegionFunctionNodeDownloadable'
+export const contextValueLambdaFunction = 'awsRegionFunctionNode-AN'
+export const contextValueLambdaFunctionImportable = 'awsRegionFunctionNodeDownloadable-AN'
 
 /**
  * An AWS Explorer node representing the Lambda Service.

--- a/src/s3/explorer/s3BucketNode.ts
+++ b/src/s3/explorer/s3BucketNode.ts
@@ -37,7 +37,7 @@ export class S3BucketNode extends AWSTreeNodeBase implements AWSResourceNode, Lo
         super(bucket.name, vscode.TreeItemCollapsibleState.Collapsed)
         this.tooltip = bucket.name
         this.iconPath = getIcon('aws-s3-bucket')
-        this.contextValue = 'awsS3BucketNode'
+        this.contextValue = 'awsS3BucketNode-AN'
     }
 
     public override async getChildren(): Promise<AWSTreeNodeBase[]> {

--- a/src/s3/explorer/s3FileNode.ts
+++ b/src/s3/explorer/s3FileNode.ts
@@ -52,7 +52,7 @@ export class S3FileNode extends AWSTreeNodeBase implements AWSResourceNode {
             this.description = `${readableSize}, ${getRelativeDate(file.lastModified, now)}`
         }
         this.iconPath = getIcon('vscode-file')
-        this.contextValue = 'awsS3FileNode'
+        this.contextValue = 'awsS3FileNode-AN'
         this.command = !isCloud9()
             ? {
                   command: 'aws.s3.openFile',

--- a/src/s3/explorer/s3FolderNode.ts
+++ b/src/s3/explorer/s3FolderNode.ts
@@ -34,7 +34,7 @@ export class S3FolderNode extends AWSTreeNodeBase implements AWSResourceNode, Lo
         super(folder.name, vscode.TreeItemCollapsibleState.Collapsed)
         this.tooltip = folder.path
         this.iconPath = getIcon('vscode-folder')
-        this.contextValue = 'awsS3FolderNode'
+        this.contextValue = 'awsS3FolderNode-AN'
     }
 
     public override async getChildren(): Promise<AWSTreeNodeBase[]> {

--- a/src/stepFunctions/explorer/stepFunctionsNodes.ts
+++ b/src/stepFunctions/explorer/stepFunctionsNodes.ts
@@ -20,7 +20,7 @@ import { listStateMachines } from '../../stepFunctions/utils'
 import { Commands } from '../../shared/vscode/commands'
 import { getIcon } from '../../shared/icons'
 
-export const contextValueStateMachine = 'awsStateMachineNode'
+export const contextValueStateMachine = 'awsStateMachineNode-AN'
 
 const sfnNodeMap = new Map<string, StepFunctionsNode>()
 

--- a/src/test/ecs/model.test.ts
+++ b/src/test/ecs/model.test.ts
@@ -54,7 +54,7 @@ describe('Service', function () {
 
         await assertTreeItem(service, {
             label: serviceData.serviceName,
-            contextValue: 'awsEcsServiceNode.DISABLED',
+            contextValue: 'awsEcsServiceNode-A.DISABLED',
         })
     })
 


### PR DESCRIPTION
Problem:
Not scalable to match enumerated viewItem names for standard features like "Copy URL", "Copy Name", etc.

Solution:
Define a naming convention which switches on standard features ("Copy URL", "Copy Name", …) as follows:

awsFoo-ANUED

    /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsCloudFormationFunctionNode|awsStateMachineNode|awsCloudFormationNode|awsS3BucketNode|awsS3FolderNode|awsS3FileNode|
    awsApiGatewayNode|awsIotThingNode)$|^(awsAppRunnerServiceNode|awsIotCertificateNode|awsIotPolicyNode|awsIotPolicyVersionNode)/

    awsCloudWatchLogNode|
    awsEcrRepositoryNode|
    awsEcsServiceNode|

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
