### PR TITLE
file explorer: add upoloadToAws command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1100,6 +1100,10 @@
                     "when": "false"
                 },
                 {
+                    "command": "aws.uploadToAws",
+                    "when": "false"
+                },
+                {
                     "command": "aws.dev.openMenu",
                     "when": "aws.isDevMode || isCloud9"
                 }
@@ -1272,8 +1276,8 @@
                     "group": "z_aws@2"
                 },
                 {
-                    "command": "aws.uploadLambda",
-                    "when": "explorerResourceIsFolder || isFileSystemResource && resourceFilename =~ /^template\\.(json|yml|yaml)$/",
+                    "command": "aws.uploadToAws",
+                    "when": "explorerResourceIsFolder || isFileSystemResource",
                     "group": "z_aws@3"
                 }
             ],
@@ -2397,6 +2401,16 @@
             {
                 "command": "aws.uploadLambda",
                 "title": "%AWS.command.uploadLambda%",
+                "category": "%AWS.title%",
+                "cloud9": {
+                    "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
+            },
+            {
+                "command": "aws.uploadToAws",
+                "title": "%AWS.command.uploadToAws%",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -101,6 +101,7 @@
     "AWS.command.aboutToolkit": "About Toolkit",
     "AWS.command.downloadLambda": "Download...",
     "AWS.command.uploadLambda": "Upload Lambda...",
+    "AWS.command.uploadToAws": "Upload to AWS...",
     "AWS.command.invokeLambda": "Invoke on AWS",
     "AWS.command.invokeLambda.cn": "Invoke on Amazon",
     "AWS.command.refreshAwsExplorer": "Refresh Explorer",

--- a/src/lambda/activation.ts
+++ b/src/lambda/activation.ts
@@ -15,6 +15,7 @@ import { registerSamInvokeVueCommand } from './vue/configEditor/samInvokeBackend
 import { Commands } from '../shared/vscode/commands2'
 import { DefaultLambdaClient } from '../shared/clients/lambdaClient'
 import { copyLambdaUrl } from './commands/copyLambdaUrl'
+import { uploadToAwsCommand } from './commands/uploadToAwsCommand'
 
 /**
  * Activates Lambda components.
@@ -57,6 +58,7 @@ export async function activate(context: ExtContext): Promise<void> {
             'aws.copyLambdaUrl',
             async (node: LambdaFunctionNode) => await copyLambdaUrl(node, new DefaultLambdaClient(node.regionCode))
         ),
+        Commands.register('aws.uploadToAws', async (arg: vscode.Uri) => await uploadToAwsCommand(arg)),
         registerSamInvokeVueCommand(context)
     )
 }

--- a/src/lambda/commands/uploadToAwsCommand.ts
+++ b/src/lambda/commands/uploadToAwsCommand.ts
@@ -1,0 +1,59 @@
+/*!
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as vscode from 'vscode'
+import { createQuickPick, DataQuickPickItem } from '../../shared/ui/pickerPrompter'
+import { createCommonButtons } from '../../shared/ui/buttons'
+import { uploadLambdaCommand } from './uploadLambda'
+import { CancellationError } from '../../shared/utilities/timeoutUtils'
+import { uploadFileCommand } from '../../s3/commands/uploadFile'
+import { createRegionPrompter } from '../../shared/ui/common/region'
+import { Wizard } from '../../shared/wizards/wizard'
+import { DefaultS3Client } from '../../shared/clients/s3Client'
+
+export interface UploadToAwsWizardState {
+    readonly resource: 's3' | 'lambda'
+    readonly region?: string
+}
+
+function createChooseResourcePrompter() {
+    const items: DataQuickPickItem<'s3' | 'lambda'>[] = [
+        { label: 'Upload to S3', data: 's3', detail: undefined },
+        { label: 'Upload to Lambda', data: 'lambda', detail: undefined },
+    ]
+    return createQuickPick(items, {
+        title: 'Choose an action',
+        buttons: createCommonButtons(),
+    })
+}
+
+export class UploadToAwsWizard extends Wizard<UploadToAwsWizardState> {
+    constructor() {
+        super()
+        this.form.resource.bindPrompter(() => createChooseResourcePrompter())
+        // region is needed to create an S3 client for the upload command
+        this.form.region.bindPrompter(() => createRegionPrompter().transform(region => region.id), {
+            showWhen: ({ resource }) => resource === 's3',
+        })
+    }
+}
+
+export async function uploadToAwsCommand(fileOrFolder: vscode.Uri) {
+    const response = await new UploadToAwsWizard().run()
+
+    if (!response) {
+        throw new CancellationError('user')
+    }
+
+    if (response.resource === 's3') {
+        if (response.region) {
+            const s3 = new DefaultS3Client(response.region)
+            await uploadFileCommand(s3, fileOrFolder)
+        }
+    }
+
+    if (response.resource === 'lambda') {
+        await uploadLambdaCommand(undefined, fileOrFolder)
+    }
+}


### PR DESCRIPTION
## Problem
The toolkit can upload files and folders to Lambda and S3, but the commands are only available from the AWS Explorer or the Command Palette.
## Solution
Add a context menu item to all files and folders that prompts for the resource to upload to. Initiate the appropriate wizard passing the file/folder. Current options are Lambda and S3.

## Screenshot
![upload to aws](https://user-images.githubusercontent.com/25124281/220731642-37d27098-f01a-4bca-a345-549b566e8bd1.PNG)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
