### PR TITLE
(fix codewhisperer) add subscription of vscode inline to CW % tracker

### DIFF
--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -415,6 +415,9 @@ export async function activate(context: ExtContext): Promise<void> {
                 if (e.document === vscode.window.activeTextEditor?.document) {
                     disposeSecurityDiagnostic(e)
                 }
+
+                CodeWhispererCodeCoverageTracker.getTracker(e.document.languageId)?.countTotalTokens(e)
+
                 /**
                  * Handle this keystroke event only when
                  * 1. It is in current non plaintext active editor

--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -150,7 +150,7 @@ export const identityPoolID = 'us-east-1:70717e99-906f-4add-908c-bd9074a2f5b9'
 /**
  * the interval of the background thread invocation, which is triggered by the timer
  */
-export const defaultCheckPeriodMillis = 1000 * 60 * 5
+export const defaultCheckPeriodMillis = 1000 * 60
 
 // suggestion show delay, in milliseconds
 export const suggestionShowDelay = 250

--- a/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
+++ b/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
@@ -118,6 +118,7 @@ export class CodeWhispererCodeCoverageTracker {
             })
         }
         const percentCount = ((acceptedTokens / totalTokens) * 100).toFixed(2)
+        console.log(percentCount)
         const percentage = Math.round(parseInt(percentCount))
         telemetry.codewhisperer_codePercentage.emit({
             codewhispererTotalTokens: totalTokens,
@@ -197,7 +198,7 @@ export class CodeWhispererCodeCoverageTracker {
         // only include contentChanges from user action
         if (
             !runtimeLanguageContext.isLanguageSupported(e.document.languageId) ||
-            vsCodeState.isCodeWhispererEditing ||
+            // vsCodeState.isCodeWhispererEditing ||
             e.contentChanges.length !== 1
         ) {
             return


### PR DESCRIPTION
## Problem
We had subscription from cloud9 / old CW inline but not VSC inline, thus the plugin has been not sending %code data on vsc inline users.


## Solution



## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
