### PR TITLE
tests: print debugging info when timing out

### DIFF
--- a/src/test/shared/vscode/window.ts
+++ b/src/test/shared/vscode/window.ts
@@ -447,7 +447,7 @@ export function printPendingUiElements(window = getTestWindow()) {
         parts.push('Quick Inputs: ', `  ${window.activeQuickInput.title}`)
     }
 
-    return parts.length > 0 ? ['[Pending UI Elements]', ...parts].join('\n') : '[No Pending UI Elements Found]'
+    return parts.length > 0 ? ['Pending UI Elements:', ...parts].join('\n') : '[No Pending UI Elements Found]'
 }
 
 type TestEventEmitter<T> = vscode.EventEmitter<T> & {

--- a/src/test/shared/vscode/window.ts
+++ b/src/test/shared/vscode/window.ts
@@ -432,6 +432,24 @@ export function assertNoErrorMessages() {
     }
 }
 
+export function printPendingUiElements(window = getTestWindow()) {
+    const parts: string[] = []
+    const messages = window.shownMessages.filter(m => m.visible)
+    const dialogs = window.shownDialogs.filter(d => d.visible)
+
+    if (messages.length > 0) {
+        parts.push('Messages:', ...messages.map(m => `  ${m.printDebug()}`))
+    }
+    if (dialogs.length > 0) {
+        parts.push('File System Dialogs:', ...dialogs.map(d => `  ${d.printDebug()}`))
+    }
+    if (window.activeQuickInput?.visible) {
+        parts.push('Quick Inputs: ', `  ${window.activeQuickInput.title}`)
+    }
+
+    return parts.length > 0 ? ['[Pending UI Elements]', ...parts].join('\n') : '[No Pending UI Elements Found]'
+}
+
 type TestEventEmitter<T> = vscode.EventEmitter<T> & {
     readonly onError: vscode.Event<{ event: T; error: unknown }>
 }


### PR DESCRIPTION
## Problem
It's not always clear why tests hang and timeout. 

## Solution
Print pending UI elements before stopping the test. This is a more general solution over requiring tests to specify all responses up-front which is also viable.

Example:
<img width="686" alt="Screen Shot 2023-02-22 at 2 34 22 PM" src="https://user-images.githubusercontent.com/31319484/220798152-7048ac77-6235-4dbd-aba3-bb5ca789ad59.png">

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
