### PR TITLE
prompters: add a common S3 bucket prompter that recalls recent buckets

### DIFF
--- a/src/shared/ui/common/buckets.ts
+++ b/src/shared/ui/common/buckets.ts
@@ -1,0 +1,44 @@
+/*!
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { S3 } from 'aws-sdk'
+import { DefaultS3Client, S3Client } from '../../clients/s3Client'
+import globals from '../../extensionGlobals'
+import { createCommonButtons, PrompterButtons } from '../buttons'
+import { createQuickPick, QuickPickPrompter } from '../pickerPrompter'
+import { getLogger } from '../../logger/logger'
+
+interface BucketPrompterOptions {
+    readonly s3Client?: S3Client
+    readonly title?: string
+    readonly buttons?: PrompterButtons<string>
+    readonly helpUrl?: string | vscode.Uri
+}
+export function createBucketPrompter(region: string, options: BucketPrompterOptions = {}) {
+    const lastBucketKey = 'lastSelectedBucket'
+    const lastBucket = globals.context.globalState.get<S3.Bucket>(lastBucketKey)
+    const client = options.s3Client ?? new DefaultS3Client(region)
+
+    const items = client.listBucketsIterable().map(b => [
+        {
+            label: b.Name,
+            data: b.Name,
+            recentlyUsed: b.Name === lastBucket,
+        },
+    ])
+
+    const prompter = createQuickPick(items, {
+        title: options.title ?? 'Select an S3 Bucket',
+        placeholder: 'Filter bucket name',
+        buttons: createCommonButtons(options.helpUrl),
+    })
+
+    return prompter.transform(item => {
+        getLogger().debug('createBucketPrompter: selected %O', item)
+        globals.context.globalState.update(lastBucketKey, item)
+        return item
+    })
+}

--- a/src/test/shared/ui/prompters/bucketPrompter.test.ts
+++ b/src/test/shared/ui/prompters/bucketPrompter.test.ts
@@ -1,0 +1,37 @@
+/*!
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createBucketPrompter } from '../../../../shared/ui/common/bucketPrompter'
+import { createQuickPickPrompterTester } from '../testUtils'
+import { S3Client } from '../../../../shared/clients/s3Client'
+import { mock, instance, when } from '../../../utilities/mockito'
+
+describe('createBucketPrompter', function () {
+    let s3: S3Client
+
+    beforeEach(function () {
+        s3 = mock()
+        when(s3.listBuckets()).thenResolve({
+            buckets: [
+                { name: 'bucketA', region: 'region', arn: 'arn' },
+                { name: 'bucketB', region: 'region', arn: 'arn' },
+                { name: 'bucketC', region: 'region', arn: 'arn' },
+            ],
+        })
+    })
+    it('prompts for bucket', async function () {
+        const prompter = await createBucketPrompter('region', { s3Client: instance(s3) })
+        const tester = createQuickPickPrompterTester(prompter)
+        tester.assertItems(['bucketA', 'bucketB', 'bucketC'])
+    })
+
+    it('moves recent bucket to top', async function () {
+        const prompter = await createBucketPrompter('region', { s3Client: instance(s3) })
+        const tester = createQuickPickPrompterTester(prompter)
+        tester.acceptItem('bucketC')
+        const newTester = createQuickPickPrompterTester(prompter)
+        newTester.assertItems(['bucketC', 'bucketA', 'bucketB'])
+    })
+})


### PR DESCRIPTION
## Problem
Prompting for an S3 bucket is common in our command wizards, but each time they were created from scratch. They also do not have logic to recall the last bucket that was used (except sam sync).
## Solution
Create a function that returns a bucket prompter and recalls the 'recently used' bucket.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
