### PR TITLE
feat(auth): several UX improvements for browser login flows

### DIFF
--- a/.changes/next-release/Bug Fix-b901b228-a954-413d-a9c5-b47c61ec5799.json
+++ b/.changes/next-release/Bug Fix-b901b228-a954-413d-a9c5-b47c61ec5799.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "auth: \"Copy Code\" modal is shown twice when refreshing expired IAM Identity Center connections"
+}

--- a/.changes/next-release/Feature-6c58a802-1a1a-4819-bb6b-b95e66145a4c.json
+++ b/.changes/next-release/Feature-6c58a802-1a1a-4819-bb6b-b95e66145a4c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "auth: verification codes for browser logins are now shown in a notification after opening the login URL"
+}

--- a/src/codecatalyst/explorer.ts
+++ b/src/codecatalyst/explorer.ts
@@ -148,9 +148,11 @@ export class CodeCatalystRootNode implements RootNode {
         try {
             await this.authProvider.restore()
             const conn = this.authProvider.activeConnection
-            const client = conn !== undefined ? await createClient(conn) : undefined
+            if (conn !== undefined && this.authProvider.auth.getConnectionState(conn) === 'valid') {
+                const client = await createClient(conn)
 
-            return client !== undefined ? await getConnectedDevEnv(client) : undefined
+                return await getConnectedDevEnv(client)
+            }
         } catch (err) {
             getLogger().warn(`codecatalyst: failed to get Dev Environment: ${UnknownError.cast(err).message}`)
         }

--- a/src/codecatalyst/reconnect.ts
+++ b/src/codecatalyst/reconnect.ts
@@ -25,7 +25,7 @@ const maxReconnectTime = 10 * 60 * 1000
 export function watchRestartingDevEnvs(ctx: ExtContext, authProvider: CodeCatalystAuthenticationProvider) {
     let restartHandled = false
     authProvider.onDidChangeActiveConnection(async conn => {
-        if (restartHandled || conn === undefined) {
+        if (restartHandled || conn === undefined || authProvider.auth.getConnectionState(conn) !== 'valid') {
             return
         }
 

--- a/src/credentials/providers/sharedCredentialsProvider.ts
+++ b/src/credentials/providers/sharedCredentialsProvider.ts
@@ -220,7 +220,13 @@ export class SharedCredentialsProvider implements CredentialsProvider {
         const loadedCreds = await this.patchSourceCredentials()
 
         const provider = chain(this.makeCredentialsProvider(loadedCreds))
-        return resolveProviderWithCancel(this.profileName, provider())
+
+        // SSO profiles already show a notification, no need to show another
+        if (isSsoProfile(this.profile)) {
+            return provider()
+        } else {
+            return resolveProviderWithCancel(this.profileName, provider())
+        }
     }
 
     /**

--- a/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
+++ b/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
@@ -234,7 +234,7 @@ describe('SsoAccessTokenProvider', function () {
             when(oidcClient.startDeviceAuthorization(anything())).thenResolve(authorization)
 
             const resp = sut.createToken()
-            const progress = await getTestWindow().waitForMessage(/waiting for a login/i)
+            const progress = await getTestWindow().waitForMessage(/login page opened/i)
             await clock.tickAsync(750)
             assert.ok(progress.visible)
             await clock.tickAsync(750)


### PR DESCRIPTION
## Problems
* It's not always obvious that the extension is waiting for the user to login
* Some CodeCatalyst logic doesn't check for 'valid' connections prior to using them, creating noise
* The "Copy Code" modal is sometimes shown twice when refreshing expired builder ID connections

## Solutions
* Restrict connections to 1 re-auth flow at a time
* Add some extra checks in CC logic to reduce noise
* Show a progress notification while the user is connecting via the browser
<img width="478" alt="image" src="https://user-images.githubusercontent.com/31319484/221947664-e6f9fd3f-48b3-4d20-a511-cd50d9e43c84.png">

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
