### PR TITLE
s3: copy objects via drag and drop

### DIFF
--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -4,6 +4,7 @@
  */
 
 import * as vscode from 'vscode'
+import * as semver from 'semver'
 import { submitFeedback } from '../feedback/vue/submitFeedback'
 import { deleteCloudFormation } from '../lambda/commands/deleteCloudFormation'
 import { CloudFormationStackNode } from '../lambda/explorer/cloudFormationNodes'
@@ -31,6 +32,7 @@ import { once } from '../shared/utilities/functionUtils'
 import { Auth, AuthNode } from '../credentials/auth'
 import { CodeCatalystRootNode } from '../codecatalyst/explorer'
 import { CodeCatalystAuthenticationProvider } from '../codecatalyst/auth'
+import { AwsDragAndDropController } from './commands/dragAndDropController'
 
 /**
  * Activates the AWS Explorer UI and related functionality.
@@ -42,11 +44,13 @@ export async function activate(args: {
     remoteInvokeOutputChannel: vscode.OutputChannel
 }): Promise<void> {
     const awsExplorer = new AwsExplorer(globals.context, args.regionProvider)
-
-    const view = vscode.window.createTreeView(awsExplorer.viewProviderId, {
+    const awsDragDropController = semver.gte(vscode.version, '1.66.0') ? new AwsDragAndDropController() : undefined
+    const treeViewOptions = {
         treeDataProvider: awsExplorer,
         showCollapseAll: true,
-    })
+        dragAndDropController: awsDragDropController,
+    }
+    const view = vscode.window.createTreeView(awsExplorer.viewProviderId, treeViewOptions)
     globals.context.subscriptions.push(view)
 
     await registerAwsExplorerCommands(args.context, awsExplorer, args.toolkitOutputChannel)

--- a/src/awsexplorer/commands/dragAndDropController.ts
+++ b/src/awsexplorer/commands/dragAndDropController.ts
@@ -1,0 +1,49 @@
+/*!
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as vscode from 'vscode'
+import { S3FileNode } from '../../s3/explorer/s3FileNode'
+import { S3BucketNode } from '../../s3/explorer/s3BucketNode'
+
+interface S3FileDataTransfer {
+    bucketname: string
+    key: string
+    name: string
+}
+// When vscode minimum version reaches 1.66, implement vscode.TreeDragAndDropController to this class
+export class AwsDragAndDropController {
+    public dragMimeTypes: string[] = ['application/vnd.code.tree.aws.explorer']
+    public dropMimeTypes: string[] = ['application/vnd.code.tree.aws.explorer']
+
+    handleDrag(
+        source: any[],
+        dataTransfer: vscode.DataTransfer,
+        token: vscode.CancellationToken
+    ): void | Thenable<void> {
+        // Do not set the dataTransfer to any S3 node
+        if (source[0] instanceof S3FileNode) {
+            const dragData: S3FileDataTransfer = {
+                bucketname: source[0].bucket.name,
+                key: source[0].file.key,
+                name: source[0].file.name,
+            }
+            dataTransfer.set('application/vnd.code.tree.aws.explorer', new vscode.DataTransferItem(dragData))
+        }
+    }
+
+    handleDrop(target: any, dataTransfer: vscode.DataTransfer, token: vscode.CancellationToken): void | Thenable<void> {
+        const data = dataTransfer.get('application/vnd.code.tree.aws.explorer')
+        if (target instanceof S3BucketNode && data?.value.bucketname && data?.value.key) {
+            const s3 = target.s3
+
+            s3.copyObject({
+                bucket: target.bucket.name,
+                copySource: `${data.value.bucketname}/${data.value.key}`,
+                key: data.value.name,
+            })
+
+            vscode.commands.executeCommand('aws.refreshAwsExplorer', true)
+        }
+    }
+}

--- a/src/shared/clients/s3Client.ts
+++ b/src/shared/clients/s3Client.ts
@@ -129,6 +129,12 @@ export interface DeleteBucketRequest {
     readonly bucketName: string
 }
 
+export interface CopyObjectRequest {
+    readonly bucket: string
+    readonly copySource: string
+    readonly key: string
+}
+
 export class DefaultS3Client {
     public constructor(
         public readonly regionCode: string,
@@ -625,6 +631,19 @@ export class DefaultS3Client {
                 throw e
             }
         }
+    }
+    /**
+     * Copies an object to a desired bucket.
+     *
+     */
+    public async copyObject(request: CopyObjectRequest) {
+        getLogger().debug('CopyObject called with request: %O', request)
+        const s3 = await this.createS3()
+
+        const response = await s3
+            .copyObject({ Bucket: request.bucket, CopySource: request.copySource, Key: request.key })
+            .promise()
+        getLogger().debug('CopyObject returned response: %O', response)
     }
 }
 


### PR DESCRIPTION


## Problem
Version 1.66 of vscode allow for drag and drop operations, but S3 nodes have no effect with drag and drop.

## Solution
Add a drag and drop controller to the Tree View and copy an object to new bucket via dragging an file node and dropping on a bucket node.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
