### PR TITLE
fix(cwl): "circular JSON" error when clicking Log Group

### DIFF
--- a/src/cloudWatchLogs/document/logStreamsCodeLensProvider.ts
+++ b/src/cloudWatchLogs/document/logStreamsCodeLensProvider.ts
@@ -61,7 +61,8 @@ export class LogStreamCodeLensProvider implements vscode.CodeLensProvider {
         const cmd: vscode.Command = {
             command: 'aws.loadLogStreamFile',
             arguments: [streamUri, this.registry],
-            title: 'Load following Log Stream...',
+            title: 'Open this Log Stream...',
+            tooltip: 'Open the full Log Stream associated with these search results',
         }
         const codeLensLocation = new vscode.Range(idWithLine.lineNum, 0, idWithLine.lineNum, 0)
         return new vscode.CodeLens(codeLensLocation, cmd)

--- a/src/cloudWatchLogs/explorer/logGroupNode.ts
+++ b/src/cloudWatchLogs/explorer/logGroupNode.ts
@@ -19,7 +19,7 @@ export class LogGroupNode extends AWSTreeNodeBase implements AWSResourceNode {
         this.iconPath = getIcon('aws-cloudwatch-log-group')
         this.contextValue = contextValueCloudwatchLog
         this.command = {
-            command: 'aws.cloudWatchLogs.viewLogStream',
+            command: 'aws.cwl.viewLogStream',
             title: localize('AWS.command.cloudWatchLogs.viewLogStream', 'View Log Stream'),
             arguments: [this],
         }


### PR DESCRIPTION
## Problem

vscode error when clicking a CWL Log Group:

    Converting circular structure to JSON --> starting at object with
    constructor 'LogGroupNode' | property 'command' -> object with
    constructor 'Object' | property 'arguments' -> object with constructor
    'Array' --- index 0 closes the circle


## Solution

Fix the command id.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
