### PR TITLE
fix(codewhisperer): update UX for connection expiry

### DIFF
--- a/.changes/next-release/Bug Fix-bd5e0b41-d276-4c9f-9406-e12dd208c0c2.json
+++ b/.changes/next-release/Bug Fix-bd5e0b41-d276-4c9f-9406-e12dd208c0c2.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeWhipserer: improve UX when connection expired"
+}

--- a/package.json
+++ b/package.json
@@ -216,6 +216,10 @@
                         "remoteConnected": {
                             "type": "boolean",
                             "default": false
+                        },
+                        "codeWhispererConnectionExpired": {
+                            "type": "boolean",
+                            "default": false
                         }
                     },
                     "additionalProperties": false

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -209,6 +209,11 @@ export async function activate(context: ExtContext): Promise<void> {
         )
     )
 
+    if (!isCloud9() && !auth.isConnectionValid()) {
+        // this is to proactively check and reflect the state if user's connection is expired
+        await auth.getBearerToken()
+    }
+
     function activateSecurityScan() {
         context.extensionContext.subscriptions.push(
             vscode.window.registerWebviewViewProvider(SecurityPanelViewProvider.viewType, securityPanelViewProvider)

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -211,7 +211,7 @@ export async function activate(context: ExtContext): Promise<void> {
 
     if (!isCloud9() && !auth.isConnectionValid()) {
         // this is to proactively check and reflect the state if user's connection is expired
-        await auth.getBearerToken()
+        await auth.refreshCodeWhisperer()
     }
 
     function activateSecurityScan() {

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -35,7 +35,7 @@ import {
     updateReferenceLog,
     showIntroduction,
     showAccessTokenErrorLearnMore,
-    showReconnect,
+    reconnect,
 } from './commands/basicCommands'
 import { sleep } from '../shared/utilities/timeoutUtils'
 import { ReferenceLogViewProvider } from './service/referenceLogViewProvider'
@@ -169,7 +169,7 @@ export async function activate(context: ExtContext): Promise<void> {
         // sign in with sso or AWS ID
         showSsoSignIn.register(),
         // show reconnect prompt
-        showReconnect.register(),
+        reconnect.register(),
         // learn more about CodeWhisperer
         showLearnMore.register(),
         // learn more about CodeWhisperer access token migration

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -35,6 +35,7 @@ import {
     updateReferenceLog,
     showIntroduction,
     showAccessTokenErrorLearnMore,
+    showReconnect,
 } from './commands/basicCommands'
 import { sleep } from '../shared/utilities/timeoutUtils'
 import { ReferenceLogViewProvider } from './service/referenceLogViewProvider'
@@ -134,7 +135,7 @@ export async function activate(context: ExtContext): Promise<void> {
                 await set(CodeWhispererConstants.welcomeMessageKey, true, context.extensionContext.globalState)
             }
             if (!isCloud9()) {
-                setStatusBarOK()
+                await vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar')
             }
         }),
         /**
@@ -167,6 +168,8 @@ export async function activate(context: ExtContext): Promise<void> {
         showSecurityScan.register(context, securityPanelViewProvider, client),
         // sign in with sso or AWS ID
         showSsoSignIn.register(),
+        // show reconnect prompt
+        showReconnect.register(),
         // learn more about CodeWhisperer
         showLearnMore.register(),
         // learn more about CodeWhisperer access token migration
@@ -244,63 +247,13 @@ export async function activate(context: ExtContext): Promise<void> {
                     return
                 }
             }
-
+            await globals.context.globalState.update(CodeWhispererConstants.accessToken, undefined)
+            await globals.context.globalState.update(CodeWhispererConstants.accessTokenExpriedKey, true)
             await vscode.commands.executeCommand('aws.codeWhisperer.refreshRootNode')
-            const t = new Date()
-
-            if (t <= CodeWhispererConstants.accessTokenCutOffDate) {
-                maybeShowTokenMigrationWarning()
-            } else {
-                await globals.context.globalState.update(CodeWhispererConstants.accessToken, undefined)
-                await globals.context.globalState.update(CodeWhispererConstants.accessTokenExpriedKey, true)
-                await vscode.commands.executeCommand('aws.codeWhisperer.refreshRootNode')
-                maybeShowTokenMigrationError()
-            }
+            maybeShowTokenMigrationError()
         } else if (accessTokenExpired) {
             maybeShowTokenMigrationError()
         }
-    }
-
-    function maybeShowTokenMigrationWarning() {
-        const doNotShowAgain =
-            context.extensionContext.globalState.get<boolean>(
-                CodeWhispererConstants.accessTokenMigrationDoNotShowAgainKey
-            ) || false
-        const notificationLastShown: number =
-            context.extensionContext.globalState.get<number | undefined>(
-                CodeWhispererConstants.accessTokenMigrationDoNotShowLastShown
-            ) || 1
-
-        //Add 7 days to notificationLastShown to determine whether warn message should show
-        if (doNotShowAgain || notificationLastShown + 1000 * 60 * 60 * 24 * 7 >= Date.now()) {
-            return
-        }
-
-        vscode.window
-            .showWarningMessage(
-                CodeWhispererConstants.accessTokenMigrationWarningMessage,
-                CodeWhispererConstants.accessTokenMigrationWarningButtonMessage,
-                CodeWhispererConstants.accessTokenMigrationDoNotShowAgain
-            )
-            .then(async resp => {
-                if (resp === CodeWhispererConstants.accessTokenMigrationWarningButtonMessage) {
-                    await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
-                    await showSsoSignIn.execute()
-                } else if (resp === CodeWhispererConstants.accessTokenMigrationDoNotShowAgain) {
-                    await vscode.window.showInformationMessage(
-                        CodeWhispererConstants.accessTokenMigrationDoNotShowAgainInfo,
-                        'OK'
-                    )
-                    await context.extensionContext.globalState.update(
-                        CodeWhispererConstants.accessTokenMigrationDoNotShowAgainKey,
-                        true
-                    )
-                }
-            })
-        context.extensionContext.globalState.update(
-            CodeWhispererConstants.accessTokenMigrationDoNotShowLastShown,
-            Date.now()
-        )
     }
 
     function maybeShowTokenMigrationError() {
@@ -323,13 +276,13 @@ export async function activate(context: ExtContext): Promise<void> {
                 CodeWhispererConstants.accessTokenMigrationErrorMessage,
                 CodeWhispererConstants.accessTokenMigrationErrorButtonMessage,
                 CodeWhispererConstants.accessTokenMigrationLearnMore,
-                CodeWhispererConstants.accessTokenMigrationDoNotShowAgain
+                CodeWhispererConstants.DoNotShowAgain
             )
             .then(async resp => {
                 if (resp === CodeWhispererConstants.accessTokenMigrationErrorButtonMessage) {
                     await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
                     await showSsoSignIn.execute()
-                } else if (resp === CodeWhispererConstants.accessTokenMigrationDoNotShowAgain) {
+                } else if (resp === CodeWhispererConstants.DoNotShowAgain) {
                     await context.extensionContext.globalState.update(
                         CodeWhispererConstants.accessTokenExpiredDoNotShowAgainKey,
                         true
@@ -342,14 +295,6 @@ export async function activate(context: ExtContext): Promise<void> {
             CodeWhispererConstants.accessTokenExpiredDoNotShowLastShown,
             Date.now()
         )
-    }
-
-    function setStatusBarOK() {
-        if (isInlineCompletionEnabled()) {
-            InlineCompletionService.instance.setCodeWhispererStatusBarOk()
-        } else {
-            InlineCompletion.instance.setCodeWhispererStatusBarOk()
-        }
     }
 
     async function showCodeWhispererWelcomeMessage(): Promise<void> {

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -211,7 +211,7 @@ export async function activate(context: ExtContext): Promise<void> {
 
     if (!isCloud9() && !auth.isConnectionValid()) {
         // this is to proactively check and reflect the state if user's connection is expired
-        await auth.refreshCodeWhisperer()
+        auth.refreshCodeWhisperer()
     }
 
     function activateSecurityScan() {

--- a/src/codewhisperer/commands/basicCommands.ts
+++ b/src/codewhisperer/commands/basicCommands.ts
@@ -91,7 +91,7 @@ export const showSsoSignIn = Commands.declare('aws.codeWhisperer.sso', () => asy
     await showConnectionPrompt()
 })
 
-export const showReconnect = Commands.declare('aws.codeWhisperer.reconnect', () => async () => {
+export const reconnect = Commands.declare('aws.codeWhisperer.reconnect', () => async () => {
     await AuthUtil.instance.reauthenticate()
 })
 

--- a/src/codewhisperer/commands/basicCommands.ts
+++ b/src/codewhisperer/commands/basicCommands.ts
@@ -57,7 +57,7 @@ export const showSecurityScan = Commands.declare(
     (context: ExtContext, securityPanelViewProvider: SecurityPanelViewProvider, client: DefaultCodeWhispererClient) =>
         async () => {
             if (AuthUtil.instance.isConnectionExpired()) {
-                await AuthUtil.instance.showReauthenticatePrompt()
+                await AuthUtil.instance.notifyReauthenticate()
             }
             const editor = vscode.window.activeTextEditor
             if (editor) {
@@ -89,6 +89,10 @@ export const showSsoSignIn = Commands.declare('aws.codeWhisperer.sso', () => asy
     telemetry.ui_click.emit({ elementId: 'cw_signUp_Cta' })
 
     await showConnectionPrompt()
+})
+
+export const showReconnect = Commands.declare('aws.codeWhisperer.reconnect', () => async () => {
+    await AuthUtil.instance.reauthenticate()
 })
 
 export const showLearnMore = Commands.declare('aws.codeWhisperer.learnMore', () => async () => {

--- a/src/codewhisperer/commands/invokeRecommendation.ts
+++ b/src/codewhisperer/commands/invokeRecommendation.ts
@@ -12,7 +12,6 @@ import { isCloud9 } from '../../shared/extensionUtilities'
 import { RecommendationHandler } from '../service/recommendationHandler'
 import { isInlineCompletionEnabled } from '../util/commonUtil'
 import { InlineCompletionService } from '../service/inlineCompletionService'
-import { AuthUtil } from '../util/authUtil'
 import { TelemetryHelper } from '../util/telemetryHelper'
 
 /**
@@ -77,9 +76,6 @@ export async function invokeRecommendation(
                 RecommendationHandler.instance.isGenerateRecommendationInProgress = false
             }
         } else if (isInlineCompletionEnabled()) {
-            if (AuthUtil.instance.isConnectionExpired()) {
-                await AuthUtil.instance.showReauthenticatePrompt()
-            }
             TelemetryHelper.instance.setInvokeSuggestionStartTime()
             await InlineCompletionService.instance.getPaginatedRecommendation(client, editor, 'OnDemand', config)
         } else {

--- a/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
+++ b/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
@@ -13,6 +13,7 @@ import {
     showLearnMore,
     showSsoSignIn,
     showFreeTierLimit,
+    showReconnect,
 } from '../commands/basicCommands'
 import { codeScanState } from '../models/model'
 
@@ -60,6 +61,12 @@ export const createSecurityScanNode = () => {
 export const createSsoSignIn = () =>
     showSsoSignIn.build().asTreeNode({
         label: localize('AWS.explorerNode.sSoSignInNode.label', 'Start'),
+        iconPath: getIcon('vscode-debug-start'),
+    })
+
+export const createReconnectNode = () =>
+    showReconnect.build().asTreeNode({
+        label: localize('AWS.explorerNode.reconnectNode.label', 'Reconnect'),
         iconPath: getIcon('vscode-debug-start'),
     })
 

--- a/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
+++ b/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
@@ -13,7 +13,7 @@ import {
     showLearnMore,
     showSsoSignIn,
     showFreeTierLimit,
-    showReconnect,
+    reconnect,
 } from '../commands/basicCommands'
 import { codeScanState } from '../models/model'
 
@@ -65,7 +65,7 @@ export const createSsoSignIn = () =>
     })
 
 export const createReconnectNode = () =>
-    showReconnect.build().asTreeNode({
+    reconnect.build().asTreeNode({
         label: localize('AWS.explorerNode.reconnectNode.label', 'Reconnect'),
         iconPath: getIcon('vscode-debug-start'),
     })

--- a/src/codewhisperer/explorer/codewhispererNode.ts
+++ b/src/codewhisperer/explorer/codewhispererNode.ts
@@ -14,6 +14,7 @@ import {
     createLearnMore,
     createSsoSignIn,
     createFreeTierLimitMetNode,
+    createReconnectNode,
 } from './codewhispererChildrenNodes'
 import { Commands } from '../../shared/vscode/commands2'
 import { RootNode } from '../../awsexplorer/localExplorer'
@@ -77,6 +78,8 @@ export class CodeWhispererNode implements RootNode {
             return AuthUtil.instance.isEnterpriseSsoInUse()
                 ? 'IAM Identity Center Connected'
                 : 'AWS Builder ID Connected'
+        } else if (AuthUtil.instance.isConnectionExpired()) {
+            return 'Expired Connection'
         }
         return ''
     }
@@ -97,9 +100,12 @@ export class CodeWhispererNode implements RootNode {
                 return [createLearnMore(), createEnableCodeSuggestionsNode()]
             }
         } else {
-            const accessToken = this.getDescription()
-            if (accessToken || AuthUtil.instance.isConnected()) {
+            const isAccessToken = this.getDescription() === 'Access Token'
+            if (isAccessToken || AuthUtil.instance.isConnected()) {
                 if (termsAccepted) {
+                    if (AuthUtil.instance.isConnectionExpired()) {
+                        return [createReconnectNode(), createLearnMore()]
+                    }
                     if (this._showFreeTierLimitReachedNode) {
                         return [createFreeTierLimitMetNode(), createSecurityScanNode(), createOpenReferenceLogNode()]
                     } else {

--- a/src/codewhisperer/explorer/codewhispererNode.ts
+++ b/src/codewhisperer/explorer/codewhispererNode.ts
@@ -74,7 +74,7 @@ export class CodeWhispererNode implements RootNode {
         if (accessToken) {
             return 'Access Token'
         }
-        if (AuthUtil.instance.isUsingSavedConnection && AuthUtil.instance.isConnectionValid()) {
+        if (AuthUtil.instance.isConnectionValid()) {
             return AuthUtil.instance.isEnterpriseSsoInUse()
                 ? 'IAM Identity Center Connected'
                 : 'AWS Builder ID Connected'

--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -246,8 +246,6 @@ export const failedToConnectIamIdentityCenter = `Failed to connect to IAM Identi
 
 export const connectionExpired = `Connection expired. To continue using CodeWhisperer, connect with AWS Builder ID or AWS IAM Identity center.`
 
-export const connectionExpiredDoNotShowAgainKey = 'CODEWHISPERER_CONNECTION_EXIPRED_DO_NOT_SHOW_AGAIN'
-
 export const accessTokenMigrationLearnMore = `Learn More`
 
 export const DoNotShowAgain = `Don\'t Show Again`

--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -246,11 +246,11 @@ export const failedToConnectIamIdentityCenter = `Failed to connect to IAM Identi
 
 export const connectionExpired = `AWS Toolkit: Connection expired. Reauthenticate to continue.`
 
+export const connectionExpiredDoNotShowAgainKey = 'CODEWHISPERER_CONNECTION_EXIPRED_DO_NOT_SHOW_AGAIN'
+
 export const accessTokenMigrationLearnMore = `Learn More`
 
-export const accessTokenMigrationDoNotShowAgain = `Don\'t Show Again`
-
-export const accessTokenMigrationDoNotShowAgainKey = 'CODEWHISPERER_ACCESS_TOKEN_MIGRATION_DO_NOT_SHOW_AGAIN'
+export const DoNotShowAgain = `Don\'t Show Again`
 
 export const accessTokenExpiredDoNotShowAgainKey = 'CODEWHISPERER_ACCESS_TOKEN_EXPIRED_DO_NOT_SHOW_AGAIN'
 

--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -244,7 +244,7 @@ export const failedToConnectAwsBuilderId = `Failed to connect to AWS Builder ID`
 
 export const failedToConnectIamIdentityCenter = `Failed to connect to IAM Identity Center`
 
-export const connectionExpired = `AWS Toolkit: Connection expired. Reauthenticate to continue.`
+export const connectionExpired = `Connection expired. To continue using CodeWhisperer, connect with AWS Builder ID or AWS IAM Identity center.`
 
 export const connectionExpiredDoNotShowAgainKey = 'CODEWHISPERER_CONNECTION_EXIPRED_DO_NOT_SHOW_AGAIN'
 

--- a/src/codewhisperer/service/inlineCompletion.ts
+++ b/src/codewhisperer/service/inlineCompletion.ts
@@ -19,7 +19,6 @@ import {
     CodewhispererAutomatedTriggerType,
     CodewhispererTriggerType,
 } from '../../shared/telemetry/telemetry'
-import { AuthUtil } from '../util/authUtil'
 
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
@@ -331,10 +330,6 @@ export class InlineCompletion {
         autoTriggerType?: CodewhispererAutomatedTriggerType
     ) {
         const isManualTrigger = triggerType === 'OnDemand'
-        if (AuthUtil.instance.isConnectionExpired()) {
-            await AuthUtil.instance.notifyReauthenticate(!isManualTrigger)
-            return
-        }
         RecommendationHandler.instance.reportUserDecisionOfRecommendation(editor, -1)
         RecommendationHandler.instance.clearRecommendations()
         this.setCodeWhispererStatusBarLoading()
@@ -498,19 +493,11 @@ export class InlineCompletion {
 
     setCodeWhispererStatusBarLoading() {
         this.codewhispererStatusBar.text = ` $(loading~spin)CodeWhisperer`
-        ;(this.codewhispererStatusBar as any).backgroundColor = undefined
         this.codewhispererStatusBar.show()
     }
 
     setCodeWhispererStatusBarOk() {
         this.codewhispererStatusBar.text = ` $(check)CodeWhisperer`
-        ;(this.codewhispererStatusBar as any).backgroundColor = undefined
-        this.codewhispererStatusBar.show()
-    }
-
-    setCodeWhispererStatusBarDisconnected() {
-        this.codewhispererStatusBar.text = ` $(debug-disconnect)CodeWhisperer`
-        ;(this.codewhispererStatusBar as any).backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
         this.codewhispererStatusBar.show()
     }
 

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -18,11 +18,10 @@ import { getLogger } from '../../shared/logger/logger'
 import { TelemetryHelper } from '../util/telemetryHelper'
 import { runtimeLanguageContext } from '../util/runtimeLanguageContext'
 import { Commands } from '../../shared/vscode/commands2'
-import { getPrefixSuffixOverlap, isInlineCompletionEnabled } from '../util/commonUtil'
+import { getPrefixSuffixOverlap } from '../util/commonUtil'
 import globals from '../../shared/extensionGlobals'
 import { AuthUtil } from '../util/authUtil'
 import { shared } from '../../shared/utilities/functionUtils'
-import { InlineCompletion } from './inlineCompletion'
 
 class CWInlineCompletionItemProvider implements vscode.InlineCompletionItemProvider {
     private activeItemIndex: number | undefined
@@ -498,12 +497,8 @@ export class InlineCompletionService {
 
 export const refreshStatusBar = Commands.declare('aws.codeWhisperer.refreshStatusBar', () => () => {
     if (AuthUtil.instance.isConnectionValid()) {
-        isInlineCompletionEnabled()
-            ? InlineCompletionService.instance.setCodeWhispererStatusBarOk()
-            : InlineCompletion.instance.setCodeWhispererStatusBarOk()
+        InlineCompletionService.instance.setCodeWhispererStatusBarOk()
     } else {
-        isInlineCompletionEnabled()
-            ? InlineCompletionService.instance.setCodeWhispererStatusBarDisconnected()
-            : InlineCompletion.instance.setCodeWhispererStatusBarDisconnected()
+        InlineCompletionService.instance.setCodeWhispererStatusBarDisconnected()
     }
 })

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -442,6 +442,7 @@ export class InlineCompletionService {
     setCodeWhispererStatusBarLoading() {
         this._isPaginationRunning = true
         this.statusBar.text = ` $(loading~spin)CodeWhisperer`
+        this.statusBar.command = undefined
         ;(this.statusBar as any).backgroundColor = undefined
         this.statusBar.show()
     }
@@ -449,12 +450,14 @@ export class InlineCompletionService {
     setCodeWhispererStatusBarOk() {
         this._isPaginationRunning = false
         this.statusBar.text = ` $(check)CodeWhisperer`
+        this.statusBar.command = undefined
         ;(this.statusBar as any).backgroundColor = undefined
         this.statusBar.show()
     }
 
     setCodeWhispererStatusBarDisconnected() {
         this.statusBar.text = ` $(debug-disconnect)CodeWhisperer`
+        this.statusBar.command = 'aws.codeWhisperer.reconnect'
         ;(this.statusBar as any).backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
         this.statusBar.show()
     }

--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -55,18 +55,18 @@ export class AuthUtil {
             if (conn?.type === 'sso') {
                 if (this.auth.getConnectionState(conn) === 'valid') {
                     await this.clearAccessToken()
-                    await Promise.all([
-                        vscode.commands.executeCommand('aws.codeWhisperer.refresh'),
-                        vscode.commands.executeCommand('aws.codeWhisperer.refreshRootNode'),
-                        vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar'),
-                        vscode.commands.executeCommand('aws.codeWhisperer.updateReferenceLog'),
-                    ])
                 }
                 this.usingEnterpriseSSO = !isBuilderIdConnection(conn)
             } else {
                 this.usingEnterpriseSSO = false
             }
             TelemetryHelper.instance.startUrl = this.conn?.startUrl
+            await Promise.all([
+                vscode.commands.executeCommand('aws.codeWhisperer.refresh'),
+                vscode.commands.executeCommand('aws.codeWhisperer.refreshRootNode'),
+                vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar'),
+                vscode.commands.executeCommand('aws.codeWhisperer.updateReferenceLog'),
+            ])
         })
 
         Commands.register('aws.codeWhisperer.removeConnection', () => this.secondaryAuth.removeConnection())
@@ -123,13 +123,8 @@ export class AuthUtil {
         if (this.conn === undefined) {
             throw new ToolkitError('No connection found', { code: 'NoConnection' })
         }
-        try {
-            const bearerToken = await this.conn.getToken()
-            return bearerToken.accessToken
-        } catch {
-            await this.refreshCodeWhisperer()
-            return ''
-        }
+        const bearerToken = await this.conn.getToken()
+        return bearerToken.accessToken
     }
 
     public isConnectionValid(): boolean {

--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -153,8 +153,8 @@ export class AuthUtil {
 
     public async showReauthenticatePrompt(isAutoTrigger?: boolean) {
         const settings = PromptSettings.instance
-        const doNotShow = await settings.isPromptEnabled('codeWhispererConnectionExpired')
-        if (doNotShow || (isAutoTrigger && this.reauthenticatePromptShown)) {
+        const shouldShow = await settings.isPromptEnabled('codeWhispererConnectionExpired')
+        if (!shouldShow || (isAutoTrigger && this.reauthenticatePromptShown)) {
             return
         }
         await vscode.window


### PR DESCRIPTION
## Problem
the current UX when user's CW connection expired is confusing. Sometimes they will be waiting for recommendations but don't realize the connection expired.
## Solution
make it more obvious for user when connection is expired:
1.  When it's expired, update the CW node panel and the status bar item to reflect the state.
2. When user manual trigger, they will see prompt to re-authenticate
3. When user type and we are about to auto-trigger, they will see prompt to re-authenticate once(per restart of IDE).

![connection_new](https://user-images.githubusercontent.com/60411978/222807272-a03936df-fc80-42b6-bbcb-a08ba6f908bb.gif)



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
