### PR TITLE
marketplace: add "Code" and "Whisperer" keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
         "AWS",
         "CodeCatalyst",
         "CodeWhisperer",
-        "Lambda",
-        "Serverless"
+        "Code",
+        "Whisperer"
     ],
     "preview": false,
     "qna": "https://github.com/aws/aws-toolkit-vscode/issues",


### PR DESCRIPTION
## Problem:
AWS Toolkit does not appear in VS marketplace searches for "Code Whisperer" (as opposed to "CodeWhisperer"). VS marketplace limits us to 5 keywords.

## Solution:
Replace other keywords with "Code" and "Whisperer".


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
