### PR TITLE
fix(codewhisperer): update the total recommendation count in visual cue

### DIFF
--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -334,6 +334,7 @@ export class InlineCompletionService {
             return
         }
         if (this.isSuggestionVisible()) {
+            // to force refresh the visual cue so that the total recommendation count can be updated
             const index = this.inlineCompletionProvider?.getActiveItemIndex
             await this.showRecommendation(index ? index : 0, true)
             return

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -159,7 +159,7 @@ class CWInlineCompletionItemProvider implements vscode.InlineCompletionItemProvi
         const iteratingIndexes = this.getIteratingIndexes()
         const prefix = document.getText(new vscode.Range(start, end)).replace(/\r\n/g, '\n')
         const matchedCount = RecommendationHandler.instance.recommendations.filter(
-            r => r.content.length > 0 && r.content.startsWith(prefix)
+            r => r.content.length > 0 && r.content.startsWith(prefix) && r.content !== prefix
         ).length
         for (const i of iteratingIndexes) {
             const r = RecommendationHandler.instance.recommendations[i]
@@ -179,7 +179,11 @@ class CWInlineCompletionItemProvider implements vscode.InlineCompletionItemProvi
             TelemetryHelper.instance.tryRecordClientComponentLatency(document.languageId)
             this._onDidShow.fire()
             if (matchedCount >= 2 || RecommendationHandler.instance.hasNextToken()) {
-                return [item, { insertText: 'x' }]
+                const result = [item]
+                for (let j = 0; j < matchedCount - 1; j++) {
+                    result.push({ insertText: `${item.insertText}${j}`, range: item.range })
+                }
+                return result
             }
             return [item]
         }
@@ -326,7 +330,12 @@ export class InlineCompletionService {
 
     async tryShowRecommendation() {
         const editor = vscode.window.activeTextEditor
-        if (this.isSuggestionVisible() || editor === undefined) {
+        if (editor === undefined) {
+            return
+        }
+        if (this.isSuggestionVisible()) {
+            const index = this.inlineCompletionProvider?.getActiveItemIndex
+            await this.showRecommendation(index ? index : 0, true)
             return
         }
         if (


### PR DESCRIPTION
## Problem
the total number of recommendations on the visual cue is not correct due to pagination
## Solution
mitigation to allow the total index to be correct while the long-term fix rely on inline api's support of pagination

https://user-images.githubusercontent.com/60411978/224853441-ecf21063-0f84-4752-934c-03a2593b0e0c.mov



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
