### PR TITLE
auth(IDE-10230): Change OIDC client name to something nicer

### DIFF
--- a/src/credentials/sso/ssoAccessTokenProvider.ts
+++ b/src/credentials/sso/ssoAccessTokenProvider.ts
@@ -165,7 +165,7 @@ export class SsoAccessTokenProvider {
 
     private async registerClient(): Promise<ClientRegistration> {
         return this.oidc.registerClient({
-            clientName: `aws-toolkit-vscode-${globals.clock.Date.now()}`,
+            clientName: `AWS Toolkit for VSCode`,
             clientType: clientRegistrationType,
             scopes: this.profile.scopes,
         })


### PR DESCRIPTION
New name is "AWS Toolkit for VSCode"

BuilderID setup webpage:
<img width="705" alt="Screen Shot 2023-03-14 at 10 58 27 AM" src="https://user-images.githubusercontent.com/118216176/225045093-12963727-df7c-4466-bd19-e53b5db83448.png">


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
