### PR TITLE
auth: prompt existing builder id signout on new builder id

### DIFF
--- a/.changes/next-release/Feature-542918a0-d601-4ab2-9b22-7aa04fdd223f.json
+++ b/.changes/next-release/Feature-542918a0-d601-4ab2-9b22-7aa04fdd223f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Option to sign out of existing Builder ID when adding a new one"
+}

--- a/src/credentials/auth.ts
+++ b/src/credentials/auth.ts
@@ -770,9 +770,7 @@ const switchConnections = Commands.register('aws.auth.switchConnections', (auth:
     }
 })
 
-async function signout(auth: Auth) {
-    const conn = auth.activeConnection
-
+async function signout(auth: Auth, conn: Connection | undefined = auth.activeConnection) {
     if (conn?.type === 'sso') {
         // TODO: does deleting the connection make sense UX-wise?
         // this makes it disappear from the list of available connections
@@ -865,38 +863,53 @@ export async function createStartUrlPrompter(title: string, ignoreScopes = true)
 export async function createBuilderIdConnection(auth: Auth) {
     const newProfile = createBuilderIdProfile()
     const existingConn = (await auth.listConnections()).find(isBuilderIdConnection)
-    if (existingConn && !hasScopes(existingConn, newProfile.scopes)) {
-        return migrateBuilderId(auth, existingConn, newProfile)
+    if (!existingConn) {
+        return auth.createConnection(newProfile)
     }
 
-    return existingConn ?? (await auth.createConnection(newProfile))
+    const userResponse = await promptLogoutExistingBuilderIdConnection()
+    if (userResponse !== 'signout') {
+        throw new CancellationError('user')
+    }
+
+    await signout(auth, existingConn)
+
+    return auth.createConnection(newProfile)
+}
+
+/**
+ * Prompts the user to log out of an existing Builder ID connection.
+ *
+ * @returns The name of the action performed by the user
+ */
+async function promptLogoutExistingBuilderIdConnection(): Promise<'signout' | 'cancel'> {
+    const items: DataQuickPickItem<'signout' | 'cancel'>[] = [
+        {
+            data: 'signout',
+            label: `Currently signed in with ${getIdeProperties().company} Builder ID. Sign out to add another?`,
+            detail: `This will sign out of your current ${
+                getIdeProperties().company
+            } Builder ID and open the sign-in page in browser.`,
+        },
+        { data: 'cancel', label: 'Cancel' },
+    ]
+    const resp = await showQuickPick(items, {
+        title: `Sign in to different ${getIdeProperties().company} Builder ID`,
+        buttons: createCommonButtons() as vscode.QuickInputButton[],
+    })
+
+    return resp === undefined ? 'cancel' : resp
 }
 
 Commands.register('aws.auth.help', async () => {
     vscode.env.openExternal(vscode.Uri.parse(authHelpUrl))
     telemetry.aws_help.emit()
 })
+
 Commands.register('aws.auth.signout', () => {
     telemetry.ui_click.emit({ elementId: 'devtools_signout' })
-
     return signout(Auth.instance)
 })
-
-// XXX: right now users can only have 1 builder id connection, so de-dupe
-// This logic can be removed or re-purposed once we have access to identities
-async function migrateBuilderId(auth: Auth, existingConn: SsoConnection, newProfile: SsoProfile) {
-    const newConn = await auth.createConnection(newProfile)
-    const shouldUseConnection = auth.activeConnection?.id === existingConn.id
-    await auth.deleteConnection(existingConn).catch(err => {
-        getLogger().warn(`auth: failed to remove old connection "${existingConn.id}": %s`, err)
-    })
-
-    if (shouldUseConnection) {
-        return auth.useConnection(newConn)
-    }
-
-    return newConn
-}
 
 const addConnection = Commands.register('aws.auth.addConnection', async () => {
     const c9IamItem = createIamItem()

--- a/src/credentials/auth.ts
+++ b/src/credentials/auth.ts
@@ -199,10 +199,6 @@ export class ProfileStore {
     public async addProfile(id: string, profile: SsoProfile): Promise<StoredProfile<SsoProfile>>
     public async addProfile(id: string, profile: IamProfile): Promise<StoredProfile<IamProfile>>
     public async addProfile(id: string, profile: Profile): Promise<StoredProfile> {
-        if (this.getProfile(id) !== undefined) {
-            throw new Error(`Profile already exists: ${id}`)
-        }
-
         return this.putProfile(id, this.initMetadata(profile))
     }
 

--- a/src/test/credentials/auth.test.ts
+++ b/src/test/credentials/auth.test.ts
@@ -134,9 +134,11 @@ describe('Auth', function () {
         assert.strictEqual(auth.activeConnection, undefined)
     })
 
-    it('throws when creating a duplicate connection', async function () {
-        await auth.createConnection(ssoProfile)
-        await assert.rejects(() => auth.createConnection(ssoProfile))
+    it('does not throw when creating a duplicate connection', async function () {
+        const initialConn = await auth.createConnection({ ...ssoProfile, scopes: ['a'] })
+        const duplicateConn = await auth.createConnection({ ...ssoProfile, scopes: ['b'] })
+        assert.deepStrictEqual(initialConn.scopes, ['a'])
+        assert.deepStrictEqual(duplicateConn.scopes, ['a', 'b'])
     })
 
     it('throws when using an invalid connection that was deleted', async function () {


### PR DESCRIPTION
# Problem:

When a user is already signed in to their Builder ID, but they want to use a different one, they are not able to use a different ID.

This is confusing since nothing happens when they try to add another one.

# Solution:

When attempting to add a new Builder ID but one already exists, this will prompt the user to choose if they wish to sign out of the existing one, and will then complete the builder id verification process.

# Demo
![Kapture 2023-03-14 at 15 21 24](https://user-images.githubusercontent.com/118216176/225114705-216a8fbd-cbbd-4833-8edd-6d3e78b050fb.gif)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
