### PR TITLE
utils: add more functions for working with async iterables

### DIFF
--- a/src/shared/clients/codecatalystClient.ts
+++ b/src/shared/clients/codecatalystClient.ts
@@ -15,7 +15,7 @@ import { Timeout, waitTimeout, waitUntil } from '../utilities/timeoutUtils'
 import { showMessageWithCancel } from '../utilities/messages'
 import { assertHasProps, ClassToInterfaceType, isNonNullable, RequiredProps } from '../utilities/tsUtils'
 import { AsyncCollection, toCollection } from '../utilities/asyncCollection'
-import { pageableToCollection } from '../utilities/collectionUtils'
+import { joinAll, pageableToCollection } from '../utilities/collectionUtils'
 import { DevSettings } from '../settings'
 import { CodeCatalyst } from 'aws-sdk'
 import { ToolkitError } from '../errors'
@@ -451,20 +451,11 @@ class CodeCatalystClientInternal {
     public listResources(resourceType: 'repo'): AsyncCollection<CodeCatalystRepo[]>
     public listResources(resourceType: 'devEnvironment'): AsyncCollection<DevEnvironment[]>
     public listResources(resourceType: CodeCatalystResource['type']): AsyncCollection<CodeCatalystResource[]> {
-        // Don't really want to expose this apart of the `AsyncCollection` API yet
-        // The semantics of concatenating async iterables is rather ambiguous
-        // For example, an array of async iterables can be joined either in-order or out-of-order.
-        // In-order concatenations only makes sense for finite iterables, though I'm unaware of any
-        // convention to declare an iterable to be finite.
         function mapInner<T, U>(
             collection: AsyncCollection<T[]>,
             fn: (element: T) => AsyncCollection<U[]>
         ): AsyncCollection<U[]> {
-            return toCollection(async function* () {
-                for await (const element of await collection.promise()) {
-                    yield* await Promise.all(element.map(e => fn(e).flatten().promise()))
-                }
-            })
+            return toCollection(joinAll(collection.flatten().map(fn)))
         }
 
         switch (resourceType) {

--- a/src/shared/utilities/asyncCollection.ts
+++ b/src/shared/utilities/asyncCollection.ts
@@ -26,6 +26,12 @@ export interface AsyncCollection<T> extends AsyncIterable<T> {
     filter<U extends T>(predicate: (item: T) => boolean): AsyncCollection<U>
 
     /**
+     * Resolves the first element that matches the predicate.
+     */
+    find<U extends T>(predicate: (item: T) => item is U): Promise<U | undefined>
+    find<U extends T>(predicate: (item: T) => boolean): Promise<U | undefined>
+
+    /**
      * Uses only the first 'count' number of values returned by the generator.
      */
     limit(count: number): AsyncCollection<T>
@@ -62,7 +68,19 @@ const asyncCollection = Symbol('asyncCollection')
  * function. That is, any 'final' operation uses its own contextually bound generator function separate from
  * any predecessor collections.
  */
-export function toCollection<T>(generator: () => AsyncGenerator<T, T | undefined | void>): AsyncCollection<T> {
+export function toCollection<T>(iterable: AsyncIterable<T>): AsyncCollection<T>
+export function toCollection<T>(generator: () => AsyncGenerator<T, T | undefined | void>): AsyncCollection<T>
+export function toCollection<T>(
+    generatorOrIterable: (() => AsyncGenerator<T, T | undefined | void>) | AsyncIterable<T>
+): AsyncCollection<T> {
+    const generator = isAsyncIterable(generatorOrIterable)
+        ? async function* () {
+              for await (const val of generatorOrIterable) {
+                  yield val
+              }
+          }
+        : generatorOrIterable
+
     async function* unboxIter() {
         const last = yield* generator()
         if (last !== undefined) {
@@ -76,6 +94,7 @@ export function toCollection<T>(generator: () => AsyncGenerator<T, T | undefined
 
     return Object.assign(iterable, {
         [asyncCollection]: true,
+        find: <U extends T>(predicate: Predicate<T, U>) => find(iterable, predicate),
         flatten: () => toCollection<SafeUnboxIterable<T>>(() => delegateGenerator(generator(), flatten)),
         filter: <U extends T>(predicate: Predicate<T, U>) =>
             toCollection<U>(() => filterGenerator<T, U>(generator(), predicate)),
@@ -90,6 +109,14 @@ export function toCollection<T>(generator: () => AsyncGenerator<T, T | undefined
 
 export function isAsyncCollection<T>(iterable: AsyncIterable<T>): iterable is AsyncCollection<T> {
     return asyncCollection in iterable
+}
+
+function isIterable<T>(obj: any): obj is Iterable<T> {
+    return obj !== undefined && typeof obj[Symbol.iterator] === 'function'
+}
+
+function isAsyncIterable<T>(obj: any): obj is AsyncIterable<T> {
+    return obj && typeof obj === 'object' && typeof obj[Symbol.asyncIterator] === 'function'
 }
 
 async function* mapGenerator<T, U, R = T>(
@@ -162,7 +189,7 @@ async function* delegateGenerator<T, U, R = T>(
 }
 
 async function* flatten<T, U extends SafeUnboxIterable<T>>(item: T) {
-    if (isIterable<U>(item)) {
+    if (isIterable<U>(item) || isAsyncIterable<U>(item)) {
         yield* item
     } else {
         yield item as unknown as U
@@ -181,11 +208,7 @@ function takeFrom<T>(count: number) {
 /**
  * Either 'unbox' an Iterable value or leave it as-is if it's not an Iterable
  */
-type SafeUnboxIterable<T> = T extends Iterable<infer U> ? U : T
-
-export function isIterable<T>(obj: any): obj is Iterable<T> {
-    return obj !== undefined && typeof obj[Symbol.iterator] === 'function'
-}
+type SafeUnboxIterable<T> = T extends Iterable<infer U> ? U : T extends AsyncIterable<infer U> ? U : T
 
 async function promise<T>(iterable: AsyncIterable<T>): Promise<T[]> {
     const result: T[] = []
@@ -224,4 +247,12 @@ async function asyncIterableToMap<T, K extends StringProperty<T>, U extends stri
     }
 
     return result
+}
+
+async function find<T, U extends T>(iterable: AsyncIterable<T>, predicate: (item: T) => item is U) {
+    for await (const item of iterable) {
+        if (predicate(item)) {
+            return item
+        }
+    }
 }

--- a/src/shared/utilities/collectionUtils.ts
+++ b/src/shared/utilities/collectionUtils.ts
@@ -457,7 +457,8 @@ class AsyncIterableCollection<T, U = undefined> {
  * can be in any order.
  */
 export async function* join<T, U>(left: AsyncIterable<T>, right: AsyncIterable<U>): AsyncGenerator<T | U, void> {
-    const iterables = (new AsyncIterableCollection() < T) | (U > iterables.add(left))
+    const iterables = new AsyncIterableCollection<T | U>()
+    iterables.add(left)
     iterables.add(right)
 
     do {


### PR DESCRIPTION
## Problem
It's difficult to orchestrate paginated API calls

## Solution
* Add some extra utility functions combine multiple async iterables into a single iterable
  * Modified CodeCatalyst to use `joinAll` when listing resources
* Minor improvements to `asyncCollection.ts`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
