### PR TITLE
test(integ): fix getDefaultSchemas()

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,7 +119,7 @@ export async function activate(context: vscode.ExtensionContext) {
         globals.loginManager = loginManager
         globals.awsContextCommands = new AwsContextCommands(regionProvider, Auth.instance)
         globals.sdkClientBuilder = new DefaultAWSClientBuilder(awsContext)
-        globals.schemaService = new SchemaService(context)
+        globals.schemaService = new SchemaService()
         globals.resourceManager = new AwsResourceManager(context)
 
         const settings = Settings.instance

--- a/src/integrationTest/schema/schema.test.ts
+++ b/src/integrationTest/schema/schema.test.ts
@@ -67,8 +67,6 @@ describe('Sam Schema Regression', function () {
 })
 
 describe('getDefaultSchemas()', () => {
-    let extensionContext: FakeExtensionContext
-
     beforeEach(async () => {})
 
     it('uses cache on subsequent request for CFN/SAM schema', async () => {

--- a/src/integrationTest/schema/schema.test.ts
+++ b/src/integrationTest/schema/schema.test.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import globals from '../../shared/extensionGlobals'
 import { getDefaultSchemas, samAndCfnSchemaUrl } from '../../shared/schemas'
 import { FakeExtensionContext } from '../../test/fakeExtensionContext'
 import {
@@ -68,12 +69,10 @@ describe('Sam Schema Regression', function () {
 describe('getDefaultSchemas()', () => {
     let extensionContext: FakeExtensionContext
 
-    beforeEach(async () => {
-        extensionContext = await FakeExtensionContext.create()
-    })
+    beforeEach(async () => {})
 
     it('uses cache on subsequent request for CFN/SAM schema', async () => {
-        await getDefaultSchemas(extensionContext)
+        await getDefaultSchemas()
 
         // IMPORTANT: Since CFN and SAM use the same schema, the order their schema is retrieved is irrelevant
 
@@ -92,20 +91,24 @@ describe('getDefaultSchemas()', () => {
     })
 
     it('uses cache for all requests on second function call', async () => {
-        await getDefaultSchemas(extensionContext)
+        globals.telemetry.telemetryEnabled = true
+        globals.telemetry.clearRecords()
+        globals.telemetry.logger.clear()
+
+        await getDefaultSchemas()
         // Call a second time
-        await getDefaultSchemas(extensionContext)
+        await getDefaultSchemas()
 
         // Only cache is used
         assertTelemetry(
             'toolkit_getExternalResource',
             { url: samAndCfnSchemaUrl, passive: true, result: 'Cancelled', reason: 'Cache hit' },
-            2
+            0
         )
         assertTelemetry(
             'toolkit_getExternalResource',
             { url: samAndCfnSchemaUrl, passive: true, result: 'Cancelled', reason: 'Cache hit' },
-            3
+            1
         )
     })
 })

--- a/src/integrationTest/schema/schema.test.ts
+++ b/src/integrationTest/schema/schema.test.ts
@@ -5,7 +5,6 @@
 
 import globals from '../../shared/extensionGlobals'
 import { getDefaultSchemas, samAndCfnSchemaUrl } from '../../shared/schemas'
-import { FakeExtensionContext } from '../../test/fakeExtensionContext'
 import {
     getCITestSchemas,
     JSONObject,

--- a/src/test/shared/schemas.test.ts
+++ b/src/test/shared/schemas.test.ts
@@ -6,7 +6,6 @@
 import * as vscode from 'vscode'
 import * as assert from 'assert'
 import { anything, deepEqual, instance, mock, verify } from '../utilities/mockito'
-import { ExtensionContext } from 'vscode'
 import { YamlExtension } from '../../shared/extensions/yaml'
 import {
     JsonSchemaHandler,
@@ -16,23 +15,20 @@ import {
     SchemaType,
     YamlSchemaHandler,
 } from '../../shared/schemas'
-import { FakeExtensionContext } from '../fakeExtensionContext'
 import { Settings } from '../../shared/settings'
 
 describe('SchemaService', function () {
     let service: SchemaService
-    let fakeExtensionContext: ExtensionContext
     let config: Settings
     let fakeYamlExtension: YamlExtension
     const cfnSchema = vscode.Uri.file('cfn')
     const samSchema = vscode.Uri.file('sam')
 
     beforeEach(async function () {
-        fakeExtensionContext = await FakeExtensionContext.create()
         fakeYamlExtension = mock()
         config = new Settings(vscode.ConfigurationTarget.Workspace)
 
-        service = new SchemaService(fakeExtensionContext, {
+        service = new SchemaService({
             schemas: {
                 cfn: cfnSchema,
                 sam: samSchema,
@@ -105,7 +101,7 @@ describe('SchemaService', function () {
 
     it('processes no updates if schemas are unavailable', async function () {
         fakeYamlExtension = mock()
-        service = new SchemaService(fakeExtensionContext, {
+        service = new SchemaService({
             handlers: new Map<SchemaType, SchemaHandler>([
                 ['json', new JsonSchemaHandler()],
                 ['yaml', new YamlSchemaHandler(instance(fakeYamlExtension))],
@@ -123,7 +119,7 @@ describe('SchemaService', function () {
 
     it('processes no updates if yaml extension unavailable', async function () {
         fakeYamlExtension = mock()
-        service = new SchemaService(fakeExtensionContext)
+        service = new SchemaService()
 
         service.registerMapping({
             uri: vscode.Uri.parse('/foo'),


### PR DESCRIPTION
Problem:
Test fails in CI because of unpredictable telemetry and extension activation.

Solution:
- In test 1: assert telemetry from extension activation.
- In test 2: clear telemetry.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
