### PR TITLE
fix(codewhisperer): bug with right context handling

### DIFF
--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -89,7 +89,7 @@ class CWInlineCompletionItemProvider implements vscode.InlineCompletionItemProvi
 
     truncateOverlapWithRightContext(document: vscode.TextDocument, suggestion: string): string {
         let rightContextRange: vscode.Range | undefined = undefined
-        const pos = RecommendationHandler.instance.startPos
+        const pos = vscode.window.activeTextEditor?.selection.active || RecommendationHandler.instance.startPos
         if (suggestion.split(/\r?\n/).length > 1) {
             rightContextRange = new vscode.Range(pos, document.positionAt(document.offsetAt(pos) + suggestion.length))
         } else {


### PR DESCRIPTION
## Problem
right context handling currently don't take the typeahead into account, which result in some cases are not handled:
<img width="507" alt="Screenshot 2023-03-16 at 9 01 10 AM" src="https://user-images.githubusercontent.com/60411978/225680501-49e60729-4a53-4d0a-9fcf-36bf7f46c4a4.png">
## Solution
update the start position for right context to be the cursor position and fall back to invocation position
<img width="525" alt="Screenshot 2023-03-16 at 9 02 42 AM" src="https://user-images.githubusercontent.com/60411978/225680870-9d4cf74a-1f5e-4ff9-9d0d-3f5de8b2d01c.png">

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
