### PR TITLE
build(stepfunctions): amazon-states-language-service 1.8.0->1.9.0

### DIFF
--- a/.changes/next-release/Bug Fix-9d690880-88ff-4125-859c-22dcc094aa84.json
+++ b/.changes/next-release/Bug Fix-9d690880-88ff-4125-859c-22dcc094aa84.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Update dependency amazon-states-language-service from 1.8.0 -> 1.9.0. This will allow newlines in Step Functions intrinsic functions."
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "@aws-sdk/util-arn-parser": "^3.46.0",
                 "@iarna/toml": "^2.2.5",
                 "adm-zip": "^0.5.9",
-                "amazon-states-language-service": "^1.8.0",
+                "amazon-states-language-service": "^1.9.0",
                 "async-lock": "^1.3.0",
                 "aws-sdk": "^2.1267.0",
                 "aws-ssm-document-language-service": "^1.0.0",
@@ -3851,9 +3851,9 @@
             }
         },
         "node_modules/amazon-states-language-service": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.8.0.tgz",
-            "integrity": "sha512-F5hTDQqAVOYEJCm4PTBf6ZjLQYqzLfnGfyNqxNMTYqilbZk/3T0GQManc0pgt5CbtFw62DB6ovBcEUQQa9xsvA==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.9.0.tgz",
+            "integrity": "sha512-qbqJK1ZE5TUlzk/IANX9EX7oXwP1WYA1mXnOni2GEhkSnhSA14NCbvd9sOwADEPJB7Innwt7RqgVNQGGNz6x1g==",
             "dependencies": {
                 "js-yaml": "^3.14.0",
                 "vscode-json-languageservice": "3.4.9",
@@ -17739,9 +17739,9 @@
             "requires": {}
         },
         "amazon-states-language-service": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.8.0.tgz",
-            "integrity": "sha512-F5hTDQqAVOYEJCm4PTBf6ZjLQYqzLfnGfyNqxNMTYqilbZk/3T0GQManc0pgt5CbtFw62DB6ovBcEUQQa9xsvA==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.9.0.tgz",
+            "integrity": "sha512-qbqJK1ZE5TUlzk/IANX9EX7oXwP1WYA1mXnOni2GEhkSnhSA14NCbvd9sOwADEPJB7Innwt7RqgVNQGGNz6x1g==",
             "requires": {
                 "js-yaml": "^3.14.0",
                 "vscode-json-languageservice": "3.4.9",

--- a/package.json
+++ b/package.json
@@ -3538,7 +3538,7 @@
         "@aws-sdk/util-arn-parser": "^3.46.0",
         "@iarna/toml": "^2.2.5",
         "adm-zip": "^0.5.9",
-        "amazon-states-language-service": "^1.8.0",
+        "amazon-states-language-service": "^1.9.0",
         "async-lock": "^1.3.0",
         "aws-sdk": "^2.1267.0",
         "aws-ssm-document-language-service": "^1.0.0",


### PR DESCRIPTION
## Problem
v1.9.0 of amazon-states-language-service fixes #3068.

## Solution

This new release allows newlines in Step Functions Intrinsic Functions.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
