### PR TITLE
fix(ecs): "Enable Command Execution" shows wrong message

### DIFF
--- a/.changes/next-release/Bug Fix-611d45b0-5a98-4190-9db0-549d561c2200.json
+++ b/.changes/next-release/Bug Fix-611d45b0-5a98-4190-9db0-549d561c2200.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "\"Enable Command Execution\" shows wrong message"
+}

--- a/src/ecs/commands.ts
+++ b/src/ecs/commands.ts
@@ -63,7 +63,7 @@ export async function toggleExecuteCommandFlag(
     const yesDontAskAgain = localize('AWS.message.prompt.yesDontAskAgain', "Yes, don't ask again")
     const no = localize('AWS.generic.response.no', 'No')
 
-    const isNotEnabled = service.description.enableExecuteCommand ?? false
+    const isNotEnabled = !service.description.enableExecuteCommand ?? false
     const prompt = isNotEnabled ? EcsRunCommandPrompt.Enable : EcsRunCommandPrompt.Disable
 
     const warningMessage = isNotEnabled


### PR DESCRIPTION
Problem:
"Enable Command Execution" and "Disable Command Execution" commands show the wrong message.

Solution:
Flip the logic.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
