### PR TITLE
feat(IDE-9298): Dev Env Project Quick Pick selector

### DIFF
--- a/src/codecatalyst/wizards/selectResource.ts
+++ b/src/codecatalyst/wizards/selectResource.ts
@@ -111,10 +111,10 @@ export function createOrgPrompter(
 
 export function createProjectPrompter(
     client: codecatalyst.CodeCatalystClient,
-    org?: codecatalyst.CodeCatalystOrg
+    spaceName?: codecatalyst.CodeCatalystOrg['name']
 ): QuickPickPrompter<codecatalyst.CodeCatalystProject> {
     const helpUri = isCloud9() ? docs.cloud9.main : docs.vscode.main
-    const projects = org ? client.listProjects({ spaceName: org.name }) : client.listResources('project')
+    const projects = spaceName ? client.listProjects({ spaceName }) : client.listResources('project')
 
     return createResourcePrompter(projects, helpUri, {
         title: 'Select a CodeCatalyst Project',


### PR DESCRIPTION
## Problem:

When using the Create Dev Env webview we used
a drop down menu to provide all possible Projects.

The problem is that querying all Projects takes time and nothing would show on the screen for a while.

Additionally, if the user had many projects from
multiple spaces it was not easy to find

## Solution:

Instead of a dropdown menu use an async quick pick which will continuously load new Projects as they
are returned in the the paginated query for all Projects.

- Project loading is started immediately upon the webview loading. This will provide Projects quickly when the quick pick menu is opened
- Along with using a quick pick, the user can easily filter the Projects using the quick picks built in filtering mechanism.
- If the user specifically edits a Project, only Projects from the current space will appear in the quick pick

![Kapture 2023-03-17 at 16 06 14](https://user-images.githubusercontent.com/118216176/226022812-14a947b5-856f-41a0-9aed-58986dc2563e.gif)



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
