### PR TITLE
fix(codecatalyst): fix CC refresh button on some pickers

### DIFF
--- a/src/shared/clients/codecatalystClient.ts
+++ b/src/shared/clients/codecatalystClient.ts
@@ -455,7 +455,7 @@ class CodeCatalystClientInternal {
             collection: AsyncCollection<T[]>,
             fn: (element: T) => AsyncCollection<U[]>
         ): AsyncCollection<U[]> {
-            return toCollection(joinAll(collection.flatten().map(fn)))
+            return toCollection(() => joinAll(collection.flatten().map(fn)))
         }
 
         switch (resourceType) {

--- a/src/shared/utilities/asyncCollection.ts
+++ b/src/shared/utilities/asyncCollection.ts
@@ -68,19 +68,7 @@ const asyncCollection = Symbol('asyncCollection')
  * function. That is, any 'final' operation uses its own contextually bound generator function separate from
  * any predecessor collections.
  */
-export function toCollection<T>(iterable: AsyncIterable<T>): AsyncCollection<T>
-export function toCollection<T>(generator: () => AsyncGenerator<T, T | undefined | void>): AsyncCollection<T>
-export function toCollection<T>(
-    generatorOrIterable: (() => AsyncGenerator<T, T | undefined | void>) | AsyncIterable<T>
-): AsyncCollection<T> {
-    const generator = isAsyncIterable(generatorOrIterable)
-        ? async function* () {
-              for await (const val of generatorOrIterable) {
-                  yield val
-              }
-          }
-        : generatorOrIterable
-
+export function toCollection<T>(generator: () => AsyncGenerator<T, T | undefined | void>): AsyncCollection<T> {
     async function* unboxIter() {
         const last = yield* generator()
         if (last !== undefined) {


### PR DESCRIPTION
## Problem
https://github.com/aws/aws-toolkit-vscode/pull/3234 tried to make things more ergonomic by converting async iterables into async collections implicitly. This does work but unfortunately it consumes the iterable and thus cannot be re-used for things like refreshing

## Solution
* Remove the implicit conversion
* Add regression test

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
