### PR TITLE
test(integ): assert telemetry list

### DIFF
--- a/src/integrationTest/schema/schema.test.ts
+++ b/src/integrationTest/schema/schema.test.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import globals from '../../shared/extensionGlobals'
 import { getDefaultSchemas, samAndCfnSchemaUrl } from '../../shared/schemas'
 import {
     getCITestSchemas,
@@ -65,47 +64,20 @@ describe('Sam Schema Regression', function () {
     })
 })
 
-describe.skip('getDefaultSchemas()', () => {
+describe('getDefaultSchemas()', () => {
     beforeEach(async () => {})
 
-    it('uses cache on subsequent request for CFN/SAM schema', async () => {
+    it('uses cache after initial fetch for CFN/SAM schema', async () => {
         await getDefaultSchemas()
-
-        // IMPORTANT: Since CFN and SAM use the same schema, the order their schema is retrieved is irrelevant
-
-        // Schema is downloaded on initial retrieval
-        assertTelemetry(
-            'toolkit_getExternalResource',
+        await getDefaultSchemas()
+        await getDefaultSchemas()
+        assertTelemetry('toolkit_getExternalResource', [
+            // Initial retrieval.
+            // (Technically, this is done on activation, not any of the getDefaultSchemas() calls above.)
             { url: samAndCfnSchemaUrl, passive: true, result: 'Succeeded' },
-            0
-        )
-        // Schema is retrieved from cache on subsequent retrieval
-        assertTelemetry(
-            'toolkit_getExternalResource',
+            // Use cache after initial fetch.
             { url: samAndCfnSchemaUrl, passive: true, result: 'Cancelled', reason: 'Cache hit' },
-            1
-        )
-    })
-
-    it('uses cache for all requests on second function call', async () => {
-        globals.telemetry.telemetryEnabled = true
-        globals.telemetry.clearRecords()
-        globals.telemetry.logger.clear()
-
-        await getDefaultSchemas()
-        // Call a second time
-        await getDefaultSchemas()
-
-        // Only cache is used
-        assertTelemetry(
-            'toolkit_getExternalResource',
             { url: samAndCfnSchemaUrl, passive: true, result: 'Cancelled', reason: 'Cache hit' },
-            0
-        )
-        assertTelemetry(
-            'toolkit_getExternalResource',
-            { url: samAndCfnSchemaUrl, passive: true, result: 'Cancelled', reason: 'Cache hit' },
-            1
-        )
+        ])
     })
 })

--- a/src/shared/telemetry/telemetryLogger.ts
+++ b/src/shared/telemetry/telemetryLogger.ts
@@ -87,6 +87,10 @@ export class TelemetryLogger {
      * Queries telemetry for metrics, returning the entire structure.
      */
     public queryFull(query: MetricQuery): MetricDatum[] {
+        // const found: MetricDatum[] = []
+        // for (const q of quer) {
+        //     const foo = this._metrics.findIndex
+        // }
         return this._metrics.filter(m => m.MetricName === query.metricName)
     }
 }

--- a/src/test/testUtil.ts
+++ b/src/test/testUtil.ts
@@ -146,46 +146,69 @@ export function getMetrics<K extends MetricName>(
 }
 
 /**
- * Finds the emitted telemetry metric with the given name, then checks if the metadata fields
- * match the expected values. Defaults to checking against the first occurrence, but this
- * can be overidden.
+ * Finds the emitted telemetry metrics with the given `name`, then checks if the metadata fields
+ * match the expected values, in the (non-continguous) order specified by `expected`.
  *
- * @param eventNum The nth occurrence of the event you want to test against, defaults to the first.
+ * @param name Metric name
+ * @param expected Metric(s) shape(s) which are compared _in order_ (non-continguous) to metrics matching `name`.
  */
 export function assertTelemetry<K extends MetricName>(
     name: K,
-    expected: MetricShapes[K],
-    eventNum?: number
+    expected: MetricShapes[K] | MetricShapes[K][]
 ): void | never
 export function assertTelemetry<K extends MetricName>(
     name: K,
-    expected: MetricShapes[MetricName],
-    eventNum?: number
+    expected: MetricShapes[MetricName] | MetricShapes[MetricName][]
 ): void | never
 export function assertTelemetry<K extends MetricName>(
     name: K,
-    expected: MetricShapes[K],
-    eventNum: number = 0
+    expected: MetricShapes[K] | MetricShapes[K][]
 ): void | never {
-    const expectedCopy = { ...expected } as { -readonly [P in keyof MetricShapes[K]]: MetricShapes[K][P] }
-    const passive = expectedCopy?.passive
+    const expectedList = Array.isArray(expected) ? expected : [expected]
     const query = { metricName: name, excludeKeys: ['awsAccount', 'duration'] }
-    delete expectedCopy['passive']
+    let metadata = globals.telemetry.logger.query(query)
+    assert.ok(metadata.length > 0, `telemetry not found for metric name: "${name}"`)
 
-    Object.keys(expectedCopy).forEach(
-        k => ((expectedCopy as any)[k] = (expectedCopy as Record<string, any>)[k]?.toString())
-    )
+    for (let i = 0; i <= expectedList.length; i++) {
+        const metric = expectedList[i]
+        const expectedCopy = { ...metric } as { -readonly [P in keyof MetricShapes[K]]: MetricShapes[K][P] }
+        const passive = expectedCopy?.passive
+        delete expectedCopy['passive']
 
-    // Telemetry client should add awsRegion to all metrics.
-    ;(expectedCopy as any)['awsRegion'] = globals.regionProvider.guessDefaultRegion()
+        Object.keys(expectedCopy).forEach(
+            k => ((expectedCopy as any)[k] = (expectedCopy as Record<string, any>)[k]?.toString())
+        )
 
-    const metadata = globals.telemetry.logger.query(query)
-    assert.ok(metadata.length > 0, `Telemetry did not contain any metrics with the name "${name}"`)
-    assert.deepStrictEqual(metadata[eventNum], expectedCopy)
+        // Telemetry client adds awsRegion to all metrics.
+        ;(expectedCopy as any)['awsRegion'] = globals.regionProvider.guessDefaultRegion()
 
-    if (passive !== undefined) {
-        const metric = globals.telemetry.logger.queryFull(query)
-        assert.strictEqual(metric[0].Passive, passive)
+        if (expectedList.length == 1) {
+            assert.deepStrictEqual(metadata[0], expectedCopy)
+        } else {
+            const found = metadata.findIndex(val => {
+                // Hacky way to "deep compare".
+                try {
+                    assert.deepStrictEqual(val, expectedCopy)
+                } catch (e) {
+                    return false
+                }
+                return true
+            })
+            assert.ok(
+                found >= 0,
+                `telemetry item ${i + 1} (of ${
+                    expectedList.length
+                }) not found (in the expected order) for metric name: "${name}" `
+            )
+            // Remove all items up to the found item, to ensure we are checking the expected _order_.
+            metadata = metadata.splice(found, metadata.length - 1)
+        }
+
+        // Check this explicitly because we deleted it above.
+        if (passive !== undefined) {
+            const metric = globals.telemetry.logger.queryFull(query)
+            assert.strictEqual(metric[0].Passive, passive)
+        }
     }
 }
 


### PR DESCRIPTION
Problem:
Checking a _sequence_ of metrics is awkward, leading to problems like: 9be5bbfcc11e.

Solution:
Enhance assertTelemetry to support checking a sequence.



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
