### PR TITLE
feat(codewhisperer): do not format code on acceptance

### DIFF
--- a/.changes/next-release/Bug Fix-10942e31-b4d4-4eb2-8b12-4c792a831e98.json
+++ b/.changes/next-release/Bug Fix-10942e31-b4d4-4eb2-8b12-4c792a831e98.json
@@ -1,4 +1,0 @@
-{
-	"type": "Bug Fix",
-	"description": "CodeWhisperer won't automatically format code after acceping code suggestions"
-}

--- a/.changes/next-release/Bug Fix-10942e31-b4d4-4eb2-8b12-4c792a831e98.json
+++ b/.changes/next-release/Bug Fix-10942e31-b4d4-4eb2-8b12-4c792a831e98.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeWhisperer won't automatically format code after acceping code suggestions"
+}

--- a/.changes/next-release/Feature-e19735b8-3902-4ace-826f-5809bb6e8b7d.json
+++ b/.changes/next-release/Feature-e19735b8-3902-4ace-826f-5809bb6e8b7d.json
@@ -1,4 +1,4 @@
 {
 	"type": "Feature",
-	"description": "CodeWhisperer won't automatically format code after accepting code suggestions"
+	"description": "CodeWhisperer will no longer automatically format code after accepting code suggestions"
 }

--- a/.changes/next-release/Feature-e19735b8-3902-4ace-826f-5809bb6e8b7d.json
+++ b/.changes/next-release/Feature-e19735b8-3902-4ace-826f-5809bb6e8b7d.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "CodeWhisperer won't automatically format code after accepting code suggestions"
+}

--- a/src/codewhisperer/commands/onInlineAcceptance.ts
+++ b/src/codewhisperer/commands/onInlineAcceptance.ts
@@ -85,8 +85,6 @@ export async function onInlineAcceptance(
             acceptanceEntry.editor,
             acceptanceEntry.acceptIndex
         )
-        // codewhisperer will be doing editing while formatting.
-        // formatting should not trigger auto trigger
         vsCodeState.isCodeWhispererEditing = true
         /**
          * Mitigation to right context handling mainly for auto closing bracket use case

--- a/src/codewhisperer/commands/onInlineAcceptance.ts
+++ b/src/codewhisperer/commands/onInlineAcceptance.ts
@@ -9,8 +9,6 @@ import { vsCodeState, OnRecommendationAcceptanceEntry } from '../models/model'
 import { runtimeLanguageContext } from '../util/runtimeLanguageContext'
 import { CodeWhispererTracker } from '../tracker/codewhispererTracker'
 import { CodeWhispererCodeCoverageTracker } from '../tracker/codewhispererCodeCoverageTracker'
-import { TextEdit, WorkspaceEdit, workspace } from 'vscode'
-import { getTabSizeSetting } from '../../shared/utilities/editorUtilities'
 import { getLogger } from '../../shared/logger/logger'
 import { RecommendationHandler } from '../service/recommendationHandler'
 import { InlineCompletionService } from '../service/inlineCompletionService'
@@ -83,13 +81,12 @@ export async function onInlineAcceptance(
         const languageContext = runtimeLanguageContext.getLanguageContext(acceptanceEntry.editor.document.languageId)
         const start = acceptanceEntry.range.start
         const end = acceptanceEntry.editor.selection.active
-        const languageId = acceptanceEntry.editor.document.languageId
         RecommendationHandler.instance.reportUserDecisionOfRecommendation(
             acceptanceEntry.editor,
             acceptanceEntry.acceptIndex
         )
         // codewhisperer will be doing editing while formatting.
-        // formatting should not trigger consoals auto trigger
+        // formatting should not trigger auto trigger
         vsCodeState.isCodeWhispererEditing = true
         /**
          * Mitigation to right context handling mainly for auto closing bracket use case
@@ -105,29 +102,7 @@ export async function onInlineAcceptance(
         } catch (error) {
             getLogger().error(`${error} in handling right contexts`)
         }
-        try {
-            if (languageId === CodeWhispererConstants.python) {
-                await vscode.commands.executeCommand('editor.action.format')
-            } else {
-                const range = new vscode.Range(start, end)
-                const edits: TextEdit[] | undefined = await vscode.commands.executeCommand(
-                    'vscode.executeFormatRangeProvider',
-                    acceptanceEntry.editor.document.uri,
-                    range,
-                    {
-                        tabSize: getTabSizeSetting(),
-                        insertSpaces: true,
-                    }
-                )
-                if (edits && acceptanceEntry.editor) {
-                    const wEdit = new WorkspaceEdit()
-                    wEdit.set(acceptanceEntry.editor.document.uri, edits)
-                    await workspace.applyEdit(wEdit)
-                }
-            }
-        } finally {
-            vsCodeState.isCodeWhispererEditing = false
-        }
+        vsCodeState.isCodeWhispererEditing = false
 
         CodeWhispererTracker.getTracker().enqueue({
             time: new Date(),

--- a/src/test/codewhisperer/commands/onInlineAcceptance.test.ts
+++ b/src/test/codewhisperer/commands/onInlineAcceptance.test.ts
@@ -46,61 +46,6 @@ describe('onInlineAcceptance', function () {
             assert.ok(spy.calledWith())
         })
 
-        it('Should format python code with command editor.action.format when current active document is python', async function () {
-            const mockEditor = createMockTextEditor()
-            const commandSpy = sinon.spy(vscode.commands, 'executeCommand')
-            const globalState = new FakeMemento()
-            await onInlineAcceptance(
-                {
-                    editor: mockEditor,
-                    range: new vscode.Range(new vscode.Position(1, 0), new vscode.Position(1, 21)),
-                    acceptIndex: 0,
-                    recommendation: "print('Hello World!')",
-                    requestId: '',
-                    sessionId: '',
-                    triggerType: 'OnDemand',
-                    completionType: 'Line',
-                    language: 'python',
-                    references: undefined,
-                },
-                globalState
-            )
-            assert.ok(commandSpy.calledWith('editor.action.format'))
-        })
-
-        it('Should format code selection with command vscode.executeFormatRangeProvider when current active document is not python', async function () {
-            const mockEditor = createMockTextEditor("console.log('Hello')", 'test.js', 'javascript', 1, 0)
-            const commandStub = sinon.stub(vscode.commands, 'executeCommand')
-            const globalState = new FakeMemento()
-            const fakeReferences = [
-                {
-                    message: '',
-                    licenseName: 'MIT',
-                    repository: 'http://github.com/fake',
-                    recommendationContentSpan: {
-                        start: 0,
-                        end: 10,
-                    },
-                },
-            ]
-            await onInlineAcceptance(
-                {
-                    editor: mockEditor,
-                    range: new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 27)),
-                    acceptIndex: 0,
-                    recommendation: "console.log('Hello World!')",
-                    requestId: '',
-                    sessionId: '',
-                    triggerType: 'OnDemand',
-                    completionType: 'Line',
-                    language: 'javascript',
-                    references: fakeReferences,
-                },
-                globalState
-            )
-            assert.ok(commandStub.calledWith('vscode.executeFormatRangeProvider'))
-        })
-
         it('Should report telemetry that records this user decision event', async function () {
             const mockEditor = createMockTextEditor()
             RecommendationHandler.instance.requestId = 'test'


### PR DESCRIPTION
## Problem
we received user feedback on not wanting CodeWhisperer to format their documents
## Solution
don't automatically format user's code on acceptance
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
