### PR TITLE
fix(codecatalyst): DevEnv connect sometimes fails

### DIFF
--- a/.changes/next-release/Bug Fix-3732d82a-1e83-45c8-a5b8-4a927d6e7418.json
+++ b/.changes/next-release/Bug Fix-3732d82a-1e83-45c8-a5b8-4a927d6e7418.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeCatalyst: connecting to a Dev Environment while it is updating sometimes fails"
+}


### PR DESCRIPTION
Problem:
- Connecting to a CodeCatalyst DevEnv sometimes fails.
- After doing "Update" on a connected DevEnv, polling may fail with this service error:
  ```
  [ERROR]: aws.codecatalyst.openDevEnv: [ConflictException: Cannot start Dev Environment because update process is still going on
  ```

Solution:
- Catch `ConflictException` and continue waiting.
- If the DevEnv transitions from STARTING > STOPPING, wait for STARTING a bit before giving up.
- Log state transitions for visibility: 
  ```
  2023-… [DEBUG]: devenv not started, waiting (time: 18.023 s): 9981abbc-87f6-4c28- / [ STOPPED/4956ms STARTING/11974ms]
  ...
  2023-… [DEBUG]: devenv not started, waiting (time: 41.723 s): 9981abbc-87f6-4c28- / [ STOPPED/4956ms STARTING/35674ms]
  2023-… [DEBUG]: devenv not started, waiting (time: 65.485 s): 9981abbc-87f6-4c28- / [ STOPPED/4956ms STARTING/59436ms]
  2023-… [INFO]: devenv started after 66.572 s: 9981abbc-87f6-4c28- / [ STOPPED/4956ms STARTING/60523ms RUNNING/1ms]
  ```

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
