### PR TITLE
fix(codecatalyst): Disable new branch name for 3p repo

### DIFF
--- a/.changes/next-release/Bug Fix-c6fcd706-c5dc-4041-9fac-9260bd9994dd.json
+++ b/.changes/next-release/Bug Fix-c6fcd706-c5dc-4041-9fac-9260bd9994dd.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Disable new branch option when creating new dev env for linked repo"
+	"description": "CodeCatalyst: Disable new branch option when creating new Dev Environment for linked repo"
 }

--- a/.changes/next-release/Bug Fix-c6fcd706-c5dc-4041-9fac-9260bd9994dd.json
+++ b/.changes/next-release/Bug Fix-c6fcd706-c5dc-4041-9fac-9260bd9994dd.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Disable new branch option when creating new dev env for linked repo"
+}

--- a/.changes/next-release/Bug Fix-cd02d5c6-a80d-4e99-a1c9-16699843db88.json
+++ b/.changes/next-release/Bug Fix-cd02d5c6-a80d-4e99-a1c9-16699843db88.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Show only internal CodeCatalyst repos when trying to clone"
+	"description": "CodeCatalyst: `Clone CodeCatalyst Repository` command now only lists non-linked repos"
 }

--- a/.changes/next-release/Bug Fix-cd02d5c6-a80d-4e99-a1c9-16699843db88.json
+++ b/.changes/next-release/Bug Fix-cd02d5c6-a80d-4e99-a1c9-16699843db88.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Show only internal CodeCatalyst repos when trying to clone"
+}

--- a/src/codecatalyst/vue/create/backend.ts
+++ b/src/codecatalyst/vue/create/backend.ts
@@ -26,6 +26,7 @@ import {
     CodeCatalystProject,
     CodeCatalystClient,
     DevEnvironment,
+    isThirdPartyRepo,
 } from '../../../shared/clients/codecatalystClient'
 import { CancellationError } from '../../../shared/utilities/timeoutUtils'
 import { isCloud9 } from '../../../shared/extensionUtilities'
@@ -34,6 +35,7 @@ import { isNonNullable } from '../../../shared/utilities/tsUtils'
 import { recordSource } from '../../utils'
 import { QuickPickPrompter } from '../../../shared/ui/pickerPrompter'
 import { createProjectPrompter } from '../../wizards/selectResource'
+import { GetSourceRepositoryCloneUrlsRequest } from 'aws-sdk/clients/codecatalyst'
 
 interface LinkedResponse {
     readonly type: 'linked'
@@ -120,6 +122,10 @@ export class CodeCatalystCreateWebview extends VueWebview {
         )
 
         return branches.flatten().promise()
+    }
+
+    public isThirdPartyRepo(codeCatalystRepo: GetSourceRepositoryCloneUrlsRequest): Promise<boolean> {
+        return isThirdPartyRepo(this.client, codeCatalystRepo)
     }
 
     public getAllInstanceDescriptions() {

--- a/src/codecatalyst/vue/create/source.vue
+++ b/src/codecatalyst/vue/create/source.vue
@@ -51,12 +51,13 @@
             <!-- New Branch -->
             <span class="flex-sizing">
                 <label class="options-label soft mb-8" style="display: block" for="branch-input"
-                    >Optional - Create a Branch from an Existing Branch</label
+                    >Create Branch - Optional for CodeCatalyst Repos</label
                 >
                 <input
                     id="branch-input"
                     type="text"
-                    placeholder="branch-name"
+                    :placeholder="newBranchNamePlaceholder"
+                    :disabled="!newBranchNameAllowed"
                     v-model="model.newBranch"
                     @input="update"
                 />
@@ -116,6 +117,8 @@ export default defineComponent({
             branches: {} as Record<string, CodeCatalystBranch[] | undefined>,
             loadingProjects: false,
             loadingBranches: {} as Record<string, boolean | undefined>,
+            newBranchNameAllowed: false,
+            newBranchNamePlaceholder: 'Select branch first...',
         }
     },
     async created() {
@@ -131,6 +134,40 @@ export default defineComponent({
                     this.loadingBranches[project.name] = false
                 })
                 this.useFirstBranch()
+            }
+        },
+        async 'model.selectedBranch'(branch?: CodeCatalystBranch) {
+            if (this.model.type !== 'linked' || branch === undefined) {
+                this.newBranchNameAllowed = false
+                this.newBranchNamePlaceholder = ''
+                return
+            }
+
+            // Disable user input for new branch name while calculating
+            this.newBranchNameAllowed = false
+            this.newBranchNamePlaceholder = 'Loading...'
+
+            // Clear the existing new branch value so user does not see it
+            const previousNewBranch = this.model.newBranch
+            this.$emit('update:modelValue', { ...this.model, newBranch: undefined })
+
+            // Only want to allow users to set a branch name if first party repo
+            const isThirdPartyRepo = await client.isThirdPartyRepo({
+                spaceName: branch.org.name,
+                projectName: branch.project.name,
+                sourceRepositoryName: branch.repo.name,
+            })
+            if (isThirdPartyRepo) {
+                this.newBranchNamePlaceholder = 'Not Applicable for Linked Repo'
+                this.newBranchNameAllowed = false
+                // Clear the new branch in case one was already selected
+                this.$emit('update:modelValue', { ...this.model, newBranch: undefined })
+            } else {
+                // First Party
+                this.newBranchNamePlaceholder = 'branch-name'
+                this.newBranchNameAllowed = true
+                // Since this can have a new branch, set this back to what it previously was
+                this.$emit('update:modelValue', { ...this.model, newBranch: previousNewBranch })
             }
         },
     },

--- a/src/shared/clients/codecatalystClient.ts
+++ b/src/shared/clients/codecatalystClient.ts
@@ -745,7 +745,7 @@ export async function excludeThirdPartyRepos(
  *
  * 1P is CodeCatalyst, 3P is something like Github.
  */
-async function isThirdPartyRepo(
+export async function isThirdPartyRepo(
     client: CodeCatalystClient,
     codeCatalystRepo: GetSourceRepositoryCloneUrlsRequest
 ): Promise<boolean> {


### PR DESCRIPTION
 ## Problem:
    
When creating a new Dev Env in the webview, users
have the option to create a new branch name from a
linked repo.

The issue though is we are not able to create a new
branch name for third party (github) repos.

## Solution:

Do not allow input of a new branch name when the selected
branch is from a third party repo.

Fixes IDE-10216

- This allows input from the user only when necessary
- Otherwise input is disabled
- Verifies if new branch is allowed once a user selects
  an existing branch

![Kapture 2023-03-21 at 17 17 32](https://user-images.githubusercontent.com/118216176/226743325-acecdaa2-9fa0-4fb2-8304-f8b7c4a6a573.gif)

# Updated

When user selects a 3P repo, they cannot enter a new branch name:
![Screen Shot 2023-03-22 at 5 02 18 PM](https://user-images.githubusercontent.com/118216176/227037491-8958329a-fccc-474f-a998-23ddeb74f246.png)


Signed-off-by: Nikolas Komonen <nkomonen@amazon.com>
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
