### PR TITLE
feat(codecatalyst): increase DevEnv connect timeout

### DIFF
--- a/.changes/next-release/Feature-9a4d4d77-3755-492f-b016-963744e61b81.json
+++ b/.changes/next-release/Feature-9a4d4d77-3755-492f-b016-963744e61b81.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "CodeCatalyst: wait up to 1 hour (instead of 3 minutes) for Dev Environment to start"
+}

--- a/src/shared/clients/codecatalystClient.ts
+++ b/src/shared/clients/codecatalystClient.ts
@@ -559,7 +559,7 @@ class CodeCatalystClientInternal {
     public async startDevEnvironmentWithProgress(
         args: CodeCatalyst.StartDevEnvironmentRequest,
         status: string,
-        timeout: Timeout = new Timeout(180000)
+        timeout: Timeout = new Timeout(1000 * 60 * 60)
     ): Promise<DevEnvironment> {
         // Track the status changes chronologically so that we can
         // 1. reason about hysterisis (weird flip-flops)

--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -37,8 +37,6 @@ interface TypedCancellationToken extends CancellationToken {
 /**
  * Timeout that can handle both cancellation token-style and time limit-style timeout situations. Timeouts
  * cannot be used after 'complete' has been called or if the Timeout expired.
- *
- * @param timeoutLength Length of timeout duration (in ms)
  */
 export class Timeout {
     private _startTime: number
@@ -51,6 +49,9 @@ export class Timeout {
     private readonly _onCompletionEmitter = new EventEmitter<void>()
     public readonly onCompletion = this._onCompletionEmitter.event
 
+    /**
+     * @param timeoutLength Timeout duration (in ms)
+     */
     public constructor(timeoutLength: number) {
         this._startTime = globals.clock.Date.now()
         this._endTime = this._startTime + timeoutLength


### PR DESCRIPTION
## Problem

3 minutes is not long enough time to wait for a Dev Env to connect.

## Solution

Increase to 1 hour.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
