### PR TITLE
fix(codecatalyst): Create dev env quick pick from empty

### DIFF
--- a/src/codecatalyst/vue/create/source.vue
+++ b/src/codecatalyst/vue/create/source.vue
@@ -68,15 +68,23 @@
     </div>
 
     <div class="source-pickers" v-if="model.type === 'none'">
-        <span style="width: 100%">
-            <label class="option-label soft">Project</label>
-            <select class="picker" v-model="model.selectedProject" @input="update">
-                <option disabled :value="undefined">{{ loadingProjects ? 'Loading...' : 'Select a project' }}</option>
-                <option v-for="project in projects" :key="project.name" :value="project">
-                    {{ `${project.org.name} / ${project.name}` }}
-                </option>
-            </select>
-        </span>
+        <div class="modes flex-sizing mt-16">
+            <span class="flex-sizing mt-8">
+                <label class="option-label soft">Space</label>
+                <button class="project-button" @click="quickPickProject()">
+                    {{ selectedSpaceName }}
+                    <span class="icon icon-lg icon-vscode-edit edit-icon"></span>
+                </button>
+            </span>
+
+            <span class="flex-sizing mt-8">
+                <label class="option-label soft">Project</label>
+                <button class="project-button" @click="quickPickProject(model.selectedProject?.org.name)">
+                    {{ selectedProjectName }}
+                    <span class="icon icon-lg icon-vscode-edit edit-icon"></span>
+                </button>
+            </span>
+        </div>
     </div>
 </template>
 


### PR DESCRIPTION
## Problem:

From a recent change we added a quick pick to select a project when creating a dev env.

But the quick pick code was not replicated if you selected "Create an empty Dev Environment",
it was only done "Use an existing CodeCatalyst repository"

## Solution:

Swap the old dropdown menu code with the existing
quick pick code.

Now to new quickpick style of selecting a project will work

### Before:
![image](https://user-images.githubusercontent.com/118216176/227589087-ccfdd2ca-40d3-43c7-96c1-93acdc2ebbf5.png)

### After:
![Screen Shot 2023-03-24 at 12 48 58 PM](https://user-images.githubusercontent.com/118216176/227589427-250dd73f-86a1-49eb-8ff0-49bd5be1104a.png)





<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
