### PR TITLE
fix(s3): file system provider is not case-sensitive

### DIFF
--- a/src/s3/activation.ts
+++ b/src/s3/activation.ts
@@ -39,8 +39,8 @@ export async function activate(ctx: ExtContext): Promise<void> {
 
     ctx.extensionContext.subscriptions.push(manager)
     ctx.extensionContext.subscriptions.push(
-        vscode.workspace.registerFileSystemProvider(s3EditScheme, fs),
-        vscode.workspace.registerFileSystemProvider(s3ReadScheme, fs, { isReadonly: true }),
+        vscode.workspace.registerFileSystemProvider(s3EditScheme, fs, { isCaseSensitive: true }),
+        vscode.workspace.registerFileSystemProvider(s3ReadScheme, fs, { isReadonly: true, isCaseSensitive: true }),
         Commands.register('aws.s3.copyPath', async (node: S3FolderNode | S3FileNode) => {
             await copyPathCommand(node)
         }),


### PR DESCRIPTION
## Problem:

When the s3 file system provider was registered it was not set to be case sensitive. So paths like
`/aws/Test/temp.json` and `/aws/test/temp.json` were
seen as the same thing.

## Solution:

Set the case sensitive flag when registering the
file system provider so that it will uniquely
identify files with the same text but different
case sensitivity.

Fixes #3276 

### Additional Info

Before setting case sensitivity, this line would return an existing text document instead of a new one (that had a different case). It was the hint that VSCode was handling it different from our expectations.
https://github.com/aws/aws-toolkit-vscode/blob/3a22329dbc6d1eb819a65ea6ef84599f24d2cb48/src/s3/fileViewerManager.ts#L171

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
