### PR TITLE
fix(codecatalyst): create dev env branch selection width

### DIFF
--- a/src/codecatalyst/vue/create/source.vue
+++ b/src/codecatalyst/vue/create/source.vue
@@ -265,6 +265,8 @@ export default defineComponent({
 <style scope>
 .picker {
     min-width: 300px;
+    width: 100%;
+    box-sizing: border-box;
 }
 
 .source-pickers {
@@ -315,6 +317,8 @@ body.vscode-light .mode-container[data-disabled='true'] .config-item {
 
 #branch-input {
     min-width: 300px;
+    width: 100%;
+    box-sizing: border-box;
 }
 
 .project-button {


### PR DESCRIPTION
## Problem:

When there was an existing branch with a very long name, the width of the input box would mess up the UI.

## Solution:

Fix how the widths work for the branch selectiong/naming input boxes.

Fixes IDE-10388

### Before:
![image](https://user-images.githubusercontent.com/118216176/228079834-71312480-2f0d-4efe-a00c-2a97731178b9.png)

### After:
![Kapture 2023-03-27 at 18 16 07](https://user-images.githubusercontent.com/118216176/228079738-4cebc208-44d2-439a-9f94-64d9b90a9c0f.gif)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
