### PR TITLE
feat(cwl): Remember previous selection for search/filter

### DIFF
--- a/src/cloudWatchLogs/changeLogSearch.ts
+++ b/src/cloudWatchLogs/changeLogSearch.ts
@@ -38,7 +38,8 @@ export async function getNewData(
         case 'filterPattern':
             newPattern = await showInputBox({
                 title: oldData.logGroupInfo.streamName ? 'Filter Log Stream' : 'Search Log Group',
-                placeholder: oldData.parameters.filterPattern ?? 'Enter Text Here',
+                placeholder: 'Enter Text Here',
+                value: oldData.parameters.filterPattern ?? undefined,
             })
             if (newPattern === undefined) {
                 return
@@ -47,7 +48,7 @@ export async function getNewData(
             break
 
         case 'timeFilter':
-            newTimeRange = (await new TimeFilterSubmenu().prompt()) as TimeFilterResponse
+            newTimeRange = (await new TimeFilterSubmenu(oldData.parameters).prompt()) as TimeFilterResponse
             if (newTimeRange === undefined) {
                 return
             }


### PR DESCRIPTION
## Problem:

To search a CWL log group you must enter a date
range, and an optional string to filter the
event text.

Once openend there are buttons in the editor/title that are the calendar and magnifying glass.

If you click on one of these you can re-adjust their value through a quickpick/input prompter.

The problem is that users cannot see what they previously selected, it is not that good for UX

## Solution:

When the user attempts to re-adjust their previous selection, autofill the previous values in the prompter so they can see what they previously chose.

### Before 
![BeforeCwl](https://user-images.githubusercontent.com/118216176/228324513-92e84a32-2e5f-448e-b14b-e1043348736d.gif)

### After
Notice how `Last 12 Hours` and `Hello` are autofilled once I go to re-adjust the values.

![AfterCwl](https://user-images.githubusercontent.com/118216176/228324562-b115932b-afb2-4506-bdf0-d31669738c36.gif)

Fixes IDE-8248

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
