### PR TITLE
fix(codecatalyst): DevEnv connect sometimes fails

### DIFF
--- a/.changes/next-release/Feature-757720a7-873c-43b8-bad6-b82db3b7f211.json
+++ b/.changes/next-release/Feature-757720a7-873c-43b8-bad6-b82db3b7f211.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "CodeCatalyst: retry connection to \"FAILED\" Dev Environments"
+}

--- a/.changes/next-release/Feature-901c2c8e-af73-4265-863c-cb68c8cd3804.json
+++ b/.changes/next-release/Feature-901c2c8e-af73-4265-863c-cb68c8cd3804.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "CodeCatalyst: improved messages and logging when connecting to Dev Environment"
+}

--- a/src/codecatalyst/model.ts
+++ b/src/codecatalyst/model.ts
@@ -190,14 +190,11 @@ export async function prepareDevEnvConnection(
     { topic, timeout }: { topic?: string; timeout?: Timeout } = {}
 ): Promise<DevEnvConnection> {
     const { ssm, vsc, ssh } = (await ensureDependencies()).unwrap()
-    const runningDevEnv = await client.startDevEnvironmentWithProgress(
-        {
-            id,
-            spaceName: org.name,
-            projectName: project.name,
-        },
-        'RUNNING'
-    )
+    const runningDevEnv = await client.startDevEnvironmentWithProgress({
+        id,
+        spaceName: org.name,
+        projectName: project.name,
+    })
 
     const hostname = getHostNameFromEnv({ id, org, project })
     const logPrefix = topic ? `codecatalyst ${topic} (${id})` : `codecatalyst (${id})`

--- a/src/shared/clients/codecatalystClient.ts
+++ b/src/shared/clients/codecatalystClient.ts
@@ -665,7 +665,7 @@ class CodeCatalystClientInternal {
                 }
 
                 const lastStatus = statuses[statuses.length - 1]
-                const elapsed = Date.now() - item.start
+                const elapsed = Date.now() - lastStatus.start
                 const resp = await this.getDevEnvironment(args)
                 alias = resp.alias
 

--- a/src/shared/clients/codecatalystClient.ts
+++ b/src/shared/clients/codecatalystClient.ts
@@ -625,7 +625,9 @@ class CodeCatalystClientInternal {
         }
 
         const doLog = (kind: 'debug' | 'error' | 'info', msg: string) => {
-            const fmt = `${msg} (time: %ds${startAttempts <= 1 ? '' : ', startAttempts: ' + startAttempts}): %s %s`
+            const fmt = `${msg} (time: %ds${
+                startAttempts <= 1 ? '' : ', startAttempts: ' + startAttempts.toString()
+            }): %s %s`
             if (kind === 'debug') {
                 this.log.debug(fmt, timeout.elapsedTime / 1000, getName(), statusesToString())
             } else if (kind === 'error') {

--- a/src/shared/clients/codecatalystClient.ts
+++ b/src/shared/clients/codecatalystClient.ts
@@ -675,10 +675,10 @@ class CodeCatalystClientInternal {
                     lastStatus &&
                     ['STOPPED', 'FAILED'].includes(lastStatus.status) &&
                     ['STOPPED', 'FAILED'].includes(resp.status) &&
-                    elapsed > 10000 &&
+                    elapsed > 60000 &&
                     startAttempts > 2
                 ) {
-                    // If still STOPPED/FAILED after 10+ seconds, don't keep retrying for 1 hour...
+                    // If still STOPPED/FAILED after 60+ seconds, don't keep retrying for 1 hour...
                     throw new ToolkitError(failedStartMsg(), { code: 'FailedDevEnv' })
                 } else if (['STOPPED', 'FAILED'].includes(resp.status)) {
                     progress.report({


### PR DESCRIPTION
Problem:
Toolkit may fail to connect to FAILED DevEnvs (or potentially other states).

Solution:

- Always try to start DevEnv, regardless of its current or previous state(s).
- Improve logging.
  ```
  … [DEBUG]: devenv not started, waiting (time: 1.641s): d8d8eecf-809d-4f35-… [FAILED/0ms]
  … [ERROR]: devenv failed to start (time: 15.603s, startAttempts: 3): d8d8eecf-809d-4f35-… [FAILED/13963ms]
  … [INFO]: Command: (not started) [ssh -G aws-devenv-test] (running processes: 0)
  … [DEBUG]: devenv not started, waiting (time: 1.318s): d8d8eecf-809d-4f35-… [FAILED/0ms]
  … [INFO]: devenv failed to start (user cancelled) (time: 8.571s, startAttempts: 2): d8d8eecf-809d-4f35-… [FAILED/7256ms]
  … [INFO]: Command: (not started) [ssh -G aws-devenv-test] (running processes: 0)
  … [DEBUG]: devenv not started, waiting (time: 1.287s): jmk-mar24 [STOPPED/0ms]
  … [DEBUG]: devenv not started, waiting (time: 6.904s): jmk-mar24 [STOPPED/5617ms STARTING/0ms]
  … [INFO]: devenv failed to start (user cancelled) (time: 13.327s): jmk-mar24 [STOPPED/5617ms STARTING/6425ms]
  … [INFO]: Command: (not started) [ssh -G aws-devenv-test] (running processes: 0)
  … [DEBUG]: devenv not started, waiting (time: 1.333s): jmk-mar24 [STARTING/1ms]
  … [DEBUG]: devenv not started, waiting (time: 30.994s): jmk-mar24 [STARTING/29662ms RUNNING/0ms]
  … [INFO]: devenv started (time: 30.995s): jmk-mar24 [STARTING/29662ms RUNNING/2187ms]
  ```


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
