### PR TITLE
fix(codecatalyst): Dev Env Space quick pick shows all Spaces + Projects

### DIFF
--- a/.changes/next-release/Bug Fix-132bdce0-d348-4c2b-bb87-5630a54a22d4.json
+++ b/.changes/next-release/Bug Fix-132bdce0-d348-4c2b-bb87-5630a54a22d4.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Dev Env Space quick pick shows all Spaces + Projects"
+}

--- a/src/testE2E/codecatalyst/client.test.ts
+++ b/src/testE2E/codecatalyst/client.test.ts
@@ -117,6 +117,7 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
             const emptyDevEnvSettings = buildDevEnvSettings()
             const emptyDevEnv = await webviewClient.createDevEnvOfType(emptyDevEnvSettings, {
                 type: 'none',
+                selectedSpace: { name: spaceName },
                 selectedProject: { name: projectName, org: { name: spaceName }, type: 'project' },
             })
             assert.strictEqual(emptyDevEnv.project.name, projectName)
@@ -128,6 +129,7 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
 
             const actualDevEnv = await webviewClient.createDevEnvOfType(differentDevEnvSettings, {
                 type: 'none',
+                selectedSpace: { name: spaceName },
                 selectedProject: { name: projectName, org: { name: spaceName }, type: 'project' },
             })
 
@@ -202,6 +204,7 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
             // Create multiple Dev Envs
             const projectSource: SourceResponse = {
                 type: 'none',
+                selectedSpace: { name: spaceName },
                 selectedProject: { name: isolatedProjectName, org: { name: spaceName }, type: 'project' },
             }
             const createdDevEnvs = await Promise.all([


### PR DESCRIPTION
## Problem:

When selecting a Space while creating a Dev Env, the user sees a quick pick of all Spaces + Projects.

## Solution:

When the user selects a Space, show only the Space names.

## Additional:

- The Project is disabled until a Space is chosen
- Upon initial loading of the webview, Space names are pre-loaded
- Upon selection of a Space, Projects are pre-loaded before the user clicks the 'edit' icon on a Project

![Kapture 2023-03-29 at 16 39 59](https://user-images.githubusercontent.com/118216176/228662355-e018a3b0-dd1f-44c1-a311-1aab0075a437.gif)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
