### PR TITLE
dev: custom logfile path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,6 +236,18 @@ Toolkit for testing and development purposes. To use a setting just add it to
 your `settings.json`. At runtime, if the Toolkit reads any of these settings,
 the "AWS" statusbar item will [change its color](https://github.com/aws/aws-toolkit-vscode/blob/479b9d45b5f5ad30fc10567e649b59801053aeba/src/credentials/awsCredentialsStatusBarItem.ts#L45). Use the setting `aws.dev.forceDevMode` to trigger this effect on start-up.
 
+### Logging
+
+The `aws.dev.logfile` setting allows you to set the path of the logfile. This makes it easy to
+follow and filter the logfile using shell tools like `tail` and `grep`. For example in
+settings.json,
+
+    "aws.dev.logfile": "~/awstoolkit.log",
+
+then following the log with:
+
+    tail -F ~/awstoolkit.log
+
 ### Service Endpoints
 
 Endpoint overrides can be set per-service using the `aws.dev.endpoints` settings. This is a JSON object where each key is the service ID (case-insensitive) and each value is the endpoint. Refer to the SDK [API models](https://github.com/aws/aws-sdk-js/tree/master/apis) to find relevant service IDs.

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -7,7 +7,6 @@ import * as vscode from 'vscode'
 
 import { isCloud9 } from './extensionUtilities'
 
-export const extensionSettingsPrefix = 'aws'
 export const regionSettingKey = 'region'
 export const profileSettingKey = 'profile'
 export const productName: string = 'aws-toolkit-vscode'

--- a/src/shared/logger/activation.ts
+++ b/src/shared/logger/activation.ts
@@ -9,7 +9,6 @@ import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 import * as fs from 'fs-extra'
 import { Logger, LogLevel, getLogger } from '.'
-import { extensionSettingsPrefix } from '../constants'
 import { setLogger } from './logger'
 import { logOutputChannel } from './outputChannel'
 import { WinstonToolkitLogger } from './winstonToolkitLogger'
@@ -18,6 +17,7 @@ import { cleanLogFiles } from './util'
 import { Settings } from '../settings'
 import { Logging } from './commands'
 import { SystemUtilities } from '../systemUtilities'
+import { resolvePath } from '../utilities/pathUtils'
 
 const localize = nls.loadMessageBundle()
 
@@ -31,7 +31,11 @@ export async function activate(
     outputChannel: vscode.OutputChannel
 ): Promise<void> {
     const chan = logOutputChannel
-    const logUri = vscode.Uri.joinPath(extensionContext.logUri, makeLogFilename())
+    const settings = Settings.instance.getSection('aws')
+    const devLogfile = settings.get('dev.logfile', '')
+    const logUri = devLogfile
+        ? vscode.Uri.file(resolvePath(devLogfile))
+        : vscode.Uri.joinPath(extensionContext.logUri, makeLogFilename())
 
     await SystemUtilities.createDirectory(extensionContext.logUri)
 
@@ -139,8 +143,7 @@ export function makeLogger(
 }
 
 function getLogLevel(): LogLevel {
-    const configuration = Settings.instance.getSection(extensionSettingsPrefix)
-
+    const configuration = Settings.instance.getSection('aws')
     return configuration.get('logLevel', defaultLogLevel)
 }
 

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -539,6 +539,7 @@ export class Experiments extends Settings.define(
 }
 
 const devSettings = {
+    logfile: String,
     forceCloud9: Boolean,
     forceDevMode: Boolean,
     forceInstallTools: Boolean,

--- a/src/shared/utilities/pathUtils.ts
+++ b/src/shared/utilities/pathUtils.ts
@@ -8,6 +8,19 @@ import * as _path from 'path'
 
 export const driveLetterRegex = /^[a-zA-Z]\:/
 
+/**
+ * Expands "~" at the start of `fname` to user home dir.
+ * TODO: expand env vars too.
+ */
+export function resolvePath(fname: string) {
+    const homedir = os.homedir()
+    if (fname.startsWith('~/') || fname.startsWith('~\\')) {
+        return _path.join(homedir, fname.substring(2))
+    }
+
+    return fname
+}
+
 function isUncPath(path: string) {
     return /^\s*[\/\\]{2}[^\/\\]+/.test(path)
 }


### PR DESCRIPTION
Problem:
vscode always changes the logfile location, so following it with "tail -F" is not easy.

Solution:
Introduce setting "aws.dev.logfile" which sets a fixed logfile path.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
