### PR TITLE
fix(codecatalyst): disallow non-vscode Dev Environment

### DIFF
--- a/.changes/next-release/Bug Fix-5ec947ce-d7aa-439a-b77c-110a309bcc00.json
+++ b/.changes/next-release/Bug Fix-5ec947ce-d7aa-439a-b77c-110a309bcc00.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeCatalyst: Toolkit attempts reconnect to non-vscode Dev Environment"
+}

--- a/src/codecatalyst/devfile.ts
+++ b/src/codecatalyst/devfile.ts
@@ -16,7 +16,7 @@ import { checkUnsavedChanges } from '../shared/utilities/workspaceUtils'
 import { ToolkitError } from '../shared/errors'
 
 async function updateDevfile(uri: vscode.Uri): Promise<void> {
-    const client = new DevEnvClient()
+    const client = DevEnvClient.instance
     if (!client.isCodeCatalystDevEnv()) {
         throw new Error('Cannot update devfile outside a Dev Environment')
     }
@@ -60,7 +60,7 @@ export class DevfileCodeLensProvider implements vscode.CodeLensProvider {
 
     public constructor(
         registry: DevfileRegistry,
-        private readonly client = new DevEnvClient(),
+        private readonly client = DevEnvClient.instance,
         workspace: Workspace = vscode.workspace
     ) {
         this.disposables.push(this._onDidChangeCodeLenses)

--- a/src/codecatalyst/model.ts
+++ b/src/codecatalyst/model.ts
@@ -21,7 +21,7 @@ import { writeFile } from 'fs-extra'
 import { sshAgentSocketVariable, startSshAgent, startVscodeRemote } from '../shared/extensions/ssh'
 import { ChildProcess } from '../shared/utilities/childProcess'
 import { ensureDependencies, hostNamePrefix } from './tools'
-import { isCodeCatalystVSCode } from './utils'
+import { isDevenvVscode } from './utils'
 import { Timeout } from '../shared/utilities/timeoutUtils'
 import { Commands } from '../shared/vscode/commands2'
 import { areEqual } from '../shared/utilities/pathUtils'
@@ -150,7 +150,7 @@ export interface ConnectedDevEnv {
 
 export async function getConnectedDevEnv(
     codeCatalystClient: CodeCatalystClient,
-    devenvClient = new DevEnvClient()
+    devenvClient = DevEnvClient.instance
 ): Promise<ConnectedDevEnv | undefined> {
     const devEnvId = devenvClient.id
     if (!devEnvId || !devenvClient.isCodeCatalystDevEnv()) {
@@ -313,7 +313,7 @@ export function associateDevEnv(
         const devenvs = await client
             .listResources('devEnvironment')
             .flatten()
-            .filter(env => env.repositories.length > 0 && isCodeCatalystVSCode(env.ides))
+            .filter(env => env.repositories.length > 0 && isDevenvVscode(env.ides))
             .toMap(env => `${env.org.name}.${env.project.name}.${env.repositories[0].repositoryName}`)
 
         yield* repos.map(repo => ({

--- a/src/codecatalyst/utils.ts
+++ b/src/codecatalyst/utils.ts
@@ -52,7 +52,8 @@ export function openCodeCatalystUrl(o: CodeCatalystResource) {
     vscode.env.openExternal(vscode.Uri.parse(url))
 }
 
-export function isCodeCatalystVSCode(ides: Ides | undefined): boolean {
+/** Returns true if the dev env has a "vscode" IDE runtime. */
+export function isDevenvVscode(ides: Ides | undefined): boolean {
     return ides !== undefined && ides.findIndex(ide => ide.name === 'VSCode') !== -1
 }
 

--- a/src/codecatalyst/wizards/selectResource.ts
+++ b/src/codecatalyst/wizards/selectResource.ts
@@ -17,7 +17,7 @@ import { AsyncCollection } from '../../shared/utilities/asyncCollection'
 import { getRelativeDate } from '../../shared/utilities/textUtilities'
 import { isValidResponse } from '../../shared/wizards/wizard'
 import { associateDevEnv, docs } from '../model'
-import { getHelpUrl, isCodeCatalystVSCode } from '../utils'
+import { getHelpUrl, isDevenvVscode } from '../utils'
 
 export function createRepoLabel(r: codecatalyst.CodeCatalystRepo): string {
     return `${r.org.name} / ${r.project.name} / ${r.name}`
@@ -144,7 +144,7 @@ export function createDevEnvPrompter(
 ): QuickPickPrompter<codecatalyst.DevEnvironment> {
     const helpUri = isCloud9() ? docs.cloud9.devenv : docs.vscode.devenv
     const envs = proj ? client.listDevEnvironments(proj) : client.listResources('devEnvironment')
-    const filtered = envs.map(arr => arr.filter(env => isCodeCatalystVSCode(env.ides)))
+    const filtered = envs.map(arr => arr.filter(env => isDevenvVscode(env.ides)))
     const isData = <T>(obj: T | DataQuickPickItem<T>['data']): obj is T => {
         return typeof obj !== 'function' && isValidResponse(obj)
     }

--- a/src/shared/clients/devenvClient.ts
+++ b/src/shared/clients/devenvClient.ts
@@ -38,11 +38,11 @@ export class DevEnvClient implements vscode.Disposable {
                 if (this.lastStatus !== r.status) {
                     const newStatus = r.status ?? 'NULL'
                     getLogger().info(
-                        'codecatalyst: DevEnvClient: status change (old=%s new=%s) action=%s: %s',
+                        'codecatalyst: DevEnvClient: status change (old=%s new=%s)%s%s',
                         this.lastStatus,
                         newStatus,
-                        r.actionId ?? '?',
-                        r.message ?? '(no message)'
+                        r.actionId ? ` action=${r.actionId}` : '',
+                        r.message ? `: "${r.message}"` : ''
                     )
                     if (this.onStatusChangeFn) {
                         this.onStatusChangeFn(this.lastStatus, newStatus)

--- a/src/shared/clients/devenvClient.ts
+++ b/src/shared/clients/devenvClient.ts
@@ -3,14 +3,65 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as vscode from 'vscode'
 import got from 'got'
+import globals from '../extensionGlobals'
+import { getLogger } from '../logger/logger'
 import { getCodeCatalystDevEnvId } from '../vscode/env'
 
 const environmentAuthToken = '__MDE_ENV_API_AUTHORIZATION_TOKEN'
 const environmentEndpoint = 'http://127.0.0.1:1339'
 
-export class DevEnvClient {
-    public constructor(private readonly endpoint: string = environmentEndpoint) {}
+/**
+ * Client to the MDE quasi-IMDS localhost endpoint.
+ */
+export class DevEnvClient implements vscode.Disposable {
+    static #instance: DevEnvClient
+    private readonly timer
+    private lastStatus = ''
+    private onStatusChangeFn: undefined | ((oldStatus: string, newStatus: string) => void)
+
+    /** Singleton instance (to avoid multiple polling workers). */
+    public static get instance() {
+        return (this.#instance ??= new this())
+    }
+
+    /** @internal */
+    public constructor(private readonly endpoint: string = environmentEndpoint) {
+        if (!this.id) {
+            getLogger().debug('codecatalyst: DevEnvClient skipped (local)')
+            this.timer = undefined
+        } else {
+            getLogger().info('codecatalyst: DevEnvClient started')
+            this.timer = globals.clock.setInterval(async () => {
+                const r = await this.getStatus()
+                if (this.lastStatus !== r.status) {
+                    const newStatus = r.status ?? 'NULL'
+                    getLogger().info(
+                        'codecatalyst: DevEnvClient: status change (old=%s new=%s) action=%s: %s',
+                        this.lastStatus,
+                        newStatus,
+                        r.actionId ?? '?',
+                        r.message ?? '(no message)'
+                    )
+                    if (this.onStatusChangeFn) {
+                        this.onStatusChangeFn(this.lastStatus, newStatus)
+                    }
+                    this.lastStatus = newStatus ?? 'NULL'
+                }
+            }, 1000)
+        }
+    }
+
+    public onStatusChange(fn: (oldStatus: string, newStatus: string) => void) {
+        this.onStatusChangeFn = fn
+    }
+
+    public dispose() {
+        if (this.timer) {
+            globals.clock.clearInterval(this.timer)
+        }
+    }
 
     public get id(): string | undefined {
         return getCodeCatalystDevEnvId()
@@ -33,6 +84,9 @@ export class DevEnvClient {
     }
 
     // Get status and action type
+    //
+    // Example:
+    //      { status: 'IMAGES-UPDATE-AVAILABLE', location: 'devfile.yaml' }
     public async getStatus(): Promise<GetStatusResponse> {
         const response = await this.got<GetStatusResponse>('status')
 
@@ -75,4 +129,12 @@ export interface StartDevfileRequest {
     recreateHomeVolumes?: boolean
 }
 
-export type Status = 'PENDING' | 'STABLE' | 'CHANGED'
+export type Status =
+    | 'PENDING'
+    | 'STABLE'
+    | 'CHANGED'
+    /**
+     * The image on-disk in the DE is different from the one in the container registry.
+     * Client should call "/devfile/pull" to pull the latest image from the registry.
+     */
+    | 'IMAGES-UPDATE-AVAILABLE'


### PR DESCRIPTION
Problem:
If customer changed the "IDE runtime" (in the CodeCatalyst console), AWS Toolkit will attempt to reconnect to the Dev Environment, which is inconsistent with other IDEs (jetbrains, cloud9).

Solution:
Check the `ides` field on connect. Disconnect if the ide runtime is not "vscode".


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
