### PR TITLE
fix(settings): `endpoints` is incorrectly trapped by `DevSettings`

### DIFF
--- a/.changes/next-release/Bug Fix-caeb3b17-655d-42e1-b76d-2bb417794228.json
+++ b/.changes/next-release/Bug Fix-caeb3b17-655d-42e1-b76d-2bb417794228.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "The AWS status bar item is colored despite there not being anything that needs user attention"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
             "devDependencies": {
                 "@aws-toolkits/telemetry": "^1.0.120",
                 "@cspotcode/source-map-support": "^0.8.1",
-                "@sinonjs/fake-timers": "^8.1.0",
+                "@sinonjs/fake-timers": "^10.0.2",
                 "@types/adm-zip": "^0.4.34",
                 "@types/async-lock": "^1.4.0",
                 "@types/bytes": "^3.1.0",
@@ -69,7 +69,7 @@
                 "@types/readline-sync": "^1.4.3",
                 "@types/semver": "^7.3.6",
                 "@types/sinon": "^10.0.5",
-                "@types/sinonjs__fake-timers": "^8.1.1",
+                "@types/sinonjs__fake-timers": "^8.1.2",
                 "@types/tcp-port-used": "^1.0.1",
                 "@types/uuid": "^8.3.3",
                 "@types/vscode": "1.50.0",
@@ -2641,12 +2641,21 @@
             }
         },
         "node_modules/@sinonjs/fake-timers": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz",
-            "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+            "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
             "dev": true,
             "dependencies": {
-                "@sinonjs/commons": "^1.7.0"
+                "@sinonjs/commons": "^2.0.0"
+            }
+        },
+        "node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+            "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+            "dev": true,
+            "dependencies": {
+                "type-detect": "4.0.8"
             }
         },
         "node_modules/@sinonjs/samsam": {
@@ -3071,9 +3080,9 @@
             }
         },
         "node_modules/@types/sinonjs__fake-timers": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
-            "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
+            "version": "8.1.2",
+            "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
+            "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
             "dev": true
         },
         "node_modules/@types/sockjs": {
@@ -16687,12 +16696,23 @@
             }
         },
         "@sinonjs/fake-timers": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz",
-            "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+            "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
             "dev": true,
             "requires": {
-                "@sinonjs/commons": "^1.7.0"
+                "@sinonjs/commons": "^2.0.0"
+            },
+            "dependencies": {
+                "@sinonjs/commons": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+                    "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+                    "dev": true,
+                    "requires": {
+                        "type-detect": "4.0.8"
+                    }
+                }
             }
         },
         "@sinonjs/samsam": {
@@ -17106,9 +17126,9 @@
             }
         },
         "@types/sinonjs__fake-timers": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
-            "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
+            "version": "8.1.2",
+            "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
+            "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
             "dev": true
         },
         "@types/sockjs": {

--- a/package.json
+++ b/package.json
@@ -3441,7 +3441,7 @@
     "devDependencies": {
         "@aws-toolkits/telemetry": "^1.0.120",
         "@cspotcode/source-map-support": "^0.8.1",
-        "@sinonjs/fake-timers": "^8.1.0",
+        "@sinonjs/fake-timers": "^10.0.2",
         "@types/adm-zip": "^0.4.34",
         "@types/async-lock": "^1.4.0",
         "@types/bytes": "^3.1.0",
@@ -3457,7 +3457,7 @@
         "@types/readline-sync": "^1.4.3",
         "@types/semver": "^7.3.6",
         "@types/sinon": "^10.0.5",
-        "@types/sinonjs__fake-timers": "^8.1.1",
+        "@types/sinonjs__fake-timers": "^8.1.2",
         "@types/tcp-port-used": "^1.0.1",
         "@types/uuid": "^8.3.3",
         "@types/vscode": "1.50.0",

--- a/src/awsexplorer/localExplorer.ts
+++ b/src/awsexplorer/localExplorer.ts
@@ -6,6 +6,7 @@
 import * as vscode from 'vscode'
 import { ResourceTreeDataProvider, TreeNode } from '../shared/treeview/resourceTreeDataProvider'
 import { isCloud9 } from '../shared/extensionUtilities'
+import { throttle } from '../shared/utilities/functionUtils'
 
 export interface RootNode<T = unknown> extends TreeNode<T> {
     /**
@@ -19,26 +20,6 @@ export interface RootNode<T = unknown> extends TreeNode<T> {
      * If not implemented, it is assumed that the node is always visible.
      */
     canShow?(): Promise<boolean> | boolean
-}
-
-function throttle<T>(cb: () => T | Promise<T>, delay: number): () => Promise<T> {
-    let timer: NodeJS.Timeout | undefined
-    let promise: Promise<T> | undefined
-
-    return () => {
-        timer?.refresh()
-
-        return (promise ??= new Promise<T>((resolve, reject) => {
-            timer = setTimeout(async () => {
-                timer = promise = undefined
-                try {
-                    resolve(await cb())
-                } catch (err) {
-                    reject(err)
-                }
-            }, delay)
-        }))
-    }
 }
 
 /**

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -25,7 +25,7 @@ type Workspace = Pick<typeof vscode.workspace, 'getConfiguration' | 'onDidChange
  */
 export class Settings {
     public constructor(
-        private readonly target = vscode.ConfigurationTarget.Global,
+        private readonly updateTarget = vscode.ConfigurationTarget.Global,
         private readonly scope: vscode.ConfigurationScope | undefined = undefined,
         private readonly workspace: Workspace = vscode.workspace
     ) {}
@@ -59,7 +59,7 @@ export class Settings {
      */
     public async update(key: string, value: unknown): Promise<boolean> {
         try {
-            await this.getConfig().update(key, value, this.target)
+            await this.getConfig().update(key, value, this.updateTarget)
 
             return true
         } catch (error) {
@@ -67,6 +67,20 @@ export class Settings {
 
             return false
         }
+    }
+
+    /**
+     * Checks if the key has been set in any non-language scope.
+     */
+    public isSet(key: string, section?: string): boolean {
+        const config = this.getConfig(section)
+        const info = config.inspect(key)
+
+        return (
+            info?.globalValue !== undefined ||
+            info?.workspaceValue !== undefined ||
+            info?.workspaceFolderValue !== undefined
+        )
     }
 
     /**
@@ -84,13 +98,11 @@ export class Settings {
      * ```
      */
     public getSection(section: string): ResetableMemento {
-        const parts = section.split('.')
-        const targetKey = parts.pop() ?? section
-        const parentSection = parts.join('.')
+        const [targetKey, parentSection] = splitKey(section)
 
         return {
             get: (key, defaultValue?) => this.getConfig(section).get(key, defaultValue),
-            reset: async () => this.getConfig().update(section, undefined, this.target),
+            reset: async () => this.getConfig().update(section, undefined, this.updateTarget),
             update: async (key, value) => {
                 // VS Code's settings API can read nested props but not write to them.
                 // We need to write to the parent if we cannot write to the child.
@@ -99,13 +111,13 @@ export class Settings {
                 // handle this asymmetry with try/catch
 
                 try {
-                    return await this.getConfig(section).update(key, value, this.target)
+                    return await this.getConfig(section).update(key, value, this.updateTarget)
                 } catch (error) {
                     const parent = this.getConfig(parentSection)
                     const val = parent.get(targetKey)
 
                     if (typeof val === 'object') {
-                        return parent.update(targetKey, { ...val, [key]: value }, this.target)
+                        return parent.update(targetKey, { ...val, [key]: value }, this.updateTarget)
                     }
 
                     throw error
@@ -159,6 +171,24 @@ export class Settings {
     public static get instance() {
         return (this.#instance ??= new this())
     }
+}
+
+/**
+ * Splits a key into 'leaf' and 'section' components.
+ *
+ * The leaf is assumed to be the last dot-separated component. Example:
+ *
+ * ```ts
+ * const [leaf, section] = this.split('aws.cloudWatchLogs.limit')
+ * console.log(leaf, section) // aws.cloudWatchLogs limit
+ * ```
+ */
+function splitKey(key: string): [leaf: string, section: string] {
+    const parts = key.split('.')
+    const leaf = parts.pop() ?? key
+    const section = parts.join('.')
+
+    return [leaf, section]
 }
 
 // Keeping a separate function without a return type allows us to infer protected methods
@@ -236,6 +266,10 @@ function createSettingsClass<T extends TypeDescriptor>(section: string, descript
 
         public dispose() {
             return vscode.Disposable.from(this.getChangedEmitter(), ...this.disposables).dispose()
+        }
+
+        protected isSet(key: keyof Inner & string) {
+            return this.settings.isSet(key, section)
         }
 
         protected getOrThrow<K extends keyof Inner>(key: K & string, defaultValue?: Inner[K]) {
@@ -594,11 +628,14 @@ export class DevSettings extends Settings.define('aws.dev', devSettings) {
     }
 
     public override get<K extends AwsDevSetting>(key: K, defaultValue: ResolvedDevSettings[K]) {
-        const result = super.get(key, defaultValue)
+        if (!this.isSet(key)) {
+            this.unset(key)
 
-        if (result !== defaultValue) {
-            this.trap(key, result)
+            return defaultValue
         }
+
+        const result = super.get(key, defaultValue)
+        this.trap(key, result)
 
         return result
     }
@@ -606,6 +643,13 @@ export class DevSettings extends Settings.define('aws.dev', devSettings) {
     private trap<K extends AwsDevSetting>(key: K, value: ResolvedDevSettings[K]) {
         if (this.trappedSettings[key] !== value) {
             this.trappedSettings[key] = value
+            this.onDidChangeActiveSettingsEmitter.fire()
+        }
+    }
+
+    private unset(key: AwsDevSetting) {
+        if (key in this.trappedSettings) {
+            delete this.trappedSettings[key]
             this.onDidChangeActiveSettingsEmitter.fire()
         }
     }

--- a/src/shared/utilities/timeoutUtils.ts
+++ b/src/shared/utilities/timeoutUtils.ts
@@ -275,7 +275,6 @@ export async function waitTimeout<T, R = void, B extends boolean = true>(
  *
  * Attempts to use the extension-scoped `setTimeout` if it exists, otherwise will fallback to the global scheduler.
  */
-
 export function sleep(duration: number = 0): Promise<void> {
     const schedule = globals?.clock?.setTimeout ?? setTimeout
     return new Promise(r => schedule(r, Math.max(duration, 0)))

--- a/src/test/shared/utilities/functionUtils.test.ts
+++ b/src/test/shared/utilities/functionUtils.test.ts
@@ -4,7 +4,8 @@
  */
 
 import * as assert from 'assert'
-import { once } from '../../../shared/utilities/functionUtils'
+import { once, throttle } from '../../../shared/utilities/functionUtils'
+import { installFakeClock } from '../../testUtil'
 
 describe('once', function () {
     it('does not execute sync functions returning void more than once', function () {
@@ -16,5 +17,52 @@ describe('once', function () {
 
         fn()
         assert.strictEqual(counter, 1)
+    })
+})
+
+describe('throttle', function () {
+    let counter: number
+    let fn: () => Promise<unknown>
+
+    beforeEach(function () {
+        counter = 0
+        fn = throttle(() => void counter++)
+    })
+
+    it('prevents a function from executing more than once in the `delay` window', async function () {
+        await Promise.all([fn(), fn()])
+        assert.strictEqual(counter, 1)
+    })
+
+    it('returns references to the promises', async function () {
+        const invokes = [fn(), fn()]
+        assert.strictEqual(invokes[0], invokes[1])
+        await Promise.all(invokes)
+    })
+
+    it('allows the function to be called again after resolving', async function () {
+        await Promise.all([fn(), fn()])
+        await Promise.all([fn(), fn(), fn()])
+        assert.strictEqual(counter, 2)
+    })
+
+    it('rolls the delay window when called', async function () {
+        fn = fn = throttle(() => void counter++, 10)
+        const clock = installFakeClock()
+        const calls: ReturnType<typeof fn>[] = []
+        const callAndSleep = async (delayInMs: number) => {
+            calls.push(fn())
+            await clock.tickAsync(delayInMs)
+        }
+
+        await callAndSleep(5) // timeout set at T+10ms
+        await callAndSleep(5) // timeout moved to T+15ms
+        await callAndSleep(10) // timeout moved to T+20ms
+        await callAndSleep(10) // timeout expired, start new one at T+30ms
+
+        // finish at T+40ms
+        await Promise.all(calls)
+        assert.strictEqual(counter, 2)
+        assert.strictEqual(calls.length, 4)
     })
 })

--- a/src/test/shared/utilities/functionUtils.test.ts
+++ b/src/test/shared/utilities/functionUtils.test.ts
@@ -46,7 +46,7 @@ describe('throttle', function () {
         assert.strictEqual(counter, 2)
     })
 
-    describe('windo rolling', function () {
+    describe('window rolling', function () {
         let clock: ReturnType<typeof installFakeClock>
         const calls: ReturnType<typeof fn>[] = []
         const callAndSleep = async (delayInMs: number) => {

--- a/src/test/shared/utilities/timeoutUtils.test.ts
+++ b/src/test/shared/utilities/timeoutUtils.test.ts
@@ -98,19 +98,14 @@ describe('timeoutUtils', async function () {
         })
 
         it('Correctly reports elapsed time with refresh', async function () {
-            // TODO: fake timers `refresh` is not implemented correctly for the non-global case
-            this.skip()
-
             const longTimer = (this.timer = new timeoutUtils.Timeout(10))
             clock.tick(5)
             longTimer.refresh()
             assert.strictEqual(longTimer.remainingTime, 10)
 
-            clock.tick(10)
-            assert.strictEqual(longTimer.elapsedTime, 15)
+            clock.tick(5)
+            assert.strictEqual(longTimer.elapsedTime, 10)
             assert.strictEqual(longTimer.remainingTime, 5)
-
-            clock = installFakeClock()
         })
 
         it('Refresh pushes back the start time', async function () {
@@ -121,8 +116,6 @@ describe('timeoutUtils', async function () {
         })
 
         it('does not reject if refreshed', async function () {
-            this.skip()
-
             const longTimer = (this.timer = new timeoutUtils.Timeout(10))
             clock.tick(5)
             longTimer.refresh()
@@ -329,20 +322,6 @@ describe('timeoutUtils', async function () {
     })
 
     describe('waitTimeout', async function () {
-        let clock: FakeTimers.InstalledClock
-
-        before(function () {
-            clock = installFakeClock()
-        })
-
-        after(function () {
-            clock.uninstall()
-        })
-
-        afterEach(function () {
-            clock.reset()
-        })
-
         async function testFunction(delay: number = 500, error?: Error) {
             await sleep(delay)
 

--- a/src/test/utilities/testSettingsConfiguration.ts
+++ b/src/test/utilities/testSettingsConfiguration.ts
@@ -88,9 +88,10 @@ export class TestSettings implements ClassToInterfaceType<Settings> {
         })
     }
 
-    public async disabledExperiments(pluginName: string): Promise<void> {}
-    public async enabledExperiments(pluginName: string): Promise<void> {}
-    public async getExperimentsSetting(promptName: string): Promise<{ [prompt: string]: boolean } | undefined> {
-        return {}
+    public isSet(key: string, section?: string): boolean {
+        const merged = section ? [section, key].join('.') : key
+        const value = get(this.data, merged.split('.'))
+
+        return value !== undefined
     }
 }


### PR DESCRIPTION
## Problem
Calling `DevSettings.instance.get('endpoints', {})` always treats `endpoints` as being an enabled setting. This would enable 'dev mode' despite no explicit setting being present.

## Solution
Remove the fragile reference comparison for trapping settings. Explicitly check for set values instead.

Other changes:
* Small refactor on the status bar item to make it more robust
* Dev settings that have been unset can now be detected
* Move `throttle` so it can be re-used; add tests (TODO: remove `lodash`)
  * Had to bump `@sinonjs/faketimers` to make one test work w/ fake timers. It'd work without fakes but might be flaky.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
