### PR TITLE
fix(codecatalyst): No solution for 'connection is invalid or expired'

### DIFF
--- a/src/codecatalyst/commands.ts
+++ b/src/codecatalyst/commands.ts
@@ -18,11 +18,12 @@ import { DevEnvironmentId, getConnectedDevEnv, openDevEnv } from './model'
 import { showConfigureDevEnv } from './vue/configure/backend'
 import { showCreateDevEnv } from './vue/create/backend'
 import { CancellationError } from '../shared/utilities/timeoutUtils'
-import { ToolkitError } from '../shared/errors'
+import { ToolkitError, errorCode } from '../shared/errors'
 import { telemetry } from '../shared/telemetry/telemetry'
 import { showConfirmationMessage } from '../shared/utilities/messages'
 import { AccountStatus } from '../shared/telemetry/telemetryClient'
 import { CreateDevEnvironmentRequest, UpdateDevEnvironmentRequest } from 'aws-sdk/clients/codecatalyst'
+import { Auth, SsoConnection } from '../credentials/auth'
 
 /** "List CodeCatalyst Commands" command. */
 export async function listCommands(): Promise<void> {
@@ -135,11 +136,41 @@ function createClientInjector(authProvider: CodeCatalystAuthenticationProvider):
 
         await authProvider.restore()
         const conn = authProvider.activeConnection ?? (await authProvider.promptNotConnected())
-        const client = await createClient(conn)
+        const validatedConn = await validateConnection(conn, authProvider.auth)
+        const client = await createClient(validatedConn)
         telemetry.record({ userId: client.identity.id })
 
         return command(client, ...args)
     }
+}
+
+/**
+ * Returns a connection that is ensured to be authenticated.
+ *
+ * Provides the user the ability to re-authenticate if needed,
+ * otherwise throwing an error.
+ */
+async function validateConnection(conn: SsoConnection, auth: Auth): Promise<SsoConnection> {
+    if (auth.getConnectionState(conn) === 'valid') {
+        return conn
+    }
+
+    // Have user try to log in
+    const loginMessage = localize('aws.auth.invalidConnection', 'Connection is invalid or expired, login again?')
+    const result = await vscode.window.showErrorMessage(loginMessage, 'Login')
+
+    if (result !== 'Login') {
+        throw new ToolkitError('User cancelled login.', { cancelled: true, code: errorCode.invalidConnection })
+    }
+
+    conn = await auth.reauthenticate(conn)
+
+    // Log in attempt failed
+    if (auth.getConnectionState(conn) !== 'valid') {
+        throw new ToolkitError('Login failed.', { code: errorCode.invalidConnection })
+    }
+
+    return conn
 }
 
 function createCommandDecorator(commands: CodeCatalystCommands): CommandDecorator {

--- a/src/credentials/auth.ts
+++ b/src/credentials/auth.ts
@@ -17,7 +17,7 @@ import { Commands } from '../shared/vscode/commands2'
 import { createQuickPick, DataQuickPickItem, showQuickPick } from '../shared/ui/pickerPrompter'
 import { isValidResponse } from '../shared/wizards/wizard'
 import { CancellationError } from '../shared/utilities/timeoutUtils'
-import { formatError, ToolkitError, UnknownError } from '../shared/errors'
+import { errorCode, formatError, ToolkitError, UnknownError } from '../shared/errors'
 import { getCache } from './sso/cache'
 import { createFactoryFunction, Mutable } from '../shared/utilities/tsUtils'
 import { builderIdStartUrl, SsoToken } from './sso/model'
@@ -676,7 +676,7 @@ export class Auth implements AuthService, ConnectionManager {
 
         if (previousState === 'invalid') {
             throw new ToolkitError('Connection is invalid or expired. Try logging in again.', {
-                code: 'InvalidConnection',
+                code: errorCode.invalidConnection,
                 cause: this.#validationErrors.get(id),
             })
         }
@@ -687,7 +687,7 @@ export class Auth implements AuthService, ConnectionManager {
             if (resp !== localizedText.yes) {
                 throw new ToolkitError('User cancelled login', {
                     cancelled: true,
-                    code: 'InvalidConnection',
+                    code: errorCode.invalidConnection,
                     cause: this.#validationErrors.get(id),
                 })
             }

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -11,6 +11,10 @@ import { Result } from './telemetry/telemetry'
 import { CancellationError } from './utilities/timeoutUtils'
 import { isNonNullable } from './utilities/tsUtils'
 
+export const errorCode = {
+    invalidConnection: 'InvalidConnection',
+}
+
 export interface ErrorInformation {
     /**
      * Error names are optional, but if provided they should be generic yet self-explanatory.


### PR DESCRIPTION
## Problem:

When using an MDE + CodeCatalyst, if the BuilderId connection became expired, on attempts to use the CodeCatalyst client users would get an error 'Connection is invalid...' with no obvious way to resolve it.

## Solution:

Provide the user the ability to re-authenticate their BuilderId.

This commit verifies the BuilderId connection is valid before setting up the CodeCatalyst client. If it is not valid, users will be prompted to login again. They can click the login button on a pop up window, and be redirected through the BuilderId authentication process again.

![Screen Shot 2023-04-03 at 6 12 05 PM](https://user-images.githubusercontent.com/118216176/229640060-f9a17af0-5f56-4a2a-a41c-9ee9ed4754bd.png)



## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
