### PR TITLE
tests: hook up E2E tests to CI

### DIFF
--- a/buildspec/linuxE2ETests.yml
+++ b/buildspec/linuxE2ETests.yml
@@ -1,0 +1,39 @@
+version: 0.2
+
+env:
+    variables:
+        AWS_TOOLKIT_TEST_NO_COLOR: '1'
+        NO_COVERAGE: 'true'
+        # Suppress noisy apt-get/dpkg warnings like "debconf: unable to initialize frontend: Dialog").
+        DEBIAN_FRONTEND: 'noninteractive'
+        LOGIN_SECRET_ARN: 'codecatalyst-test-account'
+
+phases:
+    install:
+        commands:
+            - '>/dev/null add-apt-repository universe'
+            - '>/dev/null apt-get -qq install -y apt-transport-https'
+            - '>/dev/null apt-get -qq update'
+            - '>/dev/null apt-get -qq install -y ca-certificates'
+            - 'apt-get install --reinstall ca-certificates'
+            # Dependencies for running vscode.
+            - '>/dev/null apt-get -yqq install libatk1.0-0 libgtk-3-dev libxss1 xvfb libnss3-dev libasound2 libasound2-plugins libsecret-1-0'
+
+    build:
+        commands:
+            - npm ci --unsafe-perm
+            # We cannot run `code` as root during tests
+            # From: https://github.com/aws/aws-codebuild-docker-images/blob/2f796bb9c81fcfbc8585832b99a5f780ae2b2f52/ubuntu/standard/6.0/Dockerfile#L56
+            - mkdir -p /home/codebuild-user
+            - chown -R codebuild-user:codebuild-user /tmp /home/codebuild-user .
+            - su codebuild-user -c "xvfb-run npm run testE2E"
+            - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
+            - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g')
+            - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"
+        finally:
+            - rm -rf ~/.aws/sso/cache || true
+reports:
+    integ-test:
+        files:
+            - '*'
+        base-directory: '.test-reports'

--- a/buildspec/linuxE2ETests.yml
+++ b/buildspec/linuxE2ETests.yml
@@ -6,7 +6,6 @@ env:
         NO_COVERAGE: 'true'
         # Suppress noisy apt-get/dpkg warnings like "debconf: unable to initialize frontend: Dialog").
         DEBIAN_FRONTEND: 'noninteractive'
-        LOGIN_SECRET_ARN: 'codecatalyst-test-account'
 
 phases:
     install:
@@ -33,7 +32,7 @@ phases:
         finally:
             - rm -rf ~/.aws/sso/cache || true
 reports:
-    integ-test:
+    e2e-test:
         files:
             - '*'
         base-directory: '.test-reports'

--- a/package.json
+++ b/package.json
@@ -3422,6 +3422,7 @@
         "postinstall": "npm run generateTelemetry && npm run generateConfigurationAttributes",
         "testCompile": "npm run buildScripts && tsc -p ./ && npm run instrument",
         "test": "npm run testCompile && ts-node ./scripts/test/test.ts && npm run report",
+        "testE2E": "npm run testCompile && ts-node ./scripts/test/testE2E.ts && npm run report",
         "integrationTest": "npm run testCompile && ts-node ./scripts/test/integrationTest.ts && npm run report",
         "lint": "eslint -c .eslintrc.js --ext .ts .",
         "lintfix": "eslint -c .eslintrc.js --fix --ext .ts .",

--- a/scripts/test/launchTestUtilities.ts
+++ b/scripts/test/launchTestUtilities.ts
@@ -124,6 +124,12 @@ async function setupVSCode(): Promise<string> {
     await installVSCodeExtension(vsCodeExecutablePath, VSCODE_EXTENSION_ID.go)
     await installVSCodeExtension(vsCodeExecutablePath, VSCODE_EXTENSION_ID.java)
     await installVSCodeExtension(vsCodeExecutablePath, VSCODE_EXTENSION_ID.javadebug)
+
+    // On stable/insiders we can install the ssh extension during the tests but not on minver
+    if (process.env[envvarVscodeTestVersion] === minimum) {
+        await installVSCodeExtension(vsCodeExecutablePath, VSCODE_EXTENSION_ID.remotessh)
+    }
+
     console.log('VS Code Test instance has been set up')
     return vsCodeExecutablePath
 }
@@ -146,6 +152,7 @@ export async function runToolkitTests(suiteName: string, relativeEntryPoint: str
                 VSCODE_EXTENSION_ID.java,
                 VSCODE_EXTENSION_ID.javadebug,
                 VSCODE_EXTENSION_ID.git,
+                VSCODE_EXTENSION_ID.remotessh,
             ],
         })
         const args = {

--- a/src/codecatalyst/tools.ts
+++ b/src/codecatalyst/tools.ts
@@ -24,6 +24,7 @@ import { getLogger } from '../shared/logger'
 import { getIdeProperties } from '../shared/extensionUtilities'
 import { showConfirmationMessage } from '../shared/utilities/messages'
 import { getSshConfigPath } from '../shared/extensions/ssh'
+import { VSCODE_EXTENSION_ID } from '../shared/extensions'
 
 interface DependencyPaths {
     readonly vsc: string
@@ -39,8 +40,8 @@ interface MissingTool {
 export const hostNamePrefix = 'aws-devenv-'
 
 export async function ensureDependencies(): Promise<Result<DependencyPaths, CancellationError | Error>> {
-    if (!isExtensionInstalled('ms-vscode-remote.remote-ssh')) {
-        showInstallExtensionMsg('ms-vscode-remote.remote-ssh', 'Remote SSH', 'Connecting to Dev Environment')
+    if (!isExtensionInstalled(VSCODE_EXTENSION_ID.remotessh)) {
+        showInstallExtensionMsg(VSCODE_EXTENSION_ID.remotessh, 'Remote SSH', 'Connecting to Dev Environment')
 
         return Result.err(
             new ToolkitError('Remote SSH extension not installed', {

--- a/src/integrationTest/globalSetup.test.ts
+++ b/src/integrationTest/globalSetup.test.ts
@@ -11,13 +11,12 @@ import { VSCODE_EXTENSION_ID } from '../shared/extensions'
 import { getLogger } from '../shared/logger'
 import { WinstonToolkitLogger } from '../shared/logger/winstonToolkitLogger'
 import { activateExtension } from '../shared/utilities/vsCodeUtils'
-import { invokeLambda, patchObject, setRunnableTimeout } from '../test/setupUtil'
+import { patchObject, setRunnableTimeout } from '../test/setupUtil'
 import { getTestWindow, resetTestWindow } from '../test/shared/vscode/window'
 
 // ASSUMPTION: Tests are not run concurrently
 
 let windowPatch: vscode.Disposable
-let authHook: vscode.Disposable
 const maxTestDuration = 300_000
 
 export async function mochaGlobalSetup(this: Mocha.Runner) {
@@ -53,47 +52,6 @@ export const mochaHooks = {
 
 function patchWindow() {
     windowPatch?.dispose()
-    authHook?.dispose()
     resetTestWindow()
-    authHook = registerAuthHook()
     windowPatch = patchObject(vscode, 'window', getTestWindow())
-}
-
-/**
- * Registers a hook to proxy SSO logins to a Lambda function.
- *
- * The function is expected to perform a browser login using the following parameters:
- * * `secret` - a SecretsManager secret containing login credentials.
- * * `userCode` - the user verification code e.g. `ABCD-EFGH`. This is returned by the device authorization flow.
- * * `verificationUri` - the url to login with. This is returned by the device authorization flow.
- */
-function registerAuthHook(secret = process.env['LOGIN_SECRET_ARN'], lambdaId = process.env['AUTH_UTIL_LAMBDA_ARN']) {
-    return getTestWindow().onDidShowMessage(message => {
-        if (message.items[0].title.match(/Copy Code/)) {
-            if (!lambdaId) {
-                const baseMessage = 'Browser login flow was shown during testing without an authorizer function'
-                if (process.env['AWS_TOOLKIT_AUTOMATION'] === 'local') {
-                    throw new Error(`${baseMessage}. You may need to login manually before running tests.`)
-                } else {
-                    throw new Error(`${baseMessage}. Check that environment variables are set correctly.`)
-                }
-            }
-
-            const openStub = patchObject(vscode.env, 'openExternal', async target => {
-                try {
-                    await invokeLambda(lambdaId, {
-                        secret,
-                        userCode: await vscode.env.clipboard.readText(),
-                        verificationUri: target.toString(),
-                    })
-                } finally {
-                    openStub.dispose()
-                }
-
-                return true
-            })
-
-            message.items[0].select()
-        }
-    })
 }

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -20,7 +20,6 @@ import { fileExists, tryRemoveFolder } from '../shared/filesystemUtilities'
 import { AddSamDebugConfigurationInput } from '../shared/sam/debugger/commands/addSamDebugConfiguration'
 import { findParentProjectFile } from '../shared/utilities/workspaceUtils'
 import * as testUtils from './integrationTestsUtilities'
-import { setTestTimeout } from './globalSetup.test'
 import { waitUntil } from '../shared/utilities/timeoutUtils'
 import { AwsSamDebuggerConfiguration } from '../shared/sam/debugger/awsSamDebugConfiguration.gen'
 import { AwsSamTargetType } from '../shared/sam/debugger/awsSamDebugConfiguration'
@@ -34,8 +33,6 @@ const projectFolder = testUtils.getTestWorkspaceFolder()
 /* Test constants go here */
 const codelensTimeout: number = 60000
 const codelensRetryInterval: number = 200
-// note: this refers to the _test_ timeout, not the invocation timeout
-const debugTimeout: number = 240000
 const noDebugSessionTimeout: number = 5000
 const noDebugSessionInterval: number = 100
 
@@ -562,7 +559,6 @@ describe('SAM Integration Tests', async function () {
                         this.skip()
                     }
 
-                    setTestTimeout(this.test?.fullTitle(), debugTimeout)
                     await testTarget('api', {
                         api: {
                             path: '/hello',
@@ -577,7 +573,6 @@ describe('SAM Integration Tests', async function () {
                         this.skip()
                     }
 
-                    setTestTimeout(this.test?.fullTitle(), debugTimeout)
                     await testTarget('template')
                 })
 

--- a/src/shared/extensions.ts
+++ b/src/shared/extensions.ts
@@ -22,6 +22,7 @@ export const VSCODE_EXTENSION_ID = {
     java: 'redhat.java',
     javadebug: 'vscjava.vscode-java-debug',
     git: 'vscode.git',
+    remotessh: 'ms-vscode-remote.remote-ssh',
 }
 
 /**

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -392,7 +392,7 @@ async function promptInstallYamlPlugin(disposables: vscode.Disposable[]) {
         case installBtn:
             // Available options are:
             // extension.open: opens extension page in VS Code extension marketplace view
-            // workspace.extension.installPlugin: autoinstalls plugin with no additional feedback
+            // workbench.extensions.installExtension: autoinstalls plugin with no additional feedback
             // workspace.extension.search: preloads and executes a search in the extension sidebar with the given term
 
             // not sure if these are 100% stable.

--- a/src/shared/systemUtilities.ts
+++ b/src/shared/systemUtilities.ts
@@ -123,7 +123,7 @@ export class SystemUtilities {
             'code', // $PATH
         ]
         for (const vsc of vscs) {
-            if (vsc !== 'code' && !fs.existsSync(vsc)) {
+            if (!vsc || (vsc !== 'code' && !fs.existsSync(vsc))) {
                 continue
             }
             const proc = new ChildProcess(vsc, ['--version'])
@@ -132,7 +132,7 @@ export class SystemUtilities {
                 SystemUtilities.vscPath = vsc
                 return vsc
             }
-            getLogger().warn('getVscodeCliPath: failed: %s', proc)
+            getLogger().warn('getVscodeCliPath: failed: %s %O', proc, proc.result())
         }
 
         return undefined

--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -22,7 +22,8 @@ import { activateExtension } from '../shared/utilities/vsCodeUtils'
 import { FakeExtensionContext, FakeMemento } from './fakeExtensionContext'
 import { TestLogger } from './testLogger'
 import * as testUtil from './testUtil'
-import { printPendingUiElements, getTestWindow, resetTestWindow } from './shared/vscode/window'
+import { getTestWindow, resetTestWindow } from './shared/vscode/window'
+import { setRunnableTimeout } from './setupUtil'
 
 const testReportDir = join(__dirname, '../../../.test-reports')
 const testLogOutput = join(testReportDir, 'testLog.log')
@@ -33,7 +34,7 @@ const maxTestDuration = 30_000
 let testLogger: TestLogger | undefined
 let openExternalStub: sinon.SinonStub<Parameters<typeof vscode['env']['openExternal']>, Thenable<boolean>>
 
-before(async function () {
+export async function mochaGlobalSetup(this: Mocha.Context) {
     // Clean up and set up test logs
     try {
         await remove(testLogOutput)
@@ -48,68 +49,51 @@ before(async function () {
     fakeContext.globalStorageUri = (await testUtil.createTestWorkspaceFolder('globalStoragePath')).uri
     fakeContext.extensionPath = globals.context.extensionPath
     Object.assign(globals, { context: fakeContext })
-})
+}
 
-after(async function () {
+export async function mochaGlobalTeardown(this: Mocha.Context) {
     testUtil.deleteTestTempDirs()
-})
+}
 
-beforeEach(async function () {
-    // Set every test up so that TestLogger is the logger used by toolkit code
-    testLogger = setupTestLogger()
-    globals.templateRegistry = new CloudFormationTemplateRegistry()
-    globals.codelensRootRegistry = new CodelensRootRegistry()
+export const mochaHooks = {
+    async beforeEach(this: Mocha.Context) {
+        // Set every test up so that TestLogger is the logger used by toolkit code
+        testLogger = setupTestLogger()
+        globals.templateRegistry = new CloudFormationTemplateRegistry()
+        globals.codelensRootRegistry = new CodelensRootRegistry()
 
-    // In general, we do not want to "fake" the `vscode` API. The only exception is for things
-    // that _require_ user input apart of a workflow. Even then, these replacements are intended
-    // to be minimally intrusive and as close to the real thing as possible.
-    globalSandbox.replace(vscode, 'window', getTestWindow())
-    openExternalStub = globalSandbox.stub(vscode.env, 'openExternal')
-    openExternalStub.rejects(
-        new Error('No return value has been set. Use `getOpenExternalStub().resolves` to set one.')
-    )
+        // In general, we do not want to "fake" the `vscode` API. The only exception is for things
+        // that _require_ user input apart of a workflow. Even then, these replacements are intended
+        // to be minimally intrusive and as close to the real thing as possible.
+        globalSandbox.replace(vscode, 'window', getTestWindow())
+        openExternalStub = globalSandbox.stub(vscode.env, 'openExternal')
+        openExternalStub.rejects(
+            new Error('No return value has been set. Use `getOpenExternalStub().resolves` to set one.')
+        )
 
-    // Wraps the test function to bubble up errors that occurred in events from `TestWindow`
-    if (this.currentTest?.fn) {
-        const testFn = this.currentTest.fn
-        this.currentTest.fn = async function (done) {
-            return Promise.race([
-                testFn.call(this, done),
-                new Promise<void>((_, reject) => {
-                    getTestWindow().onError(({ event, error }) => {
-                        event.dispose()
-                        reject(error)
-                    })
-
-                    // Set a hard time limit per-test so CI doesn't hang
-                    // Mocha's `timeout` method isn't used because we want to emit a custom message
-                    setTimeout(() => {
-                        const message = `Test length exceeded max duration\n${printPendingUiElements()}`
-                        reject(new Error(message))
-                    }, maxTestDuration)
-                }),
-            ])
+        // Wraps the test function to bubble up errors that occurred in events from `TestWindow`
+        if (this.currentTest?.fn) {
+            setRunnableTimeout(this.currentTest, maxTestDuration)
         }
-    }
 
-    // Enable telemetry features for tests. The metrics won't actually be posted.
-    globals.telemetry.telemetryEnabled = true
-    globals.telemetry.clearRecords()
-    globals.telemetry.logger.clear()
-    ;(globals.context as FakeExtensionContext).globalState = new FakeMemento()
+        // Enable telemetry features for tests. The metrics won't actually be posted.
+        globals.telemetry.telemetryEnabled = true
+        globals.telemetry.clearRecords()
+        globals.telemetry.logger.clear()
+        ;(globals.context as FakeExtensionContext).globalState = new FakeMemento()
 
-    await testUtil.closeAllEditors()
-})
-
-afterEach(function () {
-    // Prevent other tests from using the same TestLogger instance
-    teardownTestLogger(this.currentTest?.fullTitle() as string)
-    testLogger = undefined
-    resetTestWindow()
-    globals.templateRegistry.dispose()
-    globals.codelensRootRegistry.dispose()
-    globalSandbox.restore()
-})
+        await testUtil.closeAllEditors()
+    },
+    afterEach(this: Mocha.Context) {
+        // Prevent other tests from using the same TestLogger instance
+        teardownTestLogger(this.currentTest?.fullTitle() as string)
+        testLogger = undefined
+        resetTestWindow()
+        globals.templateRegistry.dispose()
+        globals.codelensRootRegistry.dispose()
+        globalSandbox.restore()
+    },
+}
 
 /**
  * Provides the TestLogger to tests that want to access it.

--- a/src/test/setupUtil.ts
+++ b/src/test/setupUtil.ts
@@ -1,0 +1,150 @@
+/*!
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { parse } from '@aws-sdk/util-arn-parser'
+import { Lambda, STS } from 'aws-sdk'
+import * as vscode from 'vscode'
+import { getLogger } from '../shared/logger'
+import { hasKey } from '../shared/utilities/tsUtils'
+import { getTestWindow, printPendingUiElements } from './shared/vscode/window'
+
+const runnableTimeout = Symbol('runnableTimeout')
+
+/**
+ * Wraps the test function to bubble up errors that occurred in events from `TestWindow`
+ */
+export function setRunnableTimeout(test: Mocha.Runnable, maxTestDuration: number): Mocha.Runnable {
+    const testFn = test.fn
+    if (!testFn) {
+        return test
+    }
+
+    // The timeout duration is stored within the function itself, allowing
+    // us to know if we've already added a timeout
+    if (!hasKey(test.fn, runnableTimeout)) {
+        const fn = function (this: Mocha.Context, done: Mocha.Done) {
+            const maxTestDuration = (fn as any)[runnableTimeout] as number
+
+            return Promise.race([
+                testFn.call(this, done),
+                new Promise<void>((_, reject) => {
+                    getTestWindow().onError(({ event, error }) => {
+                        event.dispose()
+                        reject(error)
+                    })
+
+                    // Set a hard time limit per-test so CI doesn't hang
+                    // Mocha's `timeout` method isn't used because we want to emit a custom message
+                    setTimeout(() => {
+                        const duration = `${maxTestDuration / 1000} seconds`
+                        const message = `Test length exceeded max duration: ${duration}\n${printPendingUiElements()}`
+                        reject(new Error(message))
+                    }, maxTestDuration)
+                }),
+            ])
+        }
+
+        test.fn = fn
+    }
+
+    Object.assign(test.fn!, { [runnableTimeout]: maxTestDuration })
+
+    return test
+}
+
+export function patchObject<T extends Record<string, any>, U extends keyof T>(
+    obj: T,
+    key: U,
+    value: T[U]
+): vscode.Disposable {
+    return patchObjectDescriptor(obj, key, { value })
+}
+
+export function patchObjectDescriptor<T extends Record<string, any>, U extends keyof T>(
+    obj: T,
+    key: U,
+    descriptor: TypedPropertyDescriptor<T[U]>
+): vscode.Disposable {
+    const original = Object.getOwnPropertyDescriptor(obj, key)
+    Object.defineProperty(obj, key, descriptor)
+
+    function dispose() {
+        if (original === undefined) {
+            delete obj[key]
+        } else {
+            Object.defineProperty(obj, key, original)
+        }
+    }
+
+    return { dispose }
+}
+
+async function createLambdaClient(functionId: string) {
+    if (!functionId.startsWith('arn:aws:lambda')) {
+        return Object.assign(new Lambda(), { isCrossAccount: false })
+    }
+
+    const sts = new STS()
+    const { region, accountId } = parse(functionId)
+    const identity = await sts.getCallerIdentity().promise()
+    const client = new Lambda({ region })
+
+    return Object.assign(client, { isCrossAccount: identity.Account !== accountId })
+}
+
+export async function invokeLambda(id: string, request: unknown): Promise<unknown> {
+    const client = await createLambdaClient(id)
+    const response = await client
+        .invoke({
+            FunctionName: id,
+            // Setting this to `Tail` with cross account calls results in
+            // `AccessDeniedException: Cross-account log access is not allowed`
+            LogType: client.isCrossAccount ? 'None' : 'Tail',
+            Payload: JSON.stringify(request),
+        })
+        .promise()
+        .catch(err => {
+            if (err instanceof Error) {
+                err.message = maskArns(err.message)
+            }
+            throw err
+        })
+
+    if (response.LogResult) {
+        const logs = Buffer.from(response.LogResult, 'base64').toString()
+        getLogger().debug('lambda invocation logs: %s', maskArns(logs))
+    } else {
+        getLogger().debug('lambda invocation request id: %s', response.$response.requestId)
+    }
+
+    const respStr = response.Payload?.toString('utf-8') ?? ''
+    if (respStr === 'null') {
+        return
+    }
+
+    const respPayload = JSON.parse(respStr)
+    if (response.FunctionError) {
+        const error = new Error()
+        error.name = respPayload.errorType || error.name
+        error.message = maskArns(respPayload.errorMessage || error.message)
+
+        throw error
+    }
+
+    return respPayload
+}
+
+function maskArns(text: string) {
+    return text.replace(/arn:aws:(?:.*?):(.*?):(.*?):./g, (match, region, account) => {
+        if (region) {
+            match = match.replace(region, '[omitted]')
+        }
+        if (account) {
+            match = match.replace(account, '[omitted]')
+        }
+
+        return match
+    })
+}

--- a/src/test/shared/vscode/statusbar.ts
+++ b/src/test/shared/vscode/statusbar.ts
@@ -21,6 +21,7 @@ export function createTestStatusBarItem(item: vscode.StatusBarItem): TestStatusB
     }
 
     return new Proxy(item, {
+        set: (target, prop, val) => Reflect.set(target, prop, val, target),
         get: (target, prop: keyof TestStatusBarItem, recv) => {
             if (isKeyOf(prop, state)) {
                 return state[prop]

--- a/src/testE2E/codecatalyst/client.test.ts
+++ b/src/testE2E/codecatalyst/client.test.ts
@@ -4,6 +4,7 @@
  */
 
 import * as assert from 'assert'
+import * as vscode from 'vscode'
 import {
     CodeCatalystClient,
     CodeCatalystOrg,
@@ -12,7 +13,7 @@ import {
     DevEnvironment,
 } from '../../shared/clients/codecatalystClient'
 import { prepareDevEnvConnection } from '../../codecatalyst/model'
-import { Auth, SsoConnection } from '../../credentials/auth'
+import { Auth, createBuilderIdProfile, SsoConnection } from '../../credentials/auth'
 import { CodeCatalystAuthenticationProvider, isValidCodeCatalystConnection } from '../../codecatalyst/auth'
 import { CodeCatalystCommands, DevEnvironmentSettings } from '../../codecatalyst/commands'
 import globals from '../../shared/extensionGlobals'
@@ -20,15 +21,20 @@ import { CodeCatalystCreateWebview, SourceResponse } from '../../codecatalyst/vu
 import { waitUntil } from '../../shared/utilities/timeoutUtils'
 import { AccessDeniedException } from '@aws-sdk/client-sso-oidc'
 import { GetDevEnvironmentRequest } from 'aws-sdk/clients/codecatalyst'
-import { integrationSuite } from '../../../scripts/test/launchTestUtilities'
+import { getTestWindow } from '../../test/shared/vscode/window'
+import { patchObject } from '../../test/setupUtil'
+import { isExtensionInstalled } from '../../shared/utilities/vsCodeUtils'
+import { VSCODE_EXTENSION_ID } from '../../shared/extensions'
+import { captureEventOnce } from '../../test/testUtil'
+import { toStream } from '../../shared/utilities/collectionUtils'
+import { toCollection } from '../../shared/utilities/asyncCollection'
+import { getLogger } from '../../shared/logger'
+import { SystemUtilities } from '../../shared/systemUtilities'
+import { ChildProcess } from '../../shared/utilities/childProcess'
+import { isMinimumVersion } from '../../shared/vscode/env'
 
 let spaceName: CodeCatalystOrg['name']
 let projectName: CodeCatalystProject['name']
-
-// This is a public Space, use it carefully.
-// Ask someone from the VSCode team to add you to this CC space
-// if needed. It has many Projects in it
-const multiUserOrg = 'multiUserOrg'
 
 /**
  * Key Information:
@@ -81,11 +87,12 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
     let commands: CodeCatalystCommands
     let webviewClient: CodeCatalystCreateWebview
 
-    before(async function () {
-        if (!['local', integrationSuite].includes(process.env['AWS_TOOLKIT_AUTOMATION'] ?? '')) {
-            this.skip()
-        }
+    /**
+     * Stores all dev environments created during this test suite
+     */
+    const testDevEnvironments: DevEnvironment[] = []
 
+    before(async function () {
         // These instances all interact with the CC API at some point.
         // Use the right one for your use case.
         commands = await createTestCodeCatalystCommands()
@@ -94,8 +101,6 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
 
         spaceName = (await getCurrentUsersSpace()).name
         projectName = (await tryCreateTestProject(spaceName)).name
-
-        await deleteExistingDevEnvs(projectName)
     })
 
     describe('Dev Environment functionality', function () {
@@ -105,21 +110,38 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
         const isolatedProjectName = 'aws-toolkit-integ-test-project-isolated'
 
         before(async function () {
+            // Attempt to reap older dev environments associated with the test projects
+            await Promise.all([deleteOldDevEnvironments(projectName), deleteOldDevEnvironments(isolatedProjectName)])
+
             defaultDevEnvSettings = buildDevEnvSettings()
             defaultDevEnv = await createDevEnv(defaultDevEnvSettings)
         })
 
         after(async function () {
-            await Promise.all([deleteExistingDevEnvs(projectName), deleteExistingDevEnvs(isolatedProjectName)])
+            await deleteTestDevEnvs()
+        })
+
+        beforeEach(function () {
+            // Installing the SSH extension doesn't seem to work on minver
+            // It probably needs to be installed prior to running the tests
+            if (isMinimumVersion()) {
+                this.currentTest?.skip()
+            }
+
+            getTestWindow().onDidShowMessage(m => {
+                const updateSshConfigItem = m.items.find(i => i.title === 'Update SSH config')
+                updateSshConfigItem?.select()
+            })
         })
 
         it('creates an empty Dev Environment', async function () {
             const emptyDevEnvSettings = buildDevEnvSettings()
-            const emptyDevEnv = await webviewClient.createDevEnvOfType(emptyDevEnvSettings, {
+            const emptyDevEnv = await createDevEnvFromWebview(emptyDevEnvSettings, {
                 type: 'none',
                 selectedSpace: { name: spaceName },
                 selectedProject: { name: projectName, org: { name: spaceName }, type: 'project' },
             })
+
             assert.strictEqual(emptyDevEnv.project.name, projectName)
             assert.strictEqual(emptyDevEnv.org.name, spaceName)
         })
@@ -127,7 +149,7 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
         it('creates a Dev Environment with a different instance type + storage', async function () {
             const differentDevEnvSettings = buildDevEnvSettings('dev.standard1.medium', { sizeInGiB: 32 })
 
-            const actualDevEnv = await webviewClient.createDevEnvOfType(differentDevEnvSettings, {
+            const actualDevEnv = await createDevEnvFromWebview(differentDevEnvSettings, {
                 type: 'none',
                 selectedSpace: { name: spaceName },
                 selectedProject: { name: projectName, org: { name: spaceName }, type: 'project' },
@@ -145,6 +167,37 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
             // due to this we'll want to revisit this test.
             // For now, we can manually create repository in the test project
             // and then continue this test from that point.
+        })
+
+        it('prompts to install the ssh extension if not available', async function () {
+            if (isExtensionInstalled(VSCODE_EXTENSION_ID.remotessh)) {
+                this.skip()
+            }
+
+            await assert.rejects(
+                prepareDevEnvConnection(client, { ...defaultDevEnv }),
+                /Remote SSH extension not installed/
+            )
+            const notification = await getTestWindow().waitForMessage(
+                /Connecting to Dev Environment requires the Remote SSH extension/
+            )
+
+            // Normally selecting `Install...` would open up the extensions tab
+            // But for this test we actually do want to install the extension programtically
+            const executeCommand = vscode.commands.executeCommand
+            const patchInstall = patchObject(vscode.commands, 'executeCommand', (command, ...args) => {
+                if (command === 'extension.open') {
+                    patchInstall.dispose()
+                    return executeCommand('workbench.extensions.installExtension', ...args)
+                } else {
+                    return executeCommand(command, ...args)
+                }
+            })
+
+            notification.selectItem('Install...')
+            await captureEventOnce(vscode.extensions.onDidChange, 30_000).catch(() => {
+                throw new Error('Timed out waiting to install remote SSH extension')
+            })
         })
 
         it('connects to a running Dev Environment', async function () {
@@ -199,7 +252,7 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
             // We want a clean project for this test due to additional dev envs
             // from previous tests polluting the 'list dev env' output.
             await tryCreateTestProject(spaceName, isolatedProjectName)
-            await deleteExistingDevEnvs(isolatedProjectName)
+            await deleteTestDevEnvs(isolatedProjectName)
 
             // Create multiple Dev Envs
             const projectSource: SourceResponse = {
@@ -208,13 +261,13 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
                 selectedProject: { name: isolatedProjectName, org: { name: spaceName }, type: 'project' },
             }
             const createdDevEnvs = await Promise.all([
-                webviewClient.createDevEnvOfType(buildDevEnvSettings(), projectSource),
-                webviewClient.createDevEnvOfType(buildDevEnvSettings(), projectSource),
+                createDevEnvFromWebview(buildDevEnvSettings(), projectSource),
+                createDevEnvFromWebview(buildDevEnvSettings(), projectSource),
             ])
             assert.strictEqual(createdDevEnvs.length, 2)
 
             // List all Dev Envs
-            const listedDevEnvs = await getAllDevEnvs(isolatedProjectName)
+            const listedDevEnvs = await getAllTestDevEnvironments(isolatedProjectName)
 
             const actualDevEnvIds = listedDevEnvs.map(d => d.id)
             const expectedDevEnvIds = createdDevEnvs.map(d => d.id)
@@ -226,7 +279,7 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
 
             // Delete all Dev Envs
             await Promise.all(listedDevEnvs.map(devEnv => commands.deleteDevEnv(devEnv)))
-            const remainingDevEnvs = await getAllDevEnvs(isolatedProjectName)
+            const remainingDevEnvs = await getAllTestDevEnvironments(isolatedProjectName)
             if (remainingDevEnvs.length > 0) {
                 // Dev Envs may still be returned if they are still in the process of being deleted.
                 // Just ensure they are in the process or fully deleted.
@@ -238,10 +291,7 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
 
         it('lists all spaces for the given user', async function () {
             const spaces = await client.listSpaces().flatten().promise()
-            const expectedSpaces = [spaceName, multiUserOrg]
-            spaces.forEach(space => {
-                assert.ok(expectedSpaces.includes(space.name))
-            })
+            assert.ok(spaces.find(space => space.name === spaceName))
         })
 
         it('lists all projects for the given user', async function () {
@@ -272,13 +322,25 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
             return `test-alias-${Date.now() + Math.random()}`
         }
 
-        function createDevEnv(devEnvSettings: DevEnvironmentSettings): Promise<DevEnvironment> {
-            return client.createDevEnvironment({
+        async function createDevEnv(devEnvSettings: DevEnvironmentSettings): Promise<DevEnvironment> {
+            const env = await client.createDevEnvironment({
                 spaceName,
                 projectName,
                 ides: [{ name: 'VSCode' }],
                 ...devEnvSettings,
             })
+
+            testDevEnvironments.push(env)
+            return env
+        }
+
+        async function createDevEnvFromWebview(
+            ...args: Parameters<typeof webviewClient.createDevEnvOfType>
+        ): Promise<DevEnvironment> {
+            const env = await webviewClient.createDevEnvOfType(...args)
+            testDevEnvironments.push(env)
+
+            return env
         }
     })
 
@@ -301,7 +363,7 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
      * Creates a CodeCatalyst api client.
      */
     async function createTestCodeCatalystClient(auth: Auth): Promise<CodeCatalystClient> {
-        const conn = await getCodeCatalystSsoConnection(auth)
+        const conn = await useCodeCatalystSsoConnection(auth)
         return await createCodeCatalystClient(conn)
     }
 
@@ -309,12 +371,14 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
      * Returns the existing Sso connection that has been
      * verified to work with CodeCatalyst.
      *
-     * This relies on SSO information already being configured.
+     * A new connection will be created if one is not available.
+     * The returned connection is set as the active connection if not already.
      */
-    async function getCodeCatalystSsoConnection(auth: Auth): Promise<SsoConnection> {
+    async function useCodeCatalystSsoConnection(auth: Auth): Promise<SsoConnection> {
         const builderIdSsoConnection = (await auth.listConnections()).find(isValidCodeCatalystConnection)
-        assert.ok(builderIdSsoConnection, 'To fix, setup Builder Id as if you were a user of the extension.')
-        return builderIdSsoConnection
+        const conn = builderIdSsoConnection ?? (await auth.createConnection(createBuilderIdProfile()))
+
+        return auth.useConnection(conn)
     }
 
     /**
@@ -353,24 +417,45 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
     }
 
     /**
-     * Deletes any existing dev envs from the given project, resolves only
-     * once all are fully deleted on the server side.
+     * Deletes any existing dev envs created by this test suite, resolves only
+     * once all are fully deleted on the server side. Can optionally filter per-project.
      */
-    async function deleteExistingDevEnvs(projectName: CodeCatalystProject['name']): Promise<void> {
-        const currentDevEnvs = await getAllDevEnvs(projectName)
+    async function deleteTestDevEnvs(projectName?: CodeCatalystProject['name']): Promise<void> {
+        const environments = await getAllTestDevEnvironments(projectName)
 
         // Deleting a dev env that has already been deleted will throw an error.
         // We need to be selective about which dev envs get explicitly deleted.
-        const devEnvsToDelete = currentDevEnvs
+        const devEnvsToDelete = environments
             .filter(devEnv => !['DELETING', 'DELETED'].includes(devEnv.status))
-            .map(async devEnv => deleteDevEnv(projectName, devEnv.id))
+            .map(async devEnv => deleteDevEnv(devEnv.project.name, devEnv.id))
 
         // These dev envs are already in the process of being deleted, so we just need to wait until they are fully deleted.
-        const devEnvsToWaitForDeletion = currentDevEnvs
+        const devEnvsToWaitForDeletion = environments
             .filter(devEnv => ['DELETING'].includes(devEnv.status))
-            .map(async devEnv => waitUntilDevEnvDeleted(projectName, devEnv.id))
+            .map(async devEnv => waitUntilDevEnvDeleted(devEnv.project.name, devEnv.id))
 
         await Promise.all([...devEnvsToDelete, ...devEnvsToWaitForDeletion])
+    }
+
+    /**
+     * Deletes all dev environments associated with the project that are older than one day
+     */
+    async function deleteOldDevEnvironments(projectName: CodeCatalystProject['name']): Promise<void> {
+        const environments = await getAllDevEnvs(projectName)
+
+        // Deleting a dev env that has already been deleted will throw an error.
+        // We need to be selective about which dev envs get explicitly deleted.
+        const oneDayInMs = 60 * 60 * 24 * 1000
+        await Promise.all(
+            environments
+                .filter(devEnv => Date.now() - devEnv.lastUpdatedTime.getTime() >= oneDayInMs)
+                .filter(devEnv => !['DELETING', 'DELETED'].includes(devEnv.status))
+                .map(devEnv =>
+                    deleteDevEnv(devEnv.project.name, devEnv.id).catch(err => {
+                        getLogger().warn(`tests: failed to deleted old dev environment "${devEnv.id}": %s`, err)
+                    })
+                )
+        )
     }
 
     async function getAllDevEnvs(projectName: CodeCatalystProject['name']): Promise<DevEnvironment[]> {
@@ -379,6 +464,19 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
             .flatten()
             .promise()
         return currentDevEnvs
+    }
+
+    function getAllTestDevEnvironments(projectName?: CodeCatalystProject['name']) {
+        const projects = Array.from(
+            testDevEnvironments.map(env => env.project.name).reduce((set, name) => set.add(name), new Set<string>())
+        )
+
+        const currentDevEnvs = toCollection(() => toStream(projects.map(name => getAllDevEnvs(name))))
+            .flatten()
+            .filter(env => !!testDevEnvironments.find(other => other.id === env.id))
+            .filter(env => !projectName || env.project.name === projectName)
+
+        return currentDevEnvs.promise()
     }
 
     /**

--- a/src/testE2E/codecatalyst/client.test.ts
+++ b/src/testE2E/codecatalyst/client.test.ts
@@ -29,9 +29,6 @@ import { captureEventOnce } from '../../test/testUtil'
 import { toStream } from '../../shared/utilities/collectionUtils'
 import { toCollection } from '../../shared/utilities/asyncCollection'
 import { getLogger } from '../../shared/logger'
-import { SystemUtilities } from '../../shared/systemUtilities'
-import { ChildProcess } from '../../shared/utilities/childProcess'
-import { isMinimumVersion } from '../../shared/vscode/env'
 
 let spaceName: CodeCatalystOrg['name']
 let projectName: CodeCatalystProject['name']
@@ -122,12 +119,6 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
         })
 
         beforeEach(function () {
-            // Installing the SSH extension doesn't seem to work on minver
-            // It probably needs to be installed prior to running the tests
-            if (isMinimumVersion()) {
-                this.currentTest?.skip()
-            }
-
             getTestWindow().onDidShowMessage(m => {
                 const updateSshConfigItem = m.items.find(i => i.title === 'Update SSH config')
                 updateSshConfigItem?.select()


### PR DESCRIPTION
## Problem
E2E tests must be ran manually

## Solution
Run them automatically through CodeBuild

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
