### PR TITLE
fix(codecatalyst): Notify ssh extension min version required

### DIFF
--- a/src/codecatalyst/tools.ts
+++ b/src/codecatalyst/tools.ts
@@ -24,7 +24,7 @@ import { getLogger } from '../shared/logger'
 import { getIdeProperties } from '../shared/extensionUtilities'
 import { showConfirmationMessage } from '../shared/utilities/messages'
 import { getSshConfigPath } from '../shared/extensions/ssh'
-import { VSCODE_EXTENSION_ID } from '../shared/extensions'
+import { VSCODE_EXTENSION_ID, vscodeExtensionMinVersion } from '../shared/extensions'
 
 interface DependencyPaths {
     readonly vsc: string
@@ -40,8 +40,13 @@ interface MissingTool {
 export const hostNamePrefix = 'aws-devenv-'
 
 export async function ensureDependencies(): Promise<Result<DependencyPaths, CancellationError | Error>> {
-    if (!isExtensionInstalled(VSCODE_EXTENSION_ID.remotessh)) {
-        showInstallExtensionMsg(VSCODE_EXTENSION_ID.remotessh, 'Remote SSH', 'Connecting to Dev Environment')
+    if (!isExtensionInstalled(VSCODE_EXTENSION_ID.remotessh, vscodeExtensionMinVersion.remotessh)) {
+        showInstallExtensionMsg(
+            VSCODE_EXTENSION_ID.remotessh,
+            'Remote SSH',
+            'Connecting to Dev Environment',
+            vscodeExtensionMinVersion.remotessh
+        )
 
         return Result.err(
             new ToolkitError('Remote SSH extension not installed', {

--- a/src/shared/extensions.ts
+++ b/src/shared/extensions.ts
@@ -25,6 +25,10 @@ export const VSCODE_EXTENSION_ID = {
     remotessh: 'ms-vscode-remote.remote-ssh',
 }
 
+export const vscodeExtensionMinVersion = {
+    remotessh: '0.98.0',
+}
+
 /**
  * Long-lived, extension-scoped, shared globals.
  */

--- a/src/testE2E/codecatalyst/client.test.ts
+++ b/src/testE2E/codecatalyst/client.test.ts
@@ -24,7 +24,7 @@ import { GetDevEnvironmentRequest } from 'aws-sdk/clients/codecatalyst'
 import { getTestWindow } from '../../test/shared/vscode/window'
 import { patchObject, registerAuthHook, using } from '../../test/setupUtil'
 import { isExtensionInstalled } from '../../shared/utilities/vsCodeUtils'
-import { VSCODE_EXTENSION_ID } from '../../shared/extensions'
+import { VSCODE_EXTENSION_ID, vscodeExtensionMinVersion } from '../../shared/extensions'
 import { captureEventOnce } from '../../test/testUtil'
 import { toStream } from '../../shared/utilities/collectionUtils'
 import { toCollection } from '../../shared/utilities/asyncCollection'
@@ -167,7 +167,7 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
         })
 
         it('prompts to install the ssh extension if not available', async function () {
-            if (isExtensionInstalled(VSCODE_EXTENSION_ID.remotessh)) {
+            if (isExtensionInstalled(VSCODE_EXTENSION_ID.remotessh, vscodeExtensionMinVersion.remotessh)) {
                 this.skip()
             }
 


### PR DESCRIPTION
## Problem:

When a user attempted to start a dev env, it failed since the ssh extension version was too old.

## Solution:

Enforce a minumum version of the ssh extension.
If the version is unsupported we will notify the user through an error message.

This solution can be used by any future extension
as well.

![Screen Shot 2023-04-05 at 12 20 27 PM](https://user-images.githubusercontent.com/118216176/230145327-8677b283-5f3e-46cb-ae08-041a28f88db5.png)


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
