### PR TITLE
telemetry: update SAM CLI UA env var to something more generic

### DIFF
--- a/src/shared/awsClientBuilder.ts
+++ b/src/shared/awsClientBuilder.ts
@@ -126,7 +126,7 @@ export class DefaultAWSClientBuilder implements AWSClientBuilder {
         }
 
         if (userAgent && !opt.customUserAgent) {
-            opt.customUserAgent = await getUserAgent({ includeClientId: true })
+            opt.customUserAgent = await getUserAgent({ includePlatform: true, includeClientId: true })
         }
 
         const apiConfig = (opt as { apiConfig?: { metadata?: Record<string, string> } } | undefined)?.apiConfig

--- a/src/shared/sam/cli/samCliInvokerUtils.ts
+++ b/src/shared/sam/cli/samCliInvokerUtils.ts
@@ -105,7 +105,7 @@ export async function addTelemetryEnvVar(options: SpawnOptions | undefined): Pro
     return {
         ...options,
         env: {
-            SAM_CLI_TELEMETRY_FROM_IDE: await getUserAgent({ includeClientId: false }),
+            AWS_TOOLING_USER_AGENT: await getUserAgent({ includeClientId: false }),
             ...options?.env,
         },
     }

--- a/src/shared/telemetry/util.ts
+++ b/src/shared/telemetry/util.ts
@@ -61,17 +61,22 @@ export const getClientId = shared(
     }
 )
 
+export const platformPair = () => `${env.appName.replace(/\s/g, '-')}/${version}`
+
 /**
  * Returns a string that should be used as the extension's user agent.
  *
- * Omits the `ClientId` pair by default.
+ * Omits the platform and `ClientId` pairs by default.
  */
 export async function getUserAgent(
-    opt?: { includeClientId?: boolean },
+    opt?: { includePlatform?: boolean; includeClientId?: boolean },
     globalState = globals.context.globalState
 ): Promise<string> {
-    const platformName = env.appName.replace(/\s/g, '-')
-    const pairs = [`AWS-Toolkit-For-VSCode/${extensionVersion}`, `${platformName}/${version}`]
+    const pairs = [`AWS-Toolkit-For-VSCode/${extensionVersion}`]
+
+    if (opt?.includePlatform) {
+        pairs.push(platformPair())
+    }
 
     if (opt?.includeClientId) {
         const clientId = await getClientId(globalState)

--- a/src/test/shared/sam/cli/samCliInvokerUtils.test.ts
+++ b/src/test/shared/sam/cli/samCliInvokerUtils.test.ts
@@ -93,7 +93,7 @@ describe('addTelemetryEnvVar', async function () {
         assert.deepStrictEqual(result, {
             cwd: '/foo',
             env: {
-                SAM_CLI_TELEMETRY_FROM_IDE: result.env?.['SAM_CLI_TELEMETRY_FROM_IDE'],
+                AWS_TOOLING_USER_AGENT: result.env?.['AWS_TOOLING_USER_AGENT'],
                 AWS_REGION: 'us-east-1',
             },
         })


### PR DESCRIPTION
## Problem
The name `SAM_CLI_TELEMETRY_FROM_IDE` is too specific. We're also sending more than what SAM CLI expects.

## Solution
Use `AWS_TOOLING_USER_AGENT` instead and remove extraneous pairs

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
