### PR TITLE
feat(cwl): jump to search log group from log stream quick pick

### DIFF
--- a/src/cloudWatchLogs/activation.ts
+++ b/src/cloudWatchLogs/activation.ts
@@ -83,11 +83,15 @@ export async function activate(context: vscode.ExtensionContext, configuration: 
         // Here instead of in ../awsexplorer/activation due to dependence on the registry.
         Commands.register('aws.cwl.viewLogStream', async (node: LogGroupNode) => await viewLogStream(node, registry)),
 
-        Commands.register(
-            'aws.cwl.searchLogGroup',
-            async (node: LogGroupNode | CloudWatchLogsNode) =>
-                await searchLogGroup(node instanceof LogGroupNode ? node : undefined, registry)
-        ),
+        Commands.register('aws.cwl.searchLogGroup', async (node: LogGroupNode | CloudWatchLogsNode) => {
+            let logGroupInfo = undefined
+
+            if (node instanceof LogGroupNode) {
+                logGroupInfo = { regionName: node.regionCode, groupName: node.logGroup.logGroupName! }
+            }
+
+            await searchLogGroup(registry, logGroupInfo)
+        }),
 
         Commands.register('aws.cwl.changeFilterPattern', async () => changeLogSearchParams(registry, 'filterPattern')),
 

--- a/src/test/cloudWatchLogs/commands/viewLogStream.test.ts
+++ b/src/test/cloudWatchLogs/commands/viewLogStream.test.ts
@@ -12,24 +12,25 @@ import {
     SelectLogStreamWizardContext,
     SelectLogStreamWizard,
     convertDescribeLogToQuickPickItems,
+    LogSearchChoice,
 } from '../../../cloudWatchLogs/commands/viewLogStream'
 import { LogGroupNode } from '../../../cloudWatchLogs/explorer/logGroupNode'
 import { LOCALIZED_DATE_FORMAT } from '../../../shared/constants'
 import globals from '../../../shared/extensionGlobals'
 
 class MockSelectLogStreamWizardContext implements SelectLogStreamWizardContext {
-    public constructor(private readonly pickLogStreamResponses: (string | undefined)[] = []) {
+    public constructor(private readonly pickLogStreamResponses: LogSearchChoice[] = []) {
         this.pickLogStreamResponses = pickLogStreamResponses.reverse()
     }
 
-    public async pickLogStream(): Promise<string | undefined> {
+    public async pickLogStream(): Promise<LogSearchChoice> {
         if (this.pickLogStreamResponses.length <= 0) {
             throw new Error('pickLogStream was called more times than expected')
         }
 
         const response = this.pickLogStreamResponses.pop()
         if (!response) {
-            return undefined
+            return { kind: 'cancelled' }
         }
 
         return response
@@ -40,11 +41,11 @@ describe('viewLogStreamWizard', async function () {
     it('exits when cancelled', async function () {
         const wizard = new SelectLogStreamWizard(
             new LogGroupNode('region', {}),
-            new MockSelectLogStreamWizardContext([undefined])
+            new MockSelectLogStreamWizardContext([{ kind: 'cancelled' }])
         )
         const result = await wizard.run()
 
-        assert.ok(!result)
+        assert.strictEqual(result?.kind, 'cancelled')
     })
 
     it('returns the selected log stream name', async function () {
@@ -53,14 +54,20 @@ describe('viewLogStreamWizard', async function () {
         const groupName = 'grouper'
         const wizard = new SelectLogStreamWizard(
             new LogGroupNode(region, { logGroupName: groupName }),
-            new MockSelectLogStreamWizardContext([streamName])
+            new MockSelectLogStreamWizardContext([
+                { kind: 'selectedLogStream', region: region, logGroupName: groupName, logStreamName: streamName },
+            ])
         )
         const result = await wizard.run()
 
         assert.ok(result)
-        assert.strictEqual(result?.logGroupName, groupName)
-        assert.strictEqual(result?.logStreamName, streamName)
-        assert.strictEqual(result?.region, region)
+        // HACK: using '===' since following this assertion the exact
+        // type of 'result' is narrowed down to 'selectedLogStream'.
+        // Otherwise we get TS2339 error.
+        assert.ok(result.kind === 'selectedLogStream')
+        assert.strictEqual(result.logGroupName, groupName)
+        assert.strictEqual(result.logStreamName, streamName)
+        assert.strictEqual(result.region, region)
     })
 })
 


### PR DESCRIPTION
## Problem:

By default when a user clicks on a Log Group in the explorer
they will be shown a quick pick of only Log Streams.

If they want to search the whole Log Group, they have to
exit out of it, right click, then select search log group.

## Solution:

Add a quickpick item as the first item of the Log Stream
selection. This item if chosen will redirect them to the
Search Log Stream quick pick flow.

- When a Log Group is left clicked the user is shown the following:

![Screen Shot 2023-04-17 at 11 33 54 AM](https://user-images.githubusercontent.com/118216176/232536906-fc847754-2ffa-4790-8b40-2d0de8ecc612.png)


- If they select the first item they are brought to the following:

![Screen Shot 2023-04-06 at 5 38 01 PM](https://user-images.githubusercontent.com/118216176/230502776-56c14344-3e59-4654-b365-22231b487390.png)




## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
