### PR TITLE
fix(auth): address several edge-cases

### DIFF
--- a/src/credentials/auth.ts
+++ b/src/credentials/auth.ts
@@ -16,7 +16,7 @@ import { codicon, getIcon } from '../shared/icons'
 import { Commands } from '../shared/vscode/commands2'
 import { createQuickPick, DataQuickPickItem, showQuickPick } from '../shared/ui/pickerPrompter'
 import { isValidResponse } from '../shared/wizards/wizard'
-import { CancellationError } from '../shared/utilities/timeoutUtils'
+import { CancellationError, Timeout } from '../shared/utilities/timeoutUtils'
 import { errorCode, formatError, ToolkitError, UnknownError } from '../shared/errors'
 import { getCache } from './sso/cache'
 import { createFactoryFunction, Mutable } from '../shared/utilities/tsUtils'
@@ -306,6 +306,7 @@ export class Auth implements AuthService, ConnectionManager {
     readonly #validationErrors = new Map<Connection['id'], Error>()
     readonly #onDidChangeActiveConnection = new vscode.EventEmitter<StatefulConnection | undefined>()
     readonly #onDidChangeConnectionState = new vscode.EventEmitter<ConnectionStateChangeEvent>()
+    readonly #invalidCredentialsTimeouts = new Map<Connection['id'], Timeout>()
     public readonly onDidChangeActiveConnection = this.#onDidChangeActiveConnection.event
     public readonly onDidChangeConnectionState = this.#onDidChangeConnectionState.event
 
@@ -495,6 +496,7 @@ export class Auth implements AuthService, ConnectionManager {
         const profile = await this.store.updateProfile(id, { connectionState })
         if (connectionState !== 'invalid') {
             this.#validationErrors.delete(id)
+            this.#invalidCredentialsTimeouts.get(id)?.dispose()
         }
 
         if (this.#activeConnection?.id === id) {
@@ -680,10 +682,16 @@ export class Auth implements AuthService, ConnectionManager {
                 cause: this.#validationErrors.get(id),
             })
         }
-        // TODO: cancellable notification?
         if (previousState === 'valid') {
+            const timeout = new Timeout(60000)
+            this.#invalidCredentialsTimeouts.set(id, timeout)
+
             const message = localize('aws.auth.invalidConnection', 'Connection is invalid or expired, login again?')
-            const resp = await vscode.window.showInformationMessage(message, localizedText.yes, localizedText.no)
+            const resp = await Promise.race([
+                vscode.window.showInformationMessage(message, localizedText.yes, localizedText.no),
+                timeout.promisify(),
+            ])
+
             if (resp !== localizedText.yes) {
                 throw new ToolkitError('User cancelled login', {
                     cancelled: true,
@@ -700,6 +708,16 @@ export class Auth implements AuthService, ConnectionManager {
         if (this.activeConnection !== undefined) {
             return
         }
+
+        // Clear anything stuck in an 'authenticating...' state
+        // This can rarely happen when closing VS Code during authentication
+        await Promise.all(
+            this.store.listProfiles().map(async ([id, profile]) => {
+                if (profile.metadata.connectionState === 'authenticating') {
+                    await this.store.updateProfile(id, { connectionState: 'invalid' })
+                }
+            })
+        )
 
         // Use the environment token if available
         if (getCodeCatalystDevEnvId() !== undefined) {

--- a/src/credentials/providers/sharedCredentialsProvider.ts
+++ b/src/credentials/providers/sharedCredentialsProvider.ts
@@ -31,6 +31,7 @@ import {
     Section,
 } from '../sharedCredentials'
 import { hasScopes, SsoProfile } from '../auth'
+import { builderIdStartUrl } from '../sso/model'
 
 const sharedCredentialProperties = {
     AWS_ACCESS_KEY_ID: 'aws_access_key_id',
@@ -138,6 +139,20 @@ export class SharedCredentialsProvider implements CredentialsProvider {
             getLogger().error(`Profile ${this.profileName} is not a valid Credential Profile: ${validationMessage}`)
             return false
         }
+
+        // XXX: hide builder ID profiles until account linking is supported
+        try {
+            const ssoProfile = this.getSsoProfileFromProfile()
+            if (ssoProfile.startUrl === builderIdStartUrl) {
+                getLogger().verbose(
+                    `Profile ${this.profileName} uses Builder ID which is not supported for sigv4 auth.`
+                )
+                return false
+            }
+        } catch {
+            // Swallow error. Continue as-if it were valid.
+        }
+
         return true
     }
 

--- a/src/test/credentials/auth.test.ts
+++ b/src/test/credentials/auth.test.ts
@@ -214,6 +214,15 @@ describe('Auth', function () {
         assert.notStrictEqual(t1.accessToken, t3.accessToken, 'Access tokens should change after `reauthenticate`')
     })
 
+    it('releases all notification locks after reauthenticating', async function () {
+        const conn = await setupInvalidSsoConnection(auth, ssoProfile)
+        const pendingToken = conn.getToken()
+        await getTestWindow().waitForMessage(/connection is invalid or expired/i)
+        await auth.reauthenticate(conn)
+        await assert.rejects(pendingToken)
+        assert.ok(await conn.getToken())
+    })
+
     describe('SSO Connections', function () {
         async function runExpiredGetTokenFlow(conn: SsoConnection, selection: string | RegExp) {
             const token = conn.getToken()


### PR DESCRIPTION
## Problem
* Builder ID profiles are showing in the connection picker
* Users can rarely be left in a bad auth state

## Solution
* Hide builder ID profiles 
* Clean profiles left in a bad state on reload
* Free invalid credentials lock after reauth

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
