### PR TITLE
dev: introduce `Tasks` module

### DIFF
--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -32,6 +32,7 @@ import { Auth, AuthNode } from '../credentials/auth'
 import { CodeCatalystRootNode } from '../codecatalyst/explorer'
 import { CodeCatalystAuthenticationProvider } from '../codecatalyst/auth'
 import { S3FolderNode } from '../s3/explorer/s3FolderNode'
+import { getTasksRootNode } from '../dev/activation'
 
 /**
  * Activates the AWS Explorer UI and related functionality.
@@ -79,7 +80,7 @@ export async function activate(args: {
 
     const authProvider = CodeCatalystAuthenticationProvider.fromContext(args.context.extensionContext)
     const codecatalystNode = isCloud9('classic') ? [] : [new CodeCatalystRootNode(authProvider)]
-    const nodes = [new AuthNode(Auth.instance), ...codecatalystNode, cdkNode, codewhispererNode]
+    const nodes = [new AuthNode(Auth.instance), ...codecatalystNode, cdkNode, codewhispererNode, getTasksRootNode()]
     const developerTools = createLocalExplorerView(nodes)
     args.context.extensionContext.subscriptions.push(developerTools)
 

--- a/src/awsexplorer/awsExplorer.ts
+++ b/src/awsexplorer/awsExplorer.ts
@@ -9,6 +9,7 @@ import { getIdeProperties } from '../shared/extensionUtilities'
 import { getIcon } from '../shared/icons'
 import { getLogger, Logger } from '../shared/logger'
 import { RegionProvider } from '../shared/regions/regionProvider'
+import { runTask } from '../shared/tasks'
 import { RefreshableAwsTreeProvider } from '../shared/treeview/awsTreeProvider'
 import { AWSCommandTreeNode } from '../shared/treeview/nodes/awsCommandTreeNode'
 import { AWSTreeNodeBase } from '../shared/treeview/nodes/awsTreeNodeBase'
@@ -59,7 +60,7 @@ export class AwsExplorer implements vscode.TreeDataProvider<AWSTreeNodeBase>, Re
         return element
     }
 
-    public async getChildren(element?: AWSTreeNodeBase): Promise<AWSTreeNodeBase[]> {
+    public async _getChildren(element?: AWSTreeNodeBase): Promise<AWSTreeNodeBase[]> {
         if (element) {
             this.regionProvider.setLastTouchedRegion(element.regionCode)
         }
@@ -90,6 +91,12 @@ export class AwsExplorer implements vscode.TreeDataProvider<AWSTreeNodeBase>, Re
         }
 
         return childNodes
+    }
+
+    public async getChildren(element?: AWSTreeNodeBase): Promise<AWSTreeNodeBase[]> {
+        const name = `AwsExplorer.getChildren(${element ? `"${element.id ?? element.label}"` : ''})`
+
+        return runTask(name, () => this._getChildren(element))
     }
 
     public getRegionNodesSize(): number {

--- a/src/credentials/auth.ts
+++ b/src/credentials/auth.ts
@@ -1060,8 +1060,6 @@ export function createConnectionPrompter(auth: Auth, type?: 'iam' | 'sso') {
 
         return {
             detail: getDetail(),
-            data: conn,
-            invalidSelection: true,
             label: codicon`${getIcon('vscode-error')} ${conn.label}`,
             description:
                 state === 'authenticating'
@@ -1070,28 +1068,7 @@ export function createConnectionPrompter(auth: Auth, type?: 'iam' | 'sso') {
                           'aws.auth.promptConnection.expired.description',
                           'Expired or Invalid, select to authenticate'
                       ),
-            onClick:
-                state !== 'authenticating'
-                    ? async () => {
-                          // XXX: this is hack because only 1 picker can be shown at a time
-                          // Some legacy auth providers will show a picker, hiding this one
-                          // If we detect this then we'll jump straight into using the connection
-                          let hidden = false
-                          const sub = prompter.quickPick.onDidHide(() => {
-                              hidden = true
-                              sub.dispose()
-                          })
-                          const newConn = await reauthCommand.execute(auth, conn)
-                          if (hidden && newConn && auth.getConnectionState(newConn) === 'valid') {
-                              await auth.useConnection(newConn)
-                          } else {
-                              await prompter.clearAndLoadItems(loadItems())
-                              prompter.selectItems(
-                                  ...prompter.quickPick.items.filter(i => i.label.includes(conn.label))
-                              )
-                          }
-                      }
-                    : undefined,
+            data: () => reauthCommand.execute(auth, conn),
         }
     }
 

--- a/src/credentials/credentialsCreator.ts
+++ b/src/credentials/credentialsCreator.ts
@@ -4,11 +4,10 @@
  */
 
 import * as nls from 'vscode-nls'
+import { createInputBox } from '../shared/ui/inputPrompter'
+import { CancellationError } from '../shared/utilities/timeoutUtils'
+import { isValidResponse } from '../shared/wizards/wizard'
 const localize = nls.loadMessageBundle()
-
-import { createInputBox, promptUser } from '../shared/ui/input'
-
-const errorMessageUserCancelled = localize('AWS.error.mfa.userCancelled', 'User cancelled entering authentication code')
 
 /**
  * @description Prompts user for MFA token
@@ -22,19 +21,17 @@ const errorMessageUserCancelled = localize('AWS.error.mfa.userCancelled', 'User 
  */
 export async function getMfaTokenFromUser(mfaSerial: string, profileName: string): Promise<string> {
     const inputBox = createInputBox({
-        options: {
-            ignoreFocusOut: true,
-            placeHolder: localize('AWS.prompt.mfa.enterCode.placeholder', 'Enter Authentication Code Here'),
-            title: localize('AWS.prompt.mfa.enterCode.title', 'MFA Challenge for {0}', profileName),
-            prompt: localize('AWS.prompt.mfa.enterCode.prompt', 'Enter code for MFA device {0}', mfaSerial),
-        },
+        ignoreFocusOut: true,
+        placeholder: localize('AWS.prompt.mfa.enterCode.placeholder', 'Enter Authentication Code Here'),
+        title: localize('AWS.prompt.mfa.enterCode.title', 'MFA Challenge for {0}', profileName),
+        prompt: localize('AWS.prompt.mfa.enterCode.prompt', 'Enter code for MFA device {0}', mfaSerial),
     })
 
-    const token = await promptUser({ inputBox: inputBox })
+    const token = await inputBox.prompt()
 
     // Distinguish user cancel vs code entry issues with the error message
-    if (!token) {
-        throw new Error(errorMessageUserCancelled)
+    if (!isValidResponse(token)) {
+        throw new CancellationError('user')
     }
 
     return token

--- a/src/ecs/commands.ts
+++ b/src/ecs/commands.ts
@@ -15,7 +15,7 @@ import { PromptSettings, Settings } from '../shared/settings'
 import { ChildProcess } from '../shared/utilities/childProcess'
 import { showMessageWithCancel, showOutputMessage } from '../shared/utilities/messages'
 import { removeAnsi } from '../shared/utilities/textUtilities'
-import { CancellationError, Timeout } from '../shared/utilities/timeoutUtils'
+import { CancellationError } from '../shared/utilities/timeoutUtils'
 import { Commands } from '../shared/vscode/commands2'
 import { checkPermissionsForSsm, EcsSettings } from './util'
 import { CommandWizard, CommandWizardState } from './wizards/executeCommand'
@@ -93,8 +93,7 @@ export const runCommandInContainer = Commands.register('aws.ecs.runCommandInCont
         span.record({ ecsExecuteCommandType: 'command' })
 
         const { container, task, command } = await runCommandWizard(obj)
-        const timeout = new Timeout(600000)
-        showMessageWithCancel('Running command...', timeout)
+        showMessageWithCancel('Running command...')
 
         try {
             const { path, args, dispose } = await container.prepareCommandForTask(command, task)
@@ -108,7 +107,6 @@ export const runCommandInContainer = Commands.register('aws.ecs.runCommandInCont
             const proc = new ChildProcess(path, args, { logging: 'noparams' })
             await proc
                 .run({
-                    timeout,
                     rejectOnError: true,
                     rejectOnErrorCode: true,
                     // TODO: `showOutputMessage` should not be writing to the logs...
@@ -130,8 +128,6 @@ export const runCommandInContainer = Commands.register('aws.ecs.runCommandInCont
                 'Failed to execute command in container.'
             )
             throw ToolkitError.chain(err, failedMessage)
-        } finally {
-            timeout.dispose()
         }
     })
 })

--- a/src/lambda/vue/remoteInvoke/invokeLambda.ts
+++ b/src/lambda/vue/remoteInvoke/invokeLambda.ts
@@ -20,6 +20,7 @@ import * as nls from 'vscode-nls'
 import { VueWebview } from '../../../webviews/main'
 import { telemetry } from '../../../shared/telemetry/telemetry'
 import { Result } from '../../../shared/telemetry/telemetry'
+import { runTask } from '../../../shared/tasks'
 
 const localize = nls.loadMessageBundle()
 
@@ -83,10 +84,12 @@ export class RemoteInvokeWebview extends VueWebview {
     }
 
     public async getSample(requestName: string) {
-        const sampleUrl = `${sampleRequestPath}${requestName}`
-        const sample = (await new HttpResourceFetcher(sampleUrl, { showUrl: true }).get()) ?? ''
+        return runTask('getSample', async () => {
+            const sampleUrl = `${sampleRequestPath}${requestName}`
+            const sample = (await new HttpResourceFetcher(sampleUrl, { showUrl: true }).get()) ?? ''
 
-        return sample
+            return sample
+        })
     }
 
     public async promptFile() {

--- a/src/s3/commands/downloadFileAs.ts
+++ b/src/s3/commands/downloadFileAs.ts
@@ -60,7 +60,7 @@ async function downloadS3File(
         ? streamToFile(downloadStream, options.saveLocation)
         : streamToBuffer(downloadStream, file.sizeBytes)
 
-    options?.timeout?.token.onCancellationRequested(({ agent }) => downloadStream.destroy(new CancellationError(agent)))
+    options?.timeout?.token.onCancellationRequested(({ reason }) => downloadStream.destroy(reason))
 
     if (options?.progressLocation) {
         vscode.window.withProgress(

--- a/src/shared/asyncLocalStorage.ts
+++ b/src/shared/asyncLocalStorage.ts
@@ -1,0 +1,60 @@
+/*!
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AsyncLocalStorage as AsyncLocalStorageClass } from 'async_hooks'
+
+export const AsyncLocalStorage: typeof AsyncLocalStorageClass =
+    require('async_hooks').AsyncLocalStorage ??
+    class<T> {
+        readonly #store: T[] = []
+        #disabled = false
+
+        public disable() {
+            this.#disabled = true
+        }
+
+        public getStore() {
+            return this.#disabled ? undefined : this.#store[0]
+        }
+
+        public run<R>(store: T, callback: (...args: any[]) => R, ...args: any[]): R {
+            this.#disabled = false
+            this.#store.unshift(store)
+
+            try {
+                const result = callback(...args)
+                if (result instanceof Promise) {
+                    return result.finally(() => this.#store.shift()) as unknown as R
+                }
+                this.#store.shift()
+                return result
+            } catch (err) {
+                this.#store.shift()
+                throw err
+            }
+        }
+
+        public exit<R>(callback: (...args: any[]) => R, ...args: any[]): R {
+            const saved = this.#store.shift()
+
+            try {
+                const result = callback(...args)
+                if (result instanceof Promise) {
+                    return result.finally(() => saved !== undefined && this.#store.unshift(saved)) as unknown as R
+                }
+                saved !== undefined && this.#store.unshift(saved)
+                return result
+            } catch (err) {
+                saved !== undefined && this.#store.unshift(saved)
+                throw err
+            }
+        }
+
+        public enterWith(store: T): void {
+            // XXX: you need hooks into async resource lifecycles to implement this correctly
+            this.#store.shift()
+            this.#store.unshift(store)
+        }
+    }

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -26,7 +26,7 @@ import {
     goRuntimes,
     RuntimeFamily,
 } from '../../../lambda/models/samLambdaRuntime'
-import { Timeout } from '../../utilities/timeoutUtils'
+import { CancelToken, Timeout } from '../../utilities/timeoutUtils'
 import * as csharpDebug from './csharpSamDebug'
 import * as javaDebug from './javaSamDebug'
 import * as pythonDebug from './pythonSamDebug'
@@ -207,7 +207,7 @@ export interface SamLaunchRequestArgs extends AwsSamDebuggerConfiguration {
     //  Non-serializable...
     //
     samLocalInvokeCommand?: SamLocalInvokeCommand
-    onWillAttachDebugger?(debugPort: number, timeout: Timeout): Promise<void>
+    onWillAttachDebugger?(debugPort: number, timeout: Timeout | CancelToken): Promise<void>
 
     /**
      * Specifies container architecture. Necessary for C#, to either swap debugger download or to force into no-debug mode

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -583,6 +583,7 @@ const devSettings = {
     renderDebugDetails: Boolean,
     endpoints: Record(String, String),
     cawsStage: String,
+    showTasksExplorer: Boolean,
 }
 type ResolvedDevSettings = FromDescriptor<typeof devSettings>
 type AwsDevSetting = keyof ResolvedDevSettings

--- a/src/shared/tasks.ts
+++ b/src/shared/tasks.ts
@@ -1,0 +1,361 @@
+/*!
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { Result } from './utilities/result'
+import { AsyncResource } from 'async_hooks'
+import { ToolkitError, UnknownError } from './errors'
+import { AsyncLocalStorage } from './asyncLocalStorage'
+import { isNonNullable, Mutable } from './utilities/tsUtils'
+import { CancellationError, CancelToken } from './utilities/timeoutUtils'
+
+interface TaskOptions {
+    readonly name?: string
+    readonly type?: string
+    readonly metadata?: Record<string, any>
+}
+
+interface TaskWithOptions<T, U extends any[]> extends TaskOptions {
+    readonly fn: (...args: U) => Promise<T>
+}
+
+interface BaseTask {
+    readonly id: number
+    readonly info: TaskInfo
+    readonly state: 'stopped' | 'pending' | 'cancelling' | 'cancelled' | 'completed'
+    dispose(): void
+}
+
+interface StoppedTask<T = unknown, U extends any[] = []> extends BaseTask {
+    start(...args: U): PendingTask<T> 
+    cancel(reason?: Error): void
+    isPending(): this is PendingTask<T>
+    isCompleted(): this is CompletedTask<T>
+    isCancelled(): this is CancelledTask<T>
+}
+
+interface PendingTask<T = unknown> extends BaseTask {
+    promise(): Promise<T>
+    cancel(reason?: Error): void
+    isCompleted(): this is CompletedTask<T>
+    isCancelled(): this is CancelledTask<T>
+}
+
+interface CompletedTask<T = unknown> extends BaseTask{
+    readonly result: Result<T>
+}
+
+interface CancelledTask<T = unknown> extends BaseTask {
+    readonly result: Result<T>
+    readonly reason?: unknown
+}
+
+
+export const isCancellable = <T, U extends any[]>(task: Task<T, U>): task is StoppedTask<T, U> | PendingTask<T> => {
+    return task.state === 'pending' || task.state === 'stopped'
+}
+
+export const isCompleted = <T, U extends any[]>(task: Task<T, U>): task is CompletedTask<T> => {
+    return task.state === 'completed'
+}
+
+// Discriminated union types are not used here because Typescript there's
+// no way to invalidate Typescript's control-flow analysis. Some of the
+// methods on these interfaces cause `state` to mutate, so `const` types
+// are misleading.
+//
+// The current implementation makes it so these interfaces accumulate as
+// tasks change state. It's not quite as nice as discriminated union types
+// but it is an accurate representation.
+export type Task<T = unknown, U extends any[] = []> =
+    | StoppedTask<T, U>
+    | PendingTask<T>
+    | CompletedTask<T>
+    | CancelledTask<T>
+
+interface ExecutionContext {
+    readonly taskId: Task['id']
+    readonly cancelToken: CancelToken
+}
+
+interface TaskInfo extends TaskOptions {
+    readonly state: Task['state']
+    readonly parent?: Task['id']
+    readonly children: Task['id'][]
+    readonly fulfilled: boolean
+}
+
+type TaskOrOptions<T, U extends any[]> = ((...args: U) => Promise<T>) | TaskWithOptions<T, U>
+
+// TODO: use these types if we can find a way to make type-safe discriminated union interfaces that mutate
+// type IntersectDiscriminatedType<T, U extends keyof T> = (T extends any ? (x: Omit<T, U>) => any : never) extends (x: infer U) => any ? U : never
+// type Merged<T = unknown, U extends any[] = []> = IntersectDiscriminatedType<Task<T, U>, 'state'> & Pick<Task, 'state'>
+
+export class Tasks {
+    #counter = 0
+    #onDidAddTask?: vscode.EventEmitter<Task>
+    #onDidRemoveTask?: vscode.EventEmitter<Task>
+    #onDidChangeTaskState?: vscode.EventEmitter<Task>
+    readonly #tasks = new Map<Task['id'], Task & { info: TaskInfo }>
+    readonly #context = new AsyncLocalStorage<ExecutionContext>()
+
+    public get context() {
+        return this.#context.getStore()    
+    }
+
+    public get currentTask() {
+        const id = this.context?.taskId
+        return id !== undefined ? this.getTask(id) : undefined
+    }
+
+    public get onDidAddTask() {
+        this.#onDidAddTask ??= new vscode.EventEmitter()
+        return this.#onDidAddTask.event
+    }
+
+    public get onDidRemoveTask() {
+        this.#onDidRemoveTask ??= new vscode.EventEmitter()
+        return this.#onDidRemoveTask.event
+    }
+
+    public get onDidChangeTaskState() {
+        this.#onDidChangeTaskState ??= new vscode.EventEmitter()
+        return this.#onDidChangeTaskState.event
+    }
+
+    public createTask<T, U extends any[]>(fn: (...args: U) => Promise<T>): StoppedTask<T, U>
+    public createTask<T, U extends any[]>(opt: TaskWithOptions<T, U>): StoppedTask<T, U>
+    public createTask<T, U extends any[]>(taskOrOpt: TaskOrOptions<T, U>): StoppedTask<T, U> {
+        const opt = typeof taskOrOpt === 'function' ? {} : taskOrOpt
+        const fn = typeof taskOrOpt === 'function' ? taskOrOpt : taskOrOpt.fn
+        const cancelToken = new CancelToken()
+        const taskInfo = {
+            ...opt,
+            children: [],
+            fulfilled: false,
+        }
+
+        const setResult = (result: Result<T>) => (task as Mutable<CompletedTask<T>>).result ??= result
+        const setReason = (reason?: unknown) => (task as Mutable<CancelledTask<T>>).reason = reason
+        const setPromise = (promise: Promise<T>) => (task as Mutable<PendingTask<T>>).promise = () => promise
+        const chainReason = (reason?: unknown) => new ToolkitError(`Task "${this.getTaskLabel(task)}" cancelled`, {
+            cause: reason ? UnknownError.cast(reason) : undefined,
+        })
+
+        cancelToken.onCancellationRequested(event => {
+            if (!isCancellable(task)) {
+                return
+            }
+
+            setReason(event.reason)    
+            this.updateInfo(task.id, { state: 'cancelling' })
+            
+            for (const child of this.getChildren(task)) {
+                if (isCancellable(child)) {
+                    child.cancel(event.reason)
+                }
+            }
+        })
+
+        const task = {
+            id: this.#counter++,
+            info: taskInfo,
+            state: 'stopped',
+            dispose: () => cancelToken.dispose(), // TODO: potentially force sweep on disposed tasks
+            cancel: cancelToken.cancel.bind(cancelToken),
+            isPending: () => task.state === 'pending',
+            isCompleted: () => task.state === 'completed',
+            isCancelled: () => task.state === 'cancelled',
+            start: (...args: Parameters<typeof fn>) => {
+                if ((task as PendingTask<T>).promise !== undefined) {
+                    return task
+                }
+
+                const throwIfCancelled = () => {
+                    if (cancelToken.isCancellationRequested) {
+                        setResult(Result.err(cancelToken.reason))
+                        this.updateInfo(task.id, { fulfilled: true, state: 'cancelled' })
+    
+                        throw chainReason(cancelToken.reason)
+                    }
+                }
+
+                if (this.context) {
+                    if (this.context.cancelToken.isCancellationRequested) {
+                        const message = `Parent task "${this.context.taskId}" cancelled`
+                        cancelToken.cancel(new ToolkitError(message, { cause: this.context.cancelToken.reason }))
+                    } 
+
+                    throwIfCancelled()
+                    this.link(task, this.context)
+                } else {
+                    throwIfCancelled()
+                    this.updateInfo(task.id, { state: 'pending' })
+                }
+
+                const ctx = { taskId: task.id, cancelToken }
+                const promise = this.#context.run(ctx, (fn as (...args: any[]) => Promise<T>), ...args)
+                    .then(val => {
+                        setResult(Result.ok(val))
+                        throwIfCancelled()
+
+                        return val
+                    })
+                    .catch(err => {
+                        setResult(Result.err(err))
+
+                        if (err !== cancelToken.reason) {
+                            if (err instanceof CancellationError || (err instanceof ToolkitError && err.cancelled)) {
+                                cancelToken.cancel(err)
+                            } else {
+                                throwIfCancelled()
+                            }    
+                        }
+
+                        throw err
+                    })
+                    .finally(() => {
+                        const finalState = task.state === 'pending' ? 'completed' : 'cancelled'
+                        this.updateInfo(task.id, { fulfilled: true, state: finalState })
+                        this.sweep(task.id)
+                    }) 
+
+                setPromise(promise)
+                return task
+            }
+        } as unknown as Task<T, U>
+            
+        this.addTask(task)
+        return task as StoppedTask<T, U>
+    }
+
+    public getChildren(task: Pick<Task, 'id'>) {
+        const children = this.getTask(task.id)?.info.children ?? []
+        
+        return children.map(child => this.getTask(child)).filter(isNonNullable)
+    }
+
+    public getAllTasks() {        
+        return Array.from(this.#tasks.values())
+    }
+
+    public getRootTasks(): Task[] {
+        const roots = new Map(this.#tasks.entries())
+        const allChildren = Array.from(this.#tasks.values()).map(t => t.info.children)
+        for (const children of allChildren) {
+            children.forEach(c => roots.delete(c))
+        }
+
+        return Array.from(roots.values())
+    }
+
+    public dispose() {
+        vscode.Disposable.from(
+            ...this.getAllTasks(),
+            ...[this.#onDidAddTask, this.#onDidRemoveTask, this.#onDidChangeTaskState].filter(isNonNullable)
+        ).dispose()
+    }
+
+    private addTask(task: Task & { info: TaskInfo }) {
+        this.#tasks.set(task.id, task)
+        this.#onDidAddTask?.fire(task)
+    }
+
+    private getTask(id: Task['id']) {
+        return this.#tasks.get(id)
+    }
+    
+    private getTaskLabel(task: Pick<Task, 'id'>) {
+        const opt = this.getTask(task.id)?.info
+
+        return opt?.name ? `${opt.name} (${task.id})` : `${task.id}`
+    }
+
+    private updateInfo(id: Task['id'], info: Partial<TaskInfo>) {
+        const task = this.getTask(id)
+        if (task === undefined) {
+            return
+        }
+    
+        const oldState = task.info.state
+        task.info = { ...task.info, ...info }
+        if (info.state !== undefined) {
+            ;(task as Mutable<typeof task>).state = info.state
+            if (info.state !== oldState) {
+                this.#onDidChangeTaskState?.fire(task)
+            }
+        }
+    }
+
+    private sweep(id: Task['id']) {
+        const task = this.getTask(id)
+        if (!task?.info.fulfilled || this.getChildren(task).length > 0) {
+            return
+        }
+
+        task.dispose()
+        this.#tasks.delete(id)
+
+        if (task.info.parent !== undefined) {
+            this.sweep(task.info.parent)
+        }
+
+        this.#onDidRemoveTask?.fire(task)
+    }
+
+    private link(task: Task, ctx: ExecutionContext) {
+        this.updateInfo(task.id, { parent: ctx.taskId, state: 'pending' })
+        this.getTask(ctx.taskId)?.info.children.push(task.id)
+    }
+
+    static #instance: Tasks
+    public static get instance() {
+        return this.#instance ??= new this()
+    }
+}
+
+export function getExecutionContext(service = Tasks.instance) {
+    return service.context
+}
+
+export function getExecutionContextOrThrow(service = Tasks.instance) {
+    const ctx = service.context
+    if (!ctx) {
+        throw new Error('Tried to get the current execution context without being in a task')
+    }
+    return ctx
+}
+
+export function isCancellationRequested() {
+    return Tasks.instance.context?.cancelToken?.isCancellationRequested
+}
+
+export function onCancellationRequested(fn: () => unknown) {
+    const token = Tasks.instance.context?.cancelToken
+    if (token) {
+        return token.onCancellationRequested(fn)
+    }
+}
+
+export function isRootTask(service = Tasks.instance) {
+    const task = service.currentTask
+
+    return task === undefined
+}
+
+export function runTask<T>(task: TaskWithOptions<T, []>): Promise<T>
+export function runTask<T>(name: string, fn: () => Promise<T>): Promise<T>
+export function runTask<T>(taskOrName: string | TaskWithOptions<T, []>, fn?: () => Promise<T>): Promise<T> {
+    const task = typeof taskOrName === 'string' ? {
+        name: taskOrName,
+        fn: fn!,
+    } : taskOrName
+        
+    return Tasks.instance.createTask(task).start().promise()
+}
+
+export function bindToOuterScope<T extends (...args: any[]) => any>(fn: T): T {
+    return AsyncResource.bind(fn)
+}

--- a/src/shared/telemetry/spans.ts
+++ b/src/shared/telemetry/spans.ts
@@ -5,7 +5,6 @@
 
 import globals from '../extensionGlobals'
 
-import type { AsyncLocalStorage as AsyncLocalStorageClass } from 'async_hooks'
 import {
     definitions,
     Metric,
@@ -16,60 +15,7 @@ import {
     TelemetryBase,
 } from './telemetry.gen'
 import { getTelemetryReason, getTelemetryResult } from '../errors'
-
-const AsyncLocalStorage: typeof AsyncLocalStorageClass =
-    require('async_hooks').AsyncLocalStorage ??
-    class<T> {
-        readonly #store: T[] = []
-        #disabled = false
-
-        public disable() {
-            this.#disabled = true
-        }
-
-        public getStore() {
-            return this.#disabled ? undefined : this.#store[0]
-        }
-
-        public run<R>(store: T, callback: (...args: any[]) => R, ...args: any[]): R {
-            this.#disabled = false
-            this.#store.unshift(store)
-
-            try {
-                const result = callback(...args)
-                if (result instanceof Promise) {
-                    return result.finally(() => this.#store.shift()) as unknown as R
-                }
-                this.#store.shift()
-                return result
-            } catch (err) {
-                this.#store.shift()
-                throw err
-            }
-        }
-
-        public exit<R>(callback: (...args: any[]) => R, ...args: any[]): R {
-            const saved = this.#store.shift()
-
-            try {
-                const result = callback(...args)
-                if (result instanceof Promise) {
-                    return result.finally(() => saved !== undefined && this.#store.unshift(saved)) as unknown as R
-                }
-                saved !== undefined && this.#store.unshift(saved)
-                return result
-            } catch (err) {
-                saved !== undefined && this.#store.unshift(saved)
-                throw err
-            }
-        }
-
-        public enterWith(store: T): void {
-            // XXX: you need hooks into async resource lifecycles to implement this correctly
-            this.#store.shift()
-            this.#store.unshift(store)
-        }
-    }
+import { AsyncLocalStorage } from '../asyncLocalStorage'
 
 function getValidatedState(state: Partial<MetricBase>, definition: MetricDefinition) {
     const missingFields: string[] = []

--- a/src/shared/ui/inputPrompter.ts
+++ b/src/shared/ui/inputPrompter.ts
@@ -4,6 +4,7 @@
  */
 
 import * as vscode from 'vscode'
+import { getExecutionContext } from '../tasks'
 import { assign } from '../utilities/collectionUtils'
 import { isValidResponse, StepEstimator, WIZARD_BACK, WIZARD_EXIT } from '../wizards/wizard'
 import { QuickInputButton, PrompterButtons } from './buttons'
@@ -103,6 +104,11 @@ export class InputBoxPrompter extends Prompter<string> {
     }
 
     protected async promptUser(): Promise<PromptResult<string>> {
+        getExecutionContext()?.cancelToken.onCompletion(() => {
+            this.inputBox.hide()
+            this.inputBox.dispose()
+        })
+
         const promptPromise = new Promise<PromptResult<string>>(resolve => {
             this.inputBox.onDidAccept(() => {
                 this.recentItem = this.inputBox.value
@@ -128,7 +134,7 @@ export class InputBoxPrompter extends Prompter<string> {
             this.inputBox.dispose()
         })
 
-        return await promptPromise
+        return promptPromise
     }
 
     public setStepEstimator(estimator: StepEstimator<string>): void {

--- a/src/shared/utilities/cliUtils.ts
+++ b/src/shared/utilities/cliUtils.ts
@@ -16,7 +16,7 @@ import { HttpResourceFetcher } from '../resourcefetcher/httpResourceFetcher'
 import { ChildProcess } from '../utilities/childProcess'
 
 import * as nls from 'vscode-nls'
-import { Timeout, CancellationError } from './timeoutUtils'
+import { CancellationError } from './timeoutUtils'
 import { showMessageWithCancel } from './messages'
 import { DevSettings } from '../settings'
 import { telemetry } from '../telemetry/telemetry'
@@ -105,24 +105,18 @@ export async function installCli(cli: AwsClis, confirm: boolean): Promise<string
             throw new CancellationError('user')
         }
 
-        const timeout = new Timeout(600000)
         const progress = await showMessageWithCancel(
             localize('AWS.cli.installProgress', 'Installing: {0} CLI', cliToInstall.name),
-            timeout
         )
 
         tempDir = await makeTemporaryToolkitFolder()
         let cliPath: string
-        try {
-            switch (cli) {
-                case 'session-manager-plugin':
-                    cliPath = await installSsmCli(tempDir, progress, timeout)
-                    break
-                default:
-                    throw new InstallerError(`Invalid not found for CLI: ${cli}`)
-            }
-        } finally {
-            timeout.dispose()
+        switch (cli) {
+            case 'session-manager-plugin':
+                cliPath = await installSsmCli(tempDir, progress)
+                break
+            default:
+                throw new InstallerError(`Invalid not found for CLI: ${cli}`)
         }
         // validate
         if (!(await hasCliCommand(cliToInstall, false))) {
@@ -207,10 +201,10 @@ function getOsCliSource(cli: Cli): string {
     }
 }
 
-async function downloadCliSource(cli: Cli, tempDir: string, timeout: Timeout): Promise<string> {
+async function downloadCliSource(cli: Cli, tempDir: string): Promise<string> {
     const installerSource = getOsCliSource(cli)
     const destinationFile = path.join(tempDir, path.parse(getOsCliSource(cli)).base)
-    const fetcher = new HttpResourceFetcher(installerSource, { showUrl: true, timeout })
+    const fetcher = new HttpResourceFetcher(installerSource, { showUrl: true })
     getLogger().info(`Downloading installer from ${installerSource}...`)
     await fetcher.get(destinationFile)
 
@@ -242,15 +236,14 @@ function handleError<T extends Promise<unknown>>(promise: T): T {
 
 async function installSsmCli(
     tempDir: string,
-    progress: vscode.Progress<{ message?: string; increment?: number }>,
-    timeout: Timeout
+    progress: vscode.Progress<{ message?: string; increment?: number }>
 ): Promise<string> {
     progress.report({ message: msgDownloading })
 
-    const ssmInstaller = await downloadCliSource(awsClis['session-manager-plugin'], tempDir, timeout)
+    const ssmInstaller = await downloadCliSource(awsClis['session-manager-plugin'], tempDir)
     const outDir = path.join(getToolkitLocalCliPath(), 'sessionmanagerplugin')
     const finalPath = path.join(getToolkitLocalCliPath(), getOsCommand(awsClis['session-manager-plugin']))
-    const TimedProcess = ChildProcess.extend({ timeout, rejectOnError: true, rejectOnErrorCode: true })
+    const TimedProcess = ChildProcess.extend({ rejectOnError: true, rejectOnErrorCode: true })
 
     getLogger('channel').info(`Installing SSM CLI from ${ssmInstaller} to ${outDir}...`)
     progress.report({ message: msgInstallingLocal })

--- a/src/shared/utilities/messages.ts
+++ b/src/shared/utilities/messages.ts
@@ -9,11 +9,12 @@ import * as localizedText from '../localizedText'
 import { getLogger, showLogOutputChannel } from '../../shared/logger'
 import { Env } from '../../shared/vscode/env'
 import { getIdeProperties, isCloud9 } from '../extensionUtilities'
-import { sleep } from './timeoutUtils'
+import { CancelToken, sleep } from './timeoutUtils'
 import { Timeout } from './timeoutUtils'
 import { addCodiconToString } from './textUtilities'
 import { getIcon, codicon } from '../icons'
 import globals from '../extensionGlobals'
+import { getExecutionContextOrThrow } from '../tasks'
 
 export const messages = {
     editCredentials(icon: boolean) {
@@ -154,7 +155,7 @@ export function showOutputMessage(message: string, outputChannel: vscode.OutputC
  */
 async function showProgressWithTimeout(
     options: vscode.ProgressOptions,
-    timeout: Timeout
+    timeout: Timeout | CancelToken
 ): Promise<vscode.Progress<{ message?: string; increment?: number }>> {
     // Cloud9 doesn't support Progress notifications. User won't be able to cancel.
     if (isCloud9()) {
@@ -183,7 +184,7 @@ async function showProgressWithTimeout(
  */
 export async function showMessageWithCancel(
     message: string,
-    timeout: Timeout
+    timeout: Timeout | CancelToken = getExecutionContextOrThrow().cancelToken
 ): Promise<vscode.Progress<{ message?: string; increment?: number }>> {
     const progressOptions = { location: vscode.ProgressLocation.Notification, title: message, cancellable: true }
     return showProgressWithTimeout(progressOptions, timeout)

--- a/src/shared/utilities/tsUtils.ts
+++ b/src/shared/utilities/tsUtils.ts
@@ -138,3 +138,5 @@ export type Mutable<T> = { -readonly [P in keyof T]: T[P] }
 export type FactoryFunction<T extends abstract new (...args: any[]) => any> = (
     ...args: ConstructorParameters<T>
 ) => InstanceType<T>
+
+export type OptionalKeys<T, U extends keyof T> = Omit<T, U> & Partial<Pick<T, U>>

--- a/src/test/shared/resourceFetcher/httpResourceFetcher.test.ts
+++ b/src/test/shared/resourceFetcher/httpResourceFetcher.test.ts
@@ -17,7 +17,7 @@ describe('getPropertyFromJsonUrl', function () {
     })
 
     it('undefined if resource is not present', async function () {
-        when(mockFetcher.get()).thenResolve(undefined)
+        when(mockFetcher.get()).thenResolve('')
         assert.strictEqual(await getPropertyFromJsonUrl(dummyUrl, dummyProperty, instance(mockFetcher)), undefined)
     })
 

--- a/src/test/shared/tasks.test.ts
+++ b/src/test/shared/tasks.test.ts
@@ -1,0 +1,362 @@
+/*!
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import { ToolkitError } from '../../shared/errors'
+import { bindToOuterScope, Task, Tasks } from '../../shared/tasks'
+import { CancellationError } from '../../shared/utilities/timeoutUtils'
+import { captureEvent, EventCapturer } from '../testUtil'
+
+describe('Tasks', function () {
+    let tasks: Tasks
+    let addedTasks: EventCapturer<Task>
+    let removedTasks: EventCapturer<Task>
+    let updatedTasks: EventCapturer<Task>
+
+    beforeEach(function () {
+        tasks = new Tasks()
+        addedTasks = captureEvent(tasks.onDidAddTask)
+        removedTasks = captureEvent(tasks.onDidAddTask)
+        updatedTasks = captureEvent(tasks.onDidChangeTaskState)
+    })
+
+    afterEach(function () {
+        tasks?.dispose()
+        addedTasks.dispose()
+        removedTasks.dispose()
+        updatedTasks.dispose()
+    })
+
+    function createTestTask<T = void>() {
+        let resolve!: (val: T) => void
+        let reject!: (err?: any) => void
+        
+        const promise = new Promise<T>((resolve_, reject_) => {
+            resolve = resolve_
+            reject = reject_
+        })
+
+        const task = tasks.createTask(() => promise)
+
+        return Object.assign(task, { resolve, reject })
+    }
+
+    it('can create a new task in the "stopped" state', function () {
+        const task = tasks.createTask(async () => { })
+        assert.strictEqual(task.state, 'stopped')  
+    })
+
+    it('starts the task by executing the callback', async function () {
+        const task = tasks.createTask(async () => 'hello').start()
+        assert.strictEqual(task.state, 'pending')  
+        assert.strictEqual(await task.promise(), 'hello')
+    })
+
+    it('sets a completed state when the task finishes and was not cancelled', async function () {
+        const task = tasks.createTask(async () => 'hello').start()
+        await task.promise()
+        assert.strictEqual(task.state, 'completed')  
+    })
+
+    it('is idempotent with respect to `start`', async function () {
+        let counter = 0
+        const task = tasks.createTask(async () => counter++)
+        const [t1, t2] = [task.start(), task.start()]
+        await Promise.all([t1.promise(), t2.promise()])
+        assert.strictEqual(counter, 1)
+    })
+
+    it('returns the same task when calling `start` on a pending task', async function () {
+        const task = tasks.createTask(async () => 'hello')
+        const [t1, t2] = [task.start(), task.start()]
+        assert.strictEqual(t1, t2)
+    })
+
+    it('does not swallow errors', async function () {
+        const task = tasks.createTask(async () => { throw new Error() }).start()
+        await assert.rejects(task.promise())
+    })
+
+    describe('async context', function () {
+        function createContextCheckTask() {
+            const task = tasks.createTask(async () => { 
+                assert.strictEqual(tasks.currentTask, task)
+                return 
+            })
+
+            return task
+        }
+
+        it('tracks the current task in independent async contexts', async function () {
+            const task1 = createContextCheckTask().start()
+            const task2 = createContextCheckTask().start()
+            await Promise.all([task1.promise(), task2.promise()])
+        })
+    
+        it('tracks the current task in nested async contexts', async function () {
+            const task1 = tasks.createTask(async () => {     
+                const task2 = createContextCheckTask().start()
+                const task3 = createContextCheckTask().start()
+    
+                await task2.promise()
+                assert.strictEqual(tasks.currentTask, task1)
+                await task3.promise()
+    
+                return 
+            }).start()
+            
+            await task1.promise()
+        })    
+
+        it('marks nested tasks as children of the parent', async function () {
+            const task1 = tasks.createTask(async () => {     
+                const task2 = createContextCheckTask().start()
+                const task3 = createContextCheckTask().start()
+                assert.ok(tasks.currentTask)
+                assert.deepStrictEqual(tasks.getChildren(tasks.currentTask).map(t => t.id), [task2.id, task3.id])
+
+                await Promise.all([task2.promise(), task3.promise()])
+                return
+            }).start()
+            
+            await task1.promise()
+        })    
+    })
+
+    describe('completed tasks', function () {
+        async function runToCompletion(fn: () => Promise<unknown>) {
+            const task = tasks.createTask(fn).start()
+            await task.promise().catch(() => { })
+            
+            return task
+        }
+
+        it('provides the result', async function () {
+            const task = await runToCompletion(async () => 'hello')
+            assert.ok(task.isCompleted())
+            assert.strictEqual(task.result.unwrap(), 'hello')
+        })
+
+        it('provides the result for completed but failed tasks', async function () {
+            const testError = new Error('hello')
+            const task = await runToCompletion(async () => { throw testError })
+            assert.ok(task.isCompleted())
+            assert.throws(() => task.result.unwrap(), testError)
+        })
+
+        it('does not remove the task if it still has children tasks', async function () {
+            const child = createTestTask()
+            await runToCompletion(async () => child.start())
+            assert.strictEqual(tasks.getAllTasks().length, 2)
+            child.resolve()
+            await child.start().promise()
+            assert.strictEqual(tasks.getAllTasks().length, 0)
+        })
+    })
+
+    describe('cancellations', function () {
+        it('results in a rejected promise when cancelled', async function () {
+            const task = tasks.createTask(async () => 'hello').start()
+            task.cancel()
+            await assert.rejects(task.promise())
+        })
+
+        it('respects cancellations that occur before the task was started', function () {
+            const task = tasks.createTask(async () => 'hello')
+            task.cancel()
+            assert.throws(() => task.start())
+        })
+
+        it('stores the cancel reason on the task', async function () {
+            const reason = new Error('goodbye')
+            const task = tasks.createTask(async () => 'hello').start()
+            task.cancel(reason)
+            await assert.rejects(task.promise())
+            assert.ok(task.isCancelled())
+            assert.strictEqual(task.reason, reason)
+        })
+
+        it('throws if starting a cancelled task', function () {
+            const task = tasks.createTask(async () => 'hello')
+            task.cancel()
+            assert.throws(() => task.start())
+            assert.ok(task.isCancelled())
+        })
+
+        it('provides a cancel token for cancelling the current task', async function () {
+            const task = tasks.createTask(async () => {
+                assert.ok(tasks.context?.cancelToken)
+                tasks.context.cancelToken.cancel()
+            })
+            await assert.rejects(() => task.start().promise())
+            assert.ok(task.isCancelled())
+        })
+
+        it('ignores additional cancel reasons beyond the first', async function () {
+            const reason1 = new Error('1')
+            const reason2 = new Error('2')
+            const task = tasks.createTask(async () => 'hello').start()
+            task.cancel(reason1)
+            task.cancel(reason2)
+            await assert.rejects(task.promise())
+            assert.ok(task.isCancelled())
+            assert.strictEqual(task.reason, reason1)
+        })
+
+        it('uses cancel reasons as the cause for cancellation', async function () {
+            const reason = new Error('goodbye')
+            const task = tasks.createTask(async () => 'hello').start()
+            task.cancel(reason)
+            const err = await task.promise().catch(e => e)
+            assert.ok(err instanceof ToolkitError)
+            assert.strictEqual(err.cause, reason)
+        })
+
+        it('propagates cancels to cancel tokens', async function () {
+            const task = tasks.createTask({
+                name: 'test',
+                fn: async () => {
+                    assert.ok(tasks.context?.cancelToken)
+                    const event = await captureEvent(tasks.context.cancelToken.onCancellationRequested).next()
+                    assert.strictEqual(event.reason.message, 'Task "test" cancelled')
+                },
+            }).start()
+            task.cancel()
+            await assert.rejects(() => task.promise())
+            assert.ok(task.isCancelled())
+        })
+
+        it('propagates cancels to children tasks that have started', async function () {
+            const parent = tasks.createTask(async () => {
+                const child = tasks.createTask(async () => 'hello').start()
+                parent.cancel()
+                await assert.rejects(child.promise())
+    
+                return 'passed'
+            })
+
+            await assert.rejects(parent.start().promise())
+            assert.ok(parent.isCancelled())
+            assert.strictEqual(parent.result.unwrap(), 'passed')
+        })
+
+        it('propagates cancels to children tasks that have not started', async function () {
+            const child = tasks.createTask(async () => 'hello')     // task 0
+            const parent = tasks.createTask(async () => {           // task 1
+                parent.cancel()
+                await child.start().promise()    
+            })
+
+            await assert.rejects(parent.start().promise(), /Task "0" cancelled/)
+            assert.ok(child.isCancelled())
+            assert.ok(parent.isCancelled())
+            assert.ok(child.reason instanceof ToolkitError)
+            assert.strictEqual(child.reason.message, 'Parent task "1" cancelled')
+        })
+
+        describe('cancel propagation from within task', function () {
+            async function runTaskWithError(err: Error) {
+                const task = tasks.createTask(async () => { throw err }).start()
+                const result = await task.promise().catch(e => e)
+
+                return { task, result }
+            }
+    
+            it('treats the task as cancelled if it throws a cancellation error', async function () {
+                const reason = new CancellationError('user')
+                const { task, result } = await runTaskWithError(reason)
+                assert.strictEqual(result, reason)
+                assert.ok(task.isCancelled())
+            })
+    
+            it('treats the task as cancelled if it throws a cancelled `ToolkitError`', async function () {
+                const reason = new ToolkitError('test', { cancelled: true })
+                const { task, result } = await runTaskWithError(reason)
+                assert.strictEqual(result, reason)
+                assert.ok(task.isCancelled())
+            })
+        })
+    })
+
+    describe('execution scopes', function () {
+        let emitter: vscode.EventEmitter<void>
+        let capturedTasks: Tasks['currentTask'][] 
+
+        beforeEach(function () {
+            emitter = new vscode.EventEmitter<void>()
+            capturedTasks = []
+        })
+
+        it('uses the scope of the event sender by default', async function () {
+            const task1 = tasks.createTask(async () => {
+                emitter.event(() => capturedTasks.push(tasks.currentTask))
+            })
+            const task2 = tasks.createTask(async () => emitter.fire())
+            await Promise.all([task1.start().promise(), task2.start().promise()])
+            assert.deepStrictEqual(capturedTasks, [task2])
+        })
+
+        it('uses the scope of the event receiver if `bindToOuterScope` is applied', async function () {
+            const task1 = tasks.createTask(async () => {
+                emitter.event(bindToOuterScope(() => capturedTasks.push(tasks.currentTask)))
+            })
+            const task2 = tasks.createTask(async () => emitter.fire())
+            await Promise.all([task1.start().promise(), task2.start().promise()])
+            assert.deepStrictEqual(capturedTasks, [task1])
+        })
+    })
+
+    describe('events', function () {
+        let addedTasks: EventCapturer<Task>
+        let removedTasks: EventCapturer<Task>
+        let updatedTasks: EventCapturer<Task>
+
+        beforeEach(function () {
+            addedTasks = captureEvent(tasks.onDidAddTask)
+            removedTasks = captureEvent(tasks.onDidAddTask)
+            updatedTasks = captureEvent(tasks.onDidChangeTaskState)
+        })
+
+        afterEach(function () {
+            addedTasks.dispose()
+            removedTasks.dispose()
+            updatedTasks.dispose()
+        })
+
+        it('emits an event when creating a task', async function () {
+            const task = tasks.createTask(async () => 'hello')
+            assert.strictEqual(await addedTasks.next(), task)
+        })
+
+        it('emits an event when removing a task', async function () {
+            const task = tasks.createTask(async () => 'hello').start()
+            await task.promise()
+            assert.strictEqual(await removedTasks.next(), task)
+        })
+
+        it('removes children tasks before parent tasks', async function () {
+            const child = tasks.createTask(async () => 'hello')
+            const parent = tasks.createTask(async () => { await child.start().promise() }).start()
+            await parent.promise()
+            assert.strictEqual(await removedTasks.next(), child)
+            assert.strictEqual(await removedTasks.next(), parent)
+        })
+    
+        it('emits events as the task changes state', async function () {
+            tasks.createTask(async () => 'hello').start()
+            assert.strictEqual((await updatedTasks.next()).state, 'pending')
+            assert.strictEqual((await updatedTasks.next()).state, 'completed')
+        })
+
+        it('handles cancellations', async function () {
+            const task = tasks.createTask(async () => 'hello').start()
+            assert.strictEqual((await updatedTasks.next()).state, 'pending')
+            task.cancel()
+            assert.strictEqual((await updatedTasks.next()).state, 'cancelling')
+            assert.strictEqual((await updatedTasks.next()).state, 'cancelled')
+        })
+    })
+})

--- a/src/test/shared/utilities/timeoutUtils.test.ts
+++ b/src/test/shared/utilities/timeoutUtils.test.ts
@@ -162,7 +162,9 @@ describe('timeoutUtils', async function () {
             beforeEach(function () {
                 timer = this.timer = new timeoutUtils.Timeout(checkTimerMs * 6)
                 cancellation = new Promise<'user' | 'timeout' | 'completed'>((resolve, reject) => {
-                    timer.token.onCancellationRequested(({ agent }) => resolve(agent))
+                    timer.token.onCancellationRequested((
+                        { reason }) => reason instanceof timeoutUtils.CancellationError ? resolve(reason.agent) : reject(reason)
+                    )
                     timer.onCompletion(() => resolve('completed'))
                     setTimeout(() => reject(new Error('Timed out waiting for event')), 1000)
                 })


### PR DESCRIPTION
## Problems
* Lack of cohesion for cancellations
* No easy way to instrument logic without using telemetry
* It can be hard to understand the relationship between functions, even with logs

## Solution
Add a new module that allows callers to create arbitrary "tasks". Tasks do three important things:
* Handle cancellations as gracefully as possible
* Allows logic within a task to deal with cancellations isolated to that particular task
* Tracks when tasks are started within an existing task, creating a hierarchy of tasks

For functionality beyond this, callers can use lifecycle hooks to do whatever they need to do. 

### Other Changes
Several existing implementations have been adapted to use tasks. More testing is needed to ensure correctness.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
