### PR TITLE
auth: Setup initial Auth Add Connections webview

### DIFF
--- a/package.json
+++ b/package.json
@@ -1984,6 +1984,11 @@
                 "category": "%AWS.title%"
             },
             {
+                "command": "aws.auth.showConnectionsPage",
+                "title": "%AWS.command.auth.showConnectionsPage%",
+                "category": "%AWS.title%"
+            },
+            {
                 "command": "aws.auth.switchConnections",
                 "title": "%AWS.command.auth.switchConnections%",
                 "category": "%AWS.title%"

--- a/package.json
+++ b/package.json
@@ -1100,6 +1100,10 @@
                     "when": "false"
                 },
                 {
+                    "command": "aws.auth.showConnectionsPage",
+                    "when": "aws.isDevMode"
+                },
+                {
                     "command": "aws.dev.openMenu",
                     "when": "aws.isDevMode || isCloud9"
                 }
@@ -1986,7 +1990,8 @@
             {
                 "command": "aws.auth.showConnectionsPage",
                 "title": "%AWS.command.auth.showConnectionsPage%",
-                "category": "%AWS.title%"
+                "category": "%AWS.title%",
+                "enablement": "aws.isDevMode"
             },
             {
                 "command": "aws.auth.switchConnections",

--- a/package.nls.json
+++ b/package.nls.json
@@ -76,6 +76,7 @@
     "AWS.command.apig.invokeRemoteRestApi": "Invoke on AWS",
     "AWS.command.apig.invokeRemoteRestApi.cn": "Invoke on Amazon",
     "AWS.command.auth.addConnection": "Add New Connection",
+    "AWS.command.auth.showConnectionsPage": "Show Auth Connections Page",
     "AWS.command.auth.switchConnections": "Switch Connections",
     "AWS.command.auth.signout": "Sign out",
     "AWS.command.github": "View Source on GitHub",

--- a/src/credentials/activation.ts
+++ b/src/credentials/activation.ts
@@ -9,6 +9,7 @@ import { Settings } from '../shared/settings'
 import { Auth } from './auth'
 import { LoginManager } from './loginManager'
 import { fromString } from './providers/credentials'
+import { AuthCommandDeclarations } from './commands'
 
 export async function initialize(
     extensionContext: vscode.ExtensionContext,
@@ -24,4 +25,7 @@ export async function initialize(
             loginManager.logout()
         }
     })
+
+    const authCommands = new AuthCommandDeclarations(extensionContext)
+    authCommands.registerCommandsWithVSCode()
 }

--- a/src/credentials/activation.ts
+++ b/src/credentials/activation.ts
@@ -9,7 +9,8 @@ import { Settings } from '../shared/settings'
 import { Auth } from './auth'
 import { LoginManager } from './loginManager'
 import { fromString } from './providers/credentials'
-import { AuthCommandDeclarations } from './commands'
+import { AuthCommandBackend, AuthCommandDeclarations } from './commands'
+import { registerCommandsWithVSCode } from '../shared/vscode/commands2'
 
 export async function initialize(
     extensionContext: vscode.ExtensionContext,
@@ -28,6 +29,9 @@ export async function initialize(
 
     // TODO: To enable this in prod we need to remove the 'when' clause
     // for: '"command": "aws.auth.showConnectionsPage"' in package.json
-    const authCommands = new AuthCommandDeclarations(extensionContext)
-    authCommands.registerCommandsWithVSCode()
+    registerCommandsWithVSCode(
+        extensionContext,
+        new AuthCommandDeclarations(),
+        new AuthCommandBackend(extensionContext)
+    )
 }

--- a/src/credentials/activation.ts
+++ b/src/credentials/activation.ts
@@ -26,6 +26,8 @@ export async function initialize(
         }
     })
 
+    // TODO: To enable this in prod we need to remove the 'when' clause
+    // for: '"command": "aws.auth.showConnectionsPage"' in package.json
     const authCommands = new AuthCommandDeclarations(extensionContext)
     authCommands.registerCommandsWithVSCode()
 }

--- a/src/credentials/commands.ts
+++ b/src/credentials/commands.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BaseCommandDeclarations, Commands } from '../shared/vscode/commands2'
+import { CommandDeclarations, Commands } from '../shared/vscode/commands2'
 import * as vscode from 'vscode'
 import { showAuthWebview } from './vue/show'
 
@@ -11,7 +11,7 @@ import { showAuthWebview } from './vue/show'
  * The methods with backend logic for the Auth commands.
  */
 export class AuthCommandBackend {
-    constructor(readonly extContext: vscode.ExtensionContext) {}
+    constructor(private readonly extContext: vscode.ExtensionContext) {}
 
     public async showConnectionsPage() {
         await showAuthWebview(this.extContext)
@@ -21,12 +21,8 @@ export class AuthCommandBackend {
 /**
  * Declared commands related to Authentication in the toolkit.
  */
-export class AuthCommandDeclarations extends BaseCommandDeclarations<AuthCommandBackend> {
-    constructor(extContext: vscode.ExtensionContext) {
-        super(extContext, new AuthCommandBackend(extContext))
-    }
-
-    public override readonly declared = {
+export class AuthCommandDeclarations implements CommandDeclarations<AuthCommandBackend> {
+    public readonly declared = {
         showConnectionsPage: Commands.from(AuthCommandBackend).declareShowConnectionsPage({
             id: 'aws.auth.showConnectionsPage',
         }),

--- a/src/credentials/commands.ts
+++ b/src/credentials/commands.ts
@@ -1,0 +1,34 @@
+/*!
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BaseCommandDeclarations, Commands } from '../shared/vscode/commands2'
+import * as vscode from 'vscode'
+import { showAuthWebview } from './vue/show'
+
+/**
+ * The methods with backend logic for the Auth commands.
+ */
+export class AuthCommandBackend {
+    constructor(readonly extContext: vscode.ExtensionContext) {}
+
+    public async showConnectionsPage() {
+        await showAuthWebview(this.extContext)
+    }
+}
+
+/**
+ * Declared commands related to Authentication in the toolkit.
+ */
+export class AuthCommandDeclarations extends BaseCommandDeclarations<AuthCommandBackend> {
+    constructor(extContext: vscode.ExtensionContext) {
+        super(extContext, new AuthCommandBackend(extContext))
+    }
+
+    public override readonly declared = {
+        showConnectionsPage: Commands.from(AuthCommandBackend).declareShowConnectionsPage({
+            id: 'aws.auth.showConnectionsPage',
+        }),
+    } as const
+}

--- a/src/credentials/vue/index.ts
+++ b/src/credentials/vue/index.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This module is run within the webview, and will mount the Vue app.
+ */
+
+import { createApp } from 'vue'
+import component from './root.vue'
+
+const create = () => createApp(component)
+const app = create()
+
+app.mount('#vue-app')
+window.addEventListener('remount', () => {
+    app.unmount()
+    create().mount('#vue-app')
+})

--- a/src/credentials/vue/root.vue
+++ b/src/credentials/vue/root.vue
@@ -1,0 +1,52 @@
+<template>
+    <div class="flex-container" style="display: flex">
+        <div id="left-column">I am left column</div>
+        <div id="right-column">I am right column</div>
+    </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+    name: 'MyComponent',
+})
+</script>
+
+<style>
+/** By default  */
+.flex-container {
+    display: flex;
+    flex-direction: row;
+    width: 1200px;
+}
+
+/* Makes webview responsive and changes to single column when necessary */
+@media (max-width: 1200px) {
+    .flex-container {
+        flex-direction: column;
+
+        color: red;
+    }
+}
+
+#left-column {
+    flex-grow: 1;
+    max-width: 40%;
+
+    /* This can be deleted, for development purposes */
+    background-color: yellow;
+    color: black;
+    height: 200px;
+}
+
+#right-column {
+    flex-grow: 1;
+    max-width: 60%;
+
+    /* This can be deleted, for development purposes */
+    background-color: aqua;
+    color: black;
+    height: 200px;
+}
+</style>

--- a/src/credentials/vue/show.ts
+++ b/src/credentials/vue/show.ts
@@ -1,0 +1,45 @@
+/*!
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This module sets up the necessary components
+ * for the webview to be shown.
+ */
+
+import { getIdeProperties, isCloud9 } from '../../shared/extensionUtilities'
+import { VueWebview } from '../../webviews/main'
+import * as vscode from 'vscode'
+
+class AuthWebview extends VueWebview {
+    public override id: string = 'authWebview'
+    public override source: string = 'src/credentials/vue/index.js'
+}
+
+const Panel = VueWebview.compilePanel(AuthWebview)
+let activePanel: InstanceType<typeof Panel> | undefined
+let subscriptions: vscode.Disposable[] | undefined
+let submitPromise: Promise<void> | undefined
+
+export async function showAuthWebview(ctx: vscode.ExtensionContext): Promise<void> {
+    submitPromise ??= new Promise<void>((resolve, reject) => {
+        activePanel ??= new Panel(ctx)
+    })
+
+    const webview = await activePanel!.show({
+        title: `Add Connection to ${getIdeProperties().company}`,
+        viewColumn: isCloud9() ? vscode.ViewColumn.One : vscode.ViewColumn.Active,
+    })
+
+    if (!subscriptions) {
+        subscriptions = [
+            webview.onDidDispose(() => {
+                vscode.Disposable.from(...(subscriptions ?? [])).dispose()
+                activePanel = undefined
+                subscriptions = undefined
+                submitPromise = undefined
+            }),
+        ]
+    }
+
+    return submitPromise
+}

--- a/src/shared/vscode/commands2.ts
+++ b/src/shared/vscode/commands2.ts
@@ -70,25 +70,24 @@ interface DeclaredCommand<T extends Callback = Callback, U extends any[] = any[]
  *
  * @param T The class that declares the commands
  */
-interface CommandDeclarations<T> {
-    readonly backend: T
-
+export interface CommandDeclarations<T> {
     readonly declared: { [K in FunctionKeys<T>]: DeclaredCommand<Functions<T>[K], [T]> }
 }
 
-export abstract class BaseCommandDeclarations<T> implements CommandDeclarations<T> {
-    public readonly declared: { [K in FunctionKeys<T>]: DeclaredCommand<Functions<T>[K], [T]> } = {} as any
-
-    public constructor(readonly extContext: vscode.ExtensionContext, readonly backend: T) {}
-
-    /**
-     * Registers all declared commands with VS Code commands api.
-     */
-    public registerCommandsWithVSCode(): void {
-        this.extContext.subscriptions.push(
-            ...Object.values<DeclaredCommand>(this.declared).map(c => c.register(this.backend))
-        )
-    }
+/**
+ * Using the given inputs will register the given commands with VS Code.
+ *
+ * @param declarations Has the mapping of command names to the backend logic
+ * @param backend The backend logic of the commands
+ */
+export function registerCommandsWithVSCode<T>(
+    extContext: vscode.ExtensionContext,
+    declarations: CommandDeclarations<T>,
+    backend: T
+): void {
+    extContext.subscriptions.push(
+        ...Object.values<DeclaredCommand>(declarations.declared).map(c => c.register(backend))
+    )
 }
 
 /**


### PR DESCRIPTION
## Problem
We want to create a webview for Auth setup


## Solution
This PR does the following:

- Creates a vscode command which can be executed in the command palette to open the webview
- Sets up the initial code for a webview to be shown

The actual content will be added in future commits

![Kapture 2023-04-13 at 10 18 52](https://user-images.githubusercontent.com/118216176/231788335-b2e482b9-b8f8-4120-a4c6-888e592721ab.gif)

### End goal for context
![image](https://user-images.githubusercontent.com/118216176/231805989-cac34dec-80e8-43a3-bc13-4accce8813ee.png)


Fixes IDE-10461

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
