### PR TITLE
fix(icon): change custom unicode range

### DIFF
--- a/.changes/next-release/Bug Fix-a401606f-1768-452b-967b-ba24fc834b27.json
+++ b/.changes/next-release/Bug Fix-a401606f-1768-452b-967b-ba24fc834b27.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "offset icons in webviews"
+	"description": "Incorrect offset icons in webviews"
 }

--- a/.changes/next-release/Bug Fix-a401606f-1768-452b-967b-ba24fc834b27.json
+++ b/.changes/next-release/Bug Fix-a401606f-1768-452b-967b-ba24fc834b27.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "offset icons in webviews"
+}

--- a/package.json
+++ b/package.json
@@ -3280,133 +3280,133 @@
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
-                    "fontCharacter": "\\e1a5"
+                    "fontCharacter": "\\f1a5"
                 }
             },
             "aws-cdk-logo": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
-                    "fontCharacter": "\\e1a6"
+                    "fontCharacter": "\\f1a6"
                 }
             },
             "aws-cloudformation-stack": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
-                    "fontCharacter": "\\e1a7"
+                    "fontCharacter": "\\f1a7"
                 }
             },
             "aws-cloudwatch-log-group": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
-                    "fontCharacter": "\\e1a8"
+                    "fontCharacter": "\\f1a8"
                 }
             },
             "aws-codecatalyst-logo": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
-                    "fontCharacter": "\\e1a9"
+                    "fontCharacter": "\\f1a9"
                 }
             },
             "aws-ecr-registry": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
-                    "fontCharacter": "\\e1aa"
+                    "fontCharacter": "\\f1aa"
                 }
             },
             "aws-ecs-cluster": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
-                    "fontCharacter": "\\e1ab"
+                    "fontCharacter": "\\f1ab"
                 }
             },
             "aws-ecs-container": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
-                    "fontCharacter": "\\e1ac"
+                    "fontCharacter": "\\f1ac"
                 }
             },
             "aws-ecs-service": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
-                    "fontCharacter": "\\e1ad"
+                    "fontCharacter": "\\f1ad"
                 }
             },
             "aws-generic-attach-file": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
-                    "fontCharacter": "\\e1ae"
+                    "fontCharacter": "\\f1ae"
                 }
             },
             "aws-iot-certificate": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
-                    "fontCharacter": "\\e1af"
+                    "fontCharacter": "\\f1af"
                 }
             },
             "aws-iot-policy": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
-                    "fontCharacter": "\\e1b0"
+                    "fontCharacter": "\\f1b0"
                 }
             },
             "aws-iot-thing": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
-                    "fontCharacter": "\\e1b1"
+                    "fontCharacter": "\\f1b1"
                 }
             },
             "aws-lambda-function": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
-                    "fontCharacter": "\\e1b2"
+                    "fontCharacter": "\\f1b2"
                 }
             },
             "aws-s3-bucket": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
-                    "fontCharacter": "\\e1b3"
+                    "fontCharacter": "\\f1b3"
                 }
             },
             "aws-s3-create-bucket": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
-                    "fontCharacter": "\\e1b4"
+                    "fontCharacter": "\\f1b4"
                 }
             },
             "aws-schemas-registry": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
-                    "fontCharacter": "\\e1b5"
+                    "fontCharacter": "\\f1b5"
                 }
             },
             "aws-schemas-schema": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
-                    "fontCharacter": "\\e1b6"
+                    "fontCharacter": "\\f1b6"
                 }
             },
             "aws-stepfunctions-preview": {
                 "description": "AWS Contributed Icon",
                 "default": {
                     "fontPath": "./resources/fonts/aws-toolkit-icons.woff",
-                    "fontCharacter": "\\e1b7"
+                    "fontCharacter": "\\f1b7"
                 }
             }
         }

--- a/resources/css/base.css
+++ b/resources/css/base.css
@@ -237,7 +237,6 @@ textarea {
     display: inline;
     height: 16px;
     width: 16px;
-    padding: 8px;
     background-repeat: no-repeat;
     background-position: center;
 }

--- a/scripts/build/generateIcons.ts
+++ b/scripts/build/generateIcons.ts
@@ -102,7 +102,7 @@ async function generate(mappings: Record<string, number | undefined> = {}) {
         files: iconSources,
         fontName: fontId,
         formats: ['woff'],
-        startUnicode: 0xe000,
+        startUnicode: 0xf000,
         verbose: true,
         normalize: true,
         sort: true,
@@ -201,11 +201,10 @@ async function loadCodiconMappings(): Promise<Record<string, number | undefined>
     const codicons = path.join(projectDir, 'node_modules', '@vscode', 'codicons', 'src')
     const data = JSON.parse(await fs.readFile(path.join(codicons, 'template', 'mapping.json'), 'utf-8'))
     const mappings: Record<string, number | undefined> = {}
-    let counter = 0xf000
     for (const [k, v] of Object.entries(data)) {
         if (typeof k === 'string' && typeof v === 'number') {
-            mappings[`vscode-${k}`] = counter
-            counter += 1
+            // Assumption in the 0XE000 range, verify in mapping.json if needed
+            mappings[`vscode-${k}`] = v
         }
     }
 

--- a/scripts/build/generateIcons.ts
+++ b/scripts/build/generateIcons.ts
@@ -201,9 +201,11 @@ async function loadCodiconMappings(): Promise<Record<string, number | undefined>
     const codicons = path.join(projectDir, 'node_modules', '@vscode', 'codicons', 'src')
     const data = JSON.parse(await fs.readFile(path.join(codicons, 'template', 'mapping.json'), 'utf-8'))
     const mappings: Record<string, number | undefined> = {}
+    let counter = 0xf000
     for (const [k, v] of Object.entries(data)) {
         if (typeof k === 'string' && typeof v === 'number') {
-            mappings[`vscode-${k}`] = v - 0xd000
+            mappings[`vscode-${k}`] = counter
+            counter += 1
         }
     }
 

--- a/scripts/build/generateIcons.ts
+++ b/scripts/build/generateIcons.ts
@@ -203,7 +203,10 @@ async function loadCodiconMappings(): Promise<Record<string, number | undefined>
     const mappings: Record<string, number | undefined> = {}
     for (const [k, v] of Object.entries(data)) {
         if (typeof k === 'string' && typeof v === 'number') {
-            // Assumption in the 0XE000 range, verify in mapping.json if needed
+            if (v < 0xe000 || v >= 0xf000) {
+                // Will warn us if the codepoint moves outside the expected range
+                throw new Error(`Codicon "${k}" has unexpected codepoint: ${v}`)
+            }
             mappings[`vscode-${k}`] = v
         }
     }

--- a/src/codecatalyst/vue/create/source.vue
+++ b/src/codecatalyst/vue/create/source.vue
@@ -344,7 +344,6 @@ body.vscode-light .mode-container[data-disabled='true'] .config-item {
 }
 
 .edit-icon {
-    margin-left: 10px;
     color: #0078d7;
 }
 </style>

--- a/src/codecatalyst/vue/summary.vue
+++ b/src/codecatalyst/vue/summary.vue
@@ -157,7 +157,7 @@ export default defineComponent({
 
 #stop-icon {
     color: var(--vscode-debugIcon-stopForeground);
-    padding: 4px;
+    margin-right: 5px;
     vertical-align: -0.2em;
 }
 </style>


### PR DESCRIPTION
## Problem:

With the current implementation we write to a certain
unicode range which intentionally offsets the alignment
of the unicode character.

![Screen Shot 2023-04-14 at 3 58 37 PM](https://user-images.githubusercontent.com/118216176/232143620-465a62e2-d6fc-4ddb-a9bb-4b8d28d86dcf.png)


## Solution:

Use the safe range starting a 0xE000-0xF8FF.

- VSCode unicode characters will be in the 0xF000 range
- Other unicode characters will be in the 0xE000 range

Due to this we shouldn't have a collision

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
