### PR TITLE
fix(codecatalyst): reduce noisy `getUserDetails` API calls

### DIFF
--- a/src/codecatalyst/activation.ts
+++ b/src/codecatalyst/activation.ts
@@ -14,7 +14,6 @@ import { CodeCatalystAuthenticationProvider } from './auth'
 import { registerDevfileWatcher } from './devfile'
 import { DevEnvClient } from '../shared/clients/devenvClient'
 import { watchRestartingDevEnvs } from './reconnect'
-import { getCodeCatalystDevEnvId } from '../shared/vscode/env'
 import { PromptSettings } from '../shared/settings'
 import { dontShow } from '../shared/localizedText'
 import { isCloud9 } from '../shared/extensionUtilities'
@@ -62,9 +61,12 @@ export async function activate(ctx: ExtContext): Promise<void> {
         ctx.extensionContext.subscriptions.push(registerDevfileWatcher(DevEnvClient.instance))
     }
 
-    const settings = PromptSettings.instance
-    if (getCodeCatalystDevEnvId()) {
-        const thisDevenv = await getThisDevEnv(authProvider)
+    const thisDevenv = (await getThisDevEnv(authProvider))?.unwrapOrElse(err => {
+        getLogger().warn('codecatalyst: failed to get current dev enviroment: %s', err)
+        return undefined
+    })
+
+    if (thisDevenv) {
         getLogger().info('codecatalyst: Dev Environment ides=%O', thisDevenv?.summary.ides)
         if (thisDevenv && !isDevenvVscode(thisDevenv.summary.ides)) {
             // Prevent Toolkit from reconnecting to a "non-vscode" devenv by actively closing it.
@@ -73,6 +75,7 @@ export async function activate(ctx: ExtContext): Promise<void> {
             return
         }
 
+        const settings = PromptSettings.instance
         if (await settings.isPromptEnabled('remoteConnected')) {
             const message = localize(
                 'AWS.codecatalyst.connectedMessage',

--- a/src/codecatalyst/commands.ts
+++ b/src/codecatalyst/commands.ts
@@ -184,11 +184,11 @@ interface CodeCatalystCommand<T extends any[], U> {
 }
 
 interface ClientInjector {
-    <T extends any[], U>(command: CodeCatalystCommand<T, U>, ...args: T): Promise<U | undefined>
+    <T extends any[], U>(command: CodeCatalystCommand<T, U>, ...args: T): Promise<U>
 }
 
 interface CommandDecorator {
-    <T extends any[], U>(command: CodeCatalystCommand<T, U>): (...args: T) => Promise<U | undefined>
+    <T extends any[], U>(command: CodeCatalystCommand<T, U>): (...args: T) => Promise<U>
 }
 
 type Inject<T, U> = T extends (...args: infer P) => infer R
@@ -280,10 +280,6 @@ export class CodeCatalystCommands {
 
     public async openDevEnvSettings(): Promise<void> {
         const devenv = await this.withClient(getConnectedDevEnv)
-
-        if (!devenv) {
-            throw new Error('No devenv available')
-        }
 
         return this.withClient(showConfigureDevEnv, globals.context, devenv, CodeCatalystCommands.declared)
     }

--- a/src/codecatalyst/explorer.ts
+++ b/src/codecatalyst/explorer.ts
@@ -15,6 +15,7 @@ import { CodeCatalystAuthenticationProvider } from './auth'
 import { CodeCatalystCommands } from './commands'
 import { ConnectedDevEnv, getDevfileLocation, getThisDevEnv } from './model'
 import * as codecatalyst from './model'
+import { getLogger } from '../shared/logger'
 
 const getStartedCommand = Commands.register(
     'aws.codecatalyst.getStarted',
@@ -125,7 +126,10 @@ export class CodeCatalystRootNode implements RootNode {
     }
 
     public async getTreeItem() {
-        this.devenv = await getThisDevEnv(this.authProvider)
+        this.devenv = (await getThisDevEnv(this.authProvider))?.unwrapOrElse(err => {
+            getLogger().warn('codecatalyst: failed to get current dev enviroment: %s', err)
+            return undefined
+        })
 
         const item = new vscode.TreeItem('CodeCatalyst', vscode.TreeItemCollapsibleState.Collapsed)
         item.contextValue = this.authProvider.isUsingSavedConnection


### PR DESCRIPTION
## Problem
We try to call `getDevEnvironment` (and by proxy `getUserDetails`) even though we can check if it will fail ahead of time. This happens when rendering the developer tools view.

## Solution
Check our environment variables before making the call. Also move error handling up so the meaning of `undefined` is not conflated with errors. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
