### PR TITLE
Trigger on a not-yet-saved .ipynb file will no longer open a read-only file

### DIFF
--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -440,9 +440,6 @@ export class InlineCompletionService {
     }
 
     async showRecommendation(indexShift: number, isFirstRecommendation: boolean = false) {
-        if (vscode.window.activeTextEditor) {
-            vscode.window.showTextDocument(vscode.window.activeTextEditor.document)
-        }
         this.inlineCompletionProvider = new CWInlineCompletionItemProvider(
             this.inlineCompletionProvider?.getActiveItemIndex,
             indexShift


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/89420755/232974964-86bba1d9-115e-4fe4-b0cf-bc027d691257.mov


After:

https://user-images.githubusercontent.com/89420755/232974953-bded8844-5998-460d-bcea-ea539488a758.mov



## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
