### PR TITLE
Right side auth webview

### DIFF
--- a/src/credentials/vue/ServiceItemContent.vue
+++ b/src/credentials/vue/ServiceItemContent.vue
@@ -1,0 +1,29 @@
+<template>
+    <div id="service-item-content-container">TODO</div>
+</template>
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export const ServiceItemContent = defineComponent({})
+
+export default ServiceItemContent
+</script>
+<style>
+#service-item-content-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+
+    border-style: solid;
+    border-width: 2px;
+    border-radius: 4px;
+    border-color: #0097fb;
+
+    width: 700px;
+    height: 100%;
+
+    /* For testing purposes, before we have content to fill */
+    min-height: 600px;
+}
+</style>

--- a/src/credentials/vue/root.vue
+++ b/src/credentials/vue/root.vue
@@ -1,62 +1,88 @@
 <template>
-    <div class="flex-container" style="display: flex">
+    <div class="flex-container">
         <div id="left-column">
             <div>
                 <h1>Select a feature to get started</h1>
-                <div v-for="itemId in unlockedItemIds">
+                <ul class="service-item-list" v-for="itemId in unlockedItemIds">
                     <ServiceItem
                         :title="getServiceItemProps(itemId).title"
                         :description="getServiceItemProps(itemId).description"
                         :status="'UNLOCKED'"
                         :isSelected="isServiceSelected(itemId)"
+                        :isLandscape="isLandscape"
                         :id="itemId"
                         :key="buildServiceItemKey(itemId, 'UNLOCKED')"
                         @service-item-clicked="serviceWasSelected(itemId)"
                     >
+                        <template v-slot:service-item-content-slot v-if="isServiceSelected(itemId) && !isLandscape">
+                            <ServiceItemContent></ServiceItemContent>
+                        </template>
                     </ServiceItem>
-                </div>
+                </ul>
             </div>
 
             <div>
                 <h3>UNLOCK ADDITIONAL FEATURES</h3>
                 <div>Some features have additional authentication requirements to use. <a>Read more.</a></div>
 
-                <div v-for="itemId in lockedItemIds">
+                <ul class="service-item-list" v-for="itemId in lockedItemIds">
                     <ServiceItem
                         :title="getServiceItemProps(itemId).title"
                         :description="getServiceItemProps(itemId).description"
                         :status="'LOCKED'"
                         :isSelected="isServiceSelected(itemId)"
+                        :isLandscape="isLandscape"
                         :id="itemId"
                         :key="buildServiceItemKey(itemId, 'LOCKED')"
                         @service-item-clicked="serviceWasSelected(itemId)"
                     >
+                        <template v-slot:service-item-content-slot v-if="isServiceSelected(itemId) && !isLandscape">
+                            <ServiceItemContent></ServiceItemContent>
+                        </template>
                     </ServiceItem>
-                </div>
+                </ul>
             </div>
             <h3></h3>
         </div>
-        <div id="right-column"></div>
+        <div v-if="isLandscape && isAnyServiceSelected" id="right-column">
+            <ServiceItemContent></ServiceItemContent>
+        </div>
     </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue'
 import ServiceItem, { ServiceItemsState, ServiceItemId, ServiceStatus, StaticServiceItemProps } from './ServiceItem.vue'
+import ServiceItemContent from './ServiceItemContent.vue'
 
 const serviceItemsState = new ServiceItemsState()
 
 export default defineComponent({
-    components: { ServiceItem },
+    components: { ServiceItem, ServiceItemContent },
     name: 'AuthRoot',
     data() {
         return {
             unlockedItemIds: [] as ServiceItemId[],
             lockedItemIds: [] as ServiceItemId[],
+            currWindowWidth: window.innerWidth,
         }
     },
     created() {
         this.renderItems()
+    },
+    mounted() {
+        window.addEventListener('resize', this.updateWindowWidth)
+    },
+    unmounted() {
+        window.removeEventListener('resize', this.updateWindowWidth)
+    },
+    computed: {
+        isLandscape() {
+            return this.currWindowWidth > 1300
+        },
+        isAnyServiceSelected(): boolean {
+            return serviceItemsState.selected !== undefined
+        },
     },
     methods: {
         /**
@@ -86,6 +112,9 @@ export default defineComponent({
         buildServiceItemKey(id: ServiceItemId, lockStatus: ServiceStatus) {
             return id + '_' + (this.isServiceSelected(id) ? `${lockStatus}_SELECTED` : `${lockStatus}`)
         },
+        updateWindowWidth() {
+            this.currWindowWidth = window.innerWidth
+        },
     },
 })
 </script>
@@ -95,32 +124,28 @@ export default defineComponent({
 .flex-container {
     display: flex;
     flex-direction: row;
-    width: 1200px;
-}
-
-/* Makes webview responsive and changes to single column when necessary */
-@media (max-width: 1200px) {
-    .flex-container {
-        flex-direction: column;
-
-        color: red;
-    }
 }
 
 #left-column {
-    flex-grow: 1;
-    max-width: 40%;
+    width: 500px;
     box-sizing: border-box;
     margin: 10px;
 }
 
-#right-column {
-    flex-grow: 1;
-    max-width: 60%;
+.service-item-list {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+}
 
+.service-item-list li {
+    /* Creates an even separation between all list items*/
+    margin-top: 10px;
+}
+
+#right-column {
     /* This can be deleted, for development purposes */
-    background-color: aqua;
-    color: black;
-    height: 200px;
+    height: 800px;
+    margin: 10px;
 }
 </style>


### PR DESCRIPTION

## Problem

- We want to create the content box on the right side to eventually put content in to it

- Also if the page shrinks we cannot fit the content box on the right side anymore
## Solution

- Create the initial structure of the content box on the right side, we will focus on filling in the appropriate content later

- When the page shrinks render the content box under the clicked service item box

![Kapture 2023-04-19 at 09 17 51](https://user-images.githubusercontent.com/118216176/233087069-0b34418a-bde5-425d-a95b-ea84c4efb7ad.gif)


Fixes IDE-10510
Fixes IDE-10511

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
