### PR TITLE
fix(codecatalyst): use 'AWS Cloud9' client name with SSO when in C9

### DIFF
--- a/src/credentials/sso/ssoAccessTokenProvider.ts
+++ b/src/credentials/sso/ssoAccessTokenProvider.ts
@@ -19,6 +19,7 @@ import { getRequestId, getTelemetryReason, getTelemetryResult, isClientFault, To
 import { getLogger } from '../../shared/logger'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { DevSettings } from '../../shared/settings'
+import { getIdeProperties, isCloud9 } from '../../shared/extensionUtilities'
 
 const clientRegistrationType = 'public'
 const deviceGrantType = 'urn:ietf:params:oauth:grant-type:device_code'
@@ -179,8 +180,9 @@ export class SsoAccessTokenProvider {
     }
 
     private async registerClient(): Promise<ClientRegistration> {
+        const companyName = getIdeProperties().company
         return this.oidc.registerClient({
-            clientName: `AWS Toolkit for VSCode`,
+            clientName: isCloud9() ? `${companyName} Cloud9` : `${companyName} Toolkit for VSCode`,
             clientType: clientRegistrationType,
             scopes: this.profile.scopes,
         })


### PR DESCRIPTION
Partially fixes IDE-10533

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
