### PR TITLE
fix(codecatalyst): e2e test updateDevEnv failing

### DIFF
--- a/src/testE2E/codecatalyst/client.test.ts
+++ b/src/testE2E/codecatalyst/client.test.ts
@@ -132,7 +132,11 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
         })
 
         describe('getThisDevEnv', function () {
-            const ccAuth = CodeCatalystAuthenticationProvider.fromContext(globals.context)
+            let ccAuth: CodeCatalystAuthenticationProvider
+
+            before(function () {
+                ccAuth = CodeCatalystAuthenticationProvider.fromContext(globals.context)
+            })
 
             it('returns `undefined` if not in a dev environment', async function () {
                 const result = await getThisDevEnv(ccAuth)
@@ -260,6 +264,9 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
             assert.notStrictEqual(defaultDevEnv.alias, newDevEnvSettings.alias)
             assert.notStrictEqual(defaultDevEnv.instanceType, newDevEnvSettings.instanceType)
 
+            // Sanity Check due to: https://issues.amazon.com/Velox-Bug-42
+            assert.ok(defaultDevEnv.id, 'Dev Env ID should not be empty.')
+
             // Update dev env
             const updatedDevEnv = await commands.updateDevEnv(defaultDevEnv, newDevEnvSettings)
 
@@ -334,6 +341,7 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
                 instanceType,
                 persistentStorage,
                 alias: createAlias(),
+                inactivityTimeoutMinutes: 15,
             }
         }
 


### PR DESCRIPTION
For some reason the cc backend did not receive at
dev env id from our e2e test updateDevEnv api call.

This commit verifies we are giving a dev env id
before sending the api request.

Additional:

We used the variable 'globals' before it could
be properly initialized and due to the order of
execution this variable was accessed before it
could be properly initialized.

To fix this it was moved inside a 'before' block
which will ensure it gets executed AFTER all the
pre-test hooks are run, which includes initializing the global variable

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
