### PR TITLE
fix(codewhisperer): auto-connect on vscode startup

### DIFF
--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -202,10 +202,7 @@ export async function activate(context: ExtContext): Promise<void> {
         )
     )
 
-    if (!isCloud9() && !auth.isConnectionValid()) {
-        // this is to proactively check and reflect the state if user's connection is expired
-        auth.refreshCodeWhisperer()
-    }
+    await auth.restore()
 
     function activateSecurityScan() {
         context.extensionContext.subscriptions.push(

--- a/src/codewhisperer/explorer/codewhispererNode.ts
+++ b/src/codewhisperer/explorer/codewhispererNode.ts
@@ -34,10 +34,6 @@ export class CodeWhispererNode implements RootNode {
     constructor() {}
 
     public getTreeItem() {
-        if (!isCloud9()) {
-            AuthUtil.instance.restore()
-        }
-
         const item = new vscode.TreeItem('CodeWhisperer')
         item.description = this.getDescription()
         item.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -320,6 +320,7 @@ export class InlineCompletionService {
         vsCodeState.isCodeWhispererEditing = false
         ReferenceInlineProvider.instance.removeInlineReference()
         ImportAdderProvider.instance.clear()
+        await InlineCompletionService.instance.clearInlineCompletionStates(vscode.window.activeTextEditor)
     }
 
     async onCursorChange(e: vscode.TextEditorSelectionChangeEvent) {

--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -230,7 +230,6 @@ export class AuthUtil {
     }
 
     public async notifyReauthenticate(isAutoTrigger?: boolean) {
-        await this.refreshCodeWhisperer()
         this.showReauthenticatePrompt(isAutoTrigger)
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -195,6 +195,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
         await activateCloudFormationTemplateRegistry(context)
 
+        await activateCodeWhisperer(extContext)
+
         await activateAwsExplorer({
             context: extContext,
             regionProvider,
@@ -216,8 +218,6 @@ export async function activate(context: vscode.ExtensionContext) {
         await activateSam(extContext)
 
         await activateS3(extContext)
-
-        await activateCodeWhisperer(extContext)
 
         await activateEcr(context)
 


### PR DESCRIPTION
This PR also fixes some other issues:
1. Clear the inlineCompletionState on focus change so that they should still be able to invoke CW when they invoked CW and then switched to another app and switched back.
2. put activateCodeWhipserer() to be before activateAwsExplorer() since the refreshStatusBar() and showReferenceLog() commands are used within activateAwsExplorer() when the connection is changed. These
 commands are not registered until activateCodeWhisperer() has been called.
3. Remove unnecessary call to refreshCodeWhisperer(), this only needs to be called when there's a connection change.

Before:

https://user-images.githubusercontent.com/89420755/233482893-7c97b057-043d-4d1c-a761-9112c09eaaa0.mov


After:

https://user-images.githubusercontent.com/89420755/233482649-62aac6cc-2ca5-4016-ad89-54a6f7197fd4.mov




## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
