### PR TITLE
fix(auth): invalid sso tokens being loaded

### DIFF
--- a/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
+++ b/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
@@ -8,7 +8,12 @@ import * as FakeTimers from '@sinonjs/fake-timers'
 import * as sinon from 'sinon'
 import { SsoAccessTokenProvider } from '../../../credentials/sso/ssoAccessTokenProvider'
 import { installFakeClock } from '../../testUtil'
-import { getCache } from '../../../credentials/sso/cache'
+import {
+    getCache,
+    getTokenCacheFile,
+    isDirSafeToDeleteFrom,
+    getRegistrationCacheFile,
+} from '../../../credentials/sso/cache'
 
 import { instance, mock, when, anything, reset } from '../../utilities/mockito'
 import { makeTemporaryToolkitFolder, tryRemoveFolder } from '../../../shared/filesystemUtilities'
@@ -25,6 +30,8 @@ import { getOpenExternalStub } from '../../globalSetup.test'
 import { getTestWindow } from '../../shared/vscode/window'
 import { SeverityLevel } from '../../shared/vscode/message'
 import { ToolkitError } from '../../../shared/errors'
+import * as fs from 'fs'
+import * as path from 'path'
 
 const hourInMs = 3600000
 
@@ -66,6 +73,13 @@ describe('SsoAccessTokenProvider', function () {
         }
     }
 
+    async function makeTemporaryTokenCacheFolder() {
+        const root = await makeTemporaryToolkitFolder()
+        const cacheDir = path.join(root, '.aws', 'sso', 'cache')
+        fs.mkdirSync(cacheDir, { recursive: true })
+        return cacheDir
+    }
+
     before(function () {
         clock = installFakeClock()
     })
@@ -75,7 +89,7 @@ describe('SsoAccessTokenProvider', function () {
     })
 
     beforeEach(async function () {
-        tempDir = await makeTemporaryToolkitFolder()
+        tempDir = await makeTemporaryTokenCacheFolder()
         cache = getCache(tempDir)
         sut = new SsoAccessTokenProvider({ region, startUrl }, cache, instance(oidcClient))
     })
@@ -113,6 +127,74 @@ describe('SsoAccessTokenProvider', function () {
             await sut.getToken()
 
             assert.strictEqual(await cache.token.load(startUrl), undefined)
+        })
+
+        describe('does not return old tokens', function () {
+            // A file is old when the creation time is under a certain date
+            const oldTime: Date = new Date(2023, 3, 10) // April 10, 2023
+            const nonOldTime: Date = new Date(2023, 3, 15) // April 15, 2023
+
+            function oldBirthtime(file: fs.PathLike): fs.Stats {
+                return { birthtimeMs: oldTime.getTime(), birthtime: oldTime } as fs.Stats
+            }
+
+            /** Windows edge case where birthtime does not exist, instead check ctime */
+            function noBirthtimeOldCTime(file: fs.PathLike): fs.Stats {
+                return { birthtimeMs: 0, ctime: oldTime } as fs.Stats
+            }
+
+            const oldStatsFuncs = [oldBirthtime, noBirthtimeOldCTime]
+
+            oldStatsFuncs.forEach(invalidStatsFunc => {
+                it(`deletes old invalid tokens when ${invalidStatsFunc.name} then returns undefined`, async function () {
+                    await cache.token.save(startUrl, { region, startUrl, token: createToken(hourInMs) })
+                    const tokenCacheFile = getTokenCacheFile(tempDir, startUrl)
+                    assert.strictEqual(fs.existsSync(tokenCacheFile), true)
+
+                    // Set the func which returns Stats that are always 'invalid'
+                    cache = getCache(tempDir, invalidStatsFunc)
+
+                    assert.strictEqual(await cache.token.load(startUrl), undefined)
+                    assert.strictEqual(fs.existsSync(tokenCacheFile), false)
+                })
+
+                it(`deletes old invalid registrations when ${invalidStatsFunc.name} then returns undefined`, async function () {
+                    const registrationKey = { region }
+                    await cache.registration.save(registrationKey, createRegistration(hourInMs))
+                    const registrationCacheFile = getRegistrationCacheFile(tempDir, registrationKey)
+                    assert.strictEqual(fs.existsSync(registrationCacheFile), true)
+
+                    // Set the func which returns Stats that are always 'invalid'
+                    cache = getCache(tempDir, invalidStatsFunc)
+                    assert.strictEqual(await cache.token.load(startUrl), undefined)
+                    assert.strictEqual(fs.existsSync(registrationCacheFile), false)
+                })
+            })
+
+            function nonOldBirthtime(file: fs.PathLike): fs.Stats {
+                return { birthtimeMs: nonOldTime.getTime() } as fs.Stats
+            }
+
+            it(`returns token from non-old file`, async function () {
+                const token = createToken(hourInMs)
+                await cache.token.save(startUrl, { region, startUrl, token })
+                const tokenCacheFile = getTokenCacheFile(tempDir, startUrl)
+                assert.strictEqual(fs.existsSync(tokenCacheFile), true)
+
+                cache = getCache(tempDir, nonOldBirthtime)
+
+                assert.deepStrictEqual((await cache.token.load(startUrl))!.token, token)
+                assert.strictEqual(fs.existsSync(tokenCacheFile), true)
+            })
+
+            it('isDirSafeToDeleteFrom()', function () {
+                assert.ok(!isDirSafeToDeleteFrom('.'))
+                assert.ok(!isDirSafeToDeleteFrom('/'))
+                assert.ok(!isDirSafeToDeleteFrom('not/an/absolute/path'))
+                assert.ok(!isDirSafeToDeleteFrom('/a/b/c')) // Too shallow
+
+                assert.ok(isDirSafeToDeleteFrom('/a/b/c/d'))
+            })
         })
 
         it('returns `undefined` for expired tokens that cannot be refreshed', async function () {

--- a/src/test/techdebt.test.ts
+++ b/src/test/techdebt.test.ts
@@ -42,4 +42,12 @@ describe('tech debt', function () {
             'with node16+, we can use crypto.randomUUID and remove the "uuid" dependency'
         )
     })
+
+    it('temporary code removed', function () {
+        // Reason: https://sim.amazon.com/issues/IDE-10559
+        // At this point in time most users who would have run in to this error
+        // will have already had their old files deleted.
+        const august2023 = new Date(2023, 7, 1)
+        assert.ok(Date.now() < august2023.getTime(), 'remove `deleteOldFiles()` in `cache.ts`')
+    })
 })


### PR DESCRIPTION
## Problem:

At a certain point in time sso tokens became invalid.
We stored those tokens in cache and eventually they will
throw errors to the user when the are attempted to be
refreshed.

## Solution:

When the cache is being setup delete any invalid files.
Invalid files are files that were created before
a certain date.

Signed-off-by: Nikolas Komonen <nkomonen@amazon.com>

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
