### PR TITLE
fix(codewhisperer): credentials refresh does not happen on C9

### DIFF
--- a/.changes/next-release/Bug Fix-816f109a-df92-4584-8ce0-4b9f3095cc7a.json
+++ b/.changes/next-release/Bug Fix-816f109a-df92-4584-8ce0-4b9f3095cc7a.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeWhisperer shows \"The security token included in this request is expired\" in Cloud9"
+}

--- a/scripts/newChange.ts
+++ b/scripts/newChange.ts
@@ -7,6 +7,7 @@ import * as child_process from 'child_process'
 import * as fs from 'fs-extra'
 import { join } from 'path'
 import * as readlineSync from 'readline-sync'
+import * as crypto from 'crypto'
 
 const directory = join(process.cwd(), '.changes', 'next-release')
 const changeTypes = ['Breaking Change', 'Feature', 'Bug Fix', 'Deprecation', 'Removal', 'Test']

--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -187,12 +187,10 @@ export class AuthUtil {
     }
 
     public async reauthenticate() {
-        if (this.isConnectionExpired()) {
-            try {
-                await this.auth.reauthenticate(this.conn!)
-            } catch (err) {
-                throw ToolkitError.chain(err, 'Unable to authenticate connection')
-            }
+        try {
+            await this.auth.reauthenticate(this.conn!)
+        } catch (err) {
+            throw ToolkitError.chain(err, 'Unable to authenticate connection')
         }
     }
 


### PR DESCRIPTION
## Problem
We can't tell if the default connection is expired or not on C9 until after making an API call. So the `reauthenticate` logic in `authUtil.ts` does not work on C9

## Solution
Remove the check to always force a refresh

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
