### PR TITLE
package: increase minimum vscode to 1.68

### DIFF
--- a/.changes/next-release/Breaking Change-5d46678e-8c2e-4fb3-8398-2adf4fe2ebbd.json
+++ b/.changes/next-release/Breaking Change-5d46678e-8c2e-4fb3-8398-2adf4fe2ebbd.json
@@ -1,0 +1,4 @@
+{
+	"type": "Breaking Change",
+	"description": "Minimum required VS Code version is now 1.68"
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "url": "https://github.com/aws/aws-toolkit-vscode"
     },
     "engines": {
-        "vscode": "^1.65.0"
+        "vscode": "^1.68.0"
     },
     "icon": "resources/marketplace/aws-icon-256x256.png",
     "bugs": {

--- a/src/test/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/src/test/codewhisperer/util/crossFileContextUtil.test.ts
@@ -6,7 +6,6 @@
 import assert from 'assert'
 import * as vscode from 'vscode'
 import * as sinon from 'sinon'
-import * as semver from 'semver'
 import * as crossFile from '../../../codewhisperer/util/supplementalContext/crossFileContextUtil'
 import { createMockTextEditor } from '../testUtil'
 import { CodeWhispererUserGroupSettings } from '../../../codewhisperer/util/userGroupUtil'
@@ -21,19 +20,10 @@ import {
 } from '../../testUtil'
 import { areEqual, normalize } from '../../../shared/utilities/pathUtils'
 import * as path from 'path'
-import { getMinVscodeVersion } from '../../../shared/vscode/env'
 import { crossFileContextConfig } from '../../../codewhisperer/models/constants'
 
 const userGroupSettings = CodeWhispererUserGroupSettings.instance
 let tempFolder: string
-
-// VSCode tab APIs are available since 1.68.0
-function shouldRunTheTest(): boolean {
-    if (semver.gte(getMinVscodeVersion(), '1.68.0')) {
-        throw new Error('Minimum VSCode version is greater than 1.68.0, this check should be removed')
-    }
-    return !!(semver.valid(vscode.version) && semver.gte(vscode.version, '1.68.0'))
-}
 
 describe('crossFileContextUtil', function () {
     const fakeCancellationToken: vscode.CancellationToken = {
@@ -64,19 +54,11 @@ describe('crossFileContextUtil', function () {
             }
 
             it('control group', async function () {
-                if (!shouldRunTheTest()) {
-                    this.skip()
-                }
-
                 CodeWhispererUserGroupSettings.instance.userGroup = UserGroup.Control
                 await assertCorrectCodeChunk()
             })
 
             it('treatment group', async function () {
-                if (!shouldRunTheTest()) {
-                    this.skip()
-                }
-
                 CodeWhispererUserGroupSettings.instance.userGroup = UserGroup.CrossFile
                 await assertCorrectCodeChunk()
             })
@@ -113,10 +95,6 @@ describe('crossFileContextUtil', function () {
         })
 
         it('should return opened files, exclude test files and sorted ascendingly by file distance', async function () {
-            if (!shouldRunTheTest()) {
-                this.skip()
-            }
-
             const targetFile = path.join('src', 'service', 'microService', 'CodeWhispererFileContextProvider.java')
             const fileWithDistance3 = path.join('src', 'service', 'CodewhispererRecommendationService.java')
             const fileWithDistance5 = path.join('src', 'util', 'CodeWhispererConstants.java')
@@ -182,10 +160,6 @@ describe('crossFileContextUtil', function () {
 
         fileExtLists.forEach(fileExt => {
             it('should be empty if userGroup is control', async function () {
-                if (!shouldRunTheTest()) {
-                    this.skip()
-                }
-
                 const editor = await openATextEditorWithText('content-1', `file-1.${fileExt}`, tempFolder)
                 await openATextEditorWithText('content-2', `file-2.${fileExt}`, tempFolder, { preview: false })
                 await openATextEditorWithText('content-3', `file-3.${fileExt}`, tempFolder, { preview: false })
@@ -218,10 +192,6 @@ describe('crossFileContextUtil', function () {
 
         fileExtLists.forEach(fileExt => {
             it('should be non empty if usergroup is Crossfile', async function () {
-                if (!shouldRunTheTest()) {
-                    this.skip()
-                }
-
                 const editor = await openATextEditorWithText('content-1', `file-1.${fileExt}`, tempFolder)
                 await openATextEditorWithText('content-2', `file-2.${fileExt}`, tempFolder, { preview: false })
                 await openATextEditorWithText('content-3', `file-3.${fileExt}`, tempFolder, { preview: false })
@@ -254,10 +224,6 @@ describe('crossFileContextUtil', function () {
 
         fileExtLists.forEach(fileExt => {
             it('should be non empty', async function () {
-                if (!shouldRunTheTest()) {
-                    this.skip()
-                }
-
                 const editor = await openATextEditorWithText('content-1', `file-1.${fileExt}`, tempFolder)
                 await openATextEditorWithText('content-2', `file-2.${fileExt}`, tempFolder, { preview: false })
                 await openATextEditorWithText('content-3', `file-3.${fileExt}`, tempFolder, { preview: false })

--- a/src/test/shared/utilities/editorUtilities.test.ts
+++ b/src/test/shared/utilities/editorUtilities.test.ts
@@ -3,21 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as vscode from 'vscode'
 import assert from 'assert'
 import * as path from 'path'
-import * as semver from 'semver'
 import { closeAllEditors, assertTabCount, createTestWorkspaceFolder, openATextEditorWithText } from '../../testUtil'
 import { getOpenFilesInWindow } from '../../../shared/utilities/editorUtilities'
-import { getMinVscodeVersion } from '../../../shared/vscode/env'
-
-// VSCode tab APIs are available since 1.68.0
-function shouldRunTheTest(): boolean {
-    if (semver.gte(getMinVscodeVersion(), '1.68.0')) {
-        throw new Error('Minimum VSCode version is greater than 1.68.0, this check should be removed')
-    }
-    return !!(semver.valid(vscode.version) && semver.gte(vscode.version, '1.68.0'))
-}
 
 describe('supplementalContextUtil', function () {
     let tempFolder: string
@@ -37,10 +26,6 @@ describe('supplementalContextUtil', function () {
         })
 
         it('no filter provided as argument, should return all files opened', async function () {
-            if (!shouldRunTheTest()) {
-                this.skip()
-            }
-
             await openATextEditorWithText('content-1', 'file-1.java', tempFolder, { preview: false })
             await openATextEditorWithText('content-2', 'file-2.java', tempFolder, { preview: false })
             await openATextEditorWithText('content-3', 'file-3.java', tempFolder, { preview: false })
@@ -57,10 +42,6 @@ describe('supplementalContextUtil', function () {
         })
 
         it('filter argument provided, should return only files matching the predicate', async function () {
-            if (!shouldRunTheTest()) {
-                this.skip()
-            }
-
             await openATextEditorWithText('content-1', 'file-1.java', tempFolder, { preview: false })
             await openATextEditorWithText('content-2', 'file-2.java', tempFolder, { preview: false })
             await openATextEditorWithText('content-3', 'file-3.txt', tempFolder, { preview: false })

--- a/src/testInteg/cloudformation/templateRegistry.test.ts
+++ b/src/testInteg/cloudformation/templateRegistry.test.ts
@@ -10,7 +10,6 @@ import { CloudFormationTemplateRegistry } from '../../shared/fs/templateRegistry
 import { makeSampleSamTemplateYaml, strToYamlFile } from '../../test/shared/cloudformation/cloudformationTestUtils'
 import { getTestWorkspaceFolder } from '../integrationTestsUtilities'
 import { sleep, waitUntil } from '../../shared/utilities/timeoutUtils'
-import { isMinimumVersion } from '../../shared/vscode/env'
 
 /**
  * Note: these tests are pretty shallow right now. They do not test the following:
@@ -49,10 +48,7 @@ describe('CloudFormation Template Registry', async function () {
         await registryHasTargetNumberOfFiles(registry, 2)
     })
 
-    it('adds dynamically-added template files with yaml and yml extensions at various nesting levels', async function () {
-        if (!isMinimumVersion()) {
-            this.skip()
-        }
+    it.skip('adds dynamically-added template files with yaml and yml extensions at various nesting levels', async function () {
         await registry.addWatchPattern('**/test.{yaml,yml}')
 
         await strToYamlFile(makeSampleSamTemplateYaml(false), path.join(testDir, 'test.yml'))

--- a/src/testInteg/sam.test.ts
+++ b/src/testInteg/sam.test.ts
@@ -82,33 +82,6 @@ const scenarios: TestScenario[] = [
         dependencyManager: 'npm',
         vscodeMinimum: '1.50.0',
     },
-    // {
-    //     runtime: 'python3.7',
-    //     displayName: 'python3.7 (ZIP)',
-    //     path: 'hello_world/app.py',
-    //     debugSessionType: 'python',
-    //     language: 'python',
-    //     dependencyManager: 'pip',
-    //     vscodeMinimum: '1.50.0',
-    // },
-    // {
-    //     runtime: 'python3.8',
-    //     displayName: 'python3.8 (ZIP)',
-    //     path: 'hello_world/app.py',
-    //     debugSessionType: 'python',
-    //     language: 'python',
-    //     dependencyManager: 'pip',
-    //     vscodeMinimum: '1.50.0',
-    // },
-    // TODO: Add Python3.9 support to integration test hosts
-    // {
-    //     runtime: 'python3.9',
-    //     displayName: 'python3.9 (ZIP)',
-    //     path: 'hello_world/app.py',
-    //     debugSessionType: 'python',
-    //     language: 'python',
-    //     dependencyManager: 'pip',
-    // },
     {
         runtime: 'python3.10',
         displayName: 'python 3.10 (ZIP)',
@@ -117,7 +90,7 @@ const scenarios: TestScenario[] = [
         language: 'python',
         dependencyManager: 'pip',
         // https://github.com/microsoft/vscode-python/blob/main/package.json
-        vscodeMinimum: '1.78.0',
+        vscodeMinimum: '1.77.0',
     },
     {
         runtime: 'python3.11',
@@ -166,7 +139,6 @@ const scenarios: TestScenario[] = [
     //     // https://github.com/golang/vscode-go/blob/master/package.json
     //     vscodeMinimum: '1.67.0',
     // },
-    // { runtime: 'dotnetcore3.1', path: 'src/HelloWorld/Function.cs', debugSessionType: 'coreclr', language: 'csharp' },
 
     // images
     {
@@ -199,36 +171,6 @@ const scenarios: TestScenario[] = [
         dependencyManager: 'npm',
         vscodeMinimum: '1.50.0',
     },
-    // {
-    //     runtime: 'python3.7',
-    //     displayName: 'python3.7 (Image)',
-    //     baseImage: `amazon/python3.7-base`,
-    //     path: 'hello_world/app.py',
-    //     debugSessionType: 'python',
-    //     language: 'python',
-    //     dependencyManager: 'pip',
-    //     vscodeMinimum: '1.50.0',
-    // },
-    // {
-    //     runtime: 'python3.8',
-    //     displayName: 'python3.8 (Image)',
-    //     baseImage: `amazon/python3.8-base`,
-    //     path: 'hello_world/app.py',
-    //     debugSessionType: 'python',
-    //     language: 'python',
-    //     dependencyManager: 'pip',
-    //     vscodeMinimum: '1.50.0',
-    // },
-    // TODO: Add Python3.9 support to integration test hosts
-    // {
-    //     runtime: 'python3.9',
-    //     displayName: 'python3.9 (Image)',
-    //     baseImage: `amazon/python3.9-base`,
-    //     path: 'hello_world/app.py',
-    //     debugSessionType: 'python',
-    //     language: 'python',
-    //     dependencyManager: 'pip',
-    // },
     {
         runtime: 'python3.10',
         displayName: 'python 3.10 (ZIP)',
@@ -238,7 +180,7 @@ const scenarios: TestScenario[] = [
         language: 'python',
         dependencyManager: 'pip',
         // https://github.com/microsoft/vscode-python/blob/main/package.json
-        vscodeMinimum: '1.78.0',
+        vscodeMinimum: '1.77.0',
     },
     {
         runtime: 'python3.11',
@@ -292,7 +234,6 @@ const scenarios: TestScenario[] = [
         dependencyManager: 'maven',
         vscodeMinimum: '1.50.0',
     },
-    // { runtime: 'dotnetcore3.1', path: 'src/HelloWorld/Function.cs', debugSessionType: 'coreclr', language: 'csharp' },
 ]
 
 async function openSamAppFile(applicationPath: string): Promise<vscode.Uri> {


### PR DESCRIPTION
## Problem

Since #3328 5439f9527224d8d1c0b98cd9941ee55a0cefb9ae , CI job "Integration Tests - minimum" fails (timeout) of some (not all) "invokes and attaches" tests:

    5 failing
    1) SAM Integration Tests
         SAM runtime: python 3.10 (ZIP)
           Starting with a newly created python 3.10 (ZIP) SAM Application...
             target=api: invokes and attaches on debug request (F5):
       Error: Test length exceeded max duration: 300 seconds
    ...

## Notes

- Major difference is that [vscode 1.65 has nodejs 14, while vscode 1.66+ has nodejs 16](https://github.com/aws/aws-toolkit-vscode/pull/3315#issuecomment-1506896655).
- cloud9-classic has vscode extension host 1.68 + nodejs 16 ~~nodejs 12(!).~~
- cloud9-codecatalyst has vscode 1.68 + node 14.19

## Testing

Tested in vscode local, vscode remote codecatalyst, cloud9-classic, cloud9-codecatalyst.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
