### PR TITLE
fix(tests): use `go install` instead of the Go extension to install deps

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -38,6 +38,8 @@ phases:
             - '>/dev/null VERSION=$(goenv install --list | tail -n 1) && 2>/dev/null goenv install $VERSION'
             - '>/dev/null goenv global $VERSION && go env -w GOPROXY=direct'
             - go version
+            - go install golang.org/x/tools/gopls@latest
+            - go install github.com/go-delve/delve/cmd/dlv@latest
             # login to DockerHub so we don't get throttled
             - docker login --username $(echo $DOCKER_HUB_TOKEN | jq -r '.username') --password $(echo $DOCKER_HUB_TOKEN | jq -r '.password') || true
             # increase file watcher count so CodeLens tests do not fail unexpectedly (ENOSPC error)

--- a/src/integrationTest/integrationTestsUtilities.ts
+++ b/src/integrationTest/integrationTestsUtilities.ts
@@ -41,37 +41,6 @@ export async function configurePythonExtension(): Promise<void> {
     await configPy.update('linting.enabled', false, false)
 }
 
-// Installs tools that the Go extension wants (it complains a lot if we don't)
-// Had to dig around for the commands used by the Go extension.
-// Ref: https://github.com/golang/vscode-go/blob/0058bd16ba31394f98aa3396056998e4808998a7/src/goTools.ts#L211
-export async function configureGoExtension(): Promise<void> {
-    console.log('Setting up Go...')
-
-    const gopls = {
-        name: 'gopls',
-        importPath: 'golang.org/x/tools/gopls',
-        replacedByGopls: false,
-        isImportant: true,
-        description: 'Language Server from Google',
-        minimumGoVersion: '1.12',
-        latestVersion: '0.6.4',
-        latestVersionTimestamp: '2021-01-19',
-        latestPrereleaseVersion: '0.6.4',
-        latestPrereleaseVersionTimestamp: '2021-01-19',
-    }
-
-    const dlv = {
-        name: 'dlv',
-        importPath: 'github.com/go-delve/delve/cmd/dlv',
-        modulePath: 'github.com/go-delve/delve',
-        replacedByGopls: false,
-        isImportant: true,
-        description: 'Debugging',
-    }
-
-    await vscode.commands.executeCommand('go.tools.install', [gopls, dlv])
-}
-
 export async function getAddConfigCodeLens(
     documentUri: vscode.Uri,
     timeout: number,

--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -398,7 +398,6 @@ describe('SAM Integration Tests', async function () {
         await activateExtensions()
         await testUtils.configureAwsToolkitExtension()
         await testUtils.configurePythonExtension()
-        await testUtils.configureGoExtension()
 
         testSuiteRoot = await mkdtemp(path.join(projectFolder, 'inttest'))
         console.log('testSuiteRoot: ', testSuiteRoot)


### PR DESCRIPTION
## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
