### PR TITLE
telemetry(auth): report request IDs when refreshing a token fails

### DIFF
--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -579,7 +579,6 @@ const devSettings = {
     forceInstallTools: Boolean,
     telemetryEndpoint: String,
     telemetryUserPool: String,
-    reportRequestIds: Boolean,
     renderDebugDetails: Boolean,
     endpoints: Record(String, String),
     cawsStage: String,


### PR DESCRIPTION
## Problem
Some users run into obscure service errors that do not surface useful information in the error messages

## Solution
Report the request ID in telemetry so we can investigate on the service-side

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
