### PR TITLE
fix(ci): avoid rate-limiting

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -2,6 +2,9 @@ version: 0.2
 
 env:
     variables:
+        # Implicitly passed by the AWS automation pipeline:
+        # VSCODE_TEST_VERSION
+        # GITHUB_READONLY_TOKEN
         AWS_TOOLKIT_TEST_USER_DIR: '/tmp/'
         AWS_TOOLKIT_TEST_NO_COLOR: '1'
         NO_COVERAGE: 'true'
@@ -16,6 +19,7 @@ phases:
             java: latest
 
         commands:
+            - bash buildspec/setup-github-token.sh
             - '>/dev/null add-apt-repository universe'
             - '>/dev/null apt-get -qq install -y apt-transport-https'
             - '>/dev/null apt-get -qq update'
@@ -68,6 +72,10 @@ phases:
             - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
             - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g')
             - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"
+    post_build:
+        commands:
+            # Destroy .netrc to avoid leaking $GITHUB_READONLY_TOKEN.
+            - rm "$HOME/.netrc"
 reports:
     integ-test:
         files:

--- a/buildspec/setup-github-token.sh
+++ b/buildspec/setup-github-token.sh
@@ -1,0 +1,15 @@
+#!/bin/env bash
+
+set -e
+
+test -n "$GITHUB_READONLY_TOKEN" || { echo 'missing $GITHUB_READONLY_TOKEN'; exit 1; }
+
+# Authenticate all "git" (and "curl --netrc") github calls, to avoid rate-limiting.
+# NOTE: the "login" value is arbitrary.
+printf "machine github.com         login oauth password ${GITHUB_READONLY_TOKEN:-unknown}\n" >> "$HOME/.netrc"
+printf "machine api.github.com     login oauth password ${GITHUB_READONLY_TOKEN:-unknown}\n" >> "$HOME/.netrc"
+printf "machine uploads.github.com login oauth password ${GITHUB_READONLY_TOKEN:-unknown}\n" >> "$HOME/.netrc"
+# Print ratelimit info.
+2>/dev/null curl --netrc -L -I https://api.github.com/ | grep x-ratelimit | sed 's/\(.*\)/    \1/'
+# Validate ratelimit.
+2>/dev/null curl --netrc -L -I https://api.github.com/ | >/dev/null grep 'x-ratelimit-limit: *[0-9][0-9][0-9][0-9]\+' || { echo 'invalid github token, or rate limit too low (expected 5000+)'; exit 1; }


### PR DESCRIPTION

## Problem

github timeouts on various requests:

    Cloning into '/codebuild/output/src577833252/src/github.com/aws/aws-toolkit-vscode/node_modules/.zzz-awssdk2'...
    fatal: unable to access 'https://github.com/aws/aws-sdk-js.git/': Failed to connect to github.com port 443 after 130288 ms: Connection timed out


## Solution

use a github token for all "git" operations to avoid rate-limiting


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
