### PR TITLE
fix(codewhisperer): Fixes some tests that fail when run locally

### DIFF
--- a/src/test/codewhisperer/commands/onAcceptance.test.ts
+++ b/src/test/codewhisperer/commands/onAcceptance.test.ts
@@ -123,6 +123,8 @@ describe('onAcceptance', function () {
         })
 
         it('Should report telemetry that records this user decision event', async function () {
+            const testStartUrl = 'testStartUrl'
+            sinon.stub(TelemetryHelper.instance, 'startUrl').value(testStartUrl)
             const mockEditor = createMockTextEditor()
             RecommendationHandler.instance.requestId = 'test'
             RecommendationHandler.instance.sessionId = 'test'
@@ -159,6 +161,7 @@ describe('onAcceptance', function () {
                 codewhispererSuggestionReferenceCount: 0,
                 codewhispererCompletionType: 'Line',
                 codewhispererLanguage: 'python',
+                credentialStartUrl: testStartUrl,
             })
         })
     })

--- a/src/test/codewhisperer/commands/onInlineAcceptance.test.ts
+++ b/src/test/codewhisperer/commands/onInlineAcceptance.test.ts
@@ -47,6 +47,8 @@ describe('onInlineAcceptance', function () {
         })
 
         it('Should report telemetry that records this user decision event', async function () {
+            const testStartUrl = 'testStartUrl'
+            sinon.stub(TelemetryHelper.instance, 'startUrl').value(testStartUrl)
             const mockEditor = createMockTextEditor()
             RecommendationHandler.instance.requestId = 'test'
             RecommendationHandler.instance.sessionId = 'test'
@@ -83,6 +85,7 @@ describe('onInlineAcceptance', function () {
                 codewhispererSuggestionReferenceCount: 0,
                 codewhispererCompletionType: 'Line',
                 codewhispererLanguage: 'python',
+                credentialStartUrl: testStartUrl,
             })
         })
     })

--- a/src/test/codewhisperer/explorer/codewhispererNode.test.ts
+++ b/src/test/codewhisperer/explorer/codewhispererNode.test.ts
@@ -10,6 +10,17 @@ import { codewhispererNode } from '../../../codewhisperer/explorer/codewhisperer
 import { AuthUtil } from '../../../codewhisperer/util/authUtil'
 
 describe('codewhispererNode', function () {
+    let isConnectionValid: sinon.SinonStub
+    let isConnected: sinon.SinonStub
+
+    beforeEach(function () {
+        isConnectionValid = sinon.stub(AuthUtil.instance, 'isConnectionValid')
+        isConnectionValid.returns(false)
+
+        isConnected = sinon.stub(AuthUtil.instance, 'isConnected')
+        isConnected.returns(false)
+    })
+
     describe('getTreeItem', function () {
         afterEach(function () {
             sinon.restore()
@@ -26,7 +37,8 @@ describe('codewhispererNode', function () {
 
         it('should create a node showing AWS Builder ID connection', function () {
             sinon.stub(AuthUtil.instance, 'isUsingSavedConnection').get(() => true)
-            sinon.stub(AuthUtil.instance, 'isConnectionValid').resolves(true)
+            isConnectionValid.returns(true)
+
             const node = codewhispererNode
             const treeItem = node.getTreeItem()
 
@@ -38,8 +50,9 @@ describe('codewhispererNode', function () {
 
         it('should create a node showing enterprise SSO connection', function () {
             sinon.stub(AuthUtil.instance, 'isUsingSavedConnection').get(() => true)
-            sinon.stub(AuthUtil.instance, 'isConnectionValid').resolves(true)
             sinon.stub(AuthUtil.instance, 'isEnterpriseSsoInUse').resolves(true)
+            isConnectionValid.returns(true)
+
             const node = codewhispererNode
             const treeItem = node.getTreeItem()
 

--- a/src/test/codewhisperer/service/recommendationHandler.test.ts
+++ b/src/test/codewhisperer/service/recommendationHandler.test.ts
@@ -34,12 +34,14 @@ describe('recommendationHandler', function () {
         const fakeMemeto = new FakeMemento()
         const mockClient = stub(DefaultCodeWhispererClient)
         const mockEditor = createMockTextEditor()
+        const testStartUrl = 'testStartUrl'
 
         beforeEach(function () {
             sinon.restore()
             resetCodeWhispererGlobalVariables()
             mockClient.listRecommendations.resolves({})
             mockClient.generateRecommendations.resolves({})
+            sinon.stub(TelemetryHelper.instance, 'startUrl').value(testStartUrl)
         })
 
         afterEach(function () {
@@ -130,6 +132,7 @@ describe('recommendationHandler', function () {
                 codewhispererLineNumber: 1,
                 codewhispererCursorOffset: 38,
                 codewhispererLanguage: 'python',
+                credentialStartUrl: testStartUrl,
             })
         })
 
@@ -163,6 +166,7 @@ describe('recommendationHandler', function () {
                 codewhispererSuggestionReferenceCount: 0,
                 codewhispererCompletionType: 'Line',
                 codewhispererLanguage: 'python',
+                credentialStartUrl: testStartUrl,
             })
         })
     })

--- a/src/test/codewhisperer/tracker/codewhispererTracker.test.ts
+++ b/src/test/codewhisperer/tracker/codewhispererTracker.test.ts
@@ -9,6 +9,7 @@ import globals from '../../../shared/extensionGlobals'
 import { assertTelemetryCurried } from '../../testUtil'
 import { CodeWhispererTracker } from '../../../codewhisperer/tracker/codewhispererTracker'
 import { resetCodeWhispererGlobalVariables, createAcceptedSuggestionEntry } from '../testUtil'
+import { TelemetryHelper } from '../../../codewhisperer/util/telemetryHelper'
 
 describe('codewhispererTracker', function () {
     describe('enqueue', function () {
@@ -80,6 +81,8 @@ describe('codewhispererTracker', function () {
 
     describe('emitTelemetryOnSuggestion', function () {
         it('Should call recordCodewhispererUserModification with suggestion event', async function () {
+            const testStartUrl = 'testStartUrl'
+            sinon.stub(TelemetryHelper.instance, 'startUrl').value(testStartUrl)
             const suggestion = createAcceptedSuggestionEntry()
             const assertTelemetry = assertTelemetryCurried('codewhisperer_userModification')
             await CodeWhispererTracker.getTracker().emitTelemetryOnSuggestion(suggestion)
@@ -91,6 +94,7 @@ describe('codewhispererTracker', function () {
                 codewhispererModificationPercentage: 1,
                 codewhispererCompletionType: 'Line',
                 codewhispererLanguage: 'java',
+                credentialStartUrl: testStartUrl,
             })
         })
     })

--- a/src/test/codewhisperer/util/telemetryHelper.test.ts
+++ b/src/test/codewhisperer/util/telemetryHelper.test.ts
@@ -78,7 +78,6 @@ describe('telemetryHelper', function () {
                 codewhispererSuggestionReferenceCount: 0,
                 codewhispererCompletionType: 'Line',
                 codewhispererLanguage: 'python',
-                credentialStartUrl: 'https://view.awsapps.com/start',
             })
         })
     })


### PR DESCRIPTION
When unit tests are run locally + CW is setup with Builder ID the `credentialStartUrl` value will be defined, this causes unit tests to fail.

To fix it, this change adds to the assertion whatever the current `startUrl` is.

- Additionally, some tests assume that CW connection is not configured automatically. This ensures the connection is not set up and prevents any failures due to the test env.

For more info see sim IDE-10578


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
