### PR TITLE
test: run git-secrets during CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -83,3 +83,22 @@ jobs:
                   verbose: true
                   file: ./coverage/coverage-final.json
                   flags: windows-unittests
+
+    lint:
+        name: Ubuntu nodejs Lint
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [16.x]
+                vscode-version: [stable]
+        env:
+            NODE_OPTIONS: '--max-old-space-size=8192'
+        steps:
+            - uses: actions/checkout@v3
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - run: npm ci
+            - run: npm run testCompile
+            - run: npm run lint

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -137,6 +137,14 @@
             },
             "outFiles": ["${workspaceFolder}/dist/**/*.js"],
             "preLaunchTask": "${defaultBuildTask}"
+        },
+        {
+            "name": "Test Lint",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceFolder}/scripts/lint/testLint.ts",
+            "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+            "preLaunchTask": "${defaultBuildTask}"
         }
     ],
     "compounds": [

--- a/docs/TESTPLAN.md
+++ b/docs/TESTPLAN.md
@@ -15,7 +15,7 @@ Ratio of unit to integ tests: 90% unit tests, 10% system/acceptance tests.
 
 ## Test categories
 
-The test suite has two categories of tests:
+The test suite has the following categories of tests:
 
 -   Unit Tests: **fast** tests
     -   Live in `src/test/`
@@ -27,6 +27,11 @@ The test suite has two categories of tests:
     -   May use the filesystem.
     -   Main property is that [the test is fast](https://pycon-2012-notes.readthedocs.io/en/latest/fast_tests_slow_tests.html).
     -   Global state is shared across tests, thus there is a risk that later tests are polluted by earlier tests.
+-   Lint Tests:
+    -   Live in `src/testLint`
+    -   Can run from CLI with `npm run lint`
+    -   Any type of test related to the format/quality/content of the code
+    -   Does not have context of the `vscode` api
 -   Integration Tests: **slow** tests
     -   Live in `src/integrationTest/`
     -   Use a full instance of VSCode with an activated instance of the extension.

--- a/package.json
+++ b/package.json
@@ -3431,7 +3431,7 @@
         }
     },
     "scripts": {
-        "vscode:prepublish": "npm run clean && npm run buildScripts && npm run lint && webpack --mode production && npm run copyFiles -- --webpacked",
+        "vscode:prepublish": "npm run clean && npm run buildScripts && webpack --mode production && npm run copyFiles -- --webpacked",
         "clean": "ts-node ./scripts/clean.ts dist",
         "reset": "npm run clean -- node_modules && npm install",
         "copyFiles": "ts-node ./scripts/build/copyFiles.ts",
@@ -3443,7 +3443,7 @@
         "test": "npm run testCompile && ts-node ./scripts/test/test.ts && npm run report",
         "testE2E": "npm run testCompile && ts-node ./scripts/test/testE2E.ts && npm run report",
         "integrationTest": "npm run testCompile && ts-node ./scripts/test/integrationTest.ts && npm run report",
-        "lint": "eslint -c .eslintrc.js --ext .ts .",
+        "lint": "ts-node ./scripts/lint/testLint.ts",
         "lintfix": "eslint -c .eslintrc.js --fix --ext .ts .",
         "package": "ts-node ./scripts/build/package.ts",
         "install-plugin": "vsce package -o aws-toolkit-vscode-test.vsix && code --install-extension aws-toolkit-vscode-test.vsix",

--- a/scripts/lint/testLint.ts
+++ b/scripts/lint/testLint.ts
@@ -1,0 +1,29 @@
+/*!
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { glob } from 'glob'
+import * as Mocha from 'mocha'
+;(async () => {
+    try {
+        console.log('Running linting tests...')
+
+        const mocha = new Mocha()
+
+        const testFiles = glob.sync('dist/src/testLint/**/*.test.js')
+        testFiles.forEach(file => {
+            mocha.addFile(file)
+        })
+
+        mocha.run(failures => {
+            const exitCode = failures ? 1 : 0
+            console.log(`Finished running Main test suite with result code: ${exitCode}`)
+            process.exit(exitCode)
+        })
+    } catch (err) {
+        console.error(err)
+        console.error('Failed to run tests')
+        process.exit(1)
+    }
+})()

--- a/src/test/gitSecrets.test.ts
+++ b/src/test/gitSecrets.test.ts
@@ -1,0 +1,146 @@
+/*!
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe } from 'mocha'
+
+import { SpawnSyncOptions, spawnSync } from 'child_process'
+import * as assert from 'assert'
+import { getProjectDir } from './testUtil'
+import * as path from 'path'
+import { platform } from 'os'
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'fs'
+
+/**
+ * NOTES:
+ * - git-secrets patterns are set in the project's `.git/config` file
+ */
+describe('git-secrets', function () {
+    let accessKeyFilePath: string
+    let toolkitProjectDir: string
+    let testFixturesPath: string
+    let gitSecrets: string // path to the git-secrets executable
+
+    /** git-secrets patterns that will not cause a failure during the scan */
+    function setAllowListPatterns(gitSecrets: string) {
+        const allowListPatterns: string[] = ['"accountId": "123456789012"']
+
+        allowListPatterns.forEach(pattern => {
+            // Returns non-zero exit code if pattern already exists
+            runCmd([gitSecrets, '--add', '--allowed', pattern], { cwd: toolkitProjectDir, throws: false })
+        })
+    }
+
+    function setDenyListPatterns(gitSecrets: string) {
+        const denyListPatterns: string[] = []
+
+        denyListPatterns.forEach(pattern => {
+            // Returns non-zero exit code if pattern already exists
+            runCmd([gitSecrets, '--add', pattern], { cwd: toolkitProjectDir, throws: false })
+        })
+    }
+
+    function setupTestFixturesDir(toolkitProjectDir: string) {
+        const testFixturesPath = path.join(toolkitProjectDir, 'src', 'testFixtures', 'bin')
+        mkdirSync(testFixturesPath, { recursive: true })
+        return testFixturesPath
+    }
+
+    function setupAccessKeyFile(testFixturesPath: string) {
+        const accessKeyFilePath = path.join(testFixturesPath, 'fileWithAccessKey.ts')
+        deleteFileIfExists(accessKeyFilePath)
+        return accessKeyFilePath
+    }
+
+    function setupGitSecretsExecutable(testFixturesPath: string) {
+        const gitSecretsExecutablePath = path.join(testFixturesPath, 'git-secrets')
+
+        if (existsSync(gitSecretsExecutablePath)) {
+            console.log('INFO: git-secrets already installed')
+        } else {
+            console.log('INFO: Installing git-secrets...')
+            runCmd(['mkdir', '-p', path.parse(gitSecretsExecutablePath).dir])
+            runCmd([
+                'curl',
+                '-o',
+                gitSecretsExecutablePath,
+                'https://raw.githubusercontent.com/awslabs/git-secrets/99d01d58ebcc06e237c0e3f3ff5ae628aeef6aa6/git-secrets',
+            ])
+            runCmd(['chmod', '+x', gitSecretsExecutablePath])
+        }
+
+        return gitSecretsExecutablePath
+    }
+
+    function deleteFileIfExists(filePath: string) {
+        if (existsSync(filePath)) {
+            unlinkSync(filePath)
+        }
+    }
+
+    function createFileWithSecretKey(accessKeyFilePath: string) {
+        // Create file in project that has secret key value.
+        // Need to build access key string incrementally to not trigger git-secrets.
+        const keyValue = 'yAki21XLhAIBiKvyaxr4p/ltr8OxkZTHISISFAKE'
+        const mySecretAccessKey = `const x = { "aws_secret_access_key": "${keyValue}" }`
+        const fileContent = `
+/*!
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+${mySecretAccessKey}
+`.trim()
+        writeFileSync(accessKeyFilePath, fileContent)
+    }
+
+    before(function () {
+        if (platform() === 'win32') {
+            this.skip()
+        }
+
+        toolkitProjectDir = path.join(getProjectDir(), '..', '..')
+        testFixturesPath = setupTestFixturesDir(toolkitProjectDir)
+        gitSecrets = setupGitSecretsExecutable(testFixturesPath)
+        accessKeyFilePath = setupAccessKeyFile(testFixturesPath)
+
+        // Register all patterns with `git-secrets`
+        runCmd([gitSecrets, '--register-aws'], { cwd: toolkitProjectDir })
+        setDenyListPatterns(gitSecrets)
+        setAllowListPatterns(gitSecrets)
+    })
+
+    afterEach(function () {
+        deleteFileIfExists(accessKeyFilePath)
+    })
+
+    it('ensures no git secrets are found', function () {
+        const result = runCmd([gitSecrets, '--scan'], { cwd: toolkitProjectDir })
+        assert.strictEqual(result.status, 0, `Failure output: ${result.stderr.toString()}`)
+    })
+
+    it('sanity check it finds secrets', function () {
+        createFileWithSecretKey(accessKeyFilePath)
+        const result = runCmd([gitSecrets, '--scan', accessKeyFilePath], { cwd: toolkitProjectDir, throws: false })
+        assert.strictEqual(result.status, 1)
+    })
+})
+
+function runCmd(args: string[], options?: SpawnSyncOptions & { throws?: boolean }) {
+    const result = spawnSync(args[0], args.slice(1), options)
+
+    const throws = options?.throws ?? true
+    if (throws && result.status !== 0) {
+        throw new Error(`
+-----
+Error running: $ ${args.join(' ')}
+
+status: ${result.status}
+error: ${result.error?.toString()}
+stdout: ${result.stdout?.toString()}
+stderr: ${result.stderr?.toString()}
+-----`)
+    }
+    return result
+}

--- a/src/testLint/README.md
+++ b/src/testLint/README.md
@@ -1,0 +1,4 @@
+# Lint Tests
+
+These are linting related tests that must pass in CI. Lint code is nodejs-only, they
+must not use the vscode API.

--- a/src/testLint/eslint.test.ts
+++ b/src/testLint/eslint.test.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { runCmd } from './testUtils'
+
+describe('eslint', function () {
+    this.timeout(180_000)
+
+    it('passes eslint', function () {
+        const result = runCmd(['./node_modules/.bin/eslint', '-c', '.eslintrc.js', '--ext', '.ts', '.'], {
+            throws: false,
+        })
+        assert.strictEqual(result.status, 0, result.error)
+    })
+})

--- a/src/testLint/gitSecrets.test.ts
+++ b/src/testLint/gitSecrets.test.ts
@@ -5,12 +5,11 @@
 
 import { describe } from 'mocha'
 
-import { SpawnSyncOptions, spawnSync } from 'child_process'
 import * as assert from 'assert'
-import { getProjectDir } from './testUtil'
 import * as path from 'path'
 import { platform } from 'os'
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'fs'
+import { runCmd } from './testUtils'
 
 /**
  * NOTES:
@@ -100,7 +99,7 @@ ${mySecretAccessKey}
             this.skip()
         }
 
-        toolkitProjectDir = path.join(getProjectDir(), '..', '..')
+        toolkitProjectDir = path.resolve()
         testFixturesPath = setupTestFixturesDir(toolkitProjectDir)
         gitSecrets = setupGitSecretsExecutable(testFixturesPath)
         accessKeyFilePath = setupAccessKeyFile(testFixturesPath)
@@ -126,21 +125,3 @@ ${mySecretAccessKey}
         assert.strictEqual(result.status, 1)
     })
 })
-
-function runCmd(args: string[], options?: SpawnSyncOptions & { throws?: boolean }) {
-    const result = spawnSync(args[0], args.slice(1), options)
-
-    const throws = options?.throws ?? true
-    if (throws && result.status !== 0) {
-        throw new Error(`
------
-Error running: $ ${args.join(' ')}
-
-status: ${result.status}
-error: ${result.error?.toString()}
-stdout: ${result.stdout?.toString()}
-stderr: ${result.stderr?.toString()}
------`)
-    }
-    return result
-}

--- a/src/testLint/testUtils.ts
+++ b/src/testLint/testUtils.ts
@@ -1,0 +1,24 @@
+/*!
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SpawnSyncOptions, spawnSync } from 'child_process'
+
+export function runCmd(args: string[], options?: SpawnSyncOptions & { throws?: boolean }) {
+    const result = spawnSync(args[0], args.slice(1), options)
+
+    const throws = options?.throws ?? true
+    if (throws && result.status !== 0) {
+        throw new Error(`
+-----
+Error running: $ ${args.join(' ')}
+
+status: ${result.status}
+error: ${result.error?.toString()}
+stdout: ${result.stdout?.toString()}
+stderr: ${result.stderr?.toString()}
+-----`)
+    }
+    return result
+}


### PR DESCRIPTION
This PR

- Creates a new test directory called `testLint/` which will hold our code linting related tests
  - Creates a git-secrets test in `testLint/` which runs `git-secrets` on our codebase
  - Creates a eslint test in `testLint/` which runs `eslint` on our codebase
- Adds a new CI job that runs the `testLint/` tests as well as the existing code coverage tests which were running in the regular tests before
- Can run the lint tests with the new `launch.json` command or `npm run lint` from cli

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
