### PR TITLE
fix(ci): update minimum vscode version required by extensions

### DIFF
--- a/src/integrationTest/sam.test.ts
+++ b/src/integrationTest/sam.test.ts
@@ -116,7 +116,8 @@ const scenarios: TestScenario[] = [
         debugSessionType: 'python',
         language: 'python',
         dependencyManager: 'pip',
-        vscodeMinimum: '1.65.0',
+        // https://github.com/microsoft/vscode-python/blob/main/package.json
+        vscodeMinimum: '1.78.0',
     },
     {
         runtime: 'java8',
@@ -153,7 +154,7 @@ const scenarios: TestScenario[] = [
         language: 'go',
         dependencyManager: 'mod',
         // https://github.com/golang/vscode-go/blob/master/package.json
-        vscodeMinimum: '1.59.0',
+        vscodeMinimum: '1.67.0',
     },
     // { runtime: 'dotnetcore3.1', path: 'src/HelloWorld/Function.cs', debugSessionType: 'coreclr', language: 'csharp' },
 
@@ -226,7 +227,8 @@ const scenarios: TestScenario[] = [
         debugSessionType: 'python',
         language: 'python',
         dependencyManager: 'pip',
-        vscodeMinimum: '1.65.0',
+        // https://github.com/microsoft/vscode-python/blob/main/package.json
+        vscodeMinimum: '1.78.0',
     },
     {
         runtime: 'go1.x',
@@ -237,7 +239,7 @@ const scenarios: TestScenario[] = [
         language: 'go',
         dependencyManager: 'mod',
         // https://github.com/golang/vscode-go/blob/master/package.json
-        vscodeMinimum: '1.59.0',
+        vscodeMinimum: '1.67.0',
     },
     {
         runtime: 'java8',


### PR DESCRIPTION
## Problem

integ tests timing out for python3.10 and go1.x for "minimum" job.

## Solution

bump the required minimum expected by the related vscode extensions.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
