### PR TITLE
fix: failing ssh extension install test

### DIFF
--- a/src/testE2E/codecatalyst/client.test.ts
+++ b/src/testE2E/codecatalyst/client.test.ts
@@ -219,7 +219,7 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
             })
 
             notification.selectItem('Install...')
-            await captureEventOnce(vscode.extensions.onDidChange, 30_000).catch(() => {
+            await captureEventOnce(vscode.extensions.onDidChange, 60_000).catch(() => {
                 throw new Error('Timed out waiting to install remote SSH extension')
             })
         })


### PR DESCRIPTION
It was timing out. This increases the timeout period to hopefully have the extension installed in time.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
