### PR TITLE
fix(codewhisperer): fix time to first recommendation telemetry

### DIFF
--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -202,7 +202,9 @@ export class RecommendationHandler {
                 sessionId = resp?.$response?.httpResponse?.headers['x-amzn-sessionid']
                 TelemetryHelper.instance.setFirstResponseRequestId(requestId)
                 TelemetryHelper.instance.setSessionId(sessionId)
-                TelemetryHelper.instance.setFirstRecommendationResponseTime(performance.now())
+                if (page === 0) {
+                    TelemetryHelper.instance.setTimeToFirstRecommendation(performance.now())
+                }
                 if (nextToken === '') {
                     TelemetryHelper.instance.setLastRequestId(requestId)
                     TelemetryHelper.instance.setAllPaginationEndTime()

--- a/src/codewhisperer/util/telemetryHelper.ts
+++ b/src/codewhisperer/util/telemetryHelper.ts
@@ -68,7 +68,7 @@ export class TelemetryHelper {
     private timeSinceLastModification = 0
     private lastTriggerDecisionTime = 0
     private invocationTime = 0
-    private firstRecommendationTime = 0
+    private timeToFirstRecommendation = 0
     private classifierResult?: number = undefined
 
     constructor() {
@@ -263,7 +263,7 @@ export class TelemetryHelper {
             codewhispererTimeSinceLastUserDecision: this.lastTriggerDecisionTime
                 ? performance.now() - this.lastTriggerDecisionTime
                 : undefined,
-            codewhispererTimeToFirstRecommendation: this.firstRecommendationTime - this.invocationTime,
+            codewhispererTimeToFirstRecommendation: this.timeToFirstRecommendation,
             codewhispererTriggerCharacter: autoTriggerType === 'SpecialCharacters' ? this.triggerChar : undefined,
             codewhispererSuggestionState: this.getAggregatedUserDecision(this.sessionDecisions),
             codewhispererPreviousSuggestionState: this.prevTriggerDecision,
@@ -313,8 +313,10 @@ export class TelemetryHelper {
         this.invocationTime = invocationTime
     }
 
-    public setFirstRecommendationResponseTime(firstRecommendationTime: number) {
-        this.firstRecommendationTime = firstRecommendationTime
+    public setTimeToFirstRecommendation(timeToFirstRecommendation: number) {
+        if (this.invocationTime) {
+            this.timeToFirstRecommendation = timeToFirstRecommendation - this.invocationTime
+        }
     }
 
     private resetUserTriggerDecisionTelemetry() {
@@ -326,8 +328,7 @@ export class TelemetryHelper {
         this.numberOfRequests = 0
         this.typeAheadLength = 0
         this.timeSinceLastModification = 0
-        this.invocationTime = 0
-        this.firstRecommendationTime = 0
+        this.timeToFirstRecommendation = 0
         this.classifierResult = undefined
     }
 


### PR DESCRIPTION
## Problem
 if the next trigger happens before emiting of the prev. user trigger event, the invocation time got reset and the time to first recommendation becomes negative

## Solution
set the time when we get the response and don't clear the invocation time after emiting

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
