### PR TITLE
fix(codewhisperer): hide status bar if not connected

### DIFF
--- a/.changes/next-release/Bug Fix-d3b72a5f-4c18-47ab-afd9-ad97411e4bc6.json
+++ b/.changes/next-release/Bug Fix-d3b72a5f-4c18-47ab-afd9-ad97411e4bc6.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeWhisperer status bar showing even when not in use"
+}

--- a/src/codewhisperer/commands/basicCommands.ts
+++ b/src/codewhisperer/commands/basicCommands.ts
@@ -147,7 +147,9 @@ async function showCodeWhispererWelcomeMessage(context: ExtContext): Promise<voi
 export const refreshStatusBar = Commands.declare('aws.codeWhisperer.refreshStatusBar', () => () => {
     if (AuthUtil.instance.isConnectionValid()) {
         InlineCompletionService.instance.setCodeWhispererStatusBarOk()
-    } else {
+    } else if (AuthUtil.instance.isConnectionExpired()) {
         InlineCompletionService.instance.setCodeWhispererStatusBarDisconnected()
+    } else {
+        InlineCompletionService.instance.hideCodeWhispererStatusBar()
     }
 })

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -500,6 +500,7 @@ export class InlineCompletionService {
     }
 
     hideCodeWhispererStatusBar() {
+        this._isPaginationRunning = false
         this.statusBar.hide()
     }
 


### PR DESCRIPTION
## Problem
when users are not using CWSPR, we shouldn't show the status bar
## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
