### PR TITLE
authWebview: Auth refactoring + new funcs

### DIFF
--- a/src/credentials/providers/sharedCredentialsProvider.ts
+++ b/src/credentials/providers/sharedCredentialsProvider.ts
@@ -28,12 +28,11 @@ import {
     getSectionOrThrow,
     isProfileSection,
     Profile,
-    SectionName,
     Section,
 } from '../sharedCredentials'
 import { hasScopes, SsoProfile } from '../auth'
 import { builderIdStartUrl } from '../sso/model'
-import { SharedCredentialsKeys } from '../types'
+import { SectionName, SharedCredentialsKeys } from '../types'
 
 const credentialSources = {
     ECS_CONTAINER: 'EcsContainer',

--- a/src/credentials/sharedCredentials.ts
+++ b/src/credentials/sharedCredentials.ts
@@ -244,7 +244,9 @@ export async function saveProfileToCredentials(
     profileData: StaticCredentialsProfileData
 ): Promise<void> {
     if (await profileExists(profileName)) {
-        throw new Error(`Cannot save profile, ${profileName}, because it already exists.`)
+        throw new ToolkitError(`Cannot save profile "${profileName}" because it already exists.`, {
+            code: 'ProfileAlreadyExists',
+        })
     }
 
     return UserCredentialsUtils.generateCredentialsFile({
@@ -257,7 +259,7 @@ export async function saveProfileToCredentials(
 /**
  * Checks if a profile exists in a shared credentials file.
  */
-async function profileExists(profileName: SectionName): Promise<boolean> {
+export async function profileExists(profileName: SectionName): Promise<boolean> {
     const existingProfiles = await loadSharedCredentialsProfiles()
     return Object.keys(existingProfiles).includes(profileName)
 }

--- a/src/credentials/sharedCredentials.ts
+++ b/src/credentials/sharedCredentials.ts
@@ -8,7 +8,7 @@ import { SystemUtilities } from '../shared/systemUtilities'
 import { ToolkitError } from '../shared/errors'
 import { assertHasProps } from '../shared/utilities/tsUtils'
 import { getConfigFilename, getCredentialsFilename } from './sharedCredentialsFile'
-import { StaticCredentialsProfileData } from './types'
+import { SectionName, StaticCredentialsProfileData } from './types'
 import { UserCredentialsUtils } from '../shared/credentials/userCredentialsUtils'
 
 export async function updateAwsSdkLoadConfigEnvVar(): Promise<void> {
@@ -240,7 +240,7 @@ async function loadCredentialsFile(credentialsUri?: vscode.Uri): Promise<ReturnT
  * Saves the given profile data to the credentials file.
  */
 export async function saveProfileToCredentials(
-    profileName: ProfileName,
+    profileName: SectionName,
     profileData: StaticCredentialsProfileData
 ): Promise<void> {
     if (await profileExists(profileName)) {
@@ -257,17 +257,10 @@ export async function saveProfileToCredentials(
 /**
  * Checks if a profile exists in a shared credentials file.
  */
-async function profileExists(profileName: ProfileName): Promise<boolean> {
+async function profileExists(profileName: SectionName): Promise<boolean> {
     const existingProfiles = await loadSharedCredentialsProfiles()
     return Object.keys(existingProfiles).includes(profileName)
 }
-
-/**
- * The name of a section in a credentials/config file
- *
- * The is the value of `{A}` in `[ {A} ]` or `[ {B} {A} ]`.
- */
-export type SectionName = string
 
 export interface Profile {
     [key: string]: string | undefined

--- a/src/credentials/sharedCredentialsValidation.ts
+++ b/src/credentials/sharedCredentialsValidation.ts
@@ -1,0 +1,40 @@
+/*!
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This module focuses on the validation of shared credentials properties
+ */
+
+import { localize } from 'vscode-nls'
+import { SharedCredentialsKeys } from './types'
+
+/**
+ * The format validators for shared credentials keys.
+ *
+ * A format validator validates the format of the data,
+ * but not the validity of the content.
+ */
+export const CredentialsKeyFormatValidators = {
+    [SharedCredentialsKeys.AWS_ACCESS_KEY_ID]: getAccessKeyIdFormatError,
+    [SharedCredentialsKeys.AWS_SECRET_ACCESS_KEY]: getSecretAccessKeyFormatError,
+} as const
+
+const accessKeyPattern = /[\w]{16,128}/
+
+function getAccessKeyIdFormatError(awsAccessKeyId: string): string | undefined {
+    if (awsAccessKeyId === '') {
+        return localize('AWS.credentials.error.emptyAccessKey', 'Access key must not be empty')
+    }
+    if (!accessKeyPattern.test(awsAccessKeyId)) {
+        return localize(
+            'AWS.credentials.error.emptyAccessKey',
+            'Access key must be alphanumeric and between 16 and 128 characters'
+        )
+    }
+}
+
+function getSecretAccessKeyFormatError(awsSecretAccessKey: string): string | undefined {
+    if (awsSecretAccessKey === '') {
+        return localize('AWS.credentials.error.emptySecretKey', 'Secret key must not be empty')
+    }
+}

--- a/src/credentials/sharedCredentialsValidation.ts
+++ b/src/credentials/sharedCredentialsValidation.ts
@@ -6,7 +6,9 @@
  */
 
 import { localize } from 'vscode-nls'
-import { SharedCredentialsKeys } from './types'
+import { SectionName, SharedCredentialsKeys, StaticCredentialsProfileData } from './types'
+import { ToolkitError } from '../shared/errors'
+import { profileExists } from './sharedCredentials'
 
 /**
  * The format validators for shared credentials keys.
@@ -19,9 +21,42 @@ export const CredentialsKeyFormatValidators = {
     [SharedCredentialsKeys.AWS_SECRET_ACCESS_KEY]: getSecretAccessKeyFormatError,
 } as const
 
+/**
+ * Holds the error for each key of static credentials data,
+ * if it exists. This allows the user to get all the errors
+ * at once.
+ */
+export type StaticCredentialsErrorResult = {
+    [k in keyof StaticCredentialsProfileData]: string | undefined
+}
+
+export function getStaticCredentialsDataErrors(
+    data: StaticCredentialsProfileData
+): StaticCredentialsErrorResult | undefined {
+    const accessKeyIdError = CredentialsKeyFormatValidators[SharedCredentialsKeys.AWS_ACCESS_KEY_ID](
+        data[SharedCredentialsKeys.AWS_ACCESS_KEY_ID]
+    )
+    const secretAccessKeyError = CredentialsKeyFormatValidators[SharedCredentialsKeys.AWS_SECRET_ACCESS_KEY](
+        data[SharedCredentialsKeys.AWS_SECRET_ACCESS_KEY]
+    )
+
+    if (accessKeyIdError === undefined && secretAccessKeyError === undefined) {
+        return undefined
+    }
+
+    return {
+        [SharedCredentialsKeys.AWS_ACCESS_KEY_ID]: accessKeyIdError,
+        [SharedCredentialsKeys.AWS_SECRET_ACCESS_KEY]: secretAccessKeyError,
+    }
+}
+
 const accessKeyPattern = /[\w]{16,128}/
 
-function getAccessKeyIdFormatError(awsAccessKeyId: string): string | undefined {
+function getAccessKeyIdFormatError(awsAccessKeyId: string | undefined): string | undefined {
+    if (awsAccessKeyId === undefined) {
+        return undefined
+    }
+
     if (awsAccessKeyId === '') {
         return localize('AWS.credentials.error.emptyAccessKey', 'Access key must not be empty')
     }
@@ -33,8 +68,27 @@ function getAccessKeyIdFormatError(awsAccessKeyId: string): string | undefined {
     }
 }
 
-function getSecretAccessKeyFormatError(awsSecretAccessKey: string): string | undefined {
+function getSecretAccessKeyFormatError(awsSecretAccessKey: string | undefined): string | undefined {
+    if (awsSecretAccessKey === undefined) {
+        return undefined
+    }
+
     if (awsSecretAccessKey === '') {
         return localize('AWS.credentials.error.emptySecretKey', 'Secret key must not be empty')
+    }
+}
+
+/** To be used as a sanity check to validate all core parts of a credentials profile */
+export async function validateCredentialsProfile(profileName: SectionName, profileData: StaticCredentialsProfileData) {
+    if (await profileExists(profileName)) {
+        throw new ToolkitError(`Credentials profile "${profileName}" already exists`)
+    }
+
+    const credentialsDataErrors = getStaticCredentialsDataErrors(profileData)
+    if (credentialsDataErrors !== undefined) {
+        throw new ToolkitError(`Errors in credentials data: ${credentialsDataErrors}`, {
+            code: 'InvalidCredentialsData',
+            details: credentialsDataErrors,
+        })
     }
 }

--- a/src/credentials/types.ts
+++ b/src/credentials/types.ts
@@ -33,3 +33,10 @@ export interface StaticCredentialsProfileData {
     [SharedCredentialsKeys.AWS_ACCESS_KEY_ID]: string
     [SharedCredentialsKeys.AWS_SECRET_ACCESS_KEY]: string
 }
+
+/**
+ * The name of a section in a credentials/config file
+ *
+ * The is the value of `{A}` in `[ {A} ]` or `[ {B} {A} ]`.
+ */
+export type SectionName = string

--- a/src/credentials/wizards/templates.ts
+++ b/src/credentials/wizards/templates.ts
@@ -12,12 +12,11 @@ import { ProfileTemplateProvider } from './createProfile'
 import { createCommonButtons } from '../../shared/ui/buttons'
 import { credentialHelpUrl } from '../../shared/constants'
 import { SharedCredentialsKeys, StaticCredentialsProfileData } from '../types'
+import { CredentialsKeyFormatValidators } from '../sharedCredentialsValidation'
 
 function getTitle(profileName: string): string {
     return localize('AWS.title.createCredentialProfile', 'Creating new profile "{0}"', profileName)
 }
-
-const accessKeyPattern = /[\w]{16,128}/
 
 export const staticCredentialsTemplate: ProfileTemplateProvider<StaticCredentialsProfileData> = {
     label: 'Static Credentials',
@@ -34,17 +33,7 @@ export const staticCredentialsTemplate: ProfileTemplateProvider<StaticCredential
                     'Input the {0} Access Key',
                     getIdeProperties().company
                 ),
-                validateInput: accessKey => {
-                    if (accessKey === '') {
-                        return localize('AWS.credentials.error.emptyAccessKey', 'Access key must not be empty')
-                    }
-                    if (!accessKeyPattern.test(accessKey)) {
-                        return localize(
-                            'AWS.credentials.error.emptyAccessKey',
-                            'Access key must be alphanumeric and between 16 and 128 characters'
-                        )
-                    }
-                },
+                validateInput: CredentialsKeyFormatValidators.aws_access_key_id,
             }),
         [SharedCredentialsKeys.AWS_SECRET_ACCESS_KEY]: name =>
             createInputBox({
@@ -57,11 +46,7 @@ export const staticCredentialsTemplate: ProfileTemplateProvider<StaticCredential
                     'Input the {0} Secret Key',
                     getIdeProperties().company
                 ),
-                validateInput: secretKey => {
-                    if (secretKey === '') {
-                        return localize('AWS.credentials.error.emptySecretKey', 'Secret key must not be empty')
-                    }
-                },
+                validateInput: CredentialsKeyFormatValidators.aws_secret_access_key,
                 password: true,
             }),
     },


### PR DESCRIPTION
- Refactors some existing auth code
- Adds a new sharedCredentialsValidation class which centralizes validation of shared credentials data
  - Previous validation functionality was moved in to this file
- Added function to be able to save credentials data (aws access key, secret key) at once to the credentials file.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
