### PR TITLE
fix(codecatalyst): "Open Dev Environment" fails on flatpak

### DIFF
--- a/.changes/next-release/Bug Fix-141dd557-3cb2-4651-a93e-afdaffca9637.json
+++ b/.changes/next-release/Bug Fix-141dd557-3cb2-4651-a93e-afdaffca9637.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "\"Open CodeCatalyst Dev Environment\" fails on flatpak (steamdeck)"
+}

--- a/src/shared/systemUtilities.ts
+++ b/src/shared/systemUtilities.ts
@@ -197,6 +197,9 @@ export class SystemUtilities {
         const vscExe = process.argv0
         // https://github.com/microsoft/vscode-test/blob/4bdccd4c386813a8158b0f9b96f31cbbecbb3374/lib/util.ts#L133
         const vscs = [
+            // Special case for flatpak (steamdeck). #V896741845
+            // https://github.com/flathub/com.visualstudio.code/blob/master/code.sh
+            '/app/bin/code',
             // Note: macOS does not have a separate "code-insiders" binary.
             path.resolve(`${vscode.env.appRoot}/bin/code`), // macOS
             path.resolve(`${vscode.env.appRoot}/../../bin/code`), // Windows


### PR DESCRIPTION
Problem:
"Open CodeCatalyst Dev Environment" fails on flatpak (steamdeck).

Solution:
Prefer the special flatpak path `/app/bin/code`, instead of the $appRoot-relative path inferred from the current vscode process.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
