### PR TITLE
refactor: Credentials Validation

### DIFF
--- a/src/credentials/auth.ts
+++ b/src/credentials/auth.ts
@@ -46,8 +46,8 @@ import { AsyncCollection, toCollection } from '../shared/utilities/asyncCollecti
 import { join, toStream } from '../shared/utilities/collectionUtils'
 import { getConfigFilename } from './sharedCredentialsFile'
 import { saveProfileToCredentials } from './sharedCredentials'
-import { SectionName, StaticCredentialsProfileData } from './types'
-import { validateCredentialsProfile } from './sharedCredentialsValidation'
+import { SectionName, StaticCredentialsProfileKeys } from './types'
+import { throwOnInvalidCredentials } from './sharedCredentialsValidation'
 
 export const ssoScope = 'sso:account:access'
 export const codecatalystScopes = ['codecatalyst:read_write']
@@ -1204,10 +1204,10 @@ const addConnection = Commands.register('aws.auth.addConnection', async () => {
 
 export async function tryAddCredentials(
     profileName: SectionName,
-    profileData: StaticCredentialsProfileData,
+    profileData: StaticCredentialsProfileKeys,
     tryConnect = true
 ): Promise<boolean> {
-    await validateCredentialsProfile(profileName, profileData)
+    await throwOnInvalidCredentials(profileName, profileData)
     await saveProfileToCredentials(profileName, profileData)
     if (tryConnect) {
         const auth = Auth.instance

--- a/src/credentials/sharedCredentials.ts
+++ b/src/credentials/sharedCredentials.ts
@@ -8,7 +8,7 @@ import { SystemUtilities } from '../shared/systemUtilities'
 import { ToolkitError } from '../shared/errors'
 import { assertHasProps } from '../shared/utilities/tsUtils'
 import { getConfigFilename, getCredentialsFilename } from './sharedCredentialsFile'
-import { SectionName, StaticCredentialsProfileData } from './types'
+import { SectionName, StaticCredentialsProfileKeys } from './types'
 import { UserCredentialsUtils } from '../shared/credentials/userCredentialsUtils'
 
 export async function updateAwsSdkLoadConfigEnvVar(): Promise<void> {
@@ -241,7 +241,7 @@ async function loadCredentialsFile(credentialsUri?: vscode.Uri): Promise<ReturnT
  */
 export async function saveProfileToCredentials(
     profileName: SectionName,
-    profileData: StaticCredentialsProfileData
+    profileData: StaticCredentialsProfileKeys
 ): Promise<void> {
     if (await profileExists(profileName)) {
         throw new ToolkitError(`Cannot save profile "${profileName}" because it already exists.`, {

--- a/src/credentials/types.ts
+++ b/src/credentials/types.ts
@@ -24,15 +24,18 @@ export const SharedCredentialsKeys = {
     SSO_REGISTRATION_SCOPES: 'sso_registration_scopes',
 } as const
 
+/** An object that has only credentials data */
+export type CredentialsData = Partial<Record<CredentialsKey, string>>
+
+export type CredentialsKey = (typeof SharedCredentialsKeys)[keyof typeof SharedCredentialsKeys]
+
 /**
  * The required keys for a static credentials profile
  *
  * https://docs.aws.amazon.com/sdkref/latest/guide/feature-static-credentials.html
  */
-export interface StaticCredentialsProfileData {
-    [SharedCredentialsKeys.AWS_ACCESS_KEY_ID]: string
-    [SharedCredentialsKeys.AWS_SECRET_ACCESS_KEY]: string
-}
+export type StaticCredentialsProfileKeysOptional = Pick<CredentialsData, 'aws_access_key_id' | 'aws_secret_access_key'>
+export type StaticCredentialsProfileKeys = Required<StaticCredentialsProfileKeysOptional>
 
 /**
  * The name of a section in a credentials/config file

--- a/src/credentials/wizards/templates.ts
+++ b/src/credentials/wizards/templates.ts
@@ -11,14 +11,14 @@ import { getIdeProperties } from '../../shared/extensionUtilities'
 import { ProfileTemplateProvider } from './createProfile'
 import { createCommonButtons } from '../../shared/ui/buttons'
 import { credentialHelpUrl } from '../../shared/constants'
-import { SharedCredentialsKeys, StaticCredentialsProfileData } from '../types'
-import { CredentialsKeyFormatValidators } from '../sharedCredentialsValidation'
+import { SharedCredentialsKeys, StaticCredentialsProfileKeys } from '../types'
+import { getCredentialError } from '../sharedCredentialsValidation'
 
 function getTitle(profileName: string): string {
     return localize('AWS.title.createCredentialProfile', 'Creating new profile "{0}"', profileName)
 }
 
-export const staticCredentialsTemplate: ProfileTemplateProvider<StaticCredentialsProfileData> = {
+export const staticCredentialsTemplate: ProfileTemplateProvider<StaticCredentialsProfileKeys> = {
     label: 'Static Credentials',
     description: 'Use this for credentials that never expire',
     prompts: {
@@ -33,7 +33,7 @@ export const staticCredentialsTemplate: ProfileTemplateProvider<StaticCredential
                     'Input the {0} Access Key',
                     getIdeProperties().company
                 ),
-                validateInput: CredentialsKeyFormatValidators.aws_access_key_id,
+                validateInput: value => getCredentialError(SharedCredentialsKeys.AWS_ACCESS_KEY_ID, value),
             }),
         [SharedCredentialsKeys.AWS_SECRET_ACCESS_KEY]: name =>
             createInputBox({
@@ -46,7 +46,7 @@ export const staticCredentialsTemplate: ProfileTemplateProvider<StaticCredential
                     'Input the {0} Secret Key',
                     getIdeProperties().company
                 ),
-                validateInput: CredentialsKeyFormatValidators.aws_secret_access_key,
+                validateInput: value => getCredentialError(SharedCredentialsKeys.AWS_SECRET_ACCESS_KEY, value),
                 password: true,
             }),
     },


### PR DESCRIPTION
This refactors the credentials validation code that previously had multiple validation functions for each credentials key.

This refactor changes this to use a switch case instead so that all validations of a certain type are contained within
the same function. This improves readability and reduces noise.

### Additional

- Name changes

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
