### PR TITLE
fix(logging): log sam cli location only if it changed

### DIFF
--- a/src/shared/sam/cli/samCliLocator.ts
+++ b/src/shared/sam/cli/samCliLocator.ts
@@ -51,8 +51,6 @@ abstract class BaseSamCliLocator {
             location = await this.getSystemPathLocation()
         }
 
-        this.logger.info(`SAM CLI location: ${location}`)
-
         return location
     }
 

--- a/src/shared/utilities/functionUtils.ts
+++ b/src/shared/utilities/functionUtils.ts
@@ -34,7 +34,7 @@ export function shared<T, U extends any[]>(fn: (...args: U) => Promise<T>): (...
 }
 
 /**
- * Special-case of `memoize`. Ensures a function is executed only once.
+ * Special-case of `memoize`: creates a function that is executed only once.
  */
 export function once<T>(fn: () => T): () => T {
     let val: T
@@ -44,12 +44,31 @@ export function once<T>(fn: () => T): () => T {
 }
 
 /**
+ * Special-case of `memoize`: creates a function that runs only if the args
+ * changed versus the previous invocation.
+ *
+ * @note See note on {@link memoize}
+ *
+ * TODO: use lib?: https://github.com/anywhichway/nano-memoize
+ */
+export function onceChanged<T, U extends any[]>(fn: (...args: U) => T): (...args: U) => T {
+    let val: T
+    let ran = false
+    let prevArgs = ''
+
+    return (...args) => ((ran && prevArgs === args.map(String).join(':'))
+        ? val
+        : ((val = fn(...args)), (ran = true), (prevArgs = args.map(String).join(':')), val))
+}
+
+/**
  * Creates a new function that stores the result of a call.
  *
- * ### Important
- * This currently uses an extremely simple mechanism for creating keys from parameters.
+ * @note This uses an extremely simple mechanism for creating keys from parameters.
  * Objects are effectively treated as a single key, while primitive values will behave as
  * expected with a few very uncommon exceptions.
+ *
+ * TODO: use lib?: https://github.com/anywhichway/nano-memoize
  */
 export function memoize<T, U extends any[]>(fn: (...args: U) => T): (...args: U) => T {
     const cache: { [key: string]: T | undefined } = {}

--- a/src/test/shared/utilities/functionUtils.test.ts
+++ b/src/test/shared/utilities/functionUtils.test.ts
@@ -4,11 +4,11 @@
  */
 
 import * as assert from 'assert'
-import { once, throttle } from '../../../shared/utilities/functionUtils'
+import { once, onceChanged, throttle } from '../../../shared/utilities/functionUtils'
 import { installFakeClock } from '../../testUtil'
 
-describe('once', function () {
-    it('does not execute sync functions returning void more than once', function () {
+describe('functionUtils', function () {
+    it('once()', function () {
         let counter = 0
         const fn = once(() => void counter++)
 
@@ -17,6 +17,36 @@ describe('once', function () {
 
         fn()
         assert.strictEqual(counter, 1)
+    })
+
+    it('onceChanged()', function () {
+        let counter = 0
+        const arg2 = {}
+        const arg2_ = { a: 42 }
+        const fn = onceChanged((s: string, o: object) => void counter++)
+
+        fn('arg1', arg2)
+        assert.strictEqual(counter, 1)
+
+        fn('arg1', arg2)
+        fn('arg1', arg2)
+        assert.strictEqual(counter, 1)
+
+        fn('arg1_', arg2)
+        assert.strictEqual(counter, 2)
+
+        fn('arg1_', arg2)
+        fn('arg1_', arg2)
+        fn('arg1_', arg2)
+        assert.strictEqual(counter, 2)
+
+        fn('arg1', arg2_)
+        assert.strictEqual(counter, 3)
+
+        // TODO: bug/limitation: Objects are not discriminated.
+        // TODO: use lib?: https://github.com/anywhichway/nano-memoize
+        fn('arg1', arg2_)
+        assert.strictEqual(counter, 3)
     })
 })
 


### PR DESCRIPTION
Problem:
1. sam cli location is not logged correctly (`SAM CLI location: [object Object]`)
2. sam cli location log message appears redundantly in the logs.

Solution:
1. fix log call
2. only log the location if it changed.

before:

    2023-05-08 05:06:29 [INFO]: SAM CLI location: /opt/homebrew/bin/sam
    2023-05-08 05:06:29 [INFO]: SAM CLI location: /opt/homebrew/bin/sam
    2023-05-08 05:06:29 [INFO]: SAM CLI location: /opt/homebrew/bin/sam
    2023-05-08 05:06:30 [INFO]: SAM CLI location: /opt/homebrew/bin/sam
    ...
    2023-05-08 05:06:32 [INFO]: SAM CLI location: /opt/homebrew/bin/sam

after

    2023-05-08 05:04:46 [INFO]: SAM CLI location: /opt/homebrew/bin/sam


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
