### PR TITLE
perf(sam): avoid searching for SAM CLI

### DIFF
--- a/src/shared/logger/logger.ts
+++ b/src/shared/logger/logger.ts
@@ -142,3 +142,24 @@ export function getNullLogger(type?: 'channel' | 'debugConsole' | 'main'): Logge
 export function setLogger(logger: Logger | undefined, type?: 'channel' | 'debugConsole' | 'main') {
     toolkitLoggers[type ?? 'main'] = logger
 }
+
+export class PerfLog {
+    private log
+    public readonly start
+
+    public constructor(public readonly topic: string) {
+        const log = getLogger()
+        this.log = log
+        if (log.logLevelEnabled('verbose')) {
+            this.start = Date.now()
+        }
+    }
+
+    public done(): void {
+        if (!this.start) {
+            return
+        }
+        const elapsed = Date.now() - this.start
+        this.log.verbose('%s took %dms', this.topic, elapsed.toFixed(1))
+    }
+}

--- a/src/shared/sam/cli/samCliLocator.ts
+++ b/src/shared/sam/cli/samCliLocator.ts
@@ -177,6 +177,7 @@ class WindowsSamCliLocator extends BaseSamCliLocator {
 
 class UnixSamCliLocator extends BaseSamCliLocator {
     private static readonly locationPaths: string[] = [
+        '/opt/homebrew/bin/sam',
         '/usr/local/bin',
         '/usr/bin',
         // WEIRD BUT TRUE: brew installs to /home/linuxbrew/.linuxbrew if

--- a/src/shared/sam/cli/samCliLocator.ts
+++ b/src/shared/sam/cli/samCliLocator.ts
@@ -22,7 +22,7 @@ export class DefaultSamCliLocationProvider implements SamCliLocationProvider {
 
     /** Checks that the given `sam` actually works by invoking `sam --version`. */
     private static async isValidSamLocation(samPath: string) {
-        return await SystemUtilities.tryRun(samPath, ['--version'], true, 'SAM CLI')
+        return await SystemUtilities.tryRun(samPath, ['--version'], 'no', 'SAM CLI')
     }
 
     /**

--- a/src/shared/sam/cli/samCliLocator.ts
+++ b/src/shared/sam/cli/samCliLocator.ts
@@ -34,12 +34,13 @@ export class DefaultSamCliLocationProvider implements SamCliLocationProvider {
         const cachedLoc = DefaultSamCliLocationProvider.cachedSamLocation
 
         // Avoid searching the system for `sam` (especially slow on Windows).
-        if (cachedLoc && await DefaultSamCliLocationProvider.isValidSamLocation(cachedLoc.path)) {
+        if (cachedLoc && (await DefaultSamCliLocationProvider.isValidSamLocation(cachedLoc.path))) {
             perflog.done()
             return cachedLoc
         }
 
-        DefaultSamCliLocationProvider.cachedSamLocation = await DefaultSamCliLocationProvider.getSamCliLocator().getLocation()
+        DefaultSamCliLocationProvider.cachedSamLocation =
+            await DefaultSamCliLocationProvider.getSamCliLocator().getLocation()
         perflog.done()
         return DefaultSamCliLocationProvider.cachedSamLocation
     }
@@ -105,7 +106,9 @@ abstract class BaseSamCliLocator {
                         BaseSamCliLocator.didFind = true
                         return { path: fullPath, version: validationResult.version }
                     }
-                    this.logger.warn(`samCliLocator: found invalid SAM CLI: (${validationResult.validation}): ${fullPath}`)
+                    this.logger.warn(
+                        `samCliLocator: found invalid SAM CLI: (${validationResult.validation}): ${fullPath}`
+                    )
                 } catch (e) {
                     const err = e as Error
                     this.logger.error('samCliLocator failed: %s', err.message)

--- a/src/shared/sam/cli/samCliSettings.ts
+++ b/src/shared/sam/cli/samCliSettings.ts
@@ -95,9 +95,9 @@ export class SamCliSettings extends fromExtensionManifest('aws.samcli', descript
 
     /**
      * Gets location of `sam` from:
-     * 1. previous saved location (if valid), or
-     * 2. user config (if valid), or
-     * 3. tries to find `sam` on the system if the user config is invalid.
+     * 1. user config (if any; overrides auto-detected location)
+     * 2. previous cached location (if valid)
+     * 3. searching for `sam` on the system
      *
      * @returns `autoDetected=true` if auto-detection was _attempted_.
      */

--- a/src/shared/sam/cli/samCliSettings.ts
+++ b/src/shared/sam/cli/samCliSettings.ts
@@ -94,8 +94,10 @@ export class SamCliSettings extends fromExtensionManifest('aws.samcli', descript
     }
 
     /**
-     * Gets location of `sam` from user config, or tries to find `sam` on the
-     * system if the user config is invalid.
+     * Gets location of `sam` from:
+     * 1. previous saved location (if valid), or
+     * 2. user config (if valid), or
+     * 3. tries to find `sam` on the system if the user config is invalid.
      *
      * @returns `autoDetected=true` if auto-detection was _attempted_.
      */

--- a/src/shared/systemUtilities.ts
+++ b/src/shared/systemUtilities.ts
@@ -192,7 +192,12 @@ export class SystemUtilities {
      * @param doLog log failures
      * @param expected output must contain this string
      */
-    public static async tryRun(p: string, args: string[], logging: 'yes' | 'no' | 'noresult' = 'yes', expected?: string): Promise<boolean> {
+    public static async tryRun(
+        p: string,
+        args: string[],
+        logging: 'yes' | 'no' | 'noresult' = 'yes',
+        expected?: string
+    ): Promise<boolean> {
         const proc = new ChildProcess(p, args, { logging: 'no' })
         const r = await proc.run()
         const ok = r.exitCode === 0 && (expected === undefined || r.stdout.includes(expected))

--- a/src/shared/utilities/asyncCollection.ts
+++ b/src/shared/utilities/asyncCollection.ts
@@ -222,11 +222,11 @@ async function promise<T>(iterable: AsyncIterable<T>): Promise<T[]> {
 function addToMap<T, U extends string>(map: Map<string, T>, selector: KeySelector<T, U> | StringProperty<T>, item: T) {
     const key = typeof selector === 'function' ? selector(item) : item[selector]
     if (key) {
-        if (map.has(key as keyof typeof map['keys'])) {
+        if (map.has(key as keyof (typeof map)['keys'])) {
             throw new Error(`Duplicate key found when converting AsyncIterable to map: ${key}`)
         }
 
-        map.set(key as keyof typeof map['keys'], item)
+        map.set(key as keyof (typeof map)['keys'], item)
     }
 }
 

--- a/src/shared/utilities/functionUtils.ts
+++ b/src/shared/utilities/functionUtils.ts
@@ -56,9 +56,10 @@ export function onceChanged<T, U extends any[]>(fn: (...args: U) => T): (...args
     let ran = false
     let prevArgs = ''
 
-    return (...args) => ((ran && prevArgs === args.map(String).join(':'))
-        ? val
-        : ((val = fn(...args)), (ran = true), (prevArgs = args.map(String).join(':')), val))
+    return (...args) =>
+        ran && prevArgs === args.map(String).join(':')
+            ? val
+            : ((val = fn(...args)), (ran = true), (prevArgs = args.map(String).join(':')), val)
 }
 
 /**

--- a/src/shared/utilities/typeConstructors.ts
+++ b/src/shared/utilities/typeConstructors.ts
@@ -51,7 +51,7 @@ export type FromDescriptor<T extends TypeDescriptor> = {
 
 // `Symbol` and `BigInt` are included here, though in-practice
 const primitives = [Number, String, Boolean, Object, Symbol, BigInt]
-function isPrimitiveConstructor(type: unknown): type is typeof primitives[number] {
+function isPrimitiveConstructor(type: unknown): type is (typeof primitives)[number] {
     return !!primitives.find(p => p === type)
 }
 

--- a/src/stepFunctions/activation.ts
+++ b/src/stepFunctions/activation.ts
@@ -88,7 +88,9 @@ async function registerStepFunctionCommands(
     )
 }
 
-export function initalizeWebviewPaths(context: vscode.ExtensionContext): typeof globals['visualizationResourcePaths'] {
+export function initalizeWebviewPaths(
+    context: vscode.ExtensionContext
+): (typeof globals)['visualizationResourcePaths'] {
     // Location for script in body of webview that handles input from user
     // and calls the code to render state machine graph
 

--- a/src/test/shared/sam/cli/samCliTestUtils.ts
+++ b/src/test/shared/sam/cli/samCliTestUtils.ts
@@ -21,9 +21,9 @@ export class MockSamCliProcessInvoker implements SamCliProcessInvoker {
 
         this.validateArgs(invokeSettings.arguments)
 
-        return ({
+        return {
             exitCode: 0,
-        } as any) as ChildProcessResult
+        } as any as ChildProcessResult
     }
 }
 

--- a/src/test/shared/sam/cli/samCliValidator.test.ts
+++ b/src/test/shared/sam/cli/samCliValidator.test.ts
@@ -26,9 +26,6 @@ describe('DefaultSamCliValidator', async function () {
             return this.mockSamLocation
         }
 
-        public async getSamCliExecutableId(): Promise<string> {
-            return this.samCliVersionId
-        }
         public async getSamCliInfo(): Promise<SamCliInfoResponse> {
             this.getInfoCallCount++
 
@@ -115,29 +112,6 @@ describe('DefaultSamCliValidator', async function () {
                     'sam cli version validation mismatch'
                 )
             })
-        })
-
-        it('Uses the cached validation result', async function () {
-            const validatorContext = new TestSamCliValidatorContext(minSamCliVersion)
-            const samCliValidator = new DefaultSamCliValidator(validatorContext)
-
-            await samCliValidator.getVersionValidatorResult()
-            await samCliValidator.getVersionValidatorResult()
-
-            assert.strictEqual(validatorContext.getInfoCallCount, 1, 'getInfo called more than once')
-        })
-
-        it('Does not use the cached validation result if the SAM CLI timestamp changed', async function () {
-            const validatorContext = new TestSamCliValidatorContext(minSamCliVersion)
-            const samCliValidator = new DefaultSamCliValidator(validatorContext)
-
-            await samCliValidator.getVersionValidatorResult()
-
-            // Oh look, a new SAM CLI timestamp
-            validatorContext.samCliVersionId = validatorContext.samCliVersionId + 'x'
-            await samCliValidator.getVersionValidatorResult()
-
-            assert.strictEqual(validatorContext.getInfoCallCount, 2, 'getInfo was not called both times')
         })
     })
 


### PR DESCRIPTION
## Problem

- `SamCliLocationProvider.getLocation()` is called many times and always  searches for sam on the system, which is slow (especially on Windows).
- Hard to follow the logic of SamCliValidator, too much indirection  involving `isSamCliVersionCached()` and `getSamCliExecutableId()`.

## Solution
- Cache the last-found sam location in `DefaultSamCliLocationProvider`  instead of whatever `DefaultSamCliValidator` was trying to do.
- Use the cached location unless it fails `tryRun()`. This means Toolkit  still "shells out" to `sam`, which can be slow, but at least it avoids  a system search.

## Results

- Sample from CI shows that the first getLocation takes 800ms, later calls get a 5x speedup.
- Testing on Windows indicates first call can take 2-8(!) seconds, later calls are ~300ms.

```
2023-05-08 15:50:11 [VERBOSE]: samCliLocator: getLocation took 822ms
2023-05-08 15:50:16 [VERBOSE]: samCliLocator: getLocation took 119ms
2023-05-08 15:50:17 [VERBOSE]: samCliLocator: getLocation took 122ms
```

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
