### PR TITLE
ci: update xvfb action

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,7 +29,7 @@ jobs:
             - run: npm ci
             - run: npm run vscode:prepublish
             - name: Tests
-              uses: GabrielBB/xvfb-action@v1
+              uses: coactions/setup-xvfb@v1
               with:
                   run: npm test
             - name: Code coverage


### PR DESCRIPTION
Problem:
https://github.com/GabrielBB/xvfb-action is deprecated and hasn't been updated since 2021.

Solution:
Use https://github.com/coactions/setup-xvfb instead.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
