### PR TITLE
codecatalyst: logging

### DIFF
--- a/src/shared/clients/codecatalystClient.ts
+++ b/src/shared/clients/codecatalystClient.ts
@@ -29,7 +29,7 @@ import {
     ListSourceRepositoriesItem,
     ListSourceRepositoriesItems,
 } from 'aws-sdk/clients/codecatalyst'
-import { truncate } from '../utilities/textUtilities'
+import { truncateProps } from '../utilities/textUtilities'
 
 interface CodeCatalystConfig {
     readonly region: string
@@ -267,12 +267,17 @@ class CodeCatalystClientInternal {
                             'API request failed (time: %dms): %s\nparams: %O\nerror: %O\nheaders: %O',
                             timecost,
                             r.operation,
-                            r.params,
+                            truncateProps(r.params, 20, ['nextToken']),
                             errNoStack,
                             logHeaders
                         )
                     } else {
-                        log.error('API request failed (time: %dms):%O\nheaders: %O', timecost, req, logHeaders)
+                        log.error(
+                            'API request failed (time: %dms):%O\nheaders: %O',
+                            timecost,
+                            truncateProps(req, 20, ['nextToken']),
+                            logHeaders
+                        )
                     }
                     if (silent) {
                         if (defaultVal === undefined) {
@@ -285,19 +290,12 @@ class CodeCatalystClientInternal {
                     return
                 }
                 if (log.logLevelEnabled('verbose')) {
-                    const truncatedData = {
-                        ...data,
-                        nextToken: (data as any)?.nextToken ?? '',
-                    }
-                    if (truncatedData.nextToken && typeof truncatedData.nextToken === 'string') {
-                        truncatedData.nextToken = truncate(truncatedData.nextToken, 20)
-                    }
                     log.verbose(
                         'API request (time: %dms): %s\nparams: %O\nresponse: %O',
                         timecost,
                         r.operation ?? '?',
-                        r.params ?? '?',
-                        truncatedData
+                        r.params ? truncateProps(r.params, 20, ['nextToken']) : '?',
+                        truncateProps(data as object, 20, ['nextToken'])
                     )
                 }
                 resolve(data)

--- a/src/shared/clients/codecatalystClient.ts
+++ b/src/shared/clients/codecatalystClient.ts
@@ -29,7 +29,6 @@ import {
     ListSourceRepositoriesItems,
 } from 'aws-sdk/clients/codecatalyst'
 
-// REMOVE ME SOON: only used for development
 interface CodeCatalystConfig {
     readonly region: string
     readonly endpoint: string
@@ -237,19 +236,16 @@ class CodeCatalystClientInternal {
                     const logHeaders = {}
                     // Selected headers which are useful for logging.
                     const logHeaderNames = [
+                        'x-amzn-requestid',
+                        'x-amzn-trace-id',
+                        'x-amzn-served-from',
+                        'x-cache',
+                        'x-amz-cf-id',
+                        'x-amz-cf-pop',
                         // 'access-control-expose-headers',
                         // 'cache-control',
                         // 'strict-transport-security',
-                        'x-amz-apigw-id',
-                        'x-amz-cf-id',
-                        'x-amz-cf-pop',
-                        'x-amzn-remapped-content-length',
-                        'x-amzn-remapped-x-amzn-requestid',
-                        'x-amzn-requestid',
-                        'x-amzn-served-from',
-                        'x-amzn-trace-id',
-                        'x-cache',
-                        'x-request-id', // <- Request id for caws/fusi!
+                        // 'x-amz-apigw-id',
                     ]
                     if (allHeaders && Object.keys(allHeaders).length > 0) {
                         for (const k of logHeaderNames) {
@@ -260,10 +256,7 @@ class CodeCatalystClientInternal {
                     // Stack is noisy and useless in production.
                     const errNoStack = { ...e }
                     delete errNoStack.stack
-                    // Remove confusing "requestId" field (= "x-amzn-requestid" header)
-                    // because for caws/fusi, "x-request-id" is more relevant.
-                    // All of the various request-ids can be found in the logged headers.
-                    delete errNoStack.requestId
+                    delete errNoStack.requestId // redundant (= "x-amzn-requestid" header).
 
                     if (r.operation || r.params) {
                         log.error(

--- a/src/shared/logger/logger.ts
+++ b/src/shared/logger/logger.ts
@@ -4,6 +4,7 @@
  */
 
 import { Uri } from 'vscode'
+import globals from '../extensionGlobals'
 
 const toolkitLoggers: {
     main: Logger | undefined
@@ -144,22 +145,24 @@ export function setLogger(logger: Logger | undefined, type?: 'channel' | 'debugC
 }
 
 export class PerfLog {
-    private log
+    private readonly log
     public readonly start
 
     public constructor(public readonly topic: string) {
         const log = getLogger()
         this.log = log
-        if (log.logLevelEnabled('verbose')) {
-            this.start = Date.now()
-        }
+        this.start = globals.clock.Date.now()
+    }
+
+    public elapsed(): number {
+        return globals.clock.Date.now() - this.start
     }
 
     public done(): void {
-        if (!this.start) {
+        if (!this.log.logLevelEnabled('verbose')) {
             return
         }
-        const elapsed = Date.now() - this.start
+        const elapsed = this.elapsed()
         this.log.verbose('%s took %dms', this.topic, elapsed.toFixed(1))
     }
 }

--- a/src/test/shared/utilities/textUtilities.test.ts
+++ b/src/test/shared/utilities/textUtilities.test.ts
@@ -4,7 +4,46 @@
  */
 
 import * as assert from 'assert'
-import { getRelativeDate, getStringHash, removeAnsi } from '../../../shared/utilities/textUtilities'
+import { getRelativeDate, getStringHash, removeAnsi, truncateProps } from '../../../shared/utilities/textUtilities'
+
+describe('textUtilities', async function () {
+    it('truncateProps()', async function () {
+        const testObj = {
+            a: 34234234234,
+            b: '123456789',
+            c: new Date(2023, 1, 1),
+            d: '123456789_abcdefg_ABCDEFG',
+            e: {
+                e1: [4, 3, 7],
+                e2: 'loooooooooo \n nnnnnnnnnnn \n gggggggg \n string',
+            },
+            f: () => {
+                throw Error()
+            },
+        }
+        const expected = {
+            ...testObj,
+            e: {
+                e1: [...testObj.e.e1],
+                e2: testObj.e.e2,
+            },
+        }
+
+        assert.deepStrictEqual(truncateProps(testObj, 25), expected)
+        assert.deepStrictEqual(truncateProps(testObj, 3, ['b']), {
+            ...expected,
+            b: '123…',
+        })
+        // Assert that original object didn't change.
+        assert.deepStrictEqual(truncateProps(testObj, 25), expected)
+
+        assert.deepStrictEqual(truncateProps(testObj, 3, ['a', 'b', 'd', 'f']), {
+            ...expected,
+            b: '123…',
+            d: '123…',
+        })
+    })
+})
 
 describe('removeAnsi', async function () {
     it('removes ansi code from text', async function () {


### PR DESCRIPTION
## Problem

- old outdated fields listed in codecatalyst API logs
- no timing/profiling info for codecatalyst API calls
- very long fields like `nextToken` are noisy in the logs

## Solution

- add timing/profiling info to logs
- truncate some fields like `nextToken`
    - this is experimental, maybe the field should just be omitted if the value is not useful. OTOH, truncating it is somewhat equivalent to writing `[omitted]` but gives a hint about the "shape" of the value.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
