### PR TITLE
fix!: remove legacy settings

### DIFF
--- a/.changes/next-release/Removal-4234d2e9-3519-4f0b-ae6e-bcd5b93059a9.json
+++ b/.changes/next-release/Removal-4234d2e9-3519-4f0b-ae6e-bcd5b93059a9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Removal",
+	"description": "Removed legacy setting `aws.sam.enableCodeLenses` (use `aws.samcli.enableCodeLenses` instead)"
+}

--- a/.changes/next-release/Removal-773d85b9-9d85-40e4-9518-c784b4b13c74.json
+++ b/.changes/next-release/Removal-773d85b9-9d85-40e4-9518-c784b4b13c74.json
@@ -1,0 +1,4 @@
+{
+	"type": "Removal",
+	"description": "Removed legacy setting `aws.manuallySelectedBuckets` (use `aws.samcli.manuallySelectedBuckets` instead)"
+}

--- a/.changes/next-release/Removal-c111b554-676b-4080-9e59-68e95a727793.json
+++ b/.changes/next-release/Removal-c111b554-676b-4080-9e59-68e95a727793.json
@@ -1,0 +1,4 @@
+{
+	"type": "Removal",
+	"description": "Removed legacy setting `aws.samcli.lambda.timeout` (use `aws.samcli.lambdaTimeout` instead)"
+}

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -37,7 +37,7 @@ import { addSamDebugConfiguration } from './debugger/commands/addSamDebugConfigu
 import { lazyLoadSamTemplateStrings } from '../../lambda/models/samTemplates'
 import { PromptSettings } from '../settings'
 import { shared } from '../utilities/functionUtils'
-import { migrateLegacySettings, SamCliSettings } from './cli/samCliSettings'
+import { SamCliSettings } from './cli/samCliSettings'
 import { Commands } from '../vscode/commands2'
 import { registerSync } from './sync'
 
@@ -48,7 +48,6 @@ const sharedDetectSamCli = shared(detectSamCli)
  */
 export async function activate(ctx: ExtContext): Promise<void> {
     await createYamlExtensionPrompt()
-    await migrateLegacySettings()
     const config = SamCliSettings.instance
 
     ctx.extensionContext.subscriptions.push(

--- a/src/shared/sam/cli/samCliSettings.ts
+++ b/src/shared/sam/cli/samCliSettings.ts
@@ -4,38 +4,11 @@
  */
 
 import { getLogger } from '../../logger'
-import { fromExtensionManifest, migrateSetting, Settings } from '../../settings'
+import { fromExtensionManifest, Settings } from '../../settings'
 import { stripUndefined, toRecord } from '../../utilities/collectionUtils'
 import { ClassToInterfaceType, keys } from '../../utilities/tsUtils'
 import { DefaultSamCliLocationProvider, SamCliLocationProvider } from './samCliLocator'
 import { onceChanged } from '../../utilities/functionUtils'
-
-// TODO(sijaden): remove after a few releases
-export async function migrateLegacySettings() {
-    await migrateSetting(
-        {
-            key: 'aws.manuallySelectedBuckets',
-            type: SavedBuckets,
-        },
-        { key: 'aws.samcli.manuallySelectedBuckets' }
-    )
-
-    await migrateSetting(
-        {
-            key: 'aws.sam.enableCodeLenses',
-            type: Boolean,
-        },
-        { key: 'aws.samcli.enableCodeLenses' }
-    )
-
-    await migrateSetting(
-        {
-            key: 'aws.samcli.lambda.timeout',
-            type: Number,
-        },
-        { key: 'aws.samcli.lambdaTimeout' }
-    )
-}
 
 const localTimeoutDefaultMillis: number = 90000
 interface SavedBuckets {


### PR DESCRIPTION
## Problem

Migration logic has existed for 1+ year to support old settings names.

## Solution

Remove support of old settings names.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
