### PR TITLE
perf: avoid filewatchers if enableCodeLenses=false

### DIFF
--- a/.changes/next-release/Feature-c91d7727-d6b0-4859-8023-a68fd3402189.json
+++ b/.changes/next-release/Feature-c91d7727-d6b0-4859-8023-a68fd3402189.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Faster startup and less filesystem usage when the `aws.samcli.enableCodeLenses` setting is disabled"
+}

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -26,8 +26,7 @@ import { SamTemplateCodeLensProvider } from '../codelens/samTemplateCodeLensProv
 import * as jsLensProvider from '../codelens/typescriptCodeLensProvider'
 import { ExtContext, VSCODE_EXTENSION_ID } from '../extensions'
 import { getIdeProperties, getIdeType, IDE, isCloud9 } from '../extensionUtilities'
-import { getLogger } from '../logger/logger'
-import { TelemetryService } from '../telemetry/telemetryService'
+import { PerfLog, getLogger } from '../logger/logger'
 import { NoopWatcher } from '../fs/watchedFiles'
 import { detectSamCli } from './cli/samCliDetection'
 import { CodelensRootRegistry } from '../fs/codelensRootRegistry'
@@ -43,20 +42,41 @@ import { registerSync } from './sync'
 
 const sharedDetectSamCli = shared(detectSamCli)
 
+const supportedLanguages: {
+    [language: string]: codelensUtils.OverridableCodeLensProvider
+} = {}
+
 /**
  * Activate SAM-related functionality.
  */
 export async function activate(ctx: ExtContext): Promise<void> {
+    let didActivateCodeLensProviders = false
     await createYamlExtensionPrompt()
     const config = SamCliSettings.instance
 
-    ctx.extensionContext.subscriptions.push(
-        ...(await activateCodeLensProviders(ctx, config, ctx.outputChannel, ctx.telemetryService))
-    )
+    // Do this "on-demand" because it is slow.
+    async function activateSlowCodeLensesOnce(): Promise<void> {
+        if (!didActivateCodeLensProviders) {
+            didActivateCodeLensProviders = true
+            const disposeable = await activateCodefileOverlays(ctx, config)
+            ctx.extensionContext.subscriptions.push(...disposeable)
+        }
+    }
 
-    await registerServerlessCommands(ctx, config)
+    if (config.get('enableCodeLenses', false)) {
+        activateSlowCodeLensesOnce()
+    }
+
+    await registerCommands(ctx, config)
+    Commands.register('aws.addSamDebugConfig', async () => {
+        if (!didActivateCodeLensProviders) {
+            await activateSlowCodeLensesOnce()
+            await samDebugConfigCmd()
+        }
+    })
 
     ctx.extensionContext.subscriptions.push(
+        activateSamYamlOverlays(),
         vscode.debug.registerDebugConfigurationProvider(AWS_SAM_DEBUG_TYPE, new SamDebugConfigProvider(ctx))
     )
 
@@ -72,10 +92,19 @@ export async function activate(ctx: ExtContext): Promise<void> {
         )
     )
 
-    config.onDidChange(event => {
-        if (event.key === 'location') {
-            // This only shows a message (passive=true), does not set anything.
-            sharedDetectSamCli({ passive: true, showMessage: true })
+    config.onDidChange(async event => {
+        switch (event.key) {
+            case 'location':
+                // This only shows a message (passive=true), does not set anything.
+                sharedDetectSamCli({ passive: true, showMessage: true })
+                break
+            case 'enableCodeLenses':
+                if (config.get(event.key, false) && !didActivateCodeLensProviders) {
+                    await activateSlowCodeLensesOnce()
+                }
+                break
+            default:
+                break
         }
     })
 
@@ -88,7 +117,7 @@ export async function activate(ctx: ExtContext): Promise<void> {
     registerSync()
 }
 
-async function registerServerlessCommands(ctx: ExtContext, settings: SamCliSettings): Promise<void> {
+async function registerCommands(ctx: ExtContext, settings: SamCliSettings): Promise<void> {
     lazyLoadSamTemplateStrings()
     ctx.extensionContext.subscriptions.push(
         Commands.register({ id: 'aws.samcli.detect', autoconnect: false }, () =>
@@ -123,6 +152,10 @@ async function registerServerlessCommands(ctx: ExtContext, settings: SamCliSetti
                     settings,
                 }
             )
+        }),
+        Commands.register({ id: 'aws.toggleSamCodeLenses', autoconnect: false }, async () => {
+            const toggled = !settings.get('enableCodeLenses', false)
+            settings.update('enableCodeLenses', toggled)
         })
     )
 }
@@ -158,12 +191,70 @@ async function activateCodeLensRegistry(context: ExtContext) {
     context.extensionContext.subscriptions.push(globals.codelensRootRegistry)
 }
 
-async function activateCodeLensProviders(
+async function samDebugConfigCmd() {
+    const activeEditor = vscode.window.activeTextEditor
+    if (!activeEditor) {
+        getLogger().error(`aws.addSamDebugConfig was called without an active text editor`)
+        vscode.window.showErrorMessage(
+            localize('AWS.pickDebugHandler.noEditor', 'Toolkit could not find an active editor')
+        )
+
+        return
+    }
+    const document = activeEditor.document
+    const provider = supportedLanguages[document.languageId]
+    if (!provider) {
+        getLogger().error(`aws.addSamDebugConfig called on a document with an invalid language: ${document.languageId}`)
+        vscode.window.showErrorMessage(
+            localize(
+                'AWS.pickDebugHandler.invalidLanguage',
+                'Toolkit cannot detect handlers in language: {0}',
+                document.languageId
+            )
+        )
+
+        return
+    }
+
+    // TODO: No reason for this to depend on the codelense provider (which scans the whole workspace and creates filewatchers).
+    const lenses = (await provider.provideCodeLenses(document, new vscode.CancellationTokenSource().token, true)) ?? []
+    codelensUtils.invokeCodeLensCommandPalette(document, lenses)
+}
+
+/**
+ * Creates vscode.CodeLensProvider for SAM "template.yaml" files.
+ *
+ * Used for:
+ * 1. showing codelenses in SAM template.yaml files
+ */
+function activateSamYamlOverlays(): vscode.Disposable {
+    return vscode.languages.registerCodeLensProvider(
+        [
+            {
+                language: 'yaml',
+                scheme: 'file',
+                pattern: '**/*template.{yml,yaml}',
+            },
+        ],
+        new SamTemplateCodeLensProvider()
+    )
+}
+
+/**
+ * EXPENSIVE AND SLOW. Creates filewatchers and vscode.CodeLensProvider objects
+ * for codefiles (as opposed to SAM template.yaml files).
+ *
+ * Used for:
+ * 1. showing codelenses
+ * 2. "Add SAM Debug Configuration" command (TODO: remove dependency on
+ *    codelense provider (which scans the whole workspace and creates
+ *    filewatchers)).
+ */
+async function activateCodefileOverlays(
     context: ExtContext,
-    configuration: SamCliSettings,
-    toolkitOutputChannel: vscode.OutputChannel,
-    telemetryService: TelemetryService
+    configuration: SamCliSettings
 ): Promise<vscode.Disposable[]> {
+    const perflog = new PerfLog('activateCodefileOverlays')
     const disposables: vscode.Disposable[] = []
     const tsCodeLensProvider = codelensUtils.makeTypescriptCodeLensProvider(configuration)
     const pyCodeLensProvider = await codelensUtils.makePythonCodeLensProvider(configuration)
@@ -175,12 +266,8 @@ async function activateCodeLensProviders(
     // the event to notify on when their results change.
     await activateCodeLensRegistry(context)
 
-    const supportedLanguages: {
-        [language: string]: codelensUtils.OverridableCodeLensProvider
-    } = {
-        [jsLensProvider.javascriptLanguage]: tsCodeLensProvider,
-        [pyLensProvider.pythonLanguage]: pyCodeLensProvider,
-    }
+    supportedLanguages[jsLensProvider.javascriptLanguage] = tsCodeLensProvider
+    supportedLanguages[pyLensProvider.pythonLanguage] = pyCodeLensProvider
 
     if (!isCloud9()) {
         supportedLanguages[javaLensProvider.javaLanguage] = javaCodeLensProvider
@@ -189,66 +276,13 @@ async function activateCodeLensProviders(
         supportedLanguages[jsLensProvider.typescriptLanguage] = tsCodeLensProvider
     }
 
-    disposables.push(
-        vscode.languages.registerCodeLensProvider(
-            [
-                {
-                    language: 'yaml',
-                    scheme: 'file',
-                    pattern: '**/*template.{yml,yaml}',
-                },
-            ],
-            new SamTemplateCodeLensProvider()
-        )
-    )
-
     disposables.push(vscode.languages.registerCodeLensProvider(jsLensProvider.typescriptAllFiles, tsCodeLensProvider))
     disposables.push(vscode.languages.registerCodeLensProvider(pyLensProvider.pythonAllfiles, pyCodeLensProvider))
     disposables.push(vscode.languages.registerCodeLensProvider(javaLensProvider.javaAllfiles, javaCodeLensProvider))
     disposables.push(vscode.languages.registerCodeLensProvider(csLensProvider.csharpAllfiles, csCodeLensProvider))
     disposables.push(vscode.languages.registerCodeLensProvider(goLensProvider.goAllfiles, goCodeLensProvider))
 
-    disposables.push(
-        Commands.register({ id: 'aws.toggleSamCodeLenses', autoconnect: false }, async () => {
-            const toggled = !configuration.get('enableCodeLenses', false)
-            configuration.update('enableCodeLenses', toggled)
-        })
-    )
-
-    disposables.push(
-        Commands.register('aws.addSamDebugConfig', async () => {
-            const activeEditor = vscode.window.activeTextEditor
-            if (!activeEditor) {
-                getLogger().error(`aws.addSamDebugConfig was called without an active text editor`)
-                vscode.window.showErrorMessage(
-                    localize('AWS.pickDebugHandler.noEditor', 'Toolkit could not find an active editor')
-                )
-
-                return
-            }
-            const document = activeEditor.document
-            const provider = supportedLanguages[document.languageId]
-            if (!provider) {
-                getLogger().error(
-                    `aws.addSamDebugConfig called on a document with an invalid language: ${document.languageId}`
-                )
-                vscode.window.showErrorMessage(
-                    localize(
-                        'AWS.pickDebugHandler.invalidLanguage',
-                        'Toolkit cannot detect handlers in language: {0}',
-                        document.languageId
-                    )
-                )
-
-                return
-            }
-
-            const lenses =
-                (await provider.provideCodeLenses(document, new vscode.CancellationTokenSource().token, true)) ?? []
-            codelensUtils.invokeCodeLensCommandPalette(document, lenses)
-        })
-    )
-
+    perflog.done()
     return disposables
 }
 


### PR DESCRIPTION
Problem:
`aws.samcli.enableCodeLenses` setting was added in 136a67bf64b6568eaaf5ca345b1262cb2cb0ee2d #1681 as a cosmetic feature, it didn't actually disable initialization of the codelense filewatchers(!).

Solution:
- Split the codelense setup logic for "sam template.yaml files" from "code files".
- Only initialize "code file" codelenses and filewatchers if:
    1 . `aws.samcli.enableCodeLenses` setting is enabled (at startup _or_ dynamically at runtime)
    2 . user invokes "Add SAM Debug Configuration"

Related: #3216

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
