### PR TITLE
telemetry: disable SAM CLI telemetry if Toolkit telemetry is disabled

### DIFF
--- a/src/shared/sam/cli/samCliInvokerUtils.ts
+++ b/src/shared/sam/cli/samCliInvokerUtils.ts
@@ -4,6 +4,7 @@
  */
 
 import { SpawnOptions } from 'child_process'
+import globals from '../../extensionGlobals'
 import { getLogger } from '../../logger'
 import { getUserAgent } from '../../telemetry/util'
 import { ChildProcessResult, ChildProcessOptions } from '../../utilities/childProcess'
@@ -102,11 +103,16 @@ function startsWithError(text: string): boolean {
 }
 
 export async function addTelemetryEnvVar(options: SpawnOptions | undefined): Promise<SpawnOptions> {
+    const samTelemetry = {
+        SAM_CLI_TELEMETRY: process.env.SAM_CLI_TELEMETRY ?? (globals.telemetry.telemetryEnabled ? '1' : '0'),
+    }
+
     return {
         ...options,
         env: {
             AWS_TOOLING_USER_AGENT: await getUserAgent({ includeClientId: false }),
             ...options?.env,
+            ...samTelemetry,
         },
     }
 }


### PR DESCRIPTION
## Problem

Toolkit sends sam cli telemetry even if customer has opted-out of Toolkit telemetry.

## Solution

Set sam cli env var correctly.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
