### PR TITLE
fix(sam): "Detect SAM CLI" uses cached sam location

### DIFF
--- a/src/shared/sam/cli/samCliDetection.ts
+++ b/src/shared/sam/cli/samCliDetection.ts
@@ -32,7 +32,7 @@ export async function detectSamCli(args: { passive: boolean; showMessage: boolea
         await config.delete('location')
     }
 
-    const sam = await config.getOrDetectSamCli()
+    const sam = await config.getOrDetectSamCli(true)
     const notFound = sam.path === ''
 
     // Update the user setting.

--- a/src/shared/sam/cli/samCliLocator.ts
+++ b/src/shared/sam/cli/samCliLocator.ts
@@ -13,7 +13,7 @@ import { SystemUtilities } from '../../systemUtilities'
 import { PerfLog } from '../../logger/logger'
 
 export interface SamCliLocationProvider {
-    getLocation(): Promise<{ path: string; version: string } | undefined>
+    getLocation(forceSearch?: boolean): Promise<{ path: string; version: string } | undefined>
 }
 
 export class DefaultSamCliLocationProvider implements SamCliLocationProvider {
@@ -29,9 +29,9 @@ export class DefaultSamCliLocationProvider implements SamCliLocationProvider {
      * Gets the last-found `sam` location, or searches the system if a working
      * `sam` wasn't previously found and cached.
      */
-    public async getLocation() {
+    public async getLocation(forceSearch?: boolean) {
         const perflog = new PerfLog('samCliLocator: getLocation')
-        const cachedLoc = DefaultSamCliLocationProvider.cachedSamLocation
+        const cachedLoc = forceSearch ? undefined : DefaultSamCliLocationProvider.cachedSamLocation
 
         // Avoid searching the system for `sam` (especially slow on Windows).
         if (cachedLoc && (await DefaultSamCliLocationProvider.isValidSamLocation(cachedLoc.path))) {
@@ -107,7 +107,7 @@ abstract class BaseSamCliLocator {
                         return { path: fullPath, version: validationResult.version }
                     }
                     this.logger.warn(
-                        `samCliLocator: found invalid SAM CLI: (${validationResult.validation}): ${fullPath}`
+                        `samCliLocator: found invalid SAM CLI (${validationResult.validation}): ${fullPath}`
                     )
                 } catch (e) {
                     const err = e as Error

--- a/src/shared/sam/cli/samCliSettings.ts
+++ b/src/shared/sam/cli/samCliSettings.ts
@@ -68,22 +68,24 @@ export class SamCliSettings extends fromExtensionManifest('aws.samcli', descript
 
     /**
      * Gets location of `sam` from:
-     * 1. user config (if any; overrides auto-detected location)
-     * 2. previous cached location (if valid)
-     * 3. searching for `sam` on the system
+     * 1. user config (if any)
+     * 2. previous location cached in `getLocation` (if valid)
+     * 3. system search (done by `getLocation`)
      *
      * @returns `autoDetected=true` if auto-detection was _attempted_.
      */
-    public async getOrDetectSamCli(): Promise<{ path: string | undefined; autoDetected: boolean }> {
+    public async getOrDetectSamCli(
+        forceSearch?: boolean
+    ): Promise<{ path: string | undefined; autoDetected: boolean }> {
         const fromConfig = this.get('location', '')
 
         if (fromConfig) {
-            SamCliSettings.logIfChanged(`SAM CLI location: ${fromConfig}`)
+            SamCliSettings.logIfChanged(`SAM CLI location (from settings): ${fromConfig}`)
             return { path: fromConfig, autoDetected: false }
         }
 
-        const fromSearch = await this.locationProvider.getLocation()
-        SamCliSettings.logIfChanged(`SAM CLI location: ${fromSearch?.path}`)
+        const fromSearch = await this.locationProvider.getLocation(forceSearch)
+        SamCliSettings.logIfChanged(`SAM CLI location (version: ${fromSearch?.version}): ${fromSearch?.path}`)
         return { path: fromSearch?.path, autoDetected: true }
     }
 


### PR DESCRIPTION
Problem:
- Cached sam location is not evicted by the "AWS: Detect SAM CLI" command.
- Toolkit logs the sam cli location but not its version, which makes troubleshooting less obvious. #3381

Solution:
- Specify `forceSearch` when "AWS: Detect SAM CLI" calls `getOrDetectSamCli()`.
- Log the sam version.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
