### PR TITLE
codecatalyst: "Open Dev Environment": filter by space, project

### DIFF
--- a/.changes/next-release/Feature-1e701503-730e-4065-b376-8be7dfa9dda7.json
+++ b/.changes/next-release/Feature-1e701503-730e-4065-b376-8be7dfa9dda7.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "CodeCatalyst: `AWS: Open CodeCatalyst Dev Environment` command allows filtering by Space and Project name"
+}

--- a/.changes/next-release/Feature-2c7d476f-6f8f-48d9-bd85-cbc53dab7216.json
+++ b/.changes/next-release/Feature-2c7d476f-6f8f-48d9-bd85-cbc53dab7216.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "CodeCatalyst: `AWS: Open CodeCatalyst Dev Environment` command now sorts Dev Environments by most recent usage"
+}

--- a/src/codecatalyst/wizards/selectResource.ts
+++ b/src/codecatalyst/wizards/selectResource.ts
@@ -53,30 +53,28 @@ function fromDevEnv(env: codecatalyst.DevEnvironment): Omit<DataQuickPickItem<un
     const labelParts = [] as string[]
 
     if (env.status === 'RUNNING') {
-        labelParts.push('$(pass) ')
+        labelParts.push('$(pass)')
     } else {
-        labelParts.push('$(circle-slash) ') // TODO(sijaden): get actual 'stopped' icon
+        labelParts.push('$(circle-slash)') // TODO(sijaden): get actual 'stopped' icon
     }
+
+    labelParts.push(env.alias ? env.alias : env.id)
 
     const repo = env.repositories[0]
+    const branchName = repo?.branchName?.replace('refs/heads/', '')
+    const repoLabel = repo
+        ? branchName
+            ? `${repo.repositoryName}/${branchName}`
+            : repo.repositoryName
+        : '(no repository)'
 
-    if (repo) {
-        const branchName = repo.branchName?.replace('refs/heads/', '')
-        labelParts.push(branchName ? `${repo.repositoryName}/${branchName}` : repo.repositoryName)
-    } else {
-        labelParts.push(`${env.id} (no repository)`)
-    }
-
-    if (env.alias) {
-        labelParts.push(` ${env.alias}`)
-    }
-
-    const lastUsed = `Last used: ${getRelativeDate(env.lastUpdatedTime)}`
+    const statusLabel = env.status === 'RUNNING' ? 'RUNNING - IN USE' : env.status
+    const desc = `${statusLabel} ${getRelativeDate(env.lastUpdatedTime)}`
 
     return {
-        label: labelParts.join(''),
-        description: env.status === 'RUNNING' ? 'RUNNING - IN USE' : env.status,
-        detail: `${env.org.name}/${env.project.name}, ${lastUsed}`,
+        label: labelParts.join(' '),
+        description: desc,
+        detail: `${env.org.name}/${env.project.name}/${repoLabel}`,
     }
 }
 
@@ -90,6 +88,7 @@ function createResourcePrompter<T extends codecatalyst.CodeCatalystResource>(
     const prompter = createQuickPick(items, {
         buttons: [refresh, ...createCommonButtons(helpUri)],
         ...presentation,
+        matchOnDetail: true,
     })
 
     refresh.onClick = () => {

--- a/src/codecatalyst/wizards/selectResource.ts
+++ b/src/codecatalyst/wizards/selectResource.ts
@@ -153,11 +153,7 @@ export function createDevEnvPrompter(
         placeholder: 'Search for a Dev Environment',
         compare: (a, b) => {
             if (isData(a.data) && isData(b.data)) {
-                if (a.data.status === b.data.status) {
-                    return b.data.lastUpdatedTime.getTime() - a.data.lastUpdatedTime.getTime()
-                }
-
-                return a.data.status === 'RUNNING' ? 1 : b.data.status === 'RUNNING' ? -1 : 0
+                return b.data.lastUpdatedTime.getTime() - a.data.lastUpdatedTime.getTime()
             }
 
             return 0


### PR DESCRIPTION
## Problem:
"Open Dev Environment" menu:
- shows env id prominently which is not human-friendly
- user cannot filter by space or project name
- "Last used" string takes unnecessary space
- places "RUNNING" environments at the bottom of the list.

## Solution:
- Set `matchOnDetail=true` so the list can be filtered by the detail description, not just the label.
- Drop "Last used" label; the timestamp is clear enough on its own.
- When sorting the list, only compare "last used".

### Before

![listdevenvs-before](https://github.com/aws/aws-toolkit-vscode/assets/55561878/3fd94fb0-5415-4583-afd6-4d84d000577b)


### After

![Screenshot 2023-05-12 at 06 44 07](https://github.com/aws/aws-toolkit-vscode/assets/55561878/378aa7f2-dd3f-4004-9044-05e6c50e1112)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
