### PR TITLE
fix(codecatalyst): only get projects the user is a member of

### DIFF
--- a/src/shared/clients/codecatalystClient.ts
+++ b/src/shared/clients/codecatalystClient.ts
@@ -397,6 +397,15 @@ class CodeCatalystClientInternal {
      * Gets a list of all projects for the given CodeCatalyst user.
      */
     public listProjects(request: CodeCatalyst.ListProjectsRequest): AsyncCollection<CodeCatalystProject[]> {
+        // Only get projects the user is a member of.
+        request.filters = [
+            ...(request.filters ?? []),
+            {
+                key: 'hasAccessTo',
+                values: ['true'],
+            },
+        ]
+
         const requester = async (request: CodeCatalyst.ListProjectsRequest) =>
             this.call(this.sdkClient.listProjects(request), true, { items: [] })
         const collection = pageableToCollection(requester, request, 'nextToken', 'items')


### PR DESCRIPTION
Improves performance and avoids "AccessDeniedException" noise in the logs.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
