### PR TITLE
authWebview: Builder Id sign in for CC + CW

### DIFF
--- a/src/codecatalyst/auth.ts
+++ b/src/codecatalyst/auth.ts
@@ -225,9 +225,13 @@ export class CodeCatalystAuthenticationProvider {
         }
     }
 
-    private static instance: CodeCatalystAuthenticationProvider
+    static #instance: CodeCatalystAuthenticationProvider | undefined
+
+    public static get instance(): CodeCatalystAuthenticationProvider | undefined {
+        return CodeCatalystAuthenticationProvider.#instance
+    }
 
     public static fromContext(ctx: Pick<vscode.ExtensionContext, 'secrets' | 'globalState'>) {
-        return (this.instance ??= new this(new CodeCatalystAuthStorage(ctx.secrets), ctx.globalState))
+        return (this.#instance ??= new this(new CodeCatalystAuthStorage(ctx.secrets), ctx.globalState))
     }
 }

--- a/src/codecatalyst/auth.ts
+++ b/src/codecatalyst/auth.ts
@@ -70,6 +70,10 @@ export class CodeCatalystAuthenticationProvider {
         return this.secondaryAuth.isUsingSavedConnection
     }
 
+    public isConnectionValid(): boolean {
+        return this.activeConnection !== undefined && !this.secondaryAuth.isConnectionExpired
+    }
+
     // Get rid of this? Not sure where to put PAT code.
     public async getPat(client: CodeCatalystClient, username = client.identity.name): Promise<string> {
         const stored = await this.storage.getPat(username)

--- a/src/codecatalyst/explorer.ts
+++ b/src/codecatalyst/explorer.ts
@@ -17,7 +17,7 @@ import { ConnectedDevEnv, getDevfileLocation, getThisDevEnv } from './model'
 import * as codecatalyst from './model'
 import { getLogger } from '../shared/logger'
 
-const getStartedCommand = Commands.register(
+export const getStartedCommand = Commands.register(
     'aws.codecatalyst.getStarted',
     async (authProvider: CodeCatalystAuthenticationProvider) => {
         const conn = authProvider.activeConnection ?? (await authProvider.promptNotConnected())

--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -101,6 +101,10 @@ export class AuthUtil {
         return this.conn !== undefined && this.usingEnterpriseSSO
     }
 
+    public isBuilderIdInUse(): boolean {
+        return this.conn !== undefined && isBuilderIdConnection(this.conn)
+    }
+
     public async connectToAwsBuilderId() {
         let conn = (await this.auth.listConnections()).find(isBuilderIdConnection)
 

--- a/src/credentials/auth.ts
+++ b/src/credentials/auth.ts
@@ -1054,7 +1054,7 @@ const switchConnections = Commands.register('aws.auth.switchConnections', (auth:
     }
 })
 
-async function signout(auth: Auth, conn: Connection | undefined = auth.activeConnection) {
+export async function signout(auth: Auth, conn: Connection | undefined = auth.activeConnection) {
     if (conn?.type === 'sso') {
         // TODO: does deleting the connection make sense UX-wise?
         // this makes it disappear from the list of available connections

--- a/src/credentials/vue/authForms/baseAuth.vue
+++ b/src/credentials/vue/authForms/baseAuth.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
-import { AuthFormId, AuthStatus } from './shared.vue'
+import { AuthStatus } from './shared.vue'
+import { AuthFormId } from './types.vue'
 
 export default defineComponent({
     emits: ['auth-connection-updated'],

--- a/src/credentials/vue/authForms/baseAuth.vue
+++ b/src/credentials/vue/authForms/baseAuth.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
+import { AuthFormId, AuthStatus } from './shared.vue'
 
 export default defineComponent({
     emits: ['auth-connection-updated'],
@@ -10,22 +11,9 @@ export default defineComponent({
     },
 })
 
-export interface AuthStatus {
-    /**
-     * Returns true if the auth is successfully connected.
-     */
-    isAuthConnected(): Promise<boolean>
-}
-
 export class UnimplementedAuthStatus implements AuthStatus {
     isAuthConnected(): Promise<boolean> {
         return Promise.resolve(false)
     }
 }
-
-export const authForms = {
-    CREDENTIALS: 'CREDENTIALS',
-} as const
-
-export type AuthFormId = (typeof authForms)[keyof typeof authForms]
 </script>

--- a/src/credentials/vue/authForms/manageBuilderId.vue
+++ b/src/credentials/vue/authForms/manageBuilderId.vue
@@ -1,0 +1,161 @@
+<template>
+    <div class="auth-form container-background border-common" id="builder-id-form">
+        <div v-show="canShowAll">
+            <FormTitle :isConnected="isConnected">AWS Builder ID</FormTitle>
+
+            <div v-if="stage === stages.START">
+                <div class="form-section">
+                    <div>
+                        With AWS Builder ID, sign in for free without an AWS account.
+                        <a href="https://docs.aws.amazon.com/signin/latest/userguide/sign-in-aws_builder_id.html"
+                            >Read more.</a
+                        >
+                    </div>
+                </div>
+
+                <div class="form-section">
+                    <button v-on:click="startSignIn()">Sign up or Sign in</button>
+                </div>
+            </div>
+
+            <div v-if="stage === stages.WAITING_ON_USER">
+                <div class="form-section">
+                    <div>Follow instructions...</div>
+                </div>
+            </div>
+
+            <div v-if="stage === stages.CONNECTED">
+                <div class="form-section">
+                    <div v-on:click="signout()" style="cursor: pointer; color: #75beff">Sign out</div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+<script lang="ts">
+import { PropType, defineComponent } from 'vue'
+import BaseAuthForm from './baseAuth.vue'
+import FormTitle from './formTitle.vue'
+import { AuthStatus } from './shared.vue'
+import { WebviewClientFactory } from '../../../webviews/client'
+import { AuthWebview } from '../show'
+import authForms, { AuthFormId } from './types.vue'
+
+const client = WebviewClientFactory.create<AuthWebview>()
+
+/** Where the user is currently in the builder id setup process */
+export const stages = {
+    START: 'START',
+    WAITING_ON_USER: 'WAITING_ON_USER',
+    CONNECTED: 'CONNECTED',
+} as const
+type BuilderIdStage = (typeof stages)[keyof typeof stages]
+
+export default defineComponent({
+    name: 'CredentialsForm',
+    extends: BaseAuthForm,
+    components: { FormTitle },
+    props: {
+        state: {
+            type: Object as PropType<BaseBuilderIdState>,
+            required: true,
+        },
+        stages: {
+            type: Object as PropType<typeof stages>,
+            default: stages,
+        },
+    },
+    data() {
+        return {
+            stage: stages.START as BuilderIdStage,
+            isConnected: false,
+            builderIdCode: '',
+            canShowAll: false,
+        }
+    },
+    async created() {
+        await this.update()
+        this.canShowAll = true
+    },
+    methods: {
+        async startSignIn() {
+            this.stage = this.stages.WAITING_ON_USER
+            await this.state.startBuilderIdSetup()
+            await this.update()
+        },
+        async update() {
+            this.stage = await this.state.stage()
+            this.isConnected = await this.state.isAuthConnected()
+            this.emitAuthConnectionUpdated(this.state.id)
+        },
+        async signout() {
+            await this.state.signout()
+
+            this.update()
+        },
+    },
+})
+
+/**
+ * Manages the state of Builder ID.
+ */
+abstract class BaseBuilderIdState implements AuthStatus {
+    protected _stage: BuilderIdStage = stages.START
+
+    abstract get id(): AuthFormId
+    protected abstract _startBuilderIdSetup(): Promise<void>
+    abstract isAuthConnected(): Promise<boolean>
+
+    async startBuilderIdSetup(): Promise<void> {
+        this._stage = stages.WAITING_ON_USER
+        return this._startBuilderIdSetup()
+    }
+
+    async stage(): Promise<BuilderIdStage> {
+        const isAuthConnected = await this.isAuthConnected()
+        this._stage = isAuthConnected ? stages.CONNECTED : stages.START
+        return this._stage
+    }
+
+    async signout(): Promise<void> {
+        await client.signoutBuilderId()
+    }
+}
+
+export class CodeWhispererBuilderIdState extends BaseBuilderIdState {
+    override get id(): AuthFormId {
+        return authForms.BUILDER_ID_CODE_WHISPERER
+    }
+
+    override isAuthConnected(): Promise<boolean> {
+        return client.isCodeWhispererBuilderIdConnected()
+    }
+
+    protected override _startBuilderIdSetup(): Promise<void> {
+        return client.startCodeWhispererBuilderIdSetup()
+    }
+}
+
+export class CodeCatalystBuilderIdState extends BaseBuilderIdState {
+    override get id(): AuthFormId {
+        return authForms.BUILDER_ID_CODE_CATALYST
+    }
+
+    override isAuthConnected(): Promise<boolean> {
+        return client.isCodeCatalystBuilderIdConnected()
+    }
+
+    protected override _startBuilderIdSetup(): Promise<void> {
+        return client.startCodeCatalystBuilderIdSetup()
+    }
+}
+</script>
+<style>
+@import './sharedAuthForms.css';
+@import '../shared.css';
+
+#builder-id-form {
+    width: 250px;
+    height: fit-content;
+}
+</style>

--- a/src/credentials/vue/authForms/manageCredentials.vue
+++ b/src/credentials/vue/authForms/manageCredentials.vue
@@ -50,11 +50,12 @@
 </template>
 <script lang="ts">
 import { PropType, defineComponent } from 'vue'
-import BaseAuthForm, { AuthStatus } from './baseAuth.vue'
+import BaseAuthForm from './baseAuth.vue'
 import FormTitle from './formTitle.vue'
 import { SectionName, StaticProfile } from '../../types'
 import { WebviewClientFactory } from '../../../webviews/client'
 import { AuthWebview } from '../show'
+import { AuthStatus } from './shared.vue'
 
 const client = WebviewClientFactory.create<AuthWebview>()
 

--- a/src/credentials/vue/authForms/shared.vue
+++ b/src/credentials/vue/authForms/shared.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { CodeCatalystBuilderIdState, CodeWhispererBuilderIdState } from './manageBuilderId.vue'
 import { CredentialsState } from './manageCredentials.vue'
 import authForms from './types.vue'
 
@@ -7,6 +8,8 @@ import authForms from './types.vue'
  */
 const authFormsState = {
     [authForms.CREDENTIALS]: new CredentialsState(),
+    [authForms.BUILDER_ID_CODE_WHISPERER]: new CodeWhispererBuilderIdState(),
+    [authForms.BUILDER_ID_CODE_CATALYST]: new CodeCatalystBuilderIdState(),
 } as const
 
 export interface AuthStatus {

--- a/src/credentials/vue/authForms/shared.vue
+++ b/src/credentials/vue/authForms/shared.vue
@@ -1,11 +1,6 @@
 <script lang="ts">
 import { CredentialsState } from './manageCredentials.vue'
-
-export const authForms = {
-    CREDENTIALS: 'CREDENTIALS',
-} as const
-
-export type AuthFormId = (typeof authForms)[keyof typeof authForms]
+import authForms from './types.vue'
 
 /**
  * The state instance of all auth forms

--- a/src/credentials/vue/authForms/shared.vue
+++ b/src/credentials/vue/authForms/shared.vue
@@ -1,6 +1,11 @@
 <script lang="ts">
 import { CredentialsState } from './manageCredentials.vue'
-import { authForms } from './baseAuth.vue'
+
+export const authForms = {
+    CREDENTIALS: 'CREDENTIALS',
+} as const
+
+export type AuthFormId = (typeof authForms)[keyof typeof authForms]
 
 /**
  * The state instance of all auth forms
@@ -8,6 +13,13 @@ import { authForms } from './baseAuth.vue'
 const authFormsState = {
     [authForms.CREDENTIALS]: new CredentialsState(),
 } as const
+
+export interface AuthStatus {
+    /**
+     * Returns true if the auth is successfully connected.
+     */
+    isAuthConnected(): Promise<boolean>
+}
 
 export default authFormsState
 </script>

--- a/src/credentials/vue/authForms/sharedAuthForms.css
+++ b/src/credentials/vue/authForms/sharedAuthForms.css
@@ -21,6 +21,7 @@
 
 .auth-form-title {
     font-size: 14px;
+    font-weight: bold;
     color: #ffffff;
 }
 
@@ -53,4 +54,9 @@ input[data-invalid='true'] {
 input[data-invalid='true']:focus {
     /* Ensures the border stays red even when selected */
     outline: none !important;
+}
+
+/* Remove underline from anchor elements */
+a {
+    text-decoration: none;
 }

--- a/src/credentials/vue/authForms/types.vue
+++ b/src/credentials/vue/authForms/types.vue
@@ -1,6 +1,8 @@
 <script lang="ts">
 export const authForms = {
     CREDENTIALS: 'CREDENTIALS',
+    BUILDER_ID_CODE_WHISPERER: 'BUILDER_ID_CODE_WHISPERER',
+    BUILDER_ID_CODE_CATALYST: 'BUILDER_ID_CODE_CATALYST',
 } as const
 
 export type AuthFormId = (typeof authForms)[keyof typeof authForms]

--- a/src/credentials/vue/authForms/types.vue
+++ b/src/credentials/vue/authForms/types.vue
@@ -1,0 +1,9 @@
+<script lang="ts">
+export const authForms = {
+    CREDENTIALS: 'CREDENTIALS',
+} as const
+
+export type AuthFormId = (typeof authForms)[keyof typeof authForms]
+
+export default authForms
+</script>

--- a/src/credentials/vue/root.vue
+++ b/src/credentials/vue/root.vue
@@ -46,7 +46,7 @@
                             <component
                                 :is="getServiceItemContent(itemId)"
                                 :state="serviceItemsAuthStatus[itemId]"
-                                :key="itemId"
+                                :key="itemId + rerenderContentWindowKey"
                                 @is-auth-connected="onIsAuthConnected"
                             ></component>
                         </template>
@@ -72,7 +72,7 @@
                             <component
                                 :is="getServiceItemContent(itemId)"
                                 :state="serviceItemsAuthStatus[itemId]"
-                                :key="itemId"
+                                :key="itemId + rerenderContentWindowKey"
                                 @is-auth-connected="onIsAuthConnected"
                             ></component>
                         </template>
@@ -85,7 +85,7 @@
             <component
                 :is="getServiceItemContent(getSelectedService())"
                 :state="serviceItemsAuthStatus[getSelectedService()]"
-                :key="getSelectedService()"
+                :key="getSelectedService() + rerenderContentWindowKey"
                 @is-auth-connected="onIsAuthConnected"
             ></component>
         </div>
@@ -96,7 +96,10 @@
 import { defineComponent } from 'vue'
 import ServiceItem, { ServiceItemsState, ServiceItemId, ServiceStatus, StaticServiceItemProps } from './serviceItem.vue'
 import serviceItemsContent, { serviceItemsAuthStatus } from './serviceItemContent/shared.vue'
+import { WebviewClientFactory } from '../../webviews/client'
+import { AuthWebview } from './show'
 
+const client = WebviewClientFactory.create<AuthWebview>()
 const serviceItemsState = new ServiceItemsState()
 
 export default defineComponent({
@@ -109,11 +112,24 @@ export default defineComponent({
             currWindowWidth: window.innerWidth,
 
             serviceItemsAuthStatus: serviceItemsAuthStatus,
+
+            rerenderContentWindowKey: 0,
         }
     },
     async created() {
         await this.updateServiceConnections()
-        this.renderItems()
+
+        // This handles the case where non-webview auth setup is used.
+        // This will detect their resulting changes to auth
+        // and it will have this webview update to get the latest info.
+        client.onDidConnectionUpdate(() => {
+            this.updateServiceConnections()
+            // This handles the edge case where we have selected a service item
+            // and its content window is being shown. If there is an external
+            // event that changes the state of this service (eg: disconnected)
+            // this forced rerender will display the new state
+            this.rerenderSelectedContentWindow()
+        })
     },
     mounted() {
         window.addEventListener('resize', this.updateWindowWidth)
@@ -179,9 +195,7 @@ export default defineComponent({
             // In some cases, during the connection process for one auth method,
             // an already connected auth can be disconnected. This refreshes all
             // auths to show the user the latest state of everything.
-            this.updateServiceConnections().then(() => {
-                this.renderItems()
-            })
+            this.updateServiceConnections()
         },
         async updateServiceConnections() {
             return Promise.all([
@@ -194,7 +208,14 @@ export default defineComponent({
                 this.serviceItemsAuthStatus.CODE_CATALYST.isAuthConnected().then(isConnected => {
                     this.updateServiceLock('CODE_CATALYST', isConnected)
                 }),
-            ])
+            ]).then(() => this.renderItems())
+        },
+        /**
+         * This will trigger a re-rendering of the currently shown content window.
+         */
+        rerenderSelectedContentWindow() {
+            // Arbitrarily toggles value between 0 and 1
+            this.rerenderContentWindowKey = this.rerenderContentWindowKey === 0 ? 1 : 0
         },
     },
 })

--- a/src/credentials/vue/serviceItemContent/awsExplorerContent.vue
+++ b/src/credentials/vue/serviceItemContent/awsExplorerContent.vue
@@ -11,10 +11,9 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue'
-import { AuthStatus } from '../authForms/baseAuth.vue'
 import CredentialsForm, { CredentialsState } from '../authForms/manageCredentials.vue'
 import BaseServiceItemContent from './baseServiceItemContent.vue'
-import authFormsState from '../authForms/shared.vue'
+import authFormsState, { AuthStatus } from '../authForms/shared.vue'
 
 export default defineComponent({
     name: 'AwsExplorerContent',

--- a/src/credentials/vue/serviceItemContent/baseServiceItemContent.vue
+++ b/src/credentials/vue/serviceItemContent/baseServiceItemContent.vue
@@ -5,7 +5,7 @@
 <script lang="ts">
 import { PropType, defineComponent } from 'vue'
 import { ServiceItemId } from '../serviceItem.vue'
-import { AuthStatus } from '../authForms/baseAuth.vue'
+import { AuthStatus } from '../authForms/shared.vue';
 
 export default defineComponent({
     name: 'BaseServiceItemContent',

--- a/src/credentials/vue/serviceItemContent/codeCatalystContent.vue
+++ b/src/credentials/vue/serviceItemContent/codeCatalystContent.vue
@@ -1,0 +1,42 @@
+<template>
+    <div class="service-item-content-container border-common">
+        <div>
+            <BuilderIdForm :state="builderIdState" @auth-connection-updated="onAuthConnectionUpdated"></BuilderIdForm>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import BuilderIdForm, { CodeCatalystBuilderIdState } from '../authForms/manageBuilderId.vue'
+import BaseServiceItemContent from './baseServiceItemContent.vue'
+import authFormsState, { AuthStatus } from '../authForms/shared.vue'
+
+export default defineComponent({
+    name: 'CodeCatalystContent',
+    components: { BuilderIdForm },
+    extends: BaseServiceItemContent,
+    computed: {
+        builderIdState(): CodeCatalystBuilderIdState {
+            return authFormsState.BUILDER_ID_CODE_CATALYST
+        },
+    },
+    methods: {
+        async onAuthConnectionUpdated() {
+            const isConnected = await this.state.isAuthConnected()
+            this.emitIsAuthConnected('CODE_CATALYST', isConnected)
+        },
+    },
+})
+
+export class CodeCatalystContentState implements AuthStatus {
+    async isAuthConnected(): Promise<boolean> {
+        return authFormsState.BUILDER_ID_CODE_CATALYST.isAuthConnected()
+    }
+}
+</script>
+
+<style>
+@import './baseServiceItemContent.css';
+@import '../shared.css';
+</style>

--- a/src/credentials/vue/serviceItemContent/codeWhispererContent.vue
+++ b/src/credentials/vue/serviceItemContent/codeWhispererContent.vue
@@ -1,0 +1,42 @@
+<template>
+    <div class="service-item-content-container border-common">
+        <div>
+            <BuilderIdForm :state="builderIdState" @auth-connection-updated="onAuthConnectionUpdated"></BuilderIdForm>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import BuilderIdForm, { CodeWhispererBuilderIdState } from '../authForms/manageBuilderId.vue'
+import BaseServiceItemContent from './baseServiceItemContent.vue'
+import authFormsState, { AuthStatus } from '../authForms/shared.vue'
+
+export default defineComponent({
+    name: 'CodeWhispererContent',
+    components: { BuilderIdForm },
+    extends: BaseServiceItemContent,
+    computed: {
+        builderIdState(): CodeWhispererBuilderIdState {
+            return authFormsState.BUILDER_ID_CODE_WHISPERER
+        },
+    },
+    methods: {
+        async onAuthConnectionUpdated() {
+            const isConnected = await this.state.isAuthConnected()
+            this.emitIsAuthConnected('CODE_WHISPERER', isConnected)
+        },
+    },
+})
+
+export class CodeWhispererContentState implements AuthStatus {
+    async isAuthConnected(): Promise<boolean> {
+        return authFormsState.BUILDER_ID_CODE_WHISPERER.isAuthConnected()
+    }
+}
+</script>
+
+<style>
+@import './baseServiceItemContent.css';
+@import '../shared.css';
+</style>

--- a/src/credentials/vue/serviceItemContent/shared.vue
+++ b/src/credentials/vue/serviceItemContent/shared.vue
@@ -2,7 +2,8 @@
 import AwsExplorerContent, { ResourceExplorerContentState } from './awsExplorerContent.vue'
 import BaseServiceItemContent from './baseServiceItemContent.vue'
 import { ServiceItemId, serviceItemIds } from '../serviceItem.vue'
-import { AuthStatus, UnimplementedAuthStatus } from '../authForms/baseAuth.vue'
+import { UnimplementedAuthStatus } from '../authForms/baseAuth.vue'
+import { AuthStatus } from '../authForms/shared.vue'
 
 /** Maps a service item id to its respective component */
 const serviceItemsContent = {

--- a/src/credentials/vue/serviceItemContent/shared.vue
+++ b/src/credentials/vue/serviceItemContent/shared.vue
@@ -4,13 +4,15 @@ import BaseServiceItemContent from './baseServiceItemContent.vue'
 import { ServiceItemId, serviceItemIds } from '../serviceItem.vue'
 import { UnimplementedAuthStatus } from '../authForms/baseAuth.vue'
 import { AuthStatus } from '../authForms/shared.vue'
+import CodeWhispererContent, { CodeWhispererContentState } from './codeWhispererContent.vue'
+import CodeCatalystContent, { CodeCatalystContentState } from './codeCatalystContent.vue'
 
 /** Maps a service item id to its respective component */
 const serviceItemsContent = {
     [serviceItemIds.NON_AUTH_FEATURES]: BaseServiceItemContent,
     [serviceItemIds.RESOURCE_EXPLORER]: AwsExplorerContent,
-    [serviceItemIds.CODE_CATALYST]: BaseServiceItemContent,
-    [serviceItemIds.CODE_WHISPERER]: BaseServiceItemContent,
+    [serviceItemIds.CODE_CATALYST]: CodeCatalystContent,
+    [serviceItemIds.CODE_WHISPERER]: CodeWhispererContent,
 } as const
 
 /**
@@ -22,8 +24,8 @@ const serviceItemsContent = {
 export const serviceItemsAuthStatus: Record<ServiceItemId, AuthStatus> = {
     [serviceItemIds.NON_AUTH_FEATURES]: new UnimplementedAuthStatus(),
     [serviceItemIds.RESOURCE_EXPLORER]: new ResourceExplorerContentState(),
-    [serviceItemIds.CODE_CATALYST]: new UnimplementedAuthStatus(),
-    [serviceItemIds.CODE_WHISPERER]: new UnimplementedAuthStatus(),
+    [serviceItemIds.CODE_CATALYST]: new CodeCatalystContentState(),
+    [serviceItemIds.CODE_WHISPERER]: new CodeWhispererContentState(),
 } as const
 
 export default serviceItemsContent

--- a/src/credentials/vue/shared.css
+++ b/src/credentials/vue/shared.css
@@ -1,5 +1,6 @@
 /* Shared */
 
+button,
 .border-common {
     border-style: solid;
     border-width: 2px;

--- a/src/credentials/vue/show.ts
+++ b/src/credentials/vue/show.ts
@@ -10,14 +10,30 @@ import { getIdeProperties, isCloud9 } from '../../shared/extensionUtilities'
 import { VueWebview } from '../../webviews/main'
 import * as vscode from 'vscode'
 import { CredentialsData, CredentialsKey, SectionName, StaticProfile, StaticProfileKeyErrorMessage } from '../types'
-import { Auth, tryAddCredentials } from '../auth'
+import { Auth, isBuilderIdConnection, signout, tryAddCredentials } from '../auth'
 import { getCredentialFormatError, getCredentialsErrors } from '../sharedCredentialsValidation'
 import { profileExists } from '../sharedCredentials'
 import { getLogger } from '../../shared/logger'
+import { AuthUtil as CodeWhispererAuth } from '../../codewhisperer/util/authUtil'
+import { awsIdSignIn } from '../../codewhisperer/util/showSsoPrompt'
+import { CodeCatalystAuthenticationProvider } from '../../codecatalyst/auth'
+import { getStartedCommand } from '../../codecatalyst/explorer'
+import { ToolkitError } from '../../shared/errors'
 
 export class AuthWebview extends VueWebview {
     public override id: string = 'authWebview'
     public override source: string = 'src/credentials/vue/index.js'
+
+    private codeCatalystAuth: CodeCatalystAuthenticationProvider
+
+    constructor() {
+        super()
+        const ccAuth = CodeCatalystAuthenticationProvider.instance
+        if (ccAuth === undefined) {
+            throw new ToolkitError('Code Catalyst auth instance singleton was not created externally yet.')
+        }
+        this.codeCatalystAuth = ccAuth
+    }
 
     async getProfileNameError(profileName?: SectionName, required = true): Promise<string | undefined> {
         if (!profileName) {
@@ -51,12 +67,64 @@ export class AuthWebview extends VueWebview {
         if (!conn) {
             return false
         }
-
+        // Maybe need to use SecondaryAuth registerAuthListener()
+        /**
+         *
+         * When a Builder ID is active and cred is not, the BID is
+         * the main active connection. BID's are saveable and checked
+         * by registerAuthListenter().
+         *
+         * What this means is that when creds are activated they become
+         * the main Auth.instance.activeConnection and BID is a secondary
+         * one.
+         *
+         * TODO: Show the quickpick and tell them to pick a credentials
+         * connection to use.
+         *
+         */
         return conn.type === 'iam' && conn.state === 'valid'
     }
 
     async getAuthenticatedCredentialsError(data: StaticProfile): Promise<StaticProfileKeyErrorMessage | undefined> {
         return Auth.instance.authenticateData(data)
+    }
+
+    async startCodeWhispererBuilderIdSetup(): Promise<void> {
+        try {
+            await awsIdSignIn()
+        } catch (e) {
+            return
+        }
+    }
+
+    async startCodeCatalystBuilderIdSetup(): Promise<void> {
+        return getStartedCommand.execute(this.codeCatalystAuth)
+    }
+
+    isCodeWhispererBuilderIdConnected(): boolean {
+        return CodeWhispererAuth.instance.isBuilderIdInUse() && CodeWhispererAuth.instance.isConnectionValid()
+    }
+
+    isCodeCatalystBuilderIdConnected(): boolean {
+        return this.codeCatalystAuth.isConnectionValid()
+    }
+
+    async signoutBuilderId(): Promise<void> {
+        await this.deleteSavedBuilderIdConns()
+
+        // Deletes active connection
+        const builderIdConn = (await Auth.instance.listConnections()).find(isBuilderIdConnection)
+        await signout(Auth.instance, builderIdConn)
+    }
+
+    private async deleteSavedBuilderIdConns(): Promise<void> {
+        if (CodeWhispererAuth.instance.isBuilderIdInUse()) {
+            await CodeWhispererAuth.instance.secondaryAuth.removeConnection()
+        }
+
+        if (this.codeCatalystAuth.activeConnection) {
+            await this.codeCatalystAuth.removeSavedConnection()
+        }
     }
 }
 


### PR DESCRIPTION
### What this change includes

- Users can signup/signin to builder ID for CC or CW
- They will be guided through the existing signin flow
- CC and CW signin must be done individually. User will
  need to complete signin for each.
- When signed in, a 'signout' option is shown, and if
  clicked all of BuilderID will be signed out and
  CC + CW will be updated in the UI

- Listening to events from the backend. Eg: when
  a user interacts with builder id auth using an
  alternative to the webview, the webview will
  update with the latest status.

### Builder ID Sign in
![Kapture 2023-05-15 at 15 10 40](https://github.com/aws/aws-toolkit-vscode/assets/118216176/fbf3331b-6d05-4cbc-9ac3-4d32cfd5e859)

### External Auth interactions update the webview
![Kapture 2023-05-18 at 10 55 22](https://github.com/aws/aws-toolkit-vscode/assets/118216176/1563b715-e9c3-4729-accf-a2094abc3e3c)


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
