### PR TITLE
feat(telemetry): add request ID to events on failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
                 "yaml-cfn": "^0.3.2"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.127",
+                "@aws-toolkits/telemetry": "^1.0.129",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^10.0.2",
                 "@types/adm-zip": "^0.4.34",
@@ -1807,9 +1807,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.127",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.127.tgz",
-            "integrity": "sha512-JSlqchDEKXq7kKH23L6ki0aLf3V59hkfvMKOue+d9rBJWUraZmZHikv4EOhuyunfzsQwqgJzlLVthApMaGT8FQ==",
+            "version": "1.0.129",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.129.tgz",
+            "integrity": "sha512-f7ZTfkoxA44llngN1fLFthpSXjBNqfApbU3f8GHi4rokhbLIbCID/3b/hv6ukC/0VdFOUPvM+La+cBvR6mR1uA==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",
@@ -16174,9 +16174,9 @@
             }
         },
         "@aws-toolkits/telemetry": {
-            "version": "1.0.127",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.127.tgz",
-            "integrity": "sha512-JSlqchDEKXq7kKH23L6ki0aLf3V59hkfvMKOue+d9rBJWUraZmZHikv4EOhuyunfzsQwqgJzlLVthApMaGT8FQ==",
+            "version": "1.0.129",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.129.tgz",
+            "integrity": "sha512-f7ZTfkoxA44llngN1fLFthpSXjBNqfApbU3f8GHi4rokhbLIbCID/3b/hv6ukC/0VdFOUPvM+La+cBvR6mR1uA==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -3460,7 +3460,7 @@
         "report": "nyc report --reporter=html --reporter=json"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.127",
+        "@aws-toolkits/telemetry": "^1.0.129",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/adm-zip": "^0.4.34",


### PR DESCRIPTION
## Problem
No way to connect service-side issues with client-side failures.

## Solution
Add `requestId` plus the service name to the current event and any subsequent events. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
