### PR TITLE
fix(codewhisperer): Remove command registration in deprecated code path

### DIFF
--- a/package.json
+++ b/package.json
@@ -3178,26 +3178,6 @@
                 "when": "inlineSuggestionVisible && !editorReadonly && CODEWHISPERER_ENABLED"
             },
             {
-                "command": "aws.codeWhisperer.rejectCodeSuggestion",
-                "key": "backspace",
-                "mac": "backspace",
-                "when": "editorTextFocus && CODEWHISPERER_SERVICE_ACTIVE"
-            },
-            {
-                "command": "aws.codeWhisperer.rejectCodeSuggestion",
-                "key": "up",
-                "mac": "up",
-                "when": "editorTextFocus && CODEWHISPERER_SERVICE_ACTIVE",
-                "args": "up"
-            },
-            {
-                "command": "aws.codeWhisperer.rejectCodeSuggestion",
-                "key": "down",
-                "mac": "down",
-                "when": "editorTextFocus && CODEWHISPERER_SERVICE_ACTIVE",
-                "args": "down"
-            },
-            {
                 "command": "aws.codeWhisperer.acceptCodeSuggestion",
                 "key": "tab",
                 "mac": "tab",

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -453,18 +453,6 @@ export async function activate(context: ExtContext): Promise<void> {
                     await InlineCompletion.instance.rejectRecommendation(vscode.window.activeTextEditor)
                 }
             }),
-            Commands.register('aws.codeWhisperer.rejectCodeSuggestion', async e => {
-                if (vscode.window.activeTextEditor) {
-                    await InlineCompletion.instance.rejectRecommendation(vscode.window.activeTextEditor)
-                    if (e === 'up') {
-                        await vscode.commands.executeCommand('cursorUp')
-                    } else if (e === 'down') {
-                        await vscode.commands.executeCommand('cursorDown')
-                    } else if (e !== undefined) {
-                        getLogger().warn(`Unexpected argument for rejectCodeSuggestion ${e}`)
-                    }
-                }
-            }),
             /**
              * Recommendation navigation
              */


### PR DESCRIPTION
## Problem

The command registration in deprecated code path is causing unit test / CI to fail. This PR is to remove one of it. A larger scale clean up will be done later.

No change log is needed. No customer facing impact.

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
