### PR TITLE
authWebview: Identity Center for CW

### DIFF
--- a/src/auth/sso/validation.ts
+++ b/src/auth/sso/validation.ts
@@ -1,0 +1,52 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as vscode from 'vscode'
+import { UnknownError } from '../../shared/errors'
+import { AuthType } from '../auth'
+import { isSsoConnection, SsoConnection, hasScopes } from '../connection'
+
+export function validateSsoUrl(auth: AuthType, url: string, requiredScopes?: string[]) {
+    const urlFormatError = validateSsoUrlFormat(url)
+    if (urlFormatError) {
+        return urlFormatError
+    }
+
+    return validateIsNewSsoUrlAsync(auth, url, requiredScopes)
+}
+
+export function validateSsoUrlFormat(url: string) {
+    if (!url.match(/^(http|https):\/\//i)) {
+        return 'URLs must start with http:// or https://. Example: https://d-xxxxxxxxxx.awsapps.com/start'
+    }
+}
+
+export async function validateIsNewSsoUrlAsync(
+    auth: AuthType,
+    url: string,
+    requiredScopes?: string[]
+): Promise<string | undefined> {
+    return auth.listConnections().then(conns => {
+        return validateIsNewSsoUrl(url, requiredScopes, conns.filter(isSsoConnection))
+    })
+}
+
+export function validateIsNewSsoUrl(
+    url: string,
+    requiredScopes?: string[],
+    existingSsoConns: SsoConnection[] = []
+): string | undefined {
+    try {
+        const uri = vscode.Uri.parse(url, true)
+        const isSameAuthority = (a: vscode.Uri, b: vscode.Uri) =>
+            a.authority.toLowerCase() === b.authority.toLowerCase()
+        const oldConn = existingSsoConns.find(conn => isSameAuthority(vscode.Uri.parse(conn.startUrl), uri))
+
+        if (oldConn && (!requiredScopes || hasScopes(oldConn, requiredScopes))) {
+            return 'A connection for this start URL already exists. Sign out before creating a new one.'
+        }
+    } catch (err) {
+        return `URL is malformed: ${UnknownError.cast(err).message}`
+    }
+}

--- a/src/auth/ui/vue/authForms/manageIdentityCenter.vue
+++ b/src/auth/ui/vue/authForms/manageIdentityCenter.vue
@@ -1,0 +1,223 @@
+<template>
+    <div class="auth-form container-background border-common" id="identity-center-form">
+        <div v-show="canShowAll">
+            <FormTitle :isConnected="isConnected">IAM Identity Center</FormTitle>
+            <div v-if="!isConnected">Successor to AWS Single Sign-on</div>
+
+            <div v-if="stage === 'START'">
+                <div class="form-section">
+                    If your organization has provided you a CodeWhisperer license, sign in with your Identity Center
+                    access portal login page.
+                    <a>Read more.</a>
+                </div>
+
+                <div class="form-section">
+                    <label class="input-title">Start URL</label>
+                    <label class="small-description">The Start URL</label>
+                    <input v-model="data.startUrl" type="text" :data-invalid="!!errors.startUrl" />
+                    <div class="small-description error-text">{{ errors.startUrl }}</div>
+                </div>
+
+                <div class="form-section">
+                    <label class="input-title">Region</label>
+                    <label class="small-description">The Region</label>
+
+                    <select v-on:click="getRegion()">
+                        <option v-if="!!data.region" :selected="true">{{ data.region }}</option>
+                    </select>
+                </div>
+
+                <div class="form-section">
+                    <button v-on:click="signin()" :disabled="!canSubmit">Sign up or Sign in</button>
+                </div>
+            </div>
+
+            <div v-if="stage === 'WAITING_ON_USER'">
+                <div class="form-section">
+                    <div>Follow instructions...</div>
+                </div>
+            </div>
+
+            <div v-if="stage === 'CONNECTED'">
+                <div class="form-section">
+                    <div v-on:click="signout()" style="cursor: pointer; color: #75beff">Sign out</div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+<script lang="ts">
+import { PropType, defineComponent } from 'vue'
+import BaseAuthForm from './baseAuth.vue'
+import FormTitle from './formTitle.vue'
+import { WebviewClientFactory } from '../../../../webviews/client'
+import { AuthWebview } from '../show'
+import { AuthStatus } from './shared.vue'
+import { AuthFormId, authForms } from './types.vue'
+import { Region } from '../../../../shared/regions/endpoints'
+
+const client = WebviewClientFactory.create<AuthWebview>()
+
+export type IdentityCenterStage = 'START' | 'WAITING_ON_USER' | 'CONNECTED'
+
+export default defineComponent({
+    name: 'IdentityCenterForm',
+    extends: BaseAuthForm,
+    components: { FormTitle },
+    props: {
+        state: {
+            type: Object as PropType<BaseIdentityCenterState>,
+            required: true,
+        },
+    },
+    data() {
+        return {
+            data: {
+                startUrl: '',
+                region: '' as Region['id'],
+            },
+            errors: {
+                startUrl: '',
+            },
+            canSubmit: false,
+            isConnected: false,
+
+            stage: 'START' as IdentityCenterStage,
+
+            canShowAll: false,
+        }
+    },
+
+    async created() {
+        // Populate form if data already exists (triggers 'watch' functions)
+        this.data.startUrl = this.state.getValue('startUrl')
+        this.data.region = this.state.getValue('region')
+
+        await this.update()
+        this.canShowAll = true
+    },
+    computed: {},
+    methods: {
+        async signin(): Promise<void> {
+            await this.state.startIdentityCenterSetup()
+        },
+        async signout(): Promise<void> {
+            await this.state.signout()
+        },
+        async update() {
+            this.stage = await this.state.stage()
+            this.isConnected = await this.state.isAuthConnected()
+            this.emitAuthConnectionUpdated(this.state.id)
+        },
+        async getRegion() {
+            const region = await this.state.getRegion()
+            this.data.region = region.id
+        },
+        async updateData(key: IdentityCenterKey, value: string) {
+            this.state.setValue(key, value)
+
+            if (key === 'startUrl') {
+                this.errors.startUrl = await this.state.getStartUrlError()
+            }
+
+            this.canSubmit = await this.state.canSubmit()
+        },
+    },
+    watch: {
+        'data.startUrl'(value: string) {
+            this.updateData('startUrl', value)
+        },
+        'data.region'(value: string) {
+            this.updateData('region', value)
+        },
+    },
+})
+
+type IdentityCenterData = { startUrl: string; region: Region['id'] }
+type IdentityCenterKey = keyof IdentityCenterData
+
+/**
+ * Manages the state of Builder ID.
+ */
+abstract class BaseIdentityCenterState implements AuthStatus {
+    protected _data: IdentityCenterData
+    protected _stage: IdentityCenterStage = 'START'
+
+    constructor() {
+        this._data = {
+            startUrl: '',
+            region: '',
+        }
+    }
+
+    abstract get id(): AuthFormId
+    protected abstract _startIdentityCenterSetup(): Promise<void>
+    abstract isAuthConnected(): Promise<boolean>
+
+    setValue(key: IdentityCenterKey, value: string) {
+        this._data[key] = value
+    }
+
+    getValue(key: IdentityCenterKey): string {
+        return this._data[key]
+    }
+
+    async startIdentityCenterSetup(): Promise<void> {
+        this._stage = 'WAITING_ON_USER'
+        return this._startIdentityCenterSetup()
+    }
+
+    async stage(): Promise<IdentityCenterStage> {
+        const isAuthConnected = await this.isAuthConnected()
+        this._stage = isAuthConnected ? 'CONNECTED' : 'START'
+        return this._stage
+    }
+
+    async signout(): Promise<void> {
+        return client.signoutIdentityCenter()
+    }
+
+    async getRegion(): Promise<Region> {
+        return client.getIdentityCenterRegion()
+    }
+
+    async getStartUrlError() {
+        const error = await client.getSsoUrlError(this._data.startUrl)
+        return error ?? ''
+    }
+
+    async canSubmit() {
+        const allFieldsFilled = Object.values(this._data).every(val => !!val)
+        const hasErrors = await this.getStartUrlError()
+        return allFieldsFilled && !hasErrors
+    }
+
+    protected async getSubmittableDataOrThrow(): Promise<IdentityCenterData> {
+        return this._data as IdentityCenterData
+    }
+}
+
+export class CodeWhispererIdentityCenterState extends BaseIdentityCenterState {
+    override get id(): AuthFormId {
+        return authForms.IDENTITY_CENTER_CODE_WHISPERER
+    }
+
+    protected override async _startIdentityCenterSetup(): Promise<void> {
+        const data = await this.getSubmittableDataOrThrow()
+        return client.startIdentityCenterSetup(data.startUrl, data.region)
+    }
+
+    override async isAuthConnected(): Promise<boolean> {
+        return client.isCodeWhispererIdentityCenterConnected()
+    }
+}
+</script>
+<style>
+@import './sharedAuthForms.css';
+@import '../shared.css';
+
+#identity-center-form {
+    width: 250px;
+    height: fit-content;
+}
+</style>

--- a/src/auth/ui/vue/authForms/shared.vue
+++ b/src/auth/ui/vue/authForms/shared.vue
@@ -1,7 +1,8 @@
 <script lang="ts">
 import { CodeCatalystBuilderIdState, CodeWhispererBuilderIdState } from './manageBuilderId.vue'
 import { CredentialsState } from './manageCredentials.vue'
-import authForms from './types.vue'
+import { authForms } from './types.vue'
+import { CodeWhispererIdentityCenterState } from './manageIdentityCenter.vue'
 
 /**
  * The state instance of all auth forms
@@ -10,6 +11,7 @@ const authFormsState = {
     [authForms.CREDENTIALS]: new CredentialsState(),
     [authForms.BUILDER_ID_CODE_WHISPERER]: new CodeWhispererBuilderIdState(),
     [authForms.BUILDER_ID_CODE_CATALYST]: new CodeCatalystBuilderIdState(),
+    [authForms.IDENTITY_CENTER_CODE_WHISPERER]: new CodeWhispererIdentityCenterState(),
 } as const
 
 export interface AuthStatus {

--- a/src/auth/ui/vue/authForms/types.vue
+++ b/src/auth/ui/vue/authForms/types.vue
@@ -3,6 +3,7 @@ export const authForms = {
     CREDENTIALS: 'CREDENTIALS',
     BUILDER_ID_CODE_WHISPERER: 'BUILDER_ID_CODE_WHISPERER',
     BUILDER_ID_CODE_CATALYST: 'BUILDER_ID_CODE_CATALYST',
+    IDENTITY_CENTER_CODE_WHISPERER: 'IDENTITY_CENTER_CODE_WHISPERER',
 } as const
 
 export type AuthFormId = (typeof authForms)[keyof typeof authForms]

--- a/src/auth/ui/vue/serviceItemContent/baseServiceItemContent.css
+++ b/src/auth/ui/vue/serviceItemContent/baseServiceItemContent.css
@@ -12,3 +12,9 @@
     /* For testing purposes, before we have content to fill */
     min-height: 600px;
 }
+
+.form-container {
+    display: flex;
+    flex-direction: row;
+    gap: 20px;
+}

--- a/src/auth/ui/vue/serviceItemContent/codeWhispererContent.vue
+++ b/src/auth/ui/vue/serviceItemContent/codeWhispererContent.vue
@@ -1,7 +1,11 @@
 <template>
     <div class="service-item-content-container border-common">
-        <div>
+        <div class="form-container">
             <BuilderIdForm :state="builderIdState" @auth-connection-updated="onAuthConnectionUpdated"></BuilderIdForm>
+            <IdentityCenterForm
+                :state="identityCenterState"
+                @auth-connection-updated="onAuthConnectionUpdated"
+            ></IdentityCenterForm>
         </div>
     </div>
 </template>
@@ -9,16 +13,20 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import BuilderIdForm, { CodeWhispererBuilderIdState } from '../authForms/manageBuilderId.vue'
+import IdentityCenterForm, { CodeWhispererIdentityCenterState } from '../authForms/manageIdentityCenter.vue'
 import BaseServiceItemContent from './baseServiceItemContent.vue'
 import authFormsState, { AuthStatus } from '../authForms/shared.vue'
 
 export default defineComponent({
     name: 'CodeWhispererContent',
-    components: { BuilderIdForm },
+    components: { BuilderIdForm, IdentityCenterForm },
     extends: BaseServiceItemContent,
     computed: {
         builderIdState(): CodeWhispererBuilderIdState {
             return authFormsState.BUILDER_ID_CODE_WHISPERER
+        },
+        identityCenterState(): CodeWhispererIdentityCenterState {
+            return authFormsState.IDENTITY_CENTER_CODE_WHISPERER
         },
     },
     methods: {
@@ -31,7 +39,11 @@ export default defineComponent({
 
 export class CodeWhispererContentState implements AuthStatus {
     async isAuthConnected(): Promise<boolean> {
-        return authFormsState.BUILDER_ID_CODE_WHISPERER.isAuthConnected()
+        const result = await Promise.all([
+            authFormsState.BUILDER_ID_CODE_WHISPERER.isAuthConnected(),
+            authFormsState.IDENTITY_CENTER_CODE_WHISPERER.isAuthConnected(),
+        ])
+        return result.filter(isConnected => isConnected).length > 0
     }
 }
 </script>


### PR DESCRIPTION
Adds in Identity Center SSO sign in for CW in the auth webview
- Validates start url field
- Can sign out and will fully delete the connections

### Signing in to Identity Center
![Kapture 2023-05-18 at 13 31 10](https://github.com/aws/aws-toolkit-vscode/assets/118216176/7ba03251-640a-4b29-a10d-71034f90c478)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
