### PR TITLE
fix(stepfunctions): offline sfn visualizer

### DIFF
--- a/.changes/next-release/Bug Fix-5dd44ab8-9083-4dd8-ac28-585d99895aca.json
+++ b/.changes/next-release/Bug Fix-5dd44ab8-9083-4dd8-ac28-585d99895aca.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Add fallback to local cached files for Step Function Visualizations where host doesn't have internet."
+}

--- a/src/stepFunctions/commands/visualizeStateMachine/abstractAslVisualizationManager.ts
+++ b/src/stepFunctions/commands/visualizeStateMachine/abstractAslVisualizationManager.ts
@@ -56,4 +56,14 @@ export abstract class AbstractAslVisualizationManager<T extends AslVisualization
     protected getExistingVisualization(key: string): T | undefined {
         return this.managedVisualizations.get(key)
     }
+
+    protected async updateCache(globalStorage: vscode.Memento, logger: Logger): Promise<void> {
+        try {
+            await this.cache.updateCache(globalStorage)
+        } catch (err) {
+            // So we can't update the cache, but can we use an existing on disk version.
+            logger.warn('Updating State Machine Graph Visualisation assets failed, checking for fallback local cache.')
+            await this.cache.confirmCacheExists()
+        }
+    }
 }

--- a/src/stepFunctions/commands/visualizeStateMachine/aslVisualizationManager.ts
+++ b/src/stepFunctions/commands/visualizeStateMachine/aslVisualizationManager.ts
@@ -33,8 +33,7 @@ export class AslVisualizationManager extends AbstractAslVisualizationManager {
 
         // Existing visualization does not exist, construct new visualization
         try {
-            await this.cache.updateCache(globalStorage)
-
+            await this.updateCache(globalStorage, logger)
             const newVisualization = new AslVisualization(document)
             this.handleNewVisualization(document.uri.fsPath, newVisualization)
 

--- a/src/stepFunctions/utils.ts
+++ b/src/stepFunctions/utils.ts
@@ -117,6 +117,30 @@ export class StateMachineGraphCache {
         }
     }
 
+    // Coordinates check for multiple cached files.
+    public async confirmCacheExists(): Promise<boolean> {
+        const cssExists = await this.fileExists(this.cssFilePath)
+        const jsExists = await this.fileExists(this.jsFilePath)
+
+        if (cssExists && jsExists) {
+            return true
+        }
+
+        if (!cssExists) {
+            // Help users setup on disconnected C9/VSCode instances.
+            this.logger.error(
+                `Failed to locate cached State Machine Graph css assets. Expected to find: "${visualizationCssUrl}" at "${this.cssFilePath}"`
+            )
+        }
+        if (!jsExists) {
+            // Help users setup on disconnected C9/VSCode instances.
+            this.logger.error(
+                `Failed to locate cached State Machine Graph js assets. Expected to find: "${visualizationScriptUrl}" at "${this.jsFilePath}"`
+            )
+        }
+        throw new Error('Failed to located cached State Machine Graph assets')
+    }
+
     protected async writeToLocalStorage(destinationPath: string, data: string): Promise<void> {
         const storageFolder = this.dirPath
 

--- a/src/test/stepFunctions/utils.test.ts
+++ b/src/test/stepFunctions/utils.test.ts
@@ -122,6 +122,42 @@ describe('StateMachineGraphCache', function () {
             assert.ok(globalStorage.update.notCalled)
             assert.ok(writeFile.notCalled)
         })
+        it('it passes if both files required exist', async function () {
+            const getFileData = sinon.stub().resolves(true)
+            const fileExists = sinon.stub().resolves(true)
+
+            const writeFile = sinon.spy()
+
+            const cache = new StateMachineGraphCache({
+                getFileData,
+                fileExists,
+                writeFile,
+                cssFilePath: '',
+                jsFilePath: '',
+                dirPath: '',
+            })
+
+            await cache.confirmCacheExists()
+
+            assert.ok(fileExists.calledTwice)
+        })
+        it('it rejects if both files required do not exist on filesystem', async function () {
+            const getFileData = sinon.stub()
+            const fileExists = sinon.stub().onFirstCall().resolves(true).onSecondCall().resolves(false)
+
+            const writeFile = sinon.spy()
+
+            const cache = new StateMachineGraphCache({
+                getFileData,
+                fileExists,
+                writeFile,
+                cssFilePath: 'one',
+                jsFilePath: 'two',
+                dirPath: '',
+            })
+
+            assert.rejects(cache.confirmCacheExists())
+        })
 
         it('creates assets directory when it does not exist', async function () {
             const globalStorage = {


### PR DESCRIPTION
Step Functions Render Graph visualizer will now work offline, as long as there is a cached local copy of the generating js and css files.

Closes #2922.

There is now a  graceful fallback when internet connectivity isn't available to a c9 or vscode host but where the required files are available in the local filesystem cache (either by previous automatic caching, or by manual user intervention).

Implementation avoids confusing the return type of 'updateCache' or 'updateCachedFile' and instead only checks for local files after a updateCache call fails.

This commit merges 3 previous work in progress commits made for PR #3098. The current change submitted in this PR incorporates all the review comments from the previous PR.

Once this PR merges to main you can close #3098.

With great thanks for the original work by @simis2626!

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
