### PR TITLE
build(stepfunctions): amazon-states-language-service 1.9.0->1.10.0

### DIFF
--- a/.changes/next-release/Bug Fix-778b8105-0121-49bb-ac19-a5796d9e0b57.json
+++ b/.changes/next-release/Bug Fix-778b8105-0121-49bb-ac19-a5796d9e0b57.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Update dependency amazon-states-language-service from 1.9->1.10. This fixes  support for Yaml Comments in states machines, ProcessorConfig property & Credentials key."
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "@aws-sdk/util-arn-parser": "^3.46.0",
                 "@iarna/toml": "^2.2.5",
                 "adm-zip": "^0.5.9",
-                "amazon-states-language-service": "^1.9.0",
+                "amazon-states-language-service": "^1.10.0",
                 "async-lock": "^1.4.0",
                 "aws-sdk": "^2.1369.0",
                 "aws-ssm-document-language-service": "^1.0.0",
@@ -3516,6 +3516,11 @@
             "integrity": "sha512-VdgpnD75swH9hpXjd34VBgQ2w2quK63WljodlUcOoJDPKiV+rPjHrcUc2sjLCNKxhl6oKqmsZgwOWcDAY2GKKQ==",
             "dev": true
         },
+        "node_modules/@vscode/l10n": {
+            "version": "0.0.13",
+            "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.13.tgz",
+            "integrity": "sha512-A3uY356uOU9nGa+TQIT/i3ziWUgJjVMUrGGXSrtRiTwklyCFjGVWIOHoEIHbJpiyhDkJd9kvIWUOfXK1IkK8XQ=="
+        },
         "node_modules/@vscode/test-electron": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.2.3.tgz",
@@ -4065,36 +4070,16 @@
             }
         },
         "node_modules/amazon-states-language-service": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.9.0.tgz",
-            "integrity": "sha512-qbqJK1ZE5TUlzk/IANX9EX7oXwP1WYA1mXnOni2GEhkSnhSA14NCbvd9sOwADEPJB7Innwt7RqgVNQGGNz6x1g==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.10.0.tgz",
+            "integrity": "sha512-LRlnIzCBXeD7Ebm2M5J7r7o3Mz1Wqeo3euxqf4Rrbbycot35+6vA1JmdK9RXF4BIXy3I0wECPzKDtnQV8keK7g==",
             "dependencies": {
-                "js-yaml": "^3.14.0",
-                "vscode-json-languageservice": "3.4.9",
+                "js-yaml": "^4.1.0",
+                "vscode-json-languageservice": "5.3.5",
                 "vscode-languageserver": "^6.1.1",
                 "vscode-languageserver-textdocument": "^1.0.0",
                 "vscode-languageserver-types": "^3.15.1",
-                "yaml-language-server": "0.10.0"
-            }
-        },
-        "node_modules/amazon-states-language-service/node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
-        "node_modules/amazon-states-language-service/node_modules/js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
+                "yaml-language-server": "0.15.0"
             }
         },
         "node_modules/ansi-colors": {
@@ -13595,26 +13580,21 @@
             }
         },
         "node_modules/vscode-json-languageservice": {
-            "version": "3.4.9",
-            "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-3.4.9.tgz",
-            "integrity": "sha512-4VCpZ9ooea/Zc/MTnj1ccc9C7rqcoinKVQLhLoi6jw6yueSf4y4tg/YIUiPPVMlEAG7ZCPS+NVmqxisQ+mOsSw==",
+            "version": "5.3.5",
+            "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-5.3.5.tgz",
+            "integrity": "sha512-DasT+bKtpaS2rTPEB4VMROnvO1WES2KD8RZZxXbumnk9sk5wco10VdB6sJgTlsKQN14tHQLZDXuHnSoSAlE8LQ==",
             "dependencies": {
-                "jsonc-parser": "^2.2.0",
-                "vscode-languageserver-textdocument": "^1.0.0-next.4",
-                "vscode-languageserver-types": "^3.15.0-next.6",
-                "vscode-nls": "^4.1.1",
-                "vscode-uri": "^2.1.0"
+                "@vscode/l10n": "^0.0.13",
+                "jsonc-parser": "^3.2.0",
+                "vscode-languageserver-textdocument": "^1.0.8",
+                "vscode-languageserver-types": "^3.17.3",
+                "vscode-uri": "^3.0.7"
             }
         },
-        "node_modules/vscode-json-languageservice/node_modules/jsonc-parser": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
-            "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="
-        },
-        "node_modules/vscode-json-languageservice/node_modules/vscode-nls": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
-            "integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
+        "node_modules/vscode-json-languageservice/node_modules/vscode-uri": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
+            "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA=="
         },
         "node_modules/vscode-jsonrpc": {
             "version": "5.0.1",
@@ -13675,9 +13655,9 @@
             "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
         },
         "node_modules/vscode-languageserver-types": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+            "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
         },
         "node_modules/vscode-nls": {
             "version": "5.2.0",
@@ -14585,19 +14565,20 @@
             }
         },
         "node_modules/yaml-language-server": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-0.10.0.tgz",
-            "integrity": "sha512-d2/7eGgonEIRcnW9kK+k+ERG4gTOk5BXHr9KjTVv8gEarXKa62Kk+nyFE4AXgMDZ0LXTu8nTuN/AdboJiGN+pQ==",
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-0.15.0.tgz",
+            "integrity": "sha512-idaCYstdGoV5Pi7PKxbUkGHt6jAI3l+nxNWrsVCetxrEgfH6T7qytfT0pF3n4NdfDNPHPHcqnl69FzCFDVfHnQ==",
             "dependencies": {
                 "js-yaml": "^3.13.1",
                 "jsonc-parser": "^2.2.1",
                 "request-light": "^0.2.4",
-                "vscode-json-languageservice": "^3.6.0",
+                "vscode-json-languageservice": "^3.10.0",
                 "vscode-languageserver": "^5.2.1",
+                "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.15.1",
                 "vscode-nls": "^4.1.2",
                 "vscode-uri": "^2.1.1",
-                "yaml-ast-parser-custom-tags": "0.0.43"
+                "yaml-language-server-parser": "0.1.2"
             },
             "bin": {
                 "yaml-language-server": "bin/yaml-language-server"
@@ -14608,6 +14589,11 @@
             "optionalDependencies": {
                 "prettier": "2.0.5"
             }
+        },
+        "node_modules/yaml-language-server-parser": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/yaml-language-server-parser/-/yaml-language-server-parser-0.1.2.tgz",
+            "integrity": "sha512-GQ2eRE5GcKBK8XVKBIcMyOfC8WMZmEs6gogtVc6knLKE6pG+e5L/lOMfBxZzAt2lqye5itMggQ9+6stXAVhMsw=="
         },
         "node_modules/yaml-language-server/node_modules/argparse": {
             "version": "1.0.10",
@@ -14659,9 +14645,9 @@
             }
         },
         "node_modules/yaml-language-server/node_modules/vscode-json-languageservice/node_modules/jsonc-parser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
-            "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA=="
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
         },
         "node_modules/yaml-language-server/node_modules/vscode-json-languageservice/node_modules/vscode-languageserver-types": {
             "version": "3.16.0-next.2",
@@ -14669,9 +14655,9 @@
             "integrity": "sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q=="
         },
         "node_modules/yaml-language-server/node_modules/vscode-json-languageservice/node_modules/vscode-nls": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.0.tgz",
-            "integrity": "sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA=="
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+            "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng=="
         },
         "node_modules/yaml-language-server/node_modules/vscode-jsonrpc": {
             "version": "4.0.0",
@@ -17541,6 +17527,11 @@
             "integrity": "sha512-VdgpnD75swH9hpXjd34VBgQ2w2quK63WljodlUcOoJDPKiV+rPjHrcUc2sjLCNKxhl6oKqmsZgwOWcDAY2GKKQ==",
             "dev": true
         },
+        "@vscode/l10n": {
+            "version": "0.0.13",
+            "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.13.tgz",
+            "integrity": "sha512-A3uY356uOU9nGa+TQIT/i3ziWUgJjVMUrGGXSrtRiTwklyCFjGVWIOHoEIHbJpiyhDkJd9kvIWUOfXK1IkK8XQ=="
+        },
         "@vscode/test-electron": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.2.3.tgz",
@@ -18027,35 +18018,16 @@
             "requires": {}
         },
         "amazon-states-language-service": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.9.0.tgz",
-            "integrity": "sha512-qbqJK1ZE5TUlzk/IANX9EX7oXwP1WYA1mXnOni2GEhkSnhSA14NCbvd9sOwADEPJB7Innwt7RqgVNQGGNz6x1g==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.10.0.tgz",
+            "integrity": "sha512-LRlnIzCBXeD7Ebm2M5J7r7o3Mz1Wqeo3euxqf4Rrbbycot35+6vA1JmdK9RXF4BIXy3I0wECPzKDtnQV8keK7g==",
             "requires": {
-                "js-yaml": "^3.14.0",
-                "vscode-json-languageservice": "3.4.9",
+                "js-yaml": "^4.1.0",
+                "vscode-json-languageservice": "5.3.5",
                 "vscode-languageserver": "^6.1.1",
                 "vscode-languageserver-textdocument": "^1.0.0",
                 "vscode-languageserver-types": "^3.15.1",
-                "yaml-language-server": "0.10.0"
-            },
-            "dependencies": {
-                "argparse": {
-                    "version": "1.0.10",
-                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-                    "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-                    "requires": {
-                        "sprintf-js": "~1.0.2"
-                    }
-                },
-                "js-yaml": {
-                    "version": "3.14.1",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-                    "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-                    "requires": {
-                        "argparse": "^1.0.7",
-                        "esprima": "^4.0.0"
-                    }
-                }
+                "yaml-language-server": "0.15.0"
             }
         },
         "ansi-colors": {
@@ -25288,26 +25260,21 @@
             }
         },
         "vscode-json-languageservice": {
-            "version": "3.4.9",
-            "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-3.4.9.tgz",
-            "integrity": "sha512-4VCpZ9ooea/Zc/MTnj1ccc9C7rqcoinKVQLhLoi6jw6yueSf4y4tg/YIUiPPVMlEAG7ZCPS+NVmqxisQ+mOsSw==",
+            "version": "5.3.5",
+            "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-5.3.5.tgz",
+            "integrity": "sha512-DasT+bKtpaS2rTPEB4VMROnvO1WES2KD8RZZxXbumnk9sk5wco10VdB6sJgTlsKQN14tHQLZDXuHnSoSAlE8LQ==",
             "requires": {
-                "jsonc-parser": "^2.2.0",
-                "vscode-languageserver-textdocument": "^1.0.0-next.4",
-                "vscode-languageserver-types": "^3.15.0-next.6",
-                "vscode-nls": "^4.1.1",
-                "vscode-uri": "^2.1.0"
+                "@vscode/l10n": "^0.0.13",
+                "jsonc-parser": "^3.2.0",
+                "vscode-languageserver-textdocument": "^1.0.8",
+                "vscode-languageserver-types": "^3.17.3",
+                "vscode-uri": "^3.0.7"
             },
             "dependencies": {
-                "jsonc-parser": {
-                    "version": "2.3.1",
-                    "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
-                    "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="
-                },
-                "vscode-nls": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
-                    "integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
+                "vscode-uri": {
+                    "version": "3.0.7",
+                    "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
+                    "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA=="
                 }
             }
         },
@@ -25362,9 +25329,9 @@
             "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
         },
         "vscode-languageserver-types": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+            "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
         },
         "vscode-nls": {
             "version": "5.2.0",
@@ -26048,20 +26015,21 @@
             }
         },
         "yaml-language-server": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-0.10.0.tgz",
-            "integrity": "sha512-d2/7eGgonEIRcnW9kK+k+ERG4gTOk5BXHr9KjTVv8gEarXKa62Kk+nyFE4AXgMDZ0LXTu8nTuN/AdboJiGN+pQ==",
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-0.15.0.tgz",
+            "integrity": "sha512-idaCYstdGoV5Pi7PKxbUkGHt6jAI3l+nxNWrsVCetxrEgfH6T7qytfT0pF3n4NdfDNPHPHcqnl69FzCFDVfHnQ==",
             "requires": {
                 "js-yaml": "^3.13.1",
                 "jsonc-parser": "^2.2.1",
                 "prettier": "2.0.5",
                 "request-light": "^0.2.4",
-                "vscode-json-languageservice": "^3.6.0",
+                "vscode-json-languageservice": "^3.10.0",
                 "vscode-languageserver": "^5.2.1",
+                "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.15.1",
                 "vscode-nls": "^4.1.2",
                 "vscode-uri": "^2.1.1",
-                "yaml-ast-parser-custom-tags": "0.0.43"
+                "yaml-language-server-parser": "0.1.2"
             },
             "dependencies": {
                 "argparse": {
@@ -26105,9 +26073,9 @@
                     },
                     "dependencies": {
                         "jsonc-parser": {
-                            "version": "3.0.0",
-                            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
-                            "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA=="
+                            "version": "3.2.0",
+                            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+                            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
                         },
                         "vscode-languageserver-types": {
                             "version": "3.16.0-next.2",
@@ -26115,9 +26083,9 @@
                             "integrity": "sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q=="
                         },
                         "vscode-nls": {
-                            "version": "5.0.0",
-                            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.0.tgz",
-                            "integrity": "sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA=="
+                            "version": "5.2.0",
+                            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+                            "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng=="
                         }
                     }
                 },
@@ -26164,6 +26132,11 @@
                     "integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
                 }
             }
+        },
+        "yaml-language-server-parser": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/yaml-language-server-parser/-/yaml-language-server-parser-0.1.2.tgz",
+            "integrity": "sha512-GQ2eRE5GcKBK8XVKBIcMyOfC8WMZmEs6gogtVc6knLKE6pG+e5L/lOMfBxZzAt2lqye5itMggQ9+6stXAVhMsw=="
         },
         "yargs": {
             "version": "17.5.1",

--- a/package.json
+++ b/package.json
@@ -3510,7 +3510,7 @@
         "@aws-sdk/util-arn-parser": "^3.46.0",
         "@iarna/toml": "^2.2.5",
         "adm-zip": "^0.5.9",
-        "amazon-states-language-service": "^1.9.0",
+        "amazon-states-language-service": "^1.10.0",
         "async-lock": "^1.4.0",
         "aws-sdk": "^2.1369.0",
         "aws-ssm-document-language-service": "^1.0.0",


### PR DESCRIPTION
  Upgrade to the latest release of the amazon-state-language-service.

  Closes #3152 “asl format doesn't allow Credentials key”
  Closes #3308 “Does the ASL editor not support ProcessorConfig property”
  Closes #2603 “Support for comments in YAML State Machines



## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
