### PR TITLE
feat(auth): extra retry for failed SSO OIDC request

### DIFF
--- a/.changes/next-release/Bug Fix-5496c0bc-07df-46af-b77f-e76bd53a847a.json
+++ b/.changes/next-release/Bug Fix-5496c0bc-07df-46af-b77f-e76bd53a847a.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeWhisperer: user is sometimes required to re-login before token expiration"
+}


### PR DESCRIPTION
The retries are added to all InvalidGrantException that makes sure that all the transient issues that are causing InvalidGrantException should be resolved by this retry. Using default retry stragegy with 2 retries(as the AWSSDK standard) that is 3 max attempts. With exponential backoff

Tested with manually putting wrong parameters so the createToken call throws InvalidGrantExceptions, 3 requests are logged.

related JB change:
https://github.com/aws/aws-toolkit-jetbrains/pull/3692
```
2023-05-24 21:05:24 [DEBUG]: API request (oidc.us-east-1.amazonaws.com /token): {
  clientId: ...
..........
}
2023-05-24 21:05:25 [ERROR]: API response (oidc.us-east-1.amazonaws.com /token): {
  name: 'InvalidGrantException',
  '$fault': 'client',
  '$metadata': {
    httpStatusCode: 400,
    requestId: ....
  },
  error: 'invalid_grant',
  error_description: 'Invalid grant provided',
  message: 'UnknownError'
}
2023-05-24 21:05:25 [DEBUG]: API request (oidc.us-east-1.amazonaws.com /token): {
  clientId: ...
}
2023-05-24 21:05:25 [ERROR]: API response (oidc.us-east-1.amazonaws.com /token): {
  name: 'InvalidGrantException',
  '$fault': 'client',
  '$metadata': {
    httpStatusCode: 400,
    requestId: ...
  },
  error: 'invalid_grant',
  error_description: 'Invalid grant provided',
  message: 'UnknownError'
}
2023-05-24 21:05:26 [DEBUG]: API request (oidc.us-east-1.amazonaws.com /token): {
  clientId: ...
}
2023-05-24 21:05:26 [ERROR]: API response (oidc.us-east-1.amazonaws.com /token): {
  name: 'InvalidGrantException',
  '$fault': 'client',
  '$metadata': {
    httpStatusCode: 400,
    requestId:...
  },
  error: 'invalid_grant',
  error_description: 'Invalid grant provided',
  message: 'UnknownError'
}
```
## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
