### PR TITLE
ci: skip vscode:prepublish

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,7 +27,6 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
             - run: npm ci
-            - run: npm run vscode:prepublish
             - name: Tests
               uses: coactions/setup-xvfb@v1
               with:
@@ -70,7 +69,6 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
             - run: npm ci
-            - run: npm run vscode:prepublish
             - name: Tests
               run: npm test
             - name: Code coverage


### PR DESCRIPTION
Problem:
`vscode:prepublish` takes 2 minutes in each job, but this is unnecessary. It's already tested by the `packageTestVsix.yml` CI job (`npm run package`).

Solution:
Drop `vscode:prepublish` in all CI jobs except `packageTestVsix.yml`.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
