### PR TITLE
feat(codewhisperer): roll out classifier to more languages

### DIFF
--- a/.changes/next-release/Feature-ce707655-611e-4a2f-997f-9d5b0472f7df.json
+++ b/.changes/next-release/Feature-ce707655-611e-4a2f-997f-9d5b0472f7df.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "CodeWhisperer improves auto-suggestions for java python typescript and csharp"
+}

--- a/src/codewhisperer/service/classifierTrigger.ts
+++ b/src/codewhisperer/service/classifierTrigger.ts
@@ -332,23 +332,24 @@ export class ClassifierTrigger {
 
     public shouldInvokeClassifier(language: string) {
         const mappedLanguage = runtimeLanguageContext.mapVscLanguageToCodeWhispererLanguage(language)
-        return this.isClassifierEnabled() && this.isSupportedLanguage(mappedLanguage)
+        return this.isSupportedLanguage(mappedLanguage)
     }
 
     public recordClassifierResultForManualTrigger(editor: vscode.TextEditor) {
         if (this.shouldInvokeClassifier(editor.document.languageId)) {
-            this.shouldTriggerFromClassifier(undefined, editor, undefined)
+            this.shouldTriggerFromClassifier(undefined, editor, undefined, true)
         }
     }
 
     public recordClassifierResultForAutoTrigger(
-        event: vscode.TextDocumentChangeEvent,
         editor: vscode.TextEditor,
-        triggerType: CodewhispererAutomatedTriggerType
+        triggerType?: CodewhispererAutomatedTriggerType,
+        event?: vscode.TextDocumentChangeEvent
     ) {
-        if (triggerType !== 'Classifier') {
-            this.shouldTriggerFromClassifier(event, editor, triggerType)
+        if (!triggerType) {
+            return
         }
+        this.shouldTriggerFromClassifier(event, editor, triggerType, true)
     }
 
     public isSupportedLanguage(language?: CodewhispererLanguage) {
@@ -361,7 +362,8 @@ export class ClassifierTrigger {
     public shouldTriggerFromClassifier(
         event: vscode.TextDocumentChangeEvent | undefined,
         editor: vscode.TextEditor,
-        autoTriggerType: string | undefined
+        autoTriggerType: string | undefined,
+        shouldRecordResult: boolean = false
     ): boolean {
         const fileContext = extractContextForCodeWhisperer(editor)
         const osPlatform = this.normalizeOsName(os.platform(), os.version())
@@ -382,8 +384,10 @@ export class ClassifierTrigger {
         const threshold = this.getThreshold()
 
         const shouldTrigger = classifierResult > threshold
-        TelemetryHelper.instance.setClassifierResult(classifierResult)
-        TelemetryHelper.instance.setClassifierThreshold(threshold)
+        if (shouldRecordResult) {
+            TelemetryHelper.instance.setClassifierResult(classifierResult)
+            TelemetryHelper.instance.setClassifierThreshold(threshold)
+        }
         return shouldTrigger
     }
 

--- a/src/codewhisperer/service/keyStrokeHandler.ts
+++ b/src/codewhisperer/service/keyStrokeHandler.ts
@@ -67,7 +67,7 @@ export class KeyStrokeHandler {
             }
 
             try {
-                this.invokeAutomatedTrigger('IdleTime', editor, client, config)
+                this.invokeAutomatedTrigger('IdleTime', editor, client, config, event)
             } finally {
                 if (this.idleTriggerTimer) {
                     clearInterval(this.idleTriggerTimer)
@@ -142,13 +142,7 @@ export class KeyStrokeHandler {
             }
 
             if (triggerType) {
-                if (ClassifierTrigger.instance.shouldInvokeClassifier(editor.document.languageId)) {
-                    ClassifierTrigger.instance.recordClassifierResultForAutoTrigger(event, editor, triggerType)
-                }
-                if (changedSource === DocumentChangedSource.SpecialCharsKey) {
-                    TelemetryHelper.instance.setTriggerCharForUserTriggerDecision(event.contentChanges[0].text)
-                }
-                this.invokeAutomatedTrigger(triggerType, editor, client, config)
+                this.invokeAutomatedTrigger(triggerType, editor, client, config, event)
             }
         } catch (error) {
             getLogger().error('Automated Trigger Exception : ', error)
@@ -160,7 +154,8 @@ export class KeyStrokeHandler {
         autoTriggerType: CodewhispererAutomatedTriggerType,
         editor: vscode.TextEditor,
         client: DefaultCodeWhispererClient,
-        config: ConfigurationEntry
+        config: ConfigurationEntry,
+        event: vscode.TextDocumentChangeEvent
     ): Promise<void> {
         if (editor) {
             ClassifierTrigger.instance.setLastInvocationLineNumber(editor.selection.active.line)
@@ -210,7 +205,8 @@ export class KeyStrokeHandler {
                     editor,
                     'AutoTrigger',
                     config,
-                    autoTriggerType
+                    autoTriggerType,
+                    event
                 )
             }
         }

--- a/src/test/codewhisperer/service/keyStrokeHandler.test.ts
+++ b/src/test/codewhisperer/service/keyStrokeHandler.test.ts
@@ -18,6 +18,7 @@ import { InlineCompletionService } from '../../../codewhisperer/service/inlineCo
 import * as EditorContext from '../../../codewhisperer/util/editorContext'
 import { RecommendationHandler } from '../../../codewhisperer/service/recommendationHandler'
 import { isInlineCompletionEnabled } from '../../../codewhisperer/util/commonUtil'
+import { ClassifierTrigger } from '../../../codewhisperer/service/classifierTrigger'
 
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
@@ -65,19 +66,6 @@ describe('keyStrokeHandler', function () {
             await keyStrokeHandler.processKeyStroke(mockEvent, mockEditor, mockClient, cfg)
             assert.ok(!invokeSpy.called)
             assert.ok(!startTimerSpy.called)
-        })
-
-        it('Should not call invokeAutomatedTrigger when changed text matches active recommendation prefix', async function () {
-            const mockEditor = createMockTextEditor()
-            const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
-                mockEditor.document,
-                new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)),
-                'd'
-            )
-            RecommendationHandler.instance.startPos = new vscode.Position(1, 0)
-            RecommendationHandler.instance.recommendations = [{ content: 'def two_sum(nums, target):\n for i in nums' }]
-            await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)
-            assert.ok(!invokeSpy.called)
         })
 
         it('Should not call invokeAutomatedTrigger when changed text across multiple lines', async function () {
@@ -200,7 +188,7 @@ describe('keyStrokeHandler', function () {
             assert.ok(!startTimerSpy.called)
         })
 
-        it('Should start idle trigger timer when inputing non-special characters', async function () {
+        it('Should start idle trigger timer when inputing non-special characters for non-classifier language', async function () {
             const mockEditor = createMockTextEditor('def addTwo', 'test.rb', 'ruby')
             const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
                 mockEditor.document,
@@ -209,6 +197,30 @@ describe('keyStrokeHandler', function () {
             )
             await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)
             assert.ok(startTimerSpy.called)
+        })
+
+        it('Should not call invokeAutomatedTrigger for non-special characters for classifier language if classifier says no', async function () {
+            const mockEditor = createMockTextEditor('function addTwo', 'test.js', 'javascript')
+            const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
+                mockEditor.document,
+                new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)),
+                'a'
+            )
+            sinon.stub(ClassifierTrigger.instance, 'shouldTriggerFromClassifier').returns(false)
+            await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)
+            assert.ok(!invokeSpy.called)
+        })
+
+        it('Should call invokeAutomatedTrigger for non-special characters for classifier language if classifier says yes', async function () {
+            const mockEditor = createMockTextEditor('function addTwo', 'test.js', 'javascript')
+            const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
+                mockEditor.document,
+                new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)),
+                'a'
+            )
+            sinon.stub(ClassifierTrigger.instance, 'shouldTriggerFromClassifier').returns(true)
+            await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)
+            assert.ok(invokeSpy.called)
         })
     })
 

--- a/src/test/codewhisperer/service/keyStrokeHandler.test.ts
+++ b/src/test/codewhisperer/service/keyStrokeHandler.test.ts
@@ -228,8 +228,13 @@ describe('keyStrokeHandler', function () {
         it('should call getPaginatedRecommendation when inline completion is enabled', async function () {
             const mockEditor = createMockTextEditor()
             const keyStrokeHandler = new KeyStrokeHandler()
+            const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
+                mockEditor.document,
+                new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)),
+                ' '
+            )
             const getRecommendationsStub = sinon.stub(InlineCompletionService.instance, 'getPaginatedRecommendation')
-            await keyStrokeHandler.invokeAutomatedTrigger('Enter', mockEditor, mockClient, config)
+            await keyStrokeHandler.invokeAutomatedTrigger('Enter', mockEditor, mockClient, config, mockEvent)
             assert.strictEqual(getRecommendationsStub.called, isInlineCompletionEnabled())
         })
     })

--- a/src/test/codewhisperer/service/keyStrokeHandler.test.ts
+++ b/src/test/codewhisperer/service/keyStrokeHandler.test.ts
@@ -201,7 +201,7 @@ describe('keyStrokeHandler', function () {
         })
 
         it('Should start idle trigger timer when inputing non-special characters', async function () {
-            const mockEditor = createMockTextEditor('function addTwo', 'test.js', 'javascript')
+            const mockEditor = createMockTextEditor('def addTwo', 'test.rb', 'ruby')
             const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
                 mockEditor.document,
                 new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)),


### PR DESCRIPTION
## Problem

- Roll out Classifier trigger 100% for languages
- Fix telemetry for classifier result inaccurate due to blocked triggers

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
