### PR TITLE
ci: publish prerelease on push to master, feature/x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+# This job performs the following:
+# - Publish prerelease (not release) artifacts for feature/x branches and "nightly" mainline.
+
+name: Prerelease
+on:
+    # schedule:
+    #     - cron: '5 5 * * *'
+    workflow_dispatch:
+        inputs:
+            tag_name:
+                description: 'Tag name for release'
+                required: false
+                default: prerelease
+    push:
+        branches: [master, feature/*]
+        # tags:
+        #   - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+    package:
+        runs-on: ubuntu-latest
+        env:
+            NODE_OPTIONS: '--max-old-space-size=8192'
+        outputs:
+            feature: ${{ steps.build.outputs.feature }}
+            tagname: ${{ steps.build.outputs.tagname }}
+            version: ${{ steps.build.outputs.version }}
+            changes: ${{ steps.build.outputs.changes }}
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ matrix.node-version }}
+            # - if: github.event_name == 'schedule'
+            #   run: echo 'TAG_NAME=prerelease' >> $GITHUB_ENV
+            - if: github.event_name == 'workflow_dispatch'
+              run: echo "TAG_NAME=${{ github.event.inputs.tag_name }}" >> $GITHUB_ENV
+            - if: github.ref_name != 'master'
+              run: |
+                  TAG_NAME=${{ github.ref_name }}
+                  FEAT_NAME=$(echo $TAG_NAME | sed 's/feature\///')
+                  echo "FEAT_NAME=$FEAT_NAME" >> $GITHUB_ENV
+                  echo "TAG_NAME=pre-$FEAT_NAME" >> $GITHUB_ENV
+            - if: github.ref_name == 'master'
+              run: |
+                  echo "FEAT_NAME=" >> $GITHUB_ENV
+                  echo "TAG_NAME=prerelease" >> $GITHUB_ENV
+            - run: npm ci
+            - name: vsix
+              run: |
+                  npm run createRelease  # Generate CHANGELOG.md
+                  npm run generateNonCodeFiles
+                  cp ./README.quickstart.vscode.md ./README.md
+                  npm run package -- --feature "$FEAT_NAME"
+            - uses: actions/upload-artifact@v3
+              with:
+                  name: artifacts
+                  path: '*.vsix'
+                  retention-days: 10
+            - name: Export outputs
+              id: build
+              run: |
+                  echo "feature=$FEAT_NAME" >> $GITHUB_OUTPUT
+                  echo "tagname=$TAG_NAME" >> $GITHUB_OUTPUT
+                  echo "version=$(grep -m 1 version package.json | grep -o '[0-9][^\"]\+' | sed 's/-SNAPSHOT//')" >> $GITHUB_OUTPUT
+                  echo 'changes<<EOF' >> $GITHUB_OUTPUT
+                  head -14 CHANGELOG.md >> $GITHUB_OUTPUT
+                  echo 'EOF' >> $GITHUB_OUTPUT
+
+    publish:
+        needs: [package]
+        runs-on: ubuntu-latest
+        env:
+            # For `gh`.
+            GH_REPO: ${{ github.repository }}
+            # For `gh`.
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            FEAT_NAME: ${{ needs.package.outputs.feature }}
+            TAG_NAME: ${{ needs.package.outputs.tagname }}
+            AWS_TOOLKIT_VERSION: ${{ needs.package.outputs.version }}
+            AWS_TOOLKIT_CHANGES: ${{ needs.package.outputs.changes }}
+        permissions:
+            contents: write
+        steps:
+            # Must perform checkout first, it deletes the target directory
+            # before running, thus would delete the downloaded artifacts.
+            - uses: actions/checkout@v3
+            - uses: actions/download-artifact@v3
+            - name: Delete existing prerelease
+              # "prerelease" (main branch) or "pre-<feature>"
+              if: "env.TAG_NAME == 'prerelease' || startsWith(env.TAG_NAME, 'pre-')"
+              run: |
+                  echo "SUBJECT=AWS Toolkit ${AWS_TOOLKIT_VERSION}: ${FEAT_NAME:-${TAG_NAME}}" >> $GITHUB_ENV
+                  gh release delete "$TAG_NAME" --cleanup-tag --yes || true
+                  # git push origin :"$TAG_NAME" || true
+            - name: Publish Prerelease
+              run: |
+                  # AWS_TOOLKIT_CHANGES="$(head -14 CHANGELOG.md)"
+                  envsubst < "$GITHUB_WORKSPACE/.github/workflows/release_notes.md" > "$RUNNER_TEMP/release_notes.md"
+                  gh release create $TAG_NAME --prerelease --notes-file "$RUNNER_TEMP/release_notes.md" --title "$SUBJECT" --target $GITHUB_SHA artifacts/*

--- a/.github/workflows/release_notes.md
+++ b/.github/workflows/release_notes.md
@@ -1,0 +1,10 @@
+_This is an **unsupported preview build** of AWS Toolkit, for testing new features._
+
+# Install
+
+1. Download the vsix file from "Assets" below.
+2. In VSCode, run `Extensions: Install from VSIX...` and choose the vsix file.
+
+# Changes
+
+${AWS_TOOLKIT_CHANGES}

--- a/scripts/build/package.ts
+++ b/scripts/build/package.ts
@@ -34,21 +34,37 @@ function parseArgs() {
     //   1: /…/src/scripts/build/package.ts
     //   2: foo
 
-    const givenArgs = process.argv.slice(2)
-    const validOptions = ['--debug', '--no-clean']
+    const args: { [key: string]: any } = {
+        /** Produce an unoptimized VSIX. Include git SHA in version string. */
+        debug: false,
+        /** Skips `npm run clean` when building the VSIX. This prevents file watching from breaking. */
+        skipClean: false,
+        feature: '',
+    }
 
-    for (const a of givenArgs) {
+    const givenArgs = process.argv.slice(2)
+    const validOptions = ['--debug', '--no-clean', '--feature']
+    const expectValue = ['--feature']
+
+    for (let i = 0; i < givenArgs.length; i++) {
+        const a = givenArgs[i]
+        const argName = a.replace(/^-+/, '') // "--foo" => "foo"
         if (!validOptions.includes(a)) {
             throw Error(`invalid argument: ${a}`)
         }
+        if (expectValue.includes(a)) {
+            i++
+            const val = givenArgs[i]
+            if (val === undefined) {
+                throw Error(`missing value for arg: ${a}`)
+            }
+            args[argName] = val
+        } else {
+            args[argName] = true
+        }
     }
 
-    return {
-        /** Produce an unoptimized VSIX. Include git SHA in version string. */
-        debug: givenArgs.includes('--debug'),
-        /** Skips `npm run clean` when building the VSIX. This prevents file watching from breaking. */
-        skipClean: givenArgs.includes('--no-clean'),
-    }
+    return args
 }
 
 /**
@@ -73,7 +89,7 @@ function isBeta(): boolean {
  *
  * @returns version-string suffix, for example: "-e6ecd84685a9"
  */
-function getVersionSuffix(): string {
+function getVersionSuffix(feature: string): string {
     if (isRelease()) {
         return ''
     }
@@ -81,7 +97,7 @@ function getVersionSuffix(): string {
     if (!commitId) {
         return ''
     }
-    return `-${commitId}`
+    return `${feature === '' ? '' : `-${feature}`}-${commitId}`
 }
 
 function main() {
@@ -101,7 +117,7 @@ function main() {
             fs.copyFileSync(webpackConfigJsFile, `${webpackConfigJsFile}.bk`)
 
             const packageJson: typeof manifest = JSON.parse(fs.readFileSync(packageJsonFile, { encoding: 'utf-8' }))
-            const versionSuffix = getVersionSuffix()
+            const versionSuffix = getVersionSuffix(args.feature)
             const version = packageJson.version
             // Setting the version to an arbitrarily high number stops VSC from auto-updating the beta extension
             const betaOrDebugVersion = `1.999.0${versionSuffix}`


### PR DESCRIPTION
## Problem

- Artifacts for `master` branch and `feature/x` branches are not  published to a canonical location, which makes it difficult for  scripts to consume them.
- Artifacts from `feature/x` branches are not advertised in GitHub's  "release" UI.
- Per-commit artifacts expire after a few days.

## Solution

- Publish artifacts from `feature/x` branches to a fixed `pre-x` tag.
- Publish artifacts from `master` branch to a fixed `prerelease` tag.

## Example

https://github.com/justinmk3/aws-toolkit-vscode/releases

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
