### PR TITLE
cwl: add more "relative" date default options. 

### DIFF
--- a/src/cloudWatchLogs/timeFilterSubmenu.ts
+++ b/src/cloudWatchLogs/timeFilterSubmenu.ts
@@ -76,10 +76,6 @@ export class TimeFilterSubmenu extends Prompter<TimeFilterResponse> {
             data: 60 * 24 * 31 * 3,
         })
         options.push({
-            label: 'Last 6 months', 
-            data: 60 * 24 * 31 * 6,
-        })
-        options.push({
             label: 'Last year', 
             data: 60 * 24 * 365,
         })

--- a/src/cloudWatchLogs/timeFilterSubmenu.ts
+++ b/src/cloudWatchLogs/timeFilterSubmenu.ts
@@ -60,7 +60,7 @@ export class TimeFilterSubmenu extends Prompter<TimeFilterResponse> {
             data: 60 * 24,
         })
         options.push({
-            label: 'Last 72 Hours',
+            label: 'Last 3 Days',
             data: 60 * 24 * 3,
         })
         options.push({

--- a/src/cloudWatchLogs/timeFilterSubmenu.ts
+++ b/src/cloudWatchLogs/timeFilterSubmenu.ts
@@ -56,10 +56,6 @@ export class TimeFilterSubmenu extends Prompter<TimeFilterResponse> {
             data: 60 * 3,
         })
         options.push({
-            label: 'Last 12 Hours',
-            data: 60 * 12,
-        })
-        options.push({
             label: 'Last 24 Hours',
             data: 60 * 24,
         })

--- a/src/cloudWatchLogs/timeFilterSubmenu.ts
+++ b/src/cloudWatchLogs/timeFilterSubmenu.ts
@@ -38,25 +38,42 @@ export class TimeFilterSubmenu extends Prompter<TimeFilterResponse> {
 
     private get recentTimeItems(): DataQuickPickItem<number>[] {
         const options: DataQuickPickItem<number>[] = []
+        //appromixate 31 days as month length (better to overshoot)
         options.push({
-            label: 'Any time',
+            label: 'All time',
             data: 0,
-        })
-        options.push({
-            label: 'Last 1 Minute',
-            data: 1,
-        })
-        options.push({
-            label: 'Last 30 Minutes',
-            data: 30,
-        })
-        options.push({
-            label: 'Last 1 Hour',
-            data: 60,
         })
         options.push({
             label: 'Last 12 Hours',
             data: 60 * 12,
+        })
+        options.push({
+            label: 'Last 24 Hours',
+            data: 60 * 24,
+        })
+        options.push({
+            label: 'Last 72 Hours',
+            data: 60 * 24 * 3,
+        })
+        options.push({
+            label: 'Last week',
+            data: 60 * 24 * 7,
+        })
+        options.push({
+            label: 'Last month', 
+            data: 60 * 24 * 31, 
+        })
+        options.push({
+            label: 'Last 3 months', 
+            data: 60 * 24 * 31 * 3,
+        })
+        options.push({
+            label: 'Last 6 months', 
+            data: 60 * 24 * 31 * 6,
+        })
+        options.push({
+            label: 'Last year', 
+            data: 60 * 24 * 365,
         })
         return options
     }

--- a/src/cloudWatchLogs/timeFilterSubmenu.ts
+++ b/src/cloudWatchLogs/timeFilterSubmenu.ts
@@ -44,6 +44,18 @@ export class TimeFilterSubmenu extends Prompter<TimeFilterResponse> {
             data: 0,
         })
         options.push({
+            label: 'Last 15 minutes', 
+            data: 15,
+        })
+        options.push({
+            label: 'Last hour', 
+            data: 60,
+        })
+        options.push({
+            label: 'Last 3 Hours', 
+            data: 60 * 3,
+        })
+        options.push({
             label: 'Last 12 Hours',
             data: 60 * 12,
         })


### PR DESCRIPTION
## Problem
Options for CWL date search are very recent, and don't allow any defaults beyond 12 hours. 
## Solution
Add more options, especially those that extend further back in time. 
<img width="668" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/42325418/abf11e12-5d79-40c5-b44d-ff3f990302ae">
Notes: 
- adding anymore requires the user to scroll through them. 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
