### PR TITLE
fix: lint test error message not printed

### DIFF
--- a/src/testLint/eslint.test.ts
+++ b/src/testLint/eslint.test.ts
@@ -13,6 +13,6 @@ describe('eslint', function () {
         const result = runCmd(['./node_modules/.bin/eslint', '-c', '.eslintrc.js', '--ext', '.ts', '.'], {
             throws: false,
         })
-        assert.strictEqual(result.status, 0, result.error)
+        assert.strictEqual(result.status, 0, result.stdout.toString())
     })
 })


### PR DESCRIPTION
Before the actual error message wasn't being
printed on failure

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
