### PR TITLE
cwl: add seperators to RegionSubMenu

### DIFF
--- a/src/shared/ui/common/regionSubmenu.ts
+++ b/src/shared/ui/common/regionSubmenu.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import * as vscode from 'vscode'
 import globals from '../../extensionGlobals'
 import { isValidResponse, StepEstimator } from '../../wizards/wizard'
 import { createQuickPick, ExtendedQuickPickOptions, ItemLoadTypes } from '../pickerPrompter'
@@ -37,12 +37,22 @@ export class RegionSubmenu<T> extends Prompter<RegionSubmenuResponse<T>> {
             this.itemsProvider(this.currentRegion),
             this.dataOptions as ExtendedQuickPickOptions<T | typeof switchRegion>
         )
-
+        
         prompter.quickPick.items = [
+            {
+                label: 'Actions',
+                kind: vscode.QuickPickItemKind.Separator,
+                data: undefined,
+            },
             {
                 label: 'Switch region',
                 data: switchRegion,
                 description: `current region: ${this.currentRegion}`,
+            },
+            {
+                label: 'Log Groups',
+                kind: vscode.QuickPickItemKind.Separator,
+                data: undefined,
             },
             ...prompter.quickPick.items,
         ]


### PR DESCRIPTION
## Problem
The actions and the log groups were blurred together in the prompt that gives user a region-change escape hatch. 
## Solution
Add separators (mirroring log stream prompt) that distinguish the two options given to the user. 
<img width="635" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/42325418/df936bba-4c03-44c5-988d-8a19600e0d40">
Notes: 
- The data field was required, so left it as undefined. However, according to the docs, if kind is set to separator, all other fields are ignored(with the exception of label). 
<img width="1159" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/42325418/0546813a-55ab-4927-87e5-0023c8ba7c05">


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
