### PR TITLE
cwl: change codelense message to avoid confustion. 

### DIFF
--- a/src/cloudWatchLogs/document/logStreamsCodeLensProvider.ts
+++ b/src/cloudWatchLogs/document/logStreamsCodeLensProvider.ts
@@ -61,7 +61,7 @@ export class LogStreamCodeLensProvider implements vscode.CodeLensProvider {
         const cmd: vscode.Command = {
             command: 'aws.loadLogStreamFile',
             arguments: [streamUri, this.registry],
-            title: 'Open this Log Stream...',
+            title: 'View Full Log Stream...',
             tooltip: 'Open the full Log Stream associated with these search results',
         }
         const codeLensLocation = new vscode.Range(idWithLine.lineNum, 0, idWithLine.lineNum, 0)


### PR DESCRIPTION
## Problem
The wording of `Open this Log Stream` might imply we are opening a browser. Therefore, this can be confusing to users. 
## Solution
Be more explicit and avoid the word `open` to alleviate confusion. 
<img width="737" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/42325418/2ee7962b-a839-4855-ba88-095de5f029c8">

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
