### PR TITLE
ci: reduce codecov requirement to 70%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -16,7 +16,7 @@ coverage:
                 threshold: 1
                 informational: true
             codewhisperer:
-                target: 75%
+                target: 70%
                 paths:
                     - src/codewhisperer/*
                 flags:


### PR DESCRIPTION
Problem:
Each PR has failing CI because of a 75% code coverage requirement that hasn't moved for many months.

Solution:
Reduce the requirement to 70%. We can increase to 75% if/when code coverage is increased.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
