### PR TITLE
feat(sam): support SAM CLI "nightly"

### DIFF
--- a/src/shared/sam/cli/samCliInfo.ts
+++ b/src/shared/sam/cli/samCliInfo.ts
@@ -26,6 +26,11 @@ export class SamCliInfoInvocation {
             return { version: '' }
         }
 
+        // Special case: fix sam cli "nightly" invalid semver version string.
+        // Example: "1.86.1.dev202306120901"
+        // https://github.com/aws/aws-sam-cli/releases/tag/sam-cli-nightly
+        response.version = response.version.replace(/.dev/, '-dev')
+
         return response
     }
 


### PR DESCRIPTION
Problem:
sam cli [nightly build](https://github.com/aws/aws-sam-cli/releases/tag/sam-cli-nightly) reports an invalid semver version string (example: `1.86.1.dev202306120901`) which causes SAM features in AWS Toolkit to fail or report an error because version validation fails. 

Solution:
Add special handling for sam cli "nightly" version string format.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
