### PR TITLE
feat: Update the 'forceDevMode' setting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,7 +238,9 @@ generating SDKs, etc.
 The [DevSettngs](https://github.com/aws/aws-toolkit-vscode/blob/479b9d45b5f5ad30fc10567e649b59801053aeba/src/shared/settings.ts#L553) class defines various developer-only settings that change the behavior of the
 Toolkit for testing and development purposes. To use a setting just add it to
 your `settings.json`. At runtime, if the Toolkit reads any of these settings,
-the "AWS" statusbar item will [change its color](https://github.com/aws/aws-toolkit-vscode/blob/479b9d45b5f5ad30fc10567e649b59801053aeba/src/credentials/awsCredentialsStatusBarItem.ts#L45). Use the setting `aws.dev.forceDevMode` to trigger this effect on start-up.
+the "AWS" statusbar item will [change its color](https://github.com/aws/aws-toolkit-vscode/blob/479b9d45b5f5ad30fc10567e649b59801053aeba/src/credentials/awsCredentialsStatusBarItem.ts#L45).
+
+The setting `aws.dev.forceDevMode` will take precedence over all dev settings and enable dev mode on `"aws.dev.forceDevMode": true` or disable on `"aws.dev.forceDevMode": false`.
 
 ### Logging
 

--- a/src/auth/ui/statusBarItem.ts
+++ b/src/auth/ui/statusBarItem.ts
@@ -40,12 +40,10 @@ export async function initializeAwsCredentialsStatusBarItem(
 }
 
 function handleDevSettings(statusBarItem: vscode.StatusBarItem, devSettings: DevSettings) {
-    const developerMode = Object.keys(devSettings.activeSettings)
-
-    if (developerMode.length > 0) {
+    if (devSettings.isDevMode()) {
         ;(statusBarItem as any).backgroundColor ??= new vscode.ThemeColor('statusBarItem.warningBackground')
 
-        const devSettingsStr = developerMode.join('  \n')
+        const devSettingsStr = Object.keys(devSettings.activeSettings).join('  \n')
         statusBarItem.tooltip = `Toolkit developer settings:\n${devSettingsStr}`
     }
 }

--- a/src/dev/activation.ts
+++ b/src/dev/activation.ts
@@ -87,8 +87,7 @@ export function activate(ctx: ExtContext): void {
     const devSettings = DevSettings.instance
 
     async function updateMode() {
-        const enablement = Object.keys(devSettings.activeSettings).length > 0
-        await vscode.commands.executeCommand('setContext', 'aws.isDevMode', enablement)
+        await vscode.commands.executeCommand('setContext', 'aws.isDevMode', devSettings.isDevMode())
     }
 
     ctx.extensionContext.subscriptions.push(

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -632,6 +632,20 @@ export class DevSettings extends Settings.define('aws.dev', devSettings) {
         return this.trappedSettings
     }
 
+    public isDevMode(): boolean {
+        // This setting takes precedence over everything.
+        // It must be removed completely from the settings to not be considered.
+        const forceDevMode: boolean | undefined = this.isSet('forceDevMode')
+            ? this.get('forceDevMode', false)
+            : undefined
+        if (forceDevMode !== undefined) {
+            return forceDevMode
+        }
+
+        // forceDevMode was not defined, so check other dev settings
+        return Object.keys(this.activeSettings).length > 0
+    }
+
     public override get<K extends AwsDevSetting>(key: K, defaultValue: ResolvedDevSettings[K]) {
         if (!this.isSet(key)) {
             this.unset(key)
@@ -664,7 +678,6 @@ export class DevSettings extends Settings.define('aws.dev', devSettings) {
     public static get instance() {
         if (this.#instance === undefined) {
             this.#instance = new this()
-            this.#instance.get('forceDevMode', false)
         }
 
         return this.#instance

--- a/src/test/shared/settingsConfiguration.test.ts
+++ b/src/test/shared/settingsConfiguration.test.ts
@@ -253,6 +253,30 @@ describe('DevSetting', function () {
         assert.deepStrictEqual(sut.get('endpoints', {}), {})
         assert.deepStrictEqual(sut.activeSettings, {})
     })
+
+    describe('isDevMode()', function () {
+        it('returns true if forceDevMode is true', async function () {
+            await settings.update('aws.dev.forceDevMode', true)
+            assert.strictEqual(sut.isDevMode(), true)
+        })
+        it('returns false if forceDevMode is false', async function () {
+            await settings.update('aws.dev.forceDevMode', false)
+            assert.strictEqual(sut.isDevMode(), false)
+        })
+        it('returns false if forceDevMode is not defined at all', async function () {
+            assert.strictEqual(sut.isDevMode(), false)
+        })
+
+        it('returns true if forceDevMode is not defined at all but active dev setting exists', async function () {
+            await settings.update(`aws.dev.${testSetting}`, true).then(() => sut.get(testSetting, false))
+            assert.strictEqual(sut.isDevMode(), true)
+        })
+        it('returns false if forceDevMode false even with other active dev setting', async function () {
+            await settings.update('aws.dev.forceDevMode', false)
+            await settings.update(`aws.dev.${testSetting}`, true).then(() => sut.get(testSetting, false))
+            assert.strictEqual(sut.isDevMode(), false)
+        })
+    })
 })
 
 describe('PromptSetting', function () {


### PR DESCRIPTION
### Problem:

There was not a way to explicitly enable and disable dev mode with a single setting

### Solution:

Update the logic so that aws.dev.forceDevMode takes precedence over all other settings and will honor
whatever that value is in relation to if the user
is in dev mode.

Now, a user can have all their other dev settings
in place, but when they set 'aws.dev.forceDevMode: false' they will not be in dev mode anymore.

Fix: IDE-10948

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
