### PR TITLE
fix(CodeWhisperer): show reauth prompt if connection expired at IDE restart

### DIFF
--- a/.changes/next-release/Bug Fix-95b9f0dd-0811-4703-957b-deb1cea28f05.json
+++ b/.changes/next-release/Bug Fix-95b9f0dd-0811-4703-957b-deb1cea28f05.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Show re-authentication prompt if connection expires at extension restart."
+}

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -198,6 +198,10 @@ export async function activate(context: ExtContext): Promise<void> {
 
     await auth.restore()
 
+    if (auth.isConnectionExpired()) {
+        auth.showReauthenticatePrompt()
+    }
+
     function activateSecurityScan() {
         context.extensionContext.subscriptions.push(
             vscode.window.registerWebviewViewProvider(SecurityPanelViewProvider.viewType, securityPanelViewProvider)


### PR DESCRIPTION
## Problem

When user opens IDE while CodeWhisperer connection expired, there is no prompt that informs user the connection has expired. The current status bar being disconnected is not getting enough attention, causing CodeWhisperer to stay in disconnected state. 

## Solution

Show re-auth prompt if connection expired at restart.

<img width="915" alt="Screenshot 2023-06-13 at 3 42 39 PM" src="https://github.com/aws/aws-toolkit-vscode/assets/97199248/efe16ec3-fbf5-424a-99e5-383297f09220">

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
