### PR TITLE
ui: regionSubmenu tests don't need to be cwl specific. 

### DIFF
--- a/src/test/shared/ui/prompters/regionSubmenu.test.ts
+++ b/src/test/shared/ui/prompters/regionSubmenu.test.ts
@@ -11,28 +11,28 @@ import { createQuickPickPrompterTester } from '../../../shared/ui/testUtils'
 describe('regionSubmenu', function () {
     let submenuPrompter: RegionSubmenu<string>
 
-    const region1Groups = ['group1a', 'group1b', 'group1c']
-    const region2Groups = ['group2a', 'group2b', 'group2c']
+    const region1Data = ['option1a', 'option2a', 'option3a']
+    const region2Data = ['option1b', 'option2b', 'option3b']
 
     before(async function () {
-        const fakeGroupProvider = function (regionCode: string) {
-            let groupNames: Array<string>
+        const mockDataProvider = function (regionCode: string) {
+            let data: Array<string>
             switch (regionCode) {
                 case 'us-west-1':
-                    groupNames = region1Groups
+                    data = region1Data
                     break
                 case 'us-west-2':
-                    groupNames = region2Groups
+                    data = region2Data
                     break
                 default:
-                    groupNames = []
+                    data = []
             }
-            return groupNames.map<DataQuickPickItem<string>>(groupName => ({
-                label: groupName,
-                data: groupName,
+            return data.map<DataQuickPickItem<string>>(data => ({
+                label: data,
+                data: data,
             }))
         }
-        submenuPrompter = new RegionSubmenu(fakeGroupProvider, {}, {}, 'us-west-1')
+        submenuPrompter = new RegionSubmenu(mockDataProvider, {}, {}, 'us-west-1')
     })
 
     it('allow users to swap regions via escape hatch', async function () {
@@ -41,11 +41,12 @@ describe('regionSubmenu', function () {
 
         const resp = submenuPrompter.prompt()
         assert.ok(submenuPrompter.activePrompter)
-        const logGroupTester = createQuickPickPrompterTester(
+
+        const dataPrompterTester = createQuickPickPrompterTester(
             submenuPrompter.activePrompter as Combine<typeof submenuPrompter.activePrompter>
         )
-        logGroupTester.acceptItem('Switch region')
-        await logGroupTester.result()
+        dataPrompterTester.acceptItem('Switch region')
+        await dataPrompterTester.result()
 
         const regionTester = createQuickPickPrompterTester(
             submenuPrompter.activePrompter as Combine<typeof submenuPrompter.activePrompter>
@@ -53,14 +54,14 @@ describe('regionSubmenu', function () {
         regionTester.acceptItem('US West (Oregon)')
         await regionTester.result()
 
-        const logGroupTester2 = createQuickPickPrompterTester(
+        const dataPrompterTester2 = createQuickPickPrompterTester(
             submenuPrompter.activePrompter as Combine<typeof submenuPrompter.activePrompter>
         )
-        logGroupTester2.acceptItem('group2c')
-        await logGroupTester2.result()
+        dataPrompterTester2.acceptItem('option2b')
+        await dataPrompterTester2.result()
         assert.deepStrictEqual(await resp, {
             region: 'us-west-2',
-            data: 'group2c',
+            data: 'option2b',
         })
     })
 })


### PR DESCRIPTION
## Problem
The tests currently use language specific to cwl, implying the component is only used for that purpose. However, nothing in the design of the UI component is specific to cwl and can be used outside that context.
## Solution
Change the language to be more general, and avoid cwl terms like `group` or `logData`. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
