### PR TITLE
fix: vscode command gets wrong arg

### DIFF
--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -468,7 +468,8 @@ export const useIamCredentials = Commands.register('_aws.auth.useIamCredentials'
 })
 
 // Legacy commands
-export const login = Commands.register('aws.login', async (auth: Auth = Auth.instance) => {
+export const login = Commands.register('aws.login', async () => {
+    const auth = Auth.instance
     const connections = await auth.listConnections()
     if (connections.length === 0) {
         return addConnection.execute()


### PR DESCRIPTION

## Problem

When a vscode command is called it is possible for vscode to pass in a completely separate type of object as the argument, instead of the expected auth object. This would cause it to fail.

How to recreate:

- select a node in the explorer
- then indirectly call this command using `Connect to AWS` from the explorer kebab context menu

it will then pass in that node as context instead of the expected auth.

## Solution

In this case we do not need auth as an argument and can instead define it inside the function.




<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
