### PR TITLE
authWebview: toggle for CW Identity Center form

### DIFF
--- a/src/auth/ui/vue/authForms/manageIdentityCenter.vue
+++ b/src/auth/ui/vue/authForms/manageIdentityCenter.vue
@@ -237,7 +237,7 @@ export class CodeWhispererIdentityCenterState extends BaseIdentityCenterState {
 @import '../shared.css';
 
 #identity-center-form {
-    width: 250px;
+    width: 280px;
     height: fit-content;
 }
 </style>

--- a/src/auth/ui/vue/serviceItemContent/baseServiceItemContent.css
+++ b/src/auth/ui/vue/serviceItemContent/baseServiceItemContent.css
@@ -28,6 +28,7 @@
 .service-item-content-form-section {
     display: flex;
     flex-direction: column;
+    align-items: center;
     gap: 20px;
 }
 

--- a/src/auth/ui/vue/serviceItemContent/codeWhispererContent.vue
+++ b/src/auth/ui/vue/serviceItemContent/codeWhispererContent.vue
@@ -20,14 +20,35 @@
         <hr />
 
         <div class="service-item-content-form-section">
-            <div class="service-item-content-form-container">
+            <div class="codewhisperer-content-form-container">
                 <BuilderIdForm
                     :state="builderIdState"
                     @auth-connection-updated="onAuthConnectionUpdated"
                 ></BuilderIdForm>
+
+                <div>
+                    <div
+                        v-on:click="toggleIdentityCenterShown"
+                        style="cursor: pointer; display: flex; flex-direction: row"
+                    >
+                        <div style="font-weight: bold; font-size: medium" :class="collapsibleClass"></div>
+                        <div>
+                            <div style="font-weight: bold; font-size: 14px">
+                                Have a
+                                <a href="https://aws.amazon.com/codewhisperer/pricing/">Professional Tier</a>
+                                subscription? Sign in with IAM Identity Center.
+                            </div>
+                            <div>
+                                Professional Tier offers administrative capabilities for organizations of developers.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
                 <IdentityCenterForm
                     :state="identityCenterState"
                     @auth-connection-updated="onAuthConnectionUpdated"
+                    v-show="isIdentityCenterShown"
                 ></IdentityCenterForm>
             </div>
         </div>
@@ -54,6 +75,7 @@ export default defineComponent({
                 builderIdCodeWhisperer: false,
                 identityCenterCodeWhisperer: false,
             } as Record<AuthFormId, boolean>,
+            isIdentityCenterShown: false,
         }
     },
     computed: {
@@ -63,6 +85,10 @@ export default defineComponent({
         identityCenterState(): CodeWhispererIdentityCenterState {
             return authFormsState.identityCenterCodeWhisperer
         },
+        /** The appropriate accordion symbol (collapsed/uncollapsed) */
+        collapsibleClass() {
+            return this.isIdentityCenterShown ? 'icon icon-vscode-chevron-down' : 'icon icon-vscode-chevron-right'
+        },
     },
     methods: {
         updateIsAllAuthsLoaded() {
@@ -70,10 +96,18 @@ export default defineComponent({
             this.isAllAuthsLoaded = !hasUnloaded
         },
         async onAuthConnectionUpdated(args: ConnectionUpdateArgs) {
+            if (args.id === 'identityCenterCodeWhisperer') {
+                // Want to show the identity center form if already connected
+                this.isIdentityCenterShown = await this.identityCenterState.isAuthConnected()
+            }
+
             this.isLoaded[args.id] = true
             this.updateIsAllAuthsLoaded()
 
             this.emitAuthConnectionUpdated('codewhisperer', args)
+        },
+        toggleIdentityCenterShown() {
+            this.isIdentityCenterShown = !this.isIdentityCenterShown
         },
     },
 })
@@ -92,4 +126,12 @@ export class CodeWhispererContentState implements AuthStatus {
 <style>
 @import './baseServiceItemContent.css';
 @import '../shared.css';
+
+.codewhisperer-content-form-container {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    justify-content: center;
+    align-items: center;
+}
 </style>


### PR DESCRIPTION
Creates a toggle option for showing the Identity Center form for CodeWhisperer since we want to guide users to
Builder ID and reduce confusion.

![Screen Shot 2023-06-19 at 10 35 06 AM](https://github.com/aws/aws-toolkit-vscode/assets/118216176/cbc299fd-e2dc-4f8a-879d-02cbc25870ea)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
