### PR TITLE
ui: add optional parameter for separator label in RegionSubmenu

### DIFF
--- a/src/cloudWatchLogs/commands/searchLogGroup.ts
+++ b/src/cloudWatchLogs/commands/searchLogGroup.ts
@@ -241,7 +241,8 @@ export function createRegionSubmenu() {
     return new RegionSubmenu(
         getLogGroupsFromRegion,
         { title: localize('AWS.cwl.searchLogGroup.logGroupPromptTitle', 'Select Log Group') },
-        { title: localize('AWS.cwl.searchLogGroup.regionPromptTitle', 'Select Region for Log Group') }
+        { title: localize('AWS.cwl.searchLogGroup.regionPromptTitle', 'Select Region for Log Group') },
+        "Log Groups"
     )
 }
 

--- a/src/ec2/prompter.ts
+++ b/src/ec2/prompter.ts
@@ -31,6 +31,6 @@ export function createEC2ConnectPrompter(): RegionSubmenu<string> {
         async region => (await getInstanceIdsFromRegion(region)).map(asQuickpickItem).promise(),
         { title: 'Select EC2 Instance Id' },
         { title: 'Select Region for EC2 Instance' }, 
-        "Instance Ids"
+        "Instances"
     )
 }

--- a/src/ec2/prompter.ts
+++ b/src/ec2/prompter.ts
@@ -30,6 +30,7 @@ export function createEC2ConnectPrompter(): RegionSubmenu<string> {
     return new RegionSubmenu(
         async region => (await getInstanceIdsFromRegion(region)).map(asQuickpickItem).promise(),
         { title: 'Select EC2 Instance Id' },
-        { title: 'Select Region for EC2 Instance' }
+        { title: 'Select Region for EC2 Instance' }, 
+        "Instance Ids"
     )
 }

--- a/src/shared/ui/common/regionSubmenu.ts
+++ b/src/shared/ui/common/regionSubmenu.ts
@@ -27,6 +27,7 @@ export class RegionSubmenu<T> extends Prompter<RegionSubmenuResponse<T>> {
         private readonly itemsProvider: (region: string) => ItemLoadTypes<T>,
         private readonly dataOptions?: ExtendedQuickPickOptions<T>,
         private readonly regionOptions?: ExtendedQuickPickOptions<T>,
+        private readonly separatorLabel: string = "Selections",
         private currentRegion = globals.regionProvider.guessDefaultRegion()
     ) {
         super()
@@ -50,7 +51,7 @@ export class RegionSubmenu<T> extends Prompter<RegionSubmenuResponse<T>> {
                 description: `current region: ${this.currentRegion}`,
             },
             {
-                label: 'Selections',
+                label: this.separatorLabel,
                 kind: vscode.QuickPickItemKind.Separator,
                 data: undefined,
             },

--- a/src/shared/ui/common/regionSubmenu.ts
+++ b/src/shared/ui/common/regionSubmenu.ts
@@ -27,7 +27,7 @@ export class RegionSubmenu<T> extends Prompter<RegionSubmenuResponse<T>> {
         private readonly itemsProvider: (region: string) => ItemLoadTypes<T>,
         private readonly dataOptions?: ExtendedQuickPickOptions<T>,
         private readonly regionOptions?: ExtendedQuickPickOptions<T>,
-        private readonly separatorLabel: string = "Selections",
+        private readonly separatorLabel: string = "Items",
         private currentRegion = globals.regionProvider.guessDefaultRegion()
     ) {
         super()


### PR DESCRIPTION
## Problem
Regardless of the use case of the `RegionSubmenu` component, the separator label is fixed as `"Selections"`. Since this component is now used in EC2 and CWL, this is vague and not a very helpful label. 

## Solution
Default the label to `"Selections"`, but allow for a constructor parameter to add case-specific text. 
First example: CWL can use `"Log Groups"` instead of `"Selections"`:
<img width="815" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/42325418/c359c257-7209-42a0-abc7-4063af8af16a">
Second Example: EC2 can use `"Instances"` instead of `"Selections"`:
<img width="692" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/42325418/f6f5eaec-831f-4647-9742-680c11cb933e">



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
