### PR TITLE
authWebview: Identity Center sign in for Explorer

### DIFF
--- a/src/auth/ui/vue/authForms/manageCredentials.vue
+++ b/src/auth/ui/vue/authForms/manageCredentials.vue
@@ -3,8 +3,8 @@
         <div>
             <FormTitle :isConnected="isConnected">IAM Credentials</FormTitle>
 
-            <div class="form-section">
-                <button v-if="isConnected" v-on:click="showResourceExplorer">Open Resource Explorer</button>
+            <div class="form-section" v-if="isConnected">
+                <button v-on:click="showResourceExplorer">Open Resource Explorer</button>
             </div>
 
             <div v-if="isConnected" class="form-section" v-on:click="toggleShowForm()" id="collapsible">
@@ -76,6 +76,13 @@ export default defineComponent({
             type: Object as PropType<CredentialsState>,
             required: true,
         },
+        checkIfConnected: {
+            type: Boolean,
+            default: true,
+            // In some scenarios we want to show the form and allow setup,
+            // but not care about any current identity center auth connections
+            // and if they are connected or not.
+        },
     },
     data() {
         return {
@@ -104,7 +111,7 @@ export default defineComponent({
         await this.updateDataError('profileName')
         await this.updateDataError('aws_access_key_id')
         await this.updateDataError('aws_secret_access_key')
-        this.isFormShown = !(await this.state.isAuthConnected())
+        this.isFormShown = this.checkIfConnected ? !(await this.state.isAuthConnected()) : true
         await this.updateSubmittableStatus()
 
         this.updateConnectedStatus('created')
@@ -138,8 +145,8 @@ export default defineComponent({
         },
         async updateConnectedStatus(cause?: ConnectionUpdateCause) {
             return this.state.isAuthConnected().then(isConnected => {
-                this.isConnected = isConnected
-                this.emitAuthConnectionUpdated({ id: 'credentials', isConnected: this.isConnected, cause })
+                this.isConnected = this.checkIfConnected ? isConnected : false
+                this.emitAuthConnectionUpdated({ id: 'credentials', isConnected, cause })
             })
         },
         async submitData() {

--- a/src/auth/ui/vue/authForms/manageExplorer.vue
+++ b/src/auth/ui/vue/authForms/manageExplorer.vue
@@ -1,0 +1,73 @@
+<template>
+    <div class="auth-form container-background border-common" id="identity-center-form">
+        <div>
+            <FormTitle :isConnected="isConnected">Resource Explorer</FormTitle>
+            <div v-if="!isConnected">Successor to AWS Single Sign-on</div>
+        </div>
+
+        <div v-if="isConnected" class="form-section">
+            <button v-on:click="showExplorer()">Open Resource Explorer</button>
+        </div>
+    </div>
+</template>
+<script lang="ts">
+import { PropType, defineComponent } from 'vue'
+import BaseAuthForm from './baseAuth.vue'
+import FormTitle from './formTitle.vue'
+import { WebviewClientFactory } from '../../../../webviews/client'
+import { AuthWebview } from '../show'
+import { ExplorerIdentityCenterState } from './manageIdentityCenter.vue'
+import { CredentialsState } from './manageCredentials.vue'
+
+const client = WebviewClientFactory.create<AuthWebview>()
+
+export type IdentityCenterStage = 'START' | 'WAITING_ON_USER' | 'CONNECTED'
+
+/**
+ * This component is used to represent all of the multiple auth
+ * mechanisms in one place. It aggregates the possible auth mechanisms
+ * and if one of them are connected this will show that the explorer
+ * is successfully connected.
+ */
+export default defineComponent({
+    name: 'ExplorerAggregateForm',
+    extends: BaseAuthForm,
+    components: { FormTitle },
+    props: {
+        identityCenterState: {
+            type: Object as PropType<ExplorerIdentityCenterState>,
+            required: true,
+        },
+        credentialsState: {
+            type: Object as PropType<CredentialsState>,
+            required: true,
+        },
+    },
+    data() {
+        return {
+            isConnected: false,
+        }
+    },
+
+    async created() {
+        this.isConnected =
+            (await this.identityCenterState.isAuthConnected()) || (await this.credentialsState.isAuthConnected())
+        this.emitAuthConnectionUpdated({ id: 'aggregateExplorer', isConnected: this.isConnected, cause: 'created' })
+    },
+    computed: {},
+    methods: {
+        showExplorer() {
+            client.showResourceExplorer()
+        },
+    },
+})
+</script>
+<style>
+@import './sharedAuthForms.css';
+@import '../shared.css';
+
+#identity-center-form {
+    width: 280px;
+    height: fit-content;
+}
+</style>

--- a/src/auth/ui/vue/authForms/manageIdentityCenter.vue
+++ b/src/auth/ui/vue/authForms/manageIdentityCenter.vue
@@ -216,7 +216,7 @@ export class CodeWhispererIdentityCenterState extends BaseIdentityCenterState {
 
     protected override async _startIdentityCenterSetup(): Promise<void> {
         const data = await this.getSubmittableDataOrThrow()
-        return client.startIdentityCenterSetup(data.startUrl, data.region)
+        return client.startCWIdentityCenterSetup(data.startUrl, data.region)
     }
 
     override async isAuthConnected(): Promise<boolean> {

--- a/src/auth/ui/vue/authForms/manageIdentityCenter.vue
+++ b/src/auth/ui/vue/authForms/manageIdentityCenter.vue
@@ -100,6 +100,7 @@ export default defineComponent({
     computed: {},
     methods: {
         async signin(): Promise<void> {
+            this.stage = 'WAITING_ON_USER'
             await this.state.startIdentityCenterSetup()
             await this.update('signIn')
         },

--- a/src/auth/ui/vue/authForms/manageIdentityCenter.vue
+++ b/src/auth/ui/vue/authForms/manageIdentityCenter.vue
@@ -261,6 +261,12 @@ export class ExplorerIdentityCenterState extends BaseIdentityCenterState {
         return 'Resource Explorer'
     }
 
+    override async stage(): Promise<IdentityCenterStage> {
+        // We always want to allow the user to add a new connection
+        // for this context, so we always keep it as the start
+        return 'START'
+    }
+
     protected override async _startIdentityCenterSetup(): Promise<void> {
         const data = await this.getSubmittableDataOrThrow()
         return client.createIdentityCenterConnection(data.startUrl, data.region)

--- a/src/auth/ui/vue/authForms/manageIdentityCenter.vue
+++ b/src/auth/ui/vue/authForms/manageIdentityCenter.vue
@@ -124,8 +124,9 @@ export default defineComponent({
         },
         async update(cause?: ConnectionUpdateCause) {
             this.stage = await this.state.stage()
-            this.isConnected = this.checkIfConnected ? await this.state.isAuthConnected() : false
-            this.emitAuthConnectionUpdated({ id: this.state.id, isConnected: this.isConnected, cause })
+            const actualIsConnected = await this.state.isAuthConnected()
+            this.isConnected = this.checkIfConnected ? actualIsConnected : false
+            this.emitAuthConnectionUpdated({ id: this.state.id, isConnected: actualIsConnected, cause })
         },
         async getRegion() {
             const region = await this.state.getRegion()

--- a/src/auth/ui/vue/authForms/manageIdentityCenter.vue
+++ b/src/auth/ui/vue/authForms/manageIdentityCenter.vue
@@ -1,7 +1,14 @@
 <template>
     <div class="auth-form container-background border-common" id="identity-center-form">
-        <FormTitle :isConnected="isConnected">IAM Identity Center</FormTitle>
-        <div v-if="!isConnected">Successor to AWS Single Sign-on</div>
+        <div v-if="checkIfConnected">
+            <FormTitle :isConnected="isConnected">IAM Identity Center</FormTitle>
+            <div v-if="!isConnected">Successor to AWS Single Sign-on</div>
+        </div>
+        <div v-else>
+            <!-- In this scenario we do not care about the active IC connection -->
+            <FormTitle :isConnected="false">IAM Identity Center</FormTitle>
+            <div>Successor to AWS Single Sign-on</div>
+        </div>
 
         <div v-if="stage === 'START'">
             <div class="form-section">
@@ -71,6 +78,13 @@ export default defineComponent({
             type: Object as PropType<BaseIdentityCenterState>,
             required: true,
         },
+        checkIfConnected: {
+            type: Boolean,
+            default: true,
+            // In some scenarios we want to show the form and allow setup,
+            // but not care about any current identity center auth connections
+            // and if they are connected or not.
+        },
     },
     data() {
         return {
@@ -110,7 +124,7 @@ export default defineComponent({
         },
         async update(cause?: ConnectionUpdateCause) {
             this.stage = await this.state.stage()
-            this.isConnected = await this.state.isAuthConnected()
+            this.isConnected = this.checkIfConnected ? await this.state.isAuthConnected() : false
             this.emitAuthConnectionUpdated({ id: this.state.id, isConnected: this.isConnected, cause })
         },
         async getRegion() {

--- a/src/auth/ui/vue/authForms/manageIdentityCenter.vue
+++ b/src/auth/ui/vue/authForms/manageIdentityCenter.vue
@@ -1,51 +1,49 @@
 <template>
     <div class="auth-form container-background border-common" id="identity-center-form">
-        <div v-show="canShowAll">
-            <FormTitle :isConnected="isConnected">IAM Identity Center</FormTitle>
-            <div v-if="!isConnected">Successor to AWS Single Sign-on</div>
+        <FormTitle :isConnected="isConnected">IAM Identity Center</FormTitle>
+        <div v-if="!isConnected">Successor to AWS Single Sign-on</div>
 
-            <div v-if="stage === 'START'">
-                <div class="form-section">
-                    <a href="https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/sso-credentials.html"
-                        >Learn more about IAM Identity Center.</a
-                    >
-                </div>
-
-                <div class="form-section">
-                    <label class="input-title">Start URL</label>
-                    <label class="small-description">The Start URL</label>
-                    <input v-model="data.startUrl" type="text" :data-invalid="!!errors.startUrl" />
-                    <div class="small-description error-text">{{ errors.startUrl }}</div>
-                </div>
-
-                <div class="form-section">
-                    <label class="input-title">Region</label>
-                    <label class="small-description">The Region</label>
-
-                    <select v-on:click="getRegion()">
-                        <option v-if="!!data.region" :selected="true">{{ data.region }}</option>
-                    </select>
-                </div>
-
-                <div class="form-section">
-                    <button v-on:click="signin()" :disabled="!canSubmit">Sign up or Sign in</button>
-                </div>
+        <div v-if="stage === 'START'">
+            <div class="form-section">
+                <a href="https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/sso-credentials.html"
+                    >Learn more about IAM Identity Center.</a
+                >
             </div>
 
-            <div v-if="stage === 'WAITING_ON_USER'">
-                <div class="form-section">
-                    <div>Follow instructions...</div>
-                </div>
+            <div class="form-section">
+                <label class="input-title">Start URL</label>
+                <label class="small-description">The Start URL</label>
+                <input v-model="data.startUrl" type="text" :data-invalid="!!errors.startUrl" />
+                <div class="small-description error-text">{{ errors.startUrl }}</div>
             </div>
 
-            <div v-if="stage === 'CONNECTED'">
-                <div class="form-section">
-                    <div v-on:click="signout()" style="cursor: pointer; color: #75beff">Sign out</div>
-                </div>
+            <div class="form-section">
+                <label class="input-title">Region</label>
+                <label class="small-description">The Region</label>
 
-                <div class="form-section">
-                    <button v-on:click="showView()">Open {{ authName }} in Toolkit</button>
-                </div>
+                <select v-on:click="getRegion()">
+                    <option v-if="!!data.region" :selected="true">{{ data.region }}</option>
+                </select>
+            </div>
+
+            <div class="form-section">
+                <button v-on:click="signin()" :disabled="!canSubmit">Sign up or Sign in</button>
+            </div>
+        </div>
+
+        <div v-if="stage === 'WAITING_ON_USER'">
+            <div class="form-section">
+                <div>Follow instructions...</div>
+            </div>
+        </div>
+
+        <div v-if="stage === 'CONNECTED'">
+            <div class="form-section">
+                <div v-on:click="signout()" style="cursor: pointer; color: #75beff">Sign out</div>
+            </div>
+
+            <div class="form-section">
+                <button v-on:click="showView()">Open {{ authName }} in Toolkit</button>
             </div>
         </div>
     </div>
@@ -88,7 +86,6 @@ export default defineComponent({
 
             stage: 'START' as IdentityCenterStage,
 
-            canShowAll: false,
             authName: this.state.name,
         }
     },
@@ -99,7 +96,6 @@ export default defineComponent({
         this.data.region = this.state.getValue('region')
 
         await this.update('created')
-        this.canShowAll = true
     },
     computed: {},
     methods: {

--- a/src/auth/ui/vue/authForms/shared.vue
+++ b/src/auth/ui/vue/authForms/shared.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { CodeCatalystBuilderIdState, CodeWhispererBuilderIdState } from './manageBuilderId.vue'
 import { CredentialsState } from './manageCredentials.vue'
-import { CodeWhispererIdentityCenterState } from './manageIdentityCenter.vue'
+import { CodeWhispererIdentityCenterState, ExplorerIdentityCenterState } from './manageIdentityCenter.vue'
 import { AuthFormId } from './types'
 
 /**
@@ -12,6 +12,7 @@ const authFormsState: Readonly<Record<AuthFormId, any>> = {
     builderIdCodeWhisperer: new CodeWhispererBuilderIdState(),
     builderIdCodeCatalyst: new CodeCatalystBuilderIdState(),
     identityCenterCodeWhisperer: new CodeWhispererIdentityCenterState(),
+    identityCenterExplorer: new ExplorerIdentityCenterState()
 } as const
 
 export interface AuthStatus {

--- a/src/auth/ui/vue/authForms/shared.vue
+++ b/src/auth/ui/vue/authForms/shared.vue
@@ -2,12 +2,11 @@
 import { CodeCatalystBuilderIdState, CodeWhispererBuilderIdState } from './manageBuilderId.vue'
 import { CredentialsState } from './manageCredentials.vue'
 import { CodeWhispererIdentityCenterState, ExplorerIdentityCenterState } from './manageIdentityCenter.vue'
-import { AuthFormId } from './types'
 
 /**
  * The state instance of all auth forms
  */
-const authFormsState: Readonly<Record<AuthFormId, any>> = {
+const authFormsState = {
     credentials: new CredentialsState() as CredentialsState,
     builderIdCodeWhisperer: new CodeWhispererBuilderIdState(),
     builderIdCodeCatalyst: new CodeCatalystBuilderIdState(),

--- a/src/auth/ui/vue/authForms/types.ts
+++ b/src/auth/ui/vue/authForms/types.ts
@@ -9,11 +9,13 @@ export type AuthFormId =
     | 'builderIdCodeCatalyst'
     | 'identityCenterCodeWhisperer'
     | 'identityCenterExplorer'
+    | 'aggregateExplorer'
 
 export const AuthFormDisplayName: Record<AuthFormId, string> = {
     credentials: 'IAM Credentials',
     builderIdCodeCatalyst: 'Builder ID',
     builderIdCodeWhisperer: 'Builder ID',
     identityCenterCodeWhisperer: 'IAM Identity Center',
-    identityCenterExplorer: 'IAM Identity Center'
+    identityCenterExplorer: 'IAM Identity Center',
+    aggregateExplorer: ''
 } as const

--- a/src/auth/ui/vue/authForms/types.ts
+++ b/src/auth/ui/vue/authForms/types.ts
@@ -8,10 +8,12 @@ export type AuthFormId =
     | 'builderIdCodeWhisperer'
     | 'builderIdCodeCatalyst'
     | 'identityCenterCodeWhisperer'
+    | 'identityCenterExplorer'
 
 export const AuthFormDisplayName: Record<AuthFormId, string> = {
     credentials: 'IAM Credentials',
     builderIdCodeCatalyst: 'Builder ID',
     builderIdCodeWhisperer: 'Builder ID',
     identityCenterCodeWhisperer: 'IAM Identity Center',
+    identityCenterExplorer: 'IAM Identity Center'
 } as const

--- a/src/auth/ui/vue/root.vue
+++ b/src/auth/ui/vue/root.vue
@@ -228,8 +228,15 @@ export default defineComponent({
             }
         },
         onAuthConnectionUpdated(id: ServiceItemId, args: ConnectionUpdateArgs) {
+            if (args.cause === 'created') {
+                // When the auth update is caused by a creation of the auth form
+                // there is nothing to update externally since the state hasn't changed.
+                return
+            }
             if (args.isConnected && args.cause === 'signIn') {
                 this.successfulAuthConnection = args.id
+                // On a successful sign in the state of the current content window
+                // can change. This forces a rerendering of it to have it load the latest state.
                 this.rerenderSelectedContentWindow()
             }
 

--- a/src/auth/ui/vue/serviceItemContent/awsExplorerContent.vue
+++ b/src/auth/ui/vue/serviceItemContent/awsExplorerContent.vue
@@ -23,6 +23,7 @@
             <ExplorerAggregateForm
                 :identityCenterState="identityCenterFormState"
                 :credentialsState="credentialsFormState"
+                @auth-connection-updated="onAuthConnectionUpdated"
             ></ExplorerAggregateForm>
 
             <div v-on:click="toggleShowIdentityCenter" style="cursor: pointer; display: flex; flex-direction: row">
@@ -102,6 +103,8 @@ export default defineComponent({
             isAllAuthsLoaded: false,
             isLoaded: {
                 credentials: false,
+                identityCenterExplorer: false,
+                aggregateExplorer: false,
             } as Record<AuthFormId, boolean>,
             isCredentialsShown: false,
             isIdentityCenterShown: false,
@@ -110,6 +113,11 @@ export default defineComponent({
     },
     async created() {
         this.isAuthConnected = await this.state.isAuthConnected()
+        if (!this.isAuthConnected) {
+            // This does not get loaded at all when auth is not connected
+            // so we'll mark it as loaded as to not block the overall loading
+            this.isLoaded.aggregateExplorer = true
+        }
     },
     computed: {
         credentialsFormState(): CredentialsState {

--- a/src/auth/ui/vue/serviceItemContent/awsExplorerContent.vue
+++ b/src/auth/ui/vue/serviceItemContent/awsExplorerContent.vue
@@ -19,18 +19,60 @@
 
         <hr />
 
-        <div class="service-item-content-form-section">
-            <div>
-                <div class="form-section-title">Provide IAM Credentials to access the Resource Explorer:</div>
-                <div>Don't have an AWS account? <a>Sign up for free.</a></div>
+        <div v-if="isAuthConnected" class="service-item-content-form-section">
+            <div v-on:click="toggleShowIdentityCenter" style="cursor: pointer; display: flex; flex-direction: row">
+                <div
+                    style="font-weight: bold; font-size: medium"
+                    :class="collapsibleClass(isIdentityCenterShown)"
+                ></div>
+                <div>
+                    <div style="font-weight: bold; font-size: 14px">Add another IAM Identity Center Profile</div>
+                </div>
             </div>
 
-            <div class="service-item-content-form-container">
-                <CredentialsForm
-                    :state="credentialsFormState"
-                    @auth-connection-updated="onAuthConnectionUpdated"
-                ></CredentialsForm>
+            <IdentityCenterForm
+                :state="identityCenterFormState"
+                @auth-connection-updated="onAuthConnectionUpdated"
+                :checkIfConnected="false"
+                v-show="isIdentityCenterShown"
+            ></IdentityCenterForm>
+
+            <div v-on:click="toggleShowCredentials" style="cursor: pointer; display: flex; flex-direction: row">
+                <div style="font-weight: bold; font-size: medium" :class="collapsibleClass(isCredentialsShown)"></div>
+                <div>
+                    <div style="font-weight: bold; font-size: 14px">Add another IAM User Credentials</div>
+                </div>
             </div>
+
+            <CredentialsForm
+                :state="credentialsFormState"
+                @auth-connection-updated="onAuthConnectionUpdated"
+                v-show="isCredentialsShown"
+            ></CredentialsForm>
+
+            <div>Don't have an AWS account? <a>Sign up for free.</a></div>
+        </div>
+        <div v-else class="service-item-content-form-section">
+            <IdentityCenterForm
+                :state="identityCenterFormState"
+                @auth-connection-updated="onAuthConnectionUpdated"
+                :checkIfConnected="false"
+            ></IdentityCenterForm>
+
+            <div v-on:click="toggleShowCredentials" style="cursor: pointer; display: flex; flex-direction: row">
+                <div style="font-weight: bold; font-size: medium" :class="collapsibleClass(isCredentialsShown)"></div>
+                <div>
+                    <div style="font-weight: bold; font-size: 14px">Or add IAM User Credentials</div>
+                </div>
+            </div>
+
+            <CredentialsForm
+                :state="credentialsFormState"
+                @auth-connection-updated="onAuthConnectionUpdated"
+                v-show="isCredentialsShown"
+            ></CredentialsForm>
+
+            <div>Don't have an AWS account? <a>Sign up for free.</a></div>
         </div>
     </div>
 </template>
@@ -38,6 +80,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import CredentialsForm, { CredentialsState } from '../authForms/manageCredentials.vue'
+import IdentityCenterForm, { ExplorerIdentityCenterState } from '../authForms/manageIdentityCenter.vue'
 import BaseServiceItemContent from './baseServiceItemContent.vue'
 import authFormsState, { AuthStatus } from '../authForms/shared.vue'
 import { AuthFormId } from '../authForms/types'
@@ -45,7 +88,7 @@ import { ConnectionUpdateArgs } from '../authForms/baseAuth.vue'
 
 export default defineComponent({
     name: 'AwsExplorerContent',
-    components: { CredentialsForm },
+    components: { CredentialsForm, IdentityCenterForm },
     extends: BaseServiceItemContent,
     data() {
         return {
@@ -53,11 +96,20 @@ export default defineComponent({
             isLoaded: {
                 credentials: false,
             } as Record<AuthFormId, boolean>,
+            isCredentialsShown: false,
+            isIdentityCenterShown: false,
+            isAuthConnected: false,
         }
+    },
+    async created() {
+        this.isAuthConnected = await this.state.isAuthConnected()
     },
     computed: {
         credentialsFormState(): CredentialsState {
             return authFormsState.credentials
+        },
+        identityCenterFormState(): ExplorerIdentityCenterState {
+            return authFormsState.identityCenterExplorer
         },
     },
     methods: {
@@ -70,12 +122,24 @@ export default defineComponent({
             this.updateIsAllAuthsLoaded()
             this.emitAuthConnectionUpdated('resourceExplorer', args)
         },
+        toggleShowCredentials() {
+            this.isCredentialsShown = !this.isCredentialsShown
+        },
+        toggleShowIdentityCenter() {
+            this.isIdentityCenterShown = !this.isIdentityCenterShown
+        },
+        collapsibleClass(isShown: boolean): string {
+            return isShown ? 'icon icon-vscode-chevron-down' : 'icon icon-vscode-chevron-right'
+        },
     },
 })
 
 export class ResourceExplorerContentState implements AuthStatus {
     async isAuthConnected(): Promise<boolean> {
-        return authFormsState.credentials.isAuthConnected()
+        return (
+            (await authFormsState.credentials.isAuthConnected()) ||
+            (await authFormsState.identityCenterExplorer.isAuthConnected())
+        )
     }
 }
 </script>

--- a/src/auth/ui/vue/serviceItemContent/awsExplorerContent.vue
+++ b/src/auth/ui/vue/serviceItemContent/awsExplorerContent.vue
@@ -51,6 +51,7 @@
 
             <CredentialsForm
                 :state="credentialsFormState"
+                :check-if-connected="false"
                 @auth-connection-updated="onAuthConnectionUpdated"
                 v-show="isCredentialsShown"
             ></CredentialsForm>

--- a/src/auth/ui/vue/serviceItemContent/awsExplorerContent.vue
+++ b/src/auth/ui/vue/serviceItemContent/awsExplorerContent.vue
@@ -20,6 +20,11 @@
         <hr />
 
         <div v-if="isAuthConnected" class="service-item-content-form-section">
+            <ExplorerAggregateForm
+                :identityCenterState="identityCenterFormState"
+                :credentialsState="credentialsFormState"
+            ></ExplorerAggregateForm>
+
             <div v-on:click="toggleShowIdentityCenter" style="cursor: pointer; display: flex; flex-direction: row">
                 <div
                     style="font-weight: bold; font-size: medium"
@@ -85,10 +90,11 @@ import BaseServiceItemContent from './baseServiceItemContent.vue'
 import authFormsState, { AuthStatus } from '../authForms/shared.vue'
 import { AuthFormId } from '../authForms/types'
 import { ConnectionUpdateArgs } from '../authForms/baseAuth.vue'
+import ExplorerAggregateForm from '../authForms/manageExplorer.vue'
 
 export default defineComponent({
     name: 'AwsExplorerContent',
-    components: { CredentialsForm, IdentityCenterForm },
+    components: { CredentialsForm, IdentityCenterForm, ExplorerAggregateForm },
     extends: BaseServiceItemContent,
     data() {
         return {

--- a/src/auth/ui/vue/show.ts
+++ b/src/auth/ui/vue/show.ts
@@ -169,9 +169,11 @@ export class AuthWebview extends VueWebview {
      * Creates an Identity Center connection but does not 'use' it.
      */
     async createIdentityCenterConnection(startUrl: string, regionId: Region['id']) {
-        const setupFunc = () => {
+        const setupFunc = async () => {
             const ssoProfile = createSsoProfile(startUrl, regionId)
-            return Auth.instance.createConnection(ssoProfile)
+            await Auth.instance.createConnection(ssoProfile)
+            // Trigger loading of Credentials associated with the SSO connection
+            return Auth.instance.listConnections()
         }
         return this.ssoSetup(setupFunc)
     }

--- a/src/auth/ui/vue/show.ts
+++ b/src/auth/ui/vue/show.ts
@@ -25,7 +25,7 @@ import { awsIdSignIn } from '../../../codewhisperer/util/showSsoPrompt'
 import { CodeCatalystAuthenticationProvider } from '../../../codecatalyst/auth'
 import { getStartedCommand } from '../../../codecatalyst/utils'
 import { ToolkitError } from '../../../shared/errors'
-import { isBuilderIdConnection } from '../../connection'
+import { Connection, SsoConnection, createSsoProfile, isBuilderIdConnection, isSsoConnection } from '../../connection'
 import { tryAddCredentials, signout, showRegionPrompter, addConnection, promptForConnection } from '../../utils'
 import { Region } from '../../../shared/regions/endpoints'
 import { CancellationError } from '../../../shared/utilities/timeoutUtils'
@@ -165,9 +165,30 @@ export class AuthWebview extends VueWebview {
         return showRegionPrompter()
     }
 
-    async startIdentityCenterSetup(startUrl: string, regionId: Region['id']) {
+    /**
+     * Creates an Identity Center connection but does not 'use' it.
+     */
+    async createIdentityCenterConnection(startUrl: string, regionId: Region['id']) {
+        const setupFunc = () => {
+            const ssoProfile = createSsoProfile(startUrl, regionId)
+            return Auth.instance.createConnection(ssoProfile)
+        }
+        return this.ssoSetup(setupFunc)
+    }
+
+    /**
+     * Sets up the CW Identity Center connection.
+     */
+    async startCWIdentityCenterSetup(startUrl: string, regionId: Region['id']) {
+        const setupFunc = () => {
+            return CodeWhispererAuth.instance.connectToEnterpriseSso(startUrl, regionId)
+        }
+        return this.ssoSetup(setupFunc)
+    }
+
+    private async ssoSetup(setupFunc: () => Promise<any>) {
         try {
-            await CodeWhispererAuth.instance.connectToEnterpriseSso(startUrl, regionId)
+            await setupFunc()
         } catch (e) {
             // This scenario will most likely be due to failing to connect from user error.
             // When the sso login process fails (eg: wrong url) they will come back
@@ -178,11 +199,22 @@ export class AuthWebview extends VueWebview {
         }
     }
 
+    /**
+     * Checks if a non-BuilderId Identity Center connection exists, it
+     * does not have to be active.
+     */
+    async isIdentityCenterExists(): Promise<boolean> {
+        const nonBuilderIdSsoConns = (await Auth.instance.listConnections()).find(conn =>
+            this.isNonBuilderIdSsoConnection(conn)
+        )
+        return nonBuilderIdSsoConns !== undefined
+    }
+
     isCodeWhispererIdentityCenterConnected(): boolean {
         return CodeWhispererAuth.instance.isEnterpriseSsoInUse() && CodeWhispererAuth.instance.isConnectionValid()
     }
 
-    async signoutIdentityCenter(): Promise<void> {
+    async signoutCWIdentityCenter(): Promise<void> {
         const activeConn = CodeWhispererAuth.instance.isEnterpriseSsoInUse()
             ? CodeWhispererAuth.instance.conn
             : undefined
@@ -190,21 +222,27 @@ export class AuthWebview extends VueWebview {
             // At this point CW is not actively using IAM IC,
             // even if a valid IAM IC profile exists. We only
             // want to sign out if it being actively used.
+            getLogger().warn('authWebview: Attempted to signout of CW identity center when it was not being used')
+            return
+        }
+
+        await CodeWhispererAuth.instance.secondaryAuth.removeConnection()
+        await signout(Auth.instance, activeConn) // deletes active connection
+    }
+
+    async signoutIdentityCenter(): Promise<void> {
+        const conn = Auth.instance.activeConnection
+        const activeConn = this.isNonBuilderIdSsoConnection(conn) ? conn : undefined
+        if (!activeConn) {
             getLogger().warn('authWebview: Attempted to signout of identity center when it was not being used')
             return
         }
 
-        await this.deleteSavedIdentityCenterConns()
-        await signout(Auth.instance, activeConn) // deletes active connection
+        await signout(Auth.instance, activeConn)
     }
 
-    /**
-     * Deletes the saved connection, but it is possible an active one still persists
-     */
-    private async deleteSavedIdentityCenterConns(): Promise<void> {
-        if (CodeWhispererAuth.instance.isEnterpriseSsoInUse()) {
-            await CodeWhispererAuth.instance.secondaryAuth.removeConnection()
-        }
+    private isNonBuilderIdSsoConnection(conn?: Connection): conn is SsoConnection {
+        return isSsoConnection(conn) && !isBuilderIdConnection(conn)
     }
 
     getSsoUrlError(url?: string) {


### PR DESCRIPTION
## Problem
We can get IAM Credentials from an Identity Center connection for the Resource Explorer to work, but don't currently provide a way to do that.

## Solution
Add a form for Identity Center in the Resource Explorer add connection webview.

Additionally, we still provide the ability to enter credentials directly, but hide it behind a toggle.

#### Before Connection is Set UP
![Screen Shot 2023-06-20 at 12 40 40 PM](https://github.com/aws/aws-toolkit-vscode/assets/118216176/0062e146-5b60-416f-a9bb-31c9022232b8)

#### Connection Setup
![Kapture 2023-06-20 at 13 20 21](https://github.com/aws/aws-toolkit-vscode/assets/118216176/3a186131-00f6-4eeb-86a6-da294eabc863)

#### Adding an additional connection UI
![Screen Shot 2023-06-20 at 1 29 33 PM](https://github.com/aws/aws-toolkit-vscode/assets/118216176/25a8b6ea-8585-4eec-9a1a-2486659bb285)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
