### PR TITLE
fix(ecs): only show tasks from the selected container

### DIFF
--- a/.changes/next-release/Bug Fix-7e9427f3-d9cc-4b9b-983f-7ce5c5702368.json
+++ b/.changes/next-release/Bug Fix-7e9427f3-d9cc-4b9b-983f-7ce5c5702368.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "ECS: tasks from unrelated services are shown in the \"Open Terminal...\" command"
+	"description": "ECS: tasks from unrelated task definitions are shown in the \"Open Terminal...\" command"
 }

--- a/.changes/next-release/Bug Fix-7e9427f3-d9cc-4b9b-983f-7ce5c5702368.json
+++ b/.changes/next-release/Bug Fix-7e9427f3-d9cc-4b9b-983f-7ce5c5702368.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "ECS: tasks from unrelated services are shown in the \"Open Terminal...\" command"
+}

--- a/src/ecs/model.ts
+++ b/src/ecs/model.ts
@@ -33,10 +33,17 @@ interface ContainerDescription extends ECS.ContainerDefinition {
 export class Container {
     public readonly id = this.description.name!
 
-    public constructor(private readonly client: DefaultEcsClient, public readonly description: ContainerDescription) {}
+    public constructor(
+        private readonly client: DefaultEcsClient,
+        public readonly serviceName: string,
+        public readonly description: ContainerDescription
+    ) {}
 
     public async listTasks() {
-        const resp = await this.client.listTasks({ cluster: this.description.clusterArn })
+        const resp = await this.client.listTasks({
+            cluster: this.description.clusterArn,
+            serviceName: this.serviceName,
+        })
         const tasks = await this.client.describeTasks(this.description.clusterArn, resp)
 
         return tasks.filter(createValidTaskFilter(this.description.name!))
@@ -81,7 +88,7 @@ export class Service {
 
         return containers.map(
             c =>
-                new Container(this.client, {
+                new Container(this.client, this.description.serviceName!, {
                     ...c,
                     enableExecuteCommand: this.description.enableExecuteCommand,
                     taskRoleArn: definition.taskRoleArn!,

--- a/src/test/ecs/model.test.ts
+++ b/src/test/ecs/model.test.ts
@@ -29,8 +29,10 @@ const containerData = {
 const getClient = () => stub(DefaultEcsClient, { regionCode: 'us-east-1' })
 
 describe('Container', function () {
+    const serviceName = 'my-service'
+
     it('has a tree item', async function () {
-        const container = new Container(getClient(), containerData)
+        const container = new Container(getClient(), serviceName, containerData)
 
         await assertTreeItem(container, {
             label: containerData.name,
@@ -39,7 +41,7 @@ describe('Container', function () {
     })
 
     it('has a tree item when "enableExecuteCommand" is set', async function () {
-        const container = new Container(getClient(), { ...containerData, enableExecuteCommand: true })
+        const container = new Container(getClient(), serviceName, { ...containerData, enableExecuteCommand: true })
 
         await assertTreeItem(container, {
             label: containerData.name,

--- a/src/test/ecs/wizards/executeCommand.test.ts
+++ b/src/test/ecs/wizards/executeCommand.test.ts
@@ -13,7 +13,7 @@ describe('CreateServiceWizard', function () {
     let tester: WizardTester<CommandWizardState>
 
     const createContainer = () =>
-        new Container(stub(DefaultEcsClient, { regionCode: '' }), { clusterArn: '', taskRoleArn: '' })
+        new Container(stub(DefaultEcsClient, { regionCode: '' }), '', { clusterArn: '', taskRoleArn: '' })
 
     beforeEach(function () {
         tester = createWizardTester(new CommandWizard(createContainer(), false))


### PR DESCRIPTION
## Problem
See https://github.com/aws/aws-toolkit-vscode/issues/3589

## Solution
Add `serviceName` to the `ListTasks` operation

Note that previously container instances spawned in a cluster but outside of a service were shown in the quick pick as well. If there is a valid use-case for this, we should consider adding some task-orientated UI.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
