### PR TITLE
authWebview: minor changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,6 +220,10 @@
                         "codeWhispererConnectionExpired": {
                             "type": "boolean",
                             "default": false
+                        },
+                        "manageConnections": {
+                            "type": "boolean",
+                            "default": false
                         }
                     },
                     "additionalProperties": false

--- a/src/auth/activation.ts
+++ b/src/auth/activation.ts
@@ -10,6 +10,10 @@ import { LoginManager } from './deprecated/loginManager'
 import { fromString } from './providers/credentials'
 import { registerCommandsWithVSCode } from '../shared/vscode/commands2'
 import { AuthCommandBackend, AuthCommandDeclarations } from './commands'
+import { dontShow } from '../shared/localizedText'
+import { DevSettings, PromptSettings } from '../shared/settings'
+import { waitUntil } from '../shared/utilities/timeoutUtils'
+import { CodeCatalystAuthenticationProvider } from '../codecatalyst/auth'
 
 export async function initialize(
     extensionContext: vscode.ExtensionContext,
@@ -32,4 +36,33 @@ export async function initialize(
         AuthCommandDeclarations.instance,
         new AuthCommandBackend(extensionContext)
     )
+
+    if (DevSettings.instance.isDevMode()) {
+        showManageConnectionsOnStartup()
+    }
+}
+
+/**
+ * Show the Manage Connections page when the extension starts up.
+ *
+ * Additionally, we provide an information message with a button for users to not show it
+ * again on next startup.
+ */
+async function showManageConnectionsOnStartup() {
+    await waitUntil(() => Promise.resolve(CodeCatalystAuthenticationProvider.instance), {
+        interval: 500,
+        timeout: 10000,
+    })
+    const settings = PromptSettings.instance
+
+    if (!(await settings.isPromptEnabled('manageConnections'))) {
+        return
+    }
+
+    AuthCommandDeclarations.instance.declared.showConnectionsPage.execute()
+    vscode.window.showInformationMessage("Don't show Add Connections page on startup?", dontShow).then(selection => {
+        if (selection === dontShow) {
+            settings.disablePrompt('manageConnections')
+        }
+    })
 }

--- a/src/auth/ui/vue/authForms/manageBuilderId.vue
+++ b/src/auth/ui/vue/authForms/manageBuilderId.vue
@@ -15,6 +15,7 @@
 
                 <div class="form-section">
                     <button v-on:click="startSignIn()">Sign up or Sign in</button>
+                    <div class="small-description error-text">{{ error }}</div>
                 </div>
             </div>
 
@@ -66,6 +67,7 @@ export default defineComponent({
             isConnected: false,
             builderIdCode: '',
             name: this.state.name,
+            error: '' as string,
         }
     },
     async created() {
@@ -74,8 +76,12 @@ export default defineComponent({
     methods: {
         async startSignIn() {
             this.stage = 'WAITING_ON_USER'
-            await this.state.startBuilderIdSetup()
-            await this.update('signIn')
+            this.error = await this.state.startBuilderIdSetup()
+            if (this.error) {
+                this.stage = await this.state.stage()
+            } else {
+                await this.update('signIn')
+            }
         },
         async update(cause?: ConnectionUpdateCause) {
             this.stage = await this.state.stage()
@@ -100,11 +106,11 @@ abstract class BaseBuilderIdState implements AuthStatus {
 
     abstract get name(): string
     abstract get id(): AuthFormId
-    protected abstract _startBuilderIdSetup(): Promise<void>
+    protected abstract _startBuilderIdSetup(): Promise<string>
     abstract isAuthConnected(): Promise<boolean>
     abstract showNodeInView(): Promise<void>
 
-    async startBuilderIdSetup(): Promise<void> {
+    async startBuilderIdSetup(): Promise<string> {
         this._stage = 'WAITING_ON_USER'
         return this._startBuilderIdSetup()
     }
@@ -133,7 +139,7 @@ export class CodeWhispererBuilderIdState extends BaseBuilderIdState {
         return client.isCodeWhispererBuilderIdConnected()
     }
 
-    protected override _startBuilderIdSetup(): Promise<void> {
+    protected override _startBuilderIdSetup(): Promise<string> {
         return client.startCodeWhispererBuilderIdSetup()
     }
 
@@ -155,7 +161,7 @@ export class CodeCatalystBuilderIdState extends BaseBuilderIdState {
         return client.isCodeCatalystBuilderIdConnected()
     }
 
-    protected override _startBuilderIdSetup(): Promise<void> {
+    protected override _startBuilderIdSetup(): Promise<string> {
         return client.startCodeCatalystBuilderIdSetup()
     }
 

--- a/src/auth/ui/vue/authForms/manageExplorer.vue
+++ b/src/auth/ui/vue/authForms/manageExplorer.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="auth-form container-background border-common" id="identity-center-form">
+    <div class="auth-form container-background border-common" id="explorer-form">
         <div>
             <FormTitle :isConnected="isConnected">{{ connectionName }}</FormTitle>
             <div v-if="!isConnected">Successor to AWS Single Sign-on</div>
@@ -85,7 +85,7 @@ export default defineComponent({
 @import './sharedAuthForms.css';
 @import '../shared.css';
 
-#identity-center-form {
+#explorer-form {
     width: 280px;
     height: fit-content;
 }

--- a/src/auth/ui/vue/authForms/manageIdentityCenter.vue
+++ b/src/auth/ui/vue/authForms/manageIdentityCenter.vue
@@ -1,22 +1,26 @@
 <template>
     <div class="auth-form container-background border-common" id="identity-center-form">
         <div v-if="checkIfConnected">
-            <FormTitle :isConnected="isConnected">IAM Identity Center</FormTitle>
+            <FormTitle :isConnected="isConnected"
+                >IAM Identity Center&nbsp;<a
+                    class="icon icon-lg icon-vscode-info"
+                    href="https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/sso-credentials.html"
+                ></a
+            ></FormTitle>
             <div v-if="!isConnected">Successor to AWS Single Sign-on</div>
         </div>
         <div v-else>
             <!-- In this scenario we do not care about the active IC connection -->
-            <FormTitle :isConnected="false">IAM Identity Center</FormTitle>
+            <FormTitle :isConnected="false"
+                >IAM Identity Center&nbsp;<a
+                    class="icon icon-lg icon-vscode-info"
+                    href="https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/sso-credentials.html"
+                ></a
+            ></FormTitle>
             <div>Successor to AWS Single Sign-on</div>
         </div>
 
         <div v-if="stage === 'START'">
-            <div class="form-section">
-                <a href="https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/sso-credentials.html"
-                    >Learn more about IAM Identity Center.</a
-                >
-            </div>
-
             <div class="form-section">
                 <label class="input-title">Start URL</label>
                 <label class="small-description">The Start URL</label>

--- a/src/auth/ui/vue/authForms/manageIdentityCenter.vue
+++ b/src/auth/ui/vue/authForms/manageIdentityCenter.vue
@@ -23,14 +23,14 @@
         <div v-if="stage === 'START'">
             <div class="form-section">
                 <label class="input-title">Start URL</label>
-                <label class="small-description">The Start URL</label>
+                <label class="small-description">URL for your organization, provided by an admin or help desk.</label>
                 <input v-model="data.startUrl" type="text" :data-invalid="!!errors.startUrl" />
                 <div class="small-description error-text">{{ errors.startUrl }}</div>
             </div>
 
             <div class="form-section">
                 <label class="input-title">Region</label>
-                <label class="small-description">The Region</label>
+                <label class="small-description">AWS Region that hosts Identity directory</label>
 
                 <select v-on:click="getRegion()">
                     <option v-if="!!data.region" :selected="true">{{ data.region }}</option>
@@ -316,7 +316,7 @@ export class ExplorerIdentityCenterState extends BaseIdentityCenterState {
 @import '../shared.css';
 
 #identity-center-form {
-    width: 280px;
+    width: 300px;
     height: fit-content;
 }
 </style>

--- a/src/auth/ui/vue/authForms/manageIdentityCenter.vue
+++ b/src/auth/ui/vue/authForms/manageIdentityCenter.vue
@@ -32,9 +32,10 @@
                 <label class="input-title">Region</label>
                 <label class="small-description">AWS Region that hosts Identity directory</label>
 
-                <select v-on:click="getRegion()">
-                    <option v-if="!!data.region" :selected="true">{{ data.region }}</option>
-                </select>
+                <div style="display: flex; flex-direction: row; gap: 10px">
+                    <div v-on:click="getRegion()" class="icon icon-lg icon-vscode-edit edit-icon"></div>
+                    <div style="width: 100%">{{ data.region ? data.region : 'Not Selected' }}</div>
+                </div>
             </div>
 
             <div class="form-section">

--- a/src/auth/ui/vue/authForms/manageIdentityCenter.vue
+++ b/src/auth/ui/vue/authForms/manageIdentityCenter.vue
@@ -90,6 +90,11 @@ export default defineComponent({
             // but not care about any current identity center auth connections
             // and if they are connected or not.
         },
+        /** If we don't care about the start url already existing locally */
+        allowExistingStartUrl: {
+            type: Boolean,
+            default: false,
+        },
     },
     data() {
         return {
@@ -151,10 +156,10 @@ export default defineComponent({
             this.state.setValue(key, value)
 
             if (key === 'startUrl') {
-                this.errors.startUrl = await this.state.getStartUrlError()
+                this.errors.startUrl = await this.state.getStartUrlError(this.allowExistingStartUrl)
             }
 
-            this.canSubmit = await this.state.canSubmit()
+            this.canSubmit = await this.state.canSubmit(this.allowExistingStartUrl)
         },
         showView() {
             this.state.showView()
@@ -222,14 +227,14 @@ abstract class BaseIdentityCenterState implements AuthStatus {
         return client.getIdentityCenterRegion()
     }
 
-    async getStartUrlError() {
-        const error = await client.getSsoUrlError(this._data.startUrl)
+    async getStartUrlError(canUrlExist: boolean) {
+        const error = await client.getSsoUrlError(this._data.startUrl, canUrlExist)
         return error ?? ''
     }
 
-    async canSubmit() {
+    async canSubmit(canUrlExist: boolean) {
         const allFieldsFilled = Object.values(this._data).every(val => !!val)
-        const hasErrors = await this.getStartUrlError()
+        const hasErrors = await this.getStartUrlError(canUrlExist)
         return allFieldsFilled && !hasErrors
     }
 

--- a/src/auth/ui/vue/authForms/manageIdentityCenter.vue
+++ b/src/auth/ui/vue/authForms/manageIdentityCenter.vue
@@ -215,7 +215,17 @@ abstract class BaseIdentityCenterState implements AuthStatus {
      */
     async startIdentityCenterSetup(): Promise<string> {
         this._stage = 'WAITING_ON_USER'
-        return this._startIdentityCenterSetup()
+        const error = await this._startIdentityCenterSetup()
+
+        // Successful submission, so we can clear
+        // old data.
+        if (!error) {
+            this._data = {
+                startUrl: '',
+                region: '',
+            }
+        }
+        return error
     }
 
     async stage(): Promise<IdentityCenterStage> {

--- a/src/auth/ui/vue/serviceItemContent/awsExplorerContent.vue
+++ b/src/auth/ui/vue/serviceItemContent/awsExplorerContent.vue
@@ -14,7 +14,9 @@
         </div>
 
         <div>
-            <a>Learn more about the Resource Explorer.</a>
+            <a href="https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/toolkit-navigation.html"
+                >Learn more about the Resource Explorer.</a
+            >
         </div>
 
         <hr />
@@ -57,7 +59,7 @@
                 v-show="isCredentialsShown"
             ></CredentialsForm>
 
-            <div>Don't have an AWS account? <a>Sign up for free.</a></div>
+            <div>Don't have an AWS account? <a href="https://aws.amazon.com/free/">Sign up for free.</a></div>
         </div>
         <div v-else class="service-item-content-form-section">
             <IdentityCenterForm
@@ -79,7 +81,7 @@
                 v-show="isCredentialsShown"
             ></CredentialsForm>
 
-            <div>Don't have an AWS account? <a>Sign up for free.</a></div>
+            <div>Don't have an AWS account? <a href="https://aws.amazon.com/free/">Sign up for free.</a></div>
         </div>
     </div>
 </template>

--- a/src/auth/ui/vue/serviceItemContent/awsExplorerContent.vue
+++ b/src/auth/ui/vue/serviceItemContent/awsExplorerContent.vue
@@ -48,7 +48,7 @@
             <div v-on:click="toggleShowCredentials" style="cursor: pointer; display: flex; flex-direction: row">
                 <div style="font-weight: bold; font-size: medium" :class="collapsibleClass(isCredentialsShown)"></div>
                 <div>
-                    <div style="font-weight: bold; font-size: 14px">Add another IAM User Credentials</div>
+                    <div style="font-weight: bold; font-size: 14px">Add another IAM User Credential</div>
                 </div>
             </div>
 

--- a/src/auth/ui/vue/serviceItemContent/baseServiceItemContent.css
+++ b/src/auth/ui/vue/serviceItemContent/baseServiceItemContent.css
@@ -28,7 +28,7 @@
 .service-item-content-form-section {
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: left;
     gap: 20px;
 }
 
@@ -42,5 +42,5 @@
     display: flex;
     flex-direction: row;
     gap: 20px;
-    justify-content: center;
+    justify-content: left;
 }

--- a/src/auth/ui/vue/serviceItemContent/codeCatalystContent.vue
+++ b/src/auth/ui/vue/serviceItemContent/codeCatalystContent.vue
@@ -16,7 +16,7 @@
         </div>
 
         <div>
-            <a href="https://aws.amazon.com/codewhisperer/">Learn more about CodeCatalyst.</a>
+            <a href="https://aws.amazon.com/codecatalyst/">Learn more about CodeCatalyst.</a>
         </div>
 
         <hr />

--- a/src/auth/ui/vue/serviceItemContent/codeWhispererContent.vue
+++ b/src/auth/ui/vue/serviceItemContent/codeWhispererContent.vue
@@ -47,6 +47,7 @@
 
                 <IdentityCenterForm
                     :state="identityCenterState"
+                    :allow-existing-start-url="true"
                     @auth-connection-updated="onAuthConnectionUpdated"
                     v-show="isIdentityCenterShown"
                 ></IdentityCenterForm>

--- a/src/auth/ui/vue/serviceItemContent/codeWhispererContent.vue
+++ b/src/auth/ui/vue/serviceItemContent/codeWhispererContent.vue
@@ -132,6 +132,6 @@ export class CodeWhispererContentState implements AuthStatus {
     flex-direction: column;
     gap: 20px;
     justify-content: center;
-    align-items: center;
+    align-items: left;
 }
 </style>

--- a/src/auth/ui/vue/show.ts
+++ b/src/auth/ui/vue/show.ts
@@ -32,7 +32,7 @@ import {
     isIamConnection,
     isSsoConnection,
 } from '../../connection'
-import { tryAddCredentials, signout, showRegionPrompter, addConnection, promptForConnection } from '../../utils'
+import { tryAddCredentials, signout, showRegionPrompter, addConnection, promptAndUseConnection } from '../../utils'
 import { Region } from '../../../shared/regions/endpoints'
 import { CancellationError } from '../../../shared/utilities/timeoutUtils'
 import { validateSsoUrl, validateSsoUrlFormat } from '../../sso/validation'
@@ -317,7 +317,7 @@ export class AuthWebview extends VueWebview {
     }
 
     showConnectionQuickPick() {
-        return promptForConnection(Auth.instance)
+        return promptAndUseConnection(Auth.instance)
     }
 }
 

--- a/src/auth/ui/vue/show.ts
+++ b/src/auth/ui/vue/show.ts
@@ -34,6 +34,7 @@ import { DevSettings } from '../../../shared/settings'
 import { showSsoSignIn } from '../../../codewhisperer/commands/basicCommands'
 import { ServiceItemId } from './types'
 import { awsIdSignIn } from '../../../codewhisperer/util/showSsoPrompt'
+import { connectToEnterpriseSso } from '../../../codewhisperer/util/getStartUrl'
 
 const logger = getLogger()
 export class AuthWebview extends VueWebview {
@@ -180,7 +181,7 @@ export class AuthWebview extends VueWebview {
      */
     async startCWIdentityCenterSetup(startUrl: string, regionId: Region['id']) {
         const setupFunc = () => {
-            return CodeWhispererAuth.instance.connectToEnterpriseSso(startUrl, regionId)
+            return connectToEnterpriseSso(startUrl, regionId)
         }
         return this.ssoSetup(setupFunc)
     }

--- a/src/auth/ui/vue/show.ts
+++ b/src/auth/ui/vue/show.ts
@@ -21,9 +21,8 @@ import { getCredentialFormatError, getCredentialsErrors } from '../../credential
 import { profileExists } from '../../credentials/sharedCredentials'
 import { getLogger } from '../../../shared/logger'
 import { AuthUtil as CodeWhispererAuth } from '../../../codewhisperer/util/authUtil'
-import { awsIdSignIn } from '../../../codewhisperer/util/showSsoPrompt'
 import { CodeCatalystAuthenticationProvider } from '../../../codecatalyst/auth'
-import { getStartedCommand } from '../../../codecatalyst/utils'
+import { getStartedCommand, setupCodeCatalystBuilderId } from '../../../codecatalyst/utils'
 import { ToolkitError } from '../../../shared/errors'
 import { Connection, SsoConnection, createSsoProfile, isBuilderIdConnection, isSsoConnection } from '../../connection'
 import { tryAddCredentials, signout, showRegionPrompter, addConnection, promptForConnection } from '../../utils'
@@ -34,6 +33,7 @@ import { throttle } from '../../../shared/utilities/functionUtils'
 import { DevSettings } from '../../../shared/settings'
 import { showSsoSignIn } from '../../../codewhisperer/commands/basicCommands'
 import { ServiceItemId } from './types'
+import { awsIdSignIn } from '../../../codewhisperer/util/showSsoPrompt'
 
 const logger = getLogger()
 export class AuthWebview extends VueWebview {
@@ -116,8 +116,8 @@ export class AuthWebview extends VueWebview {
         return this.ssoSetup(() => awsIdSignIn())
     }
 
-    async startCodeCatalystBuilderIdSetup(): Promise<void> {
-        return getStartedCommand.execute(this.codeCatalystAuth)
+    async startCodeCatalystBuilderIdSetup(): Promise<string> {
+        return this.ssoSetup(() => setupCodeCatalystBuilderId(this.codeCatalystAuth))
     }
 
     isCodeWhispererBuilderIdConnected(): boolean {

--- a/src/auth/ui/vue/show.ts
+++ b/src/auth/ui/vue/show.ts
@@ -28,7 +28,7 @@ import { Connection, SsoConnection, createSsoProfile, isBuilderIdConnection, isS
 import { tryAddCredentials, signout, showRegionPrompter, addConnection, promptForConnection } from '../../utils'
 import { Region } from '../../../shared/regions/endpoints'
 import { CancellationError } from '../../../shared/utilities/timeoutUtils'
-import { validateSsoUrl } from '../../sso/validation'
+import { validateSsoUrl, validateSsoUrlFormat } from '../../sso/validation'
 import { throttle } from '../../../shared/utilities/functionUtils'
 import { DevSettings } from '../../../shared/settings'
 import { showSsoSignIn } from '../../../codewhisperer/commands/basicCommands'
@@ -250,9 +250,13 @@ export class AuthWebview extends VueWebview {
         return isSsoConnection(conn) && !isBuilderIdConnection(conn)
     }
 
-    getSsoUrlError(url?: string) {
+    getSsoUrlError(url: string | undefined, canUrlExist: boolean = true) {
         if (!url) {
             return
+        }
+        if (canUrlExist) {
+            // Url is allowed to already exist, so we only check the format
+            return validateSsoUrlFormat(url)
         }
         return validateSsoUrl(Auth.instance, url)
     }

--- a/src/codecatalyst/utils.ts
+++ b/src/codecatalyst/utils.ts
@@ -58,17 +58,16 @@ export function isDevenvVscode(ides: Ides | undefined): boolean {
     return ides !== undefined && ides.findIndex(ide => ide.name === 'VSCode') !== -1
 }
 
-export const getStartedCommand = Commands.register(
-    'aws.codecatalyst.getStarted',
-    async (authProvider: CodeCatalystAuthenticationProvider) => {
-        let conn = authProvider.activeConnection ?? (await authProvider.promptNotConnected())
+export const getStartedCommand = Commands.register('aws.codecatalyst.getStarted', setupCodeCatalystBuilderId)
 
-        if (authProvider.auth.getConnectionState(conn) === 'invalid') {
-            conn = await authProvider.auth.reauthenticate(conn)
-        }
+export async function setupCodeCatalystBuilderId(authProvider: CodeCatalystAuthenticationProvider) {
+    let conn = authProvider.activeConnection ?? (await authProvider.promptNotConnected())
 
-        if (!(await authProvider.isConnectionOnboarded(conn, true))) {
-            await authProvider.promptOnboarding()
-        }
+    if (authProvider.auth.getConnectionState(conn) === 'invalid') {
+        conn = await authProvider.auth.reauthenticate(conn)
     }
-)
+
+    if (!(await authProvider.isConnectionOnboarded(conn, true))) {
+        await authProvider.promptOnboarding()
+    }
+}

--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -25,8 +25,8 @@ import {
     isBuilderIdConnection,
 } from '../../auth/connection'
 
-const defaultScopes = [...ssoAccountAccessScopes, ...codewhispererScopes]
-export const awsBuilderIdSsoProfile = createBuilderIdProfile(defaultScopes)
+export const defaultCwScopes = [...ssoAccountAccessScopes, ...codewhispererScopes]
+export const awsBuilderIdSsoProfile = createBuilderIdProfile(defaultCwScopes)
 
 export const isValidCodeWhispererConnection = (conn: Connection): conn is Connection => {
     if (isCloud9('classic')) {
@@ -105,7 +105,7 @@ export class AuthUtil {
         if (!conn) {
             conn = await this.auth.createConnection(awsBuilderIdSsoProfile)
         } else if (!isValidCodeWhispererConnection(conn)) {
-            conn = await this.secondaryAuth.addScopes(conn, defaultScopes)
+            conn = await this.secondaryAuth.addScopes(conn, defaultCwScopes)
         }
 
         if (this.auth.getConnectionState(conn) === 'invalid') {
@@ -122,12 +122,13 @@ export class AuthUtil {
         )
 
         if (!existingConn) {
-            const conn = await this.auth.createConnection(createSsoProfile(startUrl, region, defaultScopes))
+            const conn = await this.auth.createConnection(createSsoProfile(startUrl, region, defaultCwScopes))
             return this.secondaryAuth.useNewConnection(conn)
         } else if (isValidCodeWhispererConnection(existingConn)) {
             return this.secondaryAuth.useNewConnection(existingConn)
         } else if (isSsoConnection(existingConn)) {
-            return this.secondaryAuth.addScopes(existingConn, defaultScopes)
+            const conn = await this.secondaryAuth.addScopes(existingConn, defaultCwScopes)
+            return this.secondaryAuth.useNewConnection(conn)
         }
     }
 

--- a/src/codewhisperer/util/getStartUrl.ts
+++ b/src/codewhisperer/util/getStartUrl.ts
@@ -12,6 +12,7 @@ import { ToolkitError } from '../../shared/errors'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { codewhispererScopes } from '../../auth/connection'
 import { createStartUrlPrompter, showRegionPrompter } from '../../auth/utils'
+import { Region } from '../../shared/regions/endpoints'
 
 export const getStartUrl = async () => {
     const inputBox = await createStartUrlPrompter('IAM Identity Center', codewhispererScopes)
@@ -23,8 +24,12 @@ export const getStartUrl = async () => {
     telemetry.ui_click.emit({ elementId: 'connection_startUrl' })
     const region = await showRegionPrompter()
     telemetry.ui_click.emit({ elementId: 'connection_region' })
+    return connectToEnterpriseSso(userInput, region.id)
+}
+
+export async function connectToEnterpriseSso(startUrl: string, region: Region['id']) {
     try {
-        await AuthUtil.instance.connectToEnterpriseSso(userInput, region.id)
+        await AuthUtil.instance.connectToEnterpriseSso(startUrl, region)
     } catch (e) {
         throw ToolkitError.chain(e, CodeWhispererConstants.failedToConnectIamIdentityCenter, {
             code: 'FailedToConnect',

--- a/src/test/codewhisperer/util/authUtil.test.ts
+++ b/src/test/codewhisperer/util/authUtil.test.ts
@@ -4,7 +4,7 @@
  */
 
 import * as assert from 'assert'
-import { AuthUtil } from '../../../codewhisperer/util/authUtil'
+import { AuthUtil, defaultCwScopes } from '../../../codewhisperer/util/authUtil'
 import { getTestWindow } from '../../shared/vscode/window'
 import { SeverityLevel } from '../../shared/vscode/message'
 import { createBuilderIdProfile, createSsoProfile, createTestAuth } from '../../credentials/testUtil'
@@ -44,6 +44,25 @@ describe('AuthUtil', async function () {
         const conn = authUtil.conn
         assert.strictEqual(conn?.type, 'sso')
         assert.strictEqual(conn.label, 'IAM Identity Center (enterprise)')
+    })
+
+    it('should add scopes + connect to existing IAM Identity Center connection', async function () {
+        getTestWindow().onDidShowMessage(async message => {
+            assert.ok(message.modal)
+            message.selectItem('Proceed')
+        })
+        const randomScope = 'my:random:scope'
+        const ssoConn = await auth.createInvalidSsoConnection(
+            createSsoProfile({ startUrl: enterpriseSsoStartUrl, scopes: [randomScope] })
+        )
+        
+        // Method under test
+        await authUtil.connectToEnterpriseSso(ssoConn.startUrl, 'us-east-1')
+
+        const cwConn = authUtil.conn
+        assert.strictEqual(cwConn?.type, 'sso')
+        assert.strictEqual(cwConn.label, 'IAM Identity Center (enterprise)')
+        assert.deepStrictEqual(cwConn.scopes, [randomScope, ...defaultCwScopes])
     })
 
     it('should show reauthenticate prompt', async function () {


### PR DESCRIPTION
This includes:
- Add/update url links
- During SSO (BuilderID and Identity Center) when something fails in the process we show an error message under the submit button indicating what happened.
- In the scenario where an Identity Center connection already exists and the user wants to use the same IC start url to connect to CodeWhisperer we previously wouldn't allow them since the start url already existed. Now, we will instead allow them to submit using that start url and it will take them through a flow which adds the new scopes to that sso profile.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
