### PR TITLE
fix(cloud9: "Attempted to get compute region without initializing"

### DIFF
--- a/src/shared/sam/cli/samCliValidationNotification.ts
+++ b/src/shared/sam/cli/samCliValidationNotification.ts
@@ -24,23 +24,24 @@ const localize = nls.loadMessageBundle()
 
 // Notification Actions
 export interface SamCliValidationNotificationAction {
-    label: string
+    label(): string
     invoke(): Promise<void>
 }
 
 const actionGoToSamCli: SamCliValidationNotificationAction = {
-    label: localize('AWS.samcli.userChoice.visit.install.url', 'Install latest SAM CLI'),
+    label: () => localize('AWS.samcli.userChoice.visit.install.url', 'Install latest SAM CLI'),
     invoke: async () => {
         openUrl(samInstallUrl)
     },
 }
 
 const actionGoToVsCodeMarketplace: SamCliValidationNotificationAction = {
-    label: localize(
-        'AWS.samcli.userChoice.update.awstoolkit.url',
-        'Install latest {0} Toolkit',
-        getIdeProperties().company
-    ),
+    label: () =>
+        localize(
+            'AWS.samcli.userChoice.update.awstoolkit.url',
+            'Install latest {0} Toolkit',
+            getIdeProperties().company
+        ),
     invoke: async () => {
         showExtensionPage(VSCODE_EXTENSION_ID.awstoolkit)
     },
@@ -60,12 +61,12 @@ class DefaultSamCliValidationNotification implements SamCliValidationNotificatio
     public async show(): Promise<void> {
         const userResponse: string | undefined = await vscode.window.showErrorMessage(
             this.message,
-            ...this.actions.map(action => action.label)
+            ...this.actions.map(action => action.label())
         )
 
         if (userResponse) {
             const responseActions: Promise<void>[] = this.actions
-                .filter(action => action.label === userResponse)
+                .filter(action => action.label() === userResponse)
                 .map(async action => action.invoke())
 
             await Promise.all(responseActions)

--- a/src/test/shared/sam/cli/samCliValidationNotification.test.ts
+++ b/src/test/shared/sam/cli/samCliValidationNotification.test.ts
@@ -34,9 +34,9 @@ describe('getInvalidSamMsg', async function () {
                 assert.ok(message.includes('Cannot find SAM CLI'), `unexpected validation message: ${message}`)
                 assert.strictEqual(actions.length, 1, 'unexpected action count')
                 assert.strictEqual(
-                    actions[0].label,
+                    actions[0].label(),
                     actionLabelUpdateSamCli,
-                    `unexpected action label: ${actions[0].label}`
+                    `unexpected action label: ${actions[0].label()}`
                 )
 
                 return fakeSamCliValidationNotification
@@ -83,9 +83,9 @@ describe('getInvalidSamMsg', async function () {
                     assert.ok(hasMsg && hasVersion, `unexpected validation message: ${message}`)
                     assert.strictEqual(actions.length, 1, 'unexpected action count')
                     assert.strictEqual(
-                        actions[0].label,
+                        actions[0].label(),
                         test.actionLabel,
-                        `unexpected action label: ${actions[0].label}`
+                        `unexpected action label: ${actions[0].label()}`
                     )
 
                     return fakeSamCliValidationNotification


### PR DESCRIPTION
Problem:
since 4e40536c031abe09a9c5f8adb39e2018975fec85 the Toolkit can't load on cloud9:

    INFO ExtHost [error]: Error: Attempted to get compute region without initializing.
        at getComputeRegion (/opt/c9/dependencies/aws-toolkit-vscode/…/dist/src/main.js:377606:11)
        at isCn (/opt/c9/dependencies/aws-toolkit-vscode/…/dist/src/main.js:377457:22)
        at getIdeProperties (/opt/c9/dependencies/aws-toolkit-vscode/…/dist/src/main.js:377429:11)

Solution:
Lazy-load `SamCliValidationNotificationAction.label()`.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
