### PR TITLE
refactor: Remove additional prompt for CC Builder ID

### DIFF
--- a/src/codecatalyst/auth.ts
+++ b/src/codecatalyst/auth.ts
@@ -5,7 +5,6 @@
 
 import * as vscode from 'vscode'
 import { CodeCatalystClient, createClient } from '../shared/clients/codecatalystClient'
-import { getIdeProperties } from '../shared/extensionUtilities'
 import { Auth } from '../auth/auth'
 import { getSecondaryAuth } from '../auth/secondaryAuth'
 import { getLogger } from '../shared/logger'
@@ -137,15 +136,6 @@ export class CodeCatalystAuthenticationProvider {
             telemetry.record({
                 codecatalyst_connectionFlow: 'Create',
             } satisfies ConnectionFlowEvent as MetricShapes[MetricName])
-
-            const message = `The ${
-                getIdeProperties().company
-            } Toolkit extension requires a connection for CodeCatalyst to begin.\n\n Proceed to the browser to allow access?`
-
-            const resp = await vscode.window.showInformationMessage(message, { modal: true }, continueItem, cancelItem)
-            if (resp !== continueItem) {
-                throw new ToolkitError('Not connected to CodeCatalyst', { code: 'NoConnection', cancelled: true })
-            }
 
             const newConn = await createBuilderIdConnection(this.auth, defaultScopes)
             if (this.auth.activeConnection?.id !== newConn.id) {


### PR DESCRIPTION
## Problem

When connection to CodeCatalyst Builder ID there is a prompt that asks if you would like to go to the browser but then immediately follows up with a prompt to copy a code then open the browser.

The initial prompt was created before the second one existed.

## Solution

Remove the initial prompt since it is not needed.

#### Before
![BuilderIdBefore](https://github.com/aws/aws-toolkit-vscode/assets/118216176/6f702d72-ac63-4bfa-83b9-ee8c30116142)

#### After
![BuilderIdCWAfter](https://github.com/aws/aws-toolkit-vscode/assets/118216176/faa5d24e-e688-441f-8d71-b7c298d05cb1)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
