### PR TITLE
fix(cwl): change test text

### DIFF
--- a/src/test/cloudWatchLogs/commands/copyLogResource.test.ts
+++ b/src/test/cloudWatchLogs/commands/copyLogResource.test.ts
@@ -8,8 +8,7 @@ import * as vscode from 'vscode'
 import { createURIFromArgs } from '../../../cloudWatchLogs/cloudWatchLogsUtils'
 import { copyLogResource } from '../../../cloudWatchLogs/commands/copyLogResource'
 
-describe('copyLogStreamName', async function () {
-
+describe('copyLogResourceName', async function () {
     beforeEach(async function () {
         await vscode.env.clipboard.writeText('')
     })
@@ -20,21 +19,21 @@ describe('copyLogStreamName', async function () {
 
     it('copies stream names from valid URIs with stream open', async function () {
         const logGroupWithStream = {
-            groupName: 'group', 
-            regionName: 'region', 
-            streamName: 'stream'
+            groupName: 'group',
+            regionName: 'region',
+            streamName: 'stream',
         }
         const uri = createURIFromArgs(logGroupWithStream, {})
 
-        await copyLogResource(uri);
+        await copyLogResource(uri)
 
         assert.strictEqual(await vscode.env.clipboard.readText(), logGroupWithStream.streamName)
     })
 
-    it('copies group names from valid URIs with group open', async function() {
+    it('copies group names from valid URIs with group open', async function () {
         const logGroup = {
             groupName: 'group2',
-            regionName: 'region2'
+            regionName: 'region2',
         }
         const uri = createURIFromArgs(logGroup, {})
 

--- a/src/test/cloudWatchLogs/commands/copyLogResource.test.ts
+++ b/src/test/cloudWatchLogs/commands/copyLogResource.test.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode'
 import { createURIFromArgs } from '../../../cloudWatchLogs/cloudWatchLogsUtils'
 import { copyLogResource } from '../../../cloudWatchLogs/commands/copyLogResource'
 
-describe('copyLogResourceName', async function () {
+describe('copyLogResource', async function () {
     beforeEach(async function () {
         await vscode.env.clipboard.writeText('')
     })


### PR DESCRIPTION
## Problem
As part of https://github.com/aws/aws-toolkit-vscode/pull/3558, the `copyLogStreamName` was generalized to `copyLogResource`, however, the test file names the test `copyLogStreamName`. 
## Solution
To avoid confusion later and to be consistent with the rest of the toolkit, we should rename it `copyLogResource`. 

### Notes:
- the other changes in this PR are purely from styling fixes. 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
