### PR TITLE
codewhisperer: Remove trailing / or # from startUrl

### DIFF
--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -66,7 +66,11 @@ export class AuthUtil {
             } else {
                 this.usingEnterpriseSSO = false
             }
-            TelemetryHelper.instance.startUrl = isSsoConnection(this.conn) ? this.conn?.startUrl : undefined
+            // Reformat the url to remove any trailing '/' and `#`
+            // e.g. https://view.awsapps.com/start/# will become https://view.awsapps.com/start
+            TelemetryHelper.instance.startUrl = isSsoConnection(this.conn)
+                ? this.reformatStartUrl(this.conn?.startUrl)
+                : undefined
             await Promise.all([
                 vscode.commands.executeCommand('aws.codeWhisperer.refresh'),
                 vscode.commands.executeCommand('aws.codeWhisperer.refreshRootNode'),
@@ -76,6 +80,10 @@ export class AuthUtil {
 
             await vscode.commands.executeCommand('setContext', 'CODEWHISPERER_ENABLED', this.isConnected())
         })
+    }
+
+    public reformatStartUrl(startUrl: string | undefined) {
+        return !startUrl ? undefined : startUrl.replace(/[\/#]+$/g, '')
     }
 
     // current active cwspr connection

--- a/src/test/codewhisperer/util/authUtil.test.ts
+++ b/src/test/codewhisperer/util/authUtil.test.ts
@@ -55,7 +55,7 @@ describe('AuthUtil', async function () {
         const ssoConn = await auth.createInvalidSsoConnection(
             createSsoProfile({ startUrl: enterpriseSsoStartUrl, scopes: [randomScope] })
         )
-        
+
         // Method under test
         await authUtil.connectToEnterpriseSso(ssoConn.startUrl, 'us-east-1')
 
@@ -133,5 +133,15 @@ describe('AuthUtil', async function () {
         assert.strictEqual(authUtil.conn.startUrl, upgradeableConn.startUrl)
         assert.strictEqual(authUtil.conn.ssoRegion, upgradeableConn.ssoRegion)
         assert.strictEqual((await auth.listConnections()).filter(isSsoConnection).length, 1)
+    })
+
+    it('test reformatStartUrl should remove trailing slash and hash', function () {
+        const expected = 'https://view.awsapps.com/start'
+        assert.strictEqual(authUtil.reformatStartUrl(expected + '/'), expected)
+        assert.strictEqual(authUtil.reformatStartUrl(undefined), undefined)
+        assert.strictEqual(authUtil.reformatStartUrl(expected + '/#'), expected)
+        assert.strictEqual(authUtil.reformatStartUrl(expected + '#/'), expected)
+        assert.strictEqual(authUtil.reformatStartUrl(expected + '/#/'), expected)
+        assert.strictEqual(authUtil.reformatStartUrl(expected + '####'), expected)
     })
 })


### PR DESCRIPTION
This is for the consistency of such value for telemetry

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
