### PR TITLE
authWebview: Various fixes

### DIFF
--- a/src/auth/ui/vue/authForms/manageBuilderId.vue
+++ b/src/auth/ui/vue/authForms/manageBuilderId.vue
@@ -5,7 +5,7 @@
 
             <div v-if="stage === 'START'">
                 <div class="form-section">
-                    <div>
+                    <div style="color: #cccccc">
                         With AWS Builder ID, sign in for free without an AWS account.
                         <a href="https://docs.aws.amazon.com/signin/latest/userguide/sign-in-aws_builder_id.html"
                             >Read more.</a

--- a/src/auth/ui/vue/authForms/manageBuilderId.vue
+++ b/src/auth/ui/vue/authForms/manageBuilderId.vue
@@ -7,9 +7,7 @@
                 <div class="form-section">
                     <div style="color: #cccccc">
                         With AWS Builder ID, sign in for free without an AWS account.
-                        <a href="https://docs.aws.amazon.com/signin/latest/userguide/sign-in-aws_builder_id.html"
-                            >Read more.</a
-                        >
+                        <a :href="signUpUrl">Read more.</a>
                     </div>
                 </div>
 
@@ -68,9 +66,11 @@ export default defineComponent({
             builderIdCode: '',
             name: this.state.name,
             error: '' as string,
+            signUpUrl: '' as string,
         }
     },
     async created() {
+        this.signUpUrl = this.getSignUpUrl()
         await this.update('created')
     },
     methods: {
@@ -94,6 +94,9 @@ export default defineComponent({
         },
         showNodeInView() {
             this.state.showNodeInView()
+        },
+        getSignUpUrl() {
+            return this.state.getSignUpUrl()
         },
     },
 })
@@ -124,6 +127,10 @@ abstract class BaseBuilderIdState implements AuthStatus {
     async signout(): Promise<void> {
         await client.signoutBuilderId()
     }
+
+    getSignUpUrl(): string {
+        return 'https://docs.aws.amazon.com/signin/latest/userguide/sign-in-aws_builder_id.html'
+    }
 }
 
 export class CodeWhispererBuilderIdState extends BaseBuilderIdState {
@@ -145,6 +152,10 @@ export class CodeWhispererBuilderIdState extends BaseBuilderIdState {
 
     override showNodeInView(): Promise<void> {
         return client.showCodeWhispererNode()
+    }
+
+    override getSignUpUrl(): string {
+        return 'https://docs.aws.amazon.com/codewhisperer/latest/userguide/whisper-setup-indv-devs.html'
     }
 }
 

--- a/src/auth/ui/vue/authForms/manageCredentials.vue
+++ b/src/auth/ui/vue/authForms/manageCredentials.vue
@@ -17,7 +17,7 @@
                     <label class="small-description"
                         >Credentials will be added to the appropriate `~/.aws/` files.</label
                     >
-                    <div v-on:click="editCredentialsFile()" style="cursor: pointer">
+                    <div v-on:click="editCredentialsFile()" style="cursor: pointer; color: #cccccc">
                         <div class="icon icon-vscode-edit edit-icon"></div>
                         Edit file directly
                     </div>

--- a/src/auth/ui/vue/authForms/manageIdentityCenter.vue
+++ b/src/auth/ui/vue/authForms/manageIdentityCenter.vue
@@ -32,8 +32,8 @@
                 <label class="input-title">Region</label>
                 <label class="small-description">AWS Region that hosts Identity directory</label>
 
-                <div style="display: flex; flex-direction: row; gap: 10px">
-                    <div v-on:click="getRegion()" class="icon icon-lg icon-vscode-edit edit-icon"></div>
+                <div v-on:click="getRegion()" style="display: flex; flex-direction: row; gap: 10px; cursor: pointer">
+                    <div class="icon icon-lg icon-vscode-edit edit-icon"></div>
                     <div style="width: 100%; color: #cccccc">{{ data.region ? data.region : 'Not Selected' }}</div>
                 </div>
             </div>
@@ -187,10 +187,7 @@ abstract class BaseIdentityCenterState implements AuthStatus {
     protected _stage: IdentityCenterStage = 'START'
 
     constructor() {
-        this._data = {
-            startUrl: '',
-            region: '',
-        }
+        this._data = BaseIdentityCenterState.initialData()
     }
 
     abstract get id(): AuthFormId
@@ -220,10 +217,7 @@ abstract class BaseIdentityCenterState implements AuthStatus {
         // Successful submission, so we can clear
         // old data.
         if (!error) {
-            this._data = {
-                startUrl: '',
-                region: '',
-            }
+            this._data = BaseIdentityCenterState.initialData()
         }
         return error
     }
@@ -251,6 +245,13 @@ abstract class BaseIdentityCenterState implements AuthStatus {
 
     protected async getSubmittableDataOrThrow(): Promise<IdentityCenterData> {
         return this._data as IdentityCenterData
+    }
+
+    private static initialData(): IdentityCenterData {
+        return {
+            startUrl: '',
+            region: 'us-east-1',
+        }
     }
 }
 

--- a/src/auth/ui/vue/authForms/manageIdentityCenter.vue
+++ b/src/auth/ui/vue/authForms/manageIdentityCenter.vue
@@ -7,7 +7,7 @@
                     href="https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/sso-credentials.html"
                 ></a
             ></FormTitle>
-            <div v-if="!isConnected">Successor to AWS Single Sign-on</div>
+            <div v-if="!isConnected" style="color: #cccccc">Successor to AWS Single Sign-on</div>
         </div>
         <div v-else>
             <!-- In this scenario we do not care about the active IC connection -->
@@ -17,7 +17,7 @@
                     href="https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/sso-credentials.html"
                 ></a
             ></FormTitle>
-            <div>Successor to AWS Single Sign-on</div>
+            <div style="color: #cccccc">Successor to AWS Single Sign-on</div>
         </div>
 
         <div v-if="stage === 'START'">
@@ -34,7 +34,7 @@
 
                 <div style="display: flex; flex-direction: row; gap: 10px">
                     <div v-on:click="getRegion()" class="icon icon-lg icon-vscode-edit edit-icon"></div>
-                    <div style="width: 100%">{{ data.region ? data.region : 'Not Selected' }}</div>
+                    <div style="width: 100%; color: #cccccc">{{ data.region ? data.region : 'Not Selected' }}</div>
                 </div>
             </div>
 

--- a/src/auth/ui/vue/authForms/sharedAuthForms.css
+++ b/src/auth/ui/vue/authForms/sharedAuthForms.css
@@ -2,6 +2,7 @@
     display: flex;
     flex-direction: column;
     text-align: left;
+    color: #ffffff;
 
     padding: 10px;
 }
@@ -16,6 +17,11 @@
 
 /* Consistent margins between the elements of a grouping of elements */
 .auth-form .form-section > * {
+    margin-top: 3px;
+}
+
+/* Consistent margins between the elements of a grouping of elements */
+.auth-form .form-section > button {
     margin-top: 3px;
 }
 

--- a/src/auth/ui/vue/authForms/sharedAuthForms.css
+++ b/src/auth/ui/vue/authForms/sharedAuthForms.css
@@ -47,6 +47,7 @@
 
 .error-text {
     color: #f14c4c;
+    font-size: 12px;
 }
 
 input[data-invalid='true'] {

--- a/src/auth/ui/vue/root.vue
+++ b/src/auth/ui/vue/root.vue
@@ -211,7 +211,7 @@ export default defineComponent({
     },
     methods: {
         isLandscape() {
-            return this.currWindowWidth > 1350
+            return this.currWindowWidth > 1200
         },
         isAnyServiceSelected(): boolean {
             return serviceItemsState.selected !== undefined

--- a/src/auth/ui/vue/root.vue
+++ b/src/auth/ui/vue/root.vue
@@ -1,39 +1,10 @@
 <template>
-    <div style="display: flex; flex-direction: row; gap: 20px; padding-top: 20px">
-        <div :style="{ display: 'flex', flexDirection: 'column', gap: '20px' }">
-            <!-- Logo + Title -->
-            <div>
-                <div style="display: flex; justify-content: left; align-items: center; gap: 25px">
-                    <div style="fill: white">
-                        <svg
-                            id="Layer_1"
-                            data-name="Layer 1"
-                            xmlns="http://www.w3.org/2000/svg"
-                            width="52pt"
-                            height="32pt"
-                            viewBox="0 0 50 30"
-                        >
-                            <path
-                                d="M14.09,10.85a4.7,4.7,0,0,0,.19,1.48,7.73,7.73,0,0,0,.54,1.19.77.77,0,0,1,.12.38.64.64,0,0,1-.32.49l-1,.7a.83.83,0,0,1-.44.15.69.69,0,0,1-.49-.23,3.8,3.8,0,0,1-.6-.77q-.25-.42-.51-1a6.14,6.14,0,0,1-4.89,2.3,4.54,4.54,0,0,1-3.32-1.19,4.27,4.27,0,0,1-1.22-3.2A4.28,4.28,0,0,1,3.61,7.75,6.06,6.06,0,0,1,7.69,6.46a12.47,12.47,0,0,1,1.76.13q.92.13,1.91.36V5.73a3.65,3.65,0,0,0-.79-2.66A3.81,3.81,0,0,0,7.86,2.3a7.71,7.71,0,0,0-1.79.22,12.78,12.78,0,0,0-1.79.57,4.55,4.55,0,0,1-.58.22l-.26,0q-.35,0-.35-.52V2a1.09,1.09,0,0,1,.12-.58,1.2,1.2,0,0,1,.47-.35A10.88,10.88,0,0,1,5.77.32,10.19,10.19,0,0,1,8.36,0a6,6,0,0,1,4.35,1.35,5.49,5.49,0,0,1,1.38,4.09ZM7.34,13.38a5.36,5.36,0,0,0,1.72-.31A3.63,3.63,0,0,0,10.63,12,2.62,2.62,0,0,0,11.19,11a5.63,5.63,0,0,0,.16-1.44v-.7a14.35,14.35,0,0,0-1.53-.28,12.37,12.37,0,0,0-1.56-.1,3.84,3.84,0,0,0-2.47.67A2.34,2.34,0,0,0,5,11a2.35,2.35,0,0,0,.61,1.76A2.4,2.4,0,0,0,7.34,13.38Zm13.35,1.8a1,1,0,0,1-.64-.16,1.3,1.3,0,0,1-.35-.65L15.81,1.51a3,3,0,0,1-.15-.67.36.36,0,0,1,.41-.41H17.7a1,1,0,0,1,.65.16,1.4,1.4,0,0,1,.33.65l2.79,11,2.59-11A1.17,1.17,0,0,1,24.39.6a1.1,1.1,0,0,1,.67-.16H26.4a1.1,1.1,0,0,1,.67.16,1.17,1.17,0,0,1,.32.65L30,12.39,32.88,1.25A1.39,1.39,0,0,1,33.22.6a1,1,0,0,1,.65-.16h1.54a.36.36,0,0,1,.41.41,1.36,1.36,0,0,1,0,.26,3.64,3.64,0,0,1-.12.41l-4,12.86a1.3,1.3,0,0,1-.35.65,1,1,0,0,1-.64.16H29.25a1,1,0,0,1-.67-.17,1.26,1.26,0,0,1-.32-.67L25.67,3.64,23.11,14.34a1.26,1.26,0,0,1-.32.67,1,1,0,0,1-.67.17Zm21.36.44a11.28,11.28,0,0,1-2.56-.29,7.44,7.44,0,0,1-1.92-.67,1,1,0,0,1-.61-.93v-.84q0-.52.38-.52a.9.9,0,0,1,.31.06l.42.17a8.77,8.77,0,0,0,1.83.58,9.78,9.78,0,0,0,2,.2,4.48,4.48,0,0,0,2.43-.55,1.76,1.76,0,0,0,.86-1.57,1.61,1.61,0,0,0-.45-1.16A4.29,4.29,0,0,0,43,9.22l-2.41-.76A5.15,5.15,0,0,1,38,6.78a3.94,3.94,0,0,1-.83-2.41,3.7,3.7,0,0,1,.45-1.85,4.47,4.47,0,0,1,1.19-1.37A5.27,5.27,0,0,1,40.51.29,7.4,7.4,0,0,1,42.6,0a8.87,8.87,0,0,1,1.12.07q.57.07,1.08.19t.95.26a4.27,4.27,0,0,1,.7.29,1.59,1.59,0,0,1,.49.41.94.94,0,0,1,.15.55v.79q0,.52-.38.52a1.76,1.76,0,0,1-.64-.2,7.74,7.74,0,0,0-3.2-.64,4.37,4.37,0,0,0-2.21.47,1.6,1.6,0,0,0-.79,1.48,1.58,1.58,0,0,0,.49,1.18,4.94,4.94,0,0,0,1.83.92L44.55,7a5.08,5.08,0,0,1,2.57,1.6A3.76,3.76,0,0,1,47.9,11a4.21,4.21,0,0,1-.44,1.93,4.4,4.4,0,0,1-1.21,1.47,5.43,5.43,0,0,1-1.85.93A8.25,8.25,0,0,1,42.05,15.62Z"
-                            />
-                            <path
-                                class="cls-1"
-                                d="M45.19,23.81C39.72,27.85,31.78,30,25,30A36.64,36.64,0,0,1,.22,20.57c-.51-.46-.06-1.09.56-.74A49.78,49.78,0,0,0,25.53,26.4,49.23,49.23,0,0,0,44.4,22.53C45.32,22.14,46.1,23.14,45.19,23.81Z"
-                            />
-                            <path
-                                class="cls-1"
-                                d="M47.47,21.21c-.7-.9-4.63-.42-6.39-.21-.53.06-.62-.4-.14-.74,3.13-2.2,8.27-1.57,8.86-.83s-.16,5.89-3.09,8.35c-.45.38-.88.18-.68-.32C46.69,25.8,48.17,22.11,47.47,21.21Z"
-                            />
-                        </svg>
-                    </div>
-                    <div>
-                        <h3>AWS Toolkit for VSCode</h3>
-                        <h1>Welcome & Getting Started</h1>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Status Bar -->
+    <div style="display: flex; flex-direction: column; gap: 20px; padding-top: 20px">
+        <!-- Status Bars -->
+        <div
+            v-if="successfulAuthConnection || foundCredentialButNotConnected"
+            style="display: flex; flex-direction: column; gap: 20px"
+        >
             <div
                 v-if="successfulAuthConnection"
                 class="border-common"
@@ -63,8 +34,6 @@
                     class="icon icon-lg icon-vscode-chrome-close"
                 ></div>
             </div>
-
-            <!-- Status Bar -->
             <div
                 v-if="foundCredentialButNotConnected"
                 class="border-common"
@@ -94,50 +63,85 @@
                     class="icon icon-lg icon-vscode-chrome-close"
                 ></div>
             </div>
-
-            <!-- Left side clickable boxes for features/services -->
-            <div class="flex-container">
-                <div id="left-column">
-                    <div>
-                        <h1>Select a feature to begin</h1>
-                        <ul class="service-item-list" v-for="item in serviceItems">
-                            <ServiceItem
-                                :title="getServiceItemProps(item.id).title"
-                                :description="getServiceItemProps(item.id).description"
-                                :status="item.status"
-                                :isSelected="isServiceSelected(item.id)"
-                                :isLandscape="isLandscape()"
-                                :id="item.id"
-                                :key="buildServiceItemKey(item.id, item.status)"
-                                @service-item-clicked="serviceWasClicked(item.id)"
+        </div>
+        <div style="display: flex; flex-direction: row; gap: 20px">
+            <div :style="{ display: 'flex', flexDirection: 'column', gap: '20px' }">
+                <!-- Logo + Title -->
+                <div>
+                    <div style="display: flex; justify-content: left; align-items: center; gap: 25px">
+                        <div style="fill: white">
+                            <svg
+                                id="Layer_1"
+                                data-name="Layer 1"
+                                xmlns="http://www.w3.org/2000/svg"
+                                width="52pt"
+                                height="32pt"
+                                viewBox="0 0 50 30"
                             >
-                                <!-- Content window that appears under when in portrait mode -->
-                                <template
-                                    v-slot:service-item-content-slot
-                                    v-if="isServiceSelected(item.id) && !isLandscape()"
+                                <path
+                                    d="M14.09,10.85a4.7,4.7,0,0,0,.19,1.48,7.73,7.73,0,0,0,.54,1.19.77.77,0,0,1,.12.38.64.64,0,0,1-.32.49l-1,.7a.83.83,0,0,1-.44.15.69.69,0,0,1-.49-.23,3.8,3.8,0,0,1-.6-.77q-.25-.42-.51-1a6.14,6.14,0,0,1-4.89,2.3,4.54,4.54,0,0,1-3.32-1.19,4.27,4.27,0,0,1-1.22-3.2A4.28,4.28,0,0,1,3.61,7.75,6.06,6.06,0,0,1,7.69,6.46a12.47,12.47,0,0,1,1.76.13q.92.13,1.91.36V5.73a3.65,3.65,0,0,0-.79-2.66A3.81,3.81,0,0,0,7.86,2.3a7.71,7.71,0,0,0-1.79.22,12.78,12.78,0,0,0-1.79.57,4.55,4.55,0,0,1-.58.22l-.26,0q-.35,0-.35-.52V2a1.09,1.09,0,0,1,.12-.58,1.2,1.2,0,0,1,.47-.35A10.88,10.88,0,0,1,5.77.32,10.19,10.19,0,0,1,8.36,0a6,6,0,0,1,4.35,1.35,5.49,5.49,0,0,1,1.38,4.09ZM7.34,13.38a5.36,5.36,0,0,0,1.72-.31A3.63,3.63,0,0,0,10.63,12,2.62,2.62,0,0,0,11.19,11a5.63,5.63,0,0,0,.16-1.44v-.7a14.35,14.35,0,0,0-1.53-.28,12.37,12.37,0,0,0-1.56-.1,3.84,3.84,0,0,0-2.47.67A2.34,2.34,0,0,0,5,11a2.35,2.35,0,0,0,.61,1.76A2.4,2.4,0,0,0,7.34,13.38Zm13.35,1.8a1,1,0,0,1-.64-.16,1.3,1.3,0,0,1-.35-.65L15.81,1.51a3,3,0,0,1-.15-.67.36.36,0,0,1,.41-.41H17.7a1,1,0,0,1,.65.16,1.4,1.4,0,0,1,.33.65l2.79,11,2.59-11A1.17,1.17,0,0,1,24.39.6a1.1,1.1,0,0,1,.67-.16H26.4a1.1,1.1,0,0,1,.67.16,1.17,1.17,0,0,1,.32.65L30,12.39,32.88,1.25A1.39,1.39,0,0,1,33.22.6a1,1,0,0,1,.65-.16h1.54a.36.36,0,0,1,.41.41,1.36,1.36,0,0,1,0,.26,3.64,3.64,0,0,1-.12.41l-4,12.86a1.3,1.3,0,0,1-.35.65,1,1,0,0,1-.64.16H29.25a1,1,0,0,1-.67-.17,1.26,1.26,0,0,1-.32-.67L25.67,3.64,23.11,14.34a1.26,1.26,0,0,1-.32.67,1,1,0,0,1-.67.17Zm21.36.44a11.28,11.28,0,0,1-2.56-.29,7.44,7.44,0,0,1-1.92-.67,1,1,0,0,1-.61-.93v-.84q0-.52.38-.52a.9.9,0,0,1,.31.06l.42.17a8.77,8.77,0,0,0,1.83.58,9.78,9.78,0,0,0,2,.2,4.48,4.48,0,0,0,2.43-.55,1.76,1.76,0,0,0,.86-1.57,1.61,1.61,0,0,0-.45-1.16A4.29,4.29,0,0,0,43,9.22l-2.41-.76A5.15,5.15,0,0,1,38,6.78a3.94,3.94,0,0,1-.83-2.41,3.7,3.7,0,0,1,.45-1.85,4.47,4.47,0,0,1,1.19-1.37A5.27,5.27,0,0,1,40.51.29,7.4,7.4,0,0,1,42.6,0a8.87,8.87,0,0,1,1.12.07q.57.07,1.08.19t.95.26a4.27,4.27,0,0,1,.7.29,1.59,1.59,0,0,1,.49.41.94.94,0,0,1,.15.55v.79q0,.52-.38.52a1.76,1.76,0,0,1-.64-.2,7.74,7.74,0,0,0-3.2-.64,4.37,4.37,0,0,0-2.21.47,1.6,1.6,0,0,0-.79,1.48,1.58,1.58,0,0,0,.49,1.18,4.94,4.94,0,0,0,1.83.92L44.55,7a5.08,5.08,0,0,1,2.57,1.6A3.76,3.76,0,0,1,47.9,11a4.21,4.21,0,0,1-.44,1.93,4.4,4.4,0,0,1-1.21,1.47,5.43,5.43,0,0,1-1.85.93A8.25,8.25,0,0,1,42.05,15.62Z"
+                                />
+                                <path
+                                    class="cls-1"
+                                    d="M45.19,23.81C39.72,27.85,31.78,30,25,30A36.64,36.64,0,0,1,.22,20.57c-.51-.46-.06-1.09.56-.74A49.78,49.78,0,0,0,25.53,26.4,49.23,49.23,0,0,0,44.4,22.53C45.32,22.14,46.1,23.14,45.19,23.81Z"
+                                />
+                                <path
+                                    class="cls-1"
+                                    d="M47.47,21.21c-.7-.9-4.63-.42-6.39-.21-.53.06-.62-.4-.14-.74,3.13-2.2,8.27-1.57,8.86-.83s-.16,5.89-3.09,8.35c-.45.38-.88.18-.68-.32C46.69,25.8,48.17,22.11,47.47,21.21Z"
+                                />
+                            </svg>
+                        </div>
+                        <div>
+                            <h3>AWS Toolkit for VSCode</h3>
+                            <h1>Welcome & Getting Started</h1>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Left side clickable boxes for features/services -->
+                <div class="flex-container">
+                    <div id="left-column">
+                        <div>
+                            <h1>Select a feature to begin</h1>
+                            <ul class="service-item-list" v-for="item in serviceItems">
+                                <ServiceItem
+                                    :title="getServiceItemProps(item.id).title"
+                                    :description="getServiceItemProps(item.id).description"
+                                    :status="item.status"
+                                    :isSelected="isServiceSelected(item.id)"
+                                    :isLandscape="isLandscape()"
+                                    :id="item.id"
+                                    :key="buildServiceItemKey(item.id, item.status)"
+                                    @service-item-clicked="serviceWasClicked(item.id)"
                                 >
-                                    <component
-                                        :is="getServiceItemContent(item.id)"
-                                        :state="serviceItemsAuthStatus[item.id]"
-                                        :key="item.id + rerenderContentWindowKey"
-                                        @auth-connection-updated="onAuthConnectionUpdated"
-                                    ></component>
-                                </template>
-                            </ServiceItem>
-                        </ul>
+                                    <!-- Content window that appears under when in portrait mode -->
+                                    <template
+                                        v-slot:service-item-content-slot
+                                        v-if="isServiceSelected(item.id) && !isLandscape()"
+                                    >
+                                        <component
+                                            :is="getServiceItemContent(item.id)"
+                                            :state="serviceItemsAuthStatus[item.id]"
+                                            :key="item.id + rerenderContentWindowKey"
+                                            @auth-connection-updated="onAuthConnectionUpdated"
+                                        ></component>
+                                    </template>
+                                </ServiceItem>
+                            </ul>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
 
-        <!-- Content window that appears on the right -->
-        <div v-if="isLandscape() && isAnyServiceSelected()" id="right-column">
-            <component
-                :is="getServiceItemContent(getSelectedService())"
-                :state="serviceItemsAuthStatus[getSelectedService()]"
-                :key="getSelectedService() + rerenderContentWindowKey"
-                @auth-connection-updated="onAuthConnectionUpdated"
-            ></component>
+            <!-- Content window that appears on the right -->
+            <div v-if="isLandscape() && isAnyServiceSelected()" id="right-column">
+                <component
+                    :is="getServiceItemContent(getSelectedService())"
+                    :state="serviceItemsAuthStatus[getSelectedService()]"
+                    :key="getSelectedService() + rerenderContentWindowKey"
+                    @auth-connection-updated="onAuthConnectionUpdated"
+                ></component>
+            </div>
         </div>
     </div>
 </template>

--- a/src/auth/ui/vue/root.vue
+++ b/src/auth/ui/vue/root.vue
@@ -1,136 +1,143 @@
 <template>
-    <div :style="{ display: 'flex', flexDirection: 'column', gap: '20px' }">
-        <div>
-            <div style="display: flex; justify-content: left; align-items: center; gap: 25px">
-                <div style="fill: white">
-                    <svg
-                        id="Layer_1"
-                        data-name="Layer 1"
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="52pt"
-                        height="32pt"
-                        viewBox="0 0 50 30"
-                    >
-                        <path
-                            d="M14.09,10.85a4.7,4.7,0,0,0,.19,1.48,7.73,7.73,0,0,0,.54,1.19.77.77,0,0,1,.12.38.64.64,0,0,1-.32.49l-1,.7a.83.83,0,0,1-.44.15.69.69,0,0,1-.49-.23,3.8,3.8,0,0,1-.6-.77q-.25-.42-.51-1a6.14,6.14,0,0,1-4.89,2.3,4.54,4.54,0,0,1-3.32-1.19,4.27,4.27,0,0,1-1.22-3.2A4.28,4.28,0,0,1,3.61,7.75,6.06,6.06,0,0,1,7.69,6.46a12.47,12.47,0,0,1,1.76.13q.92.13,1.91.36V5.73a3.65,3.65,0,0,0-.79-2.66A3.81,3.81,0,0,0,7.86,2.3a7.71,7.71,0,0,0-1.79.22,12.78,12.78,0,0,0-1.79.57,4.55,4.55,0,0,1-.58.22l-.26,0q-.35,0-.35-.52V2a1.09,1.09,0,0,1,.12-.58,1.2,1.2,0,0,1,.47-.35A10.88,10.88,0,0,1,5.77.32,10.19,10.19,0,0,1,8.36,0a6,6,0,0,1,4.35,1.35,5.49,5.49,0,0,1,1.38,4.09ZM7.34,13.38a5.36,5.36,0,0,0,1.72-.31A3.63,3.63,0,0,0,10.63,12,2.62,2.62,0,0,0,11.19,11a5.63,5.63,0,0,0,.16-1.44v-.7a14.35,14.35,0,0,0-1.53-.28,12.37,12.37,0,0,0-1.56-.1,3.84,3.84,0,0,0-2.47.67A2.34,2.34,0,0,0,5,11a2.35,2.35,0,0,0,.61,1.76A2.4,2.4,0,0,0,7.34,13.38Zm13.35,1.8a1,1,0,0,1-.64-.16,1.3,1.3,0,0,1-.35-.65L15.81,1.51a3,3,0,0,1-.15-.67.36.36,0,0,1,.41-.41H17.7a1,1,0,0,1,.65.16,1.4,1.4,0,0,1,.33.65l2.79,11,2.59-11A1.17,1.17,0,0,1,24.39.6a1.1,1.1,0,0,1,.67-.16H26.4a1.1,1.1,0,0,1,.67.16,1.17,1.17,0,0,1,.32.65L30,12.39,32.88,1.25A1.39,1.39,0,0,1,33.22.6a1,1,0,0,1,.65-.16h1.54a.36.36,0,0,1,.41.41,1.36,1.36,0,0,1,0,.26,3.64,3.64,0,0,1-.12.41l-4,12.86a1.3,1.3,0,0,1-.35.65,1,1,0,0,1-.64.16H29.25a1,1,0,0,1-.67-.17,1.26,1.26,0,0,1-.32-.67L25.67,3.64,23.11,14.34a1.26,1.26,0,0,1-.32.67,1,1,0,0,1-.67.17Zm21.36.44a11.28,11.28,0,0,1-2.56-.29,7.44,7.44,0,0,1-1.92-.67,1,1,0,0,1-.61-.93v-.84q0-.52.38-.52a.9.9,0,0,1,.31.06l.42.17a8.77,8.77,0,0,0,1.83.58,9.78,9.78,0,0,0,2,.2,4.48,4.48,0,0,0,2.43-.55,1.76,1.76,0,0,0,.86-1.57,1.61,1.61,0,0,0-.45-1.16A4.29,4.29,0,0,0,43,9.22l-2.41-.76A5.15,5.15,0,0,1,38,6.78a3.94,3.94,0,0,1-.83-2.41,3.7,3.7,0,0,1,.45-1.85,4.47,4.47,0,0,1,1.19-1.37A5.27,5.27,0,0,1,40.51.29,7.4,7.4,0,0,1,42.6,0a8.87,8.87,0,0,1,1.12.07q.57.07,1.08.19t.95.26a4.27,4.27,0,0,1,.7.29,1.59,1.59,0,0,1,.49.41.94.94,0,0,1,.15.55v.79q0,.52-.38.52a1.76,1.76,0,0,1-.64-.2,7.74,7.74,0,0,0-3.2-.64,4.37,4.37,0,0,0-2.21.47,1.6,1.6,0,0,0-.79,1.48,1.58,1.58,0,0,0,.49,1.18,4.94,4.94,0,0,0,1.83.92L44.55,7a5.08,5.08,0,0,1,2.57,1.6A3.76,3.76,0,0,1,47.9,11a4.21,4.21,0,0,1-.44,1.93,4.4,4.4,0,0,1-1.21,1.47,5.43,5.43,0,0,1-1.85.93A8.25,8.25,0,0,1,42.05,15.62Z"
-                        />
-                        <path
-                            class="cls-1"
-                            d="M45.19,23.81C39.72,27.85,31.78,30,25,30A36.64,36.64,0,0,1,.22,20.57c-.51-.46-.06-1.09.56-.74A49.78,49.78,0,0,0,25.53,26.4,49.23,49.23,0,0,0,44.4,22.53C45.32,22.14,46.1,23.14,45.19,23.81Z"
-                        />
-                        <path
-                            class="cls-1"
-                            d="M47.47,21.21c-.7-.9-4.63-.42-6.39-.21-.53.06-.62-.4-.14-.74,3.13-2.2,8.27-1.57,8.86-.83s-.16,5.89-3.09,8.35c-.45.38-.88.18-.68-.32C46.69,25.8,48.17,22.11,47.47,21.21Z"
-                        />
-                    </svg>
-                </div>
-                <div>
-                    <h3>AWS Toolkit for VSCode</h3>
-                    <h1>Welcome & Getting Started</h1>
-                </div>
-            </div>
-        </div>
-
-        <!-- Status Bar -->
-        <div
-            v-if="successfulAuthConnection"
-            class="border-common"
-            style="
-                width: fit-content;
-                white-space: nowrap;
-                display: flex;
-                flex-direction: row;
-                background-color: #28632b;
-                color: #ffffff;
-                padding: 10px;
-            "
-        >
-            <div class="icon icon-lg icon-vscode-check"></div>
-            &nbsp; &nbsp;
-            <div style="display: flex; flex-direction: row">
-                You're connected to {{ authFormDisplayName }}! Switch between connections in the&nbsp;<a
-                    v-on:click="showConnectionQuickPick()"
-                    style="cursor: pointer"
-                    >Toolkit panel</a
-                >&nbsp;or add additional connections below.
-            </div>
-            &nbsp;&nbsp;
-            <div
-                v-on:click="closeStatusBar"
-                style="cursor: pointer"
-                class="icon icon-lg icon-vscode-chrome-close"
-            ></div>
-        </div>
-
-        <!-- Status Bar -->
-        <div
-            v-if="foundCredentialButNotConnected"
-            class="border-common"
-            style="
-                width: fit-content;
-                white-space: nowrap;
-                display: flex;
-                flex-direction: row;
-                background-color: #28632b;
-                color: #ffffff;
-                padding: 10px;
-            "
-        >
-            <div class="icon icon-lg icon-vscode-check"></div>
-            &nbsp; &nbsp;
-            <div style="display: flex; flex-direction: row">
-                IAM Credential(s) detected, but not selected. Choose one in the&nbsp;<a
-                    v-on:click="showConnectionQuickPick()"
-                    style="cursor: pointer"
-                    >Toolkit panel</a
-                >&nbsp;.
-            </div>
-            &nbsp;&nbsp;
-            <div
-                v-on:click="closeFoundCredentialStatusBar()"
-                style="cursor: pointer"
-                class="icon icon-lg icon-vscode-chrome-close"
-            ></div>
-        </div>
-
-        <div class="flex-container">
-            <div id="left-column">
-                <div>
-                    <h1>Select a feature to begin</h1>
-                    <ul class="service-item-list" v-for="item in serviceItems">
-                        <ServiceItem
-                            :title="getServiceItemProps(item.id).title"
-                            :description="getServiceItemProps(item.id).description"
-                            :status="item.status"
-                            :isSelected="isServiceSelected(item.id)"
-                            :isLandscape="isLandscape()"
-                            :id="item.id"
-                            :key="buildServiceItemKey(item.id, item.status)"
-                            @service-item-clicked="serviceWasClicked(item.id)"
+    <div style="display: flex; flex-direction: row; gap: 20px; padding-top: 20px">
+        <div :style="{ display: 'flex', flexDirection: 'column', gap: '20px' }">
+            <!-- Logo + Title -->
+            <div>
+                <div style="display: flex; justify-content: left; align-items: center; gap: 25px">
+                    <div style="fill: white">
+                        <svg
+                            id="Layer_1"
+                            data-name="Layer 1"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="52pt"
+                            height="32pt"
+                            viewBox="0 0 50 30"
                         >
-                            <template
-                                v-slot:service-item-content-slot
-                                v-if="isServiceSelected(item.id) && !isLandscape()"
-                            >
-                                <component
-                                    :is="getServiceItemContent(item.id)"
-                                    :state="serviceItemsAuthStatus[item.id]"
-                                    :key="item.id + rerenderContentWindowKey"
-                                    @auth-connection-updated="onAuthConnectionUpdated"
-                                ></component>
-                            </template>
-                        </ServiceItem>
-                    </ul>
+                            <path
+                                d="M14.09,10.85a4.7,4.7,0,0,0,.19,1.48,7.73,7.73,0,0,0,.54,1.19.77.77,0,0,1,.12.38.64.64,0,0,1-.32.49l-1,.7a.83.83,0,0,1-.44.15.69.69,0,0,1-.49-.23,3.8,3.8,0,0,1-.6-.77q-.25-.42-.51-1a6.14,6.14,0,0,1-4.89,2.3,4.54,4.54,0,0,1-3.32-1.19,4.27,4.27,0,0,1-1.22-3.2A4.28,4.28,0,0,1,3.61,7.75,6.06,6.06,0,0,1,7.69,6.46a12.47,12.47,0,0,1,1.76.13q.92.13,1.91.36V5.73a3.65,3.65,0,0,0-.79-2.66A3.81,3.81,0,0,0,7.86,2.3a7.71,7.71,0,0,0-1.79.22,12.78,12.78,0,0,0-1.79.57,4.55,4.55,0,0,1-.58.22l-.26,0q-.35,0-.35-.52V2a1.09,1.09,0,0,1,.12-.58,1.2,1.2,0,0,1,.47-.35A10.88,10.88,0,0,1,5.77.32,10.19,10.19,0,0,1,8.36,0a6,6,0,0,1,4.35,1.35,5.49,5.49,0,0,1,1.38,4.09ZM7.34,13.38a5.36,5.36,0,0,0,1.72-.31A3.63,3.63,0,0,0,10.63,12,2.62,2.62,0,0,0,11.19,11a5.63,5.63,0,0,0,.16-1.44v-.7a14.35,14.35,0,0,0-1.53-.28,12.37,12.37,0,0,0-1.56-.1,3.84,3.84,0,0,0-2.47.67A2.34,2.34,0,0,0,5,11a2.35,2.35,0,0,0,.61,1.76A2.4,2.4,0,0,0,7.34,13.38Zm13.35,1.8a1,1,0,0,1-.64-.16,1.3,1.3,0,0,1-.35-.65L15.81,1.51a3,3,0,0,1-.15-.67.36.36,0,0,1,.41-.41H17.7a1,1,0,0,1,.65.16,1.4,1.4,0,0,1,.33.65l2.79,11,2.59-11A1.17,1.17,0,0,1,24.39.6a1.1,1.1,0,0,1,.67-.16H26.4a1.1,1.1,0,0,1,.67.16,1.17,1.17,0,0,1,.32.65L30,12.39,32.88,1.25A1.39,1.39,0,0,1,33.22.6a1,1,0,0,1,.65-.16h1.54a.36.36,0,0,1,.41.41,1.36,1.36,0,0,1,0,.26,3.64,3.64,0,0,1-.12.41l-4,12.86a1.3,1.3,0,0,1-.35.65,1,1,0,0,1-.64.16H29.25a1,1,0,0,1-.67-.17,1.26,1.26,0,0,1-.32-.67L25.67,3.64,23.11,14.34a1.26,1.26,0,0,1-.32.67,1,1,0,0,1-.67.17Zm21.36.44a11.28,11.28,0,0,1-2.56-.29,7.44,7.44,0,0,1-1.92-.67,1,1,0,0,1-.61-.93v-.84q0-.52.38-.52a.9.9,0,0,1,.31.06l.42.17a8.77,8.77,0,0,0,1.83.58,9.78,9.78,0,0,0,2,.2,4.48,4.48,0,0,0,2.43-.55,1.76,1.76,0,0,0,.86-1.57,1.61,1.61,0,0,0-.45-1.16A4.29,4.29,0,0,0,43,9.22l-2.41-.76A5.15,5.15,0,0,1,38,6.78a3.94,3.94,0,0,1-.83-2.41,3.7,3.7,0,0,1,.45-1.85,4.47,4.47,0,0,1,1.19-1.37A5.27,5.27,0,0,1,40.51.29,7.4,7.4,0,0,1,42.6,0a8.87,8.87,0,0,1,1.12.07q.57.07,1.08.19t.95.26a4.27,4.27,0,0,1,.7.29,1.59,1.59,0,0,1,.49.41.94.94,0,0,1,.15.55v.79q0,.52-.38.52a1.76,1.76,0,0,1-.64-.2,7.74,7.74,0,0,0-3.2-.64,4.37,4.37,0,0,0-2.21.47,1.6,1.6,0,0,0-.79,1.48,1.58,1.58,0,0,0,.49,1.18,4.94,4.94,0,0,0,1.83.92L44.55,7a5.08,5.08,0,0,1,2.57,1.6A3.76,3.76,0,0,1,47.9,11a4.21,4.21,0,0,1-.44,1.93,4.4,4.4,0,0,1-1.21,1.47,5.43,5.43,0,0,1-1.85.93A8.25,8.25,0,0,1,42.05,15.62Z"
+                            />
+                            <path
+                                class="cls-1"
+                                d="M45.19,23.81C39.72,27.85,31.78,30,25,30A36.64,36.64,0,0,1,.22,20.57c-.51-.46-.06-1.09.56-.74A49.78,49.78,0,0,0,25.53,26.4,49.23,49.23,0,0,0,44.4,22.53C45.32,22.14,46.1,23.14,45.19,23.81Z"
+                            />
+                            <path
+                                class="cls-1"
+                                d="M47.47,21.21c-.7-.9-4.63-.42-6.39-.21-.53.06-.62-.4-.14-.74,3.13-2.2,8.27-1.57,8.86-.83s-.16,5.89-3.09,8.35c-.45.38-.88.18-.68-.32C46.69,25.8,48.17,22.11,47.47,21.21Z"
+                            />
+                        </svg>
+                    </div>
+                    <div>
+                        <h3>AWS Toolkit for VSCode</h3>
+                        <h1>Welcome & Getting Started</h1>
+                    </div>
                 </div>
             </div>
-            <div v-if="isLandscape() && isAnyServiceSelected()" id="right-column">
-                <component
-                    :is="getServiceItemContent(getSelectedService())"
-                    :state="serviceItemsAuthStatus[getSelectedService()]"
-                    :key="getSelectedService() + rerenderContentWindowKey"
-                    @auth-connection-updated="onAuthConnectionUpdated"
-                ></component>
+
+            <!-- Status Bar -->
+            <div
+                v-if="successfulAuthConnection"
+                class="border-common"
+                style="
+                    width: fit-content;
+                    white-space: nowrap;
+                    display: flex;
+                    flex-direction: row;
+                    background-color: #28632b;
+                    color: #ffffff;
+                    padding: 10px;
+                "
+            >
+                <div class="icon icon-lg icon-vscode-check"></div>
+                &nbsp; &nbsp;
+                <div style="display: flex; flex-direction: row">
+                    You're connected to {{ authFormDisplayName }}! Switch between connections in the&nbsp;<a
+                        v-on:click="showConnectionQuickPick()"
+                        style="cursor: pointer"
+                        >Toolkit panel</a
+                    >&nbsp;or add additional connections below.
+                </div>
+                &nbsp;&nbsp;
+                <div
+                    v-on:click="closeStatusBar"
+                    style="cursor: pointer"
+                    class="icon icon-lg icon-vscode-chrome-close"
+                ></div>
             </div>
+
+            <!-- Status Bar -->
+            <div
+                v-if="foundCredentialButNotConnected"
+                class="border-common"
+                style="
+                    width: fit-content;
+                    white-space: nowrap;
+                    display: flex;
+                    flex-direction: row;
+                    background-color: #28632b;
+                    color: #ffffff;
+                    padding: 10px;
+                "
+            >
+                <div class="icon icon-lg icon-vscode-check"></div>
+                &nbsp; &nbsp;
+                <div style="display: flex; flex-direction: row">
+                    IAM Credential(s) detected, but not selected. Choose one in the&nbsp;<a
+                        v-on:click="showConnectionQuickPick()"
+                        style="cursor: pointer"
+                        >Toolkit panel</a
+                    >&nbsp;.
+                </div>
+                &nbsp;&nbsp;
+                <div
+                    v-on:click="closeFoundCredentialStatusBar()"
+                    style="cursor: pointer"
+                    class="icon icon-lg icon-vscode-chrome-close"
+                ></div>
+            </div>
+
+            <!-- Left side clickable boxes for features/services -->
+            <div class="flex-container">
+                <div id="left-column">
+                    <div>
+                        <h1>Select a feature to begin</h1>
+                        <ul class="service-item-list" v-for="item in serviceItems">
+                            <ServiceItem
+                                :title="getServiceItemProps(item.id).title"
+                                :description="getServiceItemProps(item.id).description"
+                                :status="item.status"
+                                :isSelected="isServiceSelected(item.id)"
+                                :isLandscape="isLandscape()"
+                                :id="item.id"
+                                :key="buildServiceItemKey(item.id, item.status)"
+                                @service-item-clicked="serviceWasClicked(item.id)"
+                            >
+                                <!-- Content window that appears under when in portrait mode -->
+                                <template
+                                    v-slot:service-item-content-slot
+                                    v-if="isServiceSelected(item.id) && !isLandscape()"
+                                >
+                                    <component
+                                        :is="getServiceItemContent(item.id)"
+                                        :state="serviceItemsAuthStatus[item.id]"
+                                        :key="item.id + rerenderContentWindowKey"
+                                        @auth-connection-updated="onAuthConnectionUpdated"
+                                    ></component>
+                                </template>
+                            </ServiceItem>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Content window that appears on the right -->
+        <div v-if="isLandscape() && isAnyServiceSelected()" id="right-column">
+            <component
+                :is="getServiceItemContent(getSelectedService())"
+                :state="serviceItemsAuthStatus[getSelectedService()]"
+                :key="getSelectedService() + rerenderContentWindowKey"
+                @auth-connection-updated="onAuthConnectionUpdated"
+            ></component>
         </div>
     </div>
 </template>

--- a/src/auth/ui/vue/serviceItem.vue
+++ b/src/auth/ui/vue/serviceItem.vue
@@ -158,8 +158,7 @@ export class ServiceItemsState {
      */
     private readonly unlockedServices: Set<ServiceItemId> = new Set(['resourceExplorer'])
 
-    /** Note a service item is pre-selected by default */
-    private currentlySelected?: ServiceItemId = 'resourceExplorer'
+    private currentlySelected?: ServiceItemId = undefined
 
     /**
      * The Ids of the service items, separated by the ones that are locked vs. unlocked

--- a/src/auth/ui/vue/serviceItemContent/awsExplorerContent.vue
+++ b/src/auth/ui/vue/serviceItemContent/awsExplorerContent.vue
@@ -2,8 +2,9 @@
     <div class="service-item-content-container border-common" v-show="isAllAuthsLoaded">
         <div class="service-item-content-container-title">Resource Explorer</div>
 
-        <div>
+        <div class="centered-items">
             <img
+                class="service-item-content-image"
                 src="https://github.com/aws/aws-toolkit-vscode/assets/118216176/7542f78b-f6ce-47c9-aa8c-cab48cd06997"
             />
         </div>

--- a/src/auth/ui/vue/serviceItemContent/baseServiceItemContent.css
+++ b/src/auth/ui/vue/serviceItemContent/baseServiceItemContent.css
@@ -7,7 +7,7 @@
 
     border-color: #0097fb;
 
-    width: 700px;
+    width: 550px;
 
     padding: 30px;
 }
@@ -16,6 +16,10 @@
     display: inline;
     font-size: large;
     font-weight: bold;
+}
+
+.service-item-content-image {
+    height: 280px;
 }
 
 .service-item-content-container hr {

--- a/src/auth/ui/vue/serviceItemContent/codeCatalystContent.vue
+++ b/src/auth/ui/vue/serviceItemContent/codeCatalystContent.vue
@@ -2,8 +2,9 @@
     <div class="service-item-content-container border-common" v-show="isAllAuthsLoaded">
         <div class="service-item-content-container-title">Amazon CodeCatalyst</div>
 
-        <div>
+        <div class="centered-items">
             <img
+                class="service-item-content-image"
                 src="https://github.com/aws/aws-toolkit-vscode/assets/118216176/37e373c5-25f1-4098-95a8-9204daf8dde8"
             />
         </div>

--- a/src/auth/ui/vue/serviceItemContent/codeWhispererContent.vue
+++ b/src/auth/ui/vue/serviceItemContent/codeWhispererContent.vue
@@ -2,8 +2,9 @@
     <div class="service-item-content-container border-common" v-show="isAllAuthsLoaded">
         <div class="service-item-content-container-title">Amazon CodeWhisperer</div>
 
-        <div>
+        <div class="centered-items">
             <img
+                class="service-item-content-image"
                 src="https://docs.aws.amazon.com/images/codewhisperer/latest/userguide/images/cw-c9-function-from-comment.gif"
             />
         </div>

--- a/src/auth/ui/vue/shared.css
+++ b/src/auth/ui/vue/shared.css
@@ -12,3 +12,9 @@ button,
 .container-background {
     background-color: #292929;
 }
+
+.centered-items {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}


### PR DESCRIPTION
- Don't expand any of the features by default, we were previously showing the Resource Explorer form by default
- Shrink the UI to try to fit more on the screen at once
- Update CW Builder ID link to something more specific
- Improve identity center region selection
  - Can click the text as well to open quick pick
  - Set default to us-east-1

Fixes:
IDE-10998
IDE-10999
IDE-11000

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
