### PR TITLE
fix(messages): "first use" missing fallback metric

### DIFF
--- a/src/auth/activation.ts
+++ b/src/auth/activation.ts
@@ -10,9 +10,9 @@ import { LoginManager } from './deprecated/loginManager'
 import { fromString } from './providers/credentials'
 import { registerCommandsWithVSCode } from '../shared/vscode/commands2'
 import { AuthCommandBackend, AuthCommandDeclarations } from './commands'
-import { ExtensionUse } from '../shared/utilities/vsCodeUtils'
 import { getLogger } from '../shared/logger'
 import { isInDevEnv } from '../codecatalyst/utils'
+import { ExtensionUse } from './utils'
 
 export async function initialize(
     extensionContext: vscode.ExtensionContext,
@@ -28,8 +28,6 @@ export async function initialize(
         }
     })
 
-    // TODO: To enable this in prod we need to remove the 'when' clause
-    // for: '"command": "aws.auth.manageConnections"' in package.json
     registerCommandsWithVSCode(
         extensionContext,
         AuthCommandDeclarations.instance,
@@ -51,8 +49,6 @@ async function showManageConnectionsOnStartup() {
     }
 
     if (isInDevEnv()) {
-        // A dev env will have an existing connection so this scenario is redundant. But keeping
-        // for reference.
         getLogger().debug('firstStartup: Detected we are in Dev Env, skipping showing Add Connections page.')
         return
     }

--- a/src/auth/ui/vue/show.ts
+++ b/src/auth/ui/vue/show.ts
@@ -32,7 +32,7 @@ import {
     isIamConnection,
     isSsoConnection,
 } from '../../connection'
-import { tryAddCredentials, signout, showRegionPrompter, promptAndUseConnection } from '../../utils'
+import { tryAddCredentials, signout, showRegionPrompter, promptAndUseConnection, ExtensionUse } from '../../utils'
 import { Region } from '../../../shared/regions/endpoints'
 import { CancellationError } from '../../../shared/utilities/timeoutUtils'
 import { validateSsoUrl, validateSsoUrlFormat } from '../../sso/validation'
@@ -41,7 +41,6 @@ import { AuthError, ServiceItemId, userCancelled } from './types'
 import { awsIdSignIn } from '../../../codewhisperer/util/showSsoPrompt'
 import { connectToEnterpriseSso } from '../../../codewhisperer/util/getStartUrl'
 import { trustedDomainCancellation } from '../../sso/model'
-import { ExtensionUse } from '../../../shared/utilities/vsCodeUtils'
 import { FeatureId, CredentialSourceId, Result, telemetry } from '../../../shared/telemetry/telemetry'
 import { AuthFormId, isBuilderIdAuth } from './authForms/types'
 

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -43,6 +43,7 @@ import { Auth } from './auth'
 import { validateIsNewSsoUrl, validateSsoUrlFormat } from './sso/validation'
 import { openUrl } from '../shared/utilities/vsCodeUtils'
 import { AuthSource } from './ui/vue/show'
+import { getLogger } from '../shared/logger'
 
 // TODO: Look to do some refactoring to handle circular dependency later and move this to ./commands.ts
 export const showConnectionsPageCommand = 'aws.auth.manageConnections'
@@ -554,5 +555,56 @@ export class AuthNode implements TreeNode<Auth> {
         } else {
             item.description = text
         }
+    }
+}
+
+/**
+ * Class to get info about the user + use of this extension
+ *
+ * Why is this extension in this file?
+ * - Due to circular dependency issues since this class needs to use the {@link Auth}
+ *   instance. If we can find a better spot and not run in to the isssue this should be moved.
+ *
+ * Keywords for searchability:
+ * - new user
+ * - first time
+ */
+export class ExtensionUse {
+    public readonly isExtensionFirstUseKey = 'isExtensionFirstUse'
+
+    // The result of if is first use for the remainder of the extension session.
+    // This will reset on next startup.
+    private isFirstUseCurrentSession: boolean | undefined
+
+    isFirstUse(
+        state: vscode.Memento = globals.context.globalState,
+        hasExistingConnections = () => Auth.instance.hasConnections
+    ): boolean {
+        if (this.isFirstUseCurrentSession !== undefined) {
+            return this.isFirstUseCurrentSession
+        }
+
+        this.isFirstUseCurrentSession = state.get(this.isExtensionFirstUseKey)
+        if (this.isFirstUseCurrentSession === undefined) {
+            // The variable in the store is not defined yet, fallback to checking if they have existing connections.
+            this.isFirstUseCurrentSession = !hasExistingConnections()
+
+            getLogger().debug(
+                `isFirstUse: State not found, marking user as '${
+                    this.isFirstUseCurrentSession ? '' : 'NOT '
+                }first use' since they 'did ${this.isFirstUseCurrentSession ? 'NOT ' : ''}have existing connections'.`
+            )
+        }
+
+        // Update state, so next time it is not first use
+        state.update(this.isExtensionFirstUseKey, false)
+
+        return this.isFirstUseCurrentSession
+    }
+
+    static #instance: ExtensionUse
+
+    static get instance(): ExtensionUse {
+        return (this.#instance ??= new ExtensionUse())
     }
 }

--- a/src/shared/utilities/vsCodeUtils.ts
+++ b/src/shared/utilities/vsCodeUtils.ts
@@ -12,7 +12,6 @@ import { CancellationError, Timeout, waitTimeout, waitUntil } from './timeoutUti
 import { telemetry } from '../telemetry/telemetry'
 import * as semver from 'semver'
 import { isNonNullable } from './tsUtils'
-import globals from '../extensionGlobals'
 
 // TODO: Consider NLS initialization/configuration here & have packages to import localize from here
 export const localize = nls.loadMessageBundle()
@@ -45,36 +44,6 @@ export async function closeAllEditors() {
                 vscode.window.activeTextEditor!.document.fileName
             }" was still open after executing "closeAllEditors"`
         )
-    }
-}
-
-/**
- * Class to get info about the extension being first used
- */
-export class ExtensionUse {
-    private readonly isExtensionFirstUseKey = 'isExtensionFirstUse'
-
-    // The result of if is first use for the remainder of the extension session.
-    // This will reset on next startup.
-    private isFirstUseCurrentSession: boolean | undefined
-
-    isFirstUse(state: vscode.Memento = globals.context.globalState): boolean {
-        if (this.isFirstUseCurrentSession !== undefined) {
-            return this.isFirstUseCurrentSession
-        }
-
-        this.isFirstUseCurrentSession = state.get(this.isExtensionFirstUseKey, true)
-
-        // Update state, so next time it is not first use
-        state.update(this.isExtensionFirstUseKey, false)
-
-        return this.isFirstUseCurrentSession
-    }
-
-    static #instance: ExtensionUse
-
-    static get instance(): ExtensionUse {
-        return (this.#instance ??= new ExtensionUse())
     }
 }
 

--- a/src/test/credentials/utils.test.ts
+++ b/src/test/credentials/utils.test.ts
@@ -1,0 +1,64 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as vscode from 'vscode'
+import * as assert from 'assert'
+import { FakeExtensionContext } from '../fakeExtensionContext'
+import { ExtensionUse } from '../../auth/utils'
+
+describe('ExtensionUse.isFirstUse()', function () {
+    let fakeState: vscode.Memento
+    let instance: ExtensionUse
+
+    beforeEach(async function () {
+        fakeState = (await FakeExtensionContext.create()).globalState
+        instance = new ExtensionUse()
+        fakeState.update(ExtensionUse.instance.isExtensionFirstUseKey, true)
+    })
+
+    it('is true only on first startup', function () {
+        assert.strictEqual(instance.isFirstUse(fakeState), true, 'Failed on first call.')
+        assert.strictEqual(instance.isFirstUse(fakeState), true, 'Failed on second call.')
+
+        const nextStartup = nextExtensionStartup()
+        assert.strictEqual(nextStartup.isFirstUse(fakeState), false, 'Failed on new startup.')
+    })
+
+    it('true when: (state value not exists + NOT has existing connections)', async function () {
+        await makeStateValueNotExist()
+        const notHasExistingConnections = () => false
+        assert.strictEqual(
+            instance.isFirstUse(fakeState, notHasExistingConnections),
+            true,
+            'No existing connections, should be first use'
+        )
+        assert.strictEqual(nextExtensionStartup().isFirstUse(fakeState), false)
+    })
+
+    it('false when: (state value not exists + has existing connections)', async function () {
+        await makeStateValueNotExist()
+        const hasExistingConnections = () => true
+        assert.strictEqual(
+            instance.isFirstUse(fakeState, hasExistingConnections),
+            false,
+            'Found existing connections, should not be first use'
+        )
+        assert.strictEqual(nextExtensionStartup().isFirstUse(fakeState), false)
+    })
+
+    /**
+     * This makes the backend state value: undefined, mimicking a brand new user.
+     * We use this state value to track if user is a first time user.
+     */
+    async function makeStateValueNotExist() {
+        await fakeState.update(ExtensionUse.instance.isExtensionFirstUseKey, undefined)
+    }
+
+    /**
+     * Mimics when the extension startsup a subsequent time (i.e user closes vscode and opens again).
+     */
+    function nextExtensionStartup() {
+        return new ExtensionUse()
+    }
+})

--- a/src/test/shared/utilities/vscodeUtils.test.ts
+++ b/src/test/shared/utilities/vscodeUtils.test.ts
@@ -7,8 +7,6 @@ import * as assert from 'assert'
 import { VSCODE_EXTENSION_ID } from '../../../shared/extensions'
 import * as vscodeUtil from '../../../shared/utilities/vsCodeUtils'
 import * as vscode from 'vscode'
-import { FakeExtensionContext } from '../../fakeExtensionContext'
-import { ExtensionUse } from '../../../shared/utilities/vsCodeUtils'
 
 describe('vscodeUtils', async function () {
     it('activateExtension(), isExtensionActive()', async function () {
@@ -99,26 +97,5 @@ describe('buildMissingExtensionMessage()', function () {
             message,
             `${feat} requires the ${extName} extension (\'${extId}\') to be installed and enabled.`
         )
-    })
-})
-
-describe('ExtensionUse.isFirstUse()', function () {
-    let fakeState: vscode.Memento
-    let instance: ExtensionUse
-
-    beforeEach(async function () {
-        fakeState = (await FakeExtensionContext.create()).globalState
-        instance = new ExtensionUse()
-    })
-
-    it('is true only on first startup', function () {
-        assert.strictEqual(instance.isFirstUse(fakeState), true, 'Failed on first call.')
-        assert.strictEqual(instance.isFirstUse(fakeState), true, 'Failed on second call.')
-
-        // Mimic new extension startup, since a new instance
-        // is created on each load of the extension.
-        const secondInstance = new ExtensionUse()
-
-        assert.strictEqual(secondInstance.isFirstUse(fakeState), false, 'Failed on new startup.')
     })
 })


### PR DESCRIPTION
If the user has not had this run on their system yet, they will
not have the state variable existing yet. It will assume they
are a first time user.

### Solution:

- If they have no state, then fallback to checking if we are
aware of existing connections.

- Had to move the ExtensionUse class since we now have a circular
  dependency due to using the Auth class

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
