### PR TITLE
codewhisperer: update completion type Line/Block aggregation

### DIFF
--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -202,11 +202,9 @@ export class RecommendationHandler {
                 TelemetryHelper.instance.triggerType = triggerType
                 TelemetryHelper.instance.CodeWhispererAutomatedtriggerType =
                     autoTriggerType === undefined ? 'KeyStrokeCount' : autoTriggerType
-                if (
-                    recommendation.length > 0 &&
-                    recommendation[0].content.search(CodeWhispererConstants.lineBreak) !== -1
-                ) {
-                    completionType = 'Block'
+                if (page === 0 && recommendation.length > 0) {
+                    completionType =
+                        recommendation[0].content.search(CodeWhispererConstants.lineBreak) !== -1 ? 'Block' : 'Line'
                 }
                 TelemetryHelper.instance.completionType = completionType
                 requestId = resp?.$response && resp?.$response?.requestId


### PR DESCRIPTION
## Problem

As per our sci team's request, update session level `CompletionType`.

### Before 
- `Block` if there is a `Block` completion present in the session, otherwise `Line`

### After
- Only check the 'first' completion, if it's `Block`, then the session is `Block` otherwise `Line`


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
