### PR TITLE
feat(ec2): add utility functions to explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1404,6 +1404,11 @@
                     "group": "1@2"
                 },
                 {
+                    "command": "aws.ec2.copyInstanceId",
+                    "when": "view == aws.explorer && viewItem == awsEc2Node",
+                    "group": "2@0"
+                },
+                {
                     "command": "aws.ecr.copyTagUri",
                     "when": "view == aws.explorer && viewItem == awsEcrTagNode",
                     "group": "2@1"
@@ -2059,6 +2064,16 @@
                 "command": "aws.ec2.connectToInstance",
                 "title": "%AWS.command.ec2.connectToInstance%",
                 "category": "%AWS.title%",
+                "cloud9": {
+                    "cn": {
+                        "category": "%AWS.title.cn%"
+                    }
+                }
+            },
+            {
+                "command": "aws.ec2.copyInstanceId",
+                "title": "%AWS.command.ec2.copyInstanceId%",
+                "category": "%AWS.title",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"

--- a/package.json
+++ b/package.json
@@ -1590,12 +1590,12 @@
                 },
                 {
                     "command": "aws.copyName",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsCloudFormationFunctionNode|awsStateMachineNode|awsCloudFormationNode|awsS3BucketNode|awsS3FolderNode|awsS3FileNode|awsApiGatewayNode|awsIotThingNode)$|^(awsAppRunnerServiceNode|awsIotCertificateNode|awsIotPolicyNode|awsIotPolicyVersionNode)/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsCloudFormationFunctionNode|awsStateMachineNode|awsCloudFormationNode|awsS3BucketNode|awsS3FolderNode|awsS3FileNode|awsApiGatewayNode|awsIotThingNode)$|^(awsAppRunnerServiceNode|awsIotCertificateNode|awsIotPolicyNode|awsIotPolicyVersionNode|awsEc2Node)/",
                     "group": "2@1"
                 },
                 {
                     "command": "aws.copyArn",
-                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsCloudFormationFunctionNode|awsStateMachineNode|awsCloudFormationNode|awsCloudWatchLogNode|awsS3BucketNode|awsS3FolderNode|awsS3FileNode|awsApiGatewayNode|awsEcrRepositoryNode|awsIotThingNode)$|^(awsAppRunnerServiceNode|awsEcsServiceNode|awsIotCertificateNode|awsIotPolicyNode|awsIotPolicyVersionNode|awsMdeInstanceNode)/",
+                    "when": "view == aws.explorer && viewItem =~ /^(awsRegionFunctionNode|awsRegionFunctionNodeDownloadable|awsCloudFormationFunctionNode|awsStateMachineNode|awsCloudFormationNode|awsCloudWatchLogNode|awsS3BucketNode|awsS3FolderNode|awsS3FileNode|awsApiGatewayNode|awsEcrRepositoryNode|awsIotThingNode)$|^(awsAppRunnerServiceNode|awsEcsServiceNode|awsIotCertificateNode|awsIotPolicyNode|awsIotPolicyVersionNode|awsMdeInstanceNode|awsEc2Node)/",
                     "group": "2@2"
                 },
                 {

--- a/package.nls.json
+++ b/package.nls.json
@@ -109,6 +109,7 @@
     "AWS.command.refreshCdkExplorer": "Refresh CDK Explorer",
     "AWS.command.cdk.help": "View CDK Documentation",
     "AWS.command.ec2.connectToInstance": "Connect to EC2 Instance...",
+    "AWS.command.ec2.copyInstanceId": "Copy Instance Id",
     "AWS.command.ecr.copyTagUri": "Copy Tag URI",
     "AWS.command.ecr.copyRepositoryUri": "Copy Repository URI",
     "AWS.command.ecr.createRepository": "Create Repository...",

--- a/src/ec2/activation.ts
+++ b/src/ec2/activation.ts
@@ -4,7 +4,7 @@
  */
 import { ExtContext } from '../shared/extensions'
 import { Commands } from '../shared/vscode/commands2'
-import { tryConnect } from './commands'
+import { copyInstanceId, tryConnect } from './commands'
 import { telemetry } from '../shared/telemetry/telemetry'
 import { Ec2InstanceNode } from './explorer/ec2InstanceNode'
 
@@ -15,6 +15,10 @@ export async function activate(ctx: ExtContext): Promise<void> {
                 span.record({ ec2ConnectionType: 'ssm' })
                 await (node ? tryConnect(node.toSelection()) : tryConnect())
             })
+        }),
+
+        Commands.register('aws.ec2.copyInstanceId', async (node: Ec2InstanceNode) => {
+            await copyInstanceId(node.InstanceId)
         })
     )
 }

--- a/src/ec2/commands.ts
+++ b/src/ec2/commands.ts
@@ -34,13 +34,12 @@ export async function tryConnect(selection?: Ec2Selection): Promise<void> {
 }
 
 export async function copyInstanceId(instanceId: string): Promise<void> {
-    console.log('copied it!')
     try {
         if (!instanceId) {
             throw new ToolkitError(`Attempting to copy undefined instanceId.`)
         }
         await copyToClipboard(instanceId)
     } catch (e) {
-        throw new ToolkitError('Failed to copy instanceId', { cause: e as Error })
+        throw new ToolkitError('Failed to copy instanceId', { code: 'InvalidResource', cause: e as Error })
     }
 }

--- a/src/ec2/commands.ts
+++ b/src/ec2/commands.ts
@@ -10,6 +10,8 @@ import { Ec2Selection } from './utils'
 import { RegionSubmenuResponse } from '../shared/ui/common/regionSubmenu'
 import { PromptResult } from '../shared/ui/prompter'
 import { CancellationError } from '../shared/utilities/timeoutUtils'
+import { ToolkitError } from '../shared/errors'
+import { copyToClipboard } from '../shared/utilities/messages'
 
 function getSelectionFromResponse(response: PromptResult<RegionSubmenuResponse<string>>): Ec2Selection {
     if (isValidResponse(response)) {
@@ -29,4 +31,16 @@ export async function tryConnect(selection?: Ec2Selection): Promise<void> {
 
     const ec2Client = new Ec2ConnectionManager(selection.region)
     await ec2Client.attemptEc2Connection(selection)
+}
+
+export async function copyInstanceId(instanceId: string): Promise<void> {
+    console.log('copied it!')
+    try {
+        if (!instanceId) {
+            throw new ToolkitError(`Attempting to copy undefined instanceId.`)
+        }
+        await copyToClipboard(instanceId)
+    } catch (e) {
+        throw new ToolkitError('Failed to copy instanceId', { cause: e as Error })
+    }
 }

--- a/src/test/ec2/commands.test.ts
+++ b/src/test/ec2/commands.test.ts
@@ -1,0 +1,31 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import { copyInstanceId } from '../../ec2/commands'
+import { ToolkitError } from '../../shared/errors'
+
+describe('copyInstanceId', async function () {
+    beforeEach(async function () {
+        await vscode.env.clipboard.writeText('')
+    })
+
+    it('copies instance id when provided one', async function () {
+        const testInstanceId = 'thisIsMyFavoriteId'
+
+        await copyInstanceId(testInstanceId)
+
+        assert.strictEqual(await vscode.env.clipboard.readText(), testInstanceId)
+    })
+
+    it('throws error if not provided with an instanceId', async function () {
+        try {
+            await copyInstanceId(undefined!)
+            assert.ok(undefined)
+        } catch (e) {
+            assert.strictEqual((e as ToolkitError).code, 'InvalidResource')
+        }
+    })
+})


### PR DESCRIPTION
Currently a draft as it builds off work done in https://github.com/aws/aws-toolkit-vscode/pull/3640

## Problem
User's expect to be able to have this information readily available (as in line with other services). 
## Solution
commands added on right click of explorer node:
- copy `ARN`
- copy `Name`
- copy `instanceId` 

![image](https://github.com/aws/aws-toolkit-vscode/assets/42325418/e8474f30-32cc-4a0f-9b49-805c442f6eaa)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
