### PR TITLE
codecatalyst: Show warning messages when CC dev env is close to inactivity shutdown

### DIFF
--- a/src/codecatalyst/devEnv.ts
+++ b/src/codecatalyst/devEnv.ts
@@ -1,0 +1,230 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DevEnvironment } from '../shared/clients/codecatalystClient'
+import { DevEnvActivity } from '../shared/clients/devenvClient'
+import globals from '../shared/extensionGlobals'
+import * as vscode from 'vscode'
+import { Timeout } from '../shared/utilities/timeoutUtils'
+import { showMessageWithCancel } from '../shared/utilities/messages'
+import { isCloud9 } from '../shared/extensionUtilities'
+
+/** If we should be sending the dev env activity timestamps to track user activity */
+export function shouldTrackUserActivity(maxInactivityMinutes: DevEnvironment['inactivityTimeoutMinutes']): boolean {
+    // This value is a static value initialized when the dev env is first created.
+    //
+    // If it is updated, the dev env is restarted and this extension will restarted and grab the latest value.
+    // Due to this, we do not need to keep track of this value since the
+    //
+    // For more info see: https://docs.aws.amazon.com/codecatalyst/latest/APIReference/API_UpdateDevEnvironment.html#codecatalyst-UpdateDevEnvironment-request-inactivityTimeoutMinutes
+    return maxInactivityMinutes > 0
+}
+
+export class InactivityMessage implements vscode.Disposable {
+    #message: Message | undefined
+    #nextWholeMinute: NodeJS.Timeout | undefined
+    #beforeMessageShown: NodeJS.Timeout | undefined
+
+    /** Indicates to show first message 5 minutes before shutdown */
+    static readonly firstMessageBeforeShutdown = 5
+
+    /**
+     * Sets up all messages that are displayed to the user when the dev env is inactive and starts to get close to shutdown.
+     *
+     * @param maxInactivityMinutes The # of minutes a CodeCatalyst Dev Env can be inactive till it shuts down.
+     * @param devEnvActivity The DevEnvActivity client
+     * @param relativeMinuteMillis How many milliseconds we want a "minute" to be. This is
+     *                             useful for testing purposes.
+     */
+    async setupMessage(
+        maxInactivityMinutes: DevEnvironment['inactivityTimeoutMinutes'],
+        devEnvActivity: DevEnvActivity,
+        relativeMinuteMillis: number = 60_000
+    ) {
+        devEnvActivity.onActivityUpdate(async latestActivityTimestamp => {
+            this._setupMessage(maxInactivityMinutes, latestActivityTimestamp, devEnvActivity, relativeMinuteMillis)
+        })
+
+        // Send an initial update to the dev env on startup
+        devEnvActivity.sendActivityUpdate()
+    }
+
+    private _setupMessage(
+        maxInactivityMinutes: number,
+        latestTimestamp: number,
+        devEnvActivity: DevEnvActivity,
+        relativeMinuteMillis: number
+    ) {
+        this.clearOldMessage()
+
+        const { millisToWait, minutesSinceTimestamp } = this.millisUntilNextWholeMinute(
+            latestTimestamp,
+            relativeMinuteMillis
+        )
+        const minutesUntilShutdown = maxInactivityMinutes - minutesSinceTimestamp
+        const minutesUntilFirstMessage = minutesUntilShutdown - InactivityMessage.firstMessageBeforeShutdown
+
+        /** Wait until we are {@link InactivityMessage.firstMessageBeforeShutdown} minutes before shutdown. */
+        this.#beforeMessageShown = globals.clock.setTimeout(() => {
+            const userIsActive = () => devEnvActivity.sendActivityUpdate()
+            const willRefreshOnStaleTimestamp = async () => await devEnvActivity.isLocalActivityStale()
+
+            this.message().show(
+                minutesSinceTimestamp + minutesUntilFirstMessage,
+                minutesUntilShutdown - minutesUntilFirstMessage,
+                userIsActive,
+                willRefreshOnStaleTimestamp,
+                relativeMinuteMillis
+            )
+        }, millisToWait + minutesUntilFirstMessage * relativeMinuteMillis)
+    }
+
+    private clearOldMessage() {
+        if (this.#nextWholeMinute) {
+            clearTimeout(this.#nextWholeMinute)
+            this.#nextWholeMinute = undefined
+        }
+        if (this.#beforeMessageShown) {
+            clearTimeout(this.#beforeMessageShown)
+            this.#beforeMessageShown = undefined
+        }
+        if (this.#message) {
+            this.#message.dispose()
+            this.#message = undefined
+        }
+    }
+
+    /**
+     * The latest activity timestamp may not always be the current time, it may be from the past.
+     * So the amount of time that has passed since that timestamp may not be a whole minute.
+     *
+     * This returns the amount of time we need to wait until the next whole minute, along with how many
+     * minutes would have passed assuming the caller waitied until the next minute.
+     *
+     * Eg:
+     *   - 1 minute and 29 seconds have passed since the given timestamp.
+     *   - returns { millisToWait: 31_000, minutesSinceTimestamp: 2}
+     */
+    private millisUntilNextWholeMinute(
+        latestTimestamp: number,
+        relativeMinuteMillis: number
+    ): { millisToWait: number; minutesSinceTimestamp: number } {
+        const millisSinceLastTimestamp = new Date().getTime() - latestTimestamp
+        const millisSinceLastWholeMinute = millisSinceLastTimestamp % relativeMinuteMillis
+
+        const millisToWait = millisSinceLastWholeMinute !== 0 ? relativeMinuteMillis - millisSinceLastWholeMinute : 0
+        const minutesSinceTimestamp = (millisSinceLastTimestamp + millisToWait) / relativeMinuteMillis
+
+        return { millisToWait, minutesSinceTimestamp }
+    }
+
+    private message() {
+        this.clearOldMessage()
+        return (this.#message = new Message())
+    }
+
+    dispose() {
+        this.clearOldMessage()
+    }
+}
+
+class Message implements vscode.Disposable {
+    private currentWarningMessageTimeout: Timeout | undefined
+
+    /**
+     * Show the warning message
+     *
+     * @param minutesUserWasInactive total minutes user was inactive.
+     * @param minutesUntilShutdown remaining minutes until shutdown.
+     * @param userIsActive function to call when we want to indicate the user is active
+     * @param willRefreshOnStaleTimestamp sanity checks with the dev env api that the latest activity timestamp
+     *                                    is the same as what this client has locally. If stale, the warning message
+     *                                    will be refreshed asynchronously. Returns true if the message will be refreshed.
+     * @param relativeMinuteMillis How many milliseconds we want a "minute" to be. This is
+     *                             useful for testing purposes.
+     */
+    async show(
+        minutesUserWasInactive: number,
+        minutesUntilShutdown: number,
+        userIsActive: () => Promise<any> | any,
+        willRefreshOnStaleTimestamp: () => Promise<boolean>,
+        relativeMinuteMillis: number
+    ) {
+        this.clearExistingMessage()
+        // Show a new message every minute
+        this.currentWarningMessageTimeout = new Timeout(1 * relativeMinuteMillis)
+
+        if (await willRefreshOnStaleTimestamp()) {
+            return
+        }
+
+        if (minutesUntilShutdown <= 1) {
+            // Recursive base case, with only 1 minute left we do not want to show warning messages anymore,
+            // since we will show a shutdown message instead.
+            this.clearExistingMessage()
+
+            const imHere = `I'm here!`
+            vscode.window
+                .showWarningMessage(
+                    `Your CodeCatalyst Dev Environment has been inactive for ${minutesUserWasInactive} minutes, and will stop soon.`,
+                    imHere
+                )
+                .then(res => {
+                    if (res === imHere) {
+                        userIsActive()
+                    }
+                })
+            return
+        }
+
+        this.currentWarningMessageTimeout.token.onCancellationRequested(c => {
+            if (c.agent === 'user') {
+                // User clicked the 'Cancel' button, indicate they are active.
+                userIsActive()
+            } else {
+                // The message timed out, show the updated message.
+                this.show(
+                    minutesUserWasInactive + 1,
+                    minutesUntilShutdown - 1,
+                    userIsActive,
+                    willRefreshOnStaleTimestamp,
+                    relativeMinuteMillis
+                )
+            }
+        })
+
+        if (isCloud9()) {
+            // C9 does not support message with progress, so just show a warning message.
+            vscode.window
+                .showWarningMessage(
+                    this.buildInactiveWarningMessage(minutesUserWasInactive, minutesUntilShutdown),
+                    'Cancel'
+                )
+                .then(() => {
+                    this.currentWarningMessageTimeout!.cancel()
+                })
+        } else {
+            showMessageWithCancel(
+                this.buildInactiveWarningMessage(minutesUserWasInactive, minutesUntilShutdown),
+                this.currentWarningMessageTimeout
+            )
+        }
+    }
+
+    clearExistingMessage() {
+        if (this.currentWarningMessageTimeout) {
+            this.currentWarningMessageTimeout.dispose()
+            this.currentWarningMessageTimeout = undefined
+        }
+    }
+
+    dispose() {
+        this.clearExistingMessage()
+    }
+
+    private buildInactiveWarningMessage(inactiveMinutes: number, remainingMinutes: number) {
+        return `Your CodeCatalyst Dev Environment has been inactive for ${inactiveMinutes} minutes, shutting it down in ${remainingMinutes} minutes.`
+    }
+}

--- a/src/shared/clients/devenvClient.ts
+++ b/src/shared/clients/devenvClient.ts
@@ -4,10 +4,11 @@
  */
 
 import * as vscode from 'vscode'
-import got from 'got'
+import got, { HTTPError } from 'got'
 import globals from '../extensionGlobals'
 import { getLogger } from '../logger/logger'
 import { getCodeCatalystDevEnvId } from '../vscode/env'
+import { ExtensionUserActivity } from '../extensionUtilities'
 
 const environmentAuthToken = '__MDE_ENV_API_AUTHORIZATION_TOKEN'
 const environmentEndpoint = 'http://127.0.0.1:1339'
@@ -103,6 +104,123 @@ export class DevEnvClient implements vscode.Disposable {
         // `Authorization` _should_ have two parameters (RFC 7235), MDE should probably fix that
         headers: { Authorization: this.authToken },
     })
+
+    /**
+     * WARNING: You should use {@link DevEnvActivity} unless you have a reason not to.
+     */
+    async updateActivity(timestamp: number = Date.now()): Promise<number> {
+        await this.got.put('activity', { json: { timestamp: timestamp.toString() } })
+        return timestamp
+    }
+
+    /**
+     * WARNING: You should use {@link DevEnvActivity} unless you have a reason not to.
+     */
+    async getActivity(): Promise<number | undefined> {
+        const response = await this.got<GetActivityResponse>('activity')
+        return response.body.timestamp ? parseInt(response.body.timestamp) : undefined
+    }
+}
+
+/**
+ * This allows you to easily work with Dev Env user activity timestamps.
+ * 
+ * An activity is a timestamp that the server uses to
+ * determine when the user was last active.
+ */
+export class DevEnvActivity implements vscode.Disposable{
+    private activityUpdatedEmitter = new vscode.EventEmitter<number>()
+    private ideActivityListener: vscode.Disposable | undefined
+    /** The last known activity timestamp, but there could be a newer one on the server. */
+    private lastLocalActivity: number | undefined
+    private extensionUserActivity: ExtensionUserActivity
+
+    static readonly activityUpdateDelay = 10_000
+
+    /**
+     * Returns an instance if the activity mechanism is confirmed to be working.
+     */
+    static async instanceIfActivityTrackingEnabled(client: DevEnvClient, extensionUserActivity?: ExtensionUserActivity): Promise<DevEnvActivity | undefined> {
+        try {
+            await client.getActivity()
+        }
+        catch (e) {
+            const error = e instanceof HTTPError ? e.response.body : e
+            getLogger().error(`DevEnvActivity: Activity API failed:%s`, error)
+            return undefined
+        }
+        
+        return new DevEnvActivity(client, extensionUserActivity)
+    }
+
+    private constructor(private readonly client: DevEnvClient, extensionUserActivity?: ExtensionUserActivity) {
+        this.extensionUserActivity = extensionUserActivity ?? new ExtensionUserActivity(DevEnvActivity.activityUpdateDelay)
+    }
+
+    /** Send activity timestamp to the Dev Env */
+    async sendActivityUpdate(timestamp: number = Date.now()): Promise<number> {
+        await this.client.updateActivity()
+        this.lastLocalActivity = timestamp
+        this.activityUpdatedEmitter.fire(timestamp)
+        return timestamp
+    }
+
+    /** Get the latest activity timestamp from the Dev Env */
+    async getLatestActivity(): Promise<number | undefined> {
+        const lastServerActivity = await this.client.getActivity()
+        
+        // A single Dev Env can have multiple clients connected to it.
+        // So if one client updates the timestamp, it will be different from what the
+        // other clients assumed the last activity was.
+        if (lastServerActivity && lastServerActivity !== this.lastLocalActivity) {
+            this.activityUpdatedEmitter.fire(lastServerActivity)
+        }
+
+        this.lastLocalActivity = lastServerActivity
+        return this.lastLocalActivity
+    }
+
+    /** true, if the latest activity on the server is different from what this client has as the latest */
+    async isLocalActivityStale(): Promise<boolean> {
+        return await this.getLatestActivity() !== this.lastLocalActivity
+    }
+
+    /** Runs the given callback when the activity is updated */
+    onActivityUpdate(callback: (timestamp: number) => any) {
+        this.updateActivityOnIdeActivity()
+        this.activityUpdatedEmitter.event(callback)
+    }
+
+    /** Stops sending activity timestamps to the dev env on user ide activity. */
+    stopUpdatingActivityOnIdeActivity() {
+        this.ideActivityListener?.dispose()
+        this.ideActivityListener = undefined
+    }
+
+    /**
+     * Sends an activity timestamp to Dev Env when there is user activity, throttled to once every {@link DevEnvActivity.activityUpdateDelay}.
+     */
+    private updateActivityOnIdeActivity() {
+        if (this.ideActivityListener) {
+            return
+        }
+
+        this.ideActivityListener = this.extensionUserActivity.onUserActivity(async () => {
+            await this.sendActivityUpdate()
+        })
+    }
+
+    dispose() {
+        this.stopUpdatingActivityOnIdeActivity()
+    }
+}
+
+export interface GetActivityResponse {
+    timestamp?: string
+}
+
+export interface UpdateActivityRequest {
+    timestamp?: string
 }
 
 export interface GetStatusResponse {

--- a/src/shared/extensionUtilities.ts
+++ b/src/shared/extensionUtilities.ts
@@ -374,28 +374,12 @@ export class ExtensionUserActivity {
     /** The event that is triggered when the user interacts with the extension */
     onUserActivity = this.activityEvent.event
 
-    /** To be efficient we re-used instances that already have the same throttle delay */
-    private static instances: { [delay: number]: ExtensionUserActivity } = {}
-
-    /**
-     * @param delay The delay until a throttled user activity event is fired in milliseconds.
-     * @param activityEvents The events that trigger the user activity.
-     * @returns
-     */
-    static instance(delay: number = 500, activityEvents = ExtensionUserActivity.activityEvents): ExtensionUserActivity {
-        if (!ExtensionUserActivity.instances[delay]) {
-            const newInstance = new ExtensionUserActivity(delay, activityEvents)
-            ExtensionUserActivity.instances[delay] = newInstance
-        }
-        return ExtensionUserActivity.instances[delay]
-    }
-
-    private constructor(delay: number, private readonly activityEvents: vscode.Event<any>[]) {
+    constructor(delay: number = 10_000, activityEvents = ExtensionUserActivity.activityEvents) {
         const throttledEvent = _.throttle(() => this.activityEvent.fire(), delay, { leading: true })
-        this.activityEvents.forEach(event => event(throttledEvent))
+        activityEvents.forEach(event => event(throttledEvent))
     }
 
-    private static activityEvents = [
+    private static readonly activityEvents = [
         vscode.window.onDidChangeActiveTextEditor,
         vscode.window.onDidChangeTextEditorSelection,
         vscode.window.onDidChangeActiveTerminal,

--- a/src/test/shared/clients/devenvClient.test.ts
+++ b/src/test/shared/clients/devenvClient.test.ts
@@ -1,0 +1,93 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { SinonStub, SinonStubbedInstance, SinonStubbedMember, createSandbox, createStubInstance } from 'sinon'
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+
+import {ExtensionUserActivity} from '../../../shared/extensionUtilities'
+import { DevEnvClient, DevEnvActivity } from '../../../shared/clients/devenvClient'
+import { sleep } from '../../../shared/utilities/timeoutUtils'
+
+
+describe('DevEnvActivity', function () {
+    let triggerUserActivityEvent: (obj: any) => Promise<void>
+    let userActivityEvent: SinonStub<Parameters<vscode.Event<any>>, vscode.Disposable>
+    let activitySubscriber: SinonStubbedMember<(timestamp: number) => void>
+    let devEnvClientStub: SinonStubbedInstance<DevEnvClient>
+    let devEnvActivity: DevEnvActivity
+    let sandbox: sinon.SinonSandbox
+
+    before(function() {
+        sandbox = createSandbox()
+    })
+
+    beforeEach(async function () {
+        userActivityEvent = sandbox.stub(
+            vscode.window, 
+            'onDidChangeActiveColorTheme'
+        )
+        userActivityEvent.callsFake((throttledEventFire: (obj: any) => void) => {
+            triggerUserActivityEvent = async (obj: any) => {
+                throttledEventFire(obj)
+                // There are multiple layers of emitters firing
+                // so we wait a bit before returning. Otherwise,
+                // racecondition when waiting for activitySubscriber
+                // to be called
+                await sleep(100)
+            }
+            return {
+                dispose: sandbox.stub()
+            }
+        })
+        
+        devEnvClientStub = createStubInstance(DevEnvClient)
+
+        devEnvActivity = (await DevEnvActivity.instanceIfActivityTrackingEnabled(devEnvClientStub as unknown as DevEnvClient, new ExtensionUserActivity(0, [userActivityEvent])))!
+    })
+
+    afterEach(function () {
+        sandbox.restore()
+    })
+
+    it('has expected throttle delay that we send updates on user activity', function () {
+        assert.strictEqual(DevEnvActivity.activityUpdateDelay, 10_000)
+    })
+
+    it('does not allow instance to be created if activity API not working', async function () {
+        devEnvClientStub.getActivity.throws()
+        const instance = (await DevEnvActivity.instanceIfActivityTrackingEnabled(devEnvClientStub as unknown as DevEnvClient, new ExtensionUserActivity(0, [userActivityEvent])))
+        assert.strictEqual(instance, undefined)
+    })
+
+    describe('activity subscribers are properly notified', function () {
+        beforeEach(function() {
+            activitySubscriber = sandbox.stub()
+            devEnvActivity.onActivityUpdate(activitySubscriber)
+        })
+
+        it('when user activity is explicitly updated', async () => {
+            assert.strictEqual(activitySubscriber.callCount, 0)
+            await devEnvActivity.sendActivityUpdate()
+            assert.strictEqual(activitySubscriber.callCount, 1)
+        })
+
+        it('when vscode user activity event is emitted', async () => {
+            assert.strictEqual(activitySubscriber.callCount, 0)
+            await triggerUserActivityEvent({})
+            assert.strictEqual(activitySubscriber.callCount, 1)
+        })
+
+        it('when we discover a different activity timestamp on the server', async () => {
+            assert.strictEqual(activitySubscriber.callCount, 0)
+    
+            await devEnvActivity.sendActivityUpdate(111) // We send an activity update
+            assert.strictEqual(activitySubscriber.callCount, 1)
+    
+            devEnvClientStub.getActivity.resolves(222) // If we retrieve the latest activity timestamp it will be different
+            await devEnvActivity.getLatestActivity()
+            assert.strictEqual(activitySubscriber.callCount, 2)
+        })
+    })
+})

--- a/src/test/shared/extensionUtilities.test.ts
+++ b/src/test/shared/extensionUtilities.test.ts
@@ -214,22 +214,11 @@ describe('ExtensionUserActivity', function () {
         ]
         const waitFor = 500 // some additional buffer to make sure everything triggers
 
-        const instance = ExtensionUserActivity.instance(throttleDelay, [...eventsFirst, ...eventsSecond])
+        const instance = new ExtensionUserActivity(throttleDelay, [...eventsFirst, ...eventsSecond])
         instance.onUserActivity(onEventTriggered)
         await sleep(waitFor)
 
         assert.strictEqual(count, 2)
-    })
-
-    it('gives the same instance if the throttle delay is the same', function () {
-        const instance1 = ExtensionUserActivity.instance(100)
-        const instance2 = ExtensionUserActivity.instance(100)
-        const instance3 = ExtensionUserActivity.instance(200)
-        const instance4 = ExtensionUserActivity.instance(200)
-
-        assert.strictEqual(instance1, instance2)
-        assert.strictEqual(instance3, instance4)
-        assert.notStrictEqual(instance1, instance3)
     })
 
     function delayedFiringEvent(fireInMillis: number): vscode.Event<any> {

--- a/src/test/shared/extensionUtilities.test.ts
+++ b/src/test/shared/extensionUtilities.test.ts
@@ -193,6 +193,7 @@ describe('initializeComputeRegion, getComputeRegion', async function () {
 
 describe('ExtensionUserActivity', function () {
     let count: number
+    let sandbox: sinon.SinonSandbox
 
     function onEventTriggered() {
         count++
@@ -200,25 +201,142 @@ describe('ExtensionUserActivity', function () {
 
     before(function () {
         count = 0
+        sandbox = sinon.createSandbox()
     })
 
     it('triggers twice when multiple user activities are fired in separate intervals', async function () {
-        // IMPORTANT: This may be flaky in CI, so we may need to increase the intervals for more tolerance
-        const throttleDelay = 200
-        const eventsFirst = [delayedFiringEvent(100), delayedFiringEvent(101), delayedFiringEvent(102)]
-        const eventsSecond = [
-            delayedFiringEvent(250),
-            delayedFiringEvent(251),
-            delayedFiringEvent(251),
-            delayedFiringEvent(252),
-        ]
-        const waitFor = 500 // some additional buffer to make sure everything triggers
+        const throttleDelay = 2000
+        const middleOfInterval = Math.floor(throttleDelay / 2)
+        const waitFor = throttleDelay * 3 // delay * (2 event intervals + test buffer)
 
+        const eventsFirst = [
+            delayedFiringEvent(middleOfInterval + 1),
+            delayedFiringEvent(middleOfInterval + 2),
+            delayedFiringEvent(middleOfInterval + 3),
+            delayedFiringEvent(middleOfInterval + 4),
+        ]
+        const eventsSecond = [
+            delayedFiringEvent(throttleDelay + middleOfInterval + 1),
+            delayedFiringEvent(throttleDelay + middleOfInterval + 2),
+            delayedFiringEvent(throttleDelay + middleOfInterval + 2),
+            delayedFiringEvent(throttleDelay + middleOfInterval + 3),
+        ]
+        
         const instance = new ExtensionUserActivity(throttleDelay, [...eventsFirst, ...eventsSecond])
         instance.onUserActivity(onEventTriggered)
         await sleep(waitFor)
 
-        assert.strictEqual(count, 2)
+        assert.strictEqual(count, 2, 'This may be flaky in CI, so we may need to increase the intervals for better tolerance')
+    })
+
+    describe('does not fire user activity events in specific scenarios', function() {
+        let userActivitySubscriber: sinon.SinonStubbedMember<() => void>
+        let _triggerUserActivity: (obj: any) => void
+        let instance: ExtensionUserActivity
+
+        beforeEach(function () {
+            userActivitySubscriber = sandbox.stub()
+            _triggerUserActivity = () => { throw Error('Called before ExtensionUserActivity was instantiated')}
+        })
+
+        afterEach(function () {
+            instance.dispose()
+            sandbox.restore()
+        })
+
+        it('does not fire onDidChangeWindowState when not active', function() {
+            stubUserActivityEvent(vscode.window, 'onDidChangeWindowState')
+            
+            const triggerUserActivity = createTriggerActivityFunc()
+
+            triggerUserActivity({active: false})
+            assert.strictEqual(userActivitySubscriber.callCount, 0)
+
+            triggerUserActivity({active: true})
+            assert.strictEqual(userActivitySubscriber.callCount, 1)
+        })
+
+        it('does not fire onDidChangeTextEditorSelection when editor is `Output` panel', function() {
+            stubUserActivityEvent(vscode.window, 'onDidChangeTextEditorSelection')
+            
+            const triggerUserActivity = createTriggerActivityFunc()
+
+            triggerUserActivity({textEditor: {document: {uri: {scheme: 'output'}}}})
+            assert.strictEqual(userActivitySubscriber.callCount, 0)
+
+            triggerUserActivity({textEditor: {document: {uri: {scheme: 'NOToutput'}}}})
+            assert.strictEqual(userActivitySubscriber.callCount, 1)
+        })
+
+        it('does not fire onDidChangeTextEditorVisibleRanges when when editor is `Output` panel', function() {
+            stubUserActivityEvent(vscode.window, 'onDidChangeTextEditorVisibleRanges')
+            
+            const triggerUserActivity = createTriggerActivityFunc()
+
+            triggerUserActivity({textEditor: {document: {uri: {scheme: 'output'}}}})
+            assert.strictEqual(userActivitySubscriber.callCount, 0)
+
+            triggerUserActivity({textEditor: {document: {uri: {scheme: 'NOToutput'}}}})
+            assert.strictEqual(userActivitySubscriber.callCount, 1)
+        })
+
+        it('does not fire onDidChangeTextDocument when not the active user document', function() {
+            stubUserActivityEvent(vscode.workspace, 'onDidChangeTextDocument')
+            const activeEditorStub = sandbox.stub(vscode.window, 'activeTextEditor')
+            
+            const triggerUserActivity = createTriggerActivityFunc()
+
+            activeEditorStub.get(() => undefined)
+            triggerUserActivity({})
+            assert.strictEqual(userActivitySubscriber.callCount, 0, 'Was not ignored when no active editor')
+
+            activeEditorStub.get(() => {return {document: {uri: 'myUri'}}})
+            triggerUserActivity({document: {uri: 'myOtherUri'}})
+            assert.strictEqual(userActivitySubscriber.callCount, 0, 'Was not ignored when active editor document was different from the event')
+
+            triggerUserActivity({document: {uri: 'myUri'}})
+            assert.strictEqual(userActivitySubscriber.callCount, 1, 'Was ignored when the active editor document was the same as the event')
+        })
+
+        it('fires for onDidChangeActiveColorTheme (sanity check)', function () {
+            stubUserActivityEvent(vscode.window, 'onDidChangeActiveColorTheme')
+            
+            const triggerUserActivity = createTriggerActivityFunc()
+
+            triggerUserActivity({})
+            assert.strictEqual(userActivitySubscriber.callCount, 1)
+        })
+
+        /**
+         * Helper to stub a vscode event object.
+         * 
+         * Once stubbed, you can call {@link _triggerUserActivity} to fire
+         * the event.
+         */
+        function stubUserActivityEvent<T, K extends keyof T>(vscodeObj: T, eventName: K){
+            const eventStub = sandbox.stub(
+                vscodeObj, 
+                eventName
+            )
+            
+            eventStub.callsFake((callback: any) => {
+                _triggerUserActivity = callback
+                return {
+                    dispose: sandbox.stub()
+                }
+            })
+            
+            return eventStub
+        }
+
+        function createTriggerActivityFunc() {
+            instance = new ExtensionUserActivity(0)
+            instance.onUserActivity(userActivitySubscriber)
+            // Creation of the ExtensionUserActivity instance
+            // will call the stubbed event and set the value
+            // for _triggerUserActivity
+            return _triggerUserActivity
+        }
     })
 
     function delayedFiringEvent(fireInMillis: number): vscode.Event<any> {

--- a/src/testInteg/codecatalyst/devEnv.test.ts
+++ b/src/testInteg/codecatalyst/devEnv.test.ts
@@ -1,0 +1,235 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import { InactivityMessage, shouldTrackUserActivity } from '../../codecatalyst/devEnv'
+import * as sinon from 'sinon'
+import { sleep } from '../../shared/utilities/timeoutUtils'
+import { TestWindow, getTestWindow } from '../../test/shared/vscode/window'
+import { DevEnvActivity } from '../../shared/clients/devenvClient'
+
+describe('shouldTrackUserActivity', function () {
+    it('returns true when inactivity timeout > 0', function () {
+        assert.strictEqual(shouldTrackUserActivity(1), true)
+        assert.strictEqual(shouldTrackUserActivity(15), true)
+    })
+
+    it('returns false when inactivity timeout <== 0', function () {
+        assert.strictEqual(shouldTrackUserActivity(0), false)
+        assert.strictEqual(shouldTrackUserActivity(-1), false)
+    })
+})
+
+describe('InactivityMessages', function () {
+    /** Actual minute in prod is this value instead so testing is faster. */
+    let relativeMinuteMillis: number
+    let testWindow: TestWindow
+    let devEnvActivity: sinon.SinonStubbedInstance<DevEnvActivity>
+    let actualMessages: { message: string; minute: number }[] = []
+    let instance: InactivityMessage
+
+    beforeEach(function () {
+        relativeMinuteMillis = 200
+        testWindow = getTestWindow()
+        instance = new InactivityMessage()
+
+        devEnvActivity = sinon.createStubInstance(DevEnvActivity)
+        // Setup for DevEnvClient stub to call the onUserActivity event callback code when updateUserActivity() is called
+        devEnvActivity.onActivityUpdate.callsFake(activityCallback => {
+            devEnvActivity.sendActivityUpdate.callsFake(async () => {
+                const timestamp = getLatestTimestamp()
+                activityCallback(timestamp)
+                return timestamp
+            })
+        })
+        devEnvActivity.isLocalActivityStale.callsFake(async () => {
+            return false
+        })
+
+        startCapturingMessages()
+    })
+
+    afterEach(function () {
+        instance.dispose()
+        testWindow.dispose()
+    })
+
+    it('shows expected messages 5 minutes before shutdown on a 15 minute inactivity timeout', async function () {
+        instance.setupMessage(15, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
+
+        await assertMessagesShown([
+            ['Your CodeCatalyst Dev Environment has been inactive for 10 minutes, shutting it down in 5 minutes.', 10],
+            ['Your CodeCatalyst Dev Environment has been inactive for 11 minutes, shutting it down in 4 minutes.', 11],
+            ['Your CodeCatalyst Dev Environment has been inactive for 12 minutes, shutting it down in 3 minutes.', 12],
+            ['Your CodeCatalyst Dev Environment has been inactive for 13 minutes, shutting it down in 2 minutes.', 13],
+            ['Your CodeCatalyst Dev Environment has been inactive for 14 minutes, and will stop soon.', 14],
+        ])
+    })
+
+    it('shows expected messages 5 minutes before shutdown on a 60 minute inactivity timeout', async function () {
+        instance.setupMessage(60, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
+
+        await assertMessagesShown([
+            ['Your CodeCatalyst Dev Environment has been inactive for 55 minutes, shutting it down in 5 minutes.', 55],
+            ['Your CodeCatalyst Dev Environment has been inactive for 56 minutes, shutting it down in 4 minutes.', 56],
+            ['Your CodeCatalyst Dev Environment has been inactive for 57 minutes, shutting it down in 3 minutes.', 57],
+            ['Your CodeCatalyst Dev Environment has been inactive for 58 minutes, shutting it down in 2 minutes.', 58],
+            ['Your CodeCatalyst Dev Environment has been inactive for 59 minutes, and will stop soon.', 59],
+        ])
+    })
+
+    it('resets the inactivity countdown when a user clicks on a button in any activity message', async function () {
+        let isFirstMessage = true
+        testWindow.onDidShowMessage(async message => {
+            if (message.message.endsWith('stop soon.')) {
+                // User hits the 'I'm here!' button on the inactivity shutdown message
+                message.selectItem(`I'm here!`)
+                return
+            }
+
+            if (!isFirstMessage) {
+                return
+            }
+            isFirstMessage = false
+            // User hits the 'Cancel' button on the first inactivity warning message
+            message.selectItem('Cancel')
+        })
+
+        instance.setupMessage(7, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
+
+        await assertMessagesShown([
+            ['Your CodeCatalyst Dev Environment has been inactive for 2 minutes, shutting it down in 5 minutes.', 2],
+            // User clicked 'Cancel' on the warning message so timer was reset
+            ['Your CodeCatalyst Dev Environment has been inactive for 2 minutes, shutting it down in 5 minutes.', 4],
+            ['Your CodeCatalyst Dev Environment has been inactive for 3 minutes, shutting it down in 4 minutes.', 5],
+            ['Your CodeCatalyst Dev Environment has been inactive for 4 minutes, shutting it down in 3 minutes.', 6],
+            ['Your CodeCatalyst Dev Environment has been inactive for 5 minutes, shutting it down in 2 minutes.', 7],
+            ['Your CodeCatalyst Dev Environment has been inactive for 6 minutes, and will stop soon.', 8],
+            // User clicked "I'm here!" on the shutdown message so timer was reset
+            ['Your CodeCatalyst Dev Environment has been inactive for 2 minutes, shutting it down in 5 minutes.', 10],
+        ])
+    })
+
+    it('takes in to consideration 2 1/2 minutes have already passed for an inactive external client.', async function () {
+        const inactiveMinutes = 9
+        const initialOffsetMinutes = 2.5
+        // We normally show the warning message after 6 inactive minutes of user percieved time
+        // in this scenario (9 inactive minutes till shutdown).
+        //
+        // But because we are taking in to consideration 2 1/2 minutes have already passed, we show the warning
+        // 3 minutes before it typically would.
+        // Remember that minutesElapsedSinceLatestTimestamp() sleeps till the next whole minute,
+        // which is why 2 1/2 minutes becomes 3 minutes. Then we start the countdown to show the
+        // first warning message.
+        const minuteFirstMessageShown =
+            inactiveMinutes - Math.ceil(initialOffsetMinutes) - InactivityMessage.firstMessageBeforeShutdown
+        setInitialOffset(initialOffsetMinutes)
+
+        instance.setupMessage(inactiveMinutes, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
+
+        await assertMessagesShown([
+            [
+                'Your CodeCatalyst Dev Environment has been inactive for 4 minutes, shutting it down in 5 minutes.',
+                minuteFirstMessageShown,
+            ],
+            [
+                'Your CodeCatalyst Dev Environment has been inactive for 5 minutes, shutting it down in 4 minutes.',
+                minuteFirstMessageShown + 1,
+            ],
+            [
+                'Your CodeCatalyst Dev Environment has been inactive for 6 minutes, shutting it down in 3 minutes.',
+                minuteFirstMessageShown + 2,
+            ],
+            [
+                'Your CodeCatalyst Dev Environment has been inactive for 7 minutes, shutting it down in 2 minutes.',
+                minuteFirstMessageShown + 3,
+            ],
+            [
+                'Your CodeCatalyst Dev Environment has been inactive for 8 minutes, and will stop soon.',
+                minuteFirstMessageShown + 4,
+            ],
+        ])
+    })
+
+    it('does not show any inactivity message if a newer user activity is found using the api', async function () {
+        // This gets checked each time before we decide to show the message.
+        // If a new user activity exists then we abort showing the message.
+        devEnvActivity.isLocalActivityStale.callsFake(async () => {
+            return true
+        })
+
+        instance.setupMessage(
+            InactivityMessage.firstMessageBeforeShutdown + 1,
+            devEnvActivity as unknown as DevEnvActivity,
+            relativeMinuteMillis
+        )
+        await sleep(relativeMinuteMillis * 3)
+        assert.strictEqual(testWindow.shownMessages.length, 0)
+        assert.strictEqual(devEnvActivity.isLocalActivityStale.calledOnce, true)
+    })
+
+    /**
+     * Assert the expected inactivity message was shown at the
+     * right time.
+     *
+     * @param text The actual message itself
+     * @param minute The minute the message was expected to be shown at
+     */
+    async function assertMessagesShown(expectedMessages: [text: string, minute: number][]) {
+        // Sleep until all messages should have been shown.
+        //
+        // This buffer gives us a bit more time to wrap things up.
+        // Be careful setting it to >relativeMinuteMillis, as it could
+        // start a new cycle of messages if too large.
+        const expectedMinuteLastMessageShown = expectedMessages[expectedMessages.length - 1][1]
+        const buffer = relativeMinuteMillis - 1
+        await sleep(expectedMinuteLastMessageShown * relativeMinuteMillis + buffer)
+
+        if (expectedMessages.length !== actualMessages.length) {
+            assert.fail(`Expected ${expectedMessages.length} messages, but got ${actualMessages.length}`)
+        }
+
+        let i: number
+        for (i = 0; i < expectedMessages.length; i++) {
+            assert.strictEqual(actualMessages[i].message, expectedMessages[i][0])
+            assert.strictEqual(actualMessages[i].minute, expectedMessages[i][1])
+        }
+    }
+
+    /**
+     * Starts capturing all vscode messages shown and records them in {@link actualMessages}.
+     *
+     * The `minute` field in {@link actualMessages} records the minute the message was shown.
+     * This value is relative to {@link relativeMinuteMillis}.
+     */
+    function startCapturingMessages() {
+        const start = new Date().getTime()
+        const messages: { message: string; minute: number }[] = []
+        testWindow.onDidShowMessage(async message => {
+            const now = new Date().getTime()
+            messages.push({ message: message.message, minute: Math.floor((now - start) / relativeMinuteMillis) })
+        })
+        actualMessages = messages
+    }
+
+    let _initialOffset: number | undefined
+    /**
+     * This is used for the edge case where the MDE was previously updated with an activity
+     * timestamp, but once our client retrieves this value some time has already passed.
+     */
+    function setInitialOffset(minutes: number) {
+        _initialOffset = minutes * relativeMinuteMillis
+    }
+
+    function getLatestTimestamp() {
+        let timestamp = new Date().getTime()
+        if (_initialOffset) {
+            timestamp -= _initialOffset
+            _initialOffset = undefined
+        }
+
+        return timestamp
+    }
+})


### PR DESCRIPTION
## Problem

If a user is using a dev env with something like vscode, and the user stops interacting with the ide
we want to notify the dev env about this inactivity so it can automatically shutdown after a certain
amount of user inactivity.

## Solution

- A cancellable message will be shown a few minutes before shutdown, and will update
   the remaining time each minute until the final minute before shutdown.
- On the final minute a different message will be show that indicates the dev env
   will shut down in 1 minute.
- We will show messages 5 minutes before shutdown.
----
- For each message that pops up if they interact with the IDE or click one of the buttons
in the message it will refresh the shutdown timer to whatever was initially configured.
- General interactions with the IDE will cause the ide to send a heartbeat to the dev env (see `startTrackingUserActivity()`)


### Messages

#### First message
![Screen Shot 2023-07-10 at 3 22 24 PM](https://github.com/aws/aws-toolkit-vscode/assets/118216176/7aac8116-3d7b-4f7e-843d-95894e2e0c27)

#### Updated message after a minute
![Screen Shot 2023-07-10 at 3 23 21 PM](https://github.com/aws/aws-toolkit-vscode/assets/118216176/74a54cd6-8a7b-43ed-bc8e-3725b1a46c3f)

#### Final Message a minute before shutdown
![Screen Shot 2023-07-10 at 3 24 22 PM](https://github.com/aws/aws-toolkit-vscode/assets/118216176/f315af4e-dc30-45d8-9231-7c6f78577021)



Signed-off-by: Nikolas Komonen <nkomonen@amazon.com>

## License



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
