### PR TITLE
add missing changelog item

### DIFF
--- a/.changes/1.80.0.json
+++ b/.changes/1.80.0.json
@@ -1,0 +1,10 @@
+{
+	"date": "2023-07-05",
+	"version": "1.80.0",
+	"entries": [
+		{
+			"type": "Bug Fix",
+			"description": "Fix function that determined who was a first time user"
+		}
+	]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.80.0 2023-07-05
+
+- **Bug Fix** Fix function that determined who was a first time user
+
 ## 1.79.0 2023-06-30
 
 - **Feature** New Add Connection workflow


### PR DESCRIPTION
Since v 1.80.0 did not have any explicit changes from 'npm run newChange', nothing was added to the changelog and this caused the 1.80.0 entry to be missing

## Solution

Manually add an entry and update the changelog

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
