### PR TITLE
Hkobew/ec2/explorer icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1318,6 +1318,11 @@
                     "when": "viewItem == awsEc2Node"
                 },
                 {
+                    "command": "aws.ec2.openTerminal",
+                    "group": "inline@1",
+                    "when": "viewItem == awsEc2Node"
+                },
+                {
                     "command": "aws.ecr.createRepository",
                     "when": "view == aws.explorer && viewItem == awsEcrNode",
                     "group": "inline@1"
@@ -2062,6 +2067,7 @@
             {
                 "command": "aws.ec2.openTerminal",
                 "title": "%AWS.command.ec2.openTerminal%",
+                "icon": "$(terminal-view-icon)",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {

--- a/src/ec2/activation.ts
+++ b/src/ec2/activation.ts
@@ -8,21 +8,23 @@ import { telemetry } from '../shared/telemetry/telemetry'
 import { Ec2InstanceNode } from './explorer/ec2InstanceNode'
 import { promptUserForEc2Selection } from './prompter'
 import { Ec2ConnectionManager } from './model'
+import { Ec2ParentNode } from './explorer/ec2ParentNode'
 
 export async function activate(ctx: ExtContext): Promise<void> {
     ctx.extensionContext.subscriptions.push(
-        Commands.register('aws.ec2.openTerminal', async (node?: Ec2InstanceNode) => {
+        Commands.register('aws.ec2.openTerminal', async (node?: Ec2InstanceNode | Ec2ParentNode) => {
             await telemetry.ec2_connectToInstance.run(async span => {
                 span.record({ ec2ConnectionType: 'ssm' })
-                const selection = node ? node.toSelection() : await promptUserForEc2Selection()
+                const selection =
+                    node instanceof Ec2InstanceNode ? node.toSelection() : await promptUserForEc2Selection()
 
                 const connectionManager = new Ec2ConnectionManager(selection.region)
                 await connectionManager.attemptToOpenEc2Terminal(selection)
             })
         }),
 
-        Commands.register('aws.ec2.openRemoteConnection', async (node?: Ec2InstanceNode) => {
-            const selection = node ? node.toSelection() : await promptUserForEc2Selection()
+        Commands.register('aws.ec2.openRemoteConnection', async (node?: Ec2InstanceNode | Ec2ParentNode) => {
+            const selection = node instanceof Ec2InstanceNode ? node.toSelection() : await promptUserForEc2Selection()
             //const connectionManager = new Ec2ConnectionManager(selection.region)
             console.log(selection)
         })

--- a/src/ec2/activation.ts
+++ b/src/ec2/activation.ts
@@ -5,28 +5,20 @@
 import { ExtContext } from '../shared/extensions'
 import { Commands } from '../shared/vscode/commands2'
 import { telemetry } from '../shared/telemetry/telemetry'
-import { Ec2InstanceNode } from './explorer/ec2InstanceNode'
-import { promptUserForEc2Selection } from './prompter'
-import { Ec2ConnectionManager } from './model'
-import { Ec2ParentNode } from './explorer/ec2ParentNode'
+import { Ec2Node } from './explorer/ec2ParentNode'
+import { openRemoteConnection, openTerminal } from './commands'
 
 export async function activate(ctx: ExtContext): Promise<void> {
     ctx.extensionContext.subscriptions.push(
-        Commands.register('aws.ec2.openTerminal', async (node?: Ec2InstanceNode | Ec2ParentNode) => {
+        Commands.register('aws.ec2.openTerminal', async (node?: Ec2Node) => {
             await telemetry.ec2_connectToInstance.run(async span => {
                 span.record({ ec2ConnectionType: 'ssm' })
-                const selection =
-                    node instanceof Ec2InstanceNode ? node.toSelection() : await promptUserForEc2Selection()
-
-                const connectionManager = new Ec2ConnectionManager(selection.region)
-                await connectionManager.attemptToOpenEc2Terminal(selection)
+                await (node ? openTerminal(node) : openTerminal(node))
             })
         }),
 
-        Commands.register('aws.ec2.openRemoteConnection', async (node?: Ec2InstanceNode | Ec2ParentNode) => {
-            const selection = node instanceof Ec2InstanceNode ? node.toSelection() : await promptUserForEc2Selection()
-            //const connectionManager = new Ec2ConnectionManager(selection.region)
-            console.log(selection)
+        Commands.register('aws.ec2.openRemoteConnection', async (node?: Ec2Node) => {
+            await (node ? openRemoteConnection(node) : openTerminal(node))
         })
     )
 }

--- a/src/ec2/commands.ts
+++ b/src/ec2/commands.ts
@@ -1,0 +1,22 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Ec2InstanceNode } from './explorer/ec2InstanceNode'
+import { Ec2Node } from './explorer/ec2ParentNode'
+import { Ec2ConnectionManager } from './model'
+import { promptUserForEc2Selection } from './prompter'
+
+export async function openTerminal(node?: Ec2Node) {
+    const selection = node instanceof Ec2InstanceNode ? node.toSelection() : await promptUserForEc2Selection()
+
+    const connectionManager = new Ec2ConnectionManager(selection.region)
+    await connectionManager.attemptToOpenEc2Terminal(selection)
+}
+
+export async function openRemoteConnection(node?: Ec2Node) {
+    const selection = node instanceof Ec2InstanceNode ? node.toSelection() : await promptUserForEc2Selection()
+    //const connectionManager = new Ec2ConnectionManager(selection.region)
+    console.log(selection)
+}

--- a/src/ec2/explorer/ec2ParentNode.ts
+++ b/src/ec2/explorer/ec2ParentNode.ts
@@ -11,6 +11,7 @@ import { Ec2Client } from '../../shared/clients/ec2Client'
 import { updateInPlace } from '../../shared/utilities/collectionUtils'
 
 export const contextValueEc2 = 'awsEc2Node'
+export type Ec2Node = Ec2InstanceNode | Ec2ParentNode
 
 export class Ec2ParentNode extends AWSTreeNodeBase {
     protected readonly placeHolderMessage = '[No EC2 Instances Found]'

--- a/src/ec2/explorer/ec2ParentNode.ts
+++ b/src/ec2/explorer/ec2ParentNode.ts
@@ -15,6 +15,7 @@ export const contextValueEc2 = 'awsEc2Node'
 export class Ec2ParentNode extends AWSTreeNodeBase {
     protected readonly placeHolderMessage = '[No EC2 Instances Found]'
     protected readonly ec2InstanceNodes: Map<string, Ec2InstanceNode>
+    public override readonly contextValue: string = contextValueEc2
 
     public constructor(
         public override readonly regionCode: string,

--- a/src/ec2/prompter.ts
+++ b/src/ec2/prompter.ts
@@ -39,7 +39,7 @@ export function handleEc2ConnectPrompterResponse(response: RegionSubmenuResponse
 export function createEc2ConnectPrompter(): RegionSubmenu<string> {
     return new RegionSubmenu(
         async region => (await getInstancesFromRegion(region)).map(asQuickpickItem).promise(),
-        { title: 'Select EC2 Instance Id', matchOnDetail: true },
+        { title: 'Select EC2 Instance', matchOnDetail: true },
         { title: 'Select Region for EC2 Instance' },
         'Instances'
     )


### PR DESCRIPTION
Currently a draft, as it build on work done in https://github.com/aws/aws-toolkit-vscode/pull/3649

## Problem
Explorer implementation feels non-interactive, and there is no way to search for a specific instance without opening command prompt. 
## Solution
- terminal icons on EC2 instance nodes that function as entry point to `aws.ec2.openTerminal` (skipping selection).
- terminal icon on EC2 parent node that functions as entry point to `aws.ec2.connectToInstance` without skipping selection.

![image](https://github.com/aws/aws-toolkit-vscode/assets/42325418/6516ea26-25f5-46eb-b90e-a5c7737da177)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
