### PR TITLE
fix(codewhisperer): fix syntax error, which cause crossfile feat returning empty

### DIFF
--- a/.changes/next-release/Bug Fix-3e5e67c4-5bde-4d7d-b473-c1f772430c4f.json
+++ b/.changes/next-release/Bug Fix-3e5e67c4-5bde-4d7d-b473-c1f772430c4f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeWhisperer: Bug resulting failure of enhanced file context fetching"
+}

--- a/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
+++ b/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
@@ -74,9 +74,7 @@ export async function fetchSupplementalContextForSrc(
     }
 
     // DO NOT send code chunk with empty content
-    return supplementalContexts.filter(item => {
-        return item.content.trim().length !== 0
-    })
+    return supplementalContexts.filter(item => item.content.trim().length !== 0)
 }
 
 function findBestKChunkMatches(chunkInput: Chunk, chunkReferences: Chunk[], k: number): Chunk[] {

--- a/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
+++ b/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
@@ -75,7 +75,7 @@ export async function fetchSupplementalContextForSrc(
 
     // DO NOT send code chunk with empty content
     return supplementalContexts.filter(item => {
-        item.content.trim().length !== 0
+        return item.content.trim().length !== 0
     })
 }
 


### PR DESCRIPTION
## Problem

Patch fix to PR https://github.com/aws/aws-toolkit-vscode/commit/219c586c72eb4127d008d68a880466ef47b79ede of which syntax error is causing crossfile context will return empty all the time

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
