### PR TITLE
feat(codewhisperer): factor in filedistance when fetching crossfile context

### DIFF
--- a/src/test/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/src/test/codewhisperer/util/crossFileContextUtil.test.ts
@@ -19,7 +19,7 @@ import {
     shuffleList,
 } from '../../testUtil'
 import { areEqual, normalize } from '../../../shared/utilities/pathUtils'
-import path from 'path'
+import * as path from 'path'
 import { getMinVscodeVersion } from '../../../shared/vscode/env'
 
 const userGroupSettings = CodeWhispererUserGroupSettings.instance

--- a/src/test/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/src/test/codewhisperer/util/crossFileContextUtil.test.ts
@@ -11,7 +11,15 @@ import * as crossFile from '../../../codewhisperer/util/supplementalContext/cros
 import { createMockTextEditor } from '../testUtil'
 import { CodeWhispererUserGroupSettings } from '../../../codewhisperer/util/userGroupUtil'
 import { UserGroup } from '../../../codewhisperer/models/constants'
-import { assertTabCount, closeAllEditors, createTestWorkspaceFolder, openATextEditorWithText } from '../../testUtil'
+import {
+    assertTabCount,
+    closeAllEditors,
+    createTestWorkspaceFolder,
+    openATextEditorWithText,
+    shuffleList,
+} from '../../testUtil'
+import { areEqual, normalize } from '../../../shared/utilities/pathUtils'
+import path from 'path'
 import { getMinVscodeVersion } from '../../../shared/vscode/env'
 
 const userGroupSettings = CodeWhispererUserGroupSettings.instance
@@ -46,6 +54,71 @@ describe('crossFileContextUtil', function () {
             const actual = await crossFile.fetchSupplementalContextForSrc(mockEditor, fakeCancellationToken)
 
             assert.strictEqual(actual, undefined)
+        })
+    })
+
+    describe('getCrossFileCandidate', function () {
+        before(async function () {
+            this.timeout(60000)
+        })
+
+        beforeEach(async function () {
+            tempFolder = (await createTestWorkspaceFolder()).uri.fsPath
+        })
+
+        afterEach(async function () {
+            await closeAllEditors()
+        })
+
+        it('should return opened files, exclude test files and sorted ascendingly by file distance', async function () {
+            if (!shouldRunTheTest()) {
+                this.skip()
+            }
+
+            const targetFile = path.join('src', 'service', 'microService', 'CodeWhispererFileContextProvider.java')
+            const fileWithDistance3 = path.join('src', 'service', 'CodewhispererRecommendationService.java')
+            const fileWithDistance5 = path.join('src', 'util', 'CodeWhispererConstants.java')
+            const fileWithDistance6 = path.join('src', 'ui', 'popup', 'CodeWhispererPopupManager.java')
+            const fileWithDistance7 = path.join('src', 'ui', 'popup', 'components', 'CodeWhispererPopup.java')
+            const fileWithDistance8 = path.join(
+                'src',
+                'ui',
+                'popup',
+                'components',
+                'actions',
+                'AcceptRecommendationAction.java'
+            )
+            const testFile1 = path.join('test', 'service', 'CodeWhispererFileContextProviderTest.java')
+            const testFile2 = path.join('test', 'ui', 'CodeWhispererPopupManagerTest.java')
+
+            const expectedFilePaths = [
+                fileWithDistance3,
+                fileWithDistance5,
+                fileWithDistance6,
+                fileWithDistance7,
+                fileWithDistance8,
+            ]
+
+            const shuffledFilePaths = shuffleList(expectedFilePaths)
+
+            for (const filePath of shuffledFilePaths) {
+                await openATextEditorWithText('', filePath, tempFolder, { preview: false })
+            }
+
+            await openATextEditorWithText('', testFile1, tempFolder, { preview: false })
+            await openATextEditorWithText('', testFile2, tempFolder, { preview: false })
+            const editor = await openATextEditorWithText('', targetFile, tempFolder, { preview: false })
+
+            await assertTabCount(shuffledFilePaths.length + 3)
+
+            const actual = await crossFile.getCrossFileCandidates(editor)
+
+            assert.ok(actual.length === 5)
+            actual.forEach((actualFile, index) => {
+                const expectedFile = path.join(tempFolder, expectedFilePaths[index])
+                assert.strictEqual(normalize(expectedFile), normalize(actualFile))
+                assert.ok(areEqual(tempFolder, actualFile, expectedFile))
+            })
         })
     })
 

--- a/src/test/testUtil.ts
+++ b/src/test/testUtil.ts
@@ -385,3 +385,17 @@ export function captureEventOnce<T>(event: vscode.Event<T>, timeout?: number): P
         }
     })
 }
+
+/**
+ * Shuffle a list, Fisher-Yates Sorting Algorithm
+ */
+export function shuffleList<T>(list: T[]): T[] {
+    const shuffledList = [...list]
+
+    for (let i = shuffledList.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1))
+        ;[shuffledList[i], shuffledList[j]] = [shuffledList[j], shuffledList[i]]
+    }
+
+    return shuffledList
+}


### PR DESCRIPTION
## Problem
### Before
- Crossfile file candidates are fetched by opened tabs without any sorting, e.g. files will be returned based on theirs orders in the IDE tabs (from the left to the right)

### After
- Crossfile file candidates fetched will be sorted by their file distance ascendingly. Files with smaller file distance will be prioritized than others.

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
