### PR TITLE
fix(tests): closeAllEditors() sometimes fails

### DIFF
--- a/src/shared/utilities/vsCodeUtils.ts
+++ b/src/shared/utilities/vsCodeUtils.ts
@@ -8,44 +8,13 @@ import * as nls from 'vscode-nls'
 import { getIdeProperties } from '../extensionUtilities'
 import * as pathutils from './pathUtils'
 import { getLogger } from '../logger/logger'
-import { CancellationError, Timeout, waitTimeout, waitUntil } from './timeoutUtils'
+import { CancellationError, Timeout, waitTimeout } from './timeoutUtils'
 import { telemetry } from '../telemetry/telemetry'
 import * as semver from 'semver'
 import { isNonNullable } from './tsUtils'
 
 // TODO: Consider NLS initialization/configuration here & have packages to import localize from here
 export const localize = nls.loadMessageBundle()
-
-/**
- * Executes the close all editors command and waits for all visible editors to disappear
- */
-export async function closeAllEditors() {
-    await vscode.commands.executeCommand('workbench.action.closeAllEditors')
-
-    // The output channel counts as an editor, but you can't really close that...
-    const noVisibleEditor: boolean | undefined = await waitUntil(
-        async () => {
-            const visibleEditors = vscode.window.visibleTextEditors.filter(
-                editor => !editor.document.fileName.includes('extension-output') // Output channels are named with the prefix 'extension-output'
-            )
-
-            return visibleEditors.length === 0
-        },
-        {
-            timeout: 2500, // Arbitrary values. Should succeed except when VS Code is lagging heavily.
-            interval: 250,
-            truthy: true,
-        }
-    )
-
-    if (!noVisibleEditor) {
-        throw new Error(
-            `Editor "${
-                vscode.window.activeTextEditor!.document.fileName
-            }" was still open after executing "closeAllEditors"`
-        )
-    }
-}
 
 /**
  * Checks if an extension is installed and active.

--- a/src/test/testUtil.ts
+++ b/src/test/testUtil.ts
@@ -249,31 +249,34 @@ export async function closeAllEditors(): Promise<void> {
     // Note: `workbench.action.closeAllEditors` is unreliable.
     const closeAllCmd = 'openEditors.closeAll'
 
-    // Output channels are named with the prefix 'extension-output'
+    // Output channels are named with prefix "extension-output". https://github.com/microsoft/vscode/issues/148993#issuecomment-1167654358
     // Maybe we can close these with a command?
     const ignorePatterns = [/extension-output/, /tasks/]
+    const editors: vscode.TextEditor[] = []
 
     const noVisibleEditor: boolean | undefined = await waitUntil(
         async () => {
             // Race: documents could appear after the call to closeAllEditors(), so retry.
             await vscode.commands.executeCommand(closeAllCmd)
-            const visibleEditors = vscode.window.visibleTextEditors.filter(
-                editor => !ignorePatterns.find(p => p.test(editor.document.fileName))
+            editors.length = 0
+            editors.push(
+                ...vscode.window.visibleTextEditors.filter(
+                    editor => !ignorePatterns.find(p => p.test(editor.document.fileName))
+                )
             )
 
-            return visibleEditors.length === 0
+            return editors.length === 0
         },
         {
-            timeout: 2500, // Arbitrary values. Should succeed except when VS Code is lagging heavily.
+            timeout: 5000, // Arbitrary values. Should succeed except when VS Code is lagging heavily.
             interval: 250,
             truthy: true,
         }
     )
 
     if (!noVisibleEditor) {
-        const editors = vscode.window.visibleTextEditors.map(editor => `\t${editor.document.fileName}`)
-
-        throw new Error(`The following editors were still open after closeAllEditors():\n${editors.join('\n')}`)
+        const editorNames = editors.map(editor => `\t${editor.document.fileName}`)
+        throw new Error(`Editors were still open after closeAllEditors():\n${editorNames.join('\n')}`)
     }
 }
 


### PR DESCRIPTION
Problem:

- closeAllEditors() sometimes fails (example below).
- Its failure message has a race with the waitUntil() callback.


      2 failing
      1) FileViewerManager
           "after each" hook for "opens a new editor if no document exists":
         Error: The following editors were still open after closeAllEditors():
        extension-output-amazonwebservices.aws-toolkit-vscode-#17-test channel
        /us-west-2/bucket-name/test1.txt
          at /Users/runner/work/aws-toolkit-vscode/aws-toolkit-vscode/src/test/testUtil.ts:276:15
          at Generator.next (<anonymous>)
          at fulfilled (dist/src/test/testUtil.js:9:58)

      2) "before each" hook: beforeEach for "Test AslVisualizationManager managedVisualizations set does not add duplicate renders when multiple Vis active":
         Error: The following editors were still open after closeAllEditors():
        extension-output-amazonwebservices.aws-toolkit-vscode-#1-AWS Toolkit Logs
          at Object.<anonymous> (src/test/testUtil.ts:276:15)
          at Generator.next (<anonymous>)
          at fulfilled (dist/src/test/testUtil.js:9:58)

Solution:
- Increase the waitUntil() timeout.
- Store the editor list from waitUntil() and use that in the failure message.
- Delete redundant, unused closeAllEditors() from src/shared/utilities/vsCodeUtils.ts.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
