### PR TITLE
feat: support only .mjs extension for node18+ lambdas

### DIFF
--- a/.changes/next-release/Feature-fb427da2-9ded-464d-ab03-11d52a46b604.json
+++ b/.changes/next-release/Feature-fb427da2-9ded-464d-ab03-11d52a46b604.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Lambda \"Download\" action now expects \".mjs\" extension for Node18+ lambdas"
+}

--- a/src/lambda/models/samLambdaRuntime.ts
+++ b/src/lambda/models/samLambdaRuntime.ts
@@ -34,6 +34,20 @@ export const nodeJsRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>([
     'nodejs14.x',
     'nodejs12.x',
 ])
+export function getNodeMajorVersion(version?: string): number | undefined {
+    if (!version) {
+        return undefined
+    }
+
+    const match = version.match(/^nodejs(\d+)\./)
+
+    if (match) {
+        return Number(match[1])
+    } else {
+        return undefined
+    }
+}
+
 export const pythonRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>([
     'python3.10',
     'python3.9',

--- a/src/lambda/utils.ts
+++ b/src/lambda/utils.ts
@@ -11,7 +11,7 @@ import { CloudFormation, Lambda } from 'aws-sdk'
 import * as vscode from 'vscode'
 import { CloudFormationClient } from '../shared/clients/cloudFormationClient'
 import { LambdaClient } from '../shared/clients/lambdaClient'
-import { getFamily, RuntimeFamily } from './models/samLambdaRuntime'
+import { getFamily, getNodeMajorVersion, RuntimeFamily } from './models/samLambdaRuntime'
 import { getLogger } from '../shared/logger'
 import { ResourceFetcher } from '../shared/resourcefetcher/resourcefetcher'
 import { CompositeResourceFetcher } from '../shared/resourcefetcher/compositeResourceFetcher'
@@ -64,9 +64,16 @@ export function getLambdaDetails(configuration: Lambda.FunctionConfiguration): {
         case RuntimeFamily.Python:
             runtimeExtension = 'py'
             break
-        case RuntimeFamily.NodeJS:
-            runtimeExtension = 'js'
+        case RuntimeFamily.NodeJS: {
+            const nodeVersion = getNodeMajorVersion(configuration.Runtime)
+            if (nodeVersion && nodeVersion >= 18) {
+                // node18+ defaults to using the .mjs extension
+                runtimeExtension = 'mjs'
+            } else {
+                runtimeExtension = 'js'
+            }
             break
+        }
         default:
             throw new Error(`Toolkit does not currently support imports for runtime: ${configuration.Runtime}`)
     }

--- a/src/test/lambda/models/samLambdaRuntime.test.ts
+++ b/src/test/lambda/models/samLambdaRuntime.test.ts
@@ -13,6 +13,8 @@ import {
     RuntimeFamily,
     samImageLambdaRuntimes,
     samLambdaCreatableRuntimes,
+    getNodeMajorVersion,
+    nodeJsRuntimes,
 } from '../../../lambda/models/samLambdaRuntime'
 
 describe('compareSamLambdaRuntime', async function () {
@@ -121,5 +123,32 @@ describe('runtimes', function () {
             'python3.8',
             'python3.9',
         ])
+    })
+})
+
+describe('getNodeMajorVersion()', () => {
+    it('returns 12 on "nodejs12.x"', () => {
+        const version = getNodeMajorVersion('nodejs12.x')
+        assert.strictEqual(version, 12)
+    })
+
+    it('returns 18 on "nodejs18.x"', () => {
+        const version = getNodeMajorVersion('nodejs18.x')
+        assert.strictEqual(version, 18)
+    })
+
+    it('returns undefined on invalid input', () => {
+        const version = getNodeMajorVersion('python12.x')
+        assert.strictEqual(version, undefined)
+    })
+
+    describe('extracts a version from existing runtimes', function () {
+        nodeJsRuntimes.forEach(versionString => {
+            it(`extracts from runtime: "${versionString}"`, () => {
+                const version = getNodeMajorVersion(versionString)
+                assert(version !== undefined)
+                assert(0 < version && version < 999)
+            })
+        })
     })
 })

--- a/src/test/lambda/utils.test.ts
+++ b/src/test/lambda/utils.test.ts
@@ -21,18 +21,23 @@ describe('lambda utils', async function () {
                 Runtime: 'nodejs12.x',
                 Handler: 'asdf/jkl/app.lambda_handler',
             })
+            const node18ModuleParsedName = getLambdaDetails({
+                Runtime: 'nodejs18.x',
+                Handler: 'asdf/jkl/app.lambda_handler',
+            })
             const PyNestedParsedName = getLambdaDetails({
                 Runtime: 'python3.8',
                 Handler: 'asdf/jkl/app.lambda_handler',
             })
-            assert(jsNonNestedParsedName.fileName, 'app.js')
-            assert(pyNonNestedParsedName.fileName, 'app.py')
-            assert(jsNestedParsedName.fileName, 'asdf/jkl/app.js')
-            assert(PyNestedParsedName.fileName, 'asdf/jkl/app.py')
-            assert(jsNonNestedParsedName.functionName, 'lambda_handler')
-            assert(pyNonNestedParsedName.functionName, 'lambda_handler')
-            assert(jsNestedParsedName.functionName, 'lambda_handler')
-            assert(PyNestedParsedName.functionName, 'lambda_handler')
+            assert.strictEqual(jsNonNestedParsedName.fileName, 'app.js')
+            assert.strictEqual(pyNonNestedParsedName.fileName, 'app.py')
+            assert.strictEqual(jsNestedParsedName.fileName, 'asdf/jkl/app.js')
+            assert.strictEqual(node18ModuleParsedName.fileName, 'asdf/jkl/app.mjs')
+            assert.strictEqual(PyNestedParsedName.fileName, 'asdf/jkl/app.py')
+            assert.strictEqual(jsNonNestedParsedName.functionName, 'lambda_handler')
+            assert.strictEqual(pyNonNestedParsedName.functionName, 'lambda_handler')
+            assert.strictEqual(jsNestedParsedName.functionName, 'lambda_handler')
+            assert.strictEqual(PyNestedParsedName.functionName, 'lambda_handler')
         })
 
         it('throws if the handler is not a supported runtime', async function () {


### PR DESCRIPTION
By default when a nodejs lambda was created,
the default file would be .js, but now with
node 18 the default file is .mjs.

The extension could not find node18 users files since the extension was
in .mjs but we were expecting it to be .js

### Solution:

Only support .mjs files for node18+ lambdas


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
