### PR TITLE
ci: don't fail fast on macos tests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,6 +14,7 @@ jobs:
         name: test macOS
         runs-on: macos-latest
         strategy:
+            fail-fast: false
             matrix:
                 node-version: [16.x]
                 vscode-version: [minimum, stable, insiders]


### PR DESCRIPTION
Usually if one of the macos tests fails, we
will abort all other ones.

But, recently vs code insiders is failing exclusively and it aborts the other tests even though they should be fine. Due to this we cannot easily see that everything else is passing.

Solution:

Don't fail fast on mac os tests, let all of them
run and maybe we can tell if it is just a vscode
insiders problem more easily.

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
