### PR TITLE
fix(codewhisperer): Change settings.shareCodeWhispererContentWithAWS to application

### DIFF
--- a/.changes/next-release/Bug Fix-e9afd2b9-cd47-4013-a2c0-8618d7b2ed15.json
+++ b/.changes/next-release/Bug Fix-e9afd2b9-cd47-4013-a2c0-8618d7b2ed15.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Change one of CodeWhisperer settings to User level settings"
+	"description": "User setting for \"Share CodeWhisperer Content With AWS\" was not reflected in workspace-level settings"
 }

--- a/.changes/next-release/Bug Fix-e9afd2b9-cd47-4013-a2c0-8618d7b2ed15.json
+++ b/.changes/next-release/Bug Fix-e9afd2b9-cd47-4013-a2c0-8618d7b2ed15.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Change one of CodeWhisperer settings to User level settings"
+}

--- a/package.json
+++ b/package.json
@@ -251,7 +251,8 @@
                 "aws.codeWhisperer.shareCodeWhispererContentWithAWS": {
                     "type": "boolean",
                     "markdownDescription": "%AWS.configuration.description.codewhisperer.shareCodeWhispererContentWithAWS%",
-                    "default": true
+                    "default": true,
+                    "scope": "application"
                 },
                 "aws.codeWhisperer.javaCompilationOutput": {
                     "type": "string",


### PR DESCRIPTION
## Problem

https://github.com/aws/aws-toolkit-vscode/issues/3477

## Solution

Change the scope this shareCodeWhispererContentWithAWS settings to application.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
