### PR TITLE
fix(codewhisperer): use stored session id in aggregated user decision events

### DIFF
--- a/src/codewhisperer/util/telemetryHelper.ts
+++ b/src/codewhisperer/util/telemetryHelper.ts
@@ -219,7 +219,7 @@ export class TelemetryHelper {
             (this.lastRequestId && this.lastRequestId === requestId) ||
             (this.sessionDecisions.length && this.sessionDecisions.length === this.numberOfRequests)
         ) {
-            this.sendUserTriggerDecisionTelemetry(sessionId, supplementalContextMetadata)
+            this.sendUserTriggerDecisionTelemetry(supplementalContextMetadata)
         }
     }
 
@@ -260,7 +260,6 @@ export class TelemetryHelper {
     }
 
     private sendUserTriggerDecisionTelemetry(
-        sessionId: string,
         supplementalContextMetadata?: Omit<CodeWhispererSupplementalContext, 'supplementalContextItems'> | undefined
     ) {
         // the user trigger decision will aggregate information from request level user decisions within one session
@@ -273,7 +272,7 @@ export class TelemetryHelper {
         const autoTriggerType = this.sessionDecisions[0].codewhispererAutomatedTriggerType
         const language = this.sessionDecisions[0].codewhispererLanguage
         const aggregated: CodewhispererUserTriggerDecision = {
-            codewhispererSessionId: sessionId,
+            codewhispererSessionId: this.sessionDecisions[0].codewhispererSessionId,
             codewhispererFirstRequestId: this.sessionDecisions[0].codewhispererFirstRequestId,
             credentialStartUrl: this.sessionDecisions[0].credentialStartUrl,
             codewhispererCompletionType: this.getAggregatedCompletionType(this.sessionDecisions),


### PR DESCRIPTION
## Problem
The session id can be empty in the aggregated user decision events.

To reproduce it, you can invoke, and keep pressing Esc. 

When you press Esc frequently, multiple clear state function can be run in parallel, causing race conditions that set the session id to empty string.

## Solution

Use the pre-existing, stored, non-empty session id in the aggregated user decision events. 

This solution only works for aggregated user decision events, it does not solve the global state problem in this code base. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
