### PR TITLE
fix(ec2): use IAM Role instead of instance profile. 

### DIFF
--- a/src/ec2/model.ts
+++ b/src/ec2/model.ts
@@ -47,10 +47,11 @@ export class Ec2ConnectionManager {
     }
 
     protected async getAttachedPolicies(instanceId: string): Promise<IAM.AttachedPolicy[]> {
-        const IamRole = await this.ec2Client.getAttachedIamRole(instanceId)
-        if (!IamRole?.Arn) {
+        const IamInstanceProfile = await this.ec2Client.getAttachedIamInstanceProfile(instanceId)
+        if (!IamInstanceProfile?.Arn) {
             return []
         }
+        const IamRole = await this.iamClient.getIAMRoleFromInstanceProfile(IamInstanceProfile!.Arn!)
         try {
             const attachedPolicies = await this.iamClient.listAttachedRolePolicies(IamRole.Arn)
             return attachedPolicies
@@ -87,7 +88,7 @@ export class Ec2ConnectionManager {
     }
 
     protected async throwPolicyError(selection: Ec2Selection) {
-        const role = await this.ec2Client.getAttachedIamRole(selection.instanceId)
+        const role = await this.ec2Client.getAttachedIamInstanceProfile(selection.instanceId)
 
         const baseMessage = 'Ensure an IAM role with the required policies is attached to the instance.'
         const messageExtension =

--- a/src/ec2/model.ts
+++ b/src/ec2/model.ts
@@ -80,7 +80,7 @@ export class Ec2ConnectionManager {
         const isInstanceRunning = await this.isInstanceRunning(selection.instanceId)
 
         if (!isInstanceRunning) {
-            const message = 'Ensure the target instance is running and not currently starting, stopping, or stopped.'
+            const message = 'Ensure the target instance is running.'
             this.throwConnectionError(message, selection, { code: 'EC2SSMStatus' })
         }
     }

--- a/src/ec2/model.ts
+++ b/src/ec2/model.ts
@@ -8,7 +8,7 @@ import { IAM } from 'aws-sdk'
 import { Ec2Selection } from './utils'
 import { getOrInstallCli } from '../shared/utilities/cliUtils'
 import { isCloud9 } from '../shared/extensionUtilities'
-import { ToolkitError, isAwsError } from '../shared/errors'
+import { ToolkitError } from '../shared/errors'
 import { SsmClient } from '../shared/clients/ssmClient'
 import { Ec2Client } from '../shared/clients/ec2Client'
 
@@ -50,7 +50,7 @@ export class Ec2ConnectionManager {
         return new DefaultIamClient(this.regionCode)
     }
 
-    protected async getAttachedIamRole(instanceId: string): Promise<IAM.Role> {
+    public async getAttachedIamRole(instanceId: string): Promise<IAM.Role> {
         const IamInstanceProfile = await this.ec2Client.getAttachedIamInstanceProfile(instanceId)
         if (IamInstanceProfile && IamInstanceProfile.Arn) {
             const IamRole = await this.iamClient.getIAMRoleFromInstanceProfile(IamInstanceProfile.Arn)
@@ -67,7 +67,7 @@ export class Ec2ConnectionManager {
             const attachedPolicies = await this.iamClient.listAttachedRolePolicies(IamRole.Arn)
             return attachedPolicies
         } catch (e) {
-            if (isAwsError(e) && e.code == 'NoIamInstanceProfile') {
+            if (e instanceof ToolkitError && e.code == 'NoIamInstanceProfile') {
                 getLogger().warn(
                     `ec2: failed to find IAM Instance Profile associated with instance. Returning no policies attached for instance: ${instanceId}`
                 )

--- a/src/shared/clients/ec2Client.ts
+++ b/src/shared/clients/ec2Client.ts
@@ -100,7 +100,7 @@ export class Ec2Client {
     }
 
     /**
-     * Retrieve IAM Instance Profile attached to given EC2 instance.
+     * Gets the IAM Instance Profile (not role) attached to given EC2 instance.
      * @param instanceId target EC2 instance ID
      * @returns IAM Instance Profile associated with instance or undefined if none exists.
      */

--- a/src/shared/clients/ec2Client.ts
+++ b/src/shared/clients/ec2Client.ts
@@ -100,11 +100,11 @@ export class Ec2Client {
     }
 
     /**
-     * Retrieve IAM role attached to given EC2 instance.
+     * Retrieve IAM Instance Profile attached to given EC2 instance.
      * @param instanceId target EC2 instance ID
-     * @returns IAM role associated with instance or undefined if none exists.
+     * @returns IAM Instance Profile associated with instance or undefined if none exists.
      */
-    public async getAttachedIamRole(instanceId: string): Promise<IamInstanceProfile | undefined> {
+    public async getAttachedIamInstanceProfile(instanceId: string): Promise<IamInstanceProfile | undefined> {
         const association = await this.getIamInstanceProfileAssociation(instanceId)
         return association ? association.IamInstanceProfile : undefined
     }

--- a/src/shared/clients/iamClient.ts
+++ b/src/shared/clients/iamClient.ts
@@ -8,6 +8,7 @@ import globals from '../extensionGlobals'
 import { AsyncCollection } from '../utilities/asyncCollection'
 import { pageableToCollection } from '../utilities/collectionUtils'
 import { ClassToInterfaceType } from '../utilities/tsUtils'
+import { ToolkitError } from '../errors'
 
 export type IamClient = ClassToInterfaceType<DefaultIamClient>
 
@@ -98,6 +99,9 @@ export class DefaultIamClient {
         const client = await this.createSdkClient()
         const instanceProfileName = this.getFriendlyName(instanceProfileArn)
         const response = await client.getInstanceProfile({ InstanceProfileName: instanceProfileName }).promise()
+        if (response.InstanceProfile.Roles.length === 0) {
+            throw new ToolkitError(`Failed to find IAM role associated with Instance profile ${instanceProfileArn}`)
+        }
         return response.InstanceProfile.Roles[0]
     }
 }

--- a/src/shared/clients/iamClient.ts
+++ b/src/shared/clients/iamClient.ts
@@ -93,4 +93,11 @@ export class DefaultIamClient {
 
         return policies
     }
+
+    public async getIAMRoleFromInstanceProfile(instanceProfileArn: string): Promise<IAM.Role> {
+        const client = await this.createSdkClient()
+        const instanceProfileName = this.getFriendlyName(instanceProfileArn)
+        const response = await client.getInstanceProfile({ InstanceProfileName: instanceProfileName }).promise()
+        return response.InstanceProfile.Roles[0]
+    }
 }

--- a/src/test/ec2/model.test.ts
+++ b/src/test/ec2/model.test.ts
@@ -5,10 +5,9 @@
 
 import * as assert from 'assert'
 import * as sinon from 'sinon'
-import { Ec2ConnectErrorCode, Ec2ConnectionManager } from '../../ec2/model'
+import { Ec2ConnectionManager } from '../../ec2/model'
 import { SsmClient } from '../../shared/clients/ssmClient'
 import { Ec2Client } from '../../shared/clients/ec2Client'
-import { attachedPoliciesListType } from 'aws-sdk/clients/iam'
 import { Ec2Selection } from '../../ec2/utils'
 import { ToolkitError } from '../../shared/errors'
 import { EC2, IAM } from 'aws-sdk'
@@ -47,16 +46,6 @@ describe('Ec2ConnectClient', function () {
         protected override createEc2SdkClient(): Ec2Client {
             return new MockEc2Client()
         }
-
-        public async testGetAttachedPolicies(instanceId: string): Promise<IAM.attachedPoliciesListType> {
-            return await this.getAttachedPolicies(instanceId)
-        }
-
-        protected override async throwPolicyError(selection: Ec2Selection): Promise<void> {
-            this.throwConnectionError('', selection, {
-                code: 'EC2SSMPermission',
-            })
-        }
     }
 
     describe('isInstanceRunning', async function () {
@@ -76,173 +65,132 @@ describe('Ec2ConnectClient', function () {
     })
 
     describe('handleStartSessionError', async function () {
-        let client: MockEc2ConnectClientForError
+        let client: Ec2ConnectionManager
+        let instanceSelection: Ec2Selection
 
-        class MockEc2ConnectClientForError extends MockEc2ConnectClient {
-            public override async hasProperPolicies(instanceId: string): Promise<boolean> {
-                return instanceId.split(':')[1] === 'hasPolicies'
-            }
-        }
         before(function () {
-            client = new MockEc2ConnectClientForError()
+            client = new Ec2ConnectionManager('test-region')
+            instanceSelection = { instanceId: 'testInstance', region: 'testRegion' }
         })
 
-        it('determines which error to throw based on if instance is running', async function () {
-            async function assertThrowsErrorCode(testInstance: Ec2Selection, errCode: Ec2ConnectErrorCode) {
-                try {
-                    await client.checkForStartSessionError(testInstance)
-                } catch (err: unknown) {
-                    assert.strictEqual((err as ToolkitError).code, errCode)
-                }
+        it('throws EC2SSMStatus error if instance is not running', async function () {
+            sinon.stub(Ec2ConnectionManager.prototype, 'isInstanceRunning').resolves(false)
+            try {
+                await client.checkForStartSessionError(instanceSelection)
+                assert.ok(false)
+            } catch (err) {
+                assert.strictEqual((err as ToolkitError).code, 'EC2SSMStatus')
             }
+            sinon.restore()
+        })
 
-            await assertThrowsErrorCode(
-                {
-                    instanceId: 'pending:noPolicies:Online',
-                    region: 'test-region',
-                },
-                'EC2SSMStatus'
-            )
+        it('throws EC2SSMPermission error if instance is running but has no role', async function () {
+            sinon.stub(Ec2ConnectionManager.prototype, 'isInstanceRunning').resolves(true)
+            sinon.stub(Ec2ConnectionManager.prototype, 'getAttachedIamRole').resolves(undefined)
+            try {
+                await client.checkForStartSessionError(instanceSelection)
+                assert.ok(false)
+            } catch (err) {
+                assert.strictEqual((err as ToolkitError).code, 'EC2SSMPermission')
+            }
+            sinon.restore()
+        })
 
-            await assertThrowsErrorCode(
-                {
-                    instanceId: 'shutting-down:noPolicies:Online',
-                    region: 'test-region',
-                },
-                'EC2SSMStatus'
-            )
-
-            await assertThrowsErrorCode(
-                {
-                    instanceId: 'running:noPolicies:Online',
-                    region: 'test-region',
-                },
-                'EC2SSMPermission'
-            )
-
-            await assertThrowsErrorCode(
-                {
-                    instanceId: 'running:hasPolicies:Offline',
-                    region: 'test-region',
-                },
-                'EC2SSMAgentStatus'
-            )
+        it('throws EC2SSMAgent error if instance is running and has IAM Role, but agent is not running', async function () {
+            sinon.stub(Ec2ConnectionManager.prototype, 'isInstanceRunning').resolves(true)
+            sinon.stub(Ec2ConnectionManager.prototype, 'getAttachedIamRole').resolves({ Arn: 'testRole' } as IAM.Role)
+            sinon.stub(Ec2ConnectionManager.prototype, 'hasProperPolicies').resolves(true)
+            sinon.stub(SsmClient.prototype, 'getInstanceAgentPingStatus').resolves('offline')
+            try {
+                await client.checkForStartSessionError(instanceSelection)
+                assert.ok(false)
+            } catch (err) {
+                assert.strictEqual((err as ToolkitError).code, 'EC2SSMAgentStatus')
+            }
+            sinon.restore()
         })
 
         it('does not throw an error if all checks pass', async function () {
-            const passingInstance = {
-                instanceId: 'running:hasPolicies:Online',
-                region: 'test-region',
-            }
-            assert.doesNotThrow(async () => await client.checkForStartSessionError(passingInstance))
+            sinon.stub(Ec2ConnectionManager.prototype, 'isInstanceRunning').resolves(true)
+            sinon.stub(Ec2ConnectionManager.prototype, 'getAttachedIamRole').resolves({ Arn: 'testRole' } as IAM.Role)
+            sinon.stub(Ec2ConnectionManager.prototype, 'hasProperPolicies').resolves(true)
+            sinon.stub(SsmClient.prototype, 'getInstanceAgentPingStatus').resolves('Online')
+            assert.doesNotThrow(async () => await client.checkForStartSessionError(instanceSelection))
+            sinon.restore()
         })
     })
 
     describe('hasProperPolicies', async function () {
-        let client: MockEc2ConnectClientForPolicies
-        class MockEc2ConnectClientForPolicies extends MockEc2ConnectClient {
-            protected override async getAttachedPolicies(instanceId: string): Promise<attachedPoliciesListType> {
-                switch (instanceId) {
-                    case 'firstInstance':
-                        return [
-                            {
-                                PolicyName: 'name',
-                            },
-                            {
-                                PolicyName: 'name2',
-                            },
-                            {
-                                PolicyName: 'name3',
-                            },
-                        ]
-                    case 'secondInstance':
-                        return [
-                            {
-                                PolicyName: 'AmazonSSMManagedInstanceCore',
-                            },
-                            {
-                                PolicyName: 'AmazonSSMManagedEC2InstanceDefaultPolicy',
-                            },
-                        ]
-                    case 'thirdInstance':
-                        return [
-                            {
-                                PolicyName: 'AmazonSSMManagedInstanceCore',
-                            },
-                        ]
-                    case 'fourthInstance':
-                        return [
-                            {
-                                PolicyName: 'AmazonSSMManagedEC2InstanceDefaultPolicy',
-                            },
-                        ]
-                    case 'toolkitErrorInstance':
-                        throw new ToolkitError('', { code: 'NoSuchEntity' })
-                    default:
-                        return []
-                }
-            }
-        }
-        before(function () {
-            client = new MockEc2ConnectClientForPolicies()
+        let realClient: Ec2ConnectionManager
+
+        before(async function () {
+            realClient = new Ec2ConnectionManager('test-region')
         })
 
         it('correctly determines if proper policies are included', async function () {
-            let result: boolean
-
-            result = await client.hasProperPolicies('firstInstance')
-            assert.strictEqual(result, false)
-
-            result = await client.hasProperPolicies('secondInstance')
-            assert.strictEqual(result, true)
-
-            result = await client.hasProperPolicies('thirdInstance')
-            assert.strictEqual(result, false)
-
-            result = await client.hasProperPolicies('fourthInstance')
-            assert.strictEqual(result, false)
+            async function assertAcceptsPolicies(policies: IAM.Policy[], expectedResult: boolean) {
+                sinon.stub(DefaultIamClient.prototype, 'listAttachedRolePolicies').resolves(policies)
+                const result = await realClient.hasProperPolicies('')
+                assert.strictEqual(result, expectedResult)
+                sinon.restore()
+            }
+            await assertAcceptsPolicies(
+                [{ PolicyName: 'name' }, { PolicyName: 'name2' }, { PolicyName: 'name3' }],
+                false
+            )
+            await assertAcceptsPolicies(
+                [
+                    { PolicyName: 'AmazonSSMManagedInstanceCore' },
+                    { PolicyName: 'AmazonSSMManagedEC2InstanceDefaultPolicy' },
+                ],
+                true
+            )
+            await assertAcceptsPolicies([{ PolicyName: 'AmazonSSMManagedEC2InstanceDefaultPolicy' }], false)
+            await assertAcceptsPolicies([{ PolicyName: 'AmazonSSMManagedEC2InstanceDefaultPolicy' }], false)
         })
 
         it('throws error when sdk throws error', async function () {
+            sinon.stub(DefaultIamClient.prototype, 'listAttachedRolePolicies').throws(new ToolkitError('error'))
             try {
-                await client.hasProperPolicies('toolkitErrorInstance')
+                await realClient.hasProperPolicies('')
                 assert.ok(false)
             } catch {
                 assert.ok(true)
             }
-        })
-    })
-
-    describe('getAttachedPolicies', async function () {
-        let client: MockEc2ConnectClient
-
-        before(async function () {
-            client = new MockEc2ConnectClient()
-        })
-
-        it('returns empty when IamInstanceProfile not found', async function () {
-            sinon
-                .stub(MockEc2ConnectClient.prototype, 'getAttachedIamRole')
-                .throws(new ToolkitError('', { code: 'NoIamInstanceProfile' }))
-            const response = await client.testGetAttachedPolicies('test-instance')
-            assert.deepStrictEqual(response, [])
-
             sinon.restore()
         })
-
-        it('throws error if IamRole is found but invalid', async function () {
-            sinon
-                .stub(MockEc2ConnectClient.prototype, 'getAttachedIamRole')
-                .resolves({ Arn: 'some-fake-role' } as IAM.Role)
-            sinon.stub(DefaultIamClient.prototype, 'listAttachedRolePolicies').throws('NoSuchEntity')
-            try {
-                await client.testGetAttachedPolicies('test-instance')
-                assert.ok(false)
-            } catch {
-                assert.ok(true)
-            } finally {
-                sinon.restore()
-            }
-        })
     })
+
+    // describe('getAttachedPolicies', async function () {
+    //     let client: MockEc2ConnectClient
+
+    //     before(async function () {
+    //         client = new MockEc2ConnectClient()
+    //     })
+
+    //     it('returns empty when IamInstanceProfile not found', async function () {
+    //         sinon
+    //             .stub(MockEc2ConnectClient.prototype, 'getAttachedIamRole')
+    //             .throws(new ToolkitError('', { code: 'NoIamInstanceProfile' }))
+    //         const response = await client.testGetAttachedPolicies('test-instance')
+    //         assert.deepStrictEqual(response, [])
+
+    //         sinon.restore()
+    //     })
+
+    //     it('throws error if IamRole is found but invalid', async function () {
+    //         sinon
+    //             .stub(MockEc2ConnectClient.prototype, 'getAttachedIamRole')
+    //             .resolves({ Arn: 'some-fake-role' } as IAM.Role)
+    //         sinon.stub(DefaultIamClient.prototype, 'listAttachedRolePolicies').throws('NoSuchEntity')
+    //         try {
+    //             await client.testGetAttachedPolicies('test-instance')
+    //             assert.ok(false)
+    //         } catch {
+    //             assert.ok(true)
+    //         } finally {
+    //             sinon.restore()
+    //         }
+    //     })
+    // })
 })

--- a/src/test/ec2/model.test.ts
+++ b/src/test/ec2/model.test.ts
@@ -220,8 +220,10 @@ describe('Ec2ConnectClient', function () {
             client = new MockEc2ConnectClient()
         })
 
-        it('returns empty when IamRole not found', async function () {
-            sinon.stub(Ec2Client.prototype, 'getAttachedIamRole').resolves(undefined)
+        it('returns empty when IamInstanceProfile not found', async function () {
+            sinon
+                .stub(MockEc2ConnectClient.prototype, 'getAttachedIamRole')
+                .throws(new ToolkitError('', { code: 'NoIamInstanceProfile' }))
             const response = await client.testGetAttachedPolicies('test-instance')
             assert.deepStrictEqual(response, [])
 
@@ -229,7 +231,9 @@ describe('Ec2ConnectClient', function () {
         })
 
         it('throws error if IamRole is found but invalid', async function () {
-            sinon.stub(Ec2Client.prototype, 'getAttachedIamRole').resolves({ Arn: 'some-fake-role' })
+            sinon
+                .stub(MockEc2ConnectClient.prototype, 'getAttachedIamRole')
+                .resolves({ Arn: 'some-fake-role' } as IAM.Role)
             sinon.stub(DefaultIamClient.prototype, 'listAttachedRolePolicies').throws('NoSuchEntity')
             try {
                 await client.testGetAttachedPolicies('test-instance')


### PR DESCRIPTION
## Problem
Currently, we retrieve the IAM Instance Profile associated with a target EC2 instance. This is not the same as the IAM Role attached to the EC2 instance. This issue is well hidden because the console (by-default) creates an instance profile for us when we attach a role to an EC2 instance. Specifically, 

> If you use the AWS Management Console to create a role for Amazon EC2, the console automatically creates an instance profile and gives it the same name as the role. When you then use the Amazon EC2 console to launch an instance with an IAM role, you can select a role to associate with the instance. In the console, the list that's displayed is actually a list of instance profile names. The console does not create an instance profile for a role that is not associated with Amazon EC2.
> 
More info: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html

Because the IAM instance profile and the IAM Role have the same name when the console creates it for us and the IAM SDK works with the "friendlyName" and not the entire ARN, their distinction is completely hidden for most cases. 

However, the distinction is revealed in the C9 case, where I suspect the instance profile and IAM role were manually created separately with distinct names. 

## Solution
We make an explicit distinction in the code between IAM Instance Profile and IAM Roles. Specifically, the EC2 SDK gives us the IAM Instance Profile, which we then must use to retrieve the IAM role via the IAM SDK. This extra step is needed to accommodate the case where the name of the two differ (as in C9). 

The effects of this are that the error message for c9 instances no longer gives an instance profile name instead of a role name: 
![image](https://github.com/aws/aws-toolkit-vscode/assets/42325418/6cad71e6-6b59-4ee6-a3e7-493bdc3798ca)

Additionally, we no longer need to worry about the case of explicitly handling non-existent roles from the EC2 SDK, since the underlying cause now appears to be trying to use the name of the instance profile in place of the name of the IAM role. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
