### PR TITLE
test: unreliable ExtensionUserActivity test

### DIFF
--- a/src/test/shared/extensionUtilities.test.ts
+++ b/src/test/shared/extensionUtilities.test.ts
@@ -28,6 +28,7 @@ import { FakeExtensionContext } from '../fakeExtensionContext'
 import { InstanceIdentity } from '../../shared/clients/ec2MetadataClient'
 import { extensionVersion } from '../../shared/vscode/env'
 import { sleep } from '../../shared/utilities/timeoutUtils'
+import globals from '../../shared/extensionGlobals'
 
 describe('extensionUtilities', function () {
     describe('safeGet', function () {
@@ -205,32 +206,26 @@ describe('ExtensionUserActivity', function () {
     })
 
     it('triggers twice when multiple user activities are fired in separate intervals', async function () {
-        const throttleDelay = 2000
-        const middleOfInterval = Math.floor(throttleDelay / 2)
-        const waitFor = throttleDelay * 3 // delay * (2 event intervals + test buffer)
+        const throttleDelay = 200
 
-        const eventsFirst = [
-            delayedFiringEvent(middleOfInterval + 1),
-            delayedFiringEvent(middleOfInterval + 2),
-            delayedFiringEvent(middleOfInterval + 3),
-            delayedFiringEvent(middleOfInterval + 4),
-        ]
-        const eventsSecond = [
-            delayedFiringEvent(throttleDelay + middleOfInterval + 1),
-            delayedFiringEvent(throttleDelay + middleOfInterval + 2),
-            delayedFiringEvent(throttleDelay + middleOfInterval + 2),
-            delayedFiringEvent(throttleDelay + middleOfInterval + 3),
+        const firstInvervalMillisUntilFire = [51, 52, 53, 54]
+
+        const secondIntervalStart = firstInvervalMillisUntilFire[0] + throttleDelay + 1
+        const secondIntervalMillisUntilFire = [
+            secondIntervalStart + 10,
+            secondIntervalStart + 11,
+            secondIntervalStart + 11,
+            secondIntervalStart + 12,
         ]
 
-        const instance = new ExtensionUserActivity(throttleDelay, [...eventsFirst, ...eventsSecond])
+        const instance = new ExtensionUserActivity(throttleDelay, [
+            ...firstInvervalMillisUntilFire.map(delayedTriggeredEvent),
+            ...secondIntervalMillisUntilFire.map(delayedTriggeredEvent),
+        ])
         instance.onUserActivity(onEventTriggered)
-        await sleep(waitFor)
+        await sleep(secondIntervalStart + throttleDelay + 1)
 
-        assert.strictEqual(
-            count,
-            2,
-            'This may be flaky in CI, so we may need to increase the intervals for better tolerance'
-        )
+        assert.strictEqual(count, 2)
     })
 
     describe('does not fire user activity events in specific scenarios', function () {
@@ -352,9 +347,9 @@ describe('ExtensionUserActivity', function () {
         }
     })
 
-    function delayedFiringEvent(fireInMillis: number): vscode.Event<any> {
+    function delayedTriggeredEvent(millisUntilFire: number): vscode.Event<any> {
         const event = new vscode.EventEmitter<void>()
-        setTimeout(() => event.fire(), fireInMillis)
+        globals.clock.setTimeout(() => event.fire(), millisUntilFire)
         return event.event
     }
 })


### PR DESCRIPTION
This fixes a flaky test due to the timeout delays
not being properly spaced. Because of this the
vscode Event Emitter would fire in the same
throttle interval. This caused the throttled function to treat
all calls to it to be in the same interval, such
that it only triggered once.

This fixes the delay of when the second set of
event firing goes off so that those are triggered
when we are in the next throttle interval, instead
of the first.
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
