### PR TITLE
fix(ec2): check for actions instead of policies.

### DIFF
--- a/src/ec2/model.ts
+++ b/src/ec2/model.ts
@@ -77,19 +77,10 @@ export class Ec2ConnectionManager {
         }
     }
 
-    // public async hasProperPolicies(IamRoleArn: string): Promise<boolean> {
-    //     const attachedPolicies = (await this.iamClient.listAttachedRolePolicies(IamRoleArn)).map(
-    //         policy => policy.PolicyName!
-    //     )
-    //     const requiredPolicies = ['AmazonSSMManagedInstanceCore', 'AmazonSSMManagedEC2InstanceDefaultPolicy']
-
-    //     return requiredPolicies.length !== 0 && requiredPolicies.every(policy => attachedPolicies.includes(policy))
-    // }
-
     public async hasProperPermissions(IamRoleArn: string): Promise<boolean> {
         const deniedActions = await getDeniedSsmActions(this.iamClient, IamRoleArn)
 
-        return deniedActions.length !== 0
+        return deniedActions.length === 0
     }
 
     public async isInstanceRunning(instanceId: string): Promise<boolean> {
@@ -119,9 +110,9 @@ export class Ec2ConnectionManager {
             this.throwConnectionError(message, selection, { code: 'EC2SSMPermission' })
         }
 
-        const hasProperPolicies = await this.hasProperPermissions(IamRole!.Arn)
+        const hasPermission = await this.hasProperPermissions(IamRole!.Arn)
 
-        if (!hasProperPolicies) {
+        if (!hasPermission) {
             const message = `Ensure an IAM role with the required policies is attached to the instance. Found attached role: ${
                 IamRole!.Arn
             }`

--- a/src/ec2/model.ts
+++ b/src/ec2/model.ts
@@ -113,7 +113,7 @@ export class Ec2ConnectionManager {
         const hasPermission = await this.hasProperPermissions(IamRole!.Arn)
 
         if (!hasPermission) {
-            const message = `Ensure an IAM role with the required policies is attached to the instance. Found attached role: ${
+            const message = `Ensure an IAM role with the proper permissions is attached to the instance. Found attached role: ${
                 IamRole!.Arn
             }`
             this.throwConnectionError(message, selection, {

--- a/src/ec2/model.ts
+++ b/src/ec2/model.ts
@@ -12,7 +12,12 @@ import { isCloud9 } from '../shared/extensionUtilities'
 import { ToolkitError } from '../shared/errors'
 import { SsmClient } from '../shared/clients/ssmClient'
 import { Ec2Client } from '../shared/clients/ec2Client'
-import { VscodeRemoteConnection, ensureDependencies, openRemoteTerminal } from '../shared/remoteSession'
+import {
+    VscodeRemoteConnection,
+    ensureDependencies,
+    getDeniedSsmActions,
+    openRemoteTerminal,
+} from '../shared/remoteSession'
 import { DefaultIamClient } from '../shared/clients/iamClient'
 import { ErrorInformation } from '../shared/errors'
 import { sshAgentSocketVariable, startSshAgent, startVscodeRemote } from '../shared/extensions/ssh'
@@ -72,13 +77,19 @@ export class Ec2ConnectionManager {
         }
     }
 
-    public async hasProperPolicies(IamRoleArn: string): Promise<boolean> {
-        const attachedPolicies = (await this.iamClient.listAttachedRolePolicies(IamRoleArn)).map(
-            policy => policy.PolicyName!
-        )
-        const requiredPolicies = ['AmazonSSMManagedInstanceCore', 'AmazonSSMManagedEC2InstanceDefaultPolicy']
+    // public async hasProperPolicies(IamRoleArn: string): Promise<boolean> {
+    //     const attachedPolicies = (await this.iamClient.listAttachedRolePolicies(IamRoleArn)).map(
+    //         policy => policy.PolicyName!
+    //     )
+    //     const requiredPolicies = ['AmazonSSMManagedInstanceCore', 'AmazonSSMManagedEC2InstanceDefaultPolicy']
 
-        return requiredPolicies.length !== 0 && requiredPolicies.every(policy => attachedPolicies.includes(policy))
+    //     return requiredPolicies.length !== 0 && requiredPolicies.every(policy => attachedPolicies.includes(policy))
+    // }
+
+    public async hasProperPermissions(IamRoleArn: string): Promise<boolean> {
+        const deniedActions = await getDeniedSsmActions(this.iamClient, IamRoleArn)
+
+        return deniedActions.length !== 0
     }
 
     public async isInstanceRunning(instanceId: string): Promise<boolean> {
@@ -108,7 +119,7 @@ export class Ec2ConnectionManager {
             this.throwConnectionError(message, selection, { code: 'EC2SSMPermission' })
         }
 
-        const hasProperPolicies = await this.hasProperPolicies(IamRole!.Arn)
+        const hasProperPolicies = await this.hasProperPermissions(IamRole!.Arn)
 
         if (!hasProperPolicies) {
             const message = `Ensure an IAM role with the required policies is attached to the instance. Found attached role: ${

--- a/src/ecs/util.ts
+++ b/src/ecs/util.ts
@@ -18,6 +18,7 @@ import { TaskDefinition } from 'aws-sdk/clients/ecs'
 import { getLogger } from '../shared/logger'
 import { SSM } from 'aws-sdk'
 import { fromExtensionManifest } from '../shared/settings'
+import { getDeniedSsmActions } from '../shared/remoteSession'
 
 interface EcsTaskIdentifer {
     readonly task: string
@@ -41,15 +42,7 @@ export async function checkPermissionsForSsm(
         })
     }
 
-    const deniedActions = await client.getDeniedActions({
-        PolicySourceArn: task.taskRoleArn,
-        ActionNames: [
-            'ssmmessages:CreateControlChannel',
-            'ssmmessages:CreateDataChannel',
-            'ssmmessages:OpenControlChannel',
-            'ssmmessages:OpenDataChannel',
-        ],
-    })
+    const deniedActions = await getDeniedSsmActions(client, task.taskRoleArn)
 
     if (deniedActions.length !== 0) {
         const message = localize(

--- a/src/shared/remoteSession.ts
+++ b/src/shared/remoteSession.ts
@@ -19,6 +19,8 @@ import { SystemUtilities } from './systemUtilities'
 import { getOrInstallCli } from './utilities/cliUtils'
 import { pushIf } from './utilities/collectionUtils'
 import { ChildProcess } from './utilities/childProcess'
+import { IamClient } from './clients/iamClient'
+import { IAM } from 'aws-sdk'
 
 export interface MissingTool {
     readonly name: 'code' | 'ssm' | 'ssh'
@@ -166,4 +168,18 @@ export async function handleMissingTool(tools: Err<MissingTool[]>) {
             details: { missing },
         })
     )
+}
+
+export async function getDeniedSsmActions(client: IamClient, roleArn: string): Promise<IAM.EvaluationResult[]> {
+    const deniedActions = await client.getDeniedActions({
+        PolicySourceArn: roleArn,
+        ActionNames: [
+            'ssmmessages:CreateControlChannel',
+            'ssmmessages:CreateDataChannel',
+            'ssmmessages:OpenControlChannel',
+            'ssmmessages:OpenDataChannel',
+        ],
+    })
+
+    return deniedActions
 }

--- a/src/test/ec2/model.test.ts
+++ b/src/test/ec2/model.test.ts
@@ -43,45 +43,6 @@ describe('Ec2ConnectClient', function () {
         })
     })
 
-    describe('hasProperPolicies', async function () {
-        it('correctly determines if proper policies are included', async function () {
-            async function assertAcceptsPolicies(policies: IAM.Policy[], expectedResult: boolean) {
-                sinon.stub(DefaultIamClient.prototype, 'listAttachedRolePolicies').resolves(policies)
-
-                const result = await client.hasProperPolicies('')
-                assert.strictEqual(result, expectedResult)
-
-                sinon.restore()
-            }
-            await assertAcceptsPolicies(
-                [{ PolicyName: 'name' }, { PolicyName: 'name2' }, { PolicyName: 'name3' }],
-                false
-            )
-            await assertAcceptsPolicies(
-                [
-                    { PolicyName: 'AmazonSSMManagedInstanceCore' },
-                    { PolicyName: 'AmazonSSMManagedEC2InstanceDefaultPolicy' },
-                ],
-                true
-            )
-            await assertAcceptsPolicies([{ PolicyName: 'AmazonSSMManagedEC2InstanceDefaultPolicy' }], false)
-            await assertAcceptsPolicies([{ PolicyName: 'AmazonSSMManagedEC2InstanceDefaultPolicy' }], false)
-        })
-
-        it('throws error when sdk throws error', async function () {
-            sinon.stub(DefaultIamClient.prototype, 'listAttachedRolePolicies').throws(new ToolkitError('error'))
-
-            try {
-                await client.hasProperPolicies('')
-                assert.ok(false)
-            } catch {
-                assert.ok(true)
-            }
-
-            sinon.restore()
-        })
-    })
-
     describe('isInstanceRunning', async function () {
         it('only returns true with the instance is running', async function () {
             sinon.stub(Ec2Client.prototype, 'getInstanceStatus').callsFake(async (input: string) => input.split(':')[0])
@@ -132,7 +93,7 @@ describe('Ec2ConnectClient', function () {
         it('throws EC2SSMAgent error if instance is running and has IAM Role, but agent is not running', async function () {
             sinon.stub(Ec2ConnectionManager.prototype, 'isInstanceRunning').resolves(true)
             sinon.stub(Ec2ConnectionManager.prototype, 'getAttachedIamRole').resolves({ Arn: 'testRole' } as IAM.Role)
-            sinon.stub(Ec2ConnectionManager.prototype, 'hasProperPolicies').resolves(true)
+            sinon.stub(Ec2ConnectionManager.prototype, 'hasProperPermissions').resolves(true)
             sinon.stub(SsmClient.prototype, 'getInstanceAgentPingStatus').resolves('offline')
 
             try {
@@ -148,7 +109,7 @@ describe('Ec2ConnectClient', function () {
         it('does not throw an error if all checks pass', async function () {
             sinon.stub(Ec2ConnectionManager.prototype, 'isInstanceRunning').resolves(true)
             sinon.stub(Ec2ConnectionManager.prototype, 'getAttachedIamRole').resolves({ Arn: 'testRole' } as IAM.Role)
-            sinon.stub(Ec2ConnectionManager.prototype, 'hasProperPolicies').resolves(true)
+            sinon.stub(Ec2ConnectionManager.prototype, 'hasProperPermissions').resolves(true)
             sinon.stub(SsmClient.prototype, 'getInstanceAgentPingStatus').resolves('Online')
 
             assert.doesNotThrow(async () => await client.checkForStartSessionError(instanceSelection))


### PR DESCRIPTION
## Problem 
We currently check if certain policies are attached to the IAM role in order to determine if the necessary permissions exist on the instance to open an SSM session. However, this can be done more fine-grained. 

## Solution 
https://github.com/aws/aws-toolkit-vscode/blob/a9d64f3a448480f8fed9ba96b3da33631c298265/src/ecs/util.ts#L33-L52 
Leverage the approach done by ECS to check for specific actions rather than policies. 

- Restructure testing framework to look at actions instead of policies. 
- Refactor ECS code to pull out shared functionality to `src/shared/remoteSession.ts`.
- Refactor existing code in the `src/ec2/model.ts` file to utilize the approach demonstrated above. 
- Add existing testing coverage if necessary. 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
