### PR TITLE
fix: ssoSetup() failure not logged

### DIFF
--- a/src/auth/ui/vue/show.ts
+++ b/src/auth/ui/vue/show.ts
@@ -44,7 +44,6 @@ import { trustedDomainCancellation } from '../../sso/model'
 import { FeatureId, CredentialSourceId, Result, telemetry } from '../../../shared/telemetry/telemetry'
 import { AuthFormId, isBuilderIdAuth } from './authForms/types'
 
-const logger = getLogger()
 export class AuthWebview extends VueWebview {
     public override id: string = 'authWebview'
     public override source: string = 'src/auth/ui/vue/index.js'
@@ -238,7 +237,7 @@ export class AuthWebview extends VueWebview {
                 return { id: 'badStartUrl', text: `Connection failed. Please verify your start URL.` }
             }
 
-            logger.error('Failed to setup.', e)
+            getLogger().error('AuthWebview: Failed to setup: %s', (e as Error).message)
             return { id: 'defaultFailure', text: 'Failed to setup.' }
         }
     }


### PR DESCRIPTION
Problem:
getLogger() is called in module-scope, which means it may initialize to a "console logger" if the main logger is not ready yet, depending on module load order.

Solution:
Don't call getLogger() in module-scope.



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
