### PR TITLE
fix: unreliable "ExtensionUserActivity" test

### DIFF
--- a/src/test/shared/extensionUtilities.test.ts
+++ b/src/test/shared/extensionUtilities.test.ts
@@ -206,16 +206,16 @@ describe('ExtensionUserActivity', function () {
     })
 
     it('triggers twice when multiple user activities are fired in separate intervals', async function () {
-        const throttleDelay = 200
+        const throttleDelay = 500
 
-        const firstInvervalMillisUntilFire = [51, 52, 53, 54]
+        const firstInvervalMillisUntilFire = [100, 101, 102, 103]
 
         const secondIntervalStart = firstInvervalMillisUntilFire[0] + throttleDelay + 1
         const secondIntervalMillisUntilFire = [
-            secondIntervalStart + 10,
-            secondIntervalStart + 11,
-            secondIntervalStart + 11,
-            secondIntervalStart + 12,
+            secondIntervalStart + 200,
+            secondIntervalStart + 201,
+            secondIntervalStart + 201,
+            secondIntervalStart + 202,
         ]
 
         const instance = new ExtensionUserActivity(throttleDelay, [
@@ -225,7 +225,7 @@ describe('ExtensionUserActivity', function () {
         instance.onUserActivity(onEventTriggered)
         await sleep(secondIntervalStart + throttleDelay + 1)
 
-        assert.strictEqual(count, 2)
+        assert.strictEqual(count, 2, 'May be flaky in CI, increase timings to improve reliability.')
     })
 
     describe('does not fire user activity events in specific scenarios', function () {


### PR DESCRIPTION
### Do not merge, will continuously test this in CI to make sure it is not flaky

test is still flaky in ci, increase the delay to give more flexibility

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
