### PR TITLE
refactor: remove deleteOldFiles()

### DIFF
--- a/src/auth/sso/cache.ts
+++ b/src/auth/sso/cache.ts
@@ -12,7 +12,6 @@ import { hasProps, selectFrom } from '../../shared/utilities/tsUtils'
 import { SsoToken, ClientRegistration } from './model'
 import { SystemUtilities } from '../../shared/systemUtilities'
 import { DevSettings } from '../../shared/settings'
-import { statSync, Stats, readdirSync, unlinkSync } from 'fs'
 
 interface RegistrationKey {
     readonly region: string
@@ -34,44 +33,11 @@ export interface SsoCache {
 const defaultCacheDir = path.join(SystemUtilities.getHomeDirectory(), '.aws', 'sso', 'cache')
 export const getCacheDir = () => DevSettings.instance.get('ssoCacheDirectory', defaultCacheDir)
 
-export function getCache(directory = getCacheDir(), statFunc = getFileStats): SsoCache {
-    try {
-        deleteOldFiles(directory, statFunc)
-    } catch (e) {
-        getLogger().warn('auth: error deleting old files in sso cache: %s', e)
-    }
-
+export function getCache(directory = getCacheDir()): SsoCache {
     return {
         token: getTokenCache(directory),
         registration: getRegistrationCache(directory),
     }
-}
-
-function deleteOldFiles(directory: string, statFunc: typeof getFileStats) {
-    if (!isDirSafeToDeleteFrom(directory)) {
-        getLogger().warn(`Skipped deleting files in directory: ${path.resolve(directory)}`)
-        return
-    }
-
-    const fileNames = readdirSync(directory)
-    fileNames.forEach(fileName => {
-        const filePath = path.join(directory, fileName)
-        if (path.extname(filePath) === '.json' && isOldFile(filePath, statFunc)) {
-            unlinkSync(filePath)
-            getLogger().warn(`auth: removed old cache file: ${filePath}`)
-        }
-    })
-}
-
-export function isDirSafeToDeleteFrom(dirPath: string): boolean {
-    const resolvedPath = path.resolve(dirPath)
-    const isRoot = resolvedPath === path.resolve('/')
-    const isCwd = resolvedPath === path.resolve('.')
-    const isAbsolute = path.isAbsolute(dirPath)
-    const pathDepth = resolvedPath.split(path.sep).length
-
-    const isSafe = !isRoot && !isCwd && isAbsolute && pathDepth >= 5
-    return isSafe
 }
 
 export function getRegistrationCache(directory = getCacheDir()): KeyedCache<ClientRegistration, RegistrationKey> {
@@ -144,30 +110,7 @@ export function getTokenCache(directory = getCacheDir()): KeyedCache<SsoAccess> 
     return mapCache(cache, read, write)
 }
 
-function getFileStats(file: string): Stats {
-    return statSync(file)
-}
-
-const firstValidDate = new Date(2023, 3, 14) // April 14, 2023
-
-/**
- * @returns true if file is older than the first valid date
- */
-function isOldFile(file: string, statFunc: typeof getFileStats): boolean {
-    try {
-        const statResult = statFunc(file)
-        // Depending on the Windows filesystem, birthtime may be 0, so we fall back to ctime (last time metadata was changed)
-        // https://nodejs.org/api/fs.html#stat-time-values
-        return statResult.birthtimeMs !== 0
-            ? statResult.birthtimeMs < firstValidDate.getTime()
-            : statResult.ctime < firstValidDate
-    } catch (err) {
-        getLogger().debug(`SSO cache file age not be verified: ${file}: ${err}`)
-        return false // Assume it is no old since we cannot validate
-    }
-}
-
-export function getTokenCacheFile(ssoCacheDir: string, ssoUrl: string): string {
+function getTokenCacheFile(ssoCacheDir: string, ssoUrl: string): string {
     const encoded = encodeURI(ssoUrl)
     // Per the spec: 'SSO Login Token Flow' the access token must be
     // cached as the SHA1 hash of the bytes of the UTF-8 encoded
@@ -183,7 +126,7 @@ export function getTokenCacheFile(ssoCacheDir: string, ssoUrl: string): string {
     return path.join(ssoCacheDir, `${hashedUrl}.json`)
 }
 
-export function getRegistrationCacheFile(ssoCacheDir: string, key: RegistrationKey): string {
+function getRegistrationCacheFile(ssoCacheDir: string, key: RegistrationKey): string {
     const hashScopes = (scopes: string[]) => {
         const shasum = crypto.createHash('sha256')
         scopes.forEach(s => shasum.update(s))

--- a/src/test/techdebt.test.ts
+++ b/src/test/techdebt.test.ts
@@ -42,12 +42,4 @@ describe('tech debt', function () {
             'with node16+, we can use crypto.randomUUID and remove the "uuid" dependency'
         )
     })
-
-    it('temporary code removed', function () {
-        // Reason: https://sim.amazon.com/issues/IDE-10559
-        // At this point in time most users who would have run in to this error
-        // will have already had their old files deleted.
-        const august2023 = new Date(2023, 7, 1)
-        assert.ok(Date.now() < august2023.getTime(), 'remove `deleteOldFiles()` in `cache.ts`')
-    })
 })


### PR DESCRIPTION
Problem:
- Date-triggered tech debt test started failing, which reminds us to remove old code.
- This code also was producing (harmless) failures which show up in logs (example: https://github.com/aws/aws-toolkit-vscode/issues/3403): ``` [WARN]: auth: error deleting old files in sso cache: Error: ENOENT: no such file or directory, scandir 'C:\Users\user.aws\sso\cache' [ENOENT] ```

Solution:
Remove deleteOldFiles().


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
