### PR TITLE
telemetry: emit aws_expandExplorerNode

### DIFF
--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -56,6 +56,9 @@ export async function activate(args: {
                 folder: element.element.folder,
             })
         }
+        if (element.element.serviceId) {
+            telemetry.aws_expandExplorerNode.emit({ serviceType: element.element.serviceId })
+        }
     })
     globals.context.subscriptions.push(view)
 

--- a/src/shared/treeview/nodes/awsTreeNodeBase.ts
+++ b/src/shared/treeview/nodes/awsTreeNodeBase.ts
@@ -8,6 +8,8 @@ import { isCloud9 } from '../../extensionUtilities'
 
 export abstract class AWSTreeNodeBase extends TreeItem {
     public readonly regionCode?: string
+    /** Service id as defined in the service model. May be undefined for child nodes. */
+    public serviceId: string | undefined
 
     public constructor(label: string, collapsibleState?: TreeItemCollapsibleState) {
         super(label, collapsibleState)


### PR DESCRIPTION
Emit `aws_expandExplorerNode` when a service node in AWS Explorer is expanded.

https://github.com/aws/aws-toolkit-common/commit/0b80eea4225c9991905855550d8adcbcbbd83a1d



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
