### PR TITLE
feat(auth): warn if SSO user has no accounts

### DIFF
--- a/.changes/next-release/Feature-ff7562fc-d346-404a-9e2e-86d57d12d97a.json
+++ b/.changes/next-release/Feature-ff7562fc-d346-404a-9e2e-86d57d12d97a.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "IAM Identity Center (SSO): show an error if SSO user is not assigned to an account with a Permission Set"
+}

--- a/src/auth/sso/model.ts
+++ b/src/auth/sso/model.ts
@@ -82,6 +82,10 @@ export const trustedDomainCancellation = 'TrustedDomainCancellation'
 const tryOpenHelpUrl = (url: vscode.Uri) =>
     openUrl(url).catch(e => getLogger().verbose('auth: failed to open help URL: %s', e))
 
+export function truncateStartUrl(startUrl: string) {
+    return startUrl.match(/https?:\/\/(.*)\.awsapps\.com\/start/)?.[1] ?? startUrl
+}
+
 export async function openSsoPortalLink(
     startUrl: string,
     authorization: { readonly verificationUri: string; readonly userCode: string }

--- a/src/auth/ui/vue/show.ts
+++ b/src/auth/ui/vue/show.ts
@@ -91,7 +91,7 @@ export class AuthWebview extends VueWebview {
     }
 
     /**
-     * Returns true if any credentials are found, even ones associated with an sso
+     * Returns true if any credentials are found, including those discovered from SSO service API.
      */
     async isCredentialExists(): Promise<boolean> {
         return (await Auth.instance.listAndTraverseConnections().promise()).find(isIamConnection) !== undefined

--- a/src/test/credentials/auth.test.ts
+++ b/src/test/credentials/auth.test.ts
@@ -285,6 +285,20 @@ describe('Auth', function () {
             )
         })
 
+        it('shows a user message if SSO connection returned no accounts/roles', async function () {
+            auth.ssoClient.listAccounts.returns(
+                toCollection(async function* () {
+                    yield []
+                })
+            )
+            await auth.createConnection(linkedSsoProfile)
+            await auth.listAndTraverseConnections().promise()
+            assert.strictEqual(
+                getTestWindow().shownMessages[0].message,
+                'IAM Identity Center (d-0123456789) returned no roles. Ensure the user is assigned to an account with a Permission Set.'
+            )
+        })
+
         it('does not gather linked accounts when calling `listConnections`', async function () {
             await auth.createConnection(linkedSsoProfile)
             const connections = await auth.listConnections()


### PR DESCRIPTION
Problem:
If the user connects with a IdC/SSO account that is not fully configured, selecting the connection silently does nothing.

Solution:
Show an error message (unless it was already shown).

Followup to #3704 24917d13b11904b12667da4d43d3c92f6f5b317c


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
