### PR TITLE
UX: small issues with the regionSubmenu fix. 

### DIFF
--- a/.changes/next-release/Bug Fix-f600d289-1c01-41c5-aff0-00619956aed1.json
+++ b/.changes/next-release/Bug Fix-f600d289-1c01-41c5-aff0-00619956aed1.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Regions quickpick menu shows duplicate \"recently used\" labels"
+}

--- a/src/shared/ui/common/region.ts
+++ b/src/shared/ui/common/region.ts
@@ -45,8 +45,8 @@ export function createRegionPrompter(
 
     const defaultRegionItem = items.find(item => item.detail === defaultRegion)
 
-    if (defaultRegionItem !== undefined) {
-        defaultRegionItem.description = localize('AWS.generic.recentlyUsed', '(recently used)')
+    if (defaultRegionItem !== undefined && !defaultRegionItem.recentlyUsed) {
+        defaultRegionItem.description = localize('AWS.generic.defaultRegion', '(default region)')
     }
 
     const prompter = createQuickPick(items, {

--- a/src/shared/ui/common/regionSubmenu.ts
+++ b/src/shared/ui/common/regionSubmenu.ts
@@ -46,7 +46,7 @@ export class RegionSubmenu<T> extends Prompter<RegionSubmenuResponse<T>> {
                 data: undefined,
             },
             {
-                label: 'Switch region',
+                label: 'Switch Regions',
                 data: switchRegion,
                 description: `current region: ${this.currentRegion}`,
             },

--- a/src/shared/ui/common/regionSubmenu.ts
+++ b/src/shared/ui/common/regionSubmenu.ts
@@ -46,7 +46,7 @@ export class RegionSubmenu<T> extends Prompter<RegionSubmenuResponse<T>> {
                 data: undefined,
             },
             {
-                label: 'Switch Regions',
+                label: 'Switch Region',
                 data: switchRegion,
                 description: `current region: ${this.currentRegion}`,
             },

--- a/src/test/shared/ui/prompters/regionSubmenu.test.ts
+++ b/src/test/shared/ui/prompters/regionSubmenu.test.ts
@@ -45,7 +45,7 @@ describe('regionSubmenu', function () {
         const dataPrompterTester = createQuickPickPrompterTester(
             submenuPrompter.activePrompter as Combine<typeof submenuPrompter.activePrompter>
         )
-        dataPrompterTester.acceptItem('Switch Regions')
+        dataPrompterTester.acceptItem('Switch Region')
         await dataPrompterTester.result()
 
         const regionTester = createQuickPickPrompterTester(

--- a/src/test/shared/ui/prompters/regionSubmenu.test.ts
+++ b/src/test/shared/ui/prompters/regionSubmenu.test.ts
@@ -45,7 +45,7 @@ describe('regionSubmenu', function () {
         const dataPrompterTester = createQuickPickPrompterTester(
             submenuPrompter.activePrompter as Combine<typeof submenuPrompter.activePrompter>
         )
-        dataPrompterTester.acceptItem('Switch region')
+        dataPrompterTester.acceptItem('Switch Regions')
         await dataPrompterTester.result()
 
         const regionTester = createQuickPickPrompterTester(


### PR DESCRIPTION
## Problems
This PR fixes the following two issues:
- "Switch region" --> "Switch Regions"
- Duplicate "recently used" tag is replaced by "default region" and "recently used" tags. 
## Solution
Old Version:
![image](https://github.com/aws/aws-toolkit-vscode/assets/42325418/52823844-4cf3-4260-846d-ddc36f2f3f70)
New Version:
<img width="615" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/42325418/64564fe4-439d-4a72-a6fd-690b29e3b8a0">
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
