### PR TITLE
CodeWhisperer: Fix inline suggestions not showing in the editor

### DIFF
--- a/.changes/next-release/Bug Fix-1bdf6b9c-d49a-451d-acdc-1d4fb233e02b.json
+++ b/.changes/next-release/Bug Fix-1bdf6b9c-d49a-451d-acdc-1d4fb233e02b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeWhisperer: Fix in some cases the inline suggestions are not showing in the editor"
+}

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -51,31 +51,6 @@ export class CWInlineCompletionItemProvider implements vscode.InlineCompletionIt
         this.activeItemIndex = undefined
     }
 
-    private getGhostText(prefix: string, suggestion: string): string {
-        const prefixLines = prefix.split(/\r\n|\r|\n/)
-        const n = prefixLines.length
-        if (n <= 1) {
-            return suggestion
-        }
-        let count = 1
-        for (let i = 0; i < suggestion.length; i++) {
-            if (suggestion[i] === '\n') {
-                count++
-            }
-            if (count === n) {
-                return suggestion.slice(i + 1)
-            }
-        }
-        return ''
-    }
-
-    private getGhostTextStartPos(start: vscode.Position, current: vscode.Position): vscode.Position {
-        if (start.line === current.line) {
-            return start
-        }
-        return new vscode.Position(current.line, 0)
-    }
-
     // iterate suggestions and stop at index 0 or index len - 1
     private getIteratingIndexes() {
         const len = RecommendationHandler.instance.recommendations.length
@@ -132,8 +107,8 @@ export class CWInlineCompletionItemProvider implements vscode.InlineCompletionIt
             return undefined
         }
         return {
-            insertText: this.getGhostText(prefix, truncatedSuggestion),
-            range: new vscode.Range(this.getGhostTextStartPos(start, end), end),
+            insertText: truncatedSuggestion,
+            range: new vscode.Range(start, end),
             command: {
                 command: 'aws.codeWhisperer.accept',
                 title: 'On acceptance',
@@ -168,7 +143,14 @@ export class CWInlineCompletionItemProvider implements vscode.InlineCompletionIt
             this.activeItemIndex = undefined
             return
         }
-        const start = RecommendationHandler.instance.startPos
+
+        // There's a chance that the startPos is no longer valid in the current document (e.g.
+        // when CodeWhisperer got triggered by 'Enter', the original startPos is with indentation
+        // but then this indentation got removed by VSCode when another new line is inserted,
+        // before the code reaches here). In such case, we need to update the startPos to be a
+        // valid one. Otherwise, inline completion which utilizes this position will function
+        // improperly.
+        const start = document.validatePosition(RecommendationHandler.instance.startPos)
         const end = position
         const iteratingIndexes = this.getIteratingIndexes()
         const prefix = document.getText(new vscode.Range(start, end)).replace(/\r\n/g, '\n')

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -307,7 +307,7 @@ export class RecommendationHandler {
                 }
             })
             this.recommendations = pagination ? this.recommendations.concat(recommendation) : recommendation
-            if (isInlineCompletionEnabled() && this.hasAtLeastOneValidSuggestion()) {
+            if (isInlineCompletionEnabled() && this.hasAtLeastOneValidSuggestion(editor, typedPrefix)) {
                 this._onDidReceiveRecommendation.fire()
             }
         }
@@ -329,8 +329,8 @@ export class RecommendationHandler {
         }
     }
 
-    hasAtLeastOneValidSuggestion() {
-        return this.recommendations.some(r => r.content.trim() !== '')
+    hasAtLeastOneValidSuggestion(editor: vscode.TextEditor, typedPrefix: string): boolean {
+        return this.recommendations.some(r => r.content.trim() !== '' && r.content.startsWith(typedPrefix))
     }
 
     cancelPaginatedRequest() {

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -307,7 +307,7 @@ export class RecommendationHandler {
                 }
             })
             this.recommendations = pagination ? this.recommendations.concat(recommendation) : recommendation
-            if (isInlineCompletionEnabled()) {
+            if (isInlineCompletionEnabled() && this.hasAtLeastOneValidSuggestion()) {
                 this._onDidReceiveRecommendation.fire()
             }
         }
@@ -327,6 +327,10 @@ export class RecommendationHandler {
             this.nextToken = nextToken
             this.errorCode = errorCode
         }
+    }
+
+    hasAtLeastOneValidSuggestion() {
+        return this.recommendations.some(r => r.content.trim() !== '')
     }
 
     cancelPaginatedRequest() {


### PR DESCRIPTION
There's a weird case that when an empty suggestion is provided to the inline suggestion provider, the inline suggestion UI won't show afterward even executing commands to hide/show it again.

Given that empty suggestions don't need to be shown to the users, don't call onDidReceiveRecommendations until there's at least one non-empty suggestion for the inline provider(so inline UI will be able to pick this and show up correctly)

Before: 
1. Trigger to get two suggestions, the first one is an empty string
2. The suggestions won't show in the editor, I have to do the `tab` and `backspace` trick to see the suggestions again

https://github.com/aws/aws-toolkit-vscode/assets/89420755/ae0d6315-d5e6-48cb-a21a-4bc15f8f86c3

After:
1. Trigger at the same point to get two suggestions, frist one being an empty string
2. The suggestion shows in the editor, only the second one shows (since first one is empty)


https://github.com/aws/aws-toolkit-vscode/assets/89420755/b4470cdf-5b5c-45b1-970d-b4b64c8dff6b


Fix to another case:

Before:
1. trigger by hitting "Enter", and then hit "Enter" once again
2. Some states got stuck and manual trigger at this position don't do anything

https://github.com/aws/aws-toolkit-vscode/assets/89420755/c7eb6ada-ccfd-4447-abcd-17aa535874e4



After:
1. trigger by hitting "Enter", and then hit "Enter" once again
2. The suggestion that should show got successfully shown in the editor.

https://github.com/aws/aws-toolkit-vscode/assets/89420755/696e7c17-4dea-4306-a71a-e2c867be42fc





## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
