### PR TITLE
ec2: add telemetry to instance management commands. 

### DIFF
--- a/src/ec2/activation.ts
+++ b/src/ec2/activation.ts
@@ -35,18 +35,27 @@ export async function activate(ctx: ExtContext): Promise<void> {
         }),
 
         Commands.register('aws.ec2.startInstance', async (node?: Ec2Node) => {
-            await startInstance(node)
-            refreshExplorer(node)
+            await telemetry.ec2_changeState.run(async span => {
+                span.record({ ec2InstanceState: 'start' })
+                await startInstance(node)
+                refreshExplorer(node)
+            })
         }),
 
         Commands.register('aws.ec2.stopInstance', async (node?: Ec2Node) => {
-            await stopInstance(node)
-            refreshExplorer(node)
+            await telemetry.ec2_changeState.run(async span => {
+                span.record({ ec2InstanceState: 'stop' })
+                await stopInstance(node)
+                refreshExplorer(node)
+            })
         }),
 
         Commands.register('aws.ec2.rebootInstance', async (node?: Ec2Node) => {
-            await rebootInstance(node)
-            refreshExplorer(node)
+            await telemetry.ec2_changeState.run(async span => {
+                span.record({ ec2InstanceState: 'reboot' })
+                await rebootInstance(node)
+                refreshExplorer(node)
+            })
         })
     )
 }


### PR DESCRIPTION
## Problem
Missing telemetry. 
## Solution
Use the `ec2_changeState` metric on each of the change state commands.  
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
