### PR TITLE
ci: new sam cli update causing CI to fail

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -77,7 +77,8 @@ phases:
                 fi
             # Where non-root "pip3 install" puts things:
             - 'export PATH="$HOME/.local/bin:$PATH"'
-            - '>/dev/null pip3 install --upgrade aws-sam-cli'
+            # Explicit older version since we assume the newer version is causing our CI to fail (python 3.10 sam tests specifically)
+            - '>/dev/null pip install aws-sam-cli==1.94.0'
             - '>/dev/null pip3 install --upgrade awscli'
             # Print info about sam (version, location, …).
             - 'pip3 show aws-sam-cli'

--- a/src/test/techdebt.test.ts
+++ b/src/test/techdebt.test.ts
@@ -42,4 +42,15 @@ describe('tech debt', function () {
             'with node16+, we can use crypto.randomUUID and remove the "uuid" dependency'
         )
     })
+
+    it('remove explicit sam cli version', function () {
+        // Indicate to start using the latest aws-sam-cli version in our CI
+        // https://issues.amazon.com/issues/IDE-11386
+        const nextMonth = new Date(2023, 8, 12) // September 12th, 2023
+        const now = new Date()
+        assert(
+            now < nextMonth,
+            'Remove use of 1.94.0 for aws-sam-cli in linuxIntegrationTests.yml and see if integration tests are passing now'
+        )
+    })
 })


### PR DESCRIPTION
The python 3.10 sam CI tests were failing and blocking release. This downgrades from the current version causing the issue (1.95.0) to the previous version. Now CI should pass when `/runIntegrationTests` is run.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
