### PR TITLE
test: Skip CodeCatalyst E2E tests

### DIFF
--- a/src/test/techdebt.test.ts
+++ b/src/test/techdebt.test.ts
@@ -53,4 +53,11 @@ describe('tech debt', function () {
             'Remove use of 1.94.0 for aws-sam-cli in linuxIntegrationTests.yml and see if integration tests are passing now'
         )
     })
+
+    it('stop skipping CodeCatalyst E2E Tests', function () {
+        // https://issues.amazon.com/issues/IDE-10496
+        const nextMonth = new Date(2023, 8, 12) // September 12th, 2023
+        const now = new Date()
+        assert(now < nextMonth, 'Re-evaluate if we should still keep skipping CodeCatalyst E2E Tests')
+    })
 })

--- a/src/testE2E/codecatalyst/client.test.ts
+++ b/src/testE2E/codecatalyst/client.test.ts
@@ -81,7 +81,7 @@ let projectName: CodeCatalystProject['name']
  *     integ tests, but using the ssh hostname that we get from
  *     {@link prepareDevEnvConnection}.
  */
-describe('Test how this codebase uses the CodeCatalyst API', function () {
+describe.skip('Test how this codebase uses the CodeCatalyst API', function () {
     let client: CodeCatalystClient
     let commands: CodeCatalystCommands
     let webviewClient: CodeCatalystCreateWebview


### PR DESCRIPTION
These tests always fail due to a throttling issue with CodeCatalyst, see the SIM IDE-10496 for more info.

We will eventually re-enable these tests once the CC side fixes the issues causing this.

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
