### PR TITLE
auth: Helper methods to check if connection exists

### DIFF
--- a/src/auth/connection.ts
+++ b/src/auth/connection.ts
@@ -52,6 +52,9 @@ export const isAnySsoConnection = (conn?: Connection): conn is SsoConnection => 
 export const isBaseSsoConnection = (conn?: Connection): conn is SsoConnection => isSsoConnection(conn, 'base')
 export const isBuilderIdConnection = (conn?: Connection): conn is SsoConnection => isSsoConnection(conn, 'builderId')
 
+export const isValidCodeCatalystConnection = (conn: Connection): conn is SsoConnection =>
+    isBuilderIdConnection(conn) && hasScopes(conn, codecatalystScopes)
+
 export function hasScopes(target: SsoConnection | SsoProfile, scopes: string[]): boolean {
     return scopes?.every(s => target.scopes?.includes(s))
 }

--- a/src/auth/connection.ts
+++ b/src/auth/connection.ts
@@ -27,6 +27,7 @@ export const isIamConnection = (conn?: Connection): conn is IamConnection => con
 export const isSsoConnection = (conn?: Connection): conn is SsoConnection => conn?.type === 'sso'
 export const isBuilderIdConnection = (conn?: Connection): conn is SsoConnection =>
     isSsoConnection(conn) && conn.startUrl === builderIdStartUrl
+export const isIdcConnection = (conn?: Connection) => isSsoConnection(conn) && !isBuilderIdConnection(conn)
 
 export function hasScopes(target: SsoConnection | SsoProfile, scopes: string[]): boolean {
     return scopes?.every(s => target.scopes?.includes(s))

--- a/src/auth/connection.ts
+++ b/src/auth/connection.ts
@@ -25,7 +25,7 @@ export const defaultSsoRegion = 'us-east-1'
 
 type SsoType =
     | 'any' // any type of sso
-    | 'base' // AWS Identity Center
+    | 'idc' // AWS Identity Center
     | 'builderId'
 
 export const isIamConnection = (conn?: Connection): conn is IamConnection => conn?.type === 'iam'
@@ -35,12 +35,11 @@ export const isSsoConnection = (conn?: Connection, type: SsoType = 'any'): conn 
     }
     // At this point the conn is an SSO conn, but now we must determine the specific type
     switch (type) {
-        case 'base':
-            // Any SSO type is considered an SSO connection, but in this case
-            // we only want an Identity Center connection. So we return true
-            // as long as the connection is none of the other connection types.
-
-            // IMPORTANT: This condition should grow as more SsoType's get added.
+        case 'idc':
+            // An Identity Center SSO connection is the Base/Root and doesn't
+            // have any unique identifiers, so we must eliminate the other SSO
+            // types to determine if this is Identity Center.
+            // This condition should grow as more SsoType's get added.
             return !isBuilderIdConnection(conn)
         case 'builderId':
             return conn.startUrl === builderIdStartUrl
@@ -49,7 +48,7 @@ export const isSsoConnection = (conn?: Connection, type: SsoType = 'any'): conn 
     }
 }
 export const isAnySsoConnection = (conn?: Connection): conn is SsoConnection => isSsoConnection(conn, 'any')
-export const isBaseSsoConnection = (conn?: Connection): conn is SsoConnection => isSsoConnection(conn, 'base')
+export const isIdcSsoConnection = (conn?: Connection): conn is SsoConnection => isSsoConnection(conn, 'idc')
 export const isBuilderIdConnection = (conn?: Connection): conn is SsoConnection => isSsoConnection(conn, 'builderId')
 
 export const isValidCodeCatalystConnection = (conn: Connection): conn is SsoConnection =>

--- a/src/auth/sso/validation.ts
+++ b/src/auth/sso/validation.ts
@@ -5,7 +5,7 @@
 import * as vscode from 'vscode'
 import { UnknownError } from '../../shared/errors'
 import { AuthType } from '../auth'
-import { isSsoConnection, SsoConnection, hasScopes } from '../connection'
+import { SsoConnection, hasScopes, isAnySsoConnection } from '../connection'
 
 export function validateSsoUrl(auth: AuthType, url: string, requiredScopes?: string[]) {
     const urlFormatError = validateSsoUrlFormat(url)
@@ -28,7 +28,7 @@ export async function validateIsNewSsoUrlAsync(
     requiredScopes?: string[]
 ): Promise<string | undefined> {
     return auth.listConnections().then(conns => {
-        return validateIsNewSsoUrl(url, requiredScopes, conns.filter(isSsoConnection))
+        return validateIsNewSsoUrl(url, requiredScopes, conns.filter(isAnySsoConnection))
     })
 }
 

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -37,7 +37,7 @@ import {
     createSsoProfile,
     defaultSsoRegion,
     isAnySsoConnection,
-    isBaseSsoConnection,
+    isIdcSsoConnection,
     isBuilderIdConnection,
     isIamConnection,
     isValidCodeCatalystConnection,
@@ -592,13 +592,13 @@ async function findSsoConnections(
     switch (kind) {
         case 'codewhisperer':
             predicate = (conn?: Connection) => {
-                return isBaseSsoConnection(conn) && isValidCodeWhispererConnection(conn)
+                return isIdcSsoConnection(conn) && isValidCodeWhispererConnection(conn)
             }
             break
         case 'any':
-            predicate = isBaseSsoConnection
+            predicate = isIdcSsoConnection
     }
-    return (await allConnections()).filter(predicate).filter(isBaseSsoConnection)
+    return (await allConnections()).filter(predicate).filter(isIdcSsoConnection)
 }
 
 export type BuilderIdKind = 'any' | 'codewhisperer' | 'codecatalyst'

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -47,6 +47,7 @@ import { validateIsNewSsoUrl, validateSsoUrlFormat } from './sso/validation'
 import { openUrl } from '../shared/utilities/vsCodeUtils'
 import { AuthSource } from './ui/vue/show'
 import { getLogger } from '../shared/logger'
+import { isValidCodeWhispererConnection } from '../codewhisperer/util/authUtil'
 
 // TODO: Look to do some refactoring to handle circular dependency later and move this to ./commands.ts
 export const showConnectionsPageCommand = 'aws.auth.manageConnections'
@@ -570,7 +571,7 @@ export async function hasIamCredentials(
 export type SsoKind = 'any' | 'codewhisperer'
 
 /**
- * Returns true if an Identity Center connection exists.
+ * Returns true if an Identity Center SSO connection exists.
  *
  * @param kind A specific kind of Identity Center connection that must exist.
  * @param allConnections func to get all connections that exist
@@ -588,7 +589,12 @@ async function findSsoConnections(
 ): Promise<SsoConnection[]> {
     let predicate: (c?: Connection) => boolean
     switch (kind) {
-        default:
+        case 'codewhisperer':
+            predicate = (conn?: Connection) => {
+                return isIdcConnection(conn) && isValidCodeWhispererConnection(conn)
+            }
+            break
+        case 'any':
             predicate = isIdcConnection
     }
     return (await allConnections()).filter(predicate).filter(isSsoConnection)
@@ -615,7 +621,12 @@ async function findBuilderIdConnections(
 ): Promise<SsoConnection[]> {
     let predicate: (c?: Connection) => boolean
     switch (kind) {
-        default:
+        case 'codewhisperer':
+            predicate = (conn?: Connection) => {
+                return isBuilderIdConnection(conn) && isValidCodeWhispererConnection(conn)
+            }
+            break
+        case 'any':
             predicate = isBuilderIdConnection
     }
     return (await allConnections()).filter(predicate).filter(isSsoConnection)

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -36,10 +36,10 @@ import {
     createBuilderIdProfile,
     createSsoProfile,
     defaultSsoRegion,
+    isAnySsoConnection,
+    isBaseSsoConnection,
     isBuilderIdConnection,
     isIamConnection,
-    isIdcConnection,
-    isSsoConnection,
 } from './connection'
 import { Commands } from '../shared/vscode/commands2'
 import { Auth } from './auth'
@@ -148,7 +148,7 @@ export const createIamItem = () =>
     } as DataQuickPickItem<'iam'>)
 
 export async function createStartUrlPrompter(title: string, requiredScopes?: string[]) {
-    const existingConnections = (await Auth.instance.listConnections()).filter(isSsoConnection)
+    const existingConnections = (await Auth.instance.listConnections()).filter(isAnySsoConnection)
 
     function validateSsoUrl(url: string) {
         const urlFormatError = validateSsoUrlFormat(url)
@@ -573,7 +573,7 @@ export type SsoKind = 'any' | 'codewhisperer'
 /**
  * Returns true if an Identity Center SSO connection exists.
  *
- * @param kind A specific kind of Identity Center connection that must exist.
+ * @param kind A specific kind of Identity Center SSO connection that must exist.
  * @param allConnections func to get all connections that exist
  */
 export async function hasSso(
@@ -591,13 +591,13 @@ async function findSsoConnections(
     switch (kind) {
         case 'codewhisperer':
             predicate = (conn?: Connection) => {
-                return isIdcConnection(conn) && isValidCodeWhispererConnection(conn)
+                return isBaseSsoConnection(conn) && isValidCodeWhispererConnection(conn)
             }
             break
         case 'any':
-            predicate = isIdcConnection
+            predicate = isBaseSsoConnection
     }
-    return (await allConnections()).filter(predicate).filter(isSsoConnection)
+    return (await allConnections()).filter(predicate).filter(isBaseSsoConnection)
 }
 
 export type BuilderIdKind = 'any' | 'codewhisperer'
@@ -629,7 +629,7 @@ async function findBuilderIdConnections(
         case 'any':
             predicate = isBuilderIdConnection
     }
-    return (await allConnections()).filter(predicate).filter(isSsoConnection)
+    return (await allConnections()).filter(predicate).filter(isAnySsoConnection)
 }
 
 /**

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -48,6 +48,7 @@ import { openUrl } from '../shared/utilities/vsCodeUtils'
 import { AuthSource } from './ui/vue/show'
 import { getLogger } from '../shared/logger'
 import { isValidCodeWhispererConnection } from '../codewhisperer/util/authUtil'
+import { isValidCodeCatalystConnection } from '../codecatalyst/auth'
 
 // TODO: Look to do some refactoring to handle circular dependency later and move this to ./commands.ts
 export const showConnectionsPageCommand = 'aws.auth.manageConnections'
@@ -600,7 +601,7 @@ async function findSsoConnections(
     return (await allConnections()).filter(predicate).filter(isBaseSsoConnection)
 }
 
-export type BuilderIdKind = 'any' | 'codewhisperer'
+export type BuilderIdKind = 'any' | 'codewhisperer' | 'codecatalyst'
 
 /**
  * Returns true if a Builder ID connection exists.
@@ -624,6 +625,11 @@ async function findBuilderIdConnections(
         case 'codewhisperer':
             predicate = (conn?: Connection) => {
                 return isBuilderIdConnection(conn) && isValidCodeWhispererConnection(conn)
+            }
+            break
+        case 'codecatalyst':
+            predicate = (conn?: Connection) => {
+                return isBuilderIdConnection(conn) && isValidCodeCatalystConnection(conn)
             }
             break
         case 'any':

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -40,6 +40,7 @@ import {
     isBaseSsoConnection,
     isBuilderIdConnection,
     isIamConnection,
+    isValidCodeCatalystConnection,
 } from './connection'
 import { Commands } from '../shared/vscode/commands2'
 import { Auth } from './auth'
@@ -48,7 +49,6 @@ import { openUrl } from '../shared/utilities/vsCodeUtils'
 import { AuthSource } from './ui/vue/show'
 import { getLogger } from '../shared/logger'
 import { isValidCodeWhispererConnection } from '../codewhisperer/util/authUtil'
-import { isValidCodeCatalystConnection } from '../codecatalyst/auth'
 
 // TODO: Look to do some refactoring to handle circular dependency later and move this to ./commands.ts
 export const showConnectionsPageCommand = 'aws.auth.manageConnections'

--- a/src/codecatalyst/auth.ts
+++ b/src/codecatalyst/auth.ts
@@ -15,9 +15,9 @@ import {
     ssoAccountAccessScopes,
     codecatalystScopes,
     SsoConnection,
-    hasScopes,
     Connection,
     isBuilderIdConnection,
+    isValidCodeCatalystConnection,
 } from '../auth/connection'
 import { createBuilderIdConnection } from '../auth/utils'
 
@@ -39,8 +39,6 @@ export class CodeCatalystAuthStorage {
 export const onboardingUrl = vscode.Uri.parse('https://codecatalyst.aws/onboarding/view')
 
 const defaultScopes = [...ssoAccountAccessScopes, ...codecatalystScopes]
-export const isValidCodeCatalystConnection = (conn: Connection): conn is SsoConnection =>
-    isBuilderIdConnection(conn) && hasScopes(conn, codecatalystScopes)
 
 export const isUpgradeableConnection = (conn: Connection): conn is SsoConnection =>
     isBuilderIdConnection(conn) && !isValidCodeCatalystConnection(conn)

--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -28,7 +28,7 @@ import { getLogger } from '../../shared/logger'
 export const defaultCwScopes = [...ssoAccountAccessScopes, ...codewhispererScopes]
 export const awsBuilderIdSsoProfile = createBuilderIdProfile(defaultCwScopes)
 
-export const isValidCodeWhispererConnection = (conn: Connection): conn is Connection => {
+export const isValidCodeWhispererConnection = (conn?: Connection): conn is Connection => {
     if (isCloud9('classic')) {
         return isIamConnection(conn)
     }

--- a/src/test/codewhisperer/util/authUtil.test.ts
+++ b/src/test/codewhisperer/util/authUtil.test.ts
@@ -9,7 +9,7 @@ import { getTestWindow } from '../../shared/vscode/window'
 import { SeverityLevel } from '../../shared/vscode/message'
 import { createBuilderIdProfile, createSsoProfile, createTestAuth } from '../../credentials/testUtil'
 import { captureEventOnce } from '../../testUtil'
-import { codewhispererScopes, isSsoConnection } from '../../../auth/connection'
+import { codewhispererScopes, isAnySsoConnection, isBuilderIdConnection } from '../../../auth/connection'
 
 const enterpriseSsoStartUrl = 'https://enterprise.awsapps.com/start'
 
@@ -111,9 +111,9 @@ describe('AuthUtil', async function () {
         await authUtil.connectToAwsBuilderId()
         assert.ok(authUtil.isConnected())
 
-        const ssoConnectionIds = new Set(auth.activeConnectionEvents.emits.filter(isSsoConnection).map(c => c.id))
+        const ssoConnectionIds = new Set(auth.activeConnectionEvents.emits.filter(isAnySsoConnection).map(c => c.id))
         assert.strictEqual(ssoConnectionIds.size, 1, 'Expected exactly 1 unique SSO connection id')
-        assert.strictEqual((await auth.listConnections()).filter(isSsoConnection).length, 1)
+        assert.strictEqual((await auth.listConnections()).filter(isAnySsoConnection).length, 1)
     })
 
     it('automatically upgrades connections if they do not have the required scopes', async function () {
@@ -124,11 +124,11 @@ describe('AuthUtil', async function () {
         await authUtil.connectToAwsBuilderId()
         assert.ok(authUtil.isConnected())
         assert.ok(authUtil.isConnectionValid())
-        assert.ok(isSsoConnection(authUtil.conn))
+        assert.ok(isBuilderIdConnection(authUtil.conn))
         assert.strictEqual(authUtil.conn?.id, upgradeableConn.id)
         assert.strictEqual(authUtil.conn.startUrl, upgradeableConn.startUrl)
         assert.strictEqual(authUtil.conn.ssoRegion, upgradeableConn.ssoRegion)
-        assert.strictEqual((await auth.listConnections()).filter(isSsoConnection).length, 1)
+        assert.strictEqual((await auth.listConnections()).filter(isAnySsoConnection).length, 1)
     })
 
     it('test reformatStartUrl should remove trailing slash and hash', function () {

--- a/src/test/credentials/testUtil.ts
+++ b/src/test/credentials/testUtil.ts
@@ -17,7 +17,20 @@ import globals from '../../shared/extensionGlobals'
 import { fromString } from '../../auth/providers/credentials'
 import { mergeAndValidateSections, parseIni } from '../../auth/credentials/sharedCredentials'
 import { SharedCredentialsProvider } from '../../auth/providers/sharedCredentialsProvider'
-import { Connection, ProfileStore, SsoConnection, SsoProfile } from '../../auth/connection'
+import { Connection, IamConnection, ProfileStore, SsoConnection, SsoProfile } from '../../auth/connection'
+import * as sinon from 'sinon'
+
+/** Mock Connection objects for test usage */
+export const ssoConnection: SsoConnection = {
+    type: 'sso',
+    id: '0',
+    label: 'sso',
+    ssoRegion: 'us-east-1',
+    startUrl: 'https://nkomonen.awsapps.com/start',
+    getToken: sinon.stub(),
+}
+export const builderIdConnection: SsoConnection = { ...ssoConnection, startUrl: builderIdStartUrl, label: 'builderId' }
+export const iamConnection: IamConnection = { type: 'iam', id: '0', label: 'iam', getCredentials: sinon.stub() }
 
 export function createSsoProfile(props?: Partial<Omit<SsoProfile, 'type'>>): SsoProfile {
     return {

--- a/src/test/credentials/utils.test.ts
+++ b/src/test/credentials/utils.test.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode'
 import assert from 'assert'
 import { FakeExtensionContext } from '../fakeExtensionContext'
 import { BuilderIdKind, ExtensionUse, SsoKind, hasBuilderId, hasIamCredentials, hasSso } from '../../auth/utils'
-import { Connection, SsoConnection, codewhispererScopes } from '../../auth/connection'
+import { Connection, SsoConnection, codecatalystScopes, codewhispererScopes } from '../../auth/connection'
 import { builderIdConnection, iamConnection, ssoConnection } from './testUtil'
 
 describe('ExtensionUse.isFirstUse()', function () {
@@ -75,7 +75,18 @@ describe('connection exists funcs', function () {
         scopes: codewhispererScopes,
         label: 'codeWhispererBuilderId',
     }
-    const ssoConnections: Connection[] = [ssoConnection, builderIdConnection, cwIdcConnection, cwBuilderIdConnection]
+    const ccBuilderIdConnection: SsoConnection = {
+        ...builderIdConnection,
+        scopes: codecatalystScopes,
+        label: 'codeCatalystBuilderId',
+    }
+    const ssoConnections: Connection[] = [
+        ssoConnection,
+        builderIdConnection,
+        cwIdcConnection,
+        cwBuilderIdConnection,
+        ccBuilderIdConnection,
+    ]
     const allConnections = [iamConnection, ...ssoConnections]
 
     describe('ssoExists()', function () {
@@ -116,7 +127,16 @@ describe('connection exists funcs', function () {
             return { ...c, kind: 'codewhisperer' }
         })
 
-        cwBuilderIdCases.forEach(args => {
+        const ccBuilderIdCases: BuilderIdTestCase[] = [
+            {connections: [ccBuilderIdConnection], expected: true},
+            {connections: allConnections, expected: true},
+            {connections: [], expected: false},
+            {connections: allConnections.filter(c => c !== ccBuilderIdConnection), expected: false},
+        ].map(c => { return {...c, kind: 'codecatalyst'}})
+
+        const allCases = [...cwBuilderIdCases, ...ccBuilderIdCases]
+
+        allCases.forEach(args => {
             it(`builderIdExists() returns '${args.expected}' when kind '${args.kind}' given [${args.connections
                 .map(c => c.label)
                 .join(', ')}]`, async function () {

--- a/src/test/credentials/utils.test.ts
+++ b/src/test/credentials/utils.test.ts
@@ -80,17 +80,21 @@ describe('connection exists funcs', function () {
 
     describe('ssoExists()', function () {
         const anyCases: SsoTestCase[] = [
-            {connections: [ssoConnection], expected: true},
-            {connections: allConnections, expected: true},
-            {connections: [], expected: false},
-            {connections: [iamConnection], expected: false},
-        ].map(c => { return {...c, kind: 'any'}})
+            { connections: [ssoConnection], expected: true },
+            { connections: allConnections, expected: true },
+            { connections: [], expected: false },
+            { connections: [iamConnection], expected: false },
+        ].map(c => {
+            return { ...c, kind: 'any' }
+        })
         const cwIdcCases: SsoTestCase[] = [
-            {connections: [cwIdcConnection], expected: true},
-            {connections: allConnections, expected: true},
-            {connections: [], expected: false},
-            {connections: allConnections.filter(c => c !== cwIdcConnection), expected: false},
-        ].map(c => { return {...c, kind: 'codewhisperer'}})
+            { connections: [cwIdcConnection], expected: true },
+            { connections: allConnections, expected: true },
+            { connections: [], expected: false },
+            { connections: allConnections.filter(c => c !== cwIdcConnection), expected: false },
+        ].map(c => {
+            return { ...c, kind: 'codewhisperer' }
+        })
         const allCases = [...anyCases, ...cwIdcCases]
 
         allCases.forEach(args => {
@@ -104,11 +108,13 @@ describe('connection exists funcs', function () {
 
     describe('builderIdExists()', function () {
         const cwBuilderIdCases: BuilderIdTestCase[] = [
-            {connections: [cwBuilderIdConnection], expected: true},
-            {connections: allConnections, expected: true},
-            {connections: [], expected: false},
-            {connections: allConnections.filter(c => c !== cwBuilderIdConnection), expected: false},
-        ].map(c => { return {...c, kind: 'codewhisperer'}})
+            { connections: [cwBuilderIdConnection], expected: true },
+            { connections: allConnections, expected: true },
+            { connections: [], expected: false },
+            { connections: allConnections.filter(c => c !== cwBuilderIdConnection), expected: false },
+        ].map(c => {
+            return { ...c, kind: 'codewhisperer' }
+        })
 
         cwBuilderIdCases.forEach(args => {
             it(`builderIdExists() returns '${args.expected}' when kind '${args.kind}' given [${args.connections

--- a/src/test/credentials/utils.test.ts
+++ b/src/test/credentials/utils.test.ts
@@ -5,8 +5,8 @@
 import * as vscode from 'vscode'
 import assert from 'assert'
 import { FakeExtensionContext } from '../fakeExtensionContext'
-import { ExtensionUse, SsoKind, hasIamCredentials, hasSso } from '../../auth/utils'
-import { Connection } from '../../auth/connection'
+import { BuilderIdKind, ExtensionUse, SsoKind, hasBuilderId, hasIamCredentials, hasSso } from '../../auth/utils'
+import { Connection, SsoConnection, codewhispererScopes } from '../../auth/connection'
 import { builderIdConnection, iamConnection, ssoConnection } from './testUtil'
 
 describe('ExtensionUse.isFirstUse()', function () {
@@ -65,34 +65,68 @@ describe('ExtensionUse.isFirstUse()', function () {
     }
 })
 
-type Case = { kind: SsoKind; connections: Connection[]; expected: boolean }
+type SsoTestCase = { kind: SsoKind; connections: Connection[]; expected: boolean }
+type BuilderIdTestCase = { kind: BuilderIdKind; connections: Connection[]; expected: boolean }
 
 describe('connection exists funcs', function () {
-    const anyCases: Case[] = [
-        { connections: [iamConnection], expected: true },
-        { connections: [ssoConnection, builderIdConnection, iamConnection], expected: true },
-        { connections: [], expected: false },
-        { connections: [ssoConnection, builderIdConnection], expected: false },
-    ].map(args => {
-        return { ...args, kind: 'any' }
+    const cwIdcConnection: SsoConnection = { ...ssoConnection, scopes: codewhispererScopes, label: 'codeWhispererSso' }
+    const cwBuilderIdConnection: SsoConnection = {
+        ...builderIdConnection,
+        scopes: codewhispererScopes,
+        label: 'codeWhispererBuilderId',
+    }
+    const ssoConnections: Connection[] = [ssoConnection, builderIdConnection, cwIdcConnection, cwBuilderIdConnection]
+    const allConnections = [iamConnection, ...ssoConnections]
+
+    describe('ssoExists()', function () {
+        const anyCases: SsoTestCase[] = [
+            {connections: [ssoConnection], expected: true},
+            {connections: allConnections, expected: true},
+            {connections: [], expected: false},
+            {connections: [iamConnection], expected: false},
+        ].map(c => { return {...c, kind: 'any'}})
+        const cwIdcCases: SsoTestCase[] = [
+            {connections: [cwIdcConnection], expected: true},
+            {connections: allConnections, expected: true},
+            {connections: [], expected: false},
+            {connections: allConnections.filter(c => c !== cwIdcConnection), expected: false},
+        ].map(c => { return {...c, kind: 'codewhisperer'}})
+        const allCases = [...anyCases, ...cwIdcCases]
+
+        allCases.forEach(args => {
+            it(`ssoExists() returns '${args.expected}' when kind '${args.kind}' given [${args.connections
+                .map(c => c.label)
+                .join(', ')}]`, async function () {
+                assert.strictEqual(await hasSso(args.kind, async () => args.connections), args.expected)
+            })
+        })
     })
 
-    anyCases.forEach(args => {
-        it(`idcExists() returns '${args.expected}' when kind '${args.kind}' given [${args.connections
-            .map(c => c.label)
-            .join(', ')}]`, async function () {
-            assert.strictEqual(await hasSso(args.kind, async () => args.connections), args.expected)
+    describe('builderIdExists()', function () {
+        const cwBuilderIdCases: BuilderIdTestCase[] = [
+            {connections: [cwBuilderIdConnection], expected: true},
+            {connections: allConnections, expected: true},
+            {connections: [], expected: false},
+            {connections: allConnections.filter(c => c !== cwBuilderIdConnection), expected: false},
+        ].map(c => { return {...c, kind: 'codewhisperer'}})
+
+        cwBuilderIdCases.forEach(args => {
+            it(`builderIdExists() returns '${args.expected}' when kind '${args.kind}' given [${args.connections
+                .map(c => c.label)
+                .join(', ')}]`, async function () {
+                assert.strictEqual(await hasBuilderId(args.kind, async () => args.connections), args.expected)
+            })
         })
     })
 
     describe('credentialExists()', function () {
         const cases: [Connection[], boolean][] = [
             [[iamConnection], true],
-            [[ssoConnection, builderIdConnection, iamConnection], true],
+            [allConnections, true],
             [[], false],
-            [[ssoConnection, builderIdConnection], false],
+            [allConnections.filter(c => c !== iamConnection), false],
         ]
-    
+
         cases.forEach(args => {
             it(`credentialExists() returns '${args[1]}' given [${args[0]
                 .map(c => c.label)

--- a/src/testE2E/codecatalyst/client.test.ts
+++ b/src/testE2E/codecatalyst/client.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../../shared/clients/codecatalystClient'
 import { getThisDevEnv, prepareDevEnvConnection } from '../../codecatalyst/model'
 import { Auth } from '../../auth/auth'
-import { CodeCatalystAuthenticationProvider, isValidCodeCatalystConnection } from '../../codecatalyst/auth'
+import { CodeCatalystAuthenticationProvider } from '../../codecatalyst/auth'
 import { CodeCatalystCommands, DevEnvironmentSettings } from '../../codecatalyst/commands'
 import globals from '../../shared/extensionGlobals'
 import { CodeCatalystCreateWebview, SourceResponse } from '../../codecatalyst/vue/create/backend'
@@ -30,7 +30,12 @@ import { toStream } from '../../shared/utilities/collectionUtils'
 import { toCollection } from '../../shared/utilities/asyncCollection'
 import { getLogger } from '../../shared/logger'
 import { isAwsError } from '../../shared/errors'
-import { codecatalystScopes, createBuilderIdProfile, SsoConnection } from '../../auth/connection'
+import {
+    codecatalystScopes,
+    createBuilderIdProfile,
+    isValidCodeCatalystConnection,
+    SsoConnection,
+} from '../../auth/connection'
 
 let spaceName: CodeCatalystOrg['name']
 let projectName: CodeCatalystProject['name']


### PR DESCRIPTION
This creates simple helper methods to be able to check if a connection of a certain type exists.

The methods answer questions similar to: `Is the toolkit extension aware of a Builder ID connection for CodeWhisperer, regardless of if the connection is active?`

- CodeCatalyst and CodeWhisperer have functions in their auth classes to check for connections specific to them


### Why?
These will be used in future commits by the Add Connections page for telemetry purposes.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
