### PR TITLE
fix: misleading "Permission set" warning for OIDC SSO/IdC connection

### DIFF
--- a/.changes/next-release/Bug Fix-48264e8c-a8ab-487b-ad5d-d25e49068589.json
+++ b/.changes/next-release/Bug Fix-48264e8c-a8ab-487b-ad5d-d25e49068589.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "IAM Identity Center (SSO): misleading \"Permission set\" warning for scope-based SSO/IdC connection"
+}

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -223,12 +223,16 @@ export class Auth implements AuthService, ConnectionManager {
 
             const stream = toStream(this.store.listProfiles().map(entry => this.getConnectionFromStoreEntry(entry)))
 
+            /** Decides if SSO service should be queried for "linked" IAM roles/credentials for the given SSO connection. */
             const isLinkable = (
                 entry: [string, StoredProfile<Profile>]
-            ): entry is [string, StoredProfile<SsoProfile>] =>
-                entry[1].type === 'sso' &&
-                hasScopes(entry[1], ssoAccountAccessScopes) &&
-                entry[1].metadata.connectionState === 'valid'
+            ): entry is [string, StoredProfile<SsoProfile>] => {
+                const r =
+                    entry[1].type === 'sso' &&
+                    hasScopes(entry[1], ssoAccountAccessScopes) &&
+                    entry[1].metadata.connectionState === 'valid'
+                return r
+            }
 
             const linked = this.store
                 .listProfiles()
@@ -238,8 +242,8 @@ export class Auth implements AuthService, ConnectionManager {
                         loadLinkedProfilesIntoStore(
                             this.store,
                             id,
-                            this.createSsoClient(profile.ssoRegion, this.getTokenProvider(id, profile)),
-                            profile.startUrl
+                            profile,
+                            this.createSsoClient(profile.ssoRegion, this.getTokenProvider(id, profile))
                         )
                     )
                         .catch(err => {

--- a/src/auth/providers/sharedCredentialsProvider.ts
+++ b/src/auth/providers/sharedCredentialsProvider.ts
@@ -31,7 +31,7 @@ import {
 } from '../credentials/sharedCredentials'
 import { builderIdStartUrl } from '../sso/model'
 import { SectionName, SharedCredentialsKeys } from '../credentials/types'
-import { SsoProfile, hasScopes } from '../connection'
+import { SsoProfile, hasScopes, ssoAccountAccessScopes } from '../connection'
 
 const credentialSources = {
     ECS_CONTAINER: 'EcsContainer',
@@ -150,7 +150,7 @@ export class SharedCredentialsProvider implements CredentialsProvider {
 
             return {
                 type: 'sso',
-                scopes: ['sso:account:access'],
+                scopes: ssoAccountAccessScopes,
                 startUrl: this.profile[SharedCredentialsKeys.SSO_START_URL],
                 ssoRegion: this.profile[SharedCredentialsKeys.SSO_REGION] ?? defaultRegion,
             }
@@ -348,7 +348,7 @@ export class SharedCredentialsProvider implements CredentialsProvider {
 
     private makeSsoCredentaislProvider() {
         const ssoProfile = this.getSsoProfileFromProfile()
-        if (!hasScopes(ssoProfile, ['sso:account:access'])) {
+        if (!hasScopes(ssoProfile, ssoAccountAccessScopes)) {
             throw new Error(`Session for "${this.profileName}" is missing required scope: sso:account:access`)
         }
 


### PR DESCRIPTION
Problem:
Some IdC/SSO connections have OIDC "scopes" and don't have IAM "roles" (returning IAM credentials / "Permission sets"). Such connections are useful for scope-based applications, even though they don't have IAM credentials.

Solution:
Don't warn about missing roles/permission-sets for connections that have OIDC scopes.



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
