### PR TITLE
sam: surface SAM CLI failures

### DIFF
--- a/.changes/next-release/Feature-c4dffad5-a36b-4f38-95d2-efbb2196c103.json
+++ b/.changes/next-release/Feature-c4dffad5-a36b-4f38-95d2-efbb2196c103.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "SAM run/debug detects and displays SAM CLI errors, so you spend less time inspecting the Output"
+}

--- a/.changes/next-release/Feature-f3f8fadc-c390-4099-8eff-894b78f4cc58.json
+++ b/.changes/next-release/Feature-f3f8fadc-c390-4099-8eff-894b78f4cc58.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Toolkit no longer explicitly checks if Docker is running, instead it lets SAM CLI decide that #3588"
+}

--- a/package.json
+++ b/package.json
@@ -2181,7 +2181,7 @@
             {
                 "command": "aws.ec2.copyInstanceId",
                 "title": "%AWS.command.ec2.copyInstanceId%",
-                "category": "%AWS.title",
+                "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -277,13 +277,6 @@ export async function runLambdaFunction(
     config: SamLaunchRequestArgs,
     onAfterBuild: () => Promise<void>
 ): Promise<SamLaunchRequestArgs> {
-    // Verify if Docker is running
-    const dockerResponse = await new ChildProcess('docker', ['ps'], { logging: 'no' }).run()
-    if (dockerResponse.exitCode !== 0 || dockerResponse.stdout.includes('error during connect')) {
-        throw new ToolkitError('Running AWS SAM projects locally requires Docker. Is it installed and running?', {
-            code: 'NoDocker',
-        })
-    }
     // Switch over to the output channel so the user has feedback that we're getting things ready
     ctx.outputChannel.show(true)
     if (!config.noDebug) {

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -30,6 +30,7 @@ import { CloudFormation } from '../cloudformation/cloudformation'
 import { sleep } from '../utilities/timeoutUtils'
 import { showMessageWithCancel } from '../utilities/messages'
 import { ToolkitError, UnknownError } from '../errors'
+import { SamCliError } from './cli/samCliInvokerUtils'
 
 const localize = nls.loadMessageBundle()
 
@@ -159,11 +160,11 @@ async function buildLambdaHandler(
     const failure = err ?? samBuild.failure()
     if (failure) {
         // TODO(sijaden): ask SAM CLI for a way to map exit codes to error codes
-        // We can also scrape the debug output though that won't be as reliable
         if (typeof failure === 'string') {
             throw new ToolkitError(failure, { code: 'BuildFailure' })
         } else {
-            throw ToolkitError.chain(failure, 'Failed to build SAM application', { code: 'BuildFailure' })
+            const msg = `SAM build failed${err instanceof SamCliError ? ': ' + err.message : ''}`
+            throw ToolkitError.chain(err, msg, { code: 'BuildFailure' })
         }
     }
     getLogger('channel').info(localize('AWS.output.building.sam.application.complete', 'Build complete.'))
@@ -222,10 +223,10 @@ async function invokeLambdaHandler(
                 timeout: timer,
                 name: config.name,
             })
-            .catch(e => {
-                const message = localize('AWS.error.during.apig.local', 'Failed to start local API Gateway')
+            .catch(err => {
+                const msg = `SAM local start-api failed${err instanceof SamCliError ? ': ' + err.message : ''}`
 
-                throw ToolkitError.chain(e, message)
+                throw ToolkitError.chain(err, msg)
             })
     } else {
         // 'target=code' or 'target=template'
@@ -253,10 +254,8 @@ async function invokeLambdaHandler(
         try {
             return await command.execute(timer)
         } catch (err) {
-            throw ToolkitError.chain(
-                err,
-                localize('AWS.error.during.sam.local', 'Failed to run SAM application locally')
-            )
+            const msg = `SAM local invoke failed${err instanceof SamCliError ? ': ' + err.message : ''}`
+            throw ToolkitError.chain(err, msg)
         } finally {
             if (config.sam?.buildDir === undefined) {
                 await remove(config.templatePath)

--- a/src/test/shared/sam/cli/samCliInvokerUtils.test.ts
+++ b/src/test/shared/sam/cli/samCliInvokerUtils.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert'
 import {
     addTelemetryEnvVar,
-    collectAcceptedErrorMessages,
+    collectSamErrors,
     logAndThrowIfUnexpectedExitCode,
     makeUnexpectedExitCodeError,
 } from '../../../../shared/sam/cli/samCliInvokerUtils'
@@ -45,41 +45,32 @@ describe('logAndThrowIfUnexpectedExitCode', async function () {
     })
 })
 
-/**
- * Returns a string with the 'Escape' character
- * prepended to the given text.
- *
- * This exists because using '\e' does not
- * work.
- */
+/** Prepends ESC control character to `text`. */
 function prependEscapeCode(text: string): string {
     return String.fromCharCode(27) + text
 }
 
-describe('collectAcceptedErrorMessages()', async () => {
-    let result: string[]
-
-    before(async () => {
-        const input = [
-            prependEscapeCode('[33m This is an accepted escape sequence'),
-            prependEscapeCode('[100m This is not an accepted escape sequence'),
-            'This will be ignored',
-            'Error: This is accepted due to the prefix',
-        ].join('\n')
-        result = collectAcceptedErrorMessages(input)
-    })
-
-    it('has the expected amount of messages', async () => {
-        assert.strictEqual(result.length, 2)
-    })
-    it('collects the "Error:" prefix', async () => {
-        assert(result.includes('Error: This is accepted due to the prefix'))
-    })
-    it('collects accepted escape sequence prefixes', async () => {
-        assert(result.includes(prependEscapeCode('[33m This is an accepted escape sequence')))
-    })
-    it('ignores non-accepted escape sequence prefixes', async () => {
-        assert(!result.includes(prependEscapeCode('[100m This is not an accepted escape sequence')))
+describe('collectSamErrors()', async () => {
+    it('collects messages', async () => {
+        const input = `
+        This line is ignored
+        foo bar Error: xxx Docker is not reachable!!
+        another line
+        foo Error: user is bored Error: 
+        Error: Running AWS SAM projects locally requires Docker.
+        'urllib3.exceptions.ProtocolError: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory'))'
+        ok
+        ${prependEscapeCode('[33m known escape sequence')}
+        ok again
+        ${prependEscapeCode('[100m unknown escape sequence')}
+        `
+        const result = collectSamErrors(input)
+        assert.deepStrictEqual(result, [
+            'Docker is not reachable',
+            'user is bored Error:',
+            'Running AWS SAM projects locally requires Docker.',
+            'known escape sequence',
+        ])
     })
 })
 

--- a/src/test/shared/sam/cli/testSamCliProcessInvoker.ts
+++ b/src/test/shared/sam/cli/testSamCliProcessInvoker.ts
@@ -94,12 +94,9 @@ export async function assertLogContainsBadExitInformation(
 ): Promise<void> {
     const expectedTexts = [
         {
-            text: `Unexpected exitcode (${errantChildProcessResult.exitCode}), expecting (${expectedExitCode})`,
+            text: `SAM CLI failed (exitcode: ${errantChildProcessResult.exitCode}, expected ${expectedExitCode}`,
             verifyMessage: 'Log message missing for exit code',
         },
-        { text: `Error: ${errantChildProcessResult.error}`, verifyMessage: 'Log message missing for error' },
-        { text: `stderr: ${errantChildProcessResult.stderr}`, verifyMessage: 'Log message missing for stderr' },
-        { text: `stdout: ${errantChildProcessResult.stdout}`, verifyMessage: 'Log message missing for stdout' },
     ]
 
     const logText = logger


### PR DESCRIPTION
# Problem:
When SAM run/debug fails, customer must inspect the Output logs, which is time-consuming.

- #1643
- #3588

# Solution:
Capture useful messages from SAM CLI and surface them in the user message.

<img width="531" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/55561878/ce649ef7-632d-466f-a730-21605055ded0">

![samcli-fail-runtime](https://github.com/aws/aws-toolkit-vscode/assets/55561878/e12be4cf-51ff-4fbf-a3a2-310e4135bd0e)
![samcli-fail-docker](https://github.com/aws/aws-toolkit-vscode/assets/55561878/14f0901a-a055-4938-9aa6-cfa4a0644421)
![samcli-fail-credentials](https://github.com/aws/aws-toolkit-vscode/assets/55561878/3502bfa2-c1a0-48b9-ace9-319d4488b375)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
