### PR TITLE
codewhisperer: add typescript, javascript test file naming convention

### DIFF
--- a/src/codewhisperer/util/supplementalContext/codeParsingUtil.ts
+++ b/src/codewhisperer/util/supplementalContext/codeParsingUtil.ts
@@ -32,6 +32,37 @@ export const utgLanguageConfigs: Record<string, utgLanguageConfig> = {
         classExtractionPattern: /^class\s+(\w+)\s*:/gm,
         importStatementRegExp: /from (.*) import.*/,
     },
+    // TODO: NOTE!!!! for the following configuration, [functionExtractionPattern], [classExtractionPattern], [importStatementRegExp] are placeholder and not being tested
+    // TODO: update them when JS/TS UTG are ENABLED
+    // TODO: also need to update the logic to consider dialects file extension e.g. .js & .jsx, .ts & .tsx, for now, .js will only look for .js file but not .jsx
+    typescript: {
+        extension: '.ts',
+        testFilenamePattern: /^([^/\\+]+)\.(?:spec|test)\.ts$/,
+        functionExtractionPattern: /(?:export\s+)?function\s+([a-zA-Z_][a-zA-Z0-9_]*)\s+.*/,
+        classExtractionPattern: /(?:export\s+)?class\s+([a-zA-Z_][a-zA-Z0-9_]*).*/,
+        importStatementRegExp: /import\s+([a-zA-Z_])/,
+    },
+    javascript: {
+        extension: '.js',
+        testFilenamePattern: /^([^/\\+]+)\.(?:spec|test)\.js$/,
+        functionExtractionPattern: /(?:export\s+)?function\s+([a-zA-Z_][a-zA-Z0-9_]*)\s+.*/,
+        classExtractionPattern: /(?:export\s+)?class\s+([a-zA-Z_][a-zA-Z0-9_]*).*/,
+        importStatementRegExp: /import\s+([a-zA-Z_])/,
+    },
+    typescriptreact: {
+        extension: '.tsx',
+        testFilenamePattern: /^([^/\\+]+)\.(?:spec|test)\.tsx$/,
+        functionExtractionPattern: /(?:export\s+)?function\s+([a-zA-Z_][a-zA-Z0-9_]*)\s+.*/,
+        classExtractionPattern: /(?:export\s+)?class\s+([a-zA-Z_][a-zA-Z0-9_]*).*/,
+        importStatementRegExp: /import\s+([a-zA-Z_])/,
+    },
+    javascriptreact: {
+        extension: '.jsx',
+        testFilenamePattern: /^([^/\\+]+)\.(?:spec|test)\.jsx$/,
+        functionExtractionPattern: /(?:export\s+)?function\s+([a-zA-Z_][a-zA-Z0-9_]*)\s+.*/,
+        classExtractionPattern: /(?:export\s+)?class\s+([a-zA-Z_][a-zA-Z0-9_]*).*/,
+        importStatementRegExp: /import\s+([a-zA-Z_])/,
+    },
 }
 
 export function extractFunctions(fileContent: string, regex: RegExp) {

--- a/src/codewhisperer/util/supplementalContext/utgUtils.ts
+++ b/src/codewhisperer/util/supplementalContext/utgUtils.ts
@@ -24,10 +24,10 @@ import { CodeWhispererUserGroupSettings } from '../userGroupUtil'
 import { UserGroup } from '../../models/constants'
 import { getOpenFilesInWindow } from '../../../shared/utilities/editorUtilities'
 
-type UtgSupportedLanguage = keyof typeof utgLanguageConfigs
+const UtgSupportedLanguage = new Set<vscode.TextDocument['languageId']>(['java', 'python'])
 
-function isUtgSupportedLanguage(languageId: vscode.TextDocument['languageId']): languageId is UtgSupportedLanguage {
-    return languageId in utgLanguageConfigs
+function isUtgSupportedLanguage(languageId: vscode.TextDocument['languageId']): boolean {
+    return UtgSupportedLanguage.has(languageId)
 }
 
 export function shouldFetchUtgContext(

--- a/src/test/codewhisperer/util/codeParsingUtil.test.ts
+++ b/src/test/codewhisperer/util/codeParsingUtil.test.ts
@@ -62,6 +62,186 @@ describe('RegexValidationForJava', () => {
 })
 
 describe('isTestFile', () => {
+    describe('typescript', function () {
+        const language = 'typescript'
+
+        it('isTest by file path should return true', async function () {
+            const filePaths = ['/test/MyClass.ts', '/tst/MyClass.ts', '/tests/MyClass.ts']
+
+            for (const filePath of filePaths) {
+                const result = await isTestFile(filePath, { languageId: language })
+                assert.strictEqual(result, true)
+            }
+        })
+
+        it('isTest by file path should return false', async function () {
+            const filePaths = ['/path/to/MyClass.ts', 'path/to/wrongtesttttfolder/MyClass.ts']
+
+            for (const filePath of filePaths) {
+                const result = await isTestFile(filePath, { languageId: language })
+                assert.strictEqual(result, false)
+            }
+        })
+
+        it('isTest by file name should return true', async function () {
+            const filePaths = [
+                'MyClass.test.ts',
+                '/path/to/MyClass.test.ts',
+                'MyClass.spec.ts',
+                '/path/to/MyClass.spec.ts',
+            ]
+
+            for (const filePath of filePaths) {
+                const result = await isTestFile(filePath, { languageId: language })
+                assert.strictEqual(result, true)
+            }
+        })
+
+        it('isTest by file name should return false', async function () {
+            const filePaths = ['MyClass.ts', '/path/to/MyClass.ts', 'MyClass_test.ts', 'test_MyClass.ts']
+
+            for (const filePath of filePaths) {
+                const result = await isTestFile(filePath, { languageId: language })
+                assert.strictEqual(result, false)
+            }
+        })
+    })
+
+    describe('javascript', function () {
+        const language = 'javascript'
+
+        it('isTest by file path should return true', async function () {
+            const filePaths = ['/test/MyClass.js', '/tst/MyClass.js', '/tests/MyClass.js']
+
+            for (const filePath of filePaths) {
+                const result = await isTestFile(filePath, { languageId: language })
+                assert.strictEqual(result, true)
+            }
+        })
+
+        it('isTest by file path should return false', async function () {
+            const filePaths = ['/path/to/MyClass.js', 'path/to/wrongtesttttfolder/MyClass.js']
+
+            for (const filePath of filePaths) {
+                const result = await isTestFile(filePath, { languageId: language })
+                assert.strictEqual(result, false)
+            }
+        })
+
+        it('isTest by file name should return true', async function () {
+            const filePaths = [
+                'MyClass.test.js',
+                '/path/to/MyClass.test.js',
+                'MyClass.spec.js',
+                '/path/to/MyClass.spec.js',
+            ]
+
+            for (const filePath of filePaths) {
+                const result = await isTestFile(filePath, { languageId: language })
+                assert.strictEqual(result, true)
+            }
+        })
+
+        it('isTest by file name should return false', async function () {
+            const filePaths = ['MyClass.js', '/path/to/MyClass.js', 'MyClass_test.js', 'test_MyClass.js']
+
+            for (const filePath of filePaths) {
+                const result = await isTestFile(filePath, { languageId: language })
+                assert.strictEqual(result, false)
+            }
+        })
+    })
+
+    describe('tsx', function () {
+        const language = 'typescriptreact'
+
+        it('isTest by file path should return true', async function () {
+            const filePaths = ['/test/MyClass.tsx', '/tst/MyClass.tsx', '/tests/MyClass.tsx']
+
+            for (const filePath of filePaths) {
+                const result = await isTestFile(filePath, { languageId: language })
+                assert.strictEqual(result, true)
+            }
+        })
+
+        it('isTest by file path should return false', async function () {
+            const filePaths = ['/path/to/MyClass.tsx', 'path/to/wrongtesttttfolder/MyClass.tsx']
+
+            for (const filePath of filePaths) {
+                const result = await isTestFile(filePath, { languageId: language })
+                assert.strictEqual(result, false)
+            }
+        })
+
+        it('isTest by file name should return true', async function () {
+            const filePaths = [
+                'MyClass.test.tsx',
+                '/path/to/MyClass.test.tsx',
+                'MyClass.spec.tsx',
+                '/path/to/MyClass.spec.tsx',
+            ]
+
+            for (const filePath of filePaths) {
+                const result = await isTestFile(filePath, { languageId: language })
+                assert.strictEqual(result, true)
+            }
+        })
+
+        it('isTest by file name should return false', async function () {
+            const filePaths = ['MyClass.tsx', '/path/to/MyClass.tsx', 'MyClass_test.tsx', 'test_MyClass.tsx']
+
+            for (const filePath of filePaths) {
+                const result = await isTestFile(filePath, { languageId: language })
+                assert.strictEqual(result, false)
+            }
+        })
+    })
+
+    describe('jsx', function () {
+        const language = 'javascriptreact'
+
+        it('isTest by file path should return true', async function () {
+            const filePaths = ['/test/MyClass.jsx', '/tst/MyClass.jsx', '/tests/MyClass.jsx']
+
+            for (const filePath of filePaths) {
+                const result = await isTestFile(filePath, { languageId: language })
+                assert.strictEqual(result, true)
+            }
+        })
+
+        it('isTest by file path should return false', async function () {
+            const filePaths = ['/path/to/MyClass.jsx', 'path/to/wrongtesttttfolder/MyClass.jsx']
+
+            for (const filePath of filePaths) {
+                const result = await isTestFile(filePath, { languageId: language })
+                assert.strictEqual(result, false)
+            }
+        })
+
+        it('isTest by file name should return true', async function () {
+            const filePaths = [
+                'MyClass.test.jsx',
+                '/path/to/MyClass.test.jsx',
+                'MyClass.spec.jsx',
+                '/path/to/MyClass.spec.jsx',
+            ]
+
+            for (const filePath of filePaths) {
+                const result = await isTestFile(filePath, { languageId: language })
+                assert.strictEqual(result, true)
+            }
+        })
+
+        it('isTest by file name should return false', async function () {
+            const filePaths = ['MyClass.jsx', '/path/to/MyClass.jsx', 'MyClass_test.jsx', 'test_MyClass.jsx']
+
+            for (const filePath of filePaths) {
+                const result = await isTestFile(filePath, { languageId: language })
+                assert.strictEqual(result, false)
+            }
+        })
+    })
+
     it('should return true if the file name matches the test filename pattern - Java', async () => {
         const filePaths = ['/path/to/MyClassTest.java', '/path/to/TestMyClass.java']
         const language = 'java'


### PR DESCRIPTION
## Problem
`isTest()` is the decision maker which determine the current codewhisperer invocation belongs to "src(Crossfile)" or "test(UTG)". 

`isTest` function will check
- if file path contains `test/`, `tests/`, `tst/`
- check if the file name matches the test file regex we set up


we already had JS/TS test file naming conventions on JB  but not yet on VSC. 
refer to 

https://github.com/aws/aws-toolkit-jetbrains/blob/main/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/JavascriptCodeWhispererFileCrawler.kt

https://github.com/aws/aws-toolkit-jetbrains/blob/main/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/TypescriptCodeWhispererFileCrawler.kt




## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
