### PR TITLE
Add telemetry hyperlink

### DIFF
--- a/.changes/next-release/Feature-b473d1cf-ceff-4d40-9024-29d045e4dbee.json
+++ b/.changes/next-release/Feature-b473d1cf-ceff-4d40-9024-29d045e4dbee.json
@@ -1,4 +1,4 @@
 {
 	"type": "Feature",
-	"description": "Added Hyperlink to toolkits telemetry documentation"
+	"description": "Telemetry setting description includes a details link"
 }

--- a/.changes/next-release/Feature-b473d1cf-ceff-4d40-9024-29d045e4dbee.json
+++ b/.changes/next-release/Feature-b473d1cf-ceff-4d40-9024-29d045e4dbee.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Added Hyperlink to toolkits telemetry documentation"
+}

--- a/package.nls.json
+++ b/package.nls.json
@@ -13,7 +13,7 @@
     "AWS.configuration.description.samcli.lambdaTimeout": "Maximum time (in milliseconds) to wait for SAM output while starting a Local Lambda session",
     "AWS.configuration.description.samcli.location": "Location of SAM CLI. SAM CLI is used to create, build, package, and deploy Serverless Applications. [Learn More](https://aws.amazon.com/serverless/sam/)",
     "AWS.configuration.description.samcli.legacyDeploy": "Use the legacy SAM deploy experience, disabling all SAM sync functionality.",
-    "AWS.configuration.description.telemetry": "Enable AWS Toolkit to send usage data to AWS.",
+    "AWS.configuration.description.telemetry": "Enable AWS Toolkit to send usage data to AWS. [Details](https://docs.aws.amazon.com/sdkref/latest/guide/support-maint-idetoolkits.html)",
     "AWS.configuration.description.telemetry.cn": "Enable Amazon Toolkit to send usage data to Amazon.",
     "AWS.configuration.description.suppressPrompts": "Prompts which ask for confirmation. Checking an item suppresses the prompt.",
     "AWS.configuration.enableCodeLenses": "Enable SAM hints in source files",


### PR DESCRIPTION
## Problem
Added hyperlink to toolkit telemetry documentation in Settings.
https://sim.amazon.com/issues/IDE-11334

## Solution
<img width="713" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/50885351/e12924ea-6c0a-449b-9882-79db5e2f1eba">

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
