### PR TITLE
fix: package.json invalid after 'npm run generatePackage'

### DIFF
--- a/scripts/build/generateConfigurationAttributes.ts
+++ b/scripts/build/generateConfigurationAttributes.ts
@@ -6,7 +6,7 @@
 import * as fs from 'fs'
 import { JSONSchema4 } from 'json-schema'
 import { compile } from 'json-schema-to-typescript'
-import * as packageJson from '../../package.json'
+import packageJson from '../../package.json'
 import * as nlsJson from '../../package.nls.json'
 
 const config = [

--- a/scripts/build/generateIcons.ts
+++ b/scripts/build/generateIcons.ts
@@ -6,7 +6,7 @@
 import webfont from 'webfont'
 import * as path from 'path'
 import * as fs from 'fs-extra'
-import * as packageJson from '../../package.json'
+import packageJson from '../../package.json'
 
 const fontId = 'aws-toolkit-icons'
 const projectDir = process.cwd()
@@ -164,7 +164,7 @@ ${result.template}
 
     const stylesheetPath = path.join(stylesheetsDir, 'icons.css')
     const cloud9Dest = path.join(iconsDir, 'cloud9', 'generated')
-    const isValidIcon = (i: typeof icons[number]): i is Required<typeof i> => i.data !== undefined
+    const isValidIcon = (i: (typeof icons)[number]): i is Required<typeof i> => i.data !== undefined
 
     await fs.mkdirp(fontsDir)
     await fs.writeFile(dest, result.woff)

--- a/scripts/build/package.ts
+++ b/scripts/build/package.ts
@@ -16,7 +16,7 @@
 // 3. restore the original package.json
 //
 
-import type * as manifest from '../../package.json'
+import type PackageJson from '../../package.json'
 import * as child_process from 'child_process'
 import * as fs from 'fs-extra'
 
@@ -116,7 +116,7 @@ function main() {
             fs.copyFileSync(packageJsonFile, `${packageJsonFile}.bk`)
             fs.copyFileSync(webpackConfigJsFile, `${webpackConfigJsFile}.bk`)
 
-            const packageJson: typeof manifest = JSON.parse(fs.readFileSync(packageJsonFile, { encoding: 'utf-8' }))
+            const packageJson: typeof PackageJson = JSON.parse(fs.readFileSync(packageJsonFile, { encoding: 'utf-8' }))
             const versionSuffix = getVersionSuffix(args.feature)
             const version = packageJson.version
             // Setting the version to an arbitrarily high number stops VSC from auto-updating the beta extension

--- a/scripts/test/launchTestUtilities.ts
+++ b/scripts/test/launchTestUtilities.ts
@@ -4,7 +4,7 @@
  */
 
 import * as child_process from 'child_process'
-import * as manifest from '../../package.json'
+import packageJson from '../../package.json'
 import { downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath } from '@vscode/test-electron'
 import { join, resolve } from 'path'
 import { runTests } from '@vscode/test-electron'
@@ -108,7 +108,7 @@ export async function getCliArgsToDisableExtensions(
 }
 
 export function getMinVsCodeVersion(): string {
-    const vsCodeVersion = manifest.engines.vscode
+    const vsCodeVersion = packageJson.engines.vscode
 
     // We assume that we specify a minium, so it matches ^<number>, so remove ^'s
     const sanitizedVersion = vsCodeVersion.replace('^', '')


### PR DESCRIPTION
This is related to us enabling esModuleInterop in the tsconfig. When 'npm run generatePackage' was run it would add extra values to the package.json.

As a solution it was narrowed down that we can not do namespace imports (import * as assert from 'assert') and must instead do default imports (import assert from 'assert') for the package.json file.

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
