### PR TITLE
browser: logging works in the browser

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,7 +24,7 @@
             "preLaunchTask": "watch"
         },
         {
-            "name": "Extension (web)",
+            "name": "Extension (browser)",
             "type": "pwa-extensionHost",
             "debugWebWorkerHost": true,
             "request": "launch",

--- a/src/extensionWeb.ts
+++ b/src/extensionWeb.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode'
 import { setInBrowser } from './common/browserUtils'
 
 export async function activate(context: vscode.ExtensionContext) {
-    setInBrowser(true)    
+    setInBrowser(true)
 
     vscode.window.showInformationMessage(
         'AWS Toolkit: Browser Mode Under Development. No features are currently provided',

--- a/src/extensionWeb.ts
+++ b/src/extensionWeb.ts
@@ -5,14 +5,30 @@
 
 import * as vscode from 'vscode'
 import { setInBrowser } from './common/browserUtils'
+import { activate as activateLogger } from './shared/logger/activation'
+import { initializeComputeRegion } from './shared/extensionUtilities'
+import globals from './shared/extensionGlobals'
+import { TelemetryService } from './shared/telemetry/telemetryService'
+import { TelemetryLogger } from './shared/telemetry/telemetryLogger'
 
 export async function activate(context: vscode.ExtensionContext) {
+    // This is temporary and required for the logger to run.
+    // It assumes the following exists and uses it during execution.
+    globals.telemetry = {
+        record: (event: any, awsContext?: any) => {},
+    } as TelemetryService & { logger: TelemetryLogger }
+
     setInBrowser(true)
+    await initializeComputeRegion()
 
     vscode.window.showInformationMessage(
         'AWS Toolkit: Browser Mode Under Development. No features are currently provided',
         { modal: false }
     )
+
+    // Disabling for now since this has webpack issues that will be fixed in future commits:
+    const toolkitOutputChannel = vscode.window.createOutputChannel('AWS Toolkit')
+    await activateLogger(context, toolkitOutputChannel)
 }
 
 export async function deactivate() {}

--- a/src/extensionWeb.ts
+++ b/src/extensionWeb.ts
@@ -26,7 +26,6 @@ export async function activate(context: vscode.ExtensionContext) {
         { modal: false }
     )
 
-    // Disabling for now since this has webpack issues that will be fixed in future commits:
     const toolkitOutputChannel = vscode.window.createOutputChannel('AWS Toolkit')
     await activateLogger(context, toolkitOutputChannel)
 }

--- a/src/shared/logger/activation.ts
+++ b/src/shared/logger/activation.ts
@@ -127,7 +127,7 @@ export function makeLogger(
     if (opts.useDebugConsole) {
         logger.logToDebugConsole()
     }
-    if (opts.useConsoleLog && isInBrowser()) {
+    if (opts.useConsoleLog) {
         logger.logToConsole()
     }
 

--- a/src/shared/logger/activation.ts
+++ b/src/shared/logger/activation.ts
@@ -43,6 +43,7 @@ export async function activate(
         {
             logPaths: [logUri.fsPath],
             outputChannels: [chan],
+            useConsoleLog: true,
         },
         extensionContext.subscriptions
     )
@@ -108,6 +109,7 @@ export function makeLogger(
         logPaths?: string[]
         outputChannels?: vscode.OutputChannel[]
         useDebugConsole?: boolean
+        useConsoleLog?: boolean
     },
     disposables?: vscode.Disposable[]
 ): Logger {
@@ -124,6 +126,9 @@ export function makeLogger(
     }
     if (opts.useDebugConsole) {
         logger.logToDebugConsole()
+    }
+    if (opts.useConsoleLog && isInBrowser()) {
+        logger.logToConsole()
     }
 
     if (!opts.staticLogLevel) {

--- a/src/shared/logger/consoleLogTransport.ts
+++ b/src/shared/logger/consoleLogTransport.ts
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import Transport from 'winston-transport'
+import TransportStream from 'winston-transport'
 import globals from '../extensionGlobals'
-
-const MESSAGE = Symbol.for('message') // eslint-disable-line @typescript-eslint/naming-convention
+import { MESSAGE } from './debugConsoleTransport'
 
 interface LogEntry {
     level: string
@@ -15,20 +14,51 @@ interface LogEntry {
 }
 
 /**
- * This transport sends log statements to console.log
- * It is primarily intended for testing, where having the log output could assist in diagnosing issues.
+ * Inspired from: https://github.com/MarcoMedrano/winston-transport-browserconsole/blob/master/src/lib/BrowserConsole.ts
  */
-export class ConsoleLogTransport extends Transport {
-    public constructor(options: Transport.TransportStreamOptions) {
-        super(options)
+export class ConsoleLogTransport extends TransportStream {
+    constructor(opts?: TransportStream.TransportStreamOptions, private readonly _console = console) {
+        super(opts)
     }
 
-    public override log(info: LogEntry, next: () => void): void {
-        globals.clock.setImmediate(() => {
-            this.emit('logged', info)
-            console.log(info[MESSAGE])
+    /**
+     * Does the work of logging the message to the console.
+     *
+     * @returns a promise that resolves when the log entry is written to the console, this is useful
+     *          for testing.
+     */
+    public override log(logEntry: LogEntry, next: () => void): Promise<void> {
+        const promise = new Promise<void>(resolve => {
+            // We use setImmediate to not block execution since
+            // log order does not matter in this case
+            globals.clock.setImmediate(() => {
+                const level = logEntry.level
+                const message = logEntry[MESSAGE]
+
+                if (ConsoleLogTransport.isSupportedLogLevel(level)) {
+                    this._console[level](message)
+                } else {
+                    this._console.log(message)
+                }
+                resolve()
+            })
         })
 
         next()
+        return promise
+    }
+
+    private static isSupportedLogLevel(method: string | undefined): method is Level {
+        return method !== undefined && Object.keys(Levels).includes(method)
     }
 }
+
+// https://github.com/winstonjs/winston#logging-levels
+export const Levels = {
+    error: 0,
+    warn: 1,
+    info: 2,
+    debug: 5,
+} as const
+
+export type Level = keyof typeof Levels

--- a/src/shared/logger/sharedFileTransport.ts
+++ b/src/shared/logger/sharedFileTransport.ts
@@ -1,0 +1,110 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import TransportStream from 'winston-transport'
+import { FileSystemCommon } from '../../srcShared/fs'
+import * as vscode from 'vscode'
+import globals from '../extensionGlobals'
+import { MESSAGE } from './debugConsoleTransport'
+import { WinstonToolkitLogger } from './winstonToolkitLogger'
+
+interface LogEntry {
+    level: string
+    message: string
+    /** This is the formatted message from {@link WinstonToolkitLogger} in the winston.createLogger() call */
+    [MESSAGE]: string
+}
+
+export const flushIntervalMillis = 1000
+
+/**
+ * TODO: Figure out why the log file is not being properly appended to
+ *
+ * Problem:
+ * - Doing multiple log calls will not properly append to the log file
+ * - Only the last log call is written to the log file
+ * - Looking in to the append() call, when it first reads the current content
+ *   it would not have any of the previous logs in it.
+ * - The `next()` method is intended to signal that the current log is done being
+ *   written to the file but that is not working by the looks of it.
+ * Temporary Solution:
+ * - I created a buffer that buffers incoming logs and batch writes them after
+ *   a certain timeout. This seems to improve things
+ * - Also the current append implementation is inefficient due to the underlying api
+ *   (reads whole file, concatenates, then writes) so buffering is beneficial here.
+ */
+export class SharedFileTransport extends TransportStream {
+    private logFile: vscode.Uri
+    constructor(
+        opts: TransportStream.TransportStreamOptions & { logFile: vscode.Uri },
+        private readonly append = (f: vscode.Uri, s: string) => FileSystemCommon.instance.appendFile(f, s)
+    ) {
+        super(opts)
+        this.logFile = opts.logFile
+    }
+
+    private flushTimeout: NodeJS.Timeout | undefined
+    private bufferedLogEntries: LogEntry[] = []
+    private resolvesAfterLogsWritten: Promise<void> | undefined
+    private doResolve: (() => void) | undefined
+
+    /**
+     * @returns a promise that resolves once a batch of logs are written to
+     *          the log file. 
+     */
+    public override log(logEntry: LogEntry, next: () => void): Promise<void> {
+        this.bufferedLogEntries.push(logEntry)
+
+        if (!this.resolvesAfterLogsWritten) {
+            // we create a promise which resolves once logs are written to the file
+            this.resolvesAfterLogsWritten = new Promise(resolve => {
+                this.doResolve = resolve.bind(this)
+            })
+        }
+
+        if (!this.flushTimeout) {
+            // start timeout to flush buffer after specific time passes
+            this.flushTimeout = globals.clock.setTimeout(async () => {
+                this.flushTimeout = undefined
+
+                // Clear current promise objs so new calls to log() will
+                // create new promise objs. Must happen before we call flushBufferedLogs()
+                this.resolvesAfterLogsWritten = undefined
+                const doResolve = this.doResolve
+                this.doResolve = undefined
+
+                // Write all logs to the file
+                await this.flushBufferedLogs()
+
+                // signals to anyone awaiting this function that logs have been
+                // written to the file.
+                doResolve!()
+            }, flushIntervalMillis)
+        }
+
+        next()
+        return this.resolvesAfterLogsWritten
+    }
+
+    /** Writes all buffered logs to the file */
+    private async flushBufferedLogs(): Promise<void> {
+        const latestLogIndex = this.bufferedLogEntries.length - 1
+
+        if (latestLogIndex < 0) {
+            // no logs to write to file
+            return
+        }
+
+        const logMessages = this.bufferedLogEntries.map(logEntry => logEntry[MESSAGE])
+
+        // Remove the logs that were written to the file from the buffer.
+        // But we have to keep in mind new logs may have been
+        //asynchronously added to the buffer, so we only remove what we have flushed.
+        this.bufferedLogEntries = this.bufferedLogEntries.slice(latestLogIndex + 1)
+
+        const newText = logMessages.join('\n') + '\n'
+        await this.append(this.logFile, newText)
+    }
+}

--- a/src/shared/logger/util.ts
+++ b/src/shared/logger/util.ts
@@ -54,7 +54,7 @@ export async function cleanLogFiles(logDir: string, params = defaultCleanupParam
 
 /**
  * Convenience function to get only the file name
- * from the readdir() call. 
+ * from the readdir() call.
  */
 async function readdir(dir: string): Promise<string[]> {
     return (await fs.readdir(dir)).map(f => f[0])

--- a/src/shared/logger/winstonToolkitLogger.ts
+++ b/src/shared/logger/winstonToolkitLogger.ts
@@ -6,7 +6,6 @@
 import { normalize } from 'path'
 import * as vscode from 'vscode'
 import winston from 'winston'
-import { ConsoleLogTransport } from './consoleLogTransport'
 import { DebugConsoleTransport } from './debugConsoleTransport'
 import { Logger, LogLevel, compareLogLevel } from './logger'
 import { OutputChannelTransport } from './outputChannelTransport'
@@ -14,6 +13,7 @@ import { isSourceMappingAvailable } from '../vscode/env'
 import { formatError, ToolkitError, UnknownError } from '../errors'
 import { isInBrowser } from '../../common/browserUtils'
 import { SharedFileTransport } from './sharedFileTransport'
+import { ConsoleLogTransport } from './consoleLogTransport'
 
 // Need to limit how many logs are actually tracked
 // LRU cache would work well, currently it just dumps the least recently added log

--- a/src/shared/logger/winstonToolkitLogger.ts
+++ b/src/shared/logger/winstonToolkitLogger.ts
@@ -12,6 +12,8 @@ import { Logger, LogLevel, compareLogLevel } from './logger'
 import { OutputChannelTransport } from './outputChannelTransport'
 import { isSourceMappingAvailable } from '../vscode/env'
 import { formatError, ToolkitError, UnknownError } from '../errors'
+import { isInBrowser } from '../../common/browserUtils'
+import { SharedFileTransport } from './sharedFileTransport'
 
 // Need to limit how many logs are actually tracked
 // LRU cache would work well, currently it just dumps the least recently added log
@@ -57,7 +59,13 @@ export class WinstonToolkitLogger implements Logger, vscode.Disposable {
     }
 
     public logToFile(logPath: string): void {
-        const fileTransport: winston.transport = new winston.transports.File({ filename: logPath })
+        let fileTransport: winston.transport
+        if (isInBrowser()) {
+            fileTransport = new SharedFileTransport({ logFile: vscode.Uri.file(logPath) })
+        } else {
+            fileTransport = new winston.transports.File({ filename: logPath })
+        }
+
         const fileUri: vscode.Uri = vscode.Uri.file(normalize(logPath))
         fileTransport.on('logged', (obj: any) => this.parseLogObject(fileUri, obj))
         this.logger.add(fileTransport)

--- a/src/test/shared/logger/consoleLogLogger.test.ts
+++ b/src/test/shared/logger/consoleLogLogger.test.ts
@@ -1,0 +1,53 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SinonStub, SinonStubbedMember, stub } from 'sinon'
+import * as assert from 'assert'
+import { ConsoleLogTransport, Level, Levels } from '../../../shared/logger/consoleLogTransport'
+import { MESSAGE } from '../../../shared/logger/debugConsoleTransport'
+
+describe('ConsoleLogTransport', async function () {
+    let fakeConsole: { [key in Level]: SinonStub } & { log: SinonStub }
+    let instance: ConsoleLogTransport
+    let next: SinonStubbedMember<() => void>
+
+    beforeEach(async function () {
+        fakeConsole = createBrowserFakeConsole()
+        instance = new ConsoleLogTransport(undefined, fakeConsole as unknown as typeof console)
+        next = stub()
+    })
+
+    const allLevels = Object.keys(Levels) as Level[]
+    allLevels.forEach(level => {
+        it(`logs to console with level: '${level}'`, async function () {
+            const untilLogged = instance.log({ level, message: 'myMessage', [MESSAGE]: 'myMessageFormatted' }, next)
+            await untilLogged
+            assert.strictEqual(fakeConsole[level].callCount, 1)
+            assert.strictEqual(fakeConsole[level].getCall(0).args[0], 'myMessageFormatted')
+            assert.strictEqual(next.callCount, 1)
+        })
+    })
+
+    it(`logs to the default if non-supported log level provided`, async function () {
+        const untilLogged = instance.log(
+            { level: 'non-supported', message: 'myMessage', [MESSAGE]: 'myMessageFormatted' },
+            next
+        )
+        await untilLogged
+        assert.strictEqual(fakeConsole.log.callCount, 1)
+        assert.strictEqual(fakeConsole.log.getCall(0).args[0], 'myMessageFormatted')
+        assert.strictEqual(next.callCount, 1)
+    })
+
+    function createBrowserFakeConsole() {
+        return {
+            info: stub(),
+            warn: stub(),
+            error: stub(),
+            debug: stub(),
+            log: stub(),
+        }
+    }
+})

--- a/src/test/shared/logger/sharedFileTransport.test.ts
+++ b/src/test/shared/logger/sharedFileTransport.test.ts
@@ -1,0 +1,54 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import vscode from 'vscode'
+import assert from 'assert'
+import { SharedFileTransport, flushIntervalMillis } from '../../../shared/logger/sharedFileTransport'
+import { FileSystemCommon } from '../../../srcShared/fs'
+import { stub, SinonStub } from 'sinon'
+import { MESSAGE } from '../../../shared/logger/debugConsoleTransport'
+import { createTestFile } from '../../testUtil'
+import { readFileSync } from 'fs'
+import { sleep } from '../../../shared/utilities/timeoutUtils'
+
+describe('SharedFileTransport', function () {
+    let instance: SharedFileTransport
+    let nextFunc: SinonStub<[], Promise<void>>
+    let logFile: vscode.Uri
+
+    beforeEach(async function () {
+        logFile = await createTestFile('testLogFile.log')
+        instance = new SharedFileTransport({ logFile })
+        nextFunc = stub()
+    })
+
+    afterEach(async function () {
+        await FileSystemCommon.instance.delete(logFile)
+    })
+
+    it('logs are written to file', async function () {
+        // This test will write logs at different points in time,
+        // and should all be in the log file at the end.
+
+        instance.log({ level: 'info', message: 'hello', [MESSAGE]: 'a1' }, nextFunc)
+        await sleep(flushIntervalMillis + 1) // wait a full flush interval
+
+        instance.log({ level: 'info', message: 'hello', [MESSAGE]: 'a2' }, nextFunc)
+        instance.log({ level: 'info', message: 'hello', [MESSAGE]: 'a3' }, nextFunc)
+        await sleep(flushIntervalMillis + 1) // wait a full flush interval
+
+        instance.log({ level: 'info', message: 'hello', [MESSAGE]: 'a4' }, nextFunc)
+        instance.log({ level: 'info', message: 'hello', [MESSAGE]: 'a5' }, nextFunc)
+        await sleep(flushIntervalMillis / 2) // wait half a flush interval
+
+        const lastLog = instance.log({ level: 'info', message: 'hello', [MESSAGE]: 'a6' }, nextFunc)
+        await lastLog // wait for the last log to be written to the file
+
+        // assert all logs were written to file
+        const actualText = readFileSync(logFile.fsPath, 'utf8')
+        assert.strictEqual(actualText, 'a1\na2\na3\na4\na5\na6\n')
+        assert.strictEqual(nextFunc.callCount, 6)
+    })
+})

--- a/src/test/testUtil.ts
+++ b/src/test/testUtil.ts
@@ -68,6 +68,13 @@ export async function createTestWorkspaceFolder(name?: string): Promise<vscode.W
     }
 }
 
+export async function createTestFile(fileName: string): Promise<vscode.Uri> {
+    const tempFolder = await makeTemporaryToolkitFolder()
+    const tempFilePath = path.join(tempFolder, fileName)
+    fs.writeFileSync(tempFilePath, '')
+    return vscode.Uri.file(tempFilePath)
+}
+
 export async function deleteTestTempDirs(): Promise<void> {
     let failed = 0
     for (const s of testTempDirs) {

--- a/src/test/testUtil.ts
+++ b/src/test/testUtil.ts
@@ -70,6 +70,7 @@ export async function createTestWorkspaceFolder(name?: string): Promise<vscode.W
 
 export async function createTestFile(fileName: string): Promise<vscode.Uri> {
     const tempFolder = await makeTemporaryToolkitFolder()
+    testTempDirs.push(tempFolder) // ensures this is deleted at the end
     const tempFilePath = path.join(tempFolder, fileName)
     fs.writeFileSync(tempFilePath, '')
     return vscode.Uri.file(tempFilePath)


### PR DESCRIPTION
## Problem

In the browser logging does not work with our existing code.

## Solution

- Change how we handle logging to a File since the built in "winston file transport" for logging to a file is not browser compatible
- Update the winston transport to allow us to log to the browser console

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
