### PR TITLE
fix: failing integ test

### DIFF
--- a/src/testInteg/globalSetup.test.ts
+++ b/src/testInteg/globalSetup.test.ts
@@ -6,7 +6,7 @@
 /**
  * Before/After hooks for all integration tests.
  */
-import * as vscode from 'vscode'
+import vscode from 'vscode'
 import { VSCODE_EXTENSION_ID } from '../shared/extensions'
 import { getLogger } from '../shared/logger'
 import { WinstonToolkitLogger } from '../shared/logger/winstonToolkitLogger'


### PR DESCRIPTION
## Problem:
After enabling esModuleInterop if we do a namespace import
  `import * as vscode from 'vscode'` we may run in to problems
  when trying to patch the object.

## Solution:
Use a default import, `import vscode from 'vscode``

## Why?
Probably something to do with how namespace vs. default imports are handled once something becomes an ESM module

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
