### PR TITLE
fix(cloudwatch): "Search Log Group" shows multiple progress popups

### DIFF
--- a/.changes/next-release/Bug Fix-d9e4139d-a80c-4259-8492-605a5bce232a.json
+++ b/.changes/next-release/Bug Fix-d9e4139d-a80c-4259-8492-605a5bce232a.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CloudWatch Logs: \"Search Log Group\" shows multiple progress popups"
+}

--- a/src/cloudWatchLogs/cloudWatchLogsUtils.ts
+++ b/src/cloudWatchLogs/cloudWatchLogsUtils.ts
@@ -46,6 +46,17 @@ export function uriToKey(uri: vscode.Uri): string {
 }
 
 /**
+ * Creates a message key from region + loggroup + logstream.
+ *
+ * Intentionally _ignores_ query parameters, so that the validation step can use the same progress
+ * message as the actual log group search. That results in a more fluid UX.
+ */
+export function msgKey(logGroupInfo: CloudWatchLogsGroupInfo): string {
+    const uri = createURIFromArgs(logGroupInfo, {})
+    return uri.toString()
+}
+
+/**
  * Destructures an awsCloudWatchLogs URI into its component pieces.
  * @param uri URI for a Cloudwatch Logs file
  */

--- a/src/cloudWatchLogs/commands/searchLogGroup.ts
+++ b/src/cloudWatchLogs/commands/searchLogGroup.ts
@@ -16,7 +16,7 @@ import {
 } from '../registry/logDataRegistry'
 import { DataQuickPickItem } from '../../shared/ui/pickerPrompter'
 import { isValidResponse, isWizardControl, Wizard, WIZARD_RETRY } from '../../shared/wizards/wizard'
-import { createURIFromArgs, parseCloudWatchLogsUri, recordTelemetryFilter } from '../cloudWatchLogsUtils'
+import { createURIFromArgs, msgKey, parseCloudWatchLogsUri, recordTelemetryFilter } from '../cloudWatchLogsUtils'
 import { DefaultCloudWatchLogsClient } from '../../shared/clients/cloudWatchLogsClient'
 import { CancellationError } from '../../shared/utilities/timeoutUtils'
 import { getLogger } from '../../shared/logger'
@@ -28,6 +28,7 @@ import { truncate } from '../../shared/utilities/textUtilities'
 import { createBackButton, createExitButton, createHelpButton } from '../../shared/ui/buttons'
 import { PromptResult } from '../../shared/ui/prompter'
 import { ToolkitError } from '../../shared/errors'
+import { Messages } from '../../shared/utilities/messages'
 
 const localize = nls.loadMessageBundle()
 
@@ -192,9 +193,13 @@ export class SearchPatternPrompter extends InputBoxPrompter {
                     limit: 1,
                 },
                 undefined,
-                true
+                false
             )
         } catch (e) {
+            // Validation error. Get the progress message from the global map and cancel it.
+            const msgTimeout = await Messages.putMessage(msgKey(this.logGroup), '')
+            msgTimeout.cancel()
+
             return (e as Error).message
         }
         return undefined


### PR DESCRIPTION
Problem:
When entering filter pattern for the "Search Log Group" action, the validation action does its own mini-search, before the actual search is done. The user sees multiple popups, which feels clunky.

Solution:
Ignore query parameters when calculating the message "id".



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
