### PR TITLE
fix: package-lock.json not updated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,7 @@
                 "webpack-dev-server": "^4.15.1"
             },
             "engines": {
-                "vscode": "^1.65.0"
+                "vscode": "^1.68.0"
             }
         },
         "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
## Problem:

We recently updated the vscode engine in
package.json.

'npm install' was not run so the package-lock.json was not updated.

## Solution:

Ran npm install and got the updated package-lock.json

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
