### PR TITLE
fix(cloudwatch): "View Full Log Stream" only shows 1000 events

### DIFF
--- a/.changes/next-release/Bug Fix-f8528a3d-0300-44b6-ad2b-524dd5e9cd10.json
+++ b/.changes/next-release/Bug Fix-f8528a3d-0300-44b6-ad2b-524dd5e9cd10.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CloudWatch Logs: \"View Full Log Stream\" is limited to 1000 events instead of the `aws.cwl.limit` user setting"
+}

--- a/src/cloudWatchLogs/document/logStreamsCodeLensProvider.ts
+++ b/src/cloudWatchLogs/document/logStreamsCodeLensProvider.ts
@@ -6,7 +6,12 @@
 import * as vscode from 'vscode'
 import { CLOUDWATCH_LOGS_SCHEME } from '../../shared/constants'
 import { CloudWatchLogsGroupInfo, LogDataRegistry } from '../registry/logDataRegistry'
-import { createURIFromArgs, isLogStreamUri, parseCloudWatchLogsUri } from '../cloudWatchLogsUtils'
+import {
+    CloudWatchLogsSettings,
+    createURIFromArgs,
+    isLogStreamUri,
+    parseCloudWatchLogsUri,
+} from '../cloudWatchLogsUtils'
 import { LogDataDocumentProvider } from './logDataDocumentProvider'
 
 type IdWithLine = { streamId: string; lineNum: number }
@@ -57,7 +62,9 @@ export class LogStreamCodeLensProvider implements vscode.CodeLensProvider {
     }
 
     createLogStreamCodeLens(logGroupInfo: CloudWatchLogsGroupInfo, idWithLine: IdWithLine): vscode.CodeLens {
-        const streamUri = createURIFromArgs({ ...logGroupInfo, streamName: idWithLine.streamId }, { limit: 1000 })
+        const settings = new CloudWatchLogsSettings()
+        const limit = settings.get('limit', 1000)
+        const streamUri = createURIFromArgs({ ...logGroupInfo, streamName: idWithLine.streamId }, { limit: limit })
         const cmd: vscode.Command = {
             command: 'aws.loadLogStreamFile',
             arguments: [streamUri, this.registry],


### PR DESCRIPTION
## Problem

From the results page of "Search Log Group", the "View Full Log Stream" codelens only fetches 1000 events.

## Solution

Use the configured limit instead of hardcoding 1000.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
