### PR TITLE
refactor(cloudwatch): simplify saveCurrentLogDataContent()

### DIFF
--- a/src/cloudWatchLogs/activation.ts
+++ b/src/cloudWatchLogs/activation.ts
@@ -6,7 +6,6 @@
 import * as vscode from 'vscode'
 import { CLOUDWATCH_LOGS_SCHEME } from '../shared/constants'
 import { Settings } from '../shared/settings'
-import { CloudWatchLogsSettings } from './cloudWatchLogsUtils'
 import { addLogEvents } from './commands/addLogEvents'
 import { copyLogResource } from './commands/copyLogResource'
 import { saveCurrentLogDataContent } from './commands/saveCurrentLogDataContent'
@@ -22,8 +21,7 @@ import { CloudWatchLogsNode } from './explorer/cloudWatchLogsNode'
 import { loadAndOpenInitialLogStreamFile, LogStreamCodeLensProvider } from './document/logStreamsCodeLensProvider'
 
 export async function activate(context: vscode.ExtensionContext, configuration: Settings): Promise<void> {
-    const settings = new CloudWatchLogsSettings(configuration)
-    const registry = new LogDataRegistry(settings)
+    const registry = LogDataRegistry.instance
 
     const documentProvider = new LogDataDocumentProvider(registry)
 
@@ -75,10 +73,7 @@ export async function activate(context: vscode.ExtensionContext, configuration: 
                 onDidChangeCodeLensEvent: vscode.EventEmitter<void>
             ) => addLogEvents(document, registry, headOrTail, onDidChangeCodeLensEvent)
         ),
-        Commands.register(
-            'aws.saveCurrentLogDataContent',
-            async (uri?: vscode.Uri) => await saveCurrentLogDataContent(uri, registry)
-        ),
+        Commands.register('aws.saveCurrentLogDataContent', async () => await saveCurrentLogDataContent()),
         // AWS Explorer right-click action
         // Here instead of in ../awsexplorer/activation due to dependence on the registry.
         Commands.register('aws.cwl.viewLogStream', async (node: LogGroupNode) => await viewLogStream(node, registry)),

--- a/src/cloudWatchLogs/commands/saveCurrentLogDataContent.ts
+++ b/src/cloudWatchLogs/commands/saveCurrentLogDataContent.ts
@@ -12,7 +12,7 @@ import { isLogStreamUri, parseCloudWatchLogsUri } from '../cloudWatchLogsUtils'
 import { telemetry, CloudWatchResourceType, Result } from '../../shared/telemetry/telemetry'
 import { FileSystemCommon } from '../../srcShared/fs'
 
-/** Saves the current "aws-cwl:" document. */
+/** Prompts the user to select a file location to save the currently visible "aws-cwl:" document to. */
 export async function saveCurrentLogDataContent(): Promise<void> {
     let result: Result = 'Succeeded'
     let resourceType: CloudWatchResourceType = 'logStream' // Default to stream if it fails to find URI

--- a/src/cloudWatchLogs/commands/saveCurrentLogDataContent.ts
+++ b/src/cloudWatchLogs/commands/saveCurrentLogDataContent.ts
@@ -7,29 +7,25 @@ import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
-import * as fs from 'fs-extra'
 import { SystemUtilities } from '../../shared/systemUtilities'
 import { isLogStreamUri, parseCloudWatchLogsUri } from '../cloudWatchLogsUtils'
-import { LogDataRegistry } from '../registry/logDataRegistry'
 import { telemetry, CloudWatchResourceType, Result } from '../../shared/telemetry/telemetry'
-import { generateTextFromLogEvents } from '../document/textContent'
+import { FileSystemCommon } from '../../srcShared/fs'
 
-export async function saveCurrentLogDataContent(uri: vscode.Uri | undefined, registry: LogDataRegistry): Promise<void> {
+/** Saves the current "aws-cwl:" document. */
+export async function saveCurrentLogDataContent(): Promise<void> {
     let result: Result = 'Succeeded'
     let resourceType: CloudWatchResourceType = 'logStream' // Default to stream if it fails to find URI
 
     try {
+        // Get URI from active editor.
+        const uri = vscode.window.activeTextEditor?.document.uri
         if (!uri) {
-            // No URI = used command palette as entrypoint, attempt to get URI from active editor
-            // should work correctly under any normal circumstances since the action only appears in command palette when the editor is a CloudWatch Logs editor
-            uri = vscode.window.activeTextEditor?.document.uri
-            if (!uri) {
-                throw new Error()
-            }
+            throw new Error()
         }
+
         resourceType = isLogStreamUri(uri) ? 'logStream' : 'logGroup'
-        const cachedLogEvents = registry.fetchCachedLogEvents(uri)
-        const content: string = generateTextFromLogEvents(cachedLogEvents, { timestamps: true }).text
+        const content = vscode.window.activeTextEditor?.document.getText()
         const workspaceDir = vscode.workspace.workspaceFolders
             ? vscode.workspace.workspaceFolders[0].uri
             : vscode.Uri.file(SystemUtilities.getHomeDirectory())
@@ -47,10 +43,9 @@ export async function saveCurrentLogDataContent(uri: vscode.Uri | undefined, reg
             },
         })
 
-        if (selectedUri) {
+        if (selectedUri && content) {
             try {
-                await fs.writeFile(selectedUri.fsPath, content)
-                // TODO: Open file and close virtual doc? Is this possible?
+                await FileSystemCommon.instance.writeFile(selectedUri, content)
             } catch (e) {
                 result = 'Failed'
                 const err = e as Error

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -10,6 +10,7 @@ import { DefaultCloudWatchLogsClient } from '../../shared/clients/cloudWatchLogs
 import { waitTimeout } from '../../shared/utilities/timeoutUtils'
 import { Messages } from '../../shared/utilities/messages'
 import { pageableToCollection } from '../../shared/utilities/collectionUtils'
+import { Settings } from '../../shared/settings'
 // TODO: Add debug logging statements
 
 /** Uri as a string */
@@ -20,8 +21,14 @@ export type UriString = string
 export class LogDataRegistry {
     private readonly _onDidChange: vscode.EventEmitter<vscode.Uri> = new vscode.EventEmitter<vscode.Uri>()
 
+    static #instance: LogDataRegistry
+
+    public static get instance() {
+        return (this.#instance ??= new this())
+    }
+
     public constructor(
-        public readonly configuration: CloudWatchLogsSettings,
+        public readonly configuration: CloudWatchLogsSettings = new CloudWatchLogsSettings(Settings.instance),
         private readonly registry: Map<UriString, CloudWatchLogsData> = new Map()
     ) {}
 

--- a/src/test/cloudWatchLogs/commands/saveCurrentLogDataContent.test.ts
+++ b/src/test/cloudWatchLogs/commands/saveCurrentLogDataContent.test.ts
@@ -10,13 +10,31 @@ import * as fs from 'fs-extra'
 
 import { createURIFromArgs } from '../../../cloudWatchLogs/cloudWatchLogsUtils'
 import { saveCurrentLogDataContent } from '../../../cloudWatchLogs/commands/saveCurrentLogDataContent'
-import { CloudWatchLogsEvent, LogDataRegistry } from '../../../cloudWatchLogs/registry/logDataRegistry'
 import { fileExists, makeTemporaryToolkitFolder, readFileAsString } from '../../../shared/filesystemUtilities'
 import { getTestWindow } from '../../shared/vscode/window'
+import {
+    CloudWatchLogsGroupInfo,
+    CloudWatchLogsParameters,
+    CloudWatchLogsResponse,
+    LogDataRegistry,
+} from '../../../cloudWatchLogs/registry/logDataRegistry'
+import { assertTextEditorContains } from '../../testUtil'
+
+async function testFilterLogEvents(
+    logGroupInfo: CloudWatchLogsGroupInfo,
+    apiParameters: CloudWatchLogsParameters,
+    nextToken?: string
+): Promise<CloudWatchLogsResponse> {
+    return {
+        events: [
+            { message: 'The first log event', logStreamName: 'stream1', timestamp: 1675451113 },
+            { message: 'The second log event', logStreamName: 'stream2', timestamp: 1675451114 },
+        ],
+    }
+}
 
 describe('saveCurrentLogDataContent', async function () {
     let filename: string
-    let fakeRegistry: LogDataRegistry
     let tempDir: string
     const expectedText = `1970-01-20T09:24:11.113+00:00\tThe first log event
 1970-01-20T09:24:11.114+00:00\tThe second log event
@@ -25,15 +43,6 @@ describe('saveCurrentLogDataContent', async function () {
     beforeEach(async function () {
         tempDir = await makeTemporaryToolkitFolder()
         filename = path.join(tempDir, 'bobLoblawsLawB.log')
-        fakeRegistry = {
-            fetchCachedLogEvents: (uri: vscode.Uri) => {
-                const events: CloudWatchLogsEvent[] = [
-                    { message: 'The first log event', logStreamName: 'stream1', timestamp: 1675451113 },
-                    { message: 'The second log event', logStreamName: 'stream2', timestamp: 1675451114 },
-                ]
-                return events
-            },
-        } as any as LogDataRegistry
     })
 
     afterEach(async function () {
@@ -47,9 +56,13 @@ describe('saveCurrentLogDataContent', async function () {
             streamName: 's',
         }
         const uri = createURIFromArgs(logGroupInfo, {})
+        LogDataRegistry.instance.registerInitialLog(uri, testFilterLogEvents)
+        await LogDataRegistry.instance.fetchNextLogEvents(uri)
+        vscode.window.showTextDocument(uri)
+        await assertTextEditorContains(expectedText, false) // Wait for document provider.
 
         getTestWindow().onDidShowDialog(d => d.selectItem(vscode.Uri.file(filename)))
-        await saveCurrentLogDataContent(uri, fakeRegistry)
+        await saveCurrentLogDataContent()
 
         assert.ok(await fileExists(filename))
         assert.strictEqual(await readFileAsString(filename), expectedText)
@@ -57,9 +70,8 @@ describe('saveCurrentLogDataContent', async function () {
 
     it('does not do anything if the URI is invalid', async function () {
         getTestWindow().onDidShowDialog(d => d.selectItem(vscode.Uri.file(filename)))
-        await saveCurrentLogDataContent(vscode.Uri.parse(`notCloudWatch:hahahaha`), fakeRegistry)
+        vscode.window.showTextDocument(vscode.Uri.parse(`notCloudWatch:hahahaha`))
+        await saveCurrentLogDataContent()
         assert.strictEqual(await fileExists(filename), false)
     })
-
-    // TODO: Add test for fs.writeFile failure. Apparently `fs.chmod` doesn't work on Windows?
 })

--- a/src/test/testUtil.ts
+++ b/src/test/testUtil.ts
@@ -218,7 +218,7 @@ export const assertTelemetryCurried =
  * the document must match exactly to the text editor at some point, otherwise this
  * function will timeout.
  */
-export async function assertTextEditorContains(contents: string): Promise<void | never> {
+export async function assertTextEditorContains(contents: string, exact: boolean = true): Promise<void | never> {
     const editor = await waitUntil(
         async () => {
             if (vscode.window.activeTextEditor?.document.getText() === contents) {
@@ -236,7 +236,11 @@ export async function assertTextEditorContains(contents: string): Promise<void |
         const actual = vscode.window.activeTextEditor.document
         const documentName = actual.uri.toString(true)
         const message = `Document "${documentName}" contained "${actual.getText()}", expected: "${contents}"`
-        assert.strictEqual(actual.getText(), contents, message)
+        if (exact) {
+            assert.strictEqual(actual.getText(), contents, message)
+        } else {
+            assert(actual.getText().includes(contents), message)
+        }
     }
 }
 


### PR DESCRIPTION
Problem:
saveCurrentLogDataContent() re-renders the cloudwatch logs document from the "registry", even though this command only makes sense on an existing, open editor document. Also even in the case where a document isn't open, it should just be opened instead of using the low-level registry mechanics to get the file contents.

Solution:
- Use `vscode.window.activeTextEditor?.document.getText()` to get the file contents.
- Make the test more meanginful by opening an editor document instead of passing a URI.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
