### PR TITLE
codewhisperer: add supplemental context strategy telemetry field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
                 "yaml-cfn": "^0.3.2"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.136",
+                "@aws-toolkits/telemetry": "^1.0.143",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^10.0.2",
                 "@types/adm-zip": "^0.4.34",
@@ -2349,9 +2349,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.136",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.136.tgz",
-            "integrity": "sha512-qqYyi2NFg26veVsRkadg1Q5JkPOGGdEi1bsHXOiJnwIo7lsLYZCDvCC2xHBoh6OZzAVUAeWlY/qb72cGdOUERg==",
+            "version": "1.0.143",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.143.tgz",
+            "integrity": "sha512-khMf/nlrZMpxGWGSmQH9HwPIh+nDiTbCpUJlz964zvv+IffvitZ5CaovuEpxTincKeyJq2E0TQcUtNoiWDzwfA==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",
@@ -17073,9 +17073,9 @@
             }
         },
         "@aws-toolkits/telemetry": {
-            "version": "1.0.136",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.136.tgz",
-            "integrity": "sha512-qqYyi2NFg26veVsRkadg1Q5JkPOGGdEi1bsHXOiJnwIo7lsLYZCDvCC2xHBoh6OZzAVUAeWlY/qb72cGdOUERg==",
+            "version": "1.0.143",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.143.tgz",
+            "integrity": "sha512-khMf/nlrZMpxGWGSmQH9HwPIh+nDiTbCpUJlz964zvv+IffvitZ5CaovuEpxTincKeyJq2E0TQcUtNoiWDzwfA==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -3583,7 +3583,7 @@
         "report": "nyc report --reporter=html --reporter=json"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.136",
+        "@aws-toolkits/telemetry": "^1.0.143",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/adm-zip": "^0.4.34",

--- a/src/codewhisperer/util/editorContext.ts
+++ b/src/codewhisperer/util/editorContext.ts
@@ -96,6 +96,7 @@ export async function buildListRecommendationRequest(
                   isProcessTimeout: supplementalContexts.isProcessTimeout,
                   contentsLength: supplementalContexts.contentsLength,
                   latency: supplementalContexts.latency,
+                  strategy: supplementalContexts.strategy,
               }
             : undefined
 
@@ -150,6 +151,7 @@ export async function buildGenerateRecommendationRequest(editor: vscode.TextEdit
             isProcessTimeout: supplementalContexts.isProcessTimeout,
             contentsLength: supplementalContexts.contentsLength,
             latency: supplementalContexts.latency,
+            strategy: supplementalContexts.strategy,
         }
     }
 

--- a/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
+++ b/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
@@ -108,7 +108,6 @@ export async function fetchSupplementalContextForSrc(
         supplementalContexts.push({
             filePath: chunk.fileName,
             content: chunk.nextContent,
-            strategy: 'OpenTabs_BM25',
             score: chunk.score,
         })
     }

--- a/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
+++ b/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
@@ -10,14 +10,14 @@ import { BM25Document, BM25Okapi } from './rankBm25'
 import { ToolkitError } from '../../../shared/errors'
 import { UserGroup, crossFileContextConfig, supplemetalContextFetchingTimeoutMsg } from '../../models/constants'
 import { CancellationError } from '../../../shared/utilities/timeoutUtils'
-import { CodeWhispererSupplementalContextItem } from './supplementalContextUtil'
+import { CodeWhispererSupplementalContext, CodeWhispererSupplementalContextItem } from './supplementalContextUtil'
 import { CodeWhispererUserGroupSettings } from '../userGroupUtil'
 import { isTestFile } from './codeParsingUtil'
 import { getFileDistance } from '../../../shared/filesystemUtilities'
 import { getOpenFilesInWindow } from '../../../shared/utilities/editorUtilities'
 import { getLogger } from '../../../shared/logger/logger'
 
-export type CrossFileStrategy = 'openTabs+bm25'
+export type CrossFileStrategy = 'OpenTabs_BM25'
 
 type CrossFileSupportedLanguage =
     | 'java'
@@ -53,14 +53,19 @@ interface Chunk {
 export async function fetchSupplementalContextForSrc(
     editor: vscode.TextEditor,
     cancellationToken: vscode.CancellationToken
-): Promise<CodeWhispererSupplementalContextItem[] | undefined> {
+): Promise<Pick<CodeWhispererSupplementalContext, 'supplementalContextItems' | 'strategy'> | undefined> {
     const shouldProceed = shouldFetchCrossFileContext(
         editor.document.languageId,
         CodeWhispererUserGroupSettings.instance.userGroup
     )
 
     if (!shouldProceed) {
-        return shouldProceed === undefined ? undefined : []
+        return shouldProceed === undefined
+            ? undefined
+            : {
+                  supplementalContextItems: [],
+                  strategy: 'Empty',
+              }
     }
 
     const codeChunksCalculated =
@@ -103,14 +108,17 @@ export async function fetchSupplementalContextForSrc(
         supplementalContexts.push({
             filePath: chunk.fileName,
             content: chunk.nextContent,
-            strategy: 'openTabs+bm25',
+            strategy: 'OpenTabs_BM25',
             score: chunk.score,
         })
     }
 
     // DO NOT send code chunk with empty content
     getLogger().debug(`CodeWhisperer finished fetching crossfile context out of ${relevantCrossFilePaths.length} files`)
-    return supplementalContexts.filter(item => item.content.trim().length !== 0)
+    return {
+        supplementalContextItems: supplementalContexts.filter(item => item.content.trim().length !== 0),
+        strategy: 'OpenTabs_BM25',
+    }
 }
 
 function findBestKChunkMatches(chunkInput: Chunk, chunkReferences: Chunk[], k: number): Chunk[] {

--- a/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
+++ b/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
@@ -17,6 +17,8 @@ import { getFileDistance } from '../../../shared/filesystemUtilities'
 import { getOpenFilesInWindow } from '../../../shared/utilities/editorUtilities'
 import { getLogger } from '../../../shared/logger/logger'
 
+export type CrossFileStrategy = 'openTabs+bm25'
+
 type CrossFileSupportedLanguage =
     | 'java'
     | 'python'
@@ -101,6 +103,7 @@ export async function fetchSupplementalContextForSrc(
         supplementalContexts.push({
             filePath: chunk.fileName,
             content: chunk.nextContent,
+            strategy: 'openTabs+bm25',
             score: chunk.score,
         })
     }

--- a/src/codewhisperer/util/supplementalContext/supplementalContextUtil.ts
+++ b/src/codewhisperer/util/supplementalContext/supplementalContextUtil.ts
@@ -62,7 +62,7 @@ export async function fetchSupplementalContext(
                     supplementalContextItems: value,
                     contentsLength: value.reduce((acc, curr) => acc + curr.content.length, 0),
                     latency: performance.now() - timesBeforeFetching,
-                    strategy: value[0].strategy,
+                    strategy: value[0].strategy ? value[0].strategy : 'Empty',
                 }
             } else {
                 return undefined

--- a/src/codewhisperer/util/supplementalContext/supplementalContextUtil.ts
+++ b/src/codewhisperer/util/supplementalContext/supplementalContextUtil.ts
@@ -28,7 +28,6 @@ export interface CodeWhispererSupplementalContext {
 export interface CodeWhispererSupplementalContextItem {
     content: string
     filePath: string
-    strategy: SupplementalContextStrategy
     score?: number
 }
 

--- a/src/codewhisperer/util/supplementalContext/supplementalContextUtil.ts
+++ b/src/codewhisperer/util/supplementalContext/supplementalContextUtil.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { fetchSupplementalContextForTest } from './utgUtils'
-import { fetchSupplementalContextForSrc } from './crossFileContextUtil'
+import { UtgStrategy, fetchSupplementalContextForTest } from './utgUtils'
+import { CrossFileStrategy, fetchSupplementalContextForSrc } from './crossFileContextUtil'
 import { isTestFile } from './codeParsingUtil'
 import { DependencyGraphFactory } from '../dependencyGraph/dependencyGraphFactory'
 import * as vscode from 'vscode'
@@ -14,17 +14,21 @@ import { getLogger } from '../../../shared/logger/logger'
 
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
+export type SupplementalContextStrategy = CrossFileStrategy | UtgStrategy | 'Empty'
+
 export interface CodeWhispererSupplementalContext {
     isUtg: boolean
     isProcessTimeout: boolean
     supplementalContextItems: CodeWhispererSupplementalContextItem[]
     contentsLength: number
     latency: number
+    strategy: SupplementalContextStrategy
 }
 
 export interface CodeWhispererSupplementalContextItem {
     content: string
     filePath: string
+    strategy: SupplementalContextStrategy
     score?: number
 }
 
@@ -58,6 +62,7 @@ export async function fetchSupplementalContext(
                     supplementalContextItems: value,
                     contentsLength: value.reduce((acc, curr) => acc + curr.content.length, 0),
                     latency: performance.now() - timesBeforeFetching,
+                    strategy: value[0].strategy,
                 }
             } else {
                 return undefined
@@ -71,6 +76,7 @@ export async function fetchSupplementalContext(
                     supplementalContextItems: [],
                     contentsLength: 0,
                     latency: performance.now() - timesBeforeFetching,
+                    strategy: 'Empty',
                 }
             } else {
                 getLogger().error(

--- a/src/codewhisperer/util/supplementalContext/supplementalContextUtil.ts
+++ b/src/codewhisperer/util/supplementalContext/supplementalContextUtil.ts
@@ -45,7 +45,9 @@ export async function fetchSupplementalContext(
         fileContent: editor.document.getText(),
     })
 
-    let supplementalContextPromise: Promise<CodeWhispererSupplementalContextItem[] | undefined>
+    let supplementalContextPromise: Promise<
+        Pick<CodeWhispererSupplementalContext, 'supplementalContextItems' | 'strategy'> | undefined
+    >
 
     if (isUtg) {
         supplementalContextPromise = fetchSupplementalContextForTest(editor, cancellationToken)
@@ -59,10 +61,10 @@ export async function fetchSupplementalContext(
                 return {
                     isUtg: isUtg,
                     isProcessTimeout: false,
-                    supplementalContextItems: value,
-                    contentsLength: value.reduce((acc, curr) => acc + curr.content.length, 0),
+                    supplementalContextItems: value.supplementalContextItems,
+                    contentsLength: value.supplementalContextItems.reduce((acc, curr) => acc + curr.content.length, 0),
                     latency: performance.now() - timesBeforeFetching,
-                    strategy: value[0].strategy ? value[0].strategy : 'Empty',
+                    strategy: value.strategy,
                 }
             } else {
                 return undefined

--- a/src/codewhisperer/util/supplementalContext/utgUtils.ts
+++ b/src/codewhisperer/util/supplementalContext/utgUtils.ts
@@ -127,7 +127,6 @@ function generateSupplementalContextFromFocalFile(
     return [
         {
             filePath: filePath,
-            strategy: strategy,
             content: 'UTG\n' + fileContent.slice(0, Math.min(fileContent.length, utgConfig.maxSegmentSize)),
         },
     ]

--- a/src/codewhisperer/util/supplementalContext/utgUtils.ts
+++ b/src/codewhisperer/util/supplementalContext/utgUtils.ts
@@ -27,6 +27,8 @@ import { getLogger } from '../../../shared/logger/logger'
 
 type UtgSupportedLanguage = keyof typeof utgLanguageConfigs
 
+export type UtgStrategy = 'byName' | 'byContent'
+
 function isUtgSupportedLanguage(languageId: vscode.TextDocument['languageId']): languageId is UtgSupportedLanguage {
     return languageId in utgLanguageConfigs
 }
@@ -77,7 +79,7 @@ export async function fetchSupplementalContextForTest(
     if (crossSourceFile) {
         // TODO (Metrics): 2. Success count for fetchSourceFileByName (find source file by name)
         getLogger().debug(`CodeWhisperer finished fetching utg context by file name`)
-        return generateSupplementalContextFromFocalFile(crossSourceFile, cancellationToken)
+        return generateSupplementalContextFromFocalFile(crossSourceFile, 'byName', cancellationToken)
     }
     throwIfCancelled(cancellationToken)
 
@@ -85,7 +87,7 @@ export async function fetchSupplementalContextForTest(
     if (crossSourceFile) {
         // TODO (Metrics): 3. Success count for fetchSourceFileByContent (find source file by content)
         getLogger().debug(`CodeWhisperer finished fetching utg context by file content`)
-        return generateSupplementalContextFromFocalFile(crossSourceFile, cancellationToken)
+        return generateSupplementalContextFromFocalFile(crossSourceFile, 'byContent', cancellationToken)
     }
 
     // TODO (Metrics): 4. Failure count - when unable to find focal file (supplemental context empty)
@@ -95,6 +97,7 @@ export async function fetchSupplementalContextForTest(
 
 function generateSupplementalContextFromFocalFile(
     filePath: string,
+    strategy: UtgStrategy,
     cancellationToken: vscode.CancellationToken
 ): CodeWhispererSupplementalContextItem[] {
     const fileContent = fs.readFileSync(vscode.Uri.file(filePath!).fsPath, 'utf-8')
@@ -107,6 +110,7 @@ function generateSupplementalContextFromFocalFile(
     return [
         {
             filePath: filePath,
+            strategy: strategy,
             content: 'UTG\n' + fileContent.slice(0, Math.min(fileContent.length, utgConfig.maxSegmentSize)),
         },
     ]

--- a/src/codewhisperer/util/telemetryHelper.ts
+++ b/src/codewhisperer/util/telemetryHelper.ts
@@ -299,6 +299,7 @@ export class TelemetryHelper {
             codewhispererSupplementalContextTimeout: supplementalContextMetadata?.isProcessTimeout,
             codewhispererSupplementalContextIsUtg: supplementalContextMetadata?.isUtg,
             codewhispererSupplementalContextLength: supplementalContextMetadata?.contentsLength,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             codewhispererSupplementalContextStrategyId: supplementalContextMetadata?.strategy,
         }
         telemetry.codewhisperer_userTriggerDecision.emit(aggregated)

--- a/src/codewhisperer/util/telemetryHelper.ts
+++ b/src/codewhisperer/util/telemetryHelper.ts
@@ -299,6 +299,7 @@ export class TelemetryHelper {
             codewhispererSupplementalContextTimeout: supplementalContextMetadata?.isProcessTimeout,
             codewhispererSupplementalContextIsUtg: supplementalContextMetadata?.isUtg,
             codewhispererSupplementalContextLength: supplementalContextMetadata?.contentsLength,
+            codewhispererSupplementalContextStrategyId: supplementalContextMetadata?.strategy,
         }
         telemetry.codewhisperer_userTriggerDecision.emit(aggregated)
         this.prevTriggerDecision = this.getAggregatedUserDecision(this.sessionDecisions)

--- a/src/codewhisperer/util/telemetryHelper.ts
+++ b/src/codewhisperer/util/telemetryHelper.ts
@@ -299,7 +299,7 @@ export class TelemetryHelper {
             codewhispererSupplementalContextTimeout: supplementalContextMetadata?.isProcessTimeout,
             codewhispererSupplementalContextIsUtg: supplementalContextMetadata?.isUtg,
             codewhispererSupplementalContextLength: supplementalContextMetadata?.contentsLength,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
+            // eslint-disable-next-line id-length
             codewhispererSupplementalContextStrategyId: supplementalContextMetadata?.strategy,
         }
         telemetry.codewhisperer_userTriggerDecision.emit(aggregated)

--- a/src/shared/telemetry/vscodeTelemetry.json
+++ b/src/shared/telemetry/vscodeTelemetry.json
@@ -1,11 +1,6 @@
 {
     "types": [
         {
-            "name": "codewhispererSupplementalContextStrategyId",
-            "type": "string",
-            "description": "Name tag or identifier for supplemental context fetching strategy being used for us to easier analyze corresponding acceptance rate"
-        },
-        {
             "name": "ec2ConnectionType",
             "type": "string",
             "allowedValues": ["remoteDesktop", "ssh", "scp", "ssm"],
@@ -45,125 +40,6 @@
         }
     ],
     "metrics": [
-        {
-            "name": "codewhisperer_userTriggerDecision",
-            "description": "User decision aggregated at trigger level",
-            "metadata": [
-                {
-                    "type": "codewhispererSessionId",
-                    "required": false
-                },
-                {
-                    "type": "codewhispererFirstRequestId"
-                },
-                {
-                    "type": "credentialStartUrl",
-                    "required": false
-                },
-                {
-                    "type": "codewhispererIsPartialAcceptance",
-                    "required": false
-                },
-                {
-                    "type": "codewhispererPartialAcceptanceCount",
-                    "required": false
-                },
-                {
-                    "type": "codewhispererCharactersAccepted",
-                    "required": false
-                },
-                {
-                    "type": "codewhispererCharactersRecommended",
-                    "required": false
-                },
-                {
-                    "type": "reason",
-                    "required": false
-                },
-                {
-                    "type": "codewhispererCompletionType"
-                },
-                {
-                    "type": "codewhispererLanguage"
-                },
-                {
-                    "type": "codewhispererTriggerType"
-                },
-                {
-                    "type": "codewhispererAutomatedTriggerType",
-                    "required": false
-                },
-                {
-                    "type": "codewhispererLineNumber"
-                },
-                {
-                    "type": "codewhispererCursorOffset"
-                },
-                {
-                    "type": "codewhispererSuggestionCount"
-                },
-                {
-                    "type": "codewhispererSuggestionImportCount"
-                },
-                {
-                    "type": "codewhispererTotalShownTime",
-                    "required": false
-                },
-                {
-                    "type": "codewhispererTriggerCharacter",
-                    "required": false
-                },
-                {
-                    "type": "codewhispererTypeaheadLength"
-                },
-                {
-                    "type": "codewhispererTimeSinceLastDocumentChange",
-                    "required": false
-                },
-                {
-                    "type": "codewhispererTimeSinceLastUserDecision",
-                    "required": false
-                },
-                {
-                    "type": "codewhispererTimeToFirstRecommendation",
-                    "required": false
-                },
-                {
-                    "type": "codewhispererPreviousSuggestionState",
-                    "required": false
-                },
-                {
-                    "type": "codewhispererSuggestionState"
-                },
-                {
-                    "type": "codewhispererClassifierResult",
-                    "required": false
-                },
-                {
-                    "type": "codewhispererSupplementalContextTimeout",
-                    "required": false
-                },
-                {
-                    "type": "codewhispererSupplementalContextIsUtg",
-                    "required": false
-                },
-                {
-                    "type": "codewhispererSupplementalContextLength",
-                    "required": false
-                },
-                {
-                    "type": "codewhispererSupplementalContextStrategyId",
-                    "required": false
-                },
-                {
-                    "type": "codewhispererClassifierThreshold",
-                    "required": false
-                },
-                {
-                    "type": "codewhispererUserGroup"
-                }
-            ]
-        },
         {
             "name": "vscode_executeCommand",
             "description": "Emitted whenever a registered Toolkit command is executed",

--- a/src/shared/telemetry/vscodeTelemetry.json
+++ b/src/shared/telemetry/vscodeTelemetry.json
@@ -1,6 +1,11 @@
 {
     "types": [
         {
+            "name": "codewhispererSupplementalContextStrategyId",
+            "type": "string",
+            "description": "Name tag or identifier for supplemental context fetching strategy being used for us to easier analyze corresponding acceptance rate"
+        },
+        {
             "name": "ec2ConnectionType",
             "type": "string",
             "allowedValues": ["remoteDesktop", "ssh", "scp", "ssm"],
@@ -40,6 +45,125 @@
         }
     ],
     "metrics": [
+        {
+            "name": "codewhisperer_userTriggerDecision",
+            "description": "User decision aggregated at trigger level",
+            "metadata": [
+                {
+                    "type": "codewhispererSessionId",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererFirstRequestId"
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererIsPartialAcceptance",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererPartialAcceptanceCount",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererCharactersAccepted",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererCharactersRecommended",
+                    "required": false
+                },
+                {
+                    "type": "reason",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererCompletionType"
+                },
+                {
+                    "type": "codewhispererLanguage"
+                },
+                {
+                    "type": "codewhispererTriggerType"
+                },
+                {
+                    "type": "codewhispererAutomatedTriggerType",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererLineNumber"
+                },
+                {
+                    "type": "codewhispererCursorOffset"
+                },
+                {
+                    "type": "codewhispererSuggestionCount"
+                },
+                {
+                    "type": "codewhispererSuggestionImportCount"
+                },
+                {
+                    "type": "codewhispererTotalShownTime",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererTriggerCharacter",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererTypeaheadLength"
+                },
+                {
+                    "type": "codewhispererTimeSinceLastDocumentChange",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererTimeSinceLastUserDecision",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererTimeToFirstRecommendation",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererPreviousSuggestionState",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererSuggestionState"
+                },
+                {
+                    "type": "codewhispererClassifierResult",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererSupplementalContextTimeout",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererSupplementalContextIsUtg",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererSupplementalContextLength",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererSupplementalContextStrategyId",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererClassifierThreshold",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererUserGroup"
+                }
+            ]
+        },
         {
             "name": "vscode_executeCommand",
             "description": "Emitted whenever a registered Toolkit command is executed",

--- a/src/test/codewhisperer/service/recommendationHandler.test.ts
+++ b/src/test/codewhisperer/service/recommendationHandler.test.ts
@@ -133,6 +133,7 @@ describe('recommendationHandler', function () {
                 supplementalContextItems: [],
                 contentsLength: 100,
                 latency: 0,
+                strategy: 'Empty',
             })
             sinon.stub(performance, 'now').returns(0.0)
             handler.startPos = new vscode.Position(1, 0)

--- a/src/test/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/src/test/codewhisperer/util/crossFileContextUtil.test.ts
@@ -48,9 +48,9 @@ describe('crossFileContextUtil', function () {
                 assert.ok(actual)
                 assert.ok(actual.supplementalContextItems.length === 3)
 
-                assert.strictEqual(actual[0].content.split('\n').length, 10)
-                assert.strictEqual(actual[1].content.split('\n').length, 10)
-                assert.strictEqual(actual[2].content.split('\n').length, 10)
+                assert.strictEqual(actual.supplementalContextItems[0].content.split('\n').length, 10)
+                assert.strictEqual(actual.supplementalContextItems[1].content.split('\n').length, 10)
+                assert.strictEqual(actual.supplementalContextItems[2].content.split('\n').length, 10)
             }
 
             it('control group', async function () {

--- a/src/test/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/src/test/codewhisperer/util/crossFileContextUtil.test.ts
@@ -169,10 +169,7 @@ describe('crossFileContextUtil', function () {
 
                 const actual = await crossFile.fetchSupplementalContextForSrc(editor, fakeCancellationToken)
 
-                assert.ok(
-                    actual?.supplementalContextItems.length !== undefined &&
-                        actual.supplementalContextItems.length === 0
-                )
+                assert.ok(actual && actual.supplementalContextItems.length === 0)
             })
         })
     })
@@ -204,10 +201,7 @@ describe('crossFileContextUtil', function () {
 
                 const actual = await crossFile.fetchSupplementalContextForSrc(editor, fakeCancellationToken)
 
-                assert.ok(
-                    actual?.supplementalContextItems.length !== undefined &&
-                        actual.supplementalContextItems.length !== 0
-                )
+                assert.ok(actual && actual.supplementalContextItems.length !== 0)
             })
         })
     })
@@ -239,10 +233,7 @@ describe('crossFileContextUtil', function () {
 
                 const actual = await crossFile.fetchSupplementalContextForSrc(editor, fakeCancellationToken)
 
-                assert.ok(
-                    actual?.supplementalContextItems.length !== undefined &&
-                        actual.supplementalContextItems.length !== 0
-                )
+                assert.ok(actual && actual.supplementalContextItems.length !== 0)
             })
         })
     })

--- a/src/test/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/src/test/codewhisperer/util/crossFileContextUtil.test.ts
@@ -46,7 +46,7 @@ describe('crossFileContextUtil', function () {
                 })
                 const actual = await crossFile.fetchSupplementalContextForSrc(myCurrentEditor, fakeCancellationToken)
                 assert.ok(actual)
-                assert.ok(actual.length === 3)
+                assert.ok(actual.supplementalContextItems.length === 3)
 
                 assert.strictEqual(actual[0].content.split('\n').length, 10)
                 assert.strictEqual(actual[1].content.split('\n').length, 10)
@@ -169,7 +169,10 @@ describe('crossFileContextUtil', function () {
 
                 const actual = await crossFile.fetchSupplementalContextForSrc(editor, fakeCancellationToken)
 
-                assert.ok(actual?.length !== undefined && actual.length === 0)
+                assert.ok(
+                    actual?.supplementalContextItems.length !== undefined &&
+                        actual.supplementalContextItems.length === 0
+                )
             })
         })
     })
@@ -201,7 +204,10 @@ describe('crossFileContextUtil', function () {
 
                 const actual = await crossFile.fetchSupplementalContextForSrc(editor, fakeCancellationToken)
 
-                assert.ok(actual?.length !== undefined && actual.length !== 0)
+                assert.ok(
+                    actual?.supplementalContextItems.length !== undefined &&
+                        actual.supplementalContextItems.length !== 0
+                )
             })
         })
     })
@@ -233,7 +239,10 @@ describe('crossFileContextUtil', function () {
 
                 const actual = await crossFile.fetchSupplementalContextForSrc(editor, fakeCancellationToken)
 
-                assert.ok(actual?.length !== undefined && actual.length !== 0)
+                assert.ok(
+                    actual?.supplementalContextItems.length !== undefined &&
+                        actual.supplementalContextItems.length !== 0
+                )
             })
         })
     })


### PR DESCRIPTION
## Problem
We are already able to analyze acceptance rate on either CrossFile or UTG or an aggregated number. Now we need more granular metrics for UTG `resolve source file by file name` vs. `resolve source file by file content` to help us understanding deeper the effectiveness of UTG, thus adding a new field `codewhispererSupplementalContextStrategyId` field representing the strategies being used for Crossfile and UTG.

* Crossfile
    * OpenTabs + BM25

* UTG
   * Resolve by file name (regex)
   * Resolve by file content  


there are 4 values for now
`Empty`, `ByName`, `ByContent`, `OpenTabs_BM25`


## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
