### PR TITLE
CI: group dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,21 @@ updates:
       target-branch: 'master' # Avoid updates to "staging".
       schedule:
           interval: 'daily'
-    # Check for updates to GitHub Actions every week
+      groups:
+          aws-sdk:
+              dependency-type: 'production'
+              patterns:
+                  - '@aws-sdk/*'
+          vscode-lsp:
+              dependency-type: 'production'
+              patterns:
+                  - 'vscode-lang*'
     - package-ecosystem: 'github-actions'
       directory: '/'
+      target-branch: 'master' # Avoid updates to "staging".
       schedule:
-          interval: 'weekly'
+          interval: 'daily'
+      groups:
+          github-actions:
+              patterns:
+                  - '*'


### PR DESCRIPTION
# Problem
Dependency updates can be noisy. Unmerged dependency updates can block other updates if the max is reached.

# Solution
- Use dependabot "groups" feature: https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/ 
    - Group updates to github actions. 
    - Group updates to AWS SDK. 
    - Group updates to vscode lsp packages.

Example of a grouped dependency update: https://github.com/cda-tum/setup-z3/pull/234

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
