### PR TITLE
build(stepfunctions): amazon-states-language-service 1.10→1.11

### DIFF
--- a/.changes/next-release/Feature-d124bdaa-a3b7-4d89-84c5-f7cbe495f128.json
+++ b/.changes/next-release/Feature-d124bdaa-a3b7-4d89-84c5-f7cbe495f128.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Step Functions: Upgrade amazon-states-language-service to 1.11. This new version adds Fail State fields ErrorPath and CausePath, and on Retriers MaxDelaySeconds and JitterStrategy."
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
                 "@aws-sdk/util-arn-parser": "^3.46.0",
                 "@iarna/toml": "^2.2.5",
                 "adm-zip": "^0.5.10",
-                "amazon-states-language-service": "^1.10.0",
+                "amazon-states-language-service": "^1.11.0",
                 "async-lock": "^1.4.0",
                 "aws-sdk": "^2.1384.0",
                 "aws-ssm-document-language-service": "^1.0.0",
@@ -4682,16 +4682,44 @@
             }
         },
         "node_modules/amazon-states-language-service": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.10.0.tgz",
-            "integrity": "sha512-LRlnIzCBXeD7Ebm2M5J7r7o3Mz1Wqeo3euxqf4Rrbbycot35+6vA1JmdK9RXF4BIXy3I0wECPzKDtnQV8keK7g==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.11.0.tgz",
+            "integrity": "sha512-irwUdZ81qJFyU3bKm3Ujs6lhWCS/uCVzoT/YpLQ9QgavS/pWxmq4ZlV/eSFu8/TphmurnUQsX9wURKtF6NDGcA==",
             "dependencies": {
                 "js-yaml": "^4.1.0",
                 "vscode-json-languageservice": "5.3.5",
-                "vscode-languageserver": "^6.1.1",
+                "vscode-languageserver": "^8.1.0",
                 "vscode-languageserver-textdocument": "^1.0.0",
                 "vscode-languageserver-types": "^3.15.1",
                 "yaml-language-server": "0.15.0"
+            }
+        },
+        "node_modules/amazon-states-language-service/node_modules/vscode-jsonrpc": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+            "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/amazon-states-language-service/node_modules/vscode-languageserver": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.1.0.tgz",
+            "integrity": "sha512-eUt8f1z2N2IEUDBsKaNapkz7jl5QpskN2Y0G01T/ItMxBxw1fJwvtySGB9QMecatne8jFIWJGWI61dWjyTLQsw==",
+            "dependencies": {
+                "vscode-languageserver-protocol": "3.17.3"
+            },
+            "bin": {
+                "installServerIntoExtension": "bin/installServerIntoExtension"
+            }
+        },
+        "node_modules/amazon-states-language-service/node_modules/vscode-languageserver-protocol": {
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+            "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+            "dependencies": {
+                "vscode-jsonrpc": "8.1.0",
+                "vscode-languageserver-types": "3.17.3"
             }
         },
         "node_modules/ansi-colors": {
@@ -18951,16 +18979,40 @@
             "requires": {}
         },
         "amazon-states-language-service": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.10.0.tgz",
-            "integrity": "sha512-LRlnIzCBXeD7Ebm2M5J7r7o3Mz1Wqeo3euxqf4Rrbbycot35+6vA1JmdK9RXF4BIXy3I0wECPzKDtnQV8keK7g==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/amazon-states-language-service/-/amazon-states-language-service-1.11.0.tgz",
+            "integrity": "sha512-irwUdZ81qJFyU3bKm3Ujs6lhWCS/uCVzoT/YpLQ9QgavS/pWxmq4ZlV/eSFu8/TphmurnUQsX9wURKtF6NDGcA==",
             "requires": {
                 "js-yaml": "^4.1.0",
                 "vscode-json-languageservice": "5.3.5",
-                "vscode-languageserver": "^6.1.1",
+                "vscode-languageserver": "^8.1.0",
                 "vscode-languageserver-textdocument": "^1.0.0",
                 "vscode-languageserver-types": "^3.15.1",
                 "yaml-language-server": "0.15.0"
+            },
+            "dependencies": {
+                "vscode-jsonrpc": {
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+                    "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw=="
+                },
+                "vscode-languageserver": {
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.1.0.tgz",
+                    "integrity": "sha512-eUt8f1z2N2IEUDBsKaNapkz7jl5QpskN2Y0G01T/ItMxBxw1fJwvtySGB9QMecatne8jFIWJGWI61dWjyTLQsw==",
+                    "requires": {
+                        "vscode-languageserver-protocol": "3.17.3"
+                    }
+                },
+                "vscode-languageserver-protocol": {
+                    "version": "3.17.3",
+                    "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+                    "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+                    "requires": {
+                        "vscode-jsonrpc": "8.1.0",
+                        "vscode-languageserver-types": "3.17.3"
+                    }
+                }
             }
         },
         "ansi-colors": {

--- a/package.json
+++ b/package.json
@@ -3655,7 +3655,7 @@
         "@aws-sdk/util-arn-parser": "^3.46.0",
         "@iarna/toml": "^2.2.5",
         "adm-zip": "^0.5.10",
-        "amazon-states-language-service": "^1.10.0",
+        "amazon-states-language-service": "^1.11.0",
         "async-lock": "^1.4.0",
         "aws-sdk": "^2.1384.0",
         "aws-ssm-document-language-service": "^1.0.0",


### PR DESCRIPTION
## Overview
Upgrade amazon-states-language-service 1.10→1.11

This adds Step Functions validations for:
- Fail State: ErrorPath & CausePath.
- Retry: MaxDelaySeconds & JitterStrategy.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
