### PR TITLE
logging: only log to console in browser

### DIFF
--- a/src/shared/logger/activation.ts
+++ b/src/shared/logger/activation.ts
@@ -43,7 +43,7 @@ export async function activate(
         {
             logPaths: [logUri.fsPath],
             outputChannels: [chan],
-            useConsoleLog: true,
+            useConsoleLog: isInBrowser(),
         },
         extensionContext.subscriptions
     )
@@ -100,7 +100,8 @@ export async function activate(
  * @param opts.staticLogLevel Static log level, overriding config value. Will persist overridden config value even if the config value changes.
  * @param opts.logPaths Array of paths to output log entries to
  * @param opts.outputChannels Array of output channels to log entries to
- * @param opts.useDebugConsole If true, outputs log entries to currently-active debug console. As per VS Code API, cannot specify a debug console in particular.
+ * @param opts.useDebugConsole If true, outputs log entries to `vscode.debug.activeDebugConsole`
+ * @param opts.useConsoleLog If true, outputs log entries to the nodejs or browser devtools console.
  * @param disposables Array of disposables to add a subscription to
  */
 export function makeLogger(


### PR DESCRIPTION
Problem:

From a previous change we are now logging to the Developer Tools console of a browser whether in Node.js or the Browser.

Solution:

Only log to the Developer Tools console when in the Browser and skip if we are in Node.js

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
