### PR TITLE
fix(codewhisperer): Add more debug logs for connection expiration

### DIFF
--- a/.changes/next-release/Bug Fix-a9af385a-389b-4fe9-a6e2-2578f2e6f9ca.json
+++ b/.changes/next-release/Bug Fix-a9af385a-389b-4fe9-a6e2-2578f2e6f9ca.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeWhisperer: show \"Reconnect\" instead of \"Start\" for expired connections to make reconnecting easier"
+}

--- a/src/codewhisperer/explorer/codewhispererNode.ts
+++ b/src/codewhisperer/explorer/codewhispererNode.ts
@@ -67,14 +67,13 @@ export class CodeWhispererNode implements RootNode {
     public getChildren() {
         const autoTriggerEnabled =
             globals.context.globalState.get<boolean>(CodeWhispererConstants.autoTriggerEnabledKey) || false
-
+        if (AuthUtil.instance.isConnectionExpired()) {
+            return [createReconnectNode(), createLearnMore()]
+        }
         if (!AuthUtil.instance.isConnected()) {
             return [createSsoSignIn(), createLearnMore()]
         }
-
-        if (AuthUtil.instance.isConnectionExpired()) {
-            return [createReconnectNode(), createLearnMore()]
-        } else if (this._showFreeTierLimitReachedNode) {
+        if (this._showFreeTierLimitReachedNode) {
             if (isCloud9()) {
                 return [createFreeTierLimitMetNode(), createOpenReferenceLogNode()]
             } else {

--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -183,7 +183,7 @@ export class AuthUtil {
 
     public isConnectionValid(): boolean {
         const connectionValid = this.conn !== undefined && !this.secondaryAuth.isConnectionExpired
-        getLogger().debug(`Connection is valid = ${connectionValid}, 
+        getLogger().debug(`codewhisperer: Connection is valid = ${connectionValid}, 
                             connection is undefined = ${this.conn === undefined},
                             secondaryAuth connection expired = ${this.secondaryAuth.isConnectionExpired}`)
         return connectionValid
@@ -194,11 +194,13 @@ export class AuthUtil {
             this.secondaryAuth.isConnectionExpired &&
             this.conn !== undefined &&
             isValidCodeWhispererConnection(this.conn)
-        getLogger().debug(`Connection expired = ${connectionExpired},
+        getLogger().debug(`codewhisperer: Connection expired = ${connectionExpired},
                            secondaryAuth connection expired = ${this.secondaryAuth.isConnectionExpired},
                            connection is undefined = ${this.conn === undefined}`)
         if (this.conn) {
-            getLogger().debug(`isValidCodeWhispererConnection = ${isValidCodeWhispererConnection(this.conn)}`)
+            getLogger().debug(
+                `codewhisperer: isValidCodeWhispererConnection = ${isValidCodeWhispererConnection(this.conn)}`
+            )
         }
         return connectionExpired
     }

--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -24,6 +24,7 @@ import {
     isSsoConnection,
     isBuilderIdConnection,
 } from '../../auth/connection'
+import { getLogger } from '../../shared/logger'
 
 export const defaultCwScopes = [...ssoAccountAccessScopes, ...codewhispererScopes]
 export const awsBuilderIdSsoProfile = createBuilderIdProfile(defaultCwScopes)
@@ -181,15 +182,25 @@ export class AuthUtil {
     }
 
     public isConnectionValid(): boolean {
-        return this.conn !== undefined && !this.secondaryAuth.isConnectionExpired
+        const connectionValid = this.conn !== undefined && !this.secondaryAuth.isConnectionExpired
+        getLogger().debug(`Connection is valid = ${connectionValid}, 
+                            connection is undefined = ${this.conn === undefined},
+                            secondaryAuth connection expired = ${this.secondaryAuth.isConnectionExpired}`)
+        return connectionValid
     }
 
     public isConnectionExpired(): boolean {
-        return (
+        const connectionExpired =
             this.secondaryAuth.isConnectionExpired &&
             this.conn !== undefined &&
             isValidCodeWhispererConnection(this.conn)
-        )
+        getLogger().debug(`Connection expired = ${connectionExpired},
+                           secondaryAuth connection expired = ${this.secondaryAuth.isConnectionExpired},
+                           connection is undefined = ${this.conn === undefined}`)
+        if (this.conn) {
+            getLogger().debug(`isValidCodeWhispererConnection = ${isValidCodeWhispererConnection(this.conn)}`)
+        }
+        return connectionExpired
     }
 
     public async reauthenticate() {


### PR DESCRIPTION
## Problem

This PR is to add more debug logs to help triage the  invalid_client error when customer is unable to sign-in successfully.

## Solution

1. Add more debug logs at `isConnectionExpired`.
2. Detect connection expiration first.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
