### PR TITLE
build: silence git progress

### DIFF
--- a/scripts/build/generateServiceClient.ts
+++ b/scripts/build/generateServiceClient.ts
@@ -56,9 +56,20 @@ async function cloneJsSdk(dir: string): Promise<void> {
             ? // Local repo exists already: just update it and checkout the tag.
               // Fetch only the tag we need.
               //      git fetch origin tag v2.950.0 --no-tags
-              ['-C', dir, 'fetch', 'origin', 'tag', tag, '--no-tags']
+              ['-C', dir, 'fetch', '--quiet', 'origin', 'tag', tag, '--no-tags']
             : // Local repo does not exist: clone it.
-              ['clone', '-b', tag, '--depth', '1', 'https://github.com/aws/aws-sdk-js.git', dir]
+              [
+                  '-c',
+                  'advice.detachedHead=false',
+                  'clone',
+                  '--quiet',
+                  '-b',
+                  tag,
+                  '--depth',
+                  '1',
+                  'https://github.com/aws/aws-sdk-js.git',
+                  dir,
+              ]
 
         const gitCmd = child_process.execFile('git', gitArgs, { encoding: 'utf8' })
 
@@ -69,7 +80,15 @@ async function cloneJsSdk(dir: string): Promise<void> {
             gitCmd.stdout?.removeAllListeners()
 
             // Only needed for the "update" case, but harmless for "clone".
-            const gitCheckout = child_process.spawnSync('git', ['-C', dir, 'checkout', '--force', tag])
+            const gitCheckout = child_process.spawnSync('git', [
+                '-c',
+                'advice.detachedHead=false',
+                '-C',
+                dir,
+                'checkout',
+                '--force',
+                tag,
+            ])
             if (gitCheckout.status !== undefined && gitCheckout.status !== 0) {
                 console.log(`error: git: status=${gitCheckout.status} output=${gitCheckout.output.toString()}`)
             }


### PR DESCRIPTION
Problem:
The generateServiceClient task is noisy in CI logs:

    > ts-node ./scripts/build/generateServiceClient.ts
    ...
    Updating files:  66% (2895/4337)
    Updating files:  67% (2906/4337)
    Updating files:  68% (2950/4337)
    Updating files:  69% (2993/4337)
    Updating files:  70% (3036/4337)
    ...

Solution:
Use the `--quiet` option.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
