### PR TITLE
fix: tests call openExternal() without stubbing

### DIFF
--- a/src/test/apprunner/wizards/codeRepositoryWizard.test.ts
+++ b/src/test/apprunner/wizards/codeRepositoryWizard.test.ts
@@ -117,6 +117,7 @@ describe('createConnectionPrompter', function () {
     })
 
     it('shows an option to go to documentation when no connections are available', async function () {
+        getOpenExternalStub().resolves(true)
         const tester = makeTester([])
         tester.assertItems(['No connections found'])
         tester.acceptItem('No connections found')

--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -70,9 +70,7 @@ export const mochaHooks = {
         // to be minimally intrusive and as close to the real thing as possible.
         globalSandbox.replace(vscode, 'window', getTestWindow())
         openExternalStub = globalSandbox.stub(vscode.env, 'openExternal')
-        openExternalStub.rejects(
-            new Error('No return value has been set. Use `getOpenExternalStub().resolves` to set one.')
-        )
+        openExternalStub.returns(undefined as any) // Detected in afterEach() below.
 
         // Wraps the test function to bubble up errors that occurred in events from `TestWindow`
         if (this.currentTest?.fn) {
@@ -88,6 +86,14 @@ export const mochaHooks = {
         await testUtil.closeAllEditors()
     },
     afterEach(this: Mocha.Context) {
+        if (openExternalStub.called && openExternalStub.returned(sinon.match.typeOf('undefined'))) {
+            throw new Error(
+                `Test called openExternal(${
+                    getOpenExternalStub().args[0]
+                }) without first configuring getOpenExternalStub().resolves().`
+            )
+        }
+
         // Prevent other tests from using the same TestLogger instance
         teardownTestLogger(this.currentTest?.fullTitle() as string)
         testLogger = undefined

--- a/src/test/shared/ui/prompters/roles.test.ts
+++ b/src/test/shared/ui/prompters/roles.test.ts
@@ -75,6 +75,7 @@ describe('createRolePrompter', function () {
     })
 
     it('can open documentation', async function () {
+        getOpenExternalStub().resolves(true)
         tester.pressButton('View Toolkit Documentation')
         tester.addCallback(() => assert.ok(getOpenExternalStub().calledWith(helpUri)))
         tester.hide()


### PR DESCRIPTION
Problem:

    rejected promise not handled within 1 second: Error: No return value has been set. Use `getOpenExternalStub().resolves` to set one.
    stack trace: Error: No return value has been set. Use `getOpenExternalStub().resolves` to set one.
        at Context.<anonymous> (/Users/runner/work/aws-toolkit-vscode/aws-toolkit-vscode/src/test/globalSetup.test.ts:74:13)
        at Generator.next (<anonymous>)
        at /Users/runner/work/aws-toolkit-vscode/aws-toolkit-vscode/dist/src/test/globalSetup.test.js:35:71

Solution:

- Fail in `afterEach` (this is much more useful than a silent message in the test log).
  ```
  1) "after each" hook: afterEach for "shows an option to go to documentation when no connections are available":
     Error: Test called openExternal(https://docs.aws.amazon.com/apprunner/latest/dg/manage-create.html#manage-create.create.github) without first configuring getOpenExternalStub().resolves().
  ```
- Fix the tests.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
