### PR TITLE
fix(tests): "rejected promise not handled"

### DIFF
--- a/src/test/cloudWatchLogs/commands/saveCurrentLogDataContent.test.ts
+++ b/src/test/cloudWatchLogs/commands/saveCurrentLogDataContent.test.ts
@@ -70,7 +70,9 @@ describe('saveCurrentLogDataContent', async function () {
 
     it('does not do anything if the URI is invalid', async function () {
         getTestWindow().onDidShowDialog(d => d.selectItem(vscode.Uri.file(filename)))
-        vscode.window.showTextDocument(vscode.Uri.parse(`notCloudWatch:hahahaha`))
+        await assert.rejects(
+            async () => await vscode.window.showTextDocument(vscode.Uri.parse(`notCloudWatch:hahahaha`))
+        )
         await saveCurrentLogDataContent()
         assert.strictEqual(await fileExists(filename), false)
     })


### PR DESCRIPTION
Problem:

    rejected promise not handled within 1 second: CodeExpectedError: cannot open notCloudWatch:hahahaha. Detail: Unable to resolve resource notCloudWatch:hahahaha
    stack trace: CodeExpectedError: cannot open notCloudWatch:hahahaha. Detail: Unable to resolve resource notCloudWatch:hahahaha

Solution:
Assert the failure.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
