### PR TITLE
fix(codecatalyst): remote connect may fail from Windows

### DIFF
--- a/.changes/next-release/Bug Fix-68609ebe-e769-4aa3-829e-5a4af2210a14.json
+++ b/.changes/next-release/Bug Fix-68609ebe-e769-4aa3-829e-5a4af2210a14.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeCatalyst: \"Open CodeCatalyst Dev Environment\" may fail to connect from a new Windows system"
+}

--- a/resources/codecatalyst_connect.ps1
+++ b/resources/codecatalyst_connect.ps1
@@ -68,7 +68,7 @@ function StartDevEnvironmentSession {
 }
 "@
 
-    $webRequest = Invoke-WebRequest -Method 'PUT' -Uri "$Endpoint$startSessionPath" -Headers @{"Content-Type" = "application/json"; "Authorization" = "Bearer $Token" } -Body "$startSessionQuery"
+    $webRequest = Invoke-WebRequest -Method 'PUT' -Uri "$Endpoint$startSessionPath" -Headers @{"Content-Type" = "application/json"; "Authorization" = "Bearer $Token" } -Body "$startSessionQuery" -UseBasicParsing
     ConvertFrom-Json -InputObject $webRequest
 }
 


### PR DESCRIPTION
# Problem
When connecting to a dev environment using "Open Dev Environment" from a Windows user _who has not run Explorer or Edge at least once_, vscode remote-ssh may get stuck:

    "Setting up SSH Host (details) Initializing VS Code Server"
    "kex_exchange_identification: Connection closed by remote host
    Connection closed by UNKNOWN port 65535"

https://github.com/aws/aws-toolkit-vscode/issues/3810

# Solution
Specify the `-UseBasicParsing` option.

`Invoke-WebRequest` can fail for Windows users if IE/Edge have never been run, because of missing capabilities to parse the HTTP response. If IE/Edge were not run at least once, Windows does not initialize some libraries needed in powershell.

https://stackoverflow.com/a/38054505/152142
https://learn.microsoft.com/en-us/previous-versions/powershell/module/Microsoft.PowerShell.Utility/Invoke-WebRequest?view=powershell-3.0#-usebasicparsing
> This parameter is required when Internet Explorer is not installed on the computers, such as on
> a Server Core installation of a Windows Server operating system.



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
