### PR TITLE
fix(build): "package" task fails on feature-branches

### DIFF
--- a/scripts/build/package.ts
+++ b/scripts/build/package.ts
@@ -68,11 +68,12 @@ function parseArgs() {
 }
 
 /**
- * If the current commit is tagged then it is a "release build", else it is
- * a prerelease/nightly/edge/preview build.
+ * If the _current_ commit is tagged as a release ("v1.26.0") then it is a "release build", else it
+ * is a prerelease/nightly/edge/preview build.
  */
 function isRelease(): boolean {
-    return child_process.execSync('git tag -l --contains HEAD').toString() !== ''
+    const tag = child_process.execSync('git tag -l --contains HEAD').toString()
+    return !!tag?.match(/v\d+\.\d+\.\d+/)
 }
 
 /**


### PR DESCRIPTION
# Problem
The "Package Test" CI job fails on `feature/x` branches that set `betaUrl`:

    Error: Cannot package VSIX as both a release and a beta simultaneously
        at main (/codebuild/output/src3161342786/src/github.com/aws/aws-toolkit-vscode-staging/scripts/build/package.ts:111:19)

(Note: `feature/x` branches are auto-tagged as `pre-x`, e.g. https://github.com/aws/aws-toolkit-vscode/releases/tag/pre-ec2 )

# Solution
Make `isRelease()` more precise.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
