### PR TITLE
codecatalyst: enable e2e test

### DIFF
--- a/src/test/techdebt.test.ts
+++ b/src/test/techdebt.test.ts
@@ -51,12 +51,4 @@ describe('tech debt', function () {
             'Remove use of 1.94.0 for aws-sam-cli in linuxIntegrationTests.yml and see if integration tests are passing now'
         )
     })
-
-    it('stop skipping CodeCatalyst E2E Tests', function () {
-        // https://issues.amazon.com/issues/IDE-10496
-        assert(
-            new Date() < new Date(2024, 1, 15),
-            'Re-evaluate if we should still keep skipping CodeCatalyst E2E Tests'
-        )
-    })
 })

--- a/src/testE2E/codecatalyst/client.test.ts
+++ b/src/testE2E/codecatalyst/client.test.ts
@@ -81,7 +81,7 @@ let projectName: CodeCatalystProject['name']
  *     integ tests, but using the ssh hostname that we get from
  *     {@link prepareDevEnvConnection}.
  */
-describe.skip('Test how this codebase uses the CodeCatalyst API', function () {
+describe('Test how this codebase uses the CodeCatalyst API', function () {
     let client: CodeCatalystClient
     let commands: CodeCatalystCommands
     let webviewClient: CodeCatalystCreateWebview


### PR DESCRIPTION
## Problem

The CodeCatalyst E2E tests were failing due to un-deletable Dev Environments (CodeCatalyst bug) and our code would hang, waiting for the old Dev Environments to be deleted.

## Solution

Manually removed all un-deletable Dev Environments, and now the tests work again.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
