### PR TITLE
logging: reduce log noise on debugger disconnect

### DIFF
--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -134,10 +134,18 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
                 // Forces debugger to disconnect (sometimes it fails to disconnect on its own)
                 // Note that VSCode 1.42 only allows us to get the active debug session, so
                 // the user will have to manually disconnect if using multiple debug sessions
-                const debugSession: vscode.DebugSession | undefined = vscode.debug.activeDebugSession
+                const debugSession = vscode.debug.activeDebugSession
                 if (debugSession && debugSession.name === params.name) {
-                    getLogger().debug(`forcing debugger to disconnect: name=${debugSession.name}`)
-                    debugSession.customRequest('disconnect')
+                    getLogger().debug('forcing disconnect of debugger session "%s"', debugSession.name)
+                    debugSession.customRequest('disconnect').then(
+                        () => undefined,
+                        e =>
+                            getLogger().warn(
+                                'failed to disconnect debugger session "%s": %s',
+                                debugSession.name,
+                                (e as Error).message
+                            )
+                    )
                 }
             }
         })


### PR DESCRIPTION
Problem:
CI build logs have some very noisy messages like:

    2023-09-13 17:28:03 [DEBUG]: forcing debugger to disconnect: name=test-config-1
    No debugger available, can not send 'disconnect': Error: No debugger available, can not send 'disconnect'
        at x.customRequest (vscode-file://vscode-app/codebuild/…/vscode-linux-x64-1.68.0/resources/app/out/vs/workbench/workbench.desktop.main.js:2161:16883)
        at C.$customDebugAdapterRequest (vscode-file://vscode-app/codebuild/…/vscode-linux-x64-1.68.0/resources/app/out/vs/workbench/workbench.desktop.main.js:1722:7574)
        at b._doInvokeHandler (vscode-file://vscode-app/codebuild/…/vscode-linux-x64-1.68.0/resources/app/out/vs/workbench/workbench.desktop.main.js:1731:13205)
        at b._invokeHandler (vscode-file://vscode-app/codebuild/…/vscode-linux-x64-1.68.0/resources/app/out/vs/workbench/workbench.desktop.main.js:1731:12889)
        at b._receiveRequest (vscode-file://vscode-app/codebuild/…/vscode-linux-x64-1.68.0/resources/app/out/vs/workbench/workbench.desktop.main.js:1731:11551)
        at b._receiveOneMessage (vscode-file://vscode-app/codebuild/…/vscode-linux-x64-1.68.0/resources/app/out/vs/workbench/workbench.desktop.main.js:1731:10428)
        at vscode-file://vscode-app/codebuild/…/vscode-linux-x64-1.68.0/resources/app/out/vs/workbench/workbench.desktop.main.js:1731:8338
        at m.invoke (vscode-file://vscode-app/codebuild/…/vscode-linux-x64-1.68.0/resources/app/out/vs/workbench/workbench.desktop.main.js:67:145)
        at s.deliver (vscode-file://vscode-app/codebuild/…/vscode-linux-x64-1.68.0/resources/app/out/vs/workbench/workbench.desktop.main.js:67:2265)

Solution:
The forced disconnect is "best effort", so catch the failure and log a more minimal message.

    2023-09-13 18:37:44 [DEBUG]: forcing disconnect of debugger session "test-config-0"
    2023-09-13 18:37:44 [WARN]: failed to disconnect debugger session "test-config-0": No debugger available, can not send 'disconnect'


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
