### PR TITLE
sso: use new 'confirm match' device code flow

### DIFF
--- a/src/auth/sso/model.ts
+++ b/src/auth/sso/model.ts
@@ -86,43 +86,51 @@ export function truncateStartUrl(startUrl: string) {
     return startUrl.match(/https?:\/\/(.*)\.awsapps\.com\/start/)?.[1] ?? startUrl
 }
 
-export async function openSsoPortalLink(
-    startUrl: string,
-    authorization: { readonly verificationUri: string; readonly userCode: string }
-): Promise<boolean> {
-    async function copyCodeAndOpenLink() {
-        await vscode.env.clipboard.writeText(authorization.userCode).then(undefined, err => {
-            getLogger().warn(`auth: failed to copy user code "${authorization.userCode}" to clipboard: %s`, err)
-        })
+type Authorization = { readonly verificationUri: string; readonly userCode: string }
 
-        const didOpen = await vscode.env.openExternal(vscode.Uri.parse(authorization.verificationUri))
-        if (!didOpen) {
+export const proceedToBrowser = localize('AWS.auth.loginWithBrowser.proceedToBrowser', 'Proceed To Browser')
+
+export async function openSsoPortalLink(startUrl: string, authorization: Authorization): Promise<boolean> {
+    /**
+     * Depending on the verification URL + parameters used, the way the sso login flow works changes.
+     * Previously, users were asked to copy and paste a device code in to the browser page.
+     *
+     * Now, with the URL this function creates, the user will instead be asked to confirm the device code
+     * in the browser.
+     */
+    function makeConfirmCodeUrl(authorization: Authorization): vscode.Uri {
+        return vscode.Uri.parse(`${authorization.verificationUri}?user_code=${authorization.userCode}`)
+    }
+
+    async function openSsoUrl() {
+        const ssoLoginUrl = makeConfirmCodeUrl(authorization)
+        const didOpenUrl = await vscode.env.openExternal(ssoLoginUrl)
+
+        if (!didOpenUrl) {
             throw new ToolkitError(`User clicked 'Copy' or 'Cancel' during the Trusted Domain popup`, {
                 code: trustedDomainCancellation,
                 name: trustedDomainCancellation,
             })
         }
-        return didOpen
+        return didOpenUrl
     }
 
     async function showLoginNotification() {
         const name = startUrl === builderIdStartUrl ? localizedText.builderId() : localizedText.iamIdentityCenterFull()
-        const title = localize('AWS.auth.loginWithBrowser.messageTitle', 'Copy Code for {0}', name)
+        const title = localize('AWS.auth.loginWithBrowser.messageTitle', 'Confirm Code for {0}', name)
         const detail = localize(
             'AWS.auth.loginWithBrowser.messageDetail',
-            'To proceed, open the login page and provide this code to confirm the access request: {0}',
+            'Confirm this code in the browser: {0}',
             authorization.userCode
         )
-        const copyCode = localize('AWS.auth.loginWithBrowser.copyCodeAction', 'Copy Code and Proceed')
-        const options = { modal: true, detail } as vscode.MessageOptions
 
         while (true) {
             // TODO: add the 'Help' item back once we have a suitable URL
             // const resp = await vscode.window.showInformationMessage(title, options, copyCode, localizedText.help)
-            const resp = await vscode.window.showInformationMessage(title, options, copyCode)
+            const resp = await vscode.window.showInformationMessage(title, { modal: true, detail }, proceedToBrowser)
             switch (resp) {
-                case copyCode:
-                    return copyCodeAndOpenLink()
+                case proceedToBrowser:
+                    return openSsoUrl()
                 case localizedText.help:
                     await tryOpenHelpUrl(ssoAuthHelpUrl)
                     continue

--- a/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/src/auth/sso/ssoAccessTokenProvider.ts
@@ -234,7 +234,7 @@ async function pollForTokenWithProgress<T>(
         {
             title: localize(
                 'AWS.auth.loginWithBrowser.messageDetail',
-                'Login page opened in browser. When prompted, provide this code: {0}',
+                'Confirm code "{0}" in the login page opened in your web browser.',
                 authorization.userCode
             ),
             cancellable: true,

--- a/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
+++ b/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
@@ -12,7 +12,7 @@ import { getCache } from '../../../auth/sso/cache'
 
 import { instance, mock, when, anything, reset } from '../../utilities/mockito'
 import { makeTemporaryToolkitFolder, tryRemoveFolder } from '../../../shared/filesystemUtilities'
-import { ClientRegistration, SsoToken } from '../../../auth/sso/model'
+import { ClientRegistration, SsoToken, proceedToBrowser } from '../../../auth/sso/model'
 import { OidcClient } from '../../../auth/sso/clients'
 import { CancellationError } from '../../../shared/utilities/timeoutUtils'
 import {
@@ -189,7 +189,7 @@ describe('SsoAccessTokenProvider', function () {
     describe('createToken', function () {
         beforeEach(function () {
             getTestWindow().onDidShowMessage(m => {
-                if (m.items[0]?.title.match(/copy code/i)) {
+                if (m.items[0]?.title.match(proceedToBrowser)) {
                     m.items[0].select()
                 }
             })


### PR DESCRIPTION
Problem:

Before this commit, the BuilderID/Identity Center sso flow
would require the user to copy a code and paste it in the
browser window to confirm their device.

Solution:

Now, with new changes from the identity team, if we pass
the device code in the URL a different flow will be shown
in the browser which asks them to instead confirm the
code instead of pasting it.

- This commit has users go through the new flow
- Copying code functionality is removed
- The information messages are updated to mention the requirement
  to confirm the code in the browser

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## Steps

#### This appears first

![Screenshot 2023-09-15 at 11 09 35 AM](https://github.com/aws/aws-toolkit-vscode/assets/118216176/14918ba6-8655-45ca-ba02-744cceb6de05)

#### Then the user is brought to the web page
![Screenshot 2023-09-15 at 11 09 48 AM](https://github.com/aws/aws-toolkit-vscode/assets/118216176/659e4535-3bd4-4463-8e8b-ecf48f2ed827)

#### If the user forgets the code before clicking `Confirm and Continue` and they go back to the IDE, they will see this message 
![Screenshot 2023-09-15 at 11 09 17 AM](https://github.com/aws/aws-toolkit-vscode/assets/118216176/ffee443b-063a-447d-a665-6c6111907a30)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
