### PR TITLE
codecatalyst: fix e2e test throttling

### DIFF
--- a/src/testE2E/codecatalyst/client.test.ts
+++ b/src/testE2E/codecatalyst/client.test.ts
@@ -601,6 +601,12 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
         devEnv: GetDevEnvironmentRequest,
         status: DevEnvironment['status'][]
     ): Promise<void> {
+        /**
+         * It currently takes a long time for a dev env to stop (currently >1 minute). So
+         * for this special case, we increase the time of interval that we check it has stopped.
+         */
+        const intervalToCheck = status.includes('STOPPED') ? 20_000 : 5000
+
         const result = await waitUntil(
             async function () {
                 const devEnvData = await client.getDevEnvironment({
@@ -611,7 +617,7 @@ describe('Test how this codebase uses the CodeCatalyst API', function () {
                 return status.includes(devEnvData.status)
             },
             {
-                interval: 1000,
+                interval: intervalToCheck,
                 timeout: 120000,
             }
         )


### PR DESCRIPTION
Problem:

Our tests are being throttled during the E2E CI

Solution:

Reduce the amount of API requests we make when waiting for a dev env to delete. Before this commit we checked if a dev env was deleted every second, but it typically takes >1 minute to delete.

So this commit increases the amount of time till the next check from 1 second to 20 seconds.

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
