### PR TITLE
CodeWhisperer: Fix multiple issues around reporting CodePercentage

### DIFF
--- a/.changes/next-release/Bug Fix-ed09954c-a35f-49d8-bc1f-7fa255110abf.json
+++ b/.changes/next-release/Bug Fix-ed09954c-a35f-49d8-bc1f-7fa255110abf.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeWhisperer: Fixed an issue where sometimes the suggestions are not matching the current editor context."
+}

--- a/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
+++ b/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
@@ -195,7 +195,7 @@ describe('codewhispererCodecoverageTracker', function () {
             assert.ok(!spy.called)
         })
 
-        it('Should increase both AcceptedTokens and TotalTokens', function () {
+        it('Should increase AcceptedTokens', function () {
             if (!tracker) {
                 assert.fail()
             }
@@ -205,7 +205,6 @@ describe('codewhispererCodecoverageTracker', function () {
                 text: 'a',
                 accepted: 1,
             })
-            assert.strictEqual(tracker.totalTokens['test.py'], 1)
         })
     })
 
@@ -284,6 +283,7 @@ describe('codewhispererCodecoverageTracker', function () {
                     },
                 ],
             })
+            assert.strictEqual(tracker?.totalTokens[doc.fileName], 3)
             tracker.countTotalTokens({
                 reason: undefined,
                 document: doc,
@@ -296,7 +296,7 @@ describe('codewhispererCodecoverageTracker', function () {
                     },
                 ],
             })
-            assert.strictEqual(tracker?.totalTokens[doc.fileName], 2)
+            assert.strictEqual(tracker?.totalTokens[doc.fileName], 3)
         })
 
         it('Should add tokens when type', function () {

--- a/src/test/codewhisperer/util/telemetryHelper.test.ts
+++ b/src/test/codewhisperer/util/telemetryHelper.test.ts
@@ -136,7 +136,7 @@ describe('telemetryHelper', function () {
                 ])
             )
 
-            sut.sendUserTriggerDecisionTelemetry('aFakeSessionId', aCompletion().content)
+            sut.sendUserTriggerDecisionTelemetry('aFakeSessionId', aCompletion().content, 0)
             const assertTelemetry = assertTelemetryCurried('codewhisperer_userTriggerDecision')
             assertTelemetry({
                 codewhispererSessionId: 'aFakeSessionId',
@@ -169,7 +169,7 @@ describe('telemetryHelper', function () {
                 ])
             )
 
-            sut.sendUserTriggerDecisionTelemetry('aFakeSessionId', aCompletion().content)
+            sut.sendUserTriggerDecisionTelemetry('aFakeSessionId', aCompletion().content, 0)
             const assertTelemetry = assertTelemetryCurried('codewhisperer_userTriggerDecision')
             assertTelemetry({
                 codewhispererSessionId: 'aFakeSessionId',
@@ -202,7 +202,7 @@ describe('telemetryHelper', function () {
                 ])
             )
 
-            sut.sendUserTriggerDecisionTelemetry('aFakeSessionId', aCompletion().content)
+            sut.sendUserTriggerDecisionTelemetry('aFakeSessionId', aCompletion().content, 0)
             const assertTelemetry = assertTelemetryCurried('codewhisperer_userTriggerDecision')
             assertTelemetry({
                 codewhispererSessionId: 'aFakeSessionId',


### PR DESCRIPTION
1. Add the logic to compute generatedLines count, this will enable reporting the correct count of lines from CodeWhisperer. Making it a local computation.
2. Remove the 20 chars check in countTotalTokens(). This will enable the tracker timer to start whenever there's a change.
3. Remove an additional addTotalToken() call when accepting CodeWhisperer suggestions, this avoids double counting the total tokens when accepting CW suggetions.
4. Fix an issue where the referenceCount for each trigger is not reset after assigned. Removed the global and make it a local computation.
5. Ignore deletion events when computing total tokens, since it's non trivial to track the deletion of CW suggestions. This implictly makes the metric to track the code percentage of CW suggestion among all the code user generates.

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
