### PR TITLE
Revert "build(deps): bump the github-actions group with 1 update (#38…

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -37,7 +37,7 @@ jobs:
                   # Unset NODE_OPTIONS because of https://github.com/codecov/uploader/issues/475
                   NODE_OPTIONS: ''
               if: ${{ github.repository == 'aws/aws-toolkit-vscode' && ( github.ref == 'master' || github.event_name == 'pull_request' ) }}
-              uses: codecov/codecov-action@v4
+              uses: codecov/codecov-action@v3
               with:
                   verbose: true
                   file: ./coverage/coverage-final.json
@@ -47,7 +47,7 @@ jobs:
                   # Unset NODE_OPTIONS because of https://github.com/codecov/uploader/issues/475
                   NODE_OPTIONS: ''
               if: ${{ github.repository == 'aws/aws-toolkit-vscode' && ( github.ref == 'master' || github.event_name == 'pull_request' ) }}
-              uses: codecov/codecov-action@v4
+              uses: codecov/codecov-action@v3
               with:
                   verbose: true
                   file: ./coverage/coverage-final.json
@@ -77,7 +77,7 @@ jobs:
                   # Unset NODE_OPTIONS because of https://github.com/codecov/uploader/issues/475
                   NODE_OPTIONS: ''
               if: ${{ github.repository == 'aws/aws-toolkit-vscode' && ( github.ref == 'master' || github.event_name == 'pull_request' ) }}
-              uses: codecov/codecov-action@v4
+              uses: codecov/codecov-action@v3
               with:
                   verbose: true
                   file: ./coverage/coverage-final.json


### PR DESCRIPTION
## Problem:
Our CI is broken due to the following.

The github action `codecov/codecov-action@v4` does not exist, and our github CI is showing the error:

`Error: Unable to resolve action 'codecov/codecov-action@v4', unable to find version 'v4'`

v4 is still in beta so it should look like this if we wanted to use v4: `codecov/codecov-action@v4.0.0-beta.2` from https://github.com/marketplace/actions/codecov?version=v4.0.0-beta.2

## Solution
Revert back to v3


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
