### PR TITLE
codewhisperer: loading status bar stuck on expired credentials

### DIFF
--- a/.changes/next-release/Bug Fix-ac5446a2-e6dd-4e85-b27c-cf8f75ae5aa1.json
+++ b/.changes/next-release/Bug Fix-ac5446a2-e6dd-4e85-b27c-cf8f75ae5aa1.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeWhisperer: fixed case where 'CodeWhisperer' status bar stuck loading"
+}

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -85,7 +85,6 @@ export class InlineCompletionService {
         // Call report user decisions once to report recommendations leftover from last invocation.
         RecommendationHandler.instance.reportUserDecisions(-1)
 
-        this.setCodeWhispererStatusBarLoading()
         if (ClassifierTrigger.instance.shouldInvokeClassifier(editor.document.languageId)) {
             ClassifierTrigger.instance.recordClassifierResultForAutoTrigger(editor, autoTriggerType, event)
         }
@@ -98,6 +97,9 @@ export class InlineCompletionService {
             await AuthUtil.instance.notifyReauthenticate(isAutoTrigger)
             return
         }
+
+        this.setCodeWhispererStatusBarLoading()
+
         TelemetryHelper.instance.setInvocationStartTime(performance.now())
         RecommendationHandler.instance.checkAndResetCancellationTokens()
         RecommendationHandler.instance.documentUri = editor.document.uri


### PR DESCRIPTION
## Problem:

- The function `getPaginatedRecommendation()` sets the CW status bar to loading when it starts to run.
- But it will return early if `AuthUtil.instance.isConnectionExpired()` returns true.
- The issue is when we return early we do not revert the loading status and the status bar is stuck loading.

## Solution:
- Set the status bar to loading after `AuthUtil.instance.isConnectionExpired()` check

### Gif of status bar stuck loading
![Kapture 2023-09-21 at 12 40 37](https://github.com/aws/aws-toolkit-vscode/assets/118216176/7b64c305-bb00-4df9-825d-c56568023dcc)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
