### PR TITLE
feat(sam nodejs debug): don't break on async_hooks

### DIFF
--- a/.changes/next-release/Bug Fix-9fb78a30-8692-4ed2-925b-18906bef1da8.json
+++ b/.changes/next-release/Bug Fix-9fb78a30-8692-4ed2-925b-18906bef1da8.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "SAM: Debugging a nodejs Lambda always hits breakpoint in nodejs async_hooks module before reaching the user-specified breakpoint"
+}

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -586,6 +586,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 protocol: 'inspector',
                 remoteRoot: '/var/task',
                 skipFiles: ['/var/runtime/node_modules/**/*.js', '<node_internals>/**/*.js'],
+                continueOnAttach: true,
                 stopOnEntry: false,
             }
 
@@ -739,6 +740,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 protocol: 'inspector',
                 remoteRoot: '/var/task',
                 skipFiles: ['/var/runtime/node_modules/**/*.js', '<node_internals>/**/*.js'],
+                continueOnAttach: true,
                 stopOnEntry: false,
             }
 
@@ -893,6 +895,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 protocol: 'inspector',
                 remoteRoot: '/var/task',
                 skipFiles: ['/var/runtime/node_modules/**/*.js', '<node_internals>/**/*.js'],
+                continueOnAttach: true,
                 stopOnEntry: false,
             }
 
@@ -995,7 +998,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 baseBuildDir: actual.baseBuildDir, // Random, sanity-checked by assertEqualLaunchConfigs().
                 containerEnvFile: `${actual.baseBuildDir}/container-env-vars.json`,
                 containerEnvVars: {
-                    NODE_OPTIONS: `--inspect-brk=0.0.0.0:${actual.debugPort} --max-http-header-size 81920`,
+                    NODE_OPTIONS: `--inspect=0.0.0.0:${actual.debugPort} --max-http-header-size 81920`,
                 },
                 envFile: undefined,
                 eventPayloadFile: undefined,
@@ -1025,6 +1028,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 protocol: 'inspector',
                 remoteRoot: '/var/task',
                 skipFiles: ['/var/runtime/node_modules/**/*.js', '<node_internals>/**/*.js'],
+                continueOnAttach: true,
                 stopOnEntry: false,
                 parameterOverrides: undefined,
             }
@@ -1032,7 +1036,7 @@ describe('SamDebugConfigurationProvider', async function () {
             assertEqualLaunchConfigs(actual, expected)
             assertFileText(
                 expected.containerEnvFile!,
-                `{"NODE_OPTIONS":"--inspect-brk=0.0.0.0:${actual.debugPort} --max-http-header-size 81920"}`
+                `{"NODE_OPTIONS":"--inspect=0.0.0.0:${actual.debugPort} --max-http-header-size 81920"}`
             )
 
             //
@@ -1159,6 +1163,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 protocol: 'inspector',
                 remoteRoot: '/var/task',
                 skipFiles: ['/var/runtime/node_modules/**/*.js', '<node_internals>/**/*.js'],
+                continueOnAttach: true,
                 stopOnEntry: false,
                 parameterOverrides: undefined,
             }
@@ -2928,6 +2933,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 runtime: 'nodejs12.x',
                 runtimeFamily: lambdaModel.RuntimeFamily.NodeJS,
                 skipFiles: ['/var/runtime/node_modules/**/*.js', '<node_internals>/**/*.js'],
+                continueOnAttach: true,
                 stopOnEntry: false,
             }
 


### PR DESCRIPTION
# Problem:
Debugging a nodejs sam lambda always breaks at the nodejs internal module `internal/async_hooks` before reaching the first user-specified breakpoint. This is an old problem with `--inspect-brk`. #2758

# Solution:
- For "Image" packagetype, send `NODE_OPTIONS=--inspect=…` in the container environment variables instead of  `--inspect-brk`.
- For "Zip" packagetype set the `continueOnAttach` vscode nodejs debugger option, to workaround sam cli's hardcoded NODE_OPTIONS: https://github.com/aws/aws-sam-cli/blob/1adc080b82476288804c41c553c5e2ad86f28298/samcli/local/docker/lambda_debug_settings.py#L165

# Testing

- Tested with node 14/16/18, python 3.10/3.11, "Image" and "Zip" packagetypes.
- Tested local and CodeCatalyst dev env.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
