### PR TITLE
fix(sam): deprecate nodejs 12.x

### DIFF
--- a/.changes/next-release/Deprecation-e6ff982b-e562-4803-be2e-84e8a4c29eea.json
+++ b/.changes/next-release/Deprecation-e6ff982b-e562-4803-be2e-84e8a4c29eea.json
@@ -1,0 +1,4 @@
+{
+	"type": "Deprecation",
+	"description": "SAM: removed support for Node.js 12.x [Lambda runtime](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)"
+}

--- a/README.quickstart.cloud9.md
+++ b/README.quickstart.cloud9.md
@@ -88,7 +88,7 @@ When you're satisfied with performance, you can [deploy your serverless applicat
 
 The Toolkit _local SAM debugging_ feature supports these runtimes:
 
--   JavaScript (Node.js 12.x, 14.x)
+-   JavaScript (Node.js 14.x, 16.x)
 -   Python (3.7, 3.8, 3.9, 3.10, 3.11)
 
 For more information see [Working with AWS Serverless Applications](https://docs.aws.amazon.com/cloud9/latest/user-guide/serverless-apps-toolkit.html) in the user guide.

--- a/src/apprunner/wizards/codeRepositoryWizard.ts
+++ b/src/apprunner/wizards/codeRepositoryWizard.ts
@@ -88,7 +88,7 @@ function createBranchPrompter(
 function createRuntimePrompter(): QuickPickPrompter<AppRunner.Runtime> {
     const items = [
         { label: 'python3', data: 'PYTHON_3' },
-        { label: 'nodejs12', data: 'NODEJS_12' },
+        { label: 'nodejs12', data: 'NODEJS_16' },
     ]
 
     return createQuickPick(items, {

--- a/src/lambda/models/samLambdaRuntime.ts
+++ b/src/lambda/models/samLambdaRuntime.ts
@@ -28,12 +28,7 @@ export type RuntimePackageType = 'Image' | 'Zip'
 
 // TODO: Consolidate all of the runtime constructs into a single <Runtime, Set<Runtime>> map
 //       We should be able to eliminate a fair amount of redundancy with that.
-export const nodeJsRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>([
-    'nodejs18.x',
-    'nodejs16.x',
-    'nodejs14.x',
-    'nodejs12.x',
-])
+export const nodeJsRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>(['nodejs18.x', 'nodejs16.x', 'nodejs14.x'])
 export function getNodeMajorVersion(version?: string): number | undefined {
     if (!version) {
         return undefined
@@ -98,7 +93,6 @@ export const samArmLambdaRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>
     'nodejs18.x',
     'nodejs16.x',
     'nodejs14.x',
-    'nodejs12.x',
     'java11',
     'java8.al2',
 ])

--- a/src/lambda/models/samTemplates.ts
+++ b/src/lambda/models/samTemplates.ts
@@ -131,5 +131,5 @@ export function supportsStepFuntionsTemplate(samCliVersion: string): boolean {
 }
 
 export function supportsTypeScriptBackendTemplate(runtime: Runtime): boolean {
-    return runtime === 'nodejs12.x'
+    return runtime === 'nodejs16.x'
 }

--- a/src/test/lambda/models/samLambdaRuntime.test.ts
+++ b/src/test/lambda/models/samLambdaRuntime.test.ts
@@ -22,9 +22,9 @@ describe('compareSamLambdaRuntime', async function () {
         lowerRuntime: Runtime
         higherRuntime: Runtime
     }[] = [
-        { lowerRuntime: 'nodejs12.x', higherRuntime: 'nodejs14.x' },
-        { lowerRuntime: 'nodejs14.x', higherRuntime: 'nodejs14.x (Image)' },
-        { lowerRuntime: 'nodejs12.x (Image)', higherRuntime: 'nodejs14.x' },
+        { lowerRuntime: 'nodejs14.x', higherRuntime: 'nodejs16.x' },
+        { lowerRuntime: 'nodejs16.x', higherRuntime: 'nodejs16.x (Image)' },
+        { lowerRuntime: 'nodejs14.x (Image)', higherRuntime: 'nodejs16.x' },
     ]
 
     scenarios.forEach(scenario => {
@@ -69,7 +69,6 @@ describe('getFamily', function () {
 describe('runtimes', function () {
     it('cloud9', function () {
         assert.deepStrictEqual(samLambdaCreatableRuntimes(true).toArray().sort(), [
-            'nodejs12.x',
             'nodejs14.x',
             'nodejs16.x',
             'nodejs18.x',
@@ -80,7 +79,6 @@ describe('runtimes', function () {
             'python3.9',
         ])
         assert.deepStrictEqual(samImageLambdaRuntimes(true).toArray().sort(), [
-            'nodejs12.x',
             'nodejs14.x',
             'nodejs16.x',
             'nodejs18.x',
@@ -99,7 +97,6 @@ describe('runtimes', function () {
             'java11',
             'java8',
             'java8.al2',
-            'nodejs12.x',
             'nodejs14.x',
             'nodejs16.x',
             'nodejs18.x',
@@ -117,7 +114,6 @@ describe('runtimes', function () {
             'java11',
             'java8',
             'java8.al2',
-            'nodejs12.x',
             'nodejs14.x',
             'nodejs16.x',
             'nodejs18.x',
@@ -131,14 +127,9 @@ describe('runtimes', function () {
 })
 
 describe('getNodeMajorVersion()', () => {
-    it('returns 12 on "nodejs12.x"', () => {
-        const version = getNodeMajorVersion('nodejs12.x')
-        assert.strictEqual(version, 12)
-    })
-
-    it('returns 18 on "nodejs18.x"', () => {
-        const version = getNodeMajorVersion('nodejs18.x')
-        assert.strictEqual(version, 18)
+    it('returns node version', () => {
+        assert.strictEqual(getNodeMajorVersion('nodejs12.x'), 12)
+        assert.strictEqual(getNodeMajorVersion('nodejs18.x'), 18)
     })
 
     it('returns undefined on invalid input', () => {

--- a/src/test/lambda/models/samTemplates.test.ts
+++ b/src/test/lambda/models/samTemplates.test.ts
@@ -24,7 +24,7 @@ import { samZipLambdaRuntimes } from '../../../lambda/models/samLambdaRuntime'
 
 let validTemplateOptions: Set<SamTemplate>
 let validPythonTemplateOptions: Set<SamTemplate>
-let validNode12TemplateOptions: Set<SamTemplate>
+let validNodeTemplateOptions: Set<SamTemplate>
 let validGoTemplateOptions: Set<SamTemplate>
 let defaultTemplateOptions: Set<SamTemplate>
 
@@ -46,7 +46,7 @@ before(function () {
         stepFunctionsSampleApp,
     ])
 
-    validNode12TemplateOptions = Set([helloWorldTemplate, stepFunctionsSampleApp, typeScriptBackendTemplate])
+    validNodeTemplateOptions = Set([helloWorldTemplate, stepFunctionsSampleApp, typeScriptBackendTemplate])
 
     validGoTemplateOptions = Set([
         helloWorldTemplate,
@@ -74,11 +74,11 @@ describe('getSamTemplateWizardOption', function () {
                         'Python 3.x supports additional template options'
                     )
                     break
-                case 'nodejs12.x':
+                case 'nodejs16.x':
                     assert.deepStrictEqual(
                         result,
-                        validNode12TemplateOptions,
-                        'Node12.x supports default and TS template options'
+                        validNodeTemplateOptions,
+                        'Node supports default and TS template options'
                     )
                     break
                 case 'go1.x':

--- a/src/test/lambda/utils.test.ts
+++ b/src/test/lambda/utils.test.ts
@@ -10,7 +10,7 @@ describe('lambda utils', async function () {
     describe('getLambdaDetails', function () {
         it('returns valid filenames and function names', function () {
             const jsNonNestedParsedName = getLambdaDetails({
-                Runtime: 'nodejs12.x',
+                Runtime: 'nodejs16.x',
                 Handler: 'app.lambda_handler',
             })
             const pyNonNestedParsedName = getLambdaDetails({
@@ -18,7 +18,7 @@ describe('lambda utils', async function () {
                 Handler: 'app.lambda_handler',
             })
             const jsNestedParsedName = getLambdaDetails({
-                Runtime: 'nodejs12.x',
+                Runtime: 'nodejs16.x',
                 Handler: 'asdf/jkl/app.lambda_handler',
             })
             const node18ModuleParsedName = getLambdaDetails({

--- a/src/test/shared/cloudformation/yaml/template_api_endpoint_configuration.yaml
+++ b/src/test/shared/cloudformation/yaml/template_api_endpoint_configuration.yaml
@@ -15,7 +15,7 @@ Resources:
         Properties:
             CodeUri: s3://sam-demo-bucket/member_portal.zip
             Handler: index.gethtml
-            Runtime: nodejs12.x
+            Runtime: nodejs18.x
             Events:
                 GetHtml:
                     Type: Api

--- a/src/test/shared/cloudformation/yaml/template_api_request_model.yaml
+++ b/src/test/shared/cloudformation/yaml/template_api_request_model.yaml
@@ -6,7 +6,7 @@ Resources:
         Properties:
             CodeUri: s3://sam-demo-bucket/member_portal.zip
             Handler: index.gethtml
-            Runtime: nodejs12.x
+            Runtime: nodejs18.x
             Events:
                 GetHtml:
                     Type: Api

--- a/src/test/shared/fs/templateRegistry.test.ts
+++ b/src/test/shared/fs/templateRegistry.test.ts
@@ -124,7 +124,7 @@ describe('CloudFormation Template Registry', async function () {
         Properties: {
             Handler: 'index.handler',
             CodeUri: path.join(nestedPath),
-            Runtime: 'nodejs12.x',
+            Runtime: 'nodejs16.x',
         },
     }
     const nonParentTemplate = {
@@ -379,7 +379,7 @@ describe('CloudFormation Template Registry', async function () {
                 ...resource,
                 ...{
                     Metadata: {
-                        DockerTag: 'nodejs12.x-v1',
+                        DockerTag: 'nodejs16.x-v1',
                         DockerContext: './hello-world',
                         Dockerfile: 'Dockerfile',
                     },
@@ -390,7 +390,7 @@ describe('CloudFormation Template Registry', async function () {
                 ...resource,
                 ...{
                     Metadata: {
-                        DockerTag: 'nodejs12.x-v1',
+                        DockerTag: 'nodejs16.x-v1',
                         DockerContext: './hello-world/nested',
                         Dockerfile: 'Dockerfile',
                     },

--- a/src/test/shared/sam/debugger/awsSamDebugConfigurationValidator.test.ts
+++ b/src/test/shared/sam/debugger/awsSamDebugConfigurationValidator.test.ts
@@ -42,7 +42,7 @@ function createImageTemplateConfig(): AwsSamDebuggerConfiguration {
             logicalId: 'TestResource',
         },
         lambda: {
-            runtime: 'nodejs12.x',
+            runtime: 'nodejs18.x',
         },
     }
 }

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -489,7 +489,7 @@ describe('SamDebugConfigurationProvider', async function () {
         })
 
         it('supports workspace-relative template path ("./foo.yaml")', async function () {
-            testutil.toFile(makeSampleSamTemplateYaml(true, { runtime: 'nodejs12.x' }), tempFile.fsPath)
+            testutil.toFile(makeSampleSamTemplateYaml(true, { runtime: 'nodejs18.x' }), tempFile.fsPath)
             // Register with *full* path.
             await globals.templateRegistry.addItemToRegistry(tempFile)
             // Simulates launch.json:
@@ -530,7 +530,7 @@ describe('SamDebugConfigurationProvider', async function () {
                     projectRoot: 'src',
                 },
                 lambda: {
-                    runtime: 'nodejs12.x',
+                    runtime: 'nodejs18.x',
                     // For target=code these envvars are written to the input-template.yaml.
                     environmentVariables: {
                         'test-envvar-1': 'test value 1',
@@ -551,7 +551,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 type: AWS_SAM_DEBUG_TYPE,
                 awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
-                runtime: 'nodejs12.x',
+                runtime: 'nodejs18.x',
                 runtimeFamily: lambdaModel.RuntimeFamily.NodeJS,
                 useIkpdb: false,
                 workspaceFolder: {
@@ -605,7 +605,7 @@ describe('SamDebugConfigurationProvider', async function () {
       Handler: my.test.handler
       CodeUri: >-
         ${expected.codeRoot}
-      Runtime: nodejs12.x
+      Runtime: nodejs18.x
       Environment:
         Variables:
           test-envvar-1: test value 1
@@ -682,7 +682,7 @@ describe('SamDebugConfigurationProvider', async function () {
                     projectRoot: 'src',
                 },
                 lambda: {
-                    runtime: 'nodejs12.x',
+                    runtime: 'nodejs18.x',
                     // For target=code these envvars are written to the input-template.yaml.
                     environmentVariables: {
                         'test-envvar-1': 'test value 1',
@@ -703,7 +703,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 type: AWS_SAM_DEBUG_TYPE,
                 awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
-                runtime: 'nodejs12.x',
+                runtime: 'nodejs18.x',
                 runtimeFamily: lambdaModel.RuntimeFamily.NodeJS,
                 useIkpdb: false,
                 workspaceFolder: {
@@ -759,7 +759,7 @@ describe('SamDebugConfigurationProvider', async function () {
       Handler: app.handler
       CodeUri: >-
         ${expected.codeRoot}
-      Runtime: nodejs12.x
+      Runtime: nodejs18.x
       Environment:
         Variables:
           test-envvar-1: test value 1
@@ -976,7 +976,7 @@ describe('SamDebugConfigurationProvider', async function () {
                     logicalId: 'HelloWorldFunction',
                 },
                 lambda: {
-                    runtime: 'nodejs12.x',
+                    runtime: 'nodejs18.x',
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
@@ -987,7 +987,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 type: AWS_SAM_DEBUG_TYPE,
                 awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
-                runtime: 'nodejs12.x',
+                runtime: 'nodejs18.x',
                 runtimeFamily: lambdaModel.RuntimeFamily.NodeJS,
                 useIkpdb: false,
                 workspaceFolder: {
@@ -2874,7 +2874,7 @@ describe('SamDebugConfigurationProvider', async function () {
             testutil.toFile(
                 makeSampleSamTemplateYaml(true, {
                     resourceName: resourceName,
-                    runtime: 'nodejs12.x',
+                    runtime: 'nodejs18.x',
                     handler: 'my.test.handler',
                     codeUri: 'codeuri',
                 }),
@@ -2930,7 +2930,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 protocol: 'inspector',
                 remoteRoot: '/var/task',
                 request: 'attach', // Input "direct-invoke", output "attach".
-                runtime: 'nodejs12.x',
+                runtime: 'nodejs18.x',
                 runtimeFamily: lambdaModel.RuntimeFamily.NodeJS,
                 skipFiles: ['/var/runtime/node_modules/**/*.js', '<node_internals>/**/*.js'],
                 continueOnAttach: true,

--- a/src/testFixtures/workspaceFolder/js-image-sam-app/hello-world/Dockerfile
+++ b/src/testFixtures/workspaceFolder/js-image-sam-app/hello-world/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/nodejs:12
+FROM public.ecr.aws/lambda/nodejs:18
 
 COPY app.js package.json ./
 

--- a/src/testFixtures/workspaceFolder/ts-plain-sam-app/template.yaml
+++ b/src/testFixtures/workspaceFolder/ts-plain-sam-app/template.yaml
@@ -4,4 +4,4 @@ Resources:
         Properties:
             CodeUri: src
             Handler: dist/app.handler
-            Runtime: nodejs12.x
+            Runtime: nodejs18.x


### PR DESCRIPTION
No longer supported by Lambda.
https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
