### PR TITLE
CodeWhisperer: Add telemetry optout status to SendTelemetryEventRequest

### DIFF
--- a/src/codewhisperer/client/codewhisperer.ts
+++ b/src/codewhisperer/client/codewhisperer.ts
@@ -193,10 +193,14 @@ export class DefaultCodeWhispererClient {
     }
 
     public async sendTelemetryEvent(request: SendTelemetryEventRequest) {
+        const requestWithOptOut: SendTelemetryEventRequest = {
+            ...request,
+            optOutPreference: globals.telemetry.telemetryEnabled ? 'OPTIN' : 'OPTOUT',
+        }
         if (!AuthUtil.instance.isValidEnterpriseSsoInUse()) {
             return
         }
-        const response = await (await this.createUserSdkClient()).sendTelemetryEvent(request).promise()
+        const response = await (await this.createUserSdkClient()).sendTelemetryEvent(requestWithOptOut).promise()
         getLogger().debug(`codewhisperer: sendTelemetryEvent requestID: ${response.$response.requestId}`)
     }
 }

--- a/src/codewhisperer/client/user-service-2.json
+++ b/src/codewhisperer/client/user-service-2.json
@@ -165,8 +165,8 @@
             "required": ["programmingLanguage", "acceptedCharacterCount", "totalCharacterCount", "timestamp"],
             "members": {
                 "programmingLanguage": { "shape": "ProgrammingLanguage" },
-                "acceptedCharacterCount": { "shape": "Integer" },
-                "totalCharacterCount": { "shape": "Integer" },
+                "acceptedCharacterCount": { "shape": "SensitiveInteger" },
+                "totalCharacterCount": { "shape": "SensitiveInteger" },
                 "timestamp": { "shape": "Timestamp" }
             }
         },
@@ -201,7 +201,8 @@
         },
         "CompletionType": {
             "type": "string",
-            "enum": ["BLOCK", "LINE"]
+            "enum": ["BLOCK", "LINE"],
+            "sensitive": true
         },
         "Completions": {
             "type": "list",
@@ -239,10 +240,6 @@
                 "kmsKeyArn": { "shape": "ResourceArn" }
             }
         },
-        "Double": {
-            "type": "double",
-            "box": true
-        },
         "FileContext": {
             "type": "structure",
             "required": ["leftFileContent", "rightFileContent", "filename", "programmingLanguage"],
@@ -256,7 +253,8 @@
         "FileContextFilenameString": {
             "type": "string",
             "max": 1024,
-            "min": 1
+            "min": 1,
+            "sensitive": true
         },
         "FileContextLeftFileContentString": {
             "type": "string",
@@ -343,10 +341,6 @@
             "max": 10,
             "min": 0
         },
-        "Integer": {
-            "type": "integer",
-            "box": true
-        },
         "InternalServerException": {
             "type": "structure",
             "required": ["message"],
@@ -378,6 +372,11 @@
                 "nextToken": { "shape": "PaginationToken" },
                 "codeAnalysisFindings": { "shape": "String" }
             }
+        },
+        "OptOutPreference": {
+            "type": "string",
+            "enum": ["OPTIN", "OPTOUT"],
+            "sensitive": true
         },
         "PaginationToken": {
             "type": "string",
@@ -465,12 +464,21 @@
                     "shape": "IdempotencyToken",
                     "idempotencyToken": true
                 },
-                "telemetryEvent": { "shape": "TelemetryEvent" }
+                "telemetryEvent": { "shape": "TelemetryEvent" },
+                "optOutPreference": { "shape": "OptOutPreference" }
             }
         },
         "SendTelemetryEventResponse": {
             "type": "structure",
             "members": {}
+        },
+        "SensitiveDouble": {
+            "type": "double",
+            "sensitive": true
+        },
+        "SensitiveInteger": {
+            "type": "integer",
+            "sensitive": true
         },
         "Span": {
             "type": "structure",
@@ -523,7 +531,8 @@
         "String": { "type": "string" },
         "SuggestionState": {
             "type": "string",
-            "enum": ["ACCEPT", "REJECT", "DISCARD", "EMPTY"]
+            "enum": ["ACCEPT", "REJECT", "DISCARD", "EMPTY"],
+            "sensitive": true
         },
         "SupplementalContext": {
             "type": "structure",
@@ -588,7 +597,7 @@
                 "sessionId": { "shape": "UUID" },
                 "requestId": { "shape": "UUID" },
                 "programmingLanguage": { "shape": "ProgrammingLanguage" },
-                "modificationPercentage": { "shape": "Double" },
+                "modificationPercentage": { "shape": "SensitiveDouble" },
                 "timestamp": { "shape": "Timestamp" }
             }
         },
@@ -609,10 +618,10 @@
                 "programmingLanguage": { "shape": "ProgrammingLanguage" },
                 "completionType": { "shape": "CompletionType" },
                 "suggestionState": { "shape": "SuggestionState" },
-                "recommendationLatencyMilliseconds": { "shape": "Double" },
+                "recommendationLatencyMilliseconds": { "shape": "SensitiveDouble" },
                 "timestamp": { "shape": "Timestamp" },
-                "suggestionReferenceCount": { "shape": "Integer" },
-                "generatedLine": { "shape": "Integer" }
+                "suggestionReferenceCount": { "shape": "SensitiveInteger" },
+                "generatedLine": { "shape": "SensitiveInteger" }
             }
         },
         "ValidationException": {

--- a/src/test/codewhisperer/service/codewhisperer.test.ts
+++ b/src/test/codewhisperer/service/codewhisperer.test.ts
@@ -1,0 +1,97 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import sinon from 'sinon'
+import { anyString, spy } from '../../utilities/mockito'
+import { codeWhispererClient } from '../../../codewhisperer/client/codewhisperer'
+import CodeWhispererUserClient, {
+    SendTelemetryEventResponse,
+    TelemetryEvent,
+} from '../../../codewhisperer/client/codewhispereruserclient'
+import globals from '../../../shared/extensionGlobals'
+import { AWSError, Request } from 'aws-sdk'
+
+describe('codewhisperer', async function () {
+    let clientSpy: CodeWhispererUserClient
+    let telemetryEnabledDefault: boolean
+
+    beforeEach(async function () {
+        sinon.restore()
+        clientSpy = spy(await codeWhispererClient.createUserSdkClient())
+        sinon.stub(codeWhispererClient, 'createUserSdkClient').returns(Promise.resolve(clientSpy))
+        telemetryEnabledDefault = globals.telemetry.telemetryEnabled
+    })
+
+    afterEach(function () {
+        sinon.restore()
+        globals.telemetry.telemetryEnabled = telemetryEnabledDefault
+    })
+
+    it('sendTelemetryEvent for userTriggerDecision should respect telemetry optout status', async function () {
+        await sendTelemetryEventOptoutCheckHelper({
+            userTriggerDecisionEvent: {
+                sessionId: anyString(),
+                requestId: anyString(),
+                programmingLanguage: { languageName: 'python' },
+                completionType: 'BLOCK',
+                suggestionState: 'ACCEPT',
+                recommendationLatencyMilliseconds: 1,
+                timestamp: new Date(),
+            },
+        })
+    })
+
+    it('sendTelemetryEvent for codeScan should respect telemetry optout status', async function () {
+        await sendTelemetryEventOptoutCheckHelper({
+            codeScanEvent: {
+                programmingLanguage: { languageName: 'python' },
+                codeScanJobId: anyString(),
+                timestamp: new Date(),
+            },
+        })
+    })
+
+    it('sendTelemetryEvent for codePercentage should respect telemetry optout status', async function () {
+        await sendTelemetryEventOptoutCheckHelper({
+            codeCoverageEvent: {
+                programmingLanguage: { languageName: 'python' },
+                acceptedCharacterCount: 0,
+                totalCharacterCount: 1,
+                timestamp: new Date(),
+            },
+        })
+    })
+
+    it('sendTelemetryEvent for userModification should respect telemetry optout status', async function () {
+        await sendTelemetryEventOptoutCheckHelper({
+            userModificationEvent: {
+                sessionId: anyString(),
+                requestId: anyString(),
+                programmingLanguage: { languageName: 'python' },
+                modificationPercentage: 2.0,
+                timestamp: new Date(),
+            },
+        })
+    })
+
+    async function sendTelemetryEventOptoutCheckHelper(payload: TelemetryEvent) {
+        const stub = sinon.stub(clientSpy, 'sendTelemetryEvent').returns({
+            promise: () =>
+                Promise.resolve({
+                    $response: {
+                        requestId: anyString(),
+                    },
+                }),
+        } as Request<SendTelemetryEventResponse, AWSError>)
+
+        globals.telemetry.telemetryEnabled = true
+        await codeWhispererClient.sendTelemetryEvent({ telemetryEvent: payload })
+        sinon.assert.calledWith(stub, sinon.match({ optOutPreference: 'OPTIN' }))
+
+        globals.telemetry.telemetryEnabled = false
+        await codeWhispererClient.sendTelemetryEvent({ telemetryEvent: payload })
+        sinon.assert.calledWith(stub, sinon.match({ optOutPreference: 'OPTOUT' }))
+    }
+})


### PR DESCRIPTION
Updated the API and put the field in SendTelemetryEvent API requests.

Corresponding JB PR: https://github.com/aws/aws-toolkit-jetbrains/pull/3887

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
