### PR TITLE
auth: change Add Connection page Identity Center submit behavior

### DIFF
--- a/src/auth/ui/vue/authForms/manageIdentityCenter.vue
+++ b/src/auth/ui/vue/authForms/manageIdentityCenter.vue
@@ -134,10 +134,14 @@ export default defineComponent({
         async signin(): Promise<void> {
             await client.startAuthFormInteraction(this.state.featureType, 'iamIdentityCenter')
 
-            // Error checks
+            // Return without actually submitting if the form has errors before submitting
             this.updateEmptyFieldErrors()
             const fieldsWithError = this.processFieldsWithError()
-            if (fieldsWithError.length > 0) {
+            // If there is an error in the submission field from a previous attempt we want to allow them to try submitting again
+            // without needing to update the form. There are cases where they may not need to update the form (eg: cancelled manually)
+            // and should be able to submit again
+            const submitErrorExcluded = fieldsWithError.filter(field => field !== 'submit')
+            if (submitErrorExcluded.length > 0) {
                 client.failedAuthAttempt({
                     authType: 'iamIdentityCenter',
                     featureType: this.state.featureType,


### PR DESCRIPTION
## Problem:

When there is an error under the submit button of the Identity Center form for the Add Connection page, the 'sign in' button looks like it is stuck because we expect the user to update the Identity Center form (eg: change the start url) and then allow them to click 'sign in'.

The issue is in certain cases where they have an error but want to retry (eg: cancelled during the sing in process) they are unable to do this.

## Solution:

If an error is detected under the 'sign in' button, which is caused by a previous failed attempt, we will still allow the user to click 'sign in' again.


#### Before
![Kapture 2023-09-27 at 11 59 21](https://github.com/aws/aws-toolkit-vscode/assets/118216176/cf20c3cc-8bf9-4cf8-ae44-bd16d8782beb)

#### After
![Kapture 2023-09-27 at 12 07 18](https://github.com/aws/aws-toolkit-vscode/assets/118216176/0175a2f0-b66b-4a97-b6b7-4cb6d494c350)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
