### PR TITLE
fix(sam): remove .NET core 3.1

### DIFF
--- a/.changes/next-release/Deprecation-f9d02208-eb97-4c44-810c-013fabb4a7d9.json
+++ b/.changes/next-release/Deprecation-f9d02208-eb97-4c44-810c-013fabb4a7d9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Deprecation",
+	"description": "SAM: removed support for .NET core 3.1 [Lambda runtime](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)"
+}

--- a/src/lambda/local/debugConfiguration.ts
+++ b/src/lambda/local/debugConfiguration.ts
@@ -25,7 +25,7 @@ import globals from '../../shared/extensionGlobals'
  * Magic path on the Docker image.
  * https://github.com/aws/aws-sam-cli/blob/2201b17bff0a438b934abbb53f6c76eff9ccfa6d/samcli/local/docker/lambda_container.py#L25
  */
-export const dotnetCoreDebuggerPath = '/tmp/lambci_debug_files/vsdbg'
+export const dotnetDebuggerPath = '/tmp/lambci_debug_files/vsdbg'
 export const goDebuggerPath = '/tmp/lambci_debug_files'
 
 export interface NodejsDebugConfiguration extends SamLaunchRequestArgs {
@@ -68,8 +68,8 @@ export interface PythonCloud9DebugConfiguration extends SamLaunchRequestArgs {
     readonly remoteRoot: string
 }
 
-export interface DotNetCoreDebugConfiguration extends SamLaunchRequestArgs {
-    readonly runtimeFamily: RuntimeFamily.DotNetCore
+export interface DotNetDebugConfiguration extends SamLaunchRequestArgs {
+    readonly runtimeFamily: RuntimeFamily.DotNet
     processName: string
     pipeTransport: PipeTransport
     windows: {
@@ -90,7 +90,7 @@ export interface GoDebugConfiguration extends SamLaunchRequestArgs {
 export interface PipeTransport {
     pipeProgram: 'sh' | 'powershell'
     pipeArgs: string[]
-    debuggerPath: typeof dotnetCoreDebuggerPath
+    debuggerPath: typeof dotnetDebuggerPath
     pipeCwd: string
 }
 

--- a/src/lambda/models/samLambdaRuntime.ts
+++ b/src/lambda/models/samLambdaRuntime.ts
@@ -19,7 +19,7 @@ export enum RuntimeFamily {
     Unknown,
     Python,
     NodeJS,
-    DotNetCore,
+    DotNet,
     Go,
     Java,
 }
@@ -52,7 +52,7 @@ export const pythonRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>([
 ])
 export const goRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>(['go1.x'])
 export const javaRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>(['java11', 'java8', 'java8.al2'])
-export const dotNetRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>(['dotnetcore3.1', 'dotnet6'])
+export const dotNetRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>(['dotnet6'])
 
 /**
  * Deprecated runtimes can be found at https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html
@@ -74,7 +74,7 @@ export const deprecatedRuntimes: ImmutableSet<Runtime> = ImmutableSet<Runtime>([
 const defaultRuntimes = ImmutableMap<RuntimeFamily, Runtime>([
     [RuntimeFamily.NodeJS, 'nodejs14.x'],
     [RuntimeFamily.Python, 'python3.9'],
-    [RuntimeFamily.DotNetCore, 'dotnetcore3.1'],
+    [RuntimeFamily.DotNet, 'dotnet6'],
     [RuntimeFamily.Go, 'go1.x'],
     [RuntimeFamily.Java, 'java11'],
 ])
@@ -143,7 +143,7 @@ export function getFamily(runtime: string): RuntimeFamily {
     } else if (pythonRuntimes.has(runtime)) {
         return RuntimeFamily.Python
     } else if (dotNetRuntimes.has(runtime) || runtime === dotnet50) {
-        return RuntimeFamily.DotNetCore
+        return RuntimeFamily.DotNet
     } else if (goRuntimes.has(runtime)) {
         return RuntimeFamily.Go
     } else if (javaRuntimes.has(runtime)) {
@@ -192,7 +192,7 @@ export function getRuntimeFamily(langId: string): RuntimeFamily {
         case 'javascript':
             return RuntimeFamily.NodeJS
         case 'csharp':
-            return RuntimeFamily.DotNetCore
+            return RuntimeFamily.DotNet
         case 'python':
             return RuntimeFamily.Python
         case 'go':
@@ -219,7 +219,7 @@ function getRuntimesForFamily(family: RuntimeFamily): ImmutableSet<Runtime> | un
             return nodeJsRuntimes
         case RuntimeFamily.Python:
             return pythonRuntimes
-        case RuntimeFamily.DotNetCore:
+        case RuntimeFamily.DotNet:
             return dotNetRuntimes
         case RuntimeFamily.Go:
             return goRuntimes

--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -346,7 +346,7 @@ export async function makeCSharpCodeLensProvider(configuration: SamCliSettings):
                 document,
                 handlers,
                 token,
-                runtimeFamily: RuntimeFamily.DotNetCore,
+                runtimeFamily: RuntimeFamily.DotNet,
             })
         },
     }

--- a/src/shared/sam/cli/samCliValidator.ts
+++ b/src/shared/sam/cli/samCliValidator.ts
@@ -14,7 +14,6 @@ export const minSamCliVersionForImageSupport = '1.13.0'
 export const maxSamCliVersionExclusive = '2.0.0'
 export const minSamCliVersionForGoSupport = '1.18.1'
 export const minSamCliVersionForArmSupport = '1.33.0'
-export const minSamCliVersionForDotnet31Support = '1.4.0'
 
 // Errors
 export class InvalidSamCliError extends ToolkitError {}

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -636,7 +636,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
                 launchConfig = await pythonDebug.makePythonDebugConfig(launchConfig)
                 break
             }
-            case RuntimeFamily.DotNetCore: {
+            case RuntimeFamily.DotNet: {
                 // Make a DotNet launch-config from the generic config.
                 launchConfig = await csharpDebug.makeCsharpConfig(launchConfig)
                 break
@@ -711,7 +711,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
                 config.type = 'python'
                 return await pythonDebug.invokePythonLambda(this.ctx, config as PythonDebugConfiguration)
             }
-            case RuntimeFamily.DotNetCore: {
+            case RuntimeFamily.DotNet: {
                 config.type = 'coreclr'
                 return await csharpDebug.invokeCsharpLambda(this.ctx, config)
             }

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -532,7 +532,7 @@ export function shouldAppendRelativePathToFuncHandler(runtime: string): boolean 
         case RuntimeFamily.NodeJS:
         case RuntimeFamily.Python:
             return true
-        case RuntimeFamily.DotNetCore:
+        case RuntimeFamily.DotNet:
             return false
         // if the runtime exists but for some reason we forgot to cover it here, throw anyway so we remember to cover it
         default:

--- a/src/test/lambda/local/debugConfiguration.test.ts
+++ b/src/test/lambda/local/debugConfiguration.test.ts
@@ -10,7 +10,7 @@ import * as fs from 'fs-extra'
 import { RuntimeFamily } from '../../../lambda/models/samLambdaRuntime'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 import { DefaultSamLocalInvokeCommand } from '../../../shared/sam/cli/samCliLocalInvoke'
-import { makeCoreCLRDebugConfiguration } from '../../../shared/sam/debugger/csharpSamDebug'
+import { makeDotnetDebugConfiguration } from '../../../shared/sam/debugger/csharpSamDebug'
 import * as testutil from '../../testUtil'
 import { SamLaunchRequestArgs } from '../../../shared/sam/debugger/awsSamDebugger'
 import * as pathutil from '../../../shared/utilities/pathUtils'
@@ -43,7 +43,7 @@ describe('makeCoreCLRDebugConfiguration', function () {
             name: 'fake-launch-config',
             workspaceFolder: fakeWorkspaceFolder,
             codeRoot: fakeWorkspaceFolder.uri.fsPath,
-            runtimeFamily: RuntimeFamily.DotNetCore,
+            runtimeFamily: RuntimeFamily.DotNet,
             type: 'coreclr',
             request: 'attach',
             // cfnTemplate?: CloudFormation.Template
@@ -73,7 +73,7 @@ describe('makeCoreCLRDebugConfiguration', function () {
 
     async function makeConfig({ codeUri = tempFolder }: { codeUri?: string; port?: number }) {
         const fakeLaunchConfig = await makeFakeSamLaunchConfig()
-        return makeCoreCLRDebugConfiguration(fakeLaunchConfig, codeUri)
+        return makeDotnetDebugConfiguration(fakeLaunchConfig, codeUri)
     }
 
     describe('windows', function () {
@@ -144,7 +144,7 @@ describe('isImageLambdaConfig', function () {
             name: 'fake-launch-config',
             workspaceFolder: fakeWorkspaceFolder,
             codeRoot: fakeWorkspaceFolder.uri.fsPath,
-            runtimeFamily: RuntimeFamily.DotNetCore,
+            runtimeFamily: RuntimeFamily.DotNet,
             request: 'launch',
             type: 'launch',
             runtime: 'fakedotnet' as Runtime,
@@ -173,7 +173,7 @@ describe('isImageLambdaConfig', function () {
             name: 'fake-launch-config',
             workspaceFolder: fakeWorkspaceFolder,
             codeRoot: fakeWorkspaceFolder.uri.fsPath,
-            runtimeFamily: RuntimeFamily.DotNetCore,
+            runtimeFamily: RuntimeFamily.DotNet,
             request: 'launch',
             type: 'launch',
             runtime: 'fakedotnet' as Runtime,
@@ -199,7 +199,7 @@ describe('isImageLambdaConfig', function () {
             name: 'fake-launch-config',
             workspaceFolder: fakeWorkspaceFolder,
             codeRoot: fakeWorkspaceFolder.uri.fsPath,
-            runtimeFamily: RuntimeFamily.DotNetCore,
+            runtimeFamily: RuntimeFamily.DotNet,
             request: 'launch',
             type: 'launch',
             runtime: 'fakedotnet' as Runtime,

--- a/src/test/lambda/models/samLambdaRuntime.test.ts
+++ b/src/test/lambda/models/samLambdaRuntime.test.ts
@@ -92,7 +92,6 @@ describe('runtimes', function () {
     it('vscode', function () {
         assert.deepStrictEqual(samLambdaCreatableRuntimes(false).toArray().sort(), [
             'dotnet6',
-            'dotnetcore3.1',
             'go1.x',
             'java11',
             'java8',
@@ -109,7 +108,6 @@ describe('runtimes', function () {
         assert.deepStrictEqual(samImageLambdaRuntimes(false).toArray().sort(), [
             'dotnet5.0',
             'dotnet6',
-            'dotnetcore3.1',
             'go1.x',
             'java11',
             'java8',

--- a/src/test/shared/fs/templateRegistry.test.ts
+++ b/src/test/shared/fs/templateRegistry.test.ts
@@ -153,7 +153,7 @@ describe('CloudFormation Template Registry', async function () {
         Properties: {
             Handler: 'Asdf::Asdf.Function::FunctionHandler',
             CodeUri: path.join(nestedPath),
-            Runtime: 'dotnetcore3.1',
+            Runtime: 'dotnet6',
         },
     }
     const dotNetTemplate = {

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -1617,7 +1617,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'dotnet6', // lambdaModel.dotNetRuntimes[0],
-                runtimeFamily: lambdaModel.RuntimeFamily.DotNetCore,
+                runtimeFamily: lambdaModel.RuntimeFamily.DotNet,
                 useIkpdb: false,
                 type: AWS_SAM_DEBUG_TYPE,
                 workspaceFolder: {
@@ -1783,7 +1783,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'dotnet6', // lambdaModel.dotNetRuntimes[0],
-                runtimeFamily: lambdaModel.RuntimeFamily.DotNetCore,
+                runtimeFamily: lambdaModel.RuntimeFamily.DotNet,
                 useIkpdb: false,
                 type: AWS_SAM_DEBUG_TYPE,
                 workspaceFolder: {
@@ -1936,7 +1936,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 awsCredentials: fakeCredentials,
                 request: 'attach', // Input "direct-invoke", output "attach".
                 runtime: 'dotnet6', // lambdaModel.dotNetRuntimes[0],
-                runtimeFamily: lambdaModel.RuntimeFamily.DotNetCore,
+                runtimeFamily: lambdaModel.RuntimeFamily.DotNet,
                 useIkpdb: false,
                 type: AWS_SAM_DEBUG_TYPE,
                 workspaceFolder: {


### PR DESCRIPTION
No longer supported by Lambda.
https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

## Testing

- confirmed no regressions with dotnet6 on a CodeCatalyst dev env (linux)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
