### PR TITLE
codeWhisperer: fix for auto-enable suggestion on window reload and changes in Telemetry events

### DIFF
--- a/src/codewhisperer/commands/basicCommands.ts
+++ b/src/codewhisperer/commands/basicCommands.ts
@@ -22,7 +22,6 @@ import { openUrl } from '../../shared/utilities/vsCodeUtils'
 import { CodeWhispererCommandDeclarations } from '../commands/gettingStartedPageCommands'
 import { getIcon } from '../../shared/icons'
 import { localize } from '../../shared/utilities/vsCodeUtils'
-import { PromptSettings } from '../../shared/settings'
 
 export const toggleCodeSuggestions = Commands.declare(
     'aws.codeWhisperer.toggleCodeSuggestion',
@@ -57,14 +56,6 @@ export const enableCodeSuggestions = Commands.declare(
         await set(CodeWhispererConstants.autoTriggerEnabledKey, true, context.extensionContext.globalState)
         await vscode.commands.executeCommand('setContext', 'CODEWHISPERER_ENABLED', true)
         await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
-        const prompts = PromptSettings.instance
-
-        const shouldShow = await prompts.isPromptEnabled('codeWhispererNewWelcomeMessage')
-        //If user login old or new, If welcome message is not shown then open the Getting Started Page after this mark it as SHOWN.
-        if (shouldShow) {
-            vscode.commands.executeCommand('aws.codeWhisperer.gettingStarted', createGettingStartedNode())
-            prompts.update('codeWhispererNewWelcomeMessage', true)
-        }
         if (!isCloud9()) {
             await vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar')
         }

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -309,6 +309,7 @@ export class RecommendationHandler {
                     latency,
                     session.startPos.line,
                     session.language,
+                    session.taskType,
                     reason,
                     session.requestContext.supplementalMetadata
                 )

--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -72,7 +72,17 @@ export class AuthUtil {
                 vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar'),
                 vscode.commands.executeCommand('aws.codeWhisperer.updateReferenceLog'),
             ])
+            const prompts = PromptSettings.instance
 
+            const shouldShow = await prompts.isPromptEnabled('codeWhispererNewWelcomeMessage')
+            // To check valid connection
+            if (this.isValidEnterpriseSsoInUse() || (this.isBuilderIdInUse() && !this.isConnectionExpired())) {
+                //If user login old or new, If welcome message is not shown then open the Getting Started Page after this mark it as SHOWN.
+                if (shouldShow) {
+                    vscode.commands.executeCommand('aws.codeWhisperer.gettingStarted')
+                    prompts.update('codeWhispererNewWelcomeMessage', true)
+                }
+            }
             await vscode.commands.executeCommand('setContext', 'CODEWHISPERER_ENABLED', this.isConnected())
         })
     }

--- a/src/codewhisperer/util/telemetryHelper.ts
+++ b/src/codewhisperer/util/telemetryHelper.ts
@@ -8,6 +8,7 @@ import { runtimeLanguageContext } from './runtimeLanguageContext'
 import { codeWhispererClient as client, RecommendationsList } from '../client/codewhisperer'
 import { LicenseUtil } from './licenseUtil'
 import {
+    CodewhispererGettingStartedTask,
     CodewhispererLanguage,
     CodewhispererPreviousSuggestionState,
     CodewhispererServiceInvocation,
@@ -86,6 +87,7 @@ export class TelemetryHelper {
         duration: number | undefined,
         lineNumber: number | undefined,
         language: CodewhispererLanguage,
+        taskType: CodewhispererGettingStartedTask | undefined,
         reason: string,
         supplementalContextMetadata?: Omit<CodeWhispererSupplementalContext, 'supplementalContextItems'> | undefined
     ) {
@@ -100,6 +102,7 @@ export class TelemetryHelper {
             codewhispererLineNumber: lineNumber || 0,
             codewhispererCursorOffset: this.cursorOffset || 0,
             codewhispererLanguage: language,
+            CodewhispererGettingStartedTask: taskType,
             reason: reason ? reason.substring(0, 200) : undefined,
             credentialStartUrl: AuthUtil.instance.startUrl,
             codewhispererImportRecommendationEnabled: CodeWhispererSettings.instance.isImportRecommendationEnabled(),
@@ -245,6 +248,7 @@ export class TelemetryHelper {
             credentialStartUrl: events[0].credentialStartUrl,
             codewhispererCompletionType: this.getAggregatedCompletionType(events),
             codewhispererLanguage: events[0].codewhispererLanguage,
+            codewhispererGettingStartedTask: session.taskType,
             codewhispererTriggerType: events[0].codewhispererTriggerType,
             codewhispererSuggestionCount: events.length,
             codewhispererAutomatedTriggerType: serviceInvocation.codewhispererAutomatedTriggerType,
@@ -288,7 +292,7 @@ export class TelemetryHelper {
             credentialStartUrl: this.sessionDecisions[0].credentialStartUrl,
             codewhispererCompletionType: aggregatedCompletionType,
             codewhispererLanguage: language,
-            codewhispererGettingStartedTask: this.sessionDecisions[0].codewhispererGettingStartedTask,
+            codewhispererGettingStartedTask: session.taskType,
             codewhispererTriggerType: this.sessionDecisions[0].codewhispererTriggerType,
             codewhispererSuggestionCount: this.sessionDecisions
                 .map(e => e.codewhispererSuggestionCount)


### PR DESCRIPTION
## Problem

- Auto-Enable suggestion on window reload
- Missing "CodewhispererGettingStartedTask" attribute in both "serviceInvocation" and "userTriggerDecision" events.

## Solution

- Fixed auto enable suggestion on window reload by adding check for Getting started function instead of enable suggestions.
- Added "CodewhispererGettingStartedTask" attribute to "serviceInvocation" and "userTriggerDecision" events.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
