### PR TITLE
feat(codewhisperer): remove unnecessary "Proceed to login" prompt

### DIFF
--- a/.changes/next-release/Feature-359dac4a-ed1e-4b0e-b909-6c450cf639b9.json
+++ b/.changes/next-release/Feature-359dac4a-ed1e-4b0e-b909-6c450cf639b9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "CodeWhisperer: remove unnecessary \"Proceed to login\" prompt"
+}

--- a/src/auth/secondaryAuth.ts
+++ b/src/auth/secondaryAuth.ts
@@ -5,11 +5,7 @@
 
 import globals from '../shared/extensionGlobals'
 
-import * as nls from 'vscode-nls'
-const localize = nls.loadMessageBundle()
-
 import * as vscode from 'vscode'
-import * as localizedText from '../shared/localizedText'
 import { getLogger } from '../shared/logger'
 import { showQuickPick } from '../shared/ui/pickerPrompter'
 import { cast, Optional } from '../shared/utilities/typeConstructors'
@@ -18,7 +14,6 @@ import { once } from '../shared/utilities/functionUtils'
 import { telemetry } from '../shared/telemetry/telemetry'
 import { createExitButton, createHelpButton } from '../shared/ui/buttons'
 import { isNonNullable } from '../shared/utilities/tsUtils'
-import { builderIdStartUrl } from './sso/model'
 import { CancellationError } from '../shared/utilities/timeoutUtils'
 import { Connection, SsoConnection, StatefulConnection } from './connection'
 
@@ -63,22 +58,6 @@ async function promptUseNewConnection(newConn: Connection, oldConn: Connection, 
     }
 
     return resp
-}
-
-async function promptForRescope(conn: SsoConnection, toolLabel: string) {
-    const message = localize(
-        'aws.auth.rescopeConnection.message',
-        '{0} requires access to your {1} connection. Proceed to login to grant {0} access?',
-        toolLabel,
-        conn.startUrl === builderIdStartUrl ? localizedText.builderId() : localizedText.iamIdentityCenter
-    )
-    const resp = await vscode.window.showInformationMessage(message, { modal: true }, localizedText.proceed)
-    if (resp !== localizedText.proceed) {
-        telemetry.ui_click.emit({ elementId: 'connection_rescope_cancel' })
-        throw new CancellationError('user')
-    }
-
-    telemetry.ui_click.emit({ elementId: 'connection_rescope_proceed' })
 }
 
 let oldConn: Auth['activeConnection']
@@ -234,7 +213,6 @@ export class SecondaryAuth<T extends Connection = Connection> {
     }
 
     public async addScopes(conn: T & SsoConnection, extraScopes: string[]) {
-        await promptForRescope(conn, this.toolLabel)
         const oldScopes = conn.scopes ?? []
         const newScopes = Array.from(new Set([...oldScopes, ...extraScopes]))
 


### PR DESCRIPTION
# Problem:
Since https://github.com/aws/aws-toolkit-vscode/pull/3264 if a builder id is already in use by e.g. the CodeCatalyst feature of the Toolkit, clicking `Start` in the CodeWhisperer panel shows an unnecessary (modal!) prompt:

    "CodeWhisperer requires access to your AWS Builder ID connection.
    Proceed to login to grant CodeWhisperer access?"

This prompt is unnecessary because:
1. Customer has already explicitly said they want to login.
2. We don't show such a prompt when starting from zero (which is logically equivalent to "augmenting" an existing builder id connection).
3. The prompt is redundant with the browser flow, which shows the scopes and asks for confirmation.

## Data:

    metric                            unique clients
    --------------------------------|---------------
    connection_rescope_cancel       | 58
    connection_rescope_proceed      | 1155

# Solution:
Remove the prompt.

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
