### PR TITLE
fix(auth): client registration expiry not checked when creating token

### DIFF
--- a/.changes/next-release/Bug Fix-628d74cf-3fbf-4bdd-bf03-93d0992660bf.json
+++ b/.changes/next-release/Bug Fix-628d74cf-3fbf-4bdd-bf03-93d0992660bf.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "BuilderID/IdentityCenter: Fix 'Invalid Client' error in the browser when re-authenticating"
+}

--- a/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/src/auth/sso/ssoAccessTokenProvider.ts
@@ -108,14 +108,15 @@ export class SsoAccessTokenProvider {
     }
 
     private async runFlow() {
-        const cacheKey = this.registrationCacheKey
-        const registration = await loadOr(this.cache.registration, cacheKey, () => this.registerClient())
-
+        const registration = await this.getValidatedClientRegistration()
         try {
             return await this.authorize(registration)
         } catch (err) {
             if (err instanceof SSOOIDCServiceException && isClientFault(err)) {
-                await this.cache.registration.clear(cacheKey, `client fault: SSOOIDCServiceException: ${err.message}`)
+                await this.cache.registration.clear(
+                    this.registrationCacheKey,
+                    `client fault: SSOOIDCServiceException: ${err.message}`
+                )
             }
 
             throw err
@@ -166,6 +167,7 @@ export class SsoAccessTokenProvider {
     }
 
     private async authorize(registration: ClientRegistration) {
+        // This will NOT throw on expired clientId/Secret, but WILL throw on invalid clientId/Secret
         const authorization = await this.oidc.startDeviceAuthorization({
             startUrl: this.profile.startUrl,
             clientId: registration.clientId,
@@ -185,6 +187,23 @@ export class SsoAccessTokenProvider {
 
         const token = await pollForTokenWithProgress(() => this.oidc.createToken(tokenRequest), authorization)
         return this.formatToken(token, registration)
+    }
+
+    /**
+     * If the registration already exists locally, it
+     * will be validated before being returned. Otherwise, a client registration is
+     * created and returned.
+     */
+    private async getValidatedClientRegistration(): Promise<ClientRegistration> {
+        const cacheKey = this.registrationCacheKey
+        const cachedRegistration = await this.cache.registration.load(cacheKey)
+
+        // Clear cached if registration is expired
+        if (cachedRegistration && isExpired(cachedRegistration)) {
+            await this.invalidate()
+        }
+
+        return loadOr(this.cache.registration, cacheKey, () => this.registerClient())
     }
 
     private async registerClient(): Promise<ClientRegistration> {


### PR DESCRIPTION
## Problem:
Users would run in to an `Invalid Client` error screen in the browser when reauthenticating with SSO (BuilderID or Identity Center).

In the scenario a client registration was expired and `SsoAccessTokenProvider.createToken()` was called, the expired client registration would be used to create the new token. This would result in the user being able to make it all the way to the browser web page, verifying their device code, and then they would see the `Invalid Client` error message in the browser.

This scenario was not expected to occurr since it was assumed that `getToken()` would be called before`createToken()` and `getToken()` would do the work of invalidating the expired client registration so that `createToken()` would not need to check if the client registration is expired.

## Solution:

Since we cannot guarantee `createToken()` is always run before `getToken()`, in `createToken()` we will now verify that the client registration is not expired. If it is expired, we will create a new registration then continue with the same process as before.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
