### PR TITLE
CodeWhisperer: Security Issue Hover Provider

### DIFF
--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -50,6 +50,7 @@ import { ImportAdderProvider } from './service/importAdderProvider'
 import { TelemetryHelper } from './util/telemetryHelper'
 import { openUrl } from '../shared/utilities/vsCodeUtils'
 import { CodeWhispererCommandBackend, CodeWhispererCommandDeclarations } from './commands/gettingStartedPageCommands'
+import { SecurityIssueHoverProvider } from './service/securityIssueHoverProvider'
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
 export async function activate(context: ExtContext): Promise<void> {
@@ -202,6 +203,10 @@ export async function activate(context: ExtContext): Promise<void> {
         vscode.languages.registerCodeLensProvider(
             [...CodeWhispererConstants.supportedLanguages, { scheme: 'untitled' }],
             ImportAdderProvider.instance
+        ),
+        vscode.languages.registerHoverProvider(
+            [...CodeWhispererConstants.supportedLanguages],
+            SecurityIssueHoverProvider.instance
         )
     )
 

--- a/src/codewhisperer/service/diagnosticsProvider.ts
+++ b/src/codewhisperer/service/diagnosticsProvider.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode'
 import { CodeScanIssue, AggregatedCodeScanIssue } from '../models/model'
+import { SecurityIssueHoverProvider } from './securityIssueHoverProvider'
 
 interface SecurityScanRender {
     securityDiagnosticCollection: vscode.DiagnosticCollection | undefined
@@ -26,6 +27,7 @@ export function initSecurityScanRender(
         updateSecurityDiagnosticCollection(securityRecommendation)
     })
     securityScanRender.initialized = true
+    SecurityIssueHoverProvider.instance.issues = securityRecommendationList
 }
 
 export function updateSecurityDiagnosticCollection(securityRecommendation: AggregatedCodeScanIssue) {

--- a/src/codewhisperer/service/securityIssueHoverProvider.ts
+++ b/src/codewhisperer/service/securityIssueHoverProvider.ts
@@ -1,0 +1,46 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as vscode from 'vscode'
+import { AggregatedCodeScanIssue, CodeScanIssue } from '../models/model'
+
+export class SecurityIssueHoverProvider implements vscode.HoverProvider {
+    static #instance: SecurityIssueHoverProvider
+    private _issues: AggregatedCodeScanIssue[] = []
+
+    public static get instance() {
+        return (this.#instance ??= new this())
+    }
+
+    public set issues(issues: AggregatedCodeScanIssue[]) {
+        this._issues = issues
+    }
+
+    public provideHover(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        _token: vscode.CancellationToken
+    ): vscode.ProviderResult<vscode.Hover> {
+        const contents: vscode.MarkdownString[] = []
+
+        for (const group of this._issues) {
+            if (document.fileName !== group.filePath) {
+                continue
+            }
+
+            for (const issue of group.issues) {
+                const range = new vscode.Range(issue.startLine, 0, issue.endLine, 0)
+                if (range.contains(position)) {
+                    contents.push(this._getContent(issue))
+                }
+            }
+        }
+
+        return new vscode.Hover(contents)
+    }
+
+    private _getContent(issue: CodeScanIssue) {
+        return new vscode.MarkdownString('TBD')
+    }
+}

--- a/src/codewhisperer/service/securityIssueHoverProvider.ts
+++ b/src/codewhisperer/service/securityIssueHoverProvider.ts
@@ -21,7 +21,7 @@ export class SecurityIssueHoverProvider implements vscode.HoverProvider {
         document: vscode.TextDocument,
         position: vscode.Position,
         _token: vscode.CancellationToken
-    ): vscode.ProviderResult<vscode.Hover> {
+    ): vscode.Hover {
         const contents: vscode.MarkdownString[] = []
 
         for (const group of this._issues) {

--- a/src/test/codewhisperer/service/securityIssueHoverProvider.test.ts
+++ b/src/test/codewhisperer/service/securityIssueHoverProvider.test.ts
@@ -1,0 +1,49 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { SecurityIssueHoverProvider } from '../../../codewhisperer/service/securityIssueHoverProvider'
+import { createMockDocument } from '../testUtil'
+import assert from 'assert'
+
+describe('securityIssueHoverProvider', () => {
+    describe('providerHover', () => {
+        it('should return hover for each issue for the current position', () => {
+            const securityIssueHoverProvider = new SecurityIssueHoverProvider()
+            const mockDocument = createMockDocument('def two_sum(nums, target):\nfor', 'test.py', 'python')
+            securityIssueHoverProvider.issues = [
+                {
+                    filePath: mockDocument.fileName,
+                    issues: [
+                        { startLine: 0, endLine: 1, comment: 'issue on this line' },
+                        { startLine: 0, endLine: 1, comment: 'some other issue' },
+                    ],
+                },
+            ]
+
+            const token = new vscode.CancellationTokenSource()
+            const actual = securityIssueHoverProvider.provideHover(mockDocument, new vscode.Position(0, 0), token.token)
+
+            assert.strictEqual(actual.contents.length, 2)
+            assert.strictEqual((actual.contents[0] as vscode.MarkdownString).value, 'TBD')
+            assert.strictEqual((actual.contents[1] as vscode.MarkdownString).value, 'TBD')
+        })
+
+        it('should return empty contents if there is no issue on the current position', () => {
+            const securityIssueHoverProvider = new SecurityIssueHoverProvider()
+            const mockDocument = createMockDocument('def two_sum(nums, target):\nfor', 'test.py', 'python')
+            securityIssueHoverProvider.issues = [
+                {
+                    filePath: mockDocument.fileName,
+                    issues: [{ startLine: 0, endLine: 1, comment: 'issue on this line' }],
+                },
+            ]
+
+            const token = new vscode.CancellationTokenSource()
+            const actual = securityIssueHoverProvider.provideHover(mockDocument, new vscode.Position(2, 0), token.token)
+            assert.strictEqual(actual.contents.length, 0)
+        })
+    })
+})


### PR DESCRIPTION
## Problem

Currently hovering over a security issue will show the issue details in plain text, but there is no flexibility to add links or images, etc. due to vscode's `Diagnostic` message restricted to `string` type.

## Solution

Create and register a hover provider that adds a custom hover object to each security issue which has markdown support. This will add a "TBD" message whenever a security diagnostic message is rendered. 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
