### PR TITLE
StepFunctions: graph visualization supports ItemProcessor field

### DIFF
--- a/.changes/next-release/Feature-3d9dd25d-a1c3-40a8-b520-a19b339bd4dd.json
+++ b/.changes/next-release/Feature-3d9dd25d-a1c3-40a8-b520-a19b339bd4dd.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Support rendering SFN graph with ItemProcessor field"
+}

--- a/.changes/next-release/Feature-3d9dd25d-a1c3-40a8-b520-a19b339bd4dd.json
+++ b/.changes/next-release/Feature-3d9dd25d-a1c3-40a8-b520-a19b339bd4dd.json
@@ -1,4 +1,4 @@
 {
 	"type": "Feature",
-	"description": "Support rendering SFN graph with ItemProcessor field"
+	"description": "StepFunctions: Support rendering SFN graph with ItemProcessor field"
 }

--- a/src/stepFunctions/utils.ts
+++ b/src/stepFunctions/utils.ts
@@ -24,8 +24,8 @@ import { fromExtensionManifest } from '../shared/settings'
 const documentSettings: DocumentLanguageSettings = { comments: 'error', trailingCommas: 'error' }
 const languageService = getLanguageService({})
 
-const visualizationScriptUrl = 'https://do0of8uwbahzz.cloudfront.net/sfn-0.1.5.js'
-const visualizationCssUrl = 'https://do0of8uwbahzz.cloudfront.net/graph-0.1.5.css'
+const visualizationScriptUrl = 'https://d3p8cpu0nuk1gf.cloudfront.net/sfn-0.1.8.js'
+const visualizationCssUrl = 'https://d3p8cpu0nuk1gf.cloudfront.net/graph-0.1.8.css'
 
 const scriptsLastDownloadedUrl = 'SCRIPT_LAST_DOWNLOADED_URL'
 const cssLastDownloadedUrl = 'CSS_LAST_DOWNLOADED_URL'


### PR DESCRIPTION
## Problem

Updating to latest version of State Machine graph static assets which supports the `ItemProcessor` field in Map states. This is necessary to visualize distributed map states and inline maps states using the new syntax.

Resolves https://github.com/aws/aws-toolkit-vscode/issues/3515

## Solution

Bump graph version to latest version.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Testing

Visualized example state machine from #3515

<img width="1574" alt="Screenshot 2023-10-11 at 9 21 27 AM" src="https://github.com/aws/aws-toolkit-vscode/assets/55506708/47a3a36b-8238-4e46-ba03-ab21245b679d">

