### PR TITLE
auth: remove multiple auth prompts

### DIFF
--- a/src/auth/secondaryAuth.ts
+++ b/src/auth/secondaryAuth.ts
@@ -123,10 +123,15 @@ export class SecondaryAuth<T extends Connection = Connection> {
     }
 
     public get activeConnection(): T | undefined {
-        return (
-            this.#savedConnection ??
-            (this.#activeConnection && this.isUsable(this.#activeConnection) ? this.#activeConnection : undefined)
-        )
+        if (this.#savedConnection) {
+            return this.#savedConnection
+        }
+
+        if (this.#activeConnection && this.isUsable(this.#activeConnection)) {
+            return this.#activeConnection
+        }
+
+        return undefined
     }
 
     public get hasSavedConnection() {

--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -27,11 +27,9 @@ import { telemetry } from '../shared/telemetry/telemetry'
 import { cdkNode, CdkRootNode } from '../cdk/explorer/rootNode'
 import { CodeWhispererNode, codewhispererNode } from '../codewhisperer/explorer/codewhispererNode'
 import { once } from '../shared/utilities/functionUtils'
-import { Auth } from '../auth/auth'
 import { CodeCatalystRootNode } from '../codecatalyst/explorer'
 import { CodeCatalystAuthenticationProvider } from '../codecatalyst/auth'
 import { S3FolderNode } from '../s3/explorer/s3FolderNode'
-import { AuthNode } from '../auth/utils'
 import { TreeNode } from '../shared/treeview/resourceTreeDataProvider'
 
 /**
@@ -78,9 +76,8 @@ export async function activate(args: {
     )
 
     const authProvider = CodeCatalystAuthenticationProvider.fromContext(args.context.extensionContext)
-    const authNode = new AuthNode(Auth.instance)
     const codecatalystNode = isCloud9('classic') ? [] : [new CodeCatalystRootNode(authProvider)]
-    const nodes = [authNode, ...codecatalystNode, cdkNode, codewhispererNode]
+    const nodes = [...codecatalystNode, cdkNode, codewhispererNode]
     const developerTools = createLocalExplorerView(nodes)
     args.context.extensionContext.subscriptions.push(developerTools)
 
@@ -99,7 +96,6 @@ export async function activate(args: {
     })
 
     registerDeveloperToolsCommands(args.context.extensionContext, developerTools, {
-        auth: authNode,
         codeCatalyst: codecatalystNode ? codecatalystNode[0] : undefined,
         codeWhisperer: codewhispererNode,
     })
@@ -175,7 +171,6 @@ async function registerDeveloperToolsCommands(
     ctx: vscode.ExtensionContext,
     developerTools: vscode.TreeView<TreeNode>,
     nodes: {
-        auth: AuthNode
         codeWhisperer: CodeWhispererNode
         codeCatalyst: CodeCatalystRootNode | undefined
     }
@@ -203,10 +198,9 @@ async function registerDeveloperToolsCommands(
         )
     }
 
-    registerShowDeveloperToolsNode('CodeWhisperer', codewhispererNode)
+    registerShowDeveloperToolsNode('CodeWhisperer', nodes.codeWhisperer)
 
-    const codeCatalystNode = nodes.codeCatalyst
-    if (codeCatalystNode) {
-        registerShowDeveloperToolsNode('CodeCatalyst', codeCatalystNode)
+    if (nodes.codeCatalyst) {
+        registerShowDeveloperToolsNode('CodeCatalyst', nodes.codeCatalyst)
     }
 }

--- a/src/codecatalyst/auth.ts
+++ b/src/codecatalyst/auth.ts
@@ -66,7 +66,7 @@ export class CodeCatalystAuthenticationProvider {
     }
 
     public get isUsingSavedConnection() {
-        return this.secondaryAuth.isUsingSavedConnection
+        return this.secondaryAuth.hasSavedConnection
     }
 
     public isConnectionValid(): boolean {

--- a/src/codecatalyst/auth.ts
+++ b/src/codecatalyst/auth.ts
@@ -8,7 +8,6 @@ import { CodeCatalystClient, createClient } from '../shared/clients/codecatalyst
 import { Auth } from '../auth/auth'
 import { getSecondaryAuth } from '../auth/secondaryAuth'
 import { getLogger } from '../shared/logger'
-import * as localizedText from '../shared/localizedText'
 import { ToolkitError, isAwsError } from '../shared/errors'
 import { MetricName, MetricShapes, telemetry } from '../shared/telemetry/telemetry'
 import { openUrl } from '../shared/utilities/vsCodeUtils'
@@ -123,14 +122,22 @@ export class CodeCatalystAuthenticationProvider {
         throw new ToolkitError('Not onboarded with CodeCatalyst', { code: 'NotOnboarded', cancelled: true })
     }
 
-    public async promptNotConnected(): Promise<SsoConnection> {
+    /**
+     * Return a Builder ID connection that works with CodeCatalyst.
+     *
+     * This cannot create a Builder ID, but will return an existing Builder ID,
+     * upgrading the scopes if necessary.
+     */
+    public async tryGetBuilderIdConnection(): Promise<SsoConnection> {
+        if (this.activeConnection && isBuilderIdConnection(this.activeConnection)) {
+            return this.activeConnection
+        }
+
         type ConnectionFlowEvent = Partial<MetricShapes[MetricName]> & {
             readonly codecatalyst_connectionFlow: 'Create' | 'Switch' | 'Upgrade' // eslint-disable-line @typescript-eslint/naming-convention
         }
 
         const conn = (await this.auth.listConnections()).find(isBuilderIdConnection)
-        const continueItem: vscode.MessageItem = { title: localizedText.continueText }
-        const cancelItem: vscode.MessageItem = { title: localizedText.cancel, isCloseAffordance: true }
 
         if (conn === undefined) {
             telemetry.record({
@@ -153,20 +160,10 @@ export class CodeCatalystAuthenticationProvider {
             return this.secondaryAuth.addScopes(conn, defaultScopes)
         }
 
-        if (isBuilderIdConnection(conn) && this.auth.activeConnection?.id !== conn.id) {
+        if (this.auth.activeConnection?.id !== conn.id) {
             telemetry.record({
                 codecatalyst_connectionFlow: 'Switch',
             } satisfies ConnectionFlowEvent as MetricShapes[MetricName])
-
-            const resp = await vscode.window.showInformationMessage(
-                'CodeCatalyst requires an AWS Builder ID connection.\n\n Switch to it now?',
-                { modal: true },
-                continueItem,
-                cancelItem
-            )
-            if (resp !== continueItem) {
-                throw new ToolkitError('Not connected to CodeCatalyst', { code: 'NoConnection', cancelled: true })
-            }
 
             if (isUpgradeableConnection(conn)) {
                 await upgrade()

--- a/src/codecatalyst/commands.ts
+++ b/src/codecatalyst/commands.ts
@@ -136,7 +136,7 @@ function createClientInjector(authProvider: CodeCatalystAuthenticationProvider):
         telemetry.record({ userId: AccountStatus.NotSet })
 
         await authProvider.restore()
-        const conn = authProvider.activeConnection ?? (await authProvider.promptNotConnected())
+        const conn = await authProvider.tryGetBuilderIdConnection()
         const validatedConn = await validateConnection(conn, authProvider.auth)
         const client = await createClient(validatedConn)
         telemetry.record({ userId: client.identity.id })

--- a/src/codecatalyst/utils.ts
+++ b/src/codecatalyst/utils.ts
@@ -69,7 +69,7 @@ export function isInDevEnv(): boolean {
 export const getStartedCommand = Commands.register('aws.codecatalyst.getStarted', setupCodeCatalystBuilderId)
 
 export async function setupCodeCatalystBuilderId(authProvider: CodeCatalystAuthenticationProvider) {
-    let conn = authProvider.activeConnection ?? (await authProvider.promptNotConnected())
+    let conn = await authProvider.tryGetBuilderIdConnection()
 
     if (authProvider.auth.getConnectionState(conn) === 'invalid') {
         conn = await authProvider.auth.reauthenticate(conn)

--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -104,7 +104,7 @@ export class AuthUtil {
     }
 
     public get isUsingSavedConnection() {
-        return this.conn !== undefined && this.secondaryAuth.isUsingSavedConnection
+        return this.conn !== undefined && this.secondaryAuth.hasSavedConnection
     }
 
     public isConnected(): boolean {


### PR DESCRIPTION
## Problem

When adding additional auth connections like Builder ID, there are scenarios where the user is eventually shown a dialog asking them if they want to use their existing connection + new one. This is confusing to users.

![Screenshot 2023-07-25 at 8 46 08 AM](https://github.com/aws/aws-toolkit-vscode/assets/118216176/b9bc18d6-3548-41b5-af96-13f57f68e368)

## Solution

Remove the prompt shown above, and always implicitly select the `Yes` option. This will cause the default behavior to now be additive. For example, if they have AWS Credentials and add a Builder ID for CodeWhisperer, then AWS Credentials will be used for the explorer while Builder ID will be used for CodeWhisperer

![Kapture 2023-10-11 at 11 30 36](https://github.com/aws/aws-toolkit-vscode/assets/118216176/f181aea6-0b06-489c-99bf-dd1073029e2b)

## Additional:

### CodeCatalyst Switch Connections
#### Before:
Previously, if a user has a CodeWhisperer Builder ID set up, then adds a CodeCatalyst Builder ID, they are prompted if they want to switch connections.

<img width="402" alt="Screenshot 2023-10-11 at 2 19 08 PM" src="https://github.com/aws/aws-toolkit-vscode/assets/118216176/9ac0610b-83e4-4a76-94a3-508a6c82f8a4">

#### After:
With this PR, we will skip the modal above and immediately show them the modal to open the browser so that they can accept the scopes in the browser.

### Remove the parent auth node from the `Developer Tools` menu
This confuses users and we can remove it without losing significant functionality
#### Before
<img width="315" alt="Screenshot 2023-10-11 at 2 22 51 PM" src="https://github.com/aws/aws-toolkit-vscode/assets/118216176/8093f86c-fd7f-4830-97eb-06be525b1d7a">

#### After
<img width="315" alt="Screenshot 2023-10-11 at 2 23 05 PM" src="https://github.com/aws/aws-toolkit-vscode/assets/118216176/6c5ba1bb-fe44-4e13-821d-bffc87219d15">

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
