### PR TITLE
Enable SentTelemetryEvent for Builder ID users

### DIFF
--- a/src/codewhisperer/client/codewhisperer.ts
+++ b/src/codewhisperer/client/codewhisperer.ts
@@ -197,7 +197,7 @@ export class DefaultCodeWhispererClient {
             ...request,
             optOutPreference: globals.telemetry.telemetryEnabled ? 'OPTIN' : 'OPTOUT',
         }
-        if (!AuthUtil.instance.isValidEnterpriseSsoInUse()) {
+        if (!AuthUtil.instance.isValidEnterpriseSsoInUse() && !globals.telemetry.telemetryEnabled) {
             return
         }
         const response = await (await this.createUserSdkClient()).sendTelemetryEvent(requestWithOptOut).promise()


### PR DESCRIPTION
1. and the api will only be called when the user has optin telemetry.

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
