### PR TITLE
codewhisperer: suppress token filling from auto-trigger

### DIFF
--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -265,6 +265,7 @@ export enum UserGroup {
     Classifier = 'Classifier',
     CrossFile = 'CrossFile',
     Control = 'Control',
+    RightContext = 'RightContext',
 }
 
 export const isClassifierEnabledKey = 'CODEWHISPERER_CLASSIFIER_TRIGGER_ENABLED'

--- a/src/codewhisperer/util/userGroupUtil.ts
+++ b/src/codewhisperer/util/userGroupUtil.ts
@@ -56,7 +56,9 @@ export class CodeWhispererUserGroupSettings {
     }
 
     private guessUserGroup(): UserGroup {
-        return UserGroup.Control
+        const randomNum = Math.random()
+        const result = randomNum <= 1 / 2 ? UserGroup.Control : UserGroup.RightContext
+        return result
     }
 
     static #instance: CodeWhispererUserGroupSettings | undefined


### PR DESCRIPTION
## Problem
We don't want to trigger when there is immediate right context on the same line, with "}" as an exception
This will be an A/B test
## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
