### PR TITLE
auth: show wizard in c9 instead of webview

### DIFF
--- a/src/auth/commands.ts
+++ b/src/auth/commands.ts
@@ -6,7 +6,8 @@ import * as vscode from 'vscode'
 import { CommandDeclarations, Commands } from '../shared/vscode/commands2'
 import { AuthSource, showAuthWebview } from './ui/vue/show'
 import { ServiceItemId, isServiceItemId } from './ui/vue/types'
-import { showConnectionsPageCommand } from './utils'
+import { addConnection, showConnectionsPageCommand } from './utils'
+import { isCloud9 } from '../shared/extensionUtilities'
 
 /**
  * The methods with backend logic for the Auth commands.
@@ -14,7 +15,13 @@ import { showConnectionsPageCommand } from './utils'
 export class AuthCommandBackend {
     constructor(private readonly extContext: vscode.ExtensionContext) {}
 
-    public showConnectionsPage(source: AuthSource, serviceToShow?: ServiceItemId) {
+    public showManageConnections(source: AuthSource, serviceToShow?: ServiceItemId) {
+        // The auth webview page does not make sense to use in C9,
+        // so show the auth quick pick instead.
+        if (isCloud9('any')) {
+            return addConnection.execute()
+        }
+
         // Edge case where called by vscode UI and non ServiceItemId object
         // is passed in.
         if (typeof source !== 'string') {
@@ -41,7 +48,7 @@ export class AuthCommandDeclarations implements CommandDeclarations<AuthCommandB
     private constructor() {}
 
     public readonly declared = {
-        showConnectionsPage: Commands.from(AuthCommandBackend).declareShowConnectionsPage({
+        showManageConnections: Commands.from(AuthCommandBackend).declareShowManageConnections({
             id: showConnectionsPageCommand,
         }),
     } as const

--- a/src/codecatalyst/explorer.ts
+++ b/src/codecatalyst/explorer.ts
@@ -35,7 +35,7 @@ async function getLocalCommands(auth: CodeCatalystAuthenticationProvider) {
     const docsUrl = isCloud9() ? codecatalyst.docs.cloud9.overview : codecatalyst.docs.vscode.overview
     if (!isBuilderIdConnection(auth.activeConnection) || !(await auth.isConnectionOnboarded(auth.activeConnection))) {
         return [
-            AuthCommandDeclarations.instance.declared.showConnectionsPage
+            AuthCommandDeclarations.instance.declared.showManageConnections
                 .build('codecatalystDeveloperTools', 'codecatalyst')
                 .asTreeNode({
                     label: 'Start',

--- a/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
+++ b/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
@@ -59,7 +59,7 @@ export const createSecurityScanNode = () => {
 }
 
 export const createSsoSignIn = () =>
-    AuthCommandDeclarations.instance.declared.showConnectionsPage
+    AuthCommandDeclarations.instance.declared.showManageConnections
         .build('codewhispererDeveloperTools', 'codewhisperer')
         .asTreeNode({
             label: localize('AWS.explorerNode.sSoSignInNode.label', 'Start'),


### PR DESCRIPTION
- Will now show the auth wizard instead of the auth webview to users when in c9 classic or codecatalyst
- There will be no automatic opening of any auth setup when the user is a first time user in c9
- Renamed method to `showManageConnections()` since there are different outcomes depending on the IDE now.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
