### PR TITLE
codewhisperer: fix bash not supported in C9

### DIFF
--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -101,6 +101,7 @@ export const supportedLanguages = [
     'rust',
     'scala',
     'shellscript',
+    'sh', // Cloud9 reports bash files with this language-id
     'sql',
 ] as const
 

--- a/src/codewhisperer/util/runtimeLanguageContext.ts
+++ b/src/codewhisperer/util/runtimeLanguageContext.ts
@@ -44,6 +44,7 @@ export class RuntimeLanguageContext {
             ruby: 'ruby',
             rust: 'rust',
             scala: 'scala',
+            sh: 'shell',
             shellscript: 'shell',
             sql: 'sql',
         })
@@ -64,6 +65,7 @@ export class RuntimeLanguageContext {
             ruby: 'rb',
             rust: 'rs',
             scala: 'scala',
+            sh: 'sh',
             shellscript: 'sh',
             sql: 'sql',
         })


### PR DESCRIPTION
## Problem
cloud9 has different language id for bash/shellscript
## Solution
add that id to supported list

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
