### PR TITLE
codewhisperer: refactor keyStrokeHandler test and remove outdated tests

### DIFF
--- a/src/test/codewhisperer/service/keyStrokeHandler.test.ts
+++ b/src/test/codewhisperer/service/keyStrokeHandler.test.ts
@@ -22,8 +22,6 @@ import { ClassifierTrigger } from '../../../codewhisperer/service/classifierTrig
 import { CodeWhispererUserGroupSettings } from '../../../codewhisperer/util/userGroupUtil'
 import * as CodeWhispererConstants from '../../../codewhisperer/models/constants'
 
-const performance = globalThis.performance ?? require('perf_hooks').performance
-
 describe('keyStrokeHandler', function () {
     const config: ConfigurationEntry = {
         isShowMethodsEnabled: true,
@@ -72,147 +70,33 @@ describe('keyStrokeHandler', function () {
         })
 
         it('Should not call invokeAutomatedTrigger when changed text across multiple lines', async function () {
-            const mockEditor = createMockTextEditor()
-            const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
-                mockEditor.document,
-                new vscode.Range(new vscode.Position(0, 0), new vscode.Position(1, 0)),
-                '\nprint(n'
-            )
-            await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)
-            assert.ok(!invokeSpy.called)
-            assert.ok(!startTimerSpy.called)
+            await testShouldInvoke('\nprint(n', false)
         })
 
         it('Should not call invokeAutomatedTrigger when doing delete or undo (empty changed text)', async function () {
-            const mockEditor = createMockTextEditor()
-            const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
-                mockEditor.document,
-                new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)),
-                ''
-            )
-            await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)
-            assert.ok(!invokeSpy.called)
-            assert.ok(!startTimerSpy.called)
-        })
-
-        it('Should call invokeAutomatedTrigger if previous text input is within 2 seconds but the new input is new line', async function () {
-            const mockEditor = createMockTextEditor('function addTwo', 'test.js', 'javascript')
-            const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
-                mockEditor.document,
-                new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)),
-                '\n'
-            )
-            RecommendationHandler.instance.lastInvocationTime = performance.now() - 1500
-            await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)
-            assert.ok(invokeSpy.called)
-        })
-
-        it('Should call invokeAutomatedTrigger if previous text input is within 2 seconds but the new input is a specialcharacter', async function () {
-            const mockEditor = createMockTextEditor('function addTwo', 'test.js', 'javascript')
-            const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
-                mockEditor.document,
-                new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)),
-                '('
-            )
-            RecommendationHandler.instance.lastInvocationTime = performance.now() - 1500
-            await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)
-            assert.ok(invokeSpy.called)
+            await testShouldInvoke('', false)
         })
 
         it('Should call invokeAutomatedTrigger with Enter when inputing \n', async function () {
-            const mockEditor = createMockTextEditor('function addTwo', 'test.js', 'javascript')
-            const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
-                mockEditor.document,
-                new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)),
-                '\n'
-            )
-            await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)
-            invokeSpy('Enter', mockEditor, mockClient)
-            assert.ok(invokeSpy.called)
+            await testShouldInvoke('\n', true)
         })
 
         it('Should call invokeAutomatedTrigger with Enter when inputing \r\n', async function () {
-            const mockEditor = createMockTextEditor('function addTwo', 'test.js', 'javascript')
-            const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
-                mockEditor.document,
-                new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 2)),
-                '\r\n'
-            )
-            await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)
-            invokeSpy('Enter', mockEditor, mockClient)
-            assert.ok(invokeSpy.called)
+            await testShouldInvoke('\r\n', true)
         })
 
         it('Should call invokeAutomatedTrigger with SpecialCharacter when inputing {', async function () {
-            const mockEditor = createMockTextEditor('function addTwo', 'test.js', 'javascript')
-            const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
-                mockEditor.document,
-                new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)),
-                '{'
-            )
-            await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)
-            invokeSpy('SpecialCharacters', mockEditor, mockClient)
-            assert.ok(invokeSpy.called)
-        })
-
-        it('Should call invokeAutomatedTrigger with SpecialCharacter when inputing spaces equivalent to \t', async function () {
-            const mockEditor = createMockTextEditor('function addTwo', 'test.js', 'javascript')
-            const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
-                mockEditor.document,
-                new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)),
-                '  '
-            )
-            EditorContext.updateTabSize(2)
-            await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)
-            invokeSpy('SpecialCharacters', mockEditor, mockClient)
-            assert.ok(invokeSpy.called)
-        })
-
-        it('Should not call invokeAutomatedTrigger with SpecialCharacter when inputing spaces not equivalent to \t', async function () {
-            const mockEditor = createMockTextEditor('function addTwo', 'test.js', 'javascript')
-            const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
-                mockEditor.document,
-                new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)),
-                '   '
-            )
-            EditorContext.updateTabSize(2)
-            await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)
-            assert.ok(!invokeSpy.called)
-        })
-
-        it('Should not start idle trigger timer when inputing special characters', async function () {
-            const mockEditor = createMockTextEditor('function addTwo', 'test.js', 'javascript')
-            const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
-                mockEditor.document,
-                new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)),
-                '('
-            )
-            await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)
-            assert.ok(!startTimerSpy.called)
+            await testShouldInvoke('{', true)
         })
 
         it('Should not call invokeAutomatedTrigger for non-special characters for classifier language if classifier says no', async function () {
-            const mockEditor = createMockTextEditor('function addTwo', 'test.js', 'javascript')
-            const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
-                mockEditor.document,
-                new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)),
-                'a'
-            )
             sinon.stub(ClassifierTrigger.instance, 'shouldTriggerFromClassifier').returns(false)
-            await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)
-            assert.ok(!invokeSpy.called)
+            await testShouldInvoke('a', false)
         })
 
         it('Should call invokeAutomatedTrigger for non-special characters for classifier language if classifier says yes', async function () {
-            const mockEditor = createMockTextEditor('function addTwo', 'test.js', 'javascript')
-            const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
-                mockEditor.document,
-                new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)),
-                'a'
-            )
             sinon.stub(ClassifierTrigger.instance, 'shouldTriggerFromClassifier').returns(true)
-            await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)
-            assert.ok(invokeSpy.called)
+            await testShouldInvoke('a', true)
         })
 
         it('Should skip invoking if there is immediate right context on the same line and not a single } for the user group', async function () {
@@ -243,28 +127,25 @@ describe('keyStrokeHandler', function () {
                 },
             ]
             casesForSuppressTokenFilling.forEach(async ({ rightContext, shouldInvoke }) => {
-                await testIfRightContextShouldInvoke(
-                    rightContext,
-                    shouldInvoke,
-                    CodeWhispererConstants.UserGroup.RightContext
-                )
+                await testShouldInvoke('{', shouldInvoke, rightContext, CodeWhispererConstants.UserGroup.RightContext)
             })
         })
 
         it('Should not skip invoking based on right context for control group', async function () {
-            await testIfRightContextShouldInvoke('add', true, CodeWhispererConstants.UserGroup.Control)
+            await testShouldInvoke('{', true, 'add')
         })
 
-        async function testIfRightContextShouldInvoke(
-            rightContext: string,
+        async function testShouldInvoke(
+            input: string,
             shouldTrigger: boolean,
-            userGroup: CodeWhispererConstants.UserGroup
+            rightContext: string = '',
+            userGroup: CodeWhispererConstants.UserGroup = CodeWhispererConstants.UserGroup.Control
         ) {
-            const mockEditor = createMockTextEditor(rightContext, 'test.js', 'javascript', 1, 1)
+            const mockEditor = createMockTextEditor(rightContext, 'test.js', 'javascript')
             const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
                 mockEditor.document,
                 new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)),
-                '{'
+                input
             )
             CodeWhispererUserGroupSettings.instance.userGroup = userGroup
             await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)


### PR DESCRIPTION
## Problem
KeyStrokeHandler tests has too much repetition and some tests are outdated 
## Solution
remove the no longer needed tests for 2s rule for character based trigger and time based trigger, and refactor the test 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
