### PR TITLE
codewhisperer: add chars accepted in telemetry

### DIFF
--- a/src/codewhisperer/util/telemetryHelper.ts
+++ b/src/codewhisperer/util/telemetryHelper.ts
@@ -322,6 +322,7 @@ export class TelemetryHelper {
             codewhispererSupplementalContextLength: supplementalContextMetadata?.contentsLength,
             // eslint-disable-next-line id-length
             codewhispererSupplementalContextStrategyId: supplementalContextMetadata?.strategy,
+            codewhispererCharactersAccepted: acceptedRecommendationContent.length,
         }
         telemetry.codewhisperer_userTriggerDecision.emit(aggregated)
         this.prevTriggerDecision = this.getAggregatedSuggestionState(this.sessionDecisions)

--- a/src/test/codewhisperer/util/telemetryHelper.test.ts
+++ b/src/test/codewhisperer/util/telemetryHelper.test.ts
@@ -151,6 +151,7 @@ describe('telemetryHelper', function () {
                 codewhispererUserGroup: 'Control',
                 codewhispererCompletionType: 'Block',
                 codewhispererTypeaheadLength: 0,
+                codewhispererCharactersAccepted: aCompletion().content.length,
             })
         })
 
@@ -184,6 +185,7 @@ describe('telemetryHelper', function () {
                 codewhispererUserGroup: 'Control',
                 codewhispererCompletionType: 'Line',
                 codewhispererTypeaheadLength: 0,
+                codewhispererCharactersAccepted: aCompletion().content.length,
             })
         })
 
@@ -202,7 +204,7 @@ describe('telemetryHelper', function () {
                 ])
             )
 
-            sut.sendUserTriggerDecisionTelemetry('aFakeSessionId', aCompletion().content, 0)
+            sut.sendUserTriggerDecisionTelemetry('aFakeSessionId', '', 0)
             const assertTelemetry = assertTelemetryCurried('codewhisperer_userTriggerDecision')
             assertTelemetry({
                 codewhispererSessionId: 'aFakeSessionId',
@@ -217,6 +219,7 @@ describe('telemetryHelper', function () {
                 codewhispererUserGroup: 'Control',
                 codewhispererCompletionType: 'Line',
                 codewhispererTypeaheadLength: 0,
+                codewhispererCharactersAccepted: 0,
             })
         })
     })


### PR DESCRIPTION
## Problem
need to add # of chars accepted in userTriggerDecision event
## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
