### PR TITLE
codewhisperer: security hover update range and format

### DIFF
--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -303,6 +303,8 @@ export async function activate(context: ExtContext): Promise<void> {
                  */
                 disposeSecurityDiagnostic(e)
 
+                SecurityIssueHoverProvider.instance.updateRanges(e)
+
                 CodeWhispererCodeCoverageTracker.getTracker(e.document.languageId)?.countTotalTokens(e)
 
                 /**

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -303,7 +303,7 @@ export async function activate(context: ExtContext): Promise<void> {
                  */
                 disposeSecurityDiagnostic(e)
 
-                SecurityIssueHoverProvider.instance.updateRanges(e)
+                SecurityIssueHoverProvider.instance.handleDocumentChange(e)
 
                 CodeWhispererCodeCoverageTracker.getTracker(e.document.languageId)?.countTotalTokens(e)
 

--- a/src/codewhisperer/service/diagnosticsProvider.ts
+++ b/src/codewhisperer/service/diagnosticsProvider.ts
@@ -94,7 +94,7 @@ export function disposeSecurityDiagnostic(event: vscode.TextDocumentChangeEvent)
     securityScanRender.securityDiagnosticCollection?.set(uri, newSecurityDiagnostics)
 }
 
-function getLineOffset(range: vscode.Range, text: string) {
+export function getLineOffset(range: vscode.Range, text: string) {
     const originLines = range.end.line - range.start.line + 1
     const changedLines = text.split('\n').length
     return changedLines - originLines

--- a/src/codewhisperer/service/diagnosticsProvider.ts
+++ b/src/codewhisperer/service/diagnosticsProvider.ts
@@ -94,7 +94,7 @@ export function disposeSecurityDiagnostic(event: vscode.TextDocumentChangeEvent)
     securityScanRender.securityDiagnosticCollection?.set(uri, newSecurityDiagnostics)
 }
 
-export function getLineOffset(range: vscode.Range, text: string) {
+function getLineOffset(range: vscode.Range, text: string) {
     const originLines = range.end.line - range.start.line + 1
     const changedLines = text.split('\n').length
     return changedLines - originLines

--- a/src/codewhisperer/service/securityIssueHoverProvider.ts
+++ b/src/codewhisperer/service/securityIssueHoverProvider.ts
@@ -5,7 +5,6 @@
 import * as vscode from 'vscode'
 import { AggregatedCodeScanIssue, CodeScanIssue } from '../models/model'
 import globals from '../../shared/extensionGlobals'
-import { getLineOffset } from './diagnosticsProvider'
 
 export class SecurityIssueHoverProvider implements vscode.HoverProvider {
     static #instance: SecurityIssueHoverProvider
@@ -45,9 +44,15 @@ export class SecurityIssueHoverProvider implements vscode.HoverProvider {
     public updateRanges(event: vscode.TextDocumentChangeEvent) {
         const changedRange = event.contentChanges[0].range
         const changedText = event.contentChanges[0].text
-        const lineOffset = getLineOffset(changedRange, changedText)
+        const lineOffset = this._getLineOffset(changedRange, changedText)
 
         this._issues = this._issues.map(issues => this._applyRangeOffset(event.document.fileName, issues, lineOffset))
+    }
+
+    private _getLineOffset(range: vscode.Range, text: string) {
+        const originLines = range.end.line - range.start.line + 1
+        const changedLines = text.split('\n').length
+        return changedLines - originLines
     }
 
     private _applyRangeOffset(

--- a/src/codewhisperer/service/securityIssueHoverProvider.ts
+++ b/src/codewhisperer/service/securityIssueHoverProvider.ts
@@ -41,6 +41,12 @@ export class SecurityIssueHoverProvider implements vscode.HoverProvider {
         return new vscode.Hover(contents)
     }
 
+    /**
+     * Updates the position of each hover when the text document is changed. The underlying security issues
+     * will be updated with new line numbers to reflect the new positions of the hover.
+     *
+     * @param event Event that triggered the text document change
+     */
     public updateRanges(event: vscode.TextDocumentChangeEvent) {
         const changedRange = event.contentChanges[0].range
         const changedText = event.contentChanges[0].text
@@ -127,23 +133,8 @@ export class SecurityIssueHoverProvider implements vscode.HoverProvider {
      */
     private _makeCodeBlock(code: string, language?: string) {
         const lines = code.split('\n').slice(1) // Ignore the first line for diff header
-        // Get the length of the longest line to pad each line to be the same length
         const maxLineChars = lines.reduce((acc, curr) => Math.max(acc, curr.length), 0)
-        // Get the number of leading whitespaces that can be removed to hide unnecessary indentation
-        const minLeadingWhitespaces = lines.reduce((acc, curr) => {
-            const numWhitespaces = curr.slice(1).search(/\S/)
-            if (numWhitespaces < 0) {
-                return acc
-            }
-            return Math.min(acc, numWhitespaces)
-        }, maxLineChars)
-        const paddedLines = lines.map((line, i) => {
-            const paddedLine = line.padEnd(maxLineChars + 2)
-            if (minLeadingWhitespaces > 1) {
-                return paddedLine[0] + paddedLine.slice(minLeadingWhitespaces)
-            }
-            return paddedLine
-        })
+        const paddedLines = lines.map(line => line.padEnd(maxLineChars + 2))
 
         // Group the lines into sections so consecutive lines of the same type can be placed in
         // the same span below


### PR DESCRIPTION
## Problem

Hovers positions are not being updated if the document changes.

## Solution

Add an event handler which either removes the hover or offsets the line number depending on what was changed (similar to how [diagnostics are updated](https://github.com/aws/aws-toolkit-vscode/blob/0974becd8d26bc12a640b34bfbefc2e20fe8cb17/src/codewhisperer/service/diagnosticsProvider.ts#L61-L93
)) 
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
