### PR TITLE
web: remove various commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -281,6 +281,7 @@
         "debuggers": [
             {
                 "type": "aws-sam",
+                "when": "!isWeb",
                 "label": "%AWS.configuration.description.awssam.debug.label%",
                 "configurationAttributes": {
                     "direct-invoke": {
@@ -705,7 +706,8 @@
             "aws-explorer": [
                 {
                     "id": "aws.explorer",
-                    "name": "%AWS.lambda.explorerTitle%"
+                    "name": "%AWS.lambda.explorerTitle%",
+                    "when": "!isWeb"
                 },
                 {
                     "id": "aws.developerTools",
@@ -724,7 +726,8 @@
             {
                 "id": "aws.auth",
                 "label": "%AWS.submenu.auth.title%",
-                "icon": "$(ellipsis)"
+                "icon": "$(ellipsis)",
+                "when": "!isWeb"
             }
         ],
         "menus": {
@@ -1985,6 +1988,7 @@
                 "command": "aws.launchConfigForm",
                 "title": "%AWS.command.launchConfigForm.title%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -1995,6 +1999,7 @@
                 "command": "aws.apig.copyUrl",
                 "title": "%AWS.command.apig.copyUrl%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2005,6 +2010,7 @@
                 "command": "aws.apig.invokeRemoteRestApi",
                 "title": "%AWS.command.apig.invokeRemoteRestApi%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%",
@@ -2016,6 +2022,7 @@
                 "command": "aws.lambda.createNewSamApp",
                 "title": "%AWS.command.createNewSamApp%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2026,6 +2033,7 @@
                 "command": "aws.login",
                 "title": "%AWS.command.login%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "title": "%AWS.command.login.cn%",
@@ -2056,47 +2064,51 @@
             {
                 "command": "aws.codecatalyst.openOrg",
                 "title": "%AWS.command.codecatalyst.openOrg%",
-                "category": "AWS"
+                "category": "AWS",
+                "enablement": "!isWeb"
             },
             {
                 "command": "aws.codecatalyst.openProject",
                 "title": "%AWS.command.codecatalyst.openProject%",
-                "category": "AWS"
+                "category": "AWS",
+                "enablement": "!isWeb"
             },
             {
                 "command": "aws.codecatalyst.openRepo",
                 "title": "%AWS.command.codecatalyst.openRepo%",
-                "category": "AWS"
+                "category": "AWS",
+                "enablement": "!isWeb"
             },
             {
                 "command": "aws.codecatalyst.openDevEnv",
                 "title": "%AWS.command.codecatalyst.openDevEnv%",
                 "category": "AWS",
-                "enablement": "!isCloud9"
+                "enablement": "!isCloud9 && !isWeb"
             },
             {
                 "command": "aws.codecatalyst.listCommands",
                 "title": "%AWS.command.codecatalyst.listCommands%",
                 "category": "AWS",
-                "enablement": "!isCloud9"
+                "enablement": "!isCloud9 && !isWeb"
             },
             {
                 "command": "aws.codecatalyst.cloneRepo",
                 "title": "%AWS.command.codecatalyst.cloneRepo%",
                 "category": "AWS",
-                "enablement": "!isCloud9"
+                "enablement": "!isCloud9 && !isWeb"
             },
             {
                 "command": "aws.codecatalyst.createDevEnv",
                 "title": "%AWS.command.codecatalyst.createDevEnv%",
                 "category": "AWS",
-                "enablement": "!isCloud9"
+                "enablement": "!isCloud9 && !isWeb"
             },
             {
                 "command": "aws.codecatalyst.removeConnection",
                 "title": "%AWS.command.codecatalyst.removeConnection%",
                 "category": "AWS",
-                "icon": "$(debug-disconnect)"
+                "icon": "$(debug-disconnect)",
+                "enablement": "!isWeb"
             },
             {
                 "command": "aws.logout",
@@ -2150,6 +2162,7 @@
                 "title": "%AWS.command.ec2.openTerminal%",
                 "icon": "$(terminal-view-icon)",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2161,6 +2174,7 @@
                 "title": "%AWS.command.ec2.openRemoteConnection%",
                 "icon": "$(remote-explorer)",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2172,6 +2186,7 @@
                 "title": "%AWS.command.ec2.startInstance%",
                 "icon": "$(debug-start)",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2183,6 +2198,7 @@
                 "title": "%AWS.command.ec2.stopInstance%",
                 "icon": "$(debug-stop)",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2194,6 +2210,7 @@
                 "title": "%AWS.command.ec2.rebootInstance%",
                 "icon": "$(debug-restart)",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2204,6 +2221,7 @@
                 "command": "aws.ec2.copyInstanceId",
                 "title": "%AWS.command.ec2.copyInstanceId%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2214,6 +2232,7 @@
                 "command": "aws.ecr.copyTagUri",
                 "title": "%AWS.command.ecr.copyTagUri%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2224,6 +2243,7 @@
                 "command": "aws.ecr.deleteTag",
                 "title": "%AWS.command.ecr.deleteTag%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2234,6 +2254,7 @@
                 "command": "aws.ecr.copyRepositoryUri",
                 "title": "%AWS.command.ecr.copyRepositoryUri%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2244,6 +2265,7 @@
                 "command": "aws.ecr.createRepository",
                 "title": "%AWS.command.ecr.createRepository%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(add)",
                 "cloud9": {
                     "cn": {
@@ -2255,6 +2277,7 @@
                 "command": "aws.ecr.deleteRepository",
                 "title": "%AWS.command.ecr.deleteRepository%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2265,6 +2288,7 @@
                 "command": "aws.showRegion",
                 "title": "%AWS.command.showRegion%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2275,6 +2299,7 @@
                 "command": "aws.iot.createThing",
                 "title": "%AWS.command.iot.createThing%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(add)",
                 "cloud9": {
                     "cn": {
@@ -2286,6 +2311,7 @@
                 "command": "aws.iot.deleteThing",
                 "title": "%AWS.generic.promptDelete%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2296,6 +2322,7 @@
                 "command": "aws.iot.createCert",
                 "title": "%AWS.command.iot.createCert%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(add)",
                 "cloud9": {
                     "cn": {
@@ -2307,6 +2334,7 @@
                 "command": "aws.iot.deleteCert",
                 "title": "%AWS.generic.promptDelete%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2317,6 +2345,7 @@
                 "command": "aws.iot.attachCert",
                 "title": "%AWS.command.iot.attachCert%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(aws-generic-attach-file)",
                 "cloud9": {
                     "cn": {
@@ -2328,6 +2357,7 @@
                 "command": "aws.iot.attachPolicy",
                 "title": "%AWS.command.iot.attachPolicy%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(aws-generic-attach-file)",
                 "cloud9": {
                     "cn": {
@@ -2339,6 +2369,7 @@
                 "command": "aws.iot.activateCert",
                 "title": "%AWS.command.iot.activateCert%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2349,6 +2380,7 @@
                 "command": "aws.iot.deactivateCert",
                 "title": "%AWS.command.iot.deactivateCert%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2359,6 +2391,7 @@
                 "command": "aws.iot.revokeCert",
                 "title": "%AWS.command.iot.revokeCert%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2369,6 +2402,7 @@
                 "command": "aws.iot.createPolicy",
                 "title": "%AWS.command.iot.createPolicy%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(add)",
                 "cloud9": {
                     "cn": {
@@ -2380,6 +2414,7 @@
                 "command": "aws.iot.deletePolicy",
                 "title": "%AWS.generic.promptDelete%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2390,6 +2425,7 @@
                 "command": "aws.iot.createPolicyVersion",
                 "title": "%AWS.command.iot.createPolicyVersion%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2400,6 +2436,7 @@
                 "command": "aws.iot.deletePolicyVersion",
                 "title": "%AWS.generic.promptDelete%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2410,6 +2447,7 @@
                 "command": "aws.iot.detachCert",
                 "title": "%AWS.command.iot.detachCert%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2420,6 +2458,7 @@
                 "command": "aws.iot.detachPolicy",
                 "title": "%AWS.command.iot.detachCert%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2430,6 +2469,7 @@
                 "command": "aws.iot.viewPolicyVersion",
                 "title": "%AWS.command.iot.viewPolicyVersion%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2440,6 +2480,7 @@
                 "command": "aws.iot.setDefaultPolicy",
                 "title": "%AWS.command.iot.setDefaultPolicy%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2450,6 +2491,7 @@
                 "command": "aws.iot.copyEndpoint",
                 "title": "%AWS.command.iot.copyEndpoint%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2469,12 +2511,14 @@
             {
                 "command": "aws.s3.presignedURL",
                 "title": "%AWS.command.s3.presignedURL%",
-                "category": "%AWS.title%"
+                "category": "%AWS.title%",
+                "enablement": "!isWeb"
             },
             {
                 "command": "aws.s3.copyPath",
                 "title": "%AWS.command.s3.copyPath%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2485,6 +2529,7 @@
                 "command": "aws.s3.downloadFileAs",
                 "title": "%AWS.command.s3.downloadFileAs%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(cloud-download)",
                 "cloud9": {
                     "cn": {
@@ -2496,18 +2541,21 @@
                 "command": "aws.s3.openFile",
                 "title": "%AWS.command.s3.openFile%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(open-preview)"
             },
             {
                 "command": "aws.s3.editFile",
                 "title": "%AWS.command.s3.editFile%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(edit)"
             },
             {
                 "command": "aws.s3.uploadFile",
                 "title": "%AWS.command.s3.uploadFile%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(cloud-upload)",
                 "cloud9": {
                     "cn": {
@@ -2519,6 +2567,7 @@
                 "command": "aws.s3.uploadFileToParent",
                 "title": "%AWS.command.s3.uploadFileToParent%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2529,6 +2578,7 @@
                 "command": "aws.s3.createFolder",
                 "title": "%AWS.command.s3.createFolder%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(new-folder)",
                 "cloud9": {
                     "cn": {
@@ -2540,6 +2590,7 @@
                 "command": "aws.s3.createBucket",
                 "title": "%AWS.command.s3.createBucket%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(aws-s3-create-bucket)",
                 "cloud9": {
                     "cn": {
@@ -2551,6 +2602,7 @@
                 "command": "aws.s3.deleteBucket",
                 "title": "%AWS.generic.promptDelete%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2561,6 +2613,7 @@
                 "command": "aws.s3.deleteFile",
                 "title": "%AWS.generic.promptDelete%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2571,6 +2624,7 @@
                 "command": "aws.invokeLambda",
                 "title": "%AWS.command.invokeLambda%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "title": "%AWS.command.invokeLambda.cn%",
@@ -2582,7 +2636,7 @@
                 "command": "aws.downloadLambda",
                 "title": "%AWS.command.downloadLambda%",
                 "category": "%AWS.title%",
-                "enablement": "viewItem == awsRegionFunctionNodeDownloadable",
+                "enablement": "viewItem == awsRegionFunctionNodeDownloadable && !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2592,6 +2646,7 @@
             {
                 "command": "aws.uploadLambda",
                 "title": "%AWS.command.uploadLambda%",
+                "enablement": "!isWeb",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
@@ -2602,6 +2657,7 @@
             {
                 "command": "aws.deleteLambda",
                 "title": "%AWS.generic.promptDelete%",
+                "enablement": "!isWeb",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
@@ -2612,6 +2668,7 @@
             {
                 "command": "aws.copyLambdaUrl",
                 "title": "%AWS.generic.copyUrl%",
+                "enablement": "!isWeb",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
@@ -2622,6 +2679,7 @@
             {
                 "command": "aws.deploySamApplication",
                 "title": "%AWS.command.deploySamApplication%",
+                "enablement": "!isWeb",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
@@ -2643,6 +2701,7 @@
             {
                 "command": "aws.refreshAwsExplorer",
                 "title": "%AWS.command.refreshAwsExplorer%",
+                "enablement": "!isWeb",
                 "category": "%AWS.title%",
                 "icon": {
                     "dark": "resources/icons/vscode/dark/refresh.svg",
@@ -2652,6 +2711,7 @@
             {
                 "command": "aws.samcli.detect",
                 "title": "%AWS.command.samcli.detect%",
+                "enablement": "!isWeb",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
@@ -2662,6 +2722,7 @@
             {
                 "command": "aws.deleteCloudFormation",
                 "title": "%AWS.command.deleteCloudFormation%",
+                "enablement": "!isWeb",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
@@ -2672,6 +2733,7 @@
             {
                 "command": "aws.downloadStateMachineDefinition",
                 "title": "%AWS.command.downloadStateMachineDefinition%",
+                "enablement": "!isWeb",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
@@ -2682,6 +2744,7 @@
             {
                 "command": "aws.executeStateMachine",
                 "title": "%AWS.command.executeStateMachine%",
+                "enablement": "!isWeb",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
@@ -2692,6 +2755,7 @@
             {
                 "command": "aws.renderStateMachineGraph",
                 "title": "%AWS.command.renderStateMachineGraph%",
+                "enablement": "!isWeb",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
@@ -2703,6 +2767,7 @@
                 "command": "aws.copyArn",
                 "title": "%AWS.command.copyArn%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2713,6 +2778,7 @@
                 "command": "aws.copyName",
                 "title": "%AWS.command.copyName%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2734,6 +2800,7 @@
                 "command": "aws.viewSchemaItem",
                 "title": "%AWS.command.viewSchemaItem%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2744,6 +2811,7 @@
                 "command": "aws.searchSchema",
                 "title": "%AWS.command.searchSchema%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2754,6 +2822,7 @@
                 "command": "aws.searchSchemaPerRegistry",
                 "title": "%AWS.command.searchSchemaPerRegistry%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2764,6 +2833,7 @@
                 "command": "aws.downloadSchemaItemCode",
                 "title": "%AWS.command.downloadSchemaItemCode%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2809,6 +2879,7 @@
                 "command": "aws.cdk.refresh",
                 "title": "%AWS.command.refreshCdkExplorer%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": {
                     "dark": "resources/icons/vscode/dark/refresh.svg",
                     "light": "resources/icons/vscode/light/refresh.svg"
@@ -2822,12 +2893,14 @@
             {
                 "command": "aws.cdk.viewDocs",
                 "title": "%AWS.generic.viewDocs%",
-                "category": "%AWS.title%"
+                "category": "%AWS.title%",
+                "enablement": "!isWeb"
             },
             {
                 "command": "aws.stepfunctions.createStateMachineFromTemplate",
                 "title": "%AWS.command.stepFunctions.createStateMachineFromTemplate%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2838,6 +2911,7 @@
                 "command": "aws.stepfunctions.publishStateMachine",
                 "title": "%AWS.command.stepFunctions.publishStateMachine%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2848,6 +2922,7 @@
                 "command": "aws.previewStateMachine",
                 "title": "%AWS.command.stepFunctions.previewStateMachine%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(aws-stepfunctions-preview)",
                 "cloud9": {
                     "cn": {
@@ -2858,6 +2933,7 @@
             {
                 "command": "aws.cdk.renderStateMachineGraph",
                 "title": "%AWS.command.cdk.previewStateMachine%",
+                "enablement": "!isWeb",
                 "category": "AWS",
                 "icon": "$(aws-stepfunctions-preview)"
             },
@@ -2869,6 +2945,7 @@
             {
                 "command": "aws.cwl.viewLogStream",
                 "title": "%AWS.command.viewLogStream%",
+                "enablement": "!isWeb",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
@@ -2880,6 +2957,7 @@
                 "command": "aws.ssmDocument.createLocalDocument",
                 "title": "%AWS.command.ssmDocument.createLocalDocument%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2890,6 +2968,7 @@
                 "command": "aws.ssmDocument.openLocalDocument",
                 "title": "%AWS.command.ssmDocument.openLocalDocument%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(cloud-download)",
                 "cloud9": {
                     "cn": {
@@ -2901,6 +2980,7 @@
                 "command": "aws.ssmDocument.openLocalDocumentJson",
                 "title": "%AWS.command.ssmDocument.openLocalDocumentJson%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2911,6 +2991,7 @@
                 "command": "aws.ssmDocument.openLocalDocumentYaml",
                 "title": "%AWS.command.ssmDocument.openLocalDocumentYaml%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2921,6 +3002,7 @@
                 "command": "aws.ssmDocument.deleteDocument",
                 "title": "%AWS.command.ssmDocument.deleteDocument%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2931,6 +3013,7 @@
                 "command": "aws.ssmDocument.publishDocument",
                 "title": "%AWS.command.ssmDocument.publishDocument%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(cloud-upload)",
                 "cloud9": {
                     "cn": {
@@ -2942,6 +3025,7 @@
                 "command": "aws.ssmDocument.updateDocumentVersion",
                 "title": "%AWS.command.ssmDocument.updateDocumentVersion%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2952,6 +3036,7 @@
                 "command": "aws.copyLogResource",
                 "title": "%AWS.command.copyLogResource%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(files)",
                 "cloud9": {
                     "cn": {
@@ -2963,6 +3048,7 @@
                 "command": "aws.cwl.searchLogGroup",
                 "title": "%AWS.command.cloudWatchLogs.searchLogGroup%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(search-view-icon)",
                 "cloud9": {
                     "cn": {
@@ -2974,6 +3060,7 @@
                 "command": "aws.saveCurrentLogDataContent",
                 "title": "%AWS.command.saveCurrentLogDataContent%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(save)",
                 "cloud9": {
                     "cn": {
@@ -2985,6 +3072,7 @@
                 "command": "aws.cwl.changeFilterPattern",
                 "title": "%AWS.command.cwl.changeFilterPattern%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(search-view-icon)",
                 "cloud9": {
                     "cn": {
@@ -2996,6 +3084,7 @@
                 "command": "aws.cwl.changeTimeFilter",
                 "title": "%AWS.command.cwl.changeTimeFilter%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(calendar)",
                 "cloud9": {
                     "cn": {
@@ -3007,6 +3096,7 @@
                 "command": "aws.addSamDebugConfig",
                 "title": "%AWS.command.addSamDebugConfig%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3017,6 +3107,7 @@
                 "command": "aws.toggleSamCodeLenses",
                 "title": "%AWS.command.toggleSamCodeLenses%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3027,7 +3118,7 @@
                 "command": "aws.ecs.runCommandInContainer",
                 "title": "%AWS.ecs.runCommandInContainer%",
                 "category": "%AWS.title%",
-                "enablement": "viewItem == awsEcsContainerNodeExecEnabled",
+                "enablement": "viewItem == awsEcsContainerNodeExecEnabled && !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3038,7 +3129,7 @@
                 "command": "aws.ecs.openTaskInTerminal",
                 "title": "%AWS.ecs.openTaskInTerminal%",
                 "category": "%AWS.title%",
-                "enablement": "viewItem == awsEcsContainerNodeExecEnabled",
+                "enablement": "viewItem == awsEcsContainerNodeExecEnabled && !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3049,6 +3140,7 @@
                 "command": "aws.ecs.enableEcsExec",
                 "title": "%AWS.ecs.enableEcsExec%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3059,6 +3151,7 @@
                 "command": "aws.ecs.viewDocumentation",
                 "title": "%AWS.generic.viewDocs%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3069,6 +3162,7 @@
                 "command": "aws.resources.copyIdentifier",
                 "title": "%AWS.command.resources.copyIdentifier%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3079,6 +3173,7 @@
                 "command": "aws.resources.openResourcePreview",
                 "title": "%AWS.generic.preview%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(open-preview)",
                 "cloud9": {
                     "cn": {
@@ -3090,6 +3185,7 @@
                 "command": "aws.resources.createResource",
                 "title": "%AWS.generic.create%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(add)",
                 "cloud9": {
                     "cn": {
@@ -3101,6 +3197,7 @@
                 "command": "aws.resources.deleteResource",
                 "title": "%AWS.generic.promptDelete%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3111,6 +3208,7 @@
                 "command": "aws.resources.updateResource",
                 "title": "%AWS.generic.promptUpdate%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(pencil)",
                 "cloud9": {
                     "cn": {
@@ -3122,6 +3220,7 @@
                 "command": "aws.resources.updateResourceInline",
                 "title": "%AWS.generic.promptUpdate%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(pencil)",
                 "cloud9": {
                     "cn": {
@@ -3133,6 +3232,7 @@
                 "command": "aws.resources.saveResource",
                 "title": "%AWS.generic.save%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(save)",
                 "cloud9": {
                     "cn": {
@@ -3144,6 +3244,7 @@
                 "command": "aws.resources.closeResource",
                 "title": "%AWS.generic.close%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(close)",
                 "cloud9": {
                     "cn": {
@@ -3155,6 +3256,7 @@
                 "command": "aws.resources.viewDocs",
                 "title": "%AWS.generic.viewDocs%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(book)",
                 "cloud9": {
                     "cn": {
@@ -3166,6 +3268,7 @@
                 "command": "aws.resources.configure",
                 "title": "%AWS.command.resources.configure%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "icon": "$(gear)",
                 "cloud9": {
                     "cn": {
@@ -3177,6 +3280,7 @@
                 "command": "aws.apprunner.createService",
                 "title": "%AWS.command.apprunner.createService%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3187,6 +3291,7 @@
                 "command": "aws.ecs.disableEcsExec",
                 "title": "%AWS.ecs.disableEcsExec%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3197,6 +3302,7 @@
                 "command": "aws.apprunner.createServiceFromEcr",
                 "title": "%AWS.command.apprunner.createServiceFromEcr%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3207,6 +3313,7 @@
                 "command": "aws.apprunner.pauseService",
                 "title": "%AWS.command.apprunner.pauseService%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3217,6 +3324,7 @@
                 "command": "aws.apprunner.resumeService",
                 "title": "%AWS.command.apprunner.resumeService%",
                 "category": "AWS",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3227,6 +3335,7 @@
                 "command": "aws.apprunner.copyServiceUrl",
                 "title": "%AWS.command.apprunner.copyServiceUrl%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3237,6 +3346,7 @@
                 "command": "aws.apprunner.open",
                 "title": "%AWS.command.apprunner.open%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3247,6 +3357,7 @@
                 "command": "aws.apprunner.deleteService",
                 "title": "%AWS.generic.promptDelete%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3257,6 +3368,7 @@
                 "command": "aws.apprunner.startDeployment",
                 "title": "%AWS.command.apprunner.startDeployment%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3267,6 +3379,7 @@
                 "command": "aws.cloudFormation.newTemplate",
                 "title": "%AWS.command.cloudFormation.newTemplate%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3277,6 +3390,7 @@
                 "command": "aws.sam.newTemplate",
                 "title": "%AWS.command.sam.newTemplate%",
                 "category": "%AWS.title%",
+                "enablement": "!isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3286,7 +3400,8 @@
             {
                 "command": "aws.samcli.sync",
                 "title": "%AWS.command.samcli.sync%",
-                "category": "%AWS.title%"
+                "category": "%AWS.title%",
+                "enablement": "!isWeb"
             },
             {
                 "command": "aws.codeWhisperer",


### PR DESCRIPTION
## Problem
The web extension is showing a lot of commands that we don't want to show.

## Solution
Add a lot of `!isWeb` to command, debugger, and view registrations. This will render those code paths inaccessible directly via command, but will not fix any underlying compatibility issues if the code paths are exercised by alternate means.
* Using `isWeb` will still show these commands if we're running through the `Extension (browser)` debug target. We can create our own context, but since that requires the context to be written, we will see the views and commands pop in and out once the context is written. We cannot overwrite the `isWeb` context, as well.
  * For now, use `npm run runInBrowser` (no debugger support though)
* Limiting on the command (instead of at the menu level) should still prevent these from showing up in menus (like the command palette)

Currently-exposed commands, and proof that the AWS explorer view is removed:
![image](https://github.com/aws/aws-toolkit-vscode/assets/29374703/ed374457-555f-4140-9add-4e8b28430eb3)


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
