### PR TITLE
fix(codewhisperer): "Learn" page may appear after restart

### DIFF
--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -98,7 +98,7 @@ export class AuthUtil {
                 //If user login old or new, If welcome message is not shown then open the Getting Started Page after this mark it as SHOWN.
                 if (shouldShow) {
                     vscode.commands.executeCommand('aws.codeWhisperer.gettingStarted')
-                    prompts.update('codeWhispererNewWelcomeMessage', true)
+                    prompts.disablePrompt('codeWhispererNewWelcomeMessage')
                 }
             }
             await vscode.commands.executeCommand('setContext', 'CODEWHISPERER_ENABLED', this.isConnected())


### PR DESCRIPTION
## Problem
Learn CodeWhisperer Page appears on VSCode Startup
## Solution
Used DisablePrompt to disable the page to appear automatically to the user after first time signIn.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
