### PR TITLE
codewhisperer: miss refreshing codewhisperer widget after allowlist status change

### DIFF
--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -58,6 +58,7 @@ export class AuthUtil {
         }
         this._isCustomizationFeatureEnabled = value
         vscode.commands.executeCommand('aws.codeWhisperer.refresh')
+        vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar')
     }
 
     public readonly secondaryAuth = getSecondaryAuth(


### PR DESCRIPTION

## Problem

### Before

https://github.com/aws/aws-toolkit-vscode/assets/96078566/e3b4d24e-156c-48d3-b26a-9fc1c088ff1b


### After

https://github.com/aws/aws-toolkit-vscode/assets/96078566/00380c89-5e35-48d9-8121-acf779c1a7bd




## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
