### PR TITLE
c9: fix mkdir not working 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7943,12 +7943,6 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true
         },
-        "node_modules/fast-diff": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-            "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-            "peer": true
-        },
         "node_modules/fast-fifo": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
@@ -8972,14 +8966,6 @@
                 "url": "https://github.com/sponsors/typicode"
             }
         },
-        "node_modules/hyperdyperid": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
-            "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
-            "engines": {
-                "node": ">=10.18"
-            }
-        },
         "node_modules/iconv-lite": {
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -9801,40 +9787,6 @@
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
         },
-        "node_modules/json-joy": {
-            "version": "9.5.1",
-            "resolved": "https://registry.npmjs.org/json-joy/-/json-joy-9.5.1.tgz",
-            "integrity": "sha512-XMSpdxaiWUZlc+CAUbPS3G2MZbGxm6clFatqjta/DLrq5V4Y5JU4cx7Qvy7l+XTVPvmRWaYuzzAuCf9uUc40IA==",
-            "dependencies": {
-                "arg": "^5.0.2",
-                "hyperdyperid": "^1.2.0"
-            },
-            "bin": {
-                "json-pack": "bin/json-pack.js",
-                "json-pack-test": "bin/json-pack-test.js",
-                "json-patch": "bin/json-patch.js",
-                "json-patch-test": "bin/json-patch-test.js",
-                "json-pointer": "bin/json-pointer.js",
-                "json-pointer-test": "bin/json-pointer-test.js",
-                "json-unpack": "bin/json-unpack.js"
-            },
-            "engines": {
-                "node": ">=10.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/streamich"
-            },
-            "peerDependencies": {
-                "quill-delta": "^5",
-                "rxjs": "7",
-                "tslib": "2"
-            }
-        },
-        "node_modules/json-joy/node_modules/arg": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-            "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
-        },
         "node_modules/json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -10281,12 +10233,6 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
-        "node_modules/lodash.clonedeep": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-            "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-            "peer": true
-        },
         "node_modules/lodash.flattendeep": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -10298,12 +10244,6 @@
             "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
             "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
             "dev": true
-        },
-        "node_modules/lodash.isequal": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-            "peer": true
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
@@ -12487,20 +12427,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/quill-delta": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
-            "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
-            "peer": true,
-            "dependencies": {
-                "fast-diff": "^1.3.0",
-                "lodash.clonedeep": "^4.5.0",
-                "lodash.isequal": "^4.5.0"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
         "node_modules/randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -13100,15 +13026,6 @@
             ],
             "dependencies": {
                 "queue-microtask": "^1.2.2"
-            }
-        },
-        "node_modules/rxjs": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.1.0"
             }
         },
         "node_modules/safe-buffer": {
@@ -14135,17 +14052,6 @@
             },
             "engines": {
                 "node": ">=0.8"
-            }
-        },
-        "node_modules/thingies": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.12.0.tgz",
-            "integrity": "sha512-AiGqfYC1jLmJagbzQGuoZRM48JPsr9yB734a7K6wzr34NMhjUPrWSQrkF7ZBybf3yCerCL2Gcr02kMv4NmaZfA==",
-            "engines": {
-                "node": ">=10.18"
-            },
-            "peerDependencies": {
-                "tslib": "^2"
             }
         },
         "node_modules/through": {
@@ -16003,7 +15909,6 @@
         "src/browser": {
             "license": "Apache-2.0",
             "dependencies": {
-                "memfs": "^4.2.1",
                 "os-browserify": "^0.3.0",
                 "path-browserify": "^1.0.1",
                 "process": "^0.11.10",
@@ -16011,25 +15916,6 @@
             },
             "devDependencies": {
                 "assert": "^2.0.0"
-            }
-        },
-        "src/browser/node_modules/memfs": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.2.1.tgz",
-            "integrity": "sha512-CINEB6cNAAhLUfRGrB4lj2Pj47ygerEmw3jxPb6R1gkD6Jfp484gJLteQ6MzqIjGWtFWuVzDl+KN7HiipMuKSw==",
-            "dependencies": {
-                "json-joy": "^9.2.0",
-                "thingies": "^1.11.1"
-            },
-            "engines": {
-                "node": ">= 4.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/streamich"
-            },
-            "peerDependencies": {
-                "tslib": "2"
             }
         }
     },
@@ -20394,22 +20280,10 @@
             "version": "file:src/browser",
             "requires": {
                 "assert": "^2.0.0",
-                "memfs": "^4.2.1",
                 "os-browserify": "^0.3.0",
                 "path-browserify": "^1.0.1",
                 "process": "^0.11.10",
                 "stream-browserify": "^3.0.0"
-            },
-            "dependencies": {
-                "memfs": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.2.1.tgz",
-                    "integrity": "sha512-CINEB6cNAAhLUfRGrB4lj2Pj47ygerEmw3jxPb6R1gkD6Jfp484gJLteQ6MzqIjGWtFWuVzDl+KN7HiipMuKSw==",
-                    "requires": {
-                        "json-joy": "^9.2.0",
-                        "thingies": "^1.11.1"
-                    }
-                }
             }
         },
         "browser-stdout": {
@@ -22284,12 +22158,6 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true
         },
-        "fast-diff": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-            "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-            "peer": true
-        },
         "fast-fifo": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
@@ -23055,11 +22923,6 @@
             "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
             "dev": true
         },
-        "hyperdyperid": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
-            "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A=="
-        },
         "iconv-lite": {
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -23641,22 +23504,6 @@
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
         },
-        "json-joy": {
-            "version": "9.5.1",
-            "resolved": "https://registry.npmjs.org/json-joy/-/json-joy-9.5.1.tgz",
-            "integrity": "sha512-XMSpdxaiWUZlc+CAUbPS3G2MZbGxm6clFatqjta/DLrq5V4Y5JU4cx7Qvy7l+XTVPvmRWaYuzzAuCf9uUc40IA==",
-            "requires": {
-                "arg": "^5.0.2",
-                "hyperdyperid": "^1.2.0"
-            },
-            "dependencies": {
-                "arg": {
-                    "version": "5.0.2",
-                    "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-                    "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
-                }
-            }
-        },
         "json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -24043,12 +23890,6 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
-        "lodash.clonedeep": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-            "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-            "peer": true
-        },
         "lodash.flattendeep": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -24060,12 +23901,6 @@
             "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
             "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
             "dev": true
-        },
-        "lodash.isequal": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-            "peer": true
         },
         "lodash.merge": {
             "version": "4.6.2",
@@ -25693,17 +25528,6 @@
             "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
             "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
         },
-        "quill-delta": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
-            "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
-            "peer": true,
-            "requires": {
-                "fast-diff": "^1.3.0",
-                "lodash.clonedeep": "^4.5.0",
-                "lodash.isequal": "^4.5.0"
-            }
-        },
         "randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -26160,15 +25984,6 @@
             "dev": true,
             "requires": {
                 "queue-microtask": "^1.2.2"
-            }
-        },
-        "rxjs": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-            "peer": true,
-            "requires": {
-                "tslib": "^2.1.0"
             }
         },
         "safe-buffer": {
@@ -26975,12 +26790,6 @@
             "requires": {
                 "thenify": ">= 3.1.0 < 4"
             }
-        },
-        "thingies": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.12.0.tgz",
-            "integrity": "sha512-AiGqfYC1jLmJagbzQGuoZRM48JPsr9yB734a7K6wzr34NMhjUPrWSQrkF7ZBybf3yCerCL2Gcr02kMv4NmaZfA==",
-            "requires": {}
         },
         "through": {
             "version": "2.3.8",

--- a/src/browser/package.json
+++ b/src/browser/package.json
@@ -3,7 +3,6 @@
     "description": "Browser specific modules to separate concerns from main package.json",
     "license": "Apache-2.0",
     "dependencies": {
-        "memfs": "^4.2.1",
         "os-browserify": "^0.3.0",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",

--- a/webpack.browser.config.js
+++ b/webpack.browser.config.js
@@ -24,7 +24,6 @@ const webConfig = {
         new webpack.ProvidePlugin({
             process: require.resolve('process/browser'),
             Buffer: ['buffer', 'Buffer'],
-            fs: require.resolve('memfs'),
         }),
         new webpack.EnvironmentPlugin({
             NODE_DEBUG: 'development',

--- a/webpack.browser.config.js
+++ b/webpack.browser.config.js
@@ -38,7 +38,7 @@ const webConfig = {
             os: require.resolve('os-browserify/browser'),
             path: require.resolve('path-browserify'),
             assert: require.resolve('assert'),
-            fs: require.resolve('memfs'),
+            fs: false,
 
             // *** If one of these modules actually gets used an error will be raised ***
             // You may see something like: "TypeError: path_ignored_0.join is not a function"


### PR DESCRIPTION
## Problem
- Due to a recent change, we stopped using
  the `fs` modules mkdir, and instead started
  using the `vscode.workspace.fs` mkdir implementation
  instead.

- The problem with the change is that `vscode.ExtensionContext.logUri`
  is not allowed by the C9 implementation of `vscode.workspace.fs`
  even though it works with the original `vscode.workspace.fs`

## Solution

- This commit will have `mkdir()` revert to using `fs` in the scenario
  that we are in C9. This will allow `logUri` to be mkdir'd successfully

- Also this change has been tested to work in the browser mode. Since
  we only call `fs` if in C9, the non-browser-compatible `fs` module will
  not be executed at any point in the browser.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
