### PR TITLE
feat(settings): check that user settings.json is valid

### DIFF
--- a/.changes/next-release/Feature-177a8535-0502-4135-a0f5-a2888f98949e.json
+++ b/.changes/next-release/Feature-177a8535-0502-4135-a0f5-a2888f98949e.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Detect and notify about invalid settings.json #3910"
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,7 +69,7 @@ import { Auth } from './auth/auth'
 import { openUrl } from './shared/utilities/vsCodeUtils'
 import { isUserCancelledError, resolveErrorMessageToDisplay, ToolkitError } from './shared/errors'
 import { Logging } from './shared/logger/commands'
-import { showMessageWithUrl } from './shared/utilities/messages'
+import { showMessageWithUrl, showViewLogsMessage } from './shared/utilities/messages'
 import { registerWebviewErrorHandler } from './webviews/server'
 import { initializeManifestPaths } from './extensionShared'
 
@@ -257,7 +257,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
         showWelcomeMessage(context)
 
-        recordToolkitInitialization(activationStartedOn, getLogger())
+        const settingsValid = await checkSettingsHealth(settings)
+        recordToolkitInitialization(activationStartedOn, settingsValid, getLogger())
 
         if (!isReleaseVersion()) {
             globals.telemetry.assertPassiveTelemetry(globals.didReload)
@@ -303,12 +304,16 @@ function makeEndpointsProvider() {
     }
 }
 
-function recordToolkitInitialization(activationStartedOn: number, logger?: Logger) {
+function recordToolkitInitialization(activationStartedOn: number, settingsValid: boolean, logger?: Logger) {
     try {
         const activationFinishedOn = Date.now()
         const duration = activationFinishedOn - activationStartedOn
 
-        telemetry.toolkit_init.emit({ duration })
+        if (settingsValid) {
+            telemetry.toolkit_init.emit({ duration })
+        } else {
+            telemetry.toolkit_init.emit({ duration, result: 'Failed', reason: 'UserSettings' })
+        }
     } catch (err) {
         logger?.error(err as Error)
     }
@@ -391,6 +396,20 @@ export function logAndShowWebviewError(err: unknown, webviewId: string, command:
     const detailedError = ToolkitError.chain(err, `Webview backend command failed: "${command}()"`)
     const userFacingError = ToolkitError.chain(detailedError, 'Webview error')
     logAndShowError(userFacingError, `webviewId="${webviewId}"`, 'Webview error')
+}
+
+async function checkSettingsHealth(settings: Settings): Promise<boolean> {
+    const ok = await settings.isValid()
+    if (!ok) {
+        const msg = 'User settings.json file appears to be invalid. Check settings.json for syntax errors.'
+        const openSettingsItem = 'Open settings.json'
+        showViewLogsMessage(msg, 'error', [openSettingsItem]).then(async resp => {
+            if (resp === openSettingsItem) {
+                vscode.commands.executeCommand('workbench.action.openSettingsJson')
+            }
+        })
+    }
+    return ok
 }
 
 // Unique extension entrypoint names, so that they can be obtained from the webpack bundle

--- a/src/test/utilities/testSettingsConfiguration.ts
+++ b/src/test/utilities/testSettingsConfiguration.ts
@@ -48,6 +48,10 @@ export class TestSettings implements ClassToInterfaceType<Settings> {
         return !type || value === undefined ? value : cast(value, type)
     }
 
+    public async isValid(): Promise<boolean> {
+        return true
+    }
+
     public async update(key: string, value: unknown): Promise<boolean> {
         const parts = key.split('.')
 


### PR DESCRIPTION
Problem:
vscode notifies the user if `settings.json` is complete nonsense, but is silent if there are only "recoverable" JSON syntax errors. So _reading_ settings will appear to work, but _writing_ settings will throw an exception. #3910

Solution:
On startup, check that we can actually _write_ settings, and show an error message if not.

<img width="446" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/55561878/c1088c2e-5705-4f8e-a9cd-8184557f436b">



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
