### PR TITLE
auth: ellipsis + right click options for `Developer Tools`

### DIFF
--- a/package.json
+++ b/package.json
@@ -785,7 +785,7 @@
                     "when": "false"
                 },
                 {
-                    "command": "aws.codeWhisperer.removeConnection",
+                    "command": "aws.codeWhisperer.signout",
                     "when": "false"
                 },
                 {
@@ -1917,13 +1917,13 @@
                     "group": "inline@1"
                 },
                 {
-                    "command": "aws.codeWhisperer.removeConnection",
-                    "when": "viewItem == awsCodeWhispererNodeSaved",
+                    "command": "aws.codeWhisperer.signout",
+                    "when": "viewItem =~ /^awsCodeWhispererNode/ && CODEWHISPERER_ENABLED",
                     "group": "0@1"
                 },
                 {
-                    "command": "aws.codeWhisperer.removeConnection",
-                    "when": "viewItem == awsCodeWhispererNodeSaved",
+                    "command": "aws.codeWhisperer.signout",
+                    "when": "viewItem =~ /^awsCodeWhispererNode/ && CODEWHISPERER_ENABLED",
                     "group": "inline@3"
                 },
                 {
@@ -3431,8 +3431,8 @@
                 }
             },
             {
-                "command": "aws.codeWhisperer.removeConnection",
-                "title": "%AWS.command.codewhisperer.removeConnection%",
+                "command": "aws.codeWhisperer.signout",
+                "title": "%AWS.command.codewhisperer.signout%",
                 "category": "%AWS.title%",
                 "icon": "$(debug-disconnect)"
             },

--- a/package.json
+++ b/package.json
@@ -728,6 +728,17 @@
                 "label": "%AWS.submenu.auth.title%",
                 "icon": "$(ellipsis)",
                 "when": "!isWeb"
+            },
+            {
+                "id": "aws.codewhisperer.submenu",
+                "label": "%AWS.codewhisperer.submenu.title%",
+                "icon": "$(ellipsis)"
+            },
+            {
+                "id": "aws.codecatalyst.submenu",
+                "label": "%AWS.codecatalyst.submenu.title%",
+                "icon": "$(ellipsis)",
+                "when": "!isWeb"
             }
         ],
         "menus": {
@@ -781,11 +792,7 @@
                     "when": "!isCloud9"
                 },
                 {
-                    "command": "aws.codecatalyst.signout",
-                    "when": "false"
-                },
-                {
-                    "command": "aws.codeWhisperer.signout",
+                    "command": "aws.codewhisperer.signout",
                     "when": "false"
                 },
                 {
@@ -1330,16 +1337,6 @@
                     "command": "aws.apig.invokeRemoteRestApi",
                     "when": "view == aws.explorer && viewItem =~ /^(awsApiGatewayNode)$/",
                     "group": "0@1"
-                },
-                {
-                    "command": "aws.codecatalyst.signout",
-                    "when": "viewItem =~ /^awsCodeCatalystNode/ && CODECATALYST_CONNECTED && !isCloud9",
-                    "group": "0@1"
-                },
-                {
-                    "command": "aws.codecatalyst.signout",
-                    "when": "viewItem =~ /^awsCodeCatalystNode/ && CODECATALYST_CONNECTED && !isCloud9",
-                    "group": "inline@1"
                 },
                 {
                     "command": "aws.ec2.openTerminal",
@@ -1907,24 +1904,9 @@
                     "when": "view == aws.explorer && viewItem == awsCloudFormationRootNode"
                 },
                 {
-                    "command": "aws.codeWhisperer.configure",
-                    "when": "viewItem =~ /^awsCodeWhispererNode/ && !isCloud9",
-                    "group": "inline@2"
-                },
-                {
                     "command": "aws.codeWhisperer.introduction",
                     "when": "viewItem =~ /^awsCodeWhispererNode/ && !isCloud9 && CODEWHISPERER_TERMS_ACCEPTED",
                     "group": "inline@1"
-                },
-                {
-                    "command": "aws.codeWhisperer.signout",
-                    "when": "viewItem =~ /^awsCodeWhispererNode/ && CODEWHISPERER_ENABLED",
-                    "group": "0@1"
-                },
-                {
-                    "command": "aws.codeWhisperer.signout",
-                    "when": "viewItem =~ /^awsCodeWhispererNode/ && CODEWHISPERER_ENABLED",
-                    "group": "inline@3"
                 },
                 {
                     "command": "aws.cdk.refresh",
@@ -1965,6 +1947,41 @@
                     "submenu": "aws.auth",
                     "when": "viewItem == awsAuthNode",
                     "group": "inline@2"
+                },
+                {
+                    "submenu": "aws.codecatalyst.submenu",
+                    "when": "viewItem =~ /^awsCodeCatalystNode/",
+                    "group": "inline@1"
+                },
+                {
+                    "command": "aws.codecatalyst.manageConnections",
+                    "when": "viewItem =~ /^awsCodeCatalystNode/",
+                    "group": "0@1"
+                },
+                {
+                    "command": "aws.codecatalyst.signout",
+                    "when": "viewItem =~ /^awsCodeCatalystNode/&& !isCloud9 && aws.codecatalyst.connected",
+                    "group": "0@2"
+                },
+                {
+                    "submenu": "aws.codewhisperer.submenu",
+                    "when": "viewItem =~ /^awsCodeWhispererNode/",
+                    "group": "inline@1"
+                },
+                {
+                    "command": "aws.codewhisperer.manageConnections",
+                    "when": "viewItem =~ /^awsCodeWhispererNode/",
+                    "group": "0@1"
+                },
+                {
+                    "command": "aws.codeWhisperer.configure",
+                    "when": "viewItem =~ /^awsCodeWhispererNode/",
+                    "group": "0@2"
+                },
+                {
+                    "command": "aws.codewhisperer.signout",
+                    "when": "viewItem =~ /^awsCodeWhispererNode/ && !isCloud9 && CODEWHISPERER_ENABLED",
+                    "group": "0@3"
                 }
             ],
             "aws.auth": [
@@ -1979,6 +1996,32 @@
                 {
                     "command": "aws.auth.signout",
                     "enablement": "!isCloud9",
+                    "group": "0@3"
+                }
+            ],
+            "aws.codecatalyst.submenu": [
+                {
+                    "command": "aws.codecatalyst.manageConnections",
+                    "group": "0@1"
+                },
+                {
+                    "command": "aws.codecatalyst.signout",
+                    "when": "aws.codecatalyst.connected",
+                    "group": "0@2"
+                }
+            ],
+            "aws.codewhisperer.submenu": [
+                {
+                    "command": "aws.codewhisperer.manageConnections",
+                    "group": "0@1"
+                },
+                {
+                    "command": "aws.codeWhisperer.configure",
+                    "group": "0@2"
+                },
+                {
+                    "command": "aws.codewhisperer.signout",
+                    "when": "CODEWHISPERER_ENABLED",
                     "group": "0@3"
                 }
             ]
@@ -2127,6 +2170,16 @@
             },
             {
                 "command": "aws.auth.manageConnections",
+                "title": "%AWS.command.auth.showConnectionsPage%",
+                "category": "%AWS.title%"
+            },
+            {
+                "command": "aws.codecatalyst.manageConnections",
+                "title": "%AWS.command.auth.showConnectionsPage%",
+                "category": "%AWS.title%"
+            },
+            {
+                "command": "aws.codewhisperer.manageConnections",
                 "title": "%AWS.command.auth.showConnectionsPage%",
                 "category": "%AWS.title%"
             },
@@ -3431,7 +3484,7 @@
                 }
             },
             {
-                "command": "aws.codeWhisperer.signout",
+                "command": "aws.codewhisperer.signout",
                 "title": "%AWS.command.codewhisperer.signout%",
                 "category": "%AWS.title%",
                 "icon": "$(debug-disconnect)"

--- a/package.json
+++ b/package.json
@@ -781,7 +781,7 @@
                     "when": "!isCloud9"
                 },
                 {
-                    "command": "aws.codecatalyst.removeConnection",
+                    "command": "aws.codecatalyst.signout",
                     "when": "false"
                 },
                 {
@@ -1332,13 +1332,13 @@
                     "group": "0@1"
                 },
                 {
-                    "command": "aws.codecatalyst.removeConnection",
-                    "when": "viewItem == awsCodeCatalystNodeSaved",
+                    "command": "aws.codecatalyst.signout",
+                    "when": "viewItem =~ /^awsCodeCatalystNode/ && CODECATALYST_CONNECTED && !isCloud9",
                     "group": "0@1"
                 },
                 {
-                    "command": "aws.codecatalyst.removeConnection",
-                    "when": "viewItem == awsCodeCatalystNodeSaved",
+                    "command": "aws.codecatalyst.signout",
+                    "when": "viewItem =~ /^awsCodeCatalystNode/ && CODECATALYST_CONNECTED && !isCloud9",
                     "group": "inline@1"
                 },
                 {
@@ -2104,8 +2104,8 @@
                 "enablement": "!isCloud9 && !isWeb"
             },
             {
-                "command": "aws.codecatalyst.removeConnection",
-                "title": "%AWS.command.codecatalyst.removeConnection%",
+                "command": "aws.codecatalyst.signout",
+                "title": "%AWS.command.codecatalyst.signout%",
                 "category": "AWS",
                 "icon": "$(debug-disconnect)",
                 "enablement": "!isWeb"

--- a/package.nls.json
+++ b/package.nls.json
@@ -98,7 +98,7 @@
     "AWS.command.codecatalyst.listCommands": "List CodeCatalyst Commands",
     "AWS.command.codecatalyst.login": "Connect to CodeCatalyst",
     "AWS.command.codecatalyst.logout": "Sign out of CodeCatalyst",
-    "AWS.command.codecatalyst.removeConnection": "Remove Connection from Tool",
+    "AWS.command.codecatalyst.signout": "Sign out",
     "AWS.command.deploySamApplication": "Deploy SAM Application",
     "AWS.command.aboutToolkit": "About Toolkit",
     "AWS.command.downloadLambda": "Download...",

--- a/package.nls.json
+++ b/package.nls.json
@@ -195,7 +195,7 @@
     "AWS.command.resources.configure": "Show Resources...",
     "AWS.command.codewhisperer.introduction": "What is CodeWhisperer?",
     "AWS.command.codewhisperer.configure": "CodeWhisperer Settings",
-    "AWS.command.codewhisperer.removeConnection": "Remove Connection from Tool",
+    "AWS.command.codewhisperer.signout": "Sign out",
     "AWS.lambda.explorerTitle": "Explorer",
     "AWS.developerTools.explorerTitle": "Developer Tools",
     "AWS.cwl.limit.desc": "Maximum amount of log entries pulled per request from CloudWatch Logs (max 10000)",

--- a/package.nls.json
+++ b/package.nls.json
@@ -3,6 +3,7 @@
     "AWS.title.cn": "Amazon",
     "AWS.productName": "AWS Toolkit",
     "AWS.productName.cn": "Amazon Toolkit",
+    "AWS.codecatalyst.submenu.title": "Manage CodeCatalyst",
     "AWS.configuration.profileDescription": "The name of the credential profile to obtain credentials from.",
     "AWS.configuration.description.lambda.recentlyUploaded": "Recently selected Lambda upload targets.",
     "AWS.configuration.description.ecs.openTerminalCommand": "The command to run when starting a new interactive terminal session.",
@@ -225,5 +226,6 @@
     "AWS.codewhisperer.customization.quickPick.title": "Select a Customization",
     "AWS.codewhisperer.customization.quickPick.placeholder": "You have access to the following customizations",
     "AWS.codewhisperer.customization.notification.new_customizations.select": "Select Customization",
-    "AWS.codewhisperer.customization.notification.new_customizations.learn_more": "Learn More"
+    "AWS.codewhisperer.customization.notification.new_customizations.learn_more": "Learn More",
+    "AWS.codewhisperer.submenu.title": "Manage CodeWhisperer"
 }

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -121,9 +121,12 @@ export class Auth implements AuthService, ConnectionManager {
     readonly #onDidChangeActiveConnection = new vscode.EventEmitter<StatefulConnection | undefined>()
     readonly #onDidChangeConnectionState = new vscode.EventEmitter<ConnectionStateChangeEvent>()
     readonly #onDidUpdateConnection = new vscode.EventEmitter<StatefulConnection>()
+    readonly #onDidDeleteConnection = new vscode.EventEmitter<Connection['id']>()
     public readonly onDidChangeActiveConnection = this.#onDidChangeActiveConnection.event
     public readonly onDidChangeConnectionState = this.#onDidChangeConnectionState.event
     public readonly onDidUpdateConnection = this.#onDidUpdateConnection.event
+    /** Fired when a connection and its metadata has been completely deleted */
+    public readonly onDidDeleteConnection = this.#onDidDeleteConnection.event
 
     public constructor(
         private readonly store: ProfileStore,
@@ -284,13 +287,15 @@ export class Auth implements AuthService, ConnectionManager {
     }
 
     public async deleteConnection(connection: Pick<Connection, 'id'>): Promise<void> {
-        if (connection.id === this.#activeConnection?.id) {
+        const connId = connection.id
+        if (connId === this.#activeConnection?.id) {
             await this.logout()
         } else {
-            await this.invalidateConnection(connection.id)
+            await this.invalidateConnection(connId)
         }
 
-        await this.store.deleteProfile(connection.id)
+        await this.store.deleteProfile(connId)
+        this.#onDidDeleteConnection.fire(connId)
     }
 
     public async getConnection(connection: Pick<Connection, 'id'>): Promise<Connection | undefined> {

--- a/src/auth/secondaryAuth.ts
+++ b/src/auth/secondaryAuth.ts
@@ -103,7 +103,7 @@ export class SecondaryAuth<T extends Connection = Connection> {
                 this.#savedConnection &&
                 this.#savedConnection.id === this.#activeConnection?.id
             ) {
-                await this.removeConnection()
+                await this.removeSavedConnection()
             } else {
                 this.#activeConnection = conn
                 this.#onDidChangeActiveConnection.fire(this.activeConnection)
@@ -148,7 +148,8 @@ export class SecondaryAuth<T extends Connection = Connection> {
         this.#onDidChangeActiveConnection.fire(this.activeConnection)
     }
 
-    public async removeConnection() {
+    /** Stops using the saved connection and fallsback to using the active connection, if it is usable. */
+    public async removeSavedConnection() {
         await this.memento.update(this.key, undefined)
         this.#savedConnection = undefined
         this.#onDidChangeActiveConnection.fire(this.activeConnection)

--- a/src/auth/secondaryAuth.ts
+++ b/src/auth/secondaryAuth.ts
@@ -120,6 +120,12 @@ export class SecondaryAuth<T extends Connection = Connection> {
         // Register listener and handle connection immediately in case we were instantiated late
         handleConnectionChanged(this.auth.activeConnection)
         this.auth.onDidChangeActiveConnection(handleConnectionChanged)
+        this.auth.onDidDeleteConnection(async (deletedConnId: Connection['id']) => {
+            if (deletedConnId === this.#savedConnection?.id) {
+                // There is no more savedConnection since it was deleted, so stop using it
+                await this.detachConnection()
+            }
+        })
     }
 
     public get activeConnection(): T | undefined {

--- a/src/auth/ui/vue/show.ts
+++ b/src/auth/ui/vue/show.ts
@@ -155,7 +155,7 @@ export class AuthWebview extends VueWebview {
 
     private async deleteSavedBuilderIdConns(): Promise<void> {
         if (CodeWhispererAuth.instance.isBuilderIdInUse()) {
-            await CodeWhispererAuth.instance.secondaryAuth.removeConnection()
+            await CodeWhispererAuth.instance.secondaryAuth.removeSavedConnection()
         }
 
         if (this.codeCatalystAuth.activeConnection) {
@@ -280,7 +280,7 @@ export class AuthWebview extends VueWebview {
             return
         }
 
-        await CodeWhispererAuth.instance.secondaryAuth.removeConnection()
+        await CodeWhispererAuth.instance.secondaryAuth.removeSavedConnection()
         await signout(Auth.instance, activeConn) // deletes active connection
     }
 

--- a/src/auth/ui/vue/show.ts
+++ b/src/auth/ui/vue/show.ts
@@ -146,21 +146,9 @@ export class AuthWebview extends VueWebview {
     }
 
     async signoutBuilderId(): Promise<void> {
-        await this.deleteSavedBuilderIdConns()
-
-        // Deletes active connection
         const builderIdConn = (await Auth.instance.listConnections()).find(isBuilderIdConnection)
+        // this will fire events to signal the secondary auths
         await signout(Auth.instance, builderIdConn)
-    }
-
-    private async deleteSavedBuilderIdConns(): Promise<void> {
-        if (CodeWhispererAuth.instance.isBuilderIdInUse()) {
-            await CodeWhispererAuth.instance.secondaryAuth.removeSavedConnection()
-        }
-
-        if (this.codeCatalystAuth.activeConnection) {
-            await this.codeCatalystAuth.removeSavedConnection()
-        }
     }
 
     async showResourceExplorer(): Promise<void> {
@@ -280,8 +268,7 @@ export class AuthWebview extends VueWebview {
             return
         }
 
-        await CodeWhispererAuth.instance.secondaryAuth.removeSavedConnection()
-        await signout(Auth.instance, activeConn) // deletes active connection
+        await CodeWhispererAuth.instance.secondaryAuth.deleteConnection()
     }
 
     async signoutIdentityCenter(): Promise<void> {

--- a/src/codecatalyst/activation.ts
+++ b/src/codecatalyst/activation.ts
@@ -40,7 +40,7 @@ export async function activate(ctx: ExtContext): Promise<void> {
     )
 
     Commands.register('aws.codecatalyst.removeConnection', () => {
-        authProvider.removeSavedConnection()
+        authProvider.secondaryAuth.deleteConnection()
     })
 
     if (!isCloud9()) {

--- a/src/codecatalyst/activation.ts
+++ b/src/codecatalyst/activation.ts
@@ -23,6 +23,7 @@ import { isDevenvVscode } from './utils'
 import { getThisDevEnv } from './model'
 import { getLogger } from '../shared/logger/logger'
 import { InactivityMessage, shouldTrackUserActivity } from './devEnv'
+import { AuthCommandDeclarations } from '../auth/commands'
 
 const localize = nls.loadMessageBundle()
 
@@ -36,12 +37,17 @@ export async function activate(ctx: ExtContext): Promise<void> {
 
     ctx.extensionContext.subscriptions.push(
         uriHandlers.register(ctx.uriHandler, CodeCatalystCommands.declared),
-        ...Object.values(CodeCatalystCommands.declared).map(c => c.register(commands))
+        ...Object.values(CodeCatalystCommands.declared).map(c => c.register(commands)),
+        Commands.register('aws.codecatalyst.manageConnections', () => {
+            AuthCommandDeclarations.instance.declared.showManageConnections.execute(
+                'codecatalystDeveloperTools',
+                'codecatalyst'
+            )
+        }),
+        Commands.register('aws.codecatalyst.signout', () => {
+            return authProvider.secondaryAuth.deleteConnection()
+        })
     )
-
-    Commands.register('aws.codecatalyst.signout', () => {
-        authProvider.secondaryAuth.deleteConnection()
-    })
 
     if (!isCloud9()) {
         GitExtension.instance.registerRemoteSourceProvider(remoteSourceProvider).then(disposable => {

--- a/src/codecatalyst/activation.ts
+++ b/src/codecatalyst/activation.ts
@@ -39,7 +39,7 @@ export async function activate(ctx: ExtContext): Promise<void> {
         ...Object.values(CodeCatalystCommands.declared).map(c => c.register(commands))
     )
 
-    Commands.register('aws.codecatalyst.removeConnection', () => {
+    Commands.register('aws.codecatalyst.signout', () => {
         authProvider.secondaryAuth.deleteConnection()
     })
 

--- a/src/codecatalyst/auth.ts
+++ b/src/codecatalyst/auth.ts
@@ -46,7 +46,7 @@ export const isUpgradeableConnection = (conn: Connection): conn is SsoConnection
     isBuilderIdConnection(conn) && !isValidCodeCatalystConnection(conn)
 
 export function setCodeCatalystConnectedContext(isConnected: boolean) {
-    return vscode.commands.executeCommand('setContext', 'CODECATALYST_CONNECTED', isConnected)
+    return vscode.commands.executeCommand('setContext', 'aws.codecatalyst.connected', isConnected)
 }
 
 export class CodeCatalystAuthenticationProvider {

--- a/src/codecatalyst/auth.ts
+++ b/src/codecatalyst/auth.ts
@@ -102,7 +102,7 @@ export class CodeCatalystAuthenticationProvider {
     }
 
     public async removeSavedConnection() {
-        await this.secondaryAuth.removeConnection()
+        await this.secondaryAuth.removeSavedConnection()
     }
 
     public async restore() {

--- a/src/codecatalyst/auth.ts
+++ b/src/codecatalyst/auth.ts
@@ -45,6 +45,10 @@ export const isValidCodeCatalystConnection = (conn: Connection): conn is SsoConn
 export const isUpgradeableConnection = (conn: Connection): conn is SsoConnection =>
     isBuilderIdConnection(conn) && !isValidCodeCatalystConnection(conn)
 
+export function setCodeCatalystConnectedContext(isConnected: boolean) {
+    return vscode.commands.executeCommand('setContext', 'CODECATALYST_CONNECTED', isConnected)
+}
+
 export class CodeCatalystAuthenticationProvider {
     public readonly onDidChangeActiveConnection = this.secondaryAuth.onDidChangeActiveConnection
 
@@ -58,7 +62,14 @@ export class CodeCatalystAuthenticationProvider {
             'CodeCatalyst',
             isValidCodeCatalystConnection
         )
-    ) {}
+    ) {
+        this.secondaryAuth.onDidChangeActiveConnection(async () => {
+            await setCodeCatalystConnectedContext(this.isConnectionValid())
+        })
+
+        // set initial context in case event does not trigger
+        setCodeCatalystConnectedContext(this.isConnectionValid())
+    }
 
     public get activeConnection() {
         return this.secondaryAuth.activeConnection

--- a/src/codecatalyst/auth.ts
+++ b/src/codecatalyst/auth.ts
@@ -101,10 +101,6 @@ export class CodeCatalystAuthenticationProvider {
         }
     }
 
-    public async removeSavedConnection() {
-        await this.secondaryAuth.removeSavedConnection()
-    }
-
     public async restore() {
         await this.secondaryAuth.restoreConnection()
     }

--- a/src/codecatalyst/explorer.ts
+++ b/src/codecatalyst/explorer.ts
@@ -150,9 +150,18 @@ export class CodeCatalystRootNode implements RootNode {
             item.description = 'Connected to Dev Environment'
             item.iconPath = addColor(getIcon('vscode-pass'), 'testing.iconPassed')
         } else {
-            item.description = this.authProvider.isUsingSavedConnection ? 'AWS Builder ID Connected' : undefined
+            item.description = this.getDescription()
         }
 
         return item
+    }
+
+    private getDescription(): string {
+        if (this.authProvider.activeConnection) {
+            return this.authProvider.secondaryAuth.isConnectionExpired
+                ? 'Expired Connection'
+                : 'AWS Builder ID Connected'
+        }
+        return ''
     }
 }

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -54,6 +54,7 @@ import { TelemetryHelper } from './util/telemetryHelper'
 import { openUrl } from '../shared/utilities/vsCodeUtils'
 import { notifyNewCustomizations } from './util/customizationUtil'
 import { CodeWhispererCommandBackend, CodeWhispererCommandDeclarations } from './commands/gettingStartedPageCommands'
+import { AuthCommandDeclarations } from '../auth/commands'
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
 export async function activate(context: ExtContext): Promise<void> {
@@ -90,6 +91,14 @@ export async function activate(context: ExtContext): Promise<void> {
     ImportAdderProvider.instance
 
     context.extensionContext.subscriptions.push(
+        Commands.register('aws.codewhisperer.signout', () => auth.secondaryAuth.deleteConnection()),
+        /** Opens the Add Connections webview with CW highlighted */
+        Commands.register('aws.codewhisperer.manageConnections', () => {
+            AuthCommandDeclarations.instance.declared.showManageConnections.execute(
+                'codewhispererDeveloperTools',
+                'codewhisperer'
+            )
+        }),
         /**
          * Configuration change
          */

--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -8,7 +8,6 @@ import * as CodeWhispererConstants from '../models/constants'
 import { Auth } from '../../auth/auth'
 import { ToolkitError } from '../../shared/errors'
 import { getSecondaryAuth } from '../../auth/secondaryAuth'
-import { Commands } from '../../shared/vscode/commands2'
 import { isCloud9 } from '../../shared/extensionUtilities'
 import { PromptSettings } from '../../shared/settings'
 import {
@@ -182,8 +181,6 @@ export class AuthUtil {
         }
 
         const self = (this.#instance = new this())
-        Commands.register('aws.codeWhisperer.signout', () => self.secondaryAuth.deleteConnection())
-
         return self
     }
 

--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -182,7 +182,7 @@ export class AuthUtil {
         }
 
         const self = (this.#instance = new this())
-        Commands.register('aws.codeWhisperer.removeConnection', () => self.secondaryAuth.deleteConnection())
+        Commands.register('aws.codeWhisperer.signout', () => self.secondaryAuth.deleteConnection())
 
         return self
     }

--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -182,7 +182,7 @@ export class AuthUtil {
         }
 
         const self = (this.#instance = new this())
-        Commands.register('aws.codeWhisperer.removeConnection', () => self.secondaryAuth.removeSavedConnection())
+        Commands.register('aws.codeWhisperer.removeConnection', () => self.secondaryAuth.deleteConnection())
 
         return self
     }

--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -182,7 +182,7 @@ export class AuthUtil {
         }
 
         const self = (this.#instance = new this())
-        Commands.register('aws.codeWhisperer.removeConnection', () => self.secondaryAuth.removeConnection())
+        Commands.register('aws.codeWhisperer.removeConnection', () => self.secondaryAuth.removeSavedConnection())
 
         return self
     }


### PR DESCRIPTION
This commit allows user to right click to root CW or CC
Node or click the new ellipsis icon, and they will get
the options to Add Connection or Signout (if appropriate)

![Screenshot 2023-10-20 at 10 50 42 AM](https://github.com/aws/aws-toolkit-vscode/assets/118216176/c934c3b6-4b8b-40b8-a24e-2c8a7a1988c6)

![Kapture 2023-10-20 at 10 36 27](https://github.com/aws/aws-toolkit-vscode/assets/118216176/aa8b0309-4981-475c-a5bd-47d4c00db478)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
