### PR TITLE
fix(redshift): fix cache in connection wizard

### DIFF
--- a/.changes/next-release/Bug Fix-7c1f7a4d-132c-4b88-b19d-b76dab547915.json
+++ b/.changes/next-release/Bug Fix-7c1f7a4d-132c-4b88-b19d-b76dab547915.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Redshift: The output message is not clear when a sql query is successful but returns no record."
+}

--- a/.changes/next-release/Bug Fix-7c49d65e-079c-4578-9c69-9dd7d4925b4e.json
+++ b/.changes/next-release/Bug Fix-7c49d65e-079c-4578-9c69-9dd7d4925b4e.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Redshift: 1. Remove the cache when the connection wizard is re-launched. 2. Modify the output message when a sql query is successful but doesn't return any record."
+	"description": "Redshift: Re-launched connection wizard shows the old (stale) connection."
 }

--- a/.changes/next-release/Bug Fix-7c49d65e-079c-4578-9c69-9dd7d4925b4e.json
+++ b/.changes/next-release/Bug Fix-7c49d65e-079c-4578-9c69-9dd7d4925b4e.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Redshift: 1. Remove the cache when the connection wizard is re-launched. 2. Modify the output message when a sql query is successful but doesn't return any record."
+}

--- a/src/redshift/activation.ts
+++ b/src/redshift/activation.ts
@@ -9,7 +9,7 @@ import { RedshiftNotebookSerializer } from './notebook/redshiftNotebookSerialize
 import { RedshiftNotebookController } from './notebook/redshiftNotebookController'
 import { CellStatusBarItemProvider } from './notebook/cellStatusBarItemProvider'
 import { Commands } from '../shared/vscode/commands2'
-import { NotebookConnectionWizard } from './wizards/connectionWizard'
+import { NotebookConnectionWizard, RedshiftNodeConnectionWizard } from './wizards/connectionWizard'
 import { ConnectionParams, ConnectionType } from './models/models'
 import { DefaultRedshiftClient } from '../shared/clients/redshiftClient'
 import { localize } from '../shared/utilities/vsCodeUtils'
@@ -119,7 +119,7 @@ function getNotebookConnectClickedHandler(
 function getEditConnectionHandler(outputChannel: vscode.OutputChannel) {
     return async (redshiftWarehouseNode: RedshiftWarehouseNode) => {
         try {
-            const connectionParams = await redshiftWarehouseNode.connectionWizard!.run()
+            const connectionParams = await new RedshiftNodeConnectionWizard(redshiftWarehouseNode).run()
             if (connectionParams) {
                 if (connectionParams.connectionType === ConnectionType.DatabaseUser) {
                     const secretArnFetched =

--- a/src/redshift/explorer/redshiftWarehouseNode.ts
+++ b/src/redshift/explorer/redshiftWarehouseNode.ts
@@ -43,8 +43,7 @@ export class RedshiftWarehouseNode extends AWSTreeNodeBase implements AWSResourc
     constructor(
         public readonly parent: RedshiftNode,
         public readonly redshiftWarehouse: AWSResourceNode,
-        public readonly warehouseType: RedshiftWarehouseType,
-        public readonly connectionWizard?: RedshiftNodeConnectionWizard
+        public readonly warehouseType: RedshiftWarehouseType
     ) {
         super(redshiftWarehouse.name, vscode.TreeItemCollapsibleState.Collapsed)
         this.tooltip = redshiftWarehouse.name
@@ -52,7 +51,6 @@ export class RedshiftWarehouseNode extends AWSTreeNodeBase implements AWSResourc
         this.arn = redshiftWarehouse.arn
         this.name = redshiftWarehouse.name
         this.redshiftClient = parent.redshiftClient
-        this.connectionWizard = connectionWizard ?? new RedshiftNodeConnectionWizard(this)
         const existingConnectionParams = getConnectionParamsState(this.arn)
         if (existingConnectionParams && existingConnectionParams !== deleteConnection) {
             this.connectionParams = existingConnectionParams as ConnectionParams
@@ -125,7 +123,7 @@ export class RedshiftWarehouseNode extends AWSTreeNodeBase implements AWSResourc
                     this.connectionParams = existingConnectionParams as ConnectionParams
                 } else {
                     // No connectionParams: trigger connection wizard to get user input
-                    this.connectionParams = await this.connectionWizard!.run()
+                    this.connectionParams = await new RedshiftNodeConnectionWizard(this).run()
                     if (!this.connectionParams) {
                         return this.getClickToEstablishConnectionNode()
                     }

--- a/src/redshift/notebook/redshiftNotebookController.ts
+++ b/src/redshift/notebook/redshiftNotebookController.ts
@@ -97,7 +97,7 @@ export class RedshiftNotebookController {
                     records.push(...result.statementResultResponse.Records)
                 } else {
                     return new vscode.NotebookCellOutput([
-                        vscode.NotebookCellOutputItem.text('No records.', 'text/plain'),
+                        vscode.NotebookCellOutputItem.text('Query completed — No rows returned.', 'text/plain'),
                     ])
                 }
             } while (nextToken)

--- a/src/redshift/wizards/connectionWizard.ts
+++ b/src/redshift/wizards/connectionWizard.ts
@@ -21,21 +21,9 @@ import { SecretsManagerClient } from '../../shared/clients/secretsManagerClient'
 import { redshiftHelpUrl } from '../../shared/constants'
 
 export class RedshiftNodeConnectionWizard extends Wizard<ConnectionParams> {
-    public constructor(
-        node: RedshiftWarehouseNode,
-        connectionType?: ConnectionType,
-        database?: string,
-        username?: string,
-        password?: string,
-        secret?: string
-    ) {
+    public constructor(node: RedshiftWarehouseNode) {
         super({
             initState: {
-                connectionType: connectionType ? connectionType : undefined,
-                database: database ? database : undefined,
-                username: username ? username : undefined,
-                password: password ? password : undefined,
-                secret: secret ? secret : undefined,
                 warehouseIdentifier: node.name,
                 warehouseType: node.warehouseType,
             },
@@ -48,13 +36,13 @@ export class RedshiftNodeConnectionWizard extends Wizard<ConnectionParams> {
         )
 
         this.form.database.bindPrompter(getDatabasePrompter, {
-            relativeOrder: 3,
+            relativeOrder: 2,
         })
         this.form.username.bindPrompter(getUsernamePrompter, {
             showWhen: state =>
                 (state.database !== undefined && state.connectionType === ConnectionType.TempCreds) ||
                 state.connectionType === ConnectionType.DatabaseUser,
-            relativeOrder: 2,
+            relativeOrder: 3,
         })
         this.form.password.bindPrompter(getPasswordPrompter, {
             showWhen: state => state.username !== undefined && state.connectionType === ConnectionType.DatabaseUser,
@@ -121,7 +109,7 @@ export class NotebookConnectionWizard extends Wizard<ConnectionParams> {
                 }
             }
         })
-        this.form.connectionType.bindPrompter(state => getConnectionTypePrompterNB(state?.warehouseType), {
+        this.form.connectionType.bindPrompter(state => getConnectionTypePrompter(undefined, state?.warehouseType), {
             relativeOrder: 3,
         })
 
@@ -134,12 +122,12 @@ export class NotebookConnectionWizard extends Wizard<ConnectionParams> {
         })
         this.form.password.bindPrompter(getPasswordPrompter, {
             showWhen: state => state.username !== undefined && state.connectionType === ConnectionType.DatabaseUser,
-            relativeOrder: 5,
+            relativeOrder: 6,
         })
 
         this.form.secret.bindPrompter(state => getSecretPrompter(state.region!.id), {
             showWhen: state => state.database !== undefined && state.connectionType === ConnectionType.SecretsManager,
-            relativeOrder: 6,
+            relativeOrder: 5,
         })
     }
 }
@@ -215,16 +203,6 @@ function getConnectionTypePrompter(
         const selectedItems = warehouseType === RedshiftWarehouseType.SERVERLESS ? [items[0], items[1]] : items
         return createSelectConnectionQuickPick(selectedItems)
     }
-}
-
-function getConnectionTypePrompterNB(warehouseType?: RedshiftWarehouseType): Prompter<ConnectionType> {
-    const items: DataQuickPickItem<ConnectionType>[] = Object.values(ConnectionType).map(type => ({
-        label: type,
-        data: type,
-    }))
-    // Determine which items to use based on warehouseType
-    const selectedItems = warehouseType === RedshiftWarehouseType.SERVERLESS ? [items[0], items[1]] : items
-    return createSelectConnectionQuickPick(selectedItems)
 }
 
 async function* fetchWarehouses(redshiftClient: DefaultRedshiftClient) {

--- a/src/test/redshift/explorer/redshiftWarehouseNode.test.ts
+++ b/src/test/redshift/explorer/redshiftWarehouseNode.test.ts
@@ -56,9 +56,9 @@ describe('redshiftWarehouseNode', function () {
             undefined
         )
         const redshiftNode = new RedshiftNode(redshiftClient)
-        let connectionWizardStub: RedshiftNodeConnectionWizard
         let listDatabasesStub: sinon.SinonStub
         let warehouseNode: RedshiftWarehouseNode
+        let connectionWizardStub: sinon.SinonStub
 
         beforeEach(function () {
             listDatabasesStub = sandbox.stub()
@@ -67,16 +67,11 @@ describe('redshiftWarehouseNode', function () {
 
         afterEach(function () {
             sandbox.reset()
+            connectionWizardStub.restore()
         })
-
         it('gets databases for a warehouse and adds a start button', async () => {
-            connectionWizardStub = { run: () => Promise.resolve(connectionParams) } as RedshiftNodeConnectionWizard
-            warehouseNode = new RedshiftWarehouseNode(
-                redshiftNode,
-                resourceNode,
-                RedshiftWarehouseType.PROVISIONED,
-                connectionWizardStub
-            )
+            connectionWizardStub = sinon.stub(RedshiftNodeConnectionWizard.prototype, 'run').resolves(connectionParams)
+            warehouseNode = new RedshiftWarehouseNode(redshiftNode, resourceNode, RedshiftWarehouseType.PROVISIONED)
             listDatabasesStub.returns({ promise: () => Promise.resolve(expectedResponse) })
 
             const childNodes = await warehouseNode.getChildren()
@@ -85,13 +80,8 @@ describe('redshiftWarehouseNode', function () {
         })
 
         it('gets databases for a warehouse, adds a start button and a load more button if there are more results', async () => {
-            connectionWizardStub = { run: () => Promise.resolve(connectionParams) } as RedshiftNodeConnectionWizard
-            warehouseNode = new RedshiftWarehouseNode(
-                redshiftNode,
-                resourceNode,
-                RedshiftWarehouseType.PROVISIONED,
-                connectionWizardStub
-            )
+            connectionWizardStub = sinon.stub(RedshiftNodeConnectionWizard.prototype, 'run').resolves(connectionParams)
+            warehouseNode = new RedshiftWarehouseNode(redshiftNode, resourceNode, RedshiftWarehouseType.PROVISIONED)
             listDatabasesStub.returns({ promise: () => Promise.resolve(expectedResponseWithNextToken) })
 
             const childNodes = await warehouseNode.getChildren()
@@ -100,25 +90,15 @@ describe('redshiftWarehouseNode', function () {
         })
 
         it('shows a node with retry if user exits wizard', async () => {
-            connectionWizardStub = { run: () => Promise.resolve(undefined) } as RedshiftNodeConnectionWizard
-            warehouseNode = new RedshiftWarehouseNode(
-                redshiftNode,
-                resourceNode,
-                RedshiftWarehouseType.PROVISIONED,
-                connectionWizardStub
-            )
+            connectionWizardStub = sinon.stub(RedshiftNodeConnectionWizard.prototype, 'run').resolves(undefined)
+            warehouseNode = new RedshiftWarehouseNode(redshiftNode, resourceNode, RedshiftWarehouseType.PROVISIONED)
             const childNodes = await warehouseNode.getChildren()
             verifyRetryNode(childNodes)
         })
 
         it('shows a node with retry if there is error fetching databases', async () => {
-            connectionWizardStub = { run: () => Promise.resolve(connectionParams) } as RedshiftNodeConnectionWizard
-            warehouseNode = new RedshiftWarehouseNode(
-                redshiftNode,
-                resourceNode,
-                RedshiftWarehouseType.PROVISIONED,
-                connectionWizardStub
-            )
+            connectionWizardStub = sinon.stub(RedshiftNodeConnectionWizard.prototype, 'run').resolves(connectionParams)
+            warehouseNode = new RedshiftWarehouseNode(redshiftNode, resourceNode, RedshiftWarehouseType.PROVISIONED)
             listDatabasesStub.returns({ promise: () => Promise.reject('Failed') })
             const childNodes = await warehouseNode.getChildren()
             verifyRetryNode(childNodes)


### PR DESCRIPTION
## Problem
1. When the connection parameters is removed, the re-launched connection wizard still show the earlier connection parameters.
2. When a sql query is successful but doesn't return any record, the output message is not clear. 
<img width="606" alt="Screenshot 2023-10-20 at 11 52 12 AM" src="https://github.com/aws/aws-toolkit-vscode/assets/141669322/ebed2a31-68cf-4291-bb3d-d6c2fcf72ffc">
<img width="705" alt="Screenshot 2023-10-20 at 11 51 17 AM" src="https://github.com/aws/aws-toolkit-vscode/assets/141669322/a0736174-a488-4fc6-845c-7a0be6e735d4">

## Solution
1. Remove the connection wizard from the redshiftWarehouseNode constructor. Create a new instance when a connection wizard is launched.
2. Modify the output message when a sql query is successful but doesn't return any record.
<img width="609" alt="Screenshot 2023-10-20 at 11 47 56 AM" src="https://github.com/aws/aws-toolkit-vscode/assets/141669322/035e5262-b423-409e-b5ee-b8c1787b7239">
<img width="659" alt="Screenshot 2023-10-20 at 11 46 39 AM" src="https://github.com/aws/aws-toolkit-vscode/assets/141669322/7013bf19-9388-406c-b934-9085ec129b97">

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
