### PR TITLE
fix(codewihsperer): mapping language code before calling sendTelemetry API

### DIFF
--- a/src/codewhisperer/client/codewhisperer.ts
+++ b/src/codewhisperer/client/codewhisperer.ts
@@ -207,6 +207,11 @@ export class DefaultCodeWhispererClient {
         if (!AuthUtil.instance.isValidEnterpriseSsoInUse() && !globals.telemetry.telemetryEnabled) {
             return
         }
+
+        // TODO
+        if (request.telemetryEvent) {
+        }
+
         const response = await (await this.createUserSdkClient()).sendTelemetryEvent(requestWithOptOut).promise()
         getLogger().debug(`codewhisperer: sendTelemetryEvent requestID: ${response.$response.requestId}`)
     }

--- a/src/codewhisperer/client/codewhisperer.ts
+++ b/src/codewhisperer/client/codewhisperer.ts
@@ -208,10 +208,6 @@ export class DefaultCodeWhispererClient {
             return
         }
 
-        // TODO
-        if (request.telemetryEvent) {
-        }
-
         const response = await (await this.createUserSdkClient()).sendTelemetryEvent(requestWithOptOut).promise()
         getLogger().debug(`codewhisperer: sendTelemetryEvent requestID: ${response.$response.requestId}`)
     }

--- a/src/codewhisperer/client/codewhisperer.ts
+++ b/src/codewhisperer/client/codewhisperer.ts
@@ -207,7 +207,6 @@ export class DefaultCodeWhispererClient {
         if (!AuthUtil.instance.isValidEnterpriseSsoInUse() && !globals.telemetry.telemetryEnabled) {
             return
         }
-
         const response = await (await this.createUserSdkClient()).sendTelemetryEvent(requestWithOptOut).promise()
         getLogger().debug(`codewhisperer: sendTelemetryEvent requestID: ${response.$response.requestId}`)
     }

--- a/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
+++ b/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
@@ -132,13 +132,21 @@ export class CodeWhispererCodeCoverageTracker {
             codewhispererUserGroup: CodeWhispererUserGroupSettings.getUserGroup().toString(),
             codewhispererCustomizationArn: selectedCustomization.arn === '' ? undefined : selectedCustomization.arn,
         })
+
+        let codewhispererRuntimeLanguage: string = this._language
+        if (this._language === 'jsx') {
+            codewhispererRuntimeLanguage = 'javascript'
+        } else if (this._language === 'tsx') {
+            codewhispererRuntimeLanguage = 'typescript'
+        }
+
         client
             .sendTelemetryEvent({
                 telemetryEvent: {
                     codeCoverageEvent: {
                         customizationArn: selectedCustomization.arn === '' ? undefined : selectedCustomization.arn,
                         programmingLanguage: {
-                            languageName: this._language,
+                            languageName: codewhispererRuntimeLanguage,
                         },
                         acceptedCharacterCount: acceptedTokens,
                         totalCharacterCount: totalTokens,

--- a/src/codewhisperer/tracker/codewhispererTracker.ts
+++ b/src/codewhisperer/tracker/codewhispererTracker.ts
@@ -95,6 +95,13 @@ export class CodeWhispererTracker {
         } catch (e) {
             getLogger().verbose(`Exception Thrown from CodeWhispererTracker: ${e}`)
         } finally {
+            let codewhispererRuntimeLanguage: string = suggestion.language
+            if (codewhispererRuntimeLanguage === 'jsx') {
+                codewhispererRuntimeLanguage = 'javascript'
+            } else if (codewhispererRuntimeLanguage === 'tsx') {
+                codewhispererRuntimeLanguage = 'typescript'
+            }
+
             telemetry.codewhisperer_userModification.emit({
                 codewhispererRequestId: suggestion.requestId ? suggestion.requestId : 'undefined',
                 codewhispererSessionId: suggestion.sessionId ? suggestion.sessionId : undefined,

--- a/src/codewhisperer/util/telemetryHelper.ts
+++ b/src/codewhisperer/util/telemetryHelper.ts
@@ -340,6 +340,13 @@ export class TelemetryHelper {
             e2eLatency = performance.now() - session.invokeSuggestionStartTime
         }
 
+        let codewhispererRuntimeLanguage: string = this.sessionDecisions[0].codewhispererLanguage
+        if (codewhispererRuntimeLanguage === 'jsx') {
+            codewhispererRuntimeLanguage = 'javascript'
+        } else if (codewhispererRuntimeLanguage === 'tsx') {
+            codewhispererRuntimeLanguage = 'typescript'
+        }
+
         client
             .sendTelemetryEvent({
                 telemetryEvent: {
@@ -348,7 +355,7 @@ export class TelemetryHelper {
                         requestId: this.sessionDecisions[0].codewhispererFirstRequestId,
                         customizationArn: selectedCustomization.arn === '' ? undefined : selectedCustomization.arn,
                         programmingLanguage: {
-                            languageName: this.sessionDecisions[0].codewhispererLanguage,
+                            languageName: codewhispererRuntimeLanguage,
                         },
                         completionType: this.getSendTelemetryCompletionType(aggregatedCompletionType),
                         suggestionState: this.getSendTelemetrySuggestionState(aggregatedSuggestionState),
@@ -581,6 +588,14 @@ export class TelemetryHelper {
     }
     public sendCodeScanEvent(languageId: string, jobId: string) {
         getLogger().debug(`start sendCodeScanEvent: jobId: "${jobId}", languageId: "${languageId}"`)
+
+        let codewhispererRuntimeLanguage: string = languageId
+        if (codewhispererRuntimeLanguage === 'jsx') {
+            codewhispererRuntimeLanguage = 'javascript'
+        } else if (codewhispererRuntimeLanguage === 'tsx') {
+            codewhispererRuntimeLanguage = 'typescript'
+        }
+
         client
             .sendTelemetryEvent({
                 telemetryEvent: {


### PR DESCRIPTION
## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
