### PR TITLE
watchedfiles: add watch patterns once to avoid rebuilding n times

### DIFF
--- a/.changes/next-release/Bug Fix-b3e30500-5dbe-4b08-ae36-aaba6b020c8f.json
+++ b/.changes/next-release/Bug Fix-b3e30500-5dbe-4b08-ae36-aaba6b020c8f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Improved CloudFormation file watcher startup"
+}

--- a/.changes/next-release/Bug Fix-b3e30500-5dbe-4b08-ae36-aaba6b020c8f.json
+++ b/.changes/next-release/Bug Fix-b3e30500-5dbe-4b08-ae36-aaba6b020c8f.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Improved CloudFormation file watcher startup"
+	"description": "Improved performance of CloudFormation file watcher startup"
 }

--- a/src/codecatalyst/devfile.ts
+++ b/src/codecatalyst/devfile.ts
@@ -110,7 +110,7 @@ export class DevfileCodeLensProvider implements vscode.CodeLensProvider {
 export function registerDevfileWatcher(devenvClient: DevEnvClient): vscode.Disposable {
     const registry = new DevfileRegistry()
     const codelensProvider = new DevfileCodeLensProvider(registry, devenvClient)
-    registry.addWatchPattern(devfileGlobPattern)
+    registry.addWatchPatterns(devfileGlobPattern)
 
     const codelensDisposable = vscode.languages.registerCodeLensProvider(
         {

--- a/src/codecatalyst/devfile.ts
+++ b/src/codecatalyst/devfile.ts
@@ -110,7 +110,7 @@ export class DevfileCodeLensProvider implements vscode.CodeLensProvider {
 export function registerDevfileWatcher(devenvClient: DevEnvClient): vscode.Disposable {
     const registry = new DevfileRegistry()
     const codelensProvider = new DevfileCodeLensProvider(registry, devenvClient)
-    registry.addWatchPatterns(devfileGlobPattern)
+    registry.addWatchPatterns([devfileGlobPattern])
 
     const codelensDisposable = vscode.languages.registerCodeLensProvider(
         {

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -69,7 +69,7 @@ function setTemplateRegistryInGlobals(registry: CloudFormationTemplateRegistry) 
     const registrySetupFunc = async (registry: CloudFormationTemplateRegistry) => {
         await registry.addExcludedPattern(devfileExcludePattern)
         await registry.addExcludedPattern(templateFileExcludePattern)
-        await registry.addWatchPattern(templateFileGlobPattern)
+        await registry.addWatchPatterns(templateFileGlobPattern)
         await registry.watchUntitledFiles()
     }
 

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -69,7 +69,7 @@ function setTemplateRegistryInGlobals(registry: CloudFormationTemplateRegistry) 
     const registrySetupFunc = async (registry: CloudFormationTemplateRegistry) => {
         await registry.addExcludedPattern(devfileExcludePattern)
         await registry.addExcludedPattern(templateFileExcludePattern)
-        await registry.addWatchPatterns(templateFileGlobPattern)
+        await registry.addWatchPatterns([templateFileGlobPattern])
         await registry.watchUntitledFiles()
     }
 

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -168,14 +168,16 @@ async function activateCodeLensRegistry(context: ExtContext) {
 
         //
         // "**/…" string patterns watch recursively across _all_ workspace
-        // folders (see documentation for addWatchPattern()).
+        // folders (see documentation for addWatchPatterns()).
         //
-        await registry.addWatchPattern(pyLensProvider.pythonBasePattern)
-        await registry.addWatchPattern(jsLensProvider.javascriptBasePattern)
-        await registry.addWatchPattern(csLensProvider.csharpBasePattern)
-        await registry.addWatchPattern(goLensProvider.goBasePattern)
-        await registry.addWatchPattern(javaLensProvider.gradleBasePattern)
-        await registry.addWatchPattern(javaLensProvider.mavenBasePattern)
+        await registry.addWatchPatterns([
+            pyLensProvider.pythonBasePattern,
+            jsLensProvider.javascriptBasePattern,
+            csLensProvider.csharpBasePattern,
+            goLensProvider.goBasePattern,
+            javaLensProvider.gradleBasePattern,
+            javaLensProvider.mavenBasePattern,
+        ])
     } catch (e) {
         vscode.window.showErrorMessage(
             localize(

--- a/src/test/shared/debug/launchConfiguration.test.ts
+++ b/src/test/shared/debug/launchConfiguration.test.ts
@@ -105,7 +105,7 @@ describe('LaunchConfiguration', function () {
     const templateUriCsharp = vscode.Uri.file(path.join(workspace.uri.fsPath, 'csharp6-zip/template.yaml'))
 
     beforeEach(async function () {
-        await globals.templateRegistry.addWatchPatterns(templateFileGlobPattern)
+        await globals.templateRegistry.addWatchPatterns([templateFileGlobPattern])
 
         // TODO: remove mocks in favor of testing src/testFixtures/ data.
         mockConfigSource = mock()

--- a/src/test/shared/debug/launchConfiguration.test.ts
+++ b/src/test/shared/debug/launchConfiguration.test.ts
@@ -105,7 +105,7 @@ describe('LaunchConfiguration', function () {
     const templateUriCsharp = vscode.Uri.file(path.join(workspace.uri.fsPath, 'csharp6-zip/template.yaml'))
 
     beforeEach(async function () {
-        await globals.templateRegistry.addWatchPattern(templateFileGlobPattern)
+        await globals.templateRegistry.addWatchPatterns(templateFileGlobPattern)
 
         // TODO: remove mocks in favor of testing src/testFixtures/ data.
         mockConfigSource = mock()

--- a/src/testInteg/cloudformation/templateRegistry.test.ts
+++ b/src/testInteg/cloudformation/templateRegistry.test.ts
@@ -10,6 +10,7 @@ import { CloudFormationTemplateRegistry } from '../../shared/fs/templateRegistry
 import { makeSampleSamTemplateYaml, strToYamlFile } from '../../test/shared/cloudformation/cloudformationTestUtils'
 import { getTestWorkspaceFolder } from '../integrationTestsUtilities'
 import { sleep, waitUntil } from '../../shared/utilities/timeoutUtils'
+import assert from 'assert'
 
 /**
  * Note: these tests are pretty shallow right now. They do not test the following:
@@ -43,13 +44,13 @@ describe('CloudFormation Template Registry', async function () {
         await strToYamlFile(makeSampleSamTemplateYaml(true), path.join(testDir, 'test.yaml'))
         await strToYamlFile(makeSampleSamTemplateYaml(false), path.join(testDirNested, 'test.yml'))
 
-        await registry.addWatchPattern('**/test.{yaml,yml}')
+        await registry.addWatchPatterns(['**/test.{yaml,yml}'])
 
         await registryHasTargetNumberOfFiles(registry, 2)
     })
 
     it.skip('adds dynamically-added template files with yaml and yml extensions at various nesting levels', async function () {
-        await registry.addWatchPattern('**/test.{yaml,yml}')
+        await registry.addWatchPatterns(['**/test.{yaml,yml}'])
 
         await strToYamlFile(makeSampleSamTemplateYaml(false), path.join(testDir, 'test.yml'))
         await strToYamlFile(makeSampleSamTemplateYaml(true), path.join(testDirNested, 'test.yaml'))
@@ -58,7 +59,7 @@ describe('CloudFormation Template Registry', async function () {
     })
 
     it('Ignores templates matching excluded patterns', async function () {
-        await registry.addWatchPattern('**/test.{yaml,yml}')
+        await registry.addWatchPatterns(['**/test.{yaml,yml}'])
         await registry.addExcludedPattern(/.*nested.*/)
 
         await strToYamlFile(makeSampleSamTemplateYaml(false), path.join(testDir, 'test.yml'))
@@ -71,7 +72,7 @@ describe('CloudFormation Template Registry', async function () {
         const filepath = path.join(testDir, 'changeMe.yml')
         await strToYamlFile(makeSampleSamTemplateYaml(false), filepath)
 
-        await registry.addWatchPattern('**/changeMe.yml')
+        await registry.addWatchPatterns(['**/changeMe.yml'])
 
         await registryHasTargetNumberOfFiles(registry, 1)
 
@@ -83,7 +84,7 @@ describe('CloudFormation Template Registry', async function () {
     })
 
     it('can handle deleted files', async function () {
-        await registry.addWatchPattern('**/deleteMe.yml')
+        await registry.addWatchPatterns(['**/deleteMe.yml'])
 
         // Specifically creating the file after the watcher is added
         // Otherwise, it seems the file is deleted before the file watcher realizes the file exists
@@ -96,6 +97,13 @@ describe('CloudFormation Template Registry', async function () {
         await fs.remove(filepath)
 
         await registryHasTargetNumberOfFiles(registry, 0)
+    })
+
+    it('fails if you set watch patterns multiple times', async function () {
+        await registry.addWatchPatterns(['first/set'])
+        await assert.rejects(async () => {
+            await registry.addWatchPatterns(['second/set'])
+        }, 'CloudFormationTemplateRegistry: watch patterns have already been established')
     })
 })
 

--- a/src/testInteg/cloudformation/templateRegistry.test.ts
+++ b/src/testInteg/cloudformation/templateRegistry.test.ts
@@ -103,7 +103,7 @@ describe('CloudFormation Template Registry', async function () {
         await registry.addWatchPatterns(['first/set'])
         await assert.rejects(async () => {
             await registry.addWatchPatterns(['second/set'])
-        }, 'CloudFormationTemplateRegistry: watch patterns have already been established')
+        }, new Error('CloudFormationTemplateRegistry: watch patterns have already been established'))
     })
 })
 


### PR DESCRIPTION
## Problem
WatchedFiles takes a long time to process the watched files

## Solution
There's probably a lot of problems here, but this is definitely one of them: rebuilding after each additional watch pattern meant we were processing globs n times, with each run containing `{1, 2, 3, ... , n-1, n}` patterns. Swapping this to an array and enforcing adding the patterns once ensures we only process 1 time, for n globs on initial load. We aren't adding globs dynamically at any point; if we ever feel the need to, we can implement some fancy caching/expiry business.

FWIW it seems like getting the files in the glob is fairly fast, so if processing files is the bottleneck, this might be the cure? I'm sure we can improve more going forward regardless.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
