### PR TITLE
codewhisperer: add quick fix code actions for issues

### DIFF
--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -55,6 +55,7 @@ import { openUrl } from '../shared/utilities/vsCodeUtils'
 import { notifyNewCustomizations } from './util/customizationUtil'
 import { CodeWhispererCommandBackend, CodeWhispererCommandDeclarations } from './commands/gettingStartedPageCommands'
 import { SecurityIssueHoverProvider } from './service/securityIssueHoverProvider'
+import { SecurityIssueCodeActionProvider } from './service/securityIssueCodeActionProvider'
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
 export async function activate(context: ExtContext): Promise<void> {
@@ -217,6 +218,10 @@ export async function activate(context: ExtContext): Promise<void> {
         vscode.languages.registerHoverProvider(
             [...CodeWhispererConstants.supportedLanguages],
             SecurityIssueHoverProvider.instance
+        ),
+        vscode.languages.registerCodeActionsProvider(
+            [...CodeWhispererConstants.supportedLanguages],
+            SecurityIssueCodeActionProvider.instance
         )
     )
 
@@ -304,6 +309,7 @@ export async function activate(context: ExtContext): Promise<void> {
                 disposeSecurityDiagnostic(e)
 
                 SecurityIssueHoverProvider.instance.handleDocumentChange(e)
+                SecurityIssueCodeActionProvider.instance.handleDocumentChange(e)
 
                 CodeWhispererCodeCoverageTracker.getTracker(e.document.languageId)?.countTotalTokens(e)
 

--- a/src/codewhisperer/service/diagnosticsProvider.ts
+++ b/src/codewhisperer/service/diagnosticsProvider.ts
@@ -6,6 +6,7 @@
 import * as vscode from 'vscode'
 import { CodeScanIssue, AggregatedCodeScanIssue } from '../models/model'
 import { SecurityIssueHoverProvider } from './securityIssueHoverProvider'
+import { SecurityIssueCodeActionProvider } from './securityIssueCodeActionProvider'
 
 interface SecurityScanRender {
     securityDiagnosticCollection: vscode.DiagnosticCollection | undefined
@@ -28,6 +29,7 @@ export function initSecurityScanRender(
     })
     securityScanRender.initialized = true
     SecurityIssueHoverProvider.instance.issues = securityRecommendationList
+    SecurityIssueCodeActionProvider.instance.issues = securityRecommendationList
 }
 
 export function updateSecurityDiagnosticCollection(securityRecommendation: AggregatedCodeScanIssue) {

--- a/src/codewhisperer/service/securityIssueCodeActionProvider.ts
+++ b/src/codewhisperer/service/securityIssueCodeActionProvider.ts
@@ -1,0 +1,44 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { SecurityIssueProvider } from './securityIssueProvider'
+
+export class SecurityIssueCodeActionProvider extends SecurityIssueProvider implements vscode.CodeActionProvider {
+    static #instance: SecurityIssueCodeActionProvider
+
+    public static get instance() {
+        return (this.#instance ??= new this())
+    }
+
+    public provideCodeActions(
+        document: vscode.TextDocument,
+        range: vscode.Range | vscode.Selection,
+        _context: vscode.CodeActionContext,
+        _token: vscode.CancellationToken
+    ): vscode.CodeAction[] {
+        const codeActions: vscode.CodeAction[] = []
+
+        for (const group of this.issues) {
+            if (document.fileName !== group.filePath) {
+                continue
+            }
+
+            for (const issue of group.issues) {
+                const issueRange = new vscode.Range(issue.startLine, 0, issue.endLine, 0)
+                if (issueRange.contains(range)) {
+                    const [suggestedFix] = issue.suggestedFixes ?? []
+                    if (suggestedFix) {
+                        const fixIssue = new vscode.CodeAction(`Fix "${issue.title}"`, vscode.CodeActionKind.QuickFix)
+                        // TODO: Add apply fix command
+                        codeActions.push(fixIssue)
+                    }
+                }
+            }
+        }
+
+        return codeActions
+    }
+}

--- a/src/codewhisperer/service/securityIssueProvider.ts
+++ b/src/codewhisperer/service/securityIssueProvider.ts
@@ -1,0 +1,55 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { AggregatedCodeScanIssue } from '../models/model'
+
+export abstract class SecurityIssueProvider {
+    private _issues: AggregatedCodeScanIssue[] = []
+    public get issues() {
+        return this._issues
+    }
+
+    public set issues(issues: AggregatedCodeScanIssue[]) {
+        this._issues = issues
+    }
+
+    public handleDocumentChange(event: vscode.TextDocumentChangeEvent) {
+        const changedRange = event.contentChanges[0].range
+        const changedText = event.contentChanges[0].text
+        const lineOffset = this._getLineOffset(changedRange, changedText)
+
+        this._issues = this._issues.map(group => {
+            if (group.filePath !== event.document.fileName) {
+                return group
+            }
+            return {
+                ...group,
+                issues: group.issues
+                    .filter(issue => {
+                        const range = new vscode.Range(issue.startLine, 0, issue.endLine, 0)
+                        const intersection = changedRange.intersection(range)
+                        return !(intersection && (/\S/.test(changedText) || changedText === ''))
+                    })
+                    .map(issue => {
+                        if (issue.startLine < changedRange.end.line) {
+                            return issue
+                        }
+                        return {
+                            ...issue,
+                            startLine: issue.startLine + lineOffset,
+                            endLine: issue.endLine + lineOffset,
+                        }
+                    }),
+            }
+        })
+    }
+
+    private _getLineOffset(range: vscode.Range, text: string) {
+        const originLines = range.end.line - range.start.line + 1
+        const changedLines = text.split('\n').length
+        return changedLines - originLines
+    }
+}

--- a/src/test/codewhisperer/service/securityIssueCodeActionProvider.test.ts
+++ b/src/test/codewhisperer/service/securityIssueCodeActionProvider.test.ts
@@ -1,0 +1,53 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { createCodeActionContext, createCodeScanIssue, createMockDocument } from '../testUtil'
+import assert from 'assert'
+import { SecurityIssueCodeActionProvider } from '../../../codewhisperer/service/securityIssueCodeActionProvider'
+
+describe('securityIssueCodeActionProvider', () => {
+    let securityIssueCodeActionProvider: SecurityIssueCodeActionProvider
+    let mockDocument: vscode.TextDocument
+    let context: vscode.CodeActionContext
+    let token: vscode.CancellationTokenSource
+
+    beforeEach(() => {
+        securityIssueCodeActionProvider = new SecurityIssueCodeActionProvider()
+        mockDocument = createMockDocument('def two_sum(nums, target):\nfor', 'test.py', 'python')
+        context = createCodeActionContext()
+        token = new vscode.CancellationTokenSource()
+    })
+
+    it('should provide quick fix for each issue that has a suggested fix', () => {
+        securityIssueCodeActionProvider.issues = [
+            {
+                filePath: mockDocument.fileName,
+                issues: [createCodeScanIssue({ title: 'issue 1' }), createCodeScanIssue({ title: 'issue 2' })],
+            },
+        ]
+        const range = new vscode.Range(0, 0, 0, 0)
+        const actual = securityIssueCodeActionProvider.provideCodeActions(mockDocument, range, context, token.token)
+
+        assert.strictEqual(actual.length, 2)
+        assert.strictEqual(actual[0].title, 'Fix "issue 1"')
+        assert.strictEqual(actual[0].kind, vscode.CodeActionKind.QuickFix)
+        assert.strictEqual(actual[1].title, 'Fix "issue 2"')
+        assert.strictEqual(actual[1].kind, vscode.CodeActionKind.QuickFix)
+    })
+
+    it('should not provide quick fix if the issue does not have a suggested fix', () => {
+        securityIssueCodeActionProvider.issues = [
+            {
+                filePath: mockDocument.fileName,
+                issues: [createCodeScanIssue({ suggestedFixes: [] })],
+            },
+        ]
+        const range = new vscode.Range(0, 0, 0, 0)
+        const actual = securityIssueCodeActionProvider.provideCodeActions(mockDocument, range, context, token.token)
+
+        assert.strictEqual(actual.length, 0)
+    })
+})

--- a/src/test/codewhisperer/service/securityIssueHoverProvider.test.ts
+++ b/src/test/codewhisperer/service/securityIssueHoverProvider.test.ts
@@ -5,29 +5,9 @@
 
 import * as vscode from 'vscode'
 import { SecurityIssueHoverProvider } from '../../../codewhisperer/service/securityIssueHoverProvider'
-import { createMockDocument, createTextDocumentChangeEvent } from '../testUtil'
+import { createCodeScanIssue, createMockDocument } from '../testUtil'
 import assert from 'assert'
-import { CodeScanIssue } from '../../../codewhisperer/models/model'
 import sinon from 'sinon'
-
-const makeIssue = (overrides?: Partial<CodeScanIssue>): CodeScanIssue => ({
-    startLine: 0,
-    endLine: 0,
-    comment: 'comment',
-    title: 'title',
-    description: {
-        text: 'description',
-        markdown: 'description',
-    },
-    detectorId: 'language/cool-detector@v1.0',
-    detectorName: 'detectorName',
-    relatedVulnerabilities: [],
-    severity: 'High',
-    suggestedFixes: [
-        { description: 'fix', code: '@@ -1,1 +1,1 @@\nfirst line\n-second line\n+third line\nfourth line' },
-    ],
-    ...overrides,
-})
 
 describe('securityIssueHoverProvider', () => {
     let securityIssueHoverProvider: SecurityIssueHoverProvider
@@ -40,126 +20,66 @@ describe('securityIssueHoverProvider', () => {
         token = new vscode.CancellationTokenSource()
     })
 
-    describe('providerHover', () => {
-        it('should return hover for each issue for the current position', () => {
-            sinon.stub(vscode.Uri, 'joinPath').callsFake(() => vscode.Uri.parse('myPath'))
+    it('should return hover for each issue for the current position', () => {
+        sinon.stub(vscode.Uri, 'joinPath').callsFake(() => vscode.Uri.parse('myPath'))
 
-            securityIssueHoverProvider.issues = [
-                {
-                    filePath: mockDocument.fileName,
-                    issues: [
-                        makeIssue({ startLine: 0, endLine: 1 }),
-                        makeIssue({ startLine: 0, endLine: 1, suggestedFixes: [] }),
-                    ],
-                },
-            ]
+        securityIssueHoverProvider.issues = [
+            {
+                filePath: mockDocument.fileName,
+                issues: [createCodeScanIssue(), createCodeScanIssue({ suggestedFixes: [] })],
+            },
+        ]
 
-            const actual = securityIssueHoverProvider.provideHover(mockDocument, new vscode.Position(0, 0), token.token)
+        const actual = securityIssueHoverProvider.provideHover(mockDocument, new vscode.Position(0, 0), token.token)
 
-            assert.strictEqual(actual.contents.length, 2)
-            assert.strictEqual(
-                (actual.contents[0] as vscode.MarkdownString).value,
-                '## Suggested Fix for title ![High](file:///myPath)\n' +
-                    'description\n\n' +
-                    '[$(eye) View Details](command:aws.codewhisperer.viewSecurityIssue)\n' +
-                    ' | [$(wrench) Apply Fix](command:aws.codewhisperer.applySecurityFix)\n\n' +
-                    '<span class="codicon codicon-none" style="background-color:var(--vscode-textCodeBlock-background);">\n\n' +
-                    '```language\n' +
-                    'first line    \n' +
-                    '```\n\n' +
-                    '</span>\n' +
-                    '<br />\n' +
-                    '<span class="codicon codicon-none" style="background-color:var(--vscode-diffEditor-removedTextBackground);">\n\n' +
-                    '```diff\n' +
-                    '-second line  \n' +
-                    '```\n\n' +
-                    '</span>\n' +
-                    '<br />\n' +
-                    '<span class="codicon codicon-none" style="background-color:var(--vscode-diffEditor-insertedTextBackground);">\n\n' +
-                    '```diff\n' +
-                    '+third line   \n' +
-                    '```\n\n' +
-                    '</span>\n' +
-                    '<br />\n' +
-                    '<span class="codicon codicon-none" style="background-color:var(--vscode-textCodeBlock-background);">\n\n' +
-                    '```language\n' +
-                    'fourth line   \n' +
-                    '```\n\n' +
-                    '</span>\n\n'
-            )
-            assert.strictEqual(
-                (actual.contents[1] as vscode.MarkdownString).value,
-                '## title ![High](file:///myPath)\n' +
-                    'description\n\n' +
-                    '[$(eye) View Details](command:aws.codewhisperer.viewSecurityIssue)\n'
-            )
-        })
+        assert.strictEqual(actual.contents.length, 2)
+        assert.strictEqual(
+            (actual.contents[0] as vscode.MarkdownString).value,
+            '## Suggested Fix for title ![High](file:///myPath)\n' +
+                'description\n\n' +
+                '[$(eye) View Details](command:aws.codewhisperer.viewSecurityIssue)\n' +
+                ' | [$(wrench) Apply Fix](command:aws.codewhisperer.applySecurityFix)\n\n' +
+                '<span class="codicon codicon-none" style="background-color:var(--vscode-textCodeBlock-background);">\n\n' +
+                '```language\n' +
+                'first line    \n' +
+                '```\n\n' +
+                '</span>\n' +
+                '<br />\n' +
+                '<span class="codicon codicon-none" style="background-color:var(--vscode-diffEditor-removedTextBackground);">\n\n' +
+                '```diff\n' +
+                '-second line  \n' +
+                '```\n\n' +
+                '</span>\n' +
+                '<br />\n' +
+                '<span class="codicon codicon-none" style="background-color:var(--vscode-diffEditor-insertedTextBackground);">\n\n' +
+                '```diff\n' +
+                '+third line   \n' +
+                '```\n\n' +
+                '</span>\n' +
+                '<br />\n' +
+                '<span class="codicon codicon-none" style="background-color:var(--vscode-textCodeBlock-background);">\n\n' +
+                '```language\n' +
+                'fourth line   \n' +
+                '```\n\n' +
+                '</span>\n\n'
+        )
+        assert.strictEqual(
+            (actual.contents[1] as vscode.MarkdownString).value,
+            '## title ![High](file:///myPath)\n' +
+                'description\n\n' +
+                '[$(eye) View Details](command:aws.codewhisperer.viewSecurityIssue)\n'
+        )
+    })
 
-        it('should return empty contents if there is no issue on the current position', () => {
-            securityIssueHoverProvider.issues = [
-                {
-                    filePath: mockDocument.fileName,
-                    issues: [makeIssue({ startLine: 0, endLine: 1 })],
-                },
-            ]
+    it('should return empty contents if there is no issue on the current position', () => {
+        securityIssueHoverProvider.issues = [
+            {
+                filePath: mockDocument.fileName,
+                issues: [createCodeScanIssue()],
+            },
+        ]
 
-            const actual = securityIssueHoverProvider.provideHover(mockDocument, new vscode.Position(2, 0), token.token)
-            assert.strictEqual(actual.contents.length, 0)
-        })
-
-        it('removes the issue hover if the document change on the same line', () => {
-            securityIssueHoverProvider.issues = [
-                {
-                    filePath: mockDocument.fileName,
-                    issues: [makeIssue({ startLine: 0, endLine: 1 })],
-                },
-            ]
-            let actual = securityIssueHoverProvider.provideHover(mockDocument, new vscode.Position(0, 0), token.token)
-            assert.strictEqual(actual.contents.length, 1)
-
-            const changeEvent = createTextDocumentChangeEvent(mockDocument, new vscode.Range(0, 0, 0, 0), 'a')
-            securityIssueHoverProvider.handleDocumentChange(changeEvent)
-
-            actual = securityIssueHoverProvider.provideHover(mockDocument, new vscode.Position(0, 0), token.token)
-            assert.strictEqual(actual.contents.length, 0)
-        })
-
-        it('offsets the existing issue down a line if a new line is inserted above', () => {
-            securityIssueHoverProvider.issues = [
-                {
-                    filePath: mockDocument.fileName,
-                    issues: [makeIssue({ startLine: 1, endLine: 2 })],
-                },
-            ]
-            let actual = securityIssueHoverProvider.provideHover(mockDocument, new vscode.Position(1, 0), token.token)
-            assert.strictEqual(actual.contents.length, 1)
-
-            const changeEvent = createTextDocumentChangeEvent(mockDocument, new vscode.Range(0, 0, 0, 0), '\n')
-            securityIssueHoverProvider.handleDocumentChange(changeEvent)
-
-            actual = securityIssueHoverProvider.provideHover(mockDocument, new vscode.Position(1, 0), token.token)
-            assert.strictEqual(actual.contents.length, 0)
-
-            actual = securityIssueHoverProvider.provideHover(mockDocument, new vscode.Position(2, 0), token.token)
-            assert.strictEqual(actual.contents.length, 1)
-        })
-
-        it('does not move the issue if the document changed below the line', () => {
-            securityIssueHoverProvider.issues = [
-                {
-                    filePath: mockDocument.fileName,
-                    issues: [makeIssue({ startLine: 0, endLine: 1 })],
-                },
-            ]
-
-            let actual = securityIssueHoverProvider.provideHover(mockDocument, new vscode.Position(0, 0), token.token)
-            assert.strictEqual(actual.contents.length, 1)
-
-            const changeEvent = createTextDocumentChangeEvent(mockDocument, new vscode.Range(2, 0, 2, 0), '\n')
-            securityIssueHoverProvider.handleDocumentChange(changeEvent)
-
-            actual = securityIssueHoverProvider.provideHover(mockDocument, new vscode.Position(0, 0), token.token)
-            assert.strictEqual(actual.contents.length, 1)
-        })
+        const actual = securityIssueHoverProvider.provideHover(mockDocument, new vscode.Position(2, 0), token.token)
+        assert.strictEqual(actual.contents.length, 0)
     })
 })

--- a/src/test/codewhisperer/service/securityIssueProvider.test.ts
+++ b/src/test/codewhisperer/service/securityIssueProvider.test.ts
@@ -1,0 +1,59 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { SecurityIssueProvider } from '../../../codewhisperer/service/securityIssueProvider'
+import { createCodeScanIssue, createMockDocument, createTextDocumentChangeEvent } from '../testUtil'
+import assert from 'assert'
+
+class MockProvider extends SecurityIssueProvider {}
+
+describe('securityIssueProvider', () => {
+    let mockProvider: MockProvider
+    let mockDocument: vscode.TextDocument
+
+    beforeEach(() => {
+        mockProvider = new MockProvider()
+        mockDocument = createMockDocument('def two_sum(nums, target):\nfor', 'test.py', 'python')
+    })
+
+    it('removes the issue if the document change on the same line', () => {
+        mockProvider.issues = [{ filePath: mockDocument.fileName, issues: [createCodeScanIssue()] }]
+
+        assert.strictEqual(mockProvider.issues[0].issues.length, 1)
+
+        const changeEvent = createTextDocumentChangeEvent(mockDocument, new vscode.Range(0, 0, 0, 0), 'a')
+        mockProvider.handleDocumentChange(changeEvent)
+
+        assert.strictEqual(mockProvider.issues[0].issues.length, 0)
+    })
+
+    it('offsets the existing issue down a line if a new line is inserted above', () => {
+        mockProvider.issues = [
+            { filePath: mockDocument.fileName, issues: [createCodeScanIssue({ startLine: 1, endLine: 2 })] },
+        ]
+        assert.strictEqual(mockProvider.issues[0].issues[0].startLine, 1)
+        assert.strictEqual(mockProvider.issues[0].issues[0].endLine, 2)
+
+        const changeEvent = createTextDocumentChangeEvent(mockDocument, new vscode.Range(0, 0, 0, 0), '\n')
+        mockProvider.handleDocumentChange(changeEvent)
+
+        assert.strictEqual(mockProvider.issues[0].issues[0].startLine, 2)
+        assert.strictEqual(mockProvider.issues[0].issues[0].endLine, 3)
+    })
+
+    it('does not move the issue if the document changed below the line', () => {
+        mockProvider.issues = [{ filePath: mockDocument.fileName, issues: [createCodeScanIssue()] }]
+
+        assert.strictEqual(mockProvider.issues[0].issues[0].startLine, 0)
+        assert.strictEqual(mockProvider.issues[0].issues[0].endLine, 1)
+
+        const changeEvent = createTextDocumentChangeEvent(mockDocument, new vscode.Range(2, 0, 2, 0), '\n')
+        mockProvider.handleDocumentChange(changeEvent)
+
+        assert.strictEqual(mockProvider.issues[0].issues[0].startLine, 0)
+        assert.strictEqual(mockProvider.issues[0].issues[0].endLine, 1)
+    })
+})

--- a/src/test/codewhisperer/testUtil.ts
+++ b/src/test/codewhisperer/testUtil.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode'
 import * as sinon from 'sinon'
 import * as codewhispererClient from '../../codewhisperer/client/codewhisperer'
-import { vsCodeState, AcceptedSuggestionEntry } from '../../codewhisperer/models/model'
+import { vsCodeState, AcceptedSuggestionEntry, CodeScanIssue } from '../../codewhisperer/models/model'
 import { MockDocument } from '../fake/fakeDocument'
 import { getLogger } from '../../shared/logger'
 import { CodeWhispererCodeCoverageTracker } from '../../codewhisperer/tracker/codewhispererCodeCoverageTracker'
@@ -138,5 +138,34 @@ export function createTextDocumentChangeEvent(document: vscode.TextDocument, ran
                 text: text,
             },
         ],
+    }
+}
+
+export function createCodeScanIssue(overrides?: Partial<CodeScanIssue>): CodeScanIssue {
+    return {
+        startLine: 0,
+        endLine: 1,
+        comment: 'comment',
+        title: 'title',
+        description: {
+            text: 'description',
+            markdown: 'description',
+        },
+        detectorId: 'language/cool-detector@v1.0',
+        detectorName: 'detectorName',
+        relatedVulnerabilities: ['CWE-1'],
+        severity: 'High',
+        suggestedFixes: [
+            { description: 'fix', code: '@@ -1,1 +1,1 @@\nfirst line\n-second line\n+third line\nfourth line' },
+        ],
+        ...overrides,
+    }
+}
+
+export function createCodeActionContext(): vscode.CodeActionContext {
+    return {
+        diagnostics: [],
+        only: vscode.CodeActionKind.Empty,
+        triggerKind: vscode.CodeActionTriggerKind.Automatic,
     }
 }


### PR DESCRIPTION
## Problem

Currently the Apply Fix action is hidden behind the hover panel and requires user to mouse over the issue. It should be more accessible without having to leave the keyboard.

## Solution

- Added code action provider to provide a Quick Fix action for each issue (that has at least 1 security patch available).
- The menu can be accessed using the  ⌘ + . keyboard shortcut or by clicking the light bulb icon
- Added an abstract class `SecurityIssueProvider` which has text document change handler common for `SecurityIssueHoverProvider` and `SecurityIssueCodeActionProvider`

![image](https://github.com/aws/aws-toolkit-vscode/assets/16008563/e4d40823-fd54-4ea8-8320-e3b22698b29a)


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
