### PR TITLE
feat(cloudwatchlogs): preserve position while loading items

### DIFF
--- a/.changes/next-release/Feature-bd1ff59d-583c-4611-9e14-3e47a9014e72.json
+++ b/.changes/next-release/Feature-bd1ff59d-583c-4611-9e14-3e47a9014e72.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "CloudWatch Logs: Preserve quickpick menu position when loading more items."
+}

--- a/src/shared/ui/picker.ts
+++ b/src/shared/ui/picker.ts
@@ -47,6 +47,7 @@ export function createQuickPick<T extends vscode.QuickPickItem>({
     buttons?: vscode.QuickInputButton[]
 }): vscode.QuickPick<T> {
     const picker = vscode.window.createQuickPick<T>()
+    picker.keepScrollPosition = true
 
     if (options) {
         picker.title = options.title

--- a/src/shared/ui/pickerPrompter.ts
+++ b/src/shared/ui/pickerPrompter.ts
@@ -63,6 +63,8 @@ export type ExtendedQuickPickOptions<T> = Omit<
     errorItem?: DataQuickPickItem<T>
     /** Description for recently used item */
     recentlyUsed?: string
+    /** Defined on `vscode.QuickPick` but not `vscode.QuickPickOptions` 🤷 */
+    keepScrollPosition?: boolean
 }
 
 /** See {@link ExtendedQuickPickOptions.noItemsFoundItem noItemsFoundItem} for setting a different item */
@@ -85,6 +87,7 @@ export const defaultQuickpickOptions: ExtendedQuickPickOptions<any> = {
     ignoreFocusOut: true,
     noItemsFoundItem: defaultNoItemsItem,
     errorItem: defaultErrorItem,
+    keepScrollPosition: true,
 }
 
 type QuickPickData<T> = PromptResult<T> | (() => Promise<PromptResult<T>>)


### PR DESCRIPTION
Problem:
When trying to select a CloudWatch Log Stream, the UI scrolls to the top while fetching all streams, which is very difficult to use.

Solution:
Set `keepScrollPosition = true` by default.
Closes #2379


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
