### PR TITLE
filewatcher: template watcher lazy-loads if enableCodeLenses is off

### DIFF
--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -271,7 +271,7 @@ export async function createNewSamApplication(
         // Race condition where SAM app is created but template doesn't register in time.
         // Poll for 5 seconds, otherwise direct user to codelens.
         const isTemplateRegistered = await waitUntil(
-            async () => globals.templateRegistry.getRegisteredItem(templateUri),
+            async () => (await globals.templateRegistry).getRegisteredItem(templateUri),
             {
                 timeout: 5000,
                 interval: 500,

--- a/src/lambda/commands/downloadLambda.ts
+++ b/src/lambda/commands/downloadLambda.ts
@@ -206,11 +206,8 @@ async function addLaunchConfigEntry(
     )
 
     const launchConfig = new LaunchConfiguration(vscode.Uri.file(lambdaLocation))
-    if (
-        !getReferencedHandlerPaths(launchConfig).has(
-            pathutils.normalize(path.join(path.dirname(lambdaLocation), handler))
-        )
-    ) {
+    const refPaths = await getReferencedHandlerPaths(launchConfig)
+    if (!refPaths.has(pathutils.normalize(path.join(path.dirname(lambdaLocation), handler)))) {
         await launchConfig.addDebugConfiguration(samDebugConfig)
     }
 }

--- a/src/lambda/local/debugConfiguration.ts
+++ b/src/lambda/local/debugConfiguration.ts
@@ -100,10 +100,10 @@ export interface PipeTransport {
  * - For "code" configs this is the `projectRoot` field.
  * - For "template" configs this is the `CodeUri` field in the template.
  */
-export function getCodeRoot(
+export async function getCodeRoot(
     folder: vscode.WorkspaceFolder | undefined,
     config: AwsSamDebuggerConfiguration
-): string | undefined {
+): Promise<string | undefined> {
     switch (config.invokeTarget.target) {
         case 'code': {
             const codeInvoke = config.invokeTarget as CodeTargetProperties
@@ -112,11 +112,11 @@ export function getCodeRoot(
         case 'api':
         case 'template': {
             const templateInvoke = config.invokeTarget as TemplateTargetProperties
-            const template = getTemplate(folder, config)
+            const template = await getTemplate(folder, config)
             if (!template) {
                 return undefined
             }
-            const templateResource = getTemplateResource(folder, config)
+            const templateResource = await getTemplateResource(folder, config)
             if (!templateResource?.Properties) {
                 return undefined
             }
@@ -142,10 +142,10 @@ export function getCodeRoot(
 /**
  * Gets the lambda handler name specified in the given config.
  */
-export function getHandlerName(
+export async function getHandlerName(
     folder: vscode.WorkspaceFolder | undefined,
     config: AwsSamDebuggerConfiguration
-): string {
+): Promise<string> {
     switch (config.invokeTarget.target) {
         case 'code': {
             const codeInvoke = config.invokeTarget as CodeTargetProperties
@@ -153,11 +153,11 @@ export function getHandlerName(
         }
         case 'api':
         case 'template': {
-            const template = getTemplate(folder, config)
+            const template = await getTemplate(folder, config)
             if (!template) {
                 return ''
             }
-            const templateResource = getTemplateResource(folder, config)
+            const templateResource = await getTemplateResource(folder, config)
             if (CloudFormation.isImageLambdaResource(templateResource?.Properties)) {
                 return config.invokeTarget.logicalId
             }
@@ -184,16 +184,16 @@ export function getHandlerName(
 }
 
 /** Gets a template object from the given config. */
-export function getTemplate(
+export async function getTemplate(
     folder: vscode.WorkspaceFolder | undefined,
     config: AwsSamDebuggerConfiguration
-): CloudFormation.Template | undefined {
+): Promise<CloudFormation.Template | undefined> {
     if (!['api', 'template'].includes(config.invokeTarget.target)) {
         return undefined
     }
     const templateInvoke = config.invokeTarget as TemplateTargetProperties
     const fullPath = tryGetAbsolutePath(folder, templateInvoke.templatePath)
-    const cfnTemplate = globals.templateRegistry.getRegisteredItem(fullPath)?.item
+    const cfnTemplate = (await globals.templateRegistry).getRegisteredItem(fullPath)?.item
     return cfnTemplate
 }
 
@@ -201,15 +201,15 @@ export function getTemplate(
  * Gets the template resources object specified by the `logicalId`
  * field (if the config has `target=template` or `target=api`).
  */
-export function getTemplateResource(
+export async function getTemplateResource(
     folder: vscode.WorkspaceFolder | undefined,
     config: AwsSamDebuggerConfiguration
-): CloudFormation.Resource | undefined {
+): Promise<CloudFormation.Resource | undefined> {
     if (!['api', 'template'].includes(config.invokeTarget.target)) {
         return undefined
     }
     const templateInvoke = config.invokeTarget as TemplateTargetProperties
-    const cfnTemplate = getTemplate(folder, config)
+    const cfnTemplate = await getTemplate(folder, config)
     if (!cfnTemplate) {
         throw Error(`template not found (not registered?): ${templateInvoke.templatePath}`)
     }
@@ -231,8 +231,8 @@ export function getTemplateResource(
  *
  * Intended for use only by the language-specific `makeConfig` functions.
  */
-export function isImageLambdaConfig(config: SamLaunchRequestArgs): boolean {
-    const templateResource = getTemplateResource(config.workspaceFolder, config)
+export async function isImageLambdaConfig(config: SamLaunchRequestArgs): Promise<boolean> {
+    const templateResource = await getTemplateResource(config.workspaceFolder, config)
 
     return CloudFormation.isImageLambdaResource(templateResource?.Properties)
 }

--- a/src/lambda/vue/configEditor/samInvokeBackend.ts
+++ b/src/lambda/vue/configEditor/samInvokeBackend.ts
@@ -94,7 +94,7 @@ export class SamInvokeWebview extends VueWebview {
         }
         const uri = workspaceFolder.uri
         const launchConfig = new LaunchConfiguration(uri)
-        const pickerItems = getLaunchConfigQuickPickItems(launchConfig, uri)
+        const pickerItems = await getLaunchConfigQuickPickItems(launchConfig, uri)
         if (pickerItems.length === 0) {
             pickerItems.push({
                 index: -1,
@@ -161,7 +161,7 @@ export class SamInvokeWebview extends VueWebview {
     public async getTemplate() {
         const items: (vscode.QuickPickItem & { templatePath: string })[] = []
         const noTemplate = 'NOTEMPLATEFOUND'
-        for (const template of globals.templateRegistry.registeredItems) {
+        for (const template of (await globals.templateRegistry).registeredItems) {
             const resources = template.item.Resources
             if (resources) {
                 for (const resource of Object.keys(resources)) {
@@ -227,6 +227,7 @@ export class SamInvokeWebview extends VueWebview {
             return
         }
         const launchConfig = new LaunchConfiguration(uri)
+        const launchConfigItems = await getLaunchConfigQuickPickItems(launchConfig, uri)
         const pickerItems = [
             {
                 label: addCodiconToString(
@@ -236,7 +237,7 @@ export class SamInvokeWebview extends VueWebview {
                 index: -1,
                 alwaysShow: true,
             },
-            ...getLaunchConfigQuickPickItems(launchConfig, uri),
+            ...launchConfigItems,
         ]
 
         const qp = picker.createQuickPick({
@@ -343,9 +344,13 @@ function getUriFromLaunchConfig(config: AwsSamDebuggerConfiguration): vscode.Uri
     return undefined
 }
 
-function getLaunchConfigQuickPickItems(launchConfig: LaunchConfiguration, uri: vscode.Uri): LaunchConfigPickItem[] {
+async function getLaunchConfigQuickPickItems(
+    launchConfig: LaunchConfiguration,
+    uri: vscode.Uri
+): Promise<LaunchConfigPickItem[]> {
     const existingConfigs = launchConfig.getDebugConfigurations()
     const samValidator = new DefaultAwsSamDebugConfigurationValidator(vscode.workspace.getWorkspaceFolder(uri))
+    const registry = await globals.templateRegistry
     return existingConfigs
         .map((val, index) => {
             return {
@@ -353,7 +358,10 @@ function getLaunchConfigQuickPickItems(launchConfig: LaunchConfiguration, uri: v
                 index,
             }
         })
-        .filter(o => samValidator.validate(o.config as any as AwsSamDebuggerConfiguration, true)?.isValid)
+        .filter(o => {
+            const res = samValidator.validate(o.config as any as AwsSamDebuggerConfiguration, registry, true)
+            return res?.isValid
+        })
         .map(val => {
             return {
                 index: val.index,

--- a/src/lambda/wizards/samDeployWizard.ts
+++ b/src/lambda/wizards/samDeployWizard.ts
@@ -211,7 +211,7 @@ export class DefaultSamDeployWizardContext implements SamDeployWizardContext {
     }
 
     public async determineIfTemplateHasImages(templatePath: vscode.Uri): Promise<boolean> {
-        const template = globals.templateRegistry.getRegisteredItem(templatePath.fsPath)
+        const template = (await globals.templateRegistry).getRegisteredItem(templatePath.fsPath)
         const resources = template?.item?.Resources
         if (resources === undefined) {
             return false
@@ -933,7 +933,7 @@ function validateStackName(value: string): string | undefined {
 }
 
 async function getTemplateChoices(...workspaceFolders: vscode.Uri[]): Promise<SamTemplateQuickPickItem[]> {
-    const templateUris = globals.templateRegistry.registeredItems.map(o => vscode.Uri.file(o.path))
+    const templateUris = (await globals.templateRegistry).registeredItems.map(o => vscode.Uri.file(o.path))
     const uriToLabel: Map<vscode.Uri, string> = new Map<vscode.Uri, string>()
     const labelCounts: Map<string, number> = new Map()
 

--- a/src/shared/awsFiletypes.ts
+++ b/src/shared/awsFiletypes.ts
@@ -67,7 +67,7 @@ export function activate(): void {
         vscode.workspace.onDidOpenTextDocument(async (doc: vscode.TextDocument) => {
             const isAwsFileExt = isAwsFiletype(doc)
             const isSchemaHandled = globals.schemaService.isMapped(doc.uri)
-            const isCfnTemplate = !!globals.templateRegistry.registeredItems.find(
+            const isCfnTemplate = !!(await globals.templateRegistry).registeredItems.find(
                 t => pathutil.normalize(t.path) === pathutil.normalize(doc.fileName)
             )
             if (!isAwsFileExt && !isSchemaHandled && !isCfnTemplate) {

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode'
 import { getLogger } from '../logger'
-import { localize } from '../utilities/vsCodeUtils'
+import { isToolkitActive, localize } from '../utilities/vsCodeUtils'
 
 import { AsyncCloudFormationTemplateRegistry, CloudFormationTemplateRegistry } from '../fs/templateRegistry'
 import { getIdeProperties } from '../extensionUtilities'
@@ -13,6 +13,7 @@ import { NoopWatcher } from '../fs/watchedFiles'
 import { createStarterTemplateFile } from './cloudformation'
 import { Commands } from '../vscode/commands2'
 import globals from '../extensionGlobals'
+import { SamCliSettings } from '../sam/cli/samCliSettings'
 
 export const templateFileGlobPattern = '**/*.{yaml,yml}'
 
@@ -48,7 +49,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
         getLogger().error('Failed to activate template registry: %s', e)
         // This prevents us from breaking for any reason later if it fails to load. Since
         // Noop watcher is always empty, we will get back empty arrays with no issues.
-        globals.templateRegistry = new NoopWatcher() as unknown as CloudFormationTemplateRegistry
+        globals.templateRegistry = (async () => new NoopWatcher() as unknown as CloudFormationTemplateRegistry)()
     }
     // If setting it up worked, add it to subscriptions so it is cleaned up at exit
     extensionContext.subscriptions.push(
@@ -71,6 +72,8 @@ function setTemplateRegistryInGlobals(registry: CloudFormationTemplateRegistry) 
         await registry.addExcludedPattern(templateFileExcludePattern)
         await registry.addWatchPatterns([templateFileGlobPattern])
         await registry.watchUntitledFiles()
+
+        return registry
     }
 
     const asyncRegistry = new AsyncCloudFormationTemplateRegistry(registry, registrySetupFunc)
@@ -79,7 +82,7 @@ function setTemplateRegistryInGlobals(registry: CloudFormationTemplateRegistry) 
         set(newInstance: CloudFormationTemplateRegistry) {
             this.cfnInstance = newInstance
         },
-        get() {
+        async get() {
             // This condition handles testing scenarios where we may have
             // already set a mock object before activation.
             // Though in prod nothing should be calling this 'set' function.
@@ -87,7 +90,11 @@ function setTemplateRegistryInGlobals(registry: CloudFormationTemplateRegistry) 
                 return this.cfnInstance
             }
 
-            return asyncRegistry.getInstance()
+            // prevent eager load if codelenses are off
+            const config = SamCliSettings.instance
+            if (config.get('enableCodeLenses', false) || isToolkitActive()) {
+                return await asyncRegistry.getInstance()
+            }
         },
     })
 }

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -95,6 +95,8 @@ function setTemplateRegistryInGlobals(registry: CloudFormationTemplateRegistry) 
             if (config.get('enableCodeLenses', false) || isToolkitActive()) {
                 return await asyncRegistry.getInstance()
             }
+
+            return NoopWatcher
         },
     })
 }

--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -25,6 +25,7 @@ import * as goCodelens from './goCodeLensProvider'
 import { VSCODE_EXTENSION_ID } from '../extensions'
 import { getIdeProperties } from '../extensionUtilities'
 import { SamCliSettings } from '../sam/cli/samCliSettings'
+import globals from '../extensionGlobals'
 
 export type Language = 'python' | 'javascript' | 'csharp' | 'go' | 'java' | 'typescript'
 
@@ -59,7 +60,12 @@ export async function makeCodeLenses({
                   )
 
         try {
-            const associatedResources = getResourcesForHandler(handler.filename, handler.handlerName)
+            const registry = await globals.templateRegistry
+            const associatedResources = getResourcesForHandler(
+                handler.filename,
+                handler.handlerName,
+                registry.registeredItems
+            )
             const templateConfigs: AddSamDebugConfigurationInput[] = []
 
             if (associatedResources.length > 0) {

--- a/src/shared/codelens/samTemplateCodeLensProvider.ts
+++ b/src/shared/codelens/samTemplateCodeLensProvider.ts
@@ -31,8 +31,8 @@ export class SamTemplateCodeLensProvider implements vscode.CodeLensProvider {
         }
 
         // User already has launch configs for:
-        const mappedApiConfigs = Array.from(getConfigsMappedToTemplates(launchConfig, 'api'))
-        const mappedFunConfigs = Array.from(getConfigsMappedToTemplates(launchConfig, 'template'))
+        const mappedApiConfigs = Array.from(await getConfigsMappedToTemplates(launchConfig, 'api'))
+        const mappedFunConfigs = Array.from(await getConfigsMappedToTemplates(launchConfig, 'template'))
 
         const unmappedApis = apiResources.filter(
             r =>

--- a/src/shared/debug/launchConfiguration.ts
+++ b/src/shared/debug/launchConfiguration.ts
@@ -130,7 +130,8 @@ class DefaultDebugConfigSource implements DebugConfigurationSource {
 }
 
 async function getSamCodeTargets(launchConfig: LaunchConfiguration): Promise<CodeTargetProperties[]> {
-    return _(await launchConfig.getSamDebugConfigurations())
+    const debugConfigs = await launchConfig.getSamDebugConfigurations()
+    return _(debugConfigs)
         .map(samConfig => samConfig.invokeTarget)
         .filter(isCodeTargetProperties)
         .value()

--- a/src/shared/debug/launchConfiguration.ts
+++ b/src/shared/debug/launchConfiguration.ts
@@ -26,6 +26,7 @@ import { getLogger } from '../logger'
 import { makeFailedWriteMessage, showViewLogsMessage } from '../utilities/messages'
 import { launchConfigDocUrl } from '../constants'
 import { openUrl } from '../utilities/vsCodeUtils'
+import globals from '../extensionGlobals'
 
 const localize = nls.loadMessageBundle()
 
@@ -68,11 +69,12 @@ export class LaunchConfiguration {
     /**
      * Returns all valid Sam Debug Configurations.
      */
-    public getSamDebugConfigurations(): AwsSamDebuggerConfiguration[] {
+    public async getSamDebugConfigurations(): Promise<AwsSamDebuggerConfiguration[]> {
         const configs = this.getDebugConfigurations().filter(o =>
             isAwsSamDebugConfiguration(o)
         ) as AwsSamDebuggerConfiguration[]
-        return configs.filter(o => this.samValidator.validate(o)?.isValid)
+        const registry = await globals.templateRegistry
+        return configs.filter(o => this.samValidator.validate(o, registry)?.isValid)
     }
 
     /**
@@ -127,8 +129,8 @@ class DefaultDebugConfigSource implements DebugConfigurationSource {
     }
 }
 
-function getSamCodeTargets(launchConfig: LaunchConfiguration): CodeTargetProperties[] {
-    return _(launchConfig.getSamDebugConfigurations())
+async function getSamCodeTargets(launchConfig: LaunchConfiguration): Promise<CodeTargetProperties[]> {
+    return _(await launchConfig.getSamDebugConfigurations())
         .map(samConfig => samConfig.invokeTarget)
         .filter(isCodeTargetProperties)
         .value()
@@ -141,18 +143,18 @@ function getSamCodeTargets(launchConfig: LaunchConfiguration): CodeTargetPropert
  * @param launchConfig Launch config to check
  * @param type  target type ('api' or 'template'), or undefined for 'both'
  */
-export function getConfigsMappedToTemplates(
+export async function getConfigsMappedToTemplates(
     launchConfig: LaunchConfiguration,
     type: AwsSamTargetType | undefined
-): Set<AwsSamDebuggerConfiguration> {
+): Promise<Set<AwsSamDebuggerConfiguration>> {
     if (type === 'code') {
         throw Error()
     }
     const folder = launchConfig.workspaceFolder
     // Launch configs with target=template or target=api.
-    const templateConfigs = launchConfig
-        .getSamDebugConfigurations()
-        .filter(o => isTemplateTargetProperties(o.invokeTarget))
+    const templateConfigs = (await launchConfig.getSamDebugConfigurations()).filter(o =>
+        isTemplateTargetProperties(o.invokeTarget)
+    )
     const filtered = templateConfigs.filter(
         t =>
             (type === undefined || t.invokeTarget.target === type) &&
@@ -175,8 +177,8 @@ export function getConfigsMappedToTemplates(
  *
  * @param launchConfig Launch config to check
  */
-export function getReferencedHandlerPaths(launchConfig: LaunchConfiguration): Set<string> {
-    const existingSamCodeTargets = getSamCodeTargets(launchConfig)
+export async function getReferencedHandlerPaths(launchConfig: LaunchConfiguration): Promise<Set<string>> {
+    const existingSamCodeTargets = await getSamCodeTargets(launchConfig)
 
     return _(existingSamCodeTargets)
         .map(target => {

--- a/src/shared/extensionGlobals.ts
+++ b/src/shared/extensionGlobals.ts
@@ -109,7 +109,7 @@ interface ToolkitGlobals {
     regionProvider: RegionProvider
     sdkClientBuilder: AWSClientBuilder
     telemetry: TelemetryService & { logger: TelemetryLogger }
-    templateRegistry: CloudFormationTemplateRegistry
+    templateRegistry: Promise<CloudFormationTemplateRegistry>
     schemaService: SchemaService
     codelensRootRegistry: CodelensRootRegistry
     resourceManager: AwsResourceManager

--- a/src/shared/fs/templateRegistry.ts
+++ b/src/shared/fs/templateRegistry.ts
@@ -83,6 +83,7 @@ export class AsyncCloudFormationTemplateRegistry {
     private isSetup = false
     /** The message that is shown to the user to indicate the registry is being set up */
     private setupProgressMessage: Thenable<void> | undefined = undefined
+    private setupPromise: Thenable<void> | undefined
 
     /**
      * @param asyncSetupFunc registry setup that will be run async
@@ -104,7 +105,10 @@ export class AsyncCloudFormationTemplateRegistry {
 
         const config = SamCliSettings.instance
         if (config.get('enableCodeLenses', false)) {
-            this.asyncSetupFunc(this.instance).then(() => {
+            if (!this.setupPromise) {
+                this.setupPromise = this.asyncSetupFunc(this.instance)
+            }
+            this.setupPromise.then(() => {
                 this.isSetup = true
                 return this.instance
             })

--- a/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
@@ -19,7 +19,7 @@ import {
     API_TARGET_TYPE,
 } from './awsSamDebugConfiguration'
 import { tryGetAbsolutePath } from '../../utilities/workspaceUtils'
-import globals from '../../extensionGlobals'
+import { CloudFormationTemplateRegistry } from '../../fs/templateRegistry'
 
 export interface ValidationResult {
     isValid: boolean
@@ -27,7 +27,7 @@ export interface ValidationResult {
 }
 
 export interface AwsSamDebugConfigurationValidator {
-    validate(config: AwsSamDebuggerConfiguration): ValidationResult
+    validate(config: AwsSamDebuggerConfiguration, registry: CloudFormationTemplateRegistry): ValidationResult
 }
 
 export class DefaultAwsSamDebugConfigurationValidator implements AwsSamDebugConfigurationValidator {
@@ -36,7 +36,11 @@ export class DefaultAwsSamDebugConfigurationValidator implements AwsSamDebugConf
     /**
      * Validates debug configuration properties.
      */
-    public validate(config: AwsSamDebuggerConfiguration, resolveVars?: boolean): ValidationResult {
+    public validate(
+        config: AwsSamDebuggerConfiguration,
+        registry: CloudFormationTemplateRegistry,
+        resolveVars?: boolean
+    ): ValidationResult {
         let rv: ValidationResult = { isValid: false, message: undefined }
         if (resolveVars) {
             config = doTraverseAndReplace(config, this.workspaceFolder?.uri.fsPath ?? '')
@@ -68,7 +72,7 @@ export class DefaultAwsSamDebugConfigurationValidator implements AwsSamDebugConf
                 const fullpath = tryGetAbsolutePath(this.workspaceFolder, config.invokeTarget.templatePath)
                 // Normalize to absolute path for use in the runner.
                 config.invokeTarget.templatePath = fullpath
-                cfnTemplate = globals.templateRegistry.getRegisteredItem(fullpath)?.item
+                cfnTemplate = registry.getRegisteredItem(fullpath)?.item
             }
             rv = this.validateTemplateConfig(config, config.invokeTarget.templatePath, cfnTemplate)
         } else if (config.invokeTarget.target === CODE_TARGET_TYPE) {

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -254,7 +254,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         const configs: AwsSamDebuggerConfiguration[] = []
         if (folder) {
             const folderPath = folder.uri.fsPath
-            const templates = globals.templateRegistry.registeredItems
+            const templates = (await globals.templateRegistry).registeredItems
 
             for (const templateDatum of templates) {
                 if (isInDirectory(folderPath, templateDatum.path)) {
@@ -438,7 +438,8 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
                 ],
             })
         } else {
-            const rv = configValidator.validate(config)
+            const registry = await globals.templateRegistry
+            const rv = configValidator.validate(config, registry)
             if (!rv.isValid) {
                 throw new ToolkitError(`Invalid launch configuration: ${rv.message}`, { code: 'BadLaunchConfig' })
             } else if (rv.message) {
@@ -449,14 +450,14 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
 
         const editor = vscode.window.activeTextEditor
         const templateInvoke = config.invokeTarget as TemplateTargetProperties
-        const template = getTemplate(folder, config)
-        const templateResource = getTemplateResource(folder, config)
-        const codeRoot = getCodeRoot(folder, config)
+        const template = await getTemplate(folder, config)
+        const templateResource = await getTemplateResource(folder, config)
+        const codeRoot = await getCodeRoot(folder, config)
         const architecture = getArchitecture(template, templateResource, config.invokeTarget)
         // Handler is the only field that we need to parse refs for.
         // This is necessary for Python debugging since we have to create the temporary entry file
         // Other refs can fail; SAM will handle them.
-        const handlerName = getHandlerName(folder, config)
+        const handlerName = await getHandlerName(folder, config)
 
         config.baseBuildDir = resolve(folder.uri.fsPath, config.sam?.buildDir ?? (await makeTemporaryToolkitFolder()))
         fs.ensureDir(config.baseBuildDir)
@@ -699,7 +700,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
             debug: !config.noDebug,
             runtime: config.runtime as Runtime,
             lambdaArchitecture: config.architecture,
-            lambdaPackageType: isImageLambdaConfig(config) ? 'Image' : 'Zip',
+            lambdaPackageType: (await isImageLambdaConfig(config)) ? 'Image' : 'Zip',
             version: await getSamCliVersion(getSamCliContext()),
         })
 

--- a/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
@@ -57,7 +57,7 @@ export async function addSamDebugConfiguration(
         let preloadedConfig = undefined
 
         if (workspaceFolder) {
-            const templateDatum = globals.templateRegistry.getRegisteredItem(rootUri)
+            const templateDatum = (await globals.templateRegistry).getRegisteredItem(rootUri)
             if (templateDatum) {
                 const resource = templateDatum.item.Resources![resourceName]
                 if (!resource) {

--- a/src/shared/sam/debugger/csharpSamDebug.ts
+++ b/src/shared/sam/debugger/csharpSamDebug.ts
@@ -36,7 +36,7 @@ export async function makeCsharpConfig(config: SamLaunchRequestArgs): Promise<Sa
     if (!config.baseBuildDir) {
         throw Error('invalid state: config.baseBuildDir was not set')
     }
-    config.codeRoot = getCodeRoot(config.workspaceFolder, config)!
+    config.codeRoot = (await getCodeRoot(config.workspaceFolder, config))!
     // TODO: avoid the reassignment
     // TODO: walk the tree to find .sln, .csproj ?
     const originalCodeRoot = config.codeRoot
@@ -225,7 +225,7 @@ export async function makeDotnetDebugConfiguration(
     config.debuggerPath = pathutil.normalize(getDebuggerPath(codeUri))
     await ensureDir(config.debuggerPath)
 
-    const isImageLambda = isImageLambdaConfig(config)
+    const isImageLambda = await isImageLambdaConfig(config)
 
     if (isImageLambda && !config.noDebug) {
         config.containerEnvVars = {

--- a/src/shared/sam/debugger/goSamDebug.ts
+++ b/src/shared/sam/debugger/goSamDebug.ts
@@ -115,7 +115,7 @@ export async function makeGoConfig(config: SamLaunchRequestArgs): Promise<GoDebu
     // We want to persist the binary we build since it takes a non-trivial amount of time to build
     config.debuggerPath = path.join(globals.context.globalStorageUri.fsPath, 'debuggers', 'delve')
 
-    const isImageLambda = isImageLambdaConfig(config)
+    const isImageLambda = await isImageLambdaConfig(config)
 
     // Reference: https://github.com/aws/aws-sam-cli/blob/4543732bf3c0da3b57fe1e5aa43ce3f41d2bd0ba/samcli/local/docker/lambda_debug_settings.py#L94-L103
     // These are the default settings. For some reason SAM CLI is not setting them even if the container

--- a/src/shared/sam/debugger/javaSamDebug.ts
+++ b/src/shared/sam/debugger/javaSamDebug.ts
@@ -21,7 +21,7 @@ export async function makeJavaConfig(config: SamLaunchRequestArgs): Promise<SamL
         request: config.noDebug ? 'launch' : 'attach',
     }
 
-    config.codeRoot = getCodeRoot(config.workspaceFolder, config)!
+    config.codeRoot = (await getCodeRoot(config.workspaceFolder, config))!
 
     config.type = 'java'
     config.runtimeFamily = RuntimeFamily.Java
@@ -29,7 +29,7 @@ export async function makeJavaConfig(config: SamLaunchRequestArgs): Promise<SamL
     if (!config.noDebug) {
         config.hostName = '127.0.0.1'
         config.port = config.debugPort
-        if (isImageLambdaConfig(config)) {
+        if (await isImageLambdaConfig(config)) {
             config.containerEnvVars = {
                 _JAVA_OPTIONS:
                     // https://github.com/aws/aws-sam-cli/blob/86f88cbd7df365960f7015c5d086b0db7aedd9d5/samcli/local/docker/lambda_debug_settings.py#L53

--- a/src/shared/sam/debugger/pythonSamDebug.ts
+++ b/src/shared/sam/debugger/pythonSamDebug.ts
@@ -95,7 +95,7 @@ export async function makePythonDebugConfig(
 
     let manifestPath: string | undefined
     if (!config.noDebug) {
-        const isImageLambda = isImageLambdaConfig(config)
+        const isImageLambda = await isImageLambdaConfig(config)
 
         if (!config.useIkpdb) {
             // Mounted in the Docker container as: /tmp/lambci_debug_files

--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -76,7 +76,7 @@ export async function makeTypescriptConfig(config: SamLaunchRequestArgs): Promis
     // compile typescript code and convert lambda handler if necessary
     await compileTypeScript(config)
 
-    const isImageLambda = isImageLambdaConfig(config)
+    const isImageLambda = await isImageLambdaConfig(config)
 
     if (isImageLambda && !config.noDebug) {
         // Need --inspect to enable debugging. SAM CLI doesn't send env vars for "Image" packagetype.

--- a/src/shared/sam/localLambdaRunner.ts
+++ b/src/shared/sam/localLambdaRunner.ts
@@ -243,7 +243,8 @@ async function invokeLambdaHandler(
             debugArgs: config.debugArgs,
             containerEnvFile: config.containerEnvFile,
             extraArgs: config.sam?.localArguments,
-            skipPullImage: config.sam?.skipNewImageCheck ?? (isImageLambdaConfig(config) || config.sam?.containerBuild),
+            skipPullImage:
+                config.sam?.skipNewImageCheck ?? ((await isImageLambdaConfig(config)) || config.sam?.containerBuild),
             parameterOverrides: config.parameterOverrides,
             name: config.name,
         }

--- a/src/shared/sam/sync.ts
+++ b/src/shared/sam/sync.ts
@@ -46,6 +46,7 @@ import { getAwsConsoleUrl } from '../awsConsole'
 import { openUrl } from '../utilities/vsCodeUtils'
 import { showOnce } from '../utilities/messages'
 import { IamConnection } from '../../auth/connection'
+import { CloudFormationTemplateRegistry } from '../fs/templateRegistry'
 
 const localize = nls.loadMessageBundle()
 
@@ -185,10 +186,10 @@ interface TemplateItem {
     readonly data: CloudFormation.Template
 }
 
-function createTemplatePrompter() {
+function createTemplatePrompter(registry: CloudFormationTemplateRegistry) {
     const folders = new Set<string>()
     const recentTemplatePath = getRecentResponse('global', 'templatePath')
-    const items = globals.templateRegistry.registeredItems.map(({ item, path: filePath }) => {
+    const items = registry.registeredItems.map(({ item, path: filePath }) => {
         const uri = vscode.Uri.file(filePath)
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri)
         const label = workspaceFolder ? path.relative(workspaceFolder.uri.fsPath, uri.fsPath) : uri.fsPath
@@ -227,11 +228,14 @@ function hasImageBasedResources(template: CloudFormation.Template) {
 }
 
 export class SyncWizard extends Wizard<SyncParams> {
-    public constructor(state: Pick<SyncParams, 'deployType'> & Partial<SyncParams>) {
+    public constructor(
+        state: Pick<SyncParams, 'deployType'> & Partial<SyncParams>,
+        registry: CloudFormationTemplateRegistry
+    ) {
         super({ initState: state, exitPrompterProvider: createExitPrompter })
 
         this.form.region.bindPrompter(() => createRegionPrompter().transform(r => r.id))
-        this.form.template.bindPrompter(() => createTemplatePrompter())
+        this.form.template.bindPrompter(() => createTemplatePrompter(registry))
         this.form.stackName.bindPrompter(({ region }) => createStackPrompter(new DefaultCloudFormationClient(region!)))
         this.form.bucketName.bindPrompter(({ region }) => createBucketPrompter(new DefaultS3Client(region!)))
         this.form.ecrRepoUri.bindPrompter(({ region }) => createEcrPrompter(new DefaultEcrClient(region!)), {
@@ -538,7 +542,8 @@ export function registerSync() {
         const input = cast(arg, Optional(Union(Instance(Uri), Instance(AWSTreeNodeBase))))
 
         await confirmDevStack()
-        const params = await new SyncWizard({ deployType, ...(await prepareSyncParams(input)) }).run()
+        const registry = await globals.templateRegistry
+        const params = await new SyncWizard({ deployType, ...(await prepareSyncParams(input)) }, registry).run()
         if (params === undefined) {
             throw new CancellationError('user')
         }

--- a/src/shared/utilities/vsCodeUtils.ts
+++ b/src/shared/utilities/vsCodeUtils.ts
@@ -12,6 +12,7 @@ import { CancellationError, Timeout, waitTimeout } from './timeoutUtils'
 import { telemetry } from '../telemetry/telemetry'
 import * as semver from 'semver'
 import { isNonNullable } from './tsUtils'
+import { VSCODE_EXTENSION_ID } from '../extensions'
 
 // TODO: Consider NLS initialization/configuration here & have packages to import localize from here
 export const localize = nls.loadMessageBundle()
@@ -225,4 +226,8 @@ export async function openUrl(url: vscode.Uri): Promise<boolean> {
         }
         return didOpen
     })
+}
+
+export function isToolkitActive(): boolean {
+    return isExtensionActive(VSCODE_EXTENSION_ID.awstoolkit)
 }

--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -62,7 +62,7 @@ export const mochaHooks = {
     async beforeEach(this: Mocha.Context) {
         // Set every test up so that TestLogger is the logger used by toolkit code
         testLogger = setupTestLogger()
-        globals.templateRegistry = new CloudFormationTemplateRegistry()
+        globals.templateRegistry = (async () => new CloudFormationTemplateRegistry())()
         globals.codelensRootRegistry = new CodelensRootRegistry()
 
         // In general, we do not want to "fake" the `vscode` API. The only exception is for things
@@ -85,7 +85,7 @@ export const mochaHooks = {
 
         await testUtil.closeAllEditors()
     },
-    afterEach(this: Mocha.Context) {
+    async afterEach(this: Mocha.Context) {
         if (openExternalStub.called && openExternalStub.returned(sinon.match.typeOf('undefined'))) {
             throw new Error(
                 `Test called openExternal(${
@@ -98,7 +98,8 @@ export const mochaHooks = {
         teardownTestLogger(this.currentTest?.fullTitle() as string)
         testLogger = undefined
         resetTestWindow()
-        globals.templateRegistry.dispose()
+        const r = await globals.templateRegistry
+        r.dispose()
         globals.codelensRootRegistry.dispose()
         globalSandbox.restore()
     },

--- a/src/test/lambda/commands/createNewSamApp.test.ts
+++ b/src/test/lambda/commands/createNewSamApp.test.ts
@@ -75,7 +75,8 @@ describe('createNewSamApp', function () {
 
     afterEach(async function () {
         await fs.remove(tempFolder)
-        globals.templateRegistry.reset()
+        const r = await globals.templateRegistry
+        r.reset()
     })
 
     describe('getProjectUri', function () {
@@ -108,7 +109,7 @@ describe('createNewSamApp', function () {
             testutil.toFile(makeSampleSamTemplateYaml(true), tempTemplate.fsPath)
 
             // without runtime
-            await globals.templateRegistry.addItemToRegistry(tempTemplate)
+            await (await globals.templateRegistry).addItemToRegistry(tempTemplate)
             const launchConfigs = await addInitialLaunchConfiguration(
                 fakeContext,
                 fakeWorkspaceFolder,
@@ -144,7 +145,7 @@ describe('createNewSamApp', function () {
             testutil.toFile(makeSampleSamTemplateYaml(true), tempTemplate.fsPath)
 
             // without runtime
-            await globals.templateRegistry.addItemToRegistry(tempTemplate)
+            await (await globals.templateRegistry).addItemToRegistry(tempTemplate)
             const launchConfigs = (await addInitialLaunchConfiguration(
                 fakeContext,
                 fakeWorkspaceFolder,
@@ -181,7 +182,7 @@ describe('createNewSamApp', function () {
         it('returns a blank array if it does not match any launch configs', async function () {
             testutil.toFile(makeSampleSamTemplateYaml(true), tempTemplate.fsPath)
 
-            await globals.templateRegistry.addItemToRegistry(tempTemplate)
+            await (await globals.templateRegistry).addItemToRegistry(tempTemplate)
             const launchConfigs = await addInitialLaunchConfiguration(
                 fakeContext,
                 fakeWorkspaceFolder,
@@ -197,7 +198,7 @@ describe('createNewSamApp', function () {
 
             testutil.toFile(makeSampleSamTemplateYaml(true), tempTemplate.fsPath)
 
-            await globals.templateRegistry.addItemToRegistry(tempTemplate)
+            await (await globals.templateRegistry).addItemToRegistry(tempTemplate)
             const launchConfigs = await addInitialLaunchConfiguration(
                 fakeContext,
                 fakeWorkspaceFolder,
@@ -231,9 +232,9 @@ describe('createNewSamApp', function () {
             testutil.toFile(makeSampleSamTemplateYaml(true), otherTemplate2.fsPath)
             testutil.toFile('target file', path.join(otherFolder1, templateYaml))
 
-            await globals.templateRegistry.addItemToRegistry(tempTemplate)
-            await globals.templateRegistry.addItemToRegistry(otherTemplate1)
-            await globals.templateRegistry.addItemToRegistry(otherTemplate2)
+            await (await globals.templateRegistry).addItemToRegistry(tempTemplate)
+            await (await globals.templateRegistry).addItemToRegistry(otherTemplate1)
+            await (await globals.templateRegistry).addItemToRegistry(otherTemplate2)
 
             const launchConfigs1 = await addInitialLaunchConfiguration(
                 fakeContext,

--- a/src/test/lambda/config/templates.test.ts
+++ b/src/test/lambda/config/templates.test.ts
@@ -785,7 +785,8 @@ describe('getExistingConfiguration', async function () {
 
     afterEach(async function () {
         await remove(tempFolder)
-        globals.templateRegistry.reset()
+        const r = await globals.templateRegistry
+        r.reset()
     })
 
     it("returns undefined if the legacy config file doesn't exist", async () => {
@@ -796,7 +797,7 @@ describe('getExistingConfiguration', async function () {
     it('returns undefined if the legacy config file is not valid JSON', async function () {
         await writeFile(tempTemplateFile.fsPath, makeSampleSamTemplateYaml(true, { handler: matchedHandler }), 'utf8')
         await writeFile(tempConfigFile, makeSampleSamTemplateYaml(true, { handler: matchedHandler }), 'utf8')
-        await globals.templateRegistry.addItemToRegistry(tempTemplateFile)
+        await (await globals.templateRegistry).addItemToRegistry(tempTemplateFile)
         const val = await getExistingConfiguration(fakeWorkspaceFolder, matchedHandler, tempTemplateFile)
         assert.strictEqual(val, undefined)
     })
@@ -817,7 +818,7 @@ describe('getExistingConfiguration', async function () {
             },
         }
         await writeFile(tempConfigFile, JSON.stringify(configData), 'utf8')
-        await globals.templateRegistry.addItemToRegistry(tempTemplateFile)
+        await (await globals.templateRegistry).addItemToRegistry(tempTemplateFile)
         const val = await getExistingConfiguration(fakeWorkspaceFolder, matchedHandler, tempTemplateFile)
         assert.ok(val)
         if (val) {

--- a/src/test/lambda/local/debugConfiguration.test.ts
+++ b/src/test/lambda/local/debugConfiguration.test.ts
@@ -132,7 +132,7 @@ describe('isImageLambdaConfig', function () {
             name: 'It was me, fakeWorkspaceFolder!',
             index: 0,
         }
-        registry = globals.templateRegistry
+        registry = await globals.templateRegistry
         appDir = pathutil.normalize(path.join(testutil.getProjectDir(), 'testFixtures/workspaceFolder/'))
     })
 

--- a/src/test/lambda/local/debugConfiguration.test.ts
+++ b/src/test/lambda/local/debugConfiguration.test.ts
@@ -162,7 +162,7 @@ describe('isImageLambdaConfig', function () {
             },
         } as SamLaunchRequestArgs
 
-        assert.strictEqual(isImageLambdaConfig(input), true)
+        assert.strictEqual(await isImageLambdaConfig(input), true)
     })
 
     it('false for ZIP-backed template', async function () {
@@ -191,7 +191,7 @@ describe('isImageLambdaConfig', function () {
             },
         } as SamLaunchRequestArgs
 
-        assert.strictEqual(isImageLambdaConfig(input), false)
+        assert.strictEqual(await isImageLambdaConfig(input), false)
     })
 
     it('false for code-type', async function () {
@@ -214,7 +214,7 @@ describe('isImageLambdaConfig', function () {
             },
         } as SamLaunchRequestArgs
 
-        assert.strictEqual(isImageLambdaConfig(input), false)
+        assert.strictEqual(await isImageLambdaConfig(input), false)
     })
 })
 

--- a/src/test/shared/awsFiletypes.test.ts
+++ b/src/test/shared/awsFiletypes.test.ts
@@ -39,7 +39,7 @@ describe('awsFiletypes', function () {
     })
 
     it('emit telemetry when opened by user', async function () {
-        await globals.templateRegistry.addItemToRegistry(cfnUri!)
+        await (await globals.templateRegistry).addItemToRegistry(cfnUri!)
         await vscode.commands.executeCommand('vscode.open', cfnUri)
         await vscode.commands.executeCommand('vscode.open', awsConfigUri)
         await vscode.workspace.openTextDocument({
@@ -70,7 +70,7 @@ describe('awsFiletypes', function () {
     })
 
     it('emit telemetry exactly once per filetype in a given flush window', async function () {
-        await globals.templateRegistry.addItemToRegistry(cfnUri!)
+        await (await globals.templateRegistry).addItemToRegistry(cfnUri!)
         await vscode.commands.executeCommand('vscode.open', cfnUri)
         async function getMetrics() {
             return await waitUntil(

--- a/src/test/shared/debug/launchConfiguration.test.ts
+++ b/src/test/shared/debug/launchConfiguration.test.ts
@@ -207,6 +207,15 @@ describe('LaunchConfiguration', function () {
 })
 
 describe('getReferencedHandlerPaths', function () {
+    before(async function () {
+        // init for the first test
+        await globals.templateRegistry
+    })
+
+    after(async function () {
+        ;(await globals.templateRegistry).reset()
+    })
+
     it('includes all resources as absolute paths to root dir + handlers', async function () {
         const mockLaunchConfig = instance(createMockLaunchConfig())
 

--- a/src/test/shared/debug/launchConfiguration.test.ts
+++ b/src/test/shared/debug/launchConfiguration.test.ts
@@ -172,12 +172,12 @@ describe('LaunchConfiguration', function () {
         assertEqualLaunchJsons(launchConfig.getDebugConfigurations(), expected, workspace.uri, false)
     })
 
-    it('gets aws-sam debug configurations', function () {
+    it('gets aws-sam debug configurations', async function () {
         const launchConfig = new LaunchConfiguration(templateUriJsPlainApp)
         const expected = (testLaunchJsonData['configurations'] as any[]).filter(
             o => o.type === 'aws-sam' && o.request === 'direct-invoke'
         )
-        const actual = launchConfig.getSamDebugConfigurations()
+        const actual = await launchConfig.getSamDebugConfigurations()
         assertEqualLaunchJsons(actual, expected, workspace.uri, true)
     })
 

--- a/src/test/shared/debug/launchConfiguration.test.ts
+++ b/src/test/shared/debug/launchConfiguration.test.ts
@@ -207,15 +207,6 @@ describe('LaunchConfiguration', function () {
 })
 
 describe('getReferencedHandlerPaths', function () {
-    before(async function () {
-        // init for the first test
-        await globals.templateRegistry
-    })
-
-    after(async function () {
-        ;(await globals.templateRegistry).reset()
-    })
-
     it('includes all resources as absolute paths to root dir + handlers', async function () {
         const mockLaunchConfig = instance(createMockLaunchConfig())
 
@@ -260,7 +251,7 @@ function createMockLaunchConfig(): LaunchConfiguration {
     })
     when(mockLaunchConfig.scopedResource).thenReturn(vscode.Uri.file(path.join(workspaceFolder, 'template.yaml')))
     when(mockLaunchConfig.getSamDebugConfigurations()).thenReturn(
-        new Promise(() => [
+        Promise.resolve([
             // default: template target with not-in-workspace, absolute-pathed templatePath
             createMockSamDebugConfig(),
             createMockSamDebugConfig({

--- a/src/test/shared/debug/launchConfiguration.test.ts
+++ b/src/test/shared/debug/launchConfiguration.test.ts
@@ -105,30 +105,37 @@ describe('LaunchConfiguration', function () {
     const templateUriCsharp = vscode.Uri.file(path.join(workspace.uri.fsPath, 'csharp6-zip/template.yaml'))
 
     beforeEach(async function () {
-        await globals.templateRegistry.addWatchPatterns([templateFileGlobPattern])
+        const registry = await globals.templateRegistry
+        await registry.addWatchPatterns([templateFileGlobPattern])
 
         // TODO: remove mocks in favor of testing src/testFixtures/ data.
         mockConfigSource = mock()
         mockSamValidator = mock()
         when(mockConfigSource.getDebugConfigurations()).thenReturn(debugConfigurations)
-        when(mockSamValidator.validate(deepEqual(samDebugConfiguration))).thenReturn({ isValid: true })
+        when(mockSamValidator.validate(deepEqual(samDebugConfiguration), registry)).thenReturn(
+            await (async () => {
+                return { isValid: true }
+            })()
+        )
     })
 
-    afterEach(function () {
-        globals.templateRegistry.reset()
+    afterEach(async function () {
+        ;(await globals.templateRegistry).reset()
     })
 
     it('getConfigsMappedToTemplates(type=api)', async function () {
-        const actual = getConfigsMappedToTemplates(new LaunchConfiguration(templateUriJsPlainApp), 'api')
+        const actual = await getConfigsMappedToTemplates(new LaunchConfiguration(templateUriJsPlainApp), 'api')
         assert.deepStrictEqual(actual.size, 0)
 
-        const actual2 = Array.from(getConfigsMappedToTemplates(new LaunchConfiguration(templateUriPython37), 'api'))
+        const actual2 = Array.from(
+            await getConfigsMappedToTemplates(new LaunchConfiguration(templateUriPython37), 'api')
+        )
         assert.deepStrictEqual(actual2.length, 1)
         assert.deepStrictEqual(actual2[0].name, 'test-launchconfig-6-python3.7')
         assert.deepStrictEqual(actual2[0].invokeTarget.target, 'api')
         assert.deepStrictEqual((actual2[0].invokeTarget as any).logicalId, 'HelloWorldFunction')
 
-        const actual3 = Array.from(getConfigsMappedToTemplates(new LaunchConfiguration(templateUriCsharp), 'api'))
+        const actual3 = Array.from(await getConfigsMappedToTemplates(new LaunchConfiguration(templateUriCsharp), 'api'))
         assert.deepStrictEqual(actual3.length, 1)
         assert.deepStrictEqual(actual3[0].name, 'test-launchconfig-8-api')
         assert.deepStrictEqual(actual3[0].invokeTarget.target, 'api')
@@ -137,19 +144,23 @@ describe('LaunchConfiguration', function () {
 
     it('getConfigsMappedToTemplates(type=undefined) returns target=template + target=api resources', async function () {
         const actual = Array.from(
-            getConfigsMappedToTemplates(new LaunchConfiguration(templateUriJsPlainApp), undefined)
+            await getConfigsMappedToTemplates(new LaunchConfiguration(templateUriJsPlainApp), undefined)
         )
         assert.deepStrictEqual(actual.length, 1)
         assert.deepStrictEqual((actual[0].invokeTarget as any).logicalId, 'SourceCodeBesidePackageJson')
 
-        const actual2 = Array.from(getConfigsMappedToTemplates(new LaunchConfiguration(templateUriPython37), undefined))
+        const actual2 = Array.from(
+            await getConfigsMappedToTemplates(new LaunchConfiguration(templateUriPython37), undefined)
+        )
         assert.deepStrictEqual(actual2.length, 2)
         assert.deepStrictEqual(actual2[0].name, 'test-launchconfig-5-python3.7')
         assert.deepStrictEqual(actual2[1].name, 'test-launchconfig-6-python3.7')
         assert.deepStrictEqual(actual2[0].invokeTarget.target, 'template')
         assert.deepStrictEqual(actual2[1].invokeTarget.target, 'api')
 
-        const actual3 = Array.from(getConfigsMappedToTemplates(new LaunchConfiguration(templateUriCsharp), undefined))
+        const actual3 = Array.from(
+            await getConfigsMappedToTemplates(new LaunchConfiguration(templateUriCsharp), undefined)
+        )
         assert.deepStrictEqual(actual3.length, 1)
         assert.deepStrictEqual(actual3[0].name, 'test-launchconfig-8-api')
         assert.deepStrictEqual((actual3[0].invokeTarget as any).logicalId, 'HelloWorldFunction')
@@ -196,10 +207,10 @@ describe('LaunchConfiguration', function () {
 })
 
 describe('getReferencedHandlerPaths', function () {
-    it('includes all resources as absolute paths to root dir + handlers', function () {
+    it('includes all resources as absolute paths to root dir + handlers', async function () {
         const mockLaunchConfig = instance(createMockLaunchConfig())
 
-        const resultSet = getReferencedHandlerPaths(mockLaunchConfig)
+        const resultSet = await getReferencedHandlerPaths(mockLaunchConfig)
         const workspaceFolder = mockLaunchConfig.workspaceFolder!.uri.fsPath
 
         //template type handlers, these are all false as we throw all of these out
@@ -239,66 +250,68 @@ function createMockLaunchConfig(): LaunchConfiguration {
         index: 1,
     })
     when(mockLaunchConfig.scopedResource).thenReturn(vscode.Uri.file(path.join(workspaceFolder, 'template.yaml')))
-    when(mockLaunchConfig.getSamDebugConfigurations()).thenReturn([
-        // default: template target with not-in-workspace, absolute-pathed templatePath
-        createMockSamDebugConfig(),
-        createMockSamDebugConfig({
-            invokeTarget: {
-                target: 'template',
-                templatePath: 'template.yaml',
-                logicalId: 'relativePathGoodTemplate',
-            },
-        }),
-        createMockSamDebugConfig({
-            invokeTarget: {
-                target: 'template',
-                templatePath: 'template2.yaml',
-                logicalId: 'relativePathBadTemplate',
-            },
-        }),
-        createMockSamDebugConfig({
-            invokeTarget: {
-                target: 'template',
-                templatePath: pathutils.normalize(path.resolve(workspaceFolder, 'template.yaml')),
-                logicalId: 'absolutePathGoodTemplate',
-            },
-        }),
-        createMockSamDebugConfig({
-            invokeTarget: {
-                target: 'template',
-                templatePath: pathutils.normalize(path.resolve(workspaceFolder, 'template2.yaml')),
-                logicalId: 'absolutePathBadTemplate',
-            },
-        }),
-        createMockSamDebugConfig({
-            invokeTarget: {
-                target: 'code',
-                lambdaHandler: 'relativeRoot',
-                projectRoot: 'inProject',
-            },
-        }),
-        createMockSamDebugConfig({
-            invokeTarget: {
-                target: 'code',
-                lambdaHandler: 'differentRelativeRoot',
-                projectRoot: 'notInProject',
-            },
-        }),
-        createMockSamDebugConfig({
-            invokeTarget: {
-                target: 'code',
-                lambdaHandler: 'absoluteRoot',
-                projectRoot: pathutils.normalize(path.resolve(workspaceFolder, 'inProject')),
-            },
-        }),
-        createMockSamDebugConfig({
-            invokeTarget: {
-                target: 'code',
-                lambdaHandler: 'differentAbsoluteRoot',
-                projectRoot: pathutils.normalize(path.resolve(workspaceFolder, 'notInProject')),
-            },
-        }),
-    ])
+    when(mockLaunchConfig.getSamDebugConfigurations()).thenReturn(
+        new Promise(() => [
+            // default: template target with not-in-workspace, absolute-pathed templatePath
+            createMockSamDebugConfig(),
+            createMockSamDebugConfig({
+                invokeTarget: {
+                    target: 'template',
+                    templatePath: 'template.yaml',
+                    logicalId: 'relativePathGoodTemplate',
+                },
+            }),
+            createMockSamDebugConfig({
+                invokeTarget: {
+                    target: 'template',
+                    templatePath: 'template2.yaml',
+                    logicalId: 'relativePathBadTemplate',
+                },
+            }),
+            createMockSamDebugConfig({
+                invokeTarget: {
+                    target: 'template',
+                    templatePath: pathutils.normalize(path.resolve(workspaceFolder, 'template.yaml')),
+                    logicalId: 'absolutePathGoodTemplate',
+                },
+            }),
+            createMockSamDebugConfig({
+                invokeTarget: {
+                    target: 'template',
+                    templatePath: pathutils.normalize(path.resolve(workspaceFolder, 'template2.yaml')),
+                    logicalId: 'absolutePathBadTemplate',
+                },
+            }),
+            createMockSamDebugConfig({
+                invokeTarget: {
+                    target: 'code',
+                    lambdaHandler: 'relativeRoot',
+                    projectRoot: 'inProject',
+                },
+            }),
+            createMockSamDebugConfig({
+                invokeTarget: {
+                    target: 'code',
+                    lambdaHandler: 'differentRelativeRoot',
+                    projectRoot: 'notInProject',
+                },
+            }),
+            createMockSamDebugConfig({
+                invokeTarget: {
+                    target: 'code',
+                    lambdaHandler: 'absoluteRoot',
+                    projectRoot: pathutils.normalize(path.resolve(workspaceFolder, 'inProject')),
+                },
+            }),
+            createMockSamDebugConfig({
+                invokeTarget: {
+                    target: 'code',
+                    lambdaHandler: 'differentAbsoluteRoot',
+                    projectRoot: pathutils.normalize(path.resolve(workspaceFolder, 'notInProject')),
+                },
+            }),
+        ])
+    )
 
     return mockLaunchConfig
 }

--- a/src/test/shared/sam/debugger/awsSamDebugConfigurationValidator.test.ts
+++ b/src/test/shared/sam/debugger/awsSamDebugConfigurationValidator.test.ts
@@ -15,7 +15,6 @@ import {
 } from '../../../../shared/sam/debugger/awsSamDebugConfiguration'
 import { DefaultAwsSamDebugConfigurationValidator } from '../../../../shared/sam/debugger/awsSamDebugConfigurationValidator'
 import { createBaseTemplate } from '../../cloudformation/cloudformationTestUtils'
-import globals from '../../../../shared/extensionGlobals'
 import { WatchedItem } from '../../../../shared/fs/watchedFiles'
 
 function createTemplateConfig(): AwsSamDebuggerConfiguration {
@@ -104,21 +103,9 @@ describe('DefaultAwsSamDebugConfigurationValidator', function () {
 
     let validator: DefaultAwsSamDebugConfigurationValidator
 
-    let savedRegistry: CloudFormationTemplateRegistry
-
-    before(function () {
-        savedRegistry = globals.templateRegistry
-    })
-
-    after(function () {
-        globals.templateRegistry = savedRegistry
-    })
-
     beforeEach(function () {
         when(mockRegistry.getRegisteredItem('/')).thenReturn(templateData)
         when(mockRegistry.getRegisteredItem('/image')).thenReturn(imageTemplateData)
-
-        globals.templateRegistry = mockRegistry
 
         validator = new DefaultAwsSamDebugConfigurationValidator(instance(mockFolder))
     })
@@ -126,14 +113,14 @@ describe('DefaultAwsSamDebugConfigurationValidator', function () {
     it('returns invalid when resolving debug configurations with an invalid request type', function () {
         templateConfig.request = 'not-direct-invoke'
 
-        const result = validator.validate(templateConfig)
+        const result = validator.validate(templateConfig, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 
     it('returns invalid when resolving debug configurations with an invalid target type', function () {
         templateConfig.invokeTarget.target = 'not-valid' as any
 
-        const result = validator.validate(templateConfig as any)
+        const result = validator.validate(templateConfig as any, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 
@@ -143,7 +130,7 @@ describe('DefaultAwsSamDebugConfigurationValidator', function () {
 
         validator = new DefaultAwsSamDebugConfigurationValidator(instance(mockFolder))
 
-        const result = validator.validate(templateConfig)
+        const result = validator.validate(templateConfig, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 
@@ -151,7 +138,7 @@ describe('DefaultAwsSamDebugConfigurationValidator', function () {
         const target = templateConfig.invokeTarget as TemplateTargetProperties
         target.logicalId = 'wrong'
 
-        const result = validator.validate(templateConfig)
+        const result = validator.validate(templateConfig, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 
@@ -159,7 +146,7 @@ describe('DefaultAwsSamDebugConfigurationValidator', function () {
         const target = templateConfig.invokeTarget as TemplateTargetProperties
         target.logicalId = 'OtherResource'
 
-        const result = validator.validate(templateConfig)
+        const result = validator.validate(templateConfig, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 
@@ -167,7 +154,7 @@ describe('DefaultAwsSamDebugConfigurationValidator', function () {
         const properties = templateData.item.Resources?.TestResource?.Properties as CloudFormation.ZipResourceProperties
         properties.Runtime = 'invalid'
 
-        const result = validator.validate(templateConfig)
+        const result = validator.validate(templateConfig, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 
@@ -175,7 +162,7 @@ describe('DefaultAwsSamDebugConfigurationValidator', function () {
         const target = templateConfig.invokeTarget as TemplateTargetProperties
         target.logicalId = 'OtherResource'
 
-        const result = validator.validate(apiConfig)
+        const result = validator.validate(apiConfig, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 
@@ -183,7 +170,7 @@ describe('DefaultAwsSamDebugConfigurationValidator', function () {
         const config = createApiConfig()
         config.api = undefined
 
-        const result = validator.validate(config)
+        const result = validator.validate(config, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 
@@ -192,14 +179,14 @@ describe('DefaultAwsSamDebugConfigurationValidator', function () {
 
         config.api!.path = 'noleadingslash'
 
-        const result = validator.validate(config)
+        const result = validator.validate(config, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 
     it('returns invalid when resolving code debug configurations with invalid runtimes', function () {
         codeConfig.lambda = { runtime: 'asd' }
 
-        const result = validator.validate(codeConfig)
+        const result = validator.validate(codeConfig, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 
@@ -208,7 +195,7 @@ describe('DefaultAwsSamDebugConfigurationValidator', function () {
 
         delete lambda?.runtime
 
-        const result = validator.validate(templateConfig)
+        const result = validator.validate(templateConfig, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 })

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -3320,15 +3320,15 @@ describe('debugConfiguration', function () {
             },
         }
 
-        assert.strictEqual(debugConfiguration.getHandlerName(folder, config), 'my.test.handler')
+        assert.strictEqual(await debugConfiguration.getHandlerName(folder, config), 'my.test.handler')
 
         // Config with relative path:
         config.invokeTarget.projectRoot = relativePath
-        assert.strictEqual(debugConfiguration.getCodeRoot(folder, config), fullPath)
+        assert.strictEqual(await debugConfiguration.getCodeRoot(folder, config), fullPath)
 
         // Config with absolute path:
         config.invokeTarget.projectRoot = fullPath
-        assert.strictEqual(debugConfiguration.getCodeRoot(folder, config), fullPath)
+        assert.strictEqual(await debugConfiguration.getCodeRoot(folder, config), fullPath)
     })
 
     it('getCodeRoot(), getHandlerName() with invokeTarget=template', async function () {
@@ -3360,13 +3360,13 @@ describe('debugConfiguration', function () {
         // Template with relative path:
         testutil.toFile(makeSampleSamTemplateYaml(true, { codeUri: relativePath, handler: 'handler' }), tempFile.fsPath)
         await (await globals.templateRegistry).addItemToRegistry(tempFile)
-        assert.strictEqual(debugConfiguration.getCodeRoot(folder, config), fullPath)
-        assert.strictEqual(debugConfiguration.getHandlerName(folder, config), 'handler')
+        assert.strictEqual(await debugConfiguration.getCodeRoot(folder, config), fullPath)
+        assert.strictEqual(await debugConfiguration.getHandlerName(folder, config), 'handler')
 
         // Template with absolute path:
         testutil.toFile(makeSampleSamTemplateYaml(true, { codeUri: fullPath }), tempFile.fsPath)
         await (await globals.templateRegistry).addItemToRegistry(tempFile)
-        assert.strictEqual(debugConfiguration.getCodeRoot(folder, config), fullPath)
+        assert.strictEqual(await debugConfiguration.getCodeRoot(folder, config), fullPath)
 
         // Template with refs that don't override:
         const tempFileRefs = vscode.Uri.file(path.join(tempFolder, 'testRefs.yaml'))
@@ -3388,8 +3388,8 @@ describe('debugConfiguration', function () {
             tempFileRefs.fsPath
         )
         await (await globals.templateRegistry).addItemToRegistry(tempFileRefs)
-        assert.strictEqual(debugConfiguration.getCodeRoot(folder, fileRefsConfig), fullPath)
-        assert.strictEqual(debugConfiguration.getHandlerName(folder, fileRefsConfig), 'handler')
+        assert.strictEqual(await debugConfiguration.getCodeRoot(folder, fileRefsConfig), fullPath)
+        assert.strictEqual(await debugConfiguration.getHandlerName(folder, fileRefsConfig), 'handler')
 
         // Template with refs that overrides handler via default parameter value in YAML template
         const tempFileDefaultRefs = vscode.Uri.file(path.join(tempFolder, 'testDefaultRefs.yaml'))
@@ -3415,8 +3415,8 @@ describe('debugConfiguration', function () {
             tempFileDefaultRefs.fsPath
         )
         await (await globals.templateRegistry).addItemToRegistry(tempFileDefaultRefs)
-        assert.strictEqual(debugConfiguration.getCodeRoot(folder, fileDefaultRefsConfig), fullPath)
-        assert.strictEqual(debugConfiguration.getHandlerName(folder, fileDefaultRefsConfig), 'thisWillOverride')
+        assert.strictEqual(await debugConfiguration.getCodeRoot(folder, fileDefaultRefsConfig), fullPath)
+        assert.strictEqual(await debugConfiguration.getHandlerName(folder, fileDefaultRefsConfig), 'thisWillOverride')
 
         // Template with refs that overrides handler via override value in launch config
         const tempFileOverrideRef = vscode.Uri.file(path.join(tempFolder, 'testOverrideRefs.yaml'))
@@ -3437,7 +3437,7 @@ describe('debugConfiguration', function () {
             tempFileOverrideRef.fsPath
         )
         await (await globals.templateRegistry).addItemToRegistry(tempFileOverrideRef)
-        assert.strictEqual(debugConfiguration.getCodeRoot(folder, fileOverrideRefConfig), fullPath)
-        assert.strictEqual(debugConfiguration.getHandlerName(folder, fileOverrideRefConfig), 'override')
+        assert.strictEqual(await debugConfiguration.getCodeRoot(folder, fileOverrideRefConfig), fullPath)
+        assert.strictEqual(await debugConfiguration.getHandlerName(folder, fileOverrideRefConfig), 'override')
     })
 })

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -167,7 +167,7 @@ describe('SamDebugConfigurationProvider', async function () {
         if (tempFolderSimilarName) {
             await remove(tempFolderSimilarName)
         }
-        globals.templateRegistry.reset()
+        ;(await globals.templateRegistry).reset()
         sandbox.restore()
     })
 
@@ -180,7 +180,7 @@ describe('SamDebugConfigurationProvider', async function () {
 
             // Malformed template.yaml:
             testutil.toFile('bogus', tempFile.fsPath)
-            await globals.templateRegistry.addItemToRegistry(tempFile)
+            await (await globals.templateRegistry).addItemToRegistry(tempFile)
             assert.deepStrictEqual(await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder), [])
         })
 
@@ -188,14 +188,14 @@ describe('SamDebugConfigurationProvider', async function () {
             const bigYamlStr = `${makeSampleSamTemplateYaml(true)}\nTestResource2:\n .   Type: AWS::Serverless::Api`
 
             testutil.toFile(bigYamlStr, tempFile.fsPath)
-            await globals.templateRegistry.addItemToRegistry(tempFile)
+            await (await globals.templateRegistry).addItemToRegistry(tempFile)
             const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
             assert.strictEqual(provided!.length, 1)
         })
 
         it('returns one item if a template with one resource is in the workspace', async function () {
             testutil.toFile(makeSampleSamTemplateYaml(true), tempFile.fsPath)
-            await globals.templateRegistry.addItemToRegistry(tempFile)
+            await (await globals.templateRegistry).addItemToRegistry(tempFile)
             const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
             assert.notStrictEqual(provided, undefined)
             assert.strictEqual(provided!.length, 1)
@@ -211,7 +211,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 resourceName: resources[0],
             })}\n${makeSampleYamlResource({ resourceName: resources[1] })}`
             testutil.toFile(bigYamlStr, tempFile.fsPath)
-            await globals.templateRegistry.addItemToRegistry(tempFile)
+            await (await globals.templateRegistry).addItemToRegistry(tempFile)
             const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
             assert.notStrictEqual(provided, undefined)
             if (provided) {
@@ -237,9 +237,9 @@ describe('SamDebugConfigurationProvider', async function () {
             testutil.toFile(makeSampleSamTemplateYaml(true, { resourceName: resources[1] }), nestedYaml.fsPath)
             testutil.toFile(makeSampleSamTemplateYaml(true, { resourceName: badResourceName }), similarNameYaml.fsPath)
 
-            await globals.templateRegistry.addItemToRegistry(tempFile)
-            await globals.templateRegistry.addItemToRegistry(nestedYaml)
-            await globals.templateRegistry.addItemToRegistry(similarNameYaml)
+            await (await globals.templateRegistry).addItemToRegistry(tempFile)
+            await (await globals.templateRegistry).addItemToRegistry(nestedYaml)
+            await (await globals.templateRegistry).addItemToRegistry(similarNameYaml)
 
             const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
             assert.notStrictEqual(provided, undefined)
@@ -261,7 +261,7 @@ describe('SamDebugConfigurationProvider', async function () {
                         Method: get`
 
             testutil.toFile(bigYamlStr, tempFile.fsPath)
-            await globals.templateRegistry.addItemToRegistry(tempFile)
+            await (await globals.templateRegistry).addItemToRegistry(tempFile)
             const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
             assert.strictEqual(provided!.length, 2)
             assert.strictEqual(provided![1].invokeTarget.target, API_TARGET_TYPE)
@@ -276,7 +276,7 @@ describe('SamDebugConfigurationProvider', async function () {
                     Type: HttpApi`
 
             testutil.toFile(bigYamlStr, tempFile.fsPath)
-            await globals.templateRegistry.addItemToRegistry(tempFile)
+            await (await globals.templateRegistry).addItemToRegistry(tempFile)
             const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
             assert.strictEqual(provided!.length, 1)
         })
@@ -289,7 +289,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 const folder = testutil.getWorkspaceFolder(testutil.getProjectDir())
                 const launchConfig = await getConfig(
                     debugConfigProvider,
-                    globals.templateRegistry,
+                    await globals.templateRegistry,
                     'testFixtures/workspaceFolder/js-plain-sam-app/'
                 )
                 const config = launchConfig.config as AwsSamDebuggerConfiguration & {
@@ -309,7 +309,7 @@ describe('SamDebugConfigurationProvider', async function () {
         it('failure modes', async function () {
             const config = await getConfig(
                 debugConfigProvider,
-                globals.templateRegistry,
+                await globals.templateRegistry,
                 'testFixtures/workspaceFolder/csharp6-zip/'
             )
 
@@ -432,7 +432,7 @@ describe('SamDebugConfigurationProvider', async function () {
         })
 
         it("rejects when resolving template debug configurations with a template that doesn't have the set resource", async () => {
-            await createAndRegisterYaml({}, tempFile, globals.templateRegistry)
+            await createAndRegisterYaml({}, tempFile, await globals.templateRegistry)
             await assert.rejects(() =>
                 debugConfigProvider.makeConfig(undefined, createFakeConfig({ templatePath: tempFile.fsPath }))
             )
@@ -442,7 +442,7 @@ describe('SamDebugConfigurationProvider', async function () {
             await createAndRegisterYaml(
                 { resourceName, runtime: 'moreLikeRanOutOfTime' },
                 tempFile,
-                globals.templateRegistry
+                await globals.templateRegistry
             )
             await assert.rejects(
                 () =>
@@ -462,7 +462,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 makeSampleSamTemplateYaml(true, { resourceName, runtime: 'moreLikeRanOutOfTime' }),
                 tempFile.fsPath
             )
-            await globals.templateRegistry.addItemToRegistry(tempFile)
+            await (await globals.templateRegistry).addItemToRegistry(tempFile)
             await assert.rejects(() =>
                 debugConfigProvider.makeConfig(undefined, {
                     type: AWS_SAM_DEBUG_TYPE,
@@ -491,7 +491,7 @@ describe('SamDebugConfigurationProvider', async function () {
         it('supports workspace-relative template path ("./foo.yaml")', async function () {
             testutil.toFile(makeSampleSamTemplateYaml(true, { runtime: 'nodejs18.x' }), tempFile.fsPath)
             // Register with *full* path.
-            await globals.templateRegistry.addItemToRegistry(tempFile)
+            await (await globals.templateRegistry).addItemToRegistry(tempFile)
             // Simulates launch.json:
             //     "invokeTarget": {
             //         "target": "./test.yaml",
@@ -853,7 +853,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await globals.templateRegistry.addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItemToRegistry(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
 
             const expected: SamLaunchRequestArgs = {
@@ -980,7 +980,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await globals.templateRegistry.addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItemToRegistry(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
 
             const expected: SamLaunchRequestArgs = {
@@ -1119,7 +1119,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await globals.templateRegistry.addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItemToRegistry(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
 
             const expected: SamLaunchRequestArgs = {
@@ -1415,7 +1415,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await globals.templateRegistry.addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItemToRegistry(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))! as SamLaunchRequestArgs
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
             const expected: SamLaunchRequestArgs = {
@@ -1514,7 +1514,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await globals.templateRegistry.addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItemToRegistry(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))! as SamLaunchRequestArgs
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
             const expected: SamLaunchRequestArgs = {
@@ -1778,7 +1778,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await globals.templateRegistry.addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItemToRegistry(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))! as SamLaunchRequestArgs
             const codeRoot = `${appDir}/src/HelloWorld`
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
@@ -1933,7 +1933,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await globals.templateRegistry.addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItemToRegistry(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))! as SamLaunchRequestArgs
             const codeRoot = `${appDir}/src/HelloWorld`
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
@@ -2242,7 +2242,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'python3.7-plain-sam-app/template.yaml'))
-            await globals.templateRegistry.addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItemToRegistry(templatePath)
 
             // Invoke with noDebug=false (the default).
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
@@ -2368,7 +2368,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'python3.7-plain-sam-app/template.yaml'))
-            await globals.templateRegistry.addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItemToRegistry(templatePath)
 
             // Invoke with noDebug=false (the default).
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
@@ -2460,7 +2460,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'python3.7-image-sam-app/template.yaml'))
-            await globals.templateRegistry.addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItemToRegistry(templatePath)
 
             // Invoke with noDebug=false (the default).
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
@@ -2739,7 +2739,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 useIkpdb: true,
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'python3.7-plain-sam-app/template.yaml'))
-            await globals.templateRegistry.addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItemToRegistry(templatePath)
 
             // Invoke with noDebug=false (the default).
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
@@ -2885,7 +2885,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 }),
                 tempFile.fsPath
             )
-            await globals.templateRegistry.addItemToRegistry(tempFile)
+            await (await globals.templateRegistry).addItemToRegistry(tempFile)
             const actual = (await debugConfigProviderMockCredentials.makeConfig(folder, input))!
             const tempDir = path.dirname(actual.codeRoot)
 
@@ -3297,7 +3297,8 @@ describe('debugConfiguration', function () {
 
     afterEach(async function () {
         await remove(tempFolder)
-        globals.templateRegistry.reset()
+        const r = await globals.templateRegistry
+        r.reset()
     })
 
     it('getCodeRoot(), getHandlerName() with invokeTarget=code', async function () {
@@ -3358,13 +3359,13 @@ describe('debugConfiguration', function () {
 
         // Template with relative path:
         testutil.toFile(makeSampleSamTemplateYaml(true, { codeUri: relativePath, handler: 'handler' }), tempFile.fsPath)
-        await globals.templateRegistry.addItemToRegistry(tempFile)
+        await (await globals.templateRegistry).addItemToRegistry(tempFile)
         assert.strictEqual(debugConfiguration.getCodeRoot(folder, config), fullPath)
         assert.strictEqual(debugConfiguration.getHandlerName(folder, config), 'handler')
 
         // Template with absolute path:
         testutil.toFile(makeSampleSamTemplateYaml(true, { codeUri: fullPath }), tempFile.fsPath)
-        await globals.templateRegistry.addItemToRegistry(tempFile)
+        await (await globals.templateRegistry).addItemToRegistry(tempFile)
         assert.strictEqual(debugConfiguration.getCodeRoot(folder, config), fullPath)
 
         // Template with refs that don't override:
@@ -3386,7 +3387,7 @@ describe('debugConfiguration', function () {
             makeSampleSamTemplateYaml(true, { codeUri: fullPath, handler: 'handler' }, paramStr),
             tempFileRefs.fsPath
         )
-        await globals.templateRegistry.addItemToRegistry(tempFileRefs)
+        await (await globals.templateRegistry).addItemToRegistry(tempFileRefs)
         assert.strictEqual(debugConfiguration.getCodeRoot(folder, fileRefsConfig), fullPath)
         assert.strictEqual(debugConfiguration.getHandlerName(folder, fileRefsConfig), 'handler')
 
@@ -3413,7 +3414,7 @@ describe('debugConfiguration', function () {
             ),
             tempFileDefaultRefs.fsPath
         )
-        await globals.templateRegistry.addItemToRegistry(tempFileDefaultRefs)
+        await (await globals.templateRegistry).addItemToRegistry(tempFileDefaultRefs)
         assert.strictEqual(debugConfiguration.getCodeRoot(folder, fileDefaultRefsConfig), fullPath)
         assert.strictEqual(debugConfiguration.getHandlerName(folder, fileDefaultRefsConfig), 'thisWillOverride')
 
@@ -3435,7 +3436,7 @@ describe('debugConfiguration', function () {
             makeSampleSamTemplateYaml(true, { codeUri: fullPath, handler: '!Ref override' }, paramStrNoDefaultOverride),
             tempFileOverrideRef.fsPath
         )
-        await globals.templateRegistry.addItemToRegistry(tempFileOverrideRef)
+        await (await globals.templateRegistry).addItemToRegistry(tempFileOverrideRef)
         assert.strictEqual(debugConfiguration.getCodeRoot(folder, fileOverrideRefConfig), fullPath)
         assert.strictEqual(debugConfiguration.getHandlerName(folder, fileOverrideRefConfig), 'override')
     })

--- a/src/test/shared/sam/sync.test.ts
+++ b/src/test/shared/sam/sync.test.ts
@@ -16,10 +16,12 @@ import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
 import { makeTemporaryToolkitFolder } from '../../../shared/filesystemUtilities'
 import { SystemUtilities } from '../../../shared/systemUtilities'
 import { ToolkitError } from '../../../shared/errors'
+import globals from '../../../shared/extensionGlobals'
 
-describe('SyncWizard', function () {
+describe('SyncWizard', async function () {
+    const registry = await globals.templateRegistry
     const createTester = (params?: Partial<SyncParams>) =>
-        createWizardTester(new SyncWizard({ deployType: 'code', ...params }))
+        createWizardTester(new SyncWizard({ deployType: 'code', ...params }, registry))
 
     it('shows steps in correct order', function () {
         const tester = createTester()

--- a/src/testInteg/sam.test.ts
+++ b/src/testInteg/sam.test.ts
@@ -618,7 +618,7 @@ describe('SAM Integration Tests', async function () {
                     }
 
                     // XXX: force load since template registry seems a bit flakey
-                    await globals.templateRegistry.addItemToRegistry(vscode.Uri.file(cfnTemplatePath))
+                    await (await globals.templateRegistry).addItemToRegistry(vscode.Uri.file(cfnTemplatePath))
 
                     await startDebugger(scenario, scenarioIndex, target, testConfig, testDisposables, sessionLog)
                 }


### PR DESCRIPTION
## Problem
The template file watcher always ran regardless of SAM hint setting

## Solution
The template file watcher now loads on demand. This appears to work even when toggling from off to on (codelenses appear on the template file)
* ~~This may hit the startup function multiple times? Will do some more testing~~ should be resolved with https://github.com/aws/aws-toolkit-vscode/pull/3938/commits/0b1df9d39df91638e749d4825735f548e45ece28
* Confirmed SAM debug works, when coming from startup with codelenses disabled
* Confirmed the registry builds when codelenses are enabled

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
