### PR TITLE
fix(redshift): VS Code always opens Output panel

### DIFF
--- a/.changes/next-release/Bug Fix-fff4dbbd-2664-43c3-bf6f-98cf1440ace2.json
+++ b/.changes/next-release/Bug Fix-fff4dbbd-2664-43c3-bf6f-98cf1440ace2.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Redshift: Fix the issue that Output panel always opens at VS Code launch."
+	"description": "Output panel always opens at VS Code launch."
 }

--- a/.changes/next-release/Bug Fix-fff4dbbd-2664-43c3-bf6f-98cf1440ace2.json
+++ b/.changes/next-release/Bug Fix-fff4dbbd-2664-43c3-bf6f-98cf1440ace2.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Redshift: Fix the issue that Output panel always opens at VS Code launch."
+}

--- a/src/redshift/activation.ts
+++ b/src/redshift/activation.ts
@@ -21,7 +21,6 @@ import { showViewLogsMessage } from '../shared/utilities/messages'
 
 export async function activate(ctx: ExtContext): Promise<void> {
     const outputChannel = globals.outputChannel
-    outputChannel.show(true)
 
     if ('NotebookEdit' in vscode) {
         ctx.extensionContext.subscriptions.push(
@@ -86,6 +85,7 @@ function getNotebookConnectClickedHandler(
             return
         }
         redshiftNotebookController.redshiftClient = new DefaultRedshiftClient(connectionParams.region!.id)
+        outputChannel.show(true)
         try {
             const redshiftClient = (redshiftNotebookController.redshiftClient = new DefaultRedshiftClient(
                 connectionParams.region!.id
@@ -134,6 +134,7 @@ function getEditConnectionHandler(outputChannel: vscode.OutputChannel) {
                 await vscode.commands.executeCommand('aws.refreshAwsExplorerNode', redshiftWarehouseNode)
             }
         } catch (error) {
+            outputChannel.show(true)
             outputChannel.appendLine(
                 `Redshift: Failed to fetch databases for warehouse ${redshiftWarehouseNode.name} - ${
                     (error as Error).message

--- a/src/redshift/explorer/redshiftWarehouseNode.ts
+++ b/src/redshift/explorer/redshiftWarehouseNode.ts
@@ -147,6 +147,7 @@ export class RedshiftWarehouseNode extends AWSTreeNodeBase implements AWSResourc
                     await updateConnectionParamsState(this.arn, this.connectionParams)
                     return childNodes
                 } catch (error) {
+                    globals.outputChannel.show(true)
                     const msg = `Redshift: Failed to fetch databases for warehouse ${this.redshiftWarehouse.name} - ${
                         (error as Error).message
                     }`


### PR DESCRIPTION
## Problem
Output panel always opens at VS Code launch. Issue reported at https://github.com/aws/aws-toolkit-vscode/issues/3930. 
<img width="1079" alt="Screenshot 2023-10-23 at 11 04 57 AM" src="https://github.com/aws/aws-toolkit-vscode/assets/141669322/b86ea738-0d1d-4cab-9bd1-d2a843628908">

## Solution
Instead of showing Output panel at Redshift activation, change to show Output panel only when a message is added.
<img width="1080" alt="Screenshot 2023-10-23 at 11 06 40 AM" src="https://github.com/aws/aws-toolkit-vscode/assets/141669322/f73364f1-e3a5-460c-b4c5-4fa16aa6a76d">
<img width="1080" alt="Screenshot 2023-10-23 at 11 08 37 AM" src="https://github.com/aws/aws-toolkit-vscode/assets/141669322/95b2ff68-64c3-4128-84f6-3d3d5a677782">

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
