### PR TITLE
codewhisperer: switch to default model when receiving ResouceNotFoundException

### DIFF
--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -302,7 +302,10 @@ export class RecommendationHandler {
                 CodeWhispererCodeCoverageTracker.getTracker(session.language)?.incrementServiceInvocationCount()
             } else {
                 // TODO: Double-check with service side that this is an AccessDeniedException
-                if (errorMessage?.includes(invalidCustomizationMessage) && errorCode === 'AccessDeniedException') {
+                if (
+                    (errorMessage?.includes(invalidCustomizationMessage) && errorCode === 'AccessDeniedException') ||
+                    errorCode === 'ResourceNotFoundException'
+                ) {
                     getLogger()
                         .debug(`The selected customization is no longer available. Retrying with the default model.
                     Failed request id: ${requestId}`)

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -301,7 +301,6 @@ export class RecommendationHandler {
             if (invocationResult === 'Succeeded') {
                 CodeWhispererCodeCoverageTracker.getTracker(session.language)?.incrementServiceInvocationCount()
             } else {
-                // TODO: Double-check with service side that this is an AccessDeniedException
                 if (
                     (errorMessage?.includes(invalidCustomizationMessage) && errorCode === 'AccessDeniedException') ||
                     errorCode === 'ResourceNotFoundException'


### PR DESCRIPTION
## Problem

https://github.com/aws/aws-toolkit-vscode/assets/96078566/d2fb7d33-8935-4d13-ba7b-60e668e5198d



```
2023-10-23 18:39:31 [DEBUG]: The selected customization is no longer available. Retrying with the default model.
                    Failed request id: 5f8265c7-23ff-4286-bc9f-1cbd3f68d7b0
2023-10-23 18:39:31 [DEBUG]: codewhisperer: Connection expired = false,
                           secondaryAuth connection expired = false,
                           connection is undefined = false
2023-10-23 18:39:31 [DEBUG]: codewhisperer: isValidCodeWhispererConnection = true
2023-10-23 18:39:31 [DEBUG]: Selected customization CodeWhisperer foundation (Default) for IAM Identity Center (d-9067af8754)
2023-10-23 18:39:31 [DEBUG]: codewhisperer: Connection is valid = true, 
                            connection is undefined = false,
                            secondaryAuth connection expired = false
2023-10-23 18:39:31 [DEBUG]: codewhisperer: Connection expired = false,
                           secondaryAuth connection expired = false,
                           connection is undefined = false
2023-10-23 18:39:31 [DEBUG]: codewhisperer: isValidCodeWhispererConnection = true
2023-10-23 18:39:31 [DEBUG]: CodeWhisperer finished fetching crossfile context out of 0 files
2023-10-23 18:39:31 [DEBUG]: CodeWhispererSupplementalContext:
    isUtg: false,
    isProcessTimeout: false,
    contentsLength: 0,
    latency: 0.2807850241661072,

2023-10-23 18:39:31 [DEBUG]: codewhisperer: Connection expired = false,
                           secondaryAuth connection expired = false,
                           connection is undefined = false
2023-10-23 18:39:32 [DEBUG]: codewhisperer: isValidCodeWhispererConnection = true
2023-10-23 18:39:32 [DEBUG]: codewhisperer: request-id: 7f5bee77-c97c-4d3a-bbd2-c71d2704e953,
    timestamp(epoch): 1698111572442,
    timezone: America/Los_Angeles,
    datetime: 10/23/2023, 6:39:32 PM,
    vscode version: '1.79.0',
    extension version: '1.96.0-21847e6b69e1',
    filename: 'OceanBaseJob.jsx',
    left context of line:  '',
    line number: 12,
    character location: 0,
    latency: 593.0288180112839 ms.
    Recommendations:

```
## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
