### PR TITLE
refactor(redshift): logging and output message

### DIFF
--- a/src/redshift/activation.ts
+++ b/src/redshift/activation.ts
@@ -17,7 +17,7 @@ import { RedshiftWarehouseNode } from './explorer/redshiftWarehouseNode'
 import { ToolkitError } from '../shared/errors'
 import { deleteConnection, updateConnectionParamsState } from './explorer/redshiftState'
 import { showViewLogsMessage } from '../shared/utilities/messages'
-import { showConnectionMessage } from './utils'
+import { showConnectionMessage } from './messageUtils'
 
 export async function activate(ctx: ExtContext): Promise<void> {
     if ('NotebookEdit' in vscode) {

--- a/src/redshift/activation.ts
+++ b/src/redshift/activation.ts
@@ -16,12 +16,10 @@ import { localize } from '../shared/utilities/vsCodeUtils'
 import { RedshiftWarehouseNode } from './explorer/redshiftWarehouseNode'
 import { ToolkitError } from '../shared/errors'
 import { deleteConnection, updateConnectionParamsState } from './explorer/redshiftState'
-import globals from '../shared/extensionGlobals'
 import { showViewLogsMessage } from '../shared/utilities/messages'
+import { showConnectionMessage } from './utils'
 
 export async function activate(ctx: ExtContext): Promise<void> {
-    const outputChannel = globals.outputChannel
-
     if ('NotebookEdit' in vscode) {
         ctx.extensionContext.subscriptions.push(
             vscode.workspace.registerNotebookSerializer('aws-redshift-sql-notebook', new RedshiftNotebookSerializer())
@@ -34,7 +32,7 @@ export async function activate(ctx: ExtContext): Promise<void> {
         ctx.extensionContext.subscriptions.push(
             Commands.register(
                 'aws.redshift.notebookConnectClicked',
-                getNotebookConnectClickedHandler(ctx, redshiftNotebookController, outputChannel)
+                getNotebookConnectClickedHandler(ctx, redshiftNotebookController)
             )
         )
 
@@ -46,7 +44,7 @@ export async function activate(ctx: ExtContext): Promise<void> {
         )
 
         ctx.extensionContext.subscriptions.push(
-            Commands.register('aws.redshift.editConnection', getEditConnectionHandler(outputChannel))
+            Commands.register('aws.redshift.editConnection', getEditConnectionHandler())
         )
 
         ctx.extensionContext.subscriptions.push(
@@ -73,11 +71,7 @@ function getCreateNotebookClickedHandler(redshiftNotebookController: RedshiftNot
     }
 }
 
-function getNotebookConnectClickedHandler(
-    ctx: ExtContext,
-    redshiftNotebookController: RedshiftNotebookController,
-    outputChannel: vscode.OutputChannel
-) {
+function getNotebookConnectClickedHandler(ctx: ExtContext, redshiftNotebookController: RedshiftNotebookController) {
     return async (cell: vscode.NotebookCell, refreshCellStatusBar: () => void) => {
         const warehouseConnectionWizard = new NotebookConnectionWizard(ctx.regionProvider)
         let connectionParams: ConnectionParams | undefined = await warehouseConnectionWizard.run()
@@ -85,7 +79,6 @@ function getNotebookConnectClickedHandler(
             return
         }
         redshiftNotebookController.redshiftClient = new DefaultRedshiftClient(connectionParams.region!.id)
-        outputChannel.show(true)
         try {
             const redshiftClient = (redshiftNotebookController.redshiftClient = new DefaultRedshiftClient(
                 connectionParams.region!.id
@@ -98,11 +91,9 @@ function getNotebookConnectClickedHandler(
                 connectionParams.secret = secretArnFetched
             }
             await redshiftNotebookController.redshiftClient.listDatabases(connectionParams!)
-            outputChannel.appendLine(`Redshift: connected to: ${connectionParams.warehouseIdentifier}`)
+            showConnectionMessage(connectionParams.warehouseIdentifier, undefined)
         } catch (error) {
-            outputChannel.appendLine(
-                `Redshift: failed to connect to: ${connectionParams.warehouseIdentifier} - ${(error as Error).message}`
-            )
+            showConnectionMessage(connectionParams.warehouseIdentifier, error as Error)
             connectionParams = undefined
         }
         const edit = new vscode.WorkspaceEdit()
@@ -116,7 +107,7 @@ function getNotebookConnectClickedHandler(
     }
 }
 
-function getEditConnectionHandler(outputChannel: vscode.OutputChannel) {
+function getEditConnectionHandler() {
     return async (redshiftWarehouseNode: RedshiftWarehouseNode) => {
         try {
             const connectionParams = await new RedshiftNodeConnectionWizard(redshiftWarehouseNode).run()
@@ -134,12 +125,7 @@ function getEditConnectionHandler(outputChannel: vscode.OutputChannel) {
                 await vscode.commands.executeCommand('aws.refreshAwsExplorerNode', redshiftWarehouseNode)
             }
         } catch (error) {
-            outputChannel.show(true)
-            outputChannel.appendLine(
-                `Redshift: Failed to fetch databases for warehouse ${redshiftWarehouseNode.name} - ${
-                    (error as Error).message
-                }`
-            )
+            showConnectionMessage(redshiftWarehouseNode.name, error as Error)
         }
     }
 }

--- a/src/redshift/explorer/redshiftDatabaseNode.ts
+++ b/src/redshift/explorer/redshiftDatabaseNode.ts
@@ -13,13 +13,11 @@ import { ConnectionParams } from '../models/models'
 import { LoadMoreNode } from '../../shared/treeview/nodes/loadMoreNode'
 import { ChildNodeLoader, ChildNodePage } from '../../awsexplorer/childNodeLoader'
 import { getIcon } from '../../shared/icons'
-import { getLogger } from '../../shared/logger'
 import { telemetry } from '../../shared/telemetry/telemetry'
-import { showViewLogsMessage } from '../../shared/utilities/messages'
+import { showViewLogsFetchMessage } from '../utils'
 
 export class RedshiftDatabaseNode extends AWSTreeNodeBase implements LoadMoreNode {
     private readonly childLoader = new ChildNodeLoader(this, token => this.loadPage(token))
-    private readonly logger = getLogger()
 
     public constructor(
         public readonly databaseName: string,
@@ -65,9 +63,7 @@ export class RedshiftDatabaseNode extends AWSTreeNodeBase implements LoadMoreNod
                     newContinuationToken: listSchemaResponse.NextToken,
                 }
             } catch (error) {
-                const msg = `Redshift: Failed to fetch schemas for ${this.databaseName}: ${(error as Error).message}`
-                this.logger.error(msg)
-                showViewLogsMessage(msg)
+                showViewLogsFetchMessage('schemas', this.databaseName, error as Error)
                 return Promise.reject(error)
             }
         })

--- a/src/redshift/explorer/redshiftDatabaseNode.ts
+++ b/src/redshift/explorer/redshiftDatabaseNode.ts
@@ -14,7 +14,7 @@ import { LoadMoreNode } from '../../shared/treeview/nodes/loadMoreNode'
 import { ChildNodeLoader, ChildNodePage } from '../../awsexplorer/childNodeLoader'
 import { getIcon } from '../../shared/icons'
 import { telemetry } from '../../shared/telemetry/telemetry'
-import { showViewLogsFetchMessage } from '../utils'
+import { showViewLogsFetchMessage } from '../messageUtils'
 
 export class RedshiftDatabaseNode extends AWSTreeNodeBase implements LoadMoreNode {
     private readonly childLoader = new ChildNodeLoader(this, token => this.loadPage(token))

--- a/src/redshift/explorer/redshiftSchemaNode.ts
+++ b/src/redshift/explorer/redshiftSchemaNode.ts
@@ -14,7 +14,7 @@ import { ChildNodeLoader, ChildNodePage } from '../../awsexplorer/childNodeLoade
 import { LoadMoreNode } from '../../shared/treeview/nodes/loadMoreNode'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { getIcon } from '../../shared/icons'
-import { showViewLogsFetchMessage } from '../utils'
+import { showViewLogsFetchMessage } from '../messageUtils'
 
 export class RedshiftSchemaNode extends AWSTreeNodeBase implements LoadMoreNode {
     private readonly childLoader = new ChildNodeLoader(this, token => this.loadPage(token))

--- a/src/redshift/explorer/redshiftSchemaNode.ts
+++ b/src/redshift/explorer/redshiftSchemaNode.ts
@@ -12,14 +12,12 @@ import { RedshiftTableNode } from './redshiftTableNode'
 import { ConnectionParams } from '../models/models'
 import { ChildNodeLoader, ChildNodePage } from '../../awsexplorer/childNodeLoader'
 import { LoadMoreNode } from '../../shared/treeview/nodes/loadMoreNode'
-import { getLogger } from '../../shared/logger'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { getIcon } from '../../shared/icons'
-import { showViewLogsMessage } from '../../shared/utilities/messages'
+import { showViewLogsFetchMessage } from '../utils'
 
 export class RedshiftSchemaNode extends AWSTreeNodeBase implements LoadMoreNode {
     private readonly childLoader = new ChildNodeLoader(this, token => this.loadPage(token))
-    private readonly logger = getLogger()
     public constructor(
         public readonly schemaName: string,
         public readonly redshiftClient: DefaultRedshiftClient,
@@ -64,9 +62,7 @@ export class RedshiftSchemaNode extends AWSTreeNodeBase implements LoadMoreNode 
                     newContinuationToken: listTablesResponse.NextToken,
                 }
             } catch (error) {
-                const msg = `Redshift: Failed to fetch tables for ${this.schemaName}: ${(error as Error).message}`
-                this.logger.error(msg)
-                showViewLogsMessage(msg)
+                showViewLogsFetchMessage('tables', this.schemaName, error as Error)
                 return Promise.reject(error)
             }
         })

--- a/src/redshift/explorer/redshiftWarehouseNode.ts
+++ b/src/redshift/explorer/redshiftWarehouseNode.ts
@@ -19,7 +19,7 @@ import { getIcon } from '../../shared/icons'
 import { AWSCommandTreeNode } from '../../shared/treeview/nodes/awsCommandTreeNode'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { deleteConnection, getConnectionParamsState, updateConnectionParamsState } from './redshiftState'
-import { createLogsConnectionMessage, showConnectionMessage } from '../utils'
+import { createLogsConnectionMessage, showConnectionMessage } from '../messageUtils'
 
 export class CreateNotebookNode extends AWSCommandTreeNode {
     constructor(parent: RedshiftWarehouseNode) {

--- a/src/redshift/explorer/redshiftWarehouseNode.ts
+++ b/src/redshift/explorer/redshiftWarehouseNode.ts
@@ -17,10 +17,9 @@ import { RedshiftNodeConnectionWizard } from '../wizards/connectionWizard'
 import { ListDatabasesResponse } from 'aws-sdk/clients/redshiftdata'
 import { getIcon } from '../../shared/icons'
 import { AWSCommandTreeNode } from '../../shared/treeview/nodes/awsCommandTreeNode'
-import { getLogger } from '../../shared/logger'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { deleteConnection, getConnectionParamsState, updateConnectionParamsState } from './redshiftState'
-import globals from '../../shared/extensionGlobals'
+import { createLogsConnectionMessage, showConnectionMessage } from '../utils'
 
 export class CreateNotebookNode extends AWSCommandTreeNode {
     constructor(parent: RedshiftWarehouseNode) {
@@ -99,11 +98,7 @@ export class RedshiftWarehouseNode extends AWSTreeNodeBase implements AWSResourc
                     newChildren: childNodes,
                 }
             } catch (error) {
-                getLogger().error(
-                    `Redshift: Failed to fetch databases for warehouse ${this.redshiftWarehouse.name} - ${
-                        (error as Error).message
-                    }`
-                )
+                createLogsConnectionMessage(this.redshiftWarehouse.name, error as Error)
                 return Promise.reject(error)
             }
         })
@@ -145,12 +140,7 @@ export class RedshiftWarehouseNode extends AWSTreeNodeBase implements AWSResourc
                     await updateConnectionParamsState(this.arn, this.connectionParams)
                     return childNodes
                 } catch (error) {
-                    globals.outputChannel.show(true)
-                    const msg = `Redshift: Failed to fetch databases for warehouse ${this.redshiftWarehouse.name} - ${
-                        (error as Error).message
-                    }`
-                    getLogger().error(msg)
-                    globals.outputChannel.appendLine(msg)
+                    showConnectionMessage(this.redshiftWarehouse.name, error as Error)
                     await updateConnectionParamsState(this.arn, undefined)
                     return this.getRetryNode()
                 }

--- a/src/redshift/messageUtils.ts
+++ b/src/redshift/messageUtils.ts
@@ -43,7 +43,7 @@ export function createLogsConnectionMessage(warehouseIdentifier: string, error: 
  * @param error
  */
 export function showViewLogsFetchMessage(fetchType: string, identifier: string, error: Error) {
-    const message = `Redshift: Failed to fetch ${fetchType} for ${identifier}: ${(error as Error).message}`
+    const message = `Redshift: failed to fetch ${fetchType} for ${identifier}: ${(error as Error).message}`
     getLogger().error(message)
     showViewLogsMessage(message)
 }

--- a/src/redshift/utils.ts
+++ b/src/redshift/utils.ts
@@ -1,0 +1,49 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import globals from '../shared/extensionGlobals'
+import { getLogger } from '../shared/logger'
+import { showViewLogsMessage } from '../shared/utilities/messages'
+
+/**
+ * Show the connection message in output channel. Log the error message if connection fails.
+ * @param warehouseIdentifier
+ * @param error
+ */
+export function showConnectionMessage(warehouseIdentifier: string, error: Error | undefined) {
+    const outputChannel = globals.outputChannel
+    outputChannel.show(true)
+    const outputMessage = createLogsConnectionMessage(warehouseIdentifier, error)
+    outputChannel.appendLine(outputMessage)
+}
+
+/**
+ * Create the connection message and log the error if the connection fails.
+ * @param warehouseIdentifier
+ * @param error
+ * @returns the connection message to show
+ */
+export function createLogsConnectionMessage(warehouseIdentifier: string, error: Error | undefined): string {
+    let connectionMessage = ''
+    if (!error) {
+        connectionMessage = `Redshift: connected to: ${warehouseIdentifier}`
+    } else {
+        connectionMessage = `Redshift: failed to connect to: ${warehouseIdentifier}: ${(error as Error).message}`
+        getLogger().error(connectionMessage)
+    }
+    return connectionMessage
+}
+
+/**
+ * Log the fetching error message and show a window with "View Logs" button
+ * @param fetchType
+ * @param identifier
+ * @param error
+ */
+export function showViewLogsFetchMessage(fetchType: string, identifier: string, error: Error) {
+    const message = `Redshift: Failed to fetch ${fetchType} for ${identifier}: ${(error as Error).message}`
+    getLogger().error(message)
+    showViewLogsMessage(message)
+}


### PR DESCRIPTION
## Problem
There are similar logging and output message in node explorer. Refactoring code to centralize logging and message output makes it easy for maintenance. 

## Solution
Create message functions in messageUtils.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
