### PR TITLE
refactor(watchedfiles): rename getRegisteredItem => getItem

### DIFF
--- a/src/codecatalyst/devfile.ts
+++ b/src/codecatalyst/devfile.ts
@@ -66,7 +66,7 @@ export class DevfileCodeLensProvider implements vscode.CodeLensProvider {
         this.disposables.push(this._onDidChangeCodeLenses)
         this.disposables.push(
             workspace.onDidSaveTextDocument(async document => {
-                if (!registry.getRegisteredItem(document.fileName)) {
+                if (!registry.getItem(document.fileName)) {
                     return
                 }
 

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -271,7 +271,7 @@ export async function createNewSamApplication(
         // Race condition where SAM app is created but template doesn't register in time.
         // Poll for 5 seconds, otherwise direct user to codelens.
         const isTemplateRegistered = await waitUntil(
-            async () => (await globals.templateRegistry).getRegisteredItem(templateUri),
+            async () => (await globals.templateRegistry).getItem(templateUri),
             {
                 timeout: 5000,
                 interval: 500,

--- a/src/lambda/local/debugConfiguration.ts
+++ b/src/lambda/local/debugConfiguration.ts
@@ -193,7 +193,7 @@ export async function getTemplate(
     }
     const templateInvoke = config.invokeTarget as TemplateTargetProperties
     const fullPath = tryGetAbsolutePath(folder, templateInvoke.templatePath)
-    const cfnTemplate = (await globals.templateRegistry).getRegisteredItem(fullPath)?.item
+    const cfnTemplate = (await globals.templateRegistry).getItem(fullPath)?.item
     return cfnTemplate
 }
 

--- a/src/lambda/vue/configEditor/samInvokeBackend.ts
+++ b/src/lambda/vue/configEditor/samInvokeBackend.ts
@@ -161,7 +161,7 @@ export class SamInvokeWebview extends VueWebview {
     public async getTemplate() {
         const items: (vscode.QuickPickItem & { templatePath: string })[] = []
         const noTemplate = 'NOTEMPLATEFOUND'
-        for (const template of (await globals.templateRegistry).registeredItems) {
+        for (const template of (await globals.templateRegistry).items) {
             const resources = template.item.Resources
             if (resources) {
                 for (const resource of Object.keys(resources)) {

--- a/src/lambda/wizards/samDeployWizard.ts
+++ b/src/lambda/wizards/samDeployWizard.ts
@@ -211,7 +211,7 @@ export class DefaultSamDeployWizardContext implements SamDeployWizardContext {
     }
 
     public async determineIfTemplateHasImages(templatePath: vscode.Uri): Promise<boolean> {
-        const template = (await globals.templateRegistry).getRegisteredItem(templatePath.fsPath)
+        const template = (await globals.templateRegistry).getItem(templatePath.fsPath)
         const resources = template?.item?.Resources
         if (resources === undefined) {
             return false

--- a/src/lambda/wizards/samDeployWizard.ts
+++ b/src/lambda/wizards/samDeployWizard.ts
@@ -933,7 +933,7 @@ function validateStackName(value: string): string | undefined {
 }
 
 async function getTemplateChoices(...workspaceFolders: vscode.Uri[]): Promise<SamTemplateQuickPickItem[]> {
-    const templateUris = (await globals.templateRegistry).registeredItems.map(o => vscode.Uri.file(o.path))
+    const templateUris = (await globals.templateRegistry).items.map(o => vscode.Uri.file(o.path))
     const uriToLabel: Map<vscode.Uri, string> = new Map<vscode.Uri, string>()
     const labelCounts: Map<string, number> = new Map()
 

--- a/src/shared/awsFiletypes.ts
+++ b/src/shared/awsFiletypes.ts
@@ -67,7 +67,7 @@ export function activate(): void {
         vscode.workspace.onDidOpenTextDocument(async (doc: vscode.TextDocument) => {
             const isAwsFileExt = isAwsFiletype(doc)
             const isSchemaHandled = globals.schemaService.isMapped(doc.uri)
-            const isCfnTemplate = !!(await globals.templateRegistry).registeredItems.find(
+            const isCfnTemplate = !!(await globals.templateRegistry).items.find(
                 t => pathutil.normalize(t.path) === pathutil.normalize(doc.fileName)
             )
             if (!isAwsFileExt && !isSchemaHandled && !isCfnTemplate) {

--- a/src/shared/codelens/codeLensUtils.ts
+++ b/src/shared/codelens/codeLensUtils.ts
@@ -61,11 +61,7 @@ export async function makeCodeLenses({
 
         try {
             const registry = await globals.templateRegistry
-            const associatedResources = getResourcesForHandler(
-                handler.filename,
-                handler.handlerName,
-                registry.registeredItems
-            )
+            const associatedResources = getResourcesForHandler(handler.filename, handler.handlerName, registry.items)
             const templateConfigs: AddSamDebugConfigurationInput[] = []
 
             if (associatedResources.length > 0) {

--- a/src/shared/extensionGlobals.ts
+++ b/src/shared/extensionGlobals.ts
@@ -109,6 +109,7 @@ interface ToolkitGlobals {
     regionProvider: RegionProvider
     sdkClientBuilder: AWSClientBuilder
     telemetry: TelemetryService & { logger: TelemetryLogger }
+    /** template.yaml registry. _Avoid_ calling this until it is actually needed (for SAM features). */
     templateRegistry: Promise<CloudFormationTemplateRegistry>
     schemaService: SchemaService
     codelensRootRegistry: CodelensRootRegistry

--- a/src/shared/fs/watchedFiles.ts
+++ b/src/shared/fs/watchedFiles.ts
@@ -148,7 +148,7 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
         this.disposables.push(
             vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => {
                 if (isUntitledScheme(event.document.uri)) {
-                    this.addItemToRegistry(event.document.uri, true, event.document.getText())
+                    this.addItem(event.document.uri, true, event.document.getText())
                 }
             }),
             vscode.workspace.onDidCloseTextDocument((event: vscode.TextDocument) => {
@@ -175,7 +175,7 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
      * Adds an item to registry. Wipes any existing item in its place with new copy of the data
      * @param uri vscode.Uri containing the item to load in
      */
-    public async addItemToRegistry(uri: vscode.Uri, quiet?: boolean, contents?: string): Promise<void> {
+    public async addItem(uri: vscode.Uri, quiet?: boolean, contents?: string): Promise<void> {
         const excluded = this.excludedFilePatterns.find(pattern => uri.fsPath.match(pattern))
         if (excluded) {
             getLogger().verbose(`${this.name}: excluding path (matches "${excluded}"): ${uri.fsPath}`)
@@ -220,9 +220,9 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
     }
 
     /**
-     * Returns the registry's data as an array of paths to type T objects
+     * Gets all registry items as an array of paths to type `T` objects.
      */
-    public get registeredItems(): WatchedItem<T>[] {
+    public get items(): WatchedItem<T>[] {
         const arr: WatchedItem<T>[] = []
 
         for (const itemPath of this.registryData.keys()) {
@@ -273,7 +273,7 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
             try {
                 const found = await vscode.workspace.findFiles(glob, exclude)
                 for (const item of found) {
-                    await this.addItemToRegistry(item, true)
+                    await this.addItem(item, true)
                 }
             } catch (e) {
                 const err = e as Error
@@ -300,11 +300,11 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
             watcher,
             watcher.onDidChange(async uri => {
                 getLogger().verbose(`${this.name}: detected change: ${uri.fsPath}`)
-                await this.addItemToRegistry(uri)
+                await this.addItem(uri)
             }),
             watcher.onDidCreate(async uri => {
                 getLogger().verbose(`${this.name}: detected new file: ${uri.fsPath}`)
-                await this.addItemToRegistry(uri)
+                await this.addItem(uri)
             }),
             watcher.onDidDelete(async uri => {
                 getLogger().verbose(`${this.name}: detected delete: ${uri.fsPath}`)

--- a/src/shared/fs/watchedFiles.ts
+++ b/src/shared/fs/watchedFiles.ts
@@ -200,12 +200,13 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
     }
 
     /**
-     * Get a specific item's data
-     * Untitled files must be referred to by their URI
+     * Gets an item by filepath or URI.
+     *
+     * Untitled files must be referred to by URI.
+     *
      * @param path Absolute path to item of interest or a vscode.Uri to the item
      */
-    public getRegisteredItem(path: string | vscode.Uri): WatchedItem<T> | undefined {
-        // fsPath is needed for Windows, it's equivalent to path on mac/linux
+    public getItem(path: string | vscode.Uri): WatchedItem<T> | undefined {
         const normalizedPath = typeof path === 'string' ? pathutils.normalize(path) : normalizeVSCodeUri(path)
         this.assertAbsolute(normalizedPath)
         const item = this.registryData.get(normalizedPath)
@@ -225,7 +226,7 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
         const arr: WatchedItem<T>[] = []
 
         for (const itemPath of this.registryData.keys()) {
-            const item = this.getRegisteredItem(itemPath)
+            const item = this.getItem(itemPath)
             if (item) {
                 arr.push(item)
             }

--- a/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
@@ -72,7 +72,7 @@ export class DefaultAwsSamDebugConfigurationValidator implements AwsSamDebugConf
                 const fullpath = tryGetAbsolutePath(this.workspaceFolder, config.invokeTarget.templatePath)
                 // Normalize to absolute path for use in the runner.
                 config.invokeTarget.templatePath = fullpath
-                cfnTemplate = registry.getRegisteredItem(fullpath)?.item
+                cfnTemplate = registry.getItem(fullpath)?.item
             }
             rv = this.validateTemplateConfig(config, config.invokeTarget.templatePath, cfnTemplate)
         } else if (config.invokeTarget.target === CODE_TARGET_TYPE) {

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -254,7 +254,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
         const configs: AwsSamDebuggerConfiguration[] = []
         if (folder) {
             const folderPath = folder.uri.fsPath
-            const templates = (await globals.templateRegistry).registeredItems
+            const templates = (await globals.templateRegistry).items
 
             for (const templateDatum of templates) {
                 if (isInDirectory(folderPath, templateDatum.path)) {

--- a/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/commands/addSamDebugConfiguration.ts
@@ -57,7 +57,7 @@ export async function addSamDebugConfiguration(
         let preloadedConfig = undefined
 
         if (workspaceFolder) {
-            const templateDatum = (await globals.templateRegistry).getRegisteredItem(rootUri)
+            const templateDatum = (await globals.templateRegistry).getItem(rootUri)
             if (templateDatum) {
                 const resource = templateDatum.item.Resources![resourceName]
                 if (!resource) {

--- a/src/shared/sam/sync.ts
+++ b/src/shared/sam/sync.ts
@@ -189,7 +189,7 @@ interface TemplateItem {
 function createTemplatePrompter(registry: CloudFormationTemplateRegistry) {
     const folders = new Set<string>()
     const recentTemplatePath = getRecentResponse('global', 'templatePath')
-    const items = registry.registeredItems.map(({ item, path: filePath }) => {
+    const items = registry.items.map(({ item, path: filePath }) => {
         const uri = vscode.Uri.file(filePath)
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri)
         const label = workspaceFolder ? path.relative(workspaceFolder.uri.fsPath, uri.fsPath) : uri.fsPath

--- a/src/shared/utilities/workspaceUtils.ts
+++ b/src/shared/utilities/workspaceUtils.ts
@@ -98,7 +98,7 @@ export async function findParentProjectFile(
         return undefined
     }
 
-    const workspaceProjectFiles = globals.codelensRootRegistry.registeredItems
+    const workspaceProjectFiles = globals.codelensRootRegistry.items
         .filter(item => item.item.match(projectFile))
         .map(item => item.path)
 

--- a/src/test/lambda/commands/createNewSamApp.test.ts
+++ b/src/test/lambda/commands/createNewSamApp.test.ts
@@ -109,7 +109,7 @@ describe('createNewSamApp', function () {
             testutil.toFile(makeSampleSamTemplateYaml(true), tempTemplate.fsPath)
 
             // without runtime
-            await (await globals.templateRegistry).addItemToRegistry(tempTemplate)
+            await (await globals.templateRegistry).addItem(tempTemplate)
             const launchConfigs = await addInitialLaunchConfiguration(
                 fakeContext,
                 fakeWorkspaceFolder,
@@ -145,7 +145,7 @@ describe('createNewSamApp', function () {
             testutil.toFile(makeSampleSamTemplateYaml(true), tempTemplate.fsPath)
 
             // without runtime
-            await (await globals.templateRegistry).addItemToRegistry(tempTemplate)
+            await (await globals.templateRegistry).addItem(tempTemplate)
             const launchConfigs = (await addInitialLaunchConfiguration(
                 fakeContext,
                 fakeWorkspaceFolder,
@@ -182,7 +182,7 @@ describe('createNewSamApp', function () {
         it('returns a blank array if it does not match any launch configs', async function () {
             testutil.toFile(makeSampleSamTemplateYaml(true), tempTemplate.fsPath)
 
-            await (await globals.templateRegistry).addItemToRegistry(tempTemplate)
+            await (await globals.templateRegistry).addItem(tempTemplate)
             const launchConfigs = await addInitialLaunchConfiguration(
                 fakeContext,
                 fakeWorkspaceFolder,
@@ -198,7 +198,7 @@ describe('createNewSamApp', function () {
 
             testutil.toFile(makeSampleSamTemplateYaml(true), tempTemplate.fsPath)
 
-            await (await globals.templateRegistry).addItemToRegistry(tempTemplate)
+            await (await globals.templateRegistry).addItem(tempTemplate)
             const launchConfigs = await addInitialLaunchConfiguration(
                 fakeContext,
                 fakeWorkspaceFolder,
@@ -232,9 +232,9 @@ describe('createNewSamApp', function () {
             testutil.toFile(makeSampleSamTemplateYaml(true), otherTemplate2.fsPath)
             testutil.toFile('target file', path.join(otherFolder1, templateYaml))
 
-            await (await globals.templateRegistry).addItemToRegistry(tempTemplate)
-            await (await globals.templateRegistry).addItemToRegistry(otherTemplate1)
-            await (await globals.templateRegistry).addItemToRegistry(otherTemplate2)
+            await (await globals.templateRegistry).addItem(tempTemplate)
+            await (await globals.templateRegistry).addItem(otherTemplate1)
+            await (await globals.templateRegistry).addItem(otherTemplate2)
 
             const launchConfigs1 = await addInitialLaunchConfiguration(
                 fakeContext,

--- a/src/test/lambda/config/templates.test.ts
+++ b/src/test/lambda/config/templates.test.ts
@@ -797,7 +797,7 @@ describe('getExistingConfiguration', async function () {
     it('returns undefined if the legacy config file is not valid JSON', async function () {
         await writeFile(tempTemplateFile.fsPath, makeSampleSamTemplateYaml(true, { handler: matchedHandler }), 'utf8')
         await writeFile(tempConfigFile, makeSampleSamTemplateYaml(true, { handler: matchedHandler }), 'utf8')
-        await (await globals.templateRegistry).addItemToRegistry(tempTemplateFile)
+        await (await globals.templateRegistry).addItem(tempTemplateFile)
         const val = await getExistingConfiguration(fakeWorkspaceFolder, matchedHandler, tempTemplateFile)
         assert.strictEqual(val, undefined)
     })
@@ -818,7 +818,7 @@ describe('getExistingConfiguration', async function () {
             },
         }
         await writeFile(tempConfigFile, JSON.stringify(configData), 'utf8')
-        await (await globals.templateRegistry).addItemToRegistry(tempTemplateFile)
+        await (await globals.templateRegistry).addItem(tempTemplateFile)
         const val = await getExistingConfiguration(fakeWorkspaceFolder, matchedHandler, tempTemplateFile)
         assert.ok(val)
         if (val) {

--- a/src/test/lambda/local/debugConfiguration.test.ts
+++ b/src/test/lambda/local/debugConfiguration.test.ts
@@ -138,7 +138,7 @@ describe('isImageLambdaConfig', function () {
 
     it('true for Image-backed template', async function () {
         const templatePath = vscode.Uri.file(path.join(appDir, 'python3.7-image-sam-app/template.yaml'))
-        await registry.addItemToRegistry(templatePath)
+        await registry.addItem(templatePath)
 
         const input = {
             name: 'fake-launch-config',
@@ -167,7 +167,7 @@ describe('isImageLambdaConfig', function () {
 
     it('false for ZIP-backed template', async function () {
         const templatePath = vscode.Uri.file(path.join(appDir, 'python3.7-plain-sam-app/template.yaml'))
-        await registry.addItemToRegistry(templatePath)
+        await registry.addItem(templatePath)
 
         const input = {
             name: 'fake-launch-config',

--- a/src/test/shared/awsFiletypes.test.ts
+++ b/src/test/shared/awsFiletypes.test.ts
@@ -39,7 +39,7 @@ describe('awsFiletypes', function () {
     })
 
     it('emit telemetry when opened by user', async function () {
-        await (await globals.templateRegistry).addItemToRegistry(cfnUri!)
+        await (await globals.templateRegistry).addItem(cfnUri!)
         await vscode.commands.executeCommand('vscode.open', cfnUri)
         await vscode.commands.executeCommand('vscode.open', awsConfigUri)
         await vscode.workspace.openTextDocument({
@@ -70,7 +70,7 @@ describe('awsFiletypes', function () {
     })
 
     it('emit telemetry exactly once per filetype in a given flush window', async function () {
-        await (await globals.templateRegistry).addItemToRegistry(cfnUri!)
+        await (await globals.templateRegistry).addItem(cfnUri!)
         await vscode.commands.executeCommand('vscode.open', cfnUri)
         async function getMetrics() {
             return await waitUntil(

--- a/src/test/shared/fs/templateRegistry.test.ts
+++ b/src/test/shared/fs/templateRegistry.test.ts
@@ -36,13 +36,13 @@ describe('CloudFormation Template Registry', async function () {
             await fs.remove(tempFolder)
         })
 
-        describe('addItemToRegistry', async function () {
+        describe('addItem', async function () {
             it("adds data from a template to the registry and can receive the template's data", async () => {
                 const filename = vscode.Uri.file(path.join(tempFolder, 'template.yaml'))
                 await strToYamlFile(goodYaml1, filename.fsPath)
-                await testRegistry.addItemToRegistry(filename)
+                await testRegistry.addItem(filename)
 
-                assert.strictEqual(testRegistry.registeredItems.length, 1)
+                assert.strictEqual(testRegistry.items.length, 1)
 
                 const data = testRegistry.getItem(filename.fsPath)
 
@@ -53,14 +53,14 @@ describe('CloudFormation Template Registry', async function () {
                 const filename = vscode.Uri.file(path.join(tempFolder, 'template.yaml'))
                 await strToYamlFile(badYaml, filename.fsPath)
 
-                assert.strictEqual(await testRegistry.addItemToRegistry(vscode.Uri.file(filename.fsPath)), undefined)
+                assert.strictEqual(await testRegistry.addItem(vscode.Uri.file(filename.fsPath)), undefined)
             })
         })
 
         // other get cases are tested in the add section
-        describe('registeredItems', async function () {
+        describe('items', async function () {
             it('returns an empty array if the registry has no registered templates', function () {
-                assert.strictEqual(testRegistry.registeredItems.length, 0)
+                assert.strictEqual(testRegistry.items.length, 0)
             })
         })
 
@@ -69,7 +69,7 @@ describe('CloudFormation Template Registry', async function () {
             it('Returns the item from the VSCode URI', async function () {
                 const filename = vscode.Uri.file(path.join(tempFolder, 'template.yaml'))
                 await strToYamlFile(goodYaml1, filename.fsPath)
-                await testRegistry.addItemToRegistry(filename)
+                await testRegistry.addItem(filename)
 
                 const data = testRegistry.getItem(filename)
 
@@ -83,7 +83,7 @@ describe('CloudFormation Template Registry', async function () {
             it('returns undefined if the registry does not contain the template in question', async function () {
                 const filename = vscode.Uri.file(path.join(tempFolder, 'template.yaml'))
                 await strToYamlFile(goodYaml1, filename.fsPath)
-                await testRegistry.addItemToRegistry(vscode.Uri.file(filename.fsPath))
+                await testRegistry.addItem(vscode.Uri.file(filename.fsPath))
 
                 assert.strictEqual(testRegistry.getItem('/not-the-template.yaml'), undefined)
             })
@@ -93,21 +93,21 @@ describe('CloudFormation Template Registry', async function () {
             it('removes an added template', async function () {
                 const filename = vscode.Uri.file(path.join(tempFolder, 'template.yaml'))
                 await strToYamlFile(goodYaml1, filename.fsPath)
-                await testRegistry.addItemToRegistry(vscode.Uri.file(filename.fsPath))
-                assert.strictEqual(testRegistry.registeredItems.length, 1)
+                await testRegistry.addItem(vscode.Uri.file(filename.fsPath))
+                assert.strictEqual(testRegistry.items.length, 1)
 
                 await testRegistry.remove(filename)
-                assert.strictEqual(testRegistry.registeredItems.length, 0)
+                assert.strictEqual(testRegistry.items.length, 0)
             })
 
             it('does not affect the registry if a nonexistant template is removed', async function () {
                 const filename = vscode.Uri.file(path.join(tempFolder, 'template.yaml'))
                 await strToYamlFile(goodYaml1, filename.fsPath)
-                await testRegistry.addItemToRegistry(vscode.Uri.file(filename.fsPath))
-                assert.strictEqual(testRegistry.registeredItems.length, 1)
+                await testRegistry.addItem(vscode.Uri.file(filename.fsPath))
+                assert.strictEqual(testRegistry.items.length, 1)
 
                 await testRegistry.remove(vscode.Uri.file(path.join(tempFolder, 'wrong-template.yaml')))
-                assert.strictEqual(testRegistry.registeredItems.length, 1)
+                assert.strictEqual(testRegistry.items.length, 1)
             })
         })
     })

--- a/src/test/shared/fs/templateRegistry.test.ts
+++ b/src/test/shared/fs/templateRegistry.test.ts
@@ -44,7 +44,7 @@ describe('CloudFormation Template Registry', async function () {
 
                 assert.strictEqual(testRegistry.registeredItems.length, 1)
 
-                const data = testRegistry.getRegisteredItem(filename.fsPath)
+                const data = testRegistry.getItem(filename.fsPath)
 
                 assertValidTestTemplate(data, filename.fsPath)
             })
@@ -71,13 +71,13 @@ describe('CloudFormation Template Registry', async function () {
                 await strToYamlFile(goodYaml1, filename.fsPath)
                 await testRegistry.addItemToRegistry(filename)
 
-                const data = testRegistry.getRegisteredItem(filename)
+                const data = testRegistry.getItem(filename)
 
                 assertValidTestTemplate(data, filename.fsPath)
             })
 
             it('returns undefined if the registry has no registered templates', function () {
-                assert.strictEqual(testRegistry.getRegisteredItem('/template.yaml'), undefined)
+                assert.strictEqual(testRegistry.getItem('/template.yaml'), undefined)
             })
 
             it('returns undefined if the registry does not contain the template in question', async function () {
@@ -85,7 +85,7 @@ describe('CloudFormation Template Registry', async function () {
                 await strToYamlFile(goodYaml1, filename.fsPath)
                 await testRegistry.addItemToRegistry(vscode.Uri.file(filename.fsPath))
 
-                assert.strictEqual(testRegistry.getRegisteredItem('/not-the-template.yaml'), undefined)
+                assert.strictEqual(testRegistry.getItem('/not-the-template.yaml'), undefined)
             })
         })
 

--- a/src/test/shared/sam/debugger/awsSamDebugConfigurationValidator.test.ts
+++ b/src/test/shared/sam/debugger/awsSamDebugConfigurationValidator.test.ts
@@ -104,8 +104,8 @@ describe('DefaultAwsSamDebugConfigurationValidator', function () {
     let validator: DefaultAwsSamDebugConfigurationValidator
 
     beforeEach(function () {
-        when(mockRegistry.getRegisteredItem('/')).thenReturn(templateData)
-        when(mockRegistry.getRegisteredItem('/image')).thenReturn(imageTemplateData)
+        when(mockRegistry.getItem('/')).thenReturn(templateData)
+        when(mockRegistry.getItem('/image')).thenReturn(imageTemplateData)
 
         validator = new DefaultAwsSamDebugConfigurationValidator(instance(mockFolder))
     })
@@ -126,7 +126,7 @@ describe('DefaultAwsSamDebugConfigurationValidator', function () {
 
     it("returns invalid when resolving template debug configurations with a template that isn't in the registry", () => {
         const mockEmptyRegistry: CloudFormationTemplateRegistry = mock()
-        when(mockEmptyRegistry.getRegisteredItem('/')).thenReturn(undefined)
+        when(mockEmptyRegistry.getItem('/')).thenReturn(undefined)
 
         validator = new DefaultAwsSamDebugConfigurationValidator(instance(mockFolder))
 

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -180,7 +180,7 @@ describe('SamDebugConfigurationProvider', async function () {
 
             // Malformed template.yaml:
             testutil.toFile('bogus', tempFile.fsPath)
-            await (await globals.templateRegistry).addItemToRegistry(tempFile)
+            await (await globals.templateRegistry).addItem(tempFile)
             assert.deepStrictEqual(await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder), [])
         })
 
@@ -188,14 +188,14 @@ describe('SamDebugConfigurationProvider', async function () {
             const bigYamlStr = `${makeSampleSamTemplateYaml(true)}\nTestResource2:\n .   Type: AWS::Serverless::Api`
 
             testutil.toFile(bigYamlStr, tempFile.fsPath)
-            await (await globals.templateRegistry).addItemToRegistry(tempFile)
+            await (await globals.templateRegistry).addItem(tempFile)
             const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
             assert.strictEqual(provided!.length, 1)
         })
 
         it('returns one item if a template with one resource is in the workspace', async function () {
             testutil.toFile(makeSampleSamTemplateYaml(true), tempFile.fsPath)
-            await (await globals.templateRegistry).addItemToRegistry(tempFile)
+            await (await globals.templateRegistry).addItem(tempFile)
             const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
             assert.notStrictEqual(provided, undefined)
             assert.strictEqual(provided!.length, 1)
@@ -211,7 +211,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 resourceName: resources[0],
             })}\n${makeSampleYamlResource({ resourceName: resources[1] })}`
             testutil.toFile(bigYamlStr, tempFile.fsPath)
-            await (await globals.templateRegistry).addItemToRegistry(tempFile)
+            await (await globals.templateRegistry).addItem(tempFile)
             const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
             assert.notStrictEqual(provided, undefined)
             if (provided) {
@@ -237,9 +237,9 @@ describe('SamDebugConfigurationProvider', async function () {
             testutil.toFile(makeSampleSamTemplateYaml(true, { resourceName: resources[1] }), nestedYaml.fsPath)
             testutil.toFile(makeSampleSamTemplateYaml(true, { resourceName: badResourceName }), similarNameYaml.fsPath)
 
-            await (await globals.templateRegistry).addItemToRegistry(tempFile)
-            await (await globals.templateRegistry).addItemToRegistry(nestedYaml)
-            await (await globals.templateRegistry).addItemToRegistry(similarNameYaml)
+            await (await globals.templateRegistry).addItem(tempFile)
+            await (await globals.templateRegistry).addItem(nestedYaml)
+            await (await globals.templateRegistry).addItem(similarNameYaml)
 
             const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
             assert.notStrictEqual(provided, undefined)
@@ -261,7 +261,7 @@ describe('SamDebugConfigurationProvider', async function () {
                         Method: get`
 
             testutil.toFile(bigYamlStr, tempFile.fsPath)
-            await (await globals.templateRegistry).addItemToRegistry(tempFile)
+            await (await globals.templateRegistry).addItem(tempFile)
             const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
             assert.strictEqual(provided!.length, 2)
             assert.strictEqual(provided![1].invokeTarget.target, API_TARGET_TYPE)
@@ -276,7 +276,7 @@ describe('SamDebugConfigurationProvider', async function () {
                     Type: HttpApi`
 
             testutil.toFile(bigYamlStr, tempFile.fsPath)
-            await (await globals.templateRegistry).addItemToRegistry(tempFile)
+            await (await globals.templateRegistry).addItem(tempFile)
             const provided = await debugConfigProvider.provideDebugConfigurations(fakeWorkspaceFolder)
             assert.strictEqual(provided!.length, 1)
         })
@@ -462,7 +462,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 makeSampleSamTemplateYaml(true, { resourceName, runtime: 'moreLikeRanOutOfTime' }),
                 tempFile.fsPath
             )
-            await (await globals.templateRegistry).addItemToRegistry(tempFile)
+            await (await globals.templateRegistry).addItem(tempFile)
             await assert.rejects(() =>
                 debugConfigProvider.makeConfig(undefined, {
                     type: AWS_SAM_DEBUG_TYPE,
@@ -491,7 +491,7 @@ describe('SamDebugConfigurationProvider', async function () {
         it('supports workspace-relative template path ("./foo.yaml")', async function () {
             testutil.toFile(makeSampleSamTemplateYaml(true, { runtime: 'nodejs18.x' }), tempFile.fsPath)
             // Register with *full* path.
-            await (await globals.templateRegistry).addItemToRegistry(tempFile)
+            await (await globals.templateRegistry).addItem(tempFile)
             // Simulates launch.json:
             //     "invokeTarget": {
             //         "target": "./test.yaml",
@@ -853,7 +853,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await (await globals.templateRegistry).addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItem(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
 
             const expected: SamLaunchRequestArgs = {
@@ -980,7 +980,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await (await globals.templateRegistry).addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItem(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
 
             const expected: SamLaunchRequestArgs = {
@@ -1119,7 +1119,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await (await globals.templateRegistry).addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItem(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
 
             const expected: SamLaunchRequestArgs = {
@@ -1415,7 +1415,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await (await globals.templateRegistry).addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItem(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))! as SamLaunchRequestArgs
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
             const expected: SamLaunchRequestArgs = {
@@ -1514,7 +1514,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await (await globals.templateRegistry).addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItem(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))! as SamLaunchRequestArgs
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
             const expected: SamLaunchRequestArgs = {
@@ -1778,7 +1778,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await (await globals.templateRegistry).addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItem(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))! as SamLaunchRequestArgs
             const codeRoot = `${appDir}/src/HelloWorld`
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
@@ -1933,7 +1933,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await (await globals.templateRegistry).addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItem(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))! as SamLaunchRequestArgs
             const codeRoot = `${appDir}/src/HelloWorld`
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
@@ -2242,7 +2242,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'python3.7-plain-sam-app/template.yaml'))
-            await (await globals.templateRegistry).addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItem(templatePath)
 
             // Invoke with noDebug=false (the default).
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
@@ -2368,7 +2368,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'python3.7-plain-sam-app/template.yaml'))
-            await (await globals.templateRegistry).addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItem(templatePath)
 
             // Invoke with noDebug=false (the default).
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
@@ -2460,7 +2460,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'python3.7-image-sam-app/template.yaml'))
-            await (await globals.templateRegistry).addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItem(templatePath)
 
             // Invoke with noDebug=false (the default).
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
@@ -2739,7 +2739,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 useIkpdb: true,
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'python3.7-plain-sam-app/template.yaml'))
-            await (await globals.templateRegistry).addItemToRegistry(templatePath)
+            await (await globals.templateRegistry).addItem(templatePath)
 
             // Invoke with noDebug=false (the default).
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
@@ -2885,7 +2885,7 @@ describe('SamDebugConfigurationProvider', async function () {
                 }),
                 tempFile.fsPath
             )
-            await (await globals.templateRegistry).addItemToRegistry(tempFile)
+            await (await globals.templateRegistry).addItem(tempFile)
             const actual = (await debugConfigProviderMockCredentials.makeConfig(folder, input))!
             const tempDir = path.dirname(actual.codeRoot)
 
@@ -3134,7 +3134,7 @@ async function getConfig(
     const appDir = pathutil.normalize(path.join(testutil.getProjectDir(), rootFolder))
     const folder = testutil.getWorkspaceFolder(appDir)
     const templateFile = pathutil.normalize(path.join(appDir, 'template.yaml'))
-    await registry.addItemToRegistry(vscode.Uri.file(templateFile))
+    await registry.addItem(vscode.Uri.file(templateFile))
 
     // Generate config(s) from a sample project.
     const configs = await debugConfigProvider.provideDebugConfigurations(folder)
@@ -3183,7 +3183,7 @@ async function createAndRegisterYaml(
     registry: CloudFormationTemplateRegistry
 ) {
     testutil.toFile(makeSampleSamTemplateYaml(true, subValues), file.fsPath)
-    await registry.addItemToRegistry(file)
+    await registry.addItem(file)
 }
 
 describe('createTemplateAwsSamDebugConfig', function () {
@@ -3359,13 +3359,13 @@ describe('debugConfiguration', function () {
 
         // Template with relative path:
         testutil.toFile(makeSampleSamTemplateYaml(true, { codeUri: relativePath, handler: 'handler' }), tempFile.fsPath)
-        await (await globals.templateRegistry).addItemToRegistry(tempFile)
+        await (await globals.templateRegistry).addItem(tempFile)
         assert.strictEqual(await debugConfiguration.getCodeRoot(folder, config), fullPath)
         assert.strictEqual(await debugConfiguration.getHandlerName(folder, config), 'handler')
 
         // Template with absolute path:
         testutil.toFile(makeSampleSamTemplateYaml(true, { codeUri: fullPath }), tempFile.fsPath)
-        await (await globals.templateRegistry).addItemToRegistry(tempFile)
+        await (await globals.templateRegistry).addItem(tempFile)
         assert.strictEqual(await debugConfiguration.getCodeRoot(folder, config), fullPath)
 
         // Template with refs that don't override:
@@ -3387,7 +3387,7 @@ describe('debugConfiguration', function () {
             makeSampleSamTemplateYaml(true, { codeUri: fullPath, handler: 'handler' }, paramStr),
             tempFileRefs.fsPath
         )
-        await (await globals.templateRegistry).addItemToRegistry(tempFileRefs)
+        await (await globals.templateRegistry).addItem(tempFileRefs)
         assert.strictEqual(await debugConfiguration.getCodeRoot(folder, fileRefsConfig), fullPath)
         assert.strictEqual(await debugConfiguration.getHandlerName(folder, fileRefsConfig), 'handler')
 
@@ -3414,7 +3414,7 @@ describe('debugConfiguration', function () {
             ),
             tempFileDefaultRefs.fsPath
         )
-        await (await globals.templateRegistry).addItemToRegistry(tempFileDefaultRefs)
+        await (await globals.templateRegistry).addItem(tempFileDefaultRefs)
         assert.strictEqual(await debugConfiguration.getCodeRoot(folder, fileDefaultRefsConfig), fullPath)
         assert.strictEqual(await debugConfiguration.getHandlerName(folder, fileDefaultRefsConfig), 'thisWillOverride')
 
@@ -3436,7 +3436,7 @@ describe('debugConfiguration', function () {
             makeSampleSamTemplateYaml(true, { codeUri: fullPath, handler: '!Ref override' }, paramStrNoDefaultOverride),
             tempFileOverrideRef.fsPath
         )
-        await (await globals.templateRegistry).addItemToRegistry(tempFileOverrideRef)
+        await (await globals.templateRegistry).addItem(tempFileOverrideRef)
         assert.strictEqual(await debugConfiguration.getCodeRoot(folder, fileOverrideRefConfig), fullPath)
         assert.strictEqual(await debugConfiguration.getHandlerName(folder, fileOverrideRefConfig), 'override')
     })

--- a/src/testInteg/cloudformation/templateRegistry.test.ts
+++ b/src/testInteg/cloudformation/templateRegistry.test.ts
@@ -108,10 +108,8 @@ describe('CloudFormation Template Registry', async function () {
 })
 
 async function registryHasTargetNumberOfFiles(registry: CloudFormationTemplateRegistry, target: number) {
-    if (!(await waitUntil(async () => registry.registeredItems.length === target, { timeout: 30000 }))) {
-        throw new Error(
-            `watchedFiles found wrong number files: expected ${target}, got ${registry.registeredItems.length}`
-        )
+    if (!(await waitUntil(async () => registry.items.length === target, { timeout: 30000 }))) {
+        throw new Error(`watchedFiles found wrong number files: expected ${target}, got ${registry.items.length}`)
     }
 }
 

--- a/src/testInteg/cloudformation/templateRegistry.test.ts
+++ b/src/testInteg/cloudformation/templateRegistry.test.ts
@@ -123,7 +123,7 @@ async function queryRegistryForFileWithGlobalsKeyStatus(
     let foundMatch = false
     while (!foundMatch) {
         await sleep(20)
-        const obj = registry.getRegisteredItem(filepath)
+        const obj = registry.getItem(filepath)
         if (obj) {
             foundMatch = Object.keys(obj.item).includes('Globals') === hasGlobals
         }

--- a/src/testInteg/sam.test.ts
+++ b/src/testInteg/sam.test.ts
@@ -618,7 +618,7 @@ describe('SAM Integration Tests', async function () {
                     }
 
                     // XXX: force load since template registry seems a bit flakey
-                    await (await globals.templateRegistry).addItemToRegistry(vscode.Uri.file(cfnTemplatePath))
+                    await (await globals.templateRegistry).addItem(vscode.Uri.file(cfnTemplatePath))
 
                     await startDebugger(scenario, scenarioIndex, target, testConfig, testDisposables, sessionLog)
                 }

--- a/src/testInteg/shared/utilities/workspaceUtils.test.ts
+++ b/src/testInteg/shared/utilities/workspaceUtils.test.ts
@@ -94,7 +94,7 @@ describe('findParentProjectFile', async function () {
                 await writeFile(file.fsPath, '')
                 // Add it to the registry. The registry is async and we are not
                 // testing the registry in this test, so manually use it
-                await globals.codelensRootRegistry.addItemToRegistry(file)
+                await globals.codelensRootRegistry.addItem(file)
             }
             const projectFile = await findParentProjectFile(sourceCodeUri, /^.*\.csproj$/)
             if (test.expectedResult) {


### PR DESCRIPTION
Problem:
getRegisteredItem implies there is some other kind of "item", which is confusing and noisy.

Solution:
Rename to getItem.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
