### PR TITLE
fix(sam): "Invalid (or missing) template file"

### DIFF
--- a/.changes/next-release/Bug Fix-6b798eec-0914-4eef-b384-46829bc2cde0.json
+++ b/.changes/next-release/Bug Fix-6b798eec-0914-4eef-b384-46829bc2cde0.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "SAM debugging: \"Invalid (or missing) template file\" may occur even when a valid template.yaml is specified by `invokeTarget.templatePath` in the launch config. #2614"
+}

--- a/.changes/next-release/Bug Fix-9623dcac-8c9f-4687-a2ce-8a02b4e982be.json
+++ b/.changes/next-release/Bug Fix-9623dcac-8c9f-4687-a2ce-8a02b4e982be.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "`AWS: Add SAM Debug Configuration` command only works the first time it is invoked."
+}

--- a/src/shared/debug/launchConfiguration.ts
+++ b/src/shared/debug/launchConfiguration.ts
@@ -74,7 +74,14 @@ export class LaunchConfiguration {
             isAwsSamDebugConfiguration(o)
         ) as AwsSamDebuggerConfiguration[]
         const registry = await globals.templateRegistry
-        return configs.filter(o => this.samValidator.validate(o, registry)?.isValid)
+        // XXX: can't use filter() with async predicate.
+        const validConfigs: AwsSamDebuggerConfiguration[] = []
+        for (const c of configs) {
+            if ((await this.samValidator.validate(c, registry))?.isValid) {
+                validConfigs.push(c)
+            }
+        }
+        return validConfigs
     }
 
     /**

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -72,8 +72,8 @@ export async function activate(ctx: ExtContext): Promise<void> {
     Commands.register('aws.addSamDebugConfig', async () => {
         if (!didActivateCodeLensProviders) {
             await activateSlowCodeLensesOnce()
-            await samDebugConfigCmd()
         }
+        await samDebugConfigCmd()
     })
 
     ctx.extensionContext.subscriptions.push(

--- a/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
@@ -27,7 +27,7 @@ export interface ValidationResult {
 }
 
 export interface AwsSamDebugConfigurationValidator {
-    validate(config: AwsSamDebuggerConfiguration, registry: CloudFormationTemplateRegistry): ValidationResult
+    validate(config: AwsSamDebuggerConfiguration, registry: CloudFormationTemplateRegistry): Promise<ValidationResult>
 }
 
 export class DefaultAwsSamDebugConfigurationValidator implements AwsSamDebugConfigurationValidator {
@@ -36,11 +36,11 @@ export class DefaultAwsSamDebugConfigurationValidator implements AwsSamDebugConf
     /**
      * Validates debug configuration properties.
      */
-    public validate(
+    public async validate(
         config: AwsSamDebuggerConfiguration,
         registry: CloudFormationTemplateRegistry,
         resolveVars?: boolean
-    ): ValidationResult {
+    ): Promise<ValidationResult> {
         let rv: ValidationResult = { isValid: false, message: undefined }
         if (resolveVars) {
             config = doTraverseAndReplace(config, this.workspaceFolder?.uri.fsPath ?? '')
@@ -67,12 +67,15 @@ export class DefaultAwsSamDebugConfigurationValidator implements AwsSamDebugConf
             config.invokeTarget.target === TEMPLATE_TARGET_TYPE ||
             config.invokeTarget.target === API_TARGET_TYPE
         ) {
-            let cfnTemplate
+            let cfnTemplate: CloudFormation.Template | undefined
             if (config.invokeTarget.templatePath) {
                 const fullpath = tryGetAbsolutePath(this.workspaceFolder, config.invokeTarget.templatePath)
                 // Normalize to absolute path for use in the runner.
                 config.invokeTarget.templatePath = fullpath
-                cfnTemplate = registry.getItem(fullpath)?.item
+                // Forcefully add to the registry in case the registry scan somehow missed the file. #2614
+                // If the user (launch config) gave an explicit path we should always "find" it.
+                const uri = vscode.Uri.file(fullpath)
+                cfnTemplate = (await registry.addItem(uri, true))?.item
             }
             rv = this.validateTemplateConfig(config, config.invokeTarget.templatePath, cfnTemplate)
         } else if (config.invokeTarget.target === CODE_TARGET_TYPE) {

--- a/src/shared/sam/debugger/awsSamDebugger.ts
+++ b/src/shared/sam/debugger/awsSamDebugger.ts
@@ -439,7 +439,7 @@ export class SamDebugConfigProvider implements vscode.DebugConfigurationProvider
             })
         } else {
             const registry = await globals.templateRegistry
-            const rv = configValidator.validate(config, registry)
+            const rv = await configValidator.validate(config, registry)
             if (!rv.isValid) {
                 throw new ToolkitError(`Invalid launch configuration: ${rv.message}`, { code: 'BadLaunchConfig' })
             } else if (rv.message) {

--- a/src/test/shared/debug/launchConfiguration.test.ts
+++ b/src/test/shared/debug/launchConfiguration.test.ts
@@ -112,11 +112,7 @@ describe('LaunchConfiguration', function () {
         mockConfigSource = mock()
         mockSamValidator = mock()
         when(mockConfigSource.getDebugConfigurations()).thenReturn(debugConfigurations)
-        when(mockSamValidator.validate(deepEqual(samDebugConfiguration), registry)).thenReturn(
-            await (async () => {
-                return { isValid: true }
-            })()
-        )
+        when(mockSamValidator.validate(deepEqual(samDebugConfiguration), registry)).thenResolve({ isValid: true })
     })
 
     afterEach(async function () {

--- a/src/test/shared/sam/debugger/awsSamDebugConfigurationValidator.test.ts
+++ b/src/test/shared/sam/debugger/awsSamDebugConfigurationValidator.test.ts
@@ -110,92 +110,92 @@ describe('DefaultAwsSamDebugConfigurationValidator', function () {
         validator = new DefaultAwsSamDebugConfigurationValidator(instance(mockFolder))
     })
 
-    it('returns invalid when resolving debug configurations with an invalid request type', function () {
+    it('returns invalid when resolving debug configurations with an invalid request type', async () => {
         templateConfig.request = 'not-direct-invoke'
 
-        const result = validator.validate(templateConfig, mockRegistry)
+        const result = await validator.validate(templateConfig, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 
-    it('returns invalid when resolving debug configurations with an invalid target type', function () {
+    it('returns invalid when resolving debug configurations with an invalid target type', async () => {
         templateConfig.invokeTarget.target = 'not-valid' as any
 
-        const result = validator.validate(templateConfig as any, mockRegistry)
+        const result = await validator.validate(templateConfig as any, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 
-    it("returns invalid when resolving template debug configurations with a template that isn't in the registry", () => {
+    it("returns invalid when resolving template debug configurations with a template that isn't in the registry", async () => {
         const mockEmptyRegistry: CloudFormationTemplateRegistry = mock()
         when(mockEmptyRegistry.getItem('/')).thenReturn(undefined)
 
         validator = new DefaultAwsSamDebugConfigurationValidator(instance(mockFolder))
 
-        const result = validator.validate(templateConfig, mockRegistry)
+        const result = await validator.validate(templateConfig, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 
-    it("returns invalid when resolving template debug configurations with a template that doesn't have the set resource", () => {
+    it("returns invalid when resolving template debug configurations with a template that doesn't have the set resource", async () => {
         const target = templateConfig.invokeTarget as TemplateTargetProperties
         target.logicalId = 'wrong'
 
-        const result = validator.validate(templateConfig, mockRegistry)
+        const result = await validator.validate(templateConfig, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 
-    it("returns invalid when resolving template debug configurations with a template that isn't serverless", () => {
+    it("returns invalid when resolving template debug configurations with a template that isn't serverless", async () => {
         const target = templateConfig.invokeTarget as TemplateTargetProperties
         target.logicalId = 'OtherResource'
 
-        const result = validator.validate(templateConfig, mockRegistry)
+        const result = await validator.validate(templateConfig, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 
-    it('returns undefined when resolving template debug configurations with a resource that has an invalid runtime in template', function () {
+    it('returns undefined when resolving template debug configurations with a resource that has an invalid runtime in template', async () => {
         const properties = templateData.item.Resources?.TestResource?.Properties as CloudFormation.ZipResourceProperties
         properties.Runtime = 'invalid'
 
-        const result = validator.validate(templateConfig, mockRegistry)
+        const result = await validator.validate(templateConfig, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 
-    it("API config returns invalid when resolving with a template that isn't serverless", () => {
+    it("API config returns invalid when resolving with a template that isn't serverless", async () => {
         const target = templateConfig.invokeTarget as TemplateTargetProperties
         target.logicalId = 'OtherResource'
 
-        const result = validator.validate(apiConfig, mockRegistry)
+        const result = await validator.validate(apiConfig, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 
-    it('API config is invalid when it does not have an API field', function () {
+    it('API config is invalid when it does not have an API field', async () => {
         const config = createApiConfig()
         config.api = undefined
 
-        const result = validator.validate(config, mockRegistry)
+        const result = await validator.validate(config, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 
-    it("API config is invalid when its path does not start with a '/'", () => {
+    it("API config is invalid when its path does not start with a '/'", async () => {
         const config = createApiConfig()
 
         config.api!.path = 'noleadingslash'
 
-        const result = validator.validate(config, mockRegistry)
+        const result = await validator.validate(config, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 
-    it('returns invalid when resolving code debug configurations with invalid runtimes', function () {
+    it('returns invalid when resolving code debug configurations with invalid runtimes', async () => {
         codeConfig.lambda = { runtime: 'asd' }
 
-        const result = validator.validate(codeConfig, mockRegistry)
+        const result = await validator.validate(codeConfig, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 
-    it('returns invalid when Image app does not declare runtime', function () {
+    it('returns invalid when Image app does not declare runtime', async () => {
         const lambda = imageTemplateConfig.lambda
 
         delete lambda?.runtime
 
-        const result = validator.validate(templateConfig, mockRegistry)
+        const result = await validator.validate(templateConfig, mockRegistry)
         assert.strictEqual(result.isValid, false)
     })
 })

--- a/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
+++ b/src/test/shared/sam/debugger/samDebugConfigProvider.test.ts
@@ -462,7 +462,6 @@ describe('SamDebugConfigurationProvider', async function () {
                 makeSampleSamTemplateYaml(true, { resourceName, runtime: 'moreLikeRanOutOfTime' }),
                 tempFile.fsPath
             )
-            await (await globals.templateRegistry).addItem(tempFile)
             await assert.rejects(() =>
                 debugConfigProvider.makeConfig(undefined, {
                     type: AWS_SAM_DEBUG_TYPE,
@@ -853,7 +852,6 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await (await globals.templateRegistry).addItem(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
 
             const expected: SamLaunchRequestArgs = {
@@ -980,7 +978,6 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await (await globals.templateRegistry).addItem(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
 
             const expected: SamLaunchRequestArgs = {
@@ -1119,7 +1116,6 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await (await globals.templateRegistry).addItem(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
 
             const expected: SamLaunchRequestArgs = {
@@ -1415,7 +1411,6 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await (await globals.templateRegistry).addItem(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))! as SamLaunchRequestArgs
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
             const expected: SamLaunchRequestArgs = {
@@ -1514,7 +1509,6 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await (await globals.templateRegistry).addItem(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))! as SamLaunchRequestArgs
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
             const expected: SamLaunchRequestArgs = {
@@ -1778,7 +1772,6 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await (await globals.templateRegistry).addItem(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))! as SamLaunchRequestArgs
             const codeRoot = `${appDir}/src/HelloWorld`
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
@@ -1933,7 +1926,6 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'template.yaml'))
-            await (await globals.templateRegistry).addItem(templatePath)
             const actual = (await debugConfigProvider.makeConfig(folder, input))! as SamLaunchRequestArgs
             const codeRoot = `${appDir}/src/HelloWorld`
             const expectedCodeRoot = (actual.baseBuildDir ?? 'fail') + '/input'
@@ -2242,7 +2234,6 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'python3.7-plain-sam-app/template.yaml'))
-            await (await globals.templateRegistry).addItem(templatePath)
 
             // Invoke with noDebug=false (the default).
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
@@ -2368,7 +2359,6 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'python3.7-plain-sam-app/template.yaml'))
-            await (await globals.templateRegistry).addItem(templatePath)
 
             // Invoke with noDebug=false (the default).
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
@@ -2460,7 +2450,6 @@ describe('SamDebugConfigurationProvider', async function () {
                 },
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'python3.7-image-sam-app/template.yaml'))
-            await (await globals.templateRegistry).addItem(templatePath)
 
             // Invoke with noDebug=false (the default).
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
@@ -2739,7 +2728,6 @@ describe('SamDebugConfigurationProvider', async function () {
                 useIkpdb: true,
             }
             const templatePath = vscode.Uri.file(path.join(appDir, 'python3.7-plain-sam-app/template.yaml'))
-            await (await globals.templateRegistry).addItem(templatePath)
 
             // Invoke with noDebug=false (the default).
             const actual = (await debugConfigProvider.makeConfig(folder, input))!
@@ -2885,7 +2873,6 @@ describe('SamDebugConfigurationProvider', async function () {
                 }),
                 tempFile.fsPath
             )
-            await (await globals.templateRegistry).addItem(tempFile)
             const actual = (await debugConfigProviderMockCredentials.makeConfig(folder, input))!
             const tempDir = path.dirname(actual.codeRoot)
 


### PR DESCRIPTION

# Problem:
SAM debug may fail to find template.yaml even if it is explicitly given by `invokeTarget.templatePath` in the vscode launch config. #2614

# Solution:
- Always call `addItem()` in `validate()`, instead of depending on the  workspace-wide "scan".
- Log a message when `process()` fails to process the file contents.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
