### PR TITLE
Fix code-style debugs for Typescript SAM applications

### DIFF
--- a/src/shared/sam/debugger/typescriptSamDebug.ts
+++ b/src/shared/sam/debugger/typescriptSamDebug.ts
@@ -187,7 +187,7 @@ async function compileTypeScript(config: SamLaunchRequestArgs): Promise<void> {
     const compilerOptions = tsConfig.compilerOptions
 
     // determine build directory
-    const tsBuildDir = path.resolve(config.codeRoot, config.sam?.buildDir ?? compilerOptions.outDir ?? '.')
+    const tsBuildDir = path.resolve(config.baseBuildDir, 'output')
     compilerOptions.outDir = tsBuildDir
 
     // overwrite rootDir, sourceRoot
@@ -205,7 +205,7 @@ async function compileTypeScript(config: SamLaunchRequestArgs): Promise<void> {
     writeFileSync(tsConfigPath, JSON.stringify(tsConfig, undefined, 4))
 
     // resolve ts lambda handler to point into build directory relative to codeRoot
-    const tsLambdaHandler = path.relative(config.codeRoot, path.join(tsBuildDir, config.invokeTarget.lambdaHandler))
+    const tsLambdaHandler = path.join(tsBuildDir, config.invokeTarget.lambdaHandler)
     config.invokeTarget.lambdaHandler = pathutil.normalizeSeparator(tsLambdaHandler)
     getLogger('channel').info(`Resolved compiled lambda handler to ${tsLambdaHandler}`)
 


### PR DESCRIPTION
## Problem
Code-style debugs were writing the temp `tsconfig` file incorrectly:
* No `include` specified, so it used `["**/*"]` (good)
* No `exclude` specified, so it used the `outDir` (good, but...)
  * The file was being written with `outDir === sourceDir`, so EVERYTHING was excluded.

## Solution
* Force `outDir` to be the temp `output` directory
* Force the handler written to the temporary `template.yaml` to use an absolute path to the output directory
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
