### PR TITLE
fix: add longer timeout to default lambda client

### DIFF
--- a/src/shared/clients/lambdaClient.ts
+++ b/src/shared/clients/lambdaClient.ts
@@ -16,7 +16,7 @@ export class DefaultLambdaClient {
     private readonly defaultTimeoutInMs: number
 
     public constructor(public readonly regionCode: string) {
-        this.defaultTimeoutInMs = 5 * 60 * 1000 // 5 minutes
+        this.defaultTimeoutInMs = 5 * 60 * 1000 // 5 minutes (SDK default is 2 minutes)
     }
 
     public async deleteFunction(name: string): Promise<void> {

--- a/src/shared/clients/lambdaClient.ts
+++ b/src/shared/clients/lambdaClient.ts
@@ -12,13 +12,11 @@ import { ClassToInterfaceType } from '../utilities/tsUtils'
 
 export type LambdaClient = ClassToInterfaceType<DefaultLambdaClient>
 
-const fiveMinutesInMillis = 5 * 60 * 1000
-
 export class DefaultLambdaClient {
-    private readonly defaultTimeout: number
+    private readonly defaultTimeoutInMs: number
 
     public constructor(public readonly regionCode: string) {
-        this.defaultTimeout = fiveMinutesInMillis
+        this.defaultTimeoutInMs = 5 * 60 * 1000 // 5 minutes
     }
 
     public async deleteFunction(name: string): Promise<void> {
@@ -125,7 +123,7 @@ export class DefaultLambdaClient {
     private async createSdkClient(): Promise<Lambda> {
         return await globals.sdkClientBuilder.createAwsService(
             Lambda,
-            { httpOptions: { timeout: this.defaultTimeout } },
+            { httpOptions: { timeout: this.defaultTimeoutInMs } },
             this.regionCode
         )
     }

--- a/src/shared/clients/lambdaClient.ts
+++ b/src/shared/clients/lambdaClient.ts
@@ -11,8 +11,15 @@ import { getLogger } from '../logger'
 import { ClassToInterfaceType } from '../utilities/tsUtils'
 
 export type LambdaClient = ClassToInterfaceType<DefaultLambdaClient>
+
+const fiveMinutesInMillis = 5 * 60 * 1000
+
 export class DefaultLambdaClient {
-    public constructor(public readonly regionCode: string) {}
+    private readonly defaultTimeout: number
+
+    public constructor(public readonly regionCode: string) {
+        this.defaultTimeout = fiveMinutesInMillis
+    }
 
     public async deleteFunction(name: string): Promise<void> {
         const sdkClient = await this.createSdkClient()
@@ -116,6 +123,10 @@ export class DefaultLambdaClient {
     }
 
     private async createSdkClient(): Promise<Lambda> {
-        return await globals.sdkClientBuilder.createAwsService(Lambda, undefined, this.regionCode)
+        return await globals.sdkClientBuilder.createAwsService(
+            Lambda,
+            { httpOptions: { timeout: this.defaultTimeout } },
+            this.regionCode
+        )
     }
 }


### PR DESCRIPTION
## Problem

The default lambda client used across the project had a low timeout (2 minutes default for an AWS Service client).

## Solution

Add a longer timeout when creating the DefaultLambdaClient

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
