### PR TITLE
cloud9: skip "!isWeb" check

### DIFF
--- a/package.json
+++ b/package.json
@@ -281,7 +281,7 @@
         "debuggers": [
             {
                 "type": "aws-sam",
-                "when": "!isWeb",
+                "when": "isCloud9 || !isWeb",
                 "label": "%AWS.configuration.description.awssam.debug.label%",
                 "configurationAttributes": {
                     "direct-invoke": {
@@ -707,7 +707,7 @@
                 {
                     "id": "aws.explorer",
                     "name": "%AWS.lambda.explorerTitle%",
-                    "when": "!isWeb"
+                    "when": "isCloud9 || !isWeb"
                 },
                 {
                     "id": "aws.developerTools",
@@ -727,7 +727,7 @@
                 "id": "aws.auth",
                 "label": "%AWS.submenu.auth.title%",
                 "icon": "$(ellipsis)",
-                "when": "!isWeb"
+                "when": "isCloud9 || !isWeb"
             },
             {
                 "id": "aws.codewhisperer.submenu",
@@ -738,7 +738,7 @@
                 "id": "aws.codecatalyst.submenu",
                 "label": "%AWS.codecatalyst.submenu.title%",
                 "icon": "$(ellipsis)",
-                "when": "!isWeb"
+                "when": "isCloud9 || !isWeb"
             }
         ],
         "menus": {
@@ -2031,7 +2031,7 @@
                 "command": "aws.launchConfigForm",
                 "title": "%AWS.command.launchConfigForm.title%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2042,7 +2042,7 @@
                 "command": "aws.apig.copyUrl",
                 "title": "%AWS.command.apig.copyUrl%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2053,7 +2053,7 @@
                 "command": "aws.apig.invokeRemoteRestApi",
                 "title": "%AWS.command.apig.invokeRemoteRestApi%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%",
@@ -2065,7 +2065,7 @@
                 "command": "aws.lambda.createNewSamApp",
                 "title": "%AWS.command.createNewSamApp%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2076,7 +2076,7 @@
                 "command": "aws.login",
                 "title": "%AWS.command.login%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "title": "%AWS.command.login.cn%",
@@ -2108,19 +2108,19 @@
                 "command": "aws.codecatalyst.openOrg",
                 "title": "%AWS.command.codecatalyst.openOrg%",
                 "category": "AWS",
-                "enablement": "!isWeb"
+                "enablement": "isCloud9 || !isWeb"
             },
             {
                 "command": "aws.codecatalyst.openProject",
                 "title": "%AWS.command.codecatalyst.openProject%",
                 "category": "AWS",
-                "enablement": "!isWeb"
+                "enablement": "isCloud9 || !isWeb"
             },
             {
                 "command": "aws.codecatalyst.openRepo",
                 "title": "%AWS.command.codecatalyst.openRepo%",
                 "category": "AWS",
-                "enablement": "!isWeb"
+                "enablement": "isCloud9 || !isWeb"
             },
             {
                 "command": "aws.codecatalyst.openDevEnv",
@@ -2151,7 +2151,7 @@
                 "title": "%AWS.command.codecatalyst.signout%",
                 "category": "AWS",
                 "icon": "$(debug-disconnect)",
-                "enablement": "!isWeb"
+                "enablement": "isCloud9 || !isWeb"
             },
             {
                 "command": "aws.logout",
@@ -2215,7 +2215,7 @@
                 "title": "%AWS.command.ec2.openTerminal%",
                 "icon": "$(terminal-view-icon)",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2227,7 +2227,7 @@
                 "title": "%AWS.command.ec2.openRemoteConnection%",
                 "icon": "$(remote-explorer)",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2239,7 +2239,7 @@
                 "title": "%AWS.command.ec2.startInstance%",
                 "icon": "$(debug-start)",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2251,7 +2251,7 @@
                 "title": "%AWS.command.ec2.stopInstance%",
                 "icon": "$(debug-stop)",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2263,7 +2263,7 @@
                 "title": "%AWS.command.ec2.rebootInstance%",
                 "icon": "$(debug-restart)",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2274,7 +2274,7 @@
                 "command": "aws.ec2.copyInstanceId",
                 "title": "%AWS.command.ec2.copyInstanceId%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2285,7 +2285,7 @@
                 "command": "aws.ecr.copyTagUri",
                 "title": "%AWS.command.ecr.copyTagUri%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2296,7 +2296,7 @@
                 "command": "aws.ecr.deleteTag",
                 "title": "%AWS.command.ecr.deleteTag%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2307,7 +2307,7 @@
                 "command": "aws.ecr.copyRepositoryUri",
                 "title": "%AWS.command.ecr.copyRepositoryUri%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2318,7 +2318,7 @@
                 "command": "aws.ecr.createRepository",
                 "title": "%AWS.command.ecr.createRepository%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(add)",
                 "cloud9": {
                     "cn": {
@@ -2330,7 +2330,7 @@
                 "command": "aws.ecr.deleteRepository",
                 "title": "%AWS.command.ecr.deleteRepository%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2341,7 +2341,7 @@
                 "command": "aws.showRegion",
                 "title": "%AWS.command.showRegion%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2352,7 +2352,7 @@
                 "command": "aws.iot.createThing",
                 "title": "%AWS.command.iot.createThing%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(add)",
                 "cloud9": {
                     "cn": {
@@ -2364,7 +2364,7 @@
                 "command": "aws.iot.deleteThing",
                 "title": "%AWS.generic.promptDelete%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2375,7 +2375,7 @@
                 "command": "aws.iot.createCert",
                 "title": "%AWS.command.iot.createCert%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(add)",
                 "cloud9": {
                     "cn": {
@@ -2387,7 +2387,7 @@
                 "command": "aws.iot.deleteCert",
                 "title": "%AWS.generic.promptDelete%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2398,7 +2398,7 @@
                 "command": "aws.iot.attachCert",
                 "title": "%AWS.command.iot.attachCert%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(aws-generic-attach-file)",
                 "cloud9": {
                     "cn": {
@@ -2410,7 +2410,7 @@
                 "command": "aws.iot.attachPolicy",
                 "title": "%AWS.command.iot.attachPolicy%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(aws-generic-attach-file)",
                 "cloud9": {
                     "cn": {
@@ -2422,7 +2422,7 @@
                 "command": "aws.iot.activateCert",
                 "title": "%AWS.command.iot.activateCert%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2433,7 +2433,7 @@
                 "command": "aws.iot.deactivateCert",
                 "title": "%AWS.command.iot.deactivateCert%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2444,7 +2444,7 @@
                 "command": "aws.iot.revokeCert",
                 "title": "%AWS.command.iot.revokeCert%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2455,7 +2455,7 @@
                 "command": "aws.iot.createPolicy",
                 "title": "%AWS.command.iot.createPolicy%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(add)",
                 "cloud9": {
                     "cn": {
@@ -2467,7 +2467,7 @@
                 "command": "aws.iot.deletePolicy",
                 "title": "%AWS.generic.promptDelete%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2478,7 +2478,7 @@
                 "command": "aws.iot.createPolicyVersion",
                 "title": "%AWS.command.iot.createPolicyVersion%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2489,7 +2489,7 @@
                 "command": "aws.iot.deletePolicyVersion",
                 "title": "%AWS.generic.promptDelete%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2500,7 +2500,7 @@
                 "command": "aws.iot.detachCert",
                 "title": "%AWS.command.iot.detachCert%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2511,7 +2511,7 @@
                 "command": "aws.iot.detachPolicy",
                 "title": "%AWS.command.iot.detachCert%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2522,7 +2522,7 @@
                 "command": "aws.iot.viewPolicyVersion",
                 "title": "%AWS.command.iot.viewPolicyVersion%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2533,7 +2533,7 @@
                 "command": "aws.iot.setDefaultPolicy",
                 "title": "%AWS.command.iot.setDefaultPolicy%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2544,7 +2544,7 @@
                 "command": "aws.iot.copyEndpoint",
                 "title": "%AWS.command.iot.copyEndpoint%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2565,13 +2565,13 @@
                 "command": "aws.s3.presignedURL",
                 "title": "%AWS.command.s3.presignedURL%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb"
+                "enablement": "isCloud9 || !isWeb"
             },
             {
                 "command": "aws.s3.copyPath",
                 "title": "%AWS.command.s3.copyPath%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2582,7 +2582,7 @@
                 "command": "aws.s3.downloadFileAs",
                 "title": "%AWS.command.s3.downloadFileAs%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(cloud-download)",
                 "cloud9": {
                     "cn": {
@@ -2594,21 +2594,21 @@
                 "command": "aws.s3.openFile",
                 "title": "%AWS.command.s3.openFile%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(open-preview)"
             },
             {
                 "command": "aws.s3.editFile",
                 "title": "%AWS.command.s3.editFile%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(edit)"
             },
             {
                 "command": "aws.s3.uploadFile",
                 "title": "%AWS.command.s3.uploadFile%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(cloud-upload)",
                 "cloud9": {
                     "cn": {
@@ -2620,7 +2620,7 @@
                 "command": "aws.s3.uploadFileToParent",
                 "title": "%AWS.command.s3.uploadFileToParent%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2631,7 +2631,7 @@
                 "command": "aws.s3.createFolder",
                 "title": "%AWS.command.s3.createFolder%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(new-folder)",
                 "cloud9": {
                     "cn": {
@@ -2643,7 +2643,7 @@
                 "command": "aws.s3.createBucket",
                 "title": "%AWS.command.s3.createBucket%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(aws-s3-create-bucket)",
                 "cloud9": {
                     "cn": {
@@ -2655,7 +2655,7 @@
                 "command": "aws.s3.deleteBucket",
                 "title": "%AWS.generic.promptDelete%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2666,7 +2666,7 @@
                 "command": "aws.s3.deleteFile",
                 "title": "%AWS.generic.promptDelete%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2677,7 +2677,7 @@
                 "command": "aws.invokeLambda",
                 "title": "%AWS.command.invokeLambda%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "title": "%AWS.command.invokeLambda.cn%",
@@ -2689,7 +2689,7 @@
                 "command": "aws.downloadLambda",
                 "title": "%AWS.command.downloadLambda%",
                 "category": "%AWS.title%",
-                "enablement": "viewItem == awsRegionFunctionNodeDownloadable && !isWeb",
+                "enablement": "viewItem == awsRegionFunctionNodeDownloadable",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2699,7 +2699,7 @@
             {
                 "command": "aws.uploadLambda",
                 "title": "%AWS.command.uploadLambda%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
@@ -2710,7 +2710,7 @@
             {
                 "command": "aws.deleteLambda",
                 "title": "%AWS.generic.promptDelete%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
@@ -2721,7 +2721,7 @@
             {
                 "command": "aws.copyLambdaUrl",
                 "title": "%AWS.generic.copyUrl%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
@@ -2732,7 +2732,7 @@
             {
                 "command": "aws.deploySamApplication",
                 "title": "%AWS.command.deploySamApplication%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
@@ -2754,7 +2754,7 @@
             {
                 "command": "aws.refreshAwsExplorer",
                 "title": "%AWS.command.refreshAwsExplorer%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "category": "%AWS.title%",
                 "icon": {
                     "dark": "resources/icons/vscode/dark/refresh.svg",
@@ -2764,7 +2764,7 @@
             {
                 "command": "aws.samcli.detect",
                 "title": "%AWS.command.samcli.detect%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
@@ -2775,7 +2775,7 @@
             {
                 "command": "aws.deleteCloudFormation",
                 "title": "%AWS.command.deleteCloudFormation%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
@@ -2786,7 +2786,7 @@
             {
                 "command": "aws.downloadStateMachineDefinition",
                 "title": "%AWS.command.downloadStateMachineDefinition%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
@@ -2797,7 +2797,7 @@
             {
                 "command": "aws.executeStateMachine",
                 "title": "%AWS.command.executeStateMachine%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
@@ -2808,7 +2808,7 @@
             {
                 "command": "aws.renderStateMachineGraph",
                 "title": "%AWS.command.renderStateMachineGraph%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
@@ -2820,7 +2820,7 @@
                 "command": "aws.copyArn",
                 "title": "%AWS.command.copyArn%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2831,7 +2831,7 @@
                 "command": "aws.copyName",
                 "title": "%AWS.command.copyName%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2853,7 +2853,7 @@
                 "command": "aws.viewSchemaItem",
                 "title": "%AWS.command.viewSchemaItem%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2864,7 +2864,7 @@
                 "command": "aws.searchSchema",
                 "title": "%AWS.command.searchSchema%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2875,7 +2875,7 @@
                 "command": "aws.searchSchemaPerRegistry",
                 "title": "%AWS.command.searchSchemaPerRegistry%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2886,7 +2886,7 @@
                 "command": "aws.downloadSchemaItemCode",
                 "title": "%AWS.command.downloadSchemaItemCode%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2932,7 +2932,7 @@
                 "command": "aws.cdk.refresh",
                 "title": "%AWS.command.refreshCdkExplorer%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": {
                     "dark": "resources/icons/vscode/dark/refresh.svg",
                     "light": "resources/icons/vscode/light/refresh.svg"
@@ -2947,13 +2947,13 @@
                 "command": "aws.cdk.viewDocs",
                 "title": "%AWS.generic.viewDocs%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb"
+                "enablement": "isCloud9 || !isWeb"
             },
             {
                 "command": "aws.stepfunctions.createStateMachineFromTemplate",
                 "title": "%AWS.command.stepFunctions.createStateMachineFromTemplate%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2964,7 +2964,7 @@
                 "command": "aws.stepfunctions.publishStateMachine",
                 "title": "%AWS.command.stepFunctions.publishStateMachine%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -2975,7 +2975,7 @@
                 "command": "aws.previewStateMachine",
                 "title": "%AWS.command.stepFunctions.previewStateMachine%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(aws-stepfunctions-preview)",
                 "cloud9": {
                     "cn": {
@@ -2986,7 +2986,7 @@
             {
                 "command": "aws.cdk.renderStateMachineGraph",
                 "title": "%AWS.command.cdk.previewStateMachine%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "category": "AWS",
                 "icon": "$(aws-stepfunctions-preview)"
             },
@@ -2998,7 +2998,7 @@
             {
                 "command": "aws.cwl.viewLogStream",
                 "title": "%AWS.command.viewLogStream%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "category": "%AWS.title%",
                 "cloud9": {
                     "cn": {
@@ -3010,7 +3010,7 @@
                 "command": "aws.ssmDocument.createLocalDocument",
                 "title": "%AWS.command.ssmDocument.createLocalDocument%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3021,7 +3021,7 @@
                 "command": "aws.ssmDocument.openLocalDocument",
                 "title": "%AWS.command.ssmDocument.openLocalDocument%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(cloud-download)",
                 "cloud9": {
                     "cn": {
@@ -3033,7 +3033,7 @@
                 "command": "aws.ssmDocument.openLocalDocumentJson",
                 "title": "%AWS.command.ssmDocument.openLocalDocumentJson%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3044,7 +3044,7 @@
                 "command": "aws.ssmDocument.openLocalDocumentYaml",
                 "title": "%AWS.command.ssmDocument.openLocalDocumentYaml%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3055,7 +3055,7 @@
                 "command": "aws.ssmDocument.deleteDocument",
                 "title": "%AWS.command.ssmDocument.deleteDocument%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3066,7 +3066,7 @@
                 "command": "aws.ssmDocument.publishDocument",
                 "title": "%AWS.command.ssmDocument.publishDocument%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(cloud-upload)",
                 "cloud9": {
                     "cn": {
@@ -3078,7 +3078,7 @@
                 "command": "aws.ssmDocument.updateDocumentVersion",
                 "title": "%AWS.command.ssmDocument.updateDocumentVersion%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3089,7 +3089,7 @@
                 "command": "aws.copyLogResource",
                 "title": "%AWS.command.copyLogResource%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(files)",
                 "cloud9": {
                     "cn": {
@@ -3101,7 +3101,7 @@
                 "command": "aws.cwl.searchLogGroup",
                 "title": "%AWS.command.cloudWatchLogs.searchLogGroup%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(search-view-icon)",
                 "cloud9": {
                     "cn": {
@@ -3113,7 +3113,7 @@
                 "command": "aws.saveCurrentLogDataContent",
                 "title": "%AWS.command.saveCurrentLogDataContent%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(save)",
                 "cloud9": {
                     "cn": {
@@ -3125,7 +3125,7 @@
                 "command": "aws.cwl.changeFilterPattern",
                 "title": "%AWS.command.cwl.changeFilterPattern%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(search-view-icon)",
                 "cloud9": {
                     "cn": {
@@ -3137,7 +3137,7 @@
                 "command": "aws.cwl.changeTimeFilter",
                 "title": "%AWS.command.cwl.changeTimeFilter%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(calendar)",
                 "cloud9": {
                     "cn": {
@@ -3149,7 +3149,7 @@
                 "command": "aws.addSamDebugConfig",
                 "title": "%AWS.command.addSamDebugConfig%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3160,7 +3160,7 @@
                 "command": "aws.toggleSamCodeLenses",
                 "title": "%AWS.command.toggleSamCodeLenses%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3171,7 +3171,7 @@
                 "command": "aws.ecs.runCommandInContainer",
                 "title": "%AWS.ecs.runCommandInContainer%",
                 "category": "%AWS.title%",
-                "enablement": "viewItem == awsEcsContainerNodeExecEnabled && !isWeb",
+                "enablement": "viewItem == awsEcsContainerNodeExecEnabled",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3182,7 +3182,7 @@
                 "command": "aws.ecs.openTaskInTerminal",
                 "title": "%AWS.ecs.openTaskInTerminal%",
                 "category": "%AWS.title%",
-                "enablement": "viewItem == awsEcsContainerNodeExecEnabled && !isWeb",
+                "enablement": "viewItem == awsEcsContainerNodeExecEnabled",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3193,7 +3193,7 @@
                 "command": "aws.ecs.enableEcsExec",
                 "title": "%AWS.ecs.enableEcsExec%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3204,7 +3204,7 @@
                 "command": "aws.ecs.viewDocumentation",
                 "title": "%AWS.generic.viewDocs%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3215,7 +3215,7 @@
                 "command": "aws.resources.copyIdentifier",
                 "title": "%AWS.command.resources.copyIdentifier%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3226,7 +3226,7 @@
                 "command": "aws.resources.openResourcePreview",
                 "title": "%AWS.generic.preview%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(open-preview)",
                 "cloud9": {
                     "cn": {
@@ -3238,7 +3238,7 @@
                 "command": "aws.resources.createResource",
                 "title": "%AWS.generic.create%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(add)",
                 "cloud9": {
                     "cn": {
@@ -3250,7 +3250,7 @@
                 "command": "aws.resources.deleteResource",
                 "title": "%AWS.generic.promptDelete%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3261,7 +3261,7 @@
                 "command": "aws.resources.updateResource",
                 "title": "%AWS.generic.promptUpdate%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(pencil)",
                 "cloud9": {
                     "cn": {
@@ -3273,7 +3273,7 @@
                 "command": "aws.resources.updateResourceInline",
                 "title": "%AWS.generic.promptUpdate%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(pencil)",
                 "cloud9": {
                     "cn": {
@@ -3285,7 +3285,7 @@
                 "command": "aws.resources.saveResource",
                 "title": "%AWS.generic.save%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(save)",
                 "cloud9": {
                     "cn": {
@@ -3297,7 +3297,7 @@
                 "command": "aws.resources.closeResource",
                 "title": "%AWS.generic.close%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(close)",
                 "cloud9": {
                     "cn": {
@@ -3309,7 +3309,7 @@
                 "command": "aws.resources.viewDocs",
                 "title": "%AWS.generic.viewDocs%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(book)",
                 "cloud9": {
                     "cn": {
@@ -3321,7 +3321,7 @@
                 "command": "aws.resources.configure",
                 "title": "%AWS.command.resources.configure%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "icon": "$(gear)",
                 "cloud9": {
                     "cn": {
@@ -3333,7 +3333,7 @@
                 "command": "aws.apprunner.createService",
                 "title": "%AWS.command.apprunner.createService%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3344,7 +3344,7 @@
                 "command": "aws.ecs.disableEcsExec",
                 "title": "%AWS.ecs.disableEcsExec%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3355,7 +3355,7 @@
                 "command": "aws.apprunner.createServiceFromEcr",
                 "title": "%AWS.command.apprunner.createServiceFromEcr%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3366,7 +3366,7 @@
                 "command": "aws.apprunner.pauseService",
                 "title": "%AWS.command.apprunner.pauseService%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3377,7 +3377,7 @@
                 "command": "aws.apprunner.resumeService",
                 "title": "%AWS.command.apprunner.resumeService%",
                 "category": "AWS",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3388,7 +3388,7 @@
                 "command": "aws.apprunner.copyServiceUrl",
                 "title": "%AWS.command.apprunner.copyServiceUrl%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3399,7 +3399,7 @@
                 "command": "aws.apprunner.open",
                 "title": "%AWS.command.apprunner.open%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3410,7 +3410,7 @@
                 "command": "aws.apprunner.deleteService",
                 "title": "%AWS.generic.promptDelete%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3421,7 +3421,7 @@
                 "command": "aws.apprunner.startDeployment",
                 "title": "%AWS.command.apprunner.startDeployment%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3432,7 +3432,7 @@
                 "command": "aws.cloudFormation.newTemplate",
                 "title": "%AWS.command.cloudFormation.newTemplate%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3443,7 +3443,7 @@
                 "command": "aws.sam.newTemplate",
                 "title": "%AWS.command.sam.newTemplate%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb",
+                "enablement": "isCloud9 || !isWeb",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"
@@ -3454,7 +3454,7 @@
                 "command": "aws.samcli.sync",
                 "title": "%AWS.command.samcli.sync%",
                 "category": "%AWS.title%",
-                "enablement": "!isWeb"
+                "enablement": "isCloud9 || !isWeb"
             },
             {
                 "command": "aws.codeWhisperer",


### PR DESCRIPTION
Problem:
Cloud9 sets `isWeb` even though it has "compute".

Solution:
Add an explicit condition for Cloud9 wherever we check `isWeb`.

ref d2f03d52a221


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
