### PR TITLE
codewhisperer: status bar quickpick when clicked

### DIFF
--- a/src/auth/commands.ts
+++ b/src/auth/commands.ts
@@ -4,7 +4,7 @@
  */
 import * as vscode from 'vscode'
 import { CommandDeclarations, Commands } from '../shared/vscode/commands2'
-import { AuthSource, showAuthWebview } from './ui/vue/show'
+import { AuthSource, isAuthSource, showAuthWebview } from './ui/vue/show'
 import { ServiceItemId, isServiceItemId } from './ui/vue/types'
 import { addConnection, showConnectionsPageCommand } from './utils'
 import { isCloud9 } from '../shared/extensionUtilities'
@@ -24,7 +24,7 @@ export class AuthCommandBackend {
 
         // Edge case where called by vscode UI and non ServiceItemId object
         // is passed in.
-        if (typeof source !== 'string') {
+        if (!isAuthSource(source)) {
             source = 'unknown'
         }
 

--- a/src/auth/ui/vue/show.ts
+++ b/src/auth/ui/vue/show.ts
@@ -716,7 +716,6 @@ export const AuthSources = {
     addConnectionQuickPick: 'addConnectionQuickPick',
     firstStartup: 'firstStartup',
     codecatalystDeveloperTools: 'codecatalystDeveloperTools',
-    codewhispererDeveloperTools: 'codewhispererDeveloperTools',
     unknown: 'unknown',
     cwQuickPick: cwQuickPickSource,
     cwTreeNode: cwTreeNodeSource

--- a/src/auth/ui/vue/show.ts
+++ b/src/auth/ui/vue/show.ts
@@ -44,6 +44,7 @@ import { trustedDomainCancellation } from '../../sso/model'
 import { FeatureId, CredentialSourceId, Result, telemetry } from '../../../shared/telemetry/telemetry'
 import { AuthFormId, isBuilderIdAuth } from './authForms/types'
 import { handleWebviewError } from '../../../webviews/server'
+import { cwQuickPickSource, cwTreeNodeSource } from '../../../codewhisperer/commands/types'
 
 export class AuthWebview extends VueWebview {
     public override id: string = 'authWebview'
@@ -711,13 +712,21 @@ const Panel = VueWebview.compilePanel(AuthWebview)
 let activePanel: InstanceType<typeof Panel> | undefined
 let subscriptions: vscode.Disposable[] | undefined
 
-export type AuthSource =
-    | 'addConnectionQuickPick'
-    | 'firstStartup'
-    | 'codecatalystDeveloperTools'
-    | 'codewhispererDeveloperTools'
-    | 'codewhispererQuickPick'
-    | 'unknown'
+export const AuthSources = {
+    addConnectionQuickPick: 'addConnectionQuickPick',
+    firstStartup: 'firstStartup',
+    codecatalystDeveloperTools: 'codecatalystDeveloperTools',
+    codewhispererDeveloperTools: 'codewhispererDeveloperTools',
+    unknown: 'unknown',
+    cwQuickPick: cwQuickPickSource,
+    cwTreeNode: cwTreeNodeSource
+} as const
+
+export type AuthSource = typeof AuthSources[keyof typeof AuthSources]
+
+export function isAuthSource(obj: any): obj is AuthSource {
+    return Object.values(AuthSources).includes(obj)
+} 
 
 export async function showAuthWebview(
     ctx: vscode.ExtensionContext,

--- a/src/auth/ui/vue/show.ts
+++ b/src/auth/ui/vue/show.ts
@@ -716,6 +716,7 @@ export type AuthSource =
     | 'firstStartup'
     | 'codecatalystDeveloperTools'
     | 'codewhispererDeveloperTools'
+    | 'codewhispererQuickPick'
     | 'unknown'
 
 export async function showAuthWebview(

--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -25,7 +25,7 @@ import { checkExplorerForDefaultRegion } from './defaultRegion'
 import { createLocalExplorerView } from './localExplorer'
 import { telemetry } from '../shared/telemetry/telemetry'
 import { cdkNode, CdkRootNode } from '../cdk/explorer/rootNode'
-import { CodeWhispererNode, codewhispererNode } from '../codewhisperer/explorer/codewhispererNode'
+import { CodeWhispererNode, getCodewhispererNode } from '../codewhisperer/explorer/codewhispererNode'
 import { once } from '../shared/utilities/functionUtils'
 import { CodeCatalystRootNode } from '../codecatalyst/explorer'
 import { CodeCatalystAuthenticationProvider } from '../codecatalyst/auth'
@@ -77,7 +77,7 @@ export async function activate(args: {
 
     const authProvider = CodeCatalystAuthenticationProvider.fromContext(args.context.extensionContext)
     const codecatalystNode = isCloud9('classic') || isSageMaker() ? [] : [new CodeCatalystRootNode(authProvider)]
-    const nodes = [...codecatalystNode, cdkNode, codewhispererNode]
+    const nodes = [...codecatalystNode, cdkNode, getCodewhispererNode()]
     const developerTools = createLocalExplorerView(nodes)
     args.context.extensionContext.subscriptions.push(developerTools)
 
@@ -97,7 +97,7 @@ export async function activate(args: {
 
     registerDeveloperToolsCommands(args.context.extensionContext, developerTools, {
         codeCatalyst: codecatalystNode ? codecatalystNode[0] : undefined,
-        codeWhisperer: codewhispererNode,
+        codeWhisperer: getCodewhispererNode(),
     })
 }
 

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -36,6 +36,7 @@ import {
     notifyNewCustomizationsCmd,
     connectWithCustomization,
     signoutCodeWhisperer,
+    showManageConnections,
 } from './commands/basicCommands'
 import { sleep } from '../shared/utilities/timeoutUtils'
 import { ReferenceLogViewProvider } from './service/referenceLogViewProvider'
@@ -54,7 +55,6 @@ import { TelemetryHelper } from './util/telemetryHelper'
 import { openUrl } from '../shared/utilities/vsCodeUtils'
 import { notifyNewCustomizations } from './util/customizationUtil'
 import { CodeWhispererCommandBackend, CodeWhispererCommandDeclarations } from './commands/gettingStartedPageCommands'
-import { AuthCommandDeclarations } from '../auth/commands'
 import { showCodeWhispererQuickPick } from './commands/statusBarCommands'
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
@@ -93,13 +93,7 @@ export async function activate(context: ExtContext): Promise<void> {
 
     context.extensionContext.subscriptions.push(
         signoutCodeWhisperer.register(auth),
-        /** Opens the Add Connections webview with CW highlighted */
-        Commands.register('aws.codewhisperer.manageConnections', () => {
-            AuthCommandDeclarations.instance.declared.showManageConnections.execute(
-                'codewhispererTreeNode',
-                'codewhisperer'
-            )
-        }),
+        showManageConnections.register(),
         /**
          * Configuration change
          */

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -32,11 +32,9 @@ import {
     updateReferenceLog,
     showIntroduction,
     reconnect,
-    refreshStatusBar,
     selectCustomizationPrompt,
     notifyNewCustomizationsCmd,
     connectWithCustomization,
-    showCodeWhispererQuickPick,
     signoutCodeWhisperer,
 } from './commands/basicCommands'
 import { sleep } from '../shared/utilities/timeoutUtils'
@@ -47,7 +45,7 @@ import { SecurityPanelViewProvider } from './views/securityPanelViewProvider'
 import { disposeSecurityDiagnostic } from './service/diagnosticsProvider'
 import { RecommendationHandler } from './service/recommendationHandler'
 import { Commands, registerCommandsWithVSCode } from '../shared/vscode/commands2'
-import { InlineCompletionService } from './service/inlineCompletionService'
+import { InlineCompletionService, refreshStatusBar } from './service/inlineCompletionService'
 import { isInlineCompletionEnabled } from './util/commonUtil'
 import { CodeWhispererCodeCoverageTracker } from './tracker/codewhispererCodeCoverageTracker'
 import { AuthUtil } from './util/authUtil'
@@ -57,6 +55,7 @@ import { openUrl } from '../shared/utilities/vsCodeUtils'
 import { notifyNewCustomizations } from './util/customizationUtil'
 import { CodeWhispererCommandBackend, CodeWhispererCommandDeclarations } from './commands/gettingStartedPageCommands'
 import { AuthCommandDeclarations } from '../auth/commands'
+import { showCodeWhispererQuickPick } from './commands/statusBarCommands'
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
 export async function activate(context: ExtContext): Promise<void> {

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -96,7 +96,7 @@ export async function activate(context: ExtContext): Promise<void> {
         /** Opens the Add Connections webview with CW highlighted */
         Commands.register('aws.codewhisperer.manageConnections', () => {
             AuthCommandDeclarations.instance.declared.showManageConnections.execute(
-                'codewhispererDeveloperTools',
+                'codewhispererTreeNode',
                 'codewhisperer'
             )
         }),
@@ -216,7 +216,7 @@ export async function activate(context: ExtContext): Promise<void> {
             ReferenceHoverProvider.instance
         ),
         vscode.window.registerWebviewViewProvider(ReferenceLogViewProvider.viewType, ReferenceLogViewProvider.instance),
-        showReferenceLog.register(context),
+        showReferenceLog.register(),
         vscode.languages.registerCodeLensProvider(
             [...CodeWhispererConstants.platformLanguageIds],
             ReferenceInlineProvider.instance

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -55,7 +55,7 @@ import { TelemetryHelper } from './util/telemetryHelper'
 import { openUrl } from '../shared/utilities/vsCodeUtils'
 import { notifyNewCustomizations } from './util/customizationUtil'
 import { CodeWhispererCommandBackend, CodeWhispererCommandDeclarations } from './commands/gettingStartedPageCommands'
-import { showCodeWhispererQuickPick } from './commands/statusBarCommands'
+import { listCodeWhispererCommands } from './commands/statusBarCommands'
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
 export async function activate(context: ExtContext): Promise<void> {
@@ -184,7 +184,7 @@ export async function activate(context: ExtContext): Promise<void> {
         // refresh codewhisperer status bar
         refreshStatusBar.register(),
         // quick pick with codewhisperer options
-        showCodeWhispererQuickPick.register(),
+        listCodeWhispererCommands.register(),
         // manual trigger
         Commands.register({ id: 'aws.codeWhisperer', autoconnect: true }, async () => {
             invokeRecommendation(vscode.window.activeTextEditor as vscode.TextEditor, client, await getConfigEntry())

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -9,7 +9,7 @@ import { KeyStrokeHandler } from './service/keyStrokeHandler'
 import * as EditorContext from './util/editorContext'
 import * as CodeWhispererConstants from './models/constants'
 import { getCompletionItems } from './service/completionProvider'
-import { vsCodeState, ConfigurationEntry } from './models/model'
+import { vsCodeState, ConfigurationEntry, CodeSuggestionsState } from './models/model'
 import { invokeRecommendation } from './commands/invokeRecommendation'
 import { acceptSuggestion } from './commands/onInlineAcceptance'
 import { resetIntelliSenseState } from './util/globalStateUtil'
@@ -172,7 +172,7 @@ export async function activate(context: ExtContext): Promise<void> {
         // direct CodeWhisperer connection setup with customization
         connectWithCustomization.register(),
         // toggle code suggestions
-        toggleCodeSuggestions.register(context.extensionContext.globalState),
+        toggleCodeSuggestions.register(CodeSuggestionsState.instance),
         // enable code suggestions
         enableCodeSuggestions.register(context),
         // code scan
@@ -253,7 +253,7 @@ export async function activate(context: ExtContext): Promise<void> {
     }
 
     function getAutoTriggerStatus(): boolean {
-        return context.extensionContext.globalState.get<boolean>(CodeWhispererConstants.autoTriggerEnabledKey) || false
+        return CodeSuggestionsState.instance.isSuggestionsEnabled()
     }
 
     async function getConfigEntry(): Promise<ConfigurationEntry> {

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -37,6 +37,7 @@ import {
     notifyNewCustomizationsCmd,
     connectWithCustomization,
     showCodeWhispererQuickPick,
+    signoutCodeWhisperer,
 } from './commands/basicCommands'
 import { sleep } from '../shared/utilities/timeoutUtils'
 import { ReferenceLogViewProvider } from './service/referenceLogViewProvider'
@@ -92,7 +93,7 @@ export async function activate(context: ExtContext): Promise<void> {
     ImportAdderProvider.instance
 
     context.extensionContext.subscriptions.push(
-        Commands.register('aws.codewhisperer.signout', () => auth.secondaryAuth.deleteConnection()),
+        signoutCodeWhisperer.register(auth),
         /** Opens the Add Connections webview with CW highlighted */
         Commands.register('aws.codewhisperer.manageConnections', () => {
             AuthCommandDeclarations.instance.declared.showManageConnections.execute(

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -36,6 +36,7 @@ import {
     selectCustomizationPrompt,
     notifyNewCustomizationsCmd,
     connectWithCustomization,
+    showCodeWhispererQuickPick,
 } from './commands/basicCommands'
 import { sleep } from '../shared/utilities/timeoutUtils'
 import { ReferenceLogViewProvider } from './service/referenceLogViewProvider'
@@ -188,6 +189,8 @@ export async function activate(context: ExtContext): Promise<void> {
         updateReferenceLog.register(),
         // refresh codewhisperer status bar
         refreshStatusBar.register(),
+        // quick pick with codewhisperer options
+        showCodeWhispererQuickPick.register(),
         // manual trigger
         Commands.register({ id: 'aws.codeWhisperer', autoconnect: true }, async () => {
             invokeRecommendation(vscode.window.activeTextEditor as vscode.TextEditor, client, await getConfigEntry())

--- a/src/codewhisperer/commands/basicCommands.ts
+++ b/src/codewhisperer/commands/basicCommands.ts
@@ -180,9 +180,9 @@ export const refreshStatusBar = Commands.declare(
         if (AuthUtil.instance.isConnectionValid()) {
             InlineCompletionService.instance.setCodeWhispererStatusBarOk()
         } else if (AuthUtil.instance.isConnectionExpired()) {
-            InlineCompletionService.instance.setCodeWhispererStatusBarDisconnected()
+            InlineCompletionService.instance.setCodeWhispererStatusBarExpired()
         } else {
-            InlineCompletionService.instance.hideCodeWhispererStatusBar()
+            InlineCompletionService.instance.setCodeWhispererStatusBarNotConnected()
         }
     }
 )

--- a/src/codewhisperer/commands/basicCommands.ts
+++ b/src/codewhisperer/commands/basicCommands.ts
@@ -202,3 +202,8 @@ export const showCodeWhispererQuickPick = Commands.declare({ id: showCodeWhisper
         ignoreFocusOut: false,
     }).prompt()
 })
+
+export const signoutCodeWhisperer = Commands.declare(
+    'aws.codewhisperer.signout',
+    (auth: AuthUtil) => () => auth.secondaryAuth.deleteConnection()
+)

--- a/src/codewhisperer/commands/basicCommands.ts
+++ b/src/codewhisperer/commands/basicCommands.ts
@@ -27,9 +27,6 @@ import {
     showCustomizationPrompt,
 } from '../util/customizationUtil'
 import { get, set } from '../util/commonUtil'
-import { CodeWhispererCommandDeclarations } from '../commands/gettingStartedPageCommands'
-import { getIcon } from '../../shared/icons'
-import { localize } from '../../shared/utilities/vsCodeUtils'
 
 export const toggleCodeSuggestions = Commands.declare(
     'aws.codeWhisperer.toggleCodeSuggestion',
@@ -46,17 +43,6 @@ export const toggleCodeSuggestions = Commands.declare(
         })
     }
 )
-/*
-createGettingStartedNode(Learn) will be a childnode of CodeWhisperer
-onClick on this "Learn" Node will open the Learn CodeWhisperer Page.
-*/
-export const createGettingStartedNode = () =>
-    CodeWhispererCommandDeclarations.instance.declared.showGettingStartedPage
-        .build('codewhispererDeveloperTools')
-        .asTreeNode({
-            label: localize('AWS.explorerNode.codewhispererGettingStartedNode.label', 'Learn'),
-            iconPath: getIcon('aws-codewhisperer-learn'),
-        })
 
 export const enableCodeSuggestions = Commands.declare(
     'aws.codeWhisperer.enableCodeSuggestions',

--- a/src/codewhisperer/commands/basicCommands.ts
+++ b/src/codewhisperer/commands/basicCommands.ts
@@ -17,7 +17,6 @@ import { showConnectionPrompt } from '../util/showSsoPrompt'
 import { ReferenceLogViewProvider } from '../service/referenceLogViewProvider'
 import { AuthUtil } from '../util/authUtil'
 import { isCloud9 } from '../../shared/extensionUtilities'
-import { InlineCompletionService } from '../service/inlineCompletionService'
 import { getLogger } from '../../shared/logger'
 import { openUrl } from '../../shared/utilities/vsCodeUtils'
 import {
@@ -27,9 +26,6 @@ import {
     showCustomizationPrompt,
 } from '../util/customizationUtil'
 import { get, set } from '../util/commonUtil'
-import { createQuickPick } from '../../shared/ui/pickerPrompter'
-import { codewhispererNode } from '../explorer/codewhispererNode'
-import { createExitButton } from '../../shared/ui/buttons'
 
 export const toggleCodeSuggestions = Commands.declare(
     'aws.codeWhisperer.toggleCodeSuggestion',
@@ -174,34 +170,12 @@ export const updateReferenceLog = Commands.declare(
     }
 )
 
-export const refreshStatusBar = Commands.declare(
-    { id: 'aws.codeWhisperer.refreshStatusBar', logging: false },
-    () => () => {
-        if (AuthUtil.instance.isConnectionValid()) {
-            InlineCompletionService.instance.setCodeWhispererStatusBarOk()
-        } else if (AuthUtil.instance.isConnectionExpired()) {
-            InlineCompletionService.instance.setCodeWhispererStatusBarExpired()
-        } else {
-            InlineCompletionService.instance.setCodeWhispererStatusBarNotConnected()
-        }
-    }
-)
-
 export const notifyNewCustomizationsCmd = Commands.declare(
     { id: 'aws.codeWhisperer.notifyNewCustomizations', logging: false },
     () => () => {
         notifyNewCustomizations().then()
     }
 )
-
-export const showCodeWhispererQuickPickCommand = 'aws.codewhisperer.quickpick'
-export const showCodeWhispererQuickPick = Commands.declare({ id: showCodeWhispererQuickPickCommand }, () => () => {
-    createQuickPick(codewhispererNode.getChildren('item'), {
-        title: 'CodeWhisperer',
-        buttons: [createExitButton()],
-        ignoreFocusOut: false,
-    }).prompt()
-})
 
 export const signoutCodeWhisperer = Commands.declare(
     'aws.codewhisperer.signout',

--- a/src/codewhisperer/commands/basicCommands.ts
+++ b/src/codewhisperer/commands/basicCommands.ts
@@ -27,6 +27,9 @@ import {
     showCustomizationPrompt,
 } from '../util/customizationUtil'
 import { get, set } from '../util/commonUtil'
+import { createQuickPick } from '../../shared/ui/pickerPrompter'
+import { codewhispererNode } from '../explorer/codewhispererNode'
+import { createExitButton } from '../../shared/ui/buttons'
 
 export const toggleCodeSuggestions = Commands.declare(
     'aws.codeWhisperer.toggleCodeSuggestion',
@@ -190,3 +193,12 @@ export const notifyNewCustomizationsCmd = Commands.declare(
         notifyNewCustomizations().then()
     }
 )
+
+export const showCodeWhispererQuickPickCommand = 'aws.codewhisperer.quickpick'
+export const showCodeWhispererQuickPick = Commands.declare({ id: showCodeWhispererQuickPickCommand }, () => () => {
+    createQuickPick(codewhispererNode.getChildren('item'), {
+        title: 'CodeWhisperer',
+        buttons: [createExitButton()],
+        ignoreFocusOut: false,
+    }).prompt()
+})

--- a/src/codewhisperer/commands/gettingStartedPageCommands.ts
+++ b/src/codewhisperer/commands/gettingStartedPageCommands.ts
@@ -4,9 +4,10 @@
  */
 import * as vscode from 'vscode'
 import { CommandDeclarations, Commands } from '../../shared/vscode/commands2'
-import { showCodeWhispererWebview, CodeWhispererSource } from '../vue/backend'
+import { showCodeWhispererWebview } from '../vue/backend'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { PromptSettings } from '../../shared/settings'
+import { CodeWhispererSource } from './types'
 /**
  * The methods with backend logic for the Codewhisperer Getting Started Page commands.
  */

--- a/src/codewhisperer/commands/statusBarCommands.ts
+++ b/src/codewhisperer/commands/statusBarCommands.ts
@@ -10,7 +10,7 @@ import { codewhispererNode } from '../explorer/codewhispererNode'
 
 export const showCodeWhispererQuickPickCommand = 'aws.codewhisperer.quickpick'
 export const showCodeWhispererQuickPick = Commands.declare({ id: showCodeWhispererQuickPickCommand }, () => () => {
-    createQuickPick(codewhispererNode.getChildren('item'), {
+    return createQuickPick(codewhispererNode.getChildren('item'), {
         title: 'CodeWhisperer',
         buttons: [createExitButton()],
         ignoreFocusOut: false,

--- a/src/codewhisperer/commands/statusBarCommands.ts
+++ b/src/codewhisperer/commands/statusBarCommands.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createExitButton } from '../../shared/ui/buttons'
+import { createQuickPick } from '../../shared/ui/pickerPrompter'
+import { Commands } from '../../shared/vscode/commands2'
+import { codewhispererNode } from '../explorer/codewhispererNode'
+
+export const showCodeWhispererQuickPickCommand = 'aws.codewhisperer.quickpick'
+export const showCodeWhispererQuickPick = Commands.declare({ id: showCodeWhispererQuickPickCommand }, () => () => {
+    createQuickPick(codewhispererNode.getChildren('item'), {
+        title: 'CodeWhisperer',
+        buttons: [createExitButton()],
+        ignoreFocusOut: false,
+    }).prompt()
+})

--- a/src/codewhisperer/commands/statusBarCommands.ts
+++ b/src/codewhisperer/commands/statusBarCommands.ts
@@ -8,8 +8,8 @@ import { createQuickPick } from '../../shared/ui/pickerPrompter'
 import { Commands } from '../../shared/vscode/commands2'
 import { getCodewhispererNode } from '../explorer/codewhispererNode'
 
-export const showCodeWhispererQuickPickCommand = 'aws.codewhisperer.quickpick'
-export const showCodeWhispererQuickPick = Commands.declare({ id: showCodeWhispererQuickPickCommand }, () => () => {
+export const listCodeWhispererCommandsId = 'aws.codewhisperer.listCommands'
+export const listCodeWhispererCommands = Commands.declare({ id: listCodeWhispererCommandsId }, () => () => {
     return createQuickPick(getCodewhispererNode().getChildren('item'), {
         title: 'CodeWhisperer',
         buttons: [createExitButton()],

--- a/src/codewhisperer/commands/statusBarCommands.ts
+++ b/src/codewhisperer/commands/statusBarCommands.ts
@@ -6,11 +6,11 @@
 import { createExitButton } from '../../shared/ui/buttons'
 import { createQuickPick } from '../../shared/ui/pickerPrompter'
 import { Commands } from '../../shared/vscode/commands2'
-import { codewhispererNode } from '../explorer/codewhispererNode'
+import { getCodewhispererNode } from '../explorer/codewhispererNode'
 
 export const showCodeWhispererQuickPickCommand = 'aws.codewhisperer.quickpick'
 export const showCodeWhispererQuickPick = Commands.declare({ id: showCodeWhispererQuickPickCommand }, () => () => {
-    return createQuickPick(codewhispererNode.getChildren('item'), {
+    return createQuickPick(getCodewhispererNode().getChildren('item'), {
         title: 'CodeWhisperer',
         buttons: [createExitButton()],
         ignoreFocusOut: false,

--- a/src/codewhisperer/commands/types.ts
+++ b/src/codewhisperer/commands/types.ts
@@ -1,0 +1,12 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** Indicates a CodeWhisperer command was executed through a tree node */
+export const cwTreeNodeSource = 'codewhispererTreeNode'
+/** Indicates a CodeWhisperer command was executed through a quick pick item */
+export const cwQuickPickSource = 'codewhispererQuickPick'
+
+/** Indicates what caused the CodeWhisperer command to be executed, since a command can be executed from different "sources" */
+export type CodeWhispererSource = typeof cwQuickPickSource | typeof cwTreeNodeSource

--- a/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
+++ b/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
@@ -4,6 +4,7 @@
  */
 
 import { AuthCommandDeclarations } from '../../auth/commands'
+import { ToolkitError } from '../../shared/errors'
 import { codicon, getIcon } from '../../shared/icons'
 import { TreeNode } from '../../shared/treeview/resourceTreeDataProvider'
 import { DataQuickPickItem } from '../../shared/ui/pickerPrompter'
@@ -17,6 +18,7 @@ import {
     showFreeTierLimit,
     reconnect,
     selectCustomizationPrompt,
+    signoutCodeWhisperer,
 } from '../commands/basicCommands'
 import { CodeWhispererCommandDeclarations } from '../commands/gettingStartedPageCommands'
 import { codeScanState } from '../models/model'
@@ -263,5 +265,23 @@ export function createGettingStarted(type: 'item' | 'tree'): any {
                         'codewhispererDeveloperTools'
                     ),
             } as DataQuickPickItem<'gettingStarted'>
+    }
+}
+
+export function createSignout(type: 'item'): DataQuickPickItem<'signout'>
+export function createSignout(type: 'tree'): TreeNode<Command>
+export function createSignout(type: 'item' | 'tree'): DataQuickPickItem<'signout'> | TreeNode<Command>
+export function createSignout(type: 'item' | 'tree'): any {
+    const label = localize('AWS.codewhisperer.signoutNode.label', 'Sign Out')
+    const icon = getIcon('vscode-sign-out')
+    switch (type) {
+        case 'tree':
+            throw new ToolkitError('codewhisperer: Signout Node not implemented for tree.')
+        case 'item':
+            return {
+                data: 'signout',
+                label: codicon`${icon} ${label}`,
+                onClick: () => signoutCodeWhisperer.execute(),
+            } as DataQuickPickItem<'signout'>
     }
 }

--- a/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
+++ b/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import vscode from 'vscode'
 import { AuthCommandDeclarations } from '../../auth/commands'
 import { ToolkitError } from '../../shared/errors'
 import { codicon, getIcon } from '../../shared/icons'
@@ -283,5 +284,13 @@ export function createSignout(type: 'item' | 'tree'): any {
                 label: codicon`${icon} ${label}`,
                 onClick: () => signoutCodeWhisperer.execute(),
             } as DataQuickPickItem<'signout'>
+    }
+}
+
+export function createSeparator(): DataQuickPickItem<'separator'> {
+    return {
+        kind: vscode.QuickPickItemKind.Separator,
+        data: 'separator',
+        label: '',
     }
 }

--- a/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
+++ b/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
@@ -4,7 +4,6 @@
  */
 
 import vscode from 'vscode'
-import { AuthCommandDeclarations } from '../../auth/commands'
 import { ToolkitError } from '../../shared/errors'
 import { codicon, getIcon } from '../../shared/icons'
 import { TreeNode } from '../../shared/treeview/resourceTreeDataProvider'
@@ -20,6 +19,7 @@ import {
     reconnect,
     selectCustomizationPrompt,
     signoutCodeWhisperer,
+    showManageConnections,
 } from '../commands/basicCommands'
 import { CodeWhispererCommandDeclarations } from '../commands/gettingStartedPageCommands'
 import { codeScanState } from '../models/model'
@@ -122,20 +122,15 @@ export function createSignIn(type: 'item' | 'tree'): any {
 
     switch (type) {
         case 'tree':
-            return AuthCommandDeclarations.instance.declared.showManageConnections
-                .build(cwTreeNodeSource)
-                .asTreeNode({
-                    label: label,
-                    iconPath: icon,
-                })
+            return showManageConnections.build(cwTreeNodeSource).asTreeNode({
+                label: label,
+                iconPath: icon,
+            })
         case 'item':
             return {
                 data: 'signIn',
                 label: codicon`${icon} ${label}`,
-                onClick: () =>
-                    AuthCommandDeclarations.instance.declared.showManageConnections.execute(
-                        cwQuickPickSource)
-                    ,
+                onClick: () => showManageConnections.execute(cwQuickPickSource),
             } as DataQuickPickItem<'signIn'>
     }
 }

--- a/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
+++ b/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
@@ -24,6 +24,7 @@ import {
 import { CodeWhispererCommandDeclarations } from '../commands/gettingStartedPageCommands'
 import { codeScanState } from '../models/model'
 import { getNewCustomizationAvailable, getSelectedCustomization } from '../util/customizationUtil'
+import { cwQuickPickSource, cwTreeNodeSource } from '../commands/types'
 
 export function createAutoSuggestions(type: 'item', pause: boolean): DataQuickPickItem<'autoSuggestions'>
 export function createAutoSuggestions(type: 'tree', pause: boolean): TreeNode<Command>
@@ -39,7 +40,7 @@ export function createAutoSuggestions(type: 'item' | 'tree', pause: boolean): an
 
     switch (type) {
         case 'tree':
-            return toggleCodeSuggestions.build().asTreeNode(
+            return toggleCodeSuggestions.build(cwTreeNodeSource).asTreeNode(
                 pause
                     ? {
                           label: labelPause,
@@ -55,7 +56,7 @@ export function createAutoSuggestions(type: 'item' | 'tree', pause: boolean): an
                 data: 'autoSuggestions',
                 label: pause ? codicon`${iconPause} ${labelPause}` : codicon`${iconResume} ${labelResume}`,
                 description: pause ? 'Currently RUNNING' : 'Currently PAUSED',
-                onClick: () => toggleCodeSuggestions.execute(),
+                onClick: () => toggleCodeSuggestions.execute(cwQuickPickSource),
             } as DataQuickPickItem<'autoSuggestions'>
     }
 }
@@ -69,7 +70,7 @@ export function createOpenReferenceLog(type: 'item' | 'tree'): any {
 
     switch (type) {
         case 'tree':
-            return showReferenceLog.build().asTreeNode({
+            return showReferenceLog.build(cwTreeNodeSource).asTreeNode({
                 label: label,
                 iconPath: icon,
                 tooltip: localize(
@@ -82,7 +83,7 @@ export function createOpenReferenceLog(type: 'item' | 'tree'): any {
             return {
                 data: 'openReferenceLog',
                 label: codicon`${icon} ${label}`,
-                onClick: () => showReferenceLog.execute(),
+                onClick: () => showReferenceLog.execute(cwQuickPickSource),
             } as DataQuickPickItem<'openReferenceLog'>
     }
 }
@@ -97,7 +98,7 @@ export function createSecurityScan(type: 'item' | 'tree'): any {
 
     switch (type) {
         case 'tree':
-            return showSecurityScan.build().asTreeNode({
+            return showSecurityScan.build(cwTreeNodeSource).asTreeNode({
                 label: label,
                 iconPath: icon,
                 tooltip: label,
@@ -107,7 +108,7 @@ export function createSecurityScan(type: 'item' | 'tree'): any {
             return {
                 data: 'securityScan',
                 label: codicon`${icon} ${label}`,
-                onClick: () => showSecurityScan.execute(),
+                onClick: () => showSecurityScan.execute(cwQuickPickSource),
             } as DataQuickPickItem<'securityScan'>
     }
 }
@@ -122,7 +123,7 @@ export function createSignIn(type: 'item' | 'tree'): any {
     switch (type) {
         case 'tree':
             return AuthCommandDeclarations.instance.declared.showManageConnections
-                .build('codewhispererDeveloperTools', 'codewhisperer')
+                .build(cwTreeNodeSource)
                 .asTreeNode({
                     label: label,
                     iconPath: icon,
@@ -133,9 +134,8 @@ export function createSignIn(type: 'item' | 'tree'): any {
                 label: codicon`${icon} ${label}`,
                 onClick: () =>
                     AuthCommandDeclarations.instance.declared.showManageConnections.execute(
-                        'codewhispererQuickPick',
-                        'codewhisperer'
-                    ),
+                        cwQuickPickSource)
+                    ,
             } as DataQuickPickItem<'signIn'>
     }
 }
@@ -149,7 +149,7 @@ export function createReconnect(type: 'item' | 'tree'): any {
 
     switch (type) {
         case 'tree':
-            return reconnect.build().asTreeNode({
+            return reconnect.build(cwTreeNodeSource).asTreeNode({
                 label: label,
                 iconPath: icon,
             })
@@ -157,7 +157,7 @@ export function createReconnect(type: 'item' | 'tree'): any {
             return {
                 data: 'reconnect',
                 label: codicon`${icon} ${label}`,
-                onClick: () => reconnect.execute(),
+                onClick: () => reconnect.execute(cwQuickPickSource),
             } as DataQuickPickItem<'reconnect'>
     }
 }
@@ -171,7 +171,7 @@ export function createLearnMore(type: 'item' | 'tree'): any {
 
     switch (type) {
         case 'tree':
-            return showLearnMore.build().asTreeNode({
+            return showLearnMore.build(cwTreeNodeSource).asTreeNode({
                 label: label,
                 iconPath: icon,
                 contextValue: 'awsCodeWhispererLearnMoreNode',
@@ -180,7 +180,7 @@ export function createLearnMore(type: 'item' | 'tree'): any {
             return {
                 data: 'learnMore',
                 label: codicon`${icon} ${label}`,
-                onClick: () => showLearnMore.execute(),
+                onClick: () => showLearnMore.execute(cwQuickPickSource),
             } as DataQuickPickItem<'learnMore'>
     }
 }
@@ -197,7 +197,7 @@ export function createFreeTierLimitMet(type: 'tree' | 'item'): any {
 
     switch (type) {
         case 'tree':
-            return showFreeTierLimit.build().asTreeNode({
+            return showFreeTierLimit.build(cwTreeNodeSource).asTreeNode({
                 label: label,
                 iconPath: icon,
                 description: localize('AWS.explorerNode.freeTierLimitMet.tooltip', `paused until ${nextMonth}`),
@@ -207,7 +207,7 @@ export function createFreeTierLimitMet(type: 'tree' | 'item'): any {
             return {
                 data: 'freeTierLimitMet',
                 label: codicon`${icon} ${label}`,
-                onClick: () => showFreeTierLimit.execute(),
+                onClick: () => showFreeTierLimit.execute(cwQuickPickSource),
             } as DataQuickPickItem<'freeTierLimitMet'>
     }
 }
@@ -227,7 +227,7 @@ export function createSelectCustomization(type: 'tree' | 'item'): any {
 
     switch (type) {
         case 'tree':
-            return selectCustomizationPrompt.build().asTreeNode({
+            return selectCustomizationPrompt.build(cwTreeNodeSource).asTreeNode({
                 label: label,
                 iconPath: icon,
                 description: `${newText}${selectedCustomization.arn === '' ? '' : selectedCustomization.name}`,
@@ -236,7 +236,7 @@ export function createSelectCustomization(type: 'tree' | 'item'): any {
             return {
                 data: 'selectCustomization',
                 label: codicon`${icon} ${label}`,
-                onClick: () => selectCustomizationPrompt.execute(),
+                onClick: () => selectCustomizationPrompt.execute(cwQuickPickSource),
             } as DataQuickPickItem<'selectCustomization'>
     }
 }
@@ -251,7 +251,7 @@ export function createGettingStarted(type: 'item' | 'tree'): any {
     switch (type) {
         case 'tree':
             return CodeWhispererCommandDeclarations.instance.declared.showGettingStartedPage
-                .build('codewhispererDeveloperTools')
+                .build(cwTreeNodeSource)
                 .asTreeNode({
                     label: label,
                     iconPath: icon,
@@ -263,8 +263,8 @@ export function createGettingStarted(type: 'item' | 'tree'): any {
                 label: codicon`${icon} ${label}`,
                 onClick: () =>
                     CodeWhispererCommandDeclarations.instance.declared.showGettingStartedPage.execute(
-                        'codewhispererDeveloperTools'
-                    ),
+                        cwQuickPickSource)
+                    ,
             } as DataQuickPickItem<'gettingStarted'>
     }
 }
@@ -282,7 +282,7 @@ export function createSignout(type: 'item' | 'tree'): any {
             return {
                 data: 'signout',
                 label: codicon`${icon} ${label}`,
-                onClick: () => signoutCodeWhisperer.execute(),
+                onClick: () => signoutCodeWhisperer.execute(cwQuickPickSource),
             } as DataQuickPickItem<'signout'>
     }
 }

--- a/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
+++ b/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
@@ -4,7 +4,7 @@
  */
 
 import { AuthCommandDeclarations } from '../../auth/commands'
-import { getIcon } from '../../shared/icons'
+import { codicon, getIcon } from '../../shared/icons'
 import { TreeNode } from '../../shared/treeview/resourceTreeDataProvider'
 import { DataQuickPickItem } from '../../shared/ui/pickerPrompter'
 import { localize } from '../../shared/utilities/vsCodeUtils'
@@ -24,7 +24,10 @@ import { getNewCustomizationAvailable, getSelectedCustomization } from '../util/
 
 export function createAutoSuggestions(type: 'item', pause: boolean): DataQuickPickItem<'autoSuggestions'>
 export function createAutoSuggestions(type: 'tree', pause: boolean): TreeNode<Command>
-export function createAutoSuggestions(type: 'item' | 'tree', pause: boolean): DataQuickPickItem<'autoSuggestions'> | TreeNode<Command>
+export function createAutoSuggestions(
+    type: 'item' | 'tree',
+    pause: boolean
+): DataQuickPickItem<'autoSuggestions'> | TreeNode<Command>
 export function createAutoSuggestions(type: 'item' | 'tree', pause: boolean): any {
     const labelResume = localize('AWS.codewhisperer.resumeCodeWhispererNode.label', 'Resume Auto-Suggestions')
     const iconResume = getIcon('vscode-debug-start')
@@ -45,7 +48,12 @@ export function createAutoSuggestions(type: 'item' | 'tree', pause: boolean): an
                       }
             )
         case 'item':
-            break
+            return {
+                data: 'autoSuggestions',
+                label: pause ? codicon`${iconPause} ${labelPause}` : codicon`${iconResume} ${labelResume}`,
+                description: pause ? 'Currently RUNNING' : 'Currently PAUSED',
+                onClick: () => toggleCodeSuggestions.execute(),
+            } as DataQuickPickItem<'autoSuggestions'>
     }
 }
 
@@ -68,7 +76,11 @@ export function createOpenReferenceLog(type: 'item' | 'tree'): any {
                 contextValue: 'awsCodeWhispererOpenReferenceLogNode',
             })
         case 'item':
-            break
+            return {
+                data: 'openReferenceLog',
+                label: codicon`${icon} ${label}`,
+                onClick: () => showReferenceLog.execute(),
+            } as DataQuickPickItem<'openReferenceLog'>
     }
 }
 
@@ -89,7 +101,11 @@ export function createSecurityScan(type: 'item' | 'tree'): any {
                 contextValue: `awsCodeWhisperer${prefix}SecurityScanNode`,
             })
         case 'item':
-            break
+            return {
+                data: 'securityScan',
+                label: codicon`${icon} ${label}`,
+                onClick: () => showSecurityScan.execute(),
+            } as DataQuickPickItem<'securityScan'>
     }
 }
 
@@ -109,7 +125,15 @@ export function createSignIn(type: 'item' | 'tree'): any {
                     iconPath: icon,
                 })
         case 'item':
-            break
+            return {
+                data: 'signIn',
+                label: codicon`${icon} ${label}`,
+                onClick: () =>
+                    AuthCommandDeclarations.instance.declared.showManageConnections.execute(
+                        'codewhispererQuickPick',
+                        'codewhisperer'
+                    ),
+            } as DataQuickPickItem<'signIn'>
     }
 }
 
@@ -127,7 +151,11 @@ export function createReconnect(type: 'item' | 'tree'): any {
                 iconPath: icon,
             })
         case 'item':
-            break
+            return {
+                data: 'reconnect',
+                label: codicon`${icon} ${label}`,
+                onClick: () => reconnect.execute(),
+            } as DataQuickPickItem<'reconnect'>
     }
 }
 
@@ -146,7 +174,11 @@ export function createLearnMore(type: 'item' | 'tree'): any {
                 contextValue: 'awsCodeWhispererLearnMoreNode',
             })
         case 'item':
-            break
+            return {
+                data: 'learnMore',
+                label: codicon`${icon} ${label}`,
+                onClick: () => showLearnMore.execute(),
+            } as DataQuickPickItem<'learnMore'>
     }
 }
 
@@ -169,13 +201,19 @@ export function createFreeTierLimitMet(type: 'tree' | 'item'): any {
             })
 
         case 'item':
-            break
+            return {
+                data: 'freeTierLimitMet',
+                label: codicon`${icon} ${label}`,
+                onClick: () => showFreeTierLimit.execute(),
+            } as DataQuickPickItem<'freeTierLimitMet'>
     }
 }
 
 export function createSelectCustomization(type: 'item'): DataQuickPickItem<'selectCustomization'>
 export function createSelectCustomization(type: 'tree'): TreeNode<Command>
-export function createSelectCustomization(type: 'item' | 'tree'): DataQuickPickItem<'selectCustomization'> | TreeNode<Command>
+export function createSelectCustomization(
+    type: 'item' | 'tree'
+): DataQuickPickItem<'selectCustomization'> | TreeNode<Command>
 export function createSelectCustomization(type: 'tree' | 'item'): any {
     const newCustomizationsAvailable = getNewCustomizationAvailable()
     const selectedCustomization = getSelectedCustomization()
@@ -191,10 +229,12 @@ export function createSelectCustomization(type: 'tree' | 'item'): any {
                 iconPath: icon,
                 description: `${newText}${selectedCustomization.arn === '' ? '' : selectedCustomization.name}`,
             })
-            break
-
         case 'item':
-            break
+            return {
+                data: 'selectCustomization',
+                label: codicon`${icon} ${label}`,
+                onClick: () => selectCustomizationPrompt.execute(),
+            } as DataQuickPickItem<'selectCustomization'>
     }
 }
 
@@ -215,6 +255,13 @@ export function createGettingStarted(type: 'item' | 'tree'): any {
                 })
 
         case 'item':
-            break
+            return {
+                data: 'gettingStarted',
+                label: codicon`${icon} ${label}`,
+                onClick: () =>
+                    CodeWhispererCommandDeclarations.instance.declared.showGettingStartedPage.execute(
+                        'codewhispererDeveloperTools'
+                    ),
+            } as DataQuickPickItem<'gettingStarted'>
     }
 }

--- a/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
+++ b/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
@@ -10,7 +10,6 @@ import { DataQuickPickItem } from '../../shared/ui/pickerPrompter'
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { Command } from '../../shared/vscode/commands2'
 import {
-    enableCodeSuggestions,
     toggleCodeSuggestions,
     showReferenceLog,
     showSecurityScan,
@@ -22,13 +21,6 @@ import {
 import { CodeWhispererCommandDeclarations } from '../commands/gettingStartedPageCommands'
 import { codeScanState } from '../models/model'
 import { getNewCustomizationAvailable, getSelectedCustomization } from '../util/customizationUtil'
-
-export const createEnableCodeSuggestionsNode = () =>
-    enableCodeSuggestions.build().asTreeNode({
-        label: localize('AWS.explorerNode.enableCodeWhispererNode.label', 'Enable CodeWhisperer'),
-        iconPath: getIcon('vscode-debug-start'),
-        tooltip: localize('AWS.explorerNode.enableCodeWhispererNode.tooltip', 'Click to Enable CodeWhisperer'),
-    })
 
 export function createAutoSuggestions(type: 'item', pause: boolean): DataQuickPickItem<'autoSuggestions'>
 export function createAutoSuggestions(type: 'tree', pause: boolean): TreeNode<Command>

--- a/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
+++ b/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
@@ -5,7 +5,10 @@
 
 import { AuthCommandDeclarations } from '../../auth/commands'
 import { getIcon } from '../../shared/icons'
+import { TreeNode } from '../../shared/treeview/resourceTreeDataProvider'
+import { DataQuickPickItem } from '../../shared/ui/pickerPrompter'
 import { localize } from '../../shared/utilities/vsCodeUtils'
+import { Command } from '../../shared/vscode/commands2'
 import {
     enableCodeSuggestions,
     toggleCodeSuggestions,
@@ -16,6 +19,7 @@ import {
     reconnect,
     selectCustomizationPrompt,
 } from '../commands/basicCommands'
+import { CodeWhispererCommandDeclarations } from '../commands/gettingStartedPageCommands'
 import { codeScanState } from '../models/model'
 import { getNewCustomizationAvailable, getSelectedCustomization } from '../util/customizationUtil'
 
@@ -26,79 +30,199 @@ export const createEnableCodeSuggestionsNode = () =>
         tooltip: localize('AWS.explorerNode.enableCodeWhispererNode.tooltip', 'Click to Enable CodeWhisperer'),
     })
 
-export const createAutoSuggestionsNode = (pause: boolean) =>
-    toggleCodeSuggestions.build().asTreeNode(
-        pause
-            ? {
-                  label: localize('AWS.explorerNode.pauseCodeWhispererNode.label', 'Pause Auto-Suggestions'),
-                  iconPath: getIcon('vscode-debug-pause'),
-              }
-            : {
-                  label: localize('AWS.explorerNode.resumeCodeWhispererNode.label', 'Resume Auto-Suggestions'),
-                  iconPath: getIcon('vscode-debug-start'),
-              }
-    )
+export function createAutoSuggestions(type: 'item', pause: boolean): DataQuickPickItem<'autoSuggestions'>
+export function createAutoSuggestions(type: 'tree', pause: boolean): TreeNode<Command>
+export function createAutoSuggestions(type: 'item' | 'tree', pause: boolean): DataQuickPickItem<'autoSuggestions'> | TreeNode<Command>
+export function createAutoSuggestions(type: 'item' | 'tree', pause: boolean): any {
+    const labelResume = localize('AWS.codewhisperer.resumeCodeWhispererNode.label', 'Resume Auto-Suggestions')
+    const iconResume = getIcon('vscode-debug-start')
+    const labelPause = localize('AWS.codewhisperer.pauseCodeWhispererNode.label', 'Pause Auto-Suggestions')
+    const iconPause = getIcon('vscode-debug-pause')
 
-export const createOpenReferenceLogNode = () =>
-    showReferenceLog.build().asTreeNode({
-        label: localize('AWS.explorerNode.codewhispererOpenReferenceLogNode.label', 'Open Code Reference Log'),
-        iconPath: getIcon('vscode-remote'),
-        tooltip: localize(
-            'AWS.explorerNode.codewhispererOpenReferenceLogNode.tooltip',
-            'Click to open Code Reference Log'
-        ),
-        contextValue: 'awsCodeWhispererOpenReferenceLogNode',
-    })
-
-export const createSecurityScanNode = () => {
-    const prefix = codeScanState.getPrefixTextForButton()
-    return showSecurityScan.build().asTreeNode({
-        label: `${prefix} Security Scan`,
-        iconPath: codeScanState.getIconForButton(),
-        tooltip: `${prefix} Security Scan`,
-        contextValue: `awsCodeWhisperer${prefix}SecurityScanNode`,
-    })
+    switch (type) {
+        case 'tree':
+            return toggleCodeSuggestions.build().asTreeNode(
+                pause
+                    ? {
+                          label: labelPause,
+                          iconPath: iconPause,
+                      }
+                    : {
+                          label: labelResume,
+                          iconPath: iconResume,
+                      }
+            )
+        case 'item':
+            break
+    }
 }
 
-export const createSsoSignIn = () =>
-    AuthCommandDeclarations.instance.declared.showManageConnections
-        .build('codewhispererDeveloperTools', 'codewhisperer')
-        .asTreeNode({
-            label: localize('AWS.explorerNode.sSoSignInNode.label', 'Start'),
-            iconPath: getIcon('vscode-debug-start'),
-        })
+export function createOpenReferenceLog(type: 'item'): DataQuickPickItem<'openReferenceLog'>
+export function createOpenReferenceLog(type: 'tree'): TreeNode<Command>
+export function createOpenReferenceLog(type: 'item' | 'tree'): DataQuickPickItem<'openReferenceLog'> | TreeNode<Command>
+export function createOpenReferenceLog(type: 'item' | 'tree'): any {
+    const label = localize('AWS.codewhisperer.openReferenceLogNode.label', 'Open Code Reference Log')
+    const icon = getIcon('vscode-remote')
 
-export const createReconnectNode = () =>
-    reconnect.build().asTreeNode({
-        label: localize('AWS.explorerNode.reconnectNode.label', 'Reconnect'),
-        iconPath: getIcon('vscode-debug-start'),
-    })
+    switch (type) {
+        case 'tree':
+            return showReferenceLog.build().asTreeNode({
+                label: label,
+                iconPath: icon,
+                tooltip: localize(
+                    'AWS.explorerNode.codewhispererOpenReferenceLogNode.tooltip',
+                    'Click to open Code Reference Log'
+                ),
+                contextValue: 'awsCodeWhispererOpenReferenceLogNode',
+            })
+        case 'item':
+            break
+    }
+}
 
-export const createLearnMore = () =>
-    showLearnMore.build().asTreeNode({
-        label: localize('AWS.explorerNode.codewhispererLearnMore.label', 'Learn More about CodeWhisperer'),
-        iconPath: getIcon('vscode-question'),
-        contextValue: 'awsCodeWhispererLearnMoreNode',
-    })
+export function createSecurityScan(type: 'item'): DataQuickPickItem<'securityScan'>
+export function createSecurityScan(type: 'tree'): TreeNode<Command>
+export function createSecurityScan(type: 'item' | 'tree'): DataQuickPickItem<'securityScan'> | TreeNode<Command>
+export function createSecurityScan(type: 'item' | 'tree'): any {
+    const prefix = codeScanState.getPrefixTextForButton()
+    const label = `${prefix} Security Scan`
+    const icon = codeScanState.getIconForButton()
 
-export const createFreeTierLimitMetNode = () => {
+    switch (type) {
+        case 'tree':
+            return showSecurityScan.build().asTreeNode({
+                label: label,
+                iconPath: icon,
+                tooltip: label,
+                contextValue: `awsCodeWhisperer${prefix}SecurityScanNode`,
+            })
+        case 'item':
+            break
+    }
+}
+
+export function createSignIn(type: 'item'): DataQuickPickItem<'signIn'>
+export function createSignIn(type: 'tree'): TreeNode<Command>
+export function createSignIn(type: 'item' | 'tree'): DataQuickPickItem<'signIn'> | TreeNode<Command>
+export function createSignIn(type: 'item' | 'tree'): any {
+    const label = localize('AWS.codewhisperer.signInNode.label', 'Start')
+    const icon = getIcon('vscode-debug-start')
+
+    switch (type) {
+        case 'tree':
+            return AuthCommandDeclarations.instance.declared.showManageConnections
+                .build('codewhispererDeveloperTools', 'codewhisperer')
+                .asTreeNode({
+                    label: label,
+                    iconPath: icon,
+                })
+        case 'item':
+            break
+    }
+}
+
+export function createReconnect(type: 'item'): DataQuickPickItem<'reconnect'>
+export function createReconnect(type: 'tree'): TreeNode<Command>
+export function createReconnect(type: 'item' | 'tree'): DataQuickPickItem<'reconnect'> | TreeNode<Command>
+export function createReconnect(type: 'item' | 'tree'): any {
+    const label = localize('AWS.codewhisperer.reconnectNode.label', 'Reconnect')
+    const icon = getIcon('vscode-debug-start')
+
+    switch (type) {
+        case 'tree':
+            return reconnect.build().asTreeNode({
+                label: label,
+                iconPath: icon,
+            })
+        case 'item':
+            break
+    }
+}
+
+export function createLearnMore(type: 'item'): DataQuickPickItem<'learnMore'>
+export function createLearnMore(type: 'tree'): TreeNode<Command>
+export function createLearnMore(type: 'item' | 'tree'): DataQuickPickItem<'learnMore'> | TreeNode<Command>
+export function createLearnMore(type: 'item' | 'tree'): any {
+    const label = localize('AWS.codewhisperer.learnMoreNode.label', 'Learn More about CodeWhisperer')
+    const icon = getIcon('vscode-question')
+
+    switch (type) {
+        case 'tree':
+            return showLearnMore.build().asTreeNode({
+                label: label,
+                iconPath: icon,
+                contextValue: 'awsCodeWhispererLearnMoreNode',
+            })
+        case 'item':
+            break
+    }
+}
+
+export function createFreeTierLimitMet(type: 'item'): DataQuickPickItem<'freeTierLimitMet'>
+export function createFreeTierLimitMet(type: 'tree'): TreeNode<Command>
+export function createFreeTierLimitMet(type: 'item' | 'tree'): DataQuickPickItem<'freeTierLimitMet'> | TreeNode<Command>
+export function createFreeTierLimitMet(type: 'tree' | 'item'): any {
     const now = new Date()
     const nextMonth = new Date(now.getFullYear(), now.getMonth() + 1, 1).toLocaleDateString('en-US')
-    return showFreeTierLimit.build().asTreeNode({
-        label: localize('AWS.explorerNode.freeTierLimitMet.label', 'Free Tier Limit Met'),
-        iconPath: getIcon('vscode-error'),
-        description: localize('AWS.explorerNode.freeTierLimitMet.tooltip', `paused until ${nextMonth}`),
-    })
+
+    const label = localize('AWS.codewhisperer.freeTierLimitMetNode.label', 'Free Tier Limit Met')
+    const icon = getIcon('vscode-error')
+
+    switch (type) {
+        case 'tree':
+            return showFreeTierLimit.build().asTreeNode({
+                label: label,
+                iconPath: icon,
+                description: localize('AWS.explorerNode.freeTierLimitMet.tooltip', `paused until ${nextMonth}`),
+            })
+
+        case 'item':
+            break
+    }
 }
 
-export const createSelectCustomizationNode = () => {
+export function createSelectCustomization(type: 'item'): DataQuickPickItem<'selectCustomization'>
+export function createSelectCustomization(type: 'tree'): TreeNode<Command>
+export function createSelectCustomization(type: 'item' | 'tree'): DataQuickPickItem<'selectCustomization'> | TreeNode<Command>
+export function createSelectCustomization(type: 'tree' | 'item'): any {
     const newCustomizationsAvailable = getNewCustomizationAvailable()
     const selectedCustomization = getSelectedCustomization()
     const newText = newCustomizationsAvailable ? 'new!      ' : ''
 
-    return selectCustomizationPrompt.build().asTreeNode({
-        label: localize('AWS.explorerNode.selectCustomization.label', 'Select Customization'),
-        iconPath: getIcon('vscode-extensions'),
-        description: `${newText}${selectedCustomization.arn === '' ? '' : selectedCustomization.name}`,
-    })
+    const label = localize('AWS.codewhisperer.selectCustomizationNode.label', 'Select Customization')
+    const icon = getIcon('vscode-extensions')
+
+    switch (type) {
+        case 'tree':
+            return selectCustomizationPrompt.build().asTreeNode({
+                label: label,
+                iconPath: icon,
+                description: `${newText}${selectedCustomization.arn === '' ? '' : selectedCustomization.name}`,
+            })
+            break
+
+        case 'item':
+            break
+    }
+}
+
+/* Opens the Learn CodeWhisperer Page */
+export function createGettingStarted(type: 'item'): DataQuickPickItem<'gettingStarted'>
+export function createGettingStarted(type: 'tree'): TreeNode<Command>
+export function createGettingStarted(type: 'item' | 'tree'): DataQuickPickItem<'gettingStarted'> | TreeNode<Command>
+export function createGettingStarted(type: 'item' | 'tree'): any {
+    const label = localize('AWS.codewhisperer.gettingStartedNode.label', 'Learn')
+    const icon = getIcon('aws-codewhisperer-learn')
+    switch (type) {
+        case 'tree':
+            return CodeWhispererCommandDeclarations.instance.declared.showGettingStartedPage
+                .build('codewhispererDeveloperTools')
+                .asTreeNode({
+                    label: label,
+                    iconPath: icon,
+                })
+
+        case 'item':
+            break
+    }
 }

--- a/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
+++ b/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
@@ -231,6 +231,7 @@ export function createSelectCustomization(type: 'tree' | 'item'): any {
             return {
                 data: 'selectCustomization',
                 label: codicon`${icon} ${label}`,
+                description: `Using ${selectedCustomization.name}`,
                 onClick: () => selectCustomizationPrompt.execute(cwQuickPickSource),
             } as DataQuickPickItem<'selectCustomization'>
     }
@@ -258,8 +259,8 @@ export function createGettingStarted(type: 'item' | 'tree'): any {
                 label: codicon`${icon} ${label}`,
                 onClick: () =>
                     CodeWhispererCommandDeclarations.instance.declared.showGettingStartedPage.execute(
-                        cwQuickPickSource)
-                    ,
+                        cwQuickPickSource
+                    ),
             } as DataQuickPickItem<'gettingStarted'>
     }
 }

--- a/src/codewhisperer/explorer/codewhispererNode.ts
+++ b/src/codewhisperer/explorer/codewhispererNode.ts
@@ -7,16 +7,16 @@ import * as vscode from 'vscode'
 import globals from '../../shared/extensionGlobals'
 import * as CodeWhispererConstants from '../models/constants'
 import {
-    createAutoSuggestionsNode,
-    createOpenReferenceLogNode,
-    createSecurityScanNode,
+    createAutoSuggestions,
+    createOpenReferenceLog,
+    createSecurityScan,
     createLearnMore,
-    createSsoSignIn,
-    createFreeTierLimitMetNode,
-    createReconnectNode,
-    createSelectCustomizationNode,
+    createSignIn,
+    createFreeTierLimitMet,
+    createSelectCustomization,
+    createReconnect,
+    createGettingStarted,
 } from './codewhispererChildrenNodes'
-import { createGettingStartedNode } from '../commands/basicCommands'
 import { Commands } from '../../shared/vscode/commands2'
 import { RootNode } from '../../awsexplorer/localExplorer'
 import { hasVendedIamCredentials } from '../../auth/auth'
@@ -74,35 +74,35 @@ export class CodeWhispererNode implements RootNode {
         const autoTriggerEnabled =
             globals.context.globalState.get<boolean>(CodeWhispererConstants.autoTriggerEnabledKey) || false
         if (AuthUtil.instance.isConnectionExpired()) {
-            return [createReconnectNode(), createLearnMore()]
+            return [createReconnect('tree'), createLearnMore('tree')]
         }
         if (!AuthUtil.instance.isConnected()) {
-            return [createSsoSignIn(), createLearnMore()]
+            return [createSignIn('tree'), createLearnMore('tree')]
         }
         if (this._showFreeTierLimitReachedNode) {
             if (hasVendedIamCredentials()) {
-                return [createFreeTierLimitMetNode(), createOpenReferenceLogNode()]
+                return [createFreeTierLimitMet('tree'), createOpenReferenceLog('tree')]
             } else {
-                return [createFreeTierLimitMetNode(), createSecurityScanNode(), createOpenReferenceLogNode()]
+                return [createFreeTierLimitMet('tree'), createSecurityScan('tree'), createOpenReferenceLog('tree')]
             }
         } else {
             if (hasVendedIamCredentials()) {
-                return [createAutoSuggestionsNode(autoTriggerEnabled), createOpenReferenceLogNode()]
+                return [createAutoSuggestions('tree', autoTriggerEnabled), createOpenReferenceLog('tree')]
             } else {
                 if (AuthUtil.instance.isValidEnterpriseSsoInUse() && AuthUtil.instance.isCustomizationFeatureEnabled) {
                     return [
-                        createAutoSuggestionsNode(autoTriggerEnabled),
-                        createSecurityScanNode(),
-                        createSelectCustomizationNode(),
-                        createOpenReferenceLogNode(),
-                        createGettingStartedNode(), // "Learn" node : opens Learn CodeWhisperer page
+                        createAutoSuggestions('tree', autoTriggerEnabled),
+                        createSecurityScan('tree'),
+                        createSelectCustomization('tree'),
+                        createOpenReferenceLog('tree'),
+                        createGettingStarted('tree'), // "Learn" node : opens Learn CodeWhisperer page
                     ]
                 }
                 return [
-                    createAutoSuggestionsNode(autoTriggerEnabled),
-                    createSecurityScanNode(),
-                    createOpenReferenceLogNode(),
-                    createGettingStartedNode(), // "Learn" node : opens Learn CodeWhisperer page
+                    createAutoSuggestions('tree', autoTriggerEnabled),
+                    createSecurityScan('tree'),
+                    createOpenReferenceLog('tree'),
+                    createGettingStarted('tree'), // "Learn" node : opens Learn CodeWhisperer page
                 ]
             }
         }

--- a/src/codewhisperer/explorer/codewhispererNode.ts
+++ b/src/codewhisperer/explorer/codewhispererNode.ts
@@ -17,6 +17,7 @@ import {
     createReconnect,
     createGettingStarted,
     createSignout,
+    createSeparator,
 } from './codewhispererChildrenNodes'
 import { Command, Commands } from '../../shared/vscode/commands2'
 import { RootNode } from '../../awsexplorer/localExplorer'
@@ -121,7 +122,7 @@ export class CodeWhispererNode implements RootNode {
 
         // Add 'Sign Out' to quick pick if user is connected
         if (AuthUtil.instance.isConnected() && type === 'item' && !hasVendedIamCredentials()) {
-            return [...children, { kind: vscode.QuickPickItemKind.Separator, data: 'separator' }, createSignout('item')]
+            return [...children, createSeparator(), createSignout('item')]
         }
 
         return children

--- a/src/codewhisperer/explorer/codewhispererNode.ts
+++ b/src/codewhisperer/explorer/codewhispererNode.ts
@@ -17,11 +17,12 @@ import {
     createReconnect,
     createGettingStarted,
 } from './codewhispererChildrenNodes'
-import { Commands } from '../../shared/vscode/commands2'
+import { Command, Commands } from '../../shared/vscode/commands2'
 import { RootNode } from '../../awsexplorer/localExplorer'
 import { hasVendedIamCredentials } from '../../auth/auth'
 import { AuthUtil } from '../util/authUtil'
 import { TreeNode } from '../../shared/treeview/resourceTreeDataProvider'
+import { DataQuickPickItem } from '../../shared/ui/pickerPrompter'
 
 export class CodeWhispererNode implements RootNode {
     public readonly id = 'codewhisperer'
@@ -70,39 +71,42 @@ export class CodeWhispererNode implements RootNode {
         return ''
     }
 
-    public getChildren() {
+    public getChildren(): TreeNode<Command>[]
+    public getChildren(type: 'item'): DataQuickPickItem<string>[]
+    public getChildren(type: 'tree' | 'item'): TreeNode<Command>[] | DataQuickPickItem<string>[]
+    public getChildren(type: 'tree' | 'item' = 'tree'): any[] {
         const autoTriggerEnabled =
             globals.context.globalState.get<boolean>(CodeWhispererConstants.autoTriggerEnabledKey) || false
         if (AuthUtil.instance.isConnectionExpired()) {
-            return [createReconnect('tree'), createLearnMore('tree')]
+            return [createReconnect(type), createLearnMore(type)]
         }
         if (!AuthUtil.instance.isConnected()) {
-            return [createSignIn('tree'), createLearnMore('tree')]
+            return [createSignIn(type), createLearnMore(type)]
         }
         if (this._showFreeTierLimitReachedNode) {
             if (hasVendedIamCredentials()) {
-                return [createFreeTierLimitMet('tree'), createOpenReferenceLog('tree')]
+                return [createFreeTierLimitMet(type), createOpenReferenceLog(type)]
             } else {
-                return [createFreeTierLimitMet('tree'), createSecurityScan('tree'), createOpenReferenceLog('tree')]
+                return [createFreeTierLimitMet(type), createSecurityScan(type), createOpenReferenceLog(type)]
             }
         } else {
             if (hasVendedIamCredentials()) {
-                return [createAutoSuggestions('tree', autoTriggerEnabled), createOpenReferenceLog('tree')]
+                return [createAutoSuggestions(type, autoTriggerEnabled), createOpenReferenceLog(type)]
             } else {
                 if (AuthUtil.instance.isValidEnterpriseSsoInUse() && AuthUtil.instance.isCustomizationFeatureEnabled) {
                     return [
-                        createAutoSuggestions('tree', autoTriggerEnabled),
-                        createSecurityScan('tree'),
-                        createSelectCustomization('tree'),
-                        createOpenReferenceLog('tree'),
-                        createGettingStarted('tree'), // "Learn" node : opens Learn CodeWhisperer page
+                        createAutoSuggestions(type, autoTriggerEnabled),
+                        createSecurityScan(type),
+                        createSelectCustomization(type),
+                        createOpenReferenceLog(type),
+                        createGettingStarted(type), // "Learn" node : opens Learn CodeWhisperer page
                     ]
                 }
                 return [
-                    createAutoSuggestions('tree', autoTriggerEnabled),
-                    createSecurityScan('tree'),
-                    createOpenReferenceLog('tree'),
-                    createGettingStarted('tree'), // "Learn" node : opens Learn CodeWhisperer page
+                    createAutoSuggestions(type, autoTriggerEnabled),
+                    createSecurityScan(type),
+                    createOpenReferenceLog(type),
+                    createGettingStarted(type), // "Learn" node : opens Learn CodeWhisperer page
                 ]
             }
         }

--- a/src/codewhisperer/explorer/codewhispererNode.ts
+++ b/src/codewhisperer/explorer/codewhispererNode.ts
@@ -147,18 +147,21 @@ export class CodeWhispererNode implements RootNode {
     }
 }
 
-export const codewhispererNode = new CodeWhispererNode()
+let _codewhispererNode: CodeWhispererNode
+export function getCodewhispererNode(): CodeWhispererNode {
+    return (_codewhispererNode ??= new CodeWhispererNode())
+}
 export const refreshCodeWhisperer = Commands.register(
     { id: 'aws.codeWhisperer.refresh', logging: false },
     (showFreeTierLimitNode = false) => {
-        codewhispererNode.updateShowFreeTierLimitReachedNode(showFreeTierLimitNode)
-        codewhispererNode.refresh()
+        getCodewhispererNode().updateShowFreeTierLimitReachedNode(showFreeTierLimitNode)
+        getCodewhispererNode().refresh()
     }
 )
 
 export const refreshCodeWhispererRootNode = Commands.register(
     { id: 'aws.codeWhisperer.refreshRootNode', logging: false },
     () => {
-        codewhispererNode.refreshRootNode()
+        getCodewhispererNode().refreshRootNode()
     }
 )

--- a/src/codewhisperer/models/model.ts
+++ b/src/codewhisperer/models/model.ts
@@ -56,7 +56,7 @@ export class CodeSuggestionsState {
 
     static #instance: CodeSuggestionsState
     static get instance() {
-        return this.#instance ??= new this()
+        return (this.#instance ??= new this())
     }
 
     protected constructor(context: vscode.Memento = globals.context.globalState, fallback: boolean = false) {

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -19,7 +19,7 @@ import { codicon, getIcon } from '../../shared/icons'
 import { session } from '../util/codeWhispererSession'
 import { noSuggestions } from '../models/constants'
 import { Commands } from '../../shared/vscode/commands2'
-import { showCodeWhispererQuickPickCommand } from '../commands/statusBarCommands'
+import { listCodeWhispererCommandsId } from '../commands/statusBarCommands'
 
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
@@ -211,7 +211,7 @@ export class CodeWhispererStatusBar {
     async setState(status: keyof Pick<typeof states, 'ok'>, isSuggestionsEnabled: boolean): Promise<void>
     async setState(status: keyof typeof states, isSuggestionsEnabled?: boolean): Promise<void> {
         const statusBar = this.statusBar
-        statusBar.command = showCodeWhispererQuickPickCommand
+        statusBar.command = listCodeWhispererCommandsId
         statusBar.backgroundColor = undefined
 
         switch (status) {

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -189,8 +189,6 @@ export class InlineCompletionService {
     }
 }
 
-
-
 /** The states that the completion service can be in */
 const states = {
     loading: 'loading',
@@ -230,17 +228,17 @@ export class CodeWhispererStatusBar {
                 statusBar.text = codicon`${icon} CodeWhisperer${
                     selectedCustomization.arn === '' ? '' : ` | ${selectedCustomization.name}`
                 }`
-                break;
+                break
             }
-                
+
             case 'expired': {
                 statusBar.text = codicon` ${getIcon('vscode-debug-disconnect')} CodeWhisperer`
                 statusBar.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
-                break;
+                break
             }
             case 'notConnected':
                 statusBar.text = codicon` ${getIcon('vscode-chrome-close')} CodeWhisperer`
-                break;
+                break
         }
 
         statusBar.show()

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -18,7 +18,8 @@ import { getSelectedCustomization } from '../util/customizationUtil'
 import { codicon, getIcon } from '../../shared/icons'
 import { session } from '../util/codeWhispererSession'
 import { noSuggestions } from '../models/constants'
-import { showCodeWhispererQuickPickCommand } from '../commands/basicCommands'
+import { Commands } from '../../shared/vscode/commands2'
+import { showCodeWhispererQuickPickCommand } from '../commands/statusBarCommands'
 
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
@@ -190,3 +191,17 @@ export class InlineCompletionService {
         this.statusBar.hide()
     }
 }
+
+/** In this module due to circulare dependency issues */
+export const refreshStatusBar = Commands.declare(
+    { id: 'aws.codeWhisperer.refreshStatusBar', logging: false },
+    () => () => {
+        if (AuthUtil.instance.isConnectionValid()) {
+            InlineCompletionService.instance.setCodeWhispererStatusBarOk()
+        } else if (AuthUtil.instance.isConnectionExpired()) {
+            InlineCompletionService.instance.setCodeWhispererStatusBarExpired()
+        } else {
+            InlineCompletionService.instance.setCodeWhispererStatusBarNotConnected()
+        }
+    }
+)

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -18,6 +18,7 @@ import { getSelectedCustomization } from '../util/customizationUtil'
 import { codicon, getIcon } from '../../shared/icons'
 import { session } from '../util/codeWhispererSession'
 import { noSuggestions } from '../models/constants'
+import { showCodeWhispererQuickPickCommand } from '../commands/basicCommands'
 
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
@@ -148,7 +149,7 @@ export class InlineCompletionService {
         this.statusBar.text = codicon` ${getIcon('vscode-loading~spin')} CodeWhisperer${
             selectedCustomization.arn === '' ? '' : ` | ${selectedCustomization.name}`
         }`
-        this.statusBar.command = undefined
+        this.statusBar.command = showCodeWhispererQuickPickCommand
         ;(this.statusBar as any).backgroundColor = undefined
         this.statusBar.show()
     }
@@ -159,7 +160,7 @@ export class InlineCompletionService {
         this.statusBar.text = codicon`${getIcon('vscode-check')} CodeWhisperer${
             selectedCustomization.arn === '' ? '' : ` | ${selectedCustomization.name}`
         }`
-        this.statusBar.command = undefined
+        this.statusBar.command = showCodeWhispererQuickPickCommand
         ;(this.statusBar as any).backgroundColor = undefined
         this.statusBar.show()
     }

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -168,7 +168,7 @@ export class InlineCompletionService {
     setCodeWhispererStatusBarExpired() {
         this._isPaginationRunning = false
         this.statusBar.text = codicon` ${getIcon('vscode-debug-disconnect')} CodeWhisperer`
-        this.statusBar.command = 'aws.codeWhisperer.reconnect'
+        this.statusBar.command = showCodeWhispererQuickPickCommand
         ;(this.statusBar as any).backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
         this.statusBar.show()
     }

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -165,11 +165,19 @@ export class InlineCompletionService {
         this.statusBar.show()
     }
 
-    setCodeWhispererStatusBarDisconnected() {
+    setCodeWhispererStatusBarExpired() {
         this._isPaginationRunning = false
         this.statusBar.text = codicon` ${getIcon('vscode-debug-disconnect')} CodeWhisperer`
         this.statusBar.command = 'aws.codeWhisperer.reconnect'
         ;(this.statusBar as any).backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
+        this.statusBar.show()
+    }
+
+    setCodeWhispererStatusBarNotConnected() {
+        this._isPaginationRunning = false
+        this.statusBar.text = codicon` ${getIcon('vscode-chrome-close')} CodeWhisperer`
+        this.statusBar.command = showCodeWhispererQuickPickCommand
+        ;(this.statusBar as any).backgroundColor = undefined
         this.statusBar.show()
     }
 

--- a/src/codewhisperer/vue/backend.ts
+++ b/src/codewhisperer/vue/backend.ts
@@ -135,7 +135,7 @@ let subscriptions: vscode.Disposable[] | undefined
 // This function is called when the extension is activated : Webview of CodeWhisperer
 export async function showCodeWhispererWebview(
     ctx: vscode.ExtensionContext,
-    source: CodeWhispererSource
+    source: CodeWhispererSource | undefined
 ): Promise<void> {
     activePanel ??= new Panel(ctx)
     activePanel.server.setSource(source)

--- a/src/codewhisperer/vue/backend.ts
+++ b/src/codewhisperer/vue/backend.ts
@@ -14,6 +14,7 @@ import { telemetry, CodewhispererLanguage, CodewhispererGettingStartedTask } fro
 import { FileSystemCommon } from '../../srcShared/fs'
 import { getLogger } from '../../shared/logger'
 import { PromptSettings } from '../../shared/settings'
+import { CodeWhispererSource } from '../commands/types'
 export type OSType = 'Mac' | 'RestOfOS'
 export class CodeWhispererWebview extends VueWebview {
     public readonly id = 'CodeWhispererWebview'
@@ -130,8 +131,6 @@ export type CodeWhispererUiClick =
 const Panel = VueWebview.compilePanel(CodeWhispererWebview)
 let activePanel: InstanceType<typeof Panel> | undefined
 let subscriptions: vscode.Disposable[] | undefined
-
-export type CodeWhispererSource = 'codewhispererDeveloperTools'
 
 // This function is called when the extension is activated : Webview of CodeWhisperer
 export async function showCodeWhispererWebview(

--- a/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -32,8 +32,8 @@ import {
     createSignIn,
     createSignout,
 } from '../../../codewhisperer/explorer/codewhispererChildrenNodes'
-import { showCodeWhispererQuickPick } from '../../../codewhisperer/commands/statusBarCommands'
 import { waitUntil } from '../../../shared/utilities/timeoutUtils'
+import { listCodeWhispererCommands } from '../../../codewhisperer/commands/statusBarCommands'
 import { CodeSuggestionsState } from '../../../codewhisperer/models/model'
 import { cwQuickPickSource} from '../../../codewhisperer/commands/types'
 
@@ -287,7 +287,7 @@ describe('CodeWhisperer-basicCommands', function () {
         })
     })
 
-    describe('showCodeWhispererQuickPick', function () {
+    describe('listCodeWhispererCommands()', function () {
         it('shows expected items when not connected', async function () {
             sinon.stub(AuthUtil.instance, 'isConnectionExpired').returns(false)
             sinon.stub(AuthUtil.instance, 'isConnected').returns(false)
@@ -297,7 +297,7 @@ describe('CodeWhisperer-basicCommands', function () {
                 e.dispose() // skip needing to select an item to continue
             })
 
-            await showCodeWhispererQuickPick.execute()
+            await listCodeWhispererCommands.execute()
         })
 
         it('shows expected items when connection is expired', async function () {
@@ -314,7 +314,7 @@ describe('CodeWhisperer-basicCommands', function () {
                 e.dispose() // skip needing to select an item to continue
             })
 
-            await showCodeWhispererQuickPick.execute()
+            await listCodeWhispererCommands.execute()
         })
 
         it('shows expected quick pick items when connected', async function () {
@@ -332,7 +332,7 @@ describe('CodeWhisperer-basicCommands', function () {
                 e.dispose() // skip needing to select an item to continue
             })
 
-            await showCodeWhispererQuickPick.execute()
+            await listCodeWhispererCommands.execute()
         })
 
         it('also shows customizations when connected to valid sso', async function () {
@@ -354,7 +354,7 @@ describe('CodeWhisperer-basicCommands', function () {
                 e.dispose() // skip needing to select an item to continue
             })
 
-            await showCodeWhispererQuickPick.execute()
+            await listCodeWhispererCommands.execute()
         })
     })
 })

--- a/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -20,6 +20,8 @@ import { AuthUtil } from '../../../codewhisperer/util/authUtil'
 import { getTestWindow } from '../../shared/vscode/window'
 import { ExtContext } from '../../../shared/extensions'
 import { get, set } from '../../../codewhisperer/util/commonUtil'
+import { createAutoSuggestions, createGettingStarted, createLearnMore, createOpenReferenceLog, createReconnect, createSecurityScan, createSelectCustomization, createSeparator, createSignIn, createSignout } from '../../../codewhisperer/explorer/codewhispererChildrenNodes'
+import { showCodeWhispererQuickPick } from '../../../codewhisperer/commands/statusBarCommands'
 
 describe('CodeWhisperer-basicCommands', function () {
     let targetCommand: Command<any> & vscode.Disposable
@@ -130,6 +132,76 @@ describe('CodeWhisperer-basicCommands', function () {
             assert.ok(vscode.window.activeTextEditor === undefined)
             await targetCommand.execute()
             assert.strictEqual(getTestWindow().shownMessages[0].message, 'Open a valid file to scan.')
+        })
+    })
+
+    describe('showCodeWhispererQuickPick', function () {
+        it('shows expected items when not connected', async function () {
+            sinon.stub(AuthUtil.instance, 'isConnectionExpired').returns(false)
+            sinon.stub(AuthUtil.instance, 'isConnected').returns(false)
+
+            getTestWindow().onDidShowQuickPick((e) => {
+                e.assertItems([
+                    createSignIn('item'), createLearnMore('item')
+                ])
+                e.dispose() // skip needing to select an item to continue
+            })
+
+            await showCodeWhispererQuickPick.execute()
+        })
+
+        it('shows expected items when connection is expired', async function () {
+            sinon.stub(AuthUtil.instance, 'isConnectionExpired').returns(true)
+            sinon.stub(AuthUtil.instance, 'isConnected').returns(true)
+
+            getTestWindow().onDidShowQuickPick((e) => {
+                e.assertItems([
+                    createReconnect('item'), createLearnMore('item'), createSeparator(), createSignout('item')
+                ])
+                e.dispose() // skip needing to select an item to continue
+            })
+
+            await showCodeWhispererQuickPick.execute()
+        })
+
+        it('shows expected quick pick items when connected', async function () {
+            sinon.stub(AuthUtil.instance, 'isConnectionExpired').returns(false)
+            sinon.stub(AuthUtil.instance, 'isConnected').returns(true)
+            getTestWindow().onDidShowQuickPick((e) => {
+                e.assertItems([
+                    createAutoSuggestions('item', false),
+                    createSecurityScan('item'),
+                    createOpenReferenceLog('item'),
+                    createGettingStarted('item'),
+                    createSeparator(),
+                    createSignout('item'),
+                ])
+                e.dispose() // skip needing to select an item to continue
+            })
+
+            await showCodeWhispererQuickPick.execute()
+        })
+
+        it('also shows customizations when connected to valid sso', async function () {
+            sinon.stub(AuthUtil.instance, 'isConnectionExpired').returns(false)
+            sinon.stub(AuthUtil.instance, 'isConnected').returns(true)
+            sinon.stub(AuthUtil.instance, 'isValidEnterpriseSsoInUse').returns(true)
+            sinon.stub(AuthUtil.instance, 'isCustomizationFeatureEnabled').value(true)
+
+            getTestWindow().onDidShowQuickPick((e) => {
+                e.assertItems([
+                    createAutoSuggestions('item', false),
+                    createSecurityScan('item'),
+                    createSelectCustomization('item'),
+                    createOpenReferenceLog('item'),
+                    createGettingStarted('item'),
+                    createSeparator(),
+                    createSignout('item'),
+                ])
+                e.dispose() // skip needing to select an item to continue
+            })
+
+            await showCodeWhispererQuickPick.execute()
         })
     })
 })

--- a/src/test/codewhisperer/explorer/codewhispererChildrenNodes.test.ts
+++ b/src/test/codewhisperer/explorer/codewhispererChildrenNodes.test.ts
@@ -7,9 +7,15 @@ import assert from 'assert'
 import * as sinon from 'sinon'
 import {
     createEnableCodeSuggestionsNode,
-    createSsoSignIn,
+    createSignIn,
     createLearnMore,
-    createFreeTierLimitMetNode,
+    createFreeTierLimitMet,
+    createGettingStarted,
+    createAutoSuggestions,
+    createOpenReferenceLog,
+    createSecurityScan,
+    createReconnect,
+    createSelectCustomization,
 } from '../../../codewhisperer/explorer/codewhispererChildrenNodes'
 
 describe('codewhisperer children nodes', function () {
@@ -23,21 +29,57 @@ describe('codewhisperer children nodes', function () {
         assert.strictEqual(node.resource.id, 'aws.codeWhisperer.enableCodeSuggestions')
     })
 
+    it('builds the pause/resume codewhisperer command node', async function () {
+        const resumeNode = createAutoSuggestions('tree', false)
+        assert.strictEqual(resumeNode.resource.id, 'aws.codeWhisperer.toggleCodeSuggestion')
+        assert.strictEqual((await resumeNode.getTreeItem()).label, 'Resume Auto-Suggestions')
+
+        const pauseNode = createAutoSuggestions('tree', true)
+        assert.strictEqual(pauseNode.resource.id, 'aws.codeWhisperer.toggleCodeSuggestion')
+        assert.strictEqual((await pauseNode.getTreeItem()).label, 'Pause Auto-Suggestions')
+    })
+
+    it('builds the openReferenceLog command node', async function () {
+        const resumeNode = createOpenReferenceLog('tree')
+        assert.strictEqual(resumeNode.resource.id, 'aws.codeWhisperer.openReferencePanel')
+    })
+
+    it('builds the securityScan command node', async function () {
+        const resumeNode = createSecurityScan('tree')
+        assert.strictEqual(resumeNode.resource.id, 'aws.codeWhisperer.security.scan')
+    })
+
     it('should build showSsoSignIn command node', function () {
-        const node = createSsoSignIn()
+        const node = createSignIn('tree')
 
         assert.strictEqual(node.resource.id, 'aws.auth.manageConnections')
     })
 
+    it('builds the reconnect command node', async function () {
+        const resumeNode = createReconnect('tree')
+        assert.strictEqual(resumeNode.resource.id, 'aws.codeWhisperer.reconnect')
+    })
+
     it('should build showLearnMore command node', function () {
-        const node = createLearnMore()
+        const node = createLearnMore('tree')
 
         assert.strictEqual(node.resource.id, 'aws.codeWhisperer.learnMore')
     })
 
     it('should build showFreeTierLimit command node', function () {
-        const node = createFreeTierLimitMetNode()
+        const node = createFreeTierLimitMet('tree')
 
         assert.strictEqual(node.resource.id, 'aws.codeWhisperer.freeTierLimit')
+    })
+
+    it('builds the selectCustomization command node', function () {
+        const node = createSelectCustomization('tree')
+
+        assert.strictEqual(node.resource.id, 'aws.codeWhisperer.selectCustomization')
+    })
+
+    it('builds the createGettingStarted command node', function () {
+        const node = createGettingStarted('tree')
+        assert.strictEqual(node.resource.id, 'aws.codeWhisperer.gettingStarted')
     })
 })

--- a/src/test/codewhisperer/explorer/codewhispererChildrenNodes.test.ts
+++ b/src/test/codewhisperer/explorer/codewhispererChildrenNodes.test.ts
@@ -6,7 +6,6 @@
 import assert from 'assert'
 import * as sinon from 'sinon'
 import {
-    createEnableCodeSuggestionsNode,
     createSignIn,
     createLearnMore,
     createFreeTierLimitMet,
@@ -21,12 +20,6 @@ import {
 describe('codewhisperer children nodes', function () {
     afterEach(function () {
         sinon.restore()
-    })
-
-    it('should build enableCodeSuggestions command node', function () {
-        const node = createEnableCodeSuggestionsNode()
-
-        assert.strictEqual(node.resource.id, 'aws.codeWhisperer.enableCodeSuggestions')
     })
 
     it('builds the pause/resume codewhisperer command node', async function () {

--- a/src/test/codewhisperer/explorer/codewhispererChildrenNodes.test.ts
+++ b/src/test/codewhisperer/explorer/codewhispererChildrenNodes.test.ts
@@ -45,7 +45,7 @@ describe('codewhisperer children nodes', function () {
     it('should build showSsoSignIn command node', function () {
         const node = createSignIn('tree')
 
-        assert.strictEqual(node.resource.id, 'aws.auth.manageConnections')
+        assert.strictEqual(node.resource.id, 'aws.codewhisperer.manageConnections')
     })
 
     it('builds the reconnect command node', async function () {

--- a/src/test/codewhisperer/explorer/codewhispererNode.test.ts
+++ b/src/test/codewhisperer/explorer/codewhispererNode.test.ts
@@ -6,12 +6,17 @@
 import vscode from 'vscode'
 import assert from 'assert'
 import sinon from 'sinon'
-import { codewhispererNode } from '../../../codewhisperer/explorer/codewhispererNode'
+import { CodeWhispererNode, getCodewhispererNode } from '../../../codewhisperer/explorer/codewhispererNode'
 import { AuthUtil } from '../../../codewhisperer/util/authUtil'
 
 describe('codewhispererNode', function () {
     let isConnectionValid: sinon.SinonStub
     let isConnected: sinon.SinonStub
+    let codewhispererNode: CodeWhispererNode
+
+    before(function () {
+        codewhispererNode = getCodewhispererNode()
+    })
 
     beforeEach(function () {
         isConnectionValid = sinon.stub(AuthUtil.instance, 'isConnectionValid')

--- a/src/test/codewhisperer/explorer/codewhispererNode.test.ts
+++ b/src/test/codewhisperer/explorer/codewhispererNode.test.ts
@@ -88,7 +88,7 @@ describe('codewhispererNode', function () {
         it('should get correct child nodes if user is not connected', function () {
             const node = codewhispererNode
             const children = node.getChildren()
-            const ssoSignInNode = children.find(c => c.resource.id === 'aws.auth.manageConnections')
+            const ssoSignInNode = children.find(c => c.resource.id === 'aws.codewhisperer.manageConnections')
             const learnMorenNode = children.find(c => c.resource.id === 'aws.codeWhisperer.learnMore')
 
             assert.strictEqual(children.length, 2)

--- a/src/test/codewhisperer/service/inlineCompletionService.test.ts
+++ b/src/test/codewhisperer/service/inlineCompletionService.test.ts
@@ -15,7 +15,7 @@ import { CodeSuggestionsState, ConfigurationEntry } from '../../../codewhisperer
 import { CWInlineCompletionItemProvider } from '../../../codewhisperer/service/inlineCompletionItemProvider'
 import { session } from '../../../codewhisperer/util/codeWhispererSession'
 import { AuthUtil } from '../../../codewhisperer/util/authUtil'
-import { showCodeWhispererQuickPickCommand } from '../../../codewhisperer/commands/statusBarCommands'
+import { listCodeWhispererCommandsId } from '../../../codewhisperer/commands/statusBarCommands'
 
 describe('inlineCompletionService', function () {
     beforeEach(function () {
@@ -214,7 +214,7 @@ describe('codewhisperer status bar', function () {
 
         const actualStatusBar = statusBar.getStatusBar()
         assert.strictEqual(actualStatusBar.text, '$(chrome-close) CodeWhisperer')
-        assert.strictEqual(actualStatusBar.command, showCodeWhispererQuickPickCommand)
+        assert.strictEqual(actualStatusBar.command, listCodeWhispererCommandsId)
         assert.deepStrictEqual(actualStatusBar.backgroundColor, undefined)
     })
 
@@ -226,7 +226,7 @@ describe('codewhisperer status bar', function () {
 
         const actualStatusBar = statusBar.getStatusBar()
         assert.strictEqual(actualStatusBar.text, '$(debug-start) CodeWhisperer')
-        assert.strictEqual(actualStatusBar.command, showCodeWhispererQuickPickCommand)
+        assert.strictEqual(actualStatusBar.command, listCodeWhispererCommandsId)
         assert.deepStrictEqual(actualStatusBar.backgroundColor, undefined)
     })
 
@@ -238,7 +238,7 @@ describe('codewhisperer status bar', function () {
 
         const actualStatusBar = statusBar.getStatusBar()
         assert.strictEqual(actualStatusBar.text, '$(debug-pause) CodeWhisperer')
-        assert.strictEqual(actualStatusBar.command, showCodeWhispererQuickPickCommand)
+        assert.strictEqual(actualStatusBar.command, listCodeWhispererCommandsId)
         assert.deepStrictEqual(actualStatusBar.backgroundColor, undefined)
     })
 
@@ -250,7 +250,7 @@ describe('codewhisperer status bar', function () {
 
         const actualStatusBar = statusBar.getStatusBar()
         assert.strictEqual(actualStatusBar.text, '$(debug-disconnect) CodeWhisperer')
-        assert.strictEqual(actualStatusBar.command, showCodeWhispererQuickPickCommand)
+        assert.strictEqual(actualStatusBar.command, listCodeWhispererCommandsId)
         assert.deepStrictEqual(
             actualStatusBar.backgroundColor,
             new vscode.ThemeColor('statusBarItem.warningBackground')

--- a/src/test/codewhisperer/service/inlineCompletionService.test.ts
+++ b/src/test/codewhisperer/service/inlineCompletionService.test.ts
@@ -6,14 +6,16 @@
 import * as vscode from 'vscode'
 import assert from 'assert'
 import * as sinon from 'sinon'
-import { InlineCompletionService } from '../../../codewhisperer/service/inlineCompletionService'
+import { CodeWhispererStatusBar, InlineCompletionService } from '../../../codewhisperer/service/inlineCompletionService'
 import { createMockTextEditor, resetCodeWhispererGlobalVariables, createMockDocument } from '../testUtil'
 import { ReferenceInlineProvider } from '../../../codewhisperer/service/referenceInlineProvider'
 import { RecommendationHandler } from '../../../codewhisperer/service/recommendationHandler'
 import * as codewhispererSdkClient from '../../../codewhisperer/client/codewhisperer'
-import { ConfigurationEntry } from '../../../codewhisperer/models/model'
+import { CodeSuggestionsState, ConfigurationEntry } from '../../../codewhisperer/models/model'
 import { CWInlineCompletionItemProvider } from '../../../codewhisperer/service/inlineCompletionItemProvider'
 import { session } from '../../../codewhisperer/util/codeWhispererSession'
+import { AuthUtil } from '../../../codewhisperer/util/authUtil'
+import { showCodeWhispererQuickPickCommand } from '../../../codewhisperer/commands/statusBarCommands'
 
 describe('inlineCompletionService', function () {
     beforeEach(function () {
@@ -175,5 +177,81 @@ describe('CWInlineCompletionProvider', function () {
 
             assert.ok(result === undefined)
         })
+    })
+})
+
+describe('codewhisperer status bar', function () {
+    let sandbox: sinon.SinonSandbox
+    let statusBar: TestStatusBar
+    let service: InlineCompletionService
+
+    class TestStatusBar extends CodeWhispererStatusBar {
+        constructor() {
+            super()
+        }
+
+        getStatusBar() {
+            return this.statusBar
+        }
+        
+    }
+
+    beforeEach(function () {
+        resetCodeWhispererGlobalVariables()
+        sandbox = sinon.createSandbox()
+        statusBar = new TestStatusBar()
+        service = new InlineCompletionService(statusBar)
+    })
+
+    afterEach(function () {
+        sandbox.restore()
+    })
+
+    it('shows correct status bar when auth is not connected', async function () {
+        sandbox.stub(AuthUtil.instance, 'isConnectionValid').returns(false)
+        sandbox.stub(AuthUtil.instance, 'isConnectionExpired').returns(false)
+
+        await service.refreshStatusBar()
+
+        const actualStatusBar = statusBar.getStatusBar()
+        assert.strictEqual(actualStatusBar.text, '$(chrome-close) CodeWhisperer')
+        assert.strictEqual(actualStatusBar.command, showCodeWhispererQuickPickCommand)
+        assert.deepStrictEqual(actualStatusBar.backgroundColor, undefined)
+    })
+
+    it('shows correct status bar when auth is connected', async function () {
+        sandbox.stub(AuthUtil.instance, 'isConnectionValid').returns(true)
+        sandbox.stub(CodeSuggestionsState.instance, 'isSuggestionsEnabled').returns(true)
+
+        await service.refreshStatusBar()
+
+        const actualStatusBar = statusBar.getStatusBar()
+        assert.strictEqual(actualStatusBar.text, '$(debug-start) CodeWhisperer')
+        assert.strictEqual(actualStatusBar.command, showCodeWhispererQuickPickCommand)
+        assert.deepStrictEqual(actualStatusBar.backgroundColor, undefined)
+    })
+
+    it('shows correct status bar when auth is connected but paused', async function () {
+        sandbox.stub(AuthUtil.instance, 'isConnectionValid').returns(true)
+        sandbox.stub(CodeSuggestionsState.instance, 'isSuggestionsEnabled').returns(false)
+
+        await service.refreshStatusBar()
+
+        const actualStatusBar = statusBar.getStatusBar()
+        assert.strictEqual(actualStatusBar.text, '$(debug-pause) CodeWhisperer')
+        assert.strictEqual(actualStatusBar.command, showCodeWhispererQuickPickCommand)
+        assert.deepStrictEqual(actualStatusBar.backgroundColor, undefined)
+    })
+
+    it('shows correct status bar when auth is expired', async function () {
+        sandbox.stub(AuthUtil.instance, 'isConnectionValid').returns(false)
+        sandbox.stub(AuthUtil.instance, 'isConnectionExpired').returns(true)
+
+        await service.refreshStatusBar()
+
+        const actualStatusBar = statusBar.getStatusBar()
+        assert.strictEqual(actualStatusBar.text, '$(debug-disconnect) CodeWhisperer')
+        assert.strictEqual(actualStatusBar.command, showCodeWhispererQuickPickCommand)
+        assert.deepStrictEqual(actualStatusBar.backgroundColor, new vscode.ThemeColor('statusBarItem.warningBackground'))
     })
 })

--- a/src/test/codewhisperer/service/inlineCompletionService.test.ts
+++ b/src/test/codewhisperer/service/inlineCompletionService.test.ts
@@ -193,7 +193,6 @@ describe('codewhisperer status bar', function () {
         getStatusBar() {
             return this.statusBar
         }
-        
     }
 
     beforeEach(function () {
@@ -252,6 +251,9 @@ describe('codewhisperer status bar', function () {
         const actualStatusBar = statusBar.getStatusBar()
         assert.strictEqual(actualStatusBar.text, '$(debug-disconnect) CodeWhisperer')
         assert.strictEqual(actualStatusBar.command, showCodeWhispererQuickPickCommand)
-        assert.deepStrictEqual(actualStatusBar.backgroundColor, new vscode.ThemeColor('statusBarItem.warningBackground'))
+        assert.deepStrictEqual(
+            actualStatusBar.backgroundColor,
+            new vscode.ThemeColor('statusBarItem.warningBackground')
+        )
     })
 })

--- a/src/test/codewhisperer/testUtil.ts
+++ b/src/test/codewhisperer/testUtil.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode'
 import * as sinon from 'sinon'
 import * as codewhispererClient from '../../codewhisperer/client/codewhisperer'
-import { vsCodeState, AcceptedSuggestionEntry } from '../../codewhisperer/models/model'
+import { vsCodeState, AcceptedSuggestionEntry, CodeSuggestionsState } from '../../codewhisperer/models/model'
 import { MockDocument } from '../fake/fakeDocument'
 import { getLogger } from '../../shared/logger'
 import { CodeWhispererCodeCoverageTracker } from '../../codewhisperer/tracker/codewhispererCodeCoverageTracker'
@@ -19,6 +19,7 @@ export function resetCodeWhispererGlobalVariables() {
     CodeWhispererCodeCoverageTracker.instances.clear()
     globals.telemetry.logger.clear()
     session.language = 'python'
+    CodeSuggestionsState.instance.setSuggestionsEnabled(false)
 }
 
 export function createMockDocument(


### PR DESCRIPTION
When the CodeWhisperer status bar is clicked we will now show a QuickPick with different options for interacting with CodeWhisperer.

- The options in the quick pick are the same as the CodeWhisperer tree nodes in `Developer Tools` with the exception of a `sign out` option in the quick pick
- The CodeWhisperer status bar always exists and is always clickable
- Telemetry is emitted (`vscode_executeCommand`) that includes the name of the `command` that was executed as well as a `source` attribute (`codewhispererQuickPick` & `codewhispererTreeNode`) which indicates what caused it to be executed
- Updates to the CW status will be reflected in both the tree nodes and status bar

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
