### PR TITLE
build: require minimum NPM version

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,6 +23,8 @@ jobs:
             NODE_OPTIONS: '--max-old-space-size=8192'
         steps:
             - uses: actions/checkout@v4
+            - name: Disable engine-strict check
+              run: sed -i -e 's/engine.strict.true/engine-strict=false/' .npmrc
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4
               with:
@@ -65,6 +67,8 @@ jobs:
             NODE_OPTIONS: '--max-old-space-size=8192'
         steps:
             - uses: actions/checkout@v4
+            - name: Disable engine-strict check
+              run: sed -i -e 's/engine.strict.true/engine-strict=false/' .npmrc
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4
               with:
@@ -94,6 +98,8 @@ jobs:
             NODE_OPTIONS: '--max-old-space-size=8192'
         steps:
             - uses: actions/checkout@v4
+            - name: Disable engine-strict check
+              run: sed -i -e 's/engine.strict.true/engine-strict=false/' .npmrc
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4
               with:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/buildspec/linuxE2ETests.yml
+++ b/buildspec/linuxE2ETests.yml
@@ -20,6 +20,8 @@ phases:
 
     build:
         commands:
+            # Disable engine-strict in CI.
+            - sed -i -e 's/engine.strict.true/engine-strict=false/' .npmrc
             - npm ci --unsafe-perm
             # We cannot run `code` as root during tests
             # From: https://github.com/aws/aws-codebuild-docker-images/blob/2f796bb9c81fcfbc8585832b99a5f780ae2b2f52/ubuntu/standard/6.0/Dockerfile#L56

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -22,6 +22,8 @@ phases:
             java: latest
 
         commands:
+            # Disable engine-strict in CI.
+            - sed -i -e 's/engine.strict.true/engine-strict=false/' .npmrc
             - '>/dev/null add-apt-repository universe'
             - '>/dev/null apt-get -qq install -y apt-transport-https'
             - '>/dev/null apt-get -qq update'

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -13,6 +13,8 @@ phases:
         runtime-versions:
             nodejs: 16
         commands:
+            # Disable engine-strict in CI.
+            - sed -i -e 's/engine.strict.true/engine-strict=false/' .npmrc
             # Without this, "Unable to locate package libatk1.0-0".
             - '>/dev/null apt-get -yqq update'
             # Dependencies for running vscode.

--- a/buildspec/packageTestVsix.yml
+++ b/buildspec/packageTestVsix.yml
@@ -15,6 +15,8 @@ phases:
         runtime-versions:
             nodejs: 16
         commands:
+            # Disable engine-strict in CI.
+            - sed -i -e 's/engine.strict.true/engine-strict=false/' .npmrc
             # Prepare env for unprivileged user.
             - |
                 mkdir -p ~codebuild-user

--- a/package-lock.json
+++ b/package-lock.json
@@ -120,6 +120,7 @@
                 "webpack-dev-server": "^4.15.1"
             },
             "engines": {
+                "npm": "^10.1.0",
                 "vscode": "^1.68.0"
             }
         },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "url": "https://github.com/aws/aws-toolkit-vscode"
     },
     "engines": {
+        "npm": "^10.1.0",
         "vscode": "^1.68.0"
     },
     "icon": "resources/marketplace/aws-icon-256x256.png",


### PR DESCRIPTION
# Problem:
Developers may have outdated tooling, which causes weird problems.

# Solution:
- Define minimum npm version and enforce it via `.npmrc`. Outdated npm will show an error like:
  ```
  $ npm install
  npm ERR! code EBADENGINE
  npm ERR! engine Unsupported engine
  npm ERR! engine Not compatible with your version of node/npm: aws-toolkit-vscode@1.96.0-SNAPSHOT
  npm ERR! notsup Not compatible with your version of node/npm: aws-toolkit-vscode@1.96.0-SNAPSHOT
  npm ERR! notsup Required: {"npm":"^10.1.0","vscode":"^1.68.0"}
  npm ERR! notsup Actual:   {"npm":"10.0.0","node":"v20.8.0"}
  ```
- Disable the check in CI. Because it's transitive, random dependencies  like "marked" can pointlessly require aggressively-recent versions of  NPM, which isn't feasible for us to support in our CI:
  ```
  npm ERR! engine Not compatible with your version of node/npm: marked@5.0.4
  npm ERR! notsup Not compatible with your version of node/npm: marked@5.0.4
  npm ERR! notsup Required: {"node":">= 18"}
  npm ERR! notsup Actual:   {"npm":"8.19.4","node":"v16.20.2"}
  ```



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
