### PR TITLE
perf(startup): avoid templateRegistry in awsFiletypes.ts

### DIFF
--- a/src/shared/awsFiletypes.ts
+++ b/src/shared/awsFiletypes.ts
@@ -7,13 +7,13 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 import * as constants from '../shared/constants'
 import * as aslFormats from '../stepFunctions/constants/aslFormats'
-import * as pathutil from '../shared/utilities/pathUtils'
 import * as fsutil from '../shared/filesystemUtilities'
 import * as sysutil from '../shared/systemUtilities'
 import * as collectionUtil from '../shared/utilities/collectionUtils'
 import globals from './extensionGlobals'
 import { telemetry } from './telemetry/telemetry'
 import { AwsFiletype } from './telemetry/telemetry'
+import { CloudFormation } from './cloudformation/cloudformation'
 
 /** AWS filetypes: vscode language ids */
 export const awsFiletypeLangIds = {
@@ -67,9 +67,12 @@ export function activate(): void {
         vscode.workspace.onDidOpenTextDocument(async (doc: vscode.TextDocument) => {
             const isAwsFileExt = isAwsFiletype(doc)
             const isSchemaHandled = globals.schemaService.isMapped(doc.uri)
-            const isCfnTemplate = !!(await globals.templateRegistry).items.find(
-                t => pathutil.normalize(t.path) === pathutil.normalize(doc.fileName)
-            )
+            const cfnTemplate =
+                CloudFormation.isValidFilename(doc.uri) && doc.languageId === 'yaml'
+                    ? await CloudFormation.tryLoad(doc.uri)
+                    : undefined
+            const isCfnTemplate = cfnTemplate?.template !== undefined
+
             if (!isAwsFileExt && !isSchemaHandled && !isCfnTemplate) {
                 return
             }
@@ -78,11 +81,12 @@ export function activate(): void {
             let fileExt: string | undefined = path.extname(doc.fileName)
             fileExt = fileExt ? fileExt : undefined // Telemetry client will fail on empty string.
 
-            // TODO: ask templateRegistry if this is SAM or CFN.
             // TODO: ask schemaService for the precise filetype.
             let telemKind = isAwsConfig(doc.fileName) ? 'awsCredentials' : langidToAwsFiletype(doc.languageId)
-            if (telemKind === 'other') {
-                telemKind = isCfnTemplate ? 'cloudformationSam' : isSchemaHandled ? 'cloudformation' : 'other'
+            if (isCfnTemplate) {
+                telemKind = cfnTemplate.kind === 'sam' ? 'cloudformationSam' : 'cloudformation'
+            } else if (telemKind === 'other') {
+                telemKind = isSchemaHandled ? 'cloudformation' : 'other'
             }
 
             // HACK: for "~/.aws/foo" vscode sometimes _only_ emits "~/.aws/foo.git".

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -10,22 +10,10 @@ import { isToolkitActive, localize } from '../utilities/vsCodeUtils'
 import { AsyncCloudFormationTemplateRegistry, CloudFormationTemplateRegistry } from '../fs/templateRegistry'
 import { getIdeProperties } from '../extensionUtilities'
 import { NoopWatcher } from '../fs/watchedFiles'
-import { createStarterTemplateFile } from './cloudformation'
+import { CloudFormation, createStarterTemplateFile } from './cloudformation'
 import { Commands } from '../vscode/commands2'
 import globals from '../extensionGlobals'
 import { SamCliSettings } from '../sam/cli/samCliSettings'
-
-export const templateFileGlobPattern = '**/*.{yaml,yml}'
-
-/**
- * Match any file path that contains a .aws-sam folder. The way this works is:
- * match anything that starts  with a '/' or '\', then '.aws-sam', then either
- * a '/' or '\' followed by any number of characters or end of a string (so it
- * matches both /.aws-sam or /.aws-sam/<any number of characters>)
- */
-export const templateFileExcludePattern = /.*[/\\]\.aws-sam([/\\].*|$)/
-
-export const devfileExcludePattern = /.*devfile\.(yaml|yml)/i
 
 /**
  * Creates a CloudFormationTemplateRegistry which retains the state of CloudFormation templates in a workspace.
@@ -68,9 +56,9 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
  */
 function setTemplateRegistryInGlobals(registry: CloudFormationTemplateRegistry) {
     const registrySetupFunc = async (registry: CloudFormationTemplateRegistry) => {
-        await registry.addExcludedPattern(devfileExcludePattern)
-        await registry.addExcludedPattern(templateFileExcludePattern)
-        await registry.addWatchPatterns([templateFileGlobPattern])
+        await registry.addExcludedPattern(CloudFormation.devfileExcludePattern)
+        await registry.addExcludedPattern(CloudFormation.templateFileExcludePattern)
+        await registry.addWatchPatterns([CloudFormation.templateFileGlobPattern])
         await registry.watchUntitledFiles()
 
         return registry

--- a/src/test/shared/awsFiletypes.test.ts
+++ b/src/test/shared/awsFiletypes.test.ts
@@ -39,7 +39,6 @@ describe('awsFiletypes', function () {
     })
 
     it('emit telemetry when opened by user', async function () {
-        await (await globals.templateRegistry).addItem(cfnUri!)
         await vscode.commands.executeCommand('vscode.open', cfnUri)
         await vscode.commands.executeCommand('vscode.open', awsConfigUri)
         await vscode.workspace.openTextDocument({
@@ -61,16 +60,13 @@ describe('awsFiletypes', function () {
 
         assert(r, 'did not emit expected telemetry')
         assert(r.length === 3, 'emitted file_editAwsFile too many times')
-        const m1filetype = r[0].Metadata?.find(o => o.Key === 'awsFiletype')?.Value
-        const m2filetype = r[1].Metadata?.find(o => o.Key === 'awsFiletype')?.Value
-        const m3filetype = r[2].Metadata?.find(o => o.Key === 'awsFiletype')?.Value
-        assert.strictEqual(m1filetype, 'cloudformationSam')
-        assert.strictEqual(m2filetype, 'awsCredentials')
-        assert.strictEqual(m3filetype, 'ssmDocument')
+        const metrics = r.map(o => o.Metadata?.find(o => o.Key === 'awsFiletype')?.Value)
+        // The order is arbitrary (decided by vscode event system).
+        metrics.sort()
+        assert.deepStrictEqual(metrics, ['awsCredentials', 'cloudformationSam', 'ssmDocument'])
     })
 
     it('emit telemetry exactly once per filetype in a given flush window', async function () {
-        await (await globals.templateRegistry).addItem(cfnUri!)
         await vscode.commands.executeCommand('vscode.open', cfnUri)
         async function getMetrics() {
             return await waitUntil(

--- a/src/test/shared/cloudformation/cloudformation.test.ts
+++ b/src/test/shared/cloudformation/cloudformation.test.ts
@@ -34,6 +34,18 @@ describe('CloudFormation', function () {
         await fs.remove(filename)
     })
 
+    it('isValidFilename()', async function () {
+        assert.deepStrictEqual(CloudFormation.isValidFilename('/foo/bar.yaml'), true)
+        assert.deepStrictEqual(CloudFormation.isValidFilename('/foo/template.yaml'), true)
+        assert.deepStrictEqual(CloudFormation.isValidFilename('template.yaml'), true)
+        assert.deepStrictEqual(CloudFormation.isValidFilename('template.yml'), true)
+        assert.deepStrictEqual(CloudFormation.isValidFilename('/.aws-sam/template.yaml'), true)
+        assert.deepStrictEqual(CloudFormation.isValidFilename('devfile.yml'), false)
+        assert.deepStrictEqual(CloudFormation.isValidFilename('devfile.yaml'), false)
+        assert.deepStrictEqual(CloudFormation.isValidFilename('template.yml.bk'), false)
+        assert.deepStrictEqual(CloudFormation.isValidFilename('template.txt'), false)
+    })
+
     describe('load', async function () {
         it('can successfully load a file', async function () {
             const yamlStr = makeSampleSamTemplateYaml(true)

--- a/src/test/shared/debug/launchConfiguration.test.ts
+++ b/src/test/shared/debug/launchConfiguration.test.ts
@@ -17,8 +17,8 @@ import { AwsSamDebuggerConfiguration } from '../../../shared/sam/debugger/awsSam
 import { AwsSamDebugConfigurationValidator } from '../../../shared/sam/debugger/awsSamDebugConfigurationValidator'
 import * as pathutils from '../../../shared/utilities/pathUtils'
 import * as testutil from '../../testUtil'
-import { templateFileGlobPattern } from '../../../shared/cloudformation/activation'
 import globals from '../../../shared/extensionGlobals'
+import { CloudFormation } from '../../../shared/cloudformation/cloudformation'
 
 const samDebugConfiguration: AwsSamDebuggerConfiguration = {
     type: 'aws-sam',
@@ -106,7 +106,7 @@ describe('LaunchConfiguration', function () {
 
     beforeEach(async function () {
         const registry = await globals.templateRegistry
-        await registry.addWatchPatterns([templateFileGlobPattern])
+        await registry.addWatchPatterns([CloudFormation.templateFileGlobPattern])
 
         // TODO: remove mocks in favor of testing src/testFixtures/ data.
         mockConfigSource = mock()


### PR DESCRIPTION
# Problem:
The AWS Documents handler (`awsFiletypes.ts`) is triggered frequently. It calls `globals.templateRegistry` which triggers an expensive "Scanning CloudFormation templates..." process. #3510

# Solution:
Extract the validation logic out of `CloudFormationTemplateRegistry.process()` so that `awsFiletypes.ts` can use it without requesting the full registry.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
