### PR TITLE
fix(codewhisperer): load hover images from dist folder

### DIFF
--- a/src/codewhisperer/service/securityIssueHoverProvider.ts
+++ b/src/codewhisperer/service/securityIssueHoverProvider.ts
@@ -7,6 +7,7 @@ import { CodeScanIssue } from '../models/model'
 import globals from '../../shared/extensionGlobals'
 import { SecurityIssueProvider } from './securityIssueProvider'
 import { telemetry } from '../../shared/telemetry/telemetry'
+import path from 'path'
 
 export class SecurityIssueHoverProvider extends SecurityIssueProvider implements vscode.HoverProvider {
     static #instance: SecurityIssueHoverProvider
@@ -47,6 +48,9 @@ export class SecurityIssueHoverProvider extends SecurityIssueProvider implements
         markdownString.isTrusted = true
         markdownString.supportHtml = true
         markdownString.supportThemeIcons = true
+        markdownString.baseUri = vscode.Uri.file(
+            path.join(globals.context.extensionPath, 'dist/src/codewhisperer/images/')
+        )
 
         const [suggestedFix] = issue.suggestedFixes
 
@@ -82,10 +86,7 @@ export class SecurityIssueHoverProvider extends SecurityIssueProvider implements
         if (!severity) {
             return ''
         }
-        return `![${severity}](${vscode.Uri.joinPath(
-            globals.context.extensionUri,
-            `src/codewhisperer/images/severity-${severity.toLowerCase()}.svg`
-        )})`
+        return `![${severity}](severity-${severity.toLowerCase()}.svg)`
     }
 
     /**

--- a/src/test/codewhisperer/service/securityIssueHoverProvider.test.ts
+++ b/src/test/codewhisperer/service/securityIssueHoverProvider.test.ts
@@ -7,7 +7,6 @@ import * as vscode from 'vscode'
 import { SecurityIssueHoverProvider } from '../../../codewhisperer/service/securityIssueHoverProvider'
 import { createCodeScanIssue, createMockDocument } from '../testUtil'
 import assert from 'assert'
-import sinon from 'sinon'
 import { assertTelemetry } from '../../testUtil'
 
 describe('securityIssueHoverProvider', () => {
@@ -22,10 +21,13 @@ describe('securityIssueHoverProvider', () => {
     })
 
     it('should return hover for each issue for the current position', () => {
-        sinon.stub(vscode.Uri, 'joinPath').callsFake(() => vscode.Uri.parse('myPath'))
         const issues = [
             createCodeScanIssue({ findingId: 'finding-1', detectorId: 'language/detector-1' }),
-            createCodeScanIssue({ findingId: 'finding-2', detectorId: 'language/detector-2', suggestedFixes: [] }),
+            createCodeScanIssue({
+                findingId: 'finding-2',
+                detectorId: 'language/detector-2',
+                suggestedFixes: [],
+            }),
         ]
 
         securityIssueHoverProvider.issues = [
@@ -40,7 +42,7 @@ describe('securityIssueHoverProvider', () => {
         assert.strictEqual(actual.contents.length, 2)
         assert.strictEqual(
             (actual.contents[0] as vscode.MarkdownString).value,
-            '## Suggested Fix for title ![High](file:///myPath)\n' +
+            '## Suggested Fix for title ![High](severity-high.svg)\n' +
                 'description\n\n' +
                 `[$(eye) View Details](command:aws.codeWhisperer.openSecurityIssuePanel?${encodeURIComponent(
                     JSON.stringify(issues[0])
@@ -72,7 +74,7 @@ describe('securityIssueHoverProvider', () => {
         )
         assert.strictEqual(
             (actual.contents[1] as vscode.MarkdownString).value,
-            '## title ![High](file:///myPath)\n' +
+            '## title ![High](severity-high.svg)\n' +
                 'description\n\n' +
                 `[$(eye) View Details](command:aws.codeWhisperer.openSecurityIssuePanel?${encodeURIComponent(
                     JSON.stringify(issues[1])

--- a/webpack.vue.config.js
+++ b/webpack.vue.config.js
@@ -55,7 +55,15 @@ const vueConfig = {
                 test: /\.css$/,
                 use: ['vue-style-loader', 'css-loader'],
             },
-            { test: /\.(png|jpg|gif|svg)$/, use: 'file-loader' }
+            {
+                test: /\.(png|jpg|gif|svg)$/,
+                use: {
+                    loader: 'file-loader',
+                    options: {
+                        name: '[path][name].[ext]',
+                    },
+                },
+            }
         ),
     },
     plugins: (baseConfig.plugins ?? []).concat(new VueLoaderPlugin()),


### PR DESCRIPTION
## Problem

Images are broken in hover when running the extension as VSIX file

## Solution

Configure webpack to load the image files into `dist` and load it from there

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
