### PR TITLE
chore: use aws-sdk-js-codemod@0.25.5 for moving to JS SDK v3

### DIFF
--- a/src/apigateway/commands/copyUrl.ts
+++ b/src/apigateway/commands/copyUrl.ts
@@ -11,7 +11,7 @@ import * as picker from '../../shared/ui/picker'
 import * as vscode from 'vscode'
 import { ProgressLocation } from 'vscode'
 
-import { Stage } from 'aws-sdk/clients/apigateway'
+import { UpdateStageCommandOutput } from "@aws-sdk/client-api-gateway";
 import { DefaultApiGatewayClient } from '../../shared/clients/apiGatewayClient'
 import { defaultDnsSuffix, RegionProvider } from '../../shared/regions/regionProvider'
 import { getLogger } from '../../shared/logger'
@@ -27,7 +27,7 @@ export async function copyUrlCommand(node: RestApiNode, regionProvider: RegionPr
     const dnsSuffix = regionProvider.getDnsSuffixForRegion(region) || defaultDnsSuffix
     const client = new DefaultApiGatewayClient(region)
 
-    let stages: Stage[]
+    let stages: UpdateStageCommandOutput[]
     try {
         stages = await vscode.window.withProgress(
             {

--- a/src/apigateway/explorer/apiGatewayNodes.ts
+++ b/src/apigateway/explorer/apiGatewayNodes.ts
@@ -12,7 +12,7 @@ import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
 import { PlaceholderNode } from '../../shared/treeview/nodes/placeholderNode'
 import { compareTreeItems, makeChildrenNodes } from '../../shared/treeview/utils'
 import { DefaultApiGatewayClient } from '../../shared/clients/apiGatewayClient'
-import { RestApi } from 'aws-sdk/clients/apigateway'
+import { UpdateRestApiCommandOutput } from "@aws-sdk/client-api-gateway";
 import { toArrayAsync, toMap, updateInPlace } from '../../shared/utilities/collectionUtils'
 import { RestApiNode } from './apiNodes'
 
@@ -48,7 +48,7 @@ export class ApiGatewayNode extends AWSTreeNodeBase {
     }
 
     public async updateChildren(): Promise<void> {
-        const apis: Map<string, RestApi> = toMap(
+        const apis: Map<string, UpdateRestApiCommandOutput> = toMap(
             await toArrayAsync(this.client.listApis()),
             configuration => `${configuration.name} (${configuration.id})`
         )

--- a/src/apigateway/explorer/apiNodes.ts
+++ b/src/apigateway/explorer/apiNodes.ts
@@ -5,7 +5,7 @@
 
 import { AWSResourceNode } from '../../shared/treeview/nodes/awsResourceNode'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
-import { RestApi } from 'aws-sdk/clients/apigateway'
+import { UpdateRestApiCommandOutput } from "@aws-sdk/client-api-gateway";
 
 export class RestApiNode extends AWSTreeNodeBase implements AWSResourceNode {
     public override id!: string
@@ -14,14 +14,14 @@ export class RestApiNode extends AWSTreeNodeBase implements AWSResourceNode {
         public readonly parent: AWSTreeNodeBase,
         public readonly partitionId: string,
         public override readonly regionCode: string,
-        private api: RestApi
+        private api: UpdateRestApiCommandOutput
     ) {
         super('')
         this.update(api)
         this.contextValue = 'awsApiGatewayNode'
     }
 
-    public update(api: RestApi): void {
+    public update(api: UpdateRestApiCommandOutput): void {
         this.api = api
         this.label = `${this.api.name} (${this.api.id})` || ''
         this.tooltip = this.api.description

--- a/src/apigateway/vue/invokeRemoteRestApi.ts
+++ b/src/apigateway/vue/invokeRemoteRestApi.ts
@@ -8,7 +8,7 @@ import { RestApiNode } from '../explorer/apiNodes'
 import { getLogger, Logger } from '../../shared/logger'
 
 import { toArrayAsync } from '../../shared/utilities/collectionUtils'
-import { Resource } from 'aws-sdk/clients/apigateway'
+import { UpdateResourceCommandOutput } from "@aws-sdk/client-api-gateway";
 import { localize } from '../../shared/utilities/vsCodeUtils'
 import { Result } from '../../shared/telemetry/telemetry'
 import { VueWebview } from '../../webviews/main'
@@ -19,14 +19,14 @@ import { telemetry } from '../../shared/telemetry/telemetry'
 interface InvokeApiMessage {
     region: string
     body: string
-    selectedApiResource: Resource
+    selectedApiResource: UpdateResourceCommandOutput
     selectedMethod: string
     queryString: string
     api: string
 }
 
 interface ResourceMap {
-    [key: string]: Resource
+    [key: string]: UpdateResourceCommandOutput
 }
 
 export interface InvokeRemoteRestApiInitialData {
@@ -58,7 +58,7 @@ export class RemoteRestInvokeWebview extends VueWebview {
         return this.data
     }
 
-    public listValidMethods(resource: Resource): string[] {
+    public listValidMethods(resource: UpdateResourceCommandOutput): string[] {
         return listValidMethods(resource)
     }
 
@@ -150,7 +150,7 @@ export async function invokeRemoteRestApi(
     }
 }
 
-export function listValidMethods(resource: Resource): string[] {
+export function listValidMethods(resource: UpdateResourceCommandOutput): string[] {
     // OpenAPI 2 (swagger) valid methods
     const supportedOperations = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT']
 

--- a/src/apprunner/wizards/apprunnerCreateServiceWizard.ts
+++ b/src/apprunner/wizards/apprunnerCreateServiceWizard.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AppRunner } from 'aws-sdk'
+
+
+import { CreateServiceCommandInput, InstanceConfiguration, SourceConfiguration } from "@aws-sdk/client-apprunner";
 import * as nls from 'vscode-nls'
 import { createCommonButtons, QuickInputToggleButton } from '../../shared/ui/buttons'
 import * as input from '../../shared/ui/inputPrompter'
@@ -54,14 +56,14 @@ const validateName = (name: string) => {
     return undefined
 }
 
-function createInstanceStep(): Prompter<AppRunner.InstanceConfiguration> {
+function createInstanceStep(): Prompter<InstanceConfiguration> {
     const enumerations = [
         [1, 2],
         [1, 3],
         [2, 4],
     ]
 
-    const items: picker.DataQuickPickItem<AppRunner.InstanceConfiguration>[] = enumerations.map(e => ({
+    const items: picker.DataQuickPickItem<InstanceConfiguration>[] = enumerations.map(e => ({
         label: `${e[0]} vCPUs, ${e[1]} GBs Memory`,
         data: { Cpu: `${e[0]} vCPU`, Memory: `${e[1]} GB` },
     }))
@@ -74,10 +76,10 @@ function createInstanceStep(): Prompter<AppRunner.InstanceConfiguration> {
 
 function createSourcePrompter(
     autoDeployButton: QuickInputToggleButton
-): Prompter<AppRunner.CreateServiceRequest['SourceConfiguration']> {
+): Prompter<CreateServiceCommandInput['SourceConfiguration']> {
     const ecrPath = {
         label: 'ECR',
-        data: { ImageRepository: {} } as AppRunner.SourceConfiguration,
+        data: { ImageRepository: {} } as SourceConfiguration,
         detail: localize(
             'AWS.apprunner.createService.ecr.detail',
             'Create a service from a public or private Elastic Container Registry repository'
@@ -86,7 +88,7 @@ function createSourcePrompter(
 
     const repositoryPath = {
         label: 'Repository',
-        data: { CodeRepository: {} } as AppRunner.SourceConfiguration,
+        data: { CodeRepository: {} } as SourceConfiguration,
         detail: localize('AWS.apprunner.createService.repository.detail', 'Create a service from a GitHub repository'),
     }
 
@@ -96,11 +98,11 @@ function createSourcePrompter(
     })
 }
 
-export class CreateAppRunnerServiceWizard extends Wizard<AppRunner.CreateServiceRequest> {
+export class CreateAppRunnerServiceWizard extends Wizard<CreateServiceCommandInput> {
     public constructor(
         region: string,
-        initState: WizardState<AppRunner.CreateServiceRequest> = {},
-        implicitState: WizardState<AppRunner.CreateServiceRequest> = {},
+        initState: WizardState<CreateServiceCommandInput> = {},
+        implicitState: WizardState<CreateServiceCommandInput> = {},
         clients = {
             iam: new DefaultIamClient(region),
             ecr: new DefaultEcrClient(region),

--- a/src/apprunner/wizards/codeRepositoryWizard.ts
+++ b/src/apprunner/wizards/codeRepositoryWizard.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AppRunner } from 'aws-sdk'
+
+
+import { CodeRepository, ConfigurationSource, Runtime, SourceConfiguration } from "@aws-sdk/client-apprunner";
 import * as nls from 'vscode-nls'
 import { createCommonButtons, createRefreshButton, QuickInputToggleButton } from '../../shared/ui/buttons'
 import { Remote } from '../../../types/git.d'
@@ -85,7 +87,7 @@ function createBranchPrompter(
     })
 }
 
-function createRuntimePrompter(): QuickPickPrompter<AppRunner.Runtime> {
+function createRuntimePrompter(): QuickPickPrompter<Runtime> {
     const items = [
         { label: 'python3', data: 'PYTHON_3' },
         { label: 'nodejs12', data: 'NODEJS_16' },
@@ -97,7 +99,7 @@ function createRuntimePrompter(): QuickPickPrompter<AppRunner.Runtime> {
     })
 }
 
-function createBuildCommandPrompter(runtime: AppRunner.Runtime): InputBoxPrompter {
+function createBuildCommandPrompter(runtime: Runtime): InputBoxPrompter {
     const buildCommandMap = {
         python: 'pip install -r requirements.txt',
         node: 'npm install',
@@ -112,7 +114,7 @@ function createBuildCommandPrompter(runtime: AppRunner.Runtime): InputBoxPrompte
     })
 }
 
-function createStartCommandPrompter(runtime: AppRunner.Runtime): InputBoxPrompter {
+function createStartCommandPrompter(runtime: Runtime): InputBoxPrompter {
     const startCommandMap = {
         python: 'python runapp.py',
         node: 'node app.js',
@@ -181,7 +183,7 @@ export function createConnectionPrompter(client: AppRunnerClient) {
     return prompter
 }
 
-function createSourcePrompter(): QuickPickPrompter<AppRunner.ConfigurationSource> {
+function createSourcePrompter(): QuickPickPrompter<ConfigurationSource> {
     const configDetail = localize(
         'AWS.apprunner.createService.configSource.detail',
         'App Runner will read "apprunner.yaml" in the root of your repository for configuration details'
@@ -201,7 +203,7 @@ function createSourcePrompter(): QuickPickPrompter<AppRunner.ConfigurationSource
     )
 }
 
-function createCodeRepositorySubForm(git: GitExtension): WizardForm<AppRunner.CodeRepository> {
+function createCodeRepositorySubForm(git: GitExtension): WizardForm<CodeRepository> {
     const subform = new WizardForm<AppRunner.CodeRepository>()
     const form = subform.body
 
@@ -231,7 +233,7 @@ function createCodeRepositorySubForm(git: GitExtension): WizardForm<AppRunner.Co
     return subform
 }
 
-export class AppRunnerCodeRepositoryWizard extends Wizard<AppRunner.SourceConfiguration> {
+export class AppRunnerCodeRepositoryWizard extends Wizard<SourceConfiguration> {
     constructor(
         client: AppRunnerClient,
         git: GitExtension,

--- a/src/apprunner/wizards/imageRepositoryWizard.ts
+++ b/src/apprunner/wizards/imageRepositoryWizard.ts
@@ -236,7 +236,7 @@ function createImageRepositorySubForm(
     )
 
     function isPublic(imageRepo: string): boolean {
-        return imageRepo.search(/^public.ecr.aws/) !== -1
+        return imageRepo.search(/^public.ecr.aws/) !== -1;
     }
 
     form.ImageRepositoryType.setDefault(state =>

--- a/src/apprunner/wizards/imageRepositoryWizard.ts
+++ b/src/apprunner/wizards/imageRepositoryWizard.ts
@@ -4,7 +4,8 @@
  */
 
 import * as vscode from 'vscode'
-import { AppRunner, IAM } from 'aws-sdk'
+import { ImageRepository, SourceConfiguration } from "@aws-sdk/client-apprunner";
+import { Role } from "@aws-sdk/client-iam";
 import { createCommonButtons, QuickInputButton, QuickInputToggleButton } from '../../shared/ui/buttons'
 import { toArrayAsync } from '../../shared/utilities/collectionUtils'
 import { EcrClient, EcrRepository } from '../../shared/clients/ecrClient'
@@ -37,7 +38,7 @@ interface ImagePrompterOptions {
     extraButtons?: QuickInputButton<void | WizardControl>
 }
 
-function createEcrRole(client: IamClient): Promise<IAM.Role> {
+function createEcrRole(client: IamClient): Promise<Role> {
     const policy = {
         Version: '2008-10-17',
         Statement: [
@@ -221,7 +222,7 @@ export class ImageIdentifierForm extends WizardForm<{ repo: TaggedEcrRepository 
 function createImageRepositorySubForm(
     ecrClient: EcrClient,
     autoDeployButton: QuickInputToggleButton
-): WizardForm<AppRunner.ImageRepository> {
+): WizardForm<ImageRepository> {
     const subform = new WizardForm<AppRunner.ImageRepository>()
     const form = subform.body
 
@@ -251,7 +252,7 @@ function createImageRepositorySubForm(
     return subform
 }
 
-export class AppRunnerImageRepositoryWizard extends Wizard<AppRunner.SourceConfiguration> {
+export class AppRunnerImageRepositoryWizard extends Wizard<SourceConfiguration> {
     constructor(ecrClient: EcrClient, iamClient: IamClient, autoDeployButton = makeDeploymentButton()) {
         super()
         const form = this.form

--- a/src/cloudWatchLogs/commands/searchLogGroup.ts
+++ b/src/cloudWatchLogs/commands/searchLogGroup.ts
@@ -21,7 +21,7 @@ import { DefaultCloudWatchLogsClient } from '../../shared/clients/cloudWatchLogs
 import { CancellationError } from '../../shared/utilities/timeoutUtils'
 import { getLogger } from '../../shared/logger'
 import { TimeFilterResponse, TimeFilterSubmenu } from '../timeFilterSubmenu'
-import { CloudWatchLogs } from 'aws-sdk'
+import { LogGroup } from "@aws-sdk/client-cloudwatch-logs";
 import { ExtendedInputBoxOptions, InputBox, InputBoxPrompter } from '../../shared/ui/inputPrompter'
 import { RegionSubmenu, RegionSubmenuResponse } from '../../shared/ui/common/regionSubmenu'
 import { truncate } from '../../shared/utilities/textUtilities'
@@ -120,7 +120,7 @@ async function getLogGroupsFromRegion(regionCode: string): Promise<DataQuickPick
     return options
 }
 
-async function logGroupsToArray(logGroups: AsyncIterableIterator<CloudWatchLogs.LogGroup>): Promise<string[]> {
+async function logGroupsToArray(logGroups: AsyncIterableIterator<LogGroup>): Promise<string[]> {
     const logGroupsArray = []
     for await (const logGroupObject of logGroups) {
         logGroupObject.logGroupName && logGroupsArray.push(logGroupObject.logGroupName)

--- a/src/cloudWatchLogs/commands/viewLogStream.ts
+++ b/src/cloudWatchLogs/commands/viewLogStream.ts
@@ -11,7 +11,7 @@ import moment from 'moment'
 import * as picker from '../../shared/ui/picker'
 import { MultiStepWizard, WIZARD_RETRY, WIZARD_TERMINATE, WizardStep } from '../../shared/wizards/multiStepWizard'
 import { LogGroupNode } from '../explorer/logGroupNode'
-import { CloudWatchLogs } from 'aws-sdk'
+import { DescribeLogStreamsCommandInput, DescribeLogStreamsCommandOutput } from "@aws-sdk/client-cloudwatch-logs";
 
 import { DefaultCloudWatchLogsClient } from '../../shared/clients/cloudWatchLogsClient'
 import { LOCALIZED_DATE_FORMAT } from '../../shared/constants'
@@ -81,7 +81,7 @@ export class DefaultSelectLogStreamWizardContext implements SelectLogStreamWizar
 
     public async pickLogStream(): Promise<LogSearchChoice> {
         const client = new DefaultCloudWatchLogsClient(this.regionCode)
-        const request: CloudWatchLogs.DescribeLogStreamsRequest = {
+        const request: DescribeLogStreamsCommandInput = {
             logGroupName: this.logGroupName,
             orderBy: 'LastEventTime',
             descending: true,
@@ -179,7 +179,7 @@ export class DefaultSelectLogStreamWizardContext implements SelectLogStreamWizar
 }
 
 export function convertDescribeLogToQuickPickItems(
-    response: CloudWatchLogs.DescribeLogStreamsResponse
+    response: DescribeLogStreamsCommandOutput
 ): vscode.QuickPickItem[] {
     return (response.logStreams ?? []).map<vscode.QuickPickItem>(stream => ({
         label: stream.logStreamName!,

--- a/src/cloudWatchLogs/explorer/cloudWatchLogsNode.ts
+++ b/src/cloudWatchLogs/explorer/cloudWatchLogsNode.ts
@@ -6,7 +6,7 @@
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
-import { CloudWatchLogs } from 'aws-sdk'
+import { LogGroup } from "@aws-sdk/client-cloudwatch-logs";
 import * as vscode from 'vscode'
 
 import { DefaultCloudWatchLogsClient } from '../../shared/clients/cloudWatchLogsClient'
@@ -30,7 +30,7 @@ export abstract class CloudWatchLogsBase extends AWSTreeNodeBase {
         this.logGroupNodes = new Map<string, LogGroupNode>()
     }
 
-    protected abstract getLogGroups(client: DefaultCloudWatchLogsClient): Promise<Map<string, CloudWatchLogs.LogGroup>>
+    protected abstract getLogGroups(client: DefaultCloudWatchLogsClient): Promise<Map<string, LogGroup>>
 
     public override async getChildren(): Promise<AWSTreeNodeBase[]> {
         return await makeChildrenNodes({
@@ -63,7 +63,7 @@ export class CloudWatchLogsNode extends CloudWatchLogsBase {
         this.contextValue = 'awsCloudWatchLogParentNode'
     }
 
-    protected async getLogGroups(client: DefaultCloudWatchLogsClient): Promise<Map<string, CloudWatchLogs.LogGroup>> {
+    protected async getLogGroups(client: DefaultCloudWatchLogsClient): Promise<Map<string, LogGroup>> {
         return toMap(await toArrayAsync(client.describeLogGroups()), configuration => configuration.logGroupName)
     }
 }

--- a/src/cloudWatchLogs/explorer/logGroupNode.ts
+++ b/src/cloudWatchLogs/explorer/logGroupNode.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CloudWatchLogs } from 'aws-sdk'
+
+
+import { LogGroup } from "@aws-sdk/client-cloudwatch-logs";
 import * as os from 'os'
 import { AWSResourceNode } from '../../shared/treeview/nodes/awsResourceNode'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
@@ -13,7 +15,7 @@ import { localize } from '../../shared/utilities/vsCodeUtils'
 export const contextValueCloudwatchLog = 'awsCloudWatchLogNode'
 
 export class LogGroupNode extends AWSTreeNodeBase implements AWSResourceNode {
-    public constructor(public override readonly regionCode: string, public logGroup: CloudWatchLogs.LogGroup) {
+    public constructor(public override readonly regionCode: string, public logGroup: LogGroup) {
         super('')
         this.update(logGroup)
         this.iconPath = getIcon('aws-cloudwatch-log-group')
@@ -25,7 +27,7 @@ export class LogGroupNode extends AWSTreeNodeBase implements AWSResourceNode {
         }
     }
 
-    public update(logGroup: CloudWatchLogs.LogGroup): void {
+    public update(logGroup: LogGroup): void {
         this.logGroup = logGroup
         this.label = this.logGroup.logGroupName || ''
         this.tooltip = `${this.logGroup.logGroupName}${os.EOL}${this.logGroup.arn}`

--- a/src/cloudWatchLogs/registry/logDataRegistry.ts
+++ b/src/cloudWatchLogs/registry/logDataRegistry.ts
@@ -4,7 +4,7 @@
  */
 
 import * as vscode from 'vscode'
-import { CloudWatchLogs } from 'aws-sdk'
+import { FilteredLogEvent, FilterLogEventsCommandInput, OutputLogEvent } from "@aws-sdk/client-cloudwatch-logs";
 import { CloudWatchLogsSettings, parseCloudWatchLogsUri, uriToKey, msgKey } from '../cloudWatchLogsUtils'
 import { DefaultCloudWatchLogsClient } from '../../shared/clients/cloudWatchLogsClient'
 import { waitTimeout } from '../../shared/utilities/timeoutUtils'
@@ -214,7 +214,7 @@ export async function filterLogEventsFromUri(
 ): Promise<CloudWatchLogsResponse> {
     const client = new DefaultCloudWatchLogsClient(logGroupInfo.regionName)
 
-    const cwlParameters: CloudWatchLogs.FilterLogEventsRequest = {
+    const cwlParameters: FilterLogEventsCommandInput = {
         logGroupName: logGroupInfo.groupName,
         filterPattern: parameters.filterPattern,
         nextToken,
@@ -296,9 +296,9 @@ export type CloudWatchLogsParameters = {
 }
 
 export type CloudWatchLogsResponse = {
-    events: CloudWatchLogs.FilteredLogEvents
-    nextForwardToken?: CloudWatchLogs.NextToken
-    nextBackwardToken?: CloudWatchLogs.NextToken
+    events: Array<FilteredLogEvent>
+    nextForwardToken?: string
+    nextBackwardToken?: string
 }
 
 export type CloudWatchLogsAction = (
@@ -307,7 +307,7 @@ export type CloudWatchLogsAction = (
     nextToken?: string
 ) => Promise<CloudWatchLogsResponse>
 
-export type CloudWatchLogsEvent = CloudWatchLogs.OutputLogEvent & {
+export type CloudWatchLogsEvent = OutputLogEvent & {
     logStreamName?: string
     eventId?: string
 }
@@ -318,10 +318,10 @@ export class CloudWatchLogsData {
     logGroupInfo!: CloudWatchLogsGroupInfo
     retrieveLogsFunction!: CloudWatchLogsAction
     next?: {
-        token: CloudWatchLogs.NextToken
+        token: string
     }
     previous?: {
-        token: CloudWatchLogs.NextToken
+        token: string
     }
     busy: boolean = false
 }

--- a/src/codecatalyst/commands.ts
+++ b/src/codecatalyst/commands.ts
@@ -22,7 +22,7 @@ import { ToolkitError, errorCode } from '../shared/errors'
 import { telemetry } from '../shared/telemetry/telemetry'
 import { showConfirmationMessage } from '../shared/utilities/messages'
 import { AccountStatus } from '../shared/telemetry/telemetryClient'
-import { CreateDevEnvironmentRequest, UpdateDevEnvironmentRequest } from 'aws-sdk/clients/codecatalyst'
+import { CreateDevEnvironmentCommandInput, UpdateDevEnvironmentCommandInput } from "@aws-sdk/client-codecatalyst";
 import { Auth } from '../auth/auth'
 import { SsoConnection } from '../auth/connection'
 
@@ -109,12 +109,12 @@ export async function deleteDevEnv(client: CodeCatalystClient, devenv: DevEnviro
 }
 
 export type DevEnvironmentSettings = Pick<
-    CreateDevEnvironmentRequest,
+    CreateDevEnvironmentCommandInput,
     'alias' | 'instanceType' | 'inactivityTimeoutMinutes' | 'persistentStorage'
 >
 
 export type UpdateDevEnvironmentSettings = Pick<
-    UpdateDevEnvironmentRequest,
+    UpdateDevEnvironmentCommandInput,
     'alias' | 'instanceType' | 'inactivityTimeoutMinutes'
 >
 

--- a/src/codecatalyst/utils.ts
+++ b/src/codecatalyst/utils.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Ides } from 'aws-sdk/clients/codecatalyst'
+
+
+import { Ide } from "@aws-sdk/client-codecatalyst";
 import * as vscode from 'vscode'
 import { CodeCatalystResource, getCodeCatalystConfig } from '../shared/clients/codecatalystClient'
 import { pushIf } from '../shared/utilities/collectionUtils'
@@ -55,7 +57,7 @@ export function openCodeCatalystUrl(o: CodeCatalystResource) {
 }
 
 /** Returns true if the dev env has a "vscode" IDE runtime. */
-export function isDevenvVscode(ides: Ides | undefined): boolean {
+export function isDevenvVscode(ides: Array<Ide> | undefined): boolean {
     return ides !== undefined && ides.findIndex(ide => ide.name === 'VSCode') !== -1
 }
 

--- a/src/codecatalyst/vue/create/backend.ts
+++ b/src/codecatalyst/vue/create/backend.ts
@@ -33,7 +33,7 @@ import { isCloud9 } from '../../../shared/extensionUtilities'
 import { telemetry } from '../../../shared/telemetry/telemetry'
 import { isNonNullable } from '../../../shared/utilities/tsUtils'
 import { createOrgPrompter, createProjectPrompter } from '../../wizards/selectResource'
-import { GetSourceRepositoryCloneUrlsRequest } from 'aws-sdk/clients/codecatalyst'
+import { GetSourceRepositoryCloneUrlsCommandInput } from "@aws-sdk/client-codecatalyst";
 import { QuickPickPrompter } from '../../../shared/ui/pickerPrompter'
 
 interface LinkedResponse {
@@ -135,7 +135,7 @@ export class CodeCatalystCreateWebview extends VueWebview {
         return branches.flatten().promise()
     }
 
-    public isThirdPartyRepo(codeCatalystRepo: GetSourceRepositoryCloneUrlsRequest): Promise<boolean> {
+    public isThirdPartyRepo(codeCatalystRepo: GetSourceRepositoryCloneUrlsCommandInput): Promise<boolean> {
         return isThirdPartyRepo(this.client, codeCatalystRepo)
     }
 

--- a/src/codewhisperer/client/codewhisperer.ts
+++ b/src/codewhisperer/client/codewhisperer.ts
@@ -101,7 +101,7 @@ export class DefaultCodeWhispererClient {
                 ],
             } as ServiceOptions,
             undefined
-        )) as CodeWhispererClient
+        )) as CodeWhispererClient;
     }
 
     async createUserSdkClient(): Promise<CodeWhispererUserClient> {

--- a/src/dynamicResources/commands/saveResource.ts
+++ b/src/dynamicResources/commands/saveResource.ts
@@ -13,7 +13,7 @@ import { ResourceNode } from '../explorer/nodes/resourceNode'
 import { ResourceTypeNode } from '../explorer/nodes/resourceTypeNode'
 import { AwsResourceManager } from '../awsResourceManager'
 import { CloudControlClient } from '../../shared/clients/cloudControlClient'
-import { CloudControl } from 'aws-sdk'
+import { ResourceDescription } from "@aws-sdk/client-cloudcontrol";
 import globals from '../../shared/extensionGlobals'
 import { telemetry } from '../../shared/telemetry/telemetry'
 
@@ -224,7 +224,7 @@ export async function updateResource(
     )
 }
 
-function computeDiff(currentDefinition: CloudControl.ResourceDescription, updatedDefinition: string): Operation[] {
+function computeDiff(currentDefinition: ResourceDescription, updatedDefinition: string): Operation[] {
     const current = JSON.parse(currentDefinition.Properties!)
     const updated = JSON.parse(updatedDefinition)
     return compare(current, updated)

--- a/src/dynamicResources/explorer/nodes/resourceTypeNode.ts
+++ b/src/dynamicResources/explorer/nodes/resourceTypeNode.ts
@@ -15,7 +15,7 @@ import { localize } from '../../../shared/utilities/vsCodeUtils'
 import { ResourcesNode } from './resourcesNode'
 import { ResourceNode } from './resourceNode'
 import { Result } from '../../../shared/telemetry/telemetry'
-import { CloudControl } from 'aws-sdk'
+import { ResourceDescription } from "@aws-sdk/client-cloudcontrol";
 import { ResourceTypeMetadata } from '../../model/resources'
 import { DefaultS3Client } from '../../../shared/clients/s3Client'
 import { telemetry } from '../../../shared/telemetry/telemetry'
@@ -124,7 +124,7 @@ export class ResourceTypeNode extends AWSTreeNodeBase implements LoadMoreNode {
 
             newResources = response.ResourceDescriptions
                 ? response.ResourceDescriptions.reduce(
-                      (accumulator: ResourceNode[], current: CloudControl.ResourceDescription) => {
+                      (accumulator: ResourceNode[], current: ResourceDescription) => {
                           if (current.Identifier) {
                               accumulator.push(new ResourceNode(this, current.Identifier, this.childContextValue))
                           }

--- a/src/dynamicResources/explorer/nodes/resourcesNode.ts
+++ b/src/dynamicResources/explorer/nodes/resourcesNode.ts
@@ -11,7 +11,7 @@ import { PlaceholderNode } from '../../../shared/treeview/nodes/placeholderNode'
 import { makeChildrenNodes } from '../../../shared/treeview/utils'
 import { toArrayAsync, updateInPlace } from '../../../shared/utilities/collectionUtils'
 import { ResourceTypeNode } from './resourceTypeNode'
-import { CloudFormation } from 'aws-sdk'
+import { TypeSummary } from "@aws-sdk/client-cloudformation";
 import { CloudControlClient, DefaultCloudControlClient } from '../../../shared/clients/cloudControlClient'
 import { memoizedGetResourceTypes, ResourceTypeMetadata } from '../../model/resources'
 import { isCloud9 } from '../../../shared/extensionUtilities'
@@ -64,7 +64,7 @@ export class ResourcesNode extends AWSTreeNodeBase {
         const types = await toArrayAsync(this.cloudFormation.listTypes())
         types.sort((a, b) => (a.LastUpdated?.getTime() ?? 0) - (b.LastUpdated?.getTime() ?? 0))
 
-        const availableTypes: Map<string, CloudFormation.TypeSummary> = new Map()
+        const availableTypes: Map<string, TypeSummary> = new Map()
         for (const type of types) {
             if (type.TypeName) {
                 availableTypes.set(type.TypeName!, type)

--- a/src/ec2/model.ts
+++ b/src/ec2/model.ts
@@ -4,8 +4,8 @@
  */
 import * as vscode from 'vscode'
 import * as path from 'path'
-import { Session } from 'aws-sdk/clients/ssm'
-import { IAM, SSM } from 'aws-sdk'
+import { Session, StartSessionCommandOutput } from "@aws-sdk/client-ssm";
+import { Role } from "@aws-sdk/client-iam";
 import { Ec2Selection } from './prompter'
 import { getOrInstallCli } from '../shared/utilities/cliUtils'
 import { isCloud9 } from '../shared/extensionUtilities'
@@ -61,7 +61,7 @@ export class Ec2ConnectionManager {
         return new DefaultIamClient(this.regionCode)
     }
 
-    public async getAttachedIamRole(instanceId: string): Promise<IAM.Role | undefined> {
+    public async getAttachedIamRole(instanceId: string): Promise<Role | undefined> {
         const IamInstanceProfile = await this.ec2Client.getAttachedIamInstanceProfile(instanceId)
         if (IamInstanceProfile && IamInstanceProfile.Arn) {
             const IamRole = await this.iamClient.getIAMRoleFromInstanceProfile(IamInstanceProfile.Arn)
@@ -265,7 +265,7 @@ export class Ec2ConnectionManager {
     }
 }
 
-function getEc2SsmEnv(selection: Ec2Selection, ssmPath: string, session: SSM.StartSessionResponse): NodeJS.ProcessEnv {
+function getEc2SsmEnv(selection: Ec2Selection, ssmPath: string, session: StartSessionCommandOutput): NodeJS.ProcessEnv {
     return Object.assign(
         {
             AWS_REGION: selection.region,

--- a/src/ecs/model.ts
+++ b/src/ecs/model.ts
@@ -7,7 +7,7 @@ import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
 import * as vscode from 'vscode'
-import { ECS } from 'aws-sdk'
+import { Cluster, Service, Task } from "@aws-sdk/client-ecs";
 import { DefaultEcsClient } from '../shared/clients/ecsClient'
 import { ResourceTreeNode } from '../shared/treeview/resource'
 import { getIcon } from '../shared/icons'
@@ -15,13 +15,13 @@ import { AsyncCollection } from '../shared/utilities/asyncCollection'
 import { prepareCommand } from './util'
 
 function createValidTaskFilter(containerName: string) {
-    return function (t: ECS.Task): t is ECS.Task & { taskArn: string } {
+    return function (t: Task): t is Task & { taskArn: string } {
         const managed = !!t.containers?.find(
             c => c?.name === containerName && c.managedAgents?.find(a => a.name === 'ExecuteCommandAgent')
         )
 
         return t.taskArn !== undefined && managed
-    }
+    };
 }
 
 interface ContainerDescription extends ECS.ContainerDefinition {
@@ -80,7 +80,7 @@ export class Service {
     private readonly onDidChangeEmitter = new vscode.EventEmitter<void>()
     public readonly onDidChangeTreeItem = this.onDidChangeEmitter.event
 
-    public constructor(private readonly client: DefaultEcsClient, public readonly description: ECS.Service) {}
+    public constructor(private readonly client: DefaultEcsClient, public readonly description: Service) {}
 
     public async listContainers(): Promise<Container[]> {
         const definition = await this.getDefinition()
@@ -149,7 +149,7 @@ export class Service {
 export class Cluster {
     public readonly id = this.cluster.clusterArn!
 
-    public constructor(private readonly client: DefaultEcsClient, private readonly cluster: ECS.Cluster) {}
+    public constructor(private readonly client: DefaultEcsClient, private readonly cluster: Cluster) {}
 
     public listServices(): AsyncCollection<Service[]> {
         return this.client

--- a/src/ecs/util.ts
+++ b/src/ecs/util.ts
@@ -13,7 +13,7 @@ import { IamClient } from '../shared/clients/iamClient'
 import { ToolkitError } from '../shared/errors'
 import { isCloud9 } from '../shared/extensionUtilities'
 import { getOrInstallCli } from '../shared/utilities/cliUtils'
-import { TaskDefinition } from 'aws-sdk/clients/ecs'
+import { TaskDefinition } from "@aws-sdk/client-ecs";
 import { getLogger } from '../shared/logger'
 import { fromExtensionManifest } from '../shared/settings'
 import { ecsTaskPermissionsUrl } from '../shared/constants'

--- a/src/ecs/util.ts
+++ b/src/ecs/util.ts
@@ -15,7 +15,6 @@ import { isCloud9 } from '../shared/extensionUtilities'
 import { getOrInstallCli } from '../shared/utilities/cliUtils'
 import { TaskDefinition } from 'aws-sdk/clients/ecs'
 import { getLogger } from '../shared/logger'
-import { SSM } from 'aws-sdk'
 import { fromExtensionManifest } from '../shared/settings'
 import { ecsTaskPermissionsUrl } from '../shared/constants'
 

--- a/src/eventSchemas/commands/downloadSchemaItemCode.ts
+++ b/src/eventSchemas/commands/downloadSchemaItemCode.ts
@@ -5,7 +5,7 @@
 
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
-import { Schemas } from 'aws-sdk'
+import { PutCodeBindingCommandOutput } from "@aws-sdk/client-schemas";
 import fs = require('fs')
 import path = require('path')
 import * as vscode from 'vscode'
@@ -182,8 +182,8 @@ export class CodeGenerator {
 
     public async generate(
         codeDownloadRequest: SchemaCodeDownloadRequestDetails
-    ): Promise<Schemas.PutCodeBindingResponse> {
-        let response: Schemas.PutCodeBindingResponse
+    ): Promise<PutCodeBindingCommandOutput> {
+        let response: PutCodeBindingCommandOutput
         try {
             response = await this.client.putCodeBinding(
                 codeDownloadRequest.language,

--- a/src/eventSchemas/explorer/registryItemNode.ts
+++ b/src/eventSchemas/explorer/registryItemNode.ts
@@ -6,7 +6,7 @@
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
-import { Schemas } from 'aws-sdk'
+import { RegistrySummary } from "@aws-sdk/client-schemas";
 import * as os from 'os'
 import * as vscode from 'vscode'
 
@@ -24,7 +24,7 @@ export class RegistryItemNode extends AWSTreeNodeBase {
     private readonly schemaNodes: Map<string, SchemaItemNode>
     public override readonly regionCode: string = this.client.regionCode
 
-    public constructor(private registryItemOutput: Schemas.RegistrySummary, private readonly client: SchemaClient) {
+    public constructor(private registryItemOutput: RegistrySummary, private readonly client: SchemaClient) {
         super('', vscode.TreeItemCollapsibleState.Collapsed)
 
         this.update(registryItemOutput)
@@ -53,7 +53,7 @@ export class RegistryItemNode extends AWSTreeNodeBase {
         })
     }
 
-    public update(registryItemOutput: Schemas.RegistrySummary): void {
+    public update(registryItemOutput: RegistrySummary): void {
         this.registryItemOutput = registryItemOutput
         this.label = `${this.registryName}`
         let registryArn = ''

--- a/src/eventSchemas/explorer/schemaItemNode.ts
+++ b/src/eventSchemas/explorer/schemaItemNode.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Schemas } from 'aws-sdk'
+
+
+import { SchemaSummary, SchemaVersionSummary } from "@aws-sdk/client-schemas";
 
 import * as os from 'os'
 import { SchemaClient } from '../../shared/clients/schemaClient'
@@ -15,7 +17,7 @@ import { localize } from '../../shared/utilities/vsCodeUtils'
 
 export class SchemaItemNode extends AWSTreeNodeBase {
     public constructor(
-        private schemaItem: Schemas.SchemaSummary,
+        private schemaItem: SchemaSummary,
         public readonly client: SchemaClient,
         public readonly registryName: string
     ) {
@@ -30,7 +32,7 @@ export class SchemaItemNode extends AWSTreeNodeBase {
         }
     }
 
-    public update(schemaItem: Schemas.SchemaSummary): void {
+    public update(schemaItem: SchemaSummary): void {
         this.schemaItem = schemaItem
         this.label = this.schemaItem.SchemaName || ''
         let schemaArn = ''
@@ -50,7 +52,7 @@ export class SchemaItemNode extends AWSTreeNodeBase {
         return response.Content!
     }
 
-    public async listSchemaVersions(): Promise<Schemas.SchemaVersionSummary[]> {
+    public async listSchemaVersions(): Promise<SchemaVersionSummary[]> {
         const versions = await toArrayAsync(this.client.listSchemaVersions(this.registryName, this.schemaName))
 
         return versions

--- a/src/eventSchemas/models/schemaCodeLangs.ts
+++ b/src/eventSchemas/models/schemaCodeLangs.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Runtime } from 'aws-sdk/clients/lambda'
+
+
+import { Runtime } from "@aws-sdk/client-lambda";
 import { Set as ImmutableSet } from 'immutable'
 import { goRuntimes } from '../../lambda/models/samLambdaRuntime'
 

--- a/src/eventSchemas/providers/schemasDataProvider.ts
+++ b/src/eventSchemas/providers/schemasDataProvider.ts
@@ -4,7 +4,7 @@
  */
 
 import * as AWS from '@aws-sdk/types'
-import { Schemas } from 'aws-sdk'
+import { SchemaSummary } from "@aws-sdk/client-schemas";
 import { SchemaClient } from '../../shared/clients/schemaClient'
 import { getLogger, Logger } from '../../shared/logger'
 import { toArrayAsync } from '../../shared/utilities/collectionUtils'
@@ -26,7 +26,7 @@ export interface regionRegistryMap {
 
 export interface registrySchemasMap {
     registryName: string
-    schemaList: Schemas.SchemaSummary[]
+    schemaList: SchemaSummary[]
 }
 
 /**

--- a/src/eventSchemas/utils.ts
+++ b/src/eventSchemas/utils.ts
@@ -6,11 +6,11 @@
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
-import { Schemas } from 'aws-sdk'
+import { RegistrySummary, SchemaSummary, SearchSchemaSummary } from "@aws-sdk/client-schemas";
 import * as vscode from 'vscode'
 import { SchemaClient } from '../shared/clients/schemaClient'
 
-export async function* listRegistryItems(client: SchemaClient): AsyncIterableIterator<Schemas.RegistrySummary> {
+export async function* listRegistryItems(client: SchemaClient): AsyncIterableIterator<RegistrySummary> {
     const status = vscode.window.setStatusBarMessage(
         localize('AWS.message.statusBar.loading.registries', 'Loading Registry Items...')
     )
@@ -25,7 +25,7 @@ export async function* listRegistryItems(client: SchemaClient): AsyncIterableIte
 export async function* listSchemaItems(
     client: SchemaClient,
     registryName: string
-): AsyncIterableIterator<Schemas.SchemaSummary> {
+): AsyncIterableIterator<SchemaSummary> {
     const status = vscode.window.setStatusBarMessage(
         localize('AWS.message.statusBar.loading.schemaItems', 'Loading Schema Items...')
     )
@@ -41,7 +41,7 @@ export async function* searchSchemas(
     client: SchemaClient,
     keyword: string,
     registryName: string
-): AsyncIterableIterator<Schemas.SearchSchemaSummary> {
+): AsyncIterableIterator<SearchSchemaSummary> {
     const status = vscode.window.setStatusBarMessage(
         localize('AWS.message.statusBar.searching.schemas', 'Searching Schemas...')
     )

--- a/src/eventSchemas/vue/searchSchemas.ts
+++ b/src/eventSchemas/vue/searchSchemas.ts
@@ -5,7 +5,7 @@
 
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
-import { Schemas } from 'aws-sdk'
+import { SchemaSummary, SearchSchemaSummary } from "@aws-sdk/client-schemas";
 import * as vscode from 'vscode'
 import { downloadSchemaItemCode } from '../commands/downloadSchemaItemCode'
 import { RegistryItemNode } from '../explorer/registryItemNode'
@@ -93,7 +93,7 @@ export class SearchSchemasWebview extends VueWebview {
     }
 
     public async downloadCodeBindings(summary: SchemaVersionedSummary) {
-        const schemaItem: Schemas.SchemaSummary = {
+        const schemaItem: SchemaSummary = {
             SchemaName: getSchemaNameFromTitle(summary.Title),
         }
         const schemaItemNode = new SchemaItemNode(schemaItem, this.client, summary.RegistryName)
@@ -226,7 +226,7 @@ export async function getSearchResults(
     return results
 }
 
-export function getSchemaVersionedSummary(searchSummary: Schemas.SearchSchemaSummary[], prefix: string) {
+export function getSchemaVersionedSummary(searchSummary: SearchSchemaSummary[], prefix: string) {
     const results = searchSummary.map(searchSchemaSummary => ({
         RegistryName: searchSchemaSummary.RegistryName!,
         Title: prefix.concat(searchSchemaSummary.SchemaName!),

--- a/src/iot/commands/attachCertificate.ts
+++ b/src/iot/commands/attachCertificate.ts
@@ -13,7 +13,7 @@ import { createQuickPick, DataQuickPickItem } from '../../shared/ui/pickerPrompt
 import { PromptResult } from '../../shared/ui/prompter'
 import { IotClient } from '../../shared/clients/iotClient'
 import { isValidResponse } from '../../shared/wizards/wizard'
-import { Iot } from 'aws-sdk'
+import { Certificate, ListCertificatesCommandOutput } from "@aws-sdk/client-iot";
 
 export type CertGen = typeof getCertList
 
@@ -58,8 +58,8 @@ export async function attachCertificateCommand(
 /**
  * Prompts the user to pick a certificate to attach.
  */
-async function promptForCert(iot: IotClient, certFetch: CertGen): Promise<PromptResult<Iot.Certificate>> {
-    const placeHolder: DataQuickPickItem<Iot.Certificate> = {
+async function promptForCert(iot: IotClient, certFetch: CertGen): Promise<PromptResult<Certificate>> {
+    const placeHolder: DataQuickPickItem<Certificate> = {
         label: 'No certificates found',
         data: undefined,
     }
@@ -76,10 +76,10 @@ async function promptForCert(iot: IotClient, certFetch: CertGen): Promise<Prompt
  */
 async function* getCertList(iot: IotClient) {
     let marker: string | undefined = undefined
-    let filteredCerts: Iot.Certificate[]
+    let filteredCerts: Certificate[]
     do {
         try {
-            const certResponse: Iot.ListCertificatesResponse = await iot.listCertificates({ marker })
+            const certResponse: ListCertificatesCommandOutput = await iot.listCertificates({ marker })
             marker = certResponse.nextMarker
 
             /* These fields should always be defined when using the above API,

--- a/src/iot/commands/attachPolicy.ts
+++ b/src/iot/commands/attachPolicy.ts
@@ -13,7 +13,7 @@ import { PromptResult } from '../../shared/ui/prompter'
 import { IotClient } from '../../shared/clients/iotClient'
 import { isValidResponse } from '../../shared/wizards/wizard'
 import { IotCertWithPoliciesNode, IotThingCertNode } from '../explorer/iotCertificateNode'
-import { Iot } from 'aws-sdk'
+import { ListPoliciesCommandOutput, Policy } from "@aws-sdk/client-iot";
 import { IotNode } from '../explorer/iotNodes'
 
 export type PolicyGen = typeof getPolicyList
@@ -71,8 +71,8 @@ function getBaseNode(node: IotThingCertNode | IotCertWithPoliciesNode): IotNode 
 /**
  * Prompts the user to pick a policy to attach.
  */
-async function promptForPolicy(iot: IotClient, policyFetch: PolicyGen): Promise<PromptResult<Iot.Policy>> {
-    const placeHolder: DataQuickPickItem<Iot.Policy> = {
+async function promptForPolicy(iot: IotClient, policyFetch: PolicyGen): Promise<PromptResult<Policy>> {
+    const placeHolder: DataQuickPickItem<Policy> = {
         label: 'No policies found',
         data: undefined,
     }
@@ -89,10 +89,10 @@ async function promptForPolicy(iot: IotClient, policyFetch: PolicyGen): Promise<
  */
 async function* getPolicyList(iot: IotClient) {
     let marker: string | undefined = undefined
-    let filteredPolicies: Iot.Policy[]
+    let filteredPolicies: Policy[]
     do {
         try {
-            const policyResponse: Iot.ListPoliciesResponse = await iot.listPolicies({ marker })
+            const policyResponse: ListPoliciesCommandOutput = await iot.listPolicies({ marker })
             marker = policyResponse.nextMarker
 
             /* The policy name and arn should always be defined when using the

--- a/src/iot/commands/createCert.ts
+++ b/src/iot/commands/createCert.ts
@@ -12,7 +12,7 @@ import { localize } from '../../shared/utilities/vsCodeUtils'
 import { showViewLogsMessage } from '../../shared/utilities/messages'
 import { IotCertsFolderNode } from '../explorer/iotCertFolderNode'
 import { fileExists } from '../../shared/filesystemUtilities'
-import { Iot } from 'aws-sdk'
+import { CreateKeysAndCertificateCommandOutput } from "@aws-sdk/client-iot";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const MODE_RW_R_R = 0o644 //File permission 0644 rw-r--r-- for PEM files.
@@ -36,7 +36,7 @@ export async function createCertificateCommand(
         return
     }
 
-    let certificate: Iot.CreateKeysAndCertificateResponse
+    let certificate: CreateKeysAndCertificateCommandOutput
 
     try {
         certificate = await node.iot.createCertificateAndKeys({

--- a/src/iot/explorer/iotPolicyNode.ts
+++ b/src/iot/explorer/iotPolicyNode.ts
@@ -4,7 +4,7 @@
  */
 
 import * as vscode from 'vscode'
-import { Iot } from 'aws-sdk'
+import { PolicyVersion } from "@aws-sdk/client-iot";
 import { IotClient, IotPolicy } from '../../shared/clients/iotClient'
 
 import { AWSResourceNode } from '../../shared/treeview/nodes/awsResourceNode'
@@ -101,7 +101,7 @@ export class IotPolicyWithVersionsNode extends IotPolicyNode {
     }
 
     public async updateChildren(): Promise<void> {
-        const versions: Map<string, Iot.PolicyVersion> = toMap(
+        const versions: Map<string, PolicyVersion> = toMap(
             await toArrayAsync(this.iot.listPolicyVersions({ policyName: this.policy.name })),
             version => version.versionId
         )

--- a/src/iot/explorer/iotPolicyVersionNode.ts
+++ b/src/iot/explorer/iotPolicyVersionNode.ts
@@ -4,7 +4,7 @@
  */
 
 import moment from 'moment'
-import { Iot } from 'aws-sdk'
+import { PolicyVersion } from "@aws-sdk/client-iot";
 import { IotClient, IotPolicy } from '../../shared/clients/iotClient'
 import { AWSResourceNode } from '../../shared/treeview/nodes/awsResourceNode'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'
@@ -21,7 +21,7 @@ import { LOCALIZED_DATE_FORMAT } from '../../shared/constants'
 export class IotPolicyVersionNode extends AWSTreeNodeBase implements AWSResourceNode {
     public constructor(
         public policy: IotPolicy,
-        public version: Iot.PolicyVersion,
+        public version: PolicyVersion,
         public isDefault: boolean,
         public readonly parent: IotPolicyWithVersionsNode,
         public readonly iot: IotClient,
@@ -38,7 +38,7 @@ export class IotPolicyVersionNode extends AWSTreeNodeBase implements AWSResource
         this.update(version)
     }
 
-    public update(version: Iot.PolicyVersion): void {
+    public update(version: PolicyVersion): void {
         this.version = version
         this.isDefault = version.isDefaultVersion ?? false
         this.tooltip = localize(

--- a/src/lambda/commands/copyLambdaUrl.ts
+++ b/src/lambda/commands/copyLambdaUrl.ts
@@ -10,7 +10,7 @@ import { copyToClipboard } from '../../shared/utilities/messages'
 import { addCodiconToString } from '../../shared/utilities/textUtilities'
 import { createQuickPick, QuickPickPrompter } from '../../shared/ui/pickerPrompter'
 import { isValidResponse } from '../../shared/wizards/wizard'
-import { FunctionUrlConfigList } from 'aws-sdk/clients/lambda'
+import { FunctionUrlConfig } from "@aws-sdk/client-lambda";
 import { CancellationError } from '../../shared/utilities/timeoutUtils'
 import { lambdaFunctionUrlConfigUrl } from '../../shared/constants'
 
@@ -40,7 +40,7 @@ export async function copyLambdaUrl(
     }
 }
 
-async function _quickPickUrl(configList: FunctionUrlConfigList): Promise<string | undefined> {
+async function _quickPickUrl(configList: Array<FunctionUrlConfig>): Promise<string | undefined> {
     const res = await createLambdaFuncUrlPrompter(configList).prompt()
     if (!isValidResponse(res)) {
         throw new CancellationError('user')
@@ -48,7 +48,7 @@ async function _quickPickUrl(configList: FunctionUrlConfigList): Promise<string 
     return res
 }
 
-export function createLambdaFuncUrlPrompter(configList: FunctionUrlConfigList): QuickPickPrompter<string> {
+export function createLambdaFuncUrlPrompter(configList: Array<FunctionUrlConfig>): QuickPickPrompter<string> {
     const items = configList.map(c => ({
         label: c.FunctionArn,
         data: c.FunctionUrl,

--- a/src/lambda/commands/deleteLambda.ts
+++ b/src/lambda/commands/deleteLambda.ts
@@ -10,7 +10,7 @@ import * as localizedText from '../../shared/localizedText'
 import { DefaultLambdaClient } from '../../shared/clients/lambdaClient'
 import { Result } from '../../shared/telemetry/telemetry'
 import { showConfirmationMessage, showViewLogsMessage } from '../../shared/utilities/messages'
-import { FunctionConfiguration } from 'aws-sdk/clients/lambda'
+import { UpdateFunctionConfigurationCommandOutput } from "@aws-sdk/client-lambda";
 import { getLogger } from '../../shared/logger/logger'
 import { telemetry } from '../../shared/telemetry/telemetry'
 
@@ -27,7 +27,7 @@ async function confirmDeletion(functionName: string): Promise<boolean> {
 }
 
 export async function deleteLambda(
-    lambda: Pick<FunctionConfiguration, 'FunctionName'>,
+    lambda: Pick<UpdateFunctionConfigurationCommandOutput, 'FunctionName'>,
     client: Pick<DefaultLambdaClient, 'deleteFunction'>
 ): Promise<void> {
     if (!lambda.FunctionName) {

--- a/src/lambda/commands/uploadLambda.ts
+++ b/src/lambda/commands/uploadLambda.ts
@@ -32,7 +32,7 @@ import { StepEstimator, Wizard, WIZARD_BACK } from '../../shared/wizards/wizard'
 import { createSingleFileDialog } from '../../shared/ui/common/openDialog'
 import { Prompter, PromptResult } from '../../shared/ui/prompter'
 import { ToolkitError } from '../../shared/errors'
-import { FunctionConfiguration } from 'aws-sdk/clients/lambda'
+import { UpdateFunctionConfigurationCommandOutput } from "@aws-sdk/client-lambda";
 import globals from '../../shared/extensionGlobals'
 import { toArrayAsync } from '../../shared/utilities/collectionUtils'
 import { fromExtensionManifest } from '../../shared/settings'
@@ -79,7 +79,7 @@ class LambdaSettings extends fromExtensionManifest('aws.lambda', { recentlyUploa
 export interface LambdaFunction {
     readonly name: string
     readonly region: string
-    readonly configuration?: FunctionConfiguration
+    readonly configuration?: UpdateFunctionConfigurationCommandOutput
 }
 
 /**

--- a/src/lambda/explorer/lambdaFunctionNode.ts
+++ b/src/lambda/explorer/lambdaFunctionNode.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Lambda } from 'aws-sdk'
+
+
+import { UpdateFunctionConfigurationCommandOutput } from "@aws-sdk/client-lambda";
 import * as os from 'os'
 import { getIcon } from '../../shared/icons'
 
@@ -14,14 +16,14 @@ export class LambdaFunctionNode extends AWSTreeNodeBase implements AWSResourceNo
     public constructor(
         public readonly parent: AWSTreeNodeBase,
         public override readonly regionCode: string,
-        public configuration: Lambda.FunctionConfiguration
+        public configuration: UpdateFunctionConfigurationCommandOutput
     ) {
         super('')
         this.update(configuration)
         this.iconPath = getIcon('aws-lambda-function')
     }
 
-    public update(configuration: Lambda.FunctionConfiguration): void {
+    public update(configuration: UpdateFunctionConfigurationCommandOutput): void {
         this.configuration = configuration
         this.label = this.configuration.FunctionName || ''
         this.tooltip = `${this.configuration.FunctionName}${os.EOL}${this.configuration.FunctionArn}`

--- a/src/lambda/explorer/lambdaNodes.ts
+++ b/src/lambda/explorer/lambdaNodes.ts
@@ -6,7 +6,7 @@
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
-import { Lambda } from 'aws-sdk'
+import { UpdateFunctionConfigurationCommandOutput } from "@aws-sdk/client-lambda";
 import * as vscode from 'vscode'
 import { DefaultLambdaClient } from '../../shared/clients/lambdaClient'
 
@@ -51,7 +51,7 @@ export class LambdaNode extends AWSTreeNodeBase {
     }
 
     public async updateChildren(): Promise<void> {
-        const functions: Map<string, Lambda.FunctionConfiguration> = toMap(
+        const functions: Map<string, UpdateFunctionConfigurationCommandOutput> = toMap(
             await toArrayAsync(listLambdaFunctions(this.client)),
             configuration => configuration.FunctionName
         )
@@ -68,7 +68,7 @@ export class LambdaNode extends AWSTreeNodeBase {
 function makeLambdaFunctionNode(
     parent: AWSTreeNodeBase,
     regionCode: string,
-    configuration: Lambda.FunctionConfiguration
+    configuration: UpdateFunctionConfigurationCommandOutput
 ): LambdaFunctionNode {
     const node = new LambdaFunctionNode(parent, regionCode, configuration)
     node.contextValue = samLambdaImportableRuntimes.contains(node.configuration.Runtime ?? '')

--- a/src/lambda/models/samLambdaRuntime.ts
+++ b/src/lambda/models/samLambdaRuntime.ts
@@ -7,7 +7,7 @@ import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
 import * as vscode from 'vscode'
-import { Runtime } from 'aws-sdk/clients/lambda'
+import { Runtime } from "@aws-sdk/client-lambda";
 import { Map as ImmutableMap, Set as ImmutableSet } from 'immutable'
 import { isCloud9 } from '../../shared/extensionUtilities'
 import { PrompterButtons } from '../../shared/ui/buttons'

--- a/src/lambda/models/samTemplates.ts
+++ b/src/lambda/models/samTemplates.ts
@@ -6,7 +6,7 @@ import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
 import * as semver from 'semver'
-import { Runtime } from 'aws-sdk/clients/lambda'
+import { Runtime } from "@aws-sdk/client-lambda";
 import { Set as ImmutableSet } from 'immutable'
 import { supportsEventBridgeTemplates } from '../../../src/eventSchemas/models/schemaCodeLangs'
 import { RuntimePackageType } from './samLambdaRuntime'

--- a/src/lambda/utils.ts
+++ b/src/lambda/utils.ts
@@ -7,7 +7,8 @@ import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
 import xml2js = require('xml2js')
-import { CloudFormation, Lambda } from 'aws-sdk'
+import { StackSummary } from "@aws-sdk/client-cloudformation";
+import { UpdateFunctionConfigurationCommandOutput } from "@aws-sdk/client-lambda";
 import * as vscode from 'vscode'
 import { CloudFormationClient } from '../shared/clients/cloudFormationClient'
 import { LambdaClient } from '../shared/clients/lambdaClient'
@@ -22,7 +23,7 @@ import globals from '../shared/extensionGlobals'
 
 export async function* listCloudFormationStacks(
     client: CloudFormationClient
-): AsyncIterableIterator<CloudFormation.StackSummary> {
+): AsyncIterableIterator<StackSummary> {
     // TODO: this 'loading' message needs to go under each regional entry
     // in the explorer, and be removed when that region's query completes
     const status = vscode.window.setStatusBarMessage(
@@ -36,7 +37,7 @@ export async function* listCloudFormationStacks(
     }
 }
 
-export async function* listLambdaFunctions(client: LambdaClient): AsyncIterableIterator<Lambda.FunctionConfiguration> {
+export async function* listLambdaFunctions(client: LambdaClient): AsyncIterableIterator<UpdateFunctionConfigurationCommandOutput> {
     const status = vscode.window.setStatusBarMessage(
         localize('AWS.message.statusBar.loading.lambda', 'Loading Lambdas...')
     )
@@ -55,7 +56,7 @@ export async function* listLambdaFunctions(client: LambdaClient): AsyncIterableI
  * Only works for supported languages (Python/JS)
  * @param configuration Lambda configuration object from getFunction
  */
-export function getLambdaDetails(configuration: Lambda.FunctionConfiguration): {
+export function getLambdaDetails(configuration: UpdateFunctionConfigurationCommandOutput): {
     fileName: string
     functionName: string
 } {

--- a/src/lambda/vue/remoteInvoke/invokeLambda.ts
+++ b/src/lambda/vue/remoteInvoke/invokeLambda.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { _Blob } from 'aws-sdk/clients/lambda'
+
+
 import { readFileSync } from 'fs'
 import * as _ from 'lodash'
 import * as vscode from 'vscode'

--- a/src/lambda/wizards/samInitWizard.ts
+++ b/src/lambda/wizards/samInitWizard.ts
@@ -5,7 +5,7 @@
 
 import * as nls from 'vscode-nls'
 import * as AWS from '@aws-sdk/types'
-import { Runtime } from 'aws-sdk/clients/lambda'
+import { Runtime } from "@aws-sdk/client-lambda";
 import * as path from 'path'
 import * as vscode from 'vscode'
 import { SchemasDataProvider } from '../../eventSchemas/providers/schemasDataProvider'

--- a/src/redshift/explorer/redshiftWarehouseNode.ts
+++ b/src/redshift/explorer/redshiftWarehouseNode.ts
@@ -14,7 +14,7 @@ import { ChildNodeLoader, ChildNodePage } from '../../awsexplorer/childNodeLoade
 import { DefaultRedshiftClient } from '../../shared/clients/redshiftClient'
 import { ConnectionParams, ConnectionType, RedshiftWarehouseType } from '../models/models'
 import { RedshiftNodeConnectionWizard } from '../wizards/connectionWizard'
-import { ListDatabasesResponse } from 'aws-sdk/clients/redshiftdata'
+import { ListDatabasesCommandOutput } from "@aws-sdk/client-redshift-data";
 import { getIcon } from '../../shared/icons'
 import { AWSCommandTreeNode } from '../../shared/treeview/nodes/awsCommandTreeNode'
 import { telemetry } from '../../shared/telemetry/telemetry'
@@ -80,7 +80,7 @@ export class RedshiftWarehouseNode extends AWSTreeNodeBase implements AWSResourc
             const childNodes: RedshiftDatabaseNode[] = []
             // this.connectionParams cannot null here because loadPage should be called only after the connection wizard runs.
             try {
-                const listDatabasesResponse: ListDatabasesResponse = await this.redshiftClient.listDatabases(
+                const listDatabasesResponse: ListDatabasesCommandOutput = await this.redshiftClient.listDatabases(
                     this.connectionParams!,
                     token
                 )
@@ -101,7 +101,7 @@ export class RedshiftWarehouseNode extends AWSTreeNodeBase implements AWSResourc
                 createLogsConnectionMessage(this.redshiftWarehouse.name, error as Error)
                 return Promise.reject(error)
             }
-        })
+        });
     }
 
     public override async getChildren(): Promise<AWSTreeNodeBase[]> {

--- a/src/redshift/notebook/redshiftNotebookController.ts
+++ b/src/redshift/notebook/redshiftNotebookController.ts
@@ -7,7 +7,7 @@
 import * as vscode from 'vscode'
 import { DefaultRedshiftClient } from '../../shared/clients/redshiftClient'
 import { ConnectionParams } from '../models/models'
-import { RedshiftData } from 'aws-sdk'
+import { ColumnMetadata, Field } from "@aws-sdk/client-redshift-data";
 import { telemetry } from '../../shared/telemetry/telemetry'
 
 export class RedshiftNotebookController {
@@ -79,8 +79,8 @@ export class RedshiftNotebookController {
             }
 
             let executionId: string | undefined
-            let columnMetadata: RedshiftData.ColumnMetadataList | undefined
-            const records: RedshiftData.SqlRecords = []
+            let columnMetadata: Array<ColumnMetadata> | undefined
+            const records: Array<Array<Field>> = []
             let nextToken: string | undefined
             // get all the pages of the result
             do {
@@ -113,10 +113,10 @@ export class RedshiftNotebookController {
             } else {
                 throw Error('Result did not contain column metadata')
             }
-        })
+        });
     }
 
-    public getAsTable(connectionParams: ConnectionParams, columns: string[], records: RedshiftData.SqlRecords) {
+    public getAsTable(connectionParams: ConnectionParams, columns: string[], records: Array<Array<Field>>) {
         if (!records || records.length === 0) {
             return '<p>No records to display<p>'
         }

--- a/src/redshift/wizards/connectionWizard.ts
+++ b/src/redshift/wizards/connectionWizard.ts
@@ -14,9 +14,9 @@ import { DefaultRedshiftClient } from '../../shared/clients/redshiftClient'
 import { Region } from '../../shared/regions/endpoints'
 import { RegionProvider } from '../../shared/regions/regionProvider'
 import { createRegionPrompter } from '../../shared/ui/common/region'
-import { ClustersMessage } from 'aws-sdk/clients/redshift'
+import { DescribeClustersCommandOutput } from "@aws-sdk/client-redshift";
+import { ListSecretsCommandOutput } from "@aws-sdk/client-secrets-manager";
 import { Prompter } from '../../shared/ui/prompter'
-import { ListSecretsResponse } from 'aws-sdk/clients/secretsmanager'
 import { SecretsManagerClient } from '../../shared/clients/secretsManagerClient'
 import { redshiftHelpUrl } from '../../shared/constants'
 
@@ -212,7 +212,7 @@ async function* fetchWarehouses(redshiftClient: DefaultRedshiftClient) {
     let hasMoreProvisioned = true
     while (hasMoreProvisioned || hasMoreServerless) {
         if (hasMoreProvisioned) {
-            const provisionedResponse: ClustersMessage = await redshiftClient.describeProvisionedClusters(
+            const provisionedResponse: DescribeClustersCommandOutput = await redshiftClient.describeProvisionedClusters(
                 provisionedToken
             )
             provisionedToken = provisionedResponse.Marker
@@ -271,7 +271,7 @@ function getSecretPrompter(region: string): QuickPickPrompter<string> {
 
 async function* fetchSecretList(secretsManagerClient: SecretsManagerClient) {
     const secretFilter = 'Redshift'
-    const listSecretsResponse: ListSecretsResponse = await secretsManagerClient.listSecrets(secretFilter)
+    const listSecretsResponse: ListSecretsCommandOutput = await secretsManagerClient.listSecrets(secretFilter)
     if (listSecretsResponse.SecretList) {
         for await (const secret of listSecretsResponse.SecretList) {
             yield [

--- a/src/s3/commands/uploadFile.ts
+++ b/src/s3/commands/uploadFile.ts
@@ -7,7 +7,7 @@ import * as path from 'path'
 import * as mime from 'mime-types'
 import * as vscode from 'vscode'
 import { statSync } from 'fs'
-import { S3 } from 'aws-sdk'
+import { Bucket, ManagedUpload } from "@aws-sdk/client-s3";
 import { getLogger } from '../../shared/logger'
 import { S3Node } from '../explorer/s3Nodes'
 import { Commands } from '../../shared/vscode/commands'
@@ -39,7 +39,7 @@ interface UploadRequest {
     fileLocation: vscode.Uri
     fileSizeBytes: number
     s3Client: S3Client
-    ongoingUpload?: S3.ManagedUpload
+    ongoingUpload?: ManagedUpload
 }
 
 /**
@@ -390,7 +390,7 @@ async function uploadWithProgress(
 }
 
 export interface BucketQuickPickItem extends vscode.QuickPickItem {
-    bucket: S3.Bucket | undefined
+    bucket: Bucket | undefined
     folder?: Folder | undefined
 }
 
@@ -413,7 +413,7 @@ export async function promptUserForBucket(
     promptUserFunction = promptUser,
     createBucket = createBucketCommand
 ): Promise<BucketQuickPickItem | 'cancel' | 'back'> {
-    let allBuckets: S3.Bucket[]
+    let allBuckets: Bucket[]
     try {
         allBuckets = await s3client.listAllBuckets()
     } catch (e) {
@@ -426,7 +426,7 @@ export async function promptUserForBucket(
 
     const s3Buckets = allBuckets.filter(bucket => {
         return bucket && bucket.Name
-    }) as S3.Bucket[]
+    }) as Bucket[]
 
     const createNewBucket: BucketQuickPickItem = {
         label: localize('AWS.command.s3.createBucket', 'Create new bucket'),

--- a/src/shared/activationReloadState.ts
+++ b/src/shared/activationReloadState.ts
@@ -4,7 +4,7 @@
  */
 
 import * as vscode from 'vscode'
-import { Runtime } from 'aws-sdk/clients/lambda'
+import { Runtime } from "@aws-sdk/client-lambda";
 import globals from './extensionGlobals'
 
 export const activationTemplatePathKey = 'ACTIVATION_TEMPLATE_PATH_KEY'

--- a/src/shared/clients/apiGatewayClient.ts
+++ b/src/shared/clients/apiGatewayClient.ts
@@ -3,8 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { APIGateway } from 'aws-sdk'
-import { RestApi, Stages } from 'aws-sdk/clients/apigateway'
+
+
+import {
+    APIGateway,
+    GetResourcesCommandInput,
+    GetResourcesCommandOutput,
+    GetRestApisCommandInput,
+    GetRestApisCommandOutput,
+    GetStagesCommandOutput,
+    TestInvokeMethodCommandInput,
+    TestInvokeMethodCommandOutput,
+    UpdateResourceCommandOutput,
+    UpdateRestApiCommandOutput,
+} from "@aws-sdk/client-api-gateway";
+
 import globals from '../extensionGlobals'
 import { ClassToInterfaceType } from '../utilities/tsUtils'
 
@@ -12,15 +25,15 @@ export type ApiGatewayClient = ClassToInterfaceType<DefaultApiGatewayClient>
 export class DefaultApiGatewayClient {
     public constructor(public readonly regionCode: string) {}
 
-    public async *getResourcesForApi(apiId: string): AsyncIterableIterator<APIGateway.Resource> {
+    public async *getResourcesForApi(apiId: string): AsyncIterableIterator<UpdateResourceCommandOutput> {
         const client = await this.createSdkClient()
 
-        const request: APIGateway.GetResourcesRequest = {
+        const request: GetResourcesCommandInput = {
             restApiId: apiId,
         }
 
         do {
-            const response: APIGateway.Resources = await client.getResources(request).promise()
+            const response: GetResourcesCommandOutput = await client.getResources(request).promise()
 
             if (response.items !== undefined && response.items.length > 0) {
                 yield* response.items
@@ -30,23 +43,23 @@ export class DefaultApiGatewayClient {
         } while (request.position !== undefined)
     }
 
-    public async getStages(apiId: string): Promise<Stages> {
+    public async getStages(apiId: string): Promise<GetStagesCommandOutput> {
         const client = await this.createSdkClient()
 
-        const request: APIGateway.GetResourcesRequest = {
+        const request: GetResourcesCommandInput = {
             restApiId: apiId,
         }
 
         return client.getStages(request).promise()
     }
 
-    public async *listApis(): AsyncIterableIterator<RestApi> {
+    public async *listApis(): AsyncIterableIterator<UpdateRestApiCommandOutput> {
         const client = await this.createSdkClient()
 
-        const request: APIGateway.GetRestApisRequest = {}
+        const request: GetRestApisCommandInput = {}
 
         do {
-            const response: APIGateway.RestApis = await client.getRestApis(request).promise()
+            const response: GetRestApisCommandOutput = await client.getRestApis(request).promise()
 
             if (response.items !== undefined && response.items.length > 0) {
                 yield* response.items
@@ -62,9 +75,9 @@ export class DefaultApiGatewayClient {
         method: string,
         body: string,
         pathWithQueryString: string | undefined
-    ): Promise<APIGateway.TestInvokeMethodResponse> {
+    ): Promise<TestInvokeMethodCommandOutput> {
         const client = await this.createSdkClient()
-        const request: APIGateway.TestInvokeMethodRequest = {
+        const request: TestInvokeMethodCommandInput = {
             restApiId: apiId,
             resourceId: resourceId,
             httpMethod: method,

--- a/src/shared/clients/apprunnerClient.ts
+++ b/src/shared/clients/apprunnerClient.ts
@@ -3,7 +3,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AppRunner } from 'aws-sdk'
+
+
+import {
+    AppRunner,
+    CreateConnectionCommandInput,
+    CreateConnectionCommandOutput,
+    CreateServiceCommandInput,
+    CreateServiceCommandOutput,
+    DeleteServiceCommandInput,
+    DeleteServiceCommandOutput,
+    DescribeServiceCommandInput,
+    DescribeServiceCommandOutput,
+    ListConnectionsCommandInput,
+    ListConnectionsCommandOutput,
+    ListOperationsCommandInput,
+    ListOperationsCommandOutput,
+    ListServicesCommandInput,
+    ListServicesCommandOutput,
+    PauseServiceCommandInput,
+    PauseServiceCommandOutput,
+    ResumeServiceCommandInput,
+    ResumeServiceCommandOutput,
+    StartDeploymentCommandInput,
+    StartDeploymentCommandOutput,
+    UpdateServiceCommandInput,
+    UpdateServiceCommandOutput,
+} from "@aws-sdk/client-apprunner";
+
 import globals from '../extensionGlobals'
 
 import { ClassToInterfaceType } from '../utilities/tsUtils'
@@ -13,55 +40,55 @@ export type AppRunnerClient = ClassToInterfaceType<DefaultAppRunnerClient>
 export class DefaultAppRunnerClient {
     public constructor(public readonly regionCode: string) {}
 
-    public async createService(request: AppRunner.CreateServiceRequest): Promise<AppRunner.CreateServiceResponse> {
+    public async createService(request: CreateServiceCommandInput): Promise<CreateServiceCommandOutput> {
         return (await this.createSdkClient()).createService(request).promise()
     }
 
-    public async listServices(request: AppRunner.ListServicesRequest): Promise<AppRunner.ListServicesResponse> {
+    public async listServices(request: ListServicesCommandInput): Promise<ListServicesCommandOutput> {
         return (await this.createSdkClient()).listServices(request).promise()
     }
 
-    public async pauseService(request: AppRunner.PauseServiceRequest): Promise<AppRunner.PauseServiceResponse> {
+    public async pauseService(request: PauseServiceCommandInput): Promise<PauseServiceCommandOutput> {
         return (await this.createSdkClient()).pauseService(request).promise()
     }
 
-    public async resumeService(request: AppRunner.ResumeServiceRequest): Promise<AppRunner.ResumeServiceResponse> {
+    public async resumeService(request: ResumeServiceCommandInput): Promise<ResumeServiceCommandOutput> {
         return (await this.createSdkClient()).resumeService(request).promise()
     }
 
-    public async updateService(request: AppRunner.UpdateServiceRequest): Promise<AppRunner.UpdateServiceResponse> {
+    public async updateService(request: UpdateServiceCommandInput): Promise<UpdateServiceCommandOutput> {
         return (await this.createSdkClient()).updateService(request).promise()
     }
 
     public async createConnection(
-        request: AppRunner.CreateConnectionRequest
-    ): Promise<AppRunner.CreateConnectionResponse> {
+        request: CreateConnectionCommandInput
+    ): Promise<CreateConnectionCommandOutput> {
         return (await this.createSdkClient()).createConnection(request).promise()
     }
 
     public async listConnections(
-        request: AppRunner.ListConnectionsRequest = {}
-    ): Promise<AppRunner.ListConnectionsResponse> {
+        request: ListConnectionsCommandInput = {}
+    ): Promise<ListConnectionsCommandOutput> {
         return (await this.createSdkClient()).listConnections(request).promise()
     }
 
     public async describeService(
-        request: AppRunner.DescribeServiceRequest
-    ): Promise<AppRunner.DescribeServiceResponse> {
+        request: DescribeServiceCommandInput
+    ): Promise<DescribeServiceCommandOutput> {
         return (await this.createSdkClient()).describeService(request).promise()
     }
 
     public async startDeployment(
-        request: AppRunner.StartDeploymentRequest
-    ): Promise<AppRunner.StartDeploymentResponse> {
+        request: StartDeploymentCommandInput
+    ): Promise<StartDeploymentCommandOutput> {
         return (await this.createSdkClient()).startDeployment(request).promise()
     }
 
-    public async listOperations(request: AppRunner.ListOperationsRequest): Promise<AppRunner.ListOperationsResponse> {
+    public async listOperations(request: ListOperationsCommandInput): Promise<ListOperationsCommandOutput> {
         return (await this.createSdkClient()).listOperations(request).promise()
     }
 
-    public async deleteService(request: AppRunner.DeleteServiceRequest): Promise<AppRunner.DeleteServiceResponse> {
+    public async deleteService(request: DeleteServiceCommandInput): Promise<DeleteServiceCommandOutput> {
         return (await this.createSdkClient()).deleteService(request).promise()
     }
 

--- a/src/shared/clients/cloudControlClient.ts
+++ b/src/shared/clients/cloudControlClient.ts
@@ -3,7 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CloudControl } from 'aws-sdk'
+
+
+import {
+    CloudControl,
+    CreateResourceCommandInput,
+    CreateResourceCommandOutput,
+    DeleteResourceCommandInput,
+    GetResourceCommandInput,
+    GetResourceCommandOutput,
+    ListResourcesCommandInput,
+    ListResourcesCommandOutput,
+    ProgressEvent,
+    UpdateResourceCommandInput,
+} from "@aws-sdk/client-cloudcontrol";
+
 import globals from '../extensionGlobals'
 import { ClassToInterfaceType } from '../utilities/tsUtils'
 import { localize } from '../utilities/vsCodeUtils'
@@ -12,46 +26,46 @@ export type CloudControlClient = ClassToInterfaceType<DefaultCloudControlClient>
 export class DefaultCloudControlClient implements CloudControlClient {
     public constructor(public readonly regionCode: string) {}
 
-    public async createResource(request: CloudControl.CreateResourceInput): Promise<CloudControl.CreateResourceOutput> {
+    public async createResource(request: CreateResourceCommandInput): Promise<CreateResourceCommandOutput> {
         const client = await this.createSdkClient()
 
-        const createResponse = await client.createResource(request).promise()
+        const createResponse = await client.createResource(request)
 
         await this.pollForCompletion(client, createResponse.ProgressEvent!)
         return createResponse
     }
 
-    public async deleteResource(request: CloudControl.DeleteResourceInput): Promise<void> {
+    public async deleteResource(request: DeleteResourceCommandInput): Promise<void> {
         const client = await this.createSdkClient()
 
-        const deleteResponse = await client.deleteResource(request).promise()
+        const deleteResponse = await client.deleteResource(request)
 
         await this.pollForCompletion(client, deleteResponse.ProgressEvent!)
     }
 
-    public async listResources(request: CloudControl.ListResourcesInput): Promise<CloudControl.ListResourcesOutput> {
+    public async listResources(request: ListResourcesCommandInput): Promise<ListResourcesCommandOutput> {
         const client = await this.createSdkClient()
 
-        return await client.listResources(request).promise()
+        return await client.listResources(request);
     }
 
-    public async getResource(request: CloudControl.GetResourceInput): Promise<CloudControl.GetResourceOutput> {
+    public async getResource(request: GetResourceCommandInput): Promise<GetResourceCommandOutput> {
         const client = await this.createSdkClient()
 
-        return await client.getResource(request).promise()
+        return await client.getResource(request);
     }
 
-    public async updateResource(request: CloudControl.UpdateResourceInput): Promise<void> {
+    public async updateResource(request: UpdateResourceCommandInput): Promise<void> {
         const client = await this.createSdkClient()
 
-        const updateResponse = await client.updateResource(request).promise()
+        const updateResponse = await client.updateResource(request)
 
         await this.pollForCompletion(client, updateResponse.ProgressEvent!)
     }
 
     private async pollForCompletion(
         client: CloudControl,
-        progressEvent: CloudControl.ProgressEvent,
+        progressEvent: ProgressEvent,
         baseDelay: number = 500,
         maxRetries: number = 10
     ): Promise<void> {
@@ -98,7 +112,6 @@ export class DefaultCloudControlClient implements CloudControlClient {
                     .getResourceRequestStatus({
                         RequestToken: progressEvent.RequestToken!,
                     })
-                    .promise()
                 progressEvent = resourceRequestStatus.ProgressEvent!
             }
         }

--- a/src/shared/clients/cloudFormationClient.ts
+++ b/src/shared/clients/cloudFormationClient.ts
@@ -3,7 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CloudFormation } from 'aws-sdk'
+
+
+import {
+    CloudFormation,
+    DescribeStackResourcesCommandOutput,
+    DescribeTypeCommandOutput,
+    ListStacksCommandInput,
+    ListStacksCommandOutput,
+    ListTypesCommandInput,
+    ListTypesCommandOutput,
+    StackSummary,
+    TypeSummary,
+} from "@aws-sdk/client-cloudformation";
+
 import globals from '../extensionGlobals'
 import { AsyncCollection } from '../utilities/asyncCollection'
 import { pageableToCollection } from '../utilities/collectionUtils'
@@ -23,7 +36,7 @@ export class DefaultCloudFormationClient {
             .promise()
     }
 
-    public async describeType(typeName: string): Promise<CloudFormation.DescribeTypeOutput> {
+    public async describeType(typeName: string): Promise<DescribeTypeCommandOutput> {
         const client = await this.createSdkClient()
 
         return await client
@@ -36,15 +49,15 @@ export class DefaultCloudFormationClient {
 
     public async *listStacks(
         statusFilter: string[] = ['CREATE_COMPLETE', 'UPDATE_COMPLETE']
-    ): AsyncIterableIterator<CloudFormation.StackSummary> {
+    ): AsyncIterableIterator<StackSummary> {
         const client = await this.createSdkClient()
 
-        const request: CloudFormation.ListStacksInput = {
+        const request: ListStacksCommandInput = {
             StackStatusFilter: statusFilter,
         }
 
         do {
-            const response: CloudFormation.ListStacksOutput = await client.listStacks(request).promise()
+            const response: ListStacksCommandOutput = await client.listStacks(request).promise()
 
             if (response.StackSummaries) {
                 yield* response.StackSummaries
@@ -54,25 +67,25 @@ export class DefaultCloudFormationClient {
         } while (request.NextToken)
     }
 
-    public listAllStacks(request: CloudFormation.ListStacksInput = {}): AsyncCollection<CloudFormation.StackSummary[]> {
+    public listAllStacks(request: ListStacksCommandInput = {}): AsyncCollection<StackSummary[]> {
         const client = this.createSdkClient()
-        const requester = async (req: CloudFormation.ListStacksInput) => (await client).listStacks(req).promise()
+        const requester = async (req: ListStacksCommandInput) => (await client).listStacks(req).promise()
         const collection = pageableToCollection(requester, request, 'NextToken', 'StackSummaries')
 
         return collection.filter(isNonNullable)
     }
 
-    public async *listTypes(): AsyncIterableIterator<CloudFormation.TypeSummary> {
+    public async *listTypes(): AsyncIterableIterator<TypeSummary> {
         const client = await this.createSdkClient()
 
-        const request: CloudFormation.ListTypesInput = {
+        const request: ListTypesCommandInput = {
             DeprecatedStatus: 'LIVE',
             Type: 'RESOURCE',
             Visibility: 'PUBLIC',
         }
 
         do {
-            const response: CloudFormation.ListTypesOutput = await client.listTypes(request).promise()
+            const response: ListTypesCommandOutput = await client.listTypes(request).promise()
 
             if (response.TypeSummaries) {
                 yield* response.TypeSummaries
@@ -82,7 +95,7 @@ export class DefaultCloudFormationClient {
         } while (request.NextToken)
     }
 
-    public async describeStackResources(name: string): Promise<CloudFormation.DescribeStackResourcesOutput> {
+    public async describeStackResources(name: string): Promise<DescribeStackResourcesCommandOutput> {
         const client = await this.createSdkClient()
 
         return await client

--- a/src/shared/clients/cloudWatchLogsClient.ts
+++ b/src/shared/clients/cloudWatchLogsClient.ts
@@ -3,7 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CloudWatchLogs } from 'aws-sdk'
+
+
+import {
+    CloudWatchLogs,
+    DescribeLogGroupsCommandInput,
+    DescribeLogGroupsCommandOutput,
+    DescribeLogStreamsCommandInput,
+    DescribeLogStreamsCommandOutput,
+    FilterLogEventsCommandInput,
+    FilterLogEventsCommandOutput,
+    GetLogEventsCommandInput,
+    GetLogEventsCommandOutput,
+    LogGroup,
+} from "@aws-sdk/client-cloudwatch-logs";
+
 import globals from '../extensionGlobals'
 import { ClassToInterfaceType } from '../utilities/tsUtils'
 
@@ -12,8 +26,8 @@ export class DefaultCloudWatchLogsClient {
     public constructor(public readonly regionCode: string) {}
 
     public async *describeLogGroups(
-        request: CloudWatchLogs.DescribeLogGroupsRequest = {}
-    ): AsyncIterableIterator<CloudWatchLogs.LogGroup> {
+        request: DescribeLogGroupsCommandInput = {}
+    ): AsyncIterableIterator<LogGroup> {
         const sdkClient = await this.createSdkClient()
         do {
             const response = await this.invokeDescribeLogGroups(request, sdkClient)
@@ -25,34 +39,34 @@ export class DefaultCloudWatchLogsClient {
     }
 
     public async describeLogStreams(
-        request: CloudWatchLogs.DescribeLogStreamsRequest
-    ): Promise<CloudWatchLogs.DescribeLogStreamsResponse> {
+        request: DescribeLogStreamsCommandInput
+    ): Promise<DescribeLogStreamsCommandOutput> {
         const sdkClient = await this.createSdkClient()
 
-        return sdkClient.describeLogStreams(request).promise()
+        return sdkClient.describeLogStreams(request);
     }
 
     public async getLogEvents(
-        request: CloudWatchLogs.GetLogEventsRequest
-    ): Promise<CloudWatchLogs.GetLogEventsResponse> {
+        request: GetLogEventsCommandInput
+    ): Promise<GetLogEventsCommandOutput> {
         const sdkClient = await this.createSdkClient()
 
-        return sdkClient.getLogEvents(request).promise()
+        return sdkClient.getLogEvents(request);
     }
 
     public async filterLogEvents(
-        request: CloudWatchLogs.FilterLogEventsRequest
-    ): Promise<CloudWatchLogs.FilterLogEventsResponse> {
+        request: FilterLogEventsCommandInput
+    ): Promise<FilterLogEventsCommandOutput> {
         const sdkClient = await this.createSdkClient()
 
-        return sdkClient.filterLogEvents(request).promise()
+        return sdkClient.filterLogEvents(request);
     }
 
     protected async invokeDescribeLogGroups(
-        request: CloudWatchLogs.DescribeLogGroupsRequest,
+        request: DescribeLogGroupsCommandInput,
         sdkClient: CloudWatchLogs
-    ): Promise<CloudWatchLogs.DescribeLogGroupsResponse> {
-        return sdkClient.describeLogGroups(request).promise()
+    ): Promise<DescribeLogGroupsCommandOutput> {
+        return sdkClient.describeLogGroups(request);
     }
 
     protected async createSdkClient(): Promise<CloudWatchLogs> {

--- a/src/shared/clients/codecatalystClient.ts
+++ b/src/shared/clients/codecatalystClient.ts
@@ -541,7 +541,7 @@ class CodeCatalystClientInternal {
 
         // The git extension skips over credential providers if the username is included in the authority
         const uri = Uri.parse(r.https)
-        return uri.with({ authority: uri.authority.replace(/.*@/, '') }).toString()
+        return uri.with({ authority: uri.authority.replace(/.*@/, '') }).toString();
     }
 
     public async createDevEnvironment(args: CodeCatalyst.CreateDevEnvironmentRequest): Promise<DevEnvironment> {

--- a/src/shared/clients/ecrClient.ts
+++ b/src/shared/clients/ecrClient.ts
@@ -3,13 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ECR } from 'aws-sdk'
+
+
+import {
+    DescribeImagesCommandInput,
+    DescribeRepositoriesCommandInput,
+    ECR,
+    Repository,
+} from "@aws-sdk/client-ecr";
+
 import globals from '../extensionGlobals'
 import { AsyncCollection } from '../utilities/asyncCollection'
 import { pageableToCollection } from '../utilities/collectionUtils'
 import { assertHasProps, ClassToInterfaceType, isNonNullable, RequiredProps } from '../utilities/tsUtils'
 
-export type EcrRepository = RequiredProps<ECR.Repository, 'repositoryName' | 'repositoryUri' | 'repositoryArn'>
+export type EcrRepository = RequiredProps<Repository, 'repositoryName' | 'repositoryUri' | 'repositoryArn'>
 
 export type EcrClient = ClassToInterfaceType<DefaultEcrClient>
 export class DefaultEcrClient {
@@ -17,7 +25,7 @@ export class DefaultEcrClient {
 
     public async *describeTags(repositoryName: string): AsyncIterableIterator<string> {
         const sdkClient = await this.createSdkClient()
-        const request: ECR.DescribeImagesRequest = { repositoryName: repositoryName }
+        const request: DescribeImagesCommandInput = { repositoryName: repositoryName }
         do {
             const response = await sdkClient.describeImages(request).promise()
             if (response.imageDetails) {
@@ -35,7 +43,7 @@ export class DefaultEcrClient {
 
     public async *describeRepositories(): AsyncIterableIterator<EcrRepository> {
         const sdkClient = await this.createSdkClient()
-        const request: ECR.DescribeRepositoriesRequest = {}
+        const request: DescribeRepositoriesCommandInput = {}
         do {
             const response = await sdkClient.describeRepositories(request).promise()
             if (response.repositories) {
@@ -60,7 +68,7 @@ export class DefaultEcrClient {
     }
 
     public listAllRepositories(): AsyncCollection<EcrRepository[]> {
-        const requester = async (req: ECR.DescribeRepositoriesRequest) =>
+        const requester = async (req: DescribeRepositoriesCommandInput) =>
             (await this.createSdkClient()).describeRepositories(req).promise()
         const collection = pageableToCollection(requester, {}, 'nextToken', 'repositories')
 

--- a/src/shared/clients/lambdaClient.ts
+++ b/src/shared/clients/lambdaClient.ts
@@ -3,8 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Lambda } from 'aws-sdk'
-import { _Blob } from 'aws-sdk/clients/lambda'
+
+
+import {
+    FunctionUrlConfig,
+    GetFunctionCommandOutput,
+    InvokeCommandOutput,
+    Lambda,
+    ListFunctionsCommandInput,
+    ListFunctionsCommandOutput,
+    UpdateFunctionConfigurationCommandOutput,
+} from "@aws-sdk/client-lambda";
+
 import { ToolkitError } from '../errors'
 import globals from '../extensionGlobals'
 import { getLogger } from '../logger'
@@ -33,7 +43,7 @@ export class DefaultLambdaClient {
         }
     }
 
-    public async invoke(name: string, payload?: _Blob): Promise<Lambda.InvocationResponse> {
+    public async invoke(name: string, payload?: Uint8Array): Promise<InvokeCommandOutput> {
         const sdkClient = await this.createSdkClient()
 
         const response = await sdkClient
@@ -47,12 +57,12 @@ export class DefaultLambdaClient {
         return response
     }
 
-    public async *listFunctions(): AsyncIterableIterator<Lambda.FunctionConfiguration> {
+    public async *listFunctions(): AsyncIterableIterator<UpdateFunctionConfigurationCommandOutput> {
         const client = await this.createSdkClient()
 
-        const request: Lambda.ListFunctionsRequest = {}
+        const request: ListFunctionsCommandInput = {}
         do {
-            const response: Lambda.ListFunctionsResponse = await client.listFunctions(request).promise()
+            const response: ListFunctionsCommandOutput = await client.listFunctions(request).promise()
 
             if (response.Functions) {
                 yield* response.Functions
@@ -62,7 +72,7 @@ export class DefaultLambdaClient {
         } while (request.Marker)
     }
 
-    public async getFunction(name: string): Promise<Lambda.GetFunctionResponse> {
+    public async getFunction(name: string): Promise<GetFunctionCommandOutput> {
         getLogger().debug(`GetFunction called for function: ${name}`)
         const client = await this.createSdkClient()
 
@@ -80,7 +90,7 @@ export class DefaultLambdaClient {
         }
     }
 
-    public async getFunctionUrlConfigs(name: string): Promise<Lambda.FunctionUrlConfigList> {
+    public async getFunctionUrlConfigs(name: string): Promise<Array<FunctionUrlConfig>> {
         getLogger().debug(`GetFunctionUrlConfig called for function: ${name}`)
         const client = await this.createSdkClient()
 
@@ -98,7 +108,7 @@ export class DefaultLambdaClient {
         }
     }
 
-    public async updateFunctionCode(name: string, zipFile: Buffer): Promise<Lambda.FunctionConfiguration> {
+    public async updateFunctionCode(name: string, zipFile: Buffer): Promise<UpdateFunctionConfigurationCommandOutput> {
         getLogger().debug(`updateFunctionCode called for function: ${name}`)
         const client = await this.createSdkClient()
 

--- a/src/shared/clients/schemaClient.ts
+++ b/src/shared/clients/schemaClient.ts
@@ -3,7 +3,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Schemas } from 'aws-sdk'
+
+
+import {
+    DescribeCodeBindingCommandOutput,
+    DescribeSchemaCommandOutput,
+    GetCodeBindingSourceCommandOutput,
+    ListRegistriesCommandInput,
+    ListRegistriesCommandOutput,
+    ListSchemasCommandInput,
+    ListSchemasCommandOutput,
+    ListSchemaVersionsCommandInput,
+    ListSchemaVersionsCommandOutput,
+    PutCodeBindingCommandOutput,
+    RegistrySummary,
+    Schemas,
+    SchemaSummary,
+    SchemaVersionSummary,
+    SearchSchemasCommandInput,
+    SearchSchemasCommandOutput,
+    SearchSchemaSummary,
+} from "@aws-sdk/client-schemas";
+
 import globals from '../extensionGlobals'
 
 import { ClassToInterfaceType } from '../utilities/tsUtils'
@@ -12,13 +33,13 @@ export type SchemaClient = ClassToInterfaceType<DefaultSchemaClient>
 export class DefaultSchemaClient {
     public constructor(public readonly regionCode: string) {}
 
-    public async *listRegistries(): AsyncIterableIterator<Schemas.RegistrySummary> {
+    public async *listRegistries(): AsyncIterableIterator<RegistrySummary> {
         const client = await this.createSdkClient()
 
-        const request: Schemas.ListRegistriesRequest = {}
+        const request: ListRegistriesCommandInput = {}
 
         do {
-            const response: Schemas.ListRegistriesResponse = await client.listRegistries(request).promise()
+            const response: ListRegistriesCommandOutput = await client.listRegistries(request).promise()
 
             if (response.Registries) {
                 yield* response.Registries
@@ -28,15 +49,15 @@ export class DefaultSchemaClient {
         } while (request.NextToken)
     }
 
-    public async *listSchemas(registryName: string): AsyncIterableIterator<Schemas.SchemaSummary> {
+    public async *listSchemas(registryName: string): AsyncIterableIterator<SchemaSummary> {
         const client = await this.createSdkClient()
 
-        const request: Schemas.ListSchemasRequest = {
+        const request: ListSchemasCommandInput = {
             RegistryName: registryName,
         }
 
         do {
-            const response: Schemas.ListSchemasResponse = await client.listSchemas(request).promise()
+            const response: ListSchemasCommandOutput = await client.listSchemas(request).promise()
 
             if (response.Schemas) {
                 yield* response.Schemas
@@ -50,7 +71,7 @@ export class DefaultSchemaClient {
         registryName: string,
         schemaName: string,
         schemaVersion?: string
-    ): Promise<Schemas.DescribeSchemaResponse> {
+    ): Promise<DescribeSchemaCommandOutput> {
         const client = await this.createSdkClient()
 
         return await client
@@ -65,16 +86,16 @@ export class DefaultSchemaClient {
     public async *listSchemaVersions(
         registryName: string,
         schemaName: string
-    ): AsyncIterableIterator<Schemas.SchemaVersionSummary> {
+    ): AsyncIterableIterator<SchemaVersionSummary> {
         const client = await this.createSdkClient()
 
-        const request: Schemas.ListSchemaVersionsRequest = {
+        const request: ListSchemaVersionsCommandInput = {
             RegistryName: registryName,
             SchemaName: schemaName,
         }
 
         do {
-            const response: Schemas.ListSchemaVersionsResponse = await client.listSchemaVersions(request).promise()
+            const response: ListSchemaVersionsCommandOutput = await client.listSchemaVersions(request).promise()
 
             if (response.SchemaVersions) {
                 yield* response.SchemaVersions
@@ -87,16 +108,16 @@ export class DefaultSchemaClient {
     public async *searchSchemas(
         keywords: string,
         registryName: string
-    ): AsyncIterableIterator<Schemas.SearchSchemaSummary> {
+    ): AsyncIterableIterator<SearchSchemaSummary> {
         const client = await this.createSdkClient()
 
-        const request: Schemas.SearchSchemasRequest = {
+        const request: SearchSchemasCommandInput = {
             Keywords: keywords,
             RegistryName: registryName,
         }
 
         do {
-            const response: Schemas.SearchSchemasResponse = await client.searchSchemas(request).promise()
+            const response: SearchSchemasCommandOutput = await client.searchSchemas(request).promise()
 
             if (response.Schemas) {
                 yield* response.Schemas
@@ -111,7 +132,7 @@ export class DefaultSchemaClient {
         registryName: string,
         schemaName: string,
         schemaVersion: string
-    ): Promise<Schemas.GetCodeBindingSourceResponse> {
+    ): Promise<GetCodeBindingSourceCommandOutput> {
         const client = await this.createSdkClient()
 
         return await client
@@ -129,7 +150,7 @@ export class DefaultSchemaClient {
         registryName: string,
         schemaName: string,
         schemaVersion: string
-    ): Promise<Schemas.PutCodeBindingResponse> {
+    ): Promise<PutCodeBindingCommandOutput> {
         const client = await this.createSdkClient()
 
         return await client
@@ -146,7 +167,7 @@ export class DefaultSchemaClient {
         registryName: string,
         schemaName: string,
         schemaVersion: string
-    ): Promise<Schemas.DescribeCodeBindingResponse> {
+    ): Promise<DescribeCodeBindingCommandOutput> {
         const client = await this.createSdkClient()
 
         return await client

--- a/src/shared/clients/secretsManagerClient.ts
+++ b/src/shared/clients/secretsManagerClient.ts
@@ -3,14 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SecretsManager } from 'aws-sdk'
-import globals from '../extensionGlobals'
+
+
 import {
-    CreateSecretRequest,
-    CreateSecretResponse,
-    ListSecretsRequest,
-    ListSecretsResponse,
-} from 'aws-sdk/clients/secretsmanager'
+    CreateSecretCommandInput,
+    CreateSecretCommandOutput,
+    ListSecretsCommandInput,
+    ListSecretsCommandOutput,
+    SecretsManager,
+} from "@aws-sdk/client-secrets-manager";
+
+import globals from '../extensionGlobals'
 import { productName } from '../constants'
 
 export class SecretsManagerClient {
@@ -26,9 +29,9 @@ export class SecretsManagerClient {
      * @param filter tagged key filter value
      * @returns a list of the secrets
      */
-    public async listSecrets(filter: string): Promise<ListSecretsResponse> {
+    public async listSecrets(filter: string): Promise<ListSecretsCommandOutput> {
         const secretsManagerClient = await this.secretsManagerClientProvider(this.regionCode)
-        const request: ListSecretsRequest = {
+        const request: ListSecretsCommandInput = {
             IncludePlannedDeletion: false,
             Filters: [
                 {
@@ -41,9 +44,9 @@ export class SecretsManagerClient {
         return secretsManagerClient.listSecrets(request).promise()
     }
 
-    public async createSecret(secretString: string, username: string, password: string): Promise<CreateSecretResponse> {
+    public async createSecret(secretString: string, username: string, password: string): Promise<CreateSecretCommandOutput> {
         const secretsManagerClient = await this.secretsManagerClientProvider(this.regionCode)
-        const request: CreateSecretRequest = {
+        const request: CreateSecretCommandInput = {
             Description: `Database secret created with ${productName}`,
             Name: secretString ? secretString : '',
             SecretString: JSON.stringify({ username, password }),

--- a/src/shared/clients/ssmDocumentClient.ts
+++ b/src/shared/clients/ssmDocumentClient.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SSM } from 'aws-sdk'
+
+
+import { DescribeDocumentCommandOutput, DocumentIdentifier, SSM } from "@aws-sdk/client-ssm";
 import globals from '../extensionGlobals'
 
 import { ClassToInterfaceType } from '../utilities/tsUtils'
@@ -24,7 +26,7 @@ export class DefaultSsmDocumentClient {
 
     public async *listDocuments(
         request: SSM.Types.ListDocumentsRequest = {}
-    ): AsyncIterableIterator<SSM.DocumentIdentifier> {
+    ): AsyncIterableIterator<DocumentIdentifier> {
         const client = await this.createSdkClient()
 
         do {
@@ -56,7 +58,7 @@ export class DefaultSsmDocumentClient {
         } while (request.NextToken)
     }
 
-    public async describeDocument(documentName: string, documentVersion?: string): Promise<SSM.DescribeDocumentResult> {
+    public async describeDocument(documentName: string, documentVersion?: string): Promise<DescribeDocumentCommandOutput> {
         const client = await this.createSdkClient()
 
         const request: SSM.Types.DescribeDocumentRequest = {

--- a/src/shared/clients/stepFunctionsClient.ts
+++ b/src/shared/clients/stepFunctionsClient.ts
@@ -3,7 +3,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { StepFunctions } from 'aws-sdk'
+
+
+import {
+    CreateStateMachineCommandInput,
+    CreateStateMachineCommandOutput,
+    DescribeStateMachineCommandInput,
+    DescribeStateMachineCommandOutput,
+    ListStateMachinesCommandInput,
+    ListStateMachinesCommandOutput,
+    SFN,
+    StartExecutionCommandInput,
+    StartExecutionCommandOutput,
+    StateMachineListItem,
+    UpdateStateMachineCommandInput,
+    UpdateStateMachineCommandOutput,
+} from "@aws-sdk/client-sfn";
+
 import globals from '../extensionGlobals'
 import { ClassToInterfaceType } from '../utilities/tsUtils'
 
@@ -11,12 +27,12 @@ export type StepFunctionsClient = ClassToInterfaceType<DefaultStepFunctionsClien
 export class DefaultStepFunctionsClient {
     public constructor(public readonly regionCode: string) {}
 
-    public async *listStateMachines(): AsyncIterableIterator<StepFunctions.StateMachineListItem> {
+    public async *listStateMachines(): AsyncIterableIterator<StateMachineListItem> {
         const client = await this.createSdkClient()
 
-        const request: StepFunctions.ListStateMachinesInput = {}
+        const request: ListStateMachinesCommandInput = {}
         do {
-            const response: StepFunctions.ListStateMachinesOutput = await client.listStateMachines(request).promise()
+            const response: ListStateMachinesCommandOutput = await client.listStateMachines(request).promise()
 
             if (response.stateMachines) {
                 yield* response.stateMachines
@@ -26,42 +42,42 @@ export class DefaultStepFunctionsClient {
         } while (request.nextToken)
     }
 
-    public async getStateMachineDetails(arn: string): Promise<StepFunctions.DescribeStateMachineOutput> {
+    public async getStateMachineDetails(arn: string): Promise<DescribeStateMachineCommandOutput> {
         const client = await this.createSdkClient()
 
-        const request: StepFunctions.DescribeStateMachineInput = {
+        const request: DescribeStateMachineCommandInput = {
             stateMachineArn: arn,
         }
 
-        const response: StepFunctions.DescribeStateMachineOutput = await client.describeStateMachine(request).promise()
+        const response: DescribeStateMachineCommandOutput = await client.describeStateMachine(request).promise()
 
         return response
     }
 
-    public async executeStateMachine(arn: string, input?: string): Promise<StepFunctions.StartExecutionOutput> {
+    public async executeStateMachine(arn: string, input?: string): Promise<StartExecutionCommandOutput> {
         const client = await this.createSdkClient()
 
-        const request: StepFunctions.StartExecutionInput = {
+        const request: StartExecutionCommandInput = {
             stateMachineArn: arn,
             input: input,
         }
 
-        const response: StepFunctions.StartExecutionOutput = await client.startExecution(request).promise()
+        const response: StartExecutionCommandOutput = await client.startExecution(request).promise()
 
         return response
     }
 
     public async createStateMachine(
-        params: StepFunctions.CreateStateMachineInput
-    ): Promise<StepFunctions.CreateStateMachineOutput> {
+        params: CreateStateMachineCommandInput
+    ): Promise<CreateStateMachineCommandOutput> {
         const client = await this.createSdkClient()
 
         return client.createStateMachine(params).promise()
     }
 
     public async updateStateMachine(
-        params: StepFunctions.UpdateStateMachineInput
-    ): Promise<StepFunctions.UpdateStateMachineOutput> {
+        params: UpdateStateMachineCommandInput
+    ): Promise<UpdateStateMachineCommandOutput> {
         const client = await this.createSdkClient()
 
         return client.updateStateMachine(params).promise()

--- a/src/shared/clients/stsClient.ts
+++ b/src/shared/clients/stsClient.ts
@@ -3,7 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { STS } from 'aws-sdk'
+
+
+import {
+    AssumeRoleCommandInput,
+    AssumeRoleCommandOutput,
+    GetCallerIdentityCommandOutput,
+    STS,
+} from "@aws-sdk/client-sts";
+
 import { Credentials } from '@aws-sdk/types'
 import globals from '../extensionGlobals'
 import { ClassToInterfaceType } from '../utilities/tsUtils'
@@ -12,13 +20,13 @@ export type StsClient = ClassToInterfaceType<DefaultStsClient>
 export class DefaultStsClient {
     public constructor(public readonly regionCode: string, private readonly credentials?: Credentials) {}
 
-    public async assumeRole(request: STS.AssumeRoleRequest): Promise<STS.AssumeRoleResponse> {
+    public async assumeRole(request: AssumeRoleCommandInput): Promise<AssumeRoleCommandOutput> {
         const sdkClient = await this.createSdkClient()
         const response = await sdkClient.assumeRole(request).promise()
         return response
     }
 
-    public async getCallerIdentity(): Promise<STS.GetCallerIdentityResponse> {
+    public async getCallerIdentity(): Promise<GetCallerIdentityCommandOutput> {
         const sdkClient = await this.createSdkClient()
         const response = await sdkClient.getCallerIdentity().promise()
         return response

--- a/src/shared/sam/cli/samCliInit.ts
+++ b/src/shared/sam/cli/samCliInit.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Runtime } from 'aws-sdk/clients/lambda'
+
+
+import { Runtime } from "@aws-sdk/client-lambda";
 import { SchemaTemplateExtraContext } from '../../../eventSchemas/templates/schemasAppTemplateUtils'
 import { Architecture, DependencyManager } from '../../../lambda/models/samLambdaRuntime'
 import { getSamCliTemplateParameter, SamTemplate } from '../../../lambda/models/samTemplates'

--- a/src/shared/sam/debugger/awsSamDebugConfiguration.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfiguration.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode'
 import * as path from 'path'
-import { Runtime } from 'aws-sdk/clients/lambda'
+import { Runtime } from "@aws-sdk/client-lambda";
 import { getNormalizedRelativePath } from '../../utilities/pathUtils'
 import {
     APIGatewayProperties,

--- a/src/shared/sam/debugger/pythonSamDebug.ts
+++ b/src/shared/sam/debugger/pythonSamDebug.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Runtime } from 'aws-sdk/clients/lambda'
+
+
+import { Runtime } from "@aws-sdk/client-lambda";
 import { writeFile } from 'fs-extra'
 import * as os from 'os'
 import * as path from 'path'

--- a/src/shared/sam/sync.ts
+++ b/src/shared/sam/sync.ts
@@ -29,7 +29,7 @@ import { getLogger } from '../logger'
 import { isCloud9 } from '../extensionUtilities'
 import { removeAnsi } from '../utilities/textUtilities'
 import { createExitPrompter } from '../ui/common/exitPrompter'
-import { StackSummary } from 'aws-sdk/clients/cloudformation'
+import { StackSummary, Template } from "@aws-sdk/client-cloudformation";
 import { SamCliSettings } from './cli/samCliSettings'
 import { SamConfig } from './config'
 import { cast, Instance, Optional, Union } from '../utilities/typeConstructors'
@@ -183,7 +183,7 @@ export function createEnvironmentPrompter(config: SamConfig, environments = conf
 
 interface TemplateItem {
     readonly uri: vscode.Uri
-    readonly data: CloudFormation.Template
+    readonly data: Template
 }
 
 function createTemplatePrompter(registry: CloudFormationTemplateRegistry) {
@@ -216,7 +216,7 @@ function createTemplatePrompter(registry: CloudFormationTemplateRegistry) {
     })
 }
 
-function hasImageBasedResources(template: CloudFormation.Template) {
+function hasImageBasedResources(template: Template) {
     const resources = template.Resources
 
     return resources === undefined

--- a/src/shared/telemetry/telemetryPublisher.ts
+++ b/src/shared/telemetry/telemetryPublisher.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CognitoIdentity, CognitoIdentityCredentials } from 'aws-sdk'
+import { CognitoIdentityCredentials } from 'aws-sdk';
+import { CognitoIdentity } from "@aws-sdk/client-cognito-identity";
 import { MetricDatum } from './clienttelemetry'
 import { DefaultTelemetryClient } from './telemetryClient'
 import { TelemetryClient, TelemetryFeedback } from './telemetryClient'
@@ -92,7 +93,7 @@ export class DefaultTelemetryPublisher implements TelemetryPublisher {
         const region = identityPool.split(':')[0]
         try {
             const res = await new CognitoIdentity({
-                region: region,
+                region: region
             })
                 .getId({
                     IdentityPoolId: identityPool,

--- a/src/shared/ui/common/roles.ts
+++ b/src/shared/ui/common/roles.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IAM } from 'aws-sdk'
+
+
+import { Role } from "@aws-sdk/client-iam";
 import { IamClient } from '../../clients/iamClient'
 import { createCommonButtons, createPlusButton, createRefreshButton } from '../buttons'
 import { createQuickPick, DataQuickPickItem, QuickPickPrompter } from '../pickerPrompter'
@@ -21,19 +23,19 @@ interface RolePrompterOptions {
     readonly title?: string
     readonly helpUrl?: string | vscode.Uri
     readonly noRoleDetail?: string
-    readonly roleFilter?: (role: IAM.Role) => boolean
-    readonly createRole?: () => Promise<IAM.Role>
+    readonly roleFilter?: (role: Role) => boolean
+    readonly createRole?: () => Promise<Role>
 }
 
-export function createRolePrompter(client: IamClient, options: RolePrompterOptions = {}): QuickPickPrompter<IAM.Role> {
-    const placeholderItem: DataQuickPickItem<IAM.Role> = {
+export function createRolePrompter(client: IamClient, options: RolePrompterOptions = {}): QuickPickPrompter<Role> {
+    const placeholderItem: DataQuickPickItem<Role> = {
         label: localize('AWS.rolePrompter.noRoles.title', 'No valid roles found'),
         data: WIZARD_BACK,
         detail: options.noRoleDetail,
     }
 
     const loadItems = () => {
-        const filterRoles = (roles: IAM.Role[]) => (options.roleFilter ? roles.filter(options.roleFilter) : roles)
+        const filterRoles = (roles: Role[]) => (options.roleFilter ? roles.filter(options.roleFilter) : roles)
 
         return client
             .getRoles()
@@ -62,7 +64,7 @@ export function createRolePrompter(client: IamClient, options: RolePrompterOptio
 }
 
 function addCreateRoleButton(
-    prompter: QuickPickPrompter<IAM.Role>,
+    prompter: QuickPickPrompter<Role>,
     createRole: RolePrompterOptions['createRole']
 ): typeof prompter {
     if (!createRole) {

--- a/src/ssmDocument/commands/openDocumentItem.ts
+++ b/src/ssmDocument/commands/openDocumentItem.ts
@@ -6,7 +6,6 @@
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
-import { SSM } from 'aws-sdk'
 import * as vscode from 'vscode'
 import { DocumentItemNode } from '../explorer/documentItemNode'
 import { AwsContext } from '../../shared/awsContext'

--- a/src/ssmDocument/commands/publishDocument.ts
+++ b/src/ssmDocument/commands/publishDocument.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SSM } from 'aws-sdk'
+
+
+import { CreateDocumentCommandInput, UpdateDocumentCommandInput } from "@aws-sdk/client-ssm";
 import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
@@ -73,7 +75,7 @@ export async function createDocument(
     logger.info(`Creating Systems Manager Document '${wizardResponse.name}'`)
 
     try {
-        const request: SSM.CreateDocumentRequest = {
+        const request: CreateDocumentCommandInput = {
             Content: textDocument.getText(),
             Name: wizardResponse.name,
             DocumentType: wizardResponse.documentType,
@@ -107,7 +109,7 @@ export async function updateDocument(
     logger.info(`Updating Systems Manager Document '${wizardResponse.name}'`)
 
     try {
-        const request: SSM.UpdateDocumentRequest = {
+        const request: UpdateDocumentCommandInput = {
             Content: textDocument.getText(),
             Name: wizardResponse.name,
             DocumentVersion: '$LATEST',

--- a/src/ssmDocument/commands/updateDocumentVersion.ts
+++ b/src/ssmDocument/commands/updateDocumentVersion.ts
@@ -6,7 +6,6 @@
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
-import { SSM } from 'aws-sdk'
 import * as vscode from 'vscode'
 import { AwsContext } from '../../shared/awsContext'
 import { getLogger, Logger } from '../../shared/logger'

--- a/src/ssmDocument/explorer/documentItemNode.ts
+++ b/src/ssmDocument/explorer/documentItemNode.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SSM } from 'aws-sdk'
+
 
 import { SsmDocumentClient } from '../../shared/clients/ssmDocumentClient'
 import { AWSTreeNodeBase } from '../../shared/treeview/nodes/awsTreeNodeBase'

--- a/src/ssmDocument/explorer/documentItemNodeWriteable.ts
+++ b/src/ssmDocument/explorer/documentItemNodeWriteable.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SSM } from 'aws-sdk'
+
+
 import { RegistryItemNode } from './registryItemNode'
 import { SsmDocumentClient } from '../../shared/clients/ssmDocumentClient'
 import { DocumentItemNode } from './documentItemNode'

--- a/src/ssmDocument/explorer/registryItemNode.ts
+++ b/src/ssmDocument/explorer/registryItemNode.ts
@@ -6,7 +6,7 @@
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
-import { SSM } from 'aws-sdk'
+import { DocumentIdentifier, ListDocumentsCommandInput } from "@aws-sdk/client-ssm";
 import * as vscode from 'vscode'
 
 import { DefaultSsmDocumentClient, SsmDocumentClient } from '../../shared/clients/ssmDocumentClient'
@@ -64,8 +64,8 @@ export class RegistryItemNode extends AWSTreeNodeBase {
         })
     }
 
-    private async getDocumentByOwner(client: SsmDocumentClient): Promise<SSM.DocumentIdentifier[]> {
-        const request: SSM.ListDocumentsRequest = {
+    private async getDocumentByOwner(client: SsmDocumentClient): Promise<DocumentIdentifier[]> {
+        const request: ListDocumentsCommandInput = {
             Filters: [
                 {
                     Key: 'DocumentType',

--- a/src/ssmDocument/wizards/publishDocumentWizard.ts
+++ b/src/ssmDocument/wizards/publishDocumentWizard.ts
@@ -6,7 +6,6 @@
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
-import { SSM } from 'aws-sdk'
 import { createCommonButtons } from '../../shared/ui/buttons'
 import { createRegionPrompter } from '../../shared/ui/common/region'
 import { createInputBox } from '../../shared/ui/inputPrompter'

--- a/src/stepFunctions/commands/downloadStateMachineDefinition.ts
+++ b/src/stepFunctions/commands/downloadStateMachineDefinition.ts
@@ -7,7 +7,7 @@ import * as nls from 'vscode-nls'
 import * as os from 'os'
 const localize = nls.loadMessageBundle()
 
-import { StepFunctions } from 'aws-sdk'
+import { DescribeStateMachineCommandOutput } from "@aws-sdk/client-sfn";
 import * as fs from 'fs-extra'
 import * as path from 'path'
 import * as vscode from 'vscode'
@@ -29,7 +29,7 @@ export async function downloadStateMachineDefinition(params: {
     const stateMachineName = params.stateMachineNode.details.name
     try {
         const client: StepFunctionsClient = new DefaultStepFunctionsClient(params.stateMachineNode.regionCode)
-        const stateMachineDetails: StepFunctions.DescribeStateMachineOutput = await client.getStateMachineDetails(
+        const stateMachineDetails: DescribeStateMachineCommandOutput = await client.getStateMachineDetails(
             params.stateMachineNode.details.stateMachineArn
         )
 

--- a/src/stepFunctions/explorer/stepFunctionsNodes.ts
+++ b/src/stepFunctions/explorer/stepFunctionsNodes.ts
@@ -7,7 +7,7 @@ import * as os from 'os'
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
-import { StepFunctions } from 'aws-sdk'
+import { StateMachineListItem } from "@aws-sdk/client-sfn";
 import * as vscode from 'vscode'
 import { DefaultStepFunctionsClient } from '../../shared/clients/stepFunctionsClient'
 
@@ -66,7 +66,7 @@ export class StepFunctionsNode extends AWSTreeNodeBase {
     }
 
     public async updateChildren(): Promise<void> {
-        const functions: Map<string, StepFunctions.StateMachineListItem> = toMap(
+        const functions: Map<string, StateMachineListItem> = toMap(
             await toArrayAsync(listStateMachines(this.client)),
             details => details.name
         )
@@ -84,14 +84,14 @@ export class StateMachineNode extends AWSTreeNodeBase implements AWSResourceNode
     public constructor(
         public readonly parent: AWSTreeNodeBase,
         public override readonly regionCode: string,
-        public details: StepFunctions.StateMachineListItem
+        public details: StateMachineListItem
     ) {
         super('')
         this.update(details)
         this.iconPath = getIcon('aws-stepfunctions-preview')
     }
 
-    public update(details: StepFunctions.StateMachineListItem): void {
+    public update(details: StateMachineListItem): void {
         this.details = details
         this.label = this.details.name || ''
         this.tooltip = `${this.details.name}${os.EOL}${this.details.stateMachineArn}`
@@ -117,7 +117,7 @@ export class StateMachineNode extends AWSTreeNodeBase implements AWSResourceNode
 function makeStateMachineNode(
     parent: AWSTreeNodeBase,
     regionCode: string,
-    details: StepFunctions.StateMachineListItem
+    details: StateMachineListItem
 ): StateMachineNode {
     const node = new StateMachineNode(parent, regionCode, details)
     node.contextValue = contextValueStateMachine

--- a/src/stepFunctions/utils.ts
+++ b/src/stepFunctions/utils.ts
@@ -5,7 +5,8 @@
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
 
-import { IAM, StepFunctions } from 'aws-sdk'
+import { Role } from "@aws-sdk/client-iam";
+import { StateMachineListItem } from "@aws-sdk/client-sfn";
 import { mkdir, writeFile } from 'fs-extra'
 import * as vscode from 'vscode'
 import { StepFunctionsClient } from '../shared/clients/stepFunctionsClient'
@@ -188,7 +189,7 @@ async function httpsGetRequestWrapper(url: string): Promise<string> {
 
 export async function* listStateMachines(
     client: StepFunctionsClient
-): AsyncIterableIterator<StepFunctions.StateMachineListItem> {
+): AsyncIterableIterator<StateMachineListItem> {
     const status = vscode.window.setStatusBarMessage(
         localize('AWS.message.statusBar.loading.statemachines', 'Loading State Machines...')
     )
@@ -206,7 +207,7 @@ export async function* listStateMachines(
  * Checks if the given IAM Role is assumable by AWS Step Functions.
  * @param role The IAM role to check
  */
-export function isStepFunctionsRole(role: IAM.Role): boolean {
+export function isStepFunctionsRole(role: Role): boolean {
     const stepFunctionsSevicePrincipal: string = 'states.amazonaws.com'
     const assumeRolePolicyDocument: string | undefined = role.AssumeRolePolicyDocument
 

--- a/src/test/apigateway/commands/invokeRemoteRestApi.test.ts
+++ b/src/test/apigateway/commands/invokeRemoteRestApi.test.ts
@@ -5,12 +5,12 @@
 
 import assert from 'assert'
 import { listValidMethods } from '../../../apigateway/vue/invokeRemoteRestApi'
-import { Resource } from 'aws-sdk/clients/apigateway'
+import { UpdateResourceCommandOutput } from "@aws-sdk/client-api-gateway";
 
 describe('listValidMethods', function () {
     const allMethods = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT']
     it('returns all methods if "ANY" is a method', async function () {
-        const resource: Resource = {
+        const resource: UpdateResourceCommandOutput = {
             resourceMethods: {
                 ANY: {},
             },
@@ -21,7 +21,7 @@ describe('listValidMethods', function () {
         assert.deepStrictEqual(actual, allMethods)
     })
     it('returns dedupe-d all methods if "ANY" declared with another method', async function () {
-        const resource: Resource = {
+        const resource: UpdateResourceCommandOutput = {
             resourceMethods: {
                 ANY: {},
                 POST: {},
@@ -33,7 +33,7 @@ describe('listValidMethods', function () {
         assert.deepStrictEqual(actual, allMethods)
     })
     it('returns get if declares get', async function () {
-        const resource: Resource = {
+        const resource: UpdateResourceCommandOutput = {
             resourceMethods: {
                 GET: {},
             },
@@ -44,7 +44,7 @@ describe('listValidMethods', function () {
         assert.deepStrictEqual(actual, ['GET'])
     })
     it('returns nothing if no methods', async function () {
-        const resource: Resource = {}
+        const resource: UpdateResourceCommandOutput = {}
 
         const actual = listValidMethods(resource)
 

--- a/src/test/apprunner/explorer/apprunnerNode.test.ts
+++ b/src/test/apprunner/explorer/apprunnerNode.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert'
 import * as FakeTimers from '@sinonjs/fake-timers'
 import * as sinon from 'sinon'
-import { AppRunner } from 'aws-sdk'
+import { ServiceSummary } from "@aws-sdk/client-apprunner";
 import { verify, anything, instance, mock, when } from 'ts-mockito'
 import { AppRunnerNode } from '../../../apprunner/explorer/apprunnerNode'
 import { AppRunnerServiceNode } from '../../../apprunner/explorer/apprunnerServiceNode'
@@ -21,7 +21,7 @@ describe('AppRunnerNode', function () {
     let clock: FakeTimers.InstalledClock
     let refreshStub: sinon.SinonStub<[], void>
 
-    const exampleSummaries: AppRunner.ServiceSummaryList = [
+    const exampleSummaries: Array<ServiceSummary> = [
         {
             ServiceName: 'test1',
             Status: 'RUNNING',

--- a/src/test/apprunner/explorer/apprunnerServiceNode.test.ts
+++ b/src/test/apprunner/explorer/apprunnerServiceNode.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert'
 import * as sinon from 'sinon'
-import { AppRunner } from 'aws-sdk'
+import { Service } from "@aws-sdk/client-apprunner";
 import { verify, instance, mock } from 'ts-mockito'
 import { AppRunnerNode } from '../../../apprunner/explorer/apprunnerNode'
 import { AppRunnerServiceNode } from '../../../apprunner/explorer/apprunnerServiceNode'
@@ -21,7 +21,7 @@ describe('AppRunnerServiceNode', function () {
     let mockParentNode: AppRunnerNode
     let node: AppRunnerServiceNode
 
-    const exampleInfo: AppRunner.Service = {
+    const exampleInfo: Service = {
         ServiceName: 'test1',
         Status: 'RUNNING',
         ServiceArn: 'test-arn1',

--- a/src/test/apprunner/wizards/codeRepositoryWizard.test.ts
+++ b/src/test/apprunner/wizards/codeRepositoryWizard.test.ts
@@ -4,14 +4,13 @@
  */
 
 import assert from 'assert'
-import { AppRunner } from 'aws-sdk'
+import { CodeRepository, ConnectionSummary, SourceConfiguration } from "@aws-sdk/client-apprunner";
 import { createWizardTester, WizardTester } from '../../shared/wizards/wizardTestUtils'
 import {
     AppRunnerCodeRepositoryWizard,
     createConnectionPrompter,
 } from '../../../apprunner/wizards/codeRepositoryWizard'
 import { DefaultAppRunnerClient } from '../../../shared/clients/apprunnerClient'
-import { ConnectionSummary } from 'aws-sdk/clients/apprunner'
 import { WIZARD_EXIT } from '../../../shared/wizards/wizard'
 import { apprunnerConnectionHelpUrl } from '../../../shared/constants'
 import { createQuickPickPrompterTester, QuickPickPrompterTester } from '../../shared/ui/testUtils'
@@ -19,8 +18,8 @@ import { stub } from '../../utilities/stubber'
 import { getOpenExternalStub } from '../../globalSetup.test'
 
 describe('AppRunnerCodeRepositoryWizard', function () {
-    let tester: WizardTester<AppRunner.SourceConfiguration>
-    let repoTester: WizardTester<AppRunner.CodeRepository>
+    let tester: WizardTester<SourceConfiguration>
+    let repoTester: WizardTester<CodeRepository>
 
     beforeEach(function () {
         // apprunner client and git api will never be called

--- a/src/test/apprunner/wizards/createServiceWizard.test.ts
+++ b/src/test/apprunner/wizards/createServiceWizard.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { createWizardTester, WizardTester } from '../../../test/shared/wizards/wizardTestUtils'
-import { AppRunner } from 'aws-sdk'
+import { CreateServiceCommandInput } from "@aws-sdk/client-apprunner";
 import { CreateAppRunnerServiceWizard } from '../../../apprunner/wizards/apprunnerCreateServiceWizard'
 import { stub } from '../../utilities/stubber'
 import { DefaultIamClient } from '../../../shared/clients/iamClient'
@@ -12,7 +12,7 @@ import { DefaultEcrClient } from '../../../shared/clients/ecrClient'
 import { DefaultAppRunnerClient } from '../../../shared/clients/apprunnerClient'
 
 describe('CreateServiceWizard', function () {
-    let tester: WizardTester<AppRunner.CreateServiceRequest>
+    let tester: WizardTester<CreateServiceCommandInput>
 
     beforeEach(function () {
         const regionCode = 'us-east-1'

--- a/src/test/apprunner/wizards/imageRepositoryWizard.test.ts
+++ b/src/test/apprunner/wizards/imageRepositoryWizard.test.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AppRunner } from 'aws-sdk'
+
+
+import { ImageRepository, SourceConfiguration } from "@aws-sdk/client-apprunner";
 import { createWizardTester, WizardTester } from '../../shared/wizards/wizardTestUtils'
 import {
     AppRunnerImageRepositoryWizard,
@@ -12,8 +14,8 @@ import {
 } from '../../../apprunner/wizards/imageRepositoryWizard'
 
 describe('AppRunnerImageRepositoryWizard', function () {
-    let tester: WizardTester<AppRunner.SourceConfiguration>
-    let repoTester: WizardTester<AppRunner.ImageRepository>
+    let tester: WizardTester<SourceConfiguration>
+    let repoTester: WizardTester<ImageRepository>
 
     beforeEach(function () {
         const wizard = new AppRunnerImageRepositoryWizard({} as any, {} as any) // the clients will never be called

--- a/src/test/cloudWatchLogs/document/logDataDocumentProvider.test.ts
+++ b/src/test/cloudWatchLogs/document/logDataDocumentProvider.test.ts
@@ -17,7 +17,7 @@ import {
 import { Settings } from '../../../shared/settings'
 import { LogDataCodeLensProvider } from '../../../cloudWatchLogs/document/logDataCodeLensProvider'
 import { CLOUDWATCH_LOGS_SCHEME } from '../../../shared/constants'
-import { FilteredLogEvent } from 'aws-sdk/clients/cloudwatchlogs'
+import { FilteredLogEvent } from "@aws-sdk/client-cloudwatch-logs";
 
 const getLogEventsMessage = 'This is from getLogEvents'
 

--- a/src/test/cloudWatchLogs/explorer/logGroupNode.test.ts
+++ b/src/test/cloudWatchLogs/explorer/logGroupNode.test.ts
@@ -4,13 +4,13 @@
  */
 
 import assert from 'assert'
-import { CloudWatchLogs } from 'aws-sdk'
+import { LogGroup } from "@aws-sdk/client-cloudwatch-logs";
 import * as os from 'os'
 import { LogGroupNode } from '../../../cloudWatchLogs/explorer/logGroupNode'
 
 describe('LogGroupNode', function () {
     let testNode: LogGroupNode
-    let fakeLogGroup: CloudWatchLogs.LogGroup
+    let fakeLogGroup: LogGroup
 
     before(function () {
         fakeLogGroup = {

--- a/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
@@ -27,8 +27,7 @@ import {
     testLogData,
     unregisteredData,
 } from '../utils.test'
-import { CloudWatchLogs } from 'aws-sdk'
-import { FilteredLogEvents } from 'aws-sdk/clients/cloudwatchlogs'
+import { FilteredLogEvent } from "@aws-sdk/client-cloudwatch-logs";
 
 describe('LogDataRegistry', async function () {
     let registry: GetSetLogDataRegistry
@@ -115,8 +114,8 @@ describe('LogDataRegistry', async function () {
         const pageToken1 = 'page1Token'
         const pageToken2 = 'page2Token'
 
-        function createCwlEvents(id: string, count: number): FilteredLogEvents {
-            let events: CloudWatchLogs.FilteredLogEvents = []
+        function createCwlEvents(id: string, count: number): Array<FilteredLogEvent> {
+            let events: Array<FilteredLogEvent> = []
             for (let i = 0; i < count; i++) {
                 events = events.concat({ message: `message-${id}`, logStreamName: `stream-${id}` })
             }
@@ -127,10 +126,10 @@ describe('LogDataRegistry', async function () {
             return async function (
                 logGroupInfo: CloudWatchLogsGroupInfo,
                 parameters: CloudWatchLogsParameters,
-                nextToken?: CloudWatchLogs.NextToken
+                nextToken?: string
             ) {
                 return getSimulatedCwlResponse(nextToken, isPage1Empty)
-            }
+            };
         }
 
         /**
@@ -140,7 +139,7 @@ describe('LogDataRegistry', async function () {
          * @returns
          */
         function getSimulatedCwlResponse(
-            token: CloudWatchLogs.NextToken | undefined,
+            token: string | undefined,
             isPage1Empty: boolean
         ): CloudWatchLogsResponse {
             switch (token) {

--- a/src/test/cloudWatchLogs/utils.test.ts
+++ b/src/test/cloudWatchLogs/utils.test.ts
@@ -4,7 +4,6 @@
  */
 
 import assert from 'assert'
-import { CloudWatchLogs } from 'aws-sdk'
 import * as vscode from 'vscode'
 import { createURIFromArgs, parseCloudWatchLogsUri, uriToKey } from '../../cloudWatchLogs/cloudWatchLogsUtils'
 import {
@@ -26,7 +25,7 @@ export const backwardToken = 'backward'
 export async function returnPaginatedEvents(
     logGroupInfo: CloudWatchLogsGroupInfo,
     parameters: CloudWatchLogsParameters,
-    nextToken?: CloudWatchLogs.NextToken
+    nextToken?: string
 ) {
     switch (nextToken) {
         case forwardToken:
@@ -45,7 +44,7 @@ export async function returnPaginatedEvents(
 export async function returnNonEmptyPaginatedEvents(
     logGroupInfo: CloudWatchLogsGroupInfo,
     parameters: CloudWatchLogsParameters,
-    nextToken?: CloudWatchLogs.NextToken
+    nextToken?: string
 ) {
     const result = await returnPaginatedEvents(logGroupInfo, parameters, nextToken)
     if (result.events.length === 0) {

--- a/src/test/dynamicResources/explorer/moreResourcesNode.test.ts
+++ b/src/test/dynamicResources/explorer/moreResourcesNode.test.ts
@@ -11,7 +11,6 @@ import { CloudFormationClient } from '../../../shared/clients/cloudFormationClie
 import { assertNodeListOnlyHasPlaceholderNode } from '../../utilities/explorerNodeAssertions'
 import { asyncGenerator } from '../../../shared/utilities/collectionUtils'
 import { mock, instance, when } from 'ts-mockito'
-import { CloudFormation } from 'aws-sdk'
 import { CloudControlClient } from '../../../shared/clients/cloudControlClient'
 import { Settings } from '../../../shared/settings'
 import { ResourcesSettings } from '../../../dynamicResources/commands/configure'

--- a/src/test/dynamicResources/explorer/resourceTypeNode.test.ts
+++ b/src/test/dynamicResources/explorer/resourceTypeNode.test.ts
@@ -15,7 +15,6 @@ import {
 } from '../../utilities/explorerNodeAssertions'
 import { deepEqual, instance, mock, when } from '../../utilities/mockito'
 import { CloudControlClient } from '../../../shared/clients/cloudControlClient'
-import { CloudControl } from 'aws-sdk'
 import { ResourceTypeMetadata } from '../../../dynamicResources/model/resources'
 
 const fakeTypeName = 'sometype'

--- a/src/test/ec2/explorer/ec2ParentNode.test.ts
+++ b/src/test/ec2/explorer/ec2ParentNode.test.ts
@@ -13,14 +13,14 @@ import {
     assertNodeListOnlyHasPlaceholderNode,
 } from '../../utilities/explorerNodeAssertions'
 import { Ec2InstanceNode } from '../../../ec2/explorer/ec2InstanceNode'
-import { EC2 } from 'aws-sdk'
+import { Filter, Instance } from "@aws-sdk/client-ec2";
 import { AsyncCollection } from '../../../shared/utilities/asyncCollection'
 
 describe('ec2ParentNode', function () {
     let testNode: Ec2ParentNode
     let instances: Ec2Instance[]
     let client: Ec2Client
-    let getInstanceStub: sinon.SinonStub<[filters?: EC2.Filter[] | undefined], Promise<AsyncCollection<EC2.Instance>>>
+    let getInstanceStub: sinon.SinonStub<[filters?: Filter[] | undefined], Promise<AsyncCollection<Instance>>>
 
     const testRegion = 'testRegion'
     const testPartition = 'testPartition'

--- a/src/test/ec2/model.test.ts
+++ b/src/test/ec2/model.test.ts
@@ -10,7 +10,7 @@ import { SsmClient } from '../../shared/clients/ssmClient'
 import { Ec2Client } from '../../shared/clients/ec2Client'
 import { Ec2Selection } from '../../ec2/prompter'
 import { ToolkitError } from '../../shared/errors'
-import { IAM } from 'aws-sdk'
+import { Policy, Role } from "@aws-sdk/client-iam";
 import { SshKeyPair } from '../../ec2/sshKeyPair'
 import { DefaultIamClient } from '../../shared/clients/iamClient'
 
@@ -23,13 +23,13 @@ describe('Ec2ConnectClient', function () {
 
     describe('getAttachedIamRole', async function () {
         it('only returns role if recieves ARN from instance profile', async function () {
-            let role: IAM.Role | undefined
+            let role: Role | undefined
             const getInstanceProfileStub = sinon.stub(Ec2Client.prototype, 'getAttachedIamInstanceProfile')
 
             getInstanceProfileStub.resolves({ Arn: 'thisIsAnArn' })
             sinon
                 .stub(DefaultIamClient.prototype, 'getIAMRoleFromInstanceProfile')
-                .resolves({ Arn: 'ThisIsARoleArn' } as IAM.Role)
+                .resolves({ Arn: 'ThisIsARoleArn' } as Role)
 
             role = await client.getAttachedIamRole('test-instance')
             assert.ok(role)
@@ -44,7 +44,7 @@ describe('Ec2ConnectClient', function () {
 
     describe('hasProperPolicies', async function () {
         it('correctly determines if proper policies are included', async function () {
-            async function assertAcceptsPolicies(policies: IAM.Policy[], expectedResult: boolean) {
+            async function assertAcceptsPolicies(policies: Policy[], expectedResult: boolean) {
                 sinon.stub(DefaultIamClient.prototype, 'listAttachedRolePolicies').resolves(policies)
 
                 const result = await client.hasProperPolicies('')
@@ -130,7 +130,7 @@ describe('Ec2ConnectClient', function () {
 
         it('throws EC2SSMAgent error if instance is running and has IAM Role, but agent is not running', async function () {
             sinon.stub(Ec2ConnectionManager.prototype, 'isInstanceRunning').resolves(true)
-            sinon.stub(Ec2ConnectionManager.prototype, 'getAttachedIamRole').resolves({ Arn: 'testRole' } as IAM.Role)
+            sinon.stub(Ec2ConnectionManager.prototype, 'getAttachedIamRole').resolves({ Arn: 'testRole' } as Role)
             sinon.stub(Ec2ConnectionManager.prototype, 'hasProperPolicies').resolves(true)
             sinon.stub(SsmClient.prototype, 'getInstanceAgentPingStatus').resolves('offline')
 
@@ -144,7 +144,7 @@ describe('Ec2ConnectClient', function () {
 
         it('does not throw an error if all checks pass', async function () {
             sinon.stub(Ec2ConnectionManager.prototype, 'isInstanceRunning').resolves(true)
-            sinon.stub(Ec2ConnectionManager.prototype, 'getAttachedIamRole').resolves({ Arn: 'testRole' } as IAM.Role)
+            sinon.stub(Ec2ConnectionManager.prototype, 'getAttachedIamRole').resolves({ Arn: 'testRole' } as Role)
             sinon.stub(Ec2ConnectionManager.prototype, 'hasProperPolicies').resolves(true)
             sinon.stub(SsmClient.prototype, 'getInstanceAgentPingStatus').resolves('Online')
 

--- a/src/test/eventSchemas/commands/downloadSchemaItemCode.test.ts
+++ b/src/test/eventSchemas/commands/downloadSchemaItemCode.test.ts
@@ -8,7 +8,11 @@ import * as fs from 'fs-extra'
 import * as path from 'path'
 import * as vscode from 'vscode'
 
-import { Schemas } from 'aws-sdk'
+import {
+    DescribeCodeBindingCommandOutput,
+    GetCodeBindingSourceCommandOutput,
+    PutCodeBindingCommandOutput,
+} from "@aws-sdk/client-schemas";
 import * as sinon from 'sinon'
 
 import {
@@ -60,7 +64,7 @@ describe('CodeDownloader', function () {
 
     describe('codeDownloader', async function () {
         it('should return an error if the response body is not Buffer', async function () {
-            const response: Schemas.GetCodeBindingSourceResponse = {
+            const response: GetCodeBindingSourceCommandOutput = {
                 Body: 'Invalied body',
             }
             sandbox.stub(schemaClient, 'getCodeBindingSource').returns(Promise.resolve(response))
@@ -74,7 +78,7 @@ describe('CodeDownloader', function () {
 
         it('should return arrayBuffer for valid Body type', async function () {
             const myBuffer = Buffer.from('TEST STRING')
-            const response: Schemas.GetCodeBindingSourceResponse = {
+            const response: GetCodeBindingSourceCommandOutput = {
                 Body: myBuffer,
             }
 
@@ -145,7 +149,7 @@ describe('CodeGenerator', function () {
 
     describe('codeGenerator', async function () {
         it('should return the current status of code generation', async function () {
-            const response: Schemas.PutCodeBindingResponse = {
+            const response: PutCodeBindingCommandOutput = {
                 Status: CodeGenerationStatus.CREATE_IN_PROGRESS,
             }
             sandbox.stub(schemaClient, 'putCodeBinding').returns(Promise.resolve(response))
@@ -161,7 +165,7 @@ describe('CodeGenerator', function () {
         // If code bindings were not generated, but putCodeBinding was already called, ConflictException occurs
         // Return CREATE_IN_PROGRESS and keep polling in this case
         it('should return valid code generation status if it gets ConflictException', async function () {
-            const response: Schemas.PutCodeBindingResponse = {
+            const response: PutCodeBindingCommandOutput = {
                 Status: CodeGenerationStatus.CREATE_IN_PROGRESS,
             }
 
@@ -221,10 +225,10 @@ describe('CodeGeneratorStatusPoller', function () {
 
     describe('getCurrentStatus', async function () {
         it('should return the current status of code generation', async function () {
-            const firstStatus: Schemas.DescribeCodeBindingResponse = {
+            const firstStatus: DescribeCodeBindingCommandOutput = {
                 Status: CodeGenerationStatus.CREATE_IN_PROGRESS,
             }
-            const secondStatus: Schemas.DescribeCodeBindingResponse = {
+            const secondStatus: DescribeCodeBindingCommandOutput = {
                 Status: CodeGenerationStatus.CREATE_COMPLETE,
             }
 
@@ -242,7 +246,7 @@ describe('CodeGeneratorStatusPoller', function () {
 
     describe('codeGeneratorStatusPoller', async function () {
         it('fails if code generation status is invalid without retry', async function () {
-            const schemaResponse: Schemas.DescribeCodeBindingResponse = {
+            const schemaResponse: DescribeCodeBindingCommandOutput = {
                 Status: CodeGenerationStatus.CREATE_FAILED,
             }
 
@@ -263,7 +267,7 @@ describe('CodeGeneratorStatusPoller', function () {
         })
 
         it('times out after max attempts if status is still in progress', async function () {
-            const schemaResponse: Schemas.DescribeCodeBindingResponse = {
+            const schemaResponse: DescribeCodeBindingCommandOutput = {
                 Status: CodeGenerationStatus.CREATE_IN_PROGRESS,
             }
 
@@ -287,7 +291,7 @@ describe('CodeGeneratorStatusPoller', function () {
         })
 
         it('succeeds when code is previously generated without retry', async function () {
-            const schemaResponse: Schemas.DescribeCodeBindingResponse = {
+            const schemaResponse: DescribeCodeBindingCommandOutput = {
                 Status: CodeGenerationStatus.CREATE_COMPLETE,
             }
 
@@ -399,7 +403,7 @@ describe('SchemaCodeDownload', function () {
         it('should generate code if download fails with ResourceNotFound and place it into requested directory', async function () {
             sandbox.stub(poller, 'pollForCompletion').returns(Promise.resolve('CREATE_COMPLETE'))
             const codeDownloaderStub = sandbox.stub(downloader, 'download')
-            const codeGeneratorResponse: Schemas.PutCodeBindingResponse = {
+            const codeGeneratorResponse: PutCodeBindingCommandOutput = {
                 Status: 'CREATE_IN_PROGRESS',
             }
             sandbox.stub(generator, 'generate').returns(Promise.resolve(codeGeneratorResponse))

--- a/src/test/eventSchemas/commands/searchSchemas.test.ts
+++ b/src/test/eventSchemas/commands/searchSchemas.test.ts
@@ -5,7 +5,11 @@
 
 import assert from 'assert'
 
-import { Schemas } from 'aws-sdk'
+import {
+    DescribeSchemaCommandOutput,
+    SearchSchemaSummary,
+    SearchSchemaVersionSummary,
+} from "@aws-sdk/client-schemas";
 import * as sinon from 'sinon'
 import { SchemasNode } from '../../../eventSchemas/explorer/schemasNode'
 import { getTabSizeSetting } from '../../../shared/utilities/editorUtilities'
@@ -42,25 +46,25 @@ describe('Search Schemas', function () {
     const failRegistry = 'failRegistry'
     const failRegistry2 = 'failRegistry2'
 
-    const versionSummary1: Schemas.SearchSchemaVersionSummary = {
+    const versionSummary1: SearchSchemaVersionSummary = {
         SchemaVersion: '1',
     }
-    const versionSummary2: Schemas.SearchSchemaVersionSummary = {
+    const versionSummary2: SearchSchemaVersionSummary = {
         SchemaVersion: '2',
     }
-    const searchSummary1: Schemas.SearchSchemaSummary = {
+    const searchSummary1: SearchSchemaSummary = {
         RegistryName: testRegistry,
         SchemaName: 'testSchema1',
         SchemaVersions: [versionSummary1, versionSummary2],
     }
 
-    const searchSummary2: Schemas.SearchSchemaSummary = {
+    const searchSummary2: SearchSchemaSummary = {
         RegistryName: testRegistry,
         SchemaName: 'testSchema2',
         SchemaVersions: [versionSummary1],
     }
 
-    const searchSummary3: Schemas.SearchSchemaSummary = {
+    const searchSummary3: SearchSchemaSummary = {
         RegistryName: testRegistry2,
         SchemaName: 'testSchema3',
         SchemaVersions: [versionSummary1],
@@ -178,7 +182,7 @@ describe('Search Schemas', function () {
         const multipleRegistryNames = [testRegistry, testRegistry2]
         const awsEventSchemaRaw =
             '{"openapi":"3.0.0","info":{"version":"1.0.0","title":"Event"},"paths":{},"components":{"schemas":{"Event":{"type":"object"}}}}'
-        const schemaResponse: Schemas.DescribeSchemaResponse = {
+        const schemaResponse: DescribeSchemaCommandOutput = {
             Content: awsEventSchemaRaw,
         }
 

--- a/src/test/eventSchemas/commands/viewSchemaItem.test.ts
+++ b/src/test/eventSchemas/commands/viewSchemaItem.test.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Schemas } from 'aws-sdk'
+
+
+import { DescribeSchemaCommandOutput } from "@aws-sdk/client-schemas";
 
 import assert from 'assert'
 import * as sinon from 'sinon'
@@ -117,7 +119,7 @@ describe('viewSchemaItem', async function () {
     }
 
     function generateSchemaItemNode(): SchemaItemNode {
-        const schemaResponse: Schemas.DescribeSchemaResponse = {
+        const schemaResponse: DescribeSchemaCommandOutput = {
             Content: awsEventSchemaRaw,
         }
         const schemaClient = new DefaultSchemaClient('')

--- a/src/test/eventSchemas/explorer/registryItemNode.test.ts
+++ b/src/test/eventSchemas/explorer/registryItemNode.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert'
 import * as os from 'os'
 import * as sinon from 'sinon'
-import { Schemas } from 'aws-sdk'
+import { RegistrySummary, SchemaSummary } from "@aws-sdk/client-schemas";
 import { RegistryItemNode } from '../../../eventSchemas/explorer/registryItemNode'
 import { SchemaItemNode } from '../../../eventSchemas/explorer/schemaItemNode'
 import { SchemasNode } from '../../../eventSchemas/explorer/schemasNode'
@@ -21,7 +21,7 @@ import { asyncGenerator } from '../../../shared/utilities/collectionUtils'
 import { getIcon } from '../../../shared/icons'
 import { stub } from '../../utilities/stubber'
 
-function createSchemaClient(data?: { schemas?: Schemas.SchemaSummary[]; registries?: Schemas.RegistrySummary[] }) {
+function createSchemaClient(data?: { schemas?: SchemaSummary[]; registries?: RegistrySummary[] }) {
     const client = stub(DefaultSchemaClient, { regionCode: 'code' })
     client.listSchemas.callsFake(() => asyncGenerator(data?.schemas ?? []))
     client.listRegistries.callsFake(() => asyncGenerator(data?.registries ?? []))
@@ -30,7 +30,7 @@ function createSchemaClient(data?: { schemas?: Schemas.SchemaSummary[]; registri
 }
 
 describe('RegistryItemNode', function () {
-    let fakeRegistry: Schemas.RegistrySummary
+    let fakeRegistry: RegistrySummary
 
     before(function () {
         fakeRegistry = {
@@ -58,17 +58,17 @@ describe('RegistryItemNode', function () {
     })
 
     it('returns schemas that belong to Registry', async function () {
-        const schema1Item: Schemas.SchemaSummary = {
+        const schema1Item: SchemaSummary = {
             SchemaArn: 'arn:schema1',
             SchemaName: 'schema1Name',
         }
 
-        const schema2Item: Schemas.SchemaSummary = {
+        const schema2Item: SchemaSummary = {
             SchemaArn: 'arn:schema1',
             SchemaName: 'schema2Name',
         }
 
-        const schema3Item: Schemas.SchemaSummary = {
+        const schema3Item: SchemaSummary = {
             SchemaArn: 'arn:schema1',
             SchemaName: 'schema3Name',
         }

--- a/src/test/iot/commands/attachCertificate.test.ts
+++ b/src/test/iot/commands/attachCertificate.test.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from 'assert'
-import { Iot } from 'aws-sdk'
+import { Certificate } from "@aws-sdk/client-iot";
 import { attachCertificateCommand, CertGen } from '../../../iot/commands/attachCertificate'
 import { IotThingFolderNode } from '../../../iot/explorer/iotThingFolderNode'
 import { IotThingNode } from '../../../iot/explorer/iotThingNode'
@@ -19,20 +19,20 @@ import { getTestWindow } from '../../shared/vscode/window'
 describe('attachCertCommand', function () {
     const thingName = 'iot-thing'
     let iot: IotClient
-    let certs: Iot.Certificate[]
+    let certs: Certificate[]
     let thingNode: IotThingNode
     let selection: number = 0
 
-    const prompt: (iot: IotClient, certFetch: CertGen) => Promise<PromptResult<Iot.Certificate>> = async (
+    const prompt: (iot: IotClient, certFetch: CertGen) => Promise<PromptResult<Certificate>> = async (
         iot,
         certFetch
     ) => {
         const iterable = certFetch(iot)
-        const responses: DataQuickPickItem<Iot.Certificate>[] = []
+        const responses: DataQuickPickItem<Certificate>[] = []
         for await (const response of iterable) {
             responses.push(...response)
         }
-        return selection > -1 ? (responses[selection].data as Iot.Certificate) : undefined
+        return selection > -1 ? (responses[selection].data as Certificate) : undefined;
     }
 
     beforeEach(function () {

--- a/src/test/iot/commands/attachPolicy.test.ts
+++ b/src/test/iot/commands/attachPolicy.test.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from 'assert'
-import { Iot } from 'aws-sdk'
+import { Policy } from "@aws-sdk/client-iot";
 import { attachPolicyCommand, PolicyGen } from '../../../iot/commands/attachPolicy'
 import { IotCertsFolderNode } from '../../../iot/explorer/iotCertFolderNode'
 import { IotCertWithPoliciesNode } from '../../../iot/explorer/iotCertificateNode'
@@ -20,19 +20,19 @@ import { getTestWindow } from '../../shared/vscode/window'
 describe('attachPolicyCommand', function () {
     const certId = 'iot-certificate'
     let iot: IotClient
-    let policies: Iot.Policy[]
+    let policies: Policy[]
     let certNode: IotCertWithPoliciesNode
     let selection: number = 0
-    const prompt: (iot: IotClient, policyFetch: PolicyGen) => Promise<PromptResult<Iot.Policy>> = async (
+    const prompt: (iot: IotClient, policyFetch: PolicyGen) => Promise<PromptResult<Policy>> = async (
         iot,
         policyFetch
     ) => {
         const iterable = policyFetch(iot)
-        const responses: DataQuickPickItem<Iot.Policy>[] = []
+        const responses: DataQuickPickItem<Policy>[] = []
         for await (const response of iterable) {
             responses.push(...response)
         }
-        return selection > -1 ? (responses[selection].data as Iot.Policy) : undefined
+        return selection > -1 ? (responses[selection].data as Policy) : undefined;
     }
 
     beforeEach(function () {

--- a/src/test/iot/commands/createCert.test.ts
+++ b/src/test/iot/commands/createCert.test.ts
@@ -11,7 +11,7 @@ import { IotClient } from '../../../shared/clients/iotClient'
 import { anything, mock, instance, when, deepEqual, verify } from '../../utilities/mockito'
 import { FakeCommands } from '../../shared/vscode/fakeCommands'
 import { IotCertsFolderNode } from '../../../iot/explorer/iotCertFolderNode'
-import { Iot } from 'aws-sdk'
+import { CreateKeysAndCertificateCommandOutput } from "@aws-sdk/client-iot";
 import { getTestWindow } from '../../shared/vscode/window'
 
 describe('createCertificateCommand', function () {
@@ -19,7 +19,7 @@ describe('createCertificateCommand', function () {
     const certificateArn = 'arn'
     const certificatePem = 'certPem'
     const keyPair = { PrivateKey: 'private', PublicKey: 'public' }
-    const certificate: Iot.CreateKeysAndCertificateResponse = { certificateId, certificateArn, certificatePem, keyPair }
+    const certificate: CreateKeysAndCertificateCommandOutput = { certificateId, certificateArn, certificatePem, keyPair }
     let iot: IotClient
     let node: IotCertsFolderNode
     let saveLocation: vscode.Uri | undefined = vscode.Uri.file('/certificate.txt')

--- a/src/test/iot/commands/deletePolicy.test.ts
+++ b/src/test/iot/commands/deletePolicy.test.ts
@@ -4,7 +4,6 @@
  */
 
 import assert from 'assert'
-import { Iot } from 'aws-sdk'
 import { deletePolicyCommand } from '../../../iot/commands/deletePolicy'
 import { IotPolicyFolderNode } from '../../../iot/explorer/iotPolicyFolderNode'
 import { IotPolicyWithVersionsNode } from '../../../iot/explorer/iotPolicyNode'

--- a/src/test/iot/explorer/iotCertFolderNode.test.ts
+++ b/src/test/iot/explorer/iotCertFolderNode.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert'
 import { MoreResultsNode } from '../../../awsexplorer/moreResultsNode'
 import { IotNode } from '../../../iot/explorer/iotNodes'
 import { IotCertificate, IotClient } from '../../../shared/clients/iotClient'
-import { Iot } from 'aws-sdk'
+import { Certificate } from "@aws-sdk/client-iot";
 import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
 import { deepEqual, instance, mock, when } from '../../utilities/mockito'
 import { FakeWorkspace } from '../../shared/vscode/fakeWorkspace'
@@ -19,7 +19,7 @@ describe('IotCertFolderNode', function () {
     const pageSize = 250
 
     let iot: IotClient
-    const cert: Iot.Certificate = {
+    const cert: Certificate = {
         certificateId: 'cert',
         certificateArn: 'arn',
         status: 'ACTIVE',

--- a/src/test/iot/explorer/iotCertificateNode.test.ts
+++ b/src/test/iot/explorer/iotCertificateNode.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert'
 import { MoreResultsNode } from '../../../awsexplorer/moreResultsNode'
 import { IotClient, IotPolicy } from '../../../shared/clients/iotClient'
-import { Iot } from 'aws-sdk'
+import { Policy } from "@aws-sdk/client-iot";
 import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
 import { deepEqual, instance, mock, when } from '../../utilities/mockito'
 import { FakeWorkspace } from '../../shared/vscode/fakeWorkspace'
@@ -21,7 +21,7 @@ describe('IotCertificateNode', function () {
     let iot: IotClient
     const certArn = 'certArn'
     const cert = { id: 'cert', arn: certArn, activeStatus: 'ACTIVE', creationDate: new Date(0) }
-    const policy: Iot.Policy = { policyName: 'policy', policyArn: 'arn' }
+    const policy: Policy = { policyName: 'policy', policyArn: 'arn' }
     const expectedPolicy: IotPolicy = { name: 'policy', arn: 'arn' }
 
     function assertPolicyNode(node: AWSTreeNodeBase, expectedPolicy: IotPolicy): void {

--- a/src/test/iot/explorer/iotPolicyFolderNode.test.ts
+++ b/src/test/iot/explorer/iotPolicyFolderNode.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert'
 import { MoreResultsNode } from '../../../awsexplorer/moreResultsNode'
 import { IotNode } from '../../../iot/explorer/iotNodes'
 import { IotClient, IotPolicy } from '../../../shared/clients/iotClient'
-import { Iot } from 'aws-sdk'
+import { Policy } from "@aws-sdk/client-iot";
 import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
 import { deepEqual, instance, mock, when } from '../../utilities/mockito'
 import { FakeWorkspace } from '../../shared/vscode/fakeWorkspace'
@@ -19,7 +19,7 @@ describe('IotPolicyFolderNode', function () {
     const pageSize = 250
 
     let iot: IotClient
-    const policy: Iot.Policy = { policyName: 'policy', policyArn: 'arn' }
+    const policy: Policy = { policyName: 'policy', policyArn: 'arn' }
     const expectedPolicy: IotPolicy = { name: 'policy', arn: 'arn' }
 
     function assertPolicyNode(node: AWSTreeNodeBase, expectedPolicy: IotPolicy): void {

--- a/src/test/iot/explorer/iotPolicyNode.test.ts
+++ b/src/test/iot/explorer/iotPolicyNode.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert'
 import { IotClient, IotPolicy } from '../../../shared/clients/iotClient'
-import { Iot } from 'aws-sdk'
+import { PolicyVersion } from "@aws-sdk/client-iot";
 import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
 import { deepEqual, instance, mock, when } from '../../utilities/mockito'
 import { FakeWorkspace } from '../../shared/vscode/fakeWorkspace'
@@ -18,12 +18,12 @@ describe('IotPolicyNode', function () {
     let iot: IotClient
     const policyName = 'policy'
     const expectedPolicy: IotPolicy = { name: policyName, arn: 'arn' }
-    const policyVersion: Iot.PolicyVersion = { versionId: 'V1', isDefaultVersion: true }
+    const policyVersion: PolicyVersion = { versionId: 'V1', isDefaultVersion: true }
 
     function assertPolicyVersionNode(
         node: AWSTreeNodeBase,
         expectedPolicy: IotPolicy,
-        expectedVersion: Iot.PolicyVersion
+        expectedVersion: PolicyVersion
     ): void {
         assert.ok(node instanceof IotPolicyVersionNode, `Node ${node} should be a Policy Version Node`)
         assert.deepStrictEqual((node as IotPolicyVersionNode).version, expectedVersion)

--- a/src/test/iot/explorer/iotPolicyVersionNode.test.ts
+++ b/src/test/iot/explorer/iotPolicyVersionNode.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert'
 import { IotClient, IotPolicy } from '../../../shared/clients/iotClient'
-import { Iot } from 'aws-sdk'
+import { PolicyVersion } from "@aws-sdk/client-iot";
 import { IotPolicyWithVersionsNode } from '../../../iot/explorer/iotPolicyNode'
 import { IotPolicyVersionNode } from '../../../iot/explorer/iotPolicyVersionNode'
 import moment from 'moment'
@@ -17,8 +17,8 @@ describe('IotPolicyVersionNode', function () {
     const expectedPolicy: IotPolicy = { name: policyName, arn: 'arn' }
     const createDate = new Date(2021, 1, 1)
     const createDateFormatted = moment(createDate).format(LOCALIZED_DATE_FORMAT)
-    const policyVersion: Iot.PolicyVersion = { versionId: 'V1', isDefaultVersion: true, createDate }
-    const nonDefaultVersion: Iot.PolicyVersion = { versionId: 'V2', isDefaultVersion: false, createDate }
+    const policyVersion: PolicyVersion = { versionId: 'V1', isDefaultVersion: true, createDate }
+    const nonDefaultVersion: PolicyVersion = { versionId: 'V2', isDefaultVersion: false, createDate }
 
     it('creates an IoT Policy Version Node for default version', async function () {
         const node = new IotPolicyVersionNode(

--- a/src/test/iot/explorer/iotThingFolderNode.test.ts
+++ b/src/test/iot/explorer/iotThingFolderNode.test.ts
@@ -9,7 +9,7 @@ import { IotNode } from '../../../iot/explorer/iotNodes'
 import { IotThingFolderNode } from '../../../iot/explorer/iotThingFolderNode'
 import { IotThingNode } from '../../../iot/explorer/iotThingNode'
 import { IotClient, IotThing } from '../../../shared/clients/iotClient'
-import { Iot } from 'aws-sdk'
+import { ThingAttribute } from "@aws-sdk/client-iot";
 import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
 import { deepEqual, instance, mock, when } from '../../utilities/mockito'
 import { FakeWorkspace } from '../../shared/vscode/fakeWorkspace'
@@ -19,7 +19,7 @@ describe('IotThingFolderNode', function () {
     const maxResults = 150
 
     let iot: IotClient
-    const thing: Iot.ThingAttribute = { thingName: 'thing', thingArn: 'arn' }
+    const thing: ThingAttribute = { thingName: 'thing', thingArn: 'arn' }
     const expectedThing: IotThing = { name: 'thing', arn: 'arn' }
 
     function assertThingNode(node: AWSTreeNodeBase, expectedThing: IotThing): void {

--- a/src/test/iot/explorer/iotThingNode.test.ts
+++ b/src/test/iot/explorer/iotThingNode.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert'
 import { MoreResultsNode } from '../../../awsexplorer/moreResultsNode'
 import { IotCertificate, IotClient } from '../../../shared/clients/iotClient'
-import { Iot } from 'aws-sdk'
+import { Certificate } from "@aws-sdk/client-iot";
 import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
 import { deepEqual, instance, mock, when } from '../../utilities/mockito'
 import { FakeWorkspace } from '../../shared/vscode/fakeWorkspace'
@@ -21,7 +21,7 @@ describe('IotThingNode', function () {
     let iot: IotClient
     const thingName = 'thing'
     const thing = { name: thingName, arn: 'thingArn' }
-    const cert: Iot.Certificate = {
+    const cert: Certificate = {
         certificateId: 'cert',
         certificateArn: 'arn',
         status: 'ACTIVE',

--- a/src/test/lambda/commands/copyLambdaUrl.test.ts
+++ b/src/test/lambda/commands/copyLambdaUrl.test.ts
@@ -10,7 +10,7 @@ import { LambdaFunctionNode } from '../../../lambda/explorer/lambdaFunctionNode'
 import { DefaultLambdaClient, LambdaClient } from '../../../shared/clients/lambdaClient'
 import { addCodiconToString } from '../../../shared/utilities/textUtilities'
 import { env } from 'vscode'
-import { FunctionUrlConfig } from 'aws-sdk/clients/lambda'
+import { FunctionUrlConfig } from "@aws-sdk/client-lambda";
 import { createQuickPickPrompterTester } from '../../shared/ui/testUtils'
 import { getTestWindow } from '../../shared/vscode/window'
 

--- a/src/test/lambda/explorer/cloudFormationNodes.test.ts
+++ b/src/test/lambda/explorer/cloudFormationNodes.test.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from 'assert'
-import { CloudFormation } from 'aws-sdk'
+import { StackResource } from "@aws-sdk/client-cloudformation";
 import * as os from 'os'
 import {
     CloudFormationNode,
@@ -72,7 +72,7 @@ describe('CloudFormationStackNode', function () {
         return new CloudFormationStackNode(parentNode, regionCode, summary, lambdaClient, cloudFormationClient)
     }
 
-    function generateStackResources(...functionNames: string[]): CloudFormation.StackResource[] {
+    function generateStackResources(...functionNames: string[]): StackResource[] {
         return functionNames.map(name => ({
             PhysicalResourceId: name,
             LogicalResourceId: name,

--- a/src/test/lambda/explorer/lambdaFunctionNode.test.ts
+++ b/src/test/lambda/explorer/lambdaFunctionNode.test.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from 'assert'
-import { Lambda } from 'aws-sdk'
+import { UpdateFunctionConfigurationCommandOutput } from "@aws-sdk/client-lambda";
 import * as os from 'os'
 import { LambdaFunctionNode } from '../../../lambda/explorer/lambdaFunctionNode'
 import { TestAWSTreeNode } from '../../shared/treeview/nodes/testAWSTreeNode'
@@ -12,7 +12,7 @@ import { TestAWSTreeNode } from '../../shared/treeview/nodes/testAWSTreeNode'
 describe('LambdaFunctionNode', function () {
     const parentNode = new TestAWSTreeNode('test node')
     let testNode: LambdaFunctionNode
-    let fakeFunctionConfig: Lambda.FunctionConfiguration
+    let fakeFunctionConfig: UpdateFunctionConfigurationCommandOutput
 
     before(function () {
         fakeFunctionConfig = {

--- a/src/test/lambda/models/samLambdaRuntime.test.ts
+++ b/src/test/lambda/models/samLambdaRuntime.test.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from 'assert'
-import { Runtime } from 'aws-sdk/clients/lambda'
+import { Runtime } from "@aws-sdk/client-lambda";
 import {
     compareSamLambdaRuntime,
     getDependencyManager,

--- a/src/test/redshift/explorer/redshiftDatabaseNode.test.ts
+++ b/src/test/redshift/explorer/redshiftDatabaseNode.test.ts
@@ -5,7 +5,7 @@
 
 import sinon = require('sinon')
 import { RedshiftDatabaseNode } from '../../../redshift/explorer/redshiftDatabaseNode'
-import { RedshiftData } from 'aws-sdk'
+import { RedshiftData } from "@aws-sdk/client-redshift-data";
 import { DefaultRedshiftClient } from '../../../shared/clients/redshiftClient'
 import { ConnectionParams, ConnectionType, RedshiftWarehouseType } from '../../../redshift/models/models'
 import assert = require('assert')

--- a/src/test/redshift/explorer/redshiftNode.test.ts
+++ b/src/test/redshift/explorer/redshiftNode.test.ts
@@ -6,11 +6,11 @@
 import sinon = require('sinon')
 import { RedshiftNode } from '../../../redshift/explorer/redshiftNode'
 import { DefaultRedshiftClient } from '../../../shared/clients/redshiftClient'
-import { AWSError, Redshift, RedshiftServerless, Request } from 'aws-sdk'
+import { AWSError, Request } from 'aws-sdk';
+import { Cluster, DescribeClustersCommandOutput, Redshift } from "@aws-sdk/client-redshift";
+import { ListWorkgroupsCommandOutput, RedshiftServerless, Workgroup } from "@aws-sdk/client-redshift-serverless";
 import assert = require('assert')
 import { RedshiftWarehouseNode } from '../../../redshift/explorer/redshiftWarehouseNode'
-import { ClusterList, ClustersMessage } from 'aws-sdk/clients/redshift'
-import { ListWorkgroupsResponse, WorkgroupList } from 'aws-sdk/clients/redshiftserverless'
 import { RedshiftWarehouseType } from '../../../redshift/models/models'
 import { MoreResultsNode } from '../../../awsexplorer/moreResultsNode'
 import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
@@ -21,22 +21,22 @@ function success<T>(output?: T): Request<T, AWSError> {
     } as Request<any, AWSError>
 }
 
-function getExpectedProvisionedResponse(withNextToken: boolean): ClustersMessage {
+function getExpectedProvisionedResponse(withNextToken: boolean): DescribeClustersCommandOutput {
     const response = {
         Clusters: [
             { ClusterNamespaceArn: 'testArn', ClusterIdentifier: 'testId', ClusterAvailabilityStatus: 'available' },
-        ] as ClusterList,
-    } as ClustersMessage
+        ] as Array<Cluster>,
+    } as DescribeClustersCommandOutput
     if (withNextToken) {
         response.Marker = 'next'
     }
     return response
 }
 
-function getExpectedServerlessResponse(withNextToken: boolean): ListWorkgroupsResponse {
+function getExpectedServerlessResponse(withNextToken: boolean): ListWorkgroupsCommandOutput {
     const response = {
-        workgroups: [{ workgroupArn: 'testArn', workgroupName: 'testWorkgroup', status: 'available' }] as WorkgroupList,
-    } as ListWorkgroupsResponse
+        workgroups: [{ workgroupArn: 'testArn', workgroupName: 'testWorkgroup', status: 'available' }] as Array<Workgroup>,
+    } as ListWorkgroupsCommandOutput
     if (withNextToken) {
         response.nextToken = 'next'
     }

--- a/src/test/redshift/explorer/redshiftSchemaNode.test.ts
+++ b/src/test/redshift/explorer/redshiftSchemaNode.test.ts
@@ -6,11 +6,10 @@
 import * as sinon from 'sinon'
 import * as assert from 'assert'
 import { DefaultRedshiftClient } from '../../../shared/clients/redshiftClient'
-import { RedshiftData } from 'aws-sdk'
+import { ListTablesCommandOutput, RedshiftData } from "@aws-sdk/client-redshift-data";
 import { RedshiftSchemaNode } from '../../../redshift/explorer/redshiftSchemaNode'
 import { ConnectionParams, ConnectionType, RedshiftWarehouseType } from '../../../redshift/models/models'
 import { RedshiftTableNode } from '../../../redshift/explorer/redshiftTableNode'
-import { ListTablesResponse } from 'aws-sdk/clients/redshiftdata'
 import { MoreResultsNode } from '../../../awsexplorer/moreResultsNode'
 
 describe('RedshiftSchemaNode', function () {
@@ -43,7 +42,7 @@ describe('RedshiftSchemaNode', function () {
         it('gets table nodes and filters out tables with pkey', async () => {
             listTablesStub.returns({
                 promise: () =>
-                    Promise.resolve({ Tables: [{ name: 'test' }, { name: 'test_pkey' }] } as ListTablesResponse),
+                    Promise.resolve({ Tables: [{ name: 'test' }, { name: 'test_pkey' }] } as ListTablesCommandOutput),
             })
             const node = new RedshiftSchemaNode('testSchema', redshiftClient, connectionParams)
             const childNodes = await node.getChildren()
@@ -57,7 +56,7 @@ describe('RedshiftSchemaNode', function () {
                     Promise.resolve({
                         Tables: [{ name: 'test' }, { name: 'test_pkey' }],
                         NextToken: 'next',
-                    } as ListTablesResponse),
+                    } as ListTablesCommandOutput),
             })
             const node = new RedshiftSchemaNode('testSchema', redshiftClient, connectionParams)
             const childNodes = await node.getChildren()

--- a/src/test/redshift/explorer/redshiftWarehouseNode.test.ts
+++ b/src/test/redshift/explorer/redshiftWarehouseNode.test.ts
@@ -5,7 +5,7 @@
 
 import sinon = require('sinon')
 import { DefaultRedshiftClient } from '../../../shared/clients/redshiftClient'
-import { ListDatabasesResponse } from 'aws-sdk/clients/redshiftdata'
+import { ListDatabasesCommandOutput, RedshiftData } from "@aws-sdk/client-redshift-data";
 import { ConnectionParams, ConnectionType, RedshiftWarehouseType } from '../../../redshift/models/models'
 import { RedshiftWarehouseNode, CreateNotebookNode } from '../../../redshift/explorer/redshiftWarehouseNode'
 import { RedshiftNode } from '../../../redshift/explorer/redshiftNode'
@@ -39,8 +39,8 @@ function verifyRetryNode(childNodes: AWSTreeNodeBase[]) {
 describe('redshiftWarehouseNode', function () {
     describe('getChildren', function () {
         const sandbox = sinon.createSandbox()
-        const expectedResponse = { Databases: ['testDb1'] } as ListDatabasesResponse
-        const expectedResponseWithNextToken = { Databases: ['testDb1'], NextToken: 'next' } as ListDatabasesResponse
+        const expectedResponse = { Databases: ['testDb1'] } as ListDatabasesCommandOutput
+        const expectedResponseWithNextToken = { Databases: ['testDb1'], NextToken: 'next' } as ListDatabasesCommandOutput
         const connectionParams = new ConnectionParams(
             ConnectionType.TempCreds,
             'testDb1',

--- a/src/test/redshift/explorer/redshiftWarehouseNode.test.ts
+++ b/src/test/redshift/explorer/redshiftWarehouseNode.test.ts
@@ -14,7 +14,6 @@ import * as assert from 'assert'
 import { RedshiftDatabaseNode } from '../../../redshift/explorer/redshiftDatabaseNode'
 import { AWSCommandTreeNode } from '../../../shared/treeview/nodes/awsCommandTreeNode'
 import { RedshiftNodeConnectionWizard } from '../../../redshift/wizards/connectionWizard'
-import RedshiftData = require('aws-sdk/clients/redshiftdata')
 import { MoreResultsNode } from '../../../awsexplorer/moreResultsNode'
 import { AWSTreeNodeBase } from '../../../shared/treeview/nodes/awsTreeNodeBase'
 

--- a/src/test/redshift/notebook/redshiftNotebookController.test.ts
+++ b/src/test/redshift/notebook/redshiftNotebookController.test.ts
@@ -8,7 +8,7 @@ import { RedshiftNotebookController } from '../../../redshift/notebook/redshiftN
 import sinon = require('sinon')
 import assert = require('assert')
 import { DefaultRedshiftClient } from '../../../shared/clients/redshiftClient'
-import { RedshiftData } from 'aws-sdk'
+import { RedshiftData } from "@aws-sdk/client-redshift-data";
 
 describe('RedshiftNotebookController', () => {
     const mockRedshiftData = <RedshiftData>{}

--- a/src/test/s3/commands/uploadFile.test.ts
+++ b/src/test/s3/commands/uploadFile.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert'
 import * as vscode from 'vscode'
-import { S3 } from 'aws-sdk'
+import { Bucket, ManagedUpload } from "@aws-sdk/client-s3";
 import {
     FileSizeBytes,
     getFilesToUpload,
@@ -45,7 +45,7 @@ describe('uploadFileCommand', function () {
     let getBucket: (s3client: S3Client) => Promise<BucketQuickPickItem | 'cancel' | 'back'>
     let getFile: (document?: vscode.Uri) => Promise<vscode.Uri[] | undefined>
     let commands: Commands
-    let mockedUpload: S3.ManagedUpload
+    let mockedUpload: ManagedUpload
 
     beforeEach(function () {
         mockedUpload = mock()
@@ -268,7 +268,7 @@ describe('promptUserForBucket', async function () {
     const fileLocation = vscode.Uri.file('/file.jpg')
 
     let s3: S3Client
-    let buckets: S3.Bucket[]
+    let buckets: Bucket[]
 
     const promptUndef: <T extends vscode.QuickPickItem>(opts: {
         picker: vscode.QuickPick<T>

--- a/src/test/s3/util/fileViewerManager.test.ts
+++ b/src/test/s3/util/fileViewerManager.test.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from 'assert'
-import { ManagedUpload } from 'aws-sdk/clients/s3'
+import { ManagedUpload } from "@aws-sdk/client-s3";
 import * as vscode from 'vscode'
 import { S3FileProvider, S3FileViewerManager } from '../../../s3/fileViewerManager'
 import { DefaultBucket, DefaultS3Client, File, toFile } from '../../../shared/clients/s3Client'

--- a/src/test/setupUtil.ts
+++ b/src/test/setupUtil.ts
@@ -190,7 +190,7 @@ function maskArns(text: string) {
         }
 
         return match
-    })
+    });
 }
 
 /**
@@ -229,7 +229,7 @@ export function registerAuthHook(secret: string, lambdaId = process.env['AUTH_UT
 
             message.items[0].select()
         }
-    })
+    });
 }
 
 /**

--- a/src/test/shared/clients/defaultIotClient.test.ts
+++ b/src/test/shared/clients/defaultIotClient.test.ts
@@ -4,7 +4,52 @@
  */
 
 import assert from 'assert'
-import { AWSError, Request, Iot } from 'aws-sdk'
+import { AWSError, Request } from 'aws-sdk';
+
+import {
+    AttachPolicyCommandInput,
+    AttachThingPrincipalCommandInput,
+    CreateKeysAndCertificateCommandInput,
+    CreateKeysAndCertificateCommandOutput,
+    CreatePolicyCommandInput,
+    CreatePolicyCommandOutput,
+    CreatePolicyVersionCommandInput,
+    CreatePolicyVersionCommandOutput,
+    CreateThingCommandOutput,
+    DeleteCertificateCommandInput,
+    DeletePolicyCommandInput,
+    DeletePolicyVersionCommandInput,
+    DeleteThingCommandInput,
+    DeleteThingCommandOutput,
+    DescribeCertificateCommandInput,
+    DescribeCertificateCommandOutput,
+    DescribeEndpointCommandInput,
+    DescribeEndpointCommandOutput,
+    DetachPolicyCommandInput,
+    DetachThingPrincipalCommandInput,
+    GetPolicyVersionCommandInput,
+    GetPolicyVersionCommandOutput,
+    IoT,
+    ListCertificatesCommandInput,
+    ListCertificatesCommandOutput,
+    ListPoliciesCommandInput,
+    ListPoliciesCommandOutput,
+    ListPolicyVersionsCommandInput,
+    ListPolicyVersionsCommandOutput,
+    ListPrincipalPoliciesCommandInput,
+    ListPrincipalThingsCommandInput,
+    ListPrincipalThingsCommandOutput,
+    ListTargetsForPolicyCommandInput,
+    ListTargetsForPolicyCommandOutput,
+    ListThingPrincipalsCommandInput,
+    ListThingPrincipalsCommandOutput,
+    ListThingsCommandInput,
+    ListThingsCommandOutput,
+    PolicyVersion,
+    SetDefaultPolicyVersionCommandInput,
+    UpdateCertificateCommandInput,
+} from "@aws-sdk/client-iot";
+
 import { anything, deepEqual, instance, mock, verify, when } from '../../utilities/mockito'
 import { DefaultIotClient, ListThingCertificatesResponse } from '../../../shared/clients/iotClient'
 
@@ -52,7 +97,7 @@ describe('DefaultIotClient', function () {
     /* Functions that create or retrieve resources. */
 
     describe('createThing', function () {
-        const expectedResponse: Iot.CreateThingResponse = { thingName: thingName, thingArn: 'arn' }
+        const expectedResponse: CreateThingCommandOutput = { thingName: thingName, thingArn: 'arn' }
         it('creates a thing', async function () {
             when(
                 mockIot.createThing(
@@ -76,8 +121,8 @@ describe('DefaultIotClient', function () {
 
     describe('createCertificateAndKeys', function () {
         const certificateId = 'cert1'
-        const input: Iot.CreateKeysAndCertificateRequest = { setAsActive: undefined }
-        const expectedResponse: Iot.CreateKeysAndCertificateResponse = {
+        const input: CreateKeysAndCertificateCommandInput = { setAsActive: undefined }
+        const expectedResponse: CreateKeysAndCertificateCommandOutput = {
             certificateId,
             certificateArn: 'arn',
             certificatePem: 'pem',
@@ -100,9 +145,9 @@ describe('DefaultIotClient', function () {
     })
 
     describe('getEndpoint', function () {
-        const input: Iot.DescribeEndpointRequest = { endpointType: 'iot:Data-ATS' }
+        const input: DescribeEndpointCommandInput = { endpointType: 'iot:Data-ATS' }
         const endpointAddress = 'address'
-        const describeResponse: Iot.DescribeEndpointResponse = { endpointAddress }
+        const describeResponse: DescribeEndpointCommandOutput = { endpointAddress }
 
         it('gets endpoint', async function () {
             when(mockIot.describeEndpoint(deepEqual(input))).thenReturn(success(describeResponse))
@@ -120,8 +165,8 @@ describe('DefaultIotClient', function () {
     })
 
     describe('getPolicyVersion', function () {
-        const input: Iot.GetPolicyVersionRequest = { policyName, policyVersionId: '1' }
-        const expectedResponse: Iot.GetPolicyVersionResponse = {
+        const input: GetPolicyVersionCommandInput = { policyName, policyVersionId: '1' }
+        const expectedResponse: GetPolicyVersionCommandOutput = {
             policyName,
             policyDocument,
             policyArn: 'arn1',
@@ -146,7 +191,7 @@ describe('DefaultIotClient', function () {
     /* Functions that return void .*/
 
     describe('deleteThing', function () {
-        const input: Iot.DeleteThingRequest = { thingName }
+        const input: DeleteThingCommandInput = { thingName }
 
         it('deletes a thing', async function () {
             when(
@@ -155,7 +200,7 @@ describe('DefaultIotClient', function () {
                         thingName: thingName,
                     })
                 )
-            ).thenReturn(success({} as Iot.DeleteThingResponse))
+            ).thenReturn(success({} as DeleteThingCommandOutput))
 
             await createClient().deleteThing({ thingName })
 
@@ -171,7 +216,7 @@ describe('DefaultIotClient', function () {
 
     describe('deleteCertificate', function () {
         const certificateId = 'cert1'
-        const input: Iot.DeleteCertificateRequest = { certificateId, forceDelete: undefined }
+        const input: DeleteCertificateCommandInput = { certificateId, forceDelete: undefined }
 
         it('deletes a certificate', async function () {
             when(mockIot.deleteCertificate(deepEqual(input))).thenReturn(success())
@@ -190,7 +235,7 @@ describe('DefaultIotClient', function () {
 
     describe('updateCertificate', function () {
         const certificateId = 'cert1'
-        const input: Iot.UpdateCertificateRequest = { certificateId, newStatus: 'ACTIVE' }
+        const input: UpdateCertificateCommandInput = { certificateId, newStatus: 'ACTIVE' }
 
         it('updates a certificate', async function () {
             when(mockIot.updateCertificate(deepEqual(input))).thenReturn(success())
@@ -208,7 +253,7 @@ describe('DefaultIotClient', function () {
     })
 
     describe('attachThingPrincipal', function () {
-        const input: Iot.AttachThingPrincipalRequest = { thingName, principal: 'arn1' }
+        const input: AttachThingPrincipalCommandInput = { thingName, principal: 'arn1' }
 
         it('attaches a certificate to a Thing', async function () {
             when(mockIot.attachThingPrincipal(deepEqual(input))).thenReturn(success())
@@ -226,7 +271,7 @@ describe('DefaultIotClient', function () {
     })
 
     describe('detachThingPrincipal', function () {
-        const input: Iot.DetachThingPrincipalRequest = { thingName, principal: 'arn1' }
+        const input: DetachThingPrincipalCommandInput = { thingName, principal: 'arn1' }
 
         it('detaches a certificate from a Thing', async function () {
             when(mockIot.detachThingPrincipal(deepEqual(input))).thenReturn(success())
@@ -244,7 +289,7 @@ describe('DefaultIotClient', function () {
     })
 
     describe('attachPolicy', function () {
-        const input: Iot.AttachPolicyRequest = { policyName, target: 'arn1' }
+        const input: AttachPolicyCommandInput = { policyName, target: 'arn1' }
 
         it('attaches a policy to a certificate', async function () {
             when(mockIot.attachPolicy(deepEqual(input))).thenReturn(success())
@@ -262,7 +307,7 @@ describe('DefaultIotClient', function () {
     })
 
     describe('detachPolicy', function () {
-        const input: Iot.DetachPolicyRequest = { policyName, target: 'arn1' }
+        const input: DetachPolicyCommandInput = { policyName, target: 'arn1' }
 
         it('detaches a policy from a certificate', async function () {
             when(mockIot.detachPolicy(deepEqual(input))).thenReturn(success())
@@ -280,8 +325,8 @@ describe('DefaultIotClient', function () {
     })
 
     describe('createPolicy', function () {
-        const input: Iot.CreatePolicyRequest = { policyName, policyDocument }
-        const expectedResponse: Iot.CreatePolicyResponse = { policyName, policyDocument, policyArn: 'arn1' }
+        const input: CreatePolicyCommandInput = { policyName, policyDocument }
+        const expectedResponse: CreatePolicyCommandOutput = { policyName, policyDocument, policyArn: 'arn1' }
 
         it('creates a policy from a document', async function () {
             when(mockIot.createPolicy(deepEqual(input))).thenReturn(success(expectedResponse))
@@ -299,7 +344,7 @@ describe('DefaultIotClient', function () {
     })
 
     describe('deletePolicy', function () {
-        const input: Iot.DeletePolicyRequest = { policyName }
+        const input: DeletePolicyCommandInput = { policyName }
 
         it('deletes a policy', async function () {
             when(mockIot.deletePolicy(deepEqual(input))).thenReturn(success())
@@ -317,8 +362,8 @@ describe('DefaultIotClient', function () {
     })
 
     describe('createPolicyVersion', function () {
-        const input: Iot.CreatePolicyVersionRequest = { policyName, policyDocument }
-        const expectedResponse: Iot.CreatePolicyVersionResponse = { policyDocument, policyArn: 'arn1' }
+        const input: CreatePolicyVersionCommandInput = { policyName, policyDocument }
+        const expectedResponse: CreatePolicyVersionCommandOutput = { policyDocument, policyArn: 'arn1' }
 
         it('creates a policy version from a document', async function () {
             when(mockIot.createPolicyVersion(deepEqual(input))).thenReturn(success(expectedResponse))
@@ -336,7 +381,7 @@ describe('DefaultIotClient', function () {
     })
 
     describe('deletePolicyVersion', function () {
-        const input: Iot.DeletePolicyVersionRequest = { policyName, policyVersionId: '1' }
+        const input: DeletePolicyVersionCommandInput = { policyName, policyVersionId: '1' }
 
         it('deletes a policy version', async function () {
             when(mockIot.deletePolicyVersion(deepEqual(input))).thenReturn(success())
@@ -354,7 +399,7 @@ describe('DefaultIotClient', function () {
     })
 
     describe('setDefaultPolicyVersion', function () {
-        const input: Iot.SetDefaultPolicyVersionRequest = { policyName, policyVersionId: '1' }
+        const input: SetDefaultPolicyVersionCommandInput = { policyName, policyVersionId: '1' }
 
         it('deletes a policy version', async function () {
             when(mockIot.setDefaultPolicyVersion(deepEqual(input))).thenReturn(success())
@@ -374,8 +419,8 @@ describe('DefaultIotClient', function () {
     /* Functions that list resources. */
 
     describe('listThings', function () {
-        const input: Iot.ListThingsRequest = { maxResults, nextToken }
-        const expectedResponse: Iot.ListThingsResponse = { things: [{ thingName: 'thing1' }], nextToken }
+        const input: ListThingsCommandInput = { maxResults, nextToken }
+        const expectedResponse: ListThingsCommandOutput = { things: [{ thingName: 'thing1' }], nextToken }
 
         it('lists things', async function () {
             when(mockIot.listThings(deepEqual(input))).thenReturn(success(expectedResponse))
@@ -393,8 +438,8 @@ describe('DefaultIotClient', function () {
     })
 
     describe('listCertificates', function () {
-        const input: Iot.ListCertificatesRequest = { pageSize, marker, ascendingOrder: undefined }
-        const expectedResponse: Iot.ListCertificatesResponse = {
+        const input: ListCertificatesCommandInput = { pageSize, marker, ascendingOrder: undefined }
+        const expectedResponse: ListCertificatesCommandOutput = {
             certificates: [{ certificateId: 'cert1' }],
             nextMarker: marker,
         }
@@ -417,11 +462,11 @@ describe('DefaultIotClient', function () {
     describe('listThingCertificates', function () {
         const certificateId = 'cert1'
         const certArn = 'arn:aws:iot:us-west-2:0123456789:cert/cert1'
-        const input: Iot.ListThingPrincipalsRequest = { thingName, maxResults, nextToken }
-        const principalsResponse: Iot.ListThingPrincipalsResponse = { principals: [certArn], nextToken }
+        const input: ListThingPrincipalsCommandInput = { thingName, maxResults, nextToken }
+        const principalsResponse: ListThingPrincipalsCommandOutput = { principals: [certArn], nextToken }
 
-        const describeInput: Iot.DescribeCertificateRequest = { certificateId }
-        const describeResponse: Iot.DescribeCertificateResponse = {
+        const describeInput: DescribeCertificateCommandInput = { certificateId }
+        const describeResponse: DescribeCertificateCommandOutput = {
             certificateDescription: { certificateId, certificateArn: certArn },
         }
 
@@ -454,8 +499,8 @@ describe('DefaultIotClient', function () {
     })
 
     describe('listThingsForCert', function () {
-        const input: Iot.ListPrincipalThingsRequest = { principal: 'arn1', maxResults, nextToken }
-        const listResponse: Iot.ListPrincipalThingsResponse = { things: [thingName], nextToken }
+        const input: ListPrincipalThingsCommandInput = { principal: 'arn1', maxResults, nextToken }
+        const listResponse: ListPrincipalThingsCommandOutput = { things: [thingName], nextToken }
         const expectedResponse = [thingName]
 
         it('lists things', async function () {
@@ -474,8 +519,8 @@ describe('DefaultIotClient', function () {
     })
 
     describe('listPolicies', function () {
-        const input: Iot.ListPoliciesRequest = { pageSize, marker, ascendingOrder: undefined }
-        const expectedResponse: Iot.ListPoliciesResponse = { policies: [{ policyName }], nextMarker: marker }
+        const input: ListPoliciesCommandInput = { pageSize, marker, ascendingOrder: undefined }
+        const expectedResponse: ListPoliciesCommandOutput = { policies: [{ policyName }], nextMarker: marker }
 
         it('lists policies', async function () {
             when(mockIot.listPolicies(deepEqual(input))).thenReturn(success(expectedResponse))
@@ -493,13 +538,13 @@ describe('DefaultIotClient', function () {
     })
 
     describe('listPrincipalPolicies', function () {
-        const input: Iot.ListPrincipalPoliciesRequest = {
+        const input: ListPrincipalPoliciesCommandInput = {
             pageSize,
             marker,
             ascendingOrder: undefined,
             principal: 'arn1',
         }
-        const expectedResponse: Iot.ListPoliciesResponse = { policies: [{ policyName }], nextMarker: marker }
+        const expectedResponse: ListPoliciesCommandOutput = { policies: [{ policyName }], nextMarker: marker }
 
         it('lists policies for certificate', async function () {
             when(mockIot.listPrincipalPolicies(deepEqual(input))).thenReturn(success(expectedResponse))
@@ -518,8 +563,8 @@ describe('DefaultIotClient', function () {
 
     describe('listPolicyTargets', function () {
         const targets = ['arn1', 'arn2']
-        const input: Iot.ListTargetsForPolicyRequest = { policyName, pageSize, marker }
-        const listResponse: Iot.ListTargetsForPolicyResponse = { targets, nextMarker: marker }
+        const input: ListTargetsForPolicyCommandInput = { policyName, pageSize, marker }
+        const listResponse: ListTargetsForPolicyCommandOutput = { targets, nextMarker: marker }
 
         it('lists certificates', async function () {
             when(mockIot.listTargetsForPolicy(deepEqual(input))).thenReturn(success(listResponse))
@@ -537,10 +582,10 @@ describe('DefaultIotClient', function () {
     })
 
     describe('listPolicyVersions', function () {
-        const input: Iot.ListPolicyVersionsRequest = { policyName }
-        const expectedVersion1: Iot.PolicyVersion = { versionId: '1' }
-        const expectedVersion2: Iot.PolicyVersion = { versionId: '2' }
-        const listResponse: Iot.ListPolicyVersionsResponse = { policyVersions: [expectedVersion1, expectedVersion2] }
+        const input: ListPolicyVersionsCommandInput = { policyName }
+        const expectedVersion1: PolicyVersion = { versionId: '1' }
+        const expectedVersion2: PolicyVersion = { versionId: '2' }
+        const listResponse: ListPolicyVersionsCommandOutput = { policyVersions: [expectedVersion1, expectedVersion2] }
 
         it('lists policy versions', async function () {
             when(mockIot.listPolicyVersions(deepEqual(input))).thenReturn(success(listResponse))

--- a/src/test/shared/clients/defaultRedshiftClient.test.ts
+++ b/src/test/shared/clients/defaultRedshiftClient.test.ts
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Redshift, RedshiftData, RedshiftServerless, AWSError, Request } from 'aws-sdk'
+import { AWSError, Request } from 'aws-sdk';
+import { DescribeClustersCommandOutput, Redshift } from "@aws-sdk/client-redshift";
+import { ListDatabasesCommandOutput, ListSchemasCommandOutput, RedshiftData } from "@aws-sdk/client-redshift-data";
+import { ListWorkgroupsCommandOutput, RedshiftServerless } from "@aws-sdk/client-redshift-serverless";
 import { DefaultRedshiftClient } from '../../../shared/clients/redshiftClient'
 import assert = require('assert')
 import { ConnectionParams, ConnectionType, RedshiftWarehouseType } from '../../../redshift/models/models'
@@ -57,7 +60,7 @@ describe('DefaultRedshiftClient', function () {
     })
 
     describe('describeProvisionedClusters', function () {
-        const expectedResponse = { Clusters: [] } as Redshift.ClustersMessage
+        const expectedResponse = { Clusters: [] } as DescribeClustersCommandOutput
         let describeClustersStub: sinon.SinonStub
 
         beforeEach(function () {
@@ -80,7 +83,7 @@ describe('DefaultRedshiftClient', function () {
     })
 
     describe('listServerlessWorkgroups', function () {
-        const expectedResponse = { workgroups: [] } as RedshiftServerless.ListWorkgroupsResponse
+        const expectedResponse = { workgroups: [] } as ListWorkgroupsCommandOutput
         let listServerlessWorkgroupsStub: sinon.SinonStub
         beforeEach(function () {
             listServerlessWorkgroupsStub = sandbox.stub()
@@ -102,7 +105,7 @@ describe('DefaultRedshiftClient', function () {
     })
 
     describe('listDatabases', function () {
-        const expectedResponse = { Databases: [] } as RedshiftData.ListDatabasesResponse
+        const expectedResponse = { Databases: [] } as ListDatabasesCommandOutput
         let listDatabasesStub: sinon.SinonStub
         beforeEach(function () {
             listDatabasesStub = sandbox.stub()
@@ -127,7 +130,7 @@ describe('DefaultRedshiftClient', function () {
     })
 
     describe('listSchemas', function () {
-        const expectedResponse = { Schemas: [] } as RedshiftData.ListSchemasResponse
+        const expectedResponse = { Schemas: [] } as ListSchemasCommandOutput
         let listSchemasStub: sinon.SinonStub
         beforeEach(function () {
             listSchemasStub = sandbox.stub()

--- a/src/test/shared/clients/defaultS3Client.test.ts
+++ b/src/test/shared/clients/defaultS3Client.test.ts
@@ -16,7 +16,6 @@ import {
     S3,
 } from "@aws-sdk/client-s3";
 
-import { ManagedUpload } from 'aws-sdk/lib/s3/managed_upload'
 import { FileStreams } from '../../../shared/utilities/streamUtilities'
 import { anyFunction, anything, capture, deepEqual, instance, mock, verify, when } from '../../utilities/mockito'
 import * as vscode from 'vscode'

--- a/src/test/shared/clients/ec2Client.test.ts
+++ b/src/test/shared/clients/ec2Client.test.ts
@@ -8,19 +8,19 @@ import { AsyncCollection } from '../../../shared/utilities/asyncCollection'
 import { toCollection } from '../../../shared/utilities/asyncCollection'
 import { intoCollection } from '../../../shared/utilities/collectionUtils'
 import { Ec2Client, instanceHasName } from '../../../shared/clients/ec2Client'
-import { EC2 } from 'aws-sdk'
+import { Filter, Instance, Reservation } from "@aws-sdk/client-ec2";
 
 class MockEc2Client extends Ec2Client {
     public override async getInstanceStatus(instanceId: string): Promise<string> {
         return instanceId.split('-')[0]
     }
 
-    public async testUpdateInstancesDetail(instances: EC2.Instance[]) {
+    public async testUpdateInstancesDetail(instances: Instance[]) {
         return await (await this.updateInstancesDetail(intoCollection(instances))).promise()
     }
 }
 
-const completeReservationsList: EC2.ReservationList = [
+const completeReservationsList: Array<Reservation> = [
     {
         Instances: [
             {
@@ -47,14 +47,14 @@ const completeReservationsList: EC2.ReservationList = [
     },
 ]
 
-const completeInstanceList: EC2.InstanceList = [
+const completeInstanceList: Array<Instance> = [
     { InstanceId: 'running-1', Tags: [{ Key: 'Name', Value: 'name1' }] },
     { InstanceId: 'stopped-2', Tags: [{ Key: 'Name', Value: 'name2' }] },
     { InstanceId: 'pending-3', Tags: [{ Key: 'Name', Value: 'name3' }] },
     { InstanceId: 'running-4', Tags: [{ Key: 'Name', Value: 'name4' }] },
 ]
 
-const incompleteReservationsList: EC2.ReservationList = [
+const incompleteReservationsList: Array<Reservation> = [
     {
         Instances: [
             {
@@ -77,7 +77,7 @@ const incompleteReservationsList: EC2.ReservationList = [
     },
 ]
 
-const incomepleteInstanceList: EC2.InstanceList = [
+const incomepleteInstanceList: Array<Instance> = [
     { InstanceId: 'running-1' },
     { InstanceId: 'stopped-2', Tags: [] },
     { InstanceId: 'pending-3', Tags: [{ Key: 'Name', Value: 'name3' }] },
@@ -91,7 +91,7 @@ describe('extractInstancesFromReservations', function () {
             .getInstancesFromReservations(
                 toCollection(async function* () {
                     yield []
-                }) as AsyncCollection<EC2.ReservationList>
+                }) as AsyncCollection<Array<Reservation>>
             )
             .promise()
 
@@ -151,7 +151,7 @@ describe('getInstancesFilter', function () {
     it('returns proper filter when given instanceId', function () {
         const testInstanceId1 = 'test'
         const actualFilters1 = client.getInstancesFilter([testInstanceId1])
-        const expectedFilters1: EC2.Filter[] = [
+        const expectedFilters1: Filter[] = [
             {
                 Name: 'instance-id',
                 Values: [testInstanceId1],
@@ -162,7 +162,7 @@ describe('getInstancesFilter', function () {
 
         const testInstanceId2 = 'test2'
         const actualFilters2 = client.getInstancesFilter([testInstanceId1, testInstanceId2])
-        const expectedFilters2: EC2.Filter[] = [
+        const expectedFilters2: Filter[] = [
             {
                 Name: 'instance-id',
                 Values: [testInstanceId1, testInstanceId2],

--- a/src/test/shared/clients/iamClient.test.ts
+++ b/src/test/shared/clients/iamClient.test.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IAM } from 'aws-sdk'
+
+
+import { SimulatePrincipalPolicyCommandInput } from "@aws-sdk/client-iam";
 import assert from 'assert'
 import * as sinon from 'sinon'
 import { DefaultIamClient, IamClient } from '../../../shared/clients/iamClient'
@@ -11,7 +13,7 @@ import { DefaultIamClient, IamClient } from '../../../shared/clients/iamClient'
 describe('iamClient', function () {
     describe('getDeniedActions', async function () {
         const iamClient: IamClient = new DefaultIamClient('us-west-2')
-        const request: IAM.SimulatePrincipalPolicyRequest = {
+        const request: SimulatePrincipalPolicyCommandInput = {
             PolicySourceArn: 'taskRoleArn1234',
             ActionNames: ['example:permission'],
         }

--- a/src/test/shared/sshConfig.test.ts
+++ b/src/test/shared/sshConfig.test.ts
@@ -19,7 +19,7 @@ import {
     connectScriptPrefix,
     getCodeCatalystSsmEnv,
 } from '../../codecatalyst/model'
-import { StartDevEnvironmentSessionRequest } from 'aws-sdk/clients/codecatalyst'
+import { StartDevEnvironmentSessionCommandInput } from "@aws-sdk/client-codecatalyst";
 import { mkdir, readFile, writeFile } from 'fs-extra'
 import { SystemUtilities } from '../../shared/systemUtilities'
 
@@ -208,7 +208,7 @@ describe('CodeCatalyst Connect Script', function () {
                 })
 
                 const body = JSON.parse(data)
-                const expected: Pick<StartDevEnvironmentSessionRequest, 'sessionConfiguration'> = {
+                const expected: Pick<StartDevEnvironmentSessionCommandInput, 'sessionConfiguration'> = {
                     sessionConfiguration: { sessionType: 'SSH' },
                 }
 
@@ -231,7 +231,7 @@ describe('CodeCatalyst Connect Script', function () {
                     sessionId: 'an id',
                 })
             )
-        })
+        });
     }
 
     it('can run the script with environment variables', async function () {

--- a/src/test/shared/ui/prompters/roles.test.ts
+++ b/src/test/shared/ui/prompters/roles.test.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode'
 import * as sinon from 'sinon'
 import assert from 'assert'
-import { IAM } from 'aws-sdk'
+import { Role } from "@aws-sdk/client-iam";
 import { DefaultIamClient } from '../../../../shared/clients/iamClient'
 import { createQuickPickPrompterTester, QuickPickPrompterTester } from '../testUtils'
 import { createRolePrompter } from '../../../../shared/ui/common/roles'
@@ -17,9 +17,9 @@ import { getOpenExternalStub } from '../../../globalSetup.test'
 const helpUri = vscode.Uri.parse('https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html')
 
 describe('createRolePrompter', function () {
-    let roles: IAM.Role[]
-    let newRole: IAM.Role
-    let tester: QuickPickPrompterTester<IAM.Role>
+    let roles: Role[]
+    let newRole: Role
+    let tester: QuickPickPrompterTester<Role>
 
     beforeEach(function () {
         roles = [

--- a/src/test/shared/utilities/collectionUtils.test.ts
+++ b/src/test/shared/utilities/collectionUtils.test.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from 'assert'
-import { CloudWatchLogs } from 'aws-sdk'
+import { DescribeLogStreamsCommandInput, DescribeLogStreamsCommandOutput, LogStream } from "@aws-sdk/client-cloudwatch-logs";
 import * as sinon from 'sinon'
 import * as vscode from 'vscode'
 import { AsyncCollection } from '../../../shared/utilities/asyncCollection'
@@ -364,7 +364,7 @@ describe('CollectionUtils', async function () {
                 [CloudWatchLogs.DescribeLogStreamsRequest],
                 CloudWatchLogs.DescribeLogStreamsResponse
             >()
-            const responses: CloudWatchLogs.LogStreams[] = [
+            const responses: Array<LogStream>[] = [
                 [{ logStreamName: 'stream1' }, { logStreamName: 'stream2' }, { logStreamName: 'stream3' }],
                 [{ logStreamName: 'stream4' }, { logStreamName: 'stream5' }, { logStreamName: 'stream6' }],
                 [{ logStreamName: 'stream7' }, { logStreamName: 'stream8' }, { logStreamName: 'stream9' }],
@@ -387,8 +387,8 @@ describe('CollectionUtils', async function () {
                 .onCall(3)
                 .returns({})
             const params: getPaginatedAwsCallIterParams<
-                CloudWatchLogs.DescribeLogStreamsRequest,
-                CloudWatchLogs.DescribeLogStreamsResponse
+                DescribeLogStreamsCommandInput,
+                DescribeLogStreamsCommandOutput
             > = {
                 awsCall: async req => fakeCall(req),
                 nextTokenNames: {
@@ -399,7 +399,7 @@ describe('CollectionUtils', async function () {
                     logGroupName: 'imJustHereSoIWontGetFined',
                 },
             }
-            const iter: AsyncIterator<CloudWatchLogs.DescribeLogStreamsResponse> = getPaginatedAwsCallIter(params)
+            const iter: AsyncIterator<DescribeLogStreamsCommandOutput> = getPaginatedAwsCallIter(params)
             const firstResult = await iter.next()
             const secondResult = await iter.next()
             const thirdResult = await iter.next()

--- a/src/test/ssmDocument/commands/deleteDocument.test.ts
+++ b/src/test/ssmDocument/commands/deleteDocument.test.ts
@@ -10,7 +10,6 @@ import { deleteDocument } from '../../../ssmDocument/commands/deleteDocument'
 import { mock } from '../../utilities/mockito'
 import { FakeCommands } from '../../shared/vscode/fakeCommands'
 import { RegistryItemNode } from '../../../ssmDocument/explorer/registryItemNode'
-import { SSM } from 'aws-sdk'
 import { getTestWindow } from '../../shared/vscode/window'
 
 describe('deleteDocument', async function () {

--- a/src/test/ssmDocument/commands/openDocumentItem.test.ts
+++ b/src/test/ssmDocument/commands/openDocumentItem.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SSM } from 'aws-sdk'
+
 
 import assert from 'assert'
 import * as sinon from 'sinon'

--- a/src/test/ssmDocument/commands/publishDocument.test.ts
+++ b/src/test/ssmDocument/commands/publishDocument.test.ts
@@ -3,7 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SSM } from 'aws-sdk'
+
+
+import {
+    CreateDocumentCommandInput,
+    CreateDocumentCommandOutput,
+    UpdateDocumentCommandInput,
+    UpdateDocumentCommandOutput,
+} from "@aws-sdk/client-ssm";
 
 import assert from 'assert'
 import * as sinon from 'sinon'
@@ -24,15 +31,15 @@ import { SeverityLevel } from '../../shared/vscode/message'
 describe('publishDocument', async function () {
     let wizardResponse: PublishSSMDocumentWizardResponse
     let textDocument: vscode.TextDocument
-    let result: SSM.CreateDocumentResult | SSM.UpdateDocumentResult
+    let result: CreateDocumentCommandOutput | UpdateDocumentCommandOutput
 
-    const fakeCreateRequest: SSM.CreateDocumentRequest = {
+    const fakeCreateRequest: CreateDocumentCommandInput = {
         Content: 'foo',
         DocumentFormat: 'JSON',
         DocumentType: 'Automation',
         Name: 'test',
     }
-    const fakeUpdateRequest: SSM.UpdateDocumentRequest = {
+    const fakeUpdateRequest: UpdateDocumentCommandInput = {
         Content: 'foo',
         DocumentFormat: 'JSON',
         DocumentVersion: '$LATEST',

--- a/src/test/ssmDocument/commands/updateDocumentVersion.test.ts
+++ b/src/test/ssmDocument/commands/updateDocumentVersion.test.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SSM } from 'aws-sdk'
+
+
+import { DocumentVersionInfo } from "@aws-sdk/client-ssm";
 import * as sinon from 'sinon'
 import assert from 'assert'
 
@@ -32,7 +34,7 @@ describe('openDocumentItem', async function () {
 
     const fakeRegion = 'us-east-1'
 
-    const fakeSchemaList: SSM.DocumentVersionInfo[] = [
+    const fakeSchemaList: DocumentVersionInfo[] = [
         {
             Name: 'testDocument',
             DocumentVersion: '1',

--- a/src/test/ssmDocument/explorer/documentItemNode.test.ts
+++ b/src/test/ssmDocument/explorer/documentItemNode.test.ts
@@ -4,14 +4,14 @@
  */
 
 import assert from 'assert'
-import { SSM } from 'aws-sdk'
+import { DocumentIdentifier } from "@aws-sdk/client-ssm";
 import { DefaultSsmDocumentClient } from '../../../shared/clients/ssmDocumentClient'
 import { DocumentItemNode } from '../../../ssmDocument/explorer/documentItemNode'
 import { stub } from '../../utilities/stubber'
 
 describe('DocumentItemNode', async function () {
     let testNode: DocumentItemNode
-    const testDoc: SSM.DocumentIdentifier = {
+    const testDoc: DocumentIdentifier = {
         Name: 'testDoc',
         Owner: 'Amazon',
     }

--- a/src/test/stepFunctions/utils.test.ts
+++ b/src/test/stepFunctions/utils.test.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from 'assert'
-import { IAM } from 'aws-sdk'
+import { Role } from "@aws-sdk/client-iam";
 import * as fs from 'fs-extra'
 import * as sinon from 'sinon'
 import * as vscode from 'vscode'
@@ -199,7 +199,7 @@ describe('StateMachineGraphCache', function () {
 })
 
 describe('isStepFunctionsRole', function () {
-    const baseIamRole: IAM.Role = {
+    const baseIamRole: Role = {
         Path: '',
         RoleName: '',
         RoleId: 'myRole',
@@ -208,7 +208,7 @@ describe('isStepFunctionsRole', function () {
     }
 
     it('return true if the Step Functions service principal is in the AssumeRolePolicyDocument', function () {
-        const role: IAM.Role = {
+        const role: Role = {
             ...baseIamRole,
             AssumeRolePolicyDocument: JSON.stringify({
                 Version: '2012-10-17',
@@ -231,7 +231,7 @@ describe('isStepFunctionsRole', function () {
     })
 
     it("returns false if the AssumeRolePolicyDocument does not contain Step Functions' service principal", () => {
-        const role: IAM.Role = {
+        const role: Role = {
             ...baseIamRole,
             AssumeRolePolicyDocument: JSON.stringify({
                 Version: '2012-10-17',

--- a/src/testE2E/codecatalyst/client.test.ts
+++ b/src/testE2E/codecatalyst/client.test.ts
@@ -20,7 +20,7 @@ import globals from '../../shared/extensionGlobals'
 import { CodeCatalystCreateWebview, SourceResponse } from '../../codecatalyst/vue/create/backend'
 import { waitUntil } from '../../shared/utilities/timeoutUtils'
 import { AccessDeniedException } from '@aws-sdk/client-sso-oidc'
-import { GetDevEnvironmentRequest } from 'aws-sdk/clients/codecatalyst'
+import { GetDevEnvironmentCommandInput } from "@aws-sdk/client-codecatalyst";
 import { getTestWindow } from '../../test/shared/vscode/window'
 import { patchObject, registerAuthHook, skipTest, using } from '../../test/setupUtil'
 import { isExtensionInstalled } from '../../shared/utilities/vsCodeUtils'
@@ -603,7 +603,7 @@ describe.skip('Test how this codebase uses the CodeCatalyst API', function () {
      * if the timeout is reached.
      */
     async function waitUntilDevEnvStatus(
-        devEnv: GetDevEnvironmentRequest,
+        devEnv: GetDevEnvironmentCommandInput,
         status: DevEnvironment['status'][]
     ): Promise<void> {
         const result = await waitUntil(

--- a/src/testInteg/sam.test.ts
+++ b/src/testInteg/sam.test.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from 'assert'
-import { Runtime } from 'aws-sdk/clients/lambda'
+import { Runtime } from "@aws-sdk/client-lambda";
 import { mkdirpSync, mkdtemp } from 'fs-extra'
 import * as path from 'path'
 import * as semver from 'semver'


### PR DESCRIPTION
## Problem

From AWS SDK for JavaScript v2 [README](https://github.com/aws/aws-sdk-js):
> We are formalizing our plans to make the Maintenance Announcement (Phase 2) for AWS SDK for JavaScript v2 in 2023.

## Solution

This draft PR is testing [aws-sdk-js-codemod](https://www.npmjs.com/package/aws-sdk-js-codemod).

```console
$ npx aws-sdk-js-codemod@0.25.5 -t v2-to-v3 $(grep "'aws-sdk" src/**/*.ts | cut -d":" -f1 | uniq | tr '\n' ' ')
```

We would like to know from you which transformations codemod should prioritize.
The best way to help us is to create/upvote issues on GitHub at https://github.com/awslabs/aws-sdk-js-codemod/issues. You can comment on this PR too. Feel free to take over the commits/PR, or close it and re-run codemod at later stage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
