### PR TITLE
codewhisperer: use first recommendation for completionType

### DIFF
--- a/src/codewhisperer/util/telemetryHelper.ts
+++ b/src/codewhisperer/util/telemetryHelper.ts
@@ -248,10 +248,10 @@ export class TelemetryHelper {
             codewhispererSessionId: sessionId,
             codewhispererFirstRequestId: this.sessionInvocations[0].codewhispererRequestId ?? requestId,
             credentialStartUrl: events[0].credentialStartUrl,
-            codewhispererCompletionType: this.getAggregatedCompletionType(events),
             codewhispererLanguage: events[0].codewhispererLanguage,
             codewhispererGettingStartedTask: session.taskType,
             codewhispererTriggerType: events[0].codewhispererTriggerType,
+            codewhispererCompletionType: events[0].codewhispererCompletionType,
             codewhispererSuggestionCount: events.length,
             codewhispererAutomatedTriggerType: serviceInvocation.codewhispererAutomatedTriggerType,
             codewhispererLineNumber: serviceInvocation.codewhispererLineNumber,
@@ -284,7 +284,7 @@ export class TelemetryHelper {
         // TODO: add partial acceptance related metrics
         const autoTriggerType = this.sessionDecisions[0].codewhispererAutomatedTriggerType
         const language = this.sessionDecisions[0].codewhispererLanguage
-        const aggregatedCompletionType = this.getAggregatedCompletionType(this.sessionDecisions)
+        const aggregatedCompletionType = this.sessionDecisions[0].codewhispererCompletionType
         const aggregatedSuggestionState = this.getAggregatedSuggestionState(this.sessionDecisions)
         const selectedCustomization = getSelectedCustomization()
         const generatedLines =
@@ -442,13 +442,6 @@ export class TelemetryHelper {
         this.timeToFirstRecommendation = 0
         this.classifierResult = undefined
         this.classifierThreshold = undefined
-    }
-
-    private getAggregatedCompletionType(
-        // if there is any Block completion within the session, mark the session as Block completion
-        events: CodewhispererUserDecision[] | CodewhispererUserTriggerDecision[]
-    ): CodewhispererCompletionType {
-        return events.some(e => e.codewhispererCompletionType === 'Block') ? 'Block' : 'Line'
     }
 
     private getSendTelemetryCompletionType(completionType: CodewhispererCompletionType) {

--- a/src/test/codewhisperer/util/telemetryHelper.test.ts
+++ b/src/test/codewhisperer/util/telemetryHelper.test.ts
@@ -62,7 +62,7 @@ describe('telemetryHelper', function () {
             sut = new TelemetryHelper()
         })
 
-        it('should return Block and Accept', function () {
+        it('should return Line and Accept', function () {
             sut.sessionInvocations.push(aServiceInvocation())
 
             const decisions: CodewhispererUserDecision[] = [
@@ -74,7 +74,7 @@ describe('telemetryHelper', function () {
 
             const actual = sut.aggregateUserDecisionByRequest(decisions, 'aFakeRequestId', 'aFakeSessionId')
             assert.ok(actual)
-            assert.strictEqual(actual?.codewhispererCompletionType, 'Block')
+            assert.strictEqual(actual?.codewhispererCompletionType, 'Line')
             assert.strictEqual(actual?.codewhispererSuggestionState, 'Accept')
         })
 
@@ -121,7 +121,7 @@ describe('telemetryHelper', function () {
             CodeWhispererUserGroupSettings.instance.userGroup = CodeWhispererConstants.UserGroup.Control
         })
 
-        it('should return Block and Accept', function () {
+        it('should return Line and Accept', function () {
             sut.recordUserDecisionTelemetry(
                 'aFakeRequestId',
                 'aFakeSessionId',
@@ -149,7 +149,7 @@ describe('telemetryHelper', function () {
                 codewhispererSuggestionImportCount: 0,
                 codewhispererSuggestionState: 'Accept',
                 codewhispererUserGroup: 'Control',
-                codewhispererCompletionType: 'Block',
+                codewhispererCompletionType: 'Line',
                 codewhispererTypeaheadLength: 0,
                 codewhispererCharactersAccepted: aCompletion().content.length,
             })
@@ -189,7 +189,7 @@ describe('telemetryHelper', function () {
             })
         })
 
-        it('should return Block and Reject', function () {
+        it('should return Line and Reject', function () {
             sut.recordUserDecisionTelemetry(
                 'aFakeRequestId',
                 'aFakeSessionId',


### PR DESCRIPTION
## Problem
align the logic for aggregating completionType in userTriggerDecision with JB
## Solution
we should use the completionType of the first recommendation 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
