### PR TITLE
codewhisperer: emit issues with fixes count

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
                 "yaml-cfn": "^0.3.2"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.148",
+                "@aws-toolkits/telemetry": "^1.0.153",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^10.0.2",
                 "@types/adm-zip": "^0.4.34",
@@ -2356,9 +2356,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.148",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.148.tgz",
-            "integrity": "sha512-9Gdj6JVr9S6hZzSZehwLIVdMvd5hnvoFhlxcdT889Ay0tW+dd4Ynp9rhax7KCkh2/jvI4ClHpR97ZAYsA+UAZw==",
+            "version": "1.0.153",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.153.tgz",
+            "integrity": "sha512-H8hhhGh4basdshdiSE0soZFP4tBim3bp99PmY8s65z7tzMhfmjQXVXBB0u3kpaCx5FyQRku83j2xas/RJWrunA==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",
@@ -17933,9 +17933,9 @@
             }
         },
         "@aws-toolkits/telemetry": {
-            "version": "1.0.148",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.148.tgz",
-            "integrity": "sha512-9Gdj6JVr9S6hZzSZehwLIVdMvd5hnvoFhlxcdT889Ay0tW+dd4Ynp9rhax7KCkh2/jvI4ClHpR97ZAYsA+UAZw==",
+            "version": "1.0.153",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.153.tgz",
+            "integrity": "sha512-H8hhhGh4basdshdiSE0soZFP4tBim3bp99PmY8s65z7tzMhfmjQXVXBB0u3kpaCx5FyQRku83j2xas/RJWrunA==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -3845,7 +3845,7 @@
         "report": "nyc report --reporter=html --reporter=json"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.148",
+        "@aws-toolkits/telemetry": "^1.0.153",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/adm-zip": "^0.4.34",

--- a/src/codewhisperer/commands/startSecurityScan.ts
+++ b/src/codewhisperer/commands/startSecurityScan.ts
@@ -81,6 +81,7 @@ export async function startSecurityScan(
         codeScanServiceInvocationsDuration: 0,
         result: 'Succeeded',
         codewhispererCodeScanTotalIssues: 0,
+        codewhispererCodeScanIssuesWithFixes: 0,
         credentialStartUrl: AuthUtil.instance.startUrl,
     }
     try {
@@ -167,7 +168,11 @@ export async function startSecurityScan(
         const total = securityRecommendationCollection.reduce((accumulator, current) => {
             return accumulator + current.issues.length
         }, 0)
+        const issuesWithFixes = securityRecommendationCollection.reduce((accumulator, current) => {
+            return accumulator + current.issues.filter(issue => issue.suggestedFixes.length > 0).length
+        }, 0)
         codeScanTelemetryEntry.codewhispererCodeScanTotalIssues = total
+        codeScanTelemetryEntry.codewhispererCodeScanIssuesWithFixes = issuesWithFixes
         throwIfCancelled()
         getLogger().verbose(`Security scan totally found ${total} issues.`)
         if (isCloud9()) {

--- a/src/codewhisperer/commands/startSecurityScan.ts
+++ b/src/codewhisperer/commands/startSecurityScan.ts
@@ -165,14 +165,15 @@ export async function startSecurityScan(
             CodeWhispererConstants.codeScanFindingsSchema,
             projectPath
         )
-        const total = securityRecommendationCollection.reduce((accumulator, current) => {
-            return accumulator + current.issues.length
-        }, 0)
-        const issuesWithFixes = securityRecommendationCollection.reduce((accumulator, current) => {
-            return accumulator + current.issues.filter(issue => issue.suggestedFixes.length > 0).length
-        }, 0)
+        const { total, withFixes } = securityRecommendationCollection.reduce(
+            (accumulator, current) => ({
+                total: accumulator.total + current.issues.length,
+                withFixes: accumulator.withFixes + current.issues.filter(i => i.suggestedFixes.length > 0).length,
+            }),
+            { total: 0, withFixes: 0 }
+        )
         codeScanTelemetryEntry.codewhispererCodeScanTotalIssues = total
-        codeScanTelemetryEntry.codewhispererCodeScanIssuesWithFixes = issuesWithFixes
+        codeScanTelemetryEntry.codewhispererCodeScanIssuesWithFixes = withFixes
         throwIfCancelled()
         getLogger().verbose(`Security scan totally found ${total} issues.`)
         if (isCloud9()) {

--- a/src/codewhisperer/models/model.ts
+++ b/src/codewhisperer/models/model.ts
@@ -165,6 +165,7 @@ export interface CodeScanTelemetryEntry {
     result: Result
     reason?: string
     codewhispererCodeScanTotalIssues: number
+    codewhispererCodeScanIssuesWithFixes: number
     credentialStartUrl: string | undefined
 }
 


### PR DESCRIPTION
## Problem

We want to track how many issues were generated with at least 1 suggested fix

## Solution

- Update `@aws-toolkits/telemetry` version and emit the count as part of `codewhisperer_securityScan` metric

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
