### PR TITLE
Static cache key for builder ID SSO

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -17,7 +17,7 @@ import { Timeout } from '../shared/utilities/timeoutUtils'
 import { errorCode, isAwsError, isNetworkError, ToolkitError, UnknownError } from '../shared/errors'
 import { getCache } from './sso/cache'
 import { createFactoryFunction, isNonNullable, Mutable } from '../shared/utilities/tsUtils'
-import { builderIdStartUrl, SsoToken, truncateStartUrl } from './sso/model'
+import { builderIdCacheKey, builderIdStartUrl, SsoToken, truncateStartUrl } from './sso/model'
 import { SsoClient } from './sso/clients'
 import { getLogger } from '../shared/logger'
 import { CredentialsProviderManager } from './providers/credentialsProviderManager'
@@ -189,6 +189,11 @@ export class Auth implements AuthService, ConnectionManager {
 
         this.#activeConnection = conn
         this.#onDidChangeActiveConnection.fire(conn)
+        // XXX: force builder id to use the common builder ID cache key
+        // we can remove this eventually: this is to force users who have already registered with a random UUID onto the common key
+        if (isBuilderIdConnection(conn)) {
+            id = builderIdCacheKey
+        }
         await this.store.setCurrentProfileId(id)
 
         return conn

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -263,13 +263,14 @@ export class Auth implements AuthService, ConnectionManager {
         return toCollection(load.bind(this))
     }
 
-    public async createConnection(profile: SsoProfile): Promise<SsoConnection>
-    public async createConnection(profile: Profile): Promise<Connection> {
+    public async createConnection(profile: SsoProfile, id?: string): Promise<SsoConnection>
+    public async createConnection(profile: Profile, id?: string): Promise<Connection> {
         if (profile.type === 'iam') {
             throw new Error('Creating IAM connections is not supported')
         }
 
-        const id = uuid.v4()
+        // builder ID uses a static ID, otherwise use random uuid
+        id = id ?? uuid.v4()
         const tokenProvider = this.getTokenProvider(id, {
             ...profile,
             metadata: { connectionState: 'unauthenticated' },

--- a/src/auth/sso/model.ts
+++ b/src/auth/sso/model.ts
@@ -78,6 +78,7 @@ export interface SsoProfile {
 
 export const builderIdStartUrl = 'https://view.awsapps.com/start'
 export const trustedDomainCancellation = 'TrustedDomainCancellation'
+export const builderIdCacheKey = 'curr-builder-id'
 
 const tryOpenHelpUrl = (url: vscode.Uri) =>
     openUrl(url).catch(e => getLogger().verbose('auth: failed to open help URL: %s', e))

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -49,6 +49,7 @@ import { openUrl } from '../shared/utilities/vsCodeUtils'
 import { AuthSource } from './ui/vue/show'
 import { getLogger } from '../shared/logger'
 import { isValidCodeWhispererConnection } from '../codewhisperer/util/authUtil'
+import { builderIdCacheKey } from './sso/model'
 
 // TODO: Look to do some refactoring to handle circular dependency later and move this to ./commands.ts
 export const showConnectionsPageCommand = 'aws.auth.manageConnections'
@@ -172,7 +173,7 @@ export async function createBuilderIdConnection(auth: Auth, scopes?: string[]) {
     const newProfile = createBuilderIdProfile(scopes)
     const existingConn = (await auth.listConnections()).find(isBuilderIdConnection)
     if (!existingConn) {
-        return auth.createConnection(newProfile, 'curr-builder-id')
+        return auth.createConnection(newProfile, builderIdCacheKey)
     }
 
     const userResponse = await promptLogoutExistingBuilderIdConnection()

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -172,7 +172,7 @@ export async function createBuilderIdConnection(auth: Auth, scopes?: string[]) {
     const newProfile = createBuilderIdProfile(scopes)
     const existingConn = (await auth.listConnections()).find(isBuilderIdConnection)
     if (!existingConn) {
-        return auth.createConnection(newProfile)
+        return auth.createConnection(newProfile, 'curr-builder-id')
     }
 
     const userResponse = await promptLogoutExistingBuilderIdConnection()


### PR DESCRIPTION
## Problem
Using Builder ID SSO with an SSH instance would force you to log in anew with every folder you open. This is annoying since users will have to constantly log in, have their cache fill up with multiple entries, and would set different expiries for each folder

## Solution
Use a static Builder ID cache key. This will work as long as we're not expecting users to constantly be logging out of and back into Builder ID SSO.
* From a new folder, the user will have to log in as usual to create the `curr-builder-id` key in our cache.
* Subsequent folders will have you log in with the builder ID, but will not force you to go through the browser login flow afterwards.
* ***BLOCKER FROM PUSHING OUT!!!*** Some simple testing is showing that this won't undo existing folders that already have a cache key, even if you delete the cache entry. We need to find a way to force this to use the `curr-builder-id` ID.
  * If a user signs out in a folder and then signs in again later, this will pick up the correct key on the sign in. However, any "expired connections" and reconnections will continue using the old key. This includes deleting the existing cached files.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
