### PR TITLE
auth: make CW appear first in 'Add Connection' page

### DIFF
--- a/src/auth/ui/vue/serviceItem.vue
+++ b/src/auth/ui/vue/serviceItem.vue
@@ -127,13 +127,13 @@ export default defineComponent({
  */
 
 const staticServiceItemProps: Readonly<Record<ServiceItemId, { title: string; description: string }>> = {
-    awsExplorer: {
-        title: 'AWS Explorer: View, modify, and deploy AWS Resources',
-        description: 'Work with S3, CloudWatch, and more.',
-    },
     codewhisperer: {
         title: 'CodeWhisperer: AI-powered code suggestions',
         description: 'Build applications faster with your AI coding companion.',
+    },
+    awsExplorer: {
+        title: 'AWS Explorer: View, modify, and deploy AWS Resources',
+        description: 'Work with S3, CloudWatch, and more.',
     },
     codecatalyst: {
         title: 'CodeCatalyst: Launch CodeCatalyst Dev Environments',


### PR DESCRIPTION
We want to prioritize the CW sign in when users first open the page.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
