### PR TITLE
lint: no-inner-declarations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -86,8 +86,6 @@ module.exports = {
         // This currently produces 700 non fixable by --fix errors
         'sort-imports': 'off',
         '@typescript-eslint/no-namespace': 'error',
-        // Turn this on by removing off when we fix namespaces
-        'no-inner-declarations': 'off',
         // This is off because prettier takes care of it
         'no-extra-semi': 'off',
         'no-null/no-null': 'error',

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -298,6 +298,26 @@ async function activateCodefileOverlays(
 async function createYamlExtensionPrompt(): Promise<void> {
     const settings = PromptSettings.instance
 
+    /**
+     * Prompt the user to install the YAML plugin when AWSTemplateFormatVersion becomes available as a top level key
+     * in the document
+     * @param event An vscode text document change event
+     * @returns nothing
+     */
+    async function promptOnAWSTemplateFormatVersion(
+        event: vscode.TextDocumentChangeEvent,
+        yamlPromptDisposables: vscode.Disposable[]
+    ): Promise<void> {
+        for (const change of event.contentChanges) {
+            const changedLine = event.document.lineAt(change.range.start.line)
+            if (changedLine.text.includes('AWSTemplateFormatVersion')) {
+                promptInstallYamlPlugin(yamlPromptDisposables)
+                return
+            }
+        }
+        return
+    }
+
     // Show this only in VSCode since other VSCode-like IDEs (e.g. Theia) may
     // not have a marketplace or contain the YAML plugin.
     if (
@@ -327,23 +347,6 @@ async function createYamlExtensionPrompt(): Promise<void> {
             yamlPromptDisposables
         )
 
-        /**
-         * Prompt the user to install the YAML plugin when AWSTemplateFormatVersion becomes available as a top level key
-         * in the document
-         * @param event An vscode text document change event
-         * @returns nothing
-         */
-        async function promptOnAWSTemplateFormatVersion(event: vscode.TextDocumentChangeEvent): Promise<void> {
-            for (const change of event.contentChanges) {
-                const changedLine = event.document.lineAt(change.range.start.line)
-                if (changedLine.text.includes('AWSTemplateFormatVersion')) {
-                    promptInstallYamlPlugin(yamlPromptDisposables)
-                    return
-                }
-            }
-            return
-        }
-
         const promptNotifications = new Map<string, Promise<unknown>>()
         vscode.workspace.onDidChangeTextDocument(
             (event: vscode.TextDocumentChangeEvent) => {
@@ -355,7 +358,9 @@ async function createYamlExtensionPrompt(): Promise<void> {
                 ) {
                     promptNotifications.set(
                         uri,
-                        promptOnAWSTemplateFormatVersion(event).finally(() => promptNotifications.delete(uri))
+                        promptOnAWSTemplateFormatVersion(event, yamlPromptDisposables).finally(() =>
+                            promptNotifications.delete(uri)
+                        )
                     )
                 }
             },

--- a/src/shared/sam/debugger/goSamDebug.ts
+++ b/src/shared/sam/debugger/goSamDebug.ts
@@ -175,21 +175,21 @@ async function makeInstallScript(debuggerPath: string, isWindows: boolean): Prom
     // Go from trying to find the manifest file and uses GOPATH provided below.
     installOptions.env!['GO111MODULE'] = 'off'
 
+    function getDelveVersion(repo: string, silent: boolean): string {
+        try {
+            return execFileSync('git', ['-C', repo, 'describe', '--tags', '--abbrev=0']).toString().trim()
+        } catch (e) {
+            if (!silent) {
+                throw e
+            }
+            return ''
+        }
+    }
+
     // It's fine if we can't get the latest Delve version, the Toolkit will use the last built one instead
     try {
         const goPath: string = JSON.parse(execFileSync('go', ['env', '-json']).toString()).GOPATH
         let repoPath: string = path.join(goPath, 'src', delveRepo)
-
-        function getDelveVersion(repo: string, silent: boolean): string {
-            try {
-                return execFileSync('git', ['-C', repo, 'describe', '--tags', '--abbrev=0']).toString().trim()
-            } catch (e) {
-                if (!silent) {
-                    throw e
-                }
-                return ''
-            }
-        }
 
         if (!getDelveVersion(repoPath, true)) {
             getLogger('channel').info(

--- a/src/testInteg/sam.test.ts
+++ b/src/testInteg/sam.test.ts
@@ -420,6 +420,20 @@ describe('SAM Integration Tests', async function () {
         })
     })
 
+    function assertCodeLensReferencesHasSameRoot(codeLens: vscode.CodeLens, expectedUri: vscode.Uri) {
+        assert.ok(codeLens.command, 'CodeLens did not have a command')
+        const command = codeLens.command!
+
+        assert.ok(command.arguments, 'CodeLens command had no arguments')
+        const commandArguments = command.arguments!
+
+        assert.strictEqual(commandArguments.length, 3, 'CodeLens command had unexpected arg count')
+        const params: AddSamDebugConfigurationInput = commandArguments[0]
+        assert.ok(params, 'unexpected non-defined command argument')
+
+        assert.strictEqual(path.dirname(params.rootUri.fsPath), path.dirname(expectedUri.fsPath))
+    }
+
     for (let scenarioIndex = 0; scenarioIndex < scenarios.length; scenarioIndex++) {
         const scenario = scenarios[scenarioIndex]
 
@@ -624,20 +638,6 @@ describe('SAM Integration Tests', async function () {
                 }
             })
         })
-
-        function assertCodeLensReferencesHasSameRoot(codeLens: vscode.CodeLens, expectedUri: vscode.Uri) {
-            assert.ok(codeLens.command, 'CodeLens did not have a command')
-            const command = codeLens.command!
-
-            assert.ok(command.arguments, 'CodeLens command had no arguments')
-            const commandArguments = command.arguments!
-
-            assert.strictEqual(commandArguments.length, 3, 'CodeLens command had unexpected arg count')
-            const params: AddSamDebugConfigurationInput = commandArguments[0]
-            assert.ok(params, 'unexpected non-defined command argument')
-
-            assert.strictEqual(path.dirname(params.rootUri.fsPath), path.dirname(expectedUri.fsPath))
-        }
     }
 
     async function createSamApplication(location: string, scenario: TestScenario): Promise<void> {


### PR DESCRIPTION
https://eslint.org/docs/latest/rules/no-inner-declarations

Since 14aab453fea5, we can now enable this rule. The pattern that it prevents is not commonly used in our codebase, and it reduces the potential for accidents, so it's worth enabling the rule.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
