### PR TITLE
feat(codecatalyst): Add IDC connection logic

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -10,6 +10,7 @@ const localize = nls.loadMessageBundle()
 
 import * as vscode from 'vscode'
 import * as localizedText from '../shared/localizedText'
+import * as fs from 'fs'
 import * as uuid from 'uuid' // TODO: use crypto.randomUUID when C9 is on node16
 import { Credentials } from '@aws-sdk/types'
 import { SsoAccessTokenProvider } from './sso/ssoAccessTokenProvider'
@@ -24,6 +25,11 @@ import { CredentialsProviderManager } from './providers/credentialsProviderManag
 import { asString, CredentialsId, CredentialsProvider, fromString } from './providers/credentials'
 import { once } from '../shared/utilities/functionUtils'
 import { CredentialsSettings } from './credentials/utils'
+import {
+    extractDataFromSection,
+    getSectionOrThrow,
+    loadSharedCredentialsSections,
+} from './credentials/sharedCredentials'
 import { getCodeCatalystDevEnvId } from '../shared/vscode/env'
 import { partition } from '../shared/utilities/mementos'
 import { SsoCredentialsProvider } from './providers/ssoCredentialsProvider'
@@ -47,8 +53,9 @@ import {
     StoredProfile,
     codecatalystScopes,
     createBuilderIdProfile,
+    createSsoProfile,
     hasScopes,
-    isBuilderIdConnection,
+    isValidCodeCatalystConnection,
     loadIamProfilesIntoStore,
     loadLinkedProfilesIntoStore,
     ssoAccountAccessScopes,
@@ -521,10 +528,11 @@ export class Auth implements AuthService, ConnectionManager {
     }
 
     // XXX: always read from the same location in a dev environment
-    private getSsoSessionName = once(() => {
+    // This detection is fuzzy if an sso-session section exists for any other reason.
+    private detectSsoSessionNameForCodeCatalyst = once((): string => {
         try {
             const configFile = getConfigFilename()
-            const contents: string = require('fs').readFileSync(configFile, 'utf-8')
+            const contents: string = fs.readFileSync(configFile, 'utf-8')
             const identifier = contents.match(/\[sso\-session (.*)\]/)?.[1]
             if (!identifier) {
                 throw new ToolkitError('No sso-session name found in ~/.aws/config', { code: 'NoSsoSessionName' })
@@ -532,21 +540,40 @@ export class Auth implements AuthService, ConnectionManager {
 
             return identifier
         } catch (err) {
-            const defaultName = 'codecatalyst'
-            getLogger().warn(`auth: unable to get an sso session name, defaulting to "${defaultName}": %s`, err)
-
-            return defaultName
+            const identifier = 'codecatalyst'
+            getLogger().warn(`auth: unable to get an sso session name, defaulting to "${identifier}": %s`, err)
+            return identifier
         }
     })
 
+    private createCodeCatalystDevEnvProfile = async (): Promise<[id: string, profile: SsoProfile]> => {
+        const identifier = this.detectSsoSessionNameForCodeCatalyst()
+
+        const { sections } = await loadSharedCredentialsSections()
+        const { sso_region: region, sso_start_url: startUrl } = extractDataFromSection(
+            getSectionOrThrow(sections, identifier, 'sso-session')
+        )
+
+        if ([region, startUrl].some(prop => typeof prop !== 'string')) {
+            throw new ToolkitError('sso-session data missing in ~/.aws/config', { code: 'NoSsoSession' })
+        }
+
+        return startUrl === builderIdStartUrl
+            ? [identifier, createBuilderIdProfile(codecatalystScopes)]
+            : [identifier, createSsoProfile(region, startUrl, codecatalystScopes)]
+    }
+
     private getTokenProvider(id: Connection['id'], profile: StoredProfile<SsoProfile>) {
-        // XXX: Use the token created by dev environments if and only if the profile is strictly for CodeCatalyst
+        // XXX: Use the token created by Dev Environments if and only if the profile is strictly
+        // for CodeCatalyst, as indicated by its set of scopes. A consequence of these semantics is
+        // that any profile will be coerced to use this token if that profile exclusively contains
+        // CodeCatalyst scopes. Similarly, if additional scopes are added to a profile, the profile
+        // no longer matches this condition.
         const shouldUseSoftwareStatement =
             getCodeCatalystDevEnvId() !== undefined &&
-            profile.startUrl === builderIdStartUrl &&
             profile.scopes?.every(scope => codecatalystScopes.includes(scope))
 
-        const tokenIdentifier = shouldUseSoftwareStatement ? this.getSsoSessionName() : id
+        const tokenIdentifier = shouldUseSoftwareStatement ? this.detectSsoSessionNameForCodeCatalyst() : id
 
         return this.createTokenProvider(
             {
@@ -702,15 +729,28 @@ export class Auth implements AuthService, ConnectionManager {
             })
         )
 
-        // Use the environment token if available
-        // This token only has CC permissions currently!
+        // When opening a Dev Environment, use the environment token if no other CodeCatalyst
+        // credential is in use. This token only has CC permissions currently!
         if (getCodeCatalystDevEnvId() !== undefined) {
-            const connections = (await this.listConnections()).filter(isBuilderIdConnection)
+            const connections = await this.listConnections()
+            const shouldInsertDevEnvCredential = !connections.some(isValidCodeCatalystConnection)
 
-            if (connections.length === 0) {
-                const key = uuid.v4()
-                await this.store.addProfile(key, createBuilderIdProfile(codecatalystScopes))
-                await this.store.setCurrentProfileId(key)
+            if (shouldInsertDevEnvCredential) {
+                // Insert a profile based on the `~/.aws/config` sso-session:
+                try {
+                    // After creating a CodeCatalyst Dev Environment profile based on sso-session,
+                    // we discard the actual key, and we insert the profile with an arbitrary key.
+                    // The cache key for any strictly-CodeCatalyst profile is overriden to the
+                    // sso-session identifier on read. If the coerce-on-read semantics ever become
+                    // an issue, it should be possible to use the actual key here However, this
+                    // would require deleting existing profiles to avoid inserting duplicates.
+                    const [_dangerousDiscardActualKey, devEnvProfile] = await this.createCodeCatalystDevEnvProfile()
+                    const key = uuid.v4()
+                    await this.store.addProfile(key, devEnvProfile)
+                    await this.store.setCurrentProfileId(key)
+                } catch (err) {
+                    getLogger().warn(`auth: failed to insert dev env profile: %s`, err)
+                }
             }
         }
 

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -10,7 +10,6 @@ const localize = nls.loadMessageBundle()
 
 import * as vscode from 'vscode'
 import * as localizedText from '../shared/localizedText'
-import * as fs from 'fs'
 import * as uuid from 'uuid' // TODO: use crypto.randomUUID when C9 is on node16
 import { Credentials } from '@aws-sdk/types'
 import { SsoAccessTokenProvider } from './sso/ssoAccessTokenProvider'
@@ -532,7 +531,8 @@ export class Auth implements AuthService, ConnectionManager {
     private detectSsoSessionNameForCodeCatalyst = once((): string => {
         try {
             const configFile = getConfigFilename()
-            const contents: string = fs.readFileSync(configFile, 'utf-8')
+            // `require('fs')` is workaround for web mode:
+            const contents: string = require('fs').readFileSync(configFile, 'utf-8')
             const identifier = contents.match(/\[sso\-session (.*)\]/)?.[1]
             if (!identifier) {
                 throw new ToolkitError('No sso-session name found in ~/.aws/config', { code: 'NoSsoSessionName' })

--- a/src/auth/connection.ts
+++ b/src/auth/connection.ts
@@ -52,7 +52,7 @@ export const isIdcSsoConnection = (conn?: Connection): conn is SsoConnection => 
 export const isBuilderIdConnection = (conn?: Connection): conn is SsoConnection => isSsoConnection(conn, 'builderId')
 
 export const isValidCodeCatalystConnection = (conn: Connection): conn is SsoConnection =>
-    isBuilderIdConnection(conn) && hasScopes(conn, codecatalystScopes)
+    isSsoConnection(conn) && hasScopes(conn, codecatalystScopes)
 
 export function hasScopes(target: SsoConnection | SsoProfile, scopes: string[]): boolean {
     return scopes?.every(s => target.scopes?.includes(s))

--- a/src/auth/ui/vue/authForms/manageIdentityCenter.vue
+++ b/src/auth/ui/vue/authForms/manageIdentityCenter.vue
@@ -360,6 +360,45 @@ export class CodeWhispererIdentityCenterState extends BaseIdentityCenterState {
     }
 }
 
+export class CodeCatalystIdentityCenterState extends BaseIdentityCenterState {
+    override get id(): AuthFormId {
+        return 'identityCenterCodeCatalyst'
+    }
+
+    override get name(): string {
+        return 'CodeCatalyst'
+    }
+
+    override get uiClickOpenId(): AuthUiClick {
+        return 'auth_openCodeCatalyst'
+    }
+
+    override get uiClickSignout(): AuthUiClick {
+        return 'auth_codecatalyst_signoutIdentityCenter'
+    }
+
+    override get featureType(): FeatureId {
+        return 'codecatalyst'
+    }
+
+    protected override async _startIdentityCenterSetup(): Promise<AuthError | undefined> {
+        const data = await this.getSubmittableDataOrThrow()
+        return client.startCodeCatalystIdentityCenterSetup(data.startUrl, data.region)
+    }
+
+    override async isAuthConnected(): Promise<boolean> {
+        return client.isCodeCatalystIdentityCenterConnected()
+    }
+
+    override async showView(): Promise<void> {
+        client.showCodeCatalystNode()
+    }
+
+    override signout(): Promise<void> {
+        return client.signoutCodeCatalystIdentityCenter()
+    }
+}
+
 /**
  * In the context of the Explorer, an Identity Center connection
  * is not required to be active. This is due to us only needing

--- a/src/auth/ui/vue/authForms/shared.vue
+++ b/src/auth/ui/vue/authForms/shared.vue
@@ -1,7 +1,11 @@
 <script lang="ts">
 import { CodeCatalystBuilderIdState, CodeWhispererBuilderIdState } from './manageBuilderId.vue'
 import { CredentialsState } from './manageCredentials.vue'
-import { CodeWhispererIdentityCenterState, ExplorerIdentityCenterState } from './manageIdentityCenter.vue'
+import {
+    CodeCatalystIdentityCenterState,
+    CodeWhispererIdentityCenterState,
+    ExplorerIdentityCenterState,
+} from './manageIdentityCenter.vue'
 import { AuthFormId } from './types'
 
 /**
@@ -12,6 +16,7 @@ const authFormsState = {
     builderIdCodeWhisperer: CodeWhispererBuilderIdState.instance,
     builderIdCodeCatalyst: CodeCatalystBuilderIdState.instance,
     identityCenterCodeWhisperer: new CodeWhispererIdentityCenterState(),
+    identityCenterCodeCatalyst: new CodeCatalystIdentityCenterState(),
     identityCenterExplorer: new ExplorerIdentityCenterState(),
 } as const
 

--- a/src/auth/ui/vue/authForms/types.ts
+++ b/src/auth/ui/vue/authForms/types.ts
@@ -8,6 +8,7 @@ export type AuthFormId =
     | 'builderIdCodeWhisperer'
     | 'builderIdCodeCatalyst'
     | 'identityCenterCodeWhisperer'
+    | 'identityCenterCodeCatalyst'
     | 'identityCenterExplorer'
     | 'aggregateExplorer'
 
@@ -19,6 +20,7 @@ export const AuthFormDisplayName: Record<AuthFormId, string> = {
     credentials: 'IAM Credentials',
     builderIdCodeCatalyst: 'CodeCatalyst with AWS Builder ID',
     builderIdCodeWhisperer: 'CodeWhisperer with AWS Builder ID',
+    identityCenterCodeCatalyst: 'CodeCatalyst with IAM Identity Center',
     identityCenterCodeWhisperer: 'CodeWhisperer with IAM Identity Center',
     identityCenterExplorer: 'AWS Explorer with IAM Identity Center',
     aggregateExplorer: '',

--- a/src/auth/ui/vue/show.ts
+++ b/src/auth/ui/vue/show.ts
@@ -22,7 +22,6 @@ import { profileExists } from '../../credentials/sharedCredentials'
 import { getLogger } from '../../../shared/logger'
 import { AuthUtil as CodeWhispererAuth } from '../../../codewhisperer/util/authUtil'
 import { CodeCatalystAuthenticationProvider } from '../../../codecatalyst/auth'
-import { setupCodeCatalystBuilderId } from '../../../codecatalyst/utils'
 import { ToolkitError } from '../../../shared/errors'
 import {
     Connection,
@@ -135,7 +134,13 @@ export class AuthWebview extends VueWebview {
     }
 
     async startCodeCatalystBuilderIdSetup(): Promise<AuthError | undefined> {
-        return this.ssoSetup('startCodeCatalystBuilderIdSetup', () => setupCodeCatalystBuilderId(this.codeCatalystAuth))
+        return this.ssoSetup('startCodeCatalystBuilderIdSetup', () => this.codeCatalystAuth.connectToAwsBuilderId())
+    }
+
+    async startCodeCatalystIdentityCenterSetup(startUrl: string, regionId: Region['id']) {
+        return this.ssoSetup('startCodeCatalystIdentityCenterSetup', () => {
+            return this.codeCatalystAuth.connectToEnterpriseSso(startUrl, regionId)
+        })
     }
 
     isCodeWhispererBuilderIdConnected(): boolean {
@@ -143,7 +148,7 @@ export class AuthWebview extends VueWebview {
     }
 
     isCodeCatalystBuilderIdConnected(): boolean {
-        return this.codeCatalystAuth.isConnectionValid()
+        return this.codeCatalystAuth.isBuilderIdInUse() && this.codeCatalystAuth.isConnectionValid()
     }
 
     async signoutBuilderId(): Promise<void> {
@@ -257,6 +262,10 @@ export class AuthWebview extends VueWebview {
         return CodeWhispererAuth.instance.isEnterpriseSsoInUse() && CodeWhispererAuth.instance.isConnectionValid()
     }
 
+    isCodeCatalystIdentityCenterConnected(): boolean {
+        return this.codeCatalystAuth.isEnterpriseSsoInUse() && this.codeCatalystAuth.isConnectionValid()
+    }
+
     async signoutCWIdentityCenter(): Promise<void> {
         const activeConn = CodeWhispererAuth.instance.isEnterpriseSsoInUse()
             ? CodeWhispererAuth.instance.conn
@@ -270,6 +279,23 @@ export class AuthWebview extends VueWebview {
         }
 
         await CodeWhispererAuth.instance.secondaryAuth.deleteConnection()
+    }
+
+    async signoutCodeCatalystIdentityCenter(): Promise<void> {
+        const activeConn = this.codeCatalystAuth.isEnterpriseSsoInUse()
+            ? this.codeCatalystAuth.activeConnection
+            : undefined
+        if (!activeConn) {
+            // At this point CC is not actively using IAM IC,
+            // even if a valid IAM IC profile exists. We only
+            // want to sign out if it being actively used.
+            getLogger().warn(
+                'authWebview: Attempted to signout of CodeCatalyst identity center when it was not being used'
+            )
+            return
+        }
+
+        await this.codeCatalystAuth.secondaryAuth.deleteConnection()
     }
 
     async signoutIdentityCenter(): Promise<void> {
@@ -691,6 +717,7 @@ export type AuthUiClick =
     | 'auth_explorer_expandIAMIdentityCenter'
     | 'auth_explorer_expandIAMCredentials'
     | 'auth_codewhisperer_expandIAMIdentityCenter'
+    | 'auth_codecatalyst_expandIAMIdentityCenter'
     | 'auth_openConnectionSelector'
     | 'auth_openAWSExplorer'
     | 'auth_openCodeWhisperer'
@@ -699,6 +726,7 @@ export type AuthUiClick =
     | 'auth_codewhisperer_signoutBuilderId'
     | 'auth_codewhisperer_signoutIdentityCenter'
     | 'auth_codecatalyst_signoutBuilderId'
+    | 'auth_codecatalyst_signoutIdentityCenter'
     | 'auth_explorer_signoutIdentityCenter'
 
 // type AuthAreas = 'awsExplorer' | 'codewhisperer' | 'codecatalyst'

--- a/src/codecatalyst/auth.ts
+++ b/src/codecatalyst/auth.ts
@@ -41,7 +41,7 @@ export class CodeCatalystAuthStorage {
 
 export const onboardingUrl = vscode.Uri.parse('https://codecatalyst.aws/onboarding/view')
 
-const defaultScopes = [...ssoAccountAccessScopes, ...codecatalystScopes]
+export const defaultScopes = [...ssoAccountAccessScopes, ...codecatalystScopes]
 
 export const isUpgradeableConnection = (conn: Connection): conn is SsoConnection =>
     isSsoConnection(conn) && !isValidCodeCatalystConnection(conn)

--- a/src/codecatalyst/commands.ts
+++ b/src/codecatalyst/commands.ts
@@ -207,7 +207,7 @@ export class CodeCatalystCommands {
     public readonly withClient: ClientInjector
     public readonly bindClient = createCommandDecorator(this)
 
-    public constructor(authProvider: CodeCatalystAuthenticationProvider) {
+    public constructor(private authProvider: CodeCatalystAuthenticationProvider) {
         this.withClient = createClientInjector(authProvider)
     }
 
@@ -261,7 +261,11 @@ export class CodeCatalystCommands {
         await vscode.window.showTextDocument(uri)
     }
 
-    public async openDevEnv(id?: DevEnvironmentId, targetPath?: string): Promise<void> {
+    public async openDevEnv(
+        id?: DevEnvironmentId,
+        targetPath?: string,
+        connection?: { startUrl: string; region: string }
+    ): Promise<void> {
         if (vscode.env.remoteName === 'ssh-remote') {
             throw new ToolkitError('Cannot connect from a remote context. Try again from a local VS Code instance.', {
                 code: 'ConnectedToRemote',
@@ -279,7 +283,11 @@ export class CodeCatalystCommands {
             telemetry.record({ source: 'CommandPalette' })
         }
 
-        return this.withClient(openDevEnv, devenv, targetPath)
+        return this.withClient(openDevEnv, devenv, targetPath, async () => {
+            if (connection) {
+                await this.authProvider.connectToEnterpriseSso(connection.startUrl, connection.region)
+            }
+        })
     }
 
     public async openDevEnvSettings(): Promise<void> {

--- a/src/codecatalyst/commands.ts
+++ b/src/codecatalyst/commands.ts
@@ -136,7 +136,10 @@ function createClientInjector(authProvider: CodeCatalystAuthenticationProvider):
         telemetry.record({ userId: AccountStatus.NotSet })
 
         await authProvider.restore()
-        const conn = await authProvider.tryGetBuilderIdConnection()
+        const conn = authProvider.activeConnection
+        if (!conn) {
+            throw new ToolkitError('Not connected to CodeCatalyst', { code: 'NoConnectionBadState' })
+        }
         const validatedConn = await validateConnection(conn, authProvider.auth)
         const client = await createClient(validatedConn)
         telemetry.record({ userId: client.identity.id })

--- a/src/codecatalyst/model.ts
+++ b/src/codecatalyst/model.ts
@@ -252,9 +252,15 @@ export async function prepareDevEnvConnection(
 export async function openDevEnv(
     client: CodeCatalystClient,
     devenv: DevEnvironmentId,
-    targetPath?: string
+    targetPath?: string,
+    onBeforeConnect?: () => Promise<void>
 ): Promise<void> {
+    if (onBeforeConnect) {
+        await onBeforeConnect()
+    }
+
     const env = await prepareDevEnvConnection(client, devenv, { topic: 'connect' })
+
     if (!targetPath) {
         const repo = env.devenv.repositories.length === 1 ? env.devenv.repositories[0].repositoryName : undefined
         targetPath = repo ? `/projects/${repo}` : '/projects'

--- a/src/codecatalyst/uriHandlers.ts
+++ b/src/codecatalyst/uriHandlers.ts
@@ -55,15 +55,14 @@ function parseCloneParams(query: SearchParams) {
 
 export function parseConnectParams(query: SearchParams): ConnectParams {
     try {
-        const params = query.getFromKeysOrThrow(
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        const { sso_start_url, sso_region, ...rest } = query.getFromKeysOrThrow(
             'devEnvironmentId',
             'spaceName',
             'projectName',
             'sso_start_url',
             'sso_region'
         )
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        const { sso_start_url, sso_region, ...rest } = params
         return { ...rest, sso: { startUrl: sso_start_url, region: sso_region } }
     } catch {
         return query.getFromKeysOrThrow('devEnvironmentId', 'spaceName', 'projectName')

--- a/src/codecatalyst/uriHandlers.ts
+++ b/src/codecatalyst/uriHandlers.ts
@@ -8,6 +8,16 @@ import { SearchParams, UriHandler } from '../shared/vscode/uriHandler'
 import { getCodeCatalystConfig } from '../shared/clients/codecatalystClient'
 import { CodeCatalystCommands } from './commands'
 
+type ConnectParams = {
+    devEnvironmentId: string
+    spaceName: string
+    projectName: string
+    sso?: {
+        startUrl: string
+        region: string
+    }
+}
+
 export function register(
     handler: UriHandler,
     commands: Pick<typeof CodeCatalystCommands.declared, 'cloneRepo' | 'openDevEnv'>
@@ -20,12 +30,16 @@ export function register(
         }
     }
 
-    async function connectHandler(params: ReturnType<typeof parseConnectParams | typeof parseConnectParamsOld>) {
-        await commands.openDevEnv.execute({
-            id: params.devEnvironmentId,
-            org: { name: 'spaceName' in params ? params.spaceName : params.organizationName },
-            project: { name: params.projectName },
-        })
+    async function connectHandler(params: ConnectParams) {
+        await commands.openDevEnv.execute(
+            {
+                id: params.devEnvironmentId,
+                org: { name: params.spaceName },
+                project: { name: params.projectName },
+            },
+            undefined,
+            params.sso
+        )
     }
 
     return vscode.Disposable.from(
@@ -39,10 +53,28 @@ function parseCloneParams(query: SearchParams) {
     return { url: query.getAsOrThrow('url', 'A URL must be provided', v => vscode.Uri.parse(v, true)) }
 }
 
-function parseConnectParams(query: SearchParams) {
-    return query.getFromKeysOrThrow('devEnvironmentId', 'spaceName', 'projectName')
+export function parseConnectParams(query: SearchParams): ConnectParams {
+    try {
+        const params = query.getFromKeysOrThrow(
+            'devEnvironmentId',
+            'spaceName',
+            'projectName',
+            'sso_start_url',
+            'sso_region'
+        )
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        const { sso_start_url, sso_region, ...rest } = params
+        return { ...rest, sso: { startUrl: sso_start_url, region: sso_region } }
+    } catch {
+        return query.getFromKeysOrThrow('devEnvironmentId', 'spaceName', 'projectName')
+    }
 }
 
-function parseConnectParamsOld(query: SearchParams) {
-    return query.getFromKeysOrThrow('devEnvironmentId', 'organizationName', 'projectName')
+function parseConnectParamsOld(query: SearchParams): ConnectParams {
+    const params = query.getFromKeysOrThrow('devEnvironmentId', 'organizationName', 'projectName')
+    return {
+        devEnvironmentId: params.devEnvironmentId,
+        spaceName: params.organizationName,
+        projectName: params.projectName,
+    }
 }

--- a/src/codecatalyst/utils.ts
+++ b/src/codecatalyst/utils.ts
@@ -66,16 +66,9 @@ export function isInDevEnv(): boolean {
     return !!getCodeCatalystDevEnvId()
 }
 
-export const getStartedCommand = Commands.register('aws.codecatalyst.getStarted', setupCodeCatalystBuilderId)
-
-export async function setupCodeCatalystBuilderId(authProvider: CodeCatalystAuthenticationProvider) {
-    let conn = await authProvider.tryGetBuilderIdConnection()
-
-    if (authProvider.auth.getConnectionState(conn) === 'invalid') {
-        conn = await authProvider.auth.reauthenticate(conn)
+export const getStartedCommand = Commands.register(
+    'aws.codecatalyst.getStarted',
+    (auth: CodeCatalystAuthenticationProvider) => {
+        auth.connectToAwsBuilderId()
     }
-
-    if (!(await authProvider.isConnectionOnboarded(conn, true))) {
-        await authProvider.promptOnboarding()
-    }
-}
+)

--- a/src/test/codecatalyst/auth.test.ts
+++ b/src/test/codecatalyst/auth.test.ts
@@ -1,0 +1,118 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import { CodeCatalystAuthStorage, CodeCatalystAuthenticationProvider, defaultScopes } from '../../codecatalyst/auth'
+import { getTestWindow } from '../shared/vscode/window'
+import { FakeMemento, FakeSecretStorage } from '../fakeExtensionContext'
+import { createBuilderIdProfile, createSsoProfile, createTestAuth } from '../credentials/testUtil'
+import Sinon from 'sinon'
+import { isAnySsoConnection } from '../../auth/connection'
+
+const enterpriseSsoStartUrl = 'https://enterprise.awsapps.com/start'
+
+describe('CodeCatalystAuthenticationProvider', async function () {
+    let auth: ReturnType<typeof createTestAuth>
+    let codecatalystAuth: CodeCatalystAuthenticationProvider
+
+    beforeEach(async function () {
+        auth = createTestAuth()
+        codecatalystAuth = new CodeCatalystAuthenticationProvider(
+            new CodeCatalystAuthStorage(new FakeSecretStorage()),
+            new FakeMemento(),
+            auth
+        )
+    })
+
+    afterEach(async function () {
+        await auth.logout()
+    })
+
+    describe('connectToAwsBuilderId()', () => {
+        it('should create a new connection', async function () {
+            Sinon.stub(codecatalystAuth, 'isConnectionOnboarded').resolves(true)
+
+            getTestWindow().onDidShowQuickPick(async picker => {
+                await picker.untilReady()
+                picker.acceptItem(picker.items[1])
+            })
+
+            await codecatalystAuth.connectToAwsBuilderId()
+            const conn = codecatalystAuth.activeConnection
+            assert.strictEqual(conn?.type, 'sso')
+            assert.strictEqual(conn.label, 'AWS Builder ID')
+        })
+
+        it('should add scopes to existing Builder ID connection', async function () {
+            Sinon.stub(codecatalystAuth, 'isConnectionOnboarded').resolves(true)
+
+            getTestWindow().onDidShowMessage(async message => {
+                assert.ok(message.modal)
+                message.selectItem('Proceed')
+            })
+            const otherScope = 'my:other:scope'
+            const ssoConn = await auth.createInvalidSsoConnection(createBuilderIdProfile({ scopes: [otherScope] }))
+
+            // Method under test
+            await codecatalystAuth.connectToEnterpriseSso(ssoConn.startUrl, 'us-east-1')
+
+            const conn = codecatalystAuth.activeConnection
+            assert.strictEqual(conn?.type, 'sso')
+            assert.strictEqual(conn.label, 'AWS Builder ID')
+            assert.deepStrictEqual(conn.scopes, [otherScope, ...defaultScopes])
+        })
+
+        it('does not prompt to sign out of duplicate builder ID connections', async function () {
+            Sinon.stub(codecatalystAuth, 'isConnectionOnboarded').resolves(true)
+
+            await codecatalystAuth.connectToAwsBuilderId()
+            await codecatalystAuth.connectToAwsBuilderId()
+            assert.ok(codecatalystAuth.isConnected())
+
+            const ssoConnectionIds = new Set(
+                auth.activeConnectionEvents.emits.filter(isAnySsoConnection).map(c => c.id)
+            )
+            assert.strictEqual(ssoConnectionIds.size, 1, 'Expected exactly 1 unique SSO connection id')
+            assert.strictEqual((await auth.listConnections()).filter(isAnySsoConnection).length, 1)
+        })
+    })
+
+    describe('connectToEnterpriseSso()', () => {
+        it('should create a new connection', async function () {
+            Sinon.stub(codecatalystAuth, 'isConnectionOnboarded').resolves(true)
+
+            getTestWindow().onDidShowQuickPick(async picker => {
+                await picker.untilReady()
+                picker.acceptItem(picker.items[1])
+            })
+
+            await codecatalystAuth.connectToEnterpriseSso(enterpriseSsoStartUrl, 'us-east-1')
+            const conn = codecatalystAuth.activeConnection
+            assert.strictEqual(conn?.type, 'sso')
+            assert.strictEqual(conn.label, 'IAM Identity Center (enterprise)')
+        })
+
+        it('should add scopes to existing IAM Identity Center connection', async function () {
+            Sinon.stub(codecatalystAuth, 'isConnectionOnboarded').resolves(true)
+
+            getTestWindow().onDidShowMessage(async message => {
+                assert.ok(message.modal)
+                message.selectItem('Proceed')
+            })
+            const otherScope = 'my:other:scope'
+            const ssoConn = await auth.createInvalidSsoConnection(
+                createSsoProfile({ startUrl: enterpriseSsoStartUrl, scopes: [otherScope] })
+            )
+
+            // Method under test
+            await codecatalystAuth.connectToEnterpriseSso(ssoConn.startUrl, 'us-east-1')
+
+            const conn = codecatalystAuth.activeConnection
+            assert.strictEqual(conn?.type, 'sso')
+            assert.strictEqual(conn.label, 'IAM Identity Center (enterprise)')
+            assert.deepStrictEqual(conn.scopes, [otherScope, ...defaultScopes])
+        })
+    })
+})

--- a/src/test/fakeExtensionContext.ts
+++ b/src/test/fakeExtensionContext.ts
@@ -56,7 +56,7 @@ export class FakeExtensionContext implements vscode.ExtensionContext {
     public storageUri: vscode.Uri | undefined
     public logUri: vscode.Uri = vscode.Uri.file('file://fake/log/uri')
     public extensionMode: vscode.ExtensionMode = vscode.ExtensionMode.Test
-    public secrets = new SecretStorage()
+    public secrets = new FakeSecretStorage()
 
     public extension: vscode.Extension<any> = {
         activate: async () => undefined,
@@ -171,7 +171,7 @@ export class FakeMemento implements vscode.Memento {
     }
 }
 
-class SecretStorage implements vscode.SecretStorage {
+export class FakeSecretStorage implements vscode.SecretStorage {
     private _onDidChange = new vscode.EventEmitter<vscode.SecretStorageChangeEvent>()
     public readonly onDidChange = this._onDidChange.event
 


### PR DESCRIPTION
## Problem

Amazon CodeCatalyst currently supports Builder ID connections. The CodeCatalyst team is working to enable IAM Identity Center connections for CodeCatalyst, including enabling IDC connections using AWS Toolkit for Visual Studio Code.

## Solution

**This change adds the following:**

- Additions and changes within `CodeCatalystAuthenticationProvider` and surrounding modules to enable IDC connections.
  - The changes account for switching connections.
  - The changes account for extending scopes on existing connections.
- Minimal UI additions to CodeCatalyst connection form to support IDC connection flow (may be revised in subsequent revision)
- URI handler changes to support explicit IDC startUrl/region.
- `tryAutoConnect` changes to support IDC profiles.

Note that no changes were necessary for core authN/connection logic (e.g. secondaryAuth, and connection modules). Similarly, no UI changes were necessary for these existing connection flows.

**The following testing has been performed:**

- Manual testing of the connection with various permutations / combinations of Builder ID vs IDC connections for CodeCatalyst and CodeWhisperer.
- Manual testing a CodeCatalyst IDC connection successfully authenticates and works against CodeCatalyst APIs.
- Manual testing that a CodeCatalyst Dev Environment can be connected to from the Toolkit using an IDC conneciton.
- End-to-end manual testing with a CodeCatalyst Dev Environment.
- Backfilled some unit tests for `CodeCatalystAuthenticationProvider`.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
