### PR TITLE
fix: cannot cancel "Scanning CloudFormation templates..."

### DIFF
--- a/src/codecatalyst/devfile.ts
+++ b/src/codecatalyst/devfile.ts
@@ -111,7 +111,7 @@ export function registerDevfileWatcher(devenvClient: DevEnvClient): vscode.Dispo
     const registry = new DevfileRegistry()
     const codelensProvider = new DevfileCodeLensProvider(registry, devenvClient)
     registry.addWatchPatterns([devfileGlobPattern])
-    registry.rebuild(new Promise(() => {}))
+    registry.rebuild()
 
     const codelensDisposable = vscode.languages.registerCodeLensProvider(
         {

--- a/src/codecatalyst/devfile.ts
+++ b/src/codecatalyst/devfile.ts
@@ -111,6 +111,7 @@ export function registerDevfileWatcher(devenvClient: DevEnvClient): vscode.Dispo
     const registry = new DevfileRegistry()
     const codelensProvider = new DevfileCodeLensProvider(registry, devenvClient)
     registry.addWatchPatterns([devfileGlobPattern])
+    registry.rebuild(new Promise(() => {}))
 
     const codelensDisposable = vscode.languages.registerCodeLensProvider(
         {

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -56,12 +56,12 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
  * and slowing down the extension starting up.
  */
 function setTemplateRegistryInGlobals(registry: CloudFormationTemplateRegistry) {
-    const registrySetupFunc = async (registry: CloudFormationTemplateRegistry) => {
-        await registry.addExcludedPattern(CloudFormation.devfileExcludePattern)
-        await registry.addExcludedPattern(CloudFormation.templateFileExcludePattern)
-        await registry.addWatchPatterns([CloudFormation.templateFileGlobPattern])
-        await registry.watchUntitledFiles()
-
+    const registrySetupFunc = async (registry: CloudFormationTemplateRegistry, cancellationPromise: Promise<void>) => {
+        registry.addExcludedPattern(CloudFormation.devfileExcludePattern)
+        registry.addExcludedPattern(CloudFormation.templateFileExcludePattern)
+        registry.addWatchPatterns([CloudFormation.templateFileGlobPattern])
+        registry.watchUntitledFiles()
+        await registry.rebuild(cancellationPromise)
         return registry
     }
 

--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -15,6 +15,7 @@ import * as CloudFormation from './cloudformation'
 import { Commands } from '../vscode/commands2'
 import globals from '../extensionGlobals'
 import { SamCliSettings } from '../sam/cli/samCliSettings'
+import { Timeout } from '../utilities/timeoutUtils'
 
 /**
  * Creates a CloudFormationTemplateRegistry which retains the state of CloudFormation templates in a workspace.
@@ -56,12 +57,12 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
  * and slowing down the extension starting up.
  */
 function setTemplateRegistryInGlobals(registry: CloudFormationTemplateRegistry) {
-    const registrySetupFunc = async (registry: CloudFormationTemplateRegistry, cancellationPromise: Promise<void>) => {
+    const registrySetupFunc = async (registry: CloudFormationTemplateRegistry, cancellationTimeout: Timeout) => {
         registry.addExcludedPattern(CloudFormation.devfileExcludePattern)
         registry.addExcludedPattern(CloudFormation.templateFileExcludePattern)
         registry.addWatchPatterns([CloudFormation.templateFileGlobPattern])
         registry.watchUntitledFiles()
-        await registry.rebuild(cancellationPromise)
+        await registry.rebuild(cancellationTimeout)
         return registry
     }
 

--- a/src/shared/fs/templateRegistry.ts
+++ b/src/shared/fs/templateRegistry.ts
@@ -87,8 +87,10 @@ export class AsyncCloudFormationTemplateRegistry {
         }
 
         let perf: PerfLog
+        let resolver: () => void
         let rejector: () => void
-        const cancelSetupPromise = new Promise<void>((_, reject) => {
+        const cancelSetupPromise = new Promise<void>((resolve, reject) => {
+            resolver = resolve
             rejector = reject
         })
         if (!this.setupPromise) {
@@ -100,6 +102,7 @@ export class AsyncCloudFormationTemplateRegistry {
                 perf.done()
             }
             this.isSetup = true
+            resolver()
         })
         // Show user a message indicating setup is in progress
         if (this.setupProgressMessage === undefined) {

--- a/src/shared/fs/watchedFiles.ts
+++ b/src/shared/fs/watchedFiles.ts
@@ -303,11 +303,11 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
             const glob = this.globs[i]
             try {
                 const found = await vscode.workspace.findFiles(glob, exclude)
-                for (const item of found) {
-                    await this.addItem(item, true)
+                for (let j = 0; j < found.length && !isCanceled; j++) {
+                    await this.addItem(found[j], true)
                 }
             } catch (e) {
-                // inner try/catch skips over problematic files
+                // file not processable
                 skips++
                 const err = e as Error
                 getLogger().error('watchedFiles: findFiles("%s", "%s"): %s', glob, exclude, err.message)

--- a/src/shared/fs/watchedFiles.ts
+++ b/src/shared/fs/watchedFiles.ts
@@ -284,7 +284,7 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
     /**
      * Builds/rebuilds registry using current glob and exclusion patterns. ***Necessary to init registry***.
      *
-     * @param cancellationPromise Cancels additional registrations when rejected. Otherwise, this
+     * @param cancellationTimeout Optional timeout that can trigger canceling additional loading on completion (manual or timed)
      */
     public async rebuild(cancellationTimeout?: Timeout): Promise<void> {
         let skips = 0

--- a/src/shared/fs/watchedFiles.ts
+++ b/src/shared/fs/watchedFiles.ts
@@ -60,12 +60,18 @@ const getExcludePatternOnce = once(getExcludePattern)
  * for CFN templates among other things. WatchedFiles holds a list of pairs of
  * the absolute path to the file or "untitled:" URI along with a transform of it that is useful for
  * where it is used. For example, for templates, it parses the template and stores it.
+ *
+ * Initialize the registry by adding watch patterns and excluded patterns via
+ * `addWatchPatterns`, `watchUntitledFiles`, and `addExcludedPattern` and then
+ * calling the `rebuild` function to begin registering files.
  */
 export abstract class WatchedFiles<T> implements vscode.Disposable {
+    private isWatching: boolean = false
     private readonly disposables: vscode.Disposable[] = []
     private _isDisposed: boolean = false
     private readonly globs: vscode.GlobPattern[] = []
     private readonly excludedFilePatterns: RegExp[] = []
+    private watchingUntitledFiles: boolean = false
     private readonly registryData: Map<string, T> = new Map<string, T>()
 
     /**
@@ -84,7 +90,7 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
     public constructor() {
         this.disposables.push(
             vscode.workspace.onDidChangeWorkspaceFolders(async () => {
-                await this.rebuild()
+                await this.rebuild(new Promise(() => {}))
             })
         )
     }
@@ -93,7 +99,7 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
      * Creates watchers for each glob across all opened workspace folders (or see below to
      * watch _outside_ the workspace).
      *
-     * Fails if the watcher is disposed, or if globs have already been set;
+     * Fails if the watcher is disposed, or if the watcher has been initialized through the `rebuild` function;
      * enforce setting once to reduce rebuilds looping through all existing globs
      *
      * (since vscode 1.64):
@@ -120,12 +126,12 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
      *
      * @param globs Patterns to match against (across all opened workspace folders)
      */
-    public async addWatchPatterns(globs: vscode.GlobPattern[]): Promise<void> {
+    public addWatchPatterns(globs: vscode.GlobPattern[]) {
         if (this._isDisposed) {
             throw new Error(`${this.name}: manager has already been disposed!`)
         }
-        if (this.globs.length > 0) {
-            throw new Error(`${this.name}: watch patterns have already been established`)
+        if (this.isWatching) {
+            throw new Error(`${this.name}: cannot add watch patterns after watcher has begun watching`)
         }
         for (const glob of globs) {
             if (typeof glob === 'string' && !vscode.workspace.workspaceFolders?.[0]) {
@@ -136,15 +142,14 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
             const watcher = vscode.workspace.createFileSystemWatcher(glob)
             this.addWatcher(watcher)
         }
-
-        await this.rebuild()
     }
 
     /**
      * Create a special watcher that operates only on untitled files.
      * To "watch" the in-memory contents of an untitled:/ file we just subscribe to `onDidChangeTextDocument`
      */
-    public async watchUntitledFiles() {
+    public watchUntitledFiles() {
+        this.watchingUntitledFiles = true
         this.disposables.push(
             vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => {
                 if (isUntitledScheme(event.document.uri)) {
@@ -162,13 +167,14 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
     /**
      * Adds a regex pattern to ignore paths containing the pattern
      */
-    public async addExcludedPattern(pattern: RegExp): Promise<void> {
+    public addExcludedPattern(pattern: RegExp) {
         if (this._isDisposed) {
             throw new Error(`${this.name}: manager has already been disposed!`)
         }
+        if (this.isWatching) {
+            throw new Error(`${this.name}: cannot add excluded patterns after watcher has begun watching`)
+        }
         this.excludedFilePatterns.push(pattern)
-
-        await this.rebuild()
     }
 
     /**
@@ -275,26 +281,56 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
     }
 
     /**
-     * Rebuilds registry using current glob and exclusion patterns.
-     * All functionality is currently internal to class, but can be made public if we want a manual "refresh" button
+     * Builds/rebuilds registry using current glob and exclusion patterns. ***Necessary to init registry***.
+     *
+     * @param cancellationPromise Cancels additional registrations when rejected. Otherwise, this
      */
-    public async rebuild(): Promise<void> {
+    public async rebuild(cancellationPromise: Promise<void>): Promise<void> {
+        const cancellationMessage = 'cancelRebuild'
+        let skips = 0
+        let exitMessage = ''
+        this.isWatching = true
         this.reset()
 
         const exclude = getExcludePatternOnce()
-        for (const glob of this.globs) {
-            try {
-                const found = await vscode.workspace.findFiles(glob, exclude)
-                for (const item of found) {
-                    await this.addItem(item, true)
+        getLogger().info(`Building registry with the following criteria: ${this.outputPatterns()}`)
+        try {
+            cancellationPromise.then(
+                () => {},
+                () => {
+                    throw new Error(cancellationMessage)
                 }
-            } catch (e) {
-                const err = e as Error
-                if (err.name !== 'Canceled') {
+            )
+            for (const glob of this.globs) {
+                try {
+                    const found = await vscode.workspace.findFiles(glob, exclude)
+                    for (const item of found) {
+                        await this.addItem(item, true)
+                    }
+                } catch (e) {
+                    // inner try/catch skips over problematic files
+                    skips++
+                    const err = e as Error
                     getLogger().error('watchedFiles: findFiles("%s", "%s"): %s', glob, exclude, err.message)
                 }
             }
+        } catch (e) {
+            // outer try/catch cancels either systemic failures or cancellations
+            const err = e as Error
+            if (err.message === cancellationMessage) {
+                exitMessage = ' (cancelled)'
+                getLogger().info('watchedFiles: rebuild cancelled')
+            } else {
+                exitMessage = ' (errored)'
+                getLogger().error('watchedFiles: rebuild error: %s', err.message)
+            }
         }
+        getLogger().info(
+            'Registered %s items%s%s',
+            this.registryData.size,
+            exitMessage,
+            skips > 0 ? `, skipped ${skips} entries` : ''
+        )
     }
 
     /**
@@ -339,6 +375,18 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
         ) {
             throw new Error(`FileRegistry: path is relative when it should be absolute: ${pathAsString}`)
         }
+    }
+
+    private outputPatterns(): string {
+        const watch = this.globs.map(cur => cur.toString())
+        if (this.watchingUntitledFiles) {
+            watch.push('Untitled Files')
+        }
+        const exclude = this.excludedFilePatterns.map(cur => cur.toString())
+
+        return `${watch.length > 0 ? `Watching ${watch.join(', ')}` : ''}${
+            exclude.length > 0 ? `, Excluding ${exclude.join(', ')}` : ''
+        }`
     }
 }
 

--- a/src/shared/fs/watchedFiles.ts
+++ b/src/shared/fs/watchedFiles.ts
@@ -292,7 +292,7 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
         this.reset()
 
         const exclude = getExcludePatternOnce()
-        getLogger().info(`Building registry with the following criteria: ${this.outputPatterns()}`)
+        getLogger().info(`${this.name}: Building registry with the following criteria: ${this.outputPatterns()}`)
         cancellationPromise.then(
             () => {},
             () => {
@@ -310,11 +310,11 @@ export abstract class WatchedFiles<T> implements vscode.Disposable {
                 // file not processable
                 skips++
                 const err = e as Error
-                getLogger().error('watchedFiles: findFiles("%s", "%s"): %s', glob, exclude, err.message)
+                getLogger().error(`${this.name}: watchedFiles: findFiles("%s", "%s"): %s`, glob, exclude, err.message)
             }
         }
         getLogger().info(
-            'Registered %s items%s%s',
+            `${this.name}: Registered %s items%s%s`,
             this.registryData.size,
             isCanceled ? ' (cancelled)' : '',
             skips > 0 ? `, skipped ${skips} entries` : ''

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -178,7 +178,7 @@ async function activateCodeLensRegistry(context: ExtContext) {
             javaLensProvider.gradleBasePattern,
             javaLensProvider.mavenBasePattern,
         ])
-        await registry.rebuild(new Promise(() => {}))
+        await registry.rebuild()
     } catch (e) {
         vscode.window.showErrorMessage(
             localize(

--- a/src/shared/sam/activation.ts
+++ b/src/shared/sam/activation.ts
@@ -170,7 +170,7 @@ async function activateCodeLensRegistry(context: ExtContext) {
         // "**/…" string patterns watch recursively across _all_ workspace
         // folders (see documentation for addWatchPatterns()).
         //
-        await registry.addWatchPatterns([
+        registry.addWatchPatterns([
             pyLensProvider.pythonBasePattern,
             jsLensProvider.javascriptBasePattern,
             csLensProvider.csharpBasePattern,
@@ -178,6 +178,7 @@ async function activateCodeLensRegistry(context: ExtContext) {
             javaLensProvider.gradleBasePattern,
             javaLensProvider.mavenBasePattern,
         ])
+        await registry.rebuild(new Promise(() => {}))
     } catch (e) {
         vscode.window.showErrorMessage(
             localize(

--- a/src/test/shared/debug/launchConfiguration.test.ts
+++ b/src/test/shared/debug/launchConfiguration.test.ts
@@ -107,7 +107,7 @@ describe('LaunchConfiguration', function () {
     beforeEach(async function () {
         const registry = await globals.templateRegistry
         registry.addWatchPatterns([CloudFormation.templateFileGlobPattern])
-        await registry.rebuild(new Promise(() => {}))
+        await registry.rebuild()
 
         // TODO: remove mocks in favor of testing src/testFixtures/ data.
         mockConfigSource = mock()

--- a/src/test/shared/debug/launchConfiguration.test.ts
+++ b/src/test/shared/debug/launchConfiguration.test.ts
@@ -106,7 +106,8 @@ describe('LaunchConfiguration', function () {
 
     beforeEach(async function () {
         const registry = await globals.templateRegistry
-        await registry.addWatchPatterns([CloudFormation.templateFileGlobPattern])
+        registry.addWatchPatterns([CloudFormation.templateFileGlobPattern])
+        await registry.rebuild(new Promise(() => {}))
 
         // TODO: remove mocks in favor of testing src/testFixtures/ data.
         mockConfigSource = mock()

--- a/src/testInteg/cloudformation/templateRegistry.test.ts
+++ b/src/testInteg/cloudformation/templateRegistry.test.ts
@@ -44,13 +44,15 @@ describe('CloudFormation Template Registry', async function () {
         await strToYamlFile(makeSampleSamTemplateYaml(true), path.join(testDir, 'test.yaml'))
         await strToYamlFile(makeSampleSamTemplateYaml(false), path.join(testDirNested, 'test.yml'))
 
-        await registry.addWatchPatterns(['**/test.{yaml,yml}'])
+        registry.addWatchPatterns(['**/test.{yaml,yml}'])
+        await registry.rebuild(new Promise(() => {}))
 
         await registryHasTargetNumberOfFiles(registry, 2)
     })
 
     it.skip('adds dynamically-added template files with yaml and yml extensions at various nesting levels', async function () {
-        await registry.addWatchPatterns(['**/test.{yaml,yml}'])
+        registry.addWatchPatterns(['**/test.{yaml,yml}'])
+        await registry.rebuild(new Promise(() => {}))
 
         await strToYamlFile(makeSampleSamTemplateYaml(false), path.join(testDir, 'test.yml'))
         await strToYamlFile(makeSampleSamTemplateYaml(true), path.join(testDirNested, 'test.yaml'))
@@ -59,8 +61,9 @@ describe('CloudFormation Template Registry', async function () {
     })
 
     it('Ignores templates matching excluded patterns', async function () {
-        await registry.addWatchPatterns(['**/test.{yaml,yml}'])
-        await registry.addExcludedPattern(/.*nested.*/)
+        registry.addWatchPatterns(['**/test.{yaml,yml}'])
+        registry.addExcludedPattern(/.*nested.*/)
+        await registry.rebuild(new Promise(() => {}))
 
         await strToYamlFile(makeSampleSamTemplateYaml(false), path.join(testDir, 'test.yml'))
         await strToYamlFile(makeSampleSamTemplateYaml(true), path.join(testDirNested, 'test.yaml'))
@@ -72,7 +75,8 @@ describe('CloudFormation Template Registry', async function () {
         const filepath = path.join(testDir, 'changeMe.yml')
         await strToYamlFile(makeSampleSamTemplateYaml(false), filepath)
 
-        await registry.addWatchPatterns(['**/changeMe.yml'])
+        registry.addWatchPatterns(['**/changeMe.yml'])
+        await registry.rebuild(new Promise(() => {}))
 
         await registryHasTargetNumberOfFiles(registry, 1)
 
@@ -84,7 +88,8 @@ describe('CloudFormation Template Registry', async function () {
     })
 
     it('can handle deleted files', async function () {
-        await registry.addWatchPatterns(['**/deleteMe.yml'])
+        registry.addWatchPatterns(['**/deleteMe.yml'])
+        await registry.rebuild(new Promise(() => {}))
 
         // Specifically creating the file after the watcher is added
         // Otherwise, it seems the file is deleted before the file watcher realizes the file exists
@@ -99,11 +104,21 @@ describe('CloudFormation Template Registry', async function () {
         await registryHasTargetNumberOfFiles(registry, 0)
     })
 
-    it('fails if you set watch patterns multiple times', async function () {
-        await registry.addWatchPatterns(['first/set'])
+    it('fails if you set watch patterns after init', async function () {
+        registry.addWatchPatterns(['first/set'])
+        await registry.rebuild(new Promise(() => {}))
         await assert.rejects(async () => {
-            await registry.addWatchPatterns(['second/set'])
-        }, new Error('CloudFormationTemplateRegistry: watch patterns have already been established'))
+            registry.addWatchPatterns(['second/set'])
+        }, new Error('CloudFormationTemplateRegistry: cannot add excluded patterns after watcher has begun watching'))
+    })
+
+    it('cancels the rebuild if the cancellation promise is rejected', async function () {
+        registry.addWatchPatterns(['**/test.{yaml,yml}'])
+        const rejectionPromise = new Promise<void>((_, reject) => {
+            reject()
+        })
+        await registry.rebuild(rejectionPromise)
+        await registryHasTargetNumberOfFiles(registry, 0)
     })
 })
 

--- a/src/testInteg/cloudformation/templateRegistry.test.ts
+++ b/src/testInteg/cloudformation/templateRegistry.test.ts
@@ -109,6 +109,9 @@ describe('CloudFormation Template Registry', async function () {
         await registry.rebuild(new Promise(() => {}))
         await assert.rejects(async () => {
             registry.addWatchPatterns(['second/set'])
+        }, new Error('CloudFormationTemplateRegistry: cannot add watch patterns after watcher has begun watching'))
+        await assert.rejects(async () => {
+            registry.addExcludedPattern(/exclude me/)
         }, new Error('CloudFormationTemplateRegistry: cannot add excluded patterns after watcher has begun watching'))
     })
 

--- a/src/testInteg/sam.test.ts
+++ b/src/testInteg/sam.test.ts
@@ -657,6 +657,6 @@ describe('SAM Integration Tests', async function () {
         // XXX: Fixes flakiness. Ensures the files from creation of sam
         // app are processed by code lens file watcher. Otherwise, potential
         // issues of file not in registry before it is found.
-        await globals.codelensRootRegistry.rebuild()
+        await globals.codelensRootRegistry.rebuild(new Promise(() => {}))
     }
 })

--- a/src/testInteg/sam.test.ts
+++ b/src/testInteg/sam.test.ts
@@ -656,6 +656,6 @@ describe('SAM Integration Tests', async function () {
         // XXX: Fixes flakiness. Ensures the files from creation of sam
         // app are processed by code lens file watcher. Otherwise, potential
         // issues of file not in registry before it is found.
-        await globals.codelensRootRegistry.rebuild(new Promise(() => {}))
+        await globals.codelensRootRegistry.rebuild()
     }
 })


### PR DESCRIPTION
## Problem
Cancelling the CFN registry toast would continue registering YAML files in the background, and merely just hid the popup

## Solution
Cancelling through the widget should now stop after the current file finishes processing
* tested best with a breakpoint on the processing--it looks like it stops immediately but haven't tried this on a slow machine with a lot of YAML (we're getting really good at not starting the registry! it doesn't do me any favors trying to test this though...)
* some light refactoring (`registry.rebuild()` is a mandatory call--this makes it easier to pass a cancellation promise)

Note: we don't have a way to restart the load, so right now, cancelling means that you have to restart the toolkit if the registry is busted.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
