### PR TITLE
Remove deprecated Python configs

### DIFF
--- a/src/testInteg/integrationTestsUtilities.ts
+++ b/src/testInteg/integrationTestsUtilities.ts
@@ -34,13 +34,6 @@ export async function configureAwsToolkitExtension(): Promise<void> {
     await configAws.update('samcli.enableCodeLenses', true, false)
 }
 
-export async function configurePythonExtension(): Promise<void> {
-    const configPy = vscode.workspace.getConfiguration('python')
-    // Disable linting to silence some of the Python extension's log spam
-    await configPy.update('linting.pylintEnabled', false, false)
-    await configPy.update('linting.enabled', false, false)
-}
-
 // Installs tools that the Go extension wants (it complains a lot if we don't)
 // Had to dig around for the commands used by the Go extension.
 // Ref: https://github.com/golang/vscode-go/blob/0058bd16ba31394f98aa3396056998e4808998a7/src/goTools.ts#L211

--- a/src/testInteg/sam.test.ts
+++ b/src/testInteg/sam.test.ts
@@ -380,7 +380,6 @@ describe('SAM Integration Tests', async function () {
 
         await activateExtensions()
         await testUtils.configureAwsToolkitExtension()
-        await testUtils.configurePythonExtension()
         // await testUtils.configureGoExtension()
 
         testSuiteRoot = await mkdtemp(path.join(projectFolder, 'inttest'))


### PR DESCRIPTION
Fix broken integ tests. Unknown if this will give us a lot of spam, but it looks like there are no more linting settings for Python.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
