### PR TITLE
fix(ecs): exec command requires SimulatePrincipalPolicy permissions #3969

### DIFF
--- a/.changes/next-release/Bug Fix-bbaf4ca5-56ad-47cc-949c-11fc91a8bff1.json
+++ b/.changes/next-release/Bug Fix-bbaf4ca5-56ad-47cc-949c-11fc91a8bff1.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "ECS: `SimulatePrincipalPolicy` permission is no longer required for users to run `exec command`"
+}

--- a/src/ecs/commands.ts
+++ b/src/ecs/commands.ts
@@ -8,7 +8,6 @@ const localize = nls.loadMessageBundle()
 
 import moment from 'moment'
 import * as vscode from 'vscode'
-import { DefaultIamClient } from '../shared/clients/iamClient'
 import { INSIGHTS_TIMESTAMP_FORMAT } from '../shared/constants'
 import globals from '../shared/extensionGlobals'
 import { PromptSettings } from '../shared/settings'
@@ -17,7 +16,7 @@ import { showMessageWithCancel, showOutputMessage } from '../shared/utilities/me
 import { removeAnsi } from '../shared/utilities/textUtilities'
 import { CancellationError, Timeout } from '../shared/utilities/timeoutUtils'
 import { Commands } from '../shared/vscode/commands2'
-import { checkPermissionsForSsm, EcsSettings } from './util'
+import { EcsSettings } from './util'
 import { CommandWizard, CommandWizardState } from './wizards/executeCommand'
 import { isUserCancelledError, ToolkitError } from '../shared/errors'
 import { getResourceFromTreeNode } from '../shared/treeview/utils'
@@ -42,10 +41,6 @@ async function runCommandWizard(
     if (response.confirmation === 'suppress') {
         await PromptSettings.instance.disablePrompt('ecsRunCommand')
     }
-
-    await checkPermissionsForSsm(new DefaultIamClient(globals.regionProvider.defaultRegionId), {
-        taskRoleArn: container.description.taskRoleArn!,
-    })
 
     return { container, ...response }
 }

--- a/src/ecs/model.ts
+++ b/src/ecs/model.ts
@@ -50,7 +50,7 @@ export class Container {
     }
 
     public prepareCommandForTask(command: string, task: string) {
-        return prepareCommand(this.client, command, {
+        return prepareCommand(this.client, command, this.description.taskRoleArn, {
             task,
             container: this.description.name!,
             cluster: this.description.clusterArn,


### PR DESCRIPTION
https://github.com/aws/aws-toolkit-vscode/issues/3969

Problem: We attempt `SimulatePrincipalPolicy` to verify the container task role has proper permissions before running exec command. Users may not have access to simulate policies, but may otherwise be able to run exec command without issue.

Solution: Only attempt `SimulatePrincipalPolicy` if exec command fails. Otherwise, there is no need to simulate policies.

Testing: Tested manually with PowerUser case described in #3969. As expected, if `exec command` fails then the failure reason is returned along with the results of the permissions check, if it failed (e.g. from missing permissions or permission denied to simulate policies).



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
