### PR TITLE
ci: release automation lives in this repo

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-# engine-strict=true
+engine-strict=true

--- a/buildspec/release/00clonerepo.yml
+++ b/buildspec/release/00clonerepo.yml
@@ -1,0 +1,26 @@
+version: 0.2
+
+env:
+    variables:
+        NODE_OPTIONS: '--max-old-space-size=8192'
+
+phases:
+    install:
+        runtime-versions:
+            nodejs: 16
+
+    pre_build:
+        commands:
+            # Check for implicit env vars passed from the release pipeline.
+            - test -n "${TOOLKITS_GITHUB_REPO_OWNER}"
+
+    build:
+        commands:
+            - git clone https://github.com/${TOOLKITS_GITHUB_REPO_OWNER}/aws-toolkit-vscode.git aws-toolkit-vscode
+            # checkout master as we want to commit to it later
+            - cd aws-toolkit-vscode && git checkout master
+
+artifacts:
+    base-directory: aws-toolkit-vscode
+    files:
+        - '**/*'

--- a/buildspec/release/10changeversion.yml
+++ b/buildspec/release/10changeversion.yml
@@ -1,0 +1,37 @@
+version: 0.2
+
+phases:
+    pre_build:
+        commands:
+            - aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$TOOLKITS_ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO"
+
+    install:
+        runtime-versions:
+            nodejs: 16
+
+    build:
+        commands:
+            - |
+                echo "Removing SNAPSHOT from version string"
+                git config --global user.name "aws-toolkit-automation"
+                git config --global user.email "<>"
+                VERSION=$(node -e "console.log(require('./package.json').version);" | (IFS="-"; read -r version unused && echo "$version"))
+                DATE=$(date)
+                npm version --no-git-tag-version "$VERSION"
+                # Call npm ci because 'createRelease' uses ts-node
+                npm ci
+            - |
+                npm run createRelease
+            - |
+                git add package.json
+                git add package-lock.json
+                git commit -m "Release $VERSION"
+                echo "tagging commit"
+                git tag -a "v$VERSION" -m "version $VERSION $DATE"
+                # cleanup
+                git clean -fxd
+                git reset HEAD --hard
+
+artifacts:
+    files:
+        - '**/*'

--- a/buildspec/release/10changeversion.yml
+++ b/buildspec/release/10changeversion.yml
@@ -11,6 +11,8 @@ phases:
 
     build:
         commands:
+            # Disable engine-strict in CI.
+            - sed -i -e 's/engine.strict.true/engine-strict=false/' .npmrc
             - |
                 echo "Removing SNAPSHOT from version string"
                 git config --global user.name "aws-toolkit-automation"

--- a/buildspec/release/20buildrelease.yml
+++ b/buildspec/release/20buildrelease.yml
@@ -1,0 +1,31 @@
+version: 0.2
+
+env:
+    variables:
+        NODE_OPTIONS: '--max-old-space-size=8192'
+
+phases:
+    pre_build:
+        commands:
+            - aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$TOOLKITS_ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO"
+    install:
+        runtime-versions:
+            nodejs: 16
+
+        commands:
+            - apt-get update
+            - apt-get install -y libgtk-3-dev libxss1 xvfb
+            - apt-get install -y libnss3-dev libasound2
+            - apt-get install -y libasound2-plugins
+    build:
+        commands:
+            # --unsafe-perm is needed because we run as root
+            - npm ci --unsafe-perm
+            - cp ./README.quickstart.vscode.md ./README.md
+            - npm run package
+
+artifacts:
+    files:
+        - aws-toolkit-vscode*
+        - package.json
+    discard-paths: true

--- a/buildspec/release/20buildrelease.yml
+++ b/buildspec/release/20buildrelease.yml
@@ -19,6 +19,8 @@ phases:
             - apt-get install -y libasound2-plugins
     build:
         commands:
+            # Disable engine-strict in CI.
+            - sed -i -e 's/engine.strict.true/engine-strict=false/' .npmrc
             # --unsafe-perm is needed because we run as root
             - npm ci --unsafe-perm
             - cp ./README.quickstart.vscode.md ./README.md

--- a/buildspec/release/30closegate.yml
+++ b/buildspec/release/30closegate.yml
@@ -1,0 +1,19 @@
+version: 0.2
+
+phases:
+    install:
+        runtime-versions:
+            nodejs: 16
+
+    pre_build:
+        commands:
+            - STAGE_NAME=Release
+            - PIPELINE=$(echo $CODEBUILD_INITIATOR | sed -e 's/codepipeline\///')
+    build:
+        commands:
+            - |
+                aws codepipeline disable-stage-transition \
+                  --pipeline-name "$PIPELINE" \
+                  --stage-name "$STAGE_NAME" \
+                  --transition-type "Inbound" \
+                  --reason "Disabled by CloseGate (automation)"

--- a/buildspec/release/40pushtogithub.yml
+++ b/buildspec/release/40pushtogithub.yml
@@ -1,0 +1,41 @@
+version: 0.2
+
+env:
+    variables:
+        NODE_OPTIONS: '--max-old-space-size=8192'
+
+phases:
+    install:
+        runtime-versions:
+            nodejs: 16
+
+    pre_build:
+        commands:
+            # Check for implicit env vars passed from the release pipeline.
+            - test -n "${TOOLKITS_GITHUB_REPO_OWNER}"
+            - test -n "${GITHUB_TOKEN}"
+            - REPO_URL="https://$GITHUB_TOKEN@github.com/${TOOLKITS_GITHUB_REPO_OWNER}/aws-toolkit-vscode.git"
+
+    build:
+        commands:
+            - |
+                git config --global user.name "aws-toolkit-automation"
+                git config --global user.email "<>"
+                git remote add originWithCreds "$REPO_URL"
+                echo "Adding SNAPSHOT to next version string"
+                # Increase minor version
+                npm version --no-git-tag-version minor
+                VERSION=$(node -e "console.log(require('./package.json').version);")
+                # Append -SNAPSHOT
+                npm version --no-git-tag-version "${VERSION}-SNAPSHOT"
+                git add package.json
+                git add package-lock.json
+                git commit -m "Update version to snapshot version: ${VERSION}-SNAPSHOT"
+            - |
+                if [ "$STAGE" != "prod" ]; then
+                  echo "Stage is not production, skipping github push step"
+                  exit 0
+                fi
+                echo "pushing to github"
+                git push originWithCreds --tags
+                git push originWithCreds master

--- a/buildspec/release/50githubrelease.yml
+++ b/buildspec/release/50githubrelease.yml
@@ -1,0 +1,41 @@
+version: 0.2
+
+phases:
+    install:
+        runtime-versions:
+            nodejs: 16
+
+        Commands:
+            # GitHub recently changed their GPG signing key for their CLI tool
+            # These are the updated installation instructions:
+            # https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt
+            - curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+            - chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+            - echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            - apt update
+            - apt install gh -y
+
+    pre_build:
+        commands:
+            # Check for implicit env vars passed from the release pipeline.
+            - test -n "${TOOLKITS_GITHUB_REPO_OWNER}"
+            - REPO="${TOOLKITS_GITHUB_REPO_OWNER}/aws-toolkit-vscode"
+
+    build:
+        commands:
+            # pull in the build artifacts
+            - cp -r ${CODEBUILD_SRC_DIR_buildPipeline}/* .
+            - VERSION=$(node -e "console.log(require('./package.json').version);")
+            - UPLOAD_TARGET=$(ls aws-toolkit-vscode*.vsix)
+            - HASH_UPLOAD_TARGET=${UPLOAD_TARGET}.sha384
+            - 'HASH=$(sha384sum -b $UPLOAD_TARGET | cut -d" " -f1)'
+            - echo "Writing hash to $HASH_UPLOAD_TARGET"
+            - echo $HASH > $HASH_UPLOAD_TARGET
+            - echo "posting $VERSION with sha384 hash $HASH to GitHub"
+            - RELEASE_MESSAGE="AWS Toolkit for VS Code $VERSION"
+            - |
+                if [ $STAGE = "prod" ]; then
+                  gh release create --repo $REPO --title "$VERSION" --notes "$RELEASE_MESSAGE" -- "v$VERSION" "$UPLOAD_TARGET" "$HASH_UPLOAD_TARGET"
+                else
+                  echo "SKIPPED: 'gh release create --repo $REPO'"
+                fi

--- a/buildspec/release/60publish.yml
+++ b/buildspec/release/60publish.yml
@@ -1,0 +1,30 @@
+#
+# Publishes the release vsix to the marketplace.
+#
+
+version: 0.2
+
+phases:
+    install:
+        runtime-versions:
+            nodejs: 16
+        commands:
+            - apt-get update
+            - apt-get install -y libsecret-1-dev
+
+    pre_build:
+        commands:
+            # Check for implicit env vars passed from the release pipeline.
+            - test -n "${VS_MARKETPLACE_PAT}"
+
+    build:
+        commands:
+            # pull in the build artifacts
+            - cp -r ${CODEBUILD_SRC_DIR_buildPipeline}/* .
+            - |
+                if [ "$STAGE" != "prod" ]; then
+                  echo "Stage is not production, skipping publish step"
+                  exit 0
+                fi
+                UPLOAD_TARGET=$(ls aws-toolkit-vscode*.vsix)
+                npx vsce publish --pat "$VS_MARKETPLACE_PAT" --packagePath "$UPLOAD_TARGET"


### PR DESCRIPTION
## Problem

Release automation logic lives in a different repo, which adds friction to developing it, and reduces discoverability.

## Solution

Move all release automation logic into this repo. This repo should be the source of truth where possible.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
