### PR TITLE
codewhisperer: downgrade telemetry package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
                 "yaml-cfn": "^0.3.2"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.153",
+                "@aws-toolkits/telemetry": "^1.0.148",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^10.0.2",
                 "@types/adm-zip": "^0.4.34",
@@ -2358,9 +2358,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.153",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.153.tgz",
-            "integrity": "sha512-H8hhhGh4basdshdiSE0soZFP4tBim3bp99PmY8s65z7tzMhfmjQXVXBB0u3kpaCx5FyQRku83j2xas/RJWrunA==",
+            "version": "1.0.148",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.148.tgz",
+            "integrity": "sha512-9Gdj6JVr9S6hZzSZehwLIVdMvd5hnvoFhlxcdT889Ay0tW+dd4Ynp9rhax7KCkh2/jvI4ClHpR97ZAYsA+UAZw==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",
@@ -17950,9 +17950,9 @@
             }
         },
         "@aws-toolkits/telemetry": {
-            "version": "1.0.153",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.153.tgz",
-            "integrity": "sha512-H8hhhGh4basdshdiSE0soZFP4tBim3bp99PmY8s65z7tzMhfmjQXVXBB0u3kpaCx5FyQRku83j2xas/RJWrunA==",
+            "version": "1.0.148",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.148.tgz",
+            "integrity": "sha512-9Gdj6JVr9S6hZzSZehwLIVdMvd5hnvoFhlxcdT889Ay0tW+dd4Ynp9rhax7KCkh2/jvI4ClHpR97ZAYsA+UAZw==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -3845,7 +3845,7 @@
         "report": "nyc report --reporter=html --reporter=json"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.153",
+        "@aws-toolkits/telemetry": "^1.0.148",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/adm-zip": "^0.4.34",

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -231,11 +231,11 @@ export async function activate(context: ExtContext): Promise<void> {
             ImportAdderProvider.instance
         ),
         vscode.languages.registerHoverProvider(
-            [...CodeWhispererConstants.supportedLanguages],
+            [...CodeWhispererConstants.platformLanguageIds],
             SecurityIssueHoverProvider.instance
         ),
         vscode.languages.registerCodeActionsProvider(
-            [...CodeWhispererConstants.supportedLanguages],
+            [...CodeWhispererConstants.platformLanguageIds],
             SecurityIssueCodeActionProvider.instance
         )
     )


### PR DESCRIPTION
- Downgrade `@aws-toolkits/telemetry` to same version as `master` to resolve build issues
- Rename `supportedLanguages` -> `platformLanguageIds`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
