### PR TITLE
codewhisperer: telemetry metrics apply fix

### DIFF
--- a/src/codewhisperer/commands/basicCommands.ts
+++ b/src/codewhisperer/commands/basicCommands.ts
@@ -4,7 +4,7 @@
  */
 
 import * as vscode from 'vscode'
-import { CodewhispererCodeScanIssueApplyFix, Component, telemetry } from '../../shared/telemetry/telemetry'
+import { ApplyFixSource, CodewhispererCodeScanIssueApplyFix, telemetry } from '../../shared/telemetry/telemetry'
 import { ExtContext } from '../../shared/extensions'
 import { Commands } from '../../shared/vscode/commands2'
 import * as CodeWhispererConstants from '../models/constants'
@@ -218,7 +218,7 @@ export const notifyNewCustomizationsCmd = Commands.declare(
 
 export const applySecurityFix = Commands.declare(
     'aws.codeWhisperer.applySecurityFix',
-    () => async (issue: CodeScanIssue, filePath: string, source: Component) => {
+    () => async (issue: CodeScanIssue, filePath: string, source: ApplyFixSource) => {
         const [suggestedFix] = issue.suggestedFixes
         if (!suggestedFix || !filePath) {
             return
@@ -227,7 +227,7 @@ export const applySecurityFix = Commands.declare(
         const applyFixTelemetryEntry: Mutable<CodewhispererCodeScanIssueApplyFix> = {
             detectorId: issue.detectorId,
             findingId: issue.findingId,
-            component: source,
+            applyFixSource: source,
             result: 'Succeeded',
         }
 

--- a/src/codewhisperer/commands/basicCommands.ts
+++ b/src/codewhisperer/commands/basicCommands.ts
@@ -4,7 +4,7 @@
  */
 
 import * as vscode from 'vscode'
-import { ApplyFixSource, CodewhispererCodeScanIssueApplyFix, telemetry } from '../../shared/telemetry/telemetry'
+import { CodewhispererCodeScanIssueApplyFix, Component, telemetry } from '../../shared/telemetry/telemetry'
 import { ExtContext } from '../../shared/extensions'
 import { Commands } from '../../shared/vscode/commands2'
 import * as CodeWhispererConstants from '../models/constants'
@@ -218,7 +218,7 @@ export const notifyNewCustomizationsCmd = Commands.declare(
 
 export const applySecurityFix = Commands.declare(
     'aws.codeWhisperer.applySecurityFix',
-    () => async (issue: CodeScanIssue, filePath: string, source: ApplyFixSource) => {
+    () => async (issue: CodeScanIssue, filePath: string, source: Component) => {
         const [suggestedFix] = issue.suggestedFixes
         if (!suggestedFix || !filePath) {
             return
@@ -227,7 +227,7 @@ export const applySecurityFix = Commands.declare(
         const applyFixTelemetryEntry: Mutable<CodewhispererCodeScanIssueApplyFix> = {
             detectorId: issue.detectorId,
             findingId: issue.findingId,
-            applyFixSource: source,
+            component: source,
             result: 'Succeeded',
         }
 

--- a/src/codewhisperer/models/model.ts
+++ b/src/codewhisperer/models/model.ts
@@ -218,10 +218,6 @@ export interface CodeScanIssue {
     suggestedFixes: SuggestedFix[]
 }
 
-export interface CodeScanIssueCommandArgs extends CodeScanIssue {
-    filePath: string
-}
-
 export interface AggregatedCodeScanIssue {
     filePath: string
     issues: CodeScanIssue[]

--- a/src/codewhisperer/service/securityIssueCodeActionProvider.ts
+++ b/src/codewhisperer/service/securityIssueCodeActionProvider.ts
@@ -38,7 +38,7 @@ export class SecurityIssueCodeActionProvider extends SecurityIssueProvider imple
                         fixIssue.command = {
                             title: 'Apply suggested fix',
                             command: 'aws.codeWhisperer.applySecurityFix',
-                            arguments: [{ ...issue, filePath: group.filePath }],
+                            arguments: [issue, group.filePath, 'quickfix'],
                         }
                         codeActions.push(fixIssue)
                     }
@@ -46,7 +46,7 @@ export class SecurityIssueCodeActionProvider extends SecurityIssueProvider imple
                     openIssue.command = {
                         title: 'Open "CodeWhisperer Security Issue"',
                         command: 'aws.codeWhisperer.openSecurityIssuePanel',
-                        arguments: [{ ...issue, filePath: group.filePath }],
+                        arguments: [issue, group.filePath],
                     }
                     codeActions.push(openIssue)
                 }

--- a/src/codewhisperer/service/securityIssueHoverProvider.ts
+++ b/src/codewhisperer/service/securityIssueHoverProvider.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode'
 import { CodeScanIssue } from '../models/model'
 import globals from '../../shared/extensionGlobals'
 import { SecurityIssueProvider } from './securityIssueProvider'
-import { Component, telemetry } from '../../shared/telemetry/telemetry'
+import { ApplyFixSource, telemetry } from '../../shared/telemetry/telemetry'
 import path from 'path'
 
 export class SecurityIssueHoverProvider extends SecurityIssueProvider implements vscode.HoverProvider {
@@ -74,7 +74,7 @@ export class SecurityIssueHoverProvider extends SecurityIssueProvider implements
         )
 
         if (suggestedFix) {
-            const args: [CodeScanIssue, string, Component] = [issue, filePath, 'hover']
+            const args: [CodeScanIssue, string, ApplyFixSource] = [issue, filePath, 'hover']
             const applyFixCommand = vscode.Uri.parse(
                 `command:aws.codeWhisperer.applySecurityFix?${encodeURIComponent(JSON.stringify(args))}`
             )

--- a/src/codewhisperer/service/securityIssueHoverProvider.ts
+++ b/src/codewhisperer/service/securityIssueHoverProvider.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode'
 import { CodeScanIssue } from '../models/model'
 import globals from '../../shared/extensionGlobals'
 import { SecurityIssueProvider } from './securityIssueProvider'
-import { ApplyFixSource, telemetry } from '../../shared/telemetry/telemetry'
+import { Component, telemetry } from '../../shared/telemetry/telemetry'
 import path from 'path'
 
 export class SecurityIssueHoverProvider extends SecurityIssueProvider implements vscode.HoverProvider {
@@ -74,7 +74,7 @@ export class SecurityIssueHoverProvider extends SecurityIssueProvider implements
         )
 
         if (suggestedFix) {
-            const args: [CodeScanIssue, string, ApplyFixSource] = [issue, filePath, 'hover']
+            const args: [CodeScanIssue, string, Component] = [issue, filePath, 'hover']
             const applyFixCommand = vscode.Uri.parse(
                 `command:aws.codeWhisperer.applySecurityFix?${encodeURIComponent(JSON.stringify(args))}`
             )

--- a/src/codewhisperer/service/securityIssueHoverProvider.ts
+++ b/src/codewhisperer/service/securityIssueHoverProvider.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode'
 import { CodeScanIssue } from '../models/model'
 import globals from '../../shared/extensionGlobals'
 import { SecurityIssueProvider } from './securityIssueProvider'
-import { telemetry } from '../../shared/telemetry/telemetry'
+import { ApplyFixSource, telemetry } from '../../shared/telemetry/telemetry'
 import path from 'path'
 
 export class SecurityIssueHoverProvider extends SecurityIssueProvider implements vscode.HoverProvider {
@@ -64,10 +64,9 @@ export class SecurityIssueHoverProvider extends SecurityIssueProvider implements
 
         markdownString.appendMarkdown(`${issue.description.markdown}\n\n`)
 
+        const args = [issue, filePath]
         const viewDetailsCommand = vscode.Uri.parse(
-            `command:aws.codeWhisperer.openSecurityIssuePanel?${encodeURIComponent(
-                JSON.stringify({ ...issue, filePath })
-            )}`
+            `command:aws.codeWhisperer.openSecurityIssuePanel?${encodeURIComponent(JSON.stringify(args))}`
         )
 
         markdownString.appendMarkdown(
@@ -75,10 +74,9 @@ export class SecurityIssueHoverProvider extends SecurityIssueProvider implements
         )
 
         if (suggestedFix) {
+            const args: [CodeScanIssue, string, ApplyFixSource] = [issue, filePath, 'hover']
             const applyFixCommand = vscode.Uri.parse(
-                `command:aws.codeWhisperer.applySecurityFix?${encodeURIComponent(
-                    JSON.stringify({ ...issue, filePath })
-                )}`
+                `command:aws.codeWhisperer.applySecurityFix?${encodeURIComponent(JSON.stringify(args))}`
             )
             markdownString.appendMarkdown(` | [$(wrench) Apply Fix](${applyFixCommand} "Apply suggested fix")\n`)
             markdownString.appendMarkdown(

--- a/src/codewhisperer/views/securityIssue/securityIssueWebview.ts
+++ b/src/codewhisperer/views/securityIssue/securityIssueWebview.ts
@@ -5,12 +5,13 @@
 
 import * as vscode from 'vscode'
 import { VueWebview } from '../../../webviews/main'
-import { CodeScanIssueCommandArgs } from '../../models/model'
+import { CodeScanIssue } from '../../models/model'
 
 export class SecurityIssueWebview extends VueWebview {
     public readonly id = 'aws.codeWhisperer.securityIssue'
     public readonly source = 'src/codewhisperer/views/securityIssue/vue/index.js'
-    private issue: CodeScanIssueCommandArgs | undefined
+    private issue: CodeScanIssue | undefined
+    private filePath: string | undefined
 
     public constructor() {
         super()
@@ -20,12 +21,16 @@ export class SecurityIssueWebview extends VueWebview {
         return this.issue
     }
 
-    public setIssue(issue: CodeScanIssueCommandArgs) {
+    public setIssue(issue: CodeScanIssue) {
         this.issue = issue
     }
 
+    public setFilePath(filePath: string) {
+        this.filePath = filePath
+    }
+
     public applyFix() {
-        vscode.commands.executeCommand('aws.codeWhisperer.applySecurityFix', this.issue)
+        vscode.commands.executeCommand('aws.codeWhisperer.applySecurityFix', this.issue, this.filePath, 'webview')
     }
 
     public closeWebview(findingId: string) {
@@ -38,9 +43,10 @@ export class SecurityIssueWebview extends VueWebview {
 const Panel = VueWebview.compilePanel(SecurityIssueWebview)
 let activePanel: InstanceType<typeof Panel> | undefined
 
-export async function showSecurityIssueWebview(ctx: vscode.ExtensionContext, issue: CodeScanIssueCommandArgs) {
+export async function showSecurityIssueWebview(ctx: vscode.ExtensionContext, issue: CodeScanIssue, filePath: string) {
     activePanel ??= new Panel(ctx)
     activePanel.server.setIssue(issue)
+    activePanel.server.setFilePath(filePath)
 
     const webviewPanel = await activePanel.show({
         title: 'CodeWhisperer Security Issue',

--- a/src/shared/telemetry/vscodeTelemetry.json
+++ b/src/shared/telemetry/vscodeTelemetry.json
@@ -47,12 +47,6 @@
             "name": "detectorId",
             "type": "string",
             "description": "The id of the detector which produced the code scan issue"
-        },
-        {
-            "name": "applyFixSource",
-            "type": "string",
-            "allowedValues": ["hover", "webview", "quickfix"],
-            "description": "The location which triggered the apply fix command for a code scan issue"
         }
     ],
     "metrics": [
@@ -276,7 +270,7 @@
         {
             "name": "codewhisperer_codeScanIssueApplyFix",
             "description": "Called when a code scan issue suggested fix is applied",
-            "metadata": [{ "type": "findingId" }, { "type": "detectorId" }, { "type": "applyFixSource" }]
+            "metadata": [{ "type": "findingId" }, { "type": "detectorId" }, { "type": "component" }]
         }
     ]
 }

--- a/src/shared/telemetry/vscodeTelemetry.json
+++ b/src/shared/telemetry/vscodeTelemetry.json
@@ -47,6 +47,12 @@
             "name": "detectorId",
             "type": "string",
             "description": "The id of the detector which produced the code scan issue"
+        },
+        {
+            "name": "applyFixSource",
+            "type": "string",
+            "allowedValues": ["hover", "webview", "quickfix"],
+            "description": "The location which triggered the apply fix command for a code scan issue"
         }
     ],
     "metrics": [
@@ -266,6 +272,11 @@
             "name": "codewhisperer_codeScanIssueHover",
             "description": "Called when a code scan issue is hovered over",
             "metadata": [{ "type": "findingId" }, { "type": "detectorId" }]
+        },
+        {
+            "name": "codewhisperer_codeScanIssueApplyFix",
+            "description": "Called when a code scan issue suggested fix is applied",
+            "metadata": [{ "type": "findingId" }, { "type": "detectorId" }, { "type": "applyFixSource" }]
         }
     ]
 }

--- a/src/shared/telemetry/vscodeTelemetry.json
+++ b/src/shared/telemetry/vscodeTelemetry.json
@@ -47,6 +47,12 @@
             "name": "detectorId",
             "type": "string",
             "description": "The id of the detector which produced the code scan issue"
+        },
+        {
+            "name": "applyFixSource",
+            "type": "string",
+            "allowedValues": ["hover", "webview", "quickfix"],
+            "description": "The location which triggered the apply fix command for a code scan issue"
         }
     ],
     "metrics": [
@@ -270,7 +276,7 @@
         {
             "name": "codewhisperer_codeScanIssueApplyFix",
             "description": "Called when a code scan issue suggested fix is applied",
-            "metadata": [{ "type": "findingId" }, { "type": "detectorId" }, { "type": "component" }]
+            "metadata": [{ "type": "findingId" }, { "type": "detectorId" }, { "type": "applyFixSource" }]
         }
     ]
 }

--- a/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -188,7 +188,7 @@ describe('CodeWhisperer-basicCommands', function () {
             assertTelemetry('codewhisperer_codeScanIssueApplyFix', {
                 detectorId: codeScanIssue.detectorId,
                 findingId: codeScanIssue.findingId,
-                applyFixSource: 'hover',
+                component: 'hover',
                 result: 'Succeeded',
             })
         })
@@ -215,7 +215,7 @@ describe('CodeWhisperer-basicCommands', function () {
             assertTelemetry('codewhisperer_codeScanIssueApplyFix', {
                 detectorId: codeScanIssue.detectorId,
                 findingId: codeScanIssue.findingId,
-                applyFixSource: 'hover',
+                component: 'hover',
                 result: 'Failed',
                 reason: 'Error: Failed to get updated content from applying diff patch',
             })
@@ -252,7 +252,7 @@ describe('CodeWhisperer-basicCommands', function () {
             assertTelemetry('codewhisperer_codeScanIssueApplyFix', {
                 detectorId: codeScanIssue.detectorId,
                 findingId: codeScanIssue.findingId,
-                applyFixSource: 'hover',
+                component: 'hover',
                 result: 'Failed',
                 reason: 'Error: Failed to save editor text changes into the file.',
             })
@@ -288,7 +288,7 @@ describe('CodeWhisperer-basicCommands', function () {
             assertTelemetry('codewhisperer_codeScanIssueApplyFix', {
                 detectorId: codeScanIssue.detectorId,
                 findingId: codeScanIssue.findingId,
-                applyFixSource: 'hover',
+                component: 'hover',
                 result: 'Failed',
                 reason: 'Error: Writing to file failed.',
             })

--- a/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -188,7 +188,7 @@ describe('CodeWhisperer-basicCommands', function () {
             assertTelemetry('codewhisperer_codeScanIssueApplyFix', {
                 detectorId: codeScanIssue.detectorId,
                 findingId: codeScanIssue.findingId,
-                component: 'hover',
+                applyFixSource: 'hover',
                 result: 'Succeeded',
             })
         })
@@ -215,7 +215,7 @@ describe('CodeWhisperer-basicCommands', function () {
             assertTelemetry('codewhisperer_codeScanIssueApplyFix', {
                 detectorId: codeScanIssue.detectorId,
                 findingId: codeScanIssue.findingId,
-                component: 'webview',
+                applyFixSource: 'webview',
                 result: 'Failed',
                 reason: 'Error: Failed to get updated content from applying diff patch',
             })
@@ -252,7 +252,7 @@ describe('CodeWhisperer-basicCommands', function () {
             assertTelemetry('codewhisperer_codeScanIssueApplyFix', {
                 detectorId: codeScanIssue.detectorId,
                 findingId: codeScanIssue.findingId,
-                component: 'quickfix',
+                applyFixSource: 'quickfix',
                 result: 'Failed',
                 reason: 'Error: Failed to save editor text changes into the file.',
             })
@@ -288,7 +288,7 @@ describe('CodeWhisperer-basicCommands', function () {
             assertTelemetry('codewhisperer_codeScanIssueApplyFix', {
                 detectorId: codeScanIssue.detectorId,
                 findingId: codeScanIssue.findingId,
-                component: 'hover',
+                applyFixSource: 'hover',
                 result: 'Failed',
                 reason: 'Error: Writing to file failed.',
             })

--- a/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -8,7 +8,7 @@ import assert from 'assert'
 import * as sinon from 'sinon'
 import * as CodeWhispererConstants from '../../../codewhisperer/models/constants'
 import { createCodeScanIssue, createMockDocument, resetCodeWhispererGlobalVariables } from '../testUtil'
-import { assertTelemetryCurried } from '../../testUtil'
+import { assertTelemetry, assertTelemetryCurried } from '../../testUtil'
 import {
     toggleCodeSuggestions,
     showSecurityScan,
@@ -138,34 +138,46 @@ describe('CodeWhisperer-basicCommands', function () {
             await targetCommand.execute()
             assert.strictEqual(getTestWindow().shownMessages[0].message, 'Open a valid file to scan.')
         })
+    })
+
+    describe('applySecurityFix', function () {
+        let sandbox: sinon.SinonSandbox
+        let saveStub: sinon.SinonStub
+        let openTextDocumentMock: sinon.SinonStub
+        let writeFileMock: sinon.SinonStub
+
+        beforeEach(function () {
+            sandbox = sinon.createSandbox()
+            saveStub = sinon.stub()
+            openTextDocumentMock = sinon.stub()
+            writeFileMock = sinon.stub()
+        })
+
+        afterEach(function () {
+            sandbox.restore()
+        })
 
         it('should call applySecurityFix command successfully', async function () {
             const fileName = 'sample.py'
-            const saveStub = sinon.stub()
             saveStub.resolves(true)
             const textDocumentMock = new MockDocument('first line\n second line\n fourth line', fileName, saveStub)
 
-            const openTextDocumentMock = sinon.stub()
             openTextDocumentMock.resolves(textDocumentMock)
-            const sandbox = sinon.createSandbox()
             sandbox.stub(vscode.workspace, 'openTextDocument').value(openTextDocumentMock)
 
-            const writeFileMock = sinon.stub()
             writeFileMock.resolves(true)
             sinon.stub(FileSystemCommon.prototype, 'writeFile').value(writeFileMock)
 
             targetCommand = testCommand(applySecurityFix)
-            await targetCommand.execute({
-                filePath: fileName,
-                ...createCodeScanIssue({
-                    suggestedFixes: [
-                        {
-                            description: 'fix',
-                            code: '@@ -1,3 +1,3 @@\n first line\n- second line\n+ third line\n  fourth line',
-                        },
-                    ],
-                }),
+            const codeScanIssue = createCodeScanIssue({
+                suggestedFixes: [
+                    {
+                        description: 'fix',
+                        code: '@@ -1,3 +1,3 @@\n first line\n- second line\n+ third line\n  fourth line',
+                    },
+                ],
             })
+            await targetCommand.execute(codeScanIssue, fileName, 'hover')
             assert.ok(saveStub.calledOnce)
             assert.ok(writeFileMock.calledOnceWith(fileName, 'first line\n third line\n fourth line'))
 
@@ -173,104 +185,113 @@ describe('CodeWhisperer-basicCommands', function () {
                 getTestWindow().shownMessages[0].message,
                 'Code fix was applied. Run a security scan to validate the fix.'
             )
-
-            sandbox.restore()
+            assertTelemetry('codewhisperer_codeScanIssueApplyFix', {
+                detectorId: codeScanIssue.detectorId,
+                findingId: codeScanIssue.findingId,
+                applyFixSource: 'hover',
+                result: 'Succeeded',
+            })
         })
+
         it('handles patch failure', async function () {
             const textDocumentMock = createMockDocument()
 
-            const openTextDocumentMock = sinon.stub()
             openTextDocumentMock.resolves(textDocumentMock)
 
-            const sandbox = sinon.createSandbox()
             sandbox.stub(vscode.workspace, 'openTextDocument').value(openTextDocumentMock)
 
             targetCommand = testCommand(applySecurityFix)
-            await targetCommand.execute({
-                filePath: 'test.py',
-                ...createCodeScanIssue({
-                    suggestedFixes: [
-                        {
-                            code: '@@ -1,1 -1,1 @@\n-mock\n+line5',
-                            description: 'dummy',
-                        },
-                    ],
-                }),
+            const codeScanIssue = createCodeScanIssue({
+                suggestedFixes: [
+                    {
+                        code: '@@ -1,1 -1,1 @@\n-mock\n+line5',
+                        description: 'dummy',
+                    },
+                ],
             })
+            await targetCommand.execute(codeScanIssue, 'test.py', 'hover')
 
             assert.strictEqual(getTestWindow().shownMessages[0].message, 'Failed to apply suggested code fix.')
-
-            sandbox.restore()
+            assertTelemetry('codewhisperer_codeScanIssueApplyFix', {
+                detectorId: codeScanIssue.detectorId,
+                findingId: codeScanIssue.findingId,
+                applyFixSource: 'hover',
+                result: 'Failed',
+                reason: 'Error: Failed to get updated content from applying diff patch',
+            })
         })
-    })
 
-    it('handles document save failure', async function () {
-        const fileName = 'sample.py'
-        const saveStub = sinon.stub()
-        saveStub.resolves(false)
-        const textDocumentMock = new MockDocument('first line\n second line\n fourth line', fileName, saveStub)
+        it('handles document save failure', async function () {
+            const fileName = 'sample.py'
+            saveStub.resolves(false)
+            const textDocumentMock = new MockDocument('first line\n second line\n fourth line', fileName, saveStub)
 
-        const openTextDocumentMock = sinon.stub()
-        openTextDocumentMock.resolves(textDocumentMock)
+            openTextDocumentMock.resolves(textDocumentMock)
 
-        const sandbox = sinon.createSandbox()
-        sandbox.stub(vscode.workspace, 'openTextDocument').value(openTextDocumentMock)
-        const loggerStub = sinon.stub(getLogger(), 'error')
+            sandbox.stub(vscode.workspace, 'openTextDocument').value(openTextDocumentMock)
+            const loggerStub = sinon.stub(getLogger(), 'error')
 
-        targetCommand = testCommand(applySecurityFix)
-        await targetCommand.execute({
-            filePath: fileName,
-            ...createCodeScanIssue({
+            targetCommand = testCommand(applySecurityFix)
+            const codeScanIssue = createCodeScanIssue({
                 suggestedFixes: [
                     {
                         description: 'fix',
                         code: '@@ -1,3 +1,3 @@\n first line\n- second line\n+ third line\n  fourth line',
                     },
                 ],
-            }),
+            })
+            await targetCommand.execute(codeScanIssue, fileName, 'hover')
+
+            assert.ok(saveStub.calledOnce)
+            assert.ok(loggerStub.calledOnce)
+            const actual = loggerStub.getCall(0).args[0]
+            assert.strictEqual(
+                actual,
+                'Apply fix command failed. Error: Failed to save editor text changes into the file.'
+            )
+            assertTelemetry('codewhisperer_codeScanIssueApplyFix', {
+                detectorId: codeScanIssue.detectorId,
+                findingId: codeScanIssue.findingId,
+                applyFixSource: 'hover',
+                result: 'Failed',
+                reason: 'Error: Failed to save editor text changes into the file.',
+            })
         })
 
-        assert.ok(saveStub.calledOnce)
-        assert.ok(loggerStub.calledOnce)
-        const actual = loggerStub.getCall(0).args[0]
-        assert.strictEqual(actual, 'Failed to save editor text changes into the file.')
+        it('handles document write failure', async function () {
+            const fileName = 'sample.py'
+            saveStub.resolves(true)
+            const textDocumentMock = new MockDocument('first line\n second line\n fourth line', fileName, saveStub)
 
-        sandbox.restore()
-    })
-    it('handles document write failure', async function () {
-        const fileName = 'sample.py'
-        const saveStub = sinon.stub()
-        saveStub.resolves(true)
-        const textDocumentMock = new MockDocument('first line\n second line\n fourth line', fileName, saveStub)
+            openTextDocumentMock.resolves(textDocumentMock)
+            writeFileMock.rejects('Error: Writing to file failed.')
 
-        const openTextDocumentMock = sinon.stub()
-        openTextDocumentMock.resolves(textDocumentMock)
-        const writeFileMock = sinon.stub()
-        writeFileMock.rejects('writing to file failed.')
+            sandbox.stub(vscode.workspace, 'openTextDocument').value(openTextDocumentMock)
+            sinon.stub(FileSystemCommon.prototype, 'writeFile').value(writeFileMock)
+            const loggerStub = sinon.stub(getLogger(), 'error')
 
-        const sandbox = sinon.createSandbox()
-        sandbox.stub(vscode.workspace, 'openTextDocument').value(openTextDocumentMock)
-        sinon.stub(FileSystemCommon.prototype, 'writeFile').value(writeFileMock)
-        const loggerStub = sinon.stub(getLogger(), 'error')
-
-        targetCommand = testCommand(applySecurityFix)
-        await targetCommand.execute({
-            filePath: fileName,
-            ...createCodeScanIssue({
+            targetCommand = testCommand(applySecurityFix)
+            const codeScanIssue = createCodeScanIssue({
                 suggestedFixes: [
                     {
                         description: 'fix',
                         code: '@@ -1,3 +1,3 @@\n first line\n- second line\n+ third line\n  fourth line',
                     },
                 ],
-            }),
+            })
+            await targetCommand.execute(codeScanIssue, fileName, 'hover')
+
+            assert.ok(saveStub.calledOnce)
+            assert.ok(loggerStub.calledOnce)
+            const actual = loggerStub.getCall(0).args[0]
+            assert.strictEqual(actual, 'Apply fix command failed. Error: Writing to file failed.')
+            assertTelemetry('codewhisperer_codeScanIssueApplyFix', {
+                detectorId: codeScanIssue.detectorId,
+                findingId: codeScanIssue.findingId,
+                applyFixSource: 'hover',
+                result: 'Failed',
+                reason: 'Error: Writing to file failed.',
+            })
         })
-
-        assert.ok(saveStub.calledOnce)
-        assert.ok(loggerStub.calledOnce)
-        const actual = loggerStub.getCall(0).args[0]
-        assert.strictEqual(actual, 'Unable to write updated text content into the file: writing to file failed.')
-
-        sandbox.restore()
     })
 })

--- a/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -209,13 +209,13 @@ describe('CodeWhisperer-basicCommands', function () {
                     },
                 ],
             })
-            await targetCommand.execute(codeScanIssue, 'test.py', 'hover')
+            await targetCommand.execute(codeScanIssue, 'test.py', 'webview')
 
             assert.strictEqual(getTestWindow().shownMessages[0].message, 'Failed to apply suggested code fix.')
             assertTelemetry('codewhisperer_codeScanIssueApplyFix', {
                 detectorId: codeScanIssue.detectorId,
                 findingId: codeScanIssue.findingId,
-                component: 'hover',
+                component: 'webview',
                 result: 'Failed',
                 reason: 'Error: Failed to get updated content from applying diff patch',
             })
@@ -240,7 +240,7 @@ describe('CodeWhisperer-basicCommands', function () {
                     },
                 ],
             })
-            await targetCommand.execute(codeScanIssue, fileName, 'hover')
+            await targetCommand.execute(codeScanIssue, fileName, 'quickfix')
 
             assert.ok(saveStub.calledOnce)
             assert.ok(loggerStub.calledOnce)
@@ -252,7 +252,7 @@ describe('CodeWhisperer-basicCommands', function () {
             assertTelemetry('codewhisperer_codeScanIssueApplyFix', {
                 detectorId: codeScanIssue.detectorId,
                 findingId: codeScanIssue.findingId,
-                component: 'hover',
+                component: 'quickfix',
                 result: 'Failed',
                 reason: 'Error: Failed to save editor text changes into the file.',
             })

--- a/src/test/codewhisperer/service/securityIssueHoverProvider.test.ts
+++ b/src/test/codewhisperer/service/securityIssueHoverProvider.test.ts
@@ -45,10 +45,10 @@ describe('securityIssueHoverProvider', () => {
             '## Suggested Fix for title ![High](severity-high.svg)\n' +
                 'description\n\n' +
                 `[$(eye) View Details](command:aws.codeWhisperer.openSecurityIssuePanel?${encodeURIComponent(
-                    JSON.stringify({ ...issues[0], filePath: mockDocument.fileName })
+                    JSON.stringify([issues[0], mockDocument.fileName])
                 )} 'Open "CodeWhisperer Security Issue"')\n` +
                 ` | [$(wrench) Apply Fix](command:aws.codeWhisperer.applySecurityFix?${encodeURIComponent(
-                    JSON.stringify({ ...issues[0], filePath: mockDocument.fileName })
+                    JSON.stringify([issues[0], mockDocument.fileName, 'hover'])
                 )} "Apply suggested fix")\n\n` +
                 '<span class="codicon codicon-none" style="background-color:var(--vscode-textCodeBlock-background);">\n\n' +
                 '```language\n' +
@@ -79,7 +79,7 @@ describe('securityIssueHoverProvider', () => {
             '## title ![High](severity-high.svg)\n' +
                 'description\n\n' +
                 `[$(eye) View Details](command:aws.codeWhisperer.openSecurityIssuePanel?${encodeURIComponent(
-                    JSON.stringify({ ...issues[1], filePath: mockDocument.fileName })
+                    JSON.stringify([issues[1], mockDocument.fileName])
                 )} 'Open "CodeWhisperer Security Issue"')\n`
         )
         assertTelemetry('codewhisperer_codeScanIssueHover', [


### PR DESCRIPTION
## Problem

We want to track the number of times apply fix command is executed for a security scan issue.

## Solution

- Added `codewhisperer_codeScanIssueApplyFix` metric that emits when command is executed and what the resulting state is.
- Refactored `applySecurityFix` function and tests for readability

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
