### PR TITLE
refactor(ci): cleanup invalid syntax

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -60,11 +60,7 @@ phases:
             - chmod 666 /var/run/docker.sock
 
     pre_build:
-        env:
-            variables:
-                HOME: /home/codebuild-user
         commands:
-            # CodeBuild ignores the env.variables.HOME declaration above? :(
             - export HOME=/home/codebuild-user
             - bash buildspec/setup-github-token.sh
             # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
@@ -93,11 +89,7 @@ phases:
             # - go version
 
     build:
-        env:
-            variables:
-                HOME: /home/codebuild-user
         commands:
-            # CodeBuild ignores the env.variables.HOME declaration above? :(
             - export HOME=/home/codebuild-user
             - npm ci
             - xvfb-run npm run testInteg

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -27,11 +27,7 @@ phases:
                 ls -ld ~codebuild-user
 
     pre_build:
-        env:
-            variables:
-                HOME: /home/codebuild-user
         commands:
-            # CodeBuild ignores the env.variables.HOME declaration above? :(
             - export HOME=/home/codebuild-user
             # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
             # Should only affect tests run through IDEs team-hosted CodeBuild.
@@ -46,11 +42,7 @@ phases:
             - npm ci
 
     build:
-        env:
-            variables:
-                HOME: /home/codebuild-user
         commands:
-            # CodeBuild ignores the env.variables.HOME declaration above? :(
             - export HOME=/home/codebuild-user
             - xvfb-run npm test --silent
             - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"

--- a/buildspec/packageTestVsix.yml
+++ b/buildspec/packageTestVsix.yml
@@ -26,7 +26,6 @@ phases:
 
     pre_build:
         commands:
-            # CodeBuild ignores env.variables.HOME, so do it manually here :(
             - export HOME=/home/codebuild-user
             # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
             # Should only affect tests run through IDEs team-hosted CodeBuild.
@@ -42,7 +41,6 @@ phases:
 
     build:
         commands:
-            # CodeBuild ignores env.variables.HOME, so do it manually here :(
             - export HOME=/home/codebuild-user
             # Generate CHANGELOG.md
             - npm run createRelease


### PR DESCRIPTION
Problem:
codebuild shows non-fatal warning:

    [Container] 2023/11/02 21:48:22.543013 Found possible syntax errors in buildspec:
    In the section BUILD
        The following keys cannot be identified:
            env
    In the section PRE_BUILD
        The following keys cannot be identified:
            env

Solution:
Remove the (invalid) "env" directive. This was already suspected to be ignored, but wasn't certain until I saw this error in the logs.



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
