### PR TITLE
fix(telemetry): wrong requestId in UserDecision (Prod data polluted)

### DIFF
--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -68,7 +68,6 @@ const lock = new AsyncLock({ maxPending: 1 })
 export class RecommendationHandler {
     public lastInvocationTime: number
     public requestId: string
-    public requestIdList: string[]
     private nextToken: string
     private cancellationToken: vscode.CancellationTokenSource
     public isGenerateRecommendationInProgress: boolean
@@ -84,7 +83,6 @@ export class RecommendationHandler {
 
     constructor() {
         this.requestId = ''
-        this.requestIdList = []
         this.nextToken = ''
         this.lastInvocationTime = performance.now() - CodeWhispererConstants.invocationTimeIntervalThreshold * 1000
         this.cancellationToken = new vscode.CancellationTokenSource()
@@ -313,7 +311,7 @@ export class RecommendationHandler {
             ).trimStart()
             recommendations.forEach((item, index) => {
                 msg += `\n    ${index.toString().padStart(2, '0')}: ${indent(item.content, 8, true).trim()}`
-                this.requestIdList.push(requestId)
+                session.requestIdList.push(requestId)
             })
             getLogger().debug(msg)
             if (invocationResult === 'Succeeded') {
@@ -395,10 +393,10 @@ export class RecommendationHandler {
         // send Empty userDecision event if user receives no recommendations in this session at all.
         if (invocationResult === 'Succeeded' && nextToken === '') {
             if (session.recommendations.length === 0) {
-                this.requestIdList.push(requestId)
+                session.requestIdList.push(requestId)
                 // Received an empty list of recommendations
                 TelemetryHelper.instance.recordUserDecisionTelemetryForEmptyList(
-                    this.requestIdList,
+                    session.requestIdList,
                     sessionId,
                     page,
                     editor.document.languageId,
@@ -484,7 +482,7 @@ export class RecommendationHandler {
             return
         }
         TelemetryHelper.instance.recordUserDecisionTelemetry(
-            this.requestIdList,
+            session.requestIdList,
             session.sessionId,
             session.recommendations,
             acceptIndex,

--- a/src/codewhisperer/util/codeWhispererSession.ts
+++ b/src/codewhisperer/util/codeWhispererSession.ts
@@ -19,6 +19,7 @@ class CodeWhispererSession {
 
     // Per-session states
     sessionId = ''
+    requestIdList: string[] = []
     startPos = new Position(0, 0)
     leftContextOfCurrentLine = ''
     requestContext: {

--- a/src/codewhisperer/util/telemetryHelper.ts
+++ b/src/codewhisperer/util/telemetryHelper.ts
@@ -119,7 +119,7 @@ export class TelemetryHelper {
     }
 
     public recordUserDecisionTelemetryForEmptyList(
-        requestId: string,
+        requestIdList: string[],
         sessionId: string,
         paginationIndex: number,
         languageId: string,
@@ -127,7 +127,7 @@ export class TelemetryHelper {
     ) {
         const languageContext = runtimeLanguageContext.getLanguageContext(languageId)
         telemetry.codewhisperer_userDecision.emit({
-            codewhispererRequestId: requestId,
+            codewhispererRequestId: requestIdList[0],
             codewhispererSessionId: sessionId ? sessionId : undefined,
             codewhispererPaginationProgress: paginationIndex,
             codewhispererTriggerType: this.triggerType,
@@ -157,7 +157,7 @@ export class TelemetryHelper {
      */
 
     public recordUserDecisionTelemetry(
-        requestId: string,
+        requestIdList: string[],
         sessionId: string,
         recommendations: RecommendationsList,
         acceptIndex: number,
@@ -178,7 +178,7 @@ export class TelemetryHelper {
                 recommendationSuggestionState?.set(i, 'Empty')
             }
             const event: CodewhispererUserDecision = {
-                codewhispererRequestId: requestId,
+                codewhispererRequestId: requestIdList[i],
                 codewhispererSessionId: sessionId ? sessionId : undefined,
                 codewhispererPaginationProgress: paginationIndex,
                 codewhispererTriggerType: this.triggerType,
@@ -204,7 +204,7 @@ export class TelemetryHelper {
         const referenceCount = this.getAggregatedSuggestionReferenceCount(events)
 
         // aggregate user decision events at requestId level
-        const aggregatedEvent = this.aggregateUserDecisionByRequest(events, requestId, sessionId)
+        const aggregatedEvent = this.aggregateUserDecisionByRequest(events, requestIdList[0], sessionId)
         if (aggregatedEvent) {
             this.sessionDecisions.push(aggregatedEvent)
         }
@@ -220,7 +220,7 @@ export class TelemetryHelper {
         // after we have all request level user decisions, aggregate them at session level and send
         if (
             this.isRequestCancelled ||
-            (this.lastRequestId && this.lastRequestId === requestId) ||
+            (this.lastRequestId && this.lastRequestId === requestIdList[requestIdList.length - 1]) ||
             (this.sessionDecisions.length && this.sessionDecisions.length === this.numberOfRequests)
         ) {
             this.sendUserTriggerDecisionTelemetry(

--- a/src/codewhisperer/util/telemetryHelper.ts
+++ b/src/codewhisperer/util/telemetryHelper.ts
@@ -178,6 +178,7 @@ export class TelemetryHelper {
                 recommendationSuggestionState?.set(i, 'Empty')
             }
             const event: CodewhispererUserDecision = {
+                // TODO: maintain a list of RecommendationContexts with both recommendation and requestId in it, instead of two separate list items.
                 codewhispererRequestId: requestIdList[i],
                 codewhispererSessionId: sessionId ? sessionId : undefined,
                 codewhispererPaginationProgress: paginationIndex,

--- a/src/test/codewhisperer/commands/onAcceptance.test.ts
+++ b/src/test/codewhisperer/commands/onAcceptance.test.ts
@@ -83,6 +83,7 @@ describe('onAcceptance', function () {
             const testStartUrl = 'testStartUrl'
             sinon.stub(AuthUtil.instance, 'startUrl').value(testStartUrl)
             const mockEditor = createMockTextEditor()
+            RecommendationHandler.instance.requestIdList = ['test']
             RecommendationHandler.instance.requestId = 'test'
             session.sessionId = 'test'
             session.startPos = new vscode.Position(1, 0)

--- a/src/test/codewhisperer/commands/onAcceptance.test.ts
+++ b/src/test/codewhisperer/commands/onAcceptance.test.ts
@@ -83,7 +83,7 @@ describe('onAcceptance', function () {
             const testStartUrl = 'testStartUrl'
             sinon.stub(AuthUtil.instance, 'startUrl').value(testStartUrl)
             const mockEditor = createMockTextEditor()
-            RecommendationHandler.instance.requestIdList = ['test']
+            session.requestIdList = ['test']
             RecommendationHandler.instance.requestId = 'test'
             session.sessionId = 'test'
             session.startPos = new vscode.Position(1, 0)

--- a/src/test/codewhisperer/service/recommendationHandler.test.ts
+++ b/src/test/codewhisperer/service/recommendationHandler.test.ts
@@ -185,6 +185,7 @@ describe('recommendationHandler', function () {
             sinon.stub(handler, 'getServerResponse').resolves(mockServerResult)
             sinon.stub(performance, 'now').returns(0.0)
             session.startPos = new vscode.Position(1, 0)
+            session.requestIdList = ['test_request_empty']
             TelemetryHelper.instance.cursorOffset = 2
             await handler.getRecommendations(mockClient, mockEditor, 'AutoTrigger', config, 'Enter')
             const assertTelemetry = assertTelemetryCurried('codewhisperer_userDecision')

--- a/src/test/codewhisperer/util/telemetryHelper.test.ts
+++ b/src/test/codewhisperer/util/telemetryHelper.test.ts
@@ -123,7 +123,7 @@ describe('telemetryHelper', function () {
 
         it('should return Line and Accept', function () {
             sut.recordUserDecisionTelemetry(
-                'aFakeRequestId',
+                ['aFakeRequestId', 'aFakeRequestId', 'aFakeRequestId2'],
                 'aFakeSessionId',
                 [aCompletion(), aCompletion(), aCompletion(), aCompletion()],
                 0,
@@ -157,7 +157,7 @@ describe('telemetryHelper', function () {
 
         it('should return Line and Accept 2', function () {
             sut.recordUserDecisionTelemetry(
-                'aFakeRequestId',
+                ['aFakeRequestId', 'aFakeRequestId', 'aFakeRequestId2'],
                 'aFakeSessionId',
                 [aCompletion(), aCompletion(), aCompletion(), aCompletion()],
                 3,
@@ -191,7 +191,7 @@ describe('telemetryHelper', function () {
 
         it('should return Line and Reject', function () {
             sut.recordUserDecisionTelemetry(
-                'aFakeRequestId',
+                ['aFakeRequestId', 'aFakeRequestId', 'aFakeRequestId2'],
                 'aFakeSessionId',
                 [aCompletion(), aCompletion(), aCompletion(), aCompletion()],
                 -1,
@@ -283,14 +283,14 @@ describe('telemetryHelper', function () {
 
             const telemetryHelper = new TelemetryHelper()
             const response = [{ content: "print('Hello')" }]
-            const requestId = 'test_x'
+            const requestIdList = ['test_x', 'test_x', 'test_y']
             const sessionId = 'test_x'
             telemetryHelper.triggerType = 'AutoTrigger'
             const assertTelemetry = assertTelemetryCurried('codewhisperer_userDecision')
             const suggestionState = new Map<number, string>([[0, 'Showed']])
             const completionTypes = new Map<number, CodewhispererCompletionType>([[0, 'Line']])
             telemetryHelper.recordUserDecisionTelemetry(
-                requestId,
+                requestIdList,
                 sessionId,
                 response,
                 0,


### PR DESCRIPTION
## Problem
Sending last recommendation request id for all the `userDecision` telemetry events in a session/trigger.
https://issues.amazon.com/issues/ConsolasIssue-12227
## Solution
Send `userDecision` events with respective requestId of each recommendation in a session/trigger.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
