### PR TITLE
fix: failing test "publishDocument .. createDocument"

### DIFF
--- a/src/ssmDocument/activation.ts
+++ b/src/ssmDocument/activation.ts
@@ -51,7 +51,7 @@ async function registerSsmDocumentCommands(
             await openDocumentItemYaml(node, awsContext)
         }),
         Commands.register('aws.ssmDocument.publishDocument', async () => {
-            await publishSSMDocument(awsContext, regionProvider)
+            await publishSSMDocument()
         }),
         Commands.register('aws.ssmDocument.updateDocumentVersion', async (node: DocumentItemNodeWriteable) => {
             await updateDocumentVersion(node, awsContext)

--- a/src/ssmDocument/commands/publishDocument.ts
+++ b/src/ssmDocument/commands/publishDocument.ts
@@ -7,19 +7,17 @@ import { SSM } from 'aws-sdk'
 import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 const localize = nls.loadMessageBundle()
-import { AwsContext } from '../../shared/awsContext'
 import { DefaultSsmDocumentClient, SsmDocumentClient } from '../../shared/clients/ssmDocumentClient'
 import { ssmJson, ssmYaml } from '../../shared/constants'
 
 import * as localizedText from '../../shared/localizedText'
 import { getLogger, Logger } from '../../shared/logger'
-import { RegionProvider } from '../../shared/regions/regionProvider'
 import { PublishSSMDocumentWizard, PublishSSMDocumentWizardResponse } from '../wizards/publishDocumentWizard'
 import { showConfirmationMessage } from '../util/util'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { Result, SsmOperation } from '../../shared/telemetry/telemetry'
 
-export async function publishSSMDocument(awsContext: AwsContext, regionProvider: RegionProvider): Promise<void> {
+export async function publishSSMDocument(): Promise<void> {
     const logger: Logger = getLogger()
 
     const textDocument = vscode.window.activeTextEditor?.document

--- a/src/test/ssmDocument/commands/publishDocument.test.ts
+++ b/src/test/ssmDocument/commands/publishDocument.test.ts
@@ -39,15 +39,6 @@ describe('publishDocument', async function () {
         Name: 'test',
     }
 
-    before(async function () {
-        textDocument = await vscode.workspace.openTextDocument({ content: 'foo', language: 'ssm-json' })
-        await vscode.window.showTextDocument(textDocument)
-    })
-
-    after(async function () {
-        await closeAllEditors()
-    })
-
     beforeEach(async function () {
         wizardResponse = {
             action: PublishSSMDocumentAction.QuickUpdate,
@@ -60,10 +51,12 @@ describe('publishDocument', async function () {
                 Name: 'testName',
             },
         }
+        textDocument = await vscode.workspace.openTextDocument({ content: 'foo', language: 'ssm-json' })
     })
 
-    afterEach(function () {
+    afterEach(async function () {
         sinon.restore()
+        await closeAllEditors()
     })
 
     describe('createDocument', async function () {
@@ -81,7 +74,7 @@ describe('publishDocument', async function () {
             await publish.createDocument(wizardResponse, textDocument, client)
 
             assert(client.createDocument.calledOnce)
-            assert(client.createDocument.calledWith(fakeCreateRequest))
+            assert.deepStrictEqual(client.createDocument.args, [[fakeCreateRequest]])
         })
 
         it('createDocument API failed', async function () {
@@ -104,7 +97,7 @@ describe('publishDocument', async function () {
             await publish.updateDocument(wizardResponse, textDocument, client)
 
             assert(client.updateDocument.calledOnce)
-            assert(client.updateDocument.calledWith(fakeUpdateRequest))
+            assert.deepStrictEqual(client.updateDocument.args, [[fakeUpdateRequest]])
         })
 
         it('updateDocument API failed', async function () {


### PR DESCRIPTION
# Problem
"publishDocument .. createDocument" tests fail on "Insiders" CI job. #4013

# Solution
- Adjust the tests to show what was passed.
- Create the `TextDocument` in `beforeEach` instead of `before()`. Don't bother to "show" it.
    - Why does this work? Some sort of misordering or race with `before()`?

## Before:

    1) publishDocument
         createDocument
           createDocument API returns successfully:
        AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    (0, assert_1.default)(client.createDocument.calledWith(fakeCreateRequest))
        + expected - actual
        -false
        +true
        at Context.<anonymous> (src/test/ssmDocument/commands/publishDocument.test.ts:84:19)

## After:

    + actual - expected ... Lines skipped

      [
        [
          {
    +       Content: '',
    -       Content: 'foo',
            DocumentFormat: 'JSON',
    ...
          }
        ]
      ]

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
