### PR TITLE
ci: run "lint" in codebuild

### DIFF
--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -44,6 +44,9 @@ phases:
     build:
         commands:
             - export HOME=/home/codebuild-user
+            # TODO: run lint as a separate codebuild job.
+            - npm run testCompile
+            - npm run lint
             - xvfb-run npm test --silent
             - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
             - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g') # Encode `#` in the URL because otherwise the url is clipped in the Codecov.io site


### PR DESCRIPTION
Problem:
lint job doesn't run in the private repo.

Solution:
- As a temporary workaround, run lint in `linuxTests.yml`. 
- TODO: create a separate codebuild task for lint.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
