### PR TITLE
ci: move common logic into shared scripts

### DIFF
--- a/buildspec/lint.yml
+++ b/buildspec/lint.yml
@@ -5,6 +5,9 @@ run-as: codebuild-user
 
 env:
     variables:
+        # Implicitly passed by the AWS automation pipeline:
+        # VSCODE_TEST_VERSION
+        # GITHUB_READONLY_TOKEN
         AWS_TOOLKIT_TEST_NO_COLOR: '1'
 
 phases:
@@ -23,13 +26,8 @@ phases:
     build:
         commands:
             - export HOME=/home/codebuild-user
-            # TODO: remove this after lint.yml is enabled in codebuild.
-            - |
-                if [ "$VSCODE_TEST_VERSION" = 'insiders' ] ; then
-                    npm run testCompile
-                    npm run lint
-                fi
-            - xvfb-run npm test --silent
+            - npm run testCompile
+            - npm run lint
             - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
             - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g') # Encode `#` in the URL because otherwise the url is clipped in the Codecov.io site
             - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"

--- a/buildspec/linuxE2ETests.yml
+++ b/buildspec/linuxE2ETests.yml
@@ -1,5 +1,8 @@
 version: 0.2
 
+# Run unprivileged for most phases (except those marked "run-as: root").
+run-as: codebuild-user
+
 env:
     variables:
         AWS_TOOLKIT_TEST_NO_COLOR: '1'
@@ -9,25 +12,27 @@ env:
 
 phases:
     install:
+        run-as: root
+        runtime-versions:
+            nodejs: 16
         commands:
-            - '>/dev/null add-apt-repository universe'
-            - '>/dev/null apt-get -qq install -y apt-transport-https'
-            - '>/dev/null apt-get -qq update'
-            - '>/dev/null apt-get -qq install -y ca-certificates'
-            - 'apt-get install --reinstall ca-certificates'
-            # Dependencies for running vscode.
-            - '>/dev/null apt-get -yqq install libatk1.0-0 libgtk-3-dev libxss1 xvfb libnss3-dev libasound2 libasound2-plugins libsecret-1-0'
+            # - '>/dev/null add-apt-repository universe'
+            # - '>/dev/null apt-get -qq install -y apt-transport-https'
+            # - '>/dev/null apt-get -qq update'
+            # - '>/dev/null apt-get -qq install -y ca-certificates'
+            # - 'apt-get install --reinstall ca-certificates'
+            - bash buildspec/shared/linux-install.sh
+
+    pre_build:
+        commands:
+            - export HOME=/home/codebuild-user
+            - bash buildspec/shared/setup-github-token.sh
+            - bash buildspec/shared/linux-pre_build.sh
 
     build:
         commands:
-            # Disable engine-strict in CI.
-            - sed -i -e 's/engine.strict.true/engine-strict=false/' .npmrc
-            - npm ci --unsafe-perm
-            # We cannot run `code` as root during tests
-            # From: https://github.com/aws/aws-codebuild-docker-images/blob/2f796bb9c81fcfbc8585832b99a5f780ae2b2f52/ubuntu/standard/6.0/Dockerfile#L56
-            - mkdir -p /home/codebuild-user
-            - chown -R codebuild-user:codebuild-user /tmp /home/codebuild-user .
-            - su codebuild-user -c "xvfb-run npm run testE2E"
+            - export HOME=/home/codebuild-user
+            - xvfb-run npm run testE2E
             - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
             - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g')
             - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -22,8 +22,7 @@ phases:
             java: latest
 
         commands:
-            # Disable engine-strict in CI.
-            - sed -i -e 's/engine.strict.true/engine-strict=false/' .npmrc
+            - bash buildspec/shared/linux-install.sh
             - '>/dev/null add-apt-repository universe'
             - '>/dev/null apt-get -qq install -y apt-transport-https'
             - '>/dev/null apt-get -qq update'
@@ -35,8 +34,6 @@ phases:
             # Fail early if any of these not found.
             - 'python3.7 --version'
             - 'python3.8 --version'
-            # Dependencies for running vscode.
-            - '>/dev/null apt-get -yqq install libatk1.0-0 libgtk-3-dev libxss1 xvfb libasound2 libasound2-plugins'
             # login to DockerHub so we don't get throttled
             # - docker login --username $(echo $DOCKER_HUB_TOKEN | jq -r '.username') --password $(echo $DOCKER_HUB_TOKEN | jq -r '.password') || true
             # increase file watcher count so CodeLens tests do not fail unexpectedly (ENOSPC error)
@@ -44,15 +41,6 @@ phases:
             # start Docker
             # - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay&
             - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
-            #
-            # Prepare env for unprivileged user.
-            #
-            - |
-                # adduser --gecos GECOS --disabled-password toolkit-user
-                mkdir -p ~codebuild-user
-                chown -R codebuild-user:codebuild-user /tmp ~codebuild-user .
-                chmod +x ~codebuild-user
-                ls -ld ~codebuild-user
             # Add user to "docker" group.
             # - usermod -aG docker codebuild-user
             # Ensure that "docker" group has permissions to the socket.
@@ -62,17 +50,8 @@ phases:
     pre_build:
         commands:
             - export HOME=/home/codebuild-user
-            - bash buildspec/setup-github-token.sh
-            # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
-            # Should only affect tests run through IDEs team-hosted CodeBuild.
-            - |
-                if [ "$TOOLKITS_CODEARTIFACT_DOMAIN" ] && [ "$TOOLKITS_CODEARTIFACT_REPO" ] && [ "TOOLKITS_$ACCOUNT_ID" ]; then
-                    if aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$TOOLKITS_ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO" > /dev/null 2>&1; then
-                        echo "Connected to CodeArtifact"
-                    else
-                        echo "CodeArtifact connection failed. Falling back to npm"
-                    fi
-                fi
+            - bash buildspec/shared/setup-github-token.sh
+            - bash buildspec/shared/linux-pre_build.sh
             # Where non-root "pip3 install" puts things:
             - 'export PATH="$HOME/.local/bin:$PATH"'
             # Explicit older version since we assume the newer version is causing our CI to fail (python 3.10 sam tests specifically)
@@ -91,7 +70,6 @@ phases:
     build:
         commands:
             - export HOME=/home/codebuild-user
-            - npm ci
             - xvfb-run npm run testInteg
             - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
             - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g')

--- a/buildspec/packageTestVsix.yml
+++ b/buildspec/packageTestVsix.yml
@@ -15,29 +15,12 @@ phases:
         runtime-versions:
             nodejs: 16
         commands:
-            # Disable engine-strict in CI.
-            - sed -i -e 's/engine.strict.true/engine-strict=false/' .npmrc
-            # Prepare env for unprivileged user.
-            - |
-                mkdir -p ~codebuild-user
-                chown -R codebuild-user:codebuild-user /tmp ~codebuild-user .
-                chmod +x ~codebuild-user
-                ls -ld ~codebuild-user
+            - bash buildspec/shared/linux-install.sh
 
     pre_build:
         commands:
             - export HOME=/home/codebuild-user
-            # If present, log into CodeArtifact. Provides a nice safety net in case NPM is down.
-            # Should only affect tests run through IDEs team-hosted CodeBuild.
-            - |
-                if [ "$TOOLKITS_CODEARTIFACT_DOMAIN" ] && [ "$TOOLKITS_CODEARTIFACT_REPO" ] && [ "$TOOLKITS_ACCOUNT_ID" ]; then
-                    if aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$TOOLKITS_ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO" > /dev/null 2>&1; then
-                        echo "Connected to CodeArtifact"
-                    else
-                        echo "CodeArtifact connection failed. Falling back to npm"
-                    fi
-                fi
-            - npm ci
+            - bash buildspec/shared/linux-pre_build.sh
 
     build:
         commands:

--- a/buildspec/shared/linux-install.sh
+++ b/buildspec/shared/linux-install.sh
@@ -1,0 +1,29 @@
+#!/bin/env bash
+
+# Common code for "install" phase of linux codebuild CI job.
+
+set -e
+
+set +x
+test -n "$VSCODE_TEST_VERSION" || {
+    echo 'missing $VSCODE_TEST_VERSION'
+    exit 1
+}
+set -x
+
+# Disable engine-strict in CI.
+sed -i -e 's/engine.strict.true/engine-strict=false/' .npmrc
+
+# Without this, "Unable to locate package libatk1.0-0".
+apt-get > /dev/null -yqq update
+# Dependencies for running vscode.
+apt-get > /dev/null -yqq install libatk1.0-0 libgtk-3-dev libxss1 xvfb libasound2 libasound2-plugins
+
+#
+# Prepare env for unprivileged user. We cannot run vscode as root.
+#
+# "codebuild-user": https://github.com/aws/aws-codebuild-docker-images/blob/2f796bb9c81fcfbc8585832b99a5f780ae2b2f52/ubuntu/standard/6.0/Dockerfile#L56
+mkdir -p ~codebuild-user
+chown -R codebuild-user:codebuild-user /tmp ~codebuild-user .
+chmod +x ~codebuild-user
+ls -ld ~codebuild-user

--- a/buildspec/shared/linux-pre_build.sh
+++ b/buildspec/shared/linux-pre_build.sh
@@ -1,0 +1,18 @@
+#!/bin/env bash
+
+# Common code for "pre_build" phase of linux codebuild CI job.
+
+set -e
+
+# If present, log into CodeArtifact. Provides a fallback in case NPM is down.
+# Should only affect tests run through Toolkits-hosted CodeBuild.
+if [ "$TOOLKITS_CODEARTIFACT_DOMAIN" ] && [ "$TOOLKITS_CODEARTIFACT_REPO" ] && [ "$TOOLKITS_ACCOUNT_ID" ]; then
+    if aws codeartifact login --tool npm --domain "$TOOLKITS_CODEARTIFACT_DOMAIN" --domain-owner "$TOOLKITS_ACCOUNT_ID" --repository "$TOOLKITS_CODEARTIFACT_REPO" > /dev/null 2>&1; then
+        echo "Connected to CodeArtifact"
+    else
+        echo "CodeArtifact connection failed. Falling back to npm"
+    fi
+fi
+
+# TODO: do this in the "install" phase?
+npm ci

--- a/buildspec/shared/setup-github-token.sh
+++ b/buildspec/shared/setup-github-token.sh
@@ -2,7 +2,10 @@
 
 set -e
 
-test -n "$GITHUB_READONLY_TOKEN" || { echo 'missing $GITHUB_READONLY_TOKEN'; exit 1; }
+test -n "$GITHUB_READONLY_TOKEN" || {
+    echo 'missing $GITHUB_READONLY_TOKEN'
+    exit 1
+}
 
 # Authenticate all "git" (and "curl --netrc") github calls, to avoid rate-limiting.
 # NOTE: the "login" value is arbitrary.
@@ -10,6 +13,9 @@ printf "machine github.com         login oauth password ${GITHUB_READONLY_TOKEN:
 printf "machine api.github.com     login oauth password ${GITHUB_READONLY_TOKEN:-unknown}\n" >> "$HOME/.netrc"
 printf "machine uploads.github.com login oauth password ${GITHUB_READONLY_TOKEN:-unknown}\n" >> "$HOME/.netrc"
 # Print ratelimit info.
-2>/dev/null curl --netrc -L -I https://api.github.com/ | grep x-ratelimit | sed 's/\(.*\)/    \1/'
+curl 2> /dev/null --netrc -L -I https://api.github.com/ | grep x-ratelimit | sed 's/\(.*\)/    \1/'
 # Validate ratelimit.
-2>/dev/null curl --netrc -L -I https://api.github.com/ | >/dev/null grep 'x-ratelimit-limit: *[0-9][0-9][0-9][0-9]\+' || { echo 'invalid github token, or rate limit too low (expected 5000+)'; exit 1; }
+curl 2> /dev/null --netrc -L -I https://api.github.com/ | grep > /dev/null 'x-ratelimit-limit: *[0-9][0-9][0-9][0-9]\+' || {
+    echo 'invalid github token, or rate limit too low (expected 5000+)'
+    exit 1
+}


### PR DESCRIPTION
Problem:
- 6057ef46b7de was a workaround which runs lint as part of the "linuxTests" CI job.
- Too much duplicate code spread around in the CI scripts.
   - ⚠️  Inlining shell code in the buildspec yaml files makes it difficult    to automate linting via https://www.shellcheck.net and prettier.

Solution:
- Define a separate CI job in `lint.yml`.
- Put common logic in `buildspec/shared/*.sh` bash scripts.


followup to 6057ef46b7de


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
