### PR TITLE
fix: "Scanning CloudFormation templates..."

### DIFF
--- a/.changes/next-release/Bug Fix-b7a9021d-e848-46a3-8f6d-fd7017cb1784.json
+++ b/.changes/next-release/Bug Fix-b7a9021d-e848-46a3-8f6d-fd7017cb1784.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "\"Scanning CloudFormation templates...\" message `Cancel` button does not fully stop the scan"
+}

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -32,7 +32,7 @@ import { addFolderToWorkspace, tryGetAbsolutePath } from '../../shared/utilities
 import { goRuntimes } from '../models/samLambdaRuntime'
 import { eventBridgeStarterAppTemplate } from '../models/samTemplates'
 import { CreateNewSamAppWizard, CreateNewSamAppWizardForm } from '../wizards/samInitWizard'
-import { LaunchConfiguration } from '../../shared/debug/launchConfiguration'
+import { LaunchConfiguration, replaceVscodeVars } from '../../shared/debug/launchConfiguration'
 import { SamDebugConfigProvider } from '../../shared/sam/debugger/awsSamDebugger'
 import { ExtContext } from '../../shared/extensions'
 import { isTemplateTargetProperties } from '../../shared/sam/debugger/awsSamDebugConfiguration'
@@ -395,8 +395,7 @@ export async function addInitialLaunchConfiguration(
         const targetDir: string = path.dirname(targetUri.fsPath)
         const filtered = configurations.filter(config => {
             let templatePath: string = (config.invokeTarget as TemplateTargetProperties).templatePath
-            // TODO: write utility function that does this for other variables too
-            templatePath = templatePath.replace('${workspaceFolder}', folder.uri.fsPath)
+            templatePath = replaceVscodeVars(templatePath, folder.uri.fsPath)
 
             return (
                 isTemplateTargetProperties(config.invokeTarget) &&

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -32,7 +32,7 @@ import { addFolderToWorkspace, tryGetAbsolutePath } from '../../shared/utilities
 import { goRuntimes } from '../models/samLambdaRuntime'
 import { eventBridgeStarterAppTemplate } from '../models/samTemplates'
 import { CreateNewSamAppWizard, CreateNewSamAppWizardForm } from '../wizards/samInitWizard'
-import { LaunchConfiguration, replaceVscodeVars } from '../../shared/debug/launchConfiguration'
+import { LaunchConfiguration } from '../../shared/debug/launchConfiguration'
 import { SamDebugConfigProvider } from '../../shared/sam/debugger/awsSamDebugger'
 import { ExtContext } from '../../shared/extensions'
 import { isTemplateTargetProperties } from '../../shared/sam/debugger/awsSamDebugConfiguration'
@@ -48,7 +48,7 @@ import globals from '../../shared/extensionGlobals'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { LambdaArchitecture, Result, Runtime } from '../../shared/telemetry/telemetry'
 import { getTelemetryReason, getTelemetryResult } from '../../shared/errors'
-import { openUrl } from '../../shared/utilities/vsCodeUtils'
+import { openUrl, replaceVscodeVars } from '../../shared/utilities/vsCodeUtils'
 
 export const samInitTemplateFiles: string[] = ['template.yaml', 'template.yml']
 export const samInitReadmeFile: string = 'README.TOOLKIT.md'

--- a/src/shared/debug/launchConfiguration.ts
+++ b/src/shared/debug/launchConfiguration.ts
@@ -204,13 +204,3 @@ export async function getReferencedHandlerPaths(launchConfig: LaunchConfiguratio
         .thru(array => new Set(array))
         .value()
 }
-
-/**
- * Replaces magic vscode variables in a launch config value.
- */
-export function replaceVscodeVars(val: string, workspaceFolder?: string): string {
-    if (!workspaceFolder) {
-        return val
-    }
-    return val.replace('${workspaceFolder}', workspaceFolder)
-}

--- a/src/shared/debug/launchConfiguration.ts
+++ b/src/shared/debug/launchConfiguration.ts
@@ -204,3 +204,13 @@ export async function getReferencedHandlerPaths(launchConfig: LaunchConfiguratio
         .thru(array => new Set(array))
         .value()
 }
+
+/**
+ * Replaces magic vscode variables in a launch config value.
+ */
+export function replaceVscodeVars(val: string, workspaceFolder?: string): string {
+    if (!workspaceFolder) {
+        return val
+    }
+    return val.replace('${workspaceFolder}', workspaceFolder)
+}

--- a/src/shared/fs/templateRegistry.ts
+++ b/src/shared/fs/templateRegistry.ts
@@ -87,20 +87,21 @@ export class AsyncCloudFormationTemplateRegistry {
         }
 
         let perf: PerfLog
-        const cancelSetupPromise = new Timeout(30 * 60 * 1000) // 30 min
+        const cancelSetup = new Timeout(30 * 60 * 1000) // 30 min
         if (!this.setupPromise) {
             perf = new PerfLog('cfn: template registry setup')
-            this.setupPromise = this.asyncSetupFunc(this.instance, cancelSetupPromise)
+            this.setupPromise = this.asyncSetupFunc(this.instance, cancelSetup)
         }
         this.setupPromise.then(() => {
             if (perf) {
                 perf.done()
             }
             this.isSetup = true
-            cancelSetupPromise.dispose()
+            cancelSetup.dispose()
         })
         // Show user a message indicating setup is in progress
         if (this.setupProgressMessage === undefined) {
+            // TODO: use showMessageWithCancel() ?
             this.setupProgressMessage = vscode.window.withProgress(
                 {
                     location: vscode.ProgressLocation.Notification,
@@ -114,7 +115,7 @@ export class AsyncCloudFormationTemplateRegistry {
                     token.onCancellationRequested(() => {
                         // Allows for new message to be created if templateRegistry variable attempted to be used again
                         this.setupProgressMessage = undefined
-                        cancelSetupPromise.cancel()
+                        cancelSetup.cancel()
                     })
                     getLogger().debug('cfn: getInstance() requested, still initializing')
                     while (!this.isSetup) {

--- a/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { samImageLambdaRuntimes, samZipLambdaRuntimes } from '../../../lambda/models/samLambdaRuntime'
 import * as CloudFormation from '../../cloudformation/cloudformation'
-import { localize } from '../../utilities/vsCodeUtils'
+import { localize, replaceVscodeVars } from '../../utilities/vsCodeUtils'
 import {
     awsSamDebugRequestTypes,
     awsSamDebugTargetTypes,
@@ -20,7 +20,6 @@ import {
 } from './awsSamDebugConfiguration'
 import { tryGetAbsolutePath } from '../../utilities/workspaceUtils'
 import { CloudFormationTemplateRegistry } from '../../fs/templateRegistry'
-import { replaceVscodeVars } from '../../debug/launchConfiguration'
 
 export interface ValidationResult {
     isValid: boolean

--- a/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
@@ -20,6 +20,7 @@ import {
 } from './awsSamDebugConfiguration'
 import { tryGetAbsolutePath } from '../../utilities/workspaceUtils'
 import { CloudFormationTemplateRegistry } from '../../fs/templateRegistry'
+import { replaceVscodeVars } from '../../debug/launchConfiguration'
 
 export interface ValidationResult {
     isValid: boolean
@@ -69,8 +70,13 @@ export class DefaultAwsSamDebugConfigurationValidator implements AwsSamDebugConf
         ) {
             let cfnTemplate: CloudFormation.Template | undefined
             if (config.invokeTarget.templatePath) {
-                const fullpath = tryGetAbsolutePath(this.workspaceFolder, config.invokeTarget.templatePath)
+                // TODO: why wasn't ${workspaceFolder} resolved before now?
+                const resolvedPath = replaceVscodeVars(
+                    config.invokeTarget.templatePath,
+                    this.workspaceFolder?.uri.fsPath
+                )
                 // Normalize to absolute path for use in the runner.
+                const fullpath = tryGetAbsolutePath(this.workspaceFolder, resolvedPath)
                 config.invokeTarget.templatePath = fullpath
                 // Forcefully add to the registry in case the registry scan somehow missed the file. #2614
                 // If the user (launch config) gave an explicit path we should always "find" it.

--- a/src/shared/utilities/vsCodeUtils.ts
+++ b/src/shared/utilities/vsCodeUtils.ts
@@ -231,3 +231,13 @@ export async function openUrl(url: vscode.Uri): Promise<boolean> {
 export function isToolkitActive(): boolean {
     return isExtensionActive(VSCODE_EXTENSION_ID.awstoolkit)
 }
+
+/**
+ * Replaces magic vscode variables in a (launch config) user value.
+ */
+export function replaceVscodeVars(val: string, workspaceFolder?: string): string {
+    if (!workspaceFolder) {
+        return val
+    }
+    return val.replace('${workspaceFolder}', workspaceFolder)
+}


### PR DESCRIPTION
followup to https://github.com/aws/aws-toolkit-vscode/pull/3987


- changelog
- fix some minor bugs
- fix(sam): "failed to process" template URI containing `${workspaceFolder}` https://github.com/aws/aws-toolkit-vscode/pull/4020/commits/183e0e4df8b1da47549a757c12d2b0873782ef39


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
