### PR TITLE
fix: "Scanning..." progress message behavior

### DIFF
--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -57,12 +57,16 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
  * and slowing down the extension starting up.
  */
 function setTemplateRegistryInGlobals(registry: CloudFormationTemplateRegistry) {
-    const registrySetupFunc = async (registry: CloudFormationTemplateRegistry, cancellationTimeout: Timeout) => {
+    const registrySetupFunc = async (
+        registry: CloudFormationTemplateRegistry,
+        cancel: Timeout,
+        onItem?: (item: number) => void
+    ) => {
         registry.addExcludedPattern(CloudFormation.devfileExcludePattern)
         registry.addExcludedPattern(CloudFormation.templateFileExcludePattern)
         registry.addWatchPatterns([CloudFormation.templateFileGlobPattern])
         registry.watchUntitledFiles()
-        await registry.rebuild(cancellationTimeout)
+        await registry.rebuild(cancel, onItem)
         return registry
     }
 

--- a/src/shared/fs/codelensRootRegistry.ts
+++ b/src/shared/fs/codelensRootRegistry.ts
@@ -18,7 +18,7 @@ import * as vscode from 'vscode'
  * is valid for each codelense
  */
 export class CodelensRootRegistry extends WatchedFiles<string> {
-    protected name: string = 'CodelensRootRegistry'
+    public name: string = 'CodelensRootRegistry'
     protected async process(p: vscode.Uri): Promise<string> {
         const normalizedPath = pathutils.normalize(p.fsPath)
         return path.basename(normalizedPath)

--- a/src/shared/fs/devfileRegistry.ts
+++ b/src/shared/fs/devfileRegistry.ts
@@ -14,7 +14,7 @@ import globals from '../extensionGlobals'
 export const devfileGlobPattern = '**/devfile.{yaml,yml}'
 
 export class DevfileRegistry extends WatchedFiles<Devfile> {
-    protected name = 'DevfileRegistry'
+    public name = 'DevfileRegistry'
 
     protected async process(uri: vscode.Uri, contents?: string): Promise<Devfile | undefined> {
         if (!(await SystemUtilities.fileExists(uri))) {

--- a/src/shared/fs/templateRegistry.ts
+++ b/src/shared/fs/templateRegistry.ts
@@ -14,12 +14,13 @@ import { getLambdaDetails } from '../../lambda/utils'
 import { WatchedFiles, WatchedItem } from './watchedFiles'
 import { getLogger } from '../logger'
 import globals from '../extensionGlobals'
-import { Timeout, sleep } from '../utilities/timeoutUtils'
+import { Timeout } from '../utilities/timeoutUtils'
 import { localize } from '../utilities/vsCodeUtils'
 import { PerfLog } from '../logger/logger'
+import { showMessageWithCancel } from '../utilities/messages'
 
 export class CloudFormationTemplateRegistry extends WatchedFiles<CloudFormation.Template> {
-    protected name: string = 'CloudFormationTemplateRegistry'
+    public name: string = 'CloudFormationTemplateRegistry'
 
     protected async process(uri: vscode.Uri, contents?: string): Promise<CloudFormation.Template | undefined> {
         // P0: Assume all template.yaml/yml files are CFN templates and assign correct JSON schema.
@@ -61,8 +62,6 @@ export class CloudFormationTemplateRegistry extends WatchedFiles<CloudFormation.
 export class AsyncCloudFormationTemplateRegistry {
     /** Setup of the registry can take a while, this property indicates it is done */
     private isSetup = false
-    /** The message that is shown to the user to indicate the registry is being set up */
-    private setupProgressMessage: Thenable<void> | undefined = undefined
     private setupPromise: Thenable<CloudFormationTemplateRegistry> | undefined
 
     /**
@@ -72,26 +71,41 @@ export class AsyncCloudFormationTemplateRegistry {
         private readonly instance: CloudFormationTemplateRegistry,
         private readonly asyncSetupFunc: (
             instance: CloudFormationTemplateRegistry,
-            cancelSetup: Timeout
+            cancelSetup: Timeout,
+            onItem?: (item: number) => void
         ) => Promise<CloudFormationTemplateRegistry>
     ) {}
 
     /**
-     * Returns the initial registry instance if setup has completed, otherwise
-     * returning a temporary instance and showing a progress message to the user
-     * to indicate setup is in progress.
+     * Returns the initial registry instance if setup has completed, otherwise returns a temporary
+     * instance and shows a progress message ("Scanning...") until setup is done.
      */
     async getInstance(): Promise<CloudFormationTemplateRegistry> {
         if (this.isSetup) {
             return this.instance
         }
-
-        let perf: PerfLog
-        const cancelSetup = new Timeout(30 * 60 * 1000) // 30 min
-        if (!this.setupPromise) {
-            perf = new PerfLog('cfn: template registry setup')
-            this.setupPromise = this.asyncSetupFunc(this.instance, cancelSetup)
+        if (this.setupPromise) {
+            getLogger().debug('%s: getInstance() requested, still initializing', this.instance.name)
+            return this.setupPromise
         }
+
+        // Show a "Scanning..." progress message until setup is done.
+        const cancelSetup = new Timeout(30 * 60 * 1000) // 30 min
+        const msg = localize(
+            'AWS.codelens.waitingForTemplateRegistry',
+            'Scanning CloudFormation templates (except [search.exclude](command:workbench.action.openSettings?"@id:search.exclude") paths)'
+        )
+        const progress = await showMessageWithCancel(msg, cancelSetup)
+
+        const perf = new PerfLog(`${this.instance.name}: template registry setup`)
+        this.setupPromise = this.asyncSetupFunc(this.instance, cancelSetup, item => {
+            if (cancelSetup.completed) {
+                getLogger().debug('%s: getInstance() cancelled', this.instance.name)
+                return
+            }
+            progress.report({ message: item.toString() })
+        })
+
         this.setupPromise.then(() => {
             if (perf) {
                 perf.done()
@@ -99,32 +113,6 @@ export class AsyncCloudFormationTemplateRegistry {
             this.isSetup = true
             cancelSetup.dispose()
         })
-        // Show user a message indicating setup is in progress
-        if (this.setupProgressMessage === undefined) {
-            // TODO: use showMessageWithCancel() ?
-            this.setupProgressMessage = vscode.window.withProgress(
-                {
-                    location: vscode.ProgressLocation.Notification,
-                    title: localize(
-                        'AWS.codelens.waitingForTemplateRegistry',
-                        'Scanning CloudFormation templates (except [search.exclude](command:workbench.action.openSettings?"@id:search.exclude") paths)...'
-                    ),
-                    cancellable: true,
-                },
-                async (progress, token) => {
-                    token.onCancellationRequested(() => {
-                        // Allows for new message to be created if templateRegistry variable attempted to be used again
-                        this.setupProgressMessage = undefined
-                        cancelSetup.cancel()
-                    })
-                    getLogger().debug('cfn: getInstance() requested, still initializing')
-                    while (!this.isSetup) {
-                        await sleep(2000)
-                    }
-                    getLogger().debug('cfn: getInstance() ready')
-                }
-            )
-        }
 
         return this.setupPromise
     }


### PR DESCRIPTION
Problem:
Progress message does not reliably appear, its behavior is erratic.

Solution:
Create one progress message and report() to it when work is performed. Return early from getInstance(), don't create `setupPromise` multiple times.

<img width="539" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/55561878/2df1270a-f7fa-4875-9d7a-73f11a74e085">


Logs sample: shows "requested" message when a new request arrives (e.g. by opening a template.yaml file):

    2023-11-09 05:03:57 [INFO]: CloudFormationTemplateRegistry: building with: Watching **/*.{yaml,yml}, Untitled Files, Excluding /.*devfile\.(yaml|yml)/i, /.*[/\\]\.aws-sam([/\\].*|$)/
    2023-11-09 05:04:06 [DEBUG]: CloudFormationTemplateRegistry: getInstance() requested, still initializing
    2023-11-09 05:04:10 [DEBUG]: CloudFormationTemplateRegistry: getInstance() requested, still initializing
    2023-11-09 05:04:32 [DEBUG]: CloudFormationTemplateRegistry: getInstance() requested, still initializing
    2023-11-09 05:04:52 [DEBUG]: CloudFormationTemplateRegistry: getInstance() requested, still initializing
    2023-11-09 05:04:54 [INFO]: CloudFormationTemplateRegistry: processed 13 items (cancelled, 3 left)
    2023-11-09 05:04:54 [VERBOSE]: CloudFormationTemplateRegistry: template registry setup took 56826ms


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
