### PR TITLE
fix: "Toolkit PREVIEW" message for version 1.99

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -442,7 +442,7 @@ There are several ways to make pre-production changes available on a "preview" o
 -   **Beta artifacts:** For a "private beta" launch, `src/dev/beta.ts` contains
     logic to check a hardcoded, stable URL serving the latest `.vsix` build for
     the private beta. The hardcoded URL defined in [`dev/config.ts:betaUrl`](https://github.com/aws/aws-toolkit-vscode/blob/d9c27234c0732b021d07e184a865213d6efde8ec/src/dev/config.ts#L9)
-    also forces the Toolkit to declare version `1.999.0` (since "private beta"
+    also forces the Toolkit to declare version `1.9999.0` (since "private beta"
     has no semver and would conflict with the VSCode marketplace version,
     causing unwanted auto-updating by VSCode). Beta builds of the Toolkit
     automatically query the URL once per session per day.

--- a/scripts/build/package.ts
+++ b/scripts/build/package.ts
@@ -6,7 +6,7 @@
 //
 // Creates an artifact that can be given to users for testing alpha/beta builds:
 //
-//     aws-toolkit-vscode-1.999.0-xxxxxxxxxxxx.vsix
+//     aws-toolkit-vscode-1.9999.0-xxxxxxxxxxxx.vsix
 //
 // Where `xxxxxxxxxxxx` is the first 12 characters of the commit hash that produced the artifact
 //
@@ -121,7 +121,7 @@ function main() {
             const versionSuffix = getVersionSuffix(args.feature)
             const version = packageJson.version
             // Setting the version to an arbitrarily high number stops VSC from auto-updating the beta extension
-            const betaOrDebugVersion = `1.999.0${versionSuffix}`
+            const betaOrDebugVersion = `1.9999.0${versionSuffix}`
             if (isBeta() || args.debug) {
                 packageJson.version = betaOrDebugVersion
             } else {

--- a/src/shared/extensions.ts
+++ b/src/shared/extensions.ts
@@ -48,4 +48,4 @@ export interface ExtContext {
 /**
  * Version of the .vsix produced by package.ts with the --debug option.
  */
-export const extensionAlphaVersion = '1.99.0-SNAPSHOT'
+export const extensionAlphaVersion = '1.9999.0-SNAPSHOT'


### PR DESCRIPTION
Problem:
Showing "Toolkit PREVIEW" message when running version `1.99.0-SNAPSHOT`

Solution:
Define `extensionAlphaVersion` as 1.9999 instead of 1.99



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
