### PR TITLE
codewhisperer: open file in view column one

### DIFF
--- a/src/codewhisperer/views/securityIssue/securityIssueWebview.ts
+++ b/src/codewhisperer/views/securityIssue/securityIssueWebview.ts
@@ -44,10 +44,13 @@ export class SecurityIssueWebview extends VueWebview {
 
     public navigateToFile() {
         if (this.issue && this.filePath) {
-            const position = new vscode.Position(this.issue.startLine, 1)
-            const uri = vscode.Uri.file(this.filePath)
-            vscode.commands.executeCommand('vscode.open', uri, {
-                selection: new vscode.Selection(position, position),
+            const range = new vscode.Range(this.issue.startLine, 0, this.issue.endLine, 0)
+            vscode.workspace.openTextDocument(this.filePath).then(doc => {
+                vscode.window.showTextDocument(doc, {
+                    selection: range,
+                    viewColumn: vscode.ViewColumn.One,
+                    preview: true,
+                })
             })
         }
     }

--- a/src/codewhisperer/views/securityIssue/securityIssueWebview.ts
+++ b/src/codewhisperer/views/securityIssue/securityIssueWebview.ts
@@ -45,7 +45,7 @@ export class SecurityIssueWebview extends VueWebview {
     public navigateToFile() {
         if (this.issue && this.filePath) {
             const range = new vscode.Range(this.issue.startLine, 0, this.issue.endLine, 0)
-            vscode.workspace.openTextDocument(this.filePath).then(doc => {
+            return vscode.workspace.openTextDocument(this.filePath).then(doc => {
                 vscode.window.showTextDocument(doc, {
                     selection: range,
                     viewColumn: vscode.ViewColumn.One,


### PR DESCRIPTION
## Problem

Open file from webview is opening a duplicate tab in the same active pane.

## Solution

Open the file in view column one and not the active pane

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
