### PR TITLE
CodeWhisperer: Add feature fetching component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
                 "yaml-cfn": "^0.3.2"
             },
             "devDependencies": {
-                "@aws-toolkits/telemetry": "^1.0.148",
+                "@aws-toolkits/telemetry": "^1.0.162",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^10.0.2",
                 "@types/adm-zip": "^0.4.34",
@@ -2352,9 +2352,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.148",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.148.tgz",
-            "integrity": "sha512-9Gdj6JVr9S6hZzSZehwLIVdMvd5hnvoFhlxcdT889Ay0tW+dd4Ynp9rhax7KCkh2/jvI4ClHpR97ZAYsA+UAZw==",
+            "version": "1.0.165",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.165.tgz",
+            "integrity": "sha512-7l8C5lWiapXnrgdP9ui41yJ/jygJZVOc6hOX0FiNxXUMBKzJ5aqOIptbPLScjsiG0JJUJjd3YVJsHKFB3SlUIQ==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",
@@ -17847,9 +17847,9 @@
             }
         },
         "@aws-toolkits/telemetry": {
-            "version": "1.0.148",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.148.tgz",
-            "integrity": "sha512-9Gdj6JVr9S6hZzSZehwLIVdMvd5hnvoFhlxcdT889Ay0tW+dd4Ynp9rhax7KCkh2/jvI4ClHpR97ZAYsA+UAZw==",
+            "version": "1.0.165",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.165.tgz",
+            "integrity": "sha512-7l8C5lWiapXnrgdP9ui41yJ/jygJZVOc6hOX0FiNxXUMBKzJ5aqOIptbPLScjsiG0JJUJjd3YVJsHKFB3SlUIQ==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -3845,7 +3845,7 @@
         "report": "nyc report --reporter=html --reporter=json"
     },
     "devDependencies": {
-        "@aws-toolkits/telemetry": "^1.0.148",
+        "@aws-toolkits/telemetry": "^1.0.162",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/adm-zip": "^0.4.34",

--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -37,6 +37,7 @@ import {
     connectWithCustomization,
     signoutCodeWhisperer,
     showManageCwConnections,
+    fetchFeatureConfigsCmd,
 } from './commands/basicCommands'
 import { sleep } from '../shared/utilities/timeoutUtils'
 import { ReferenceLogViewProvider } from './service/referenceLogViewProvider'
@@ -198,6 +199,8 @@ export async function activate(context: ExtContext): Promise<void> {
         selectCustomizationPrompt.register(),
         // notify new customizations
         notifyNewCustomizationsCmd.register(),
+        // fetch feature configs
+        fetchFeatureConfigsCmd.register(),
         /**
          * On recommendation acceptance
          */

--- a/src/codewhisperer/commands/basicCommands.ts
+++ b/src/codewhisperer/commands/basicCommands.ts
@@ -27,6 +27,7 @@ import {
 } from '../util/customizationUtil'
 import { CodeWhispererSource } from './types'
 import { showManageConnections } from '../../auth/ui/vue/show'
+import { FeatureConfigProvider } from '../service/featureConfigProvider'
 
 export const toggleCodeSuggestions = Commands.declare(
     { id: 'aws.codeWhisperer.toggleCodeSuggestion', compositeKey: { 1: 'source' } },
@@ -196,6 +197,13 @@ export const notifyNewCustomizationsCmd = Commands.declare(
     { id: 'aws.codeWhisperer.notifyNewCustomizations', logging: false },
     () => () => {
         notifyNewCustomizations().then()
+    }
+)
+
+export const fetchFeatureConfigsCmd = Commands.declare(
+    { id: 'aws.codeWhisperer.fetchFeatureConfigs', logging: false },
+    () => () => {
+        FeatureConfigProvider.instance.fetchFeatureConfigs()
     }
 )
 

--- a/src/codewhisperer/service/completionProvider.ts
+++ b/src/codewhisperer/service/completionProvider.ts
@@ -8,7 +8,6 @@ import * as CodeWhispererConstants from '../models/constants'
 import { runtimeLanguageContext } from '../util/runtimeLanguageContext'
 import { Recommendation } from '../client/codewhisperer'
 import { LicenseUtil } from '../util/licenseUtil'
-import { TelemetryHelper } from '../util/telemetryHelper'
 import { RecommendationHandler } from './recommendationHandler'
 import { session } from '../util/codeWhispererSession'
 /**
@@ -60,7 +59,7 @@ export function getCompletionItem(
             recommendation,
             RecommendationHandler.instance.requestId,
             session.sessionId,
-            TelemetryHelper.instance.triggerType,
+            session.triggerType,
             session.getCompletionType(recommendationIndex),
             languageContext.language,
             references,

--- a/src/codewhisperer/service/featureConfigProvider.ts
+++ b/src/codewhisperer/service/featureConfigProvider.ts
@@ -1,0 +1,87 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { FeatureValue } from '../client/codewhispereruserclient'
+import { codeWhispererClient as client } from '../client/codewhisperer'
+import { AuthUtil } from '../util/authUtil'
+import { getLogger } from '../../shared/logger'
+
+export class FeatureContext {
+    constructor(public name: string, public variation: string, public value: FeatureValue) {}
+}
+
+const testFeatureName = 'testFeature'
+const featureConfigPollIntervalInMs = 30 * 60 * 1000 // 30 mins
+
+// TODO: add real feature later
+export const featureDefinitions = new Map([
+    [testFeatureName, new FeatureContext(testFeatureName, 'CONTROL', { stringValue: 'testValue' })],
+])
+
+export class FeatureConfigProvider {
+    private featureConfigs = new Map<string, FeatureContext>()
+
+    static #instance: FeatureConfigProvider
+
+    constructor() {
+        this.fetchFeatureConfigs()
+
+        setInterval(this.fetchFeatureConfigs.bind(this), featureConfigPollIntervalInMs)
+    }
+
+    public static get instance() {
+        return (this.#instance ??= new this())
+    }
+
+    async fetchFeatureConfigs(): Promise<void> {
+        if (AuthUtil.instance.isConnectionExpired()) {
+            return
+        }
+
+        getLogger().debug('Fetching feature configs')
+        try {
+            const response = await client.listFeatureEvaluations()
+
+            // Overwrite feature configs from server response
+            response.featureEvaluations.forEach(evaluation => {
+                this.featureConfigs.set(
+                    evaluation.feature,
+                    new FeatureContext(evaluation.feature, evaluation.variation, evaluation.value)
+                )
+            })
+        } catch (e) {
+            getLogger().debug('Error when fetching feature configs', e)
+        }
+        getLogger().debug(`Current feature configs: ${this.getFeatureConfigsTelemetry()}`)
+    }
+
+    getFeatureConfigsTelemetry(): string {
+        return `{${Array.from(this.featureConfigs.entries())
+            .map(([name, context]) => `${name}: ${context.variation}`)
+            .join(', ')}}`
+    }
+
+    // TODO: for all feature variations, define a contract that can be enforced upon the implementation of
+    // the business logic.
+    // When we align on a new feature config, client-side will implement specific business logic to utilize
+    // these values by:
+    // 1) Add an entry in featureDefinitions, which is <feature_name> to <feature_context>.
+    // 2) Add a function with name `getXXX`, where XXX refers to the feature name.
+    // 3) Specify the return type: One of the return type string/boolean/Long/Double should be used here.
+    // 4) Specify the key for the `getFeatureValueForKey` helper function which is the feature name.
+    // 5) Specify the corresponding type value getter for the `FeatureValue` class. For example,
+    // if the return type is Long, then the corresponding type value getter is `longValue()`.
+    // 6) Add a test case for this feature.
+    // 7) In case `getXXX()` returns undefined, it should be treated as a default/control group.
+    getTestFeature(): string | undefined {
+        return this.getFeatureValueForKey(testFeatureName).stringValue
+    }
+
+    // Get the feature value for the given key.
+    // In case of a misconfiguration, it will return a default feature value of Boolean true.
+    private getFeatureValueForKey(name: string): FeatureValue {
+        return this.featureConfigs.get(name)?.value ?? featureDefinitions.get(name)?.value ?? { boolValue: true }
+    }
+}

--- a/src/codewhisperer/service/featureConfigProvider.ts
+++ b/src/codewhisperer/service/featureConfigProvider.ts
@@ -40,7 +40,7 @@ export class FeatureConfigProvider {
             return
         }
 
-        getLogger().debug('Fetching feature configs')
+        getLogger().debug('CodeWhisperer: Fetching feature configs')
         try {
             const response = await client.listFeatureEvaluations()
 
@@ -52,11 +52,12 @@ export class FeatureConfigProvider {
                 )
             })
         } catch (e) {
-            getLogger().debug('Error when fetching feature configs', e)
+            getLogger().debug('CodeWhisperer: Error when fetching feature configs', e)
         }
-        getLogger().debug(`Current feature configs: ${this.getFeatureConfigsTelemetry()}`)
+        getLogger().debug(`CodeWhisperer: Current feature configs: ${this.getFeatureConfigsTelemetry()}`)
     }
 
+    // Sample format: "{testFeature: CONTROL}""
     getFeatureConfigsTelemetry(): string {
         return `{${Array.from(this.featureConfigs.entries())
             .map(([name, context]) => `${name}: ${context.variation}`)

--- a/src/codewhisperer/service/inlineCompletionItemProvider.ts
+++ b/src/codewhisperer/service/inlineCompletionItemProvider.ts
@@ -114,7 +114,7 @@ export class CWInlineCompletionItemProvider implements vscode.InlineCompletionIt
                     truncatedSuggestion,
                     this.requestId,
                     session.sessionId,
-                    TelemetryHelper.instance.triggerType,
+                    session.triggerType,
                     session.getCompletionType(index),
                     runtimeLanguageContext.getLanguageContext(document.languageId).language,
                     r.references,

--- a/src/codewhisperer/service/referenceLogViewProvider.ts
+++ b/src/codewhisperer/service/referenceLogViewProvider.ts
@@ -10,8 +10,8 @@ import * as CodeWhispererConstants from '../models/constants'
 import { CodeWhispererSettings } from '../util/codewhispererSettings'
 import globals from '../../shared/extensionGlobals'
 import { isCloud9 } from '../../shared/extensionUtilities'
-import { TelemetryHelper } from '../util/telemetryHelper'
 import { AuthUtil } from '../util/authUtil'
+import { session } from '../util/codeWhispererSession'
 
 export class ReferenceLogViewProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = 'aws.codeWhisperer.referenceLog'
@@ -70,13 +70,11 @@ export class ReferenceLogViewProvider implements vscode.WebviewViewProvider {
                 reference.recommendationContentSpan.end
             )
             const firstCharLineNumber =
-                editor.document.positionAt(
-                    TelemetryHelper.instance.cursorOffset + reference.recommendationContentSpan.start
-                ).line + 1
+                editor.document.positionAt(session.startCursorOffset + reference.recommendationContentSpan.start).line +
+                1
             const lastCharLineNumber =
-                editor.document.positionAt(
-                    TelemetryHelper.instance.cursorOffset + reference.recommendationContentSpan.end - 1
-                ).line + 1
+                editor.document.positionAt(session.startCursorOffset + reference.recommendationContentSpan.end - 1)
+                    .line + 1
             let lineInfo = ``
             if (firstCharLineNumber === lastCharLineNumber) {
                 lineInfo = `(line at ${firstCharLineNumber})`

--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -23,7 +23,6 @@ import {
     isBuilderIdConnection,
 } from '../../auth/connection'
 import { getLogger } from '../../shared/logger'
-import { FeatureConfigProvider } from '../service/featureConfigProvider'
 
 export const defaultCwScopes = [...ssoAccountAccessScopes, ...codewhispererScopes]
 export const awsBuilderIdSsoProfile = createBuilderIdProfile(defaultCwScopes)
@@ -107,7 +106,7 @@ export class AuthUtil {
                 }
 
                 // start the feature config polling job
-                FeatureConfigProvider.instance.fetchFeatureConfigs()
+                vscode.commands.executeCommand('aws.codewhisperer.fetchFeatureConfigs')
             }
             await vscode.commands.executeCommand('setContext', 'CODEWHISPERER_ENABLED', this.isConnected())
         })

--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -23,6 +23,7 @@ import {
     isBuilderIdConnection,
 } from '../../auth/connection'
 import { getLogger } from '../../shared/logger'
+import { FeatureConfigProvider } from '../service/featureConfigProvider'
 
 export const defaultCwScopes = [...ssoAccountAccessScopes, ...codewhispererScopes]
 export const awsBuilderIdSsoProfile = createBuilderIdProfile(defaultCwScopes)
@@ -104,6 +105,9 @@ export class AuthUtil {
                     vscode.commands.executeCommand('aws.codeWhisperer.gettingStarted')
                     prompts.disablePrompt('codeWhispererNewWelcomeMessage')
                 }
+
+                // start the feature config polling job
+                FeatureConfigProvider.instance.fetchFeatureConfigs()
             }
             await vscode.commands.executeCommand('setContext', 'CODEWHISPERER_ENABLED', this.isConnected())
         })

--- a/src/codewhisperer/util/codeWhispererSession.ts
+++ b/src/codewhisperer/util/codeWhispererSession.ts
@@ -79,6 +79,7 @@ class CodeWhispererSession {
 
     reset() {
         this.sessionId = ''
+        this.requestContext = { request: {} as any, supplementalMetadata: {} as any }
         this.requestIdList = []
         this.startPos = new Position(0, 0)
         this.startCursorOffset = 0

--- a/src/codewhisperer/util/codeWhispererSession.ts
+++ b/src/codewhisperer/util/codeWhispererSession.ts
@@ -7,6 +7,8 @@ import {
     CodewhispererCompletionType,
     CodewhispererLanguage,
     CodewhispererGettingStartedTask,
+    CodewhispererAutomatedTriggerType,
+    CodewhispererTriggerType,
 } from '../../shared/telemetry/telemetry.gen'
 import { GenerateRecommendationsRequest, ListRecommendationsRequest, Recommendation } from '../client/codewhisperer'
 import { Position } from 'vscode'
@@ -21,13 +23,17 @@ class CodeWhispererSession {
     sessionId = ''
     requestIdList: string[] = []
     startPos = new Position(0, 0)
+    startCursorOffset = 0
     leftContextOfCurrentLine = ''
     requestContext: {
         request: ListRecommendationsRequest | GenerateRecommendationsRequest
         supplementalMetadata: Omit<CodeWhispererSupplementalContext, 'supplementalContextItems'> | undefined
     } = { request: {} as any, supplementalMetadata: {} as any }
-    language: CodewhispererLanguage = 'java'
+    language: CodewhispererLanguage = 'python'
     taskType: CodewhispererGettingStartedTask | undefined
+    triggerType: CodewhispererTriggerType = 'OnDemand'
+    autoTriggerType: CodewhispererAutomatedTriggerType | undefined
+
     // Various states of recommendations
     recommendations: Recommendation[] = []
     suggestionStates = new Map<number, string>()
@@ -69,6 +75,19 @@ class CodeWhispererSession {
 
     getCompletionType(index: number): CodewhispererCompletionType {
         return this.completionTypes.get(index) || 'Line'
+    }
+
+    reset() {
+        this.sessionId = ''
+        this.requestIdList = []
+        this.startPos = new Position(0, 0)
+        this.startCursorOffset = 0
+        this.leftContextOfCurrentLine = ''
+        this.language = 'python'
+        this.triggerType = 'OnDemand'
+        this.recommendations = []
+        this.suggestionStates.clear()
+        this.completionTypes.clear()
     }
 }
 

--- a/src/codewhisperer/util/editorContext.ts
+++ b/src/codewhisperer/util/editorContext.ts
@@ -8,7 +8,6 @@ import * as codewhispererClient from '../client/codewhisperer'
 import * as path from 'path'
 import * as CodeWhispererConstants from '../models/constants'
 import { getTabSizeSetting } from '../../shared/utilities/editorUtilities'
-import { TelemetryHelper } from './telemetryHelper'
 import { getLogger } from '../../shared/logger/logger'
 import { runtimeLanguageContext } from './runtimeLanguageContext'
 import { fetchSupplementalContext } from './supplementalContext/supplementalContextUtil'
@@ -24,7 +23,6 @@ export function extractContextForCodeWhisperer(editor: vscode.TextEditor): codew
     const document = editor.document
     const curPos = editor.selection.active
     const offset = document.offsetAt(curPos)
-    TelemetryHelper.instance.cursorOffset = offset
 
     const caretLeftFileContext = editor.document.getText(
         new vscode.Range(

--- a/src/codewhisperer/util/runtimeLanguageContext.ts
+++ b/src/codewhisperer/util/runtimeLanguageContext.ts
@@ -27,6 +27,9 @@ const runtimeLanguageSet: ReadonlySet<RuntimeLanguage> = new Set([
     'shell',
     'sql',
     'typescript',
+    'json',
+    'yaml',
+    'tf',
 ])
 
 export class RuntimeLanguageContext {
@@ -56,9 +59,12 @@ export class RuntimeLanguageContext {
             csharp: 'csharp',
             c_cpp: 'cpp',
             go: 'go',
+            golang: 'go',
+            hcl: 'hcl',
             java: 'java',
             javascript: 'javascript',
             javascriptreact: 'jsx',
+            json: 'json',
             jsx: 'jsx',
             kotlin: 'kotlin',
             plaintext: 'plaintext',
@@ -71,18 +77,22 @@ export class RuntimeLanguageContext {
             shell: 'shell',
             shellscript: 'shell',
             sql: 'sql',
+            tf: 'tf',
             tsx: 'tsx',
             typescript: 'typescript',
             typescriptreact: 'tsx',
-            golang: 'go',
+            yaml: 'yaml',
+            yml: 'yaml',
         })
         this.supportedLanguageExtensionMap = createConstantMap<CodewhispererLanguage, string>({
             c: 'c',
             cpp: 'cpp',
             csharp: 'cs',
             go: 'go',
+            hcl: 'hcl',
             java: 'java',
             javascript: 'js',
+            json: 'json',
             jsx: 'jsx',
             kotlin: 'kt',
             plaintext: 'txt',
@@ -93,8 +103,11 @@ export class RuntimeLanguageContext {
             scala: 'scala',
             shell: 'sh',
             sql: 'sql',
+            tf: 'tf',
             tsx: 'tsx',
             typescript: 'ts',
+            yaml: 'yaml',
+            yml: 'yaml',
         })
     }
 

--- a/src/codewhisperer/util/telemetryHelper.ts
+++ b/src/codewhisperer/util/telemetryHelper.ts
@@ -11,17 +11,11 @@ import {
     CodewhispererGettingStartedTask,
     CodewhispererLanguage,
     CodewhispererPreviousSuggestionState,
-    CodewhispererServiceInvocation,
     CodewhispererUserDecision,
     CodewhispererUserTriggerDecision,
     telemetry,
 } from '../../shared/telemetry/telemetry'
-import {
-    CodewhispererAutomatedTriggerType,
-    CodewhispererCompletionType,
-    CodewhispererSuggestionState,
-    CodewhispererTriggerType,
-} from '../../shared/telemetry/telemetry'
+import { CodewhispererCompletionType, CodewhispererSuggestionState } from '../../shared/telemetry/telemetry'
 import { getImportCount } from './importAdderUtil'
 import { CodeWhispererSettings } from './codewhispererSettings'
 import { CodeWhispererUserGroupSettings } from './userGroupUtil'
@@ -31,20 +25,11 @@ import { isAwsError } from '../../shared/errors'
 import { getLogger } from '../../shared/logger'
 import { session } from './codeWhispererSession'
 import { CodeWhispererSupplementalContext } from '../models/model'
+import { FeatureConfigProvider } from '../service/featureConfigProvider'
 
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
 export class TelemetryHelper {
-    /**
-     * Trigger type for getting CodeWhisperer recommendation
-     */
-    public triggerType: CodewhispererTriggerType
-
-    /**
-     * the cursor offset location at invocation time
-     */
-    public cursorOffset: number
-
     // Some variables for client component latency
     private sdkApiCallEndTime = 0
     private firstSuggestionShowTime = 0
@@ -53,7 +38,6 @@ export class TelemetryHelper {
     // variables for user trigger decision
     // these will be cleared after a invocation session
     private sessionDecisions: CodewhispererUserTriggerDecision[] = []
-    public sessionInvocations: CodewhispererServiceInvocation[] = []
     private triggerChar?: string = undefined
     private prevTriggerDecision?: CodewhispererPreviousSuggestionState
     private isRequestCancelled = false
@@ -67,10 +51,7 @@ export class TelemetryHelper {
     private classifierResult?: number = undefined
     private classifierThreshold?: number = undefined
 
-    constructor() {
-        this.triggerType = 'OnDemand'
-        this.cursorOffset = 0
-    }
+    constructor() {}
 
     static #instance: TelemetryHelper
 
@@ -82,11 +63,8 @@ export class TelemetryHelper {
         requestId: string,
         sessionId: string,
         lastSuggestionIndex: number,
-        triggerType: CodewhispererTriggerType,
-        autoTriggerType: CodewhispererAutomatedTriggerType | undefined,
         result: 'Succeeded' | 'Failed',
         duration: number | undefined,
-        lineNumber: number | undefined,
         language: CodewhispererLanguage,
         taskType: CodewhispererGettingStartedTask | undefined,
         reason: string,
@@ -96,12 +74,12 @@ export class TelemetryHelper {
             codewhispererRequestId: requestId ? requestId : undefined,
             codewhispererSessionId: sessionId ? sessionId : undefined,
             codewhispererLastSuggestionIndex: lastSuggestionIndex,
-            codewhispererTriggerType: triggerType,
-            codewhispererAutomatedTriggerType: autoTriggerType,
+            codewhispererTriggerType: session.triggerType,
+            codewhispererAutomatedTriggerType: session.autoTriggerType,
             result,
             duration: duration || 0,
-            codewhispererLineNumber: lineNumber || 0,
-            codewhispererCursorOffset: this.cursorOffset || 0,
+            codewhispererLineNumber: session.startPos.line,
+            codewhispererCursorOffset: session.startCursorOffset,
             codewhispererLanguage: language,
             CodewhispererGettingStartedTask: taskType,
             reason: reason ? reason.substring(0, 200) : undefined,
@@ -115,7 +93,6 @@ export class TelemetryHelper {
             codewhispererCustomizationArn: getSelectedCustomization().arn,
         }
         telemetry.codewhisperer_serviceInvocation.emit(event)
-        this.sessionInvocations.push(event)
     }
 
     public recordUserDecisionTelemetryForEmptyList(
@@ -130,7 +107,7 @@ export class TelemetryHelper {
             codewhispererRequestId: requestIdList[0],
             codewhispererSessionId: sessionId ? sessionId : undefined,
             codewhispererPaginationProgress: paginationIndex,
-            codewhispererTriggerType: this.triggerType,
+            codewhispererTriggerType: session.triggerType,
             codewhispererSuggestionIndex: -1,
             codewhispererSuggestionState: 'Empty',
             codewhispererSuggestionReferences: undefined,
@@ -182,7 +159,7 @@ export class TelemetryHelper {
                 codewhispererRequestId: requestIdList[i],
                 codewhispererSessionId: sessionId ? sessionId : undefined,
                 codewhispererPaginationProgress: paginationIndex,
-                codewhispererTriggerType: this.triggerType,
+                codewhispererTriggerType: session.triggerType,
                 codewhispererSuggestionIndex: i,
                 codewhispererSuggestionState: this.getSuggestionState(i, acceptIndex, recommendationSuggestionState),
                 codewhispererSuggestionReferences: uniqueSuggestionReferences,
@@ -241,22 +218,21 @@ export class TelemetryHelper {
     ) {
         // the request level user decision will contain information from both the service_invocation event
         // and the user_decision events for recommendations within that request
-        const serviceInvocation = this.sessionInvocations.find(e => e.codewhispererRequestId === requestId)
-        if (!serviceInvocation || !events.length) {
+        if (!events.length) {
             return
         }
         const aggregated: CodewhispererUserTriggerDecision = {
             codewhispererSessionId: sessionId,
-            codewhispererFirstRequestId: this.sessionInvocations[0].codewhispererRequestId ?? requestId,
+            codewhispererFirstRequestId: requestId,
             credentialStartUrl: events[0].credentialStartUrl,
             codewhispererLanguage: events[0].codewhispererLanguage,
             codewhispererGettingStartedTask: session.taskType,
             codewhispererTriggerType: events[0].codewhispererTriggerType,
             codewhispererCompletionType: events[0].codewhispererCompletionType,
             codewhispererSuggestionCount: events.length,
-            codewhispererAutomatedTriggerType: serviceInvocation.codewhispererAutomatedTriggerType,
-            codewhispererLineNumber: serviceInvocation.codewhispererLineNumber,
-            codewhispererCursorOffset: serviceInvocation.codewhispererCursorOffset,
+            codewhispererAutomatedTriggerType: session.autoTriggerType,
+            codewhispererLineNumber: session.startPos.line,
+            codewhispererCursorOffset: session.startCursorOffset,
             codewhispererSuggestionState: this.getAggregatedSuggestionState(events),
             codewhispererSuggestionImportCount: events
                 .map(e => e.codewhispererSuggestionImportCount || 0)
@@ -329,6 +305,7 @@ export class TelemetryHelper {
             // eslint-disable-next-line id-length
             codewhispererSupplementalContextStrategyId: supplementalContextMetadata?.strategy,
             codewhispererCharactersAccepted: acceptedRecommendationContent.length,
+            codewhispererFeatureEvaluations: FeatureConfigProvider.instance.getFeatureConfigsTelemetry(),
         }
         telemetry.codewhisperer_userTriggerDecision.emit(aggregated)
         this.prevTriggerDecision = this.getAggregatedSuggestionState(this.sessionDecisions)
@@ -429,7 +406,6 @@ export class TelemetryHelper {
     private resetUserTriggerDecisionTelemetry() {
         this.sessionDecisions = []
         this.isRequestCancelled = false
-        this.sessionInvocations = []
         this.triggerChar = ''
         this.lastRequestId = ''
         this.numberOfRequests = 0
@@ -569,7 +545,7 @@ export class TelemetryHelper {
             codewhispererCredentialFetchingLatency: session.sdkApiCallStartTime - session.fetchCredentialStartTime,
             codewhispererPreprocessingLatency: session.fetchCredentialStartTime - session.invokeSuggestionStartTime,
             codewhispererCompletionType: 'Line',
-            codewhispererTriggerType: this.triggerType,
+            codewhispererTriggerType: session.triggerType,
             codewhispererLanguage: session.language,
             credentialStartUrl: AuthUtil.instance.startUrl,
             codewhispererUserGroup: CodeWhispererUserGroupSettings.getUserGroup().toString(),

--- a/src/test/codewhisperer/commands/onAcceptance.test.ts
+++ b/src/test/codewhisperer/commands/onAcceptance.test.ts
@@ -11,7 +11,6 @@ import { resetCodeWhispererGlobalVariables, createMockTextEditor } from '../test
 import { CodeWhispererTracker } from '../../../codewhisperer/tracker/codewhispererTracker'
 import { assertTelemetryCurried } from '../../testUtil'
 import { FakeExtensionContext } from '../../fakeExtensionContext'
-import { TelemetryHelper } from '../../../codewhisperer/util/telemetryHelper'
 import { RecommendationHandler } from '../../../codewhisperer/service/recommendationHandler'
 import globals from '../../../shared/extensionGlobals'
 import * as CodeWhispererConstants from '../../../codewhisperer/models/constants'
@@ -90,7 +89,7 @@ describe('onAcceptance', function () {
             mockEditor.selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 0))
             session.recommendations = [{ content: "print('Hello World!')" }]
             session.setSuggestionState(0, 'Showed')
-            TelemetryHelper.instance.triggerType = 'OnDemand'
+            session.triggerType = 'OnDemand'
             session.setCompletionType(0, session.recommendations[0])
             const assertTelemetry = assertTelemetryCurried('codewhisperer_userDecision')
             const extensionContext = await FakeExtensionContext.create()

--- a/src/test/codewhisperer/commands/onInlineAcceptance.test.ts
+++ b/src/test/codewhisperer/commands/onInlineAcceptance.test.ts
@@ -10,7 +10,6 @@ import { onInlineAcceptance } from '../../../codewhisperer/commands/onInlineAcce
 import { resetCodeWhispererGlobalVariables, createMockTextEditor } from '../testUtil'
 import { assertTelemetryCurried } from '../../testUtil'
 import { FakeMemento } from '../../fakeExtensionContext'
-import { TelemetryHelper } from '../../../codewhisperer/util/telemetryHelper'
 import { RecommendationHandler } from '../../../codewhisperer/service/recommendationHandler'
 import globals from '../../../shared/extensionGlobals'
 import * as CodeWhispererConstants from '../../../codewhisperer/models/constants'
@@ -63,12 +62,13 @@ describe('onInlineAcceptance', function () {
             const mockEditor = createMockTextEditor()
             session.requestIdList = ['test']
             RecommendationHandler.instance.requestId = 'test'
+            session.requestIdList = ['test']
             session.sessionId = 'test'
             session.startPos = new vscode.Position(1, 0)
             mockEditor.selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 0))
             session.recommendations = [{ content: "print('Hello World!')" }]
             session.setSuggestionState(0, 'Showed')
-            TelemetryHelper.instance.triggerType = 'OnDemand'
+            session.triggerType = 'OnDemand'
             session.setCompletionType(0, session.recommendations[0])
             const assertTelemetry = assertTelemetryCurried('codewhisperer_userDecision')
             const globalState = new FakeMemento()

--- a/src/test/codewhisperer/service/codewhisperer.test.ts
+++ b/src/test/codewhisperer/service/codewhisperer.test.ts
@@ -4,18 +4,16 @@
  */
 
 import sinon from 'sinon'
-import { anyString, spy } from '../../utilities/mockito'
+import { anyString } from '../../utilities/mockito'
 import { codeWhispererClient } from '../../../codewhisperer/client/codewhisperer'
 import CodeWhispererUserClient, {
     SendTelemetryEventResponse,
     TelemetryEvent,
 } from '../../../codewhisperer/client/codewhispereruserclient'
 import globals from '../../../shared/extensionGlobals'
-import { AWSError, Request, Service } from 'aws-sdk'
-import { DefaultAWSClientBuilder, ServiceOptions } from '../../../shared/awsClientBuilder'
-import { FakeAwsContext } from '../../utilities/fakeAwsContext'
-import userApiConfig = require('./../../../codewhisperer/client/user-service-2.json')
+import { AWSError, Request } from 'aws-sdk'
 import { AuthUtil } from '../../../codewhisperer/util/authUtil'
+import { createSpyClient } from '../testUtil'
 
 describe('codewhisperer', async function () {
     let clientSpy: CodeWhispererUserClient
@@ -34,13 +32,7 @@ describe('codewhisperer', async function () {
 
     beforeEach(async function () {
         sinon.restore()
-        const builder = new DefaultAWSClientBuilder(new FakeAwsContext())
-        clientSpy = spy(
-            (await builder.createAwsService(Service, {
-                apiConfig: userApiConfig,
-            } as ServiceOptions)) as CodeWhispererUserClient
-        )
-        sinon.stub(codeWhispererClient, 'createUserSdkClient').returns(Promise.resolve(clientSpy))
+        clientSpy = await createSpyClient()
         telemetryEnabledDefault = globals.telemetry.telemetryEnabled
     })
 

--- a/src/test/codewhisperer/service/featureConfigProvider.test.ts
+++ b/src/test/codewhisperer/service/featureConfigProvider.test.ts
@@ -5,8 +5,20 @@
 
 import assert from 'assert'
 import { FeatureConfigProvider, featureDefinitions } from '../../../codewhisperer/service/featureConfigProvider'
+import { createSpyClient } from '../testUtil'
+import sinon from 'sinon'
+import { anyString } from '../../utilities/mockito'
+import {
+    FeatureEvaluation,
+    ListFeatureEvaluationsResponse,
+} from '../../../codewhisperer/client/codewhispereruserclient'
+import { AWSError, Request } from 'aws-sdk'
 
 describe('CodeWhispererFeatureConfigServiceTest', () => {
+    afterEach(function () {
+        sinon.restore()
+    })
+
     it('featureDefinitions map is not empty', () => {
         assert.notStrictEqual(featureDefinitions.size, 0)
         assert.ok(featureDefinitions.has('testFeature'))
@@ -18,8 +30,32 @@ describe('CodeWhispererFeatureConfigServiceTest', () => {
             const method = Object.getOwnPropertyDescriptors(FeatureConfigProvider.prototype)[methodName]
 
             assert.strictEqual(method.value.name, methodName)
-
             assert.ok(method)
         }
+    })
+
+    it('test getFeatureConfigsTelemetry will return expected string', async () => {
+        const testFeatureContext = {
+            feature: 'testFeature',
+            variation: 'TREATMENT',
+            value: 'testValue',
+        } as FeatureEvaluation
+
+        let clientSpy = await createSpyClient()
+        sinon.stub(clientSpy, 'listFeatureEvaluations').returns({
+            promise: () =>
+                Promise.resolve({
+                    $response: {
+                        requestId: anyString(),
+                    },
+                    featureEvaluations: [testFeatureContext],
+                }),
+        } as Request<ListFeatureEvaluationsResponse, AWSError>)
+
+        await FeatureConfigProvider.instance.fetchFeatureConfigs()
+        assert.strictEqual(
+            FeatureConfigProvider.instance.getFeatureConfigsTelemetry(),
+            `{${testFeatureContext.feature}: ${testFeatureContext.variation}}`
+        )
     })
 })

--- a/src/test/codewhisperer/service/featureConfigProvider.test.ts
+++ b/src/test/codewhisperer/service/featureConfigProvider.test.ts
@@ -1,0 +1,25 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import { FeatureConfigProvider, featureDefinitions } from '../../../codewhisperer/service/featureConfigProvider'
+
+describe('CodeWhispererFeatureConfigServiceTest', () => {
+    it('featureDefinitions map is not empty', () => {
+        assert.notStrictEqual(featureDefinitions.size, 0)
+        assert.ok(featureDefinitions.has('testFeature'))
+    })
+
+    it('provider has getters for all the features', () => {
+        for (const name of featureDefinitions.keys()) {
+            const methodName = `get${name.charAt(0).toUpperCase() + name.slice(1)}`
+            const method = Object.getOwnPropertyDescriptors(FeatureConfigProvider.prototype)[methodName]
+
+            assert.strictEqual(method.value.name, methodName)
+
+            assert.ok(method)
+        }
+    })
+})

--- a/src/test/codewhisperer/service/recommendationHandler.test.ts
+++ b/src/test/codewhisperer/service/recommendationHandler.test.ts
@@ -11,7 +11,6 @@ import { assertTelemetryCurried } from '../../testUtil'
 import { RecommendationsList } from '../../../codewhisperer/client/codewhisperer'
 import { ConfigurationEntry } from '../../../codewhisperer/models/model'
 import { createMockTextEditor, resetCodeWhispererGlobalVariables } from '../testUtil'
-import { TelemetryHelper } from '../../../codewhisperer/util/telemetryHelper'
 import { RecommendationHandler } from '../../../codewhisperer/service/recommendationHandler'
 import { stub } from '../../utilities/stubber'
 import { CodeWhispererCodeCoverageTracker } from '../../../codewhisperer/tracker/codewhispererCodeCoverageTracker'
@@ -108,7 +107,7 @@ describe('recommendationHandler', function () {
             await handler.getRecommendations(mockClient, mockEditor, 'AutoTrigger', config, 'Enter', false)
             assert.strictEqual(handler.requestId, 'test_request')
             assert.strictEqual(session.sessionId, 'test_request')
-            assert.strictEqual(TelemetryHelper.instance.triggerType, 'AutoTrigger')
+            assert.strictEqual(session.triggerType, 'AutoTrigger')
         })
 
         it('should call telemetry function that records a CodeWhisperer service invocation', async function () {
@@ -140,7 +139,7 @@ describe('recommendationHandler', function () {
             })
             sinon.stub(performance, 'now').returns(0.0)
             session.startPos = new vscode.Position(1, 0)
-            TelemetryHelper.instance.cursorOffset = 2
+            session.startCursorOffset = 2
             await handler.getRecommendations(mockClient, mockEditor, 'AutoTrigger', config, 'Enter')
             const assertTelemetry = assertTelemetryCurried('codewhisperer_serviceInvocation')
             assertTelemetry({
@@ -186,7 +185,7 @@ describe('recommendationHandler', function () {
             sinon.stub(performance, 'now').returns(0.0)
             session.startPos = new vscode.Position(1, 0)
             session.requestIdList = ['test_request_empty']
-            TelemetryHelper.instance.cursorOffset = 2
+            session.startCursorOffset = 2
             await handler.getRecommendations(mockClient, mockEditor, 'AutoTrigger', config, 'Enter')
             const assertTelemetry = assertTelemetryCurried('codewhisperer_userDecision')
             assertTelemetry({

--- a/src/test/codewhisperer/testUtil.ts
+++ b/src/test/codewhisperer/testUtil.ts
@@ -18,7 +18,7 @@ export function resetCodeWhispererGlobalVariables() {
     vsCodeState.isCodeWhispererEditing = false
     CodeWhispererCodeCoverageTracker.instances.clear()
     globals.telemetry.logger.clear()
-    session.language = 'python'
+    session.reset()
     CodeSuggestionsState.instance.setSuggestionsEnabled(false)
 }
 

--- a/src/test/codewhisperer/testUtil.ts
+++ b/src/test/codewhisperer/testUtil.ts
@@ -12,6 +12,13 @@ import { getLogger } from '../../shared/logger'
 import { CodeWhispererCodeCoverageTracker } from '../../codewhisperer/tracker/codewhispererCodeCoverageTracker'
 import globals from '../../shared/extensionGlobals'
 import { session } from '../../codewhisperer/util/codeWhispererSession'
+import { DefaultAWSClientBuilder, ServiceOptions } from '../../shared/awsClientBuilder'
+import { FakeAwsContext } from '../utilities/fakeAwsContext'
+import { spy } from '../utilities/mockito'
+import { Service } from 'aws-sdk'
+import userApiConfig = require('./../../codewhisperer/client/user-service-2.json')
+import CodeWhispererUserClient = require('../../codewhisperer/client/codewhispereruserclient')
+import { codeWhispererClient } from '../../codewhisperer/client/codewhisperer'
 
 export function resetCodeWhispererGlobalVariables() {
     vsCodeState.isIntelliSenseActive = false
@@ -140,4 +147,15 @@ export function createTextDocumentChangeEvent(document: vscode.TextDocument, ran
             },
         ],
     }
+}
+
+export async function createSpyClient() {
+    const builder = new DefaultAWSClientBuilder(new FakeAwsContext())
+    let clientSpy = spy(
+        (await builder.createAwsService(Service, {
+            apiConfig: userApiConfig,
+        } as ServiceOptions)) as CodeWhispererUserClient
+    )
+    sinon.stub(codeWhispererClient, 'createUserSdkClient').returns(Promise.resolve(clientSpy))
+    return clientSpy
 }

--- a/src/test/codewhisperer/util/telemetryHelper.test.ts
+++ b/src/test/codewhisperer/util/telemetryHelper.test.ts
@@ -16,6 +16,7 @@ import {
     CodewhispererUserDecision,
 } from '../../../shared/telemetry/telemetry.gen'
 import { Completion } from '../../../codewhisperer/client/codewhispereruserclient'
+import { session } from '../../../codewhisperer/util/codeWhispererSession'
 
 // TODO: improve and move the following test utils to codewhisperer/testUtils.ts
 function aUserDecision(
@@ -63,8 +64,6 @@ describe('telemetryHelper', function () {
         })
 
         it('should return Line and Accept', function () {
-            sut.sessionInvocations.push(aServiceInvocation())
-
             const decisions: CodewhispererUserDecision[] = [
                 aUserDecision('Line', 0, 'Accept'),
                 aUserDecision('Line', 1, 'Discard'),
@@ -79,8 +78,6 @@ describe('telemetryHelper', function () {
         })
 
         it('should return Line and Reject', function () {
-            sut.sessionInvocations.push(aServiceInvocation())
-
             const decisions: CodewhispererUserDecision[] = [
                 aUserDecision('Line', 0, 'Discard'),
                 aUserDecision('Line', 1, 'Reject'),
@@ -95,8 +92,6 @@ describe('telemetryHelper', function () {
         })
 
         it('should return Block and Accept', function () {
-            sut.sessionInvocations.push(aServiceInvocation())
-
             const decisions: CodewhispererUserDecision[] = [
                 aUserDecision('Block', 0, 'Discard'),
                 aUserDecision('Block', 1, 'Accept'),
@@ -117,7 +112,6 @@ describe('telemetryHelper', function () {
         beforeEach(function () {
             resetCodeWhispererGlobalVariables()
             sut = new TelemetryHelper()
-            sut.sessionInvocations.push(aServiceInvocation())
             CodeWhispererUserGroupSettings.instance.userGroup = CodeWhispererConstants.UserGroup.Control
         })
 
@@ -285,7 +279,7 @@ describe('telemetryHelper', function () {
             const response = [{ content: "print('Hello')" }]
             const requestIdList = ['test_x', 'test_x', 'test_y']
             const sessionId = 'test_x'
-            telemetryHelper.triggerType = 'AutoTrigger'
+            session.triggerType = 'AutoTrigger'
             const assertTelemetry = assertTelemetryCurried('codewhisperer_userDecision')
             const suggestionState = new Map<number, string>([[0, 'Showed']])
             const completionTypes = new Map<number, CodewhispererCompletionType>([[0, 'Line']])

--- a/src/test/codewhisperer/util/telemetryHelper.test.ts
+++ b/src/test/codewhisperer/util/telemetryHelper.test.ts
@@ -11,7 +11,6 @@ import * as CodeWhispererConstants from '../../../codewhisperer/models/constants
 import { CodeWhispererUserGroupSettings } from '../../../codewhisperer/util/userGroupUtil'
 import {
     CodewhispererCompletionType,
-    CodewhispererServiceInvocation,
     CodewhispererSuggestionState,
     CodewhispererUserDecision,
 } from '../../../shared/telemetry/telemetry.gen'
@@ -34,17 +33,6 @@ function aUserDecision(
         codewhispererSuggestionState: codewhispererSuggestionState,
         codewhispererTriggerType: 'OnDemand',
         credentialStartUrl: 'https://www.amazon.com',
-        codewhispererUserGroup: 'Control',
-    }
-}
-
-function aServiceInvocation(): CodewhispererServiceInvocation {
-    return {
-        codewhispererCursorOffset: 0,
-        codewhispererLanguage: 'python',
-        codewhispererLineNumber: 0,
-        codewhispererRequestId: 'aFakeRequestId',
-        codewhispererTriggerType: 'OnDemand',
         codewhispererUserGroup: 'Control',
     }
 }


### PR DESCRIPTION
1. Add a component to fetch feature assignments every 30 mins, calling ListFeatureEvaluations API and cache values in memory.

2. Add a field in UserTriggerDecision codewhispererFeatureEvaluations to record all the feature configs in a string, which can be queried on Kibana

respective JB PR: https://github.com/aws/aws-toolkit-jetbrains/pull/3978
## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
