### PR TITLE
CodeWhisperer: fix various VSC bugs

### DIFF
--- a/src/codewhisperer/commands/invokeRecommendation.ts
+++ b/src/codewhisperer/commands/invokeRecommendation.ts
@@ -12,7 +12,6 @@ import { RecommendationHandler } from '../service/recommendationHandler'
 import { isInlineCompletionEnabled } from '../util/commonUtil'
 import { InlineCompletionService } from '../service/inlineCompletionService'
 import { AuthUtil } from '../util/authUtil'
-import { TelemetryHelper } from '../util/telemetryHelper'
 import { ClassifierTrigger } from '../service/classifierTrigger'
 import { isIamConnection } from '../../auth/connection'
 import { session } from '../util/codeWhispererSession'
@@ -100,7 +99,6 @@ export async function invokeRecommendation(
             RecommendationHandler.instance.isGenerateRecommendationInProgress = false
         }
     } else if (isInlineCompletionEnabled()) {
-        TelemetryHelper.instance.setInvokeSuggestionStartTime()
         ClassifierTrigger.instance.recordClassifierResultForManualTrigger(editor)
         await InlineCompletionService.instance.getPaginatedRecommendation(client, editor, 'OnDemand', config)
     }

--- a/src/codewhisperer/service/inlineCompletionItemProvider.ts
+++ b/src/codewhisperer/service/inlineCompletionItemProvider.ts
@@ -164,7 +164,6 @@ export class CWInlineCompletionItemProvider implements vscode.InlineCompletionIt
             ImportAdderProvider.instance.onShowRecommendation(document, this.startPos.line, r)
             this.nextMove = 0
             TelemetryHelper.instance.setFirstSuggestionShowTime()
-            TelemetryHelper.instance.tryRecordClientComponentLatency()
             this._onDidShow.fire()
             if (matchedCount >= 2 || this.nextToken !== '') {
                 const result = [item]

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -94,7 +94,7 @@ export class InlineCompletionService {
 
         // Call report user decisions once to report recommendations leftover from last invocation.
         RecommendationHandler.instance.reportUserDecisions(-1)
-
+        TelemetryHelper.instance.setInvokeSuggestionStartTime()
         ClassifierTrigger.instance.recordClassifierResultForAutoTrigger(editor, autoTriggerType, event)
 
         const triggerChar = event?.contentChanges[0]?.text

--- a/src/codewhisperer/service/keyStrokeHandler.ts
+++ b/src/codewhisperer/service/keyStrokeHandler.ts
@@ -14,7 +14,6 @@ import { CodewhispererAutomatedTriggerType } from '../../shared/telemetry/teleme
 import { getTabSizeSetting } from '../../shared/utilities/editorUtilities'
 import { isInlineCompletionEnabled } from '../util/commonUtil'
 import { InlineCompletionService } from './inlineCompletionService'
-import { TelemetryHelper } from '../util/telemetryHelper'
 import { AuthUtil } from '../util/authUtil'
 import { ClassifierTrigger } from './classifierTrigger'
 import { isIamConnection } from '../../auth/connection'
@@ -210,7 +209,6 @@ export class KeyStrokeHandler {
                 RecommendationHandler.instance.isGenerateRecommendationInProgress = false
             }
         } else if (isInlineCompletionEnabled()) {
-            TelemetryHelper.instance.setInvokeSuggestionStartTime()
             await InlineCompletionService.instance.getPaginatedRecommendation(
                 client,
                 editor,

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -181,6 +181,7 @@ export class RecommendationHandler {
         let shouldRecordServiceInvocation = true
         session.language = runtimeLanguageContext.getLanguageContext(editor.document.languageId).language
         session.taskType = await this.getTaskTypeFromEditorFileName(editor.document.fileName)
+        session.requestIdList = []
 
         if (pagination) {
             if (page === 0) {

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -181,7 +181,6 @@ export class RecommendationHandler {
         let shouldRecordServiceInvocation = true
         session.language = runtimeLanguageContext.getLanguageContext(editor.document.languageId).language
         session.taskType = await this.getTaskTypeFromEditorFileName(editor.document.fileName)
-        session.requestIdList = []
 
         if (pagination) {
             if (page === 0) {
@@ -440,6 +439,7 @@ export class RecommendationHandler {
      * Clear recommendation state
      */
     clearRecommendations() {
+        session.requestIdList = []
         session.recommendations = []
         session.suggestionStates = new Map<number, string>()
         session.completionTypes = new Map<number, CodewhispererCompletionType>()

--- a/src/test/codewhisperer/commands/onInlineAcceptance.test.ts
+++ b/src/test/codewhisperer/commands/onInlineAcceptance.test.ts
@@ -61,6 +61,7 @@ describe('onInlineAcceptance', function () {
             const testStartUrl = 'testStartUrl'
             sinon.stub(AuthUtil.instance, 'startUrl').value(testStartUrl)
             const mockEditor = createMockTextEditor()
+            session.requestIdList = ['test']
             RecommendationHandler.instance.requestId = 'test'
             session.sessionId = 'test'
             session.startPos = new vscode.Position(1, 0)


### PR DESCRIPTION
1. Fixed an issue where clientCompoentLatency telemetry event would be sent every time when navigating the suggestions, where it should only be sent once when a first suggestion has been shown.
2. Fixed an issue where the requestIdList is not reset, causing a later check to not pass and stop sending the userTriggerDecisions.
3. Fixed an issue where spamming trigger will cause the invocation start time to reset to current time for each trigger action. This will cause the e2e latency to be recorded unexpectedly.

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
