### PR TITLE
feat(settings): "invalid settings.json" message cannot be disabled

### DIFF
--- a/.changes/next-release/Feature-9f098b03-c8ed-4137-80cb-e7508d42a97f.json
+++ b/.changes/next-release/Feature-9f098b03-c8ed-4137-80cb-e7508d42a97f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Don't show \"invalid settings.json\" message if settings.json is valid but unwritable"
+}

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -16,6 +16,9 @@ import { ToolkitError } from './errors'
 
 type Workspace = Pick<typeof vscode.workspace, 'getConfiguration' | 'onDidChangeConfiguration'>
 
+/** Used by isValid(). Must be something that's defined in our package.json. */
+const testSetting = 'aws.samcli.lambdaTimeout'
+
 /**
  * A class for manipulating VS Code user settings (from all extensions).
  *
@@ -93,7 +96,7 @@ export class Settings {
      * "recoverable" JSON syntax errors.
      */
     public async isValid(): Promise<'ok' | 'invalid' | 'nowrite'> {
-        const key = 'aws.samcli.lambdaTimeout'
+        const key = testSetting
         const config = this.getConfig()
         const tempValOld = 1234 // Legacy temp value we are migrating from.
         const tempVal = 91234 // Temp value used to check that read/write works.
@@ -122,7 +125,7 @@ export class Settings {
                 return 'nowrite'
             }
 
-            const logMsg = 'settings: invalid "settings.json": %s'
+            const logMsg = 'settings: invalid settings.json: %s'
             getLogger().error(logMsg, err.message)
 
             return 'invalid'
@@ -386,7 +389,9 @@ function createSettingsClass<T extends TypeDescriptor>(section: string, descript
                 }
 
                 for (const key of props.filter(isDifferent)) {
-                    this.log('key "%s" changed', key)
+                    if (`${section}.${key}` !== testSetting) {
+                        this.log('key "%s" changed', key)
+                    }
                     emitter.fire({ key })
                 }
             })

--- a/src/test/utilities/testSettingsConfiguration.ts
+++ b/src/test/utilities/testSettingsConfiguration.ts
@@ -48,8 +48,8 @@ export class TestSettings implements ClassToInterfaceType<Settings> {
         return !type || value === undefined ? value : cast(value, type)
     }
 
-    public async isValid(): Promise<boolean> {
-        return true
+    public async isValid(): Promise<'ok' | 'invalid' | 'nowrite'> {
+        return 'ok'
     }
 
     public async update(key: string, value: unknown): Promise<boolean> {


### PR DESCRIPTION
feat(settings): "invalid settings.json" message cannot be disabled

Problem:
settings.json may be intentionally readonly, then "invalid
settings.json" is not helpful. #4043

Solution:
Only log a warning if settings.json is not writable, don't show
a message. If settings.json is invalid a message is still shown.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
