### PR TITLE
codecatalyst: Cloud9 fixes

### DIFF
--- a/src/auth/sso/model.ts
+++ b/src/auth/sso/model.ts
@@ -16,6 +16,7 @@ import { CancellationError } from '../../shared/utilities/timeoutUtils'
 import { ssoAuthHelpUrl } from '../../shared/constants'
 import { openUrl } from '../../shared/utilities/vsCodeUtils'
 import { ToolkitError } from '../../shared/errors'
+import { isCloud9 } from '../../shared/extensionUtilities'
 
 export interface SsoToken {
     /**
@@ -117,7 +118,10 @@ export async function openSsoPortalLink(startUrl: string, authorization: Authori
 
     async function showLoginNotification() {
         const name = startUrl === builderIdStartUrl ? localizedText.builderId() : localizedText.iamIdentityCenterFull()
-        const title = localize('AWS.auth.loginWithBrowser.messageTitle', 'Confirm Code for {0}', name)
+        // C9 doesn't support `detail` field with modals so we need to put it all in the `title`
+        const title = isCloud9()
+            ? `Confirm Code "${authorization.userCode}" for ${name} in the browser.`
+            : localize('AWS.auth.loginWithBrowser.messageTitle', 'Confirm Code for {0}', name)
         const detail = localize(
             'AWS.auth.loginWithBrowser.messageDetail',
             'Confirm this code in the browser: {0}',

--- a/src/auth/ui/vue/show.ts
+++ b/src/auth/ui/vue/show.ts
@@ -46,7 +46,7 @@ import { CancellationError } from '../../../shared/utilities/timeoutUtils'
 import { validateSsoUrl, validateSsoUrlFormat } from '../../sso/validation'
 import { debounce } from '../../../shared/utilities/functionUtils'
 import { AuthError, ServiceItemId, isServiceItemId, userCancelled } from './types'
-import { awsIdSignIn } from '../../../codewhisperer/util/showSsoPrompt'
+import { awsIdSignIn, showCodeWhispererConnectionPrompt } from '../../../codewhisperer/util/showSsoPrompt'
 import { connectToEnterpriseSso } from '../../../codewhisperer/util/getStartUrl'
 import { trustedDomainCancellation } from '../../sso/model'
 import { FeatureId, CredentialSourceId, Result, telemetry } from '../../../shared/telemetry/telemetry'
@@ -741,14 +741,18 @@ export type AuthSource = (typeof AuthSources)[keyof typeof AuthSources]
 export const showManageConnections = Commands.declare(
     { id: showConnectionsPageCommand, compositeKey: { 1: 'source' } },
     (context: vscode.ExtensionContext) => (_: VsCodeCommandArg, source: AuthSource, serviceToShow?: ServiceItemId) => {
+        if (_ !== placeholder) {
+            source = 'vscodeComponent'
+        }
+
         // The auth webview page does not make sense to use in C9,
         // so show the auth quick pick instead.
         if (isCloud9('any')) {
+            if (source.toLowerCase().includes('codewhisperer')) {
+                // Show CW specific quick pick for CW connections
+                return showCodeWhispererConnectionPrompt()
+            }
             return addConnection.execute()
-        }
-
-        if (_ !== placeholder) {
-            source = 'vscodeComponent'
         }
 
         if (!isServiceItemId(serviceToShow)) {

--- a/src/codecatalyst/activation.ts
+++ b/src/codecatalyst/activation.ts
@@ -35,6 +35,8 @@ export async function activate(ctx: ExtContext): Promise<void> {
     const commands = new CodeCatalystCommands(authProvider)
     const remoteSourceProvider = new CodeCatalystRemoteSourceProvider(commands, authProvider)
 
+    await authProvider.restore()
+
     ctx.extensionContext.subscriptions.push(
         uriHandlers.register(ctx.uriHandler, CodeCatalystCommands.declared),
         ...Object.values(CodeCatalystCommands.declared).map(c => c.register(commands)),

--- a/src/codewhisperer/commands/basicCommands.ts
+++ b/src/codewhisperer/commands/basicCommands.ts
@@ -13,7 +13,7 @@ import { startSecurityScanWithProgress, confirmStopSecurityScan } from './startS
 import { SecurityPanelViewProvider } from '../views/securityPanelViewProvider'
 import { CodeSuggestionsState, codeScanState } from '../models/model'
 import { connectToEnterpriseSso, getStartUrl } from '../util/getStartUrl'
-import { showConnectionPrompt } from '../util/showSsoPrompt'
+import { showCodeWhispererConnectionPrompt } from '../util/showSsoPrompt'
 import { ReferenceLogViewProvider } from '../service/referenceLogViewProvider'
 import { AuthUtil } from '../util/authUtil'
 import { isCloud9 } from '../../shared/extensionUtilities'
@@ -116,7 +116,7 @@ export const showManageCwConnections = Commands.declare(
 /** @deprecated in favor of the `Add Connection` page */
 export const showSsoSignIn = Commands.declare('aws.codeWhisperer.sso', () => async () => {
     telemetry.ui_click.emit({ elementId: 'cw_signUp_Cta' })
-    await showConnectionPrompt()
+    await showCodeWhispererConnectionPrompt()
 })
 
 // Shortcut command to directly connect to Identity Center or prompt start URL entry

--- a/src/codewhisperer/util/showSsoPrompt.ts
+++ b/src/codewhisperer/util/showSsoPrompt.ts
@@ -15,27 +15,14 @@ import { ToolkitError } from '../../shared/errors'
 import { createCommonButtons } from '../../shared/ui/buttons'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { isCloud9 } from '../../shared/extensionUtilities'
-import { isIamConnection } from '../../auth/connection'
 import { createBuilderIdItem, createSsoItem, createIamItem } from '../../auth/utils'
 
-export const showConnectionPrompt = async () => {
-    // Skip this prompt on C9 because:
-    // * The UI looks bad with C9's style of pickers
-    // * C9 will always start with _some_ form of auth so this prompt is less common
-    if (isCloud9()) {
-        if (isCloud9('classic')) {
-            const iamConn = (await AuthUtil.instance.auth.listConnections()).find(isIamConnection)
-            if (iamConn) {
-                await AuthUtil.instance.auth.useConnection(iamConn)
-            }
-        } else {
-            await AuthUtil.instance.connectToAwsBuilderId()
-        }
+export const showCodeWhispererConnectionPrompt = async () => {
+    const items = isCloud9('classic')
+        ? [createSsoItem(), createCodeWhispererIamItem()]
+        : [createBuilderIdItem(), createSsoItem(), createCodeWhispererIamItem()]
 
-        return
-    }
-
-    const resp = await showQuickPick([createBuilderIdItem(), createSsoItem(), createCodeWhispererIamItem()], {
+    const resp = await showQuickPick(items, {
         title: 'CodeWhisperer: Add Connection to AWS',
         placeholder: 'Select a connection option to start using CodeWhisperer',
         buttons: createCommonButtons() as vscode.QuickInputButton[],

--- a/src/test/codewhisperer/util/showSsoPrompt.test.ts
+++ b/src/test/codewhisperer/util/showSsoPrompt.test.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode'
 import assert from 'assert'
 import * as sinon from 'sinon'
 import { resetCodeWhispererGlobalVariables } from '../testUtil'
-import { awsIdSignIn, showConnectionPrompt } from '../../../codewhisperer/util/showSsoPrompt'
+import { awsIdSignIn, showCodeWhispererConnectionPrompt } from '../../../codewhisperer/util/showSsoPrompt'
 import { getTestLogger } from '../../globalSetup.test'
 import { AuthUtil } from '../../../codewhisperer/util/authUtil'
 import { getTestWindow } from '../../shared/vscode/window'
@@ -30,7 +30,7 @@ describe('showConnectionPrompt', function () {
             picker.acceptItem(picker.items[0])
         })
 
-        await showConnectionPrompt()
+        await showCodeWhispererConnectionPrompt()
 
         assert.ok(authUtilSpy.called)
         const assertTelemetry = assertTelemetryCurried('ui_click')


### PR DESCRIPTION
This fixes:
- CC auto connects on start to an existing valid connection
- CW Connection Prompter in C9 shows correct options when clicking `Start` node under CodeWHisperer Developer Tools
- The proceed to browser message contains the code since it was missing in C9 since C9 doesn't support the `detail` field in modal messages.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
