### PR TITLE
fix: racecondition in cw auth change

### DIFF
--- a/src/auth/secondaryAuth.ts
+++ b/src/auth/secondaryAuth.ts
@@ -157,13 +157,11 @@ export class SecondaryAuth<T extends Connection = Connection> {
     /**
      * Globally deletes the connection that this secondary auth is using,
      * effectively doing a signout.
-     *
-     * The deletion automatically propogates to the other users of this
-     * connection, assuming they've configured the event listeners.
      */
     public async deleteConnection() {
         if (this.activeConnection) {
             await this.auth.deleteConnection(this.activeConnection)
+            await this.clearSavedConnection()
         }
     }
 


### PR DESCRIPTION
### Problem:

In the Add Connection page we listen to auth
events in the backend. When one of these events
is fired the Add Connection page eventually checks if isEnterpriseSsoInUse. The issue is that this
uses a variable that is separately updated by
the event onDidChangeActiveConnection.

There is a race condition for when onDidChangeActiveConnection updates the variable used in isEnterpriseSsoInUse() versus when isEnterpriseSsoInUse() is actually called.

Also when SecondaryAuth.deleteConnection() is called the new state is not updated when the function is complete since we are relying on an event listener to do the final updating.

### Solution:

Get rid of the variable and whenever isEnterpriseSsoInUse() is called it will pull the latest state. Now we don't have to manage it.

Also in deleteConnection() do a final clearing of the saved connection state so that upon completion the user will be able to get the latest state before all the event emitters fire.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
