### PR TITLE
fix(codecatalyst): Try to ensure connection for Dev Environment URI handler flow

### DIFF
--- a/.changes/next-release/Bug Fix-2010cfac-f717-490d-b47c-5e3521cb5714.json
+++ b/.changes/next-release/Bug Fix-2010cfac-f717-490d-b47c-5e3521cb5714.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix a not connected error when starting connection to CodeCatalyst Dev Environment from link"
+}

--- a/src/codecatalyst/auth.ts
+++ b/src/codecatalyst/auth.ts
@@ -23,6 +23,7 @@ import {
     isIdcSsoConnection,
 } from '../auth/connection'
 import { createBuilderIdConnection } from '../auth/utils'
+import { builderIdStartUrl } from '../auth/sso/model'
 
 // Secrets stored on the macOS keychain appear as individual entries for each key
 // This is fine so long as the user has only a few accounts. Otherwise this should
@@ -257,6 +258,19 @@ export class CodeCatalystAuthenticationProvider {
         }
 
         return this.secondaryAuth.useNewConnection(conn)
+    }
+
+    /**
+     * Try to ensure a specific connection is active.
+     */
+    public async tryConnectTo(connection: { startUrl: string; region: string }) {
+        if (!this.isConnectionValid() || connection.startUrl !== this.activeConnection!.startUrl) {
+            if (connection.startUrl === builderIdStartUrl) {
+                await this.connectToAwsBuilderId()
+            } else {
+                await this.connectToEnterpriseSso(connection.startUrl, connection.region)
+            }
+        }
     }
 
     public async isConnectionOnboarded(conn: SsoConnection, recheck = false) {

--- a/src/codecatalyst/model.ts
+++ b/src/codecatalyst/model.ts
@@ -252,13 +252,8 @@ export async function prepareDevEnvConnection(
 export async function openDevEnv(
     client: CodeCatalystClient,
     devenv: DevEnvironmentId,
-    targetPath?: string,
-    onBeforeConnect?: () => Promise<void>
+    targetPath?: string
 ): Promise<void> {
-    if (onBeforeConnect) {
-        await onBeforeConnect()
-    }
-
     const env = await prepareDevEnvConnection(client, devenv, { topic: 'connect' })
 
     if (!targetPath) {


### PR DESCRIPTION
## Problem:

When connecting to Dev Environment while not already authenticated locally, an error is displayed, which then requires manually working around the issue by entering startUrl through the main connect flow.

## Solution:

Based on the URI handler params, attempt to connect or switch connection.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
