### PR TITLE
fix: update e2e tests

### DIFF
--- a/src/test/setupUtil.ts
+++ b/src/test/setupUtil.ts
@@ -60,9 +60,9 @@ export function skipTest(testOrCtx: Mocha.Context | Mocha.Test | undefined, reas
     let test
 
     if (testOrCtx?.type === 'test') {
-        test = (testOrCtx as Mocha.Test)
+        test = testOrCtx as Mocha.Test
     } else {
-        const context = (testOrCtx as Mocha.Context | undefined)
+        const context = testOrCtx as Mocha.Context | undefined
         test = context?.currentTest ?? context?.test
     }
 
@@ -222,10 +222,17 @@ export function registerAuthHook(secret: string, lambdaId = process.env['AUTH_UT
 
             const openStub = patchObject(vscode.env, 'openExternal', async target => {
                 try {
+                    const url = new URL(target.toString(true))
+                    const userCode = url.searchParams.get('user_code')
+
+                    // TODO: Update this to just be the full URL if the authorizer lambda ever
+                    // supports the verification URI with user code embedded (VerificationUriComplete).
+                    const verificationUri = url.origin
+
                     await invokeLambda(lambdaId, {
                         secret,
-                        userCode: await vscode.env.clipboard.readText(),
-                        verificationUri: target.toString(),
+                        userCode,
+                        verificationUri,
                     })
                 } finally {
                     openStub.dispose()

--- a/src/test/setupUtil.ts
+++ b/src/test/setupUtil.ts
@@ -10,6 +10,7 @@ import { getLogger } from '../shared/logger'
 import { hasKey } from '../shared/utilities/tsUtils'
 import { getTestWindow, printPendingUiElements } from './shared/vscode/window'
 import { ToolkitError, formatError } from '../shared/errors'
+import { proceedToBrowser } from '../auth/sso/model'
 
 const runnableTimeout = Symbol('runnableTimeout')
 
@@ -56,8 +57,14 @@ export function setRunnableTimeout(test: Mocha.Runnable, maxTestDuration: number
 }
 
 export function skipTest(testOrCtx: Mocha.Context | Mocha.Test | undefined, reason?: string) {
-    const test =
-        testOrCtx?.type === 'test' ? (testOrCtx as Mocha.Test) : (testOrCtx as Mocha.Context | undefined)?.currentTest
+    let test
+
+    if (testOrCtx?.type === 'test') {
+        test = (testOrCtx as Mocha.Test)
+    } else {
+        const context = (testOrCtx as Mocha.Context | undefined)
+        test = context?.currentTest ?? context?.test
+    }
 
     if (test) {
         test.title += ` (skipped${reason ? ` - ${reason}` : ''})`
@@ -203,7 +210,7 @@ function maskArns(text: string) {
  */
 export function registerAuthHook(secret: string, lambdaId = process.env['AUTH_UTIL_LAMBDA_ARN']) {
     return getTestWindow().onDidShowMessage(message => {
-        if (message.items[0].title.match(/Copy Code/)) {
+        if (message.items[0].title.match(new RegExp(proceedToBrowser))) {
             if (!lambdaId) {
                 const baseMessage = 'Browser login flow was shown during testing without an authorizer function'
                 if (process.env['AWS_TOOLKIT_AUTOMATION'] === 'local') {

--- a/src/testE2E/codecatalyst/client.test.ts
+++ b/src/testE2E/codecatalyst/client.test.ts
@@ -86,7 +86,7 @@ let projectName: CodeCatalystProject['name']
  *     integ tests, but using the ssh hostname that we get from
  *     {@link prepareDevEnvConnection}.
  */
-describe.skip('Test how this codebase uses the CodeCatalyst API', function () {
+describe('Test how this codebase uses the CodeCatalyst API', function () {
     let client: CodeCatalystClient
     let commands: CodeCatalystCommands
     let webviewClient: CodeCatalystCreateWebview

--- a/src/testE2E/codecatalyst/client.test.ts
+++ b/src/testE2E/codecatalyst/client.test.ts
@@ -86,7 +86,7 @@ let projectName: CodeCatalystProject['name']
  *     integ tests, but using the ssh hostname that we get from
  *     {@link prepareDevEnvConnection}.
  */
-describe('Test how this codebase uses the CodeCatalyst API', function () {
+describe.skip('Test how this codebase uses the CodeCatalyst API', function () {
     let client: CodeCatalystClient
     let commands: CodeCatalystCommands
     let webviewClient: CodeCatalystCreateWebview


### PR DESCRIPTION
## Problem
E2E tests fail when not ran locally.

## Solution
- Update SSO login dialog regex to match latest.
- Update test util to accept 'test' propert of Mocha Context.
- Update data sent to lambda authorizer to match new SSO url dialog.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
