### PR TITLE
codewhisperer: do not skip closing paren handling at any condition

### DIFF
--- a/src/codewhisperer/commands/onInlineAcceptance.ts
+++ b/src/codewhisperer/commands/onInlineAcceptance.ts
@@ -82,10 +82,7 @@ export async function onInlineAcceptance(
          * Mitigation to right context handling mainly for auto closing bracket use case
          */
         try {
-            // Do not handle extra bracket if there is a right context merge
-            if (acceptanceEntry.recommendation === session.recommendations[acceptanceEntry.acceptIndex].content) {
-                await handleExtraBrackets(acceptanceEntry.editor, acceptanceEntry.recommendation, end, start)
-            }
+            await handleExtraBrackets(acceptanceEntry.editor, acceptanceEntry.recommendation, end, start)
             await ImportAdderProvider.instance.onAcceptRecommendation(
                 acceptanceEntry.editor,
                 session.recommendations[acceptanceEntry.acceptIndex],


### PR DESCRIPTION
In most of auto-suggestion scenario, the handling logic will be skipped.

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
