### PR TITLE
feat(codecatalyst): Use MDE endpoint set by environment variable

### DIFF
--- a/.changes/next-release/Feature-666cb5e9-eff1-41d9-bcf8-1d65cda2dd2c.json
+++ b/.changes/next-release/Feature-666cb5e9-eff1-41d9-bcf8-1d65cda2dd2c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Use MDE endpoint set by environment variable"
+}

--- a/src/shared/clients/devenvClient.ts
+++ b/src/shared/clients/devenvClient.ts
@@ -11,7 +11,7 @@ import { getCodeCatalystDevEnvId } from '../vscode/env'
 import { ExtensionUserActivity } from '../extensionUtilities'
 
 const environmentAuthToken = '__MDE_ENV_API_AUTHORIZATION_TOKEN'
-const environmentEndpoint = 'http://127.0.0.1:1339'
+const environmentEndpoint = process.env['__MDE_ENVIRONMENT_API'] ?? 'http://127.0.0.1:1339'
 
 /**
  * Client to the MDE quasi-IMDS localhost endpoint.


### PR DESCRIPTION
## Problem

MDE requires use of different endpoint in some VPC configurations.

## Solution

Allow MDE to pass different endpoint as environment variable. (Default to current behavior.)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
