### PR TITLE
fix(ci): improve prerelease changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
                   echo "tagname=$TAG_NAME" >> $GITHUB_OUTPUT
                   echo "version=$(grep -m 1 version package.json | grep -o '[0-9][^\"]\+' | sed 's/-SNAPSHOT//')" >> $GITHUB_OUTPUT
                   echo 'changes<<EOF' >> $GITHUB_OUTPUT
-                  head -14 CHANGELOG.md >> $GITHUB_OUTPUT
+                  cat CHANGELOG.md | perl -ne 'BEGIN{$/="\n\n"} print; exit if $. == 2' >> $GITHUB_OUTPUT
                   echo 'EOF' >> $GITHUB_OUTPUT
 
     publish:
@@ -83,6 +83,9 @@ jobs:
             FEAT_NAME: ${{ needs.package.outputs.feature }}
             TAG_NAME: ${{ needs.package.outputs.tagname }}
             AWS_TOOLKIT_VERSION: ${{ needs.package.outputs.version }}
+            # Used in release_notes.md
+            BRANCH: ${{ github.ref_name }}
+            # Used in release_notes.md
             AWS_TOOLKIT_CHANGES: ${{ needs.package.outputs.changes }}
         permissions:
             contents: write

--- a/.github/workflows/release_notes.md
+++ b/.github/workflows/release_notes.md
@@ -1,4 +1,4 @@
-_This is an **unsupported preview build** of AWS Toolkit, for testing new features._
+_This is an **unsupported preview build** of the `${BRANCH}` branch of AWS Toolkit._
 
 # Install
 
@@ -8,3 +8,7 @@ _This is an **unsupported preview build** of AWS Toolkit, for testing new featur
 # Changes
 
 ${AWS_TOOLKIT_CHANGES}
+
+## Previous changes
+
+-   See [CHANGELOG.md](CHANGELOG.md)


### PR DESCRIPTION
Problem:
The prerelease changelog might include items from the previous release,
or omit some items if the current changelog is very long.

Solution:
Use `perl` instead of `head` to get only the first section.

before:

    ## 1.99.0 2023-11-17

    - ...
    - ...

    ## 1.98.0 2023-11-09

    - ...

after:

    ## 1.99.0 2023-11-17

    - ...
    - ...