### PR TITLE
featureDev: Move streaming client to shared client

### DIFF
--- a/packages/core/src/codewhisperer/service/transformationResultsViewProvider.ts
+++ b/packages/core/src/codewhisperer/service/transformationResultsViewProvider.ts
@@ -12,7 +12,6 @@ import vscode from 'vscode'
 
 import { ExportIntent } from '@amzn/codewhisperer-streaming'
 import { TransformByQReviewStatus, transformByQState } from '../models/model'
-import { FeatureDevClient } from '../../amazonqFeatureDev/client/featureDev'
 import { ExportResultArchiveStructure, downloadExportResultArchive } from '../../shared/utilities/download'
 import { ToolkitError } from '../../shared/errors'
 import { getLogger } from '../../shared/logger'
@@ -21,6 +20,7 @@ import { codeTransformTelemetryState } from '../../amazonqGumby/telemetry/codeTr
 import { calculateTotalLatency } from '../../amazonqGumby/telemetry/codeTransformTelemetry'
 import { MetadataResult } from '../../shared/telemetry/telemetryClient'
 import * as CodeWhispererConstants from '../models/constants'
+import { createCodeWhispererChatStreamingClient } from '../../shared/clients/codewhispererChatClient'
 
 export abstract class ProposedChangeNode {
     abstract readonly resourcePath: string
@@ -257,10 +257,8 @@ export class ProposedTransformationExplorer {
     private changeViewer: vscode.TreeView<ProposedChangeNode>
 
     public static TmpDir = os.tmpdir()
-    private featureDevClient
 
     constructor(context: vscode.ExtensionContext) {
-        this.featureDevClient = new FeatureDevClient()
         const diffModel = new DiffModel()
         const transformDataProvider = new TransformationResultsProvider(diffModel)
         this.changeViewer = vscode.window.createTreeView(TransformationResultsProvider.viewType, {
@@ -309,7 +307,7 @@ export class ProposedTransformationExplorer {
                 transformByQState.getJobId(),
                 'ExportResultsArchive.zip'
             )
-            const cwStreamingClient = await this.featureDevClient.getStreamingClient()
+            const cwStreamingClient = await createCodeWhispererChatStreamingClient()
             try {
                 await downloadExportResultArchive(
                     cwStreamingClient,

--- a/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
+++ b/packages/core/src/codewhispererChat/clients/chat/v0/chat.ts
@@ -6,11 +6,10 @@
 import { GenerateAssistantResponseCommandOutput, GenerateAssistantResponseRequest } from '@amzn/codewhisperer-streaming'
 import * as vscode from 'vscode'
 import { ToolkitError } from '../../../../shared/errors'
-import { FeatureDevClient } from '../../../../amazonqFeatureDev/client/featureDev'
+import { createCodeWhispererChatStreamingClient } from '../../../../shared/clients/codewhispererChatClient'
 
 export class ChatSession {
     private sessionId?: string
-    private featureDevClient: FeatureDevClient
 
     public get sessionIdentifier(): string | undefined {
         return this.sessionId
@@ -19,7 +18,6 @@ export class ChatSession {
     public tokenSource!: vscode.CancellationTokenSource
 
     constructor() {
-        this.featureDevClient = new FeatureDevClient()
         this.createNewTokenSource()
     }
 
@@ -32,7 +30,7 @@ export class ChatSession {
     }
 
     async chat(chatRequest: GenerateAssistantResponseRequest): Promise<GenerateAssistantResponseCommandOutput> {
-        const client = await this.featureDevClient.getStreamingClient()
+        const client = await createCodeWhispererChatStreamingClient()
 
         if (this.sessionId !== undefined && chatRequest.conversationState !== undefined) {
             chatRequest.conversationState.conversationId = this.sessionId

--- a/packages/core/src/shared/clients/codewhispererChatClient.ts
+++ b/packages/core/src/shared/clients/codewhispererChatClient.ts
@@ -1,0 +1,23 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { CodeWhispererStreaming } from '@amzn/codewhisperer-streaming'
+import { ConfiguredRetryStrategy } from '@aws-sdk/util-retry'
+import { getCodewhispererConfig } from '../../codewhisperer/client/codewhisperer'
+import { AuthUtil } from '../../codewhisperer/util/authUtil'
+
+// Create a client for featureDev streaming based off of aws sdk v3
+export async function createCodeWhispererChatStreamingClient(): Promise<CodeWhispererStreaming> {
+    const bearerToken = await AuthUtil.instance.getBearerToken()
+    const cwsprConfig = getCodewhispererConfig()
+    const streamingClient = new CodeWhispererStreaming({
+        region: cwsprConfig.region,
+        endpoint: cwsprConfig.endpoint,
+        token: { token: bearerToken },
+        // SETTING max attempts to 0 FOR BETA. RE-ENABLE FOR RE-INVENT
+        // Implement exponential back off starting with a base of 500ms (500 + attempt^10)
+        retryStrategy: new ConfiguredRetryStrategy(0, (attempt: number) => 500 + attempt ** 10),
+    })
+    return streamingClient
+}


### PR DESCRIPTION
## Problem
- Other folders were piggybacking off the streaming client

## Solution
- Move to it src/clients so it's in a more central place

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
