### PR TITLE
fix(codewhisperer): remove hardcoded telemetry metric

### DIFF
--- a/src/codewhisperer/commands/startSecurityScan.ts
+++ b/src/codewhisperer/commands/startSecurityScan.ts
@@ -183,7 +183,7 @@ export async function startSecurityScan(
         codeScanTelemetryEntry.codewhispererCodeScanTotalIssues = total
         codeScanTelemetryEntry.codewhispererCodeScanIssuesWithFixes = withFixes
         throwIfCancelled()
-        getLogger().verbose(`Security scan totally found ${total} issues.`)
+        getLogger().verbose(`Security scan totally found ${total} issues. ${withFixes} of them have fixes.`)
         if (isCloud9()) {
             securityPanelViewProvider.addLines(securityRecommendationCollection, editor)
             vscode.commands.executeCommand('workbench.view.extension.aws-codewhisperer-security-panel')
@@ -235,8 +235,7 @@ export async function emitCodeScanTelemetry(editor: vscode.TextEditor, codeScanT
         )
         codeScanTelemetryEntry.codewhispererCodeScanProjectBytes = projectSize
     }
-    // TODO: should be removed. Added this to pass tests
-    telemetry.codewhisperer_securityScan.emit({ ...codeScanTelemetryEntry, codewhispererCodeScanIssuesWithFixes: 1 })
+    telemetry.codewhisperer_securityScan.emit(codeScanTelemetryEntry)
 }
 
 export function errorPromptHelper(error: Error) {

--- a/src/test/codewhisperer/commands/startSecurityScan.test.ts
+++ b/src/test/codewhisperer/commands/startSecurityScan.test.ts
@@ -14,7 +14,7 @@ import { FakeExtensionContext } from '../../fakeExtensionContext'
 import * as diagnosticsProvider from '../../../codewhisperer/service/diagnosticsProvider'
 import { getTestWorkspaceFolder } from '../../../testInteg/integrationTestsUtilities'
 import { join } from 'path'
-import { closeAllEditors } from '../../testUtil'
+import { assertTelemetry, closeAllEditors } from '../../testUtil'
 import { stub } from '../../utilities/stubber'
 import { HttpResponse } from 'aws-sdk'
 import { getTestWindow } from '../../shared/vscode/window'
@@ -27,6 +27,7 @@ import {
     stopScanMessage,
 } from '../../../codewhisperer/models/constants'
 import * as model from '../../../codewhisperer/models/model'
+import { CodewhispererSecurityScan } from '../../../shared/telemetry/telemetry.gen'
 
 const mockCreateCodeScanResponse = {
     $response: {
@@ -265,5 +266,13 @@ describe('startSecurityScan', function () {
             extensionContext
         )
         assert.ok(commandSpy.calledWith(codeScanLogsOutputChannelId))
+        assertTelemetry('codewhisperer_securityScan', {
+            codewhispererLanguage: 'python',
+            codewhispererCodeScanTotalIssues: 1,
+            codewhispererCodeScanIssuesWithFixes: 0,
+            codewhispererCodeScanLines: 188,
+            codewhispererCodeScanSrcPayloadBytes: 5675,
+            codewhispererCodeScanSrcZipFileBytes: 4455,
+        } as CodewhispererSecurityScan)
     })
 })

--- a/src/test/codewhisperer/commands/startSecurityScan.test.ts
+++ b/src/test/codewhisperer/commands/startSecurityScan.test.ts
@@ -271,8 +271,6 @@ describe('startSecurityScan', function () {
             codewhispererCodeScanTotalIssues: 1,
             codewhispererCodeScanIssuesWithFixes: 0,
             codewhispererCodeScanLines: 188,
-            codewhispererCodeScanSrcPayloadBytes: 5675,
-            codewhispererCodeScanSrcZipFileBytes: 4455,
         } as CodewhispererSecurityScan)
     })
 })


### PR DESCRIPTION
## Problem

This was added previously to fix build errors and is misreporting the number of issues with fixes.

## Solution

Remove the hardcoded value assignment.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
