### PR TITLE
featureDev: Simplify use of the messenger

### DIFF
--- a/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -165,8 +165,7 @@ export class FeatureDevController {
         } catch (err: any) {
             if (err instanceof ContentLengthError) {
                 messenger.sendErrorMessage(err.message, this.retriesRemaining(session))
-                messenger.sendAnswer({
-                    type: 'system-prompt',
+                messenger.sendSystemPrompt({
                     followUps: [
                         {
                             pillText: 'Select files for context',
@@ -196,7 +195,6 @@ export class FeatureDevController {
         const messenger = this.messengerFactory(tabID)
 
         messenger.sendAnswer({
-            type: 'answer',
             message: 'Ok, let me create a plan. This may take a few minutes.',
         })
 
@@ -208,15 +206,13 @@ export class FeatureDevController {
         messenger.sendUpdatePlaceholder('Add more detail to iterate on the implementation plan')
 
         // Resolve the "..." with the content
-        messenger.sendAnswer({
+        messenger.sendAnswerPart({
             message: interactions.content,
-            type: 'answer-part',
             canBeVoted: true,
         })
 
-        // Follow up with action items and complete the request stream
-        messenger.sendAnswer({
-            type: 'system-prompt', // show the followups on the right side
+        // Follow up with action items on right side and complete the request stream
+        messenger.sendSystemPrompt({
             followUps: this.getFollowUpOptions(session.state.phase),
         })
 
@@ -290,11 +286,9 @@ export class FeatureDevController {
 
         if (uri instanceof vscode.Uri && !vscode.workspace.getWorkspaceFolder(uri)) {
             messenger.sendAnswer({
-                type: 'answer',
                 message: new SelectedFolderNotInWorkspaceFolderError().message,
             })
-            messenger.sendAnswer({
-                type: 'system-prompt',
+            messenger.sendSystemPrompt({
                 followUps: [
                     {
                         pillText: 'Select files for context',
@@ -310,7 +304,6 @@ export class FeatureDevController {
             session.config.sourceRoot = uri.fsPath
             messenger.sendAnswer({
                 message: `Changed source root to: ${session.config.sourceRoot}`,
-                type: 'answer',
             })
         }
     }
@@ -326,7 +319,6 @@ To learn more, visit the _[Amazon Q User Guide](${userGuideURL})_.
         const messenger = this.messengerFactory(message.tabID)
 
         messenger.sendAnswer({
-            type: 'answer',
             message: examples,
         })
     }
@@ -397,7 +389,6 @@ To learn more, visit the _[Amazon Q User Guide](${userGuideURL})_.
         const messenger = this.messengerFactory(message.tabID)
 
         messenger.sendAnswer({
-            type: 'answer',
             message: 'Follow instructions to re-authenticate ...',
         })
 
@@ -427,7 +418,6 @@ To learn more, visit the _[Amazon Q User Guide](${userGuideURL})_.
         const messenger = this.messengerFactory(message.tabID)
 
         messenger.sendAnswer({
-            type: 'answer',
             message: 'What change would you like to discuss?',
         })
         messenger.sendUpdatePlaceholder('Briefly describe a task or issue')

--- a/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
+++ b/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
@@ -29,9 +29,33 @@ export function createMessengerFactory(publisher: MessagePublisher<any>): Messen
 export class Messenger {
     public constructor(private readonly dispatcher: AppToWebViewMessageDispatcher, private readonly tabID: string) {}
 
-    public sendAnswer(params: {
+    // For sending a generic message/resolving answer streams
+    public sendAnswer(params: { message?: string; followUps?: ChatItemFollowUp[]; canBeVoted?: boolean }) {
+        this.sendChatMessage({
+            type: 'answer',
+            ...params,
+        })
+    }
+
+    // For resolving an open answer stream with content
+    public sendAnswerPart(params: { message?: string; followUps?: ChatItemFollowUp[]; canBeVoted?: boolean }) {
+        this.sendChatMessage({
+            type: 'answer-part',
+            ...params,
+        })
+    }
+
+    // For showing information on the right side
+    public sendSystemPrompt(params: { message?: string; followUps?: ChatItemFollowUp[]; canBeVoted?: boolean }) {
+        this.sendChatMessage({
+            type: 'system-prompt',
+            ...params,
+        })
+    }
+
+    private sendChatMessage(params: {
         message?: string
-        type: 'answer' | 'answer-part' | 'answer-stream' | 'system-prompt'
+        type: 'answer' | 'answer-part' | 'system-prompt'
         followUps?: ChatItemFollowUp[]
         canBeVoted?: boolean
     }) {
@@ -58,9 +82,8 @@ export class Messenger {
                     this.tabID
                 )
             )
-            this.sendAnswer({
+            this.sendSystemPrompt({
                 message: undefined,
-                type: 'system-prompt',
                 followUps: [
                     {
                         pillText: 'Send feedback',
@@ -94,9 +117,8 @@ export class Messenger {
                 break
         }
 
-        this.sendAnswer({
+        this.sendSystemPrompt({
             message: undefined,
-            type: 'system-prompt',
             followUps: [
                 {
                     pillText: 'Retry',

--- a/src/amazonqFeatureDev/session/session.ts
+++ b/src/amazonqFeatureDev/session/session.ts
@@ -47,7 +47,7 @@ export class Session {
 
             telemetry.amazonq_startChat.emit({ amazonqConversationId: this.conversationId, value: 1 })
 
-            this.messenger.sendAsyncEventProgress(this.tabID, true, undefined)
+            this.messenger.sendAsyncEventProgress(true, undefined)
         }
     }
 
@@ -99,7 +99,6 @@ export class Session {
             files,
             task: this.task,
             msg,
-            messenger: this.messenger,
             telemetry: this.telemetry,
         })
 

--- a/src/amazonqFeatureDev/storages/chatSession.ts
+++ b/src/amazonqFeatureDev/storages/chatSession.ts
@@ -3,18 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Messenger } from '../controllers/chat/messenger/messenger'
+import { MessengerFactory } from '../controllers/chat/messenger/messenger'
 import { Session } from '../session/session'
 import { createSessionConfig } from '../session/sessionConfigFactory'
 
 export class ChatSessionStorage {
     private sessions: Map<string, Session> = new Map()
 
-    constructor(private readonly messenger: Messenger) {}
+    constructor(private readonly messengerFactory: MessengerFactory) {}
 
     private async createSession(tabID: string): Promise<Session> {
         const sessionConfig = await createSessionConfig()
-        const session = new Session(sessionConfig, this.messenger, tabID)
+        const messenger = this.messengerFactory(tabID)
+        const session = new Session(sessionConfig, messenger, tabID)
         this.sessions.set(tabID, session)
         return session
     }

--- a/src/amazonqFeatureDev/types.ts
+++ b/src/amazonqFeatureDev/types.ts
@@ -5,7 +5,6 @@
 
 import * as vscode from 'vscode'
 import type { CancellationTokenSource } from 'vscode'
-import { Messenger } from './controllers/chat/messenger/messenger'
 import { FeatureDevClient } from './client/featureDev'
 import { featureDevScheme } from './constants'
 import { TelemetryHelper } from './util/telemetryHelper'
@@ -54,7 +53,6 @@ export interface SessionStateAction {
     task: string
     files: any[] // TODO: remove any
     msg: string
-    messenger: Messenger
     telemetry: TelemetryHelper
 }
 

--- a/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
+++ b/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
@@ -144,19 +144,18 @@ describe('Controller', () => {
                 messengerFactory: sinon.stub().returns(messenger),
             })
             sinon.stub(vscode.workspace, 'getWorkspaceFolder').returns(undefined)
-            const messengerSpy = sinon.spy(messenger, 'sendAnswer')
+            const answerSpy = sinon.spy(messenger, 'sendAnswer')
+            const systemPromptSpy = sinon.spy(messenger, 'sendSystemPrompt')
 
             await modifyDefaultSourceFolder(controllerSetup.emitters, controllerSetup.session, '../../')
             assert.deepStrictEqual(
-                messengerSpy.calledWith({
-                    type: 'answer',
+                answerSpy.calledWith({
                     message: new SelectedFolderNotInWorkspaceFolderError().message,
                 }),
                 true
             )
             assert.deepStrictEqual(
-                messengerSpy.calledWith({
-                    type: 'system-prompt',
+                systemPromptSpy.calledWith({
                     followUps: sinon.match.any,
                 }),
                 true

--- a/src/test/amazonqFeatureDev/session/sessionState.test.ts
+++ b/src/test/amazonqFeatureDev/session/sessionState.test.ts
@@ -8,9 +8,6 @@ import assert from 'assert'
 import sinon from 'sinon'
 import { RefinementState, PrepareRefinementState } from '../../../amazonqFeatureDev/session/sessionState'
 import { SessionStateConfig, SessionStateAction } from '../../../amazonqFeatureDev/types'
-import { Messenger } from '../../../amazonqFeatureDev/controllers/chat/messenger/messenger'
-import { AppToWebViewMessageDispatcher } from '../../../amazonqFeatureDev/views/connector/connector'
-import { MessagePublisher } from '../../../amazonq/messages/messagePublisher'
 import { FeatureDevClient } from '../../../amazonqFeatureDev/client/featureDev'
 import { PrepareRepoFailedError } from '../../../amazonqFeatureDev/errors'
 import { TelemetryHelper } from '../../../amazonqFeatureDev/util/telemetryHelper'
@@ -20,9 +17,6 @@ const mockSessionStateAction = (msg?: string): SessionStateAction => {
         task: 'test-task',
         msg: msg ?? 'test-msg',
         files: [],
-        messenger: new Messenger(
-            new AppToWebViewMessageDispatcher(new MessagePublisher<any>(new vscode.EventEmitter<any>()))
-        ),
         telemetry: new TelemetryHelper(),
     }
 }


### PR DESCRIPTION
## Problem
- We currently pass a single messenger around and have to call with it a tabID every time which can be error prone

## Solution
- Allow a messenger factory to take in a tab id and send events directly to it

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
