### PR TITLE
fix(codecatalyst): "No handler found" error

### DIFF
--- a/.changes/next-release/Bug Fix-5caa0d38-8b96-437c-9710-3b288794d9ab.json
+++ b/.changes/next-release/Bug Fix-5caa0d38-8b96-437c-9710-3b288794d9ab.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeCatalyst: \"No handler found\" error may occur when opening `vscode://` URI #4105"
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "qna": "https://github.com/aws/aws-toolkit-vscode/issues",
     "activationEvents": [
         "onStartupFinished",
+        "onUri",
         "onDebugResolve:aws-sam",
         "onView:aws.codeWhisperer.securityPanel",
         "onDebugInitialConfigurations",

--- a/src/codecatalyst/uriHandlers.ts
+++ b/src/codecatalyst/uriHandlers.ts
@@ -43,9 +43,9 @@ export function register(
     }
 
     return vscode.Disposable.from(
-        handler.registerHandler('/clone', cloneHandler, parseCloneParams),
-        handler.registerHandler('/connect/codecatalyst', connectHandler, parseConnectParams),
-        handler.registerHandler('/connect/caws', connectHandler, parseConnectParamsOld) // FIXME: remove this before GA
+        handler.onPath('/clone', cloneHandler, parseCloneParams),
+        handler.onPath('/connect/codecatalyst', connectHandler, parseConnectParams),
+        handler.onPath('/connect/caws', connectHandler, parseConnectParamsOld) // FIXME: remove this before GA
     )
 }
 

--- a/src/shared/vscode/uriHandler.ts
+++ b/src/shared/vscode/uriHandler.ts
@@ -22,23 +22,24 @@ interface HandlerWithParser<T> {
     parser?: QueryParser<T>
 }
 
+/**
+ * Note: https://code.visualstudio.com/api/references/vscode-api#window.registerUriHandler
+ * > An extension can only register a single uri handler in its entire activation lifetime.
+ */
 export class UriHandler implements vscode.UriHandler {
     public constructor() {}
 
     private handlers: Map<string, HandlerWithParser<any>> = new Map()
 
     public async handleUri(uri: vscode.Uri): Promise<void> {
-        getLogger().verbose(`UriHandler: received request on path "${uri.path}"`)
-
         const uriNoQuery = uri.with({ query: '' }).toString()
 
         if (!this.handlers.has(uri.path)) {
-            vscode.window.showErrorMessage(
-                localize('AWS.uriHandler.nohandler', 'No handler found for: {0}', uriNoQuery)
-            )
-            getLogger().verbose(`UriHandler: no valid handler found for "${uri.path}"`)
+            showViewLogsMessage(localize('AWS.uriHandler.nohandler', 'No handler for URI: {0}', uriNoQuery))
+            getLogger().warn('UriHandler: no handler for path "%s" in handlers: %O', uri.path, this.handlers)
             return
         }
+        getLogger().verbose('UriHandler: found handler for path "%s"', uri.path)
 
         const { handler, parser } = this.handlers.get(uri.path)!
         let parsedQuery: Parameters<typeof handler>[0]
@@ -74,16 +75,17 @@ export class UriHandler implements vscode.UriHandler {
     }
 
     /**
-     * Registers a new handler for external URIs targeting the extension.
+     * Adds a "path handler" for `vscode://amazonwebservices.aws-toolkit-vscode/<path>` URIs.
      *
-     * @param path Target 'path', e.g. '/foo/bar'
-     * @param handler Callback fired when the extension receives a URI that matches the path
+     *
+     * @param path Target path, e.g. "/foo/bar" handles URI: `vscode://amazonwebservices.aws-toolkit-vscode/foo/bar`.
+     * @param handler Callback fired when the extension receives a URI that matches `path`.
      * @param parser Optional callback to parse the URI parameters prior to calling the handler
      *
      * @returns A disposable to remove the handler
      * @throws When a handler has already been registered
      */
-    public registerHandler<U extends T, T = URLSearchParams>(
+    public onPath<U extends T, T = URLSearchParams>(
         path: string,
         handler: PathHandler<U>,
         parser?: QueryParser<T>

--- a/src/test/codecatalyst/uriHandlers.test.ts
+++ b/src/test/codecatalyst/uriHandlers.test.ts
@@ -61,7 +61,7 @@ describe('CodeCatalyst handlers', function () {
 
     describe('clone', function () {
         it('registers for "/clone"', function () {
-            assert.throws(() => handler.registerHandler('/clone', () => {}))
+            assert.throws(() => handler.onPath('/clone', () => {}))
         })
 
         it('ignores requests without a url', async function () {

--- a/src/test/shared/vscode/uriHandler.test.ts
+++ b/src/test/shared/vscode/uriHandler.test.ts
@@ -20,12 +20,12 @@ describe('UriHandler', function () {
     })
 
     it('can register a handler', async function () {
-        uriHandler.registerHandler(testPath, q => assert.strictEqual(q.get('key'), 'value'))
+        uriHandler.onPath(testPath, q => assert.strictEqual(q.get('key'), 'value'))
         return uriHandler.handleUri(makeUri('key=value'))
     })
 
     it('uses parser if available', async function () {
-        uriHandler.registerHandler(
+        uriHandler.onPath(
             testPath,
             q => assert.strictEqual(q.myNumber, 123),
             (q: SearchParams) => ({ myNumber: Number(q.get('myString')) })
@@ -34,20 +34,20 @@ describe('UriHandler', function () {
     })
 
     it('can handle lists', async function () {
-        uriHandler.registerHandler(testPath, q => assert.deepStrictEqual(q.get('list'), ['1', '2', '3']))
+        uriHandler.onPath(testPath, q => assert.deepStrictEqual(q.get('list'), ['1', '2', '3']))
         return uriHandler.handleUri(makeUri('list=1&list=2&list=3'))
     })
 
     it('can dispose handlers', async function () {
         return new Promise((resolve, reject) => {
-            uriHandler.registerHandler(testPath, () => reject(new Error('this should not be called'))).dispose()
+            uriHandler.onPath(testPath, () => reject(new Error('this should not be called'))).dispose()
             uriHandler.handleUri(makeUri()).then(resolve)
         })
     })
 
     it('throws when registering handler for same path', function () {
-        uriHandler.registerHandler(testPath, () => {})
-        assert.throws(() => uriHandler.registerHandler(testPath, () => {}))
+        uriHandler.onPath(testPath, () => {})
+        assert.throws(() => uriHandler.onPath(testPath, () => {}))
     })
 
     it('catches errors thrown by the parser', async function () {
@@ -58,7 +58,7 @@ describe('UriHandler', function () {
             throw new Error()
         }
 
-        uriHandler.registerHandler(testPath, handler, parser)
+        uriHandler.onPath(testPath, handler, parser)
         await assert.doesNotReject(uriHandler.handleUri(makeUri('key=value')))
     })
 
@@ -67,7 +67,7 @@ describe('UriHandler', function () {
             throw new Error()
         }
 
-        uriHandler.registerHandler(testPath, handler)
+        uriHandler.onPath(testPath, handler)
         return assert.doesNotReject(uriHandler.handleUri(makeUri()))
     })
 })


### PR DESCRIPTION
Problem:
vscode may invoke our URI handler during startup, before Toolkit activation has finished (and thus before all Toolkit services have registered their path handlers). #4105

    No handler found for: vscode://.../connect/codecatalyst URI

Solution:
- Do not call `vscode.window.registerUriHandler()` until after all Toolkit services have activated.
- Add "onUri" to package.json "activationEvents". It wasn't the root cause of the above issue, but it should be specified anyway. https://code.visualstudio.com/api/references/activation-events#onUri
- Improve visibility via logging.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
