### PR TITLE
fix: Toolkit submenus are added to other extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1407,12 +1407,12 @@
                 },
                 {
                     "submenu": "aws.submenu.feedback",
-                    "when": "view != aws.AmazonQChatView",
+                    "when": "view =~ /^aws\\./ && view != aws.AmazonQChatView",
                     "group": "y_toolkitMeta@1"
                 },
                 {
                     "submenu": "aws.submenu.help",
-                    "when": "view != aws.AmazonQChatView",
+                    "when": "view =~ /^aws\\./ && view != aws.AmazonQChatView",
                     "group": "y_toolkitMeta@2"
                 },
                 {


### PR DESCRIPTION
Problem:
The "Feedback" and "Help" submenus are added to all views for all extensions. These should only be added to AWS Toolkit views. #4111

Solution:
Constrain the "when" clause.

ref ac76d9c82c22aef414373c7825760ed310cf9e78


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
