### PR TITLE
codewhisperer: remove build requirement

### DIFF
--- a/.changes/next-release/Bug Fix-d086954c-0bde-4ab8-9d07-7eac324faaf8.json
+++ b/.changes/next-release/Bug Fix-d086954c-0bde-4ab8-9d07-7eac324faaf8.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeWhisperer: Security scans for Java no longer require build artifacts"
+}

--- a/src/test/codewhisperer/util/dependencyGraph/javaDependencyGraph.test.ts
+++ b/src/test/codewhisperer/util/dependencyGraph/javaDependencyGraph.test.ts
@@ -59,21 +59,36 @@ describe('javaDependencyGraph', function () {
     })
 
     describe('generateTruncation', function () {
+        let javaDependencyGraph: JavaDependencyGraph
         beforeEach(function () {
-            sinon.stub(JavaDependencyGraph.prototype, <any>'generateBuildFilePaths').returns([appCodePath])
+            javaDependencyGraph = new JavaDependencyGraph(languageId)
         })
         afterEach(function () {
             sinon.restore()
         })
         it('Should generate and return expected truncation', async function () {
-            const javaDependencyGraph = new JavaDependencyGraph(languageId)
-            sinon.stub(javaDependencyGraph, <any>'_outputDirs').value(new Set<string>('build'))
+            sinon.stub(JavaDependencyGraph.prototype, <any>'generateBuildFilePaths').returns([appCodePath])
+            sinon.stub(javaDependencyGraph, <any>'_outputDirs').value(new Set<string>(['build']))
             const truncation = await javaDependencyGraph.generateTruncation(vscode.Uri.parse(appCodePath))
             assert.ok(truncation.lines > 0)
             assert.ok(truncation.rootDir.includes(CodeWhispererConstants.codeScanTruncDirPrefix))
             assert.ok(truncation.srcPayloadSizeInBytes > 0)
             assert.ok(truncation.scannedFiles.size > 0)
             assert.ok(truncation.zipFilePath.includes(CodeWhispererConstants.codeScanTruncDirPrefix))
+        })
+        it('should not throw error if java compilation output path is not set', async () => {
+            sinon.stub(JavaDependencyGraph.prototype, <any>'generateBuildFilePaths').returns([appCodePath])
+            sinon.stub(javaDependencyGraph, <any>'_outputDirs').value(new Set<string>([]))
+            await assert.doesNotReject(async () => {
+                await javaDependencyGraph.generateTruncation(vscode.Uri.parse(appCodePath))
+            })
+        })
+        it('should not throw error no build files are found', async () => {
+            sinon.stub(JavaDependencyGraph.prototype, <any>'generateBuildFilePaths').returns([])
+            sinon.stub(javaDependencyGraph, <any>'_outputDirs').value(new Set<string>(['build']))
+            await assert.doesNotReject(async () => {
+                await javaDependencyGraph.generateTruncation(vscode.Uri.parse(appCodePath))
+            })
         })
     })
 


### PR DESCRIPTION
## Problem

Security scans for Java code throws an error if its not compiled. This requirement should be removed since most detectors don't require compiled code to run a scan. 

## Solution

- Don't throw an error if compilation output path is not set
- Don't throw an error if build files are not found
- If build files are found, still include them in the zip file

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
