### PR TITLE
fix(transform): check for pom.xml in root dir only

### DIFF
--- a/.changes/next-release/Breaking Change-d11aa2b2-96e2-46f7-9a06-5fceab6299ec.json
+++ b/.changes/next-release/Breaking Change-d11aa2b2-96e2-46f7-9a06-5fceab6299ec.json
@@ -1,0 +1,4 @@
+{
+	"type": "Breaking Change",
+	"description": "validate that pom.xml is in root directory of project, not anywhere in project"
+}

--- a/src/codewhisperer/service/transformByQHandler.ts
+++ b/src/codewhisperer/service/transformByQHandler.ts
@@ -109,7 +109,7 @@ export async function validateProjectSelection(project: vscode.QuickPickItem) {
         throw new ToolkitError('Project selected is not Java 8 or Java 11', { code: 'UnsupportedJavaVersion' })
     }
     const buildFile = await vscode.workspace.findFiles(
-        new vscode.RelativePattern(projectPath!, '**/pom.xml'),
+        new vscode.RelativePattern(projectPath!, 'pom.xml'),
         '**/node_modules/**',
         1
     )

--- a/src/codewhisperer/service/transformByQHandler.ts
+++ b/src/codewhisperer/service/transformByQHandler.ts
@@ -109,7 +109,7 @@ export async function validateProjectSelection(project: vscode.QuickPickItem) {
         throw new ToolkitError('Project selected is not Java 8 or Java 11', { code: 'UnsupportedJavaVersion' })
     }
     const buildFile = await vscode.workspace.findFiles(
-        new vscode.RelativePattern(projectPath!, 'pom.xml'),
+        new vscode.RelativePattern(projectPath!, 'pom.xml'), // check for pom.xml in root dir only
         '**/node_modules/**',
         1
     )

--- a/src/codewhisperer/service/transformByQHandler.ts
+++ b/src/codewhisperer/service/transformByQHandler.ts
@@ -109,7 +109,7 @@ export async function validateProjectSelection(project: vscode.QuickPickItem) {
         throw new ToolkitError('Project selected is not Java 8 or Java 11', { code: 'UnsupportedJavaVersion' })
     }
     const buildFile = await vscode.workspace.findFiles(
-        new vscode.RelativePattern(projectPath!, 'pom.xml'), // check for pom.xml in root dir only
+        new vscode.RelativePattern(projectPath!, 'pom.xml'), // check for pom.xml in root directory only
         '**/node_modules/**',
         1
     )


### PR DESCRIPTION
## Problem

We want to make sure users cannot submit a project unless a pom.xml is present in the root directory, not anywhere in the project.

## Solution

Enforce that pom.xml is in root directory specifically.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
