### PR TITLE
refactor: remove yaml dependency, use js-yaml instead.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,6 @@
                 "winston": "^3.7.1",
                 "winston-transport": "^4.5.0",
                 "xml2js": "^0.6.0",
-                "yaml": "^1.9.2",
                 "yaml-cfn": "^0.3.2"
             },
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4397,7 +4397,6 @@
         "winston": "^3.7.1",
         "winston-transport": "^4.5.0",
         "xml2js": "^0.6.0",
-        "yaml": "^1.9.2",
         "yaml-cfn": "^0.3.2"
     },
     "prettier": {

--- a/src/ssmDocument/commands/createDocumentFromTemplate.ts
+++ b/src/ssmDocument/commands/createDocumentFromTemplate.ts
@@ -8,7 +8,7 @@ const localize = nls.loadMessageBundle()
 
 import * as path from 'path'
 import * as vscode from 'vscode'
-import * as YAML from 'yaml'
+import * as yaml from 'js-yaml'
 import { getLogger, Logger } from '../../shared/logger'
 import * as picker from '../../shared/ui/picker'
 import { promptUserForDocumentFormat } from '../util/util'
@@ -114,9 +114,9 @@ export async function createSsmDocumentFromTemplate(extensionContext: vscode.Ext
     }
 }
 
-function yamlToJson(yaml: string): string {
-    const jsonObject = YAML.parse(yaml)
-    return JSON.stringify(jsonObject, undefined, '\t')
+function yamlToJson(yamlStr: string): string {
+    const jsonObject = yaml.load(yamlStr, { schema: yaml.JSON_SCHEMA })
+    return JSON.stringify(jsonObject, undefined, 4)
 }
 
 async function openTextDocumentFromSelection(

--- a/src/test/ssmDocument/commands/createDocumentFromTemplate.test.ts
+++ b/src/test/ssmDocument/commands/createDocumentFromTemplate.test.ts
@@ -14,7 +14,6 @@ import {
 import * as ssmDocumentUtil from '../../../ssmDocument/util/util'
 import * as fsUtilities from '../../../shared/filesystemUtilities'
 
-import YAML from 'yaml'
 import { FakeExtensionContext } from '../../fakeExtensionContext'
 
 describe('createDocumentFromTemplate', async function () {
@@ -31,10 +30,15 @@ describe('createDocumentFromTemplate', async function () {
         sandbox.restore()
     })
 
-    const fakeContent = `{
-        "schemaVersion": "2.2",
-        "mainSteps": []
-    }`
+    const fakeContentYaml = `---
+schemaVersion: '2.2'
+mainSteps: []
+`
+
+    const fakeContentJson = `{
+    "schemaVersion": "2.2",
+    "mainSteps": []
+}`
 
     const fakeSelectionResult: SsmDocumentTemplateQuickPickItem = {
         label: 'test template',
@@ -49,16 +53,14 @@ describe('createDocumentFromTemplate', async function () {
     it('open and save document based on selected template', async function () {
         sandbox.stub(picker, 'promptUser').returns(Promise.resolve(fakeSelection))
         sandbox.stub(picker, 'verifySinglePickerOutput').returns(fakeSelectionResult)
-        sandbox.stub(fsUtilities, 'readFileAsString').returns(Promise.resolve(fakeContent))
+        sandbox.stub(fsUtilities, 'readFileAsString').returns(Promise.resolve(fakeContentYaml))
         sandbox.stub(ssmDocumentUtil, 'promptUserForDocumentFormat').returns(Promise.resolve('JSON'))
-        sandbox.stub(JSON, 'stringify').returns(fakeContent)
-        sandbox.stub(YAML, 'stringify').returns(fakeContent)
 
         const openTextDocumentStub = sandbox.stub(vscode.workspace, 'openTextDocument')
 
         await createSsmDocumentFromTemplate(mockContext)
 
-        assert.strictEqual(openTextDocumentStub.getCall(0).args[0]?.content, fakeContent)
+        assert.strictEqual(openTextDocumentStub.getCall(0).args[0]?.content, fakeContentJson)
         assert.strictEqual(openTextDocumentStub.getCall(0).args[0]?.language, 'ssm-json')
     })
 })

--- a/src/test/stepFunctions/commands/visualizeStateMachine.test.ts
+++ b/src/test/stepFunctions/commands/visualizeStateMachine.test.ts
@@ -222,7 +222,29 @@ describe('StepFunctions VisualizeStateMachine', async function () {
             command: 'update',
             stateMachineData: mockDataJson,
             isValid: true,
-            errors: [],
+        }
+
+        assert.ok(postMessage.calledOnce)
+        assert.deepEqual(postMessage.firstCall.args, [message])
+    })
+
+    it('Test AslVisualisation sendUpdateMessage posts a correct update message for invalid YAML files', async function () {
+        const yamlDoc = await getDocument(mockDataYaml.replace('StartAt:', ']StartAt:'), YAML_ASL)
+        const postMessage = sinon.spy()
+        class MockAslVisualizationYaml extends AslVisualization {
+            public override getWebview(): vscode.Webview | undefined {
+                return { postMessage } as unknown as vscode.Webview
+            }
+        }
+
+        const visualisation = new MockAslVisualizationYaml(yamlDoc)
+
+        await visualisation.sendUpdateMessage(yamlDoc)
+
+        const message = {
+            command: 'update',
+            stateMachineData: undefined,
+            isValid: false,
         }
 
         assert.ok(postMessage.calledOnce)
@@ -246,7 +268,6 @@ describe('StepFunctions VisualizeStateMachine', async function () {
             command: 'update',
             stateMachineData: mockDataJson,
             isValid: true,
-            errors: [],
         }
 
         assert.ok(postMessage.calledOnce)


### PR DESCRIPTION
Problem: 'yaml' is outdated and requires human intervention to migrate to V2. It is only used in a few places in the codebase, whereas everywhere else, a similar yaml parser js-yaml is used.

Solution: remove usage of 'yaml' and only use 'js-yaml', as it has some features that we need (ability to write out to a string and skip invalid JSON entries, which 'yaml' does not seem to offer). We do not require all the features of 'yaml' at this time. Also, remove "errors" field from the state machines parser -> webview message. It is not used by anything and was only accessible with 'yaml'.

In one case of 'yaml', we used the 'maxAliasCount' option to prevent users from submitting state machines with aliases in them. Aliases do not prevent publishing normally to step functions if used normally; I believe it is to prevent the user from breaking the toolkit by exponentially copying anchors/aliases in the yaml. This does not affect publishing (it will fail as it is supposed to if the defintion is too large), and slightly slows down toolkit usage while the parse is happening. This validation is not necessary because this sort of behavior would be very specific and intentional from the user, and in my testing still causes slow downs and errors due to the logic centered around how the validation option was used.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
