### PR TITLE
fix: help > open logs may not work after interacting with other options

### DIFF
--- a/.changes/next-release/Bug Fix-402cf60e-4ce2-4886-9133-b77af3b6f42b.json
+++ b/.changes/next-release/Bug Fix-402cf60e-4ce2-4886-9133-b77af3b6f42b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Help > View Toolkit Logs opens an empty file if other menu items were interacted with first."
+}

--- a/src/shared/logger/commands.ts
+++ b/src/shared/logger/commands.ts
@@ -28,18 +28,16 @@ export class Logging {
         viewLogsAtMessage: Commands.from(this).declareOpenLogId('aws.viewLogsAtMessage'),
     }
 
-    public constructor(private readonly defaultLogUri: vscode.Uri, private readonly logger: Logger) {}
+    public constructor(private readonly logUri: vscode.Uri, private readonly logger: Logger) {}
 
-    public async openLogUri(logUri?: unknown): Promise<vscode.TextEditor | undefined> {
-        telemetry.toolkit_viewLogs.emit() // Perhaps add additional argument to know which log was viewed?
-
-        // If the command is called directly from a package.json menu item, then logUri may be a vscode-provided object, typically a TreeNode.
-        return vscode.window.showTextDocument(logUri instanceof vscode.Uri ? logUri : this.defaultLogUri)
+    public async openLogUri(): Promise<vscode.TextEditor | undefined> {
+        telemetry.toolkit_viewLogs.emit()
+        return vscode.window.showTextDocument(this.logUri)
     }
 
-    public async openLogId(logId: number, logUri = this.defaultLogUri) {
-        const msg = this.logger.getLogById(logId, logUri)
-        const editor = await this.openLogUri(logUri)
+    public async openLogId(logId: number) {
+        const msg = this.logger.getLogById(logId, this.logUri)
+        const editor = await this.openLogUri()
         if (!msg || !editor) {
             return
         }

--- a/src/shared/logger/commands.ts
+++ b/src/shared/logger/commands.ts
@@ -30,14 +30,11 @@ export class Logging {
 
     public constructor(private readonly defaultLogUri: vscode.Uri, private readonly logger: Logger) {}
 
-    public async openLogUri(logUri?: vscode.Uri | unknown): Promise<vscode.TextEditor | undefined> {
+    public async openLogUri(logUri?: unknown): Promise<vscode.TextEditor | undefined> {
         telemetry.toolkit_viewLogs.emit() // Perhaps add additional argument to know which log was viewed?
 
-        // If the command is called directly from a package.json menu item, then logUri may be a random object
-        if (!(logUri instanceof vscode.Uri)) {
-            logUri = this.defaultLogUri
-        }
-        return vscode.window.showTextDocument(logUri as vscode.Uri)
+        // If the command is called directly from a package.json menu item, then logUri may be a vscode-provided object, typically a TreeNode.
+        return vscode.window.showTextDocument(logUri instanceof vscode.Uri ? logUri : this.defaultLogUri)
     }
 
     public async openLogId(logId: number, logUri = this.defaultLogUri) {

--- a/src/shared/logger/commands.ts
+++ b/src/shared/logger/commands.ts
@@ -30,10 +30,14 @@ export class Logging {
 
     public constructor(private readonly defaultLogUri: vscode.Uri, private readonly logger: Logger) {}
 
-    public async openLogUri(logUri = this.defaultLogUri): Promise<vscode.TextEditor | undefined> {
+    public async openLogUri(logUri?: vscode.Uri | unknown): Promise<vscode.TextEditor | undefined> {
         telemetry.toolkit_viewLogs.emit() // Perhaps add additional argument to know which log was viewed?
 
-        return vscode.window.showTextDocument(logUri)
+        // If the command is called directly from a package.json menu item, then logUri may be a random object
+        if (!(logUri instanceof vscode.Uri)) {
+            logUri = this.defaultLogUri
+        }
+        return vscode.window.showTextDocument(logUri as vscode.Uri)
     }
 
     public async openLogId(logId: number, logUri = this.defaultLogUri) {


### PR DESCRIPTION
Problem: Interacting with other options in the Amazon Q and Explorer views ellipses menu can cause the view logs option (of the same tree) to open an empty file. Since this command and menu options are maintained in package.json only, vscode may not properly supply arguments which leads to the open logs command breaking.

Solution: Remove unused parameter, only one log file is used for toolkit logging.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
