### PR TITLE
CodeCatalystClient throws ToolkitError on call

### DIFF
--- a/src/shared/clients/codecatalystClient.ts
+++ b/src/shared/clients/codecatalystClient.ts
@@ -277,7 +277,7 @@ class CodeCatalystClientInternal {
                         resolve(defaultVal)
                     } else {
                         const err = e as AWS.AWSError
-                        reject(new ToolkitError(err.code, { cause: err }))
+                        reject(new ToolkitError(`CodeCatalyst: ${err.code}`, { code: err.code, cause: err }))
                     }
                     return
                 }

--- a/src/shared/clients/codecatalystClient.ts
+++ b/src/shared/clients/codecatalystClient.ts
@@ -276,7 +276,8 @@ class CodeCatalystClientInternal {
                         }
                         resolve(defaultVal)
                     } else {
-                        reject(e)
+                        const err = e as AWS.AWSError
+                        reject(new ToolkitError(err.code, { cause: err }))
                     }
                     return
                 }

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -310,6 +310,7 @@ export const prioritizedAwsErrors: RegExp[] = [
     /^ValidationException$/,
     /^ResourceNotFoundException$/,
     /^ServiceQuotaExceededException$/,
+    /^AccessDeniedException$/,
 ]
 
 /**


### PR DESCRIPTION
I think this is the best way to handle errors at the CodeCatalyst command level without forcibly handling errors for all commands the same way. This change should affect any errors coming through CodeCatalyst calls.

**CONSIDER:**
* Is this good enough for error consolidation?
* Should this be a warning or an error? That would have to be handled at the all-command level.

The following examples come from creating a valid Builder ID connection to CodeCatalyst, and modifying the cached credential files to make the access keys invalid, and then clicking "Clone Repository" in the CodeCatalyst view.

Old error message:
![image](https://github.com/aws/aws-toolkit-vscode/assets/29374703/4eb04878-5867-465c-915e-70ce8f5fedaf)

New error message:
![image](https://github.com/aws/aws-toolkit-vscode/assets/29374703/91aa9556-2f02-45b5-b251-22b54b3770f0)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
