### PR TITLE
Opening a SAM Template only triggers CFN registry if CodeLenses enabled

### DIFF
--- a/src/shared/codelens/samTemplateCodeLensProvider.ts
+++ b/src/shared/codelens/samTemplateCodeLensProvider.ts
@@ -11,6 +11,7 @@ import { getIdeProperties } from '../extensionUtilities'
 import { TEMPLATE_TARGET_TYPE, API_TARGET_TYPE } from '../sam/debugger/awsSamDebugConfiguration'
 import { AddSamDebugConfigurationInput } from '../sam/debugger/commands/addSamDebugConfiguration'
 import { localize } from '../utilities/vsCodeUtils'
+import { SamCliSettings } from '../sam/cli/samCliSettings'
 
 /**
  * Provides "Add Debug Configuration" CodeLenses to SAM template.yaml files,
@@ -24,6 +25,10 @@ export class SamTemplateCodeLensProvider implements vscode.CodeLensProvider {
         launchConfig = new LaunchConfiguration(document.uri),
         waitForSymbols: boolean = false
     ): Promise<vscode.CodeLens[]> {
+        const config = SamCliSettings.instance
+        if (!config.get('enableCodeLenses', false)) {
+            return []
+        }
         const apiResources = await symbolResolver.getResourcesOfKind('api', waitForSymbols)
         const funResources = await symbolResolver.getResourcesOfKind('function', waitForSymbols)
         if (_(funResources).isEmpty() && _(apiResources).isEmpty()) {


### PR DESCRIPTION
## Problem
Opening a YAML template will trigger a CFN registry load, even if SAM CodeLenses are disabled

## Solution
Escape from the CodeLensProvider early (before calls to `getConfigsMappedToTemplates`)
* This shaves off file parsing, so this should represent a very slight speedup, even if the registry was already processed
* We don't want to not register the SamTemplateCodeLensProvider because then it won't be available if a user reactivates SAM CodeLenses halfway through a session

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
