### PR TITLE
feat(amazonqFeatureDev, telemetry): improve generateApproach api error metrics and minor fixes.

### DIFF
--- a/src/amazonqFeatureDev/client/featureDev.ts
+++ b/src/amazonqFeatureDev/client/featureDev.ts
@@ -86,7 +86,7 @@ export class FeatureDevClient {
             return conversationId
         } catch (e: any) {
             getLogger().error(`${featureName}: failed to start conversation: ${e.message} RequestId: ${e.requestId}`)
-            throw new ApiError(e.message, 'CreateConversation', e.statusCode)
+            throw new ApiError(e.message, 'CreateConversation', e.code, e.statusCode)
         }
     }
 
@@ -119,7 +119,7 @@ export class FeatureDevClient {
             if (e.code === 'ValidationException' && e.message.includes('Invalid contentLength')) {
                 throw new ContentLengthError()
             }
-            throw new ApiError(e.message, 'CreateUploadUrl', e.statusCode)
+            throw new ApiError(e.message, 'CreateUploadUrl', e.code, e.statusCode)
         }
     }
 
@@ -156,7 +156,12 @@ export class FeatureDevClient {
             return assistantResponse.join(' ')
         } catch (e: any) {
             getLogger().error(`${featureName}: failed to execute planning: ${e.message} RequestId: ${e.requestId}`)
-            throw new ApiError(e.message, 'GeneratePlan', e.$metadata?.httpStatusCode ?? streamResponseErrors[e.name])
+            throw new ApiError(
+                e.message,
+                'GeneratePlan',
+                e.name,
+                e.$metadata?.httpStatusCode ?? streamResponseErrors[e.name]
+            )
         }
     }
 }

--- a/src/amazonqFeatureDev/errors.ts
+++ b/src/amazonqFeatureDev/errors.ts
@@ -70,9 +70,15 @@ export class ContentLengthError extends ToolkitError {
     }
 }
 
+export class UnknownError extends ToolkitError {
+    constructor() {
+        super('The current error is not being handled. Please, investigate the issue', { code: 'UnhandledError' })
+    }
+}
+
 export class ApiError extends ToolkitError {
-    constructor(message: string, api: string, errorName: string, errorCode: number) {
-        super(message, { code: `${api}-${errorName}-${errorCode}` })
+    constructor(message: string, api: string, errorName: string, errorCode?: number) {
+        super(message, { code: `${api}-${errorName}-${errorCode ?? 'unknown'}` })
     }
 }
 

--- a/src/amazonqFeatureDev/errors.ts
+++ b/src/amazonqFeatureDev/errors.ts
@@ -70,15 +70,15 @@ export class ContentLengthError extends ToolkitError {
     }
 }
 
-export class UnknownError extends ToolkitError {
-    constructor() {
-        super('The current error is not being handled. Please, investigate the issue', { code: 'UnhandledError' })
+export class UnknownApiError extends ToolkitError {
+    constructor(message: string, api: string) {
+        super(message, { code: `${api}-Unknown` })
     }
 }
 
 export class ApiError extends ToolkitError {
-    constructor(message: string, api: string, errorName: string, errorCode?: number) {
-        super(message, { code: `${api}-${errorName}-${errorCode ?? 'unknown'}` })
+    constructor(message: string, api: string, errorName: string, errorCode: number) {
+        super(message, { code: `${api}-${errorName}-${errorCode}` })
     }
 }
 

--- a/src/amazonqFeatureDev/errors.ts
+++ b/src/amazonqFeatureDev/errors.ts
@@ -55,12 +55,24 @@ export class PrepareRepoFailedError extends ToolkitError {
     }
 }
 
+export class IllegalStateTransition extends ToolkitError {
+    constructor() {
+        super('Illegal transition between states, restart the conversation', { code: 'IllegalStateTransition' })
+    }
+}
+
 export class ContentLengthError extends ToolkitError {
     constructor() {
         super(
             'The project you have selected for source code is too large to use as context. Please select a different folder to use for this conversation',
             { code: 'ContentLengthError' }
         )
+    }
+}
+
+export class ApiError extends ToolkitError {
+    constructor(message: string, api: string, errorCode: number) {
+        super(message, { code: `${api} - ${errorCode}` })
     }
 }
 

--- a/src/amazonqFeatureDev/errors.ts
+++ b/src/amazonqFeatureDev/errors.ts
@@ -71,8 +71,8 @@ export class ContentLengthError extends ToolkitError {
 }
 
 export class ApiError extends ToolkitError {
-    constructor(message: string, api: string, errorCode: number) {
-        super(message, { code: `${api}-${errorCode}` })
+    constructor(message: string, api: string, errorName: string, errorCode: number) {
+        super(message, { code: `${api}-${errorName}-${errorCode}` })
     }
 }
 

--- a/src/amazonqFeatureDev/errors.ts
+++ b/src/amazonqFeatureDev/errors.ts
@@ -72,7 +72,7 @@ export class ContentLengthError extends ToolkitError {
 
 export class ApiError extends ToolkitError {
     constructor(message: string, api: string, errorCode: number) {
-        super(message, { code: `${api} - ${errorCode}` })
+        super(message, { code: `${api}-${errorCode}` })
     }
 }
 

--- a/src/amazonqFeatureDev/session/sessionState.ts
+++ b/src/amazonqFeatureDev/session/sessionState.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode'
 import { ToolkitError } from '../../shared/errors'
 import { getLogger } from '../../shared/logger'
 import { telemetry } from '../../shared/telemetry/telemetry'
-import { UserMessageNotFoundError } from '../errors'
+import { IllegalStateTransition, UserMessageNotFoundError } from '../errors'
 import { SessionState, SessionStateAction, SessionStateConfig, SessionStateInteraction } from '../types'
 import { prepareRepoData } from '../util/files'
 import { uploadCode } from '../util/upload'
@@ -23,9 +23,7 @@ export class ConversationNotStartedState implements Omit<SessionState, 'uploadId
     }
 
     async interact(_action: SessionStateAction): Promise<SessionStateInteraction> {
-        throw new ToolkitError('Illegal transition between states, restart the conversation', {
-            code: 'IllegalStateTransition',
-        })
+        throw new IllegalStateTransition()
     }
 }
 

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -12,6 +12,7 @@ import { CancellationError } from './utilities/timeoutUtils'
 import { isNonNullable } from './utilities/tsUtils'
 import type * as fs from 'fs'
 import type * as os from 'os'
+import { CodeWhispererStreamingServiceException } from '@amzn/codewhisperer-streaming'
 
 export const errorCode = {
     invalidConnection: 'InvalidConnection',
@@ -368,6 +369,29 @@ export function findAwsErrorInCausalChain(error: unknown): AWSError | undefined 
     }
 
     return undefined
+}
+
+export function isCodeWhispererStreamingServiceException(
+    error: unknown
+): error is CodeWhispererStreamingServiceException {
+    if (error === undefined) {
+        return false
+    }
+
+    return error instanceof Error && hasFault(error) && hasMetadata(error) && hasName(error)
+}
+
+function hasFault<T>(error: T): error is T & { $fault: 'client' | 'server' } {
+    const fault = (error as { $fault?: unknown }).$fault
+    return typeof fault === 'string' && (fault === 'client' || fault === 'server')
+}
+
+function hasMetadata<T>(error: T): error is T & Pick<CodeWhispererStreamingServiceException, '$metadata'> {
+    return typeof (error as { $metadata?: unknown }).$metadata === 'object'
+}
+
+function hasName<T>(error: T): error is T & { name: string } {
+    return typeof (error as { name?: unknown }).name === 'string'
 }
 
 export function isAwsError(error: unknown): error is AWSError {


### PR DESCRIPTION
## Problem

Currently featureDev errors are returning a generic failure. In the purpose of understanding the specific error with telemetry finding out if it was a 403 or a 409 was hard.

## Solution

Add status code to api errors to track in telemetry.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
