### PR TITLE
codecatalyst: Bad auth state when adding connection + skip onboarding

### DIFF
--- a/src/auth/ui/vue/show.ts
+++ b/src/auth/ui/vue/show.ts
@@ -228,6 +228,15 @@ export class AuthWebview extends VueWebview {
             await setupFunc()
             return
         } catch (e) {
+            if (e instanceof ToolkitError && e.code === 'NotOnboarded') {
+                /**
+                 * Connection is fine, they just skipped onboarding so not an actual error.
+                 *
+                 * The error comes from user cancelling prompt by {@link CodeCatalystAuthenticationProvider.promptOnboarding()}
+                 */
+                return
+            }
+
             if (
                 CancellationError.isUserCancelled(e) ||
                 (e instanceof ToolkitError && (CancellationError.isUserCancelled(e.cause) || e.cancelled === true))

--- a/src/codecatalyst/explorer.ts
+++ b/src/codecatalyst/explorer.ts
@@ -30,22 +30,38 @@ const reauth = Commands.register(
     }
 )
 
+const onboardCommand = Commands.register(
+    '_aws.codecatalyst.onboard',
+    async (authProvider: CodeCatalystAuthenticationProvider) => {
+        authProvider.promptOnboarding()
+    }
+)
+
 async function getLocalCommands(auth: CodeCatalystAuthenticationProvider) {
     const docsUrl = isCloud9() ? codecatalyst.docs.cloud9.overview : codecatalyst.docs.vscode.overview
-    if (
-        !auth.activeConnection ||
-        !auth.isConnectionValid() ||
-        !(await auth.isConnectionOnboarded(auth.activeConnection))
-    ) {
+    const learnMoreNode = learnMoreCommand.build(docsUrl).asTreeNode({
+        label: 'Learn more about CodeCatalyst',
+        iconPath: getIcon('vscode-question'),
+    })
+
+    if (!auth.activeConnection || !auth.isConnectionValid()) {
         return [
             showManageConnections.build(placeholder, 'codecatalystDeveloperTools', 'codecatalyst').asTreeNode({
                 label: 'Sign in to get started',
                 iconPath: getIcon('vscode-account'),
             }),
-            learnMoreCommand.build(docsUrl).asTreeNode({
-                label: 'Learn more about CodeCatalyst',
-                iconPath: getIcon('vscode-question'),
+            learnMoreNode,
+        ]
+    }
+
+    // We are connected but not onboarded, so show them button to onboard
+    if (!(await auth.isConnectionOnboarded(auth.activeConnection))) {
+        return [
+            onboardCommand.build(auth).asTreeNode({
+                label: 'Onboard CodeCatalyst to get started',
+                iconPath: getIcon('vscode-account'),
             }),
+            learnMoreNode,
         ]
     }
 


### PR DESCRIPTION
Problem:

When a user connects to CC but skips the prompt to onboard a space, things appear to fail to the user even though things are fine. They will see a cancelled error under the Builder ID button and a "Sign in" node on the CodeCatalyst tree view.

Solution:

We ignore the error that gets raised if they cancel and successfully add the connection.

Also if they require onboarding we will show them the "You must onboard" node instead of the incorrect "You must sign in" node that we are currently showing. When they click this node it will open the CodeCatalyst page in the browser that guides them to onboard.

## Already approved in staging
https://github.com/aws/aws-toolkit-vscode-staging/pull/1522

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
