### PR TITLE
NoopWatcher returns correctly

### DIFF
--- a/src/shared/cloudformation/activation.ts
+++ b/src/shared/cloudformation/activation.ts
@@ -90,7 +90,7 @@ function setTemplateRegistryInGlobals(registry: CloudFormationTemplateRegistry) 
                 return await asyncRegistry.getInstance()
             }
 
-            return NoopWatcher
+            return new NoopWatcher()
         },
     })
 }


### PR DESCRIPTION
## Problem
Getting a template registry before activation returns `undefined` instead of a `NoopWatcher`. Thinking this might be the cause of https://github.com/aws/aws-toolkit-vscode/issues/4057

## Solution
Return the `NoopWatcher` correctly.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
