### PR TITLE
Add timed refresh to Cloud9 CodeWhisperer view after load

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,6 +78,7 @@ import { registerWebviewErrorHandler } from './webviews/server'
 import { initializeManifestPaths } from './extensionShared'
 import { ChildProcess } from './shared/utilities/childProcess'
 import { initializeNetworkAgent } from './codewhisperer/client/agent'
+import { Timeout } from './shared/utilities/timeoutUtils'
 
 let localize: nls.LocalizeFunc
 
@@ -282,6 +283,19 @@ export async function activate(context: vscode.ExtensionContext) {
 
         if (!isReleaseVersion()) {
             globals.telemetry.assertPassiveTelemetry(globals.didReload)
+        }
+        // HACK: Cloud9 currently has some issues with the Codewhisperer view,
+        //       where `getChildren` calls are executed on load but the UI doesn't respond
+        //       (the extension host disposes the commands and recreates them,
+        //       but the nodes remain tied to the old commands).
+        //       This forces a refresh after 5 seconds to ensure a refresh happens at the end of initial extension load.
+        //       If the issue is due to activity on the views,
+        //       this should be fired after planned activities have finished.
+        if (isCloud9()) {
+            const timeout = new Timeout(5000).onCompletion(() => {
+                vscode.commands.executeCommand('aws.codeWhisperer.refresh')
+                timeout.dispose()
+            })
         }
     } catch (error) {
         const stacktrace = (error as Error).stack?.split('\n')

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -292,9 +292,8 @@ export async function activate(context: vscode.ExtensionContext) {
         //       If the issue is due to activity on the views,
         //       this should be fired after planned activities have finished.
         if (isCloud9()) {
-            const timeout = new Timeout(5000).onCompletion(() => {
+            new Timeout(5000).onCompletion(() => {
                 vscode.commands.executeCommand('aws.codeWhisperer.refresh')
-                timeout.dispose()
             })
         }
     } catch (error) {


### PR DESCRIPTION
## Problem
The nodes in the CodeWhisperer view in Cloud9 sometimes don't work.
* Analyzing the browser console shows that the extension host disposes creates commands for the nodes and disposes them (these have a number tied to them as an "ID").
* Most of the time, the view picks up the most recent copy of the commands (the browser console shows the ID being executed when the node is clicked)
* Sometimes, this is tied to the ID that's disposed. In these cases, the node actions won't work, with no error feedback (outside the browser console)

## Solution
Force a refresh of the CodeWhisperer view in Cloud9 only, 5 seconds after the end of the `extension.ts` `activate()` function.
* This disposes the actions and presumably recreates the nodes in the view
* It's hard to tell if this is truly a workaround/fix: since the error is sporadic, and the node never works _immediately_ during load (it always takes a second or two at least), we can't tell for sure if the view is going to recover on its own or continue to fail.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
