### PR TITLE
feat(amazonqFeatureDev): add new metrics to api operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4847,9 +4847,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry/node_modules/fs-extra": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-            "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
             },
             "devDependencies": {
                 "@aws-sdk/types": "^3.13.1",
-                "@aws-toolkits/telemetry": "^1.0.171",
+                "@aws-toolkits/telemetry": "^1.0.172",
                 "@aws/fully-qualified-names": "^2.1.1",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^10.0.2",
@@ -4832,9 +4832,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.171",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.171.tgz",
-            "integrity": "sha512-mHHA/j/qqRX3Q5f4GiObldKrUdpf3XBwcv0qFb2BVMbDtFO9sOkHU9xsSofVVC/k9euW3Lc1WljVG9msDiMPiw==",
+            "version": "1.0.172",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.172.tgz",
+            "integrity": "sha512-9ktSFA3fSnZkOF8O1L8aRaNU5+H++R1+alYL1jrsdkB3nYfHS/vRdzV8PNrEb9jXZ5HOIreD5vasCniqgjqGQA==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -4264,7 +4264,7 @@
     },
     "devDependencies": {
         "@aws-sdk/types": "^3.13.1",
-        "@aws-toolkits/telemetry": "^1.0.171",
+        "@aws-toolkits/telemetry": "^1.0.172",
         "@aws/fully-qualified-names": "^2.1.1",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^10.0.2",

--- a/src/amazonqFeatureDev/errors.ts
+++ b/src/amazonqFeatureDev/errors.ts
@@ -55,6 +55,12 @@ export class PrepareRepoFailedError extends ToolkitError {
     }
 }
 
+export class UploadCodeError extends ToolkitError {
+    constructor(statusCode: string) {
+        super('Unable to upload code', { code: `UploadCode-${statusCode}` })
+    }
+}
+
 export class IllegalStateTransition extends ToolkitError {
     constructor() {
         super('Illegal transition between states, restart the conversation', { code: 'IllegalStateTransition' })

--- a/src/amazonqFeatureDev/session/session.ts
+++ b/src/amazonqFeatureDev/session/session.ts
@@ -60,7 +60,10 @@ export class Session {
         // Store the initial message when setting up the conversation so that if it fails we can retry with this message
         this._latestMessage = msg
 
-        this._conversationId = await this.proxyClient.createConversation()
+        telemetry.amazonq_startConversationInvoke.run(async span => {
+            this._conversationId = await this.proxyClient.createConversation()
+            span.record({ amazonqConversationId: this._conversationId })
+        })
 
         this._state = new PrepareRefinementState(
             {

--- a/src/amazonqFeatureDev/session/sessionState.ts
+++ b/src/amazonqFeatureDev/session/sessionState.ts
@@ -34,7 +34,7 @@ export class PrepareRefinementState implements Omit<SessionState, 'uploadId'> {
         this.tokenSource = new vscode.CancellationTokenSource()
     }
     async interact(action: SessionStateAction): Promise<SessionStateInteraction> {
-        const uploadId = await telemetry.amazonq_uploadCode.run(async span => {
+        const uploadId = await telemetry.amazonq_createUpload.run(async span => {
             span.record({ amazonqConversationId: this.config.conversationId })
             const { zipFileBuffer, zipFileChecksum } = await prepareRepoData(
                 this.config.sourceRoot,

--- a/src/amazonqFeatureDev/util/files.ts
+++ b/src/amazonqFeatureDev/util/files.ts
@@ -19,7 +19,7 @@ import { getLogger } from '../../shared/logger/logger'
 import { maxFileSizeBytes } from '../limits'
 import { createHash } from 'crypto'
 
-import { AmazonqUploadCode, Metric } from '../../shared/telemetry/telemetry'
+import { AmazonqCreateUpload, Metric } from '../../shared/telemetry/telemetry'
 
 export function getExcludePattern(additionalPatterns: string[] = []) {
     const globAlwaysExcludedDirs = getGlobDirExcludedPatterns().map(pattern => `**/${pattern}/*`)
@@ -86,7 +86,7 @@ const getSha256 = (file: Buffer) => createHash('sha256').update(file).digest('ba
 export async function prepareRepoData(
     repoRootPath: string,
     telemetry: TelemetryHelper,
-    span: Metric<AmazonqUploadCode>
+    span: Metric<AmazonqCreateUpload>
 ) {
     try {
         const zip = new AdmZip()

--- a/src/amazonqFeatureDev/util/files.ts
+++ b/src/amazonqFeatureDev/util/files.ts
@@ -95,16 +95,14 @@ export async function prepareRepoData(
             new vscode.RelativePattern(repoRootPath, '**'),
             getExcludePattern()
         )
-        const files = await filterOutGitignoredFiles(repoRootPath, allFiles)
 
+        const files = await filterOutGitignoredFiles(repoRootPath, allFiles)
         let totalBytes = 0
         for (const file of files) {
             const fileSize = (await vscode.workspace.fs.stat(vscode.Uri.file(file.fsPath))).size
-
             if (fileSize >= maxFileSizeBytes) {
                 continue
             }
-
             totalBytes += fileSize
 
             const relativePath = getWorkspaceRelativePath(file.fsPath)
@@ -118,8 +116,10 @@ export async function prepareRepoData(
                 )
             }
         }
+
         telemetry.setRepositorySize(totalBytes)
         span.record({ amazonqRepositorySize: totalBytes })
+
         const zipFileBuffer = zip.toBuffer()
         return {
             zipFileBuffer,

--- a/src/amazonqFeatureDev/util/upload.ts
+++ b/src/amazonqFeatureDev/util/upload.ts
@@ -32,6 +32,6 @@ export async function uploadCode(url: string, buffer: Buffer, checksumSha256: st
         })
     } catch (e: any) {
         getLogger().error(`${featureName}: failed to upload code to s3: ${(e as Error).message}`)
-        throw new UploadCodeError(e instanceof got.HTTPError ? `${e.response.statusCode}` : '')
+        throw new UploadCodeError(e instanceof got.HTTPError ? `${e.response.statusCode}` : 'Unknown')
     }
 }

--- a/src/amazonqFeatureDev/util/upload.ts
+++ b/src/amazonqFeatureDev/util/upload.ts
@@ -8,6 +8,8 @@ import got from 'got'
 import { getLogger } from '../../shared/logger/logger'
 import { featureName } from '../constants'
 
+import { UploadCodeError } from '../errors'
+
 /**
  * uploadCode
  *
@@ -28,8 +30,8 @@ export async function uploadCode(url: string, buffer: Buffer, checksumSha256: st
                 }),
             },
         })
-    } catch (e) {
+    } catch (e: any) {
         getLogger().error(`${featureName}: failed to upload code to s3: ${(e as Error).message}`)
-        throw e
+        throw new UploadCodeError(e instanceof got.HTTPError ? `${e.response.statusCode}` : '')
     }
 }

--- a/src/test/amazonqFeatureDev/util/files.test.ts
+++ b/src/test/amazonqFeatureDev/util/files.test.ts
@@ -10,6 +10,7 @@ import assert from 'assert'
 import { collectFiles, prepareRepoData } from '../../../amazonqFeatureDev/util/files'
 import { createTestWorkspace, createTestWorkspaceFolder, toFile } from '../../testUtil'
 import { TelemetryHelper } from '../../../amazonqFeatureDev/util/telemetryHelper'
+import { AmazonqCreateUpload, Metric } from '../../../shared/telemetry/telemetry'
 
 describe('file utils', () => {
     describe('collectFiles', function () {
@@ -41,7 +42,7 @@ describe('file utils', () => {
             const workspace = await createTestWorkspace(fileAmount, { fileNamePrefix, fileContent })
 
             const telemetry = new TelemetryHelper()
-            const result = await prepareRepoData(workspace.uri.fsPath, telemetry)
+            const result = await prepareRepoData(workspace.uri.fsPath, telemetry, {} as Metric<AmazonqCreateUpload>)
             assert.strictEqual(Buffer.isBuffer(result.zipFileBuffer), true)
             // checksum is not the same across different test executions because some unique random folder names are generated
             assert.strictEqual(result.zipFileChecksum.length, 44)

--- a/src/test/amazonqFeatureDev/util/files.test.ts
+++ b/src/test/amazonqFeatureDev/util/files.test.ts
@@ -10,7 +10,7 @@ import assert from 'assert'
 import { collectFiles, prepareRepoData } from '../../../amazonqFeatureDev/util/files'
 import { createTestWorkspace, createTestWorkspaceFolder, toFile } from '../../testUtil'
 import { TelemetryHelper } from '../../../amazonqFeatureDev/util/telemetryHelper'
-import { AmazonqCreateUpload, Metric } from '../../../shared/telemetry/telemetry'
+import { AmazonqCreateUpload, Metric } from '../../../shared/telemetry/telemetry.gen'
 
 describe('file utils', () => {
     describe('collectFiles', function () {
@@ -42,7 +42,9 @@ describe('file utils', () => {
             const workspace = await createTestWorkspace(fileAmount, { fileNamePrefix, fileContent })
 
             const telemetry = new TelemetryHelper()
-            const result = await prepareRepoData(workspace.uri.fsPath, telemetry, {} as Metric<AmazonqCreateUpload>)
+            const result = await prepareRepoData(workspace.uri.fsPath, telemetry, {
+                record: () => {},
+            } as unknown as Metric<AmazonqCreateUpload>)
             assert.strictEqual(Buffer.isBuffer(result.zipFileBuffer), true)
             // checksum is not the same across different test executions because some unique random folder names are generated
             assert.strictEqual(result.zipFileChecksum.length, 44)


### PR DESCRIPTION
## Problem

featureDev needed to track errors in the metrics in a more detailed way.

## Solution

add new metrics in order to get better error tracking.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


This PR needs this dependency to be merged and in this PR the version of the library updated: https://github.com/aws/aws-toolkit-common/pull/645/files
