### PR TITLE
CW: Change in payload size for Go and Ruby from 1MB to 200KB 

### DIFF
--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -200,9 +200,9 @@ export const codeScanJavaPayloadSizeLimitBytes = Math.pow(2, 20) // 1 MB
 
 export const codeScanCsharpPayloadSizeLimitBytes = Math.pow(2, 20) // 1 MB
 
-export const codeScanRubyPayloadSizeLimitBytes = Math.pow(2, 20) // 1 MB
+export const codeScanRubyPayloadSizeLimitBytes = 200 * Math.pow(2, 10) // 200 KB
 
-export const codeScanGoPayloadSizeLimitBytes = Math.pow(2, 20) // 1 MB
+export const codeScanGoPayloadSizeLimitBytes = 200 * Math.pow(2, 10) // 200 KB
 
 export const codeScanPythonPayloadSizeLimitBytes = 200 * Math.pow(2, 10) // 200 KB
 


### PR DESCRIPTION
Change in payload size for Go and Ruby from 1MB to 200KB for security scans

## Problem
At present the payload size of Go and Ruby is 1MB.
## Solution
Changed it to 200KB and If latency gets effected we can revert this back.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
