### PR TITLE
codewhisperer: update scan polling frequency

### DIFF
--- a/.changes/next-release/Bug Fix-8dafab20-12b5-41a2-8786-889ec65cc70a.json
+++ b/.changes/next-release/Bug Fix-8dafab20-12b5-41a2-8786-889ec65cc70a.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeWhisperer: Increase polling frequency for security scans."
+}

--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -188,7 +188,7 @@ export const referenceLogText = (
 ) =>
     `with code ${code} provided with reference under ${license} from repository ${repository}. Added to ${filePath} ${lineInfo}.`
 
-export const referenceLogPromptText = `Don\'t want suggestions that include code with references? Uncheck this option in
+export const referenceLogPromptText = `Don\'t want suggestions that include code with references? Uncheck this option in 
     <a href="#" onclick="openSettings();return false;">CodeWhisperer Settings</a>`
 
 export const referenceLogPromptTextEnterpriseSSO =

--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -188,7 +188,7 @@ export const referenceLogText = (
 ) =>
     `with code ${code} provided with reference under ${license} from repository ${repository}. Added to ${filePath} ${lineInfo}.`
 
-export const referenceLogPromptText = `Don\'t want suggestions that include code with references? Uncheck this option in 
+export const referenceLogPromptText = `Don\'t want suggestions that include code with references? Uncheck this option in
     <a href="#" onclick="openSettings();return false;">CodeWhisperer Settings</a>`
 
 export const referenceLogPromptTextEnterpriseSSO =
@@ -222,7 +222,7 @@ export const codeScanJobTimeoutSeconds = 50
 
 export const projectSizeCalculateTimeoutSeconds = 10
 
-export const codeScanJobPollingIntervalSeconds = 5
+export const codeScanJobPollingIntervalSeconds = 1
 
 export const artifactTypeSource = 'SourceCode'
 


### PR DESCRIPTION
## Problem

Security scans currently poll status every 5 seconds.

## Solution

Increase the frequency to every 1 second.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
