### PR TITLE
fix(codecatalyst): no longer prompt builder ID sign in when opening dev env

### DIFF
--- a/.changes/next-release/Bug Fix-9755489d-974e-41a5-9031-f4e0a50ab9e7.json
+++ b/.changes/next-release/Bug Fix-9755489d-974e-41a5-9031-f4e0a50ab9e7.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Opening a CodeCatalyst dev env triggers a builder ID login in certain situations."
+}

--- a/src/codecatalyst/commands.ts
+++ b/src/codecatalyst/commands.ts
@@ -12,7 +12,7 @@ import * as vscode from 'vscode'
 import { selectCodeCatalystRepository, selectCodeCatalystResource } from './wizards/selectResource'
 import { openCodeCatalystUrl } from './utils'
 import { CodeCatalystAuthenticationProvider } from './auth'
-import { Commands } from '../shared/vscode/commands2'
+import { Commands, placeholder } from '../shared/vscode/commands2'
 import { CodeCatalystClient, CodeCatalystResource, createClient } from '../shared/clients/codecatalystClient'
 import { DevEnvironmentId, getConnectedDevEnv, openDevEnv } from './model'
 import { showConfigureDevEnv } from './vue/configure/backend'
@@ -24,8 +24,8 @@ import { showConfirmationMessage } from '../shared/utilities/messages'
 import { AccountStatus } from '../shared/telemetry/telemetryClient'
 import { CreateDevEnvironmentRequest, UpdateDevEnvironmentRequest } from 'aws-sdk/clients/codecatalyst'
 import { Auth } from '../auth/auth'
-import { SsoConnection, defaultSsoRegion } from '../auth/connection'
-import { builderIdStartUrl } from '../auth/sso/model'
+import { SsoConnection } from '../auth/connection'
+import { showManageConnections } from '../auth/ui/vue/show'
 
 /** "List CodeCatalyst Commands" command. */
 export async function listCommands(): Promise<void> {
@@ -285,8 +285,12 @@ export class CodeCatalystCommands {
             telemetry.record({ source: 'CommandPalette' })
         }
 
-        // Try to ensure active connection, defaulting to BuilderID if not specified:
-        await this.authProvider.tryConnectTo(connection ?? { startUrl: builderIdStartUrl, region: defaultSsoRegion })
+        if (connection !== undefined) {
+            await this.authProvider.tryConnectTo(connection)
+        } else if (!this.authProvider.isConnectionValid()) {
+            showManageConnections.execute(placeholder, 'codecatalystDeveloperTools', 'codecatalyst')
+            return
+        }
 
         return this.withClient(openDevEnv, devenv, targetPath)
     }


### PR DESCRIPTION
Problem: Opening a dev env inside of the IDE will trigger logic to default to a builder ID sign in. This is because the function will not receive the proper information when opened from menu options (the connection variable is not defined when called this way), triggering the default path. Opening a dev env from the CodeCatalyst website will open it normally, because it passes the necessary information to the function that will not cause the default behavior to activate.

Solution: Check for valid connection state instead of relying on what is passed into the function. Also, remove Builder ID login as default, instead just route to the connections page. Although, this codepath should only run if something funky is going on.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
