### PR TITLE
telemetry: ui_click when deleting connection from list

### DIFF
--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -391,6 +391,7 @@ export function createConnectionPrompter(auth: Auth, type?: 'iam' | 'sso') {
     prompter.quickPick.onDidTriggerItemButton(async e => {
         // User wants to delete a specific connection
         if (e.button.tooltip === deleteConnection) {
+            telemetry.ui_click.emit({ elementId: 'connection_deleteFromList' })
             const conn = e.item.data as Connection
 
             // Set prompter in to a busy state so that


### PR DESCRIPTION
When the users sees a list of connections by clicking the AWS status bar icon, they can hover over a specific connection and delete it.

This adds a ui_click telemetry event when it is clicked.

![Screenshot 2023-12-13 at 10 30 47 AM](https://github.com/aws/aws-toolkit-vscode/assets/118216176/7a79d6fd-4c8a-4c3e-a8c9-8e249225e265)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
