### PR TITLE
SAM: fix failing SAM tests

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -54,8 +54,7 @@ phases:
             - bash buildspec/shared/linux-pre_build.sh
             # Where non-root "pip3 install" puts things:
             - 'export PATH="$HOME/.local/bin:$PATH"'
-            # Explicit older version since we assume the newer version is causing our CI to fail (python 3.10 sam tests specifically)
-            - '>/dev/null pip install aws-sam-cli==1.94.0'
+            - '>/dev/null pip3 install --upgrade aws-sam-cli'
             - '>/dev/null pip3 install --upgrade awscli'
             # Print info about sam (version, location, …).
             - 'pip3 show aws-sam-cli'

--- a/scripts/test/launchTestUtilities.ts
+++ b/scripts/test/launchTestUtilities.ts
@@ -76,6 +76,13 @@ export async function invokeVSCodeCli(vsCodeExecutablePath: string, args: string
 }
 
 export async function installVSCodeExtension(vsCodeExecutablePath: string, extensionIdentifier: string): Promise<void> {
+    // HACK: `sam.test.ts` Codelens test was failing for python due to bug in newer version, so lock to last working version.
+    // Edge Case: This specific python version does not work with the "minimum" vscode version, so we do not override it as it
+    // will choose its own python extension version that works.
+    if (extensionIdentifier === VSCODE_EXTENSION_ID.python && process.env[envvarVscodeTestVersion] !== minimum) {
+        extensionIdentifier = `${VSCODE_EXTENSION_ID.python}@2023.20.0`
+    }
+
     console.log(`Installing VS Code Extension: ${extensionIdentifier}`)
     console.log(await invokeVSCodeCli(vsCodeExecutablePath, ['--install-extension', extensionIdentifier]))
 }

--- a/src/test/techdebt.test.ts
+++ b/src/test/techdebt.test.ts
@@ -43,15 +43,6 @@ describe('tech debt', function () {
         )
     })
 
-    it('remove explicit sam cli version', function () {
-        // Indicate to start using the latest aws-sam-cli version in our CI
-        // https://issues.amazon.com/issues/IDE-11386
-        assert(
-            new Date() < new Date(2024, 1, 15),
-            'Remove use of 1.94.0 for aws-sam-cli in linuxIntegrationTests.yml and see if integration tests are passing now'
-        )
-    })
-
     it('stop skipping CodeCatalyst E2E Tests', function () {
         // https://issues.amazon.com/issues/IDE-10496
         assert(

--- a/src/test/techdebt.test.ts
+++ b/src/test/techdebt.test.ts
@@ -6,6 +6,7 @@
 import assert from 'assert'
 import * as semver from 'semver'
 import * as env from '../shared/vscode/env'
+import { installVSCodeExtension } from '../../scripts/test/launchTestUtilities'
 
 // Checks project config and dependencies, to remind us to remove old things
 // when possible.
@@ -48,6 +49,18 @@ describe('tech debt', function () {
         assert(
             new Date() < new Date(2024, 1, 15),
             'Re-evaluate if we should still keep skipping CodeCatalyst E2E Tests'
+        )
+    })
+
+    it('stop not using latest python extension version in integration CI tests', function () {
+        /**
+         * The explicitly set version is done in {@link installVSCodeExtension}
+         * The parent ticket for SAM test issues: IDE-12295
+         * Python Extension Bug Issue (if this is fixed, then this should be too): https://github.com/microsoft/vscode-python/issues/22659
+         */
+        assert(
+            new Date() < new Date(2024, 1, 15),
+            'Re-evaluate if we can use the latest python extension version in CI integration tests'
         )
     })
 })

--- a/src/testInteg/sam.test.ts
+++ b/src/testInteg/sam.test.ts
@@ -322,8 +322,7 @@ async function startDebugger(
             try {
                 await vscode.commands.executeCommand('workbench.action.debug.continue')
                 return true
-            }
-            catch {
+            } catch {
                 return false
             }
         },

--- a/src/testInteg/sam.test.ts
+++ b/src/testInteg/sam.test.ts
@@ -24,15 +24,15 @@ import { waitUntil } from '../shared/utilities/timeoutUtils'
 import { AwsSamDebuggerConfiguration } from '../shared/sam/debugger/awsSamDebugConfiguration.gen'
 import { AwsSamTargetType } from '../shared/sam/debugger/awsSamDebugConfiguration'
 import { insertTextIntoFile } from '../shared/utilities/textUtilities'
-import { sleep } from '../shared/utilities/timeoutUtils'
 import globals from '../shared/extensionGlobals'
 import { closeAllEditors } from '../test/testUtil'
+import { ToolkitError } from '../shared/errors'
 
 const projectFolder = testUtils.getTestWorkspaceFolder()
 
 /* Test constants go here */
 const codelensTimeout: number = 60000
-const codelensRetryInterval: number = 200
+const codelensRetryInterval: number = 5000
 const noDebugSessionTimeout: number = 5000
 const noDebugSessionInterval: number = 100
 
@@ -307,25 +307,33 @@ async function startDebugger(
         )
     })
 
-    // Executes the 'F5' action
+    // Executes the 'F5' action to start debugging
     await vscode.debug.startDebugging(undefined, testConfig)
     if (!vscode.debug.activeDebugSession) {
         logSession('EXIT', `${testConfig.name} (exited immediately)`)
         return
     }
     logSession('START', vscode.debug.activeDebugSession.name)
-    await sleep(400)
-    await continueDebugger()
-    await sleep(400)
-    await continueDebugger()
-    await sleep(400)
-    await continueDebugger()
+
+    // Some tests need to hit debug continue to the debugger to complete.
+    // Testing locally seemed to take 600-800 millis to run.
+    const result = await waitUntil(
+        async () => {
+            try {
+                await vscode.commands.executeCommand('workbench.action.debug.continue')
+                return true
+            }
+            catch {
+                return false
+            }
+        },
+        { interval: 500, timeout: 10_000 }
+    )
+    if (result === undefined) {
+        throw new ToolkitError(`Toolkit: Debug session did not stop. Something may have gotten stuck.`)
+    }
 
     return success
-}
-
-async function continueDebugger(): Promise<void> {
-    await vscode.commands.executeCommand('workbench.action.debug.continue')
 }
 
 async function stopDebugger(logMsg: string | undefined): Promise<void> {
@@ -488,13 +496,13 @@ describe('SAM Integration Tests', async function () {
                     ) {
                         this.skip()
                     }
-
                     const codeLenses = await testUtils.getAddConfigCodeLens(
                         samAppCodeUri,
                         codelensTimeout,
                         codelensRetryInterval
                     )
-                    assert.ok(codeLenses && codeLenses.length === 2)
+                    assert.ok(codeLenses, 'No CodeLenses provided')
+                    assert.strictEqual(codeLenses.length, 2, 'Incorrect amount of CodeLenses provided')
 
                     let manifestFile: RegExp
                     switch (scenario.language) {

--- a/src/testInteg/sam.test.ts
+++ b/src/testInteg/sam.test.ts
@@ -56,15 +56,6 @@ interface TestScenario {
 const scenarios: TestScenario[] = [
     // zips
     {
-        runtime: 'nodejs14.x',
-        displayName: 'nodejs14.x (ZIP)',
-        path: 'hello-world/app.js',
-        debugSessionType: 'pwa-node',
-        language: 'javascript',
-        dependencyManager: 'npm',
-        vscodeMinimum: '1.50.0',
-    },
-    {
         runtime: 'nodejs16.x',
         displayName: 'nodejs16.x (ZIP)',
         path: 'hello-world/app.js',
@@ -150,16 +141,6 @@ const scenarios: TestScenario[] = [
     // },
 
     // images
-    {
-        runtime: 'nodejs14.x',
-        displayName: 'nodejs14.x (Image)',
-        baseImage: 'amazon/nodejs14.x-base',
-        path: 'hello-world/app.js',
-        debugSessionType: 'pwa-node',
-        language: 'javascript',
-        dependencyManager: 'npm',
-        vscodeMinimum: '1.50.0',
-    },
     {
         runtime: 'nodejs16.x',
         displayName: 'nodejs16.x (Image)',


### PR DESCRIPTION
SAM integ tests are failing.

### Failure 1
Before, we previously created https://github.com/aws/aws-toolkit-vscode/pull/3726/files to use a specific sam cli version in our integration tests since the following version caused CI to fail. The version of sam cli we set is very old now.

Now, this PR removes explicitly setting the sam cli version to download during CI and instead grabs the latest version.
Now when running `/runIntegrationTests` the sam tests should stop failing.

### Failure 2
The python codelens tests were failing. This was due to a bug in a newer python extension version.

Now, we lock to the last working version. More info in IDE-12283
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
