### PR TITLE
telemetry: add result field to metric

### DIFF
--- a/src/codewhisperer/service/transformByQHandler.ts
+++ b/src/codewhisperer/service/transformByQHandler.ts
@@ -389,11 +389,14 @@ export async function zipCode(modulePath: string) {
         fs.rmSync(dependencyFolderPath, { recursive: true, force: true })
     }
 
+    // for now, use the pass/fail status of the maven command to determine this metric status
+    const mavenStatus = mavenFailed ? MetadataResult.Fail : MetadataResult.Pass
     telemetry.codeTransform_jobCreateZipEndTime.emit({
         codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
         // TODO: A nice to have would be getting the zipUploadSize
         codeTransformTotalByteSize: 0,
         codeTransformRunTimeLatency: calculateTotalLatency(zipStartTime),
+        result: mavenStatus,
     })
     return tempFilePath
 }


### PR DESCRIPTION
## Problem

@nkomonen-amazon reported an issue where CI was failing due to failure to include the result field in one of our metric emissions.

## Solution

Add the result field.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
