### PR TITLE
fix(codewhisperer): cloud9 chain suggestion bug

### DIFF
--- a/.changes/next-release/Bug Fix-18261950-9a6c-4fdf-b618-5c45ffaa3e82.json
+++ b/.changes/next-release/Bug Fix-18261950-9a6c-4fdf-b618-5c45ffaa3e82.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Fix a bug when accepting a recommendation in AWS Cloud9 will trigger another suggestion"
+	"description": "CodeWhisperer: Fixes a bug where accepting a recommendation in AWS Cloud9 will trigger another suggestion"
 }

--- a/.changes/next-release/Bug Fix-18261950-9a6c-4fdf-b618-5c45ffaa3e82.json
+++ b/.changes/next-release/Bug Fix-18261950-9a6c-4fdf-b618-5c45ffaa3e82.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix a bug when accepting a recommendation in AWS Cloud9 will trigger another suggestion"
+}

--- a/src/codewhisperer/service/keyStrokeHandler.ts
+++ b/src/codewhisperer/service/keyStrokeHandler.ts
@@ -17,7 +17,6 @@ import { InlineCompletionService } from './inlineCompletionService'
 import { AuthUtil } from '../util/authUtil'
 import { ClassifierTrigger } from './classifierTrigger'
 import { isIamConnection } from '../../auth/connection'
-import { session } from '../util/codeWhispererSession'
 import { extractContextForCodeWhisperer } from '../util/editorContext'
 
 const performance = globalThis.performance ?? require('perf_hooks').performance
@@ -104,11 +103,12 @@ export class KeyStrokeHandler {
                 return
             }
 
-            // Skip Cloud9 IntelliSense acceptance event
-            if (isCloud9() && event.contentChanges.length > 0 && session.recommendations.length > 0) {
-                if (event.contentChanges[0].text === session.recommendations[0].content) {
-                    return
-                }
+            // In Cloud9, do not auto trigger when
+            // 1. The input is from IntelliSense acceptance event
+            // 2. The input is from copy and paste some code
+            // event.contentChanges[0].text.length > 1 is a close estimate of 1 and 2
+            if (isCloud9() && event.contentChanges.length > 0 && event.contentChanges[0].text.length > 1) {
+                return
             }
 
             const { rightFileContent } = extractContextForCodeWhisperer(editor)


### PR DESCRIPTION
## Problem
In AWS Cloud9, accepting CW reco will trigger one more time of CodeWhisperer suggestion.


## Solution

Ignore the document change event when accepting a code recommendation in AWS Cloud9. 

This PR will be kept in draft state until 12/18/2023.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
