### PR TITLE
fix(codecatalyst): default to builder ID sign in if URI contains no IdC params

### DIFF
--- a/src/test/codecatalyst/uriHandlers.test.ts
+++ b/src/test/codecatalyst/uriHandlers.test.ts
@@ -12,8 +12,9 @@ import { VSCODE_EXTENSION_ID } from '../../shared/extensions'
 import { CodeCatalystClient } from '../../shared/clients/codecatalystClient'
 import { anything, mock, reset, when } from 'ts-mockito'
 import { SeverityLevel } from '../shared/vscode/message'
-import { DevEnvironmentId } from '../../codecatalyst/model'
 import { getTestWindow } from '../shared/vscode/window'
+import { builderIdStartUrl } from '../../auth/sso/model'
+import { defaultSsoRegion } from '../../auth/connection'
 
 type Stub<T extends (...args: any[]) => any> = sinon.SinonStub<Parameters<T>, ReturnType<T>>
 
@@ -21,12 +22,7 @@ function createCloneUri(target: string): vscode.Uri {
     return vscode.Uri.parse(`vscode://${VSCODE_EXTENSION_ID.awstoolkit}/clone?url=${encodeURIComponent(target)}`)
 }
 
-function createConnectUri(env: DevEnvironmentId): vscode.Uri {
-    const params = {
-        devEnvironmentId: env.id,
-        spaceName: env.org.name,
-        projectName: env.project.name,
-    }
+function createConnectUri(params: { [key: string]: any }): vscode.Uri {
     const encoded = Object.entries(params)
         .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
         .join('&')
@@ -37,20 +33,10 @@ function createConnectUri(env: DevEnvironmentId): vscode.Uri {
 // The path is apart of our public API! They should not be easy to change.
 
 describe('CodeCatalyst handlers', function () {
-    let handler: UriHandler
     let commandStub: Stub<typeof vscode.commands.executeCommand>
     const client = mock<CodeCatalystClient>()
 
     beforeEach(function () {
-        handler = new UriHandler()
-        register(handler, {
-            openDevEnv: {
-                execute: async () => undefined,
-            } as any,
-            cloneRepo: {
-                execute: async () => undefined,
-            } as any,
-        })
         commandStub = sinon.stub(vscode.commands, 'executeCommand')
     })
 
@@ -60,6 +46,17 @@ describe('CodeCatalyst handlers', function () {
     })
 
     describe('clone', function () {
+        let handler: UriHandler
+
+        beforeEach(function () {
+            handler = new UriHandler()
+            register(handler, {
+                cloneRepo: {
+                    execute: async () => undefined,
+                } as any,
+            } as any)
+        })
+
         it('registers for "/clone"', function () {
             assert.throws(() => handler.onPath('/clone', () => {}))
         })
@@ -82,6 +79,42 @@ describe('CodeCatalyst handlers', function () {
             org: { name: 'org' },
             project: { name: 'project' },
         }
+
+        const params = {
+            devEnvironmentId: devenvId.id,
+            spaceName: devenvId.org.name,
+            projectName: devenvId.project.name,
+        }
+
+        let openDevEnvMock: sinon.SinonExpectation
+        let handler: UriHandler
+
+        beforeEach(function () {
+            handler = new UriHandler()
+            openDevEnvMock = sinon.mock()
+            register(handler, {
+                openDevEnv: {
+                    execute: openDevEnvMock,
+                } as any,
+            } as any)
+        })
+
+        it('returns builder ID SSO if IdC params are not present', async function () {
+            await handler.handleUri(createConnectUri(params))
+            assert.ok(
+                openDevEnvMock.calledWith(devenvId, undefined, {
+                    startUrl: builderIdStartUrl,
+                    region: defaultSsoRegion,
+                })
+            )
+        })
+
+        it('returns provided IdC params', async function () {
+            const ssoStartUrl = 'https://my-url'
+            const ssoRegion = 'us-west-2'
+            await handler.handleUri(createConnectUri({ ...params, sso_start_url: ssoStartUrl, sso_region: ssoRegion }))
+            assert.ok(openDevEnvMock.calledWith(devenvId, undefined, { startUrl: ssoStartUrl, region: ssoRegion }))
+        })
 
         it('checks that the environment exists', async function () {
             // This test is not accurate anymore because dependencies are checked prior to API calls


### PR DESCRIPTION
Problem: If a user opens a vscode URI to open a dev environment and there are no IdC params, then the user is pointed to the login page instead of being routed to builder ID sign in. This means the user has to click the link again after signing in. 

Solution: Always default to builder ID if there are no IdC params in the URI, rather than prompt for sign in.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
