### PR TITLE
telemetry: improve collapse ("debounce") log message

### DIFF
--- a/src/shared/vscode/commands2.ts
+++ b/src/shared/vscode/commands2.ts
@@ -460,7 +460,7 @@ function getInstrumenter(
     if (!telemetryName && info?.startTime !== undefined && currentTime - info.startTime < threshold) {
         info.debounceCount += 1
         TelemetryDebounceInfo.instance.set(id, info)
-        getLogger().debug('commands: skipped telemetry for "%s" with key "%O"', id.id, id.compositeKey)
+        getLogger().debug('telemetry: collapsing %d "%s" metrics. key=%O', info.debounceCount, id.id, id.compositeKey)
 
         return undefined
     }


### PR DESCRIPTION
Example:

    2023-12-15 12:28:11 [DEBUG]: telemetry: collapsing 4 "aws.previewStateMachine" metrics. key={}

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
