### PR TITLE
telemetry: add code transform data byte size and result field to metrics

### DIFF
--- a/.changes/next-release/Bug Fix-d5eeec6a-5371-4075-8442-66c70c253202.json
+++ b/.changes/next-release/Bug Fix-d5eeec6a-5371-4075-8442-66c70c253202.json
@@ -1,4 +1,0 @@
-{
-	"type": "Bug Fix",
-	"description": "Code Transform Telemetry missing result metadata"
-}

--- a/.changes/next-release/Bug Fix-d5eeec6a-5371-4075-8442-66c70c253202.json
+++ b/.changes/next-release/Bug Fix-d5eeec6a-5371-4075-8442-66c70c253202.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Code Transform Telemetry missing result metadata"
+}

--- a/.changes/next-release/Feature-20c6488b-1750-4ca6-9eb3-b509f49f194b.json
+++ b/.changes/next-release/Feature-20c6488b-1750-4ca6-9eb3-b509f49f194b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Emit additional metadata in telemetry"
+}

--- a/.changes/next-release/Feature-20c6488b-1750-4ca6-9eb3-b509f49f194b.json
+++ b/.changes/next-release/Feature-20c6488b-1750-4ca6-9eb3-b509f49f194b.json
@@ -1,4 +1,4 @@
 {
 	"type": "Feature",
-	"description": "Emit additional metadata in telemetry"
+	"description": "Code Transform Telemetry includes additional metadata"
 }

--- a/src/amazonqGumby/telemetry/codeTransformTelemetry.ts
+++ b/src/amazonqGumby/telemetry/codeTransformTelemetry.ts
@@ -10,6 +10,7 @@ import { telemetry } from '../../shared/telemetry/telemetry'
 import { JDKVersion } from '../../codewhisperer/models/model'
 import * as CodeWhispererConstants from '../../codewhisperer/models/constants'
 import { codeTransformTelemetryState } from './codeTransformTelemetryState'
+import { MetadataResult } from '../../shared/telemetry/telemetryClient'
 
 export enum CancelActionPositions {
     ApiError = 'apiError',
@@ -32,11 +33,13 @@ export const logCodeTransformInitiatedMetric = (source: string): void => {
         telemetry.codeTransform_isDoubleClickedToTriggerUserModal.emit({
             codeTransformStartSrcComponents: StartActionPositions.DevToolsSidePanel,
             ...commonMetrics,
+            result: MetadataResult.Pass,
         })
     } else if (source === StartActionPositions.BottomHubPanel) {
         telemetry.codeTransform_isDoubleClickedToTriggerUserModal.emit({
             codeTransformStartSrcComponents: StartActionPositions.BottomHubPanel,
             ...commonMetrics,
+            result: MetadataResult.Pass,
         })
     }
 }

--- a/src/codewhisperer/commands/startTransformByQ.ts
+++ b/src/codewhisperer/commands/startTransformByQ.ts
@@ -37,6 +37,7 @@ import { codeTransformTelemetryState } from '../../amazonqGumby/telemetry/codeTr
 import { ToolkitError } from '../../shared/errors'
 import { TransformByQUploadArchiveFailed } from '../../amazonqGumby/models/model'
 import { CancelActionPositions, toJDKMetricValue } from '../../amazonqGumby/telemetry/codeTransformTelemetry'
+import { MetadataResult } from '../../shared/telemetry/telemetryClient'
 
 const localize = nls.loadMessageBundle()
 export const stopTransformByQButton = localize('aws.codewhisperer.stop.transform.by.q', 'Stop')
@@ -122,11 +123,13 @@ export async function startTransformByQ() {
     if (selection !== 'Transform') {
         telemetry.codeTransform_jobIsCanceledFromUserPopupClick.emit({
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
+            result: MetadataResult.Pass,
         })
         throw new ToolkitError('Transform cancelled', { code: 'DidNotConfirmDisclaimer', cancelled: true })
     } else {
         telemetry.codeTransform_jobIsStartedFromUserPopupClick.emit({
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
+            result: MetadataResult.Pass,
         })
     }
 
@@ -146,6 +149,7 @@ export async function startTransformByQ() {
         codeTransformJavaTargetVersionsAllowed: toJDKMetricValue(
             transformByQState.getTargetJDKVersion()
         ) as CodeTransformJavaTargetVersionsAllowed,
+        result: MetadataResult.Pass,
     })
 
     vscode.commands.executeCommand('workbench.view.extension.aws-codewhisperer-transformation-hub')
@@ -347,6 +351,7 @@ export async function confirmStopTransformByQ(
         telemetry.codeTransform_jobIsCancelledByUser.emit({
             codeTransformCancelSrcComponents: cancelSrc,
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
+            result: MetadataResult.Pass,
         })
     }
 }

--- a/src/codewhisperer/service/transformByQHandler.ts
+++ b/src/codewhisperer/service/transformByQHandler.ts
@@ -89,71 +89,52 @@ export async function validateProjectSelection(project: vscode.QuickPickItem) {
         '**/node_modules/**',
         1
     )
-    if (compiledJavaFiles.length < 1) {
-        vscode.window.showErrorMessage(CodeWhispererConstants.noSupportedJavaProjectsFoundMessage, { modal: true })
-        telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.emit({
-            codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
-            codeTransformPreValidationError: 'NoJavaProject',
-            result: MetadataResult.Pass,
-        })
-        throw new TransformByQJavaProjectNotFound()
-    }
-    const classFilePath = compiledJavaFiles[0].fsPath
-    const baseCommand = 'javap'
-    const args = ['-v', classFilePath]
-    const spawnResult = spawnSync(baseCommand, args, { shell: false, encoding: 'utf-8' })
-
-    if (spawnResult.error || spawnResult.status !== 0) {
-        vscode.window.showErrorMessage(CodeWhispererConstants.noSupportedJavaProjectsFoundMessage, { modal: true })
-        telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.emit({
-            codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
-            codeTransformPreValidationError: 'NoJavaProject',
-            result: MetadataResult.Pass,
-        })
-        throw new ToolkitError('Unable to determine Java version', {
-            code: 'CannotDetermineJavaVersion',
-            cause: spawnResult.error,
-        })
-    }
-    const majorVersionIndex = spawnResult.stdout.indexOf('major version: ')
-    const javaVersion = spawnResult.stdout.slice(majorVersionIndex + 15, majorVersionIndex + 17).trim()
-    if (javaVersion === CodeWhispererConstants.JDK8VersionNumber) {
-        transformByQState.setSourceJDKVersionToJDK8()
-    } else if (javaVersion === CodeWhispererConstants.JDK11VersionNumber) {
-        transformByQState.setSourceJDKVersionToJDK11()
-    } else {
-        vscode.window.showErrorMessage(CodeWhispererConstants.noSupportedJavaProjectsFoundMessage, { modal: true })
-        telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.emit({
-            codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
-            codeTransformPreValidationError: 'UnsupportedJavaVersion',
-            result: MetadataResult.Pass,
-            reason: javaVersion,
-        })
-        throw new ToolkitError('Project selected is not Java 8 or Java 11', { code: 'UnsupportedJavaVersion' })
-    }
     const buildFile = await vscode.workspace.findFiles(
         new vscode.RelativePattern(projectPath!, 'pom.xml'), // check for pom.xml in root directory only
         '**/node_modules/**',
         1
     )
-    if (buildFile.length < 1) {
-        const buildType = await checkIfGradle(projectPath!)
-        vscode.window.showErrorMessage(CodeWhispererConstants.noPomXmlFoundMessage, { modal: true })
-        if (buildType === 'Gradle') {
-            telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.emit({
-                codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
-                codeTransformPreValidationError: 'NonMavenProject',
-                result: MetadataResult.Pass,
-                reason: buildType,
+    telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.run(() => {
+        telemetry.record({ codeTransformSessionId: codeTransformTelemetryState.getSessionId() })
+        if (compiledJavaFiles.length < 1) {
+            vscode.window.showErrorMessage(CodeWhispererConstants.noSupportedJavaProjectsFoundMessage, { modal: true })
+            telemetry.record({ codeTransformPreValidationError: 'NoJavaProject' })
+            throw new TransformByQJavaProjectNotFound()
+        }
+        const classFilePath = compiledJavaFiles[0].fsPath
+        const baseCommand = 'javap'
+        const args = ['-v', classFilePath]
+        const spawnResult = spawnSync(baseCommand, args, { shell: false, encoding: 'utf-8' })
+
+        if (spawnResult.error || spawnResult.status !== 0) {
+            vscode.window.showErrorMessage(CodeWhispererConstants.noSupportedJavaProjectsFoundMessage, { modal: true })
+            telemetry.record({ codeTransformPreValidationError: 'NoJavaProject' })
+            throw new ToolkitError('Unable to determine Java version', {
+                code: 'CannotDetermineJavaVersion',
+                cause: spawnResult.error,
             })
         }
-        telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.emit({
-            codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
-            codeTransformPreValidationError: 'NoPom',
-            result: MetadataResult.Pass,
-        })
-        throw new ToolkitError('No valid Maven build file found', { code: 'CouldNotFindPomXml' })
-    }
+        const majorVersionIndex = spawnResult.stdout.indexOf('major version: ')
+        const javaVersion = spawnResult.stdout.slice(majorVersionIndex + 15, majorVersionIndex + 17).trim()
+        if (javaVersion === CodeWhispererConstants.JDK8VersionNumber) {
+            transformByQState.setSourceJDKVersionToJDK8()
+        } else if (javaVersion === CodeWhispererConstants.JDK11VersionNumber) {
+            transformByQState.setSourceJDKVersionToJDK11()
+        } else {
+            vscode.window.showErrorMessage(CodeWhispererConstants.noSupportedJavaProjectsFoundMessage, { modal: true })
+            telemetry.record({ codeTransformPreValidationError: 'UnsupportedJavaVersion' })
+            throw new ToolkitError('Project selected is not Java 8 or Java 11', { code: 'UnsupportedJavaVersion' })
+        }
+        if (buildFile.length < 1) {
+            const buildType = checkIfGradle(projectPath!)
+            vscode.window.showErrorMessage(CodeWhispererConstants.noPomXmlFoundMessage, { modal: true })
+            if (buildType === 'Gradle') {
+                telemetry.record({ codeTransformPreValidationError: 'NonMavenProject' })
+            }
+            telemetry.record({ codeTransformPreValidationError: 'NoPom' })
+            throw new ToolkitError('No valid Maven build file found', { code: 'CouldNotFindPomXml' })
+        }
+    })
 }
 
 export function getSha256(fileName: string) {
@@ -601,7 +582,7 @@ export async function pollTransformationJob(jobId: string, validStates: string[]
     return status
 }
 
-async function checkIfGradle(projectPath: string) {
+function checkIfGradle(projectPath: string) {
     const gradleBuildFilePath = path.join(projectPath, 'build.gradle')
     if (fs.existsSync(gradleBuildFilePath)) {
         return 'Gradle'

--- a/src/codewhisperer/service/transformByQHandler.ts
+++ b/src/codewhisperer/service/transformByQHandler.ts
@@ -94,7 +94,8 @@ export async function validateProjectSelection(project: vscode.QuickPickItem) {
         telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.emit({
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
             codeTransformPreValidationError: 'NoJavaProject',
-            result: MetadataResult.Pass,
+            result: MetadataResult.Fail,
+            reason: 'NoJavaProjectsAvailable',
         })
         throw new TransformByQJavaProjectNotFound()
     }
@@ -108,7 +109,8 @@ export async function validateProjectSelection(project: vscode.QuickPickItem) {
         telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.emit({
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
             codeTransformPreValidationError: 'NoJavaProject',
-            result: MetadataResult.Pass,
+            result: MetadataResult.Fail,
+            reason: 'CannotDetermineJavaVersion',
         })
         throw new ToolkitError('Unable to determine Java version', {
             code: 'CannotDetermineJavaVersion',
@@ -126,7 +128,7 @@ export async function validateProjectSelection(project: vscode.QuickPickItem) {
         telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.emit({
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
             codeTransformPreValidationError: 'UnsupportedJavaVersion',
-            result: MetadataResult.Pass,
+            result: MetadataResult.Fail,
             reason: javaVersion,
         })
         throw new ToolkitError('Project selected is not Java 8 or Java 11', { code: 'UnsupportedJavaVersion' })
@@ -143,14 +145,15 @@ export async function validateProjectSelection(project: vscode.QuickPickItem) {
             telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.emit({
                 codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
                 codeTransformPreValidationError: 'NonMavenProject',
-                result: MetadataResult.Pass,
+                result: MetadataResult.Fail,
                 reason: buildType,
             })
         }
         telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.emit({
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
             codeTransformPreValidationError: 'NoPom',
-            result: MetadataResult.Pass,
+            result: MetadataResult.Fail,
+            reason: 'CouldNotFindPomXml',
         })
         throw new ToolkitError('No valid Maven build file found', { code: 'CouldNotFindPomXml' })
     }

--- a/src/codewhisperer/service/transformByQHandler.ts
+++ b/src/codewhisperer/service/transformByQHandler.ts
@@ -94,7 +94,7 @@ export async function validateProjectSelection(project: vscode.QuickPickItem) {
         telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.emit({
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
             codeTransformPreValidationError: 'NoJavaProject',
-            result: MetadataResult.Fail,
+            result: MetadataResult.Pass,
         })
         throw new TransformByQJavaProjectNotFound()
     }
@@ -108,7 +108,7 @@ export async function validateProjectSelection(project: vscode.QuickPickItem) {
         telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.emit({
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
             codeTransformPreValidationError: 'NoJavaProject',
-            result: MetadataResult.Fail,
+            result: MetadataResult.Pass,
         })
         throw new ToolkitError('Unable to determine Java version', {
             code: 'CannotDetermineJavaVersion',
@@ -126,7 +126,7 @@ export async function validateProjectSelection(project: vscode.QuickPickItem) {
         telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.emit({
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
             codeTransformPreValidationError: 'UnsupportedJavaVersion',
-            result: MetadataResult.Fail,
+            result: MetadataResult.Pass,
             reason: javaVersion,
         })
         throw new ToolkitError('Project selected is not Java 8 or Java 11', { code: 'UnsupportedJavaVersion' })
@@ -143,14 +143,14 @@ export async function validateProjectSelection(project: vscode.QuickPickItem) {
             telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.emit({
                 codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
                 codeTransformPreValidationError: 'NonMavenProject',
-                result: MetadataResult.Fail,
+                result: MetadataResult.Pass,
                 reason: buildType,
             })
         }
         telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.emit({
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
             codeTransformPreValidationError: 'NoPom',
-            result: MetadataResult.Fail,
+            result: MetadataResult.Pass,
         })
         throw new ToolkitError('No valid Maven build file found', { code: 'CouldNotFindPomXml' })
     }
@@ -209,6 +209,7 @@ export async function uploadArtifactToS3(fileName: string, resp: CreateUploadUrl
             codeTransformApiErrorMessage: errorMessage,
             codeTransformRequestId: e?.requestId,
             result: MetadataResult.Fail,
+            reason: 'UploadToS3Failed',
         })
         // Pass along error to callee function
         throw new ToolkitError(errorMessage, { cause: e as Error })
@@ -242,6 +243,7 @@ export async function stopJob(jobId: string) {
                 codeTransformApiErrorMessage: e?.message || errorMessage,
                 codeTransformRequestId: e?.requestId,
                 result: MetadataResult.Fail,
+                reason: 'StopTransformationFailed',
             })
             throw new ToolkitError(errorMessage, { cause: e as Error })
         }
@@ -278,6 +280,7 @@ export async function uploadPayload(payloadFileName: string) {
             codeTransformApiErrorMessage: errorMessage,
             codeTransformRequestId: e?.requestId,
             result: MetadataResult.Fail,
+            reason: 'CreateUploadUrlFailed',
         })
         // Pass along error to callee function
         throw new ToolkitError(errorMessage, { cause: e as Error })
@@ -443,6 +446,7 @@ export async function startJob(uploadId: string) {
             codeTransformApiErrorMessage: errorMessage,
             codeTransformRequestId: e?.requestId,
             result: MetadataResult.Fail,
+            reason: 'StartTransformationFailed',
         })
         // Pass along error to callee function
         throw new ToolkitError(errorMessage, { cause: e as Error })
@@ -494,6 +498,7 @@ export async function getTransformationPlan(jobId: string) {
             codeTransformApiErrorMessage: errorMessage,
             codeTransformRequestId: e?.requestId,
             result: MetadataResult.Fail,
+            reason: 'GetTransformationPlanFailed',
         })
         // Pass along error to callee function
         throw new ToolkitError(errorMessage, { cause: e as Error })
@@ -526,6 +531,7 @@ export async function getTransformationSteps(jobId: string) {
             codeTransformApiErrorMessage: errorMessage,
             codeTransformRequestId: e?.requestId,
             result: MetadataResult.Fail,
+            reason: 'GetTransformationPlanFailed',
         })
         throw e
     }
@@ -586,6 +592,7 @@ export async function pollTransformationJob(jobId: string, validStates: string[]
                 codeTransformApiErrorMessage: errorMessage,
                 codeTransformRequestId: e?.requestId,
                 result: MetadataResult.Fail,
+                reason: 'GetTransformationFailed',
             })
             // Pass along error to callee function
             throw new ToolkitError(errorMessage, { cause: e as Error })

--- a/src/codewhisperer/service/transformationResultsViewProvider.ts
+++ b/src/codewhisperer/service/transformationResultsViewProvider.ts
@@ -288,6 +288,7 @@ export class ProposedTransformationExplorer {
                     codeTransformApiErrorMessage: e?.message || errorMessage,
                     codeTransformRequestId: e?.requestId,
                     result: MetadataResult.Fail,
+                    reason: 'ExportResultArchiveFailed',
                 })
                 throw new ToolkitError(errorMessage)
             }

--- a/src/codewhisperer/service/transformationResultsViewProvider.ts
+++ b/src/codewhisperer/service/transformationResultsViewProvider.ts
@@ -314,15 +314,16 @@ export class ProposedTransformationExplorer {
                 )
             } catch (e: any) {
                 deserializeErrorMessage = e?.message || 'Error during deserialization of result archive'
-            } finally {
                 getLogger().error('CodeTransform: ParseDiff error = ', deserializeErrorMessage)
+            } finally {
                 telemetry.codeTransform_jobArtifactDownloadAndDeserializeTime.emit({
                     codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
                     codeTransformJobId: transformByQState.getJobId(),
                     codeTransformRunTimeLatency: calculateTotalLatency(deserializeArchiveStartTime),
                     codeTransformTotalByteSize: exportResultsArchiveSize,
                     codeTransformRuntimeError: deserializeErrorMessage,
-                    result: MetadataResult.Pass,
+                    result: deserializeErrorMessage ? MetadataResult.Fail : MetadataResult.Pass,
+                    reason: deserializeErrorMessage ? 'DeserializationFailed' : undefined,
                 })
             }
 


### PR DESCRIPTION
## Problem
1. Code Transform artifact upload and download metrics for VSCode did not have totalByteSize.
2. Need to emit dependenciesCopied metric.
3. Several Code Transform metrics did not have `result` field.

## Solution
1. Include totalByteSize where applicable.
2. Emit dependenciesCopied metric.
3. Add `result` field to metrics.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

Validated dependenciesCopied emitted:

- `telemetry: emitted metric "codeTransform_dependenciesCopied" -> {"Metadata":[{"Key":"parentMetric","Value":"vscode_executeCommand"},{"Key":"codeTransformSessionId","Value":"<redacted>"},{"Key":"result","Value":"Succeeded"},{"Key":"awsAccount","Value":"not-set"},{"Key":"awsRegion","Value":"us-west-2"}],"MetricName":"codeTransform_dependenciesCopied","Value":1,"Unit":"None","Passive":false,"EpochTimestamp":1702660044892}`

Validated metrics are emitted with expected TotalByteSize:

- `telemetry: emitted metric "codeTransform_jobCreateZipEndTime" -> {"Metadata":[{"Key":"parentMetric","Value":"vscode_executeCommand"},{"Key":"codeTransformSessionId","Value":"<redacted>"},{"Key":"codeTransformTotalByteSize","Value":"2522725"},{"Key":"codeTransformRunTimeLatency","Value":"11208"},{"Key":"result","Value":"Succeeded"},{"Key":"awsAccount","Value":"not-set"},{"Key":"awsRegion","Value":"us-west-2"}],"MetricName":"codeTransform_jobCreateZipEndTime","Value":1,"Unit":"None","Passive":false,"EpochTimestamp":1702660047014}`
- `telemetry: emitted metric "codeTransform_logApiLatency" -> {"Metadata":[{"Key":"parentMetric","Value":"vscode_executeCommand"},{"Key":"codeTransformApiNames","Value":"UploadZip"},{"Key":"codeTransformSessionId","Value":"<redacted>"},
{"Key":"codeTransformUploadId","Value":"<redacted>"},{"Key":"codeTransformRunTimeLatency","Value":"5667"},{"Key":"codeTransformTotalByteSize","Value":"2522725"},{"Key":"result","Value":"Succeeded"},{"Key":"awsAccount","Value":"not-set"},{"Key":"awsRegion","Value":"us-west-2"}],"MetricName":"codeTransform_logApiLatency","Value":1,"Unit":"None","Passive":true,"EpochTimestamp":1702660057297}`
- `telemetry: emitted metric "codeTransform_jobArtifactDownloadAndDeserializeTime" -> {"Metadata":[{"Key":"codeTransformSessionId","Value":"<redacted>"},{"Key":"codeTransformJobId","Value":"<redacted>"},{"Key":"codeTransformRunTimeLatency","Value":"70"},{"Key":"codeTransformTotalByteSize","Value":"152486"},{"Key":"result","Value":"Succeeded"},{"Key":"awsAccount","Value":"not-set"},{"Key":"awsRegion","Value":"us-west-2"}],"MetricName":"codeTransform_jobArtifactDownloadAndDeserializeTime","Value":1,"Unit":"None","Passive":false,"EpochTimestamp":1702660482671}`
- `telemetry: emitted metric "codeTransform_logApiLatency" -> {"Metadata":[{"Key":"codeTransformApiNames","Value":"ExportResultArchive"},{"Key":"codeTransformSessionId","Value":"<redacted>"},{"Key":"codeTransformJobId","Value":"<redacted>"},{"Key":"codeTransformRunTimeLatency","Value":"1133"},{"Key":"codeTransformTotalByteSize","Value":"152486"},{"Key":"codeTransformRequestId","Value":"<redacted>"},{"Key":"awsAccount","Value":"not-set"},{"Key":"awsRegion","Value":"us-west-2"}],"MetricName":"codeTransform_logApiLatency","Value":1,"Unit":"None","Passive":true,"EpochTimestamp":1702660482600}`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
