### PR TITLE
fix(codewhisperer): support code generation for IaC languages without external plugin extensions

### DIFF
--- a/.changes/next-release/Bug Fix-ec18555e-d716-40b5-b8d1-54dad851fdc2.json
+++ b/.changes/next-release/Bug Fix-ec18555e-d716-40b5-b8d1-54dad851fdc2.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeWhisperer supports code generation for Iaac languages without external extensions"
+}

--- a/.changes/next-release/Bug Fix-ec18555e-d716-40b5-b8d1-54dad851fdc2.json
+++ b/.changes/next-release/Bug Fix-ec18555e-d716-40b5-b8d1-54dad851fdc2.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "CodeWhisperer supports code generation for Iaac languages without external extensions"
+	"description": "CodeWhisperer supports code generation for Iac languages without external extensions"
 }

--- a/src/codewhisperer/commands/onAcceptance.ts
+++ b/src/codewhisperer/commands/onAcceptance.ts
@@ -14,6 +14,7 @@ import { handleExtraBrackets } from '../util/closingBracketUtil'
 import { RecommendationHandler } from '../service/recommendationHandler'
 import { ReferenceLogViewProvider } from '../service/referenceLogViewProvider'
 import { ReferenceHoverProvider } from '../service/referenceHoverProvider'
+import { getFileExtension } from '../util/editorContext'
 
 /**
  * This function is called when user accepts a intelliSense suggestion or an inline suggestion
@@ -26,9 +27,7 @@ export async function onAcceptance(acceptanceEntry: OnRecommendationAcceptanceEn
     if (acceptanceEntry.editor) {
         const languageContext = runtimeLanguageContext.getLanguageContext(
             acceptanceEntry.editor.document.languageId,
-            acceptanceEntry.editor.document.fileName.substring(
-                acceptanceEntry.editor.document.fileName.lastIndexOf('.') + 1
-            )
+            getFileExtension(acceptanceEntry.editor.document)
         )
         const start = acceptanceEntry.range.start
         const end = isCloud9() ? acceptanceEntry.editor.selection.active : acceptanceEntry.range.end

--- a/src/codewhisperer/commands/onAcceptance.ts
+++ b/src/codewhisperer/commands/onAcceptance.ts
@@ -24,7 +24,12 @@ export async function onAcceptance(acceptanceEntry: OnRecommendationAcceptanceEn
      * Format document
      */
     if (acceptanceEntry.editor) {
-        const languageContext = runtimeLanguageContext.getLanguageContext(acceptanceEntry.editor.document.languageId)
+        const languageContext = runtimeLanguageContext.getLanguageContext(
+            acceptanceEntry.editor.document.languageId,
+            acceptanceEntry.editor.document.fileName.substring(
+                acceptanceEntry.editor.document.fileName.lastIndexOf('.') + 1
+            )
+        )
         const start = acceptanceEntry.range.start
         const end = isCloud9() ? acceptanceEntry.editor.selection.active : acceptanceEntry.range.end
 

--- a/src/codewhisperer/commands/onAcceptance.ts
+++ b/src/codewhisperer/commands/onAcceptance.ts
@@ -14,7 +14,7 @@ import { handleExtraBrackets } from '../util/closingBracketUtil'
 import { RecommendationHandler } from '../service/recommendationHandler'
 import { ReferenceLogViewProvider } from '../service/referenceLogViewProvider'
 import { ReferenceHoverProvider } from '../service/referenceHoverProvider'
-import { getFileExtension } from '../util/editorContext'
+import path from 'path'
 
 /**
  * This function is called when user accepts a intelliSense suggestion or an inline suggestion
@@ -27,7 +27,7 @@ export async function onAcceptance(acceptanceEntry: OnRecommendationAcceptanceEn
     if (acceptanceEntry.editor) {
         const languageContext = runtimeLanguageContext.getLanguageContext(
             acceptanceEntry.editor.document.languageId,
-            getFileExtension(acceptanceEntry.editor.document)
+            path.extname(acceptanceEntry.editor.document.fileName)
         )
         const start = acceptanceEntry.range.start
         const end = isCloud9() ? acceptanceEntry.editor.selection.active : acceptanceEntry.range.end

--- a/src/codewhisperer/commands/onInlineAcceptance.ts
+++ b/src/codewhisperer/commands/onInlineAcceptance.ts
@@ -27,7 +27,7 @@ import { ReferenceLogViewProvider } from '../service/referenceLogViewProvider'
 import { ReferenceHoverProvider } from '../service/referenceHoverProvider'
 import { ImportAdderProvider } from '../service/importAdderProvider'
 import { session } from '../util/codeWhispererSession'
-import { getFileExtension } from '../util/editorContext'
+import path from 'path'
 
 export const acceptSuggestion = Commands.declare(
     'aws.codeWhisperer.accept',
@@ -76,7 +76,7 @@ export async function onInlineAcceptance(
         await sleep(CodeWhispererConstants.vsCodeCursorUpdateDelay)
         const languageContext = runtimeLanguageContext.getLanguageContext(
             acceptanceEntry.editor.document.languageId,
-            getFileExtension(acceptanceEntry.editor.document)
+            path.extname(acceptanceEntry.editor.document.fileName)
         )
         const start = acceptanceEntry.range.start
         const end = acceptanceEntry.editor.selection.active

--- a/src/codewhisperer/commands/onInlineAcceptance.ts
+++ b/src/codewhisperer/commands/onInlineAcceptance.ts
@@ -73,7 +73,12 @@ export async function onInlineAcceptance(
 
     if (acceptanceEntry.editor) {
         await sleep(CodeWhispererConstants.vsCodeCursorUpdateDelay)
-        const languageContext = runtimeLanguageContext.getLanguageContext(acceptanceEntry.editor.document.languageId)
+        const languageContext = runtimeLanguageContext.getLanguageContext(
+            acceptanceEntry.editor.document.languageId,
+            acceptanceEntry.editor.document.fileName.substring(
+                acceptanceEntry.editor.document.fileName.lastIndexOf('.') + 1
+            )
+        )
         const start = acceptanceEntry.range.start
         const end = acceptanceEntry.editor.selection.active
 

--- a/src/codewhisperer/commands/onInlineAcceptance.ts
+++ b/src/codewhisperer/commands/onInlineAcceptance.ts
@@ -27,6 +27,7 @@ import { ReferenceLogViewProvider } from '../service/referenceLogViewProvider'
 import { ReferenceHoverProvider } from '../service/referenceHoverProvider'
 import { ImportAdderProvider } from '../service/importAdderProvider'
 import { session } from '../util/codeWhispererSession'
+import { getFileExtension } from '../util/editorContext'
 
 export const acceptSuggestion = Commands.declare(
     'aws.codeWhisperer.accept',
@@ -75,9 +76,7 @@ export async function onInlineAcceptance(
         await sleep(CodeWhispererConstants.vsCodeCursorUpdateDelay)
         const languageContext = runtimeLanguageContext.getLanguageContext(
             acceptanceEntry.editor.document.languageId,
-            acceptanceEntry.editor.document.fileName.substring(
-                acceptanceEntry.editor.document.fileName.lastIndexOf('.') + 1
-            )
+            getFileExtension(acceptanceEntry.editor.document)
         )
         const start = acceptanceEntry.range.start
         const end = acceptanceEntry.editor.selection.active

--- a/src/codewhisperer/commands/startSecurityScan.ts
+++ b/src/codewhisperer/commands/startSecurityScan.ts
@@ -72,7 +72,10 @@ export async function startSecurityScan(
     const codeScanStartTime = performance.now()
     let serviceInvocationStartTime = 0
     const codeScanTelemetryEntry: CodeScanTelemetryEntry = {
-        codewhispererLanguage: runtimeLanguageContext.getLanguageContext(editor.document.languageId).language,
+        codewhispererLanguage: runtimeLanguageContext.getLanguageContext(
+            editor.document.languageId,
+            editor.document.fileName.substring(editor.document.fileName.lastIndexOf('.') + 1)
+        ).language,
         codewhispererCodeScanSrcPayloadBytes: 0,
         codewhispererCodeScanSrcZipFileBytes: 0,
         codewhispererCodeScanLines: 0,

--- a/src/codewhisperer/commands/startSecurityScan.ts
+++ b/src/codewhisperer/commands/startSecurityScan.ts
@@ -33,6 +33,7 @@ import { isAwsError } from '../../shared/errors'
 import { openUrl } from '../../shared/utilities/vsCodeUtils'
 import { AuthUtil } from '../util/authUtil'
 import { DependencyGraphConstants } from '../util/dependencyGraph/dependencyGraph'
+import { getFileExtension } from '../util/editorContext'
 
 const performance = globalThis.performance ?? require('perf_hooks').performance
 const securityScanOutputChannel = vscode.window.createOutputChannel('CodeWhisperer Security Scan Logs')
@@ -74,7 +75,7 @@ export async function startSecurityScan(
     const codeScanTelemetryEntry: CodeScanTelemetryEntry = {
         codewhispererLanguage: runtimeLanguageContext.getLanguageContext(
             editor.document.languageId,
-            editor.document.fileName.substring(editor.document.fileName.lastIndexOf('.') + 1)
+            getFileExtension(editor.document)
         ).language,
         codewhispererCodeScanSrcPayloadBytes: 0,
         codewhispererCodeScanSrcZipFileBytes: 0,

--- a/src/codewhisperer/commands/startSecurityScan.ts
+++ b/src/codewhisperer/commands/startSecurityScan.ts
@@ -33,7 +33,7 @@ import { isAwsError } from '../../shared/errors'
 import { openUrl } from '../../shared/utilities/vsCodeUtils'
 import { AuthUtil } from '../util/authUtil'
 import { DependencyGraphConstants } from '../util/dependencyGraph/dependencyGraph'
-import { getFileExtension } from '../util/editorContext'
+import path from 'path'
 
 const performance = globalThis.performance ?? require('perf_hooks').performance
 const securityScanOutputChannel = vscode.window.createOutputChannel('CodeWhisperer Security Scan Logs')
@@ -75,7 +75,7 @@ export async function startSecurityScan(
     const codeScanTelemetryEntry: CodeScanTelemetryEntry = {
         codewhispererLanguage: runtimeLanguageContext.getLanguageContext(
             editor.document.languageId,
-            getFileExtension(editor.document)
+            path.extname(editor.document.fileName)
         ).language,
         codewhispererCodeScanSrcPayloadBytes: 0,
         codewhispererCodeScanSrcZipFileBytes: 0,

--- a/src/codewhisperer/service/completionProvider.ts
+++ b/src/codewhisperer/service/completionProvider.ts
@@ -10,6 +10,7 @@ import { Recommendation } from '../client/codewhisperer'
 import { LicenseUtil } from '../util/licenseUtil'
 import { RecommendationHandler } from './recommendationHandler'
 import { session } from '../util/codeWhispererSession'
+import { getFileExtension } from '../util/editorContext'
 /**
  * completion provider for intelliSense popup
  */
@@ -41,10 +42,7 @@ export function getCompletionItem(
     completionItem.preselect = true
     completionItem.sortText = String(recommendationIndex + 1).padStart(10, '0')
     completionItem.range = new vscode.Range(start, position)
-    const languageContext = runtimeLanguageContext.getLanguageContext(
-        document.languageId,
-        document.fileName.substring(document.fileName.lastIndexOf('.') + 1)
-    )
+    const languageContext = runtimeLanguageContext.getLanguageContext(document.languageId, getFileExtension(document))
     let references: typeof recommendationDetail.references
     if (recommendationDetail.references !== undefined && recommendationDetail.references.length > 0) {
         references = recommendationDetail.references

--- a/src/codewhisperer/service/completionProvider.ts
+++ b/src/codewhisperer/service/completionProvider.ts
@@ -41,7 +41,10 @@ export function getCompletionItem(
     completionItem.preselect = true
     completionItem.sortText = String(recommendationIndex + 1).padStart(10, '0')
     completionItem.range = new vscode.Range(start, position)
-    const languageContext = runtimeLanguageContext.getLanguageContext(document.languageId)
+    const languageContext = runtimeLanguageContext.getLanguageContext(
+        document.languageId,
+        document.fileName.substring(document.fileName.lastIndexOf('.') + 1)
+    )
     let references: typeof recommendationDetail.references
     if (recommendationDetail.references !== undefined && recommendationDetail.references.length > 0) {
         references = recommendationDetail.references

--- a/src/codewhisperer/service/completionProvider.ts
+++ b/src/codewhisperer/service/completionProvider.ts
@@ -10,7 +10,7 @@ import { Recommendation } from '../client/codewhisperer'
 import { LicenseUtil } from '../util/licenseUtil'
 import { RecommendationHandler } from './recommendationHandler'
 import { session } from '../util/codeWhispererSession'
-import { getFileExtension } from '../util/editorContext'
+import path from 'path'
 /**
  * completion provider for intelliSense popup
  */
@@ -42,7 +42,10 @@ export function getCompletionItem(
     completionItem.preselect = true
     completionItem.sortText = String(recommendationIndex + 1).padStart(10, '0')
     completionItem.range = new vscode.Range(start, position)
-    const languageContext = runtimeLanguageContext.getLanguageContext(document.languageId, getFileExtension(document))
+    const languageContext = runtimeLanguageContext.getLanguageContext(
+        document.languageId,
+        path.extname(document.fileName)
+    )
     let references: typeof recommendationDetail.references
     if (recommendationDetail.references !== undefined && recommendationDetail.references.length > 0) {
         references = recommendationDetail.references

--- a/src/codewhisperer/service/inlineCompletionItemProvider.ts
+++ b/src/codewhisperer/service/inlineCompletionItemProvider.ts
@@ -116,7 +116,10 @@ export class CWInlineCompletionItemProvider implements vscode.InlineCompletionIt
                     session.sessionId,
                     session.triggerType,
                     session.getCompletionType(index),
-                    runtimeLanguageContext.getLanguageContext(document.languageId).language,
+                    runtimeLanguageContext.getLanguageContext(
+                        document.languageId,
+                        document.fileName.substring(document.fileName.lastIndexOf('.') + 1)
+                    ).language,
                     r.references,
                 ],
             },

--- a/src/codewhisperer/service/inlineCompletionItemProvider.ts
+++ b/src/codewhisperer/service/inlineCompletionItemProvider.ts
@@ -11,7 +11,7 @@ import { runtimeLanguageContext } from '../util/runtimeLanguageContext'
 import { ReferenceInlineProvider } from './referenceInlineProvider'
 import { ImportAdderProvider } from './importAdderProvider'
 import { application } from '../util/codeWhispererApplication'
-import { getFileExtension } from '../util/editorContext'
+import path from 'path'
 
 export class CWInlineCompletionItemProvider implements vscode.InlineCompletionItemProvider {
     private activeItemIndex: number | undefined
@@ -117,7 +117,8 @@ export class CWInlineCompletionItemProvider implements vscode.InlineCompletionIt
                     session.sessionId,
                     session.triggerType,
                     session.getCompletionType(index),
-                    runtimeLanguageContext.getLanguageContext(document.languageId, getFileExtension(document)).language,
+                    runtimeLanguageContext.getLanguageContext(document.languageId, path.extname(document.fileName))
+                        .language,
                     r.references,
                 ],
             },

--- a/src/codewhisperer/service/inlineCompletionItemProvider.ts
+++ b/src/codewhisperer/service/inlineCompletionItemProvider.ts
@@ -11,6 +11,7 @@ import { runtimeLanguageContext } from '../util/runtimeLanguageContext'
 import { ReferenceInlineProvider } from './referenceInlineProvider'
 import { ImportAdderProvider } from './importAdderProvider'
 import { application } from '../util/codeWhispererApplication'
+import { getFileExtension } from '../util/editorContext'
 
 export class CWInlineCompletionItemProvider implements vscode.InlineCompletionItemProvider {
     private activeItemIndex: number | undefined
@@ -116,10 +117,7 @@ export class CWInlineCompletionItemProvider implements vscode.InlineCompletionIt
                     session.sessionId,
                     session.triggerType,
                     session.getCompletionType(index),
-                    runtimeLanguageContext.getLanguageContext(
-                        document.languageId,
-                        document.fileName.substring(document.fileName.lastIndexOf('.') + 1)
-                    ).language,
+                    runtimeLanguageContext.getLanguageContext(document.languageId, getFileExtension(document)).language,
                     r.references,
                 ],
             },

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -44,6 +44,7 @@ import { application } from '../util/codeWhispererApplication'
 import { openUrl } from '../../shared/utilities/vsCodeUtils'
 import { indent } from '../../shared/utilities/textUtilities'
 import { getFileExtension } from '../util/editorContext'
+import path from 'path'
 
 /**
  * This class is for getRecommendation/listRecommendation API calls and its states
@@ -405,7 +406,7 @@ export class RecommendationHandler {
                     page,
                     runtimeLanguageContext.getLanguageContext(
                         editor.document.languageId,
-                        editor.document.fileName.substring(editor.document.fileName.lastIndexOf('.') + 1)
+                        path.extname(editor.document.fileName)
                     ).language,
                     session.requestContext.supplementalMetadata
                 )

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -180,7 +180,10 @@ export class RecommendationHandler {
         let latency = 0
         let nextToken = ''
         let shouldRecordServiceInvocation = true
-        session.language = runtimeLanguageContext.getLanguageContext(editor.document.languageId).language
+        session.language = runtimeLanguageContext.getLanguageContext(
+            editor.document.languageId,
+            editor.document.fileName.substring(editor.document.fileName.lastIndexOf('.') + 1)
+        ).language
         session.taskType = await this.getTaskTypeFromEditorFileName(editor.document.fileName)
 
         if (pagination) {
@@ -399,7 +402,10 @@ export class RecommendationHandler {
                     session.requestIdList,
                     sessionId,
                     page,
-                    editor.document.languageId,
+                    runtimeLanguageContext.getLanguageContext(
+                        editor.document.languageId,
+                        editor.document.fileName.substring(editor.document.fileName.lastIndexOf('.') + 1)
+                    ).language,
                     session.requestContext.supplementalMetadata
                 )
             }
@@ -685,7 +691,10 @@ export class RecommendationHandler {
     private sendPerceivedLatencyTelemetry() {
         if (vscode.window.activeTextEditor) {
             const languageContext = runtimeLanguageContext.getLanguageContext(
-                vscode.window.activeTextEditor.document.languageId
+                vscode.window.activeTextEditor.document.languageId,
+                vscode.window.activeTextEditor.document.fileName.substring(
+                    vscode.window.activeTextEditor.document.fileName.lastIndexOf('.') + 1
+                )
             )
             telemetry.codewhisperer_perceivedLatency.emit({
                 codewhispererRequestId: this.requestId,

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -43,7 +43,6 @@ import { CWInlineCompletionItemProvider } from './inlineCompletionItemProvider'
 import { application } from '../util/codeWhispererApplication'
 import { openUrl } from '../../shared/utilities/vsCodeUtils'
 import { indent } from '../../shared/utilities/textUtilities'
-import { getFileExtension } from '../util/editorContext'
 import path from 'path'
 
 /**
@@ -184,7 +183,7 @@ export class RecommendationHandler {
         let shouldRecordServiceInvocation = true
         session.language = runtimeLanguageContext.getLanguageContext(
             editor.document.languageId,
-            getFileExtension(editor.document)
+            path.extname(editor.document.fileName)
         ).language
         session.taskType = await this.getTaskTypeFromEditorFileName(editor.document.fileName)
 

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -43,6 +43,7 @@ import { CWInlineCompletionItemProvider } from './inlineCompletionItemProvider'
 import { application } from '../util/codeWhispererApplication'
 import { openUrl } from '../../shared/utilities/vsCodeUtils'
 import { indent } from '../../shared/utilities/textUtilities'
+import { getFileExtension } from '../util/editorContext'
 
 /**
  * This class is for getRecommendation/listRecommendation API calls and its states
@@ -182,7 +183,7 @@ export class RecommendationHandler {
         let shouldRecordServiceInvocation = true
         session.language = runtimeLanguageContext.getLanguageContext(
             editor.document.languageId,
-            editor.document.fileName.substring(editor.document.fileName.lastIndexOf('.') + 1)
+            getFileExtension(editor.document)
         ).language
         session.taskType = await this.getTaskTypeFromEditorFileName(editor.document.fileName)
 

--- a/src/codewhisperer/util/editorContext.ts
+++ b/src/codewhisperer/util/editorContext.ts
@@ -76,10 +76,6 @@ export function getFileName(editor: vscode.TextEditor): string {
     return fileName.substring(0, CodeWhispererConstants.filenameCharsLimit)
 }
 
-export function getFileExtension(document: vscode.TextDocument): string {
-    return path.extname(document.fileName)
-}
-
 export function getFileNameForRequest(editor: vscode.TextEditor): string {
     const fileName = path.basename(editor.document.fileName)
 

--- a/src/codewhisperer/util/editorContext.ts
+++ b/src/codewhisperer/util/editorContext.ts
@@ -181,23 +181,16 @@ export async function buildGenerateRecommendationRequest(editor: vscode.TextEdit
 export function validateRequest(
     req: codewhispererClient.ListRecommendationsRequest | codewhispererClient.GenerateRecommendationsRequest
 ): boolean {
-    // const lastIndex = req.fileContext.filename.lastIndexOf('.')
-    // let extensionName=''
-    // if (lastIndex > 0) {
-    //     extensionName=req.fileContext.filename.substring(lastIndex+1)
-    // }
     const isLanguageNameValid = !(
-        (
-            req.fileContext.programmingLanguage.languageName === undefined ||
-            req.fileContext.programmingLanguage.languageName.length < 1 ||
-            req.fileContext.programmingLanguage.languageName.length > 128 ||
-            !(
-                runtimeLanguageContext.isLanguageSupported(req.fileContext.programmingLanguage.languageName) ||
-                runtimeLanguageContext.isFileFormatSupported(
-                    req.fileContext.filename.substring(req.fileContext.filename.lastIndexOf('.') + 1)
-                )
+        req.fileContext.programmingLanguage.languageName === undefined ||
+        req.fileContext.programmingLanguage.languageName.length < 1 ||
+        req.fileContext.programmingLanguage.languageName.length > 128 ||
+        !(
+            runtimeLanguageContext.isLanguageSupported(req.fileContext.programmingLanguage.languageName) ||
+            runtimeLanguageContext.isFileFormatSupported(
+                req.fileContext.filename.substring(req.fileContext.filename.lastIndexOf('.') + 1)
             )
-        ) //req.fileContext.filename //network.tf
+        )
     )
     const isFileNameValid = !(req.fileContext.filename === undefined || req.fileContext.filename.length < 1)
     const isFileContextValid = !(

--- a/src/codewhisperer/util/editorContext.ts
+++ b/src/codewhisperer/util/editorContext.ts
@@ -76,6 +76,10 @@ export function getFileName(editor: vscode.TextEditor): string {
     return fileName.substring(0, CodeWhispererConstants.filenameCharsLimit)
 }
 
+export function getFileExtension(document: vscode.TextDocument): string {
+    return document.fileName.substring(document.fileName.lastIndexOf('.') + 1)
+}
+
 export function getFileNameForRequest(editor: vscode.TextEditor): string {
     const fileName = path.basename(editor.document.fileName)
 
@@ -181,17 +185,14 @@ export async function buildGenerateRecommendationRequest(editor: vscode.TextEdit
 export function validateRequest(
     req: codewhispererClient.ListRecommendationsRequest | codewhispererClient.GenerateRecommendationsRequest
 ): boolean {
-    const isLanguageNameValid = !(
-        req.fileContext.programmingLanguage.languageName === undefined ||
-        req.fileContext.programmingLanguage.languageName.length < 1 ||
-        req.fileContext.programmingLanguage.languageName.length > 128 ||
-        !(
-            runtimeLanguageContext.isLanguageSupported(req.fileContext.programmingLanguage.languageName) ||
+    const isLanguageNameValid =
+        req.fileContext.programmingLanguage.languageName !== undefined &&
+        req.fileContext.programmingLanguage.languageName.length >= 1 &&
+        req.fileContext.programmingLanguage.languageName.length <= 128 &&
+        (runtimeLanguageContext.isLanguageSupported(req.fileContext.programmingLanguage.languageName) ||
             runtimeLanguageContext.isFileFormatSupported(
                 req.fileContext.filename.substring(req.fileContext.filename.lastIndexOf('.') + 1)
-            )
-        )
-    )
+            ))
     const isFileNameValid = !(req.fileContext.filename === undefined || req.fileContext.filename.length < 1)
     const isFileContextValid = !(
         req.fileContext.leftFileContent.length > CodeWhispererConstants.charactersLimit ||

--- a/src/codewhisperer/util/editorContext.ts
+++ b/src/codewhisperer/util/editorContext.ts
@@ -77,7 +77,7 @@ export function getFileName(editor: vscode.TextEditor): string {
 }
 
 export function getFileExtension(document: vscode.TextDocument): string {
-    return document.fileName.substring(document.fileName.lastIndexOf('.') + 1)
+    return path.extname(document.fileName)
 }
 
 export function getFileNameForRequest(editor: vscode.TextEditor): string {

--- a/src/codewhisperer/util/editorContext.ts
+++ b/src/codewhisperer/util/editorContext.ts
@@ -181,11 +181,23 @@ export async function buildGenerateRecommendationRequest(editor: vscode.TextEdit
 export function validateRequest(
     req: codewhispererClient.ListRecommendationsRequest | codewhispererClient.GenerateRecommendationsRequest
 ): boolean {
+    // const lastIndex = req.fileContext.filename.lastIndexOf('.')
+    // let extensionName=''
+    // if (lastIndex > 0) {
+    //     extensionName=req.fileContext.filename.substring(lastIndex+1)
+    // }
     const isLanguageNameValid = !(
-        req.fileContext.programmingLanguage.languageName === undefined ||
-        req.fileContext.programmingLanguage.languageName.length < 1 ||
-        req.fileContext.programmingLanguage.languageName.length > 128 ||
-        !runtimeLanguageContext.isLanguageSupported(req.fileContext.programmingLanguage.languageName)
+        (
+            req.fileContext.programmingLanguage.languageName === undefined ||
+            req.fileContext.programmingLanguage.languageName.length < 1 ||
+            req.fileContext.programmingLanguage.languageName.length > 128 ||
+            !(
+                runtimeLanguageContext.isLanguageSupported(req.fileContext.programmingLanguage.languageName) ||
+                runtimeLanguageContext.isFileFormatSupported(
+                    req.fileContext.filename.substring(req.fileContext.filename.lastIndexOf('.') + 1)
+                )
+            )
+        ) //req.fileContext.filename //network.tf
     )
     const isFileNameValid = !(req.fileContext.filename === undefined || req.fileContext.filename.length < 1)
     const isFileContextValid = !(

--- a/src/codewhisperer/util/runtimeLanguageContext.ts
+++ b/src/codewhisperer/util/runtimeLanguageContext.ts
@@ -158,10 +158,10 @@ export class RuntimeLanguageContext {
     }
 
     /**
-     * @param languageId : vscode language id or codewhisperer language name
+     * @param languageId : vscode language id or codewhisperer language name, fileExtension: extension of the selected file
      * @returns An object with a field language: CodewhispererLanguage, if no corresponding CodewhispererLanguage ID, plaintext is returned
      */
-    public getLanguageContext(languageId?: string, filename?: string): { language: CodewhispererLanguage } {
+    public getLanguageContext(languageId?: string, fileExtension?: string): { language: CodewhispererLanguage } {
         const extensionToLanguageMap: Record<string, CodewhispererLanguage> = {
             tf: 'tf',
             hcl: 'tf',
@@ -171,8 +171,8 @@ export class RuntimeLanguageContext {
             // Add more mappings if needed
         }
 
-        if (languageId === 'plaintext' && filename !== undefined) {
-            const languages = extensionToLanguageMap[filename]
+        if (languageId === 'plaintext' && fileExtension !== undefined) {
+            const languages = extensionToLanguageMap[fileExtension]
             if (languages) {
                 return { language: languages }
             }
@@ -220,7 +220,7 @@ export class RuntimeLanguageContext {
     /**
      *
      * @param fileFormat : vscode editor filecontext filename extension
-     * @returns  if the fileformat is supported by CodeWhisperer otherwise false
+     * @returns  true if the fileformat is supported by CodeWhisperer otherwise false
      */
     public isFileFormatSupported(fileFormat: string): boolean {
         const fileformat = this.supportedLanguageExtensionMap.get(fileFormat)

--- a/src/codewhisperer/util/runtimeLanguageContext.ts
+++ b/src/codewhisperer/util/runtimeLanguageContext.ts
@@ -161,7 +161,22 @@ export class RuntimeLanguageContext {
      * @param languageId : vscode language id or codewhisperer language name
      * @returns An object with a field language: CodewhispererLanguage, if no corresponding CodewhispererLanguage ID, plaintext is returned
      */
-    public getLanguageContext(languageId?: string): { language: CodewhispererLanguage } {
+    public getLanguageContext(languageId?: string, filename?: string): { language: CodewhispererLanguage } {
+        const extensionToLanguageMap: Record<string, CodewhispererLanguage> = {
+            tf: 'tf',
+            hcl: 'tf',
+            json: 'json',
+            yaml: 'yaml',
+            yml: 'yaml',
+            // Add more mappings if needed
+        }
+
+        if (languageId === 'plaintext' && filename !== undefined) {
+            const languages = extensionToLanguageMap[filename]
+            if (languages) {
+                return { language: languages }
+            }
+        }
         return { language: this.normalizeLanguage(languageId) ?? 'plaintext' }
     }
 
@@ -177,7 +192,10 @@ export class RuntimeLanguageContext {
         const fileContext = request.fileContext
         const runtimeLanguage: codewhispererClient.ProgrammingLanguage = {
             languageName: this.toRuntimeLanguage(
-                request.fileContext.programmingLanguage.languageName as CodewhispererLanguage
+                runtimeLanguageContext.getLanguageContext(
+                    request.fileContext.programmingLanguage.languageName,
+                    request.fileContext.filename.substring(request.fileContext.filename.lastIndexOf('.') + 1)
+                ).language
             ),
         }
 
@@ -193,11 +211,20 @@ export class RuntimeLanguageContext {
     /**
      *
      * @param languageId: either vscodeLanguageId or CodewhispererLanguage
-     * @returns ture if the language is supported by CodeWhisperer otherwise false
+     * @returns true if the language is supported by CodeWhisperer otherwise false
      */
     public isLanguageSupported(languageId: string): boolean {
         const lang = this.normalizeLanguage(languageId)
         return lang !== undefined && this.normalizeLanguage(languageId) !== 'plaintext'
+    }
+    /**
+     *
+     * @param fileFormat : vscode editor filecontext filename extension
+     * @returns  if the fileformat is supported by CodeWhisperer otherwise false
+     */
+    public isFileFormatSupported(fileFormat: string): boolean {
+        const fileformat = this.supportedLanguageExtensionMap.get(fileFormat)
+        return fileformat !== undefined && this.supportedLanguageExtensionMap.get(fileformat) !== 'txt'
     }
 }
 

--- a/src/codewhisperer/util/telemetryHelper.ts
+++ b/src/codewhisperer/util/telemetryHelper.ts
@@ -99,10 +99,9 @@ export class TelemetryHelper {
         requestIdList: string[],
         sessionId: string,
         paginationIndex: number,
-        languageId: string,
+        languageContext: CodewhispererLanguage,
         supplementalContextMetadata?: Omit<CodeWhispererSupplementalContext, 'supplementalContextItems'> | undefined
     ) {
-        const languageContext = runtimeLanguageContext.getLanguageContext(languageId)
         telemetry.codewhisperer_userDecision.emit({
             codewhispererRequestId: requestIdList[0],
             codewhispererSessionId: sessionId ? sessionId : undefined,
@@ -113,7 +112,7 @@ export class TelemetryHelper {
             codewhispererSuggestionReferences: undefined,
             codewhispererSuggestionReferenceCount: 0,
             codewhispererCompletionType: 'Line',
-            codewhispererLanguage: languageContext.language,
+            codewhispererLanguage: languageContext,
             codewhispererGettingStartedTask: session.taskType,
             credentialStartUrl: AuthUtil.instance.startUrl,
             codewhispererUserGroup: CodeWhispererUserGroupSettings.getUserGroup().toString(),

--- a/src/codewhisperer/util/telemetryHelper.ts
+++ b/src/codewhisperer/util/telemetryHelper.ts
@@ -99,7 +99,7 @@ export class TelemetryHelper {
         requestIdList: string[],
         sessionId: string,
         paginationIndex: number,
-        languageContext: CodewhispererLanguage,
+        language: CodewhispererLanguage,
         supplementalContextMetadata?: Omit<CodeWhispererSupplementalContext, 'supplementalContextItems'> | undefined
     ) {
         telemetry.codewhisperer_userDecision.emit({
@@ -112,7 +112,7 @@ export class TelemetryHelper {
             codewhispererSuggestionReferences: undefined,
             codewhispererSuggestionReferenceCount: 0,
             codewhispererCompletionType: 'Line',
-            codewhispererLanguage: languageContext,
+            codewhispererLanguage: language,
             codewhispererGettingStartedTask: session.taskType,
             credentialStartUrl: AuthUtil.instance.startUrl,
             codewhispererUserGroup: CodeWhispererUserGroupSettings.getUserGroup().toString(),

--- a/src/test/codewhisperer/util/runtimeLanguageContext.test.ts
+++ b/src/test/codewhisperer/util/runtimeLanguageContext.test.ts
@@ -281,7 +281,6 @@ describe('runtimeLanguageContext', function () {
             ['scala', 'scala'],
             ['shell', 'shell'],
             ['sql', 'sql'],
-            ['sql', 'sql'],
             ['tf', 'tf'],
             ['hcl', 'tf'],
             ['json', 'json'],

--- a/src/test/codewhisperer/util/runtimeLanguageContext.test.ts
+++ b/src/test/codewhisperer/util/runtimeLanguageContext.test.ts
@@ -281,8 +281,14 @@ describe('runtimeLanguageContext', function () {
             ['scala', 'scala'],
             ['shell', 'shell'],
             ['sql', 'sql'],
+            ['sql', 'sql'],
+            ['tf', 'tf'],
+            ['hcl', 'tf'],
+            ['json', 'json'],
+            ['yaml', 'yaml'],
+            ['yml', 'yaml'],
             ['plaintext', 'plaintext'],
-            ['arbitrary string', 'arbitrary string'],
+            // ['arbitrary string', 'arbitrary string'],
         ]
 
         this.beforeEach(function () {


### PR DESCRIPTION
## Problem
CodeWhisperer needs terraform plugin extension to generate code suggestions for `tf` and `hcl` files, as `tf` and `hcl` files are recognized as `plaintext` by VSCode. 
## Solution

- This issue can be resolved by categorizing the files based on file format/ file extensions instead of depending on editor document language.
- Code generation will be independent of external plugin extensions.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
