### PR TITLE
telemetry: add rule id to security scan metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
             },
             "devDependencies": {
                 "@aws-sdk/types": "^3.13.1",
-                "@aws-toolkits/telemetry": "^1.0.175",
+                "@aws-toolkits/telemetry": "^1.0.176",
                 "@aws/fully-qualified-names": "^2.1.1",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^10.0.2",
@@ -4831,9 +4831,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.175",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.175.tgz",
-            "integrity": "sha512-tIlIMFwvLGyIZOCT3wt0PnZiitidTK+UPRohr2GqPxN8K2I7NF7yJy2kPFZSzMNzxaYq/6NyrC5K4c5lAo8fDQ==",
+            "version": "1.0.176",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.176.tgz",
+            "integrity": "sha512-BYvdnEYcKU3n7h6uRvfYk4entmPWX6nR88PQipifwCH3F/Ujpy+MU7m9WFz26ti70zV6oamn28X9TasE3ts4/w==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
             },
             "devDependencies": {
                 "@aws-sdk/types": "^3.13.1",
-                "@aws-toolkits/telemetry": "^1.0.172",
+                "@aws-toolkits/telemetry": "^1.0.175",
                 "@aws/fully-qualified-names": "^2.1.1",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^10.0.2",
@@ -4831,9 +4831,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.172",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.172.tgz",
-            "integrity": "sha512-9ktSFA3fSnZkOF8O1L8aRaNU5+H++R1+alYL1jrsdkB3nYfHS/vRdzV8PNrEb9jXZ5HOIreD5vasCniqgjqGQA==",
+            "version": "1.0.175",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.175.tgz",
+            "integrity": "sha512-tIlIMFwvLGyIZOCT3wt0PnZiitidTK+UPRohr2GqPxN8K2I7NF7yJy2kPFZSzMNzxaYq/6NyrC5K4c5lAo8fDQ==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -4264,7 +4264,7 @@
     },
     "devDependencies": {
         "@aws-sdk/types": "^3.13.1",
-        "@aws-toolkits/telemetry": "^1.0.175",
+        "@aws-toolkits/telemetry": "^1.0.176",
         "@aws/fully-qualified-names": "^2.1.1",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^10.0.2",

--- a/package.json
+++ b/package.json
@@ -4264,7 +4264,7 @@
     },
     "devDependencies": {
         "@aws-sdk/types": "^3.13.1",
-        "@aws-toolkits/telemetry": "^1.0.172",
+        "@aws-toolkits/telemetry": "^1.0.175",
         "@aws/fully-qualified-names": "^2.1.1",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^10.0.2",

--- a/src/codewhisperer/commands/basicCommands.ts
+++ b/src/codewhisperer/commands/basicCommands.ts
@@ -251,6 +251,12 @@ export const openSecurityIssuePanel = Commands.declare(
     'aws.codeWhisperer.openSecurityIssuePanel',
     (context: ExtContext) => (issue: CodeScanIssue, filePath: string) => {
         showSecurityIssueWebview(context.extensionContext, issue, filePath)
+
+        telemetry.codewhisperer_codeScanIssueViewDetails.emit({
+            findingId: issue.findingId,
+            detectorId: issue.detectorId,
+            ruleId: issue.ruleId,
+        })
     }
 )
 
@@ -279,6 +285,7 @@ export const applySecurityFix = Commands.declare(
         const applyFixTelemetryEntry: Mutable<CodewhispererCodeScanIssueApplyFix> = {
             detectorId: issue.detectorId,
             findingId: issue.findingId,
+            ruleId: issue.ruleId,
             component: source,
             result: 'Succeeded',
         }

--- a/src/codewhisperer/models/model.ts
+++ b/src/codewhisperer/models/model.ts
@@ -478,6 +478,7 @@ export interface RawCodeScanIssue {
     detectorId: string
     detectorName: string
     findingId: string
+    ruleId?: string
     relatedVulnerabilities: string[]
     severity: string
     remediation: Remediation
@@ -492,6 +493,7 @@ export interface CodeScanIssue {
     detectorId: string
     detectorName: string
     findingId: string
+    ruleId?: string
     relatedVulnerabilities: string[]
     severity: string
     recommendation: Recommendation

--- a/src/codewhisperer/service/securityIssueHoverProvider.ts
+++ b/src/codewhisperer/service/securityIssueHoverProvider.ts
@@ -35,6 +35,7 @@ export class SecurityIssueHoverProvider extends SecurityIssueProvider implements
                     telemetry.codewhisperer_codeScanIssueHover.emit({
                         findingId: issue.findingId,
                         detectorId: issue.detectorId,
+                        ruleId: issue.ruleId,
                     })
                 }
             }

--- a/src/codewhisperer/service/securityScanHandler.ts
+++ b/src/codewhisperer/service/securityScanHandler.ts
@@ -81,6 +81,7 @@ function mapToAggregatedList(
                         detectorId: issue.detectorId,
                         detectorName: issue.detectorName,
                         findingId: issue.findingId,
+                        ruleId: issue.ruleId,
                         relatedVulnerabilities: issue.relatedVulnerabilities,
                         severity: issue.severity,
                         recommendation: issue.remediation.recommendation,

--- a/src/shared/telemetry/vscodeTelemetry.json
+++ b/src/shared/telemetry/vscodeTelemetry.json
@@ -54,6 +54,11 @@
             "description": "The id of the detector which produced the code scan issue"
         },
         {
+            "name": "ruleId",
+            "type": "string",
+            "description": "The id of the rule which produced the code scan issue"
+        },
+        {
             "name": "hasChatAuth",
             "type": "boolean",
             "description": "Whether the user has access to CodeWhisperer Chat"
@@ -614,12 +619,22 @@
         {
             "name": "codewhisperer_codeScanIssueHover",
             "description": "Called when a code scan issue is hovered over",
-            "metadata": [{ "type": "findingId" }, { "type": "detectorId" }]
+            "metadata": [{ "type": "findingId" }, { "type": "detectorId" }, { "type": "ruleId", "required": false }]
         },
         {
             "name": "codewhisperer_codeScanIssueApplyFix",
             "description": "Called when a code scan issue suggested fix is applied",
-            "metadata": [{ "type": "findingId" }, { "type": "detectorId" }, { "type": "component" }]
+            "metadata": [
+                { "type": "findingId" },
+                { "type": "detectorId" },
+                { "type": "component" },
+                { "type": "ruleId", "required": false }
+            ]
+        },
+        {
+            "name": "codewhisperer_codeScanIssueViewDetails",
+            "description": "Called when a code scan issue webview is opened",
+            "metadata": [{ "type": "findingId" }, { "type": "detectorId" }, { "type": "ruleId", "required": false }]
         },
         {
             "name": "amazonq_openChat",

--- a/src/shared/telemetry/vscodeTelemetry.json
+++ b/src/shared/telemetry/vscodeTelemetry.json
@@ -44,21 +44,6 @@
             "description": "Installed CLI"
         },
         {
-            "name": "findingId",
-            "type": "string",
-            "description": "The id of a security finding from a code scan"
-        },
-        {
-            "name": "detectorId",
-            "type": "string",
-            "description": "The id of the detector which produced the code scan issue"
-        },
-        {
-            "name": "ruleId",
-            "type": "string",
-            "description": "The id of the rule which produced the code scan issue"
-        },
-        {
             "name": "hasChatAuth",
             "type": "boolean",
             "description": "Whether the user has access to CodeWhisperer Chat"
@@ -615,26 +600,6 @@
             "name": "appcomposer_closeWfs",
             "description": "Called when Step Functions Workflow Studio is closed",
             "metadata": [{ "type": "didSave" }]
-        },
-        {
-            "name": "codewhisperer_codeScanIssueHover",
-            "description": "Called when a code scan issue is hovered over",
-            "metadata": [{ "type": "findingId" }, { "type": "detectorId" }, { "type": "ruleId", "required": false }]
-        },
-        {
-            "name": "codewhisperer_codeScanIssueApplyFix",
-            "description": "Called when a code scan issue suggested fix is applied",
-            "metadata": [
-                { "type": "findingId" },
-                { "type": "detectorId" },
-                { "type": "component" },
-                { "type": "ruleId", "required": false }
-            ]
-        },
-        {
-            "name": "codewhisperer_codeScanIssueViewDetails",
-            "description": "Called when a code scan issue webview is opened",
-            "metadata": [{ "type": "findingId" }, { "type": "detectorId" }, { "type": "ruleId", "required": false }]
         },
         {
             "name": "amazonq_openChat",

--- a/src/test/codewhisperer/service/securityIssueHoverProvider.test.ts
+++ b/src/test/codewhisperer/service/securityIssueHoverProvider.test.ts
@@ -22,11 +22,12 @@ describe('securityIssueHoverProvider', () => {
 
     it('should return hover for each issue for the current position', () => {
         const issues = [
-            createCodeScanIssue({ findingId: 'finding-1', detectorId: 'language/detector-1' }),
+            createCodeScanIssue({ findingId: 'finding-1', detectorId: 'language/detector-1', ruleId: 'Rule-123' }),
             createCodeScanIssue({
                 findingId: 'finding-2',
                 detectorId: 'language/detector-2',
                 suggestedFixes: [],
+                ruleId: 'Rule-456',
             }),
         ]
 
@@ -90,8 +91,8 @@ describe('securityIssueHoverProvider', () => {
                 )} 'Open "CodeWhisperer Security Issue"')\n`
         )
         assertTelemetry('codewhisperer_codeScanIssueHover', [
-            { findingId: 'finding-1', detectorId: 'language/detector-1' },
-            { findingId: 'finding-2', detectorId: 'language/detector-2' },
+            { findingId: 'finding-1', detectorId: 'language/detector-1', ruleId: 'Rule-123' },
+            { findingId: 'finding-2', detectorId: 'language/detector-2', ruleId: 'Rule-456' },
         ])
     })
 


### PR DESCRIPTION
## Description

- Added `ruleId` to code scan telemetry metrics
- Added new metric `codewhisperer_codeScanIssueViewDetails`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
