### PR TITLE
fix(telemetry): normalize JDK strings

### DIFF
--- a/src/amazonqGumby/telemetry/codeTransformTelemetry.ts
+++ b/src/amazonqGumby/telemetry/codeTransformTelemetry.ts
@@ -6,7 +6,11 @@
  * CodeTransform
  */
 
-import { telemetry } from '../../shared/telemetry/telemetry'
+import {
+    CodeTransformJavaSourceVersionsAllowed,
+    CodeTransformJavaTargetVersionsAllowed,
+    telemetry,
+} from '../../shared/telemetry/telemetry'
 import { JDKVersion } from '../../codewhisperer/models/model'
 import * as CodeWhispererConstants from '../../codewhisperer/models/constants'
 import { codeTransformTelemetryState } from './codeTransformTelemetryState'
@@ -44,17 +48,18 @@ export const logCodeTransformInitiatedMetric = (source: string): void => {
     }
 }
 
-//TODO: it would be better to expand JDKVersion from an enum to a class
-export const toJDKMetricValue = (source: JDKVersion): string => {
+export const JDKToTelemetryValue = (
+    source: JDKVersion
+): CodeTransformJavaSourceVersionsAllowed | CodeTransformJavaTargetVersionsAllowed | undefined => {
     switch (source) {
         case JDKVersion.JDK8:
-            return 'jdk8'
+            return 'JDK_1_8'
         case JDKVersion.JDK11:
-            return 'jdk11'
+            return 'JDK_11'
         case JDKVersion.JDK17:
-            return 'jdk17'
+            return 'JDK_17'
         default:
-            return ''
+            return undefined
     }
 }
 

--- a/src/codewhisperer/commands/startTransformByQ.ts
+++ b/src/codewhisperer/commands/startTransformByQ.ts
@@ -36,7 +36,7 @@ import {
 import { codeTransformTelemetryState } from '../../amazonqGumby/telemetry/codeTransformTelemetryState'
 import { ToolkitError } from '../../shared/errors'
 import { TransformByQUploadArchiveFailed } from '../../amazonqGumby/models/model'
-import { CancelActionPositions, toJDKMetricValue } from '../../amazonqGumby/telemetry/codeTransformTelemetry'
+import { CancelActionPositions, JDKToTelemetryValue } from '../../amazonqGumby/telemetry/codeTransformTelemetry'
 import { MetadataResult } from '../../shared/telemetry/telemetryClient'
 
 const localize = nls.loadMessageBundle()
@@ -143,10 +143,10 @@ export async function startTransformByQ() {
 
     telemetry.codeTransform_jobStartedCompleteFromPopupDialog.emit({
         codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
-        codeTransformJavaSourceVersionsAllowed: toJDKMetricValue(
+        codeTransformJavaSourceVersionsAllowed: JDKToTelemetryValue(
             transformByQState.getSourceJDKVersion()
         ) as CodeTransformJavaSourceVersionsAllowed,
-        codeTransformJavaTargetVersionsAllowed: toJDKMetricValue(
+        codeTransformJavaTargetVersionsAllowed: JDKToTelemetryValue(
             transformByQState.getTargetJDKVersion()
         ) as CodeTransformJavaTargetVersionsAllowed,
         result: MetadataResult.Pass,


### PR DESCRIPTION
## Problem

Telemetry is reporting different strings for Java versions

## Solution

Typecast/check the strings reported against the aws-toolkit-common definitions

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
