### PR TITLE
fix: include jobId in IDE feedback

### DIFF
--- a/src/feedback/vue/submitFeedback.vue
+++ b/src/feedback/vue/submitFeedback.vue
@@ -60,6 +60,7 @@ import { defineComponent } from 'vue'
 import { WebviewClientFactory } from '../../webviews/client'
 import saveData from '../../webviews/mixins/saveData'
 import { FeedbackWebview } from './submitFeedback'
+import { transformByQState } from '../../codewhisperer/models/model'
 
 const client = WebviewClientFactory.create<FeedbackWebview>()
 
@@ -81,6 +82,12 @@ export default defineComponent({
             this.error = ''
             this.isSubmitting = true
             console.log('Submitting feedback...')
+            // jobId from transform by Q
+            const jobId = transformByQState.getJobId()
+            if (jobId != '') {
+                // user must have started a job
+                this.comment += `\n Transform by Q jobId: ${jobId}`
+            }
             // identifier to help us (internally) know that feedback came from either CodeWhisperer or AWS Toolkit
             const resp = await client.submit({
                 comment:

--- a/src/feedback/vue/submitFeedback.vue
+++ b/src/feedback/vue/submitFeedback.vue
@@ -86,7 +86,7 @@ export default defineComponent({
             const jobId = transformByQState.getJobId()
             if (jobId != '') {
                 // user must have started a job
-                this.comment += `\n Transform by Q jobId: ${jobId}`
+                this.comment += `\n\n[Transform by Q jobId: ${jobId}]`
             }
             // identifier to help us (internally) know that feedback came from either CodeWhisperer or AWS Toolkit
             const resp = await client.submit({


### PR DESCRIPTION
## Problem

Users submitting feedback in VS Code had issues with Transform by Q but we had no ways to investigate.

## Solution

Add the jobId to the feedback.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
