### PR TITLE
fix: Fix missing conversationId in /dev

### DIFF
--- a/src/amazonqFeatureDev/session/session.ts
+++ b/src/amazonqFeatureDev/session/session.ts
@@ -70,7 +70,7 @@ export class Session {
         // Store the initial message when setting up the conversation so that if it fails we can retry with this message
         this._latestMessage = msg
 
-        telemetry.amazonq_startConversationInvoke.run(async span => {
+        await telemetry.amazonq_startConversationInvoke.run(async span => {
             this._conversationId = await this.proxyClient.createConversation()
             span.record({ amazonqConversationId: this._conversationId })
         })


### PR DESCRIPTION
## Problem
There is currently a problem when using `/dev` inside Q which displays the 
```
Sorry, we encountered a problem when processing your request. Amazon Q feature development request failed: Conversation id must exist before continuing
``` 
error message every time a new conversation is started.

Retrying the operation is a workaround for this, and will make the conversation work as expected.

## Solution
This CR adds a missing `await` to the creation of the conversation. The missing `await` caused the error because the toolkit tried reading the `conversationId` before it was populated.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
