### PR TITLE
AmazonQ: Incorrect range fix

### DIFF
--- a/.changes/next-release/Bug Fix-219eee10-03c2-4122-9bf8-30f0c4ce6f88.json
+++ b/.changes/next-release/Bug Fix-219eee10-03c2-4122-9bf8-30f0c4ce6f88.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Correct code selection range for one-line selections"
+	"description": "Amazon Q: correct code selection range for one-line selections"
 }

--- a/.changes/next-release/Bug Fix-219eee10-03c2-4122-9bf8-30f0c4ce6f88.json
+++ b/.changes/next-release/Bug Fix-219eee10-03c2-4122-9bf8-30f0c4ce6f88.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Correct code selection range for one-line selections"
+}

--- a/src/test/codewhispererChat/editor/context/focusArea/focusAreaExtractor.test.ts
+++ b/src/test/codewhispererChat/editor/context/focusArea/focusAreaExtractor.test.ts
@@ -91,6 +91,158 @@ describe('getSelectionInsideExtendedCodeBlock', () => {
             result
         )
     })
+    it('returns adjusted selection for one-line selection', () => {
+        // Stub originSelection and extendedCodeBlockRange
+        const originSelection = {
+            start: {
+                line: 10,
+                character: 5,
+            },
+            end: {
+                line: 10,
+                character: 50,
+            },
+        }
+
+        const extendedCodeBlockRange = {
+            start: {
+                line: 10,
+                character: 4,
+            },
+            end: {
+                line: 10,
+                character: 51,
+            },
+        }
+
+        const focusAreaContextExtractor = new FocusAreaContextExtractor()
+        const method = Reflect.get(focusAreaContextExtractor, 'getSelectionInsideExtendedCodeBlock')
+
+        const result = method.call(focusAreaContextExtractor, originSelection, extendedCodeBlockRange)
+
+        checkIfExpectedRangeEqualActualRange(
+            {
+                start: {
+                    line: 0,
+                    character: 1,
+                },
+                end: {
+                    line: 0,
+                    character: 46,
+                },
+            },
+            result
+        )
+    })
+})
+
+describe('trimRangeAccordingToLimits', () => {
+    it('cut characters from the last line', () => {
+        // Arrange
+        const document: TextDocument = createMockDocument('01234567\n0123456789\n0123456')
+        const range = {
+            start: {
+                line: 0,
+                character: 7,
+            },
+            end: {
+                line: 1,
+                character: 10,
+            },
+        }
+        const limit = 5
+
+        // Act
+        const focusAreaContextExtractor = new FocusAreaContextExtractor()
+        const method = Reflect.get(focusAreaContextExtractor, 'trimRangeAccordingToLimits')
+        const result = method.call(focusAreaContextExtractor, document, range, limit)
+
+        // Assert
+        checkIfExpectedRangeEqualActualRange(
+            {
+                start: {
+                    line: 0,
+                    character: 7,
+                },
+                end: {
+                    line: 1,
+                    character: 3,
+                },
+            },
+            result
+        )
+    })
+    it('cut the last line', () => {
+        // Arrange
+        const document: TextDocument = createMockDocument('01234567\n0123456789\n0123456')
+        const range = {
+            start: {
+                line: 0,
+                character: 0,
+            },
+            end: {
+                line: 1,
+                character: 10,
+            },
+        }
+        const limit = 9
+
+        // Act
+        const focusAreaContextExtractor = new FocusAreaContextExtractor()
+        const method = Reflect.get(focusAreaContextExtractor, 'trimRangeAccordingToLimits')
+        const result = method.call(focusAreaContextExtractor, document, range, limit)
+
+        // Assert
+        checkIfExpectedRangeEqualActualRange(
+            {
+                start: {
+                    line: 0,
+                    character: 0,
+                },
+                end: {
+                    line: 1,
+                    character: 0,
+                },
+            },
+            result
+        )
+    })
+
+    it('cut characters from the first line', () => {
+        // Arrange
+        const document: TextDocument = createMockDocument('01234567\n0123456789\n0123456')
+        const range = {
+            start: {
+                line: 0,
+                character: 0,
+            },
+            end: {
+                line: 1,
+                character: 10,
+            },
+        }
+        const limit = 5
+
+        // Act
+        const focusAreaContextExtractor = new FocusAreaContextExtractor()
+        const method = Reflect.get(focusAreaContextExtractor, 'trimRangeAccordingToLimits')
+        const result = method.call(focusAreaContextExtractor, document, range, limit)
+
+        // Assert
+        checkIfExpectedRangeEqualActualRange(
+            {
+                start: {
+                    line: 0,
+                    character: 0,
+                },
+                end: {
+                    line: 0,
+                    character: 4,
+                },
+            },
+            result
+        )
+    })
 })
 
 describe('getExtendedCodeBlockRange', () => {


### PR DESCRIPTION
## Problem

There is an issue with the range trimming logic when a customer's selection is limited to a single line. The system does not handle this case correctly and trims the selection inappropriately. This results in invalid range trimming that needs to be addressed.
An invalid range parameter results in 4xx client errors.


## Solution

The algorithm was modified and the changes were validated through the addition of new unit tests.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
