### PR TITLE
 fix: error handling, move constants, add test, remove dep

### DIFF
--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -314,6 +314,15 @@ export const jobInProgressMessage = 'Job is already in-progress'
 
 export const cancellationInProgressMessage = 'Cancellation is in-progress'
 
+export const errorStoppingJobMessage = 'Error stopping job'
+
+export const errorDownloadingDiffMessage = 'Transform by Q experienced an error when downloading the diff'
+
+export const viewProposedChangesMessage =
+    'Transformation job completed. You can view the transformation summary along with the proposed changes and accept or reject them in the Proposed Changes panel.'
+
+export const changesAppliedMessage = 'Changes applied'
+
 export const noSupportedJavaProjectsFoundMessage =
     'We could not find an upgrade-eligible application. We currently support upgrade of Java applications of version 8 and 11. Be sure to also build your project.'
 

--- a/src/codewhisperer/service/transformationResultsViewProvider.ts
+++ b/src/codewhisperer/service/transformationResultsViewProvider.ts
@@ -20,6 +20,7 @@ import { telemetry } from '../../shared/telemetry/telemetry'
 import { codeTransformTelemetryState } from '../../amazonqGumby/telemetry/codeTransformTelemetryState'
 import { calculateTotalLatency } from '../../amazonqGumby/telemetry/codeTransformTelemetry'
 import { MetadataResult } from '../../shared/telemetry/telemetryClient'
+import * as CodeWhispererConstants from '../models/constants'
 
 export abstract class ProposedChangeNode {
     abstract readonly resourcePath: string
@@ -278,7 +279,7 @@ export class ProposedTransformationExplorer {
                 )
             } catch (e: any) {
                 // This allows the customer to retry the download
-                vscode.window.showErrorMessage('Transform by Q experienced an error when downloading the diff')
+                vscode.window.showErrorMessage(CodeWhispererConstants.errorDownloadingDiffMessage)
                 vscode.commands.executeCommand('setContext', 'gumby.reviewState', TransformByQReviewStatus.NotStarted)
                 const errorMessage = 'There was a problem fetching the transformed code.'
                 getLogger().error('CodeTransform: ExportResultArchive error = ', errorMessage)
@@ -331,9 +332,7 @@ export class ProposedTransformationExplorer {
                 })
             }
 
-            await vscode.window.showInformationMessage(
-                'Transformation job completed. You can view the transformation summary along with the proposed changes and accept or reject them in the Proposed Changes panel.'
-            )
+            await vscode.window.showInformationMessage(CodeWhispererConstants.viewProposedChangesMessage)
             await vscode.commands.executeCommand('aws.amazonq.transformationHub.summary.reveal')
             telemetry.codeTransform_vcsDiffViewerVisible.emit({
                 codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
@@ -352,7 +351,7 @@ export class ProposedTransformationExplorer {
                 TransformByQReviewStatus.NotStarted
             )
             transformDataProvider.refresh()
-            await vscode.window.showInformationMessage('Changes applied')
+            await vscode.window.showInformationMessage(CodeWhispererConstants.changesAppliedMessage)
             telemetry.codeTransform_vcsViewerSubmitted.emit({
                 codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
                 codeTransformJobId: transformByQState.getJobId(),

--- a/src/feedback/vue/submitFeedback.ts
+++ b/src/feedback/vue/submitFeedback.ts
@@ -13,7 +13,6 @@ import { localize } from '../../shared/utilities/vsCodeUtils'
 import { VueWebview, VueWebviewPanel } from '../../webviews/main'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { Commands, VsCodeCommandArg, placeholder } from '../../shared/vscode/commands2'
-import { transformByQState } from '../../codewhisperer/models/model'
 
 export interface FeedbackMessage {
     comment: string
@@ -36,11 +35,6 @@ export class FeedbackWebview extends VueWebview {
 
         if (!message.sentiment) {
             return 'Choose a reaction (smile/frown)'
-        }
-
-        const jobId = transformByQState.getJobId()
-        if (jobId !== '') {
-            message.comment = `${message.comment}\n\nTransform by Q jobId: ${jobId}`
         }
 
         try {

--- a/src/feedback/vue/submitFeedback.ts
+++ b/src/feedback/vue/submitFeedback.ts
@@ -13,6 +13,7 @@ import { localize } from '../../shared/utilities/vsCodeUtils'
 import { VueWebview, VueWebviewPanel } from '../../webviews/main'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { Commands, VsCodeCommandArg, placeholder } from '../../shared/vscode/commands2'
+import { transformByQState } from '../../codewhisperer/models/model'
 
 export interface FeedbackMessage {
     comment: string
@@ -35,6 +36,11 @@ export class FeedbackWebview extends VueWebview {
 
         if (!message.sentiment) {
             return 'Choose a reaction (smile/frown)'
+        }
+
+        const jobId = transformByQState.getJobId()
+        if (jobId !== '') {
+            message.comment = `${message.comment}\n\nTransform by Q jobId: ${jobId}`
         }
 
         try {

--- a/src/shared/utilities/textUtilities.ts
+++ b/src/shared/utilities/textUtilities.ts
@@ -283,3 +283,10 @@ export function formatDateTimestamp(forceUTC: boolean, d: Date = new Date()): st
     // trim 'Z' (last char of iso string) and add offset string
     return `${iso.substring(0, iso.length - 1)}${offsetString}`
 }
+
+/**
+ * To satisfy a pentesting concern, encodes HTML to mitigate risk of HTML injection
+ */
+export function encodeHTML(str: string) {
+    return str.replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}

--- a/src/testInteg/amazonqGumby/transformByQ.test.ts
+++ b/src/testInteg/amazonqGumby/transformByQ.test.ts
@@ -66,4 +66,16 @@ describe('transformByQ', async function () {
             })
         )
     })
+
+    it('WHEN createUploadUrl then URL uses HTTPS and sets 60 second expiration', async function () {
+        const sha256 = getSha256(zippedCodePath)
+        const response = await codeWhisperer.codeWhispererClient.createUploadUrl({
+            contentChecksum: sha256,
+            contentChecksumType: CodeWhispererConstants.contentChecksumType,
+            uploadIntent: CodeWhispererConstants.uploadIntent,
+        })
+        const uploadUrl = response.uploadUrl
+        const usesHttpsAndExpiresAfter60Seconds = uploadUrl.includes('https') && uploadUrl.includes('X-Amz-Expires=60')
+        assert.strictEqual(usesHttpsAndExpiresAfter60Seconds, true)
+    })
 })


### PR DESCRIPTION
## Problem

Users submitting feedback in VS Code had issues with Transform by Q but we had no ways to investigate.

EDIT: we are currently trying to determine if the jobId is permitted to be included in the feedback, so ignore the above

Updated problem:

- 'he' dependency used but not necessary: https://sim.amazon.com/issues/EGCP-40
- stopJob error not caught
- not all constants were in the constants file
- no integration test for verifying that the pre-signed upload URL uses HTTPS and sets a 60 second timeout (needed for AppSec)

## Solution

Add the jobId to the feedback (when jobId is not empty, meaning the user must have started a transformation job).

EDIT: we are currently trying to determine if the jobId is permitted to be included in the feedback, so ignore the above

Updated solution:

- use a simple utility function instead to encode the HTML
- catch error and display error message
- move all constants to constants file
- add integration test to check those 2 conditions

Notes:

- the 'he' and 'proxyquire' dependencies will be removed from package.json and package-lock.json in the next PR; had some issues doing this properly last time so want to keep this PR organized and simple.
- this PR should fix the issue described here: https://github.com/aws/aws-toolkit-vscode/pull/4201

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
