### PR TITLE
fix(codewhisperer): fix incorrect type casting if error is not AwsError

### DIFF
--- a/.changes/next-release/Bug Fix-524dba3b-28f6-4aef-b5f6-2624b73c868c.json
+++ b/.changes/next-release/Bug Fix-524dba3b-28f6-4aef-b5f6-2624b73c868c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeWhisperer: fix incorrect error handling causing TypeError .includes is not a function"
+}

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -44,6 +44,7 @@ import { application } from '../util/codeWhispererApplication'
 import { openUrl } from '../../shared/utilities/vsCodeUtils'
 import { indent } from '../../shared/utilities/textUtilities'
 import path from 'path'
+import { instance } from 'ts-mockito'
 
 /**
  * This class is for getRecommendation/listRecommendation API calls and its states
@@ -294,7 +295,7 @@ export class RecommendationHandler {
                     await vscode.commands.executeCommand('aws.codeWhisperer.enableCodeSuggestions', false)
                 }
             } else {
-                errorMessage = error as string
+                errorMessage = error instanceof Error ? error.message : String(error)
                 reason = error ? String(error) : 'unknown'
             }
         } finally {

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -44,7 +44,6 @@ import { application } from '../util/codeWhispererApplication'
 import { openUrl } from '../../shared/utilities/vsCodeUtils'
 import { indent } from '../../shared/utilities/textUtilities'
 import path from 'path'
-import { instance } from 'ts-mockito'
 
 /**
  * This class is for getRecommendation/listRecommendation API calls and its states


### PR DESCRIPTION
## Problem (#4190 )
In CW error handling code path, a throwable is directly cast to `string` type, which doesn't contain `includes` member function. 

Thus it will cause a NPE when the `finally` block is executed where there is a `include` method call https://github.com/aws/aws-toolkit-vscode/blob/24cd83683bd8366485eb60e7be49acae735ec89d/src/codewhisperer/service/recommendationHandler.ts#L328-L329

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
