### PR TITLE
fix(codewhisperer): "Show Scanned Files" shows empty logs

### DIFF
--- a/.changes/next-release/Bug Fix-29e2ab3a-6bef-49c4-874c-05752122ea7b.json
+++ b/.changes/next-release/Bug Fix-29e2ab3a-6bef-49c4-874c-05752122ea7b.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "CodeWhisperer: Fixed an issue where Security Scan Log output is blank if log level is not \"verbose\"."
+	"description": "CodeWhisperer: Security Scan Log output is blank if log level is not \"verbose\"."
 }

--- a/.changes/next-release/Bug Fix-29e2ab3a-6bef-49c4-874c-05752122ea7b.json
+++ b/.changes/next-release/Bug Fix-29e2ab3a-6bef-49c4-874c-05752122ea7b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CodeWhisperer: Fixed an issue where Security Scan Log output is blank if log level is not \"verbose\"."
+}

--- a/src/codewhisperer/commands/startSecurityScan.ts
+++ b/src/codewhisperer/commands/startSecurityScan.ts
@@ -265,14 +265,14 @@ function populateCodeScanLogStream(scannedFiles: Set<string>) {
     securityScanOutputChannel.clear()
     const numScannedFiles = scannedFiles.size
     if (numScannedFiles === 1) {
-        codeScanLogger.verbose(`${numScannedFiles} file was scanned during the last Security Scan.`)
+        codeScanLogger.info(`${numScannedFiles} file was scanned during the last Security Scan.`)
     } else {
-        codeScanLogger.verbose(`${numScannedFiles} files were scanned during the last Security Scan.`)
+        codeScanLogger.info(`${numScannedFiles} files were scanned during the last Security Scan.`)
     }
     // Log all the scanned files to codeScanLogger
     for (const file of scannedFiles) {
         const uri = vscode.Uri.file(file)
-        codeScanLogger.verbose(`File scanned: ${uri.fsPath}`)
+        codeScanLogger.info(`File scanned: ${uri.fsPath}`)
     }
 }
 


### PR DESCRIPTION
## Problem

After running a security scan, clicking "Show Scanned Files" takes you to a blank output panel unless log level is set to `verbose`.

## Solution

Log the output using `info` level.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
