### PR TITLE
fix(auth): command 'aws.codeWhisperer.refresh' not found

### DIFF
--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -120,12 +120,13 @@ export class AuthUtil {
                 vscode.commands.executeCommand('aws.codeWhisperer.notifyNewCustomizations')
             }
             await Promise.all([
-                vscode.commands.executeCommand('aws.codeWhisperer.refresh'),
-                vscode.commands.executeCommand('aws.codeWhisperer.refreshRootNode'),
+                // onDidChangeActiveConnection may trigger before these modules are activated.
+                Commands.tryExecute('aws.codeWhisperer.refresh'),
+                Commands.tryExecute('aws.codeWhisperer.refreshRootNode'),
                 Commands.tryExecute('aws.amazonq.refresh'),
-                vscode.commands.executeCommand('aws.amazonq.refreshRootNode'),
-                vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar'),
-                vscode.commands.executeCommand('aws.codeWhisperer.updateReferenceLog'),
+                Commands.tryExecute('aws.amazonq.refreshRootNode'),
+                Commands.tryExecute('aws.codeWhisperer.refreshStatusBar'),
+                Commands.tryExecute('aws.codeWhisperer.updateReferenceLog'),
             ])
 
             await vscode.commands.executeCommand('setContext', 'CODEWHISPERER_ENABLED', this.isConnected())


### PR DESCRIPTION
Problem:
The `onDidChangeActiveConnection` event may fire before various components {and their commands) are activated (if ever). This manifests in the test logs as:

    rejected promise not handled within 1 second:
    Error: command 'aws.codeWhisperer.refresh' not found

This issue became more visible while working on https://github.com/aws/aws-toolkit-vscode/pull/1638

Solution:
Use `tryExecute()` to run the commands.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
