### PR TITLE
ci: fail on "rejected promise not handled"

### DIFF
--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -4,6 +4,8 @@ version: 0.2
 run-as: codebuild-user
 
 env:
+    # For "pipefail".
+    shell: bash
     variables:
         AWS_TOOLKIT_TEST_NO_COLOR: '1'
 
@@ -29,7 +31,26 @@ phases:
                     npm run testCompile
                     npm run lint
                 fi
-            - xvfb-run npm test --silent
+            - |
+                {
+                    set -e
+                    set -o pipefail
+                    _PROMISE_REJ_MSG='rejected promise not handled'
+                    mkfifo testout
+                    (cat testout &)
+                    xvfb-run npm test --silent | tee testout \
+                        | { >testout-rej grep --line-buffered "$_PROMISE_REJ_MSG" || true; }
+                    if [ -s testout-rej ] ; then
+                        echo ''
+                        cat testout-rej | sort
+                        printf '\n\nERROR: Found %s "%s" in test output (see above).\n%s\n\n' \
+                            "$(cat testout-rej | wc -l | tr -d ' ')" \
+                            "$_PROMISE_REJ_MSG" \
+                            '       This typically indicates a bug. Read https://developer.mozilla.org/docs/Web/JavaScript/Guide/Using_promises#error_handling'
+                        # TODO: fail the CI job
+                        # exit 1;
+                    fi
+                }
             - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
             - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g') # Encode `#` in the URL because otherwise the url is clipped in the Codecov.io site
             - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -39,6 +39,8 @@ phases:
                     mkfifo testout
                     (cat testout &)
                     xvfb-run npm test --silent | tee testout \
+                        | grep -v 'undefined..reading..range' \
+                        | grep -v CODEWHISPERER_INLINE_UPDATE_LOCK_KEY \
                         | { >testout-rej grep --line-buffered "$_PROMISE_REJ_MSG" || true; }
                     if [ -s testout-rej ] ; then
                         echo ''


### PR DESCRIPTION
# Problem:
When nodejs reports `rejected promise not handled`, CI does not fail. The CI test logs must be manually inspected to notice these problems. Requiring `await` #1638 will help, but still misses some cases.

# Solution:
Fail if "rejected promise not handled" is found in the test output. This is done in the CI script because the messages are from nodejs and I haven't found a way to scan the nodejs output from our test runner.

# Example

    rejected promise not handled within 1 second: AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
    rejected promise not handled within 1 second: Error: Download code bindings cancelled
    rejected promise not handled within 1 second: Error: EACCES: permission denied, mkdir '/my'
    rejected promise not handled within 1 second: Error: Error stopping job
    rejected promise not handled within 1 second: Error: No access

    ERROR: Found 9 "rejected promise not handled" in test output (see above).
           This typically indicates a bug. Read https://developer.mozilla.org/docs/Web/JavaScript/Guide/Using_promises#error_handling


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
