### PR TITLE
Update CWSPR telemetry client as per API model changes.

### DIFF
--- a/src/codewhisperer/client/user-service-2.json
+++ b/src/codewhisperer/client/user-service-2.json
@@ -307,7 +307,7 @@
             "type": "structure",
             "required": ["content"],
             "members": {
-                "messageId": { "shape": "AssistantResponseMessageMessageIdString" },
+                "messageId": { "shape": "MessageId" },
                 "content": { "shape": "AssistantResponseMessageContentString" },
                 "supplementaryWebLinks": { "shape": "SupplementaryWebLinks" },
                 "references": { "shape": "References" },
@@ -320,11 +320,6 @@
             "min": 0,
             "sensitive": true
         },
-        "AssistantResponseMessageMessageIdString": {
-            "type": "string",
-            "max": 128,
-            "min": 0
-        },
         "Base64EncodedPaginationToken": {
             "type": "string",
             "max": 2048,
@@ -335,11 +330,40 @@
             "type": "boolean",
             "box": true
         },
+        "ChatAddMessageEvent": {
+            "type": "structure",
+            "required": ["conversationId", "messageId"],
+            "members": {
+                "conversationId": { "shape": "ConversationId" },
+                "messageId": { "shape": "MessageId" },
+                "userIntent": { "shape": "UserIntent" },
+                "hasCodeSnippet": { "shape": "Boolean" },
+                "programmingLanguage": { "shape": "ProgrammingLanguage" },
+                "activeEditorTotalCharacters": { "shape": "Integer" },
+                "timeToFirstChunkMilliseconds": { "shape": "Double" },
+                "timeBetweenChunks": { "shape": "TimeBetweenChunks" },
+                "fullResponselatency": { "shape": "Double" },
+                "requestLength": { "shape": "Integer" },
+                "responseLength": { "shape": "Integer" }
+            }
+        },
         "ChatHistory": {
             "type": "list",
             "member": { "shape": "ChatMessage" },
             "max": 10,
             "min": 0
+        },
+        "ChatInteractWithMessageEvent": {
+            "type": "structure",
+            "required": ["conversationId", "messageId"],
+            "members": {
+                "conversationId": { "shape": "ConversationId" },
+                "messageId": { "shape": "MessageId" },
+                "interactionType": { "shape": "ChatMessageInteractionType" },
+                "interactionTarget": { "shape": "String" },
+                "acceptedCharacterCount": { "shape": "Integer" },
+                "acceptedSnippetHasReference": { "shape": "Boolean" }
+            }
         },
         "ChatMessage": {
             "type": "structure",
@@ -348,6 +372,30 @@
                 "assistantResponseMessage": { "shape": "AssistantResponseMessage" }
             },
             "union": true
+        },
+        "ChatMessageInteractionType": {
+            "type": "string",
+            "enum": [
+                "INSERT_AT_CURSOR",
+                "COPY_SNIPPET",
+                "COPY",
+                "CLICK_LINK",
+                "CLICK_BODY_LINK",
+                "CLICK_FOLLOW_UP",
+                "HOVER_REFERENCE",
+                "UPVOTE",
+                "DOWNVOTE"
+            ]
+        },
+        "ChatUserModificationEvent": {
+            "type": "structure",
+            "required": ["conversationId", "messageId", "modificationPercentage"],
+            "members": {
+                "conversationId": { "shape": "ConversationId" },
+                "messageId": { "shape": "MessageId" },
+                "programmingLanguage": { "shape": "ProgrammingLanguage" },
+                "modificationPercentage": { "shape": "Double" }
+            }
         },
         "ChatTriggerType": {
             "type": "string",
@@ -924,6 +972,11 @@
             "type": "long",
             "box": true
         },
+        "MessageId": {
+            "type": "string",
+            "max": 128,
+            "min": 0
+        },
         "MetricData": {
             "type": "structure",
             "required": ["metricName", "metricValue", "timestamp"],
@@ -1273,7 +1326,10 @@
                 "codeCoverageEvent": { "shape": "CodeCoverageEvent" },
                 "userModificationEvent": { "shape": "UserModificationEvent" },
                 "codeScanEvent": { "shape": "CodeScanEvent" },
-                "metricData": { "shape": "MetricData" }
+                "metricData": { "shape": "MetricData" },
+                "chatAddMessageEvent": { "shape": "ChatAddMessageEvent" },
+                "chatInteractWithMessageEvent": { "shape": "ChatInteractWithMessageEvent" },
+                "chatUserModificationEvent": { "shape": "ChatUserModificationEvent" }
             },
             "union": true
         },
@@ -1324,6 +1380,12 @@
             },
             "exception": true,
             "retryable": { "throttling": true }
+        },
+        "TimeBetweenChunks": {
+            "type": "list",
+            "member": { "shape": "Double" },
+            "max": 100,
+            "min": 0
         },
         "Timestamp": { "type": "timestamp" },
         "TransformationJob": {

--- a/src/codewhisperer/tracker/codewhispererTracker.ts
+++ b/src/codewhisperer/tracker/codewhispererTracker.ts
@@ -13,10 +13,7 @@ import { CodeWhispererUserGroupSettings } from '../util/userGroupUtil'
 import { AuthUtil } from '../util/authUtil'
 import { InsertedCode } from '../../codewhispererChat/controllers/chat/model'
 import { codeWhispererClient } from '../client/codewhisperer'
-import {
-    logSendTelemetryEventFailure,
-    mapToClientTelemetryEvent,
-} from '../../codewhispererChat/controllers/chat/telemetryHelper'
+import { logSendTelemetryEventFailure } from '../../codewhispererChat/controllers/chat/telemetryHelper'
 
 /**
  * This singleton class is mainly used for calculating the percentage of user modification.
@@ -111,7 +108,15 @@ export class CodeWhispererTracker {
                 telemetry.amazonq_modifyCode.emit(event)
 
                 codeWhispererClient
-                    .sendTelemetryEvent(mapToClientTelemetryEvent('amazonq_modifyCode', event))
+                    .sendTelemetryEvent({
+                        telemetryEvent: {
+                            chatUserModificationEvent: {
+                                conversationId: event.cwsprChatConversationId,
+                                messageId: event.cwsprChatMessageId,
+                                modificationPercentage: event.cwsprChatModificationPercentage,
+                            },
+                        },
+                    })
                     .then()
                     .catch(logSendTelemetryEventFailure)
             } else {

--- a/src/codewhispererChat/controllers/chat/chatRequest/converter.ts
+++ b/src/codewhispererChat/controllers/chat/chatRequest/converter.ts
@@ -14,7 +14,7 @@ import { TriggerPayload } from '../model'
 
 const fqnNameSizeDownLimit = 1
 const fqnNameSizeUpLimit = 256
-const supportedLanguagesList = [
+export const supportedLanguagesList = [
     'python',
     'javascript',
     'java',


### PR DESCRIPTION
CWSPR send telemetry API now supports 3 new event types: ChatAddMessageEvent, ChatInteractWithMessageEvent and ChatUserModificationEvent.

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
