### PR TITLE
lint: require "await" or .catch() on async calls

### DIFF
--- a/src/amazonq/onboardingPage/index.ts
+++ b/src/amazonq/onboardingPage/index.ts
@@ -51,7 +51,7 @@ export function welcome(context: vscode.ExtensionContext, cwcWebViewToAppsPublis
 
                     case 'goToHelp':
                         telemetry.record({ elementId: 'amazonq_tryExamples' })
-                        vscode.commands.executeCommand('aws.codeWhisperer.gettingStarted')
+                        void vscode.commands.executeCommand('aws.codeWhisperer.gettingStarted')
                         return
                 }
             })

--- a/src/amazonq/webview/ui/connector.ts
+++ b/src/amazonq/webview/ui/connector.ts
@@ -146,9 +146,9 @@ export class Connector {
         }
 
         if (messageData.sender === 'CWChat') {
-            this.cwChatConnector.handleMessageReceive(messageData)
+            await this.cwChatConnector.handleMessageReceive(messageData)
         } else if (messageData.sender === 'featureDevChat') {
-            this.featureDevChatConnector.handleMessageReceive(messageData)
+            await this.featureDevChatConnector.handleMessageReceive(messageData)
         }
     }
 

--- a/src/amazonqFeatureDev/app.ts
+++ b/src/amazonqFeatureDev/app.ts
@@ -67,6 +67,6 @@ export function init(appContext: AmazonQAppInitContext) {
     }, 500)
 
     AuthUtil.instance.secondaryAuth.onDidChangeActiveConnection(() => {
-        debouncedEvent()
+        return debouncedEvent()
     })
 }

--- a/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -85,7 +85,7 @@ export class FeatureDevController {
             }
         })
         this.chatControllerMessageListeners.openDiff.event(data => {
-            this.openDiff(data)
+            return this.openDiff(data)
         })
         this.chatControllerMessageListeners.stopResponse.event(data => {
             return this.stopResponse(data)
@@ -389,7 +389,7 @@ To learn more, visit the _[Amazon Q User Guide](${userGuideURL})_.
 
             const authState = await getChatAuthState()
             if (authState.amazonQ !== 'connected') {
-                this.messenger.sendAuthNeededExceptionMessage(authState, message.tabID)
+                void this.messenger.sendAuthNeededExceptionMessage(authState, message.tabID)
                 session.isAuthenticating = true
                 return
             }
@@ -448,7 +448,7 @@ To learn more, visit the _[Amazon Q User Guide](${userGuideURL})_.
     }
 
     private processLink(message: any) {
-        openUrl(vscode.Uri.parse(message.link))
+        void openUrl(vscode.Uri.parse(message.link))
     }
 
     private insertCodeAtPosition(message: any) {

--- a/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -71,17 +71,14 @@ export class FeatureDevController {
         this.chatControllerMessageListeners.followUpClicked.event(data => {
             switch (data.followUp.type) {
                 case FollowUpTypes.Retry:
-                    this.retryRequest(data)
-                    break
+                    return this.retryRequest(data)
                 case FollowUpTypes.ModifyDefaultSourceFolder:
-                    this.modifyDefaultSourceFolder(data)
-                    break
+                    return this.modifyDefaultSourceFolder(data)
                 case FollowUpTypes.DevExamples:
                     this.initialExamples(data)
                     break
                 case FollowUpTypes.NewPlan:
-                    this.newPlan(data)
-                    break
+                    return this.newPlan(data)
                 case FollowUpTypes.SendFeedback:
                     this.sendFeedback()
                     break
@@ -91,10 +88,10 @@ export class FeatureDevController {
             this.openDiff(data)
         })
         this.chatControllerMessageListeners.stopResponse.event(data => {
-            this.stopResponse(data)
+            return this.stopResponse(data)
         })
         this.chatControllerMessageListeners.tabOpened.event(data => {
-            this.tabOpened(data)
+            return this.tabOpened(data)
         })
         this.chatControllerMessageListeners.tabClosed.event(data => {
             this.tabClosed(data)
@@ -157,7 +154,7 @@ export class FeatureDevController {
 
             const authState = await getChatAuthState()
             if (authState.amazonQ !== 'connected') {
-                this.messenger.sendAuthNeededExceptionMessage(authState, message.tabID)
+                await this.messenger.sendAuthNeededExceptionMessage(authState, message.tabID)
                 session.isAuthenticating = true
                 return
             }
@@ -372,10 +369,10 @@ To learn more, visit the _[Amazon Q User Guide](${userGuideURL})_.
         if (message.deleted) {
             const fileUri = this.getOriginalFileUri(message, session)
             const basename = path.basename(message.filePath)
-            vscode.commands.executeCommand('vscode.open', fileUri, {}, `${basename} (Deleted)`)
+            await vscode.commands.executeCommand('vscode.open', fileUri, {}, `${basename} (Deleted)`)
         } else {
             const { left, right } = this.getFileDiffUris(message, session)
-            vscode.commands.executeCommand('vscode.diff', left, right)
+            await vscode.commands.executeCommand('vscode.diff', left, right)
         }
     }
 
@@ -447,7 +444,7 @@ To learn more, visit the _[Amazon Q User Guide](${userGuideURL})_.
     }
 
     private sendFeedback() {
-        submitFeedback.execute(placeholder, 'Amazon Q')
+        void submitFeedback.execute(placeholder, 'Amazon Q')
     }
 
     private processLink(message: any) {

--- a/src/amazonqGumby/activation.ts
+++ b/src/amazonqGumby/activation.ts
@@ -35,9 +35,9 @@ export async function activate(context: ExtContext) {
 
         Commands.register('aws.amazonq.stopTransformationInHub', async (cancelSrc: CancelActionPositions) => {
             if (transformByQState.isRunning()) {
-                confirmStopTransformByQ(transformByQState.getJobId(), cancelSrc)
+                void confirmStopTransformByQ(transformByQState.getJobId(), cancelSrc)
             } else {
-                vscode.window.showInformationMessage(CodeWhispererConstants.noOngoingJobMessage)
+                void vscode.window.showInformationMessage(CodeWhispererConstants.noOngoingJobMessage)
             }
         }),
 
@@ -50,7 +50,10 @@ export async function activate(context: ExtContext) {
         }),
 
         Commands.register('aws.amazonq.showTransformationPlanInHub', async () => {
-            vscode.commands.executeCommand('markdown.showPreview', vscode.Uri.file(transformByQState.getPlanFilePath()))
+            void vscode.commands.executeCommand(
+                'markdown.showPreview',
+                vscode.Uri.file(transformByQState.getPlanFilePath())
+            )
         })
     )
 

--- a/src/amazonqGumby/entrypoint.ts
+++ b/src/amazonqGumby/entrypoint.ts
@@ -24,7 +24,7 @@ export async function processTransformByQ() {
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
             result: MetadataResult.Pass,
         })
-        startTransformByQWithProgress()
+        return startTransformByQWithProgress()
     } else {
         void vscode.window.showInformationMessage(jobInProgressMessage, { modal: true })
     }

--- a/src/amazonqGumby/entrypoint.ts
+++ b/src/amazonqGumby/entrypoint.ts
@@ -15,7 +15,7 @@ import { codeTransformTelemetryState } from './telemetry/codeTransformTelemetryS
 
 export async function processTransformByQ() {
     if (!AuthUtil.instance.isEnterpriseSsoInUse()) {
-        vscode.window.showErrorMessage(noActiveIdCMessage)
+        void vscode.window.showErrorMessage(noActiveIdCMessage)
         return
     }
     if (transformByQState.isNotStarted()) {
@@ -26,6 +26,6 @@ export async function processTransformByQ() {
         })
         startTransformByQWithProgress()
     } else {
-        vscode.window.showInformationMessage(jobInProgressMessage, { modal: true })
+        void vscode.window.showInformationMessage(jobInProgressMessage, { modal: true })
     }
 }

--- a/src/applicationcomposer/messageHandlers/addFileWatchMessageHandler.ts
+++ b/src/applicationcomposer/messageHandlers/addFileWatchMessageHandler.ts
@@ -35,7 +35,7 @@ export async function addFileWatchMessageHandler(request: AddFileWatchRequestMes
                     fileContents: fileContents,
                 }
 
-                context.panel.webview.postMessage(fileChangedMessage)
+                await context.panel.webview.postMessage(fileChangedMessage)
                 context.fileWatches[filePath] = { fileContents: fileContents }
             }
         })
@@ -56,5 +56,5 @@ export async function addFileWatchMessageHandler(request: AddFileWatchRequestMes
         }
     }
 
-    context.panel.webview.postMessage(addFileWatchResponseMessage)
+    await context.panel.webview.postMessage(addFileWatchResponseMessage)
 }

--- a/src/applicationcomposer/messageHandlers/deployMessageHandler.ts
+++ b/src/applicationcomposer/messageHandlers/deployMessageHandler.ts
@@ -21,7 +21,7 @@ export async function deployMessageHandler(message: DeployRequestMessage, contex
      */
     const result = (await vscode.commands.executeCommand('aws.samcli.sync', args, false)) as SamSyncResult
     if (result?.isSuccess) {
-        vscode.window.showInformationMessage('SAM Sync succeeded!')
+        void vscode.window.showInformationMessage('SAM Sync succeeded!')
         telemetry.appcomposer_deployCompleted.emit({ result: 'Succeeded' })
     } else {
         telemetry.appcomposer_deployCompleted.emit({ result: 'Failed' })
@@ -32,5 +32,5 @@ export async function deployMessageHandler(message: DeployRequestMessage, contex
         eventId: message.eventId,
         isSuccess: result?.isSuccess,
     }
-    context.panel.webview.postMessage(response)
+    await context.panel.webview.postMessage(response)
 }

--- a/src/applicationcomposer/messageHandlers/generateResourceHandler.ts
+++ b/src/applicationcomposer/messageHandlers/generateResourceHandler.ts
@@ -31,7 +31,7 @@ export async function generateResourceHandler(request: GenerateResourceRequestMe
             isSuccess,
             traceId: request.traceId,
         }
-        context.panel.webview.postMessage(responseMessage)
+        await context.panel.webview.postMessage(responseMessage)
     } catch (error: any) {
         getLogger().error(`Error in generateResourceHandler: ${error.message}`, error)
 
@@ -46,7 +46,7 @@ export async function generateResourceHandler(request: GenerateResourceRequestMe
             metadata: {},
         }
 
-        context.panel.webview.postMessage(responseMessage)
+        await context.panel.webview.postMessage(responseMessage)
     }
 }
 

--- a/src/applicationcomposer/messageHandlers/initMessageHandler.ts
+++ b/src/applicationcomposer/messageHandlers/initMessageHandler.ts
@@ -20,5 +20,5 @@ export async function initMessageHandler(context: WebviewContext) {
             authState.codewhispererChat === 'connected' || authState.codewhispererChat === 'expired',
     }
 
-    context.panel.webview.postMessage(responseMessage)
+    await context.panel.webview.postMessage(responseMessage)
 }

--- a/src/applicationcomposer/messageHandlers/loadFileMessageHandler.ts
+++ b/src/applicationcomposer/messageHandlers/loadFileMessageHandler.ts
@@ -55,5 +55,5 @@ export async function loadFileMessageHandler(request: LoadFileRequestMessage, co
             failureReason: (e as Error).message,
         }
     }
-    context.panel.webview.postMessage(loadFileResponseMessage)
+    await context.panel.webview.postMessage(loadFileResponseMessage)
 }

--- a/src/applicationcomposer/messageHandlers/saveFileMessageHandler.ts
+++ b/src/applicationcomposer/messageHandlers/saveFileMessageHandler.ts
@@ -40,5 +40,5 @@ export async function saveFileMessageHandler(request: SaveFileRequestMessage, co
         }
     }
 
-    context.panel.webview.postMessage(saveFileResponseMessage)
+    await context.panel.webview.postMessage(saveFileResponseMessage)
 }

--- a/src/applicationcomposer/webviewManager.ts
+++ b/src/applicationcomposer/webviewManager.ts
@@ -104,7 +104,7 @@ export class ApplicationComposerManager {
     }
 
     protected handleErr(err: Error): void {
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             localize(
                 'AWS.applicationcomposer.visualisation.errors.rendering',
                 'There was an error rendering Application Composer, check logs for details.'

--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -36,6 +36,7 @@ import { CodeCatalystAuthenticationProvider } from '../codecatalyst/auth'
 import { S3FolderNode } from '../s3/explorer/s3FolderNode'
 import { amazonQNode, refreshAmazonQ, refreshAmazonQRootNode } from '../amazonq/explorer/amazonQNode'
 import { submitFeedback } from '../feedback/vue/submitFeedback'
+import { GlobalState } from '../shared/globalState'
 
 /**
  * Activates the AWS Explorer UI and related functionality.
@@ -54,7 +55,7 @@ export async function activate(args: {
     })
     view.onDidExpandElement(element => {
         if (element.element instanceof S3FolderNode) {
-            globals.context.globalState.update('aws.lastTouchedS3Folder', {
+            GlobalState.instance.tryUpdate('aws.lastTouchedS3Folder', {
                 bucket: element.element.bucket,
                 folder: element.element.folder,
             })

--- a/src/cdk/explorer/rootNode.ts
+++ b/src/cdk/explorer/rootNode.ts
@@ -56,6 +56,6 @@ export const refreshCdkExplorer = (provider?: ResourceTreeDataProvider) =>
     })
 
 Commands.register('aws.cdk.viewDocs', () => {
-    openUrl(vscode.Uri.parse(cdkDocumentationUrl))
+    void openUrl(vscode.Uri.parse(cdkDocumentationUrl))
     telemetry.aws_help.emit({ name: 'cdk' })
 })

--- a/src/cloudWatchLogs/commands/addLogEvents.ts
+++ b/src/cloudWatchLogs/commands/addLogEvents.ts
@@ -45,7 +45,7 @@ export async function addLogEvents(
         } else {
             // contingency in case lock isn't busy but still locked out. Don't want to accidentally trigger making codelens not busy
             const error = e as Error
-            vscode.window.showErrorMessage(
+            void vscode.window.showErrorMessage(
                 localize(
                     'AWS.cwl.searchLogGroup.errorRetrievingLogs2',
                     'Failed to get logs for {0}: {1}',

--- a/src/cloudWatchLogs/commands/copyLogResource.ts
+++ b/src/cloudWatchLogs/commands/copyLogResource.ts
@@ -28,7 +28,7 @@ export async function copyLogResource(uri?: vscode.Uri): Promise<void> {
         }
         await copyToClipboard(resourceName)
     } catch (e) {
-        vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             localize(
                 'AWS.cwl.invalidEditor',
                 'Invalid Cloudwatch Log stream or group: {0}',

--- a/src/cloudWatchLogs/commands/saveCurrentLogDataContent.ts
+++ b/src/cloudWatchLogs/commands/saveCurrentLogDataContent.ts
@@ -49,7 +49,7 @@ export async function saveCurrentLogDataContent(): Promise<void> {
             } catch (e) {
                 result = 'Failed'
                 const err = e as Error
-                vscode.window.showErrorMessage(
+                void vscode.window.showErrorMessage(
                     localize(
                         'AWS.command.saveCurrentLogDataContent.error',
                         'Error saving current log to {0}: {1}',
@@ -63,7 +63,7 @@ export async function saveCurrentLogDataContent(): Promise<void> {
         }
     } catch (e) {
         result = 'Failed'
-        vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             localize(
                 'AWS.cwl.invalidEditor',
                 'Not a Cloudwatch Log data source: {0}',

--- a/src/cloudWatchLogs/commands/searchLogGroup.ts
+++ b/src/cloudWatchLogs/commands/searchLogGroup.ts
@@ -67,7 +67,7 @@ export async function prepareDocument(uri: vscode.Uri, logData: CloudWatchLogsDa
         await registry.fetchNextLogEvents(uri)
         const doc = await vscode.workspace.openTextDocument(uri)
         await vscode.window.showTextDocument(doc, { preview: false })
-        vscode.languages.setTextDocumentLanguage(doc, 'log')
+        await vscode.languages.setTextDocumentLanguage(doc, 'log')
     } catch (err) {
         if (CancellationError.isUserCancelled(err)) {
             throw err

--- a/src/codecatalyst/activation.ts
+++ b/src/codecatalyst/activation.ts
@@ -111,7 +111,7 @@ export async function activate(ctx: ExtContext): Promise<void> {
         const devEnvActivity = await DevEnvActivity.instanceIfActivityTrackingEnabled(devEnvClient)
         if (shouldTrackUserActivity(maxInactivityMinutes) && devEnvActivity) {
             const inactivityMessage = new InactivityMessage()
-            void inactivityMessage.setupMessage(maxInactivityMinutes, devEnvActivity)
+            await inactivityMessage.setupMessage(maxInactivityMinutes, devEnvActivity)
 
             ctx.extensionContext.subscriptions.push(inactivityMessage, devEnvActivity)
         }

--- a/src/codecatalyst/activation.ts
+++ b/src/codecatalyst/activation.ts
@@ -41,7 +41,7 @@ export async function activate(ctx: ExtContext): Promise<void> {
         uriHandlers.register(ctx.uriHandler, CodeCatalystCommands.declared),
         ...Object.values(CodeCatalystCommands.declared).map(c => c.register(commands)),
         Commands.register('aws.codecatalyst.manageConnections', () => {
-            showManageConnections.execute(placeholder, 'codecatalystDeveloperTools', 'codecatalyst')
+            return showManageConnections.execute(placeholder, 'codecatalystDeveloperTools', 'codecatalyst')
         }),
         Commands.register('aws.codecatalyst.signout', () => {
             return authProvider.secondaryAuth.deleteConnection()
@@ -49,11 +49,11 @@ export async function activate(ctx: ExtContext): Promise<void> {
     )
 
     if (!isCloud9()) {
-        GitExtension.instance.registerRemoteSourceProvider(remoteSourceProvider).then(disposable => {
+        await GitExtension.instance.registerRemoteSourceProvider(remoteSourceProvider).then(disposable => {
             ctx.extensionContext.subscriptions.push(disposable)
         })
 
-        GitExtension.instance
+        await GitExtension.instance
             .registerCredentialsProvider({
                 getCredentials(uri: vscode.Uri) {
                     if (uri.authority.endsWith(getCodeCatalystConfig().gitHostname)) {
@@ -83,7 +83,7 @@ export async function activate(ctx: ExtContext): Promise<void> {
         if (!isCloud9() && thisDevenv && !isDevenvVscode(thisDevenv.summary.ides)) {
             // Prevent Toolkit from reconnecting to a "non-vscode" devenv by actively closing it.
             // Can happen if devenv is switched to ides="cloud9", etc.
-            vscode.commands.executeCommand('workbench.action.remote.close')
+            void vscode.commands.executeCommand('workbench.action.remote.close')
             return
         }
 
@@ -97,11 +97,11 @@ export async function activate(ctx: ExtContext): Promise<void> {
                 getIdeProperties().company
             )
             const openDevEnvSettings = localize('AWS.codecatalyst.openDevEnvSettings', 'Open Dev Environment Settings')
-            vscode.window.showInformationMessage(message, dontShow, openDevEnvSettings).then(selection => {
+            void vscode.window.showInformationMessage(message, dontShow, openDevEnvSettings).then(async selection => {
                 if (selection === dontShow) {
-                    settings.disablePrompt('remoteConnected')
+                    await settings.disablePrompt('remoteConnected')
                 } else if (selection === openDevEnvSettings) {
-                    CodeCatalystCommands.declared.openDevEnvSettings.execute()
+                    await CodeCatalystCommands.declared.openDevEnvSettings.execute()
                 }
             })
         }
@@ -111,7 +111,7 @@ export async function activate(ctx: ExtContext): Promise<void> {
         const devEnvActivity = await DevEnvActivity.instanceIfActivityTrackingEnabled(devEnvClient)
         if (shouldTrackUserActivity(maxInactivityMinutes) && devEnvActivity) {
             const inactivityMessage = new InactivityMessage()
-            inactivityMessage.setupMessage(maxInactivityMinutes, devEnvActivity)
+            void inactivityMessage.setupMessage(maxInactivityMinutes, devEnvActivity)
 
             ctx.extensionContext.subscriptions.push(inactivityMessage, devEnvActivity)
         }

--- a/src/codecatalyst/auth.ts
+++ b/src/codecatalyst/auth.ts
@@ -70,7 +70,7 @@ export class CodeCatalystAuthenticationProvider {
         })
 
         // set initial context in case event does not trigger
-        setCodeCatalystConnectedContext(this.isConnectionValid())
+        void setCodeCatalystConnectedContext(this.isConnectionValid())
     }
 
     public get activeConnection() {

--- a/src/codecatalyst/commands.ts
+++ b/src/codecatalyst/commands.ts
@@ -29,7 +29,7 @@ import { showManageConnections } from '../auth/ui/vue/show'
 
 /** "List CodeCatalyst Commands" command. */
 export async function listCommands(): Promise<void> {
-    vscode.commands.executeCommand('workbench.action.quickOpen', '> CodeCatalyst')
+    await vscode.commands.executeCommand('workbench.action.quickOpen', '> CodeCatalyst')
 }
 
 /** "Clone CodeCatalyst Repository" command. */
@@ -231,7 +231,7 @@ export class CodeCatalystCommands {
 
     public stopDevEnv(...args: WithClient<typeof stopDevEnv>) {
         return this.withClient(stopDevEnv, ...args).then(() => {
-            vscode.commands.executeCommand('workbench.action.remote.close')
+            void vscode.commands.executeCommand('workbench.action.remote.close')
         })
     }
 
@@ -288,7 +288,7 @@ export class CodeCatalystCommands {
         if (connection !== undefined) {
             await this.authProvider.tryConnectTo(connection)
         } else if (!this.authProvider.isConnectionValid()) {
-            showManageConnections.execute(placeholder, 'codecatalystDeveloperTools', 'codecatalyst')
+            void showManageConnections.execute(placeholder, 'codecatalystDeveloperTools', 'codecatalyst')
             return
         }
 

--- a/src/codecatalyst/devEnv.ts
+++ b/src/codecatalyst/devEnv.ts
@@ -194,7 +194,7 @@ class Message implements vscode.Disposable {
                 userIsActive()
             } else {
                 // The message timed out, show the updated message.
-                this.show(
+                void this.show(
                     minutesUserWasInactive + 1,
                     minutesUntilShutdown - 1,
                     userIsActive,

--- a/src/codecatalyst/devfile.ts
+++ b/src/codecatalyst/devfile.ts
@@ -111,7 +111,9 @@ export function registerDevfileWatcher(devenvClient: DevEnvClient): vscode.Dispo
     const registry = new DevfileRegistry()
     const codelensProvider = new DevfileCodeLensProvider(registry, devenvClient)
     registry.addWatchPatterns([devfileGlobPattern])
-    registry.rebuild()
+    registry.rebuild().catch(e => {
+        getLogger().error('WatchedFiles.rebuild failed: %s', (e as Error).message)
+    })
 
     const codelensDisposable = vscode.languages.registerCodeLensProvider(
         {

--- a/src/codecatalyst/explorer.ts
+++ b/src/codecatalyst/explorer.ts
@@ -33,7 +33,7 @@ const reauth = Commands.register(
 const onboardCommand = Commands.register(
     '_aws.codecatalyst.onboard',
     async (authProvider: CodeCatalystAuthenticationProvider) => {
-        authProvider.promptOnboarding()
+        void authProvider.promptOnboarding()
     }
 )
 

--- a/src/codecatalyst/utils.ts
+++ b/src/codecatalyst/utils.ts
@@ -7,9 +7,8 @@ import { Ides } from 'aws-sdk/clients/codecatalyst'
 import * as vscode from 'vscode'
 import { CodeCatalystResource, getCodeCatalystConfig } from '../shared/clients/codecatalystClient'
 import { pushIf } from '../shared/utilities/collectionUtils'
-import { CodeCatalystAuthenticationProvider } from './auth'
-import { Commands } from '../shared/vscode/commands2'
 import { getCodeCatalystDevEnvId } from '../shared/vscode/env'
+import { getLogger } from '../shared/logger'
 
 /**
  * Builds a web URL from the given CodeCatalyst object.
@@ -51,7 +50,9 @@ export function getHelpUrl(): string {
  */
 export function openCodeCatalystUrl(o: CodeCatalystResource) {
     const url = toCodeCatalystUrl(o)
-    vscode.env.openExternal(vscode.Uri.parse(url))
+    vscode.env.openExternal(vscode.Uri.parse(url)).then(undefined, e => {
+        getLogger().error('openExternal failed: %s', (e as Error).message)
+    })
 }
 
 /** Returns true if the dev env has a "vscode" IDE runtime. */
@@ -65,10 +66,3 @@ export function isDevenvVscode(ides: Ides | undefined): boolean {
 export function isInDevEnv(): boolean {
     return !!getCodeCatalystDevEnvId()
 }
-
-export const getStartedCommand = Commands.register(
-    'aws.codecatalyst.getStarted',
-    (auth: CodeCatalystAuthenticationProvider) => {
-        auth.connectToAwsBuilderId()
-    }
-)

--- a/src/codecatalyst/vue/configure/backend.ts
+++ b/src/codecatalyst/vue/configure/backend.ts
@@ -184,7 +184,7 @@ export async function showConfigureDevEnv(
 function pollDevfile(devenv: ConnectedDevEnv, server: CodeCatalystConfigureWebview): vscode.Disposable {
     let done = false
 
-    ;(async () => {
+    void (async () => {
         while (!done) {
             const resp = await devenv.devenvClient.getStatus()
             if (resp.status === 'CHANGED') {
@@ -198,14 +198,14 @@ function pollDevfile(devenv: ConnectedDevEnv, server: CodeCatalystConfigureWebvi
 }
 
 function reportClosingMessage(): void {
-    vscode.window.withProgress(
+    void vscode.window.withProgress(
         {
             location: vscode.ProgressLocation.Notification,
             title: 'Session ended. Session will restore when the Dev Environment is available again.',
         },
         async (progress, token) => {
             await sleep(2500)
-            vscode.commands.executeCommand('workbench.action.remote.close')
+            await vscode.commands.executeCommand('workbench.action.remote.close')
         }
     )
 }

--- a/src/codecatalyst/vue/create/backend.ts
+++ b/src/codecatalyst/vue/create/backend.ts
@@ -183,7 +183,7 @@ export class CodeCatalystCreateWebview extends VueWebview {
 
     public async submit(settings: DevEnvironmentSettings, source: SourceResponse) {
         const devenv = await this.createDevEnvOfType(settings, source)
-        this.commands.openDevEnv.execute(devenv)
+        void this.commands.openDevEnv.execute(devenv)
     }
 
     public async createDevEnvOfType(settings: DevEnvironmentSettings, source: SourceResponse) {

--- a/src/codecatalyst/wizards/selectResource.ts
+++ b/src/codecatalyst/wizards/selectResource.ts
@@ -93,7 +93,9 @@ function createResourcePrompter<T extends codecatalyst.CodeCatalystResource>(
     })
 
     refresh.onClick = () => {
-        prompter.clearAndLoadItems(items)
+        prompter.clearAndLoadItems(items).catch(e => {
+            getLogger().error('clearAndLoadItems failed: %s', (e as Error).message)
+        })
     }
 
     return prompter

--- a/src/codecatalyst/wizards/selectResource.ts
+++ b/src/codecatalyst/wizards/selectResource.ts
@@ -18,6 +18,7 @@ import { getRelativeDate } from '../../shared/utilities/textUtilities'
 import { isValidResponse } from '../../shared/wizards/wizard'
 import { associateDevEnv, docs } from '../model'
 import { getHelpUrl, isDevenvVscode } from '../utils'
+import { getLogger } from '../../shared/logger/logger'
 
 export function createRepoLabel(r: codecatalyst.CodeCatalystRepo): string {
     return `${r.org.name} / ${r.project.name} / ${r.name}`
@@ -226,7 +227,9 @@ export async function selectRepoForDevEnv(
     })
 
     refresh.onClick = () => {
-        prompter.clearAndLoadItems(items)
+        prompter.clearAndLoadItems(items).catch(e => {
+            getLogger().error('clearAndLoadItems failed: %s', (e as Error).message)
+        })
     }
 
     const response = await prompter.prompt()

--- a/src/codewhisperer/client/codewhisperer.ts
+++ b/src/codewhisperer/client/codewhisperer.ts
@@ -104,7 +104,9 @@ export class DefaultCodeWhispererClient {
                                     resp.error?.code === 'AccessDeniedException' &&
                                     resp.error.message.match(/expired/i)
                                 ) {
-                                    AuthUtil.instance.reauthenticate()
+                                    AuthUtil.instance.reauthenticate().catch(e => {
+                                        getLogger().error('reauthenticate failed: %s', (e as Error).message)
+                                    })
                                     resp.error.retryable = true
                                 }
                             })

--- a/src/codewhisperer/commands/basicCommands.ts
+++ b/src/codewhisperer/commands/basicCommands.ts
@@ -80,7 +80,7 @@ export const showReferenceLog = Commands.declare(
 )
 
 export const showIntroduction = Commands.declare('aws.codeWhisperer.introduction', () => async () => {
-    openUrl(vscode.Uri.parse(CodeWhispererConstants.learnMoreUriGeneral))
+    void openUrl(vscode.Uri.parse(CodeWhispererConstants.learnMoreUriGeneral))
 })
 
 export const showSecurityScan = Commands.declare(
@@ -95,7 +95,12 @@ export const showSecurityScan = Commands.declare(
                 if (codeScanState.isNotStarted()) {
                     // User intends to start as "Start Security Scan" is shown in the explorer tree
                     codeScanState.setToRunning()
-                    startSecurityScanWithProgress(securityPanelViewProvider, editor, client, context.extensionContext)
+                    void startSecurityScanWithProgress(
+                        securityPanelViewProvider,
+                        editor,
+                        client,
+                        context.extensionContext
+                    )
                 } else if (codeScanState.isRunning()) {
                     // User intends to stop as "Stop Security Scan" is shown in the explorer tree
                     // Cancel only when the code scan state is "Running"
@@ -103,7 +108,7 @@ export const showSecurityScan = Commands.declare(
                 }
                 await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
             } else {
-                vscode.window.showInformationMessage('Open a valid file to scan.')
+                void vscode.window.showInformationMessage('Open a valid file to scan.')
             }
         }
 )
@@ -117,7 +122,7 @@ export const showTransformByQ = Commands.declare(
 
         if (transformByQState.isNotStarted()) {
             logCodeTransformInitiatedMetric(source)
-            startTransformByQWithProgress()
+            await startTransformByQWithProgress()
         } else if (transformByQState.isCancelled()) {
             vscode.window.showInformationMessage(CodeWhispererConstants.cancellationInProgressMessage)
         } else if (transformByQState.isRunning()) {

--- a/src/codewhispererChat/controllers/chat/controller.ts
+++ b/src/codewhispererChat/controllers/chat/controller.ts
@@ -225,9 +225,9 @@ export class ChatController {
                     return
                 } else if (quickActionCommand === 'transform') {
                     this.generateStaticTextResponse('transform', triggerID)
-                    processTransformByQ()
-                    recordTelemetryChatRunCommand('transform')
-                    return
+                    return processTransformByQ().then(() => {
+                        return recordTelemetryChatRunCommand('transform')
+                    })
                 }
             })
             .catch(e => {

--- a/src/testInteg/codecatalyst/devEnv.test.ts
+++ b/src/testInteg/codecatalyst/devEnv.test.ts
@@ -57,7 +57,7 @@ describe('InactivityMessages', function () {
     })
 
     it('shows expected messages 5 minutes before shutdown on a 15 minute inactivity timeout', async function () {
-        instance.setupMessage(15, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
+        await instance.setupMessage(15, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
 
         await assertMessagesShown([
             ['Your CodeCatalyst Dev Environment has been inactive for 10 minutes, shutting it down in 5 minutes.', 10],
@@ -69,7 +69,7 @@ describe('InactivityMessages', function () {
     })
 
     it('shows expected messages 5 minutes before shutdown on a 60 minute inactivity timeout', async function () {
-        instance.setupMessage(60, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
+        await instance.setupMessage(60, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
 
         await assertMessagesShown([
             ['Your CodeCatalyst Dev Environment has been inactive for 55 minutes, shutting it down in 5 minutes.', 55],
@@ -97,7 +97,7 @@ describe('InactivityMessages', function () {
             message.selectItem('Cancel')
         })
 
-        instance.setupMessage(7, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
+        await instance.setupMessage(7, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
 
         await assertMessagesShown([
             ['Your CodeCatalyst Dev Environment has been inactive for 2 minutes, shutting it down in 5 minutes.', 2],
@@ -127,7 +127,7 @@ describe('InactivityMessages', function () {
             inactiveMinutes - Math.ceil(initialOffsetMinutes) - InactivityMessage.firstMessageBeforeShutdown
         setInitialOffset(initialOffsetMinutes)
 
-        instance.setupMessage(inactiveMinutes, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
+        await instance.setupMessage(inactiveMinutes, devEnvActivity as unknown as DevEnvActivity, relativeMinuteMillis)
 
         await assertMessagesShown([
             [
@@ -160,7 +160,7 @@ describe('InactivityMessages', function () {
             return true
         })
 
-        instance.setupMessage(
+        await instance.setupMessage(
             InactivityMessage.firstMessageBeforeShutdown + 1,
             devEnvActivity as unknown as DevEnvActivity,
             relativeMinuteMillis


### PR DESCRIPTION
Continued from #1638

# Problem:

- All promises or async calls should use `await`, or end with `.catch()`.
  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises
- Async calls accidentally forget `await`.
  - Example: 8863ba4a799e
- Test logs show "rejected promise not handled":
  ```
  rejected promise not handled within 1 second: HTTPError: Response code 403 (rate limit exceeded)
  rejected promise not handled within 1 second: Error: command 'aws.codeWhisperer.refreshStatusBar' not found
  rejected promise not handled within 1 second: HTTPError: Response code 404 (Not Found)
  rejected promise not handled within 1 second: CodeExpectedError: cannot open notCloudWatch:hahahaha. Detail: Unable to resolve resource notCloudWatch:hahahaha
  rejected promise not handled within 1 second: AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
  rejected promise not handled within 1 second: Error: No access
  rejected promise not handled within 1 second: Error: No access
  rejected promise not handled within 1 second: Error: Timed-out waiting for browser login flow to complete
  rejected promise not handled within 1 second: Error: Download code bindings cancelled
  rejected promise not handled within 1 second: Error: EACCES: permission denied, mkdir '/my'
  ```

# Solution:

- Enable eslint rule: https://typescript-eslint.io/rules/no-floating-promises/




<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
