### PR TITLE
fix(amazonq): "Transformation Hub" is always visible

### DIFF
--- a/.changes/next-release/Bug Fix-d4bf021f-adee-4cba-9737-b371d0be85ff.json
+++ b/.changes/next-release/Bug Fix-d4bf021f-adee-4cba-9737-b371d0be85ff.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q: \"Transformation Hub\" is always visible, even if Transform feature is not enabled or used"
+}

--- a/package.json
+++ b/package.json
@@ -769,7 +769,8 @@
                 {
                     "type": "webview",
                     "id": "aws.amazonq.transformationHub",
-                    "name": "Status"
+                    "name": "Status",
+                    "when": "gumby.isTransformAvailable || gumby.isStopButtonAvailable"
                 },
                 {
                     "id": "aws.amazonq.transformationProposedChangesTree",


### PR DESCRIPTION
Problem:
"Transformation Hub" is always visible, even when Transform feature is not enabled.

![image](https://github.com/aws/aws-toolkit-vscode/assets/55561878/5fe2186e-0309-424f-85e2-f665cef427d9)


Solution:
Define a "when" condition.



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
