### PR TITLE
fix(integ): remove go extension activation.

### DIFF
--- a/src/testInteg/sam.test.ts
+++ b/src/testInteg/sam.test.ts
@@ -345,7 +345,9 @@ async function stopDebugger(logMsg: string | undefined): Promise<void> {
 async function activateExtensions(): Promise<void> {
     console.log('Activating extensions...')
     await vscodeUtils.activateExtension(VSCODE_EXTENSION_ID.python, false)
-    await vscodeUtils.activateExtension(VSCODE_EXTENSION_ID.go, false)
+    // TODO: Must be reactivated when go tests are enabled above.
+    // Caveat: v0.40.1 of the go extension breaks this line (see changelog for this version)
+    // await vscodeUtils.activateExtension(VSCODE_EXTENSION_ID.go, false)
     await vscodeUtils.activateExtension(VSCODE_EXTENSION_ID.java, false)
     await vscodeUtils.activateExtension(VSCODE_EXTENSION_ID.javadebug, false)
     console.log('Extensions activated')


### PR DESCRIPTION
Problem: v0.40.1 of go changes how the extension is activated and breaks the integ tests.

Solution: Remove go activation, it is not required for integ tests.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
