### PR TITLE
feature(browser): enable basic global commands to be shared between browser/non-browser

### DIFF
--- a/.changes/next-release/Feature-db8301de-5d0d-4fdb-b0a3-4a55703c9de0.json
+++ b/.changes/next-release/Feature-db8301de-5d0d-4fdb-b0a3-4a55703c9de0.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Browser: Enable generic global commands in ellipses menus, e.g. About Toolkit, Report Toolkit Issue, etc."
+}

--- a/package.json
+++ b/package.json
@@ -1364,7 +1364,7 @@
                 },
                 {
                     "command": "aws.submitFeedback",
-                    "when": "view == aws.explorer",
+                    "when": "view == aws.explorer && !aws.isWebExtHost",
                     "group": "navigation@6"
                 },
                 {
@@ -2179,6 +2179,7 @@
             "aws.submenu.feedback": [
                 {
                     "command": "aws.submitFeedback",
+                    "when": "!aws.isWebExtHost",
                     "group": "1_feedback@1"
                 },
                 {
@@ -2981,6 +2982,7 @@
             {
                 "command": "aws.submitFeedback",
                 "title": "%AWS.command.submitFeedback%",
+                "enablement": "!aws.isWebExtHost",
                 "category": "%AWS.title%",
                 "icon": "$(comment)",
                 "cloud9": {

--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -35,7 +35,6 @@ import { CodeCatalystRootNode } from '../codecatalyst/explorer'
 import { CodeCatalystAuthenticationProvider } from '../codecatalyst/auth'
 import { S3FolderNode } from '../s3/explorer/s3FolderNode'
 import { amazonQNode, refreshAmazonQ, refreshAmazonQRootNode } from '../amazonq/explorer/amazonQNode'
-import { submitFeedback } from '../feedback/vue/submitFeedback'
 import { GlobalState } from '../shared/globalState'
 
 /**
@@ -161,7 +160,6 @@ async function registerAwsExplorerCommands(
                 telemetry.vscode_activeRegions.emit({ value: awsExplorer.getRegionNodesSize() })
             }
         }),
-        submitFeedback.register(context),
         Commands.register({ id: 'aws.refreshAwsExplorer', autoconnect: true }, async (passive: boolean = false) => {
             awsExplorer.refresh()
 

--- a/src/dev/activation.ts
+++ b/src/dev/activation.ts
@@ -5,7 +5,6 @@
 
 import * as vscode from 'vscode'
 import * as config from './config'
-import { ExtContext } from '../shared/extensions'
 import { createCommonButtons } from '../shared/ui/buttons'
 import { createQuickPick } from '../shared/ui/pickerPrompter'
 import { SkipPrompter } from '../shared/ui/common/skipPrompter'
@@ -26,7 +25,7 @@ interface MenuOption {
     readonly label: string
     readonly description?: string
     readonly detail?: string
-    readonly executor: (ctx: ExtContext) => Promise<unknown> | unknown
+    readonly executor: (ctx: vscode.ExtensionContext) => Promise<unknown> | unknown
 }
 
 /**
@@ -91,7 +90,7 @@ const menuOptions: Record<string, MenuOption> = {
  * re-appears after vscode restart. Ideally there should be only one scheme (aws-dev:/).
  */
 export class DevDocumentProvider implements vscode.TextDocumentContentProvider {
-    constructor(private readonly ctx: ExtContext) {}
+    constructor(private readonly ctx: vscode.ExtensionContext) {}
     provideTextDocumentContent(uri: vscode.Uri): string {
         if (uri.path === '/envvars') {
             let s = 'Environment variables known to AWS Toolkit:\n\n'
@@ -102,7 +101,7 @@ export class DevDocumentProvider implements vscode.TextDocumentContentProvider {
         } else if (uri.path === '/globalstate') {
             // lol hax
             // as of November 2023, all of a memento's properties are stored as property `f` when minified
-            return JSON.stringify((this.ctx.extensionContext.globalState as any).f, undefined, 4)
+            return JSON.stringify((this.ctx.globalState as any).f, undefined, 4)
         } else {
             return `unknown URI path: ${uri}`
         }
@@ -116,14 +115,14 @@ export class DevDocumentProvider implements vscode.TextDocumentContentProvider {
  *
  * See {@link DevSettings} for more information.
  */
-export async function activate(ctx: ExtContext): Promise<void> {
+export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     const devSettings = DevSettings.instance
 
     async function updateMode() {
         await vscode.commands.executeCommand('setContext', 'aws.isDevMode', devSettings.isDevMode())
     }
 
-    ctx.extensionContext.subscriptions.push(
+    ctx.subscriptions.push(
         devSettings.onDidChangeActiveSettings(updateMode),
         vscode.commands.registerCommand('aws.dev.openMenu', () => openMenu(ctx, menuOptions)),
         vscode.workspace.registerTextDocumentContentProvider('aws-dev2', new DevDocumentProvider(ctx))
@@ -131,15 +130,15 @@ export async function activate(ctx: ExtContext): Promise<void> {
 
     await updateMode()
 
-    const editor = new ObjectEditor(ctx.extensionContext)
-    ctx.extensionContext.subscriptions.push(openStorageCommand.register(editor))
+    const editor = new ObjectEditor(ctx)
+    ctx.subscriptions.push(openStorageCommand.register(editor))
 
     if (!isCloud9() && !isReleaseVersion() && config.betaUrl) {
-        ctx.extensionContext.subscriptions.push(watchBetaVSIX(config.betaUrl))
+        ctx.subscriptions.push(watchBetaVSIX(config.betaUrl))
     }
 }
 
-async function openMenu(ctx: ExtContext, options: typeof menuOptions): Promise<void> {
+async function openMenu(ctx: vscode.ExtensionContext, options: typeof menuOptions): Promise<void> {
     const items = entries(options).map(([_, v]) => ({
         label: v.label,
         detail: v.detail,
@@ -285,7 +284,7 @@ class ObjectEditor {
     }
 }
 
-async function openStorageFromInput(ctx: ExtContext) {
+async function openStorageFromInput(ctx: vscode.ExtensionContext) {
     const wizard = new (class extends Wizard<{ target: 'globalsView' | 'globals' | 'secrets'; key: string }> {
         constructor() {
             super()
@@ -312,7 +311,7 @@ async function openStorageFromInput(ctx: ExtContext) {
                     return new SkipPrompter('')
                 } else if (target === 'globals') {
                     // List all globalState keys in the quickpick menu.
-                    const items = ctx.extensionContext.globalState
+                    const items = ctx.globalState
                         .keys()
                         .map(key => {
                             return {

--- a/src/dev/codecatalyst.ts
+++ b/src/dev/codecatalyst.ts
@@ -11,7 +11,7 @@ import * as manifest from '../../package.json'
 import { promisify } from 'util'
 import { getLogger } from '../shared/logger'
 import { selectCodeCatalystResource } from '../codecatalyst/wizards/selectResource'
-import { ExtContext, VSCODE_EXTENSION_ID } from '../shared/extensions'
+import { VSCODE_EXTENSION_ID } from '../shared/extensions'
 import { DevEnvironment, CodeCatalystClient } from '../shared/clients/codecatalystClient'
 import { prepareDevEnvConnection } from '../codecatalyst/model'
 import { ChildProcess } from '../shared/utilities/childProcess'
@@ -53,8 +53,8 @@ function lazyProgress<T extends Record<string, any>>(timeout: Timeout): LazyProg
     }
 }
 
-export async function openTerminalCommand(ctx: ExtContext) {
-    const commands = CodeCatalystCommands.fromContext(ctx.extensionContext)
+export async function openTerminalCommand(ctx: vscode.ExtensionContext) {
+    const commands = CodeCatalystCommands.fromContext(ctx)
     const progress = lazyProgress<{ message: string }>(new Timeout(900000))
 
     await commands.withClient(openTerminal, progress).finally(() => progress.dispose())
@@ -83,8 +83,8 @@ async function openTerminal(client: CodeCatalystClient, progress: LazyProgress<{
     vscode.window.createTerminal(options).show()
 }
 
-export async function installVsixCommand(ctx: ExtContext) {
-    const commands = CodeCatalystCommands.fromContext(ctx.extensionContext)
+export async function installVsixCommand(ctx: vscode.ExtensionContext) {
+    const commands = CodeCatalystCommands.fromContext(ctx)
 
     await commands.withClient(async client => {
         const env = await selectCodeCatalystResource(client, 'devEnvironment')
@@ -103,12 +103,10 @@ export async function installVsixCommand(ctx: ExtContext) {
 }
 
 async function promptVsix(
-    ctx: ExtContext,
+    ctx: vscode.ExtensionContext,
     progress?: LazyProgress<{ message: string }>
 ): Promise<vscode.Uri | undefined> {
-    const folders = (vscode.workspace.workspaceFolders ?? [])
-        .map(f => f.uri)
-        .concat(vscode.Uri.file(ctx.extensionContext.extensionPath))
+    const folders = (vscode.workspace.workspaceFolders ?? []).map(f => f.uri).concat(vscode.Uri.file(ctx.extensionPath))
 
     enum ExtensionMode {
         Production = 1,
@@ -116,8 +114,8 @@ async function promptVsix(
         Test = 3,
     }
 
-    const isDevelopmentWindow = ctx.extensionContext.extensionMode === ExtensionMode.Development
-    const extPath = isDevelopmentWindow ? ctx.extensionContext.extensionPath : folders[0].fsPath
+    const isDevelopmentWindow = ctx.extensionMode === ExtensionMode.Development
+    const extPath = isDevelopmentWindow ? ctx.extensionPath : folders[0].fsPath
 
     const packageNew = {
         label: 'Create new VSIX',
@@ -200,7 +198,7 @@ async function promptVsix(
  * Bootstrap an environment for remote development/debugging
  */
 async function installVsix(
-    ctx: ExtContext,
+    ctx: vscode.ExtensionContext,
     client: CodeCatalystClient,
     progress: LazyProgress<{ message: string }>,
     env: DevEnvironment
@@ -269,8 +267,8 @@ async function installVsix(
     await startVscodeRemote(SessionProcess, hostname, '/projects', vscPath)
 }
 
-export async function deleteDevEnvCommand(ctx: ExtContext) {
-    const commands = CodeCatalystCommands.fromContext(ctx.extensionContext)
+export async function deleteDevEnvCommand(ctx: vscode.ExtensionContext) {
+    const commands = CodeCatalystCommands.fromContext(ctx)
 
     await commands.withClient(async client => {
         const devenv = await selectCodeCatalystResource(client, 'devEnvironment')

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,7 +73,7 @@ import { isUserCancelledError, resolveErrorMessageToDisplay, ToolkitError } from
 import { Logging } from './shared/logger/commands'
 import { showMessageWithUrl, showViewLogsMessage } from './shared/utilities/messages'
 import { registerWebviewErrorHandler } from './webviews/server'
-import { activateGlobalCommands, initializeManifestPaths } from './extensionShared'
+import { registerCommands, initializeManifestPaths } from './extensionShared'
 import { ChildProcess } from './shared/utilities/childProcess'
 import { initializeNetworkAgent } from './codewhisperer/client/agent'
 import { Timeout } from './shared/utilities/timeoutUtils'
@@ -177,7 +177,7 @@ export async function activate(context: vscode.ExtensionContext) {
             getLogger().debug(`Developer Tools (internal): failed to activate: ${(error as Error).message}`)
         }
 
-        activateGlobalCommands(context)
+        registerCommands(context)
         context.subscriptions.push(
             Commands.register('aws.quickStart', async () => {
                 try {

--- a/src/extensionShared.ts
+++ b/src/extensionShared.ts
@@ -24,7 +24,7 @@ export function initializeManifestPaths(extensionContext: vscode.ExtensionContex
     )
 }
 
-export function activateGlobalCommands(extensionContext: vscode.ExtensionContext) {
+export function registerCommands(extensionContext: vscode.ExtensionContext) {
     extensionContext.subscriptions.push(
         // No-op command used for decoration-only codelenses.
         vscode.commands.registerCommand('aws.doNothingCommand', () => {}),

--- a/src/extensionShared.ts
+++ b/src/extensionShared.ts
@@ -24,6 +24,9 @@ export function initializeManifestPaths(extensionContext: vscode.ExtensionContex
     )
 }
 
+/**
+ * Registers generic commands used by both browser and node versions of the toolkit.
+ */
 export function registerCommands(extensionContext: vscode.ExtensionContext) {
     extensionContext.subscriptions.push(
         // No-op command used for decoration-only codelenses.

--- a/src/extensionShared.ts
+++ b/src/extensionShared.ts
@@ -11,10 +11,42 @@
 import vscode from 'vscode'
 import globals from './shared/extensionGlobals'
 import { join } from 'path'
+import { Commands } from './shared/vscode/commands2'
+import { documentationUrl, githubCreateIssueUrl, githubUrl } from './shared/constants'
+import { getIdeProperties, aboutToolkit } from './shared/extensionUtilities'
+import { telemetry } from './shared/telemetry/telemetry'
+import { openUrl } from './shared/utilities/vsCodeUtils'
 
 export function initializeManifestPaths(extensionContext: vscode.ExtensionContext) {
     globals.manifestPaths.endpoints = extensionContext.asAbsolutePath(join('resources', 'endpoints.json'))
     globals.manifestPaths.lambdaSampleRequests = extensionContext.asAbsolutePath(
         join('resources', 'vs-lambda-sample-request-manifest.xml')
+    )
+}
+
+export function activateGlobalCommands(extensionContext: vscode.ExtensionContext) {
+    extensionContext.subscriptions.push(
+        // No-op command used for decoration-only codelenses.
+        vscode.commands.registerCommand('aws.doNothingCommand', () => {}),
+        // "Show AWS Commands..."
+        Commands.register('aws.listCommands', () =>
+            vscode.commands.executeCommand('workbench.action.quickOpen', `> ${getIdeProperties().company}:`)
+        ),
+        // register URLs in extension menu
+        Commands.register('aws.help', async () => {
+            openUrl(vscode.Uri.parse(documentationUrl))
+            telemetry.aws_help.emit()
+        }),
+        Commands.register('aws.github', async () => {
+            openUrl(vscode.Uri.parse(githubUrl))
+            telemetry.aws_showExtensionSource.emit()
+        }),
+        Commands.register('aws.createIssueOnGitHub', async () => {
+            openUrl(vscode.Uri.parse(githubCreateIssueUrl))
+            telemetry.aws_reportPluginIssue.emit()
+        }),
+        Commands.register('aws.aboutToolkit', async () => {
+            await aboutToolkit()
+        })
     )
 }

--- a/src/extensionWeb.ts
+++ b/src/extensionWeb.ts
@@ -12,7 +12,7 @@ import { getLogger } from './shared/logger'
 import { DefaultAwsContext } from './shared/awsContext'
 import { Settings } from './shared/settings'
 import globals, { initialize } from './shared/extensionGlobals'
-import { activateGlobalCommands, initializeManifestPaths } from './extensionShared'
+import { registerCommands, initializeManifestPaths } from './extensionShared'
 import { RegionProvider, defaultRegion } from './shared/regions/regionProvider'
 import { DefaultAWSClientBuilder } from './shared/awsClientBuilder'
 
@@ -42,7 +42,7 @@ export async function activate(context: vscode.ExtensionContext) {
         const settings = Settings.instance
 
         await activateTelemetry(context, awsContext, settings)
-        activateGlobalCommands(context)
+        registerCommands(context)
     } catch (error) {
         const stacktrace = (error as Error).stack?.split('\n')
         // truncate if the stacktrace is unusually long

--- a/src/extensionWeb.ts
+++ b/src/extensionWeb.ts
@@ -12,7 +12,7 @@ import { getLogger } from './shared/logger'
 import { DefaultAwsContext } from './shared/awsContext'
 import { Settings } from './shared/settings'
 import globals, { initialize } from './shared/extensionGlobals'
-import { initializeManifestPaths } from './extensionShared'
+import { activateGlobalCommands, initializeManifestPaths } from './extensionShared'
 import { RegionProvider, defaultRegion } from './shared/regions/regionProvider'
 import { DefaultAWSClientBuilder } from './shared/awsClientBuilder'
 
@@ -42,6 +42,7 @@ export async function activate(context: vscode.ExtensionContext) {
         const settings = Settings.instance
 
         await activateTelemetry(context, awsContext, settings)
+        activateGlobalCommands(context)
     } catch (error) {
         const stacktrace = (error as Error).stack?.split('\n')
         // truncate if the stacktrace is unusually long

--- a/src/feedback/vue/submitFeedback.ts
+++ b/src/feedback/vue/submitFeedback.ts
@@ -4,8 +4,6 @@
  */
 
 import globals from '../../shared/extensionGlobals'
-import { ExtContext } from '../../shared/extensions'
-
 import { getLogger } from '../../shared/logger'
 import * as vscode from 'vscode'
 import { TelemetryService } from '../../shared/telemetry/telemetryService'
@@ -67,7 +65,7 @@ type FeedbackId = 'AWS Toolkit' | 'CodeWhisperer' | 'Amazon Q' | 'Application Co
 
 export const submitFeedback = Commands.declare(
     { id: 'aws.submitFeedback', autoconnect: false },
-    (context: ExtContext) => async (_: VsCodeCommandArg, id: FeedbackId) => {
+    (context: vscode.ExtensionContext) => async (_: VsCodeCommandArg, id: FeedbackId) => {
         if (_ !== placeholder) {
             // No args exist, we must supply them
             id = 'AWS Toolkit'
@@ -78,9 +76,9 @@ export const submitFeedback = Commands.declare(
 
 let activeWebview: VueWebviewPanel | undefined
 
-export async function showFeedbackView(context: ExtContext, feedbackName: string) {
+export async function showFeedbackView(context: vscode.ExtensionContext, feedbackName: string) {
     const Panel = VueWebview.compilePanel(FeedbackWebview)
-    activeWebview ??= new Panel(context.extensionContext, globals.telemetry, feedbackName)
+    activeWebview ??= new Panel(context, globals.telemetry, feedbackName)
 
     const webviewPanel = await activeWebview.show({
         title: localize('AWS.submitFeedback.title', 'Send Feedback'),


### PR DESCRIPTION
Adds functionality for sharing some basic global commands between browser and desktop versions of the toolkit. Included commands:
- View Toolkit Documentation
- View Source on Github
- About Toolkit
- Report Toolkit Issue
- List Commands (*shared but inaccessible in browser at the moment)
- Send Feedback (*does not load in browser yet until vue/webview support is implemented on our end)

Not included yet:
- View Quick Start

Also removes the use of ExtContext type where used with these commands. Instead, refactor code to only pass what was used in this, which is just the actual vscode extension context.

Send Feedback... was disabled in the browser because vue is not yet supported and this feature may not be necessary for an initial
browser version of the toolkit.

#### Testing
tested both browser and regular(?) toolkit with this change.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
