### PR TITLE
Fix: codewhisperer securityIssueProvider: "TypeError: Cannot read properties of undefined (reading 'range')"

### DIFF
--- a/src/codewhisperer/service/securityIssueProvider.ts
+++ b/src/codewhisperer/service/securityIssueProvider.ts
@@ -16,7 +16,7 @@ export abstract class SecurityIssueProvider {
     }
 
     public handleDocumentChange(event: vscode.TextDocumentChangeEvent) {
-        // handleDocumentChange function may be triggered while testing by our own code generation. Adding a conditional check to return if we do not have event.
+        // handleDocumentChange function may be triggered while testing by our own code generation.
         if (!event.contentChanges || event.contentChanges.length === 0) {
             return
         }

--- a/src/codewhisperer/service/securityIssueProvider.ts
+++ b/src/codewhisperer/service/securityIssueProvider.ts
@@ -16,6 +16,7 @@ export abstract class SecurityIssueProvider {
     }
 
     public handleDocumentChange(event: vscode.TextDocumentChangeEvent) {
+        // handleDocumentChange function may be triggered while testing by our own code generation. Adding a conditional check to return if we do not have event.
         if (!event.contentChanges || event.contentChanges.length === 0) {
             return
         }

--- a/src/codewhisperer/service/securityIssueProvider.ts
+++ b/src/codewhisperer/service/securityIssueProvider.ts
@@ -5,7 +5,6 @@
 
 import * as vscode from 'vscode'
 import { AggregatedCodeScanIssue } from '../models/model'
-import { ToolkitError } from '../../shared/errors'
 export abstract class SecurityIssueProvider {
     private _issues: AggregatedCodeScanIssue[] = []
     public get issues() {
@@ -18,7 +17,7 @@ export abstract class SecurityIssueProvider {
 
     public handleDocumentChange(event: vscode.TextDocumentChangeEvent) {
         if (!event.contentChanges || event.contentChanges.length === 0) {
-            throw new ToolkitError(`invalid event.contentChanges: ${JSON.stringify(event.contentChanges)}`)
+            return
         }
         const changedRange = event.contentChanges[0].range
         const changedText = event.contentChanges[0].text

--- a/src/codewhisperer/service/securityIssueProvider.ts
+++ b/src/codewhisperer/service/securityIssueProvider.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode'
 import { AggregatedCodeScanIssue } from '../models/model'
-
+import { ToolkitError } from '../../shared/errors'
 export abstract class SecurityIssueProvider {
     private _issues: AggregatedCodeScanIssue[] = []
     public get issues() {
@@ -17,6 +17,9 @@ export abstract class SecurityIssueProvider {
     }
 
     public handleDocumentChange(event: vscode.TextDocumentChangeEvent) {
+        if (!event.contentChanges || event.contentChanges.length === 0) {
+            throw new ToolkitError(`invalid event.contentChanges: ${JSON.stringify(event.contentChanges)}`)
+        }
         const changedRange = event.contentChanges[0].range
         const changedText = event.contentChanges[0].text
         const lineOffset = this._getLineOffset(changedRange, changedText)

--- a/src/codewhisperer/util/dependencyGraph/cloudformationDependencyGraph.ts
+++ b/src/codewhisperer/util/dependencyGraph/cloudformationDependencyGraph.ts
@@ -100,4 +100,4 @@ export class cloudformationDependencyGraph extends DependencyGraph {
     }
 }
 
-export class CsharpDependencyGraphError extends Error {}
+export class cloudformationDependencyGraphError extends Error {}


### PR DESCRIPTION
## Problem
https://github.com/aws/aws-toolkit-vscode/issues/4203

## Solution
Add a check for `event.contentChanges` is `undefined` in `handleDocumentChange` function. If yes, `return`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
