### PR TITLE
fix: add missing code transform telemetry

### DIFF
--- a/src/codewhisperer/commands/startTransformByQ.ts
+++ b/src/codewhisperer/commands/startTransformByQ.ts
@@ -181,7 +181,6 @@ export async function startTransformByQ() {
             uploadId = await uploadPayload(payloadFileName)
         } catch (error) {
             errorMessage = 'Failed to upload archive'
-            getLogger().error(errorMessage, error)
             telemetry.codeTransform_logGeneralError.emit({
                 codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
                 codeTransformApiErrorMessage: errorMessage,
@@ -202,7 +201,6 @@ export async function startTransformByQ() {
             jobId = await startJob(uploadId)
         } catch (error) {
             errorMessage = 'Failed to start job'
-            getLogger().error(errorMessage, error)
             telemetry.codeTransform_logGeneralError.emit({
                 codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
                 codeTransformApiErrorMessage: errorMessage,
@@ -315,6 +313,7 @@ export async function startTransformByQ() {
             codeTransformResultStatusMessage: resultStatusMessage,
             codeTransformRunTimeLatency: durationInMs,
             result: resultStatusMessage === 'JobCompletedSuccessfully' ? MetadataResult.Pass : MetadataResult.Fail,
+            reason: resultStatusMessage,
         })
 
         if (state.project) {

--- a/src/codewhisperer/commands/startTransformByQ.ts
+++ b/src/codewhisperer/commands/startTransformByQ.ts
@@ -272,7 +272,7 @@ export async function startTransformByQ() {
         sessionPlanProgress['returnCode'] = StepProgress.Succeeded
     } catch (error) {
         if (transformByQState.isCancelled()) {
-            resultStatusMessage = 'JobCanceled'
+            resultStatusMessage = 'JobCancelled'
             try {
                 await stopJob(transformByQState.getJobId())
                 vscode.window.showErrorMessage(CodeWhispererConstants.transformByQCancelledMessage)

--- a/src/codewhisperer/service/transformByQHandler.ts
+++ b/src/codewhisperer/service/transformByQHandler.ts
@@ -328,6 +328,12 @@ function getProjectDependencies(modulePath: string): string[] {
         } else {
             getLogger().error(spawnResult.stdout)
         }
+        telemetry.codeTransform_mvnBuildFailed.emit({
+            codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
+            codeTransformMavenBuildCommand: baseCommand,
+            result: MetadataResult.Fail,
+            reason: spawnResult.error ? spawnResult.error.message : spawnResult.stdout,
+        })
         throw new ToolkitError('Maven Dependency Error', { code: 'CannotRunMavenShellCommand' })
     }
 

--- a/src/codewhisperer/service/transformationResultsViewProvider.ts
+++ b/src/codewhisperer/service/transformationResultsViewProvider.ts
@@ -262,6 +262,13 @@ export class ProposedTransformationExplorer {
         vscode.commands.registerCommand('aws.amazonq.transformationHub.reviewChanges.startReview', async () => {
             vscode.commands.executeCommand('setContext', 'gumby.reviewState', TransformByQReviewStatus.PreparingReview)
             telemetry.ui_click.emit({ elementId: 'transformationHub_startDownloadExportResultArchive' })
+
+            // This metric is emitted when user clicked download for proposed change
+            telemetry.codeTransform_vcsViewerClicked.emit({
+                codeTransformVCSViewerSrcComponents: 'toastNotification',
+                codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
+                codeTransformJobId: transformByQState.getJobId(),
+            })
             const pathToArchive = path.join(
                 ProposedTransformationExplorer.TmpDir,
                 transformByQState.getJobId(),
@@ -332,13 +339,15 @@ export class ProposedTransformationExplorer {
                 })
             }
 
-            await vscode.window.showInformationMessage(CodeWhispererConstants.viewProposedChangesMessage)
-            await vscode.commands.executeCommand('aws.amazonq.transformationHub.summary.reveal')
+            // This metric is only emitted when placed before showInformationMessage
             telemetry.codeTransform_vcsDiffViewerVisible.emit({
                 codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
                 codeTransformJobId: transformByQState.getJobId(),
                 result: MetadataResult.Pass,
             })
+
+            await vscode.window.showInformationMessage(CodeWhispererConstants.viewProposedChangesMessage)
+            await vscode.commands.executeCommand('aws.amazonq.transformationHub.summary.reveal')
         })
 
         vscode.commands.registerCommand('aws.amazonq.transformationHub.reviewChanges.acceptChanges', async () => {


### PR DESCRIPTION
## Problem
A few CodeTransform metrics were missing for VSCode:
- totalRunTime
- mvnBuildFailed
- vcsViewerClicked
- vcsDiffViewerVisible
- logGeneralError

## Solution
Add the above metrics.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

```
// totalRunTime
2024-01-02 11:37:06 [DEBUG]: telemetry: emitted metric "codeTransform_totalRunTime" -> {"Metadata":[{"Key":"parentMetric","Value":"vscode_executeCommand"},{"Key":"codeTransformSessionId","Value":"9d47005a-678f-45e9-a450-a9caf37009a5"},{"Key":"codeTransformResultStatusMessage","Value":"JobCompletedSuccessfully"},{"Key":"codeTransformRunTimeLatency","Value":"246047"},{"Key":"result","Value":"Succeeded"},{"Key":"awsAccount","Value":"not-set"},{"Key":"awsRegion","Value":"us-west-2"}],"MetricName":"codeTransform_totalRunTime","Value":1,"Unit":"None","Passive":true,"EpochTimestamp":1704224226707}

// vcsViewerClicked
2024-01-02 11:38:14 [DEBUG]: telemetry: emitted metric "codeTransform_vcsViewerClicked" -> {"Metadata":[{"Key":"codeTransformVCSViewerSrcComponents","Value":"toastNotification"},{"Key":"codeTransformSessionId","Value":"9d47005a-678f-45e9-a450-a9caf37009a5"},{"Key":"codeTransformJobId","Value":"f0661a68-8097-45d6-a57e-2efc70a344c0"},{"Key":"awsAccount","Value":"not-set"},{"Key":"awsRegion","Value":"us-west-2"}],"MetricName":"codeTransform_vcsViewerClicked","Value":1,"Unit":"None","Passive":false,"EpochTimestamp":1704224294364}

// vcsDiffViewerVisible
2024-01-02 11:38:16 [DEBUG]: telemetry: emitted metric "codeTransform_vcsDiffViewerVisible" -> {"Metadata":[{"Key":"codeTransformSessionId","Value":"9d47005a-678f-45e9-a450-a9caf37009a5"},{"Key":"codeTransformJobId","Value":"f0661a68-8097-45d6-a57e-2efc70a344c0"},{"Key":"result","Value":"Succeeded"},{"Key":"awsAccount","Value":"not-set"},{"Key":"awsRegion","Value":"us-west-2"}],"MetricName":"codeTransform_vcsDiffViewerVisible","Value":1,"Unit":"None","Passive":false,"EpochTimestamp":1704224296399}
```
logGeneralError and mvnBuildFailed are only emitted under unexpected error scenario

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
