### PR TITLE
feat(auth): don't display switch connections/add new connections in Q/CW ellipses menus

### DIFF
--- a/.changes/next-release/Removal-ca09407d-b3ce-43df-a236-d12f7fa888f3.json
+++ b/.changes/next-release/Removal-ca09407d-b3ce-43df-a236-d12f7fa888f3.json
@@ -1,0 +1,4 @@
+{
+	"type": "Removal",
+	"description": "Amazon Q, CodeWhisperer: Remove 'Switch Connections' menu item, and only show 'Add new connection' when not signed in."
+}

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -22,7 +22,8 @@ We set the following keys:
 -   `isCloud9`: This is hardcoded by Cloud9 itself, not the Toolkit.
     -   Cloud9 _does not support setContext_. So this is the only usable key there.
 -   `aws.codecatalyst.connected`: CodeCatalyst connection is active.
--   `CODEWHISPERER_ENABLED`: CodeWhisperer connection is active.
+-   `aws.codewhisperer.connected`: CodeWhisperer connection is active.
+-   `aws.codewhisperer.connectionExpired`: CodeWhisperer connection is active, but the connection is expired.
 -   `aws.isDevMode`: AWS Toolkit is running in "developer mode".
 -   `aws.isWebExtHost`: true when the _extension host_ is running in a web browser, as opposed to
     nodejs (i.e. the environment has no "compute").

--- a/package.json
+++ b/package.json
@@ -1463,23 +1463,18 @@
                     "group": "1_amazonQ@1"
                 },
                 {
-                    "command": "aws.auth.switchConnections",
-                    "when": "(view == aws.AmazonQChatView || view == aws.codewhisperer ||  view == aws.amazonq) && CODEWHISPERER_ENABLED",
-                    "group": "2_amazonQ@1"
-                },
-                {
                     "command": "aws.codewhisperer.manageConnections",
-                    "when": "view == aws.AmazonQChatView || view == aws.codewhisperer ||  view == aws.amazonq",
+                    "when": "(view == aws.AmazonQChatView || view == aws.codewhisperer ||  view == aws.amazonq) && !aws.codewhisperer.connected",
                     "group": "2_amazonQ@2"
                 },
                 {
                     "command": "aws.codewhisperer.signout",
-                    "when": "(view == aws.AmazonQChatView || view == aws.codewhisperer ||  view == aws.amazonq) && CODEWHISPERER_ENABLED",
+                    "when": "(view == aws.AmazonQChatView || view == aws.codewhisperer ||  view == aws.amazonq) && aws.codewhisperer.connected",
                     "group": "2_amazonQ@4"
                 },
                 {
                     "command": "aws.codewhisperer.reconnect",
-                    "when": "(view == aws.AmazonQChatView || view == aws.codewhisperer ||  view == aws.amazonq) && aws.codewhisperer.disconnected",
+                    "when": "(view == aws.AmazonQChatView || view == aws.codewhisperer ||  view == aws.amazonq) && aws.codewhisperer.connectionExpired",
                     "group": "2_amazonQ@3"
                 }
             ],
@@ -3897,23 +3892,23 @@
                 "command": "aws.codeWhisperer",
                 "key": "alt+c",
                 "mac": "alt+c",
-                "when": "editorTextFocus && CODEWHISPERER_ENABLED || isCloud9 && editorTextFocus"
+                "when": "editorTextFocus && aws.codewhisperer.connected || isCloud9 && editorTextFocus"
             },
             {
                 "command": "aws.codeWhisperer.rejectCodeSuggestion",
                 "key": "escape",
                 "mac": "escape",
-                "when": "inlineSuggestionVisible && !editorReadonly && CODEWHISPERER_ENABLED || isCloud9 && suggestWidgetVisible && !editorReadonly"
+                "when": "inlineSuggestionVisible && !editorReadonly && aws.codewhisperer.connected || isCloud9 && suggestWidgetVisible && !editorReadonly"
             },
             {
                 "key": "right",
                 "command": "editor.action.inlineSuggest.showNext",
-                "when": "inlineSuggestionVisible && !editorReadonly && CODEWHISPERER_ENABLED"
+                "when": "inlineSuggestionVisible && !editorReadonly && aws.codewhisperer.connected"
             },
             {
                 "key": "left",
                 "command": "editor.action.inlineSuggest.showPrevious",
-                "when": "inlineSuggestionVisible && !editorReadonly && CODEWHISPERER_ENABLED"
+                "when": "inlineSuggestionVisible && !editorReadonly && aws.codewhisperer.connected"
             }
         ],
         "grammars": [

--- a/src/codewhisperer/commands/basicCommands.ts
+++ b/src/codewhisperer/commands/basicCommands.ts
@@ -63,8 +63,8 @@ export const enableCodeSuggestions = Commands.declare(
     (context: ExtContext) =>
         async (isAuto: boolean = true) => {
             await CodeSuggestionsState.instance.setSuggestionsEnabled(isAuto)
-            await vscode.commands.executeCommand('setContext', 'CODEWHISPERER_ENABLED', true)
-            await vscode.commands.executeCommand('setContext', 'aws.codewhisperer.disconnected', false)
+            await vscode.commands.executeCommand('setContext', 'aws.codewhisperer.connected', true)
+            await vscode.commands.executeCommand('setContext', 'aws.codewhisperer.connectionExpired', false)
             await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
             if (!isCloud9()) {
                 await vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar')

--- a/src/codewhisperer/commands/invokeRecommendation.ts
+++ b/src/codewhisperer/commands/invokeRecommendation.ts
@@ -57,7 +57,7 @@ export async function invokeRecommendation(
     }
 
     if (isCloud9('any')) {
-        // C9 manual trigger key alt/option + C is ALWAYS enabled because the VSC version C9 is on doesn't support setContextKey which is used for CODEWHISPERER_ENABLED
+        // C9 manual trigger key alt/option + C is ALWAYS enabled because the VSC version C9 is on doesn't support setContextKey which is used for aws.codewhisperer.connected
         // therefore we need a connection check if there is ANY connection(regardless of the connection's state) connected to CodeWhisperer on C9
         if (!AuthUtil.instance.isConnected()) {
             return

--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -129,7 +129,7 @@ export class AuthUtil {
                 Commands.tryExecute('aws.codeWhisperer.updateReferenceLog'),
             ])
 
-            await vscode.commands.executeCommand('setContext', 'CODEWHISPERER_ENABLED', this.isConnected())
+            await vscode.commands.executeCommand('setContext', 'aws.codewhisperer.connected', this.isConnected())
 
             const memento = globals.context.globalState
             const shouldShowObject: HasAlreadySeenQWelcome = memento.get(this.mementoKey) ?? {
@@ -157,10 +157,10 @@ export class AuthUtil {
 
     public async setVscodeContextProps() {
         if (!isCloud9()) {
-            await vscode.commands.executeCommand('setContext', 'CODEWHISPERER_ENABLED', this.isConnected())
+            await vscode.commands.executeCommand('setContext', 'aws.codewhisperer.connected', this.isConnected())
             await vscode.commands.executeCommand(
                 'setContext',
-                'aws.codewhisperer.disconnected',
+                'aws.codewhisperer.connectionExpired',
                 this.isConnectionExpired()
             )
         }


### PR DESCRIPTION
Problem: Ellpises menus for Q/CW will display "Switch Connections", implying that the connection can be switched between other IdC/Builder ID connections on the fly. This isn't supported currently. Also, 'Add new connection' is displayed when already signed in, implying that you can add these new connections to swap to.

Solution: Remove 'Switch Connections' menu item, and only show 'Add new connection' when not signed in.

Also, rename the global context variables to to be more descriptive/not be in all caps.


<img width="529" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/149123719/de97e13e-f0a2-4843-bd86-0c427ac5781e">

<img width="536" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/149123719/d1e2e6e6-594b-4c2e-810a-3f7e4fac787a">

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
