### PR TITLE
lint: require "await" or .catch() on async calls

### DIFF
--- a/src/codewhisperer/activation.ts
+++ b/src/codewhisperer/activation.ts
@@ -111,7 +111,7 @@ export async function activate(context: ExtContext): Promise<void> {
             if (
                 configurationChangeEvent.affectsConfiguration('aws.codeWhisperer.includeSuggestionsWithCodeReferences')
             ) {
-                await ReferenceLogViewProvider.instance.update()
+                ReferenceLogViewProvider.instance.update()
                 if (auth.isEnterpriseSsoInUse()) {
                     await vscode.window
                         .showInformationMessage(

--- a/src/codewhisperer/commands/basicCommands.ts
+++ b/src/codewhisperer/commands/basicCommands.ts
@@ -248,7 +248,7 @@ export const updateReferenceLog = Commands.declare(
         logging: false,
     },
     () => () => {
-        return ReferenceLogViewProvider.instance.update()
+        ReferenceLogViewProvider.instance.update()
     }
 )
 

--- a/src/codewhisperer/commands/basicCommands.ts
+++ b/src/codewhisperer/commands/basicCommands.ts
@@ -124,7 +124,7 @@ export const showTransformByQ = Commands.declare(
             logCodeTransformInitiatedMetric(source)
             await startTransformByQWithProgress()
         } else if (transformByQState.isCancelled()) {
-            vscode.window.showInformationMessage(CodeWhispererConstants.cancellationInProgressMessage)
+            void vscode.window.showInformationMessage(CodeWhispererConstants.cancellationInProgressMessage)
         } else if (transformByQState.isRunning()) {
             await confirmStopTransformByQ(transformByQState.getJobId(), CancelActionPositions.DevToolsSidePanel)
         }
@@ -150,7 +150,7 @@ export const selectCustomizationPrompt = Commands.declare(
     { id: 'aws.codeWhisperer.selectCustomization', compositeKey: { 1: 'source' } },
     () => async (_: VsCodeCommandArg, source: CodeWhispererSource) => {
         telemetry.ui_click.emit({ elementId: 'cw_selectCustomization_Cta' })
-        showCustomizationPrompt().then()
+        void showCustomizationPrompt().then()
     }
 )
 
@@ -230,7 +230,7 @@ export const showLearnMore = Commands.declare(
     { id: 'aws.codeWhisperer.learnMore', compositeKey: { 0: 'source' } },
     () => async (source: CodeWhispererSource) => {
         telemetry.ui_click.emit({ elementId: 'cw_learnMore_Cta' })
-        openUrl(vscode.Uri.parse(CodeWhispererConstants.learnMoreUriGeneral))
+        void openUrl(vscode.Uri.parse(CodeWhispererConstants.learnMoreUriGeneral))
     }
 )
 
@@ -238,7 +238,7 @@ export const showLearnMore = Commands.declare(
 export const showFreeTierLimit = Commands.declare(
     { id: 'aws.codeWhisperer.freeTierLimit', compositeKey: { 1: 'source' } },
     () => async (_: VsCodeCommandArg, source: CodeWhispererSource) => {
-        openUrl(vscode.Uri.parse(CodeWhispererConstants.learnMoreUri))
+        void openUrl(vscode.Uri.parse(CodeWhispererConstants.learnMoreUri))
     }
 )
 
@@ -254,8 +254,8 @@ export const updateReferenceLog = Commands.declare(
 
 export const openSecurityIssuePanel = Commands.declare(
     'aws.codeWhisperer.openSecurityIssuePanel',
-    (context: ExtContext) => (issue: CodeScanIssue, filePath: string) => {
-        showSecurityIssueWebview(context.extensionContext, issue, filePath)
+    (context: ExtContext) => async (issue: CodeScanIssue, filePath: string) => {
+        await showSecurityIssueWebview(context.extensionContext, issue, filePath)
 
         telemetry.codewhisperer_codeScanIssueViewDetails.emit({
             findingId: issue.findingId,
@@ -268,14 +268,16 @@ export const openSecurityIssuePanel = Commands.declare(
 export const notifyNewCustomizationsCmd = Commands.declare(
     { id: 'aws.codeWhisperer.notifyNewCustomizations', logging: false },
     () => () => {
-        notifyNewCustomizations().then()
+        notifyNewCustomizations().catch(e => {
+            getLogger().error('notifyNewCustomizations failed: %s', (e as Error).message)
+        })
     }
 )
 
 export const fetchFeatureConfigsCmd = Commands.declare(
     { id: 'aws.codeWhisperer.fetchFeatureConfigs', logging: false },
-    () => () => {
-        FeatureConfigProvider.instance.fetchFeatureConfigs()
+    () => async () => {
+        await FeatureConfigProvider.instance.fetchFeatureConfigs()
     }
 )
 
@@ -302,7 +304,7 @@ export const applySecurityFix = Commands.declare(
 
             const updatedContent = applyPatch(fileContent, patch)
             if (!updatedContent) {
-                vscode.window.showErrorMessage(CodeWhispererConstants.codeFixAppliedFailedMessage)
+                void vscode.window.showErrorMessage(CodeWhispererConstants.codeFixAppliedFailedMessage)
                 throw Error('Failed to get updated content from applying diff patch')
             }
 
@@ -314,16 +316,16 @@ export const applySecurityFix = Commands.declare(
 
             // writing the patch applied version of document into the file
             await FileSystemCommon.instance.writeFile(filePath, updatedContent)
-            vscode.window
+            void vscode.window
                 .showInformationMessage(CodeWhispererConstants.codeFixAppliedSuccessMessage, {
                     title: CodeWhispererConstants.runSecurityScanButtonTitle,
                 })
                 .then(res => {
                     if (res?.title === CodeWhispererConstants.runSecurityScanButtonTitle) {
-                        vscode.commands.executeCommand('aws.codeWhisperer.security.scan')
+                        void vscode.commands.executeCommand('aws.codeWhisperer.security.scan')
                     }
                 })
-            closeSecurityIssueWebview(issue.findingId)
+            await closeSecurityIssueWebview(issue.findingId)
         } catch (err) {
             getLogger().error(`Apply fix command failed. ${err}`)
             applyFixTelemetryEntry.result = 'Failed'

--- a/src/codewhisperer/commands/invokeRecommendation.ts
+++ b/src/codewhisperer/commands/invokeRecommendation.ts
@@ -32,7 +32,7 @@ export async function invokeRecommendation(
      * IntelliSense in Cloud9 needs editor.suggest.showMethods
      */
     if (!config.isShowMethodsEnabled && isCloud9()) {
-        vscode.window.showWarningMessage('Turn on "editor.suggest.showMethods" to use CodeWhisperer')
+        void vscode.window.showWarningMessage('Turn on "editor.suggest.showMethods" to use CodeWhisperer')
         return
     }
     if (!editor) {

--- a/src/codewhisperer/service/featureConfigProvider.ts
+++ b/src/codewhisperer/service/featureConfigProvider.ts
@@ -26,7 +26,9 @@ export class FeatureConfigProvider {
     static #instance: FeatureConfigProvider
 
     constructor() {
-        this.fetchFeatureConfigs()
+        this.fetchFeatureConfigs().catch(e => {
+            getLogger().error('fetchFeatureConfigs failed: %s', (e as Error).message)
+        })
 
         setInterval(this.fetchFeatureConfigs.bind(this), featureConfigPollIntervalInMs)
     }

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -37,7 +37,7 @@ export class InlineCompletionService {
         })
 
         CodeSuggestionsState.instance.onDidChangeState(() => {
-            this.refreshStatusBar()
+            return this.refreshStatusBar()
         })
     }
 
@@ -65,14 +65,16 @@ export class InlineCompletionService {
             if (delay < CodeWhispererConstants.inlineSuggestionShowDelay) {
                 return
             }
-            try {
-                this.sharedTryShowRecommendation()
-            } finally {
-                if (this._showRecommendationTimer) {
-                    clearInterval(this._showRecommendationTimer)
-                    this._showRecommendationTimer = undefined
-                }
-            }
+            this.sharedTryShowRecommendation()
+                .catch(e => {
+                    getLogger().error('tryShowRecommendation failed: %s', (e as Error).message)
+                })
+                .finally(() => {
+                    if (this._showRecommendationTimer) {
+                        clearInterval(this._showRecommendationTimer)
+                        this._showRecommendationTimer = undefined
+                    }
+                })
         }, CodeWhispererConstants.showRecommendationTimerPollPeriod)
     }
 

--- a/src/codewhisperer/service/inlineCompletionService.ts
+++ b/src/codewhisperer/service/inlineCompletionService.ts
@@ -109,7 +109,7 @@ export class InlineCompletionService {
             return
         }
 
-        this.setState('loading')
+        await this.setState('loading')
 
         TelemetryHelper.instance.setInvocationStartTime(performance.now())
         RecommendationHandler.instance.checkAndResetCancellationTokens()
@@ -132,7 +132,7 @@ export class InlineCompletionService {
                 )
                 if (RecommendationHandler.instance.checkAndResetCancellationTokens()) {
                     RecommendationHandler.instance.reportUserDecisions(-1)
-                    vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar')
+                    await vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar')
                     TelemetryHelper.instance.setIsRequestCancelled(true)
                     return
                 }
@@ -145,9 +145,9 @@ export class InlineCompletionService {
         } catch (error) {
             getLogger().error(`Error ${error} in getPaginatedRecommendation`)
         }
-        vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar')
+        await vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar')
         if (triggerType === 'OnDemand' && session.recommendations.length === 0) {
-            showTimedMessage(response.errorMessage ? response.errorMessage : noSuggestions, 2000)
+            void showTimedMessage(response.errorMessage ? response.errorMessage : noSuggestions, 2000)
         }
         TelemetryHelper.instance.tryRecordClientComponentLatency()
     }
@@ -250,7 +250,7 @@ export class CodeWhispererStatusBar {
 /** In this module due to circulare dependency issues */
 export const refreshStatusBar = Commands.declare(
     { id: 'aws.codeWhisperer.refreshStatusBar', logging: false },
-    () => () => {
-        InlineCompletionService.instance.refreshStatusBar()
+    () => async () => {
+        await InlineCompletionService.instance.refreshStatusBar()
     }
 )

--- a/src/codewhisperer/service/keyStrokeHandler.ts
+++ b/src/codewhisperer/service/keyStrokeHandler.ts
@@ -67,14 +67,16 @@ export class KeyStrokeHandler {
                 return
             }
 
-            try {
-                this.invokeAutomatedTrigger('IdleTime', editor, client, config, event)
-            } finally {
-                if (this.idleTriggerTimer) {
-                    clearInterval(this.idleTriggerTimer)
-                    this.idleTriggerTimer = undefined
-                }
-            }
+            this.invokeAutomatedTrigger('IdleTime', editor, client, config, event)
+                .catch(e => {
+                    getLogger().error('invokeAutomatedTrigger failed: %s', (e as Error).message)
+                })
+                .finally(() => {
+                    if (this.idleTriggerTimer) {
+                        clearInterval(this.idleTriggerTimer)
+                        this.idleTriggerTimer = undefined
+                    }
+                })
         }, CodeWhispererConstants.idleTimerPollPeriod)
     }
 

--- a/src/codewhisperer/service/keyStrokeHandler.ts
+++ b/src/codewhisperer/service/keyStrokeHandler.ts
@@ -151,7 +151,7 @@ export class KeyStrokeHandler {
             }
 
             if (triggerType) {
-                this.invokeAutomatedTrigger(triggerType, editor, client, config, event)
+                await this.invokeAutomatedTrigger(triggerType, editor, client, config, event)
             }
         } catch (error) {
             getLogger().verbose(`Automated Trigger Exception : ${error}`)

--- a/src/codewhisperer/service/recommendationHandler.ts
+++ b/src/codewhisperer/service/recommendationHandler.ts
@@ -284,11 +284,11 @@ export class RecommendationHandler {
 
                 if (error?.code === 'AccessDeniedException' && errorMessage?.includes('no identity-based policy')) {
                     getLogger().error('CodeWhisperer AccessDeniedException : %s', (error as Error).message)
-                    vscode.window
+                    void vscode.window
                         .showErrorMessage(`CodeWhisperer: ${error?.message}`, CodeWhispererConstants.settingsLearnMore)
                         .then(async resp => {
                             if (resp === CodeWhispererConstants.settingsLearnMore) {
-                                openUrl(vscode.Uri.parse(CodeWhispererConstants.learnMoreUri))
+                                void openUrl(vscode.Uri.parse(CodeWhispererConstants.learnMoreUri))
                             }
                         })
                     await vscode.commands.executeCommand('aws.codeWhisperer.enableCodeSuggestions', false)
@@ -502,7 +502,9 @@ export class RecommendationHandler {
         if (isCloud9('any')) {
             this.clearRecommendations()
         } else if (isInlineCompletionEnabled()) {
-            this.clearInlineCompletionStates()
+            this.clearInlineCompletionStates().catch(e => {
+                getLogger().error('clearInlineCompletionStates failed: %s', (e as Error).message)
+            })
         }
     }
 
@@ -520,7 +522,7 @@ export class RecommendationHandler {
         }
         if (!this.isValidResponse()) {
             if (showPrompt) {
-                showTimedMessage(response.errorMessage ? response.errorMessage : noSuggestions, 3000)
+                void showTimedMessage(response.errorMessage ? response.errorMessage : noSuggestions, 3000)
             }
             reject()
             return false
@@ -561,7 +563,7 @@ export class RecommendationHandler {
             awsError.message.includes(CodeWhispererConstants.throttlingMessage)
         ) {
             if (triggerType === 'OnDemand') {
-                vscode.window.showErrorMessage(CodeWhispererConstants.freeTierLimitReached)
+                void vscode.window.showErrorMessage(CodeWhispererConstants.freeTierLimitReached)
             }
             await vscode.commands.executeCommand('aws.codeWhisperer.refresh', true)
             await Commands.tryExecute('aws.amazonq.refresh', true)

--- a/src/codewhisperer/service/referenceLogViewProvider.ts
+++ b/src/codewhisperer/service/referenceLogViewProvider.ts
@@ -41,8 +41,8 @@ export class ReferenceLogViewProvider implements vscode.WebviewViewProvider {
             webviewView.webview,
             CodeWhispererSettings.instance.isSuggestionsWithCodeReferencesEnabled()
         )
-        this._view.webview.onDidReceiveMessage(data => {
-            vscode.commands.executeCommand('aws.codeWhisperer.configure', 'codewhisperer')
+        this._view.webview.onDidReceiveMessage(async data => {
+            await vscode.commands.executeCommand('aws.codeWhisperer.configure', 'codewhisperer')
         })
     }
 

--- a/src/codewhisperer/service/referenceLogViewProvider.ts
+++ b/src/codewhisperer/service/referenceLogViewProvider.ts
@@ -46,7 +46,7 @@ export class ReferenceLogViewProvider implements vscode.WebviewViewProvider {
         })
     }
 
-    public async update() {
+    public update() {
         if (this._view) {
             const showPrompt = CodeWhispererSettings.instance.isSuggestionsWithCodeReferencesEnabled()
             this._view.webview.html = this.getHtml(this._view.webview, showPrompt)

--- a/src/codewhisperer/service/transformByQHandler.ts
+++ b/src/codewhisperer/service/transformByQHandler.ts
@@ -64,7 +64,7 @@ export function throwIfCancelled() {
 export async function getOpenProjects() {
     const folders = vscode.workspace.workspaceFolders
     if (folders === undefined) {
-        vscode.window.showErrorMessage(CodeWhispererConstants.noSupportedJavaProjectsFoundMessage)
+        void vscode.window.showErrorMessage(CodeWhispererConstants.noSupportedJavaProjectsFoundMessage)
         throw new ToolkitError('No Java projects found since no projects are open', { code: 'NoOpenProjects' })
     }
     const openProjects: vscode.QuickPickItem[] = []
@@ -86,7 +86,7 @@ export async function validateProjectSelection(project: vscode.QuickPickItem) {
     const projectPath = project.description
     const buildSystem = await checkBuildSystem(projectPath!)
     if (buildSystem !== BuildSystem.Maven) {
-        vscode.window.showErrorMessage(CodeWhispererConstants.noPomXmlFoundMessage)
+        void vscode.window.showErrorMessage(CodeWhispererConstants.noPomXmlFoundMessage)
         telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.emit({
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
             codeTransformPreValidationError: 'NonMavenProject',
@@ -101,7 +101,7 @@ export async function validateProjectSelection(project: vscode.QuickPickItem) {
         1
     )
     if (compiledJavaFiles.length < 1) {
-        vscode.window.showErrorMessage(CodeWhispererConstants.noSupportedJavaProjectsFoundMessage)
+        void vscode.window.showErrorMessage(CodeWhispererConstants.noSupportedJavaProjectsFoundMessage)
         telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.emit({
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
             codeTransformPreValidationError: 'NoJavaProject',
@@ -116,7 +116,7 @@ export async function validateProjectSelection(project: vscode.QuickPickItem) {
     const spawnResult = spawnSync(baseCommand, args, { shell: false, encoding: 'utf-8' })
 
     if (spawnResult.error || spawnResult.status !== 0) {
-        vscode.window.showErrorMessage(CodeWhispererConstants.noSupportedJavaProjectsFoundMessage)
+        void vscode.window.showErrorMessage(CodeWhispererConstants.noSupportedJavaProjectsFoundMessage)
         telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.emit({
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
             codeTransformPreValidationError: 'NoJavaProject',
@@ -135,7 +135,7 @@ export async function validateProjectSelection(project: vscode.QuickPickItem) {
     } else if (javaVersion === CodeWhispererConstants.JDK11VersionNumber) {
         transformByQState.setSourceJDKVersionToJDK11()
     } else {
-        vscode.window.showErrorMessage(CodeWhispererConstants.noSupportedJavaProjectsFoundMessage)
+        void vscode.window.showErrorMessage(CodeWhispererConstants.noSupportedJavaProjectsFoundMessage)
         telemetry.codeTransform_isDoubleClickedToTriggerInvalidProject.emit({
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
             codeTransformPreValidationError: 'UnsupportedJavaVersion',

--- a/src/codewhisperer/service/transformByQHandler.ts
+++ b/src/codewhisperer/service/transformByQHandler.ts
@@ -320,7 +320,7 @@ function getProjectDependencies(modulePath: string): string[] {
     const spawnResult = spawnSync(baseCommand, args, { cwd: modulePath, shell: false, encoding: 'utf-8' })
 
     if (spawnResult.error || spawnResult.status !== 0) {
-        vscode.window.showErrorMessage(CodeWhispererConstants.dependencyErrorMessage)
+        void vscode.window.showErrorMessage(CodeWhispererConstants.dependencyErrorMessage)
         getLogger().error('CodeTransform: Error in running Maven command = ')
         // Maven command can still go through and still return an error. Won't be caught in spawnResult.error in this case
         if (spawnResult.error) {

--- a/src/codewhisperer/service/transformationHubViewProvider.ts
+++ b/src/codewhisperer/service/transformationHubViewProvider.ts
@@ -8,6 +8,7 @@ import globals from '../../shared/extensionGlobals'
 import { getJobHistory, getPlanProgress } from '../commands/startTransformByQ'
 import { StepProgress, transformByQState } from '../models/model'
 import { convertToTimeString, getTransformationSteps } from './transformByQHandler'
+import { getLogger } from '../../shared/logger'
 
 export class TransformationHubViewProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = 'aws.amazonq.transformationHub'
@@ -23,9 +24,13 @@ export class TransformationHubViewProvider implements vscode.WebviewViewProvider
             if (this.lastClickedButton === 'job history') {
                 this._view!.webview.html = this.showJobHistory()
             } else {
-                this.showPlanProgress(startTime).then(planProgress => {
-                    this._view!.webview.html = planProgress
-                })
+                this.showPlanProgress(startTime)
+                    .then(planProgress => {
+                        this._view!.webview.html = planProgress
+                    })
+                    .catch(e => {
+                        getLogger().error('showPlanProgress failed: %s', (e as Error).message)
+                    })
             }
         }
     }
@@ -49,9 +54,13 @@ export class TransformationHubViewProvider implements vscode.WebviewViewProvider
         if (this.lastClickedButton === 'job history') {
             this._view!.webview.html = this.showJobHistory()
         } else {
-            this.showPlanProgress(Date.now()).then(planProgress => {
-                this._view!.webview.html = planProgress
-            })
+            this.showPlanProgress(Date.now())
+                .then(planProgress => {
+                    this._view!.webview.html = planProgress
+                })
+                .catch(e => {
+                    getLogger().error('showPlanProgress failed: %s', (e as Error).message)
+                })
         }
     }
 

--- a/src/codewhisperer/tracker/codewhispererTracker.ts
+++ b/src/codewhisperer/tracker/codewhispererTracker.ts
@@ -48,7 +48,9 @@ export class CodeWhispererTracker {
         }
 
         if (this._eventQueue.length >= 0) {
-            this.startTimer()
+            this.startTimer().catch(e => {
+                getLogger().error('startTimer failed: %s', (e as Error).message)
+            })
         }
 
         if (this._eventQueue.length >= CodeWhispererTracker.defaultMaxQueueSize) {
@@ -71,7 +73,7 @@ export class CodeWhispererTracker {
                 currentTime.getTime() - suggestion.time.getTime() >
                 CodeWhispererTracker.defaultModificationIntervalMillis
             ) {
-                this.emitTelemetryOnSuggestion(suggestion)
+                await this.emitTelemetryOnSuggestion(suggestion)
             } else {
                 newEventQueue.push(suggestion)
             }
@@ -179,7 +181,7 @@ export class CodeWhispererTracker {
 
         if (globals.telemetry.telemetryEnabled) {
             try {
-                this.flush()
+                await this.flush()
             } finally {
                 this._eventQueue = []
             }

--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -148,7 +148,7 @@ export class AuthUtil {
                 }
 
                 // start the feature config polling job
-                vscode.commands.executeCommand('aws.codeWhisperer.fetchFeatureConfigs')
+                await vscode.commands.executeCommand('aws.codeWhisperer.fetchFeatureConfigs')
             }
             await this.setVscodeContextProps()
         })
@@ -326,7 +326,7 @@ export class AuthUtil {
         } catch (err) {
             throw ToolkitError.chain(err, 'Unable to authenticate connection')
         } finally {
-            this.setVscodeContextProps()
+            await this.setVscodeContextProps()
         }
     }
 
@@ -357,7 +357,7 @@ export class AuthUtil {
                 if (resp === CodeWhispererConstants.connectWithAWSBuilderId) {
                     await this.reauthenticate()
                 } else if (resp === CodeWhispererConstants.DoNotShowAgain) {
-                    settings.disablePrompt('codeWhispererConnectionExpired')
+                    await settings.disablePrompt('codeWhispererConnectionExpired')
                 }
             })
         if (isAutoTrigger) {
@@ -366,8 +366,8 @@ export class AuthUtil {
     }
 
     public async notifyReauthenticate(isAutoTrigger?: boolean) {
-        this.showReauthenticatePrompt(isAutoTrigger)
-        this.setVscodeContextProps()
+        void this.showReauthenticatePrompt(isAutoTrigger)
+        await this.setVscodeContextProps()
     }
 }
 

--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -27,7 +27,6 @@ import {
     isIdcSsoConnection,
 } from '../../auth/connection'
 import { getLogger } from '../../shared/logger'
-import globals from '../../shared/extensionGlobals'
 import { getCodeCatalystDevEnvId } from '../../shared/vscode/env'
 import { Commands, placeholder } from '../../shared/vscode/commands2'
 

--- a/src/codewhisperer/util/customizationUtil.ts
+++ b/src/codewhisperer/util/customizationUtil.ts
@@ -68,12 +68,14 @@ export async function notifyNewCustomizations() {
         'AWS.codewhisperer.customization.notification.new_customizations.learn_more',
         'Learn More'
     )
-    vscode.window.showInformationMessage(newCustomizationMessage, select, learnMore).then(async resp => {
+    void vscode.window.showInformationMessage(newCustomizationMessage, select, learnMore).then(async resp => {
         if (resp === select) {
-            showCustomizationPrompt().then()
+            showCustomizationPrompt().catch(e => {
+                getLogger().error('showCustomizationPrompt failed: %s', (e as Error).message)
+            })
         } else if (resp === learnMore) {
             // TODO: figure out the right uri
-            openUrl(vscode.Uri.parse(customLearnMoreUri))
+            void openUrl(vscode.Uri.parse(customLearnMoreUri))
         }
     })
 }
@@ -116,8 +118,8 @@ export const setSelectedCustomization = async (customization: Customization) => 
     getLogger().debug(`Selected customization ${customization.name} for ${AuthUtil.instance.conn.label}`)
 
     await set(selectedCustomizationKey, selectedCustomizationObj, globals.context.globalState)
-    vscode.commands.executeCommand('aws.codeWhisperer.refresh')
-    vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar')
+    await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
+    await vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar')
 }
 
 export const getPersistedCustomizations = (): Customization[] => {
@@ -145,7 +147,7 @@ export const getNewCustomizationAvailable = () => {
 
 export const setNewCustomizationAvailable = async (available: boolean) => {
     await set(newCustomizationAvailableKey, available, globals.context.globalState)
-    vscode.commands.executeCommand('aws.codeWhisperer.refresh')
+    await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
 }
 
 export async function showCustomizationPrompt() {
@@ -190,7 +192,7 @@ const createCustomizationItems = async () => {
         items.push(createBaseCustomizationItem())
 
         // TODO: finalize the url string with documentation
-        showMessageWithUrl(
+        void showMessageWithUrl(
             localize(
                 'AWS.codewhisperer.customization.noCustomizations.description',
                 'You dont have access to any CodeWhisperer customization. Contact your admin for access.'
@@ -289,7 +291,7 @@ export const selectCustomization = async (customization: Customization) => {
     await setSelectedCustomization(customization)
     const suffix =
         customization.arn === baseCustomization.arn ? customization.name : `${customization.name} customization.`
-    vscode.window.showInformationMessage(
+    void vscode.window.showInformationMessage(
         localize(
             'AWS.codewhisperer.customization.selected.message',
             'CodeWhisperer suggestions are now coming from the {0}',
@@ -313,7 +315,7 @@ export const getAvailableCustomizationsList = async () => {
 // show notification that selected customization is not available, switching back to base
 export const switchToBaseCustomizationAndNotify = async () => {
     await setSelectedCustomization(baseCustomization)
-    vscode.window.showInformationMessage(
+    void vscode.window.showInformationMessage(
         localize(
             'AWS.codewhisperer.customization.notification.selected_customization_not_available',
             'Selected CodeWhisperer customization is not available. Contact your administrator. Your instance of CodeWhisperer is using the foundation model.'

--- a/src/codewhisperer/views/securityIssue/securityIssueWebview.ts
+++ b/src/codewhisperer/views/securityIssue/securityIssueWebview.ts
@@ -32,7 +32,7 @@ export class SecurityIssueWebview extends VueWebview {
 
     public applyFix() {
         const args: [CodeScanIssue | undefined, string | undefined, Component] = [this.issue, this.filePath, 'webview']
-        vscode.commands.executeCommand('aws.codeWhisperer.applySecurityFix', ...args)
+        void vscode.commands.executeCommand('aws.codeWhisperer.applySecurityFix', ...args)
     }
 
     public getRelativePath() {
@@ -46,7 +46,7 @@ export class SecurityIssueWebview extends VueWebview {
         if (this.issue && this.filePath) {
             const range = new vscode.Range(this.issue.startLine, 0, this.issue.endLine, 0)
             return vscode.workspace.openTextDocument(this.filePath).then(doc => {
-                vscode.window.showTextDocument(doc, {
+                void vscode.window.showTextDocument(doc, {
                     selection: range,
                     viewColumn: vscode.ViewColumn.One,
                     preview: true,

--- a/src/codewhisperer/vue/backend.ts
+++ b/src/codewhisperer/vue/backend.ts
@@ -41,8 +41,8 @@ export class CodeWhispererWebview extends VueWebview {
         const localFilePath = this.getLocalFilePath(fileName)
         if ((await FileSystemCommon.instance.fileExists(localFilePath)) && this.isFileSaved) {
             const fileUri = vscode.Uri.file(localFilePath)
-            vscode.workspace.openTextDocument(fileUri).then(doc => {
-                vscode.window.showTextDocument(doc, vscode.ViewColumn.Active).then(editor => {
+            await vscode.workspace.openTextDocument(fileUri).then(async doc => {
+                await vscode.window.showTextDocument(doc, vscode.ViewColumn.Active).then(editor => {
                     const endOfDocument = new vscode.Position(
                         doc.lineCount - 1,
                         doc.lineAt(doc.lineCount - 1).text.length
@@ -51,7 +51,7 @@ export class CodeWhispererWebview extends VueWebview {
                 })
             })
         } else {
-            this.saveFileLocally(localFilePath, fileContent)
+            await this.saveFileLocally(localFilePath, fileContent)
         }
     }
 
@@ -61,8 +61,8 @@ export class CodeWhispererWebview extends VueWebview {
             await FileSystemCommon.instance.writeFile(localFilePath, fileContent)
             this.isFileSaved = true
             // Opening the text document
-            vscode.workspace.openTextDocument(localFilePath).then(doc => {
-                vscode.window.showTextDocument(doc, vscode.ViewColumn.Active).then(editor => {
+            await vscode.workspace.openTextDocument(localFilePath).then(async doc => {
+                await vscode.window.showTextDocument(doc, vscode.ViewColumn.Active).then(editor => {
                     // Set the selection to the end of the document
                     const endOfDocument = new vscode.Position(
                         doc.lineCount - 1,
@@ -72,7 +72,7 @@ export class CodeWhispererWebview extends VueWebview {
                 })
             })
         } catch (error) {
-            vscode.window.showErrorMessage(
+            void vscode.window.showErrorMessage(
                 localize(
                     'AWS.message.error.codewhispererLearnPage.saveFileLocally',
                     'There was an error in saving the file, check log for details.'
@@ -88,12 +88,12 @@ export class CodeWhispererWebview extends VueWebview {
 
     //This function opens the Keyboard shortcuts in VSCode
     async openShortCuts(): Promise<void> {
-        vscode.commands.executeCommand('workbench.action.openGlobalKeybindings', 'codewhisperer')
+        await vscode.commands.executeCommand('workbench.action.openGlobalKeybindings', 'codewhisperer')
     }
 
     //This function opens the Feedback CodeWhisperer page in the webview
     async openFeedBack(): Promise<void> {
-        submitFeedback.execute(placeholder, 'CodeWhisperer')
+        return submitFeedback.execute(placeholder, 'CodeWhisperer')
     }
 
     //------Telemetry------

--- a/src/codewhispererChat/commands/registerCommands.ts
+++ b/src/codewhispererChat/commands/registerCommands.ts
@@ -15,7 +15,7 @@ const getCommandTriggerType = (data: any): EditorContextCommandTriggerType => {
 
 export function registerCommands(controllerPublishers: ChatControllerMessagePublishers) {
     Commands.register('aws.amazonq.explainCode', async data => {
-        focusAmazonQPanel().then(() => {
+        return focusAmazonQPanel().then(() => {
             controllerPublishers.processContextMenuCommand.publish({
                 type: 'aws.amazonq.explainCode',
                 triggerType: getCommandTriggerType(data),
@@ -23,7 +23,7 @@ export function registerCommands(controllerPublishers: ChatControllerMessagePubl
         })
     })
     Commands.register('aws.amazonq.refactorCode', async data => {
-        focusAmazonQPanel().then(() => {
+        return focusAmazonQPanel().then(() => {
             controllerPublishers.processContextMenuCommand.publish({
                 type: 'aws.amazonq.refactorCode',
                 triggerType: getCommandTriggerType(data),
@@ -31,7 +31,7 @@ export function registerCommands(controllerPublishers: ChatControllerMessagePubl
         })
     })
     Commands.register('aws.amazonq.fixCode', async data => {
-        focusAmazonQPanel().then(() => {
+        return focusAmazonQPanel().then(() => {
             controllerPublishers.processContextMenuCommand.publish({
                 type: 'aws.amazonq.fixCode',
                 triggerType: getCommandTriggerType(data),
@@ -47,7 +47,7 @@ export function registerCommands(controllerPublishers: ChatControllerMessagePubl
         })
     })
     Commands.register('aws.amazonq.sendToPrompt', async data => {
-        focusAmazonQPanel().then(() => {
+        return focusAmazonQPanel().then(() => {
             controllerPublishers.processContextMenuCommand.publish({
                 type: 'aws.amazonq.sendToPrompt',
                 triggerType: getCommandTriggerType(data),

--- a/src/test/codewhisperer/tracker/codewhispererTracker.test.ts
+++ b/src/test/codewhisperer/tracker/codewhispererTracker.test.ts
@@ -65,9 +65,11 @@ describe('codewhispererTracker', function () {
         })
 
         it('Should skip if telemetry is disabled', async function () {
+            globals.telemetry.telemetryEnabled = false
             const getTimeSpy = sinon.spy(Date.prototype, 'getTime')
             await CodeWhispererTracker.getTracker().flush()
             assert.ok(!getTimeSpy.called)
+            globals.telemetry.telemetryEnabled = true
         })
     })
 


### PR DESCRIPTION
Continued from:

- https://github.com/aws/aws-toolkit-vscode/pull/4202
- #1638

# Problem:

- All promises or async calls should use `await`, or end with `.catch()`.
  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises
- Async calls accidentally forget `await`.
  - Example: 8863ba4a799e
- Test logs show "rejected promise not handled":
  ```
  rejected promise not handled within 1 second: HTTPError: Response code 403 (rate limit exceeded)
  rejected promise not handled within 1 second: Error: command 'aws.codeWhisperer.refreshStatusBar' not found
  rejected promise not handled within 1 second: HTTPError: Response code 404 (Not Found)
  rejected promise not handled within 1 second: CodeExpectedError: cannot open notCloudWatch:hahahaha. Detail: Unable to resolve resource notCloudWatch:hahahaha
  rejected promise not handled within 1 second: AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
  rejected promise not handled within 1 second: Error: No access
  rejected promise not handled within 1 second: Error: No access
  rejected promise not handled within 1 second: Error: Timed-out waiting for browser login flow to complete
  rejected promise not handled within 1 second: Error: Download code bindings cancelled
  rejected promise not handled within 1 second: Error: EACCES: permission denied, mkdir '/my'
  ```

# Solution:

- Enable eslint rule: https://typescript-eslint.io/rules/no-floating-promises/




<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
