### PR TITLE
lint: require "await" or .catch() on async calls

### DIFF
--- a/src/extensionShared.ts
+++ b/src/extensionShared.ts
@@ -37,15 +37,15 @@ export function registerCommands(extensionContext: vscode.ExtensionContext) {
         ),
         // register URLs in extension menu
         Commands.register('aws.help', async () => {
-            openUrl(vscode.Uri.parse(documentationUrl))
+            void openUrl(vscode.Uri.parse(documentationUrl))
             telemetry.aws_help.emit()
         }),
         Commands.register('aws.github', async () => {
-            openUrl(vscode.Uri.parse(githubUrl))
+            void openUrl(vscode.Uri.parse(githubUrl))
             telemetry.aws_showExtensionSource.emit()
         }),
         Commands.register('aws.createIssueOnGitHub', async () => {
-            openUrl(vscode.Uri.parse(githubCreateIssueUrl))
+            void openUrl(vscode.Uri.parse(githubCreateIssueUrl))
             telemetry.aws_reportPluginIssue.emit()
         }),
         Commands.register('aws.aboutToolkit', async () => {

--- a/src/extensionWeb.ts
+++ b/src/extensionWeb.ts
@@ -19,7 +19,7 @@ import { DefaultAWSClientBuilder } from './shared/awsClientBuilder'
 export async function activate(context: vscode.ExtensionContext) {
     setInBrowser(true) // THIS MUST ALWAYS BE FIRST
 
-    vscode.window.showInformationMessage(
+    void vscode.window.showInformationMessage(
         'AWS Toolkit: Browser Mode Under Development. No features are currently provided'
     )
 

--- a/src/feedback/vue/submitFeedback.ts
+++ b/src/feedback/vue/submitFeedback.ts
@@ -55,7 +55,7 @@ export class FeedbackWebview extends VueWebview {
 
         this.dispose()
 
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             localize('AWS.message.info.submitFeedback.success', 'Thanks for the feedback!')
         )
     }

--- a/src/iot/commands/attachCertificate.ts
+++ b/src/iot/commands/attachCertificate.ts
@@ -38,7 +38,7 @@ export async function attachCertificateCommand(node: IotThingNode, promptFun = p
         await node.iot.attachThingPrincipal({ thingName, principal: cert.certificateArn! })
     } catch (e) {
         getLogger().error(`Failed to attach certificate ${cert.certificateId}: %s`, e)
-        showViewLogsMessage(
+        void showViewLogsMessage(
             localize('AWS.iot.attachCert.error', 'Failed to attach certificate {0}', cert.certificateId)
         )
         return undefined
@@ -85,7 +85,7 @@ async function* getCertList(iot: IotClient) {
                 ) ?? []
         } catch (e) {
             getLogger().error(`Failed to retrieve certificates: %s`, e)
-            showViewLogsMessage(localize('AWS.iot.attachCert.error', 'Failed to retrieve certificates'))
+            void showViewLogsMessage(localize('AWS.iot.attachCert.error', 'Failed to retrieve certificates'))
             return
         }
         yield filteredCerts.map(cert => ({ label: cert.certificateId!, data: cert }))

--- a/src/iot/commands/attachPolicy.ts
+++ b/src/iot/commands/attachPolicy.ts
@@ -42,7 +42,7 @@ export async function attachPolicyCommand(
         await node.iot.attachPolicy({ policyName: policy.policyName!, target: certArn })
     } catch (e) {
         getLogger().error(`Failed to attach policy ${policy.policyName}: %s`, e)
-        showViewLogsMessage(localize('AWS.iot.attachCert.error', 'Failed to attach policy {0}', policy.policyName))
+        void showViewLogsMessage(localize('AWS.iot.attachCert.error', 'Failed to attach policy {0}', policy.policyName))
         return undefined
     }
 
@@ -98,7 +98,7 @@ async function* getPolicyList(iot: IotClient) {
             filteredPolicies = policyResponse.policies?.filter(policy => policy.policyArn && policy.policyName) ?? []
         } catch (e) {
             getLogger().error(`Failed to retrieve policies: %s`, e)
-            showViewLogsMessage(localize('AWS.iot.attachPolicy.error', 'Failed to retrieve policies'))
+            void showViewLogsMessage(localize('AWS.iot.attachPolicy.error', 'Failed to retrieve policies'))
             return
         }
         yield filteredPolicies.map(policy => ({ label: policy.policyName!, data: policy }))

--- a/src/iot/commands/copyEndpoint.ts
+++ b/src/iot/commands/copyEndpoint.ts
@@ -22,9 +22,9 @@ export async function copyEndpointCommand(node: IotNode): Promise<void> {
         endpoint = await node.getEndpoint()
     } catch (e) {
         getLogger().error('Failed to retrieve endpoint: %s', e)
-        showViewLogsMessage(localize('AWS.iot.copyEndpoint.error', 'Failed to retrieve endpoint'))
+        void showViewLogsMessage(localize('AWS.iot.copyEndpoint.error', 'Failed to retrieve endpoint'))
         return
     }
 
-    copyToClipboard(endpoint, 'URL')
+    await copyToClipboard(endpoint, 'URL')
 }

--- a/src/iot/commands/createCert.ts
+++ b/src/iot/commands/createCert.ts
@@ -42,7 +42,7 @@ export async function createCertificateCommand(
         })
     } catch (e) {
         getLogger().error('Failed to create certificate: %s', e)
-        showViewLogsMessage(localize('AWS.iot.createCert.error', 'Failed to create certificate'))
+        void showViewLogsMessage(localize('AWS.iot.createCert.error', 'Failed to create certificate'))
         return undefined
     }
 
@@ -53,12 +53,12 @@ export async function createCertificateCommand(
 
     if (!certPem || !privateKey || !publicKey) {
         getLogger().error('Could not download certificate. Certificate is missing either the PEM or key pair.')
-        showViewLogsMessage(localize('AWS.iot.createCert.error', 'Failed to create certificate'))
+        void showViewLogsMessage(localize('AWS.iot.createCert.error', 'Failed to create certificate'))
         return undefined
     }
 
     getLogger().info(`Downloaded certificate ${certId}`)
-    vscode.window.showInformationMessage(localize('AWS.iot.createCert.success', 'Created certificate {0}', certId))
+    void vscode.window.showInformationMessage(localize('AWS.iot.createCert.success', 'Created certificate {0}', certId))
 
     //Save resources
     const saveSuccessful = await saveFunc(folderLocation, certId!, certPem, privateKey, publicKey)
@@ -68,7 +68,7 @@ export async function createCertificateCommand(
             await node.iot.deleteCertificate({ certificateId: certId! })
         } catch (e) {
             getLogger().error(`Failed to delete Certificate ${certId}: %s`, e)
-            showViewLogsMessage(localize('AWS.iot.deleteCert.error', 'Failed to delete Certificate {0}', certId))
+            void showViewLogsMessage(localize('AWS.iot.deleteCert.error', 'Failed to delete Certificate {0}', certId))
         }
     }
 
@@ -116,14 +116,14 @@ async function saveCredentials(
 
     if (certExists) {
         getLogger().error('Certificate path {0} already exists', certPath)
-        vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             localize('AWS.iot.createCert.error', 'Failed to create certificate. Path {0} already exists.', certPath)
         )
         return false
     }
     if (privateKeyExists) {
         getLogger().error('Key path {0} already exists', privateKeyPath)
-        vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             localize(
                 'AWS.iot.createCert.error',
                 'Failed to create certificate. Path {0} already exists.',
@@ -134,7 +134,7 @@ async function saveCredentials(
     }
     if (publicKeyExists) {
         getLogger().error('Key path {0} already exists', publicKeyPath)
-        vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             localize(
                 'AWS.iot.createCert.error',
                 'Failed to create certificate. Path {0} already exists.',
@@ -149,7 +149,7 @@ async function saveCredentials(
         await fs.writeFile(publicKeyPath, publicKey, { encoding: PEM_FILE_ENCODING, mode: MODE_RW_R_R })
     } catch (e) {
         getLogger().error('Could not save certificate: %s', e)
-        showViewLogsMessage(localize('AWS.iot.createCert.saveError', 'Failed to save certificate'))
+        void showViewLogsMessage(localize('AWS.iot.createCert.saveError', 'Failed to save certificate'))
         return false
     }
     return true

--- a/src/iot/commands/createPolicy.ts
+++ b/src/iot/commands/createPolicy.ts
@@ -36,10 +36,12 @@ export async function createPolicyCommand(node: IotPolicyFolderNode, getPolicyDo
         //Parse to ensure this is a valid JSON
         const policyJSON = JSON.parse(data.toString())
         await node.iot.createPolicy({ policyName, policyDocument: JSON.stringify(policyJSON) })
-        vscode.window.showInformationMessage(localize('AWS.iot.createPolicy.success', 'Created Policy {0}', policyName))
+        void vscode.window.showInformationMessage(
+            localize('AWS.iot.createPolicy.success', 'Created Policy {0}', policyName)
+        )
     } catch (e) {
         getLogger().error('Failed to create policy document: %s', e)
-        showViewLogsMessage(localize('AWS.iot.createPolicy.error', 'Failed to create policy {0}', policyName))
+        void showViewLogsMessage(localize('AWS.iot.createPolicy.error', 'Failed to create policy {0}', policyName))
         return
     }
 
@@ -67,7 +69,7 @@ export async function getPolicyDocument(): Promise<Buffer | undefined> {
         data = await fs.readFile(policyLocation.fsPath)
     } catch (e) {
         getLogger().error('Failed to read policy document: %s', e)
-        showViewLogsMessage(localize('AWS.iot.createPolicy.error', 'Failed to read policy document'))
+        void showViewLogsMessage(localize('AWS.iot.createPolicy.error', 'Failed to read policy document'))
         return undefined
     }
 

--- a/src/iot/commands/createPolicyVersion.ts
+++ b/src/iot/commands/createPolicyVersion.ts
@@ -34,12 +34,12 @@ export async function createPolicyVersionCommand(
             policyDocument: JSON.stringify(policyJSON),
             setAsDefault: true,
         })
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             localize('AWS.iot.createPolicy.success', 'Created new version of {0}', policyName)
         )
     } catch (e) {
         getLogger().error('Failed to create new policy version: %s', e)
-        showViewLogsMessage(
+        void showViewLogsMessage(
             localize('AWS.iot.createPolicyVersion.error', 'Failed to create new version of {0}', policyName)
         )
         return

--- a/src/iot/commands/createThing.ts
+++ b/src/iot/commands/createThing.ts
@@ -35,10 +35,12 @@ export async function createThingCommand(node: IotThingFolderNode): Promise<void
         const thing = await node.iot.createThing({ thingName })
 
         getLogger().info('Created thing: %O', thing)
-        vscode.window.showInformationMessage(localize('AWS.iot.createThing.success', 'Created Thing {0}', thingName))
+        void vscode.window.showInformationMessage(
+            localize('AWS.iot.createThing.success', 'Created Thing {0}', thingName)
+        )
     } catch (e) {
         getLogger().error(`Failed to create Thing ${thingName}: %s`, e)
-        showViewLogsMessage(localize('AWS.iot.createThing.error', 'Failed to create Thing: {0}', thingName))
+        void showViewLogsMessage(localize('AWS.iot.createThing.error', 'Failed to create Thing: {0}', thingName))
     }
 
     //Refresh the Things Folder node

--- a/src/iot/commands/deleteCert.ts
+++ b/src/iot/commands/deleteCert.ts
@@ -25,7 +25,7 @@ export async function deleteCertCommand(node: IotCertWithPoliciesNode): Promise<
 
     if (node.certificate.activeStatus === 'ACTIVE') {
         getLogger().error('Certificate is active')
-        vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             localize('AWS.iot.deleteCert.activeError', 'Active certificates cannot be deleted')
         )
         return
@@ -35,7 +35,7 @@ export async function deleteCertCommand(node: IotCertWithPoliciesNode): Promise<
         const things = await node.iot.listThingsForCert({ principal: certArn })
         if (things.length > 0) {
             getLogger().error(`Certificate ${node.certificate.id} has attached Things`)
-            vscode.window.showErrorMessage(
+            void vscode.window.showErrorMessage(
                 localize(
                     'AWS.iot.deleteCert.attachedError',
                     'Cannot delete certificate. Certificate has attached resources: {0}',
@@ -46,7 +46,7 @@ export async function deleteCertCommand(node: IotCertWithPoliciesNode): Promise<
         }
     } catch (e) {
         getLogger().error(`Failed to retrieve Things attached to cert ${node.certificate.id}: %s`, e)
-        showViewLogsMessage(
+        void showViewLogsMessage(
             localize('AWS.iot.deleteCert.retrieveError', 'Failed to retrieve {0} attached to certificate', 'Things')
         )
         return
@@ -96,12 +96,12 @@ export async function deleteCertCommand(node: IotCertWithPoliciesNode): Promise<
         await node.iot.deleteCertificate({ certificateId: node.certificate.id, forceDelete: forceDelete })
 
         getLogger().info(`deleted certificate: ${node.certificate.id}`)
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             localize('AWS.iot.deleteCert.success', 'Deleted certificate: {0}', node.certificate.id)
         )
     } catch (e) {
         getLogger().error(`Failed to delete Certificate ${node.certificate.id}: %s`, e)
-        showViewLogsMessage(
+        void showViewLogsMessage(
             localize('AWS.iot.deleteCert.error', 'Failed to delete certificate: {0}', node.certificate.id)
         )
     }

--- a/src/iot/commands/deletePolicy.ts
+++ b/src/iot/commands/deletePolicy.ts
@@ -38,7 +38,7 @@ export async function deletePolicyCommand(node: IotPolicyWithVersionsNode): Prom
         const certs = await node.iot.listPolicyTargets({ policyName })
         if (certs.length > 0) {
             getLogger().error(`Policy ${policyName} has attached Certificates`)
-            vscode.window.showErrorMessage(
+            void vscode.window.showErrorMessage(
                 localize(
                     'AWS.iot.deletePolicy.attachedError',
                     'Cannot delete {0}. Policy has attached certificates: {1}',
@@ -63,12 +63,14 @@ export async function deletePolicyCommand(node: IotPolicyWithVersionsNode): Prom
         await node.iot.deletePolicy({ policyName })
 
         getLogger().info(`deleted Policy: ${policyName}`)
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             localize('AWS.iot.deletePolicy.success', 'Deleted Policy: {0}', node.policy.name)
         )
     } catch (e) {
         getLogger().error(`Failed to delete Policy: ${policyName}: %s`, e)
-        showViewLogsMessage(localize('AWS.iot.deletePolicy.error', 'Failed to delete Policy: {0}', node.policy.name))
+        void showViewLogsMessage(
+            localize('AWS.iot.deletePolicy.error', 'Failed to delete Policy: {0}', node.policy.name)
+        )
     }
 
     //Refresh the Policy Folder node

--- a/src/iot/commands/deletePolicyVersion.ts
+++ b/src/iot/commands/deletePolicyVersion.ts
@@ -53,7 +53,7 @@ export async function deletePolicyVersionCommand(node: IotPolicyVersionNode): Pr
         )
     } catch (e) {
         getLogger().error(`Failed to delete Policy Version: ${policyVersionId}: %s`, e)
-        showViewLogsMessage(
+        void showViewLogsMessage(
             localize(
                 'AWS.iot.deletePolicyVersion.error',
                 'Failed to delete Version {0} of Policy {1}',
@@ -64,5 +64,5 @@ export async function deletePolicyVersionCommand(node: IotPolicyVersionNode): Pr
     }
 
     //Refresh the policy node
-    node.parent.refreshNode()
+    await node.parent.refreshNode()
 }

--- a/src/iot/commands/deleteThing.ts
+++ b/src/iot/commands/deleteThing.ts
@@ -37,7 +37,7 @@ export async function deleteThingCommand(node: IotThingNode): Promise<void> {
         const principalList = (await node.iot.listThingPrincipals({ thingName })).principals
         if (principalList?.length ?? 0 > 0) {
             getLogger().error(`Thing ${thingName} has attached principals: %O`, principalList)
-            vscode.window.showErrorMessage(
+            void vscode.window.showErrorMessage(
                 localize(
                     'AWS.iot.deleteThing.error',
                     'Cannot delete Thing {0}. Thing {0} has attached principals: {1}',
@@ -50,12 +50,14 @@ export async function deleteThingCommand(node: IotThingNode): Promise<void> {
         await node.iot.deleteThing({ thingName })
 
         getLogger().info(`deleted Thing: ${thingName}`)
-        vscode.window.showInformationMessage(localize('AWS.iot.deleteThing.success', 'Deleted Thing: {0}', thingName))
+        void vscode.window.showInformationMessage(
+            localize('AWS.iot.deleteThing.success', 'Deleted Thing: {0}', thingName)
+        )
     } catch (e) {
         getLogger().error(`Failed to delete Thing: ${thingName}: %s`, e)
-        showViewLogsMessage(localize('AWS.iot.deleteThing.error', 'Failed to delete Thing: {0}', thingName))
+        void showViewLogsMessage(localize('AWS.iot.deleteThing.error', 'Failed to delete Thing: {0}', thingName))
     }
 
     //Refresh the Things Folder node
-    node.parent.refreshNode()
+    await node.parent.refreshNode()
 }

--- a/src/iot/commands/detachCert.ts
+++ b/src/iot/commands/detachCert.ts
@@ -43,10 +43,10 @@ export async function detachThingCertCommand(node: IotThingCertNode): Promise<vo
         await node.iot.detachThingPrincipal({ thingName, principal: certArn })
 
         getLogger().info(`detached certificate from Thing: ${thingName}`)
-        vscode.window.showInformationMessage(localize('AWS.iot.detachCert.success', 'Detached: {0}', certId))
+        void vscode.window.showInformationMessage(localize('AWS.iot.detachCert.success', 'Detached: {0}', certId))
     } catch (e) {
         getLogger().error(`Failed to detach certificate: ${certId}: %s`, e)
-        showViewLogsMessage(localize('AWS.iot.detachCert.error', 'Failed to detach: {0}', certId))
+        void showViewLogsMessage(localize('AWS.iot.detachCert.error', 'Failed to detach: {0}', certId))
     }
 
     //Refresh the parent Thing node

--- a/src/iot/commands/detachPolicy.ts
+++ b/src/iot/commands/detachPolicy.ts
@@ -45,10 +45,10 @@ export async function detachPolicyCommand(node: IotPolicyCertNode): Promise<void
         await node.iot.detachPolicy({ policyName, target: certArn })
 
         getLogger().info(`detached policy: ${policyName}`)
-        vscode.window.showInformationMessage(localize('AWS.iot.detachPolicy.success', 'Detached: {0}', policyName))
+        void vscode.window.showInformationMessage(localize('AWS.iot.detachPolicy.success', 'Detached: {0}', policyName))
     } catch (e) {
         getLogger().error(`Failed to detach certificate: ${certId}: %s`, e)
-        showViewLogsMessage(localize('AWS.iot.detachPolicy.error', 'Failed to detach: {0}', policyName))
+        void showViewLogsMessage(localize('AWS.iot.detachPolicy.error', 'Failed to detach: {0}', policyName))
     }
 
     /* Refresh both things and certificates nodes so the status is updated in

--- a/src/iot/commands/setDefaultPolicy.ts
+++ b/src/iot/commands/setDefaultPolicy.ts
@@ -23,7 +23,7 @@ export async function setDefaultPolicy(node: IotPolicyVersionNode): Promise<void
             policyName: node.policy.name,
             policyVersionId: node.version.versionId!,
         })
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             localize(
                 'AWS.iot.setDefaultPolicy.success',
                 'Set {0} as default version of {1}',
@@ -33,7 +33,7 @@ export async function setDefaultPolicy(node: IotPolicyVersionNode): Promise<void
         )
     } catch (e) {
         getLogger().error('Failed to set default policy version: %s', e)
-        showViewLogsMessage(localize('AWS.iot.setDefaultPolicy.error', 'Failed to set default policy version'))
+        void showViewLogsMessage(localize('AWS.iot.setDefaultPolicy.error', 'Failed to set default policy version'))
     }
 
     await refreshBase(node.parent)

--- a/src/iot/commands/updateCert.ts
+++ b/src/iot/commands/updateCert.ts
@@ -48,12 +48,14 @@ export async function deactivateCertificateCommand(node: IotCertificateNode): Pr
         await node.iot.updateCertificate({ certificateId: certId, newStatus: statusInactive })
 
         getLogger().info(`deactivated certificate: ${certId}`)
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             localize('AWS.iot.deactivateCert.success', 'Deactivated: {0}', node.certificate.id)
         )
     } catch (e) {
         getLogger().error(`Failed to deactivate certificate ${certId}: %s`, e)
-        showViewLogsMessage(localize('AWS.iot.deactivateCert.error', 'Failed to deactivate: {0}', node.certificate.id))
+        void showViewLogsMessage(
+            localize('AWS.iot.deactivateCert.error', 'Failed to deactivate: {0}', node.certificate.id)
+        )
     }
 
     /* Refresh both things and certificates nodes so the status is updated in
@@ -90,12 +92,12 @@ export async function activateCertificateCommand(node: IotCertificateNode): Prom
         await node.iot.updateCertificate({ certificateId: certId, newStatus: statusActive })
 
         getLogger().info(`activated certificate: ${certId}`)
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             localize('AWS.iot.activateCert.success', 'Activated: {0}', node.certificate.id)
         )
     } catch (e) {
         getLogger().error(`Failed to activate certificate ${certId}: %s`, e)
-        showViewLogsMessage(localize('AWS.iot.activateCert.error', 'Failed to activate: {0}', node.certificate.id))
+        void showViewLogsMessage(localize('AWS.iot.activateCert.error', 'Failed to activate: {0}', node.certificate.id))
     }
 
     /* Refresh both things and certificates nodes so the status is updated in
@@ -132,12 +134,12 @@ export async function revokeCertificateCommand(node: IotCertificateNode): Promis
         await node.iot.updateCertificate({ certificateId: certId, newStatus: statusRevoked })
 
         getLogger().info(`revoked certificate: ${certId}`)
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             localize('AWS.iot.revokeCert.success', 'Revoked: {0}', node.certificate.id)
         )
     } catch (e) {
         getLogger().error(`Failed to revoke certificate ${certId}: %s`, e)
-        showViewLogsMessage(localize('AWS.iot.revokeCert.error', 'Failed to revoke: {0}', node.certificate.id))
+        void showViewLogsMessage(localize('AWS.iot.revokeCert.error', 'Failed to revoke: {0}', node.certificate.id))
     }
 
     /* Refresh both things and certificates nodes so the status is updated in

--- a/src/iot/commands/viewPolicyVersion.ts
+++ b/src/iot/commands/viewPolicyVersion.ts
@@ -23,7 +23,7 @@ export async function viewPolicyVersionCommand(node: IotPolicyVersionNode) {
         await showPolicyContent(document)
     } catch (e) {
         getLogger().error('Failed to retrieve policy document')
-        showViewLogsMessage(localize('AWS.iot.viewPolicyVersion.error', 'Failed to retrieve policy document'))
+        void showViewLogsMessage(localize('AWS.iot.viewPolicyVersion.error', 'Failed to retrieve policy document'))
         return undefined
     }
 }

--- a/src/lambda/commands/copyLambdaUrl.ts
+++ b/src/lambda/commands/copyLambdaUrl.ts
@@ -24,7 +24,7 @@ export async function copyLambdaUrl(
     const configs = await client.getFunctionUrlConfigs(node.name)
 
     if (configs.length === 0) {
-        vscode.window.showWarningMessage(noLambdaFuncMessage)
+        void vscode.window.showWarningMessage(noLambdaFuncMessage)
         vscode.window.setStatusBarMessage(addCodiconToString('circle-slash', 'No URL for Lambda function.'), 5000)
     } else {
         let url: string | undefined = undefined
@@ -35,7 +35,7 @@ export async function copyLambdaUrl(
         }
 
         if (url) {
-            copyToClipboard(url, 'URL')
+            await copyToClipboard(url, 'URL')
         }
     }
 }

--- a/src/lambda/commands/createNewSamApp.ts
+++ b/src/lambda/commands/createNewSamApp.ts
@@ -71,7 +71,7 @@ export async function resumeCreateNewSamApp(
             reason = 'error'
             // Should never happen, because `samInitState.path` is only set if
             // `uri` is in the newly-added workspace folder.
-            vscode.window.showErrorMessage(
+            void vscode.window.showErrorMessage(
                 localize(
                     'AWS.samcli.initWizard.source.error.notInWorkspace',
                     "Could not open file '{0}'. If this file exists on disk, try adding it to your workspace.",
@@ -290,7 +290,10 @@ export async function createNewSamApplication(
             )
             tryOpenReadme = await writeToolkitReadme(readmeUri.fsPath, newLaunchConfigs)
             if (newLaunchConfigs && newLaunchConfigs.length > 0) {
-                showCompletionNotification(config.name, `"${newLaunchConfigs.map(config => config.name).join('", "')}"`)
+                void showCompletionNotification(
+                    config.name,
+                    `"${newLaunchConfigs.map(config => config.name).join('", "')}"`
+                )
             }
             reason = 'complete'
         } else {
@@ -298,7 +301,7 @@ export async function createNewSamApplication(
             reason = 'fileNotFound'
 
             const helpText = localize('AWS.generic.message.getHelp', 'Get Help...')
-            vscode.window
+            void vscode.window
                 .showWarningMessage(
                     localize(
                         'AWS.samcli.initWizard.launchConfigFail',
@@ -310,7 +313,7 @@ export async function createNewSamApplication(
                 )
                 .then(async buttonText => {
                     if (buttonText === helpText) {
-                        openUrl(vscode.Uri.parse(launchConfigDocUrl))
+                        void openUrl(vscode.Uri.parse(launchConfigDocUrl))
                     }
                 })
         }
@@ -368,7 +371,7 @@ export async function getProjectUri(
             return vscode.Uri.file(cfnTemplatePath)
         }
     }
-    vscode.window.showWarningMessage(
+    void vscode.window.showWarningMessage(
         localize(
             'AWS.samcli.initWizard.source.error.notFound',
             'Project created successfully, but {0} file not found: {1}',
@@ -435,7 +438,7 @@ async function showCompletionNotification(appName: string, configs: string): Pro
     if (action === openJson) {
         await openLaunchJsonFile()
     } else if (action === learnMore) {
-        openUrl(vscode.Uri.parse(debugNewSamAppUrl))
+        void openUrl(vscode.Uri.parse(debugNewSamAppUrl))
     }
 }
 

--- a/src/lambda/commands/deleteCloudFormation.ts
+++ b/src/lambda/commands/deleteCloudFormation.ts
@@ -24,7 +24,7 @@ export async function deleteCloudFormation(refresh: () => void, node?: CloudForm
     try {
         if (!node) {
             deleteResult = 'Failed'
-            vscode.window.showErrorMessage(
+            void vscode.window.showErrorMessage(
                 localize(
                     'AWS.message.error.cloudFormation.unsupported',
                     'Unable to delete a CloudFormation Stack. No stack provided.'
@@ -49,7 +49,7 @@ export async function deleteCloudFormation(refresh: () => void, node?: CloudForm
 
             await client.deleteStack(stackName)
 
-            vscode.window.showInformationMessage(
+            void vscode.window.showInformationMessage(
                 localize('AWS.message.info.cloudFormation.delete', 'Deleted CloudFormation Stack {0}', stackName)
             )
 
@@ -59,7 +59,7 @@ export async function deleteCloudFormation(refresh: () => void, node?: CloudForm
         deleteResult = 'Failed'
         logger.error(err as Error)
 
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             localize(
                 'AWS.message.error.cloudFormation.delete',
                 'An error occurred while deleting {0}. Please check the stack events on the {1} Console',

--- a/src/lambda/commands/deleteLambda.ts
+++ b/src/lambda/commands/deleteLambda.ts
@@ -53,7 +53,7 @@ export async function deleteLambda(
             lambda.FunctionName
         )
 
-        showViewLogsMessage(message)
+        void showViewLogsMessage(message)
     } finally {
         telemetry.lambda_delete.emit({
             result: deleteResult,

--- a/src/lambda/commands/deploySamApplication.ts
+++ b/src/lambda/commands/deploySamApplication.ts
@@ -59,7 +59,7 @@ export async function deploySamApplication(
         window = getDefaultWindowFunctions(),
         refreshFn = () => {
             // no need to await, doesn't need to block further execution (true -> no telemetry)
-            vscode.commands.executeCommand('aws.refreshAwsExplorer', true)
+            void vscode.commands.executeCommand('aws.refreshAwsExplorer', true)
         },
     }: {
         awsContext: Pick<AwsContext, 'getCredentials' | 'getCredentialProfileName'>
@@ -130,7 +130,7 @@ export async function deploySamApplication(
     } catch (err) {
         deployResult = 'Failed'
         outputDeployError(err as Error)
-        vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             localize('AWS.samcli.deploy.workflow.error', 'Failed to deploy SAM application.')
         )
     } finally {
@@ -192,7 +192,7 @@ async function packageOperation(
     buildSuccessful: boolean
 ): Promise<void> {
     if (!buildSuccessful) {
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
             localize(
                 'AWS.samcli.deploy.workflow.packaging.noBuild',
                 'Attempting to package source template directory directly since "sam build" failed'
@@ -287,7 +287,7 @@ async function deploy(params: {
         )
     )
 
-    params.window.showInformationMessage(
+    void params.window.showInformationMessage(
         localize('AWS.samcli.deploy.workflow.success.general', 'SAM Application deployment succeeded.')
     )
 }

--- a/src/lambda/commands/downloadLambda.ts
+++ b/src/lambda/commands/downloadLambda.ts
@@ -41,7 +41,7 @@ async function runDownloadLambda(functionNode: LambdaFunctionNode): Promise<Resu
     const functionName = functionNode.configuration.FunctionName!
 
     if (workspaceFolders.length === 0) {
-        vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             localize(
                 'AWS.lambda.download.noWorkspaceFolders',
                 'Open a workspace and add a folder to it before downloading a Lambda function.'
@@ -97,7 +97,7 @@ async function runDownloadLambda(functionNode: LambdaFunctionNode): Promise<Resu
                 // show error and return a failure
                 const err = e as Error
                 getLogger().error(err)
-                vscode.window.showErrorMessage(
+                void vscode.window.showErrorMessage(
                     localize(
                         'AWS.lambda.download.downloadError',
                         'Error downloading Lambda function {0}: {1}',
@@ -172,7 +172,7 @@ async function downloadAndUnzipLambda(
         progress.report({ message: 'Extracting...' })
         new AdmZip(downloadLocation).extractAllTo(extractLocation, true)
     } finally {
-        tryRemoveFolder(tempDir)
+        await tryRemoveFolder(tempDir)
     }
 }
 
@@ -184,7 +184,7 @@ export async function openLambdaFile(lambdaLocation: string): Promise<void> {
             lambdaLocation
         )
         getLogger().warn(warning)
-        vscode.window.showWarningMessage(warning)
+        void vscode.window.showWarningMessage(warning)
         throw new Error()
     }
     const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(lambdaLocation))

--- a/src/lambda/config/templates.ts
+++ b/src/lambda/config/templates.ts
@@ -179,7 +179,7 @@ export function showTemplatesConfigurationError(
 ): void {
     const logger: Logger = getLogger()
 
-    showErrorMessage(
+    void showErrorMessage(
         localize(
             'AWS.lambda.configure.error.fieldtype',
             'Your templates.json file has an issue. {0} was detected as {1} instead of one of the following: [{2}]. Please change or remove this field, and try again.',
@@ -197,7 +197,7 @@ export function showTemplatesConfigurationError(
 }
 
 export async function ensureTemplatesConfigFileExists(path: string): Promise<void> {
-    ensureDir(_path.dirname(path))
+    await ensureDir(_path.dirname(path))
     try {
         await access(path)
     } catch {


### PR DESCRIPTION
Continued from:

- #1638
- #4202
- #4218
- #4220

Solution:
- Enable eslint rule: https://typescript-eslint.io/rules/no-floating-promises/

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
