### PR TITLE
codewhisperer: skip flaky tests

### DIFF
--- a/src/test/codewhisperer/service/telemetry.test.ts
+++ b/src/test/codewhisperer/service/telemetry.test.ts
@@ -37,7 +37,7 @@ type CodeWhispererResponse = ListRecommendationsResponse & {
 
 let tempFolder: string
 
-describe('CodeWhisperer telemetry', async function () {
+describe.skip('CodeWhisperer telemetry', async function () {
     let sandbox: sinon.SinonSandbox
     let client: DefaultCodeWhispererClient
 


### PR DESCRIPTION
### Problem

When running this test file locally many tests fail if you deselect the window since the tests type in to it. It will run fine in CI for the most part.

### Solution

Eventually have the CW team move this to the integration tests.

Reported issue: https://github.com/aws/aws-toolkit-vscode/issues/4203

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
