### PR TITLE
ci: report "npm WARN deprecated"

### DIFF
--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -36,9 +36,8 @@ phases:
                     . buildspec/shared/common.sh
                     2>&1 xvfb-run npm test --silent | run_and_report \
                         'rejected promise not handled' \
-                        'This typically indicates a bug. Read https://developer.mozilla.org/docs/Web/JavaScript/Guide/Using_promises#error_handling'
-                    # TODO: fail the CI job
-                    # || exit 1;
+                        'This typically indicates a bug. Read https://developer.mozilla.org/docs/Web/JavaScript/Guide/Using_promises#error_handling' \
+                        || true # TODO: fail the CI job
                 }
             - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
             - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g') # Encode `#` in the URL because otherwise the url is clipped in the Codecov.io site

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -33,25 +33,12 @@ phases:
                 fi
             - |
                 {
-                    set -e
-                    set -o pipefail
-                    _PROMISE_REJ_MSG='rejected promise not handled'
-                    mkfifo testout
-                    (cat testout &)
-                    xvfb-run npm test --silent | tee testout \
-                        | grep -v 'undefined..reading..range' \
-                        | grep -v CODEWHISPERER_INLINE_UPDATE_LOCK_KEY \
-                        | { >testout-rej grep --line-buffered "$_PROMISE_REJ_MSG" || true; }
-                    if [ -s testout-rej ] ; then
-                        echo ''
-                        cat testout-rej | sort
-                        printf '\n\nERROR: Found %s "%s" in test output (see above).\n%s\n\n' \
-                            "$(cat testout-rej | wc -l | tr -d ' ')" \
-                            "$_PROMISE_REJ_MSG" \
-                            '       This typically indicates a bug. Read https://developer.mozilla.org/docs/Web/JavaScript/Guide/Using_promises#error_handling'
-                        # TODO: fail the CI job
-                        # exit 1;
-                    fi
+                    . buildspec/shared/common.sh
+                    2>&1 xvfb-run npm test --silent | run_and_report \
+                        'rejected promise not handled' \
+                        'This typically indicates a bug. Read https://developer.mozilla.org/docs/Web/JavaScript/Guide/Using_promises#error_handling'
+                    # TODO: fail the CI job
+                    # || exit 1;
                 }
             - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
             - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g') # Encode `#` in the URL because otherwise the url is clipped in the Codecov.io site

--- a/buildspec/shared/common.sh
+++ b/buildspec/shared/common.sh
@@ -1,0 +1,30 @@
+# Common functions used by other CI scripts.
+# "Include" this file by sourcing (not executing) it:
+#     . buildspec/shared/common.sh
+
+# Expects stdin + two args:
+#   1: grep pattern
+#   2: message shown at end of report, if pattern was found in stdin.
+# Usage:
+#   echo foo | run_and_report '.*' 'You must fix this. See https://example.com'
+run_and_report() {
+    set -o pipefail
+    local pat="${1}"
+    local msg="${2}"
+    local r=0
+    mkfifo testout
+    (cat testout &)
+    # Capture messages that we may want to fail (or report) later.
+    tee testout \
+        | { grep > testout-err --line-buffered -E "$pat" || true; }
+    echo ''
+    if grep "$pat" testout-err | sort; then
+        printf '\nERROR: Found %s "%s" in test output (see above).\n%s\n\n' \
+            "$(grep "${pat}" testout-err | wc -l | tr -d ' ')" \
+            "$pat" \
+            "       ${msg}"
+        r=1
+    fi
+    rm -f testout testout-err
+    return "$r"
+}

--- a/buildspec/shared/linux-pre_build.sh
+++ b/buildspec/shared/linux-pre_build.sh
@@ -3,6 +3,12 @@
 # Common code for "pre_build" phase of linux codebuild CI job.
 
 set -e
+set -o pipefail
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Include common functions.
+. "${_SCRIPT_DIR}/common.sh"
 
 # If present, log into CodeArtifact. Provides a fallback in case NPM is down.
 # Should only affect tests run through Toolkits-hosted CodeBuild.
@@ -14,5 +20,7 @@ if [ "$TOOLKITS_CODEARTIFACT_DOMAIN" ] && [ "$TOOLKITS_CODEARTIFACT_REPO" ] && [
     fi
 fi
 
-# TODO: do this in the "install" phase?
-npm ci
+# TODO: move this to the "install" phase?
+npm 2>&1 ci | run_and_report 'npm WARN deprecated' 'Deprecated dependencies must be updated.'
+# TODO: fail the CI job
+# || { echo ''; exit 1; }

--- a/buildspec/shared/linux-pre_build.sh
+++ b/buildspec/shared/linux-pre_build.sh
@@ -21,6 +21,5 @@ if [ "$TOOLKITS_CODEARTIFACT_DOMAIN" ] && [ "$TOOLKITS_CODEARTIFACT_REPO" ] && [
 fi
 
 # TODO: move this to the "install" phase?
-npm 2>&1 ci | run_and_report 'npm WARN deprecated' 'Deprecated dependencies must be updated.'
-# TODO: fail the CI job
-# || { echo ''; exit 1; }
+npm 2>&1 ci | run_and_report 'npm WARN deprecated' 'Deprecated dependencies must be updated.' \
+    || true # TODO: fail the CI job


### PR DESCRIPTION
## Problem:
Deprecated dependencies may not be noticed for a long time.

    npm WARN deprecated querystring@0.2.0: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
    npm WARN deprecated winston@3.7.1: Please use version 3.6.0 or >3.7.1 when available due to https://github.com/winstonjs/winston/issues/2103

## Solution:
Collect these warnings when running CI.
TODO: fail if new warnings are found.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
