### PR TITLE
fix(tests): "SchemaService.isMapped was called uninitialized"

### DIFF
--- a/src/test/dynamicResources/awsResourceManager.test.ts
+++ b/src/test/dynamicResources/awsResourceManager.test.ts
@@ -56,8 +56,10 @@ describe('ResourceManager', function () {
         cloudFormation = stub(DefaultCloudFormationClient, {
             regionCode: '',
         })
-        schemaService = stub(SchemaService)
-        schemaService.registerMapping = sinon.stub()
+        schemaService = stub(SchemaService, {
+            registerMapping: sinon.stub(),
+            isMapped: sinon.stub(),
+        })
         sandbox = sinon.createSandbox()
         mockClients()
         tempFolder = await makeTemporaryToolkitFolder()


### PR DESCRIPTION
# Problem:
Since ca3dc32b2db9, `globals.schemaService` is temporarily stubbed in `awsResourceManager.test.ts`. Those tests open some filetypes that are handled by `awsFiletypes.ts`, which tries to process them by calling `SchemaService.isMapped`.

    rejected promise not handled within 1 second: TypeError: SchemaService.isMapped was called uninitialized.
    stack trace: TypeError: SchemaService.isMapped was called uninitialized.
        at Proxy.<anonymous> (d:\a\aws-toolkit-vscode\aws-toolkit-vscode\src\test\utilities\stubber.ts:48:27)
        at Object.invoke (d:\a\aws-toolkit-vscode\aws-toolkit-vscode\node_modules\sinon\lib\sinon\behavior.js:177:32)
        ...
        at f.value (d:\a\aws-toolkit-vscode\aws-toolkit-vscode\src\shared\awsFiletypes.ts:69:59)

# Solution:
Stub `isMapped`. The value that it returns isn't important because the tests aren't testing behavior of `awsFiletypes.ts`.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
