### PR TITLE
codewhisperer: add action to customization notification 

### DIFF
--- a/.changes/next-release/Feature-9c583c77-3b07-4c5e-b5c2-ba32b9d29963.json
+++ b/.changes/next-release/Feature-9c583c77-3b07-4c5e-b5c2-ba32b9d29963.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "CodeWhisperer: add select customization action to notification"
+}

--- a/src/codewhisperer/util/customizationUtil.ts
+++ b/src/codewhisperer/util/customizationUtil.ts
@@ -315,12 +315,20 @@ export const getAvailableCustomizationsList = async () => {
 // show notification that selected customization is not available, switching back to base
 export const switchToBaseCustomizationAndNotify = async () => {
     await setSelectedCustomization(baseCustomization)
-    void vscode.window.showInformationMessage(
+    const selectCustomizationLabel = localize(
+        'AWS.codewhisperer.customization.notification.selectCustomization',
+        'Select Another Customization'
+    )
+    const selection = await vscode.window.showWarningMessage(
         localize(
             'AWS.codewhisperer.customization.notification.selected_customization_not_available',
             'Selected CodeWhisperer customization is not available. Contact your administrator. Your instance of CodeWhisperer is using the foundation model.'
-        )
+        ),
+        selectCustomizationLabel
     )
+    if (selection === selectCustomizationLabel) {
+        await showCustomizationPrompt()
+    }
 }
 
 const renderDescriptionText = (label: string, isNewCustomization: boolean = false) => {


### PR DESCRIPTION
## Problem
when user's selected customization is no longer available, we want to prompt them to select a new one

## Solution
add action to the notification, and make it a warning instead of info

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
