### PR TITLE
feat(commands): disable 'View Quick Start' command for non-cloud9 instances

### DIFF
--- a/.changes/next-release/Removal-626942e3-aa4b-43c5-a198-0f22bce19919.json
+++ b/.changes/next-release/Removal-626942e3-aa4b-43c5-a198-0f22bce19919.json
@@ -1,0 +1,4 @@
+{
+	"type": "Removal",
+	"description": "Commands: Remove redundant 'View Quick Start' command from appearing in non-Cloud9 versions of the toolkit."
+}

--- a/package.json
+++ b/package.json
@@ -2190,6 +2190,7 @@
             "aws.submenu.help": [
                 {
                     "command": "aws.quickStart",
+                    "when": "isCloud9",
                     "group": "1_help@1"
                 },
                 {
@@ -3162,6 +3163,7 @@
                 "command": "aws.quickStart",
                 "title": "%AWS.command.quickStart%",
                 "category": "%AWS.title%",
+                "enablement": "isCloud9",
                 "cloud9": {
                     "cn": {
                         "category": "%AWS.title.cn%"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,6 +111,15 @@ export async function activate(context: vscode.ExtensionContext) {
 
     if (isCloud9()) {
         vscode.window.withProgress = wrapWithProgressForCloud9(globals.outputChannel)
+        context.subscriptions.push(
+            Commands.register('aws.quickStart', async () => {
+                try {
+                    await showQuickStartWebview(context)
+                } finally {
+                    telemetry.aws_helpQuickstart.emit({ result: 'Succeeded' })
+                }
+            })
+        )
     }
 
     try {
@@ -178,16 +187,7 @@ export async function activate(context: vscode.ExtensionContext) {
         }
 
         registerCommands(context)
-        context.subscriptions.push(
-            Commands.register('aws.quickStart', async () => {
-                try {
-                    await showQuickStartWebview(context)
-                } finally {
-                    telemetry.aws_helpQuickstart.emit({ result: 'Succeeded' })
-                }
-            }),
-            submitFeedback.register(context)
-        )
+        context.subscriptions.push(submitFeedback.register(context))
 
         // do not enable codecatalyst for sagemaker
         // TODO: remove setContext if SageMaker adds the context to their IDE


### PR DESCRIPTION
Problem: 'View Quick Start` command is redundant- it is the same as the marketplace page users see when they install the plugin.

Solution: Remove this command from appearing in non-Cloud9 instances. Users who use Cloud9 would generally not have installed the toolkit themselves, so displaying a guide for the provided plugin may be helpful.

#### Testing
Tested in regular and C9 instances.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
