### PR TITLE
fix(testInteg): "sync skip; aborting execution"

### DIFF
--- a/src/testInteg/codewhisperer/e2e/referenceTracker.test.ts
+++ b/src/testInteg/codewhisperer/e2e/referenceTracker.test.ts
@@ -52,8 +52,8 @@ describe('CodeWhisperer service invocation', async function () {
         validConnection = await setValidConnection()
     })
 
-    beforeEach(async function () {
-        await resetCodeWhispererGlobalVariables()
+    beforeEach(function () {
+        void resetCodeWhispererGlobalVariables()
         RecommendationHandler.instance.clearRecommendations()
         //TODO: remove this line (this.skip()) when these tests no longer auto-skipped
         this.skip()

--- a/src/testInteg/codewhisperer/e2e/securityScan.test.ts
+++ b/src/testInteg/codewhisperer/e2e/securityScan.test.ts
@@ -56,8 +56,8 @@ describe('CodeWhisperer security scan', async function () {
         validConnection = await setValidConnection()
     })
 
-    beforeEach(async function () {
-        await resetCodeWhispererGlobalVariables()
+    beforeEach(function () {
+        void resetCodeWhispererGlobalVariables()
         //valid connection required to run tests
         skiptTestIfNoValidConn(validConnection, this)
     })

--- a/src/testInteg/codewhisperer/e2e/serviceInvocations.test.ts
+++ b/src/testInteg/codewhisperer/e2e/serviceInvocations.test.ts
@@ -35,8 +35,8 @@ describe('CodeWhisperer service invocation', async function () {
         validConnection = await setValidConnection()
     })
 
-    beforeEach(async function () {
-        await resetCodeWhispererGlobalVariables()
+    beforeEach(function () {
+        void resetCodeWhispererGlobalVariables()
         RecommendationHandler.instance.clearRecommendations()
         //valid connection required to run tests
         skiptTestIfNoValidConn(validConnection, this)


### PR DESCRIPTION
# Problem:
Since 65e65fcaf3be, integ tests fail with weird symptom:

    CodeWhisperer security scan
      "before each" hook for "codescan request for file in unsupported language fails to generate dependency graph and causes scan setup to fail":
    sync skip; aborting execution

    CodeWhisperer service invocation
      "before each" hook for "invocation in unsupported language does not generate a request":
    sync skip; aborting execution

Seems like a race condition, or maybe a quirk of Mocha:
- With `beforeEach(async function…`, the Mocha test runner fails with the above message.
- With non-async `beforeEach(function…`, Mocha seems happy and reports  the test as skipped, without failing the run.

# Solution:
- To unblock CI in the near-term, use `void resetCodeWhispererGlobalVariables()`  instead of trying to properly await it.
- Create a backlog issue for the CW team to move these tests into  `testE2E/` so that the `skiptTestIfNoValidConn()` hack is not needed.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
