### PR TITLE
ci: fail on "rejected promise not handled"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,11 +176,11 @@ To run a single test in VSCode, do any one of:
 
     -   Unix/macOS/POSIX shell:
         ```
-        TEST_FILE=src/test/foo.test npm run test
+        TEST_FILE=src/test/foo.test.ts npm run test
         ```
     -   Powershell:
         ```
-        $Env:TEST_FILE = "src/test/foo.test"; npm run test
+        $Env:TEST_FILE = "src/test/foo.test.ts"; npm run test
         ```
 
 -   To run all tests in a particular subdirectory, you can edit

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -36,7 +36,7 @@ phases:
                     # Ensure that "foo | run_and_report" fails correctly.
                     set -o pipefail
                     . buildspec/shared/common.sh
-                    2>&1 xvfb-run npm test --silent | run_and_report \
+                    2>&1 xvfb-run npm test --silent | run_and_report 2 \
                         'rejected promise not handled' \
                         'This typically indicates a bug. Read https://developer.mozilla.org/docs/Web/JavaScript/Guide/Using_promises#error_handling'
                 }

--- a/buildspec/shared/common.sh
+++ b/buildspec/shared/common.sh
@@ -1,32 +1,48 @@
+#!/bin/env bash
+
 # Common functions used by other CI scripts.
 # "Include" this file by sourcing (not executing) it:
 #     . buildspec/shared/common.sh
 
+# Ignore these patterns when deciding if the build should fail.
+#   - "waiting for browser": from `ssoAccessTokenProvider.test.ts`, unclear how to fix it.
+#   - "Webview is disposed": only happens on vscode "minimum" (1.68.0)
+#   - "HTTPError: Response code …": caused by github rate-limiting.
+_ignore_pat='Timed-out waiting for browser login flow\|HTTPError: Response code 403\|HTTPError: Response code 404'
+if [ "$VSCODE_TEST_VERSION" = 'minimum' ]; then
+    _ignore_pat="$_ignore_pat"'\|Webview is disposed'
+fi
+
 # Expects stdin + two args:
-#   1: grep pattern
-#   2: message shown at end of report, if pattern was found in stdin.
+#   1: error code to return on failure
+#   2: grep pattern
+#   3: message shown at end of report, if pattern was found in stdin.
 # Usage:
-#   echo foo | run_and_report '.*' 'You must fix this. See https://example.com'
+#   echo foo | run_and_report 1 '.*' 'You must fix this. See https://example.com'
 run_and_report() {
     set -o pipefail
-    local pat="${1}"
-    local msg="${2}"
+    local errcode="${1}"
+    local pat="${2}"
+    local msg="${3}"
     local r=0
     mkfifo testout
     (cat testout &)
     # Capture messages that we may want to fail (or report) later.
     tee testout \
         | { grep > testout-err --line-buffered -E "$pat" || true; }
+
     echo ''
-    if grep "$pat" testout-err | sort; then
-        printf '\nERROR: Found %s "%s" in test output (see above).\n%s\n\n' \
-            "$(grep "${pat}" testout-err | wc -l | tr -d ' ')" \
+
+    if grep -v "${_ignore_pat}" testout-err | grep "$pat" | sort; then
+        printf '\nERROR: Test output matched this pattern %s times:\n       "%s"\n%s\n\n' \
+            "$(grep -c "${pat}" testout-err)" \
             "$pat" \
             "       ${msg}"
-        # TODO: fail the CI job
-        # r=1
-        r=0
+        r=${errcode}
+    else
+        printf '\nOK: Not found in test output: "%s"\n' "$pat"
     fi
+
     rm -f testout testout-err
     return "$r"
 }

--- a/buildspec/shared/linux-pre_build.sh
+++ b/buildspec/shared/linux-pre_build.sh
@@ -22,4 +22,5 @@ if [ "$TOOLKITS_CODEARTIFACT_DOMAIN" ] && [ "$TOOLKITS_CODEARTIFACT_REPO" ] && [
 fi
 
 # TODO: move this to the "install" phase?
-npm 2>&1 ci | run_and_report 'npm WARN deprecated' 'Deprecated dependencies must be updated.'
+# TODO: fail in CI
+npm 2>&1 ci | run_and_report 0 'npm WARN deprecated' 'Deprecated dependencies must be updated.'

--- a/src/auth/connection.ts
+++ b/src/auth/connection.ts
@@ -300,6 +300,10 @@ export async function* loadLinkedProfilesIntoStore(
 
     const stream = client
         .listAccounts()
+        .catch(e => {
+            getLogger().error('listAccounts() failed: %s', (e as Error).message)
+            return []
+        })
         .flatten()
         .map(resp => {
             accounts.add(resp.accountId)

--- a/src/codewhisperer/commands/basicCommands.ts
+++ b/src/codewhisperer/commands/basicCommands.ts
@@ -135,7 +135,7 @@ export const showTransformByQ = Commands.declare(
                 passive: false,
             })
         }
-        await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
+        await Commands.tryExecute('aws.codeWhisperer.refresh')
     }
 )
 

--- a/src/codewhisperer/util/authUtil.ts
+++ b/src/codewhisperer/util/authUtil.ts
@@ -93,9 +93,9 @@ export class AuthUtil {
             return
         }
         this._isCustomizationFeatureEnabled = value
-        void vscode.commands.executeCommand('aws.codeWhisperer.refresh')
+        void Commands.tryExecute('aws.codeWhisperer.refresh')
         void Commands.tryExecute('aws.amazonq.refresh')
-        void vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar')
+        void Commands.tryExecute('aws.codeWhisperer.refreshStatusBar')
     }
 
     public readonly secondaryAuth = getSecondaryAuth(
@@ -332,11 +332,11 @@ export class AuthUtil {
 
     public async refreshCodeWhisperer() {
         await Promise.all([
-            vscode.commands.executeCommand('aws.codeWhisperer.refresh'),
-            vscode.commands.executeCommand('aws.codeWhisperer.refreshRootNode'),
+            Commands.tryExecute('aws.codeWhisperer.refresh'),
+            Commands.tryExecute('aws.codeWhisperer.refreshRootNode'),
             Commands.tryExecute('aws.amazonq.refresh'),
-            vscode.commands.executeCommand('aws.amazonq.refreshRootNode'),
-            vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar'),
+            Commands.tryExecute('aws.amazonq.refreshRootNode'),
+            Commands.tryExecute('aws.codeWhisperer.refreshStatusBar'),
         ])
     }
 

--- a/src/codewhisperer/util/customizationUtil.ts
+++ b/src/codewhisperer/util/customizationUtil.ts
@@ -23,6 +23,7 @@ import { codicon, getIcon } from '../../shared/icons'
 import { getLogger } from '../../shared/logger'
 import { showMessageWithUrl } from '../../shared/utilities/messages'
 import { parse } from '@aws-sdk/util-arn-parser'
+import { Commands } from '../../shared/vscode/commands2'
 
 /**
  *
@@ -118,8 +119,8 @@ export const setSelectedCustomization = async (customization: Customization) => 
     getLogger().debug(`Selected customization ${customization.name} for ${AuthUtil.instance.conn.label}`)
 
     await set(selectedCustomizationKey, selectedCustomizationObj, globals.context.globalState)
-    await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
-    await vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar')
+    await Commands.tryExecute('aws.codeWhisperer.refresh')
+    await Commands.tryExecute('aws.codeWhisperer.refreshStatusBar')
 }
 
 export const getPersistedCustomizations = (): Customization[] => {
@@ -147,7 +148,7 @@ export const getNewCustomizationAvailable = () => {
 
 export const setNewCustomizationAvailable = async (available: boolean) => {
     await set(newCustomizationAvailableKey, available, globals.context.globalState)
-    await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
+    await Commands.tryExecute('aws.codeWhisperer.refresh')
 }
 
 export async function showCustomizationPrompt() {

--- a/src/codewhisperer/util/getStartUrl.ts
+++ b/src/codewhisperer/util/getStartUrl.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as vscode from 'vscode'
 import * as CodeWhispererConstants from '../models/constants'
 import { isValidResponse } from '../../shared/wizards/wizard'
 import { AuthUtil, amazonQScopes } from './authUtil'
@@ -35,7 +34,7 @@ export async function connectToEnterpriseSso(startUrl: string, region: Region['i
             code: 'FailedToConnect',
         })
     }
-    await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
+    await Commands.tryExecute('aws.codeWhisperer.refresh')
     await Commands.tryExecute('aws.amazonq.refresh')
-    await vscode.commands.executeCommand('aws.codeWhisperer.enableCodeSuggestions')
+    await Commands.tryExecute('aws.codeWhisperer.enableCodeSuggestions')
 }

--- a/src/codewhisperer/util/showSsoPrompt.ts
+++ b/src/codewhisperer/util/showSsoPrompt.ts
@@ -52,9 +52,9 @@ export async function awsIdSignIn() {
     } catch (e) {
         throw ToolkitError.chain(e, failedToConnectAwsBuilderId, { code: 'FailedToConnect' })
     }
-    await vscode.commands.executeCommand('aws.codeWhisperer.refresh')
+    await Commands.tryExecute('aws.codeWhisperer.refresh')
     await Commands.tryExecute('aws.amazonq.refresh')
-    await vscode.commands.executeCommand('aws.codeWhisperer.enableCodeSuggestions')
+    await Commands.tryExecute('aws.codeWhisperer.enableCodeSuggestions')
 }
 
 export const createCodeWhispererIamItem = () => {

--- a/src/shared/vscode/commands2.ts
+++ b/src/shared/vscode/commands2.ts
@@ -154,7 +154,10 @@ export class Commands {
             getLogger().debug('command not found: "%s"', id)
             return undefined
         }
-        return this.commands.executeCommand<ReturnType<T>>(id, ...args)
+        return this.commands.executeCommand<ReturnType<T>>(id, ...args)?.then(undefined, (e: Error) => {
+            getLogger().warn('command failed (not registered?): "%s"', id)
+            return undefined
+        })
     }
 
     /** See {@link Commands.register}. */

--- a/src/test/codewhisperer/commands/startSecurityScan.test.ts
+++ b/src/test/codewhisperer/commands/startSecurityScan.test.ts
@@ -7,6 +7,7 @@ import assert from 'assert'
 import * as vscode from 'vscode'
 import * as sinon from 'sinon'
 import * as got from 'got'
+import * as semver from 'semver'
 import { DefaultCodeWhispererClient } from '../../../codewhisperer/client/codewhisperer'
 import * as startSecurityScan from '../../../codewhisperer/commands/startSecurityScan'
 import { SecurityPanelViewProvider } from '../../../codewhisperer/views/securityPanelViewProvider'
@@ -251,6 +252,9 @@ describe('startSecurityScan', function () {
     })
 
     it('Should highlight files after scan is completed', async function () {
+        if (semver.lt(vscode.version, '1.78.0')) {
+            this.skip()
+        }
         const commandSpy = sinon.spy(vscode.commands, 'executeCommand')
         sinon.stub(got, 'default').resolves({ statusCode: 200 })
         const testWindow = getTestWindow()

--- a/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
+++ b/src/test/credentials/sso/ssoAccessTokenProvider.test.ts
@@ -237,6 +237,13 @@ describe('SsoAccessTokenProvider', function () {
         })
 
         it('respects the device authorization expiration time', async function () {
+            // XXX: Don't know how to fix this "unhandled rejection" caused by this test:
+            //      rejected promise not handled within 1 second: Error: Timed-out waiting for browser login flow to complete
+            //          at poll (…/src/auth/sso/ssoAccessTokenProvider.ts:251:15)
+            //          at async SsoAccessTokenProvider.authorize (…/src/auth/sso/ssoAccessTokenProvider.ts:188:23)
+            //          at async SsoAccessTokenProvider.runFlow (…/src/auth/sso/ssoAccessTokenProvider.ts:113:20)
+            //          at async SsoAccessTokenProvider.createToken (…/src/auth/sso/ssoAccessTokenProvider.ts:102:24)
+
             setupFlow()
             stubOpen()
             const exception = new AuthorizationPendingException({ message: '', $metadata: {} })

--- a/src/test/s3/util/fileViewerManager.test.ts
+++ b/src/test/s3/util/fileViewerManager.test.ts
@@ -204,6 +204,9 @@ describe('FileViewerManager', function () {
         })
 
         disposables = registerFileSystemProviders()
+
+        const bigImageFile = makeFile('big-image.jpg', Buffer.from('fake image', 'utf-8'))
+        s3.addFile(bigImageFile)
     })
 
     afterEach(async function () {


### PR DESCRIPTION
# Problem:
rejected promises in test logs are silently ignored:

    rejected promise not handled within 1 second: Error: command 'aws.codeWhisperer.refresh' not found

# Solution:
- Fix various cases (see commits).
- Enable CI failure for `run_and_report`.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
