### PR TITLE
feat(appcomposer): prompt for IAM credentials

### DIFF
--- a/.changes/next-release/Bug Fix-acaea338-3c74-41b5-b09a-839806679551.json
+++ b/.changes/next-release/Bug Fix-acaea338-3c74-41b5-b09a-839806679551.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Add invalid auth handling to Application Composer's Sync button"
+}

--- a/src/applicationcomposer/messageHandlers/deployMessageHandler.ts
+++ b/src/applicationcomposer/messageHandlers/deployMessageHandler.ts
@@ -7,6 +7,45 @@ import vscode from 'vscode'
 import { Command, DeployRequestMessage, DeployResponseMessage, MessageType, WebviewContext } from '../types'
 import { SamSyncResult } from '../../shared/sam/sync'
 import { telemetry } from '../../shared/telemetry/telemetry'
+import { Auth } from '../../auth/auth'
+import { promptAndUseConnection } from '../../auth/utils'
+import { StatefulConnection } from '../../auth/connection'
+import * as nls from 'vscode-nls'
+import { showMessageWithUrl } from '../../shared/utilities/messages'
+import { credentialHelpUrl } from '../../shared/constants'
+
+const localize = nls.loadMessageBundle()
+
+async function promptReauth(connection?: StatefulConnection) {
+    let errorMessage = localize(
+        'aws.applicationComposer.deploy.authModal.message',
+        'Syncing requires authentication with IAM credentials.'
+    )
+    if (connection?.state === 'valid') {
+        errorMessage =
+            localize(
+                'aws.applicationComposer.deploy.authModal.invalidAuth',
+                'Authentication through Builder ID or IAM Identity Center detected. '
+            ) + errorMessage
+    }
+    const acceptMessage = localize(
+        'aws.applicationComposer.deploy.authModal.accept',
+        'Authenticate with IAM credentials'
+    )
+    const docMessage = localize('aws.applicationComposer.deploy.authModal.docLink', 'Open documentation')
+    const modalResponse = await showMessageWithUrl(
+        errorMessage,
+        credentialHelpUrl,
+        docMessage,
+        'info',
+        [acceptMessage],
+        true
+    )
+    if (modalResponse !== acceptMessage) {
+        return
+    }
+    await promptAndUseConnection(Auth.instance, 'iam-only')
+}
 
 export async function deployMessageHandler(message: DeployRequestMessage, context: WebviewContext) {
     // SAM already handles success/failure, so we only log that the user clicked the deploy button
@@ -19,6 +58,21 @@ export async function deployMessageHandler(message: DeployRequestMessage, contex
      * so we instead check for an undefined response to determine failure. The downside is that
      * we don't get failure reasons.
      */
+    let connection = Auth.instance.activeConnection
+    if (connection?.type !== 'iam' || connection?.state !== 'valid') {
+        await promptReauth(connection)
+        connection = Auth.instance.activeConnection
+        if (connection?.type !== 'iam' || connection?.state !== 'valid') {
+            const response: DeployResponseMessage = {
+                command: Command.DEPLOY,
+                messageType: MessageType.RESPONSE,
+                eventId: message.eventId,
+                isSuccess: false,
+            }
+            await context.panel.webview.postMessage(response)
+            return
+        }
+    }
     const result = (await vscode.commands.executeCommand('aws.samcli.sync', args, false)) as SamSyncResult
     if (result?.isSuccess) {
         void vscode.window.showInformationMessage('SAM Sync succeeded!')

--- a/src/applicationcomposer/webviewManager.ts
+++ b/src/applicationcomposer/webviewManager.ts
@@ -106,7 +106,7 @@ export class ApplicationComposerManager {
     protected handleErr(err: Error): void {
         void vscode.window.showInformationMessage(
             localize(
-                'AWS.applicationcomposer.visualisation.errors.rendering',
+                'AWS.applicationComposer.visualisation.errors.rendering',
                 'There was an error rendering Application Composer, check logs for details.'
             )
         )

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -53,6 +53,8 @@ import { isValidCodeWhispererCoreConnection } from '../codewhisperer/util/authUt
 // TODO: Look to do some refactoring to handle circular dependency later and move this to ./commands.ts
 export const showConnectionsPageCommand = 'aws.auth.manageConnections'
 
+// iam-only excludes Builder ID and IAM Identity Center from the list of valid connections
+// TODO: Understand if "iam" should include these from the list at all
 export async function promptForConnection(auth: Auth, type?: 'iam' | 'iam-only' | 'sso'): Promise<Connection | void> {
     const resp = await createConnectionPrompter(auth, type).prompt()
     if (!isValidResponse(resp)) {

--- a/src/shared/sam/sync.ts
+++ b/src/shared/sam/sync.ts
@@ -45,7 +45,7 @@ import { samSyncUrl, samInitDocUrl, samUpgradeUrl, credentialHelpUrl } from '../
 import { getAwsConsoleUrl } from '../awsConsole'
 import { openUrl } from '../utilities/vsCodeUtils'
 import { showMessageWithUrl, showOnce } from '../utilities/messages'
-import { IamConnection, StatefulConnection } from '../../auth/connection'
+import { IamConnection } from '../../auth/connection'
 import { CloudFormationTemplateRegistry } from '../fs/templateRegistry'
 import { promptAndUseConnection } from '../../auth/utils'
 

--- a/src/shared/sam/sync.ts
+++ b/src/shared/sam/sync.ts
@@ -41,12 +41,13 @@ import { parse } from 'semver'
 import { isAutomation } from '../vscode/env'
 import { getOverriddenParameters } from '../../lambda/config/parameterUtils'
 import { addTelemetryEnvVar } from './cli/samCliInvokerUtils'
-import { samSyncUrl, samInitDocUrl, samUpgradeUrl } from '../constants'
+import { samSyncUrl, samInitDocUrl, samUpgradeUrl, credentialHelpUrl } from '../constants'
 import { getAwsConsoleUrl } from '../awsConsole'
 import { openUrl } from '../utilities/vsCodeUtils'
-import { showOnce } from '../utilities/messages'
-import { IamConnection } from '../../auth/connection'
+import { showMessageWithUrl, showOnce } from '../utilities/messages'
+import { IamConnection, StatefulConnection } from '../../auth/connection'
 import { CloudFormationTemplateRegistry } from '../fs/templateRegistry'
+import { promptAndUseConnection } from '../../auth/utils'
 
 const localize = nls.loadMessageBundle()
 
@@ -535,6 +536,34 @@ export type SamSyncResult = {
     isSuccess: boolean
 }
 
+async function promptReauth(connection?: StatefulConnection) {
+    let errorMessage = localize(
+        'aws.sam.sync.authModal.message',
+        'Syncing requires authentication with IAM credentials.'
+    )
+    if (connection?.state === 'valid') {
+        errorMessage =
+            localize(
+                'aws.sam.sync.authModal.invalidAuth',
+                'Authentication through Builder ID or IAM Identity Center detected. '
+            ) + errorMessage
+    }
+    const acceptMessage = localize('aws.sam.sync.authModal.accept', 'Authenticate with IAM credentials')
+    const docMessage = localize('aws.sam.sync.authModal.docLink', 'Open documentation')
+    const modalResponse = await showMessageWithUrl(
+        errorMessage,
+        credentialHelpUrl,
+        docMessage,
+        'info',
+        [acceptMessage],
+        true
+    )
+    if (modalResponse !== acceptMessage) {
+        return
+    }
+    await promptAndUseConnection(Auth.instance, 'iam-only')
+}
+
 export function registerSync() {
     async function runSync(
         deployType: SyncParams['deployType'],
@@ -543,9 +572,15 @@ export function registerSync() {
     ): Promise<SamSyncResult> {
         telemetry.record({ syncedResources: deployType === 'infra' ? 'AllResources' : 'CodeOnly' })
 
-        const connection = Auth.instance.activeConnection
-        if (connection?.type !== 'iam') {
-            throw new ToolkitError('Syncing SAM applications requires IAM credentials', { code: 'NoIAMCredentials' })
+        let connection = Auth.instance.activeConnection
+        if (connection?.type !== 'iam' || connection?.state !== 'valid') {
+            await promptReauth(connection)
+            connection = Auth.instance.activeConnection
+            if (connection?.type !== 'iam' || connection?.state !== 'valid') {
+                throw new ToolkitError('Syncing SAM applications requires IAM credentials', {
+                    code: 'NoIAMCredentials',
+                })
+            }
         }
 
         // Constructor of `vscode.Uri` is marked private but that shouldn't matter when checking the instance type

--- a/src/shared/utilities/messages.ts
+++ b/src/shared/utilities/messages.ts
@@ -35,16 +35,17 @@ export function makeFailedWriteMessage(filename: string): string {
 function showMessageWithItems(
     message: string,
     kind: 'info' | 'warn' | 'error' = 'error',
-    items: string[] = []
+    items: string[] = [],
+    useModal: boolean = false
 ): Thenable<string | undefined> {
     switch (kind) {
         case 'info':
-            return vscode.window.showInformationMessage(message, ...items)
+            return vscode.window.showInformationMessage(message, { modal: useModal }, ...items)
         case 'warn':
-            return vscode.window.showWarningMessage(message, ...items)
+            return vscode.window.showWarningMessage(message, { modal: useModal }, ...items)
         case 'error':
         default:
-            return vscode.window.showErrorMessage(message, ...items)
+            return vscode.window.showErrorMessage(message, { modal: useModal }, ...items)
     }
 }
 
@@ -56,6 +57,7 @@ function showMessageWithItems(
  * @param urlItem URL button text (default: "View Documentation")
  * @param kind  Kind of message to show
  * @param extraItems  Extra buttons shown _before_ the "View Documentation" button
+ * @param useModal Flag to use a modal instead of a toast notification
  * @returns Promise that resolves when a button is clicked or the message is
  * dismissed, and returns the selected button text.
  */
@@ -64,12 +66,13 @@ export async function showMessageWithUrl(
     url: string | vscode.Uri,
     urlItem: string = localizedText.viewDocs,
     kind: 'info' | 'warn' | 'error' = 'error',
-    extraItems: string[] = []
+    extraItems: string[] = [],
+    useModal: boolean = false
 ): Promise<string | undefined> {
     const uri = typeof url === 'string' ? vscode.Uri.parse(url) : url
     const items = [...extraItems, urlItem]
 
-    const p = showMessageWithItems(message, kind, items)
+    const p = showMessageWithItems(message, kind, items, useModal)
     return p.then<string | undefined>(selection => {
         if (selection === urlItem) {
             void openUrl(uri)


### PR DESCRIPTION
## Problem
 The built-in SAM Sync functionality provides an ambiguous error message when the user is signed in with SSO or Builder ID. The only supported form of authentication is IAM credentials. Otherwise, when the user attempts to sync, they will get this error message:

![image](https://github.com/aws/aws-toolkit-vscode/assets/65189184/4f581a64-5564-4fbb-bb90-582cb68a1c21)

This can be confusing to the user, especially if they are using IAM Identity Center for authentication.

## Solution
This adds a modal to inform the user that their current form of authentication (or lack of authentication) is not supported by SAM Sync and provides a straightforward way to switch to IAM credential authentication.

![Screenshot 2024-01-17 at 1 12 25 PM](https://github.com/aws/aws-toolkit-vscode/assets/65189184/005dbc2d-e2c7-4c59-8b29-af6e3ff02b56)

Under the new flow, if the user chooses to authenticate with IAM credentials, the user will get a quick pick menu to choose from a list of valid credentials (including all IAM credentials, but excluding SSO and Builder ID). Once selected, the sync flow will continue as normal.

Ideally, the `sam sync` workflow should support all forms of authentication. Until this is supported, this new flow helps guide the user to a working form of authentication rather than using an unhelpful error message.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
