### PR TITLE
fix(tests): "rejected promise … AssertionError"

### DIFF
--- a/src/test/codewhisperer/service/keyStrokeHandler.test.ts
+++ b/src/test/codewhisperer/service/keyStrokeHandler.test.ts
@@ -101,10 +101,11 @@ describe('keyStrokeHandler', function () {
 
         it('Should skip invoking if there is immediate right context on the same line and not a single }', async function () {
             const casesForSuppressTokenFilling = [
-                {
-                    rightContext: 'add',
-                    shouldInvoke: false,
-                },
+                // TODO: temporarily disabling this test until Zoe can fix it.
+                // {
+                //     rightContext: 'add',
+                //     shouldInvoke: false,
+                // },
                 {
                     rightContext: '}',
                     shouldInvoke: true,
@@ -134,9 +135,10 @@ describe('keyStrokeHandler', function () {
                     shouldInvoke: true,
                 },
             ]
-            casesForSuppressTokenFilling.forEach(async ({ rightContext, shouldInvoke }) => {
-                await testShouldInvoke('{', shouldInvoke, rightContext)
-            })
+
+            for (const o of casesForSuppressTokenFilling) {
+                await testShouldInvoke('{', o.shouldInvoke, o.rightContext)
+            }
         })
 
         async function testShouldInvoke(
@@ -153,7 +155,11 @@ describe('keyStrokeHandler', function () {
             )
             CodeWhispererUserGroupSettings.instance.userGroup = userGroup
             await KeyStrokeHandler.instance.processKeyStroke(mockEvent, mockEditor, mockClient, config)
-            assert.strictEqual(invokeSpy.called, shouldTrigger)
+            assert.strictEqual(
+                invokeSpy.called,
+                shouldTrigger,
+                `invokeAutomatedTrigger ${shouldTrigger ? 'NOT' : 'WAS'} called for rightContext: "${rightContext}"`
+            )
         }
     })
 

--- a/src/test/codewhisperer/service/keyStrokeHandler.test.ts
+++ b/src/test/codewhisperer/service/keyStrokeHandler.test.ts
@@ -101,11 +101,10 @@ describe('keyStrokeHandler', function () {
 
         it('Should skip invoking if there is immediate right context on the same line and not a single }', async function () {
             const casesForSuppressTokenFilling = [
-                // TODO: temporarily disabling this test until Zoe can fix it.
-                // {
-                //     rightContext: 'add',
-                //     shouldInvoke: false,
-                // },
+                {
+                    rightContext: 'add',
+                    shouldInvoke: false,
+                },
                 {
                     rightContext: '}',
                     shouldInvoke: true,
@@ -147,7 +146,7 @@ describe('keyStrokeHandler', function () {
             rightContext: string = '',
             userGroup: CodeWhispererConstants.UserGroup = CodeWhispererConstants.UserGroup.Control
         ) {
-            const mockEditor = createMockTextEditor(rightContext, 'test.js', 'javascript')
+            const mockEditor = createMockTextEditor(rightContext, 'test.js', 'javascript', 0, 0)
             const mockEvent: vscode.TextDocumentChangeEvent = createTextDocumentChangeEvent(
                 mockEditor.document,
                 new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)),


### PR DESCRIPTION
# Problem:
Unhandled promise rejections in test logs:

    rejected promise not handled within 1 second: AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
    true !== false

        at testShouldInvoke (/codebuild/output/src4225802595/src/github.com/aws/aws-toolkit-vscode/src/test/codewhisperer/service/keyStrokeHandler.test.ts:156:20)
        at async /codebuild/output/src4225802595/src/github.com/aws/aws-toolkit-vscode/src/test/codewhisperer/service/keyStrokeHandler.test.ts:138:17

The test failure was NOT failing CI because the unhandled rejection was silently missed.

# Solution:
Fix the for-loop to `await` correctly.

Now the test fails correctly:

```
  1 failing
  1) keyStrokeHandler
       processKeyStroke
         Should skip invoking if there is immediate right context on the same line and not a single }:

      AssertionError [ERR_ASSERTION]: invokeAutomatedTrigger WAS called for rightContext: add
      + expected - actual

      -true
      +false
```

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
