### PR TITLE
fix(gumby): surround path with double quotes

### DIFF
--- a/src/codewhisperer/service/transformByQHandler.ts
+++ b/src/codewhisperer/service/transformByQHandler.ts
@@ -110,7 +110,7 @@ export async function validateProjectSelection(project: vscode.QuickPickItem) {
         })
         throw new TransformByQJavaProjectNotFound()
     }
-    const classFilePath = compiledJavaFiles[0].fsPath
+    const classFilePath = `"${compiledJavaFiles[0].fsPath}"`
     const baseCommand = 'javap'
     const args = ['-v', classFilePath]
     const spawnResult = spawnSync(baseCommand, args, { shell: true, encoding: 'utf-8' })


### PR DESCRIPTION
## Problem

A PR which was very recently merged () set `shell: true` for a shell command we run to determine the Java version of a user's project (this was necessary to resolve a customer issue). An unintended side effect of this recent change is that paths containing spaces in them are not handled properly.

## Solution

Surround the path with double quotes before running the shell command.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
