### PR TITLE
fix: missing dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,22 +6,28 @@ updates:
     - package-ecosystem: 'npm'
       directory: '/' # Location of package manifests.
       target-branch: 'master' # Avoid updates to "staging".
+      commit-message:
+          prefix: 'deps'
       schedule:
           interval: 'daily'
+      allow:
+          - dependency-name: '*'
       groups:
           aws-sdk:
-              dependency-type: 'production'
               patterns:
                   - '@aws-sdk/*'
           vscode-lsp:
-              dependency-type: 'production'
               patterns:
                   - 'vscode-lang*'
     - package-ecosystem: 'github-actions'
       directory: '/'
       target-branch: 'master' # Avoid updates to "staging".
+      commit-message:
+          prefix: 'deps'
       schedule:
           interval: 'daily'
+      allow:
+          - dependency-name: '*'
       groups:
           github-actions:
               patterns:


### PR DESCRIPTION
# Problem:
Dependabot updates are much less frequent. No way to troubleshoot, but correlates with the `groups` directive added in 06507c380c67 (4 months ago).

see also https://github.com/aws/aws-toolkit-common/pull/666

# Solution:
- Review the inscrutable documentation: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
- Remove the `dependency-type: production` directive.
- Add the `allow: dependency-name: *` directive.
- Note: intentionally _not_ using ["allow: dependency-type:all" directive](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow); it enables updates for _transitive_ dependencies.



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
