### PR TITLE
fix: missing dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,8 @@
 # Documentation for configuration options:
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Troubleshooting: Insights tab > Dependency Graph > Dependabot
+# https://github.com/aws/aws-toolkit-vscode/network/updates
 
 version: 2
 updates:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,8 +23,6 @@ jobs:
             NODE_OPTIONS: '--max-old-space-size=8192'
         steps:
             - uses: actions/checkout@v4
-            - name: Disable engine-strict check
-              run: sed -i -e 's/engine.strict.true/engine-strict=false/' .npmrc
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4
               with:
@@ -67,8 +65,6 @@ jobs:
             NODE_OPTIONS: '--max-old-space-size=8192'
         steps:
             - uses: actions/checkout@v4
-            - name: Disable engine-strict check
-              run: sed -i -e 's/engine.strict.true/engine-strict=false/' .npmrc
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4
               with:
@@ -98,8 +94,6 @@ jobs:
             NODE_OPTIONS: '--max-old-space-size=8192'
         steps:
             - uses: actions/checkout@v4
-            - name: Disable engine-strict check
-              run: sed -i -e 's/engine.strict.true/engine-strict=false/' .npmrc
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4
               with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,6 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
-            - name: Disable engine-strict check
-              run: sed -i -e 's/engine.strict.true/engine-strict=false/' .npmrc
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4
               with:
@@ -93,8 +91,6 @@ jobs:
             # Must perform checkout first, it deletes the target directory
             # before running, thus would delete the downloaded artifacts.
             - uses: actions/checkout@v4
-            - name: Disable engine-strict check
-              run: sed -i -e 's/engine.strict.true/engine-strict=false/' .npmrc
             - uses: actions/download-artifact@v4
             - name: Delete existing prerelease
               # "prerelease" (main branch) or "pre-<feature>"

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,5 @@
 # ensure that the project uses the public npm registry see: https://docs.npmjs.com/cli/v8/configuring-npm/npmrc
 registry = "https://registry.npmjs.org/"
-engine-strict=true
+# `engine-strict=true` prevents dependabot from working, because _transitive_ deps can set "engines"
+# more restrictive than our own package.json. https://github.com/dependabot/dependabot-core/issues/4072
+engine-strict=false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AWS Toolkit for Visual Studio Code
 
-[![GitHub CI status](https://github.com/aws/aws-toolkit-vscode/workflows/CI/badge.svg?event=push&branch=master)](https://github.com/aws/aws-toolkit-vscode/actions?query=branch%3Amaster) [![Coverage](https://img.shields.io/codecov/c/github/aws/aws-toolkit-vscode/master.svg)](https://codecov.io/gh/aws/aws-toolkit-vscode/branch/master) [![Marketplace Version](https://img.shields.io/vscode-marketplace/v/AmazonWebServices.aws-toolkit-vscode.svg) ![Marketplace Downloads](https://img.shields.io/vscode-marketplace/d/AmazonWebServices.aws-toolkit-vscode.svg)](https://marketplace.visualstudio.com/items?itemName=AmazonWebServices.aws-toolkit-vscode)
+[![Coverage](https://img.shields.io/codecov/c/github/aws/aws-toolkit-vscode/master.svg)](https://codecov.io/gh/aws/aws-toolkit-vscode/branch/master) [![Marketplace Version](https://img.shields.io/vscode-marketplace/v/AmazonWebServices.aws-toolkit-vscode.svg) ![Marketplace Downloads](https://img.shields.io/vscode-marketplace/d/AmazonWebServices.aws-toolkit-vscode.svg)](https://marketplace.visualstudio.com/items?itemName=AmazonWebServices.aws-toolkit-vscode)
 
 The AWS Toolkit for Visual Studio Code is an [extension](https://marketplace.visualstudio.com/itemdetails?itemName=AmazonWebServices.aws-toolkit-vscode) for connecting your IDE to your AWS resources:
 

--- a/buildspec/release/10changeversion.yml
+++ b/buildspec/release/10changeversion.yml
@@ -11,8 +11,6 @@ phases:
 
     build:
         commands:
-            # Disable engine-strict in CI.
-            - sed -i -e 's/engine.strict.true/engine-strict=false/' .npmrc
             - |
                 echo "Removing SNAPSHOT from version string"
                 git config --global user.name "aws-toolkit-automation"

--- a/buildspec/release/20buildrelease.yml
+++ b/buildspec/release/20buildrelease.yml
@@ -19,8 +19,6 @@ phases:
             - apt-get install -y libasound2-plugins
     build:
         commands:
-            # Disable engine-strict in CI.
-            - sed -i -e 's/engine.strict.true/engine-strict=false/' .npmrc
             # --unsafe-perm is needed because we run as root
             - npm ci --unsafe-perm
             - cp ./README.quickstart.vscode.md ./README.md

--- a/buildspec/shared/linux-install.sh
+++ b/buildspec/shared/linux-install.sh
@@ -11,9 +11,6 @@ test -n "$VSCODE_TEST_VERSION" || {
 }
 set -x
 
-# Disable engine-strict in CI.
-sed -i -e 's/engine.strict.true/engine-strict=false/' .npmrc
-
 # Without this, "Unable to locate package libatk1.0-0".
 apt-get > /dev/null -yqq update
 # Dependencies for running vscode.


### PR DESCRIPTION
## Problem
Dependabot fails since 60ffe61e6e049cff635ee6b6cdf61279da99d675. This is because _transitive_ deps can set "engines" to something more restrictive than our own `package.json`. There's basically no way around this. https://github.com/dependabot/dependabot-core/issues/4072

`engine-strict=true` was intended to help developers avoid using outdated tooling, but because transitive deps can (and do) specify more restrictive "engines" in their `package.json`, it's unrealistic for us (unless we restrict ourselves to older versions of those deps--but that's difficult because often our _direct_ dependencies aren't aware of the transitive deps they are pulling in).

## Solution
- Remove `engine-strict`.
- TODO: write a "prepare" script that checks local developer's `npm` and `node` versions.





<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
