### PR TITLE
refactor: CI test run scripts

### DIFF
--- a/scripts/test/launchTestUtilities.ts
+++ b/scripts/test/launchTestUtilities.ts
@@ -9,6 +9,7 @@ import { downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath } from '
 import { join, resolve } from 'path'
 import { runTests } from '@vscode/test-electron'
 import { VSCODE_EXTENSION_ID } from '../../src/shared/extensions'
+import { TestOptions } from '@vscode/test-electron/out/runTest'
 
 const envvarVscodeTestVersion = 'VSCODE_TEST_VERSION'
 
@@ -17,8 +18,79 @@ const minimum = 'minimum'
 
 const disableWorkspaceTrust = '--disable-workspace-trust'
 
-export const integrationSuite = 'integration'
-export const e2eSuite = 'e2e'
+type SuiteName = 'integration' | 'e2e' | 'unit'
+
+/**
+ * This is the generalized method that is used by different test suites (unit, integration, ...) in CI to
+ * setup vscode and then run tests. An important thing to note is that in CI we do not have VS Code installed,
+ * so this script needs to do this itself.
+ *
+ * If you want to run the tests manually you should use the `Run & Debug` menu in VS Code instead.
+ */
+export async function runToolkitTests(suite: SuiteName, relativeTestEntryPoint: string) {
+    try {
+        console.log(`Running ${suite} test suite...`)
+
+        const args = await getVSCodeCliArgs({
+            vsCodeExecutablePath: await setupVSCodeTestInstance(suite),
+            relativeTestEntryPoint,
+            suite,
+        })
+        console.log(`runTests() args:\n${JSON.stringify(args, undefined, 2)}`)
+        const result = await runTests(args)
+
+        console.log(`Finished running ${suite} test suite with result code: ${result}`)
+        process.exit(result)
+    } catch (err) {
+        console.error(err)
+        console.error('Failed to run tests')
+        process.exit(1)
+    }
+}
+
+/**
+ * Resolves all args for {@link runTests}
+ */
+async function getVSCodeCliArgs(params: {
+    vsCodeExecutablePath: string
+    relativeTestEntryPoint: string
+    suite: SuiteName
+}): Promise<TestOptions> {
+    const projectRootDir = process.cwd()
+
+    let disableExtensionsArgs: string[] = []
+    let disableWorkspaceTrustArg: string[] = []
+
+    if (params.suite !== 'unit') {
+        disableExtensionsArgs = await getCliArgsToDisableExtensions(params.vsCodeExecutablePath, {
+            except: [
+                VSCODE_EXTENSION_ID.python,
+                VSCODE_EXTENSION_ID.yaml,
+                VSCODE_EXTENSION_ID.jupyter,
+                VSCODE_EXTENSION_ID.go,
+                VSCODE_EXTENSION_ID.java,
+                VSCODE_EXTENSION_ID.javadebug,
+                VSCODE_EXTENSION_ID.git,
+                VSCODE_EXTENSION_ID.remotessh,
+            ],
+        })
+        disableWorkspaceTrustArg = [disableWorkspaceTrust]
+    }
+
+    const workspacePath = join(projectRootDir, 'dist', 'src', 'testFixtures', 'workspaceFolder')
+
+    return {
+        vscodeExecutablePath: params.vsCodeExecutablePath,
+        extensionDevelopmentPath: projectRootDir,
+        extensionTestsPath: resolve(projectRootDir, params.relativeTestEntryPoint),
+        // For verbose VSCode logs, add "--verbose --log debug". c2165cf48e62c
+        launchArgs: [...disableExtensionsArgs, workspacePath, ...disableWorkspaceTrustArg],
+        extensionTestsEnv: {
+            ['DEVELOPMENT_PATH']: projectRootDir,
+            ['AWS_TOOLKIT_AUTOMATION']: params.suite,
+        },
+    }
+}
 
 /**
  * Downloads and unzips a copy of VS Code to run tests against.
@@ -30,7 +102,7 @@ export const e2eSuite = 'e2e'
  * The VS Code version under test can be altered by setting the environment variable
  * VSCODE_TEST_VERSION prior to running the tests.
  */
-export async function setupVSCodeTestInstance(): Promise<string> {
+async function setupVSCodeTestInstance(suite: SuiteName): Promise<string> {
     let vsCodeVersion = process.env[envvarVscodeTestVersion]
     if (!vsCodeVersion) {
         vsCodeVersion = stable
@@ -44,10 +116,20 @@ export async function setupVSCodeTestInstance(): Promise<string> {
     console.log(`VS Code test instance location: ${vsCodeExecutablePath}`)
     console.log(await invokeVSCodeCli(vsCodeExecutablePath, ['--version']))
 
+    // Only certain test suites require specific vscode extensions to be installed
+    if (suite !== 'unit') {
+        await installVSCodeExtension(vsCodeExecutablePath, VSCODE_EXTENSION_ID.python)
+        await installVSCodeExtension(vsCodeExecutablePath, VSCODE_EXTENSION_ID.yaml)
+        await installVSCodeExtension(vsCodeExecutablePath, VSCODE_EXTENSION_ID.go)
+        await installVSCodeExtension(vsCodeExecutablePath, VSCODE_EXTENSION_ID.java)
+        await installVSCodeExtension(vsCodeExecutablePath, VSCODE_EXTENSION_ID.javadebug)
+    }
+
+    console.log('VS Code Test instance has been set up')
     return vsCodeExecutablePath
 }
 
-export async function invokeVSCodeCli(vsCodeExecutablePath: string, args: string[]): Promise<string> {
+async function invokeVSCodeCli(vsCodeExecutablePath: string, args: string[]): Promise<string> {
     const [cli, ...cliArgs] = resolveCliArgsFromVSCodeExecutablePath(vsCodeExecutablePath)
     const cmdArgs = [...cliArgs, ...args]
 
@@ -75,7 +157,7 @@ export async function invokeVSCodeCli(vsCodeExecutablePath: string, args: string
     return spawnResult.stdout
 }
 
-export async function installVSCodeExtension(vsCodeExecutablePath: string, extensionIdentifier: string): Promise<void> {
+async function installVSCodeExtension(vsCodeExecutablePath: string, extensionIdentifier: string): Promise<void> {
     // HACK: `sam.test.ts` Codelens test was failing for python due to bug in newer version, so lock to last working version.
     // Edge Case: This specific python version does not work with the "minimum" vscode version, so we do not override it as it
     // will choose its own python extension version that works.
@@ -97,7 +179,7 @@ export async function installVSCodeExtension(vsCodeExecutablePath: string, exten
  * @returns List of args which the caller is expected to pass to vscode CLI, of the form:
  * ["--disable-extension", "foo.bar.baz", "--disable-extension", ...]
  */
-export async function getCliArgsToDisableExtensions(
+async function getCliArgsToDisableExtensions(
     vsCodeExecutablePath: string,
     params: { except: string[] }
 ): Promise<string[]> {
@@ -114,67 +196,11 @@ export async function getCliArgsToDisableExtensions(
     return ids
 }
 
-export function getMinVsCodeVersion(): string {
+function getMinVsCodeVersion(): string {
     const vsCodeVersion = packageJson.engines.vscode
 
     // We assume that we specify a minium, so it matches ^<number>, so remove ^'s
     const sanitizedVersion = vsCodeVersion.replace('^', '')
     console.log(`Using minimum VSCode version specified in package.json: ${sanitizedVersion}`)
     return sanitizedVersion
-}
-
-async function setupVSCode(): Promise<string> {
-    console.log('Setting up VS Code Test instance...')
-    const vsCodeExecutablePath = await setupVSCodeTestInstance()
-    await installVSCodeExtension(vsCodeExecutablePath, VSCODE_EXTENSION_ID.python)
-    await installVSCodeExtension(vsCodeExecutablePath, VSCODE_EXTENSION_ID.yaml)
-    await installVSCodeExtension(vsCodeExecutablePath, VSCODE_EXTENSION_ID.go)
-    await installVSCodeExtension(vsCodeExecutablePath, VSCODE_EXTENSION_ID.java)
-    await installVSCodeExtension(vsCodeExecutablePath, VSCODE_EXTENSION_ID.javadebug)
-
-    console.log('VS Code Test instance has been set up')
-    return vsCodeExecutablePath
-}
-
-export async function runToolkitTests(suiteName: string, relativeEntryPoint: string) {
-    try {
-        console.log(`Running ${suiteName} test suite...`)
-        const vsCodeExecutablePath = await setupVSCode()
-        const cwd = process.cwd()
-        const testEntrypoint = resolve(cwd, relativeEntryPoint)
-        const workspacePath = join(cwd, 'dist', 'src', 'testFixtures', 'workspaceFolder')
-        console.log(`Starting tests: ${testEntrypoint}`)
-
-        const disableExtensions = await getCliArgsToDisableExtensions(vsCodeExecutablePath, {
-            except: [
-                VSCODE_EXTENSION_ID.python,
-                VSCODE_EXTENSION_ID.yaml,
-                VSCODE_EXTENSION_ID.jupyter,
-                VSCODE_EXTENSION_ID.go,
-                VSCODE_EXTENSION_ID.java,
-                VSCODE_EXTENSION_ID.javadebug,
-                VSCODE_EXTENSION_ID.git,
-                VSCODE_EXTENSION_ID.remotessh,
-            ],
-        })
-        const args = {
-            vscodeExecutablePath: vsCodeExecutablePath,
-            extensionDevelopmentPath: cwd,
-            extensionTestsPath: testEntrypoint,
-            launchArgs: [...disableExtensions, workspacePath, disableWorkspaceTrust],
-            extensionTestsEnv: {
-                ['DEVELOPMENT_PATH']: cwd,
-                ['AWS_TOOLKIT_AUTOMATION']: suiteName,
-            },
-        }
-        console.log(`runTests() args:\n${JSON.stringify(args, undefined, 2)}`)
-        const result = await runTests(args)
-
-        console.log(`Finished running ${suiteName} test suite with result code: ${result}`)
-        process.exit(result)
-    } catch (err) {
-        console.error(err)
-        console.error('Failed to run tests')
-        process.exit(1)
-    }
 }

--- a/scripts/test/launchTestUtilities.ts
+++ b/scripts/test/launchTestUtilities.ts
@@ -25,7 +25,8 @@ type SuiteName = 'integration' | 'e2e' | 'unit'
  * setup vscode and then run tests. An important thing to note is that in CI we do not have VS Code installed,
  * so this script needs to do this itself.
  *
- * If you want to run the tests manually you should use the `Run & Debug` menu in VS Code instead.
+ * If you want to run the tests manually you should use the `Run & Debug` menu in VS Code instead
+ * to be able to use to breakpoints.
  */
 export async function runToolkitTests(suite: SuiteName, relativeTestEntryPoint: string) {
     try {

--- a/scripts/test/test.ts
+++ b/scripts/test/test.ts
@@ -4,35 +4,7 @@
  */
 
 import { resolve } from 'path'
-import { runTests } from '@vscode/test-electron'
-import { setupVSCodeTestInstance } from './launchTestUtilities'
+import { runToolkitTests } from './launchTestUtilities'
 void (async () => {
-    try {
-        console.log('Running Main test suite...')
-
-        const vsCodeExecutablePath = await setupVSCodeTestInstance()
-        const rootDir = process.cwd()
-        const testEntrypoint = resolve(rootDir, 'dist/src/test/index.js')
-        const testWorkspace = resolve(rootDir, 'src/testFixtures/workspaceFolder')
-        console.log(`Starting tests: ${testEntrypoint}`)
-
-        const result = await runTests({
-            vscodeExecutablePath: vsCodeExecutablePath,
-            extensionDevelopmentPath: rootDir,
-            extensionTestsPath: testEntrypoint,
-            // For verbose VSCode logs, add "--verbose --log debug". c2165cf48e62c
-            launchArgs: [testWorkspace],
-            extensionTestsEnv: {
-                ['DEVELOPMENT_PATH']: rootDir,
-                ['AWS_TOOLKIT_AUTOMATION']: 'unit',
-            },
-        })
-
-        console.log(`Finished running Main test suite with result code: ${result}`)
-        process.exit(result)
-    } catch (err) {
-        console.error(err)
-        console.error('Failed to run tests')
-        process.exit(1)
-    }
+    await runToolkitTests('unit', resolve('dist', 'src', 'test', 'index.js'))
 })()

--- a/scripts/test/test.ts
+++ b/scripts/test/test.ts
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { resolve } from 'path'
 import { runToolkitTests } from './launchTestUtilities'
 void (async () => {
-    await runToolkitTests('unit', resolve('dist', 'src', 'test', 'index.js'))
+    await runToolkitTests('unit', 'dist/src/test/index.js')
 })()

--- a/scripts/test/testE2E.ts
+++ b/scripts/test/testE2E.ts
@@ -4,7 +4,7 @@
  */
 
 import { resolve } from 'path'
-import { e2eSuite, runToolkitTests } from './launchTestUtilities'
+import { runToolkitTests } from './launchTestUtilities'
 void (async () => {
-    await runToolkitTests(e2eSuite, resolve('dist', 'src', 'testE2E', 'index.js'))
+    await runToolkitTests('e2e', resolve('dist', 'src', 'testE2E', 'index.js'))
 })()

--- a/scripts/test/testE2E.ts
+++ b/scripts/test/testE2E.ts
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { resolve } from 'path'
 import { runToolkitTests } from './launchTestUtilities'
 void (async () => {
-    await runToolkitTests('e2e', resolve('dist', 'src', 'testE2E', 'index.js'))
+    await runToolkitTests('e2e', 'dist/src/testE2E/index.js')
 })()

--- a/scripts/test/testInteg.ts
+++ b/scripts/test/testInteg.ts
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { resolve } from 'path'
 import { runToolkitTests } from './launchTestUtilities'
 void (async () => {
-    await runToolkitTests('integration', resolve('dist', 'src', 'testInteg', 'index.js'))
+    await runToolkitTests('integration', 'dist/src/testInteg/index.js')
 })()

--- a/scripts/test/testInteg.ts
+++ b/scripts/test/testInteg.ts
@@ -4,7 +4,7 @@
  */
 
 import { resolve } from 'path'
-import { integrationSuite, runToolkitTests } from './launchTestUtilities'
+import { runToolkitTests } from './launchTestUtilities'
 void (async () => {
-    await runToolkitTests(integrationSuite, resolve('dist', 'src', 'testInteg', 'index.js'))
+    await runToolkitTests('integration', resolve('dist', 'src', 'testInteg', 'index.js'))
 })()

--- a/src/test/techdebt.test.ts
+++ b/src/test/techdebt.test.ts
@@ -6,7 +6,6 @@
 import assert from 'assert'
 import * as semver from 'semver'
 import * as env from '../shared/vscode/env'
-import { installVSCodeExtension } from '../../scripts/test/launchTestUtilities'
 
 // Checks project config and dependencies, to remind us to remove old things
 // when possible.
@@ -46,7 +45,7 @@ describe('tech debt', function () {
 
     it('stop not using latest python extension version in integration CI tests', function () {
         /**
-         * The explicitly set version is done in {@link installVSCodeExtension}
+         * The explicitly set version is done in launchTestUtilities.ts#installVSCodeExtension
          * The parent ticket for SAM test issues: IDE-12295
          * Python Extension Bug Issue (if this is fixed, then this should be too): https://github.com/microsoft/vscode-python/issues/22659
          */

--- a/src/testInteg/shared/extensions/git.test.ts
+++ b/src/testInteg/shared/extensions/git.test.ts
@@ -13,7 +13,7 @@ import { realpath } from 'fs-extra'
 import { execFileSync } from 'child_process'
 import { sleep } from '../../../shared/utilities/timeoutUtils'
 import { getLogger } from '../../../shared/logger/logger'
-import { getMinVsCodeVersion } from '../../../../scripts/test/launchTestUtilities' // TODO: don't use stuff from 'scripts'
+import { getMinVscodeVersion } from '../../../shared/vscode/env'
 
 const testRemoteName = 'test-origin'
 const testRemoteUrl = 'https://github.com/aws/aws-toolkit-vscode'
@@ -69,7 +69,7 @@ describe.skip('GitExtension', function () {
 
     before(async function () {
         // extension is missing some functionality on the minimum version
-        if (vscode.version === getMinVsCodeVersion()) {
+        if (vscode.version === getMinVscodeVersion()) {
             this.test?.skip()
         }
 


### PR DESCRIPTION
Just doing some tidying up after learning how our test execution works.

- Behaviour is untouched
- Methods are reordered
- 'export' is removed from methods that do not need it
- runToolkitTests() is generalized to remove duplication in scripts/test/test.ts

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
