### PR TITLE
fix(codewhisperer): right context merge

### DIFF
--- a/.changes/next-release/Bug Fix-3f2c34ab-615e-4501-b697-75b38a7f4c39.json
+++ b/.changes/next-release/Bug Fix-3f2c34ab-615e-4501-b697-75b38a7f4c39.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "CodeWhisperer suggestions may be skipped under certain criteria"
+	"description": "CodeWhisperer suggestions may be trimmed under certain criteria"
 }

--- a/.changes/next-release/Bug Fix-3f2c34ab-615e-4501-b697-75b38a7f4c39.json
+++ b/.changes/next-release/Bug Fix-3f2c34ab-615e-4501-b697-75b38a7f4c39.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Fix CodeWhisperer suggestions will be swallowed under certain criteria"
+	"description": "CodeWhisperer suggestions may be skipped under certain criteria"
 }

--- a/.changes/next-release/Bug Fix-3f2c34ab-615e-4501-b697-75b38a7f4c39.json
+++ b/.changes/next-release/Bug Fix-3f2c34ab-615e-4501-b697-75b38a7f4c39.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix CodeWhisperer suggestions will be swallowed under certain criteria"
+}

--- a/src/codewhisperer/service/inlineCompletionItemProvider.ts
+++ b/src/codewhisperer/service/inlineCompletionItemProvider.ts
@@ -75,7 +75,7 @@ export class CWInlineCompletionItemProvider implements vscode.InlineCompletionIt
         const trimmedSuggestion = suggestion.trim()
         // limit of 5000 for right context matching
         const rightContext = document.getText(new vscode.Range(pos, document.positionAt(document.offsetAt(pos) + 5000)))
-        const overlap = getPrefixSuffixOverlap(trimmedSuggestion, rightContext.trim())
+        const overlap = getPrefixSuffixOverlap(trimmedSuggestion, rightContext)
         const overlapIndex = suggestion.lastIndexOf(overlap)
         if (overlapIndex >= 0) {
             const truncated = suggestion.slice(0, overlapIndex)

--- a/src/test/codewhisperer/service/inlineCompletionService.test.ts
+++ b/src/test/codewhisperer/service/inlineCompletionService.test.ts
@@ -141,15 +141,6 @@ describe('inlineCompletionService', function () {
             const result = provider.truncateOverlapWithRightContext(mockEditor.document, mockSuggestion, cursorPosition)
             assert.strictEqual(result, '')
         })
-
-        it('ignores the space at the start of right context', async function () {
-            const testRightContext = '\n\n\n\nreturn target'
-            const mockEditor = createMockTextEditor(`${doc}${testRightContext}`, fileName, language)
-            const mockSuggestion = 'return target\n'
-            const cursorPosition = new vscode.Position(2, 0)
-            const result = provider.truncateOverlapWithRightContext(mockEditor.document, mockSuggestion, cursorPosition)
-            assert.strictEqual(result, '')
-        })
     })
 })
 


### PR DESCRIPTION
## Problem
`rightContext.trim()` will result in unexpected right context merging. Should remove `trim()`

https://github.com/aws/aws-toolkit-vscode/assets/96078566/4bf8d1fd-6779-4468-96a6-4b2720c13fd7




## Solution

https://github.com/aws/aws-toolkit-vscode/assets/96078566/81298b12-77a3-48a8-adf4-4ca162aa5f0d


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
