### PR TITLE
telemetry: appcomposer_initializeProject metric

### DIFF
--- a/packages/core/src/applicationcomposer/messageHandlers/emitTelemetryMessageHandler.ts
+++ b/packages/core/src/applicationcomposer/messageHandlers/emitTelemetryMessageHandler.ts
@@ -17,7 +17,7 @@ import {
     AppcomposerOpenWfs,
     AppcomposerPostProcess,
     AppcomposerRegenerateClicked,
-    AppcomposerResourceCount,
+    AppcomposerInitializeProjectSucceeded,
     telemetry,
 } from '../../shared/telemetry/telemetry'
 import { getLogger } from '../../shared/logger'
@@ -63,7 +63,7 @@ export function emitTelemetryMessageHandler(message: EmitTelemetryMessage) {
                 sendCloseWfs(parsedData as AppcomposerCloseWfs)
                 return
             case 'TEMPLATE_OPENED':
-                sendResourceCounts(parsedData as AppcomposerResourceCount)
+                sendInitializedProject(parsedData as AppcomposerInitializeProjectSucceeded)
                 return
         }
     } catch (e) {
@@ -163,8 +163,8 @@ function sendCloseWfs(metadata: AppcomposerCloseWfs) {
     })
 }
 
-function sendResourceCounts(metadata: AppcomposerResourceCount) {
-    telemetry.appcomposer_resourceCount.emit({
+function sendInitializedProject(metadata: AppcomposerInitializeProjectSucceeded) {
+    telemetry.appcomposer_initializeProjectSucceeded.emit({
         resourceCounts: metadata.resourceCounts,
         totalResourceCount: metadata.totalResourceCount,
     })

--- a/packages/core/src/applicationcomposer/messageHandlers/emitTelemetryMessageHandler.ts
+++ b/packages/core/src/applicationcomposer/messageHandlers/emitTelemetryMessageHandler.ts
@@ -17,6 +17,7 @@ import {
     AppcomposerOpenWfs,
     AppcomposerPostProcess,
     AppcomposerRegenerateClicked,
+    AppcomposerResourceCount,
     telemetry,
 } from '../../shared/telemetry/telemetry'
 import { getLogger } from '../../shared/logger'
@@ -60,6 +61,9 @@ export function emitTelemetryMessageHandler(message: EmitTelemetryMessage) {
                 return
             case 'CLOSE_WFS':
                 sendCloseWfs(parsedData as AppcomposerCloseWfs)
+                return
+            case 'TEMPLATE_OPENED':
+                sendResourceCounts(parsedData as AppcomposerResourceCount)
                 return
         }
     } catch (e) {
@@ -156,5 +160,12 @@ function sendCloseWfs(metadata: AppcomposerCloseWfs) {
     telemetry.appcomposer_closeWfs.emit({
         result: metadata.result ?? 'Succeeded',
         didSave: metadata.didSave,
+    })
+}
+
+function sendResourceCounts(metadata: AppcomposerResourceCount) {
+    telemetry.appcomposer_resourceCount.emit({
+        resourceCounts: metadata.resourceCounts,
+        totalResourceCount: metadata.totalResourceCount,
     })
 }

--- a/packages/core/src/applicationcomposer/messageHandlers/emitTelemetryMessageHandler.ts
+++ b/packages/core/src/applicationcomposer/messageHandlers/emitTelemetryMessageHandler.ts
@@ -17,7 +17,7 @@ import {
     AppcomposerOpenWfs,
     AppcomposerPostProcess,
     AppcomposerRegenerateClicked,
-    AppcomposerInitializeProjectSucceeded,
+    AppcomposerInitializeProject,
     telemetry,
 } from '../../shared/telemetry/telemetry'
 import { getLogger } from '../../shared/logger'
@@ -63,7 +63,7 @@ export function emitTelemetryMessageHandler(message: EmitTelemetryMessage) {
                 sendCloseWfs(parsedData as AppcomposerCloseWfs)
                 return
             case 'TEMPLATE_OPENED':
-                sendInitializedProject(parsedData as AppcomposerInitializeProjectSucceeded)
+                sendInitializeProject(parsedData as AppcomposerInitializeProject)
                 return
         }
     } catch (e) {
@@ -163,8 +163,8 @@ function sendCloseWfs(metadata: AppcomposerCloseWfs) {
     })
 }
 
-function sendInitializedProject(metadata: AppcomposerInitializeProjectSucceeded) {
-    telemetry.appcomposer_initializeProjectSucceeded.emit({
+function sendInitializeProject(metadata: AppcomposerInitializeProject) {
+    telemetry.appcomposer_initializeProject.emit({
         resourceCounts: metadata.resourceCounts,
         totalResourceCount: metadata.totalResourceCount,
     })

--- a/packages/core/src/applicationcomposer/types.ts
+++ b/packages/core/src/applicationcomposer/types.ts
@@ -55,6 +55,7 @@ enum TelemetryType {
     ADD_CONNECTION = 'ADD_CONNECTION',
     OPEN_WFS = 'OPEN_WFS',
     CLOSE_WFS = 'CLOSE_WFS',
+    TEMPLATE_OPENED = 'TEMPLATE_OPENED',
 }
 
 export interface InitResponseMessage extends Message {

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -115,6 +115,16 @@
             "description": "Whether the user saved"
         },
         {
+            "name": "resourceCounts",
+            "type": "string",
+            "description": "Per-resource count of each resource in an opened template"
+        },
+        {
+            "name": "totalResourceCount",
+            "type": "int",
+            "description": "Total count of resources in an opened template"
+        },
+        {
             "name": "cwsprChatTriggerInteraction",
             "type": "string",
             "allowedValues": ["hotkeys", "click", "contextMenu"],
@@ -605,6 +615,11 @@
             "name": "appcomposer_closeWfs",
             "description": "Called when Step Functions Workflow Studio is closed",
             "metadata": [{ "type": "didSave" }]
+        },
+        {
+            "name": "appcomposer_resourceCount",
+            "description": "Called to count resources in a template when it is opened",
+            "metadata": [{ "type": "resourceCounts" }, { "type": "totalResourceCount" }]
         },
         {
             "name": "amazonq_openChat",

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -617,7 +617,7 @@
             "metadata": [{ "type": "didSave" }]
         },
         {
-            "name": "appcomposer_initializeProjectSucceeded",
+            "name": "appcomposer_initializeProject",
             "description": "Called when a project successfully loads",
             "metadata": [{ "type": "resourceCounts" }, { "type": "totalResourceCount" }]
         },

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -617,8 +617,8 @@
             "metadata": [{ "type": "didSave" }]
         },
         {
-            "name": "appcomposer_resourceCount",
-            "description": "Called to count resources in a template when it is opened",
+            "name": "appcomposer_initializeProjectSucceeded",
+            "description": "Called when a project successfully loads",
             "metadata": [{ "type": "resourceCounts" }, { "type": "totalResourceCount" }]
         },
         {


### PR DESCRIPTION
## Problem

We're tracking resource counts in the App Composer console, but not in the VS Code extension. This allows for tracking that telemetry event in VSC as well.

## Solution

This adds the `AppcomposerResourceCount` telemetry event, which records the `resourceCounts` and `totalResourceCount` values coming from `FigAssets`.

No testable changes added, as this uses existing telemetry tracking mechanisms.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
