### PR TITLE
fix(sam): allow "AWS::Lambda::Function" when validating

### DIFF
--- a/.changes/next-release/Bug Fix-ff0dcc4b-4981-43b3-9c16-75a91b5a43a6.json
+++ b/.changes/next-release/Bug Fix-ff0dcc4b-4981-43b3-9c16-75a91b5a43a6.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "SAM local debugging: Toolkit showed SamLaunchRequestError for `AWS::Lambda::Function` template resource"
+}

--- a/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
+++ b/src/shared/sam/debugger/awsSamDebugConfigurationValidator.ts
@@ -145,7 +145,9 @@ export class DefaultAwsSamDebugConfigurationValidator implements AwsSamDebugConf
             }
         }
 
-        if (!resources || !Object.keys(resources).includes(templateTarget.logicalId)) {
+        const resource = resources?.[templateTarget.logicalId]
+
+        if (!resource) {
             return {
                 isValid: false,
                 message: localize(
@@ -157,14 +159,12 @@ export class DefaultAwsSamDebugConfigurationValidator implements AwsSamDebugConf
             }
         }
 
-        const resource = resources[templateTarget.logicalId]
-
-        if (resource?.Type !== CloudFormation.SERVERLESS_FUNCTION_TYPE) {
+        if (![CloudFormation.SERVERLESS_FUNCTION_TYPE, CloudFormation.LAMBDA_FUNCTION_TYPE].includes(resource.Type)) {
             return {
                 isValid: false,
                 message: localize(
                     'AWS.sam.debugger.resourceNotAFunction',
-                    'Template Resource {0} in Template file {1} needs to be of type {2} or {3}',
+                    'Template Resource {0} in Template file {1} must be of type {2} or {3}',
                     templateTarget.logicalId,
                     templateTarget.templatePath,
                     CloudFormation.SERVERLESS_FUNCTION_TYPE,


### PR DESCRIPTION
# Problem:
`validateTemplateConfig()` fails if the given resource is "AWS::Lambda::Function", but:
1. its error message implies that "AWS::Lambda::Function" is allowed
2. 7b5aae7cf1133539e6a1d1070f9385a0608b13af implies that "AWS::Lambda::Function" is allowed
3. `getResourcesForHandlerFromTemplateDatum()` allows "AWS::Lambda::Function": https://github.com/aws/aws-toolkit-vscode/blob/8704f2cedb065087d7a85c9a9c40fc63d296f8cf/src/shared/fs/templateRegistry.ts#L184

ref #4281

# Solution:
Update the condition to allow "AWS::Lambda::Function".


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
