### PR TITLE
fix(telemetry): metrics emitted without the `result` property

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -331,7 +331,7 @@ function recordToolkitInitialization(activationStartedOn: number, settingsValid:
         const duration = activationFinishedOn - activationStartedOn
 
         if (settingsValid) {
-            telemetry.toolkit_init.emit({ duration })
+            telemetry.toolkit_init.emit({ duration, result: 'Succeeded' })
         } else {
             telemetry.toolkit_init.emit({ duration, result: 'Failed', reason: 'UserSettings' })
         }

--- a/src/shared/logger/commands.ts
+++ b/src/shared/logger/commands.ts
@@ -31,7 +31,7 @@ export class Logging {
     public constructor(private readonly logUri: vscode.Uri, private readonly logger: Logger) {}
 
     public async openLogUri(): Promise<vscode.TextEditor | undefined> {
-        telemetry.toolkit_viewLogs.emit()
+        telemetry.toolkit_viewLogs.emit({ result: 'Succeeded' })
         return vscode.window.showTextDocument(this.logUri)
     }
 


### PR DESCRIPTION
    2024-01-16 09:26:21 [WARN]: Metric Event did not pass validation: Metric `toolkit_init` was emitted without the `result` property.
    2024-01-16 09:26:39 [WARN]: Metric Event did not pass validation: Metric `toolkit_viewLogs` was emitted without the `result` property.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
