### PR TITLE
feat(sam): improve rendering of SAM output

### DIFF
--- a/.changes/next-release/Feature-a4a67f74-2ea2-4e18-9864-c8904e0128e6.json
+++ b/.changes/next-release/Feature-a4a67f74-2ea2-4e18-9864-c8904e0128e6.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "SAM lambda debugging: SAM output and other logs are now presented with VSCode's log highlighting"
+}

--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -266,7 +266,7 @@ export const connectionExpired = `Connection expired. To continue using Amazon Q
 export const DoNotShowAgain = `Don\'t Show Again`
 
 export const codeScanLogsOutputChannelId =
-    'workbench.action.output.show.extension-output-amazonwebservices.aws-toolkit-vscode-#2-CodeWhisperer Security Scan Logs'
+    'workbench.action.output.show.extension-output-amazonwebservices.aws-toolkit-vscode-#1-CodeWhisperer Security Scan Logs'
 
 export const stopScanMessage =
     'Stop security scan? This scan will be counted as one complete scan towards your monthly security scan limits.'

--- a/src/extensionWeb.ts
+++ b/src/extensionWeb.ts
@@ -27,7 +27,7 @@ export async function activate(context: vscode.ExtensionContext) {
         setupGlobalStubs()
 
         // Setup the logger
-        const toolkitOutputChannel = vscode.window.createOutputChannel('AWS Toolkit')
+        const toolkitOutputChannel = vscode.window.createOutputChannel('AWS Toolkit', { log: true })
         await activateLogger(context, toolkitOutputChannel)
 
         await initializeComputeRegion()

--- a/src/shared/logger/activation.ts
+++ b/src/shared/logger/activation.ts
@@ -27,7 +27,7 @@ const defaultLogLevel: LogLevel = 'info'
  */
 export async function activate(
     extensionContext: vscode.ExtensionContext,
-    outputChannel: vscode.OutputChannel
+    outputChannel: vscode.LogOutputChannel
 ): Promise<void> {
     const chan = logOutputChannel
     const settings = Settings.instance.getSection('aws')

--- a/src/shared/logger/outputChannel.ts
+++ b/src/shared/logger/outputChannel.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode'
 
-export const logOutputChannel: vscode.OutputChannel = vscode.window.createOutputChannel('AWS Toolkit Logs')
+export const logOutputChannel = vscode.window.createOutputChannel('AWS Toolkit Logs', { log: true })
 
 /**
  * Shows the log output channel.

--- a/src/shared/logger/outputChannelTransport.ts
+++ b/src/shared/logger/outputChannelTransport.ts
@@ -53,9 +53,9 @@ export class OutputChannelTransport extends Transport {
                 //      timestamp: '2024-01-16 08:54:30'
                 // We want the "raw" (unformatted) message without the frontmatter, because
                 // `vscode.LogOutputChannel` presents its own timestamp + loglevel.
-                const unformattedMsg = this.stripAnsi ? removeAnsi(info.message) : info.message
+                const untrimmed = this.stripAnsi ? removeAnsi(info.message) : info.message
                 // Avoid extra line breaks.
-                const msg = info.raw ? unformattedMsg.trim() : unformattedMsg
+                const msg = untrimmed.trim()
 
                 const c = this.outputChannel as vscode.LogOutputChannel
                 const loglevel = info.level as LogLevel

--- a/src/shared/logger/outputChannelTransport.ts
+++ b/src/shared/logger/outputChannelTransport.ts
@@ -44,6 +44,7 @@ export class OutputChannelTransport extends Transport {
     public override log(info: LogEntry, next: () => void): void {
         globals.clock.setImmediate(() => {
             if (this.isLogChan) {
+                const c = this.outputChannel as vscode.LogOutputChannel
                 // Example input:
                 //      message: 'Preparing to debug locally: Lambda "index.handler"'
                 //      raw: true
@@ -51,13 +52,12 @@ export class OutputChannelTransport extends Transport {
                 //      Symbol(message): '2024-01-16 08:54:30 [INFO]: Preparing to debug locally: Lambda "index.handler"'
                 //      Symbol(splat): (1) [{…}]
                 //      timestamp: '2024-01-16 08:54:30'
-                // We want the "raw" (unformatted) message without the frontmatter, because
+                // We want the "raw" message without the frontmatter, because
                 // `vscode.LogOutputChannel` presents its own timestamp + loglevel.
-                const untrimmed = this.stripAnsi ? removeAnsi(info.message) : info.message
+                const raw = this.stripAnsi ? removeAnsi(info.message) : info.message
                 // Avoid extra line breaks.
-                const msg = untrimmed.trim()
+                const msg = raw.trim()
 
-                const c = this.outputChannel as vscode.LogOutputChannel
                 const loglevel = info.level as LogLevel
                 if (loglevel === 'error') {
                     c.error(msg)

--- a/src/shared/logger/outputChannelTransport.ts
+++ b/src/shared/logger/outputChannelTransport.ts
@@ -44,8 +44,6 @@ export class OutputChannelTransport extends Transport {
     public override log(info: LogEntry, next: () => void): void {
         globals.clock.setImmediate(() => {
             if (this.isLogChan) {
-                const c = this.outputChannel as vscode.LogOutputChannel
-                const msg = this.stripAnsi ? removeAnsi(info.message) : info.message
                 // Example input:
                 //      message: 'Preparing to debug locally: Lambda "index.handler"'
                 //      raw: true
@@ -53,9 +51,13 @@ export class OutputChannelTransport extends Transport {
                 //      Symbol(message): '2024-01-16 08:54:30 [INFO]: Preparing to debug locally: Lambda "index.handler"'
                 //      Symbol(splat): (1) [{…}]
                 //      timestamp: '2024-01-16 08:54:30'
-                // We want the "raw" form without the frontmatter, because `vscode.LogOutputChannel`
-                // presents its own timestamp + loglevel.
+                // We want the "raw" (unformatted) message without the frontmatter, because
+                // `vscode.LogOutputChannel` presents its own timestamp + loglevel.
+                const unformattedMsg = this.stripAnsi ? removeAnsi(info.message) : info.message
+                // Avoid extra line breaks.
+                const msg = info.raw ? unformattedMsg.trim() : unformattedMsg
 
+                const c = this.outputChannel as vscode.LogOutputChannel
                 const loglevel = info.level as LogLevel
                 if (loglevel === 'error') {
                     c.error(msg)

--- a/src/shared/logger/outputChannelTransport.ts
+++ b/src/shared/logger/outputChannelTransport.ts
@@ -37,7 +37,7 @@ export class OutputChannelTransport extends Transport {
         this.stripAnsi = options.stripAnsi ?? false
 
         const c = this.outputChannel
-        this.isLogChan = (c as any).info && (c as any).trace && (c as any).debug && (c as any).warn && (c as any).error
+        this.isLogChan = !!((c as any).info && (c as any).debug && (c as any).warn && (c as any).error)
         // Else: we got `vscode.debug.activeDebugConsole` which does not yet implement `vscode.LogOutputChannel`.
     }
 

--- a/src/shared/logger/outputChannelTransport.ts
+++ b/src/shared/logger/outputChannelTransport.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode'
 import Transport from 'winston-transport'
 import globals from '../extensionGlobals'
 import { removeAnsi } from '../utilities/textUtilities'
+import { LogLevel } from './logger'
 
 export const MESSAGE = Symbol.for('message') // eslint-disable-line @typescript-eslint/naming-convention
 
@@ -19,6 +20,8 @@ interface LogEntry {
 
 export class OutputChannelTransport extends Transport {
     private readonly outputChannel: Pick<vscode.OutputChannel, 'append' | 'appendLine'>
+    // True if `outputChannel` is a `vscode.LogOutputChannel`.
+    private readonly isLogChan: boolean
     private readonly stripAnsi: boolean
 
     public constructor(
@@ -32,16 +35,44 @@ export class OutputChannelTransport extends Transport {
 
         this.outputChannel = options.outputChannel
         this.stripAnsi = options.stripAnsi ?? false
+
+        const c = this.outputChannel
+        this.isLogChan = (c as any).info && (c as any).trace && (c as any).debug && (c as any).warn && (c as any).error
+        // Else: we got `vscode.debug.activeDebugConsole` which does not yet implement `vscode.LogOutputChannel`.
     }
 
     public override log(info: LogEntry, next: () => void): void {
         globals.clock.setImmediate(() => {
-            const msg = this.stripAnsi ? removeAnsi(info[MESSAGE]) : info[MESSAGE]
+            if (this.isLogChan) {
+                const c = this.outputChannel as vscode.LogOutputChannel
+                const msg = this.stripAnsi ? removeAnsi(info.message) : info.message
+                // Example input:
+                //      message: 'Preparing to debug locally: Lambda "index.handler"'
+                //      raw: true
+                //      Symbol(level): 'info'
+                //      Symbol(message): '2024-01-16 08:54:30 [INFO]: Preparing to debug locally: Lambda "index.handler"'
+                //      Symbol(splat): (1) [{…}]
+                //      timestamp: '2024-01-16 08:54:30'
+                // We want the "raw" form without the frontmatter, because `vscode.LogOutputChannel`
+                // presents its own timestamp + loglevel.
 
-            if (info.raw) {
-                this.outputChannel.append(msg)
+                const loglevel = info.level as LogLevel
+                if (loglevel === 'error') {
+                    c.error(msg)
+                } else if (loglevel === 'warn') {
+                    c.warn(msg)
+                } else if (loglevel === 'debug' || loglevel === 'verbose') {
+                    c.debug(msg)
+                } else {
+                    c.info(msg)
+                }
             } else {
-                this.outputChannel.appendLine(msg)
+                const msg = this.stripAnsi ? removeAnsi(info[MESSAGE]) : info[MESSAGE]
+                if (info.raw) {
+                    this.outputChannel.append(msg)
+                } else {
+                    this.outputChannel.appendLine(msg)
+                }
             }
 
             this.emit('logged', info)

--- a/src/shared/sam/cli/samCliLocalInvoke.ts
+++ b/src/shared/sam/cli/samCliLocalInvoke.ts
@@ -80,7 +80,7 @@ export class DefaultSamLocalInvokeCommand implements SamLocalInvokeCommand {
                         this.logger.verbose('SAM: pid %d: stdout: %s', childProcess.pid(), removeAnsi(text))
                     },
                     onStderr: (text: string): void => {
-                        getLogger('debugConsole').error(text, { raw: true })
+                        getLogger('debugConsole').info(text, { raw: true })
                         // If we have a timeout (as we do on debug) refresh the timeout as we receive text
                         params.timeout?.refresh()
                         this.logger.verbose('SAM: pid %d: stderr: %s', childProcess.pid(), removeAnsi(text))

--- a/src/test/testUtil.ts
+++ b/src/test/testUtil.ts
@@ -341,9 +341,11 @@ export async function closeAllEditors(): Promise<void> {
     // Note: `workbench.action.closeAllEditors` is unreliable.
     const closeAllCmd = 'openEditors.closeAll'
 
-    // Output channels are named with prefix "extension-output". https://github.com/microsoft/vscode/issues/148993#issuecomment-1167654358
+    // Ignore these "editors" not closed by "openEditors.closeAll":
+    //  - `vscode.OutputChannel` name prefixed with "extension-output". https://github.com/microsoft/vscode/issues/148993#issuecomment-1167654358
+    //  - `vscode.LogOutputChannel` name (created with `vscode.window.createOutputChannel(…,{log:true})`
     // Maybe we can close these with a command?
-    const ignorePatterns = [/extension-output/, /tasks/]
+    const ignorePatterns = [/extension-output/, /tasks/, /amazonwebservices\.aws-toolkit-vscode\./]
     const editors: vscode.TextEditor[] = []
 
     const noVisibleEditor: boolean | undefined = await waitUntil(


### PR DESCRIPTION
## Problem

`vscode.LogOutputChannel` is now available via `createOutputChannel(..., { log: true })`, for improved highlighting and presentation of log-like output in VSCode, but AWS Toolkit still uses the old `vscode.OutputChannel` interface.

<img width="912" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/55561878/21e7cc22-851d-48c3-847e-a6ab0f4c2560">


## Solution

- Use `vscode.LogOutputChannel` when possible.
- Change SAM output to "info" level instead of "error" level.


<img width="889" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/55561878/7ce6524c-b75f-4cd9-a41e-21aedf276337">



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
