### PR TITLE
fix(gumby): set shell to false

### DIFF
--- a/.changes/next-release/Bug Fix-454d780d-97bc-49af-9391-527808d8bd33.json
+++ b/.changes/next-release/Bug Fix-454d780d-97bc-49af-9391-527808d8bd33.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q CodeTransform: open summary.md automatically when job finishes"
+}

--- a/src/codewhisperer/service/transformByQHandler.ts
+++ b/src/codewhisperer/service/transformByQHandler.ts
@@ -110,10 +110,10 @@ export async function validateProjectSelection(project: vscode.QuickPickItem) {
         })
         throw new TransformByQJavaProjectNotFound()
     }
-    const classFilePath = `"${compiledJavaFiles[0].fsPath}"`
+    const classFilePath = `${compiledJavaFiles[0].fsPath}`
     const baseCommand = 'javap'
     const args = ['-v', classFilePath]
-    const spawnResult = spawnSync(baseCommand, args, { shell: true, encoding: 'utf-8' })
+    const spawnResult = spawnSync(baseCommand, args, { shell: false, encoding: 'utf-8' })
 
     if (spawnResult.error || spawnResult.status !== 0) {
         void vscode.window.showErrorMessage(CodeWhispererConstants.noSupportedJavaProjectsFoundMessage)

--- a/src/codewhisperer/service/transformationResultsViewProvider.ts
+++ b/src/codewhisperer/service/transformationResultsViewProvider.ts
@@ -362,7 +362,7 @@ export class ProposedTransformationExplorer {
             })
 
             // Do not await this so that the summary reveals without user needing to close this notification
-            vscode.window.showInformationMessage(CodeWhispererConstants.viewProposedChangesMessage)
+            void vscode.window.showInformationMessage(CodeWhispererConstants.viewProposedChangesMessage)
             await vscode.commands.executeCommand('aws.amazonq.transformationHub.summary.reveal')
         })
 

--- a/src/codewhisperer/service/transformationResultsViewProvider.ts
+++ b/src/codewhisperer/service/transformationResultsViewProvider.ts
@@ -302,8 +302,8 @@ export class ProposedTransformationExplorer {
                     codeTransformApiNames: 'ExportResultArchive',
                     codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
                     codeTransformJobId: transformByQState.getJobId(),
-                    codeTransformApiErrorMessage: e?.message || errorMessage,
-                    codeTransformRequestId: e?.requestId,
+                    codeTransformApiErrorMessage: (e as Error).message ?? errorMessage,
+                    codeTransformRequestId: e.requestId ?? '',
                     result: MetadataResult.Fail,
                     reason: 'ExportResultArchiveFailed',
                 })
@@ -336,7 +336,7 @@ export class ProposedTransformationExplorer {
                 )
             } catch (e: any) {
                 deserializeErrorMessage =
-                    e?.message ||
+                    (e as Error).message ??
                     'Transform by Q experienced an error during the deserialization of the downloaded result archive'
                 getLogger().error('CodeTransform: ParseDiff error = ', deserializeErrorMessage)
                 void vscode.window.showErrorMessage(deserializeErrorMessage)
@@ -361,7 +361,8 @@ export class ProposedTransformationExplorer {
                 result: MetadataResult.Pass,
             })
 
-            await vscode.window.showInformationMessage(CodeWhispererConstants.viewProposedChangesMessage)
+            // Do not await this so that the summary reveals without user needing to close this notification
+            vscode.window.showInformationMessage(CodeWhispererConstants.viewProposedChangesMessage)
             await vscode.commands.executeCommand('aws.amazonq.transformationHub.summary.reveal')
         })
 


### PR DESCRIPTION
## Problem

A previous PR set shell to true for a shell command we run. This can lead to issues since special characters such as $ will be interpreted by the shell.

A smaller issue: the summary.md file was not opening automatically due to the "await" keyword.

## Solution

Set shell to false. Remove "await" keyword.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
