### PR TITLE
browser: remove non-complex uses of fs-extra for codewhisperer

### DIFF
--- a/src/amazonqFeatureDev/util/download.ts
+++ b/src/amazonqFeatureDev/util/download.ts
@@ -4,9 +4,9 @@
  */
 
 import path from 'path'
-import fs from 'fs-extra'
 import { CodeWhispererStreaming, ExportResultArchiveCommandInput } from '@amzn/codewhisperer-streaming'
 import { ToolkitError } from '../../shared/errors'
+import { fsCommon } from '../../srcShared/fs'
 
 /**
  * This class represents the structure of the archive returned by the ExportResultArchive endpoint
@@ -41,7 +41,7 @@ export async function downloadExportResultArchive(
             }
         }
 
-        fs.outputFileSync(toPath, Buffer.concat(buffer))
+        await fsCommon.writeFile(toPath, Buffer.concat(buffer))
     } catch (error) {
         throw new ToolkitError('There was a problem fetching the transformed code.')
     }

--- a/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
+++ b/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
@@ -4,7 +4,6 @@
  */
 
 import * as vscode from 'vscode'
-import * as fs from 'fs-extra'
 import path = require('path')
 import { BM25Document, BM25Okapi } from './rankBm25'
 import { ToolkitError } from '../../../shared/errors'
@@ -16,6 +15,7 @@ import { getFileDistance } from '../../../shared/filesystemUtilities'
 import { getOpenFilesInWindow } from '../../../shared/utilities/editorUtilities'
 import { getLogger } from '../../../shared/logger/logger'
 import { CodeWhispererSupplementalContext, CodeWhispererSupplementalContextItem } from '../../models/model'
+import { fsCommon } from '../../../srcShared/fs'
 
 type CrossFileSupportedLanguage =
     | 'java'
@@ -78,7 +78,7 @@ export async function fetchSupplementalContextForSrc(
     let chunkList: Chunk[] = []
     for (const relevantFile of relevantCrossFilePaths) {
         throwIfCancelled(cancellationToken)
-        const chunks: Chunk[] = splitFileToChunks(relevantFile, crossFileContextConfig.numberOfLinesEachChunk)
+        const chunks: Chunk[] = await splitFileToChunks(relevantFile, crossFileContextConfig.numberOfLinesEachChunk)
         const linkedChunks = linkChunks(chunks)
         chunkList.push(...linkedChunks)
         if (chunkList.length >= codeChunksCalculated) {
@@ -196,10 +196,10 @@ function linkChunks(chunks: Chunk[]) {
     return updatedChunks
 }
 
-export function splitFileToChunks(filePath: string, chunkSize: number): Chunk[] {
+export async function splitFileToChunks(filePath: string, chunkSize: number): Promise<Chunk[]> {
     const chunks: Chunk[] = []
 
-    const fileContent = fs.readFileSync(filePath, 'utf-8').trimEnd()
+    const fileContent = (await fsCommon.readFileAsString(filePath)).trimEnd()
     const lines = fileContent.split('\n')
 
     for (let i = 0; i < lines.length; i += chunkSize) {

--- a/src/srcShared/fs.ts
+++ b/src/srcShared/fs.ts
@@ -57,6 +57,9 @@ export class FileSystemCommon {
         return fs.readFile(path)
     }
 
+    /**
+     * Uses UTF-8 encoding.
+     */
     async readFileAsString(path: Uri | string): Promise<string> {
         path = FileSystemCommon.getUri(path)
         return FileSystemCommon.arrayToString(await this.readFile(path))
@@ -110,6 +113,10 @@ export class FileSystemCommon {
         return fs.writeFile(path, FileSystemCommon.asArray(data))
     }
 
+    async copy(source: Uri, target: Uri, overwrite?: boolean) {
+        return fs.copy(source, target, { overwrite })
+    }
+
     /**
      * The stat of the file, undefined if the file does not exist, otherwise an error is thrown.
      */
@@ -121,6 +128,20 @@ export class FileSystemCommon {
     async delete(uri: vscode.Uri | string): Promise<void> {
         const path = FileSystemCommon.getUri(uri)
         return fs.delete(path, { recursive: true })
+    }
+
+    /**
+     * Unlike delete(), does not throw an error if the path does not exist.
+     * TODO: Refactor into delete().
+     */
+    async safeDelete(uri: vscode.Uri | string): Promise<void> {
+        try {
+            return await this.delete(uri)
+        } catch (e) {
+            if (!(e instanceof vscode.FileSystemError.FileNotFound)) {
+                throw e
+            }
+        }
     }
 
     async readdir(uri: vscode.Uri | string): Promise<[string, vscode.FileType][]> {

--- a/src/test/codewhisperer/service/transformationResultsHandler.test.ts
+++ b/src/test/codewhisperer/service/transformationResultsHandler.test.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import assert from 'assert'
-import sinon from 'sinon'
-import fs from 'fs-extra'
 import {
     DiffModel,
     AddedChangeNode,
@@ -12,32 +10,20 @@ import {
     ModifiedChangeNode,
 } from '../../../codewhisperer/service/transformationResultsViewProvider'
 import path from 'path'
+import { createTestFile } from '../../testUtil'
 
 const getTestFilePath = (relativePathToFile: string) => {
     return path.resolve(__dirname, relativePathToFile)
 }
 
 describe('DiffModel', function () {
-    afterEach(() => {
-        sinon.restore()
-    })
-
     it('WHEN parsing a diff patch where a file was added THEN returns an array representing the added file', async function () {
         const testDiffModel = new DiffModel()
 
         const workspacePath = 'workspace'
-        const tmpPath = 'tmp'
+        const tmpPath = (await createTestFile('testfile.txt')).path.replace('/testfile.txt', '')
 
-        sinon.replace(fs, 'existsSync', path => {
-            const pathStr = path.toString()
-            if (pathStr.includes(workspacePath)) {
-                return false
-            }
-
-            return true
-        })
-
-        testDiffModel.parseDiff(getTestFilePath('resources/addedFile.diff'), tmpPath, workspacePath)
+        await testDiffModel.parseDiff(getTestFilePath('resources/addedFile.diff'), tmpPath, workspacePath)
 
         assert.strictEqual(testDiffModel.changes.length, 1)
         const change = testDiffModel.changes[0]
@@ -48,19 +34,10 @@ describe('DiffModel', function () {
     it('WHEN parsing a diff patch where a file was removed THEN returns an array representing the removed file', async function () {
         const testDiffModel = new DiffModel()
 
-        const workspacePath = 'workspace'
+        const workspacePath = (await createTestFile('settings.gradle')).path.replace('/settings.gradle', '')
         const tmpPath = 'tmp'
 
-        sinon.replace(fs, 'existsSync', path => {
-            const pathStr = path.toString()
-            if (pathStr.includes(workspacePath)) {
-                return true
-            }
-
-            return false
-        })
-
-        testDiffModel.parseDiff(getTestFilePath('resources/removedFile.diff'), tmpPath, workspacePath)
+        await testDiffModel.parseDiff(getTestFilePath('resources/removedFile.diff'), tmpPath, workspacePath)
 
         assert.strictEqual(testDiffModel.changes.length, 1)
         const change = testDiffModel.changes[0]
@@ -71,12 +48,9 @@ describe('DiffModel', function () {
     it('WHEN parsing a diff patch where a file was modified THEN returns an array representing the modified file', async function () {
         const testDiffModel = new DiffModel()
 
-        const workspacePath = 'workspace'
-        const tmpPath = 'tmp'
+        const path = (await createTestFile('README.md')).path.replace('/README.md', '')
 
-        sinon.replace(fs, 'existsSync', path => true)
-
-        testDiffModel.parseDiff(getTestFilePath('resources/modifiedFile.diff'), tmpPath, workspacePath)
+        await testDiffModel.parseDiff(getTestFilePath('resources/modifiedFile.diff'), path, path)
 
         assert.strictEqual(testDiffModel.changes.length, 1)
         const change = testDiffModel.changes[0]

--- a/src/test/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/src/test/codewhisperer/util/crossFileContextUtil.test.ts
@@ -247,7 +247,7 @@ describe('crossFileContextUtil', function () {
             const filePath = path.join(tempFolder, 'file.txt')
             await toFile('line_1\nline_2\nline_3\nline_4\nline_5\nline_6\nline_7', filePath)
 
-            const chunks = crossFile.splitFileToChunks(filePath, 2)
+            const chunks = await crossFile.splitFileToChunks(filePath, 2)
 
             assert.strictEqual(chunks.length, 4)
             assert.strictEqual(chunks[0].content, 'line_1\nline_2')
@@ -260,7 +260,7 @@ describe('crossFileContextUtil', function () {
             const filePath = path.join(tempFolder, 'file.txt')
             await toFile('line_1\nline_2\nline_3\nline_4\nline_5\nline_6\nline_7', filePath)
 
-            const chunks = crossFile.splitFileToChunks(filePath, 5)
+            const chunks = await crossFile.splitFileToChunks(filePath, 5)
 
             assert.strictEqual(chunks.length, 2)
             assert.strictEqual(chunks[0].content, 'line_1\nline_2\nline_3\nline_4\nline_5')
@@ -271,7 +271,7 @@ describe('crossFileContextUtil', function () {
             const filePath = path.join(tempFolder, 'file.txt')
             await toFile(sampleFileOf60Lines, filePath)
 
-            const chunks = crossFile.splitFileToChunks(filePath, crossFileContextConfig.numberOfLinesEachChunk)
+            const chunks = await crossFile.splitFileToChunks(filePath, crossFileContextConfig.numberOfLinesEachChunk)
             assert.strictEqual(chunks.length, 6)
         })
     })

--- a/src/test/srcShared/fs.test.ts
+++ b/src/test/srcShared/fs.test.ts
@@ -211,6 +211,13 @@ describe('FileSystem', function () {
         })
     })
 
+    describe('safeDelete()', function () {
+        it('does not throw error when deleting a non-existant path', async function () {
+            const dirPath = createTestPath('thingToDelete')
+            assert.doesNotThrow(async () => await fsCommon.delete(dirPath))
+        })
+    })
+
     describe('stat()', function () {
         it('gets stat of a file', async function () {
             const filePath = await makeFile('test.txt', 'hello world')

--- a/src/testE2E/amazonqGumby/transformByQ.test.ts
+++ b/src/testE2E/amazonqGumby/transformByQ.test.ts
@@ -42,7 +42,7 @@ describe('transformByQ', async function () {
     })
 
     it('WHEN upload payload with missing sha256 in headers THEN fails to upload', async function () {
-        const sha256 = getSha256(zippedCodePath)
+        const sha256 = await getSha256(zippedCodePath)
         const response = await codeWhisperer.codeWhispererClient.createUploadUrl({
             contentChecksum: sha256,
             contentChecksumType: CodeWhispererConstants.contentChecksumType,
@@ -69,7 +69,7 @@ describe('transformByQ', async function () {
     })
 
     it('WHEN createUploadUrl THEN URL uses HTTPS and sets 60 second expiration', async function () {
-        const sha256 = getSha256(zippedCodePath)
+        const sha256 = await getSha256(zippedCodePath)
         const response = await codeWhisperer.codeWhispererClient.createUploadUrl({
             contentChecksum: sha256,
             contentChecksumType: CodeWhispererConstants.contentChecksumType,


### PR DESCRIPTION
Continuation of https://github.com/aws/aws-toolkit-vscode/pull/4230

- Adds wrapper for `copy`
- Adds function for deleting something and swalling error if it doesn't exist.
- Update tests cases where immediately relevant.
- Refactors some code from functional style to loops, so that they can be awaited.

Does not update `dependencyGraph.ts` as it contains some complex uses of `fs-extra`, such as sym
links.

#### Testing
Manual testing in progress.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
