### PR TITLE
fix(logging): "debug" messages not shown in "AWS Toolkit Logs" channel

### DIFF
--- a/src/shared/logger/outputChannelTransport.ts
+++ b/src/shared/logger/outputChannelTransport.ts
@@ -64,7 +64,12 @@ export class OutputChannelTransport extends Transport {
                 } else if (loglevel === 'warn') {
                     c.warn(msg)
                 } else if (loglevel === 'debug' || loglevel === 'verbose') {
-                    c.debug(msg)
+                    // XXX: `vscode.LogOutputChannel` loglevel is currently readonly:
+                    //      https://github.com/microsoft/vscode/issues/170450
+                    //      https://github.com/PowerShell/vscode-powershell/issues/4441
+                    // So debug() will just drop messages unless the user has increased vscode's log-level.
+                    // Use info() until vscode adds a way to set the loglevel.
+                    c.info(msg)
                 } else {
                     c.info(msg)
                 }


### PR DESCRIPTION
Followup to #4285.

## Problem


`vscode.LogOutputChannel` loglevel is currently readonly:

https://github.com/microsoft/vscode/issues/170450
https://github.com/PowerShell/vscode-powershell/issues/4441

So `debug()` will just drop messages unless the user has increased vscode's log-level.

## Solution

Write "debug" logs using `info()` until vscode adds a way to set the loglevel.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
