### PR TITLE
feat(gumby): run mvnw if mvn fails

### DIFF
--- a/.changes/next-release/Feature-46a5faf6-6909-48b4-bce3-d74e390b5519.json
+++ b/.changes/next-release/Feature-46a5faf6-6909-48b4-bce3-d74e390b5519.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Amazon Q CodeTransform: use Maven wrapper (if present) to copy dependencies if Maven not installed"
+}

--- a/src/codewhisperer/models/constants.ts
+++ b/src/codewhisperer/models/constants.ts
@@ -289,7 +289,7 @@ export const selectTargetVersionPrompt = 'Select the target version'
 
 export const selectModulePrompt = 'Select the module you want to transform'
 
-export const transformByQWindowTitle = 'Transform'
+export const transformByQWindowTitle = 'Amazon Q CodeTransformation'
 
 export const stopTransformByQMessage = 'Stop Transformation?'
 

--- a/src/codewhisperer/service/transformByQHandler.ts
+++ b/src/codewhisperer/service/transformByQHandler.ts
@@ -366,19 +366,19 @@ export async function zipCode(modulePath: string) {
     throwIfCancelled()
 
     let dependencyFolderInfo: string[] = []
-    let mavenFailed = false
+    let mavenWrapperFailed = false
     try {
-        dependencyFolderInfo = getProjectDependencies('mvn', modulePath)
+        dependencyFolderInfo = getProjectDependencies('mvnw', modulePath)
     } catch (err) {
-        mavenFailed = true
+        mavenWrapperFailed = true
     }
 
-    let mavenWrapperFailed = false
-    if (mavenFailed) {
+    let mavenFailed = false
+    if (mavenWrapperFailed) {
         try {
-            dependencyFolderInfo = getProjectDependencies('mvnw', modulePath)
+            dependencyFolderInfo = getProjectDependencies('mvn', modulePath)
         } catch (err) {
-            mavenWrapperFailed = true
+            mavenFailed = true
         }
     }
 


### PR DESCRIPTION
## Problem

When `mvn` fails, we want to run `mvnw` because that may succeed, since the user could have the Maven wrapper in their workspace despite not having Maven installed.

## Solution

Run `mvnw` when `mvn` fails. Some smaller things done in this PR: 1) slight renaming and 2) collect input in a simpler way (no need to use `MultiStepInputFlowController` since we only collect 1 piece of input).

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
