### PR TITLE
browser: remove usage of got in codewhisperer

### DIFF
--- a/src/applicationcomposer/webviewManager.ts
+++ b/src/applicationcomposer/webviewManager.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
-import fetch from '../common/request'
+import request from '../common/request'
 import { ApplicationComposer } from './composerWebview'
 import { getLogger } from '../shared/logger'
 
@@ -34,7 +34,7 @@ export class ApplicationComposerManager {
 
     private async fetchWebviewHtml() {
         const source = isLocalDev ? localhost : cdn
-        const response = await fetch('GET', `${source}/index.html`).response
+        const response = await request.fetch('GET', `${source}/index.html`).response
         this.webviewHtml = await response.text()
         for (const visualization of this.managedVisualizations.values()) {
             await visualization.refreshPanel(this.extensionContext)

--- a/src/codewhisperer/service/transformByQHandler.ts
+++ b/src/codewhisperer/service/transformByQHandler.ts
@@ -16,7 +16,6 @@ import * as os from 'os'
 import * as vscode from 'vscode'
 import { spawnSync } from 'child_process'
 import AdmZip from 'adm-zip'
-import fetch from '../../common/request'
 import globals from '../../shared/extensionGlobals'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { ToolkitError } from '../../shared/errors'
@@ -24,6 +23,7 @@ import { codeTransformTelemetryState } from '../../amazonqGumby/telemetry/codeTr
 import { calculateTotalLatency, javapOutputToTelemetryValue } from '../../amazonqGumby/telemetry/codeTransformTelemetry'
 import { TransformByQJavaProjectNotFound } from '../../amazonqGumby/models/model'
 import { MetadataResult } from '../../shared/telemetry/telemetryClient'
+import request from '../../common/request'
 
 /* TODO: once supported in all browsers and past "experimental" mode, use Intl DurationFormat:
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DurationFormat#browser_compatibility
@@ -178,8 +178,10 @@ export async function uploadArtifactToS3(fileName: string, resp: CreateUploadUrl
     throwIfCancelled()
     try {
         const apiStartTime = Date.now()
-        const response = await fetch('PUT', resp.uploadUrl, { body: fs.readFileSync(fileName), headers: headersObj })
-            .response
+        const response = await request.fetch('PUT', resp.uploadUrl, {
+            body: fs.readFileSync(fileName),
+            headers: headersObj,
+        }).response
         telemetry.codeTransform_logApiLatency.emit({
             codeTransformApiNames: 'UploadZip',
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),

--- a/src/common/request.ts
+++ b/src/common/request.ts
@@ -5,25 +5,28 @@
 
 import crossFetch from 'cross-fetch'
 
-/**
- * Make a fetch request.
- *
- * @example
- * const request = fetch('GET', 'https://example.com')
- * setTimeout(() => request.cancel(), 10_000)
- * const response = await request.response
- * const text = await response.text()
- *
- * @param wrappedFetch - The actual fetch implementation
- */
-export default function fetch(
-    method: RequestMethod,
-    url: string,
-    params?: RequestParamsArg,
-    wrappedFetch = crossFetch
-): FetchRequest {
-    return new FetchRequest(url, { ...params, method }, wrappedFetch)
+const request = {
+    /**
+     * Make a fetch request.
+     *
+     * @example
+     * const request = fetch('GET', 'https://example.com')
+     * setTimeout(() => request.cancel(), 10_000)
+     * const response = await request.response
+     * const text = await response.text()
+     *
+     * @param wrappedFetch - The actual fetch implementation
+     */
+    fetch: function (
+        method: RequestMethod,
+        url: string,
+        params?: RequestParamsArg,
+        wrappedFetch = crossFetch
+    ): FetchRequest {
+        return new FetchRequest(url, { ...params, method }, wrappedFetch)
+    },
 }
+export default request
 
 type RequestMethod = 'GET' | 'POST' | 'PUT'
 /** All possible params of a fetch request (eg: headers) */

--- a/src/test/amazonqFeatureDev/session/sessionState.test.ts
+++ b/src/test/amazonqFeatureDev/session/sessionState.test.ts
@@ -6,7 +6,6 @@
 import * as vscode from 'vscode'
 import assert from 'assert'
 import sinon from 'sinon'
-import * as got from 'got'
 import { RefinementState, PrepareRefinementState } from '../../../amazonqFeatureDev/session/sessionState'
 import { SessionStateConfig, SessionStateAction } from '../../../amazonqFeatureDev/types'
 import { Messenger } from '../../../amazonqFeatureDev/controllers/chat/messenger/messenger'
@@ -16,6 +15,7 @@ import { FeatureDevClient } from '../../../amazonqFeatureDev/client/featureDev'
 import { PrepareRepoFailedError } from '../../../amazonqFeatureDev/errors'
 import { TelemetryHelper } from '../../../amazonqFeatureDev/util/telemetryHelper'
 import { assertTelemetry } from '../../testUtil'
+import { getFetchStubWithResponse } from '../../common/request.test'
 
 const mockSessionStateAction = (msg?: string): SessionStateAction => {
     return {
@@ -75,7 +75,7 @@ describe('sessionState', () => {
             sinon.stub(vscode.workspace, 'findFiles').resolves([])
             mockCreateUploadUrl = sinon.stub().resolves({ uploadId: '', uploadUrl: '' })
             mockGeneratePlan = sinon.stub().resolves(testApproach)
-            sinon.stub(got, 'default').resolves({ statusCode: 200 })
+            getFetchStubWithResponse({ status: 200 })
 
             const testAction = mockSessionStateAction()
             await new PrepareRefinementState(testConfig, testApproach, tabId).interact(testAction)

--- a/src/test/codewhisperer/commands/startSecurityScan.test.ts
+++ b/src/test/codewhisperer/commands/startSecurityScan.test.ts
@@ -6,7 +6,6 @@
 import assert from 'assert'
 import * as vscode from 'vscode'
 import * as sinon from 'sinon'
-import * as got from 'got'
 import * as semver from 'semver'
 import { DefaultCodeWhispererClient } from '../../../codewhisperer/client/codewhisperer'
 import * as startSecurityScan from '../../../codewhisperer/commands/startSecurityScan'
@@ -21,7 +20,6 @@ import { HttpResponse } from 'aws-sdk'
 import { getTestWindow } from '../../shared/vscode/window'
 import { SeverityLevel } from '../../shared/vscode/message'
 import { cancel } from '../../../shared/localizedText'
-import { sleep } from '../../../shared/utilities/timeoutUtils'
 import {
     codeScanLogsOutputChannelId,
     showScannedFilesMessage,
@@ -29,6 +27,7 @@ import {
 } from '../../../codewhisperer/models/constants'
 import * as model from '../../../codewhisperer/models/model'
 import { CodewhispererSecurityScan } from '../../../shared/telemetry/telemetry.gen'
+import { getFetchStubWithResponse } from '../../common/request.test'
 
 const mockCreateCodeScanResponse = {
     $response: {
@@ -177,7 +176,7 @@ describe('startSecurityScan', function () {
     })
 
     it('Should render security scan result', async function () {
-        sinon.stub(got, 'default').resolves({ statusCode: 200 })
+        getFetchStubWithResponse({ status: 200, statusText: 'testing stub' })
         const commandSpy = sinon.spy(vscode.commands, 'executeCommand')
         const securityScanRenderSpy = sinon.spy(diagnosticsProvider, 'initSecurityScanRender')
 
@@ -194,11 +193,7 @@ describe('startSecurityScan', function () {
     })
 
     it('Should stop security scan', async function () {
-        sinon.stub(got, 'default').callsFake(() => {
-            return sleep(1000).then(() => {
-                return { statusCode: 200 }
-            }) as any
-        })
+        getFetchStubWithResponse({ status: 200, statusText: 'testing stub' })
         const securityScanRenderSpy = sinon.spy(diagnosticsProvider, 'initSecurityScanRender')
         const securityScanStoppedErrorSpy = sinon.spy(model, 'CodeScanStoppedError')
         const testWindow = getTestWindow()
@@ -223,11 +218,7 @@ describe('startSecurityScan', function () {
     })
 
     it('Should not stop security scan when not confirmed', async function () {
-        sinon.stub(got, 'default').callsFake(() => {
-            return sleep(1000).then(() => {
-                return { statusCode: 200 }
-            }) as any
-        })
+        getFetchStubWithResponse({ status: 200, statusText: 'testing stub' })
         const securityScanRenderSpy = sinon.spy(diagnosticsProvider, 'initSecurityScanRender')
         const securityScanStoppedErrorSpy = sinon.spy(model, 'CodeScanStoppedError')
         const testWindow = getTestWindow()
@@ -256,7 +247,7 @@ describe('startSecurityScan', function () {
             this.skip()
         }
         const commandSpy = sinon.spy(vscode.commands, 'executeCommand')
-        sinon.stub(got, 'default').resolves({ statusCode: 200 })
+        getFetchStubWithResponse({ status: 200, statusText: 'testing stub' })
         const testWindow = getTestWindow()
         testWindow.onDidShowMessage(message => {
             if (message.message.includes('Security scan completed')) {

--- a/src/testE2E/amazonqGumby/transformByQ.test.ts
+++ b/src/testE2E/amazonqGumby/transformByQ.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert'
 import { getSha256, uploadArtifactToS3, zipCode } from '../../codewhisperer/service/transformByQHandler'
-import fetch from '../../common/request'
+import request from '../../common/request'
 import * as CodeWhispererConstants from '../../codewhisperer/models/constants'
 import * as codeWhisperer from '../../codewhisperer/client/codewhisperer'
 import * as os from 'os'
@@ -54,7 +54,7 @@ describe('transformByQ', async function () {
         }
         await assert.rejects(
             () =>
-                fetch('PUT', response.uploadUrl, { body: fs.readFileSync(zippedCodePath), headers: headersObj })
+                request.fetch('PUT', response.uploadUrl, { body: fs.readFileSync(zippedCodePath), headers: headersObj })
                     .response
         )
     })

--- a/src/testInteg/common/request.ts
+++ b/src/testInteg/common/request.ts
@@ -4,12 +4,12 @@
  */
 
 import { endpointsFileUrl } from '../../shared/constants'
-import fetch from '../../common/request'
+import request from '../../common/request'
 import assert from 'assert'
 
 describe('fetch()', function () {
     it('makes a fetch request', async function () {
-        const response = await fetch('GET', endpointsFileUrl).response
+        const response = await request.fetch('GET', endpointsFileUrl).response
         assert.strictEqual(response.ok, true)
         assert.strictEqual(response.status, 200)
     })


### PR DESCRIPTION
`got` package is not available in the browser. Replace usage with common `fetch` from `request.ts`

- Also refactors request.ts fetch for testing and current usages of the common fetch.
- Other minor code refactors around some usage of the fetch code.

#### Testing
Manual testing ongoing.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
