### PR TITLE
MRU list util implementation

### DIFF
--- a/src/shared/utilities/collectionUtils.ts
+++ b/src/shared/utilities/collectionUtils.ts
@@ -538,6 +538,13 @@ export class MRUList<T> {
         this.internalList.splice(0, this.internalList.length)
     }
 
+    remove(element: T) {
+        const index = this.internalList.indexOf(element)
+        if (index !== -1) {
+            this.internalList.splice(index, 1)
+        }
+    }
+
     private trimToSize() {
         while (this.internalList.length > this.maxSize) {
             this.internalList.splice(this.internalList.length - 1, 1)

--- a/src/shared/utilities/collectionUtils.ts
+++ b/src/shared/utilities/collectionUtils.ts
@@ -511,3 +511,36 @@ export function createCollectionFromPages<T>(...pages: T[]): AsyncCollection<T> 
         return pages[pages.length - 1]
     })
 }
+
+export class MRUList<T> {
+    private readonly internalList: T[] = []
+
+    constructor(private readonly maxSize: number) {}
+
+    add(element: T) {
+        const index = this.internalList.indexOf(element)
+        if (index !== -1) {
+            this.internalList.splice(index, 1)
+        }
+
+        this.internalList.unshift(element)
+        this.trimToSize()
+    }
+
+    elements(level?: number): T[] {
+        if (level) {
+            return this.internalList.slice(0, level)
+        }
+        return this.internalList
+    }
+
+    clear() {
+        this.internalList.splice(0, this.internalList.length)
+    }
+
+    private trimToSize() {
+        while (this.internalList.length > this.maxSize) {
+            this.internalList.splice(this.internalList.length - 1, 1)
+        }
+    }
+}

--- a/src/test/shared/utilities/collectionUtils.test.ts
+++ b/src/test/shared/utilities/collectionUtils.test.ts
@@ -29,6 +29,7 @@ import {
     join,
     toStream,
     joinAll,
+    MRUList,
 } from '../../../shared/utilities/collectionUtils'
 
 import { asyncGenerator } from '../../../shared/utilities/collectionUtils'
@@ -662,6 +663,45 @@ describe('CollectionUtils', async function () {
                 const iterable = joinAll(toAsyncIterable(iterables))
                 assert.deepStrictEqual(await iterateAll(iterable), expected)
             })
+        })
+    })
+
+    describe('MRUList', function () {
+        let sut: MRUList<any>
+
+        beforeEach(function () {
+            sut = new MRUList(3)
+        })
+
+        it('should evict the oldest and return elements by most recently used order', function () {
+            sut.add('foo')
+            sut.add('bar')
+            sut.add('baz')
+            sut.add('fiz')
+
+            assert.deepStrictEqual(sut.elements(), ['fiz', 'baz', 'bar'])
+            assert.deepStrictEqual(sut.elements(2), ['fiz', 'baz'])
+            assert.deepStrictEqual(sut.elements(1), ['fiz'])
+        })
+
+        it('should move up re-added element', function () {
+            sut.add('foo')
+            sut.add('bar')
+            sut.add('baz')
+            sut.add('foo')
+
+            assert.deepStrictEqual(sut.elements(), ['foo', 'baz', 'bar'])
+            assert.deepStrictEqual(sut.elements(2), ['foo', 'baz'])
+            assert.deepStrictEqual(sut.elements(1), ['foo'])
+        })
+
+        it('clear', function () {
+            sut.add('foo')
+            sut.add('bar')
+            sut.add('baz')
+            sut.clear()
+
+            assert.deepStrictEqual(sut.elements(), [])
         })
     })
 })

--- a/src/test/shared/utilities/collectionUtils.test.ts
+++ b/src/test/shared/utilities/collectionUtils.test.ts
@@ -703,5 +703,14 @@ describe('CollectionUtils', async function () {
 
             assert.deepStrictEqual(sut.elements(), [])
         })
+
+        it('should remove the specified object from the cache', function () {
+            sut.add('foo')
+            sut.add('bar')
+            sut.add('baz')
+            sut.remove('bar')
+
+            assert.deepStrictEqual(sut.elements(), ['baz', 'foo'])
+        })
     })
 })


### PR DESCRIPTION
## Problem
Not seeing relative util class existing in VSC code base and library

## Solution
Implementation is moved from AWS Toolkit JB https://github.com/aws/aws-toolkit-jetbrains/blob/main/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/MRUList.kt

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
