### PR TITLE
fix(cloud9): error when expanding S3 folder

### DIFF
--- a/.changes/next-release/Bug Fix-80b20b86-cc12-4387-976c-681c09cbd942.json
+++ b/.changes/next-release/Bug Fix-80b20b86-cc12-4387-976c-681c09cbd942.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Cloud9: error when expanding S3 folder"
+}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,6 +21,8 @@ jobs:
         env:
             VSCODE_TEST_VERSION: ${{ matrix.vscode-version }}
             NODE_OPTIONS: '--max-old-space-size=8192'
+            # Set a fixed timezone for tests. Intentionally _not_ UTC.
+            TZ: 'US/Pacific'
         steps:
             - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node-version }}
@@ -64,6 +66,8 @@ jobs:
         env:
             VSCODE_TEST_VERSION: ${{ matrix.vscode-version }}
             NODE_OPTIONS: '--max-old-space-size=8192'
+            # Set a fixed timezone for tests. Intentionally _not_ UTC.
+            TZ: 'US/Pacific'
         steps:
             - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,8 +21,6 @@ jobs:
         env:
             VSCODE_TEST_VERSION: ${{ matrix.vscode-version }}
             NODE_OPTIONS: '--max-old-space-size=8192'
-            # Set a fixed timezone for tests. Intentionally _not_ UTC.
-            TZ: 'US/Pacific'
         steps:
             - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node-version }}
@@ -66,8 +64,6 @@ jobs:
         env:
             VSCODE_TEST_VERSION: ${{ matrix.vscode-version }}
             NODE_OPTIONS: '--max-old-space-size=8192'
-            # Set a fixed timezone for tests. Intentionally _not_ UTC.
-            TZ: 'US/Pacific'
         steps:
             - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node-version }}

--- a/buildspec/linuxE2ETests.yml
+++ b/buildspec/linuxE2ETests.yml
@@ -5,6 +5,8 @@ run-as: codebuild-user
 
 env:
     variables:
+        # Set a fixed timezone for tests. Intentionally _not_ UTC.
+        TZ: 'US/Pacific'
         AWS_TOOLKIT_TEST_NO_COLOR: '1'
         NO_COVERAGE: 'true'
         # Suppress noisy apt-get/dpkg warnings like "debconf: unable to initialize frontend: Dialog").

--- a/buildspec/linuxE2ETests.yml
+++ b/buildspec/linuxE2ETests.yml
@@ -5,8 +5,6 @@ run-as: codebuild-user
 
 env:
     variables:
-        # Set a fixed timezone for tests. Intentionally _not_ UTC.
-        TZ: 'US/Pacific'
         AWS_TOOLKIT_TEST_NO_COLOR: '1'
         NO_COVERAGE: 'true'
         # Suppress noisy apt-get/dpkg warnings like "debconf: unable to initialize frontend: Dialog").

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -9,6 +9,8 @@ env:
         # VSCODE_TEST_VERSION
         # GITHUB_READONLY_TOKEN
         AWS_TOOLKIT_TEST_NO_COLOR: '1'
+        # Set a fixed timezone for tests. Intentionally _not_ UTC.
+        TZ: 'US/Pacific'
         NO_COVERAGE: 'true'
         # Suppress noisy apt-get/dpkg warnings like "debconf: unable to initialize frontend: Dialog").
         DEBIAN_FRONTEND: 'noninteractive'

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -9,8 +9,6 @@ env:
         # VSCODE_TEST_VERSION
         # GITHUB_READONLY_TOKEN
         AWS_TOOLKIT_TEST_NO_COLOR: '1'
-        # Set a fixed timezone for tests. Intentionally _not_ UTC.
-        TZ: 'US/Pacific'
         NO_COVERAGE: 'true'
         # Suppress noisy apt-get/dpkg warnings like "debconf: unable to initialize frontend: Dialog").
         DEBIAN_FRONTEND: 'noninteractive'

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -7,6 +7,8 @@ env:
     # For "pipefail".
     shell: bash
     variables:
+        # Set a fixed timezone for tests. Intentionally _not_ UTC.
+        TZ: 'US/Pacific'
         AWS_TOOLKIT_TEST_NO_COLOR: '1'
 
 phases:

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -7,8 +7,6 @@ env:
     # For "pipefail".
     shell: bash
     variables:
-        # Set a fixed timezone for tests. Intentionally _not_ UTC.
-        TZ: 'US/Pacific'
         AWS_TOOLKIT_TEST_NO_COLOR: '1'
 
 phases:

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -2,6 +2,8 @@ version: 0.2
 env:
     variables:
         AWS_TOOLKIT_TEST_NO_COLOR: '1'
+        # Set a fixed timezone for tests. Intentionally _not_ UTC.
+        TZ: 'US/Pacific'
 phases:
     install:
         runtime-versions:

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -2,8 +2,6 @@ version: 0.2
 env:
     variables:
         AWS_TOOLKIT_TEST_NO_COLOR: '1'
-        # Set a fixed timezone for tests. Intentionally _not_ UTC.
-        TZ: 'US/Pacific'
 phases:
     install:
         runtime-versions:

--- a/src/shared/utilities/textUtilities.ts
+++ b/src/shared/utilities/textUtilities.ts
@@ -246,7 +246,7 @@ export function getRelativeDate(from: Date, now: Date = new Date()): string {
  * US: Jan 5, 2020 5:30:20 PM GMT-0700
  * GB: 5 Jan 2020 17:30:20 GMT+0100
  */
-export function formatLocalized(d: Date = new Date()): string {
+export function formatLocalized(d: Date = new Date(), cloud9 = isCloud9()): string {
     const dateFormat = new Intl.DateTimeFormat('en-US', {
         year: 'numeric',
         month: 'short',
@@ -256,7 +256,7 @@ export function formatLocalized(d: Date = new Date()): string {
         hour: 'numeric',
         minute: 'numeric',
         second: 'numeric',
-        timeZoneName: 'longOffset',
+        timeZoneName: cloud9 ? 'short' : 'shortOffset',
     })
 
     return `${dateFormat.format(d)} ${timeFormat.format(d)}`

--- a/src/test/cloudWatchLogs/commands/saveCurrentLogDataContent.test.ts
+++ b/src/test/cloudWatchLogs/commands/saveCurrentLogDataContent.test.ts
@@ -36,8 +36,8 @@ async function testFilterLogEvents(
 describe('saveCurrentLogDataContent', async function () {
     let filename: string
     let tempDir: string
-    const expectedText = `1970-01-20T09:24:11.113+00:00\tThe first log event
-1970-01-20T09:24:11.114+00:00\tThe second log event
+    const expectedText = `1970-01-20T09:24:11.113-08:00\tThe first log event
+1970-01-20T09:24:11.114-08:00\tThe second log event
 `
 
     beforeEach(async function () {

--- a/src/test/cloudWatchLogs/document/textContent.test.ts
+++ b/src/test/cloudWatchLogs/document/textContent.test.ts
@@ -35,8 +35,8 @@ The second log event
 
         const { text, streamIdMap } = generateTextFromLogEvents(events, { timestamps: true })
 
-        const expectedText = `1970-01-20T09:24:11.113+00:00\tThe first log event
-1970-01-20T09:24:11.114+00:00\tThe second log event
+        const expectedText = `1970-01-20T09:24:11.113-08:00\tThe first log event
+1970-01-20T09:24:11.114-08:00\tThe second log event
 `
         const expectedStreamIdMap = new Map([
             [0, 'stream1'],
@@ -58,8 +58,8 @@ The second log event
 
         const { text, streamIdMap } = generateTextFromLogEvents(events, { timestamps: true })
 
-        const expectedText = `1970-01-20T09:24:11.113+00:00\tThe first log event
-1970-01-20T09:24:11.114+00:00\tThe second log event
+        const expectedText = `1970-01-20T09:24:11.113-08:00\tThe first log event
+1970-01-20T09:24:11.114-08:00\tThe second log event
 ${timestampSpaceEquivalent}\twith another line
 ${timestampSpaceEquivalent}\tand another
 `

--- a/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
@@ -210,7 +210,7 @@ describe('LogDataRegistry', async function () {
         it('matches CloudWatch insights timestamps', function () {
             const time = 1624201162222 // 2021-06-20 14:59:22.222 GMT+0
             const timestamp = formatDateTimestamp(true, new Date(time))
-            assert.strictEqual(timestamp, '2021-06-20T14:59:22.222+00:00')
+            assert.strictEqual(timestamp, '2021-06-20T14:59:22.222-07:00')
         })
     })
 })

--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -37,6 +37,10 @@ let openExternalStub: sinon.SinonStub<Parameters<(typeof vscode)['env']['openExt
 // let executeCommandSpy: sinon.SinonSpy | undefined
 
 export async function mochaGlobalSetup(this: Mocha.Runner) {
+    // Set a fixed timezone. Intentionally _not_ UTC, to increase variation in tests.
+    process.env.TZ = 'US/Pacific'
+    // process.env.TZ = 'Europe/London'
+
     // Clean up and set up test logs
     try {
         await remove(testLogOutput)

--- a/src/test/iot/explorer/iotPolicyVersionNode.test.ts
+++ b/src/test/iot/explorer/iotPolicyVersionNode.test.ts
@@ -14,7 +14,7 @@ import { formatLocalized } from '../../../shared/utilities/textUtilities'
 describe('IotPolicyVersionNode', function () {
     const policyName = 'policy'
     const expectedPolicy: IotPolicy = { name: policyName, arn: 'arn' }
-    const createDate = new Date(2021, 1, 1)
+    const createDate = new Date(Date.UTC(2021, 1, 1)) // Feb 1 UTC = Jan 31 PDT
     const createDateFormatted = formatLocalized(createDate)
     const policyVersion: Iot.PolicyVersion = { versionId: 'V1', isDefaultVersion: true, createDate }
     const nonDefaultVersion: Iot.PolicyVersion = { versionId: 'V2', isDefaultVersion: false, createDate }

--- a/src/test/s3/explorer/s3FileNode.test.ts
+++ b/src/test/s3/explorer/s3FileNode.test.ts
@@ -15,8 +15,8 @@ describe('S3FileNode', function () {
     const name = 'file.jpg'
     const key = 'path/to/file.jpg'
     const sizeBytes = 1024
-    const lastModified = new Date(2020, 5, 4, 3, 2, 1)
-    const now = new Date(2020, 6, 4)
+    const lastModified = new Date(Date.UTC(2020, 5, 4, 3, 2, 1))
+    const now = new Date(Date.UTC(2020, 6, 4))
     const lastModifiedReadable = formatLocalized(lastModified)
 
     it('creates an S3 File Node', async function () {

--- a/src/test/shared/utilities/textUtilities.test.ts
+++ b/src/test/shared/utilities/textUtilities.test.ts
@@ -11,7 +11,10 @@ import {
     truncate,
     truncateProps,
     indent,
+    formatLocalized,
+    formatDateTimestamp,
 } from '../../../shared/utilities/textUtilities'
+import globals from '../../../shared/extensionGlobals'
 
 describe('textUtilities', async function () {
     it('truncateProps()', async function () {
@@ -67,6 +70,18 @@ describe('textUtilities', async function () {
         assert.deepStrictEqual(indent('abc\n 123\n', 2, true), '  abc\n  123\n')
         assert.deepStrictEqual(indent('   abc\n\n  \n123\nfoo\n', 4, false), '       abc\n\n      \n    123\n    foo\n')
         assert.deepStrictEqual(indent('   abc\n\n    \n123\nfoo\n', 4, true), '    abc\n\n    \n    123\n    foo\n')
+    })
+
+    it('formatLocalized()', async function () {
+        const d = new globals.clock.Date(globals.clock.Date.UTC(2013, 11, 17, 3, 24, 0))
+        assert.deepStrictEqual(formatLocalized(d, false), 'Dec 16, 2013 7:24:00 PM GMT-8')
+        assert.deepStrictEqual(formatLocalized(d, true), 'Dec 16, 2013 7:24:00 PM PST')
+    })
+
+    it('formatDateTimestamp()', async function () {
+        const d = new globals.clock.Date(globals.clock.Date.UTC(2013, 11, 17, 3, 24, 0))
+        assert.deepStrictEqual(formatDateTimestamp(true, d), '2013-12-17T03:24:00.000-08:00')
+        assert.deepStrictEqual(formatDateTimestamp(false, d), '2013-12-16T19:24:00.000+00:00')
     })
 })
 


### PR DESCRIPTION
# Problem
Users on Cloud9 (Node.js 16) cannot view the content of an S3 bucket since Toolkit v2.3.0 (https://github.com/aws/aws-toolkit-vscode/pull/4163).

    2024-01-17 13:59:54 [ERROR]: [RangeError: Value longOffset out of range for Intl.DateTimeFormat options property timeZoneName
    at new DateTimeFormat (<anonymous>)
    at Sv (/…/dist/src/main.js:2653:1432)


# Solution:
Nodejs 16 only supports `timeZoneName: "short" | "long"`.

- Use `timeZoneName="short"` for Cloud9.
- Use `timeZoneName="shortOffset"` for VSCode; the "long" format is unnecessarily verbose.
- Add tests.
- Set a fixed timezone in CI using the $TZ env var. (No other way to force a timezone in Nodejs / javascript.)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
