### PR TITLE
fix(telemetry): metrics emitted without the `result` property

### DIFF
--- a/src/awsexplorer/activation.ts
+++ b/src/awsexplorer/activation.ts
@@ -60,7 +60,7 @@ export async function activate(args: {
             })
         }
         if (element.element.serviceId) {
-            telemetry.aws_expandExplorerNode.emit({ serviceType: element.element.serviceId })
+            telemetry.aws_expandExplorerNode.emit({ serviceType: element.element.serviceId, result: 'Succeeded' })
         }
     })
     globals.context.subscriptions.push(view)


### PR DESCRIPTION
    2024-01-17 12:50:54 [WARN]: Metric Event did not pass validation:
    Metric `aws_expandExplorerNode` was emitted without the `result` property.



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
