### PR TITLE
fix(cloud9): "Failed to run command: aws.viewLogsAtMessage"

### DIFF
--- a/src/shared/logger/commands.ts
+++ b/src/shared/logger/commands.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode'
 import { Logger } from '.'
 import { telemetry } from '../telemetry/telemetry'
 import { Commands } from '../vscode/commands2'
+import { getLogger } from './logger'
 
 function revealLines(editor: vscode.TextEditor, start: number, end: number): void {
     const startPos = editor.document.lineAt(start).range.start
@@ -45,7 +46,9 @@ export class Logging {
         // HACK: editor.document.getText() may return "stale" content, then
         // subsequent calls to openLogId() fail to highlight the specific log.
         // Invoke "revert" on the current file to force vscode to read from disk.
-        await vscode.commands.executeCommand('workbench.action.files.revert')
+        await vscode.commands.executeCommand('workbench.action.files.revert').then(undefined, (e: Error) => {
+            getLogger().warn('command failed: "workbench.action.files.revert"')
+        })
 
         // Retrieve where the message starts by counting number of newlines
         const text = editor.document.getText()


### PR DESCRIPTION
# Problem:
"View Toolkit Logs" command may show an error in Cloud9:

    2024-01-18 00:33:13 [ERROR]: aws.viewLogsAtMessage: Error: Command 'workbench.action.files.revert' not found.

The `workbench.action.files.revert` command has existed since at least 2017, and definitely exists in vscode 1.68...
https://github.com/microsoft/vscode/commit/9e5c7d0274755b2abbe6267e5601d32f9585f21c\

# Solution:
Use tryExecute(), because the use of "workbench.action.files.revert" is a best-effort workaround anyway.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
