### PR TITLE
tests: set $TZ a different way

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,8 +21,6 @@ jobs:
         env:
             VSCODE_TEST_VERSION: ${{ matrix.vscode-version }}
             NODE_OPTIONS: '--max-old-space-size=8192'
-            # Set a fixed timezone for tests. Intentionally _not_ UTC.
-            TZ: 'US/Pacific'
         steps:
             - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node-version }}
@@ -66,8 +64,6 @@ jobs:
         env:
             VSCODE_TEST_VERSION: ${{ matrix.vscode-version }}
             NODE_OPTIONS: '--max-old-space-size=8192'
-            # Set a fixed timezone for tests. Intentionally _not_ UTC.
-            TZ: 'US/Pacific'
         steps:
             - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node-version }}

--- a/buildspec/linuxE2ETests.yml
+++ b/buildspec/linuxE2ETests.yml
@@ -5,8 +5,6 @@ run-as: codebuild-user
 
 env:
     variables:
-        # Set a fixed timezone for tests. Intentionally _not_ UTC.
-        TZ: 'US/Pacific'
         AWS_TOOLKIT_TEST_NO_COLOR: '1'
         NO_COVERAGE: 'true'
         # Suppress noisy apt-get/dpkg warnings like "debconf: unable to initialize frontend: Dialog").

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -9,8 +9,6 @@ env:
         # VSCODE_TEST_VERSION
         # GITHUB_READONLY_TOKEN
         AWS_TOOLKIT_TEST_NO_COLOR: '1'
-        # Set a fixed timezone for tests. Intentionally _not_ UTC.
-        TZ: 'US/Pacific'
         NO_COVERAGE: 'true'
         # Suppress noisy apt-get/dpkg warnings like "debconf: unable to initialize frontend: Dialog").
         DEBIAN_FRONTEND: 'noninteractive'

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -7,8 +7,6 @@ env:
     # For "pipefail".
     shell: bash
     variables:
-        # Set a fixed timezone for tests. Intentionally _not_ UTC.
-        TZ: 'US/Pacific'
         AWS_TOOLKIT_TEST_NO_COLOR: '1'
 
 phases:

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -2,8 +2,6 @@ version: 0.2
 env:
     variables:
         AWS_TOOLKIT_TEST_NO_COLOR: '1'
-        # Set a fixed timezone for tests. Intentionally _not_ UTC.
-        TZ: 'US/Pacific'
 phases:
     install:
         runtime-versions:

--- a/scripts/test/launchTestUtilities.ts
+++ b/scripts/test/launchTestUtilities.ts
@@ -11,6 +11,10 @@ import { runTests } from '@vscode/test-electron'
 import { VSCODE_EXTENSION_ID } from '../../src/shared/extensions'
 import { TestOptions } from '@vscode/test-electron/out/runTest'
 
+// Set a fixed timezone. Intentionally _not_ UTC, to increase variation in tests.
+process.env.TZ = 'US/Pacific'
+// process.env.TZ = 'Europe/London'
+
 const envvarVscodeTestVersion = 'VSCODE_TEST_VERSION'
 
 const stable = 'stable'

--- a/src/test/globalSetup.test.ts
+++ b/src/test/globalSetup.test.ts
@@ -37,10 +37,6 @@ let openExternalStub: sinon.SinonStub<Parameters<(typeof vscode)['env']['openExt
 // let executeCommandSpy: sinon.SinonSpy | undefined
 
 export async function mochaGlobalSetup(this: Mocha.Runner) {
-    // Set a fixed timezone. Intentionally _not_ UTC, to increase variation in tests.
-    process.env.TZ = 'US/Pacific'
-    // process.env.TZ = 'Europe/London'
-
     // Clean up and set up test logs
     try {
         await remove(testLogOutput)


### PR DESCRIPTION
Problem:
Setting $TZ in `globalSetup.test.ts` isn't reliable (it fails CI), so the $TZ items in the buildspec scripts are required.

Solution:
Besides DRY, setting $TZ from our test entrypoint also allows the tests to work better when running them locally (without needing `TZ=… code` from the terminal).


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
