### PR TITLE
deps: update "@vscode/test-web"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,7 +109,7 @@
                 "@typescript-eslint/parser": "^5.59.1",
                 "@vscode/codicons": "^0.0.33",
                 "@vscode/test-electron": "^2.3.8",
-                "@vscode/test-web": "^0.0.48",
+                "@vscode/test-web": "^0.0.50",
                 "@vscode/vsce": "^2.19.0",
                 "@vue/compiler-sfc": "^3.3.2",
                 "c8": "^9.0.0",
@@ -4379,9 +4379,9 @@
             "dev": true
         },
         "node_modules/@koa/cors": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-4.0.0.tgz",
-            "integrity": "sha512-Y4RrbvGTlAaa04DBoPBWJqDR5gPj32OOz827ULXfgB1F7piD1MB/zwn8JR2LAnvdILhxUbXbkXGWuNVsFuVFCQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-5.0.0.tgz",
+            "integrity": "sha512-x/iUDjcS90W69PryLDIMgFyV21YLTnG9zOpPXS7Bkt2b8AsY3zZsIpOLBkYr9fBcF3HbkKaER5hOBZLfpLgYNw==",
             "dev": true,
             "dependencies": {
                 "vary": "^1.1.2"
@@ -4474,13 +4474,13 @@
             }
         },
         "node_modules/@playwright/browser-chromium": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.40.0.tgz",
-            "integrity": "sha512-+MxALUvUcUx8NEKSv2fXfkXrnBe9qcKPAqXjQsLu52gYhIxbF/C63fedLbZsWJU5hnmxIVWVDHMszq2cVl55mw==",
+            "version": "1.41.0",
+            "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.41.0.tgz",
+            "integrity": "sha512-TaHfh3rDsz4+tVKdMMo4kdFOk8/4U6cPyMXHhoiJVmhOhjHXjR0qPMoa5gz5jDGl478cn5SoXmtgKPgTDFuS0g==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
-                "playwright-core": "1.40.0"
+                "playwright-core": "1.41.0"
             },
             "engines": {
                 "node": ">=16"
@@ -6531,14 +6531,14 @@
             }
         },
         "node_modules/@vscode/test-web": {
-            "version": "0.0.48",
-            "resolved": "https://registry.npmjs.org/@vscode/test-web/-/test-web-0.0.48.tgz",
-            "integrity": "sha512-AyNBvhEnhPhrcgPadEJysAPkHsQdTA4vomhKx54CCvEde/VPnuzj86a32gjvHuwJ9zF3QIb4+F5R/AiweaX0Fg==",
+            "version": "0.0.50",
+            "resolved": "https://registry.npmjs.org/@vscode/test-web/-/test-web-0.0.50.tgz",
+            "integrity": "sha512-aFcwTyA3qirjfr6f5oKEV/07MbsbNeJEqElIh/ceNPEnJIyKYQeffbU7Cia9XtTKk1Ue1qMqwhdIO8OnUa9QBg==",
             "dev": true,
             "dependencies": {
-                "@koa/cors": "^4.0.0",
+                "@koa/cors": "^5.0.0",
                 "@koa/router": "^12.0.1",
-                "@playwright/browser-chromium": "^1.39.0",
+                "@playwright/browser-chromium": "^1.40.1",
                 "gunzip-maybe": "^1.4.2",
                 "http-proxy-agent": "^7.0.0",
                 "https-proxy-agent": "^7.0.2",
@@ -6547,7 +6547,7 @@
                 "koa-mount": "^4.0.0",
                 "koa-static": "^5.0.0",
                 "minimist": "^1.2.8",
-                "playwright": "^1.39.0",
+                "playwright": "^1.40.1",
                 "tar-fs": "^3.0.4",
                 "vscode-uri": "^3.0.8"
             },
@@ -14090,12 +14090,12 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.0.tgz",
-            "integrity": "sha512-gyHAgQjiDf1m34Xpwzaqb76KgfzYrhK7iih+2IzcOCoZWr/8ZqmdBw+t0RU85ZmfJMgtgAiNtBQ/KS2325INXw==",
+            "version": "1.41.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.0.tgz",
+            "integrity": "sha512-XOsfl5ZtAik/T9oek4V0jAypNlaCNzuKOwVhqhgYT3os6kH34PzbRb74F0VWcLYa5WFdnmxl7qyAHBXvPv7lqQ==",
             "dev": true,
             "dependencies": {
-                "playwright-core": "1.40.0"
+                "playwright-core": "1.41.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -14108,9 +14108,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.0.tgz",
-            "integrity": "sha512-fvKewVJpGeca8t0ipM56jkVSU6Eo0RmFvQ/MaCQNDYm+sdvKkMBBWTE1FdeMqIdumRaXXjZChWHvIzCGM/tA/Q==",
+            "version": "1.41.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.0.tgz",
+            "integrity": "sha512-UGKASUhXmvqm2Lxa1fNr8sFwAtqjpgBRr9jQ7XBI8Rn5uFiEowGUGwrruUQsVPIom4bk7Lt+oLGpXobnXzrBIw==",
             "dev": true,
             "bin": {
                 "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -4306,7 +4306,7 @@
         "@typescript-eslint/parser": "^5.59.1",
         "@vscode/codicons": "^0.0.33",
         "@vscode/test-electron": "^2.3.8",
-        "@vscode/test-web": "^0.0.48",
+        "@vscode/test-web": "^0.0.50",
         "@vscode/vsce": "^2.19.0",
         "@vue/compiler-sfc": "^3.3.2",
         "c8": "^9.0.0",


### PR DESCRIPTION
    $ npm audit
    @koa/cors  <5.0.0
    Severity: high
    Overly permissive origin policy - https://github.com/advisories/GHSA-qxrj-hx23-xp82
    fix available via `npm audit fix --force`
    Will install @vscode/test-web@0.0.50, which is a breaking change
    node_modules/@koa/cors
      @vscode/test-web  0.0.24 - 0.0.49
      Depends on vulnerable versions of @koa/cors
      node_modules/@vscode/test-web
    2 high severity vulnerabilities



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
