### PR TITLE
tests: explicitly set TZ for local tests

### DIFF
--- a/scripts/test/launchTestUtilities.ts
+++ b/scripts/test/launchTestUtilities.ts
@@ -11,10 +11,6 @@ import { runTests } from '@vscode/test-electron'
 import { VSCODE_EXTENSION_ID } from '../../src/shared/extensions'
 import { TestOptions } from '@vscode/test-electron/out/runTest'
 
-// Set a fixed timezone. Intentionally _not_ UTC, to increase variation in tests.
-process.env.TZ = 'US/Pacific'
-// process.env.TZ = 'Europe/London'
-
 const envvarVscodeTestVersion = 'VSCODE_TEST_VERSION'
 
 const stable = 'stable'

--- a/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
+++ b/src/test/cloudWatchLogs/registry/logDataRegistry.test.ts
@@ -210,7 +210,11 @@ describe('LogDataRegistry', async function () {
         it('matches CloudWatch insights timestamps', function () {
             const time = 1624201162222 // 2021-06-20 14:59:22.222 GMT+0
             const timestamp = formatDateTimestamp(true, new Date(time))
-            assert.strictEqual(timestamp, '2021-06-20T14:59:22.222-07:00')
+            assert.strictEqual(
+                timestamp,
+                '2021-06-20T14:59:22.222-07:00',
+                '`process.env.TZ` assignment may have been modified'
+            )
         })
     })
 })

--- a/src/test/testRunner.ts
+++ b/src/test/testRunner.ts
@@ -9,6 +9,12 @@ import Mocha from 'mocha'
 import glob from 'glob'
 import * as fs from 'fs-extra'
 
+// Set explicit timezone to ensure that tests run locally do not use the user's actual timezone, otherwise
+// the test can pass on one persons machine but not anothers.
+// Intentionally _not_ UTC, to increase variation in tests.
+// process.env.TZ = 'Europe/London'
+process.env.TZ = 'US/Pacific'
+
 /**
  * @param initTests List of relative paths to test files containing root hooks: https://mochajs.org/#available-root-hooks
  */


### PR DESCRIPTION
In #4297 we explicitly set the TZ in a part of the code that CI uses, but when running the unit tests locally it does not execute that part of the code.

Due to this the tests still fail when run locally.

Solution:

Add the TZ assignment to a part of the code that occurs a bit later, but will execute for both the CI and local tests Now unit tests will pass when run locally.

The initial reason was that some documentation said if the `Date` object was used before assigning the TZ it would lock in the users actual TZ and overriding the env var would not work anymore. But after testing this seems to work fine.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
