### PR TITLE
build: flag to zip the packaged VSIX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 .vscode-test/
 coverage/
 *.vsix
+*.vsix.zip
 *.bk
 **/.DS_Store
 .idea


### PR DESCRIPTION
This is useful for development purposes when building a VSIX to test with C9.

Just use `npm run package -- --zip` to create a zipped version of the VSIX. It is the same name but ends with `.zip`
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
