### PR TITLE
feature(QTransform): Detect and add telemetry for 1p dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
                 "aws-sdk": "^2.1384.0",
                 "aws-ssm-document-language-service": "^1.0.0",
                 "bytes": "^3.1.2",
+                "cheerio": "^1.0.0-rc.12",
                 "cross-fetch": "^4.0.0",
                 "cross-spawn": "^7.0.3",
                 "fast-json-patch": "^3.1.1",
@@ -9121,8 +9122,7 @@
         "node_modules/boolbase": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-            "dev": true
+            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
         },
         "node_modules/bowser": {
             "version": "2.11.0",
@@ -9437,7 +9437,6 @@
             "version": "1.0.0-rc.12",
             "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
             "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
-            "dev": true,
             "dependencies": {
                 "cheerio-select": "^2.1.0",
                 "dom-serializer": "^2.0.0",
@@ -9458,7 +9457,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
             "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-            "dev": true,
             "dependencies": {
                 "boolbase": "^1.0.0",
                 "css-select": "^5.1.0",
@@ -10132,7 +10130,6 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
             "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-            "dev": true,
             "dependencies": {
                 "boolbase": "^1.0.0",
                 "css-what": "^6.1.0",
@@ -10148,7 +10145,6 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
             "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-            "dev": true,
             "engines": {
                 "node": ">= 6"
             },
@@ -14793,7 +14789,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
             "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-            "dev": true,
             "dependencies": {
                 "boolbase": "^1.0.0"
             },
@@ -15367,7 +15362,6 @@
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
             "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-            "dev": true,
             "dependencies": {
                 "entities": "^4.4.0"
             },
@@ -15379,7 +15373,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
             "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
-            "dev": true,
             "dependencies": {
                 "domhandler": "^5.0.2",
                 "parse5": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -4366,6 +4366,7 @@
         "aws-sdk": "^2.1384.0",
         "aws-ssm-document-language-service": "^1.0.0",
         "bytes": "^3.1.2",
+        "cheerio": "^1.0.0-rc.12",
         "cross-fetch": "^4.0.0",
         "cross-spawn": "^7.0.3",
         "fast-json-patch": "^3.1.1",

--- a/src/shared/telemetry/vscodeTelemetry.json
+++ b/src/shared/telemetry/vscodeTelemetry.json
@@ -281,6 +281,11 @@
             "name": "cwsprChatCommandName",
             "type": "string",
             "description": "Type of chat command name executed"
+        },
+        {
+            "name": "has1pdependency",
+            "type": "boolean",
+            "description": "Project contains at least 1 dependency not available in maven central"
         }
     ],
     "metrics": [
@@ -853,6 +858,24 @@
                 {
                     "type": "cwsprChatCommandName",
                     "required": false
+                }
+            ]
+        },
+        {
+            "name": "codeTransform_projectContains1pDependencies",
+            "description": "When a project contains dependencies not available on maven central",
+            "metadata": [
+                {
+                    "type": "codeTransformSessionId",
+                    "required": true
+                },
+                {
+                    "type": "codeTransformJobId",
+                    "required": true
+                },
+                {
+                    "type": "has1pdependency",
+                    "required": true
                 }
             ]
         }


### PR DESCRIPTION
## Problem
This PR adds detection for 1p dependencies (private dependencies not available on maven central) and creates new telemetry to help the Q Transform team get more granulated information on the types of dependencies in applications submitted through the transformation.

## Solution
This change includes: 
- Running a new maven command that generates a report on dependencies that have newer versions available in maven central. This report is parsed for dependencies that are reported to be on the latest version (which can be available on maven but being used in the application at the latest version available, or be a private dependency). The small subset of dependencies parsed from this report are then checked against maven central. 
    - A few notes on latency: 
        - This approach adds about 3-5 seconds of latency for large multi-module applications tested. The `-DonlyProjectDependencies=true` flag reduced this number from ~1 minute and 40 seconds to only a few seconds. 
        - This logic is done after the transformation is complete to ensure that there is no latency impact on the customer's transformation. 
        
 ### Testing
Tests conducted for this change consisted of end-to-end transformations on the IntelliJ IDE, and tested telemetry generation locally

Sample metric from local testing:
```
2024-01-18 17:34:41 [DEBUG]: telemetry: emitted metric "codeTransform_projectContains1pDependencies" -> 
{"Metadata":[{"Key":"parentMetric","Value":"vscode_executeCommand"},
{"Key":"codeTransformSessionId","Value":"XXXXXX"},
{"Key":"codeTransformJobId","Value":"XXXXXX"},
{"Key":"has1pdependency","Value":"true"},{"Key":"result","Value":"Succeeded"},
{"Key":"awsAccount","Value":"not-set"},{"Key":"awsRegion","Value":"us-west-2"}],"MetricName":"codeTransform_projectContains1pDependencies","Value":1,"Unit":"None","Passive":false,"EpochTimestamp":1705628081678}

```
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
