### PR TITLE
fix(gumby): remove unneeded dep, improve error handling, fix button enablement bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,6 @@
                 "markdown-it": "^13.0.2",
                 "mime-types": "^2.1.32",
                 "node-fetch": "^2.7.0",
-                "parse-diff": "0.11.1",
                 "portfinder": "^1.0.32",
                 "sanitize-html": "^2.3.3",
                 "semver": "^7.5.4",
@@ -13816,11 +13815,6 @@
                 "pbkdf2": "^3.0.3",
                 "safe-buffer": "^5.1.1"
             }
-        },
-        "node_modules/parse-diff": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/parse-diff/-/parse-diff-0.11.1.tgz",
-            "integrity": "sha512-Oq4j8LAOPOcssanQkIjxosjATBIEJhCxMCxPhMu+Ci4wdNmAEdx0O+a7gzbR2PyKXgKPvRLIN5g224+dJAsKHA=="
         },
         "node_modules/parse-json": {
             "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -4382,7 +4382,6 @@
         "markdown-it": "^13.0.2",
         "mime-types": "^2.1.32",
         "node-fetch": "^2.7.0",
-        "parse-diff": "0.11.1",
         "portfinder": "^1.0.32",
         "sanitize-html": "^2.3.3",
         "semver": "^7.5.4",

--- a/package.json
+++ b/package.json
@@ -2415,7 +2415,7 @@
             {
                 "command": "aws.amazonq.transformationHub.summary.reveal",
                 "title": "%AWS.command.q.transform.showChangeSummary%",
-                "enablement": "gumby.reviewState == InReview"
+                "enablement": "gumby.isSummaryAvailable"
             },
             {
                 "command": "aws.amazonq.transformationHub.reviewChanges.reveal",
@@ -3805,7 +3805,6 @@
             {
                 "command": "aws.amazonq.showTransformationPlanInHub",
                 "title": "Show Transformation Plan",
-                "icon": "$(book)",
                 "enablement": "gumby.isPlanAvailable"
             }
         ],

--- a/src/codewhisperer/commands/startTransformByQ.ts
+++ b/src/codewhisperer/commands/startTransformByQ.ts
@@ -317,6 +317,7 @@ export async function setTransformationToRunningState(userInputState: UserInputS
     await vscode.commands.executeCommand('setContext', 'gumby.isStopButtonAvailable', true)
     await vscode.commands.executeCommand('setContext', 'gumby.isTransformAvailable', false)
     await vscode.commands.executeCommand('setContext', 'gumby.isPlanAvailable', false)
+    await vscode.commands.executeCommand('setContext', 'gumby.isSummaryAvailable', false)
     await resetReviewInProgress()
 
     await vscode.commands.executeCommand('aws.amazonq.refresh')

--- a/src/codewhisperer/service/transformationResultsViewProvider.ts
+++ b/src/codewhisperer/service/transformationResultsViewProvider.ts
@@ -140,6 +140,9 @@ export class DiffModel {
      */
     public parseDiff(pathToDiff: string, pathToWorkspace: string): ProposedChangeNode[] {
         const diffContents = fs.readFileSync(pathToDiff, 'utf8')
+        if (!diffContents) {
+            throw new ToolkitError('diff.patch file is empty', { code: 'EmptyDiffPatch' })
+        }
         const changedFiles = parsePatch(diffContents)
         // path to the directory containing copy of the changed files in the transformed project
         const pathToTmpSrcDir = this.copyProject(pathToWorkspace, changedFiles)
@@ -361,6 +364,18 @@ export class ProposedTransformationExplorer {
                 transformByQState.setSummaryFilePath(
                     path.join(pathContainingArchive, ExportResultArchiveStructure.PathToSummary)
                 )
+                transformByQState.setResultArchiveFilePath(pathContainingArchive)
+
+                // This metric is only emitted when placed before showInformationMessage
+                telemetry.codeTransform_vcsDiffViewerVisible.emit({
+                    codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
+                    codeTransformJobId: transformByQState.getJobId(),
+                    result: MetadataResult.Pass,
+                })
+
+                // Do not await this so that the summary reveals without user needing to close this notification
+                void vscode.window.showInformationMessage(CodeWhispererConstants.viewProposedChangesMessage)
+                await vscode.commands.executeCommand('aws.amazonq.transformationHub.summary.reveal')
             } catch (e: any) {
                 deserializeErrorMessage =
                     (e as Error).message ??
@@ -378,19 +393,6 @@ export class ProposedTransformationExplorer {
                     reason: deserializeErrorMessage ? 'DeserializationFailed' : undefined,
                 })
             }
-
-            transformByQState.setResultArchiveFilePath(pathContainingArchive)
-
-            // This metric is only emitted when placed before showInformationMessage
-            telemetry.codeTransform_vcsDiffViewerVisible.emit({
-                codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
-                codeTransformJobId: transformByQState.getJobId(),
-                result: MetadataResult.Pass,
-            })
-
-            // Do not await this so that the summary reveals without user needing to close this notification
-            void vscode.window.showInformationMessage(CodeWhispererConstants.viewProposedChangesMessage)
-            await vscode.commands.executeCommand('aws.amazonq.transformationHub.summary.reveal')
         })
 
         vscode.commands.registerCommand('aws.amazonq.transformationHub.reviewChanges.acceptChanges', async () => {

--- a/src/codewhisperer/service/transformationResultsViewProvider.ts
+++ b/src/codewhisperer/service/transformationResultsViewProvider.ts
@@ -365,6 +365,7 @@ export class ProposedTransformationExplorer {
                     path.join(pathContainingArchive, ExportResultArchiveStructure.PathToSummary)
                 )
                 transformByQState.setResultArchiveFilePath(pathContainingArchive)
+                await vscode.commands.executeCommand('setContext', 'gumby.isSummaryAvailable', true)
 
                 // This metric is only emitted when placed before showInformationMessage
                 telemetry.codeTransform_vcsDiffViewerVisible.emit({


### PR DESCRIPTION
## Problem

Need to remove "parse-diff" dep from package.json & package-lock.json. Need to handle case where diff is empty. Need to make sure the "Show Transformation Summary" button remains enabled even after a user accepts/rejects changes.

## Solution

`npm uninstall parse-diff` and improve error handling and ensure button remains enabled.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
