### PR TITLE
browser: share activate() setup between different entrypoints

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,8 +9,6 @@ import * as nls from 'vscode-nls'
 import * as codecatalyst from './codecatalyst/activation'
 import { activate as activateAwsExplorer } from './awsexplorer/activation'
 import { activate as activateCloudWatchLogs } from './cloudWatchLogs/activation'
-import { initialize as initializeCredentials } from './auth/activation'
-import { initializeAwsCredentialsStatusBarItem } from './auth/ui/statusBarItem'
 import { CredentialsProviderManager } from './auth/providers/credentialsProviderManager'
 import { SharedCredentialsProviderFactory } from './auth/providers/sharedCredentialsProviderFactory'
 import { activate as activateSchemas } from './eventSchemas/activation'
@@ -126,7 +124,6 @@ export async function activate(context: vscode.ExtensionContext) {
             .filter(x => x)
             .forEach(line => getLogger().info(line))
 
-        await initializeAwsCredentialsStatusBarItem(globals.awsContext, context)
         globals.regionProvider = regionProvider
         globals.awsContextCommands = new AwsContextCommands(regionProvider, Auth.instance)
         globals.schemaService = new SchemaService()
@@ -137,8 +134,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
         const settings = Settings.instance
         const experiments = Experiments.instance
-
-        await initializeCredentials(context, globals.awsContext, globals.loginManager)
 
         experiments.onDidChange(({ key }) => {
             telemetry.aws_experimentActivation.run(span => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,6 @@ import { AwsContextCommands } from './shared/awsContextCommands'
 import {
     getIdeProperties,
     getToolkitEnvironmentDetails,
-    initializeComputeRegion,
     isCloud9,
     isSageMaker,
     showWelcomeMessage,
@@ -57,7 +56,7 @@ import { EnvVarsCredentialsProvider } from './auth/providers/envVarsCredentialsP
 import { EcsCredentialsProvider } from './auth/providers/ecsCredentialsProvider'
 import { SchemaService } from './shared/schemas'
 import { AwsResourceManager } from './dynamicResources/awsResourceManager'
-import globals, { initialize } from './shared/extensionGlobals'
+import globals from './shared/extensionGlobals'
 import { Experiments, Settings } from './shared/settings'
 import { isReleaseVersion } from './shared/vscode/env'
 import { Commands, registerErrorHandler as registerCommandErrorHandler } from './shared/vscode/commands2'
@@ -68,7 +67,7 @@ import { isUserCancelledError, resolveErrorMessageToDisplay, ToolkitError } from
 import { Logging } from './shared/logger/commands'
 import { showMessageWithUrl, showViewLogsMessage } from './shared/utilities/messages'
 import { registerWebviewErrorHandler } from './webviews/server'
-import { registerCommands, initializeManifestPaths } from './extensionShared'
+import { registerCommands } from './extensionShared'
 import { ChildProcess } from './shared/utilities/childProcess'
 import { initializeNetworkAgent } from './codewhisperer/client/agent'
 import { Timeout } from './shared/utilities/timeoutUtils'
@@ -82,13 +81,10 @@ export async function activate(context: vscode.ExtensionContext) {
     await testActivate(context)
 
     initializeNetworkAgent()
-    await initializeComputeRegion()
     const activationStartedOn = Date.now()
     localize = nls.loadMessageBundle()
 
-    initialize(context)
     globals.machineId = await getMachineId()
-    initializeManifestPaths(context)
 
     const remoteInvokeOutputChannel = vscode.window.createOutputChannel(
         localize('AWS.channel.aws.remoteInvoke', '{0} Remote Invocations', getIdeProperties().company)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,7 +32,6 @@ import { HttpResourceFetcher } from './shared/resourcefetcher/httpResourceFetche
 import { activate as activateEcr } from './ecr/activation'
 import { activate as activateEc2 } from './ec2/activation'
 import { activate as activateSam } from './shared/sam/activation'
-import { activate as activateTelemetry } from './shared/telemetry/activation'
 import { activate as activateS3 } from './s3/activation'
 import * as awsFiletypes from './shared/awsFiletypes'
 import { activate as activateCodeWhisperer, shutdown as codewhispererShutdown } from './codewhisperer/activation'
@@ -139,7 +138,6 @@ export async function activate(context: vscode.ExtensionContext) {
         const settings = Settings.instance
         const experiments = Experiments.instance
 
-        await activateTelemetry(context, globals.awsContext, settings)
         await initializeCredentials(context, globals.awsContext, globals.loginManager)
 
         experiments.onDidChange(({ key }) => {

--- a/src/extensionShared.ts
+++ b/src/extensionShared.ts
@@ -49,9 +49,12 @@ export async function testActivate(context: vscode.ExtensionContext) {
     globals.loginManager = new LoginManager(globals.awsContext, new CredentialsStore())
     setupGlobalsTempStubs()
 
+    // some "initialize" functions
     await initializeComputeRegion()
     initialize(context)
     initializeManifestPaths(context)
+
+    await activateTelemetry(context, globals.awsContext, Settings.instance)
 }
 
 /**
@@ -62,8 +65,6 @@ export async function testActivate(context: vscode.ExtensionContext) {
 export async function browserActivate(context: vscode.ExtensionContext) {
     try {
         await testActivate(context)
-
-        await activateTelemetry(context, globals.awsContext, Settings.instance)
 
         await initializeCredentials(context, globals.awsContext, globals.loginManager)
         await initializeAwsCredentialsStatusBarItem(globals.awsContext, context)

--- a/src/extensionShared.ts
+++ b/src/extensionShared.ts
@@ -48,6 +48,10 @@ export async function testActivate(context: vscode.ExtensionContext) {
     globals.sdkClientBuilder = new DefaultAWSClientBuilder(globals.awsContext)
     globals.loginManager = new LoginManager(globals.awsContext, new CredentialsStore())
     setupGlobalsTempStubs()
+
+    await initializeComputeRegion()
+    initialize(context)
+    initializeManifestPaths(context)
 }
 
 /**
@@ -58,10 +62,6 @@ export async function testActivate(context: vscode.ExtensionContext) {
 export async function browserActivate(context: vscode.ExtensionContext) {
     try {
         await testActivate(context)
-
-        await initializeComputeRegion()
-        initialize(context)
-        initializeManifestPaths(context)
 
         await activateTelemetry(context, globals.awsContext, Settings.instance)
 

--- a/src/extensionShared.ts
+++ b/src/extensionShared.ts
@@ -20,24 +20,23 @@ import { openUrl } from './shared/utilities/vsCodeUtils'
 import { activate as activateLogger } from './shared/logger/activation'
 import { initializeComputeRegion } from './shared/extensionUtilities'
 import { activate as activateTelemetry } from './shared/telemetry/activation'
-import { getLogger } from './shared/logger'
 import { DefaultAwsContext } from './shared/awsContext'
 import { Settings } from './shared/settings'
-import { RegionProvider, defaultRegion } from './shared/regions/regionProvider'
 import { DefaultAWSClientBuilder } from './shared/awsClientBuilder'
 import { initialize as initializeAuth } from './auth/activation'
 import { LoginManager } from './auth/deprecated/loginManager'
 import { CredentialsStore } from './auth/credentials/store'
 import { initializeAwsCredentialsStatusBarItem } from './auth/ui/statusBarItem'
+import { RegionProvider } from './shared/regions/regionProvider'
 
 /**
- * This is a temporary activate function that I will be moving pieces in to.
- * It will run code that works in both extension and extensionWeb activations.
+ * Activation/setup code that is shared by the regular (nodejs) extension AND browser-compatible extension.
+ * Most setup code should live here, unless there is a reason not to.
  *
- * Eventually this will be renamed and by executed by both activations at startup
- * as a shared function.
+ * @param getRegionProvider - HACK telemetry requires the region provider but we cannot create it yet in this
+ * "shared" function since it breaks in browser. So for now the caller must provide it.
  */
-export async function testActivate(context: vscode.ExtensionContext) {
+export async function activateShared(context: vscode.ExtensionContext, getRegionProvider: () => RegionProvider) {
     // Setup the logger
     const toolkitOutputChannel = vscode.window.createOutputChannel('AWS Toolkit', { log: true })
     await activateLogger(context, toolkitOutputChannel)
@@ -47,12 +46,17 @@ export async function testActivate(context: vscode.ExtensionContext) {
     globals.awsContext = new DefaultAwsContext()
     globals.sdkClientBuilder = new DefaultAWSClientBuilder(globals.awsContext)
     globals.loginManager = new LoginManager(globals.awsContext, new CredentialsStore())
-    setupGlobalsTempStubs()
 
     // some "initialize" functions
     await initializeComputeRegion()
     initialize(context)
-    initializeManifestPaths(context)
+
+    // order matters here
+    globals.manifestPaths.endpoints = context.asAbsolutePath(join('resources', 'endpoints.json'))
+    globals.manifestPaths.lambdaSampleRequests = context.asAbsolutePath(
+        join('resources', 'vs-lambda-sample-request-manifest.xml')
+    )
+    globals.regionProvider = getRegionProvider()
 
     // telemetry
     await activateTelemetry(context, globals.awsContext, Settings.instance)
@@ -60,56 +64,8 @@ export async function testActivate(context: vscode.ExtensionContext) {
     // auth
     await initializeAuth(context, globals.awsContext, globals.loginManager)
     await initializeAwsCredentialsStatusBarItem(globals.awsContext, context)
-}
 
-/**
- * This function is temporary. In the following commits I will move parts of this
- * in to {@link testActivate} as I confirm that they work in both the browser
- * and node
- */
-export async function browserActivate(context: vscode.ExtensionContext) {
-    try {
-        await testActivate(context)
-
-        registerCommands(context)
-    } catch (error) {
-        const stacktrace = (error as Error).stack?.split('\n')
-        // truncate if the stacktrace is unusually long
-        if (stacktrace !== undefined && stacktrace.length > 40) {
-            stacktrace.length = 40
-        }
-        getLogger().error(`Failed to activate extension`, error)
-        throw error
-    }
-}
-
-/**
- * Since we are still incrementally enabling certain functionality
- * in the browser, certain global variables will not have been set
- * and functionality we enabled will not work.
- *
- * This function sets up the minimum-required stubs for the necessary
- * variables to get things working.
- *
- * If needed we can eventually create the real implementations instead
- * of stubbing.
- */
-function setupGlobalsTempStubs() {
-    // This is required for telemetry to run.
-    // The default region is arbitrary for now.
-    // We didn't create an actual instance since it
-    // will require non-trivial work to get the creation
-    // of the instance in the browser working.
-    globals.regionProvider = {
-        guessDefaultRegion: () => defaultRegion,
-    } as RegionProvider
-}
-
-export function initializeManifestPaths(extensionContext: vscode.ExtensionContext) {
-    globals.manifestPaths.endpoints = extensionContext.asAbsolutePath(join('resources', 'endpoints.json'))
-    globals.manifestPaths.lambdaSampleRequests = extensionContext.asAbsolutePath(
-        join('resources', 'vs-lambda-sample-request-manifest.xml')
-    )
+    registerCommands(context)
 }
 
 /**

--- a/src/extensionShared.ts
+++ b/src/extensionShared.ts
@@ -9,13 +9,104 @@
  */
 
 import vscode from 'vscode'
-import globals from './shared/extensionGlobals'
+import globals, { initialize } from './shared/extensionGlobals'
 import { join } from 'path'
 import { Commands } from './shared/vscode/commands2'
 import { documentationUrl, githubCreateIssueUrl, githubUrl } from './shared/constants'
 import { getIdeProperties, aboutToolkit } from './shared/extensionUtilities'
 import { telemetry } from './shared/telemetry/telemetry'
 import { openUrl } from './shared/utilities/vsCodeUtils'
+
+import { activate as activateLogger } from './shared/logger/activation'
+import { initializeComputeRegion } from './shared/extensionUtilities'
+import { activate as activateTelemetry } from './shared/telemetry/activation'
+import { getLogger } from './shared/logger'
+import { DefaultAwsContext } from './shared/awsContext'
+import { Settings } from './shared/settings'
+import { RegionProvider, defaultRegion } from './shared/regions/regionProvider'
+import { DefaultAWSClientBuilder } from './shared/awsClientBuilder'
+import { initialize as initializeCredentials } from './auth/activation'
+import { LoginManager } from './auth/deprecated/loginManager'
+import { CredentialsStore } from './auth/credentials/store'
+import { initializeAwsCredentialsStatusBarItem } from './auth/ui/statusBarItem'
+
+/**
+ * This is a temporary activate function that I will be moving pieces in to.
+ * It will run code that works in both extension and extensionWeb activations.
+ *
+ * Eventually this will be renamed and by executed by both activations at startup
+ * as a shared function.
+ */
+export async function testActivate(context: vscode.ExtensionContext) {
+    // Setup the logger
+    const toolkitOutputChannel = vscode.window.createOutputChannel('AWS Toolkit', { log: true })
+    await activateLogger(context, toolkitOutputChannel)
+    globals.outputChannel = toolkitOutputChannel
+}
+
+/**
+ * This function is temporary. In the following commits I will move parts of this
+ * in to {@link testActivate} as I confirm that they work in both the browser
+ * and node
+ */
+export async function browserActivate(context: vscode.ExtensionContext) {
+    try {
+        await testActivate(context)
+
+        setupGlobals()
+
+        await initializeComputeRegion()
+        initialize(context)
+        initializeManifestPaths(context)
+
+        await activateTelemetry(context, globals.awsContext, Settings.instance)
+
+        await initializeCredentials(context, globals.awsContext, globals.loginManager)
+        await initializeAwsCredentialsStatusBarItem(globals.awsContext, context)
+
+        registerCommands(context)
+    } catch (error) {
+        const stacktrace = (error as Error).stack?.split('\n')
+        // truncate if the stacktrace is unusually long
+        if (stacktrace !== undefined && stacktrace.length > 40) {
+            stacktrace.length = 40
+        }
+        getLogger().error(`Failed to activate extension`, error)
+        throw error
+    }
+}
+
+/** Set up values for the `globals` object */
+function setupGlobals() {
+    globals.awsContext = new DefaultAwsContext()
+    globals.sdkClientBuilder = new DefaultAWSClientBuilder(globals.awsContext)
+
+    globals.loginManager = new LoginManager(globals.awsContext, new CredentialsStore())
+
+    setupGlobalsTempStubs()
+}
+
+/**
+ * Since we are still incrementally enabling certain functionality
+ * in the browser, certain global variables will not have been set
+ * and functionality we enabled will not work.
+ *
+ * This function sets up the minimum-required stubs for the necessary
+ * variables to get things working.
+ *
+ * If needed we can eventually create the real implementations instead
+ * of stubbing.
+ */
+function setupGlobalsTempStubs() {
+    // This is required for telemetry to run.
+    // The default region is arbitrary for now.
+    // We didn't create an actual instance since it
+    // will require non-trivial work to get the creation
+    // of the instance in the browser working.
+    globals.regionProvider = {
+        guessDefaultRegion: () => defaultRegion,
+    } as RegionProvider
+}
 
 export function initializeManifestPaths(extensionContext: vscode.ExtensionContext) {
     globals.manifestPaths.endpoints = extensionContext.asAbsolutePath(join('resources', 'endpoints.json'))

--- a/src/extensionShared.ts
+++ b/src/extensionShared.ts
@@ -42,6 +42,12 @@ export async function testActivate(context: vscode.ExtensionContext) {
     const toolkitOutputChannel = vscode.window.createOutputChannel('AWS Toolkit', { log: true })
     await activateLogger(context, toolkitOutputChannel)
     globals.outputChannel = toolkitOutputChannel
+
+    //setup globals
+    globals.awsContext = new DefaultAwsContext()
+    globals.sdkClientBuilder = new DefaultAWSClientBuilder(globals.awsContext)
+    globals.loginManager = new LoginManager(globals.awsContext, new CredentialsStore())
+    setupGlobalsTempStubs()
 }
 
 /**
@@ -52,8 +58,6 @@ export async function testActivate(context: vscode.ExtensionContext) {
 export async function browserActivate(context: vscode.ExtensionContext) {
     try {
         await testActivate(context)
-
-        setupGlobals()
 
         await initializeComputeRegion()
         initialize(context)
@@ -74,16 +78,6 @@ export async function browserActivate(context: vscode.ExtensionContext) {
         getLogger().error(`Failed to activate extension`, error)
         throw error
     }
-}
-
-/** Set up values for the `globals` object */
-function setupGlobals() {
-    globals.awsContext = new DefaultAwsContext()
-    globals.sdkClientBuilder = new DefaultAWSClientBuilder(globals.awsContext)
-
-    globals.loginManager = new LoginManager(globals.awsContext, new CredentialsStore())
-
-    setupGlobalsTempStubs()
 }
 
 /**

--- a/src/extensionShared.ts
+++ b/src/extensionShared.ts
@@ -25,7 +25,7 @@ import { DefaultAwsContext } from './shared/awsContext'
 import { Settings } from './shared/settings'
 import { RegionProvider, defaultRegion } from './shared/regions/regionProvider'
 import { DefaultAWSClientBuilder } from './shared/awsClientBuilder'
-import { initialize as initializeCredentials } from './auth/activation'
+import { initialize as initializeAuth } from './auth/activation'
 import { LoginManager } from './auth/deprecated/loginManager'
 import { CredentialsStore } from './auth/credentials/store'
 import { initializeAwsCredentialsStatusBarItem } from './auth/ui/statusBarItem'
@@ -54,7 +54,12 @@ export async function testActivate(context: vscode.ExtensionContext) {
     initialize(context)
     initializeManifestPaths(context)
 
+    // telemetry
     await activateTelemetry(context, globals.awsContext, Settings.instance)
+
+    // auth
+    await initializeAuth(context, globals.awsContext, globals.loginManager)
+    await initializeAwsCredentialsStatusBarItem(globals.awsContext, context)
 }
 
 /**
@@ -65,9 +70,6 @@ export async function testActivate(context: vscode.ExtensionContext) {
 export async function browserActivate(context: vscode.ExtensionContext) {
     try {
         await testActivate(context)
-
-        await initializeCredentials(context, globals.awsContext, globals.loginManager)
-        await initializeAwsCredentialsStatusBarItem(globals.awsContext, context)
 
         registerCommands(context)
     } catch (error) {

--- a/src/extensionWeb.ts
+++ b/src/extensionWeb.ts
@@ -5,20 +5,7 @@
 
 import * as vscode from 'vscode'
 import { setInBrowser } from './common/browserUtils'
-import { activate as activateLogger } from './shared/logger/activation'
-import { initializeComputeRegion } from './shared/extensionUtilities'
-import { activate as activateTelemetry } from './shared/telemetry/activation'
-import { getLogger } from './shared/logger'
-import { DefaultAwsContext } from './shared/awsContext'
-import { Settings } from './shared/settings'
-import globals, { initialize } from './shared/extensionGlobals'
-import { registerCommands, initializeManifestPaths } from './extensionShared'
-import { RegionProvider, defaultRegion } from './shared/regions/regionProvider'
-import { DefaultAWSClientBuilder } from './shared/awsClientBuilder'
-import { initialize as initializeCredentials } from './auth/activation'
-import { LoginManager } from './auth/deprecated/loginManager'
-import { CredentialsStore } from './auth/credentials/store'
-import { initializeAwsCredentialsStatusBarItem } from './auth/ui/statusBarItem'
+import { browserActivate } from './extensionShared'
 
 export async function activate(context: vscode.ExtensionContext) {
     setInBrowser(true) // THIS MUST ALWAYS BE FIRST
@@ -27,64 +14,7 @@ export async function activate(context: vscode.ExtensionContext) {
         'AWS Toolkit: Browser Mode Under Development. No features are currently provided'
     )
 
-    try {
-        // Setup the logger
-        const toolkitOutputChannel = vscode.window.createOutputChannel('AWS Toolkit', { log: true })
-        await activateLogger(context, toolkitOutputChannel)
-
-        setupGlobals()
-
-        await initializeComputeRegion()
-        initialize(context)
-        initializeManifestPaths(context)
-
-        await activateTelemetry(context, globals.awsContext, Settings.instance)
-
-        await initializeCredentials(context, globals.awsContext, globals.loginManager)
-        await initializeAwsCredentialsStatusBarItem(globals.awsContext, context)
-
-        registerCommands(context)
-    } catch (error) {
-        const stacktrace = (error as Error).stack?.split('\n')
-        // truncate if the stacktrace is unusually long
-        if (stacktrace !== undefined && stacktrace.length > 40) {
-            stacktrace.length = 40
-        }
-        getLogger().error('Failed to activate extension in Browser', error)
-        throw error
-    }
-}
-
-/** Set up values for the `globals` object */
-function setupGlobals() {
-    globals.awsContext = new DefaultAwsContext()
-    globals.sdkClientBuilder = new DefaultAWSClientBuilder(globals.awsContext)
-
-    globals.loginManager = new LoginManager(globals.awsContext, new CredentialsStore())
-
-    setupGlobalsTempStubs()
-}
-
-/**
- * Since we are still incrementally enabling certain functionality
- * in the browser, certain global variables will not have been set
- * and functionality we enabled will not work.
- *
- * This function sets up the minimum-required stubs for the necessary
- * variables to get things working.
- *
- * If needed we can eventually create the real implementations instead
- * of stubbing.
- */
-function setupGlobalsTempStubs() {
-    // This is required for telemetry to run.
-    // The default region is arbitrary for now.
-    // We didn't create an actual instance since it
-    // will require non-trivial work to get the creation
-    // of the instance in the browser working.
-    globals.regionProvider = {
-        guessDefaultRegion: () => defaultRegion,
-    } as RegionProvider
+    await browserActivate(context)
 }
 
 export async function deactivate() {}


### PR DESCRIPTION
## Problem
We currently have `extension.ts#activate()` and `extensionWeb.ts#activate()` where the web version is basically a subset of the main `activate()`. This creates code duplication.

## Solution
In `extensionShared.ts` have a shared activate function which both entrypoints will call.
This function will consist of the same setup code regardless of entrypoint, this will de-duplicate the code.

Note in activation order matters, so we may have to do some hacks if we run in to any new issues as
we migrate shared code from `extension.ts` in to `extensionShared.ts`.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
