### PR TITLE
fix(appcomposer): reduce logger messages

### DIFF
--- a/src/applicationcomposer/webviewManager.ts
+++ b/src/applicationcomposer/webviewManager.ts
@@ -110,9 +110,7 @@ export class ApplicationComposerManager {
                 'There was an error rendering Application Composer, check logs for details.'
             )
         )
-
-        this.logger.debug(`${this.name}: Unable to setup webview panel.`)
-        this.logger.error(`${this.name}: unexpected exception: %s`, err)
+        this.logger.error(`${this.name}: Unable to show App Composer webview: ${err}`)
     }
 
     protected handleNewVisualization(key: string, visualization: ApplicationComposer): void {


### PR DESCRIPTION
## Problem:
- There are several places where Application Composer is making multiple logger calls in a sequence rather than combining the information into one message.

## Solution:
- This removes unnecessary logger calls and combines other logger calls into a single message.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
