### PR TITLE
tests: fix duplicate messages for featureDev tests

### DIFF
--- a/src/testE2E/amazonq/featureDev.test.ts
+++ b/src/testE2E/amazonq/featureDev.test.ts
@@ -62,6 +62,8 @@ describe('Amazon Q Feature Dev', function () {
         })
 
         it('Does NOT show /dev when feature dev is NOT enabled', () => {
+            // The beforeEach registers a framework which accepts requests. If we don't dispose before building a new one we have duplicate messages
+            framework.dispose()
             framework = new qTestingFramework('featuredev', false, true)
             const q = framework.createTab()
             const command = q.findCommand('/dev')


### PR DESCRIPTION
## Problem
- the beforeEach registers a framework which accepts requests. If we don't dispose before building a new one we get duplicate chat messages because theres two message listeners registered

## Solution
- dipose of the first framework instance before creating the second framwork instance

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
