### PR TITLE
fix(codewhisperer): Improve Code percentage reporting

### DIFF
--- a/.changes/next-release/Bug Fix-2ce4c789-d0e5-425c-affb-6cac6e5069fd.json
+++ b/.changes/next-release/Bug Fix-2ce4c789-d0e5-425c-affb-6cac6e5069fd.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Improve CodePercentage telemetry reporting"
+}

--- a/.changes/next-release/Bug Fix-2ce4c789-d0e5-425c-affb-6cac6e5069fd.json
+++ b/.changes/next-release/Bug Fix-2ce4c789-d0e5-425c-affb-6cac6e5069fd.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Improve CodePercentage telemetry reporting"
+	"description": "CodeWhisperer: Improve CodePercentage telemetry reporting"
 }

--- a/src/codewhisperer/client/user-service-2.json
+++ b/src/codewhisperer/client/user-service-2.json
@@ -417,7 +417,8 @@
                 "programmingLanguage": { "shape": "ProgrammingLanguage" },
                 "acceptedCharacterCount": { "shape": "PrimitiveInteger" },
                 "totalCharacterCount": { "shape": "PrimitiveInteger" },
-                "timestamp": { "shape": "Timestamp" }
+                "timestamp": { "shape": "Timestamp" },
+                "unmodifiedAcceptedCharacterCount": { "shape": "PrimitiveInteger" }
             }
         },
         "CodeGenerationId": {

--- a/src/codewhisperer/commands/onAcceptance.ts
+++ b/src/codewhisperer/commands/onAcceptance.ts
@@ -66,10 +66,12 @@ export async function onAcceptance(acceptanceEntry: OnRecommendationAcceptanceEn
             completionType: acceptanceEntry.completionType,
             language: languageContext.language,
         })
-        const codeRangeAfterFormat = new vscode.Range(start, acceptanceEntry.editor.selection.active)
+        // use the effective range of accepted recommendation
+        // to avoid counting typeahead in accepted tokens
+        const insertedCoderange = new vscode.Range(acceptanceEntry.effectiveRange.start, end)
         CodeWhispererCodeCoverageTracker.getTracker(languageContext.language)?.countAcceptedTokens(
-            codeRangeAfterFormat,
-            acceptanceEntry.editor.document.getText(codeRangeAfterFormat),
+            insertedCoderange,
+            acceptanceEntry.editor.document.getText(insertedCoderange),
             acceptanceEntry.editor.document.fileName
         )
         if (acceptanceEntry.references !== undefined) {

--- a/src/codewhisperer/commands/onAcceptance.ts
+++ b/src/codewhisperer/commands/onAcceptance.ts
@@ -66,9 +66,7 @@ export async function onAcceptance(acceptanceEntry: OnRecommendationAcceptanceEn
             completionType: acceptanceEntry.completionType,
             language: languageContext.language,
         })
-        // use the effective range of accepted recommendation
-        // to avoid counting typeahead in accepted tokens
-        const insertedCoderange = new vscode.Range(acceptanceEntry.effectiveRange.start, end)
+        const insertedCoderange = new vscode.Range(start, end)
         CodeWhispererCodeCoverageTracker.getTracker(languageContext.language)?.countAcceptedTokens(
             insertedCoderange,
             acceptanceEntry.editor.document.getText(insertedCoderange),

--- a/src/codewhisperer/commands/onInlineAcceptance.ts
+++ b/src/codewhisperer/commands/onInlineAcceptance.ts
@@ -116,9 +116,7 @@ export async function onInlineAcceptance(
             completionType: acceptanceEntry.completionType,
             language: languageContext.language,
         })
-        // use the effective range of accepted recommendation
-        // to avoid counting typeahead in accepted tokens
-        const insertedCoderange = new vscode.Range(acceptanceEntry.effectiveRange.start, end)
+        const insertedCoderange = new vscode.Range(start, end)
         CodeWhispererCodeCoverageTracker.getTracker(languageContext.language, globalStorage)?.countAcceptedTokens(
             insertedCoderange,
             acceptanceEntry.editor.document.getText(insertedCoderange),

--- a/src/codewhisperer/commands/onInlineAcceptance.ts
+++ b/src/codewhisperer/commands/onInlineAcceptance.ts
@@ -116,10 +116,12 @@ export async function onInlineAcceptance(
             completionType: acceptanceEntry.completionType,
             language: languageContext.language,
         })
-        const codeRangeAfterFormat = new vscode.Range(start, acceptanceEntry.editor.selection.active)
+        // use the effective range of accepted recommendation
+        // to avoid counting typeahead in accepted tokens
+        const insertedCoderange = new vscode.Range(acceptanceEntry.effectiveRange.start, end)
         CodeWhispererCodeCoverageTracker.getTracker(languageContext.language, globalStorage)?.countAcceptedTokens(
-            codeRangeAfterFormat,
-            acceptanceEntry.editor.document.getText(codeRangeAfterFormat),
+            insertedCoderange,
+            acceptanceEntry.editor.document.getText(insertedCoderange),
             acceptanceEntry.editor.document.fileName
         )
         if (acceptanceEntry.references !== undefined) {

--- a/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
+++ b/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
@@ -59,15 +59,6 @@ export class CodeWhispererCodeCoverageTracker {
         return TelemetryHelper.instance.isTelemetryEnabled() && AuthUtil.instance.isConnected()
     }
 
-    public countAcceptedTokens(range: vscode.Range, text: string, filename: string) {
-        if (!this.isActive()) {
-            return
-        }
-        // generate accepted recommendation token and stored in collection
-        this.addAcceptedTokens(filename, { range: range, text: text, accepted: text.length })
-        this.addTotalTokens(filename, text.length)
-    }
-
     public incrementServiceInvocationCount() {
         this._serviceInvocationCount += 1
     }
@@ -236,6 +227,15 @@ export class CodeWhispererCodeCoverageTracker {
         if (this._totalTokens[filename] < 0) {
             this._totalTokens[filename] = 0
         }
+    }
+
+    public countAcceptedTokens(range: vscode.Range, text: string, filename: string) {
+        if (!this.isActive()) {
+            return
+        }
+        // generate accepted recommendation token and stored in collection
+        this.addAcceptedTokens(filename, { range: range, text: text, accepted: text.length })
+        this.addTotalTokens(filename, text.length)
     }
 
     public countTotalTokens(e: vscode.TextDocumentChangeEvent) {

--- a/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
+++ b/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
@@ -122,7 +122,7 @@ export class CodeWhispererCodeCoverageTracker {
         const percentage = Math.round(parseInt(percentCount))
         const selectedCustomization = getSelectedCustomization()
         if (this._serviceInvocationCount <= 0) {
-            getLogger().info(`Skip emiting code contribution metric`)
+            getLogger().debug(`Skip emiting code contribution metric`)
             return
         }
         telemetry.codewhisperer_codePercentage.emit({

--- a/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
+++ b/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
@@ -206,6 +206,14 @@ describe('codewhispererCodecoverageTracker', function () {
                 accepted: 1,
             })
         })
+        it('Should increase TotalTokens', function () {
+            if (!tracker) {
+                assert.fail()
+            }
+            tracker.countAcceptedTokens(new vscode.Range(0, 0, 0, 1), 'a', 'test.py')
+            tracker.countAcceptedTokens(new vscode.Range(0, 0, 0, 1), 'b', 'test.py')
+            assert.deepStrictEqual(tracker.totalTokens['test.py'], 2)
+        })
     })
 
     describe('countTotalTokens', function () {
@@ -224,7 +232,7 @@ describe('codewhispererCodecoverageTracker', function () {
             CodeWhispererCodeCoverageTracker.instances.clear()
         })
 
-        it('Should skip when user copy large files', function () {
+        it('Should skip when content change size is not 1', function () {
             if (!tracker) {
                 assert.fail()
             }
@@ -266,7 +274,7 @@ describe('codewhispererCodecoverageTracker', function () {
             assert.ok(!startedSpy.called)
         })
 
-        it('Should reduce tokens when delete', function () {
+        it('Should not reduce tokens when delete', function () {
             if (!tracker) {
                 assert.fail()
             }
@@ -276,14 +284,26 @@ describe('codewhispererCodecoverageTracker', function () {
                 document: doc,
                 contentChanges: [
                     {
-                        range: new vscode.Range(0, 0, 0, 3),
+                        range: new vscode.Range(0, 0, 0, 1),
                         rangeOffset: 0,
                         rangeLength: 0,
-                        text: 'aaa',
+                        text: 'a',
                     },
                 ],
             })
-            assert.strictEqual(tracker?.totalTokens[doc.fileName], 3)
+            tracker.countTotalTokens({
+                reason: undefined,
+                document: doc,
+                contentChanges: [
+                    {
+                        range: new vscode.Range(0, 0, 0, 1),
+                        rangeOffset: 0,
+                        rangeLength: 0,
+                        text: 'b',
+                    },
+                ],
+            })
+            assert.strictEqual(tracker?.totalTokens[doc.fileName], 2)
             tracker.countTotalTokens({
                 reason: undefined,
                 document: doc,
@@ -296,7 +316,7 @@ describe('codewhispererCodecoverageTracker', function () {
                     },
                 ],
             })
-            assert.strictEqual(tracker?.totalTokens[doc.fileName], 3)
+            assert.strictEqual(tracker?.totalTokens[doc.fileName], 2)
         })
 
         it('Should add tokens when type', function () {
@@ -381,21 +401,21 @@ describe('codewhispererCodecoverageTracker', function () {
             const tracker = CodeWhispererCodeCoverageTracker.getTracker(language)
 
             const assertTelemetry = assertTelemetryCurried('codewhisperer_codePercentage')
+            tracker?.incrementServiceInvocationCount()
             tracker?.addAcceptedTokens(`test.py`, { range: new vscode.Range(0, 0, 0, 7), text: `print()`, accepted: 7 })
             tracker?.addTotalTokens(`test.py`, 100)
             tracker?.emitCodeWhispererCodeContribution()
-
             assertTelemetry({
                 codewhispererTotalTokens: 100,
                 codewhispererLanguage: language,
                 codewhispererAcceptedTokens: 7,
                 codewhispererPercentage: 7,
-                successCount: 0,
+                successCount: 1,
                 codewhispererUserGroup: 'Control',
             })
         })
 
-        it('should emit correct code coverage telemetry in java file', async function () {
+        it('should emit correct code coverage telemetry when success count = 0', async function () {
             await globals.context.globalState.update(CodeWhispererConstants.userGroupKey, {
                 group: CodeWhispererConstants.UserGroup.Control,
                 version: extensionVersion,
@@ -409,6 +429,8 @@ describe('codewhispererCodecoverageTracker', function () {
                 text: `public static main`,
                 accepted: 18,
             })
+            tracker?.incrementServiceInvocationCount()
+            tracker?.incrementServiceInvocationCount()
             tracker?.addTotalTokens(`test.java`, 30)
             tracker?.emitCodeWhispererCodeContribution()
             assertTelemetry({
@@ -416,7 +438,7 @@ describe('codewhispererCodecoverageTracker', function () {
                 codewhispererLanguage: 'java',
                 codewhispererAcceptedTokens: 18,
                 codewhispererPercentage: 60,
-                successCount: 0,
+                successCount: 2,
                 codewhispererUserGroup: 'Control',
             })
         })


### PR DESCRIPTION
## Problem
Code percentage is not accurate. 

## Solution

1. Only count user keystroke input as user tokens. Do not count code changes from copy and paste, git commands, etc.
2. Report CW tokens for below 2 options
    2.1  Sum of original accepted recommendations 
    2.2 Sum of Unmodified(retained, after user modification) accepted recommendations 
3. Do not emit code percentage if user is not invoking CW.

Tested E2E against dev env. 
Request id: 
6d7004a5-5f5f-4fa1-ad5a-56074a5ebb51 at about 01/30 6pm PST

service returned 200.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
