### PR TITLE
testing: add testing directory configuration through environment variable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,21 @@ To run a single test in VSCode, do any one of:
     rootTestsPath: __dirname + '/shared/sam/debugger/'
     ```
 
+#### Run all tests in a specific folder
+
+To run tests against a specific folder in VSCode, do any one of:
+
+-   Add the TEST_DIR environment variable to one of the testing launch configs and run it
+-   Run in your terminal
+    -   Unix/macOS/POSIX shell:
+        ```
+        TEST_DIR=src/test/foo npm run test
+        ```
+    -   Powershell:
+        ```
+        $Env:TEST_DIR = "src/test/foo"; npm run test
+        ```
+
 ### Browser Support
 
 Running the extension in the browser (eg: [vscode.dev](https://vscode.dev/)).
@@ -403,6 +418,7 @@ Environment variables can be used to modify the behaviour of VSCode. The followi
 -   `AWS_TOOLKIT_AUTOMATION`: If tests are currently being ran
 -   `DEVELOPMENT_PATH`: The path to the aws toolkit vscode project
 -   `AWS_TOOLKIT_TEST_NO_COLOR`: If the tests should include colour in their output
+-   `TEST_DIR` - The directory where the test runner should find the tests
 
 ### SAM/CFN ("goformation") JSON schema
 

--- a/scripts/test/launchTestUtilities.ts
+++ b/scripts/test/launchTestUtilities.ts
@@ -91,6 +91,7 @@ async function getVSCodeCliArgs(params: {
         extensionTestsEnv: {
             ['DEVELOPMENT_PATH']: projectRootDir,
             ['AWS_TOOLKIT_AUTOMATION']: params.suite,
+            ['TEST_DIR']: process.env.TEST_DIR,
             ...params.env,
         },
     }

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -6,5 +6,5 @@
 import { runTests } from './testRunner'
 
 export function run(): Promise<void> {
-    return runTests('src/test', ['src/test/globalSetup.test.ts'])
+    return runTests(process.env.TEST_DIR ?? 'src/test', ['src/test/globalSetup.test.ts'])
 }

--- a/src/testE2E/index.ts
+++ b/src/testE2E/index.ts
@@ -6,5 +6,5 @@
 import { runTests } from '../test/testRunner'
 
 export function run(): Promise<void> {
-    return runTests('src/testE2E', ['src/testInteg/globalSetup.test.ts'])
+    return runTests(process.env.TEST_DIR ?? 'src/testE2E', ['src/testInteg/globalSetup.test.ts'])
 }

--- a/src/testInteg/index.ts
+++ b/src/testInteg/index.ts
@@ -6,5 +6,5 @@
 import { runTests } from '../test/testRunner'
 
 export function run(): Promise<void> {
-    return runTests('src/testInteg', ['src/testInteg/globalSetup.test.ts'])
+    return runTests(process.env.TEST_DIR ?? 'src/testInteg', ['src/testInteg/globalSetup.test.ts'])
 }


### PR DESCRIPTION
## Problem
- Theres no external way to set a specific directory to use for tests

## Solution
- Add the TEST_DIR that will be used when running tests

Example:
```
export TEST_DIR=src/testE2E/amazonq
npm run testE2E
```

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
