### PR TITLE
fix(codewhisperer): Fix edge cases in Code percentage reporting

### DIFF
--- a/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
+++ b/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
@@ -244,14 +244,24 @@ export class CodeWhispererCodeCoverageTracker {
     // 1. newline character with indentation
     // 2. 2 character insertion of closing brackets
     public getCharacterCountFromComplexEvent(e: vscode.TextDocumentChangeEvent) {
-        if (e.document.languageId === 'java' && e.contentChanges.length === 2) {
+        if (e.contentChanges.length === 2) {
             const text1 = e.contentChanges[0].text
             const text2 = e.contentChanges[1].text
-            if (text2.startsWith('\n') && text2.trim().length === 0) {
-                return 1
+            if (text1.length === 0) {
+                if (text2.startsWith('\n') && text2.trim().length === 0) {
+                    return 1
+                }
+                if (autoClosingKeystrokeInputs.includes(text2)) {
+                    return 2
+                }
             }
-            if (autoClosingKeystrokeInputs.includes(text1)) {
-                return 2
+            if (text2.length === 0) {
+                if (text1.startsWith('\n') && text1.trim().length === 0) {
+                    return 1
+                }
+                if (autoClosingKeystrokeInputs.includes(text1)) {
+                    return 2
+                }
             }
         } else if (e.contentChanges.length === 1) {
             const text = e.contentChanges[0].text

--- a/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
+++ b/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
@@ -24,7 +24,7 @@ interface CodeWhispererToken {
     accepted: number
 }
 
-const autoClosingKeystrokeInputs = ['[]', '{}', '()', `\"\"`, `\'\'`]
+const autoClosingKeystrokeInputs = ['[]', '{}', '()', '""', "''"]
 
 /**
  * This singleton class is mainly used for calculating the code written by codeWhisperer

--- a/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
+++ b/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
@@ -244,33 +244,26 @@ export class CodeWhispererCodeCoverageTracker {
     // 1. newline character with indentation
     // 2. 2 character insertion of closing brackets
     public getCharacterCountFromComplexEvent(e: vscode.TextDocumentChangeEvent) {
-        if (e.contentChanges.length === 2) {
-            const text1 = e.contentChanges[0].text
-            const text2 = e.contentChanges[1].text
-            if (text1.length === 0) {
-                if (text2.startsWith('\n') && text2.trim().length === 0) {
-                    return 1
-                }
-                if (autoClosingKeystrokeInputs.includes(text2)) {
-                    return 2
-                }
+        function countChanges(cond: boolean, text: string): number {
+            if (!cond) {
+                return 0
             }
-            if (text2.length === 0) {
-                if (text1.startsWith('\n') && text1.trim().length === 0) {
-                    return 1
-                }
-                if (autoClosingKeystrokeInputs.includes(text1)) {
-                    return 2
-                }
-            }
-        } else if (e.contentChanges.length === 1) {
-            const text = e.contentChanges[0].text
-            if (text.startsWith('\n') && text.trim().length === 0) {
+            if ((text.startsWith('\n') || text.startsWith('\r\n')) && text.trim().length === 0) {
                 return 1
             }
             if (autoClosingKeystrokeInputs.includes(text)) {
                 return 2
             }
+            return 0
+        }
+        if (e.contentChanges.length === 2) {
+            const text1 = e.contentChanges[0].text
+            const text2 = e.contentChanges[1].text
+            const text2Count = countChanges(text1.length === 0, text2)
+            const text1Count = countChanges(text2.length === 0, text1)
+            return text2Count > 0 ? text2Count : text1Count
+        } else if (e.contentChanges.length === 1) {
+            return countChanges(true, e.contentChanges[0].text)
         }
         return 0
     }

--- a/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
+++ b/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
@@ -24,7 +24,7 @@ interface CodeWhispererToken {
     accepted: number
 }
 
-const autoClosingKeystrokeInputs = ['[]', '{}', '()']
+const autoClosingKeystrokeInputs = ['[]', '{}', '()', `\"\"`, `\'\'`]
 
 /**
  * This singleton class is mainly used for calculating the code written by codeWhisperer

--- a/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
+++ b/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts
@@ -240,7 +240,7 @@ export class CodeWhispererCodeCoverageTracker {
         this.addTotalTokens(filename, text.length)
     }
 
-    public isSpecialKeystrokeInput(e: vscode.TextDocumentChangeEvent) {
+    public isFromUserKeystrokeWithIDEChanges(e: vscode.TextDocumentChangeEvent) {
         if (e.document.languageId === 'java' && e.contentChanges.length === 2) {
             const text1 = e.contentChanges[0].text
             const text2 = e.contentChanges[1].text
@@ -262,7 +262,7 @@ export class CodeWhispererCodeCoverageTracker {
         return false
     }
 
-    public isOneCharacterKeystrokeInput(e: vscode.TextDocumentChangeEvent) {
+    public isFromUserKeystroke(e: vscode.TextDocumentChangeEvent) {
         return e.contentChanges.length === 1 && e.contentChanges[0].text.length === 1
     }
 
@@ -273,7 +273,11 @@ export class CodeWhispererCodeCoverageTracker {
         if (!runtimeLanguageContext.isLanguageSupported(e.document.languageId) || vsCodeState.isCodeWhispererEditing) {
             return
         }
-        if (this.isOneCharacterKeystrokeInput(e) || this.isSpecialKeystrokeInput(e)) {
+        // a user keystroke input can be
+        // 1. content change with 1 character insertion
+        // 2. newline character with indentation
+        // 3. 2 character insertion of closing brackets
+        if (this.isFromUserKeystroke(e) || this.isFromUserKeystrokeWithIDEChanges(e)) {
             const content = e.contentChanges[0]
             this.tryStartTimer()
             this.addTotalTokens(e.document.fileName, content.text.length)

--- a/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
+++ b/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
@@ -359,6 +359,26 @@ describe('codewhispererCodecoverageTracker', function () {
             assert.strictEqual(tracker?.totalTokens[doc.fileName], 1)
         })
 
+        it('Should add tokens when hitting enter with indentation in Windows', function () {
+            if (!tracker) {
+                assert.fail()
+            }
+            const doc = createMockDocument('def h():', 'test.py', 'python')
+            tracker.countTotalTokens({
+                reason: undefined,
+                document: doc,
+                contentChanges: [
+                    {
+                        range: new vscode.Range(0, 0, 0, 8),
+                        rangeOffset: 0,
+                        rangeLength: 0,
+                        text: '\r\n    ',
+                    },
+                ],
+            })
+            assert.strictEqual(tracker?.totalTokens[doc.fileName], 1)
+        })
+
         it('Should add tokens when hitting enter with indentation in Java', function () {
             if (!tracker) {
                 assert.fail()

--- a/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
+++ b/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
@@ -343,33 +343,39 @@ describe('codewhispererCodecoverageTracker', function () {
             if (!tracker) {
                 assert.fail()
             }
-            const doc = createMockDocument('import math', 'test.py', 'python')
+            const doc = createMockDocument('def h():', 'test.py', 'python')
             tracker.countTotalTokens({
                 reason: undefined,
                 document: doc,
                 contentChanges: [
                     {
-                        range: new vscode.Range(0, 0, 0, 1),
+                        range: new vscode.Range(0, 0, 0, 8),
                         rangeOffset: 0,
                         rangeLength: 0,
-                        text: '\n\t\t',
+                        text: '\n    ',
                     },
                 ],
             })
-            assert.strictEqual(tracker?.totalTokens[doc.fileName], 3)
+            assert.strictEqual(tracker?.totalTokens[doc.fileName], 5)
         })
 
         it('Should add tokens when hitting enter with indentation in Java', function () {
             if (!tracker) {
                 assert.fail()
             }
-            const doc = createMockDocument('import math', 'test.java', 'java')
+            const doc = createMockDocument('class A() {', 'test.java', 'java')
             tracker.countTotalTokens({
                 reason: undefined,
                 document: doc,
                 contentChanges: [
                     {
-                        range: new vscode.Range(0, 0, 0, 1),
+                        range: new vscode.Range(0, 0, 0, 11),
+                        rangeOffset: 0,
+                        rangeLength: 0,
+                        text: '',
+                    },
+                    {
+                        range: new vscode.Range(0, 0, 0, 11),
                         rangeOffset: 0,
                         rangeLength: 0,
                         text: '\n\t\t',
@@ -383,13 +389,13 @@ describe('codewhispererCodecoverageTracker', function () {
             if (!tracker) {
                 assert.fail()
             }
-            const doc = createMockDocument('import math', 'test.py', 'python')
+            const doc = createMockDocument('a=', 'test.py', 'python')
             tracker.countTotalTokens({
                 reason: undefined,
                 document: doc,
                 contentChanges: [
                     {
-                        range: new vscode.Range(0, 0, 0, 2),
+                        range: new vscode.Range(0, 0, 0, 3),
                         rangeOffset: 0,
                         rangeLength: 0,
                         text: '[]',
@@ -403,16 +409,22 @@ describe('codewhispererCodecoverageTracker', function () {
             if (!tracker) {
                 assert.fail()
             }
-            const doc = createMockDocument('import math', 'test.py', 'python')
+            const doc = createMockDocument('class A ', 'test.java', 'java')
             tracker.countTotalTokens({
                 reason: undefined,
                 document: doc,
                 contentChanges: [
                     {
-                        range: new vscode.Range(0, 0, 0, 2),
+                        range: new vscode.Range(0, 0, 0, 8),
                         rangeOffset: 0,
                         rangeLength: 0,
-                        text: '[]',
+                        text: '{}',
+                    },
+                    {
+                        range: new vscode.Range(0, 0, 0, 8),
+                        rangeOffset: 0,
+                        rangeLength: 0,
+                        text: '',
                     },
                 ],
             })

--- a/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
+++ b/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
@@ -356,7 +356,7 @@ describe('codewhispererCodecoverageTracker', function () {
                     },
                 ],
             })
-            assert.strictEqual(tracker?.totalTokens[doc.fileName], 5)
+            assert.strictEqual(tracker?.totalTokens[doc.fileName], 1)
         })
 
         it('Should add tokens when hitting enter with indentation in Java', function () {
@@ -382,7 +382,7 @@ describe('codewhispererCodecoverageTracker', function () {
                     },
                 ],
             })
-            assert.strictEqual(tracker?.totalTokens[doc.fileName], 3)
+            assert.strictEqual(tracker?.totalTokens[doc.fileName], 1)
         })
 
         it('Should add tokens when inserting closing brackets', function () {

--- a/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
+++ b/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
@@ -338,6 +338,86 @@ describe('codewhispererCodecoverageTracker', function () {
             })
             assert.strictEqual(tracker?.totalTokens[doc.fileName], 1)
         })
+
+        it('Should add tokens when hitting enter with indentation', function () {
+            if (!tracker) {
+                assert.fail()
+            }
+            const doc = createMockDocument('import math', 'test.py', 'python')
+            tracker.countTotalTokens({
+                reason: undefined,
+                document: doc,
+                contentChanges: [
+                    {
+                        range: new vscode.Range(0, 0, 0, 1),
+                        rangeOffset: 0,
+                        rangeLength: 0,
+                        text: '\n\t\t',
+                    },
+                ],
+            })
+            assert.strictEqual(tracker?.totalTokens[doc.fileName], 3)
+        })
+
+        it('Should add tokens when hitting enter with indentation in Java', function () {
+            if (!tracker) {
+                assert.fail()
+            }
+            const doc = createMockDocument('import math', 'test.java', 'java')
+            tracker.countTotalTokens({
+                reason: undefined,
+                document: doc,
+                contentChanges: [
+                    {
+                        range: new vscode.Range(0, 0, 0, 1),
+                        rangeOffset: 0,
+                        rangeLength: 0,
+                        text: '\n\t\t',
+                    },
+                ],
+            })
+            assert.strictEqual(tracker?.totalTokens[doc.fileName], 3)
+        })
+
+        it('Should add tokens when inserting closing brackets', function () {
+            if (!tracker) {
+                assert.fail()
+            }
+            const doc = createMockDocument('import math', 'test.py', 'python')
+            tracker.countTotalTokens({
+                reason: undefined,
+                document: doc,
+                contentChanges: [
+                    {
+                        range: new vscode.Range(0, 0, 0, 2),
+                        rangeOffset: 0,
+                        rangeLength: 0,
+                        text: '[]',
+                    },
+                ],
+            })
+            assert.strictEqual(tracker?.totalTokens[doc.fileName], 2)
+        })
+
+        it('Should add tokens when inserting closing brackets in Java', function () {
+            if (!tracker) {
+                assert.fail()
+            }
+            const doc = createMockDocument('import math', 'test.py', 'python')
+            tracker.countTotalTokens({
+                reason: undefined,
+                document: doc,
+                contentChanges: [
+                    {
+                        range: new vscode.Range(0, 0, 0, 2),
+                        rangeOffset: 0,
+                        rangeLength: 0,
+                        text: '[]',
+                    },
+                ],
+            })
+            assert.strictEqual(tracker?.totalTokens[doc.fileName], 2)
+        })
     })
 
     describe('flush', function () {


### PR DESCRIPTION
## Problem

This is a follow up PR of https://github.com/aws/aws-toolkit-vscode/pull/4350.

Edge cases when user has a keystroke input but the IDE modifies it were not captured in previous PR. 

We wanted to capture user keystroke input by only selecting one char input. However, VSC document events somehow merged what user input and what IDE inputs, creating 2 char input or newline + indentation inputs. this PR is to catch these edge cases. 

The document change event in VSC is causing those edge cases to surface while in JetBrains, what user inputs and what IDE changes are in separated events so they do not need this kind of extra handling 

No change log is needed. 

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
