### PR TITLE
feat(codecatalyst): add environment variable overrides for service configs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -329,7 +329,7 @@ Example:
 }
 ```
 
-Overrides specifically for CodeCatalyst can be set using the `aws.dev.codecatalystService` setting. This is a JSON object consisting of keys/values required to override API calls to CodeCatalyst: `region`, `endpoint`, `hostname`, and `gitHostname`. If this setting is present, then all keys need to be explicitly provided.
+<a name="codecatalyst-settings">Overrides specifically for CodeCatalyst can be set using the `aws.dev.codecatalystService` setting. This is a JSON object consisting of keys/values required to override API calls to CodeCatalyst: `region`, `endpoint`, `hostname`, and `gitHostname`. If this setting is present, then all keys need to be explicitly provided.</a>
 
 Example:
 
@@ -382,6 +382,14 @@ Environment variables can be used to modify the behaviour of VSCode. The followi
 -   `__DEV_ENVIRONMENT_PROJECT_NAME`: The project name associated with the running development environment. Automatically set when running the toolkit in Codecatalyst
 -   `__DEV_ENVIRONMENT_SPACE_NAME`: The space name associated with the running development environment. Automatically set when running the toolkit in Codecatalyst
 -   `__DEV_ENVIRONMENT_ORGANIZATION_NAME`: The organization name associated with the running development environment. Automatically set when running the toolkit in Codecatalyst
+
+The following are environment variable versions of the user `settings.json` overrides mentioned [here](#codecatalyst-settings). These will always override the toolkit defaults and those defined in `settings.json`.
+Unlike the user setting overrides, not all of these environment variables have to be set to make use of them.
+
+-   `__CODECATALYST_REGION`: for aws.dev.codecatalystService.region
+-   `__CODECATALYST_ENDPOINT`: for aws.dev.codecatalystService.endpoint
+-   `__CODECATALYST_HOSTNAME`: for aws.dev.codecatalystService.hostname
+-   `__CODECATALYST_GIT_HOSTNAME`: for aws.dev.codecatalystService.gitHostname
 
 #### Lambda
 

--- a/src/shared/clients/codecatalystClient.ts
+++ b/src/shared/clients/codecatalystClient.ts
@@ -31,12 +31,20 @@ import { truncateProps } from '../utilities/textUtilities'
 import { SsoConnection } from '../../auth/connection'
 import { DevSettings } from '../settings'
 import { RetryDelayOptions } from 'aws-sdk/lib/config-base'
+import { getServiceEnvVarConfig } from '../vscode/env'
 
 export interface CodeCatalystConfig {
     readonly region: string
     readonly endpoint: string
     readonly hostname: string
     readonly gitHostname: string
+}
+
+const configToEnvMap: { [K in keyof CodeCatalystConfig]: string } = {
+    region: '__CODECATALYST_REGION',
+    endpoint: '__CODECATALYST_ENDPOINT',
+    hostname: '__CODECATALYST_HOSTNAME',
+    gitHostname: '__CODECATALYST_GIT_HOSTNAME',
 }
 
 export const defaultServiceConfig: CodeCatalystConfig = {
@@ -47,7 +55,12 @@ export const defaultServiceConfig: CodeCatalystConfig = {
 }
 
 export function getCodeCatalystConfig(): CodeCatalystConfig {
-    return DevSettings.instance.getServiceConfig('codecatalystService', defaultServiceConfig)
+    return {
+        ...DevSettings.instance.getServiceConfig('codecatalystService', defaultServiceConfig),
+
+        // Environment variable overrides
+        ...getServiceEnvVarConfig('codecatalyst', configToEnvMap),
+    }
 }
 
 export interface DevEnvironment extends CodeCatalyst.DevEnvironmentSummary {

--- a/src/test/shared/vscode/env.test.ts
+++ b/src/test/shared/vscode/env.test.ts
@@ -1,0 +1,23 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert'
+import { getServiceEnvVarConfig } from '../../../shared/vscode/env'
+
+describe('getServiceEnvVarConfig', function () {
+    it('gets service config', async function () {
+        const service = 'codecatalyst'
+        const configToEnvMap = {
+            region: '__CODECATALYST_REGION',
+            endpoint: '__CODECATALYST_ENDPOINT',
+        }
+        process.env['__CODECATALYST_ENDPOINT'] = 'test.endpoint'
+
+        const expectedConfig = {
+            endpoint: 'test.endpoint',
+        }
+        assert.deepStrictEqual(getServiceEnvVarConfig(service, configToEnvMap), expectedConfig)
+    })
+})

--- a/src/test/shared/vscode/env.test.ts
+++ b/src/test/shared/vscode/env.test.ts
@@ -7,13 +7,25 @@ import assert from 'assert'
 import { getServiceEnvVarConfig } from '../../../shared/vscode/env'
 
 describe('getServiceEnvVarConfig', function () {
+    const envVars: string[] = []
+
+    afterEach(() => {
+        envVars.forEach(v => delete process.env[v])
+        envVars.length = 0
+    })
+
+    function addEnvVar(k: string, v: string) {
+        process.env[k] = v
+        envVars.push(k)
+    }
+
     it('gets service config', async function () {
         const service = 'codecatalyst'
         const configToEnvMap = {
             region: '__CODECATALYST_REGION',
             endpoint: '__CODECATALYST_ENDPOINT',
         }
-        process.env['__CODECATALYST_ENDPOINT'] = 'test.endpoint'
+        addEnvVar('__CODECATALYST_ENDPOINT', 'test.endpoint')
 
         const expectedConfig = {
             endpoint: 'test.endpoint',


### PR DESCRIPTION
Problem: While we have user settings.json overrides for codecatalyst, it is not easy for settings.json to be updated in CI environments.

Solution: Add ability to override on environment variables as well. Also, add generic functions for other services to do the same.

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
