### PR TITLE
env: Generalize environment variable for service overrides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -357,7 +357,7 @@ Example:
 }
 ```
 
-Overrides specifically for CodeWhisperer/Amazon Q can be set using the `aws.dev.codewhispererService` setting. This is a JSON object consisting of keys/values required to override API calls to CodeWhisperer/Amazon Q: `region` and `endpoint`. If this setting is present, then all keys need to be explicitly provided.
+<a name="codewhisperer-settings">Overrides specifically for CodeWhisperer/Amazon Q can be set using the `aws.dev.codewhispererService` setting. This is a JSON object consisting of keys/values required to override API calls to CodeWhisperer/Amazon Q: `region` and `endpoint`. If this setting is present, then all keys need to be explicitly provided.</a>
 
 Example:
 
@@ -405,6 +405,14 @@ Unlike the user setting overrides, not all of these environment variables have t
 -   `__CODECATALYST_ENDPOINT`: for aws.dev.codecatalystService.endpoint
 -   `__CODECATALYST_HOSTNAME`: for aws.dev.codecatalystService.hostname
 -   `__CODECATALYST_GIT_HOSTNAME`: for aws.dev.codecatalystService.gitHostname
+
+#### Codewhisperer/Amazon Q
+
+The following are environment variable versions of the user `settings.json` overrides mentioned [here](#codewhisperer-settings). These will always override the toolkit defaults and those defined in `settings.json`.
+Unlike the user setting overrides, not all of these environment variables have to be set to make use of them.
+
+-   `__CODEWHISPERER_REGION`: for aws.dev.codewhispererService.region
+-   `__CODEWHISPERER_ENDPOINT`: for aws.dev.codewhispererService.endpoint
 
 #### Lambda
 

--- a/src/codewhisperer/client/codewhisperer.ts
+++ b/src/codewhisperer/client/codewhisperer.ts
@@ -29,7 +29,7 @@ import { keepAliveHeader } from './agent'
 import { getOptOutPreference } from '../util/commonUtil'
 import * as os from 'os'
 import { getClientId } from '../../shared/telemetry/util'
-import { extensionVersion } from '../../shared/vscode/env'
+import { extensionVersion, getServiceEnvVarConfig } from '../../shared/vscode/env'
 import { DevSettings } from '../../shared/settings'
 
 export interface CodeWhispererConfig {
@@ -43,7 +43,12 @@ export const defaultServiceConfig: CodeWhispererConfig = {
 }
 
 export function getCodewhispererConfig(): CodeWhispererConfig {
-    return DevSettings.instance.getServiceConfig('codewhispererService', defaultServiceConfig)
+    return {
+        ...DevSettings.instance.getServiceConfig('codewhispererService', defaultServiceConfig),
+
+        // Environment variable overrides
+        ...getServiceEnvVarConfig('codewhisperer', Object.keys(defaultServiceConfig)),
+    }
 }
 
 export type ProgrammingLanguage = Readonly<

--- a/src/shared/clients/codecatalystClient.ts
+++ b/src/shared/clients/codecatalystClient.ts
@@ -40,13 +40,6 @@ export interface CodeCatalystConfig {
     readonly gitHostname: string
 }
 
-const configToEnvMap: { [K in keyof CodeCatalystConfig]: string } = {
-    region: '__CODECATALYST_REGION',
-    endpoint: '__CODECATALYST_ENDPOINT',
-    hostname: '__CODECATALYST_HOSTNAME',
-    gitHostname: '__CODECATALYST_GIT_HOSTNAME',
-}
-
 export const defaultServiceConfig: CodeCatalystConfig = {
     region: 'us-east-1',
     endpoint: 'https://codecatalyst.global.api.aws',
@@ -59,7 +52,7 @@ export function getCodeCatalystConfig(): CodeCatalystConfig {
         ...DevSettings.instance.getServiceConfig('codecatalystService', defaultServiceConfig),
 
         // Environment variable overrides
-        ...getServiceEnvVarConfig('codecatalyst', configToEnvMap),
+        ...getServiceEnvVarConfig('codecatalyst', Object.keys(defaultServiceConfig)),
     }
 }
 

--- a/src/shared/vscode/env.ts
+++ b/src/shared/vscode/env.ts
@@ -92,8 +92,9 @@ export function getCodeCatalystSpaceName(): string | undefined {
     return process.env['__DEV_ENVIRONMENT_SPACE_NAME'] || process.env['__DEV_ENVIRONMENT_ORGANIZATION_NAME']
 }
 
-type ConfigToEnvMap = { [key: string]: string }
-type ServiceConfig = Partial<{ [K in keyof ConfigToEnvMap]: any }>
+type ServiceConfig<T extends string[]> = Partial<{
+    [K in T[number]]: string
+}>
 const logConfigsOnce: { [key: string]: ReturnType<typeof onceChanged> } = {}
 
 /**
@@ -106,8 +107,8 @@ const logConfigsOnce: { [key: string]: ReturnType<typeof onceChanged> } = {}
  *  gitHostname -> __CODECATALYST_GIT_HOSTNAME
  *  region -> __CODECATALYST_REGION
  */
-function getEnvVars(service: string, envVarNames: string[]) {
-    const envVars = new Map<string, string>()
+export function getEnvVars<T extends string[]>(service: string, envVarNames: T): ServiceConfig<T> {
+    const envVars = {} as ServiceConfig<T>
     for (const name of envVarNames) {
         // convert camel case to uppercase joined by underscores
         // e.g. gitHostname -> GIT_HOSTNAME
@@ -115,7 +116,7 @@ function getEnvVars(service: string, envVarNames: string[]) {
             .split(/(?=[A-Z])/)
             .map(s => s.toUpperCase())
             .join('_')
-        envVars.set(name, `__${service.toUpperCase()}_${envVarName}`)
+        envVars[name as T[number]] = `__${service.toUpperCase()}_${envVarName}`
     }
     return envVars
 }
@@ -126,15 +127,15 @@ function getEnvVars(service: string, envVarNames: string[]) {
  * a config map with the found values. Changes are logged once for each
  * service/found env var combos.
  */
-export function getServiceEnvVarConfig(service: string, configs: string[]): ServiceConfig {
-    const config: ServiceConfig = {}
+export function getServiceEnvVarConfig<T extends string[]>(service: string, configs: T): ServiceConfig<T> {
+    const config = {} as ServiceConfig<T>
     const overriden: string[] = []
 
     // Find env vars for each field in the config
-    const envVars = getEnvVars(service, configs)
-    for (const [field, envKey] of envVars) {
+    const envVars = getEnvVars<T>(service, configs)
+    for (const [field, envKey] of Object.entries(envVars) as [string, string][]) {
         if (envKey in process.env) {
-            config[field] = process.env[envKey]
+            config[field as T[number]] = process.env[envKey]
             overriden.push(envKey)
         }
     }

--- a/src/shared/vscode/env.ts
+++ b/src/shared/vscode/env.ts
@@ -108,7 +108,7 @@ const logConfigsOnce: { [key: string]: ReturnType<typeof onceChanged> } = {}
  *  region -> __CODECATALYST_REGION
  */
 export function getEnvVars<T extends string[]>(service: string, envVarNames: T): ServiceConfig<T> {
-    const envVars = {} as ServiceConfig<T>
+    const envVars: ServiceConfig<T> = {}
     for (const name of envVarNames) {
         // convert camel case to uppercase joined by underscores
         // e.g. gitHostname -> GIT_HOSTNAME
@@ -128,7 +128,7 @@ export function getEnvVars<T extends string[]>(service: string, envVarNames: T):
  * service/found env var combos.
  */
 export function getServiceEnvVarConfig<T extends string[]>(service: string, configs: T): ServiceConfig<T> {
-    const config = {} as ServiceConfig<T>
+    const config: ServiceConfig<T> = {}
     const overriden: string[] = []
 
     // Find env vars for each field in the config

--- a/src/test/shared/vscode/env.test.ts
+++ b/src/test/shared/vscode/env.test.ts
@@ -4,31 +4,56 @@
  */
 
 import assert from 'assert'
-import { getServiceEnvVarConfig } from '../../../shared/vscode/env'
+import { getEnvVars, getServiceEnvVarConfig } from '../../../shared/vscode/env'
 
-describe('getServiceEnvVarConfig', function () {
-    const envVars: string[] = []
+describe('env', function () {
+    describe('getServiceEnvVarConfig', function () {
+        const envVars: string[] = []
 
-    afterEach(() => {
-        envVars.forEach(v => delete process.env[v])
-        envVars.length = 0
+        afterEach(() => {
+            envVars.forEach(v => delete process.env[v])
+            envVars.length = 0
+        })
+
+        function addEnvVar(k: string, v: string) {
+            process.env[k] = v
+            envVars.push(k)
+        }
+
+        it('gets service config', async function () {
+            const service = 'codecatalyst'
+            const serviceConfigs = ['region', 'endpoint', 'gitHostname']
+            addEnvVar('__CODECATALYST_ENDPOINT', 'test.endpoint')
+            addEnvVar('__CODECATALYST_GIT_HOSTNAME', 'test.gitHostname')
+
+            const expectedConfig = {
+                endpoint: 'test.endpoint',
+                gitHostname: 'test.gitHostname',
+            }
+            assert.deepStrictEqual(getServiceEnvVarConfig(service, serviceConfigs), expectedConfig)
+        })
     })
 
-    function addEnvVar(k: string, v: string) {
-        process.env[k] = v
-        envVars.push(k)
-    }
+    describe('getEnvVars', function () {
+        it('gets codecatalyst environment variables', async function () {
+            const expectedEnvVars = {
+                region: '__CODECATALYST_REGION',
+                endpoint: '__CODECATALYST_ENDPOINT',
+                hostname: '__CODECATALYST_HOSTNAME',
+                gitHostname: '__CODECATALYST_GIT_HOSTNAME',
+            }
 
-    it('gets service config', async function () {
-        const service = 'codecatalyst'
-        const serviceConfigs = ['region', 'endpoint', 'gitHostname']
-        addEnvVar('__CODECATALYST_ENDPOINT', 'test.endpoint')
-        addEnvVar('__CODECATALYST_GIT_HOSTNAME', 'test.gitHostname')
+            const envVar = getEnvVars('codecatalyst', Object.keys(expectedEnvVars))
+            assert.deepStrictEqual(envVar, expectedEnvVars)
+        })
 
-        const expectedConfig = {
-            endpoint: 'test.endpoint',
-            gitHostname: 'test.gitHostname',
-        }
-        assert.deepStrictEqual(getServiceEnvVarConfig(service, serviceConfigs), expectedConfig)
+        it('gets codewhisperer environment variables', async function () {
+            const expectedEnvVars = {
+                region: '__CODEWHISPERER_REGION',
+                endpoint: '__CODEWHISPERER_ENDPOINT',
+            }
+            const envVar = getEnvVars('codewhisperer', Object.keys(expectedEnvVars))
+            assert.deepStrictEqual(envVar, expectedEnvVars)
+        })
     })
 })

--- a/src/test/shared/vscode/env.test.ts
+++ b/src/test/shared/vscode/env.test.ts
@@ -21,15 +21,14 @@ describe('getServiceEnvVarConfig', function () {
 
     it('gets service config', async function () {
         const service = 'codecatalyst'
-        const configToEnvMap = {
-            region: '__CODECATALYST_REGION',
-            endpoint: '__CODECATALYST_ENDPOINT',
-        }
+        const serviceConfigs = ['region', 'endpoint', 'gitHostname']
         addEnvVar('__CODECATALYST_ENDPOINT', 'test.endpoint')
+        addEnvVar('__CODECATALYST_GIT_HOSTNAME', 'test.gitHostname')
 
         const expectedConfig = {
             endpoint: 'test.endpoint',
+            gitHostname: 'test.gitHostname',
         }
-        assert.deepStrictEqual(getServiceEnvVarConfig(service, configToEnvMap), expectedConfig)
+        assert.deepStrictEqual(getServiceEnvVarConfig(service, serviceConfigs), expectedConfig)
     })
 })


### PR DESCRIPTION
## Problem
- Only codecatalyst has environment variables overrides and having them for Amazon Q makes testing some things a bit easier

## Solution
- Generalize the environment variables overrides and extend them to Amazon Q

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
