### PR TITLE
fix: use IMDSv2 for all metadata service calls.

### DIFF
--- a/.changes/next-release/Bug Fix-bcc441fe-f0d3-444f-bbcb-16cc634e8a5f.json
+++ b/.changes/next-release/Bug Fix-bcc441fe-f0d3-444f-bbcb-16cc634e8a5f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "EC2 Credentials: Use IMDSv2 calls if available, otherwise fall back IMDSv1."
+}


### PR DESCRIPTION
Problem: We did not attach the token to IMDS calls, resulting in IMDSv1 being used. The SDK does support using tokens but only for calls to the endpoint `/latest/meta-data/iam/security-credentials/`. https://github.com/aws/aws-sdk-js/blob/3333f8b49283f5bbff823ab8a8469acedb7fe3d5/lib/metadata_service.js#L123-L235

Solution: Call the "private" sdk method to get the token so code isn't duplicated, and attach that in the header of our calls just like the sdk does for the above endpoint.

AWS SDK v3 does not support token handling https://github.com/aws/aws-sdk-js-v3/issues/4004

#### Testing
Deployed to C9 since its an ec2 instance, no longer throws error about ec2 creds being unavailable.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
