### PR TITLE
ci: fail CI on "npm WARN deprecated"

### DIFF
--- a/buildspec/shared/common.sh
+++ b/buildspec/shared/common.sh
@@ -8,7 +8,8 @@
 #   - "waiting for browser": from `ssoAccessTokenProvider.test.ts`, unclear how to fix it.
 #   - "Webview is disposed": only happens on vscode "minimum" (1.68.0)
 #   - "HTTPError: Response code …": caused by github rate-limiting.
-_ignore_pat='Timed-out waiting for browser login flow\|HTTPError: Response code 403\|HTTPError: Response code 404'
+#   - "npm WARN deprecated querystring": transitive dep of aws sdk v2 (check `npm ls querystring`), so that's blocked until we migrate to v3.
+_ignore_pat='Timed-out waiting for browser login flow\|HTTPError: Response code 403\|HTTPError: Response code 404\|npm WARN deprecated querystring'
 if [ "$VSCODE_TEST_VERSION" = 'minimum' ]; then
     _ignore_pat="$_ignore_pat"'\|Webview is disposed'
 fi

--- a/buildspec/shared/linux-pre_build.sh
+++ b/buildspec/shared/linux-pre_build.sh
@@ -22,5 +22,4 @@ if [ "$TOOLKITS_CODEARTIFACT_DOMAIN" ] && [ "$TOOLKITS_CODEARTIFACT_REPO" ] && [
 fi
 
 # TODO: move this to the "install" phase?
-# TODO: fail in CI
-npm 2>&1 ci | run_and_report 0 'npm WARN deprecated' 'Deprecated dependencies must be updated.'
+npm 2>&1 ci | run_and_report 2 'npm WARN deprecated' 'Deprecated dependencies must be updated.'

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,8 +66,8 @@
                 "vue": "^3.3.4",
                 "web-tree-sitter": "^0.20.7",
                 "whatwg-url": "^14.0.0",
-                "winston": "^3.7.1",
-                "winston-transport": "^4.5.0",
+                "winston": "^3.11.0",
+                "winston-transport": "^4.6.0",
                 "xml2js": "^0.6.1",
                 "yaml-cfn": "^0.3.2"
             },
@@ -18707,11 +18707,11 @@
             "dev": true
         },
         "node_modules/winston": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/winston/-/winston-3.7.1.tgz",
-            "integrity": "sha512-qKLMQVWMOvY0h9H4BA8Sfh79+KdnKi8gsyCSvfQgc+6teSlq92j82WK+zAJc6fLbAA2jwQuqkANLpQeOFA4Kug==",
-            "deprecated": "Please use version 3.6.0 or >3.7.1 when available due to https://github.com/winstonjs/winston/issues/2103",
+            "version": "3.11.0",
+            "resolved": "https://registry.npmjs.org/winston/-/winston-3.11.0.tgz",
+            "integrity": "sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==",
             "dependencies": {
+                "@colors/colors": "^1.6.0",
                 "@dabh/diagnostics": "^2.0.2",
                 "async": "^3.2.3",
                 "is-stream": "^2.0.0",
@@ -18728,16 +18728,24 @@
             }
         },
         "node_modules/winston-transport": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
-            "integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.6.0.tgz",
+            "integrity": "sha512-wbBA9PbPAHxKiygo7ub7BYRiKxms0tpfU2ljtWzb3SjRjv5yl6Ozuy/TkXf00HTAt+Uylo3gSkNwzc4ME0wiIg==",
             "dependencies": {
                 "logform": "^2.3.2",
                 "readable-stream": "^3.6.0",
                 "triple-beam": "^1.3.0"
             },
             "engines": {
-                "node": ">= 6.4.0"
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/winston/node_modules/@colors/colors": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+            "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+            "engines": {
+                "node": ">=0.1.90"
             }
         },
         "node_modules/workerpool": {

--- a/package.json
+++ b/package.json
@@ -4398,8 +4398,8 @@
         "vue": "^3.3.4",
         "web-tree-sitter": "^0.20.7",
         "whatwg-url": "^14.0.0",
-        "winston": "^3.7.1",
-        "winston-transport": "^4.5.0",
+        "winston": "^3.11.0",
+        "winston-transport": "^4.6.0",
         "xml2js": "^0.6.1",
         "yaml-cfn": "^0.3.2"
     },


### PR DESCRIPTION

Problem:
"npm WARN deprecated" warnings do not fail CI. Since winston was
updated, the only remaining warning is for `querystring`, which is
blocked until we update aws-sdk-js.

Solution:
Fail CI for "npm WARN deprecated" warnings, but make an exception for
`querystring`.

---

Problem:

    npm WARN deprecated winston@3.7.1: Please use version 3.6.0 or >3.7.1
    when available due to https://github.com/winstonjs/winston/issues/2103

Solution:
Update winston.

---

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
