### PR TITLE
fix(cloud9): use node 'fs' readdir when in cloud9 environment

### DIFF
--- a/src/srcShared/fs.ts
+++ b/src/srcShared/fs.ts
@@ -125,6 +125,13 @@ export class FileSystemCommon {
 
     async readdir(uri: vscode.Uri | string): Promise<[string, vscode.FileType][]> {
         const path = FileSystemCommon.getUri(uri)
+
+        // readdir is not a supported vscode API in Cloud9
+        if (isCloud9()) {
+            return actualFs
+                .readdirSync(path.path, { withFileTypes: true })
+                .map(e => [e.name, e.isDirectory() ? vscode.FileType.Directory : vscode.FileType.File])
+        }
         return await fs.readDirectory(path)
     }
 


### PR DESCRIPTION
Problem: Cloud9 does not support the readdir function of the vscode fs api. This results in 'not implemented' errors when the fsCommon module's readdir is called.

Solution: In `fsCommon`, use node's readdir instead of the vscode API if we are in cloud9.


#### Testing
Tested in C9, resolves the readdir issue when trying to upload a lambda from a folder.

Unit tests pending.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
