### PR TITLE
fix: Use 'fs' methods if in C9

### DIFF
--- a/.changes/next-release/Bug Fix-58f92b8d-fe98-4885-b150-3c52d640b4a0.json
+++ b/.changes/next-release/Bug Fix-58f92b8d-fe98-4885-b150-3c52d640b4a0.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Cloud9: certain filesystem calls did not work in Cloud9"
+}


### PR DESCRIPTION
## Problem:

We recently made some changes to our file system code that used the vscode.workspace.fs instance. The issue is that some of its methods are not supported in C9

## Solution:

If in C9 use the original "fs" instance methods instead for delete, readdir, and mkdir.

Also added tests.

This builds on top of @hayemaxi work from #4372 but I had to add some extra fixes for other methods



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
