### PR TITLE
fix: flaky fs test

### DIFF
--- a/packages/toolkit/src/test/srcShared/fs.test.ts
+++ b/packages/toolkit/src/test/srcShared/fs.test.ts
@@ -24,6 +24,7 @@ describe('FileSystem', function () {
 
     before(async function () {
         fakeContext = await FakeExtensionContext.create()
+        await deleteTestRoot() // incase a previous test run failed to clean
     })
 
     beforeEach(async function () {
@@ -161,7 +162,7 @@ describe('FileSystem', function () {
             it(`creates folder: '${p}'`, async function () {
                 const dirPath = createTestPath(p)
                 await fsCommon.mkdir(dirPath)
-                assert.ok(existsSync(dirPath))
+                assert(existsSync(dirPath))
             })
         })
 
@@ -173,8 +174,8 @@ describe('FileSystem', function () {
 
                 await fsCommon.mkdir(dirPath)
 
-                assert.ok(existsSync(dirPath))
-                assert.ok(mkdirSpy.calledOnce)
+                assert(existsSync(dirPath))
+                assert.strictEqual(mkdirSpy.callCount, 1)
             })
         })
     })
@@ -300,7 +301,7 @@ describe('FileSystem', function () {
     }
 
     function testRootPath() {
-        return path.join(fakeContext.globalStorageUri.fsPath, 'testDir')
+        return path.join(fakeContext.globalStorageUri.fsPath, 'fsTestDir')
     }
 
     async function makeTestRoot() {
@@ -308,6 +309,6 @@ describe('FileSystem', function () {
     }
 
     async function deleteTestRoot() {
-        return rmSync(testRootPath(), { recursive: true })
+        rmSync(testRootPath(), { recursive: true, force: true })
     }
 })


### PR DESCRIPTION
Reported by #4390, this test is failing on the mkdirSpy call count assertion.
Not exactly sure why this is flaky, but maybe it is due to the previous folders not being cleaned up.

## Solution

This commit deletes the created folders after each test finishes. Additionally, this commit checks the actual spy call count so that we can better debug the issue

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
