### PR TITLE
fix: monorepo script changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,11 +49,11 @@ jobs:
                   echo "FEAT_NAME=" >> $GITHUB_ENV
                   echo "TAG_NAME=prerelease" >> $GITHUB_ENV
             - run: npm ci
-            - name: vsix
+            - name: vsix # TODO: For packages/toolkit release only
               run: |
                   npm run createRelease  # Generate CHANGELOG.md
-                  npm run generateNonCodeFiles -w packages/toolkit
                   cp ./README.quickstart.vscode.md ./README.md
+                  cd packages/toolkit
                   npm run package -- --feature "$FEAT_NAME"
             - uses: actions/upload-artifact@v4
               with:

--- a/buildspec/packageTestVsix.yml
+++ b/buildspec/packageTestVsix.yml
@@ -27,7 +27,6 @@ phases:
             - export HOME=/home/codebuild-user
             # Generate CHANGELOG.md
             - npm run createRelease
-            - npm run generateNonCodeFiles -w packages/toolkit
             - cp ./README.quickstart.vscode.md ./README.md
             - npm run package
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,6 +31,7 @@ Current quirks of the current monorepo status that should be resolved/evaluated 
 -   `packages/toolkit/scripts/` should be generalized and moved to the root of the project as needed.
 -   LICENSE, README.md, and other non-code artifacts that must be packaged into the .vsix are currently
     being copied into the packaging subproject directory from the root project directory as part of the `copyFiles` task.
+-   Pre-release only publishes packages/toolkit extension directly. It should be extended to other added extensions. See [`release.yml`](../.github/workflows/release.yml)
 -   [**Running the test suites in VSCode has changed**](../CONTRIBUTING.md#test)
 
 ## Commands

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     },
     "scripts": {
         "prepare": "ts-node ./scripts/prepare.ts",
-        "postinstall": "npm run buildCustomLintPlugin",
+        "postinstall": "npm run buildCustomLintPlugin && npm run postinstall -ws --if-present",
         "buildCustomLintPlugin": "npm run build -w plugins/eslint-plugin-aws-toolkits",
         "compile": "npm run compile -w packages/",
         "testCompile": "npm run testCompile -w packages/",

--- a/packages/toolkit/scripts/build/package.ts
+++ b/packages/toolkit/scripts/build/package.ts
@@ -148,7 +148,7 @@ function main() {
         console.log(`VSIX Version: ${packageJson.version}`)
 
         const vsixName = `aws-toolkit-vscode-${packageJson.version}.vsix`
-        fs.moveSync(vsixName, `../../${vsixName}`)
+        fs.moveSync(vsixName, `../../${vsixName}`, { overwrite: true })
     } catch (e) {
         console.log(e)
         throw Error('package.ts: failed')


### PR DESCRIPTION
Ensure that copying the .vsix to the root folder always works. Also, make sure running npm i at root also runs postinstall scripts for all workspaces.

---

`npm run generateNonCodeFiles` is redundant, it is already called in vscode:prepublish which is called by `vsce` automatically
during `npm run publish`

Also, need to make sure we are in the proper directory to package in CI.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
