### PR TITLE
browser: move more code in to shared activation

### DIFF
--- a/packages/toolkit/src/extension.ts
+++ b/packages/toolkit/src/extension.ts
@@ -55,14 +55,11 @@ import { AwsResourceManager } from './dynamicResources/awsResourceManager'
 import globals from './shared/extensionGlobals'
 import { Experiments, Settings } from './shared/settings'
 import { isReleaseVersion } from './shared/vscode/env'
-import { Commands, registerErrorHandler as registerCommandErrorHandler } from './shared/vscode/commands2'
+import { Commands } from './shared/vscode/commands2'
 import { UriHandler } from './shared/vscode/uriHandler'
 import { telemetry } from './shared/telemetry/telemetry'
 import { Auth } from './auth/auth'
-import { isUserCancelledError, resolveErrorMessageToDisplay, ToolkitError } from './shared/errors'
-import { Logging } from './shared/logger/commands'
-import { showMessageWithUrl, showViewLogsMessage } from './shared/utilities/messages'
-import { registerWebviewErrorHandler } from './webviews/server'
+import { showViewLogsMessage } from './shared/utilities/messages'
 import { initializeNetworkAgent } from './codewhisperer/client/agent'
 import { Timeout } from './shared/utilities/timeoutUtils'
 import { submitFeedback } from './feedback/vue/submitFeedback'
@@ -78,15 +75,6 @@ export async function activate(context: vscode.ExtensionContext) {
     const remoteInvokeOutputChannel = vscode.window.createOutputChannel(
         localize('AWS.channel.aws.remoteInvoke', '{0} Remote Invocations', getIdeProperties().company)
     )
-
-    registerCommandErrorHandler((info, error) => {
-        const defaultMessage = localize('AWS.generic.message.error', 'Failed to run command: {0}', info.id)
-        void logAndShowError(error, info.id, defaultMessage)
-    })
-
-    registerWebviewErrorHandler((error: unknown, webviewId: string, command: string) => {
-        logAndShowWebviewError(error, webviewId, command)
-    })
 
     if (isCloud9()) {
         vscode.window.withProgress = wrapWithProgressForCloud9(globals.outputChannel)
@@ -333,58 +321,6 @@ function wrapWithProgressForCloud9(channel: vscode.OutputChannel): (typeof vscod
             return task(newProgress, token)
         })
     }
-}
-
-/**
- * Logs the error. Then determines what kind of error message should be shown, if
- * at all.
- *
- * @param error The error itself
- * @param topic The prefix of the error message
- * @param defaultMessage The message to show if once cannot be resolved from the given error
- *
- * SIDE NOTE:
- * This is only being used for errors from commands and webview, there's plenty of other places
- * (explorer, nodes, ...) where it could be used. It needs to be apart of some sort of `core`
- * module that is guaranteed to initialize prior to every other Toolkit component.
- * Logging and telemetry would fit well within this core module.
- */
-export async function logAndShowError(error: unknown, topic: string, defaultMessage: string) {
-    if (isUserCancelledError(error)) {
-        getLogger().verbose(`${topic}: user cancelled`)
-        return
-    }
-    const logsItem = localize('AWS.generic.message.viewLogs', 'View Logs...')
-    const logId = getLogger().error(`${topic}: %s`, error)
-    const message = resolveErrorMessageToDisplay(error, defaultMessage)
-
-    if (error instanceof ToolkitError && error.documentationUri) {
-        await showMessageWithUrl(message, error.documentationUri, 'View Documentation', 'error')
-    } else {
-        await vscode.window.showErrorMessage(message, logsItem).then(async resp => {
-            if (resp === logsItem) {
-                await Logging.declared.viewLogsAtMessage.execute(logId)
-            }
-        })
-    }
-}
-
-/**
- * Show a webview related error to the user + button that links to the logged error
- *
- * @param err The error that was thrown in the backend
- * @param webviewId Arbitrary value that identifies which webview had the error
- * @param command The high level command/function that was run which triggered the error
- */
-export function logAndShowWebviewError(err: unknown, webviewId: string, command: string) {
-    // HACK: The following implementation is a hack, influenced by the implementation of handleError().
-    // The userFacingError message will be seen in the UI, and the detailedError message will provide the
-    // detailed information in the logs.
-    const detailedError = ToolkitError.chain(err, `Webview backend command failed: "${command}()"`)
-    const userFacingError = ToolkitError.chain(detailedError, 'Webview error')
-    logAndShowError(userFacingError, `webviewId="${webviewId}"`, 'Webview error').catch(e => {
-        getLogger().error('logAndShowError failed: %s', (e as Error).message)
-    })
 }
 
 async function checkSettingsHealth(settings: Settings): Promise<boolean> {

--- a/packages/toolkit/src/extension.ts
+++ b/packages/toolkit/src/extension.ts
@@ -62,7 +62,7 @@ import { showViewLogsMessage } from './shared/utilities/messages'
 import { initializeNetworkAgent } from './codewhisperer/client/agent'
 import { Timeout } from './shared/utilities/timeoutUtils'
 import { submitFeedback } from './feedback/vue/submitFeedback'
-import { activateShared } from './extensionShared'
+import { activateShared, deactivateShared } from './extensionShared'
 
 let localize: nls.LocalizeFunc
 
@@ -243,8 +243,8 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 export async function deactivate() {
+    await deactivateShared()
     await codewhispererShutdown()
-    await globals.telemetry.shutdown()
     await globals.resourceManager.dispose()
 }
 

--- a/packages/toolkit/src/extension.ts
+++ b/packages/toolkit/src/extension.ts
@@ -63,7 +63,6 @@ import { isUserCancelledError, resolveErrorMessageToDisplay, ToolkitError } from
 import { Logging } from './shared/logger/commands'
 import { showMessageWithUrl, showViewLogsMessage } from './shared/utilities/messages'
 import { registerWebviewErrorHandler } from './webviews/server'
-import { ChildProcess } from './shared/utilities/childProcess'
 import { initializeNetworkAgent } from './codewhisperer/client/agent'
 import { Timeout } from './shared/utilities/timeoutUtils'
 import { submitFeedback } from './feedback/vue/submitFeedback'
@@ -75,8 +74,6 @@ let localize: nls.LocalizeFunc
 export async function activate(context: vscode.ExtensionContext) {
     const activationStartedOn = Date.now()
     localize = nls.loadMessageBundle()
-
-    globals.machineId = await getMachineId()
 
     const remoteInvokeOutputChannel = vscode.window.createOutputChannel(
         localize('AWS.channel.aws.remoteInvoke', '{0} Remote Invocations', getIdeProperties().company)
@@ -413,11 +410,6 @@ async function checkSettingsHealth(settings: Settings): Promise<boolean> {
         default:
             return true
     }
-}
-
-async function getMachineId(): Promise<string> {
-    const proc = new ChildProcess('hostname', [], { collect: true, logging: 'no' })
-    return (await proc.run()).stdout.trim() ?? 'unknown-host'
 }
 
 // Unique extension entrypoint names, so that they can be obtained from the webpack bundle

--- a/packages/toolkit/src/extensionShared.ts
+++ b/packages/toolkit/src/extensionShared.ts
@@ -106,6 +106,10 @@ export async function activateShared(context: vscode.ExtensionContext, getRegion
     registerCommands(context)
 }
 
+/** Deactivation code that is shared between nodejs and browser implementations */
+export async function deactivateShared() {
+    await globals.telemetry.shutdown()
+}
 /**
  * Registers generic commands used by both browser and node versions of the toolkit.
  */

--- a/packages/toolkit/src/extensionWeb.ts
+++ b/packages/toolkit/src/extensionWeb.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode'
 import { setInBrowser } from './common/browserUtils'
 import { getLogger } from './shared/logger'
-import { activateShared } from './extensionShared'
+import { activateShared, deactivateShared } from './extensionShared'
 import { RegionProvider, defaultRegion } from './shared/regions/regionProvider'
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -34,4 +34,6 @@ export async function activate(context: vscode.ExtensionContext) {
     }
 }
 
-export async function deactivate() {}
+export async function deactivate() {
+    await deactivateShared()
+}

--- a/packages/toolkit/src/shared/extensionGlobals.ts
+++ b/packages/toolkit/src/shared/extensionGlobals.ts
@@ -123,6 +123,7 @@ interface ToolkitGlobals {
     readonly context: ExtensionContext
     // TODO: make the rest of these readonly (or delete them)
     outputChannel: OutputChannel
+    invokeOutputChannel: OutputChannel
     loginManager: LoginManager
     awsContextCommands: AwsContextCommands
     awsContext: AwsContext


### PR DESCRIPTION
This moves more code in to the shared activation method so that we should be able
to start enabling CodeWhisperer (it should have all the pre-requisite setup it requires now)

- Shared code was moved out of `extension.ts#activate()` and in to `extensionShared.ts#activateShared()`
- The `ExtContext` object is now created in `activateShared()` and passed to the entrypoints as a return value

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
