### PR TITLE
fix(codewhisperer): wrong session id reported by race condition when accept/reject during pagination

### DIFF
--- a/packages/toolkit/src/codewhisperer/service/inlineCompletionService.ts
+++ b/packages/toolkit/src/codewhisperer/service/inlineCompletionService.ts
@@ -128,7 +128,6 @@ export class InlineCompletionService {
                 if (RecommendationHandler.instance.checkAndResetCancellationTokens()) {
                     RecommendationHandler.instance.reportUserDecisions(-1)
                     await vscode.commands.executeCommand('aws.codeWhisperer.refreshStatusBar')
-                    TelemetryHelper.instance.setIsRequestCancelled(true)
                     return
                 }
                 if (!RecommendationHandler.instance.hasNextToken()) {
@@ -136,7 +135,6 @@ export class InlineCompletionService {
                 }
                 page++
             }
-            TelemetryHelper.instance.setNumberOfRequestsInSession(page + 1)
         } catch (error) {
             getLogger().error(`Error ${error} in getPaginatedRecommendation`)
         }

--- a/packages/toolkit/src/codewhisperer/service/recommendationHandler.ts
+++ b/packages/toolkit/src/codewhisperer/service/recommendationHandler.ts
@@ -258,7 +258,6 @@ export class RecommendationHandler {
                 TelemetryHelper.instance.setTimeToFirstRecommendation(performance.now())
             }
             if (nextToken === '') {
-                TelemetryHelper.instance.setLastRequestId(requestId)
                 TelemetryHelper.instance.setAllPaginationEndTime()
             }
         } catch (error) {

--- a/packages/toolkit/src/codewhisperer/util/telemetryHelper.ts
+++ b/packages/toolkit/src/codewhisperer/util/telemetryHelper.ts
@@ -40,9 +40,6 @@ export class TelemetryHelper {
     private sessionDecisions: CodewhispererUserTriggerDecision[] = []
     private triggerChar?: string = undefined
     private prevTriggerDecision?: CodewhispererPreviousSuggestionState
-    private isRequestCancelled = false
-    private lastRequestId = ''
-    private numberOfRequests = 0
     private typeAheadLength = 0
     private timeSinceLastModification = 0
     private lastTriggerDecisionTime = 0
@@ -195,18 +192,12 @@ export class TelemetryHelper {
         }
 
         // after we have all request level user decisions, aggregate them at session level and send
-        if (
-            this.isRequestCancelled ||
-            (this.lastRequestId && this.lastRequestId === requestIdList[requestIdList.length - 1]) ||
-            (this.sessionDecisions.length && this.sessionDecisions.length === this.numberOfRequests)
-        ) {
-            this.sendUserTriggerDecisionTelemetry(
-                sessionId,
-                acceptedRecommendationContent,
-                referenceCount,
-                supplementalContextMetadata
-            )
-        }
+        this.sendUserTriggerDecisionTelemetry(
+            sessionId,
+            acceptedRecommendationContent,
+            referenceCount,
+            supplementalContextMetadata
+        )
     }
 
     public aggregateUserDecisionByRequest(
@@ -371,20 +362,8 @@ export class TelemetryHelper {
         this.classifierThreshold = classifierThreshold
     }
 
-    public setIsRequestCancelled(isRequestCancelled: boolean) {
-        this.isRequestCancelled = isRequestCancelled
-    }
-
     public setTriggerCharForUserTriggerDecision(triggerChar: string) {
         this.triggerChar = triggerChar
-    }
-
-    public setLastRequestId(requestId: string) {
-        this.lastRequestId = requestId
-    }
-
-    public setNumberOfRequestsInSession(numberOfRequests: number) {
-        this.numberOfRequests = numberOfRequests
     }
 
     public setTypeAheadLength(typeAheadLength: number) {
@@ -407,10 +386,7 @@ export class TelemetryHelper {
 
     private resetUserTriggerDecisionTelemetry() {
         this.sessionDecisions = []
-        this.isRequestCancelled = false
         this.triggerChar = ''
-        this.lastRequestId = ''
-        this.numberOfRequests = 0
         this.typeAheadLength = 0
         this.timeSinceLastModification = 0
         this.timeToFirstRecommendation = 0


### PR DESCRIPTION
## Problem

There is a less than 4% chance that the sessionId in STE API is reset to next session's id.  See https://github.com/aws/aws-toolkit-vscode/pull/4368 (Previous PR had incorrect solution to the problem)

Root cause:

When user accept/reject a recommendation before all the pagination API calls finish, the userTriggerDecision of this session is not sent but stored in the IDE session state. When user accept/reject a recommendation next time, the stored state of previous session is sent along with new session, causing wrong session id for some user trigger decision events.

To reproduce it, invoke a recommendation that has multiple pagination calls, managed to hit TAB or escape very fast before the 2nd pagination response arrives at the plugin.  This is tricky to reproduce but possible. 

## Solution

Invoke SendTelemetryEvent API immediately when user hit accept/reject. Remove the extra if condition and extra variables. 

In the above edge case, with this solution, the userTriggerDecision of this session is sent immediately after user hit TAB/REJECT. By the time 2nd pagination response arrives, the userdecision of this response is not be reported to service since the user session does not contain this response. 

Cases I tested:
1. Invoke, type ahead, invoke again. The 2nd invoke will emit the STE of 1st invocation.
2. invoke, accept after pagination done, correct STE are sent.
3.Invoke, accept before pagination done, correct STE are sent. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
