### PR TITLE
fix(CodeTransform): pre-select Java version

### DIFF
--- a/packages/toolkit/src/codewhisperer/models/constants.ts
+++ b/packages/toolkit/src/codewhisperer/models/constants.ts
@@ -278,7 +278,7 @@ export const newCustomizationAvailableKey = 'CODEWHISPERER_NEW_CUSTOMIZATION_AVA
 
 export const selectProjectPrompt = 'Select the project you want to transform'
 
-export const transformByQWindowTitle = 'Amazon Q CodeTransformation'
+export const transformByQWindowTitle = 'Amazon Q Code Transformation'
 
 export const stopTransformByQMessage = 'Stop Transformation?'
 
@@ -293,9 +293,9 @@ export const transformByQCompletedMessage = 'Transformation completed'
 export const transformByQPartiallyCompletedMessage = 'Transformation partially completed'
 
 export const noPomXmlFoundMessage =
-    'None of your open Java projects are supported by Q Code Transformation. We were unable to find a pom.xml in any of your Java projects. We only support Java projects built on Maven at the moment.'
+    'None of your open Java projects are supported by Amazon Q Code Transformation. We were unable to find a pom.xml in any of your Java projects. We only support Java projects built on Maven at the moment.'
 
-export const noActiveIdCMessage = 'Transform by Q requires an active IAM Identity Center connection'
+export const noActiveIdCMessage = 'Amazon Q Code Transformation requires an active IAM Identity Center connection'
 
 export const noOngoingJobMessage = 'No job is in-progress at the moment'
 
@@ -305,7 +305,7 @@ export const cancellationInProgressMessage = 'Cancellation is in-progress'
 
 export const errorStoppingJobMessage = 'Error stopping job'
 
-export const errorDownloadingDiffMessage = 'Transform by Q experienced an error when downloading the diff'
+export const errorDownloadingDiffMessage = 'Amazon Q Code Transformation experienced an error when downloading the diff'
 
 export const viewProposedChangesMessage =
     'Transformation job completed. You can view the transformation summary along with the proposed changes and accept or reject them in the Proposed Changes panel.'
@@ -313,10 +313,10 @@ export const viewProposedChangesMessage =
 export const changesAppliedMessage = 'Changes applied'
 
 export const noSupportedJavaProjectsFoundMessage =
-    'None of your open projects are supported by Q Code Transformation. We were unable to find a Java project. We only support Java projects built on Maven at the moment.'
+    'None of your open projects are supported by Amazon Q Code Transformation. We were unable to find a Java project. We only support Java projects built on Maven at the moment.'
 
 export const dependencyDisclaimer =
-    'Please confirm you are ready to proceed with the transformation. Amazon Q will upload the application code and its dependency binaries from your machine to start the upgrade. If you have not yet compiled the application on your local machine, please do so once before starting the upgrade. Install Maven to ensure all module dependencies are picked for Transformation.'
+    'Please confirm you are ready to proceed with the transformation. Amazon Q Code Transformation will upload the application code and its dependency binaries from your machine to start the upgrade. If you have not yet compiled the application on your local machine, please do so once before starting the upgrade. Install Maven to ensure all module dependencies are picked for Transformation.'
 
 export const dependencyFolderName = 'transformation_dependencies_temp_'
 

--- a/packages/toolkit/src/codewhisperer/models/constants.ts
+++ b/packages/toolkit/src/codewhisperer/models/constants.ts
@@ -276,11 +276,7 @@ export const newCustomizationAvailableKey = 'CODEWHISPERER_NEW_CUSTOMIZATION_AVA
 
 // Transform by Q
 
-export const selectTargetLanguagePrompt = 'Select the target language'
-
-export const selectTargetVersionPrompt = 'Select the target version'
-
-export const selectModulePrompt = 'Select the module you want to transform'
+export const selectProjectPrompt = 'Select the project you want to transform'
 
 export const transformByQWindowTitle = 'Amazon Q CodeTransformation'
 
@@ -297,7 +293,7 @@ export const transformByQCompletedMessage = 'Transformation completed'
 export const transformByQPartiallyCompletedMessage = 'Transformation partially completed'
 
 export const noPomXmlFoundMessage =
-    'We could not find a valid configuration file. We currently support Maven build tool and require a POM.xml in the root directory to identify build configurations. Be sure to also build your project.'
+    'None of your open Java projects are supported by Q Code Transformation. We were unable to find a pom.xml in any of your Java projects. We only support Java projects built on Maven at the moment.'
 
 export const noActiveIdCMessage = 'Transform by Q requires an active IAM Identity Center connection'
 
@@ -317,7 +313,7 @@ export const viewProposedChangesMessage =
 export const changesAppliedMessage = 'Changes applied'
 
 export const noSupportedJavaProjectsFoundMessage =
-    'We could not find an upgrade-eligible application. We currently support upgrade of Java applications of version 8 and 11. Be sure to also build your project.'
+    'None of your open projects are supported by Q Code Transformation. We were unable to find a Java project. We only support Java projects built on Maven at the moment.'
 
 export const dependencyDisclaimer =
     'Please confirm you are ready to proceed with the transformation. Amazon Q will upload the application code and its dependency binaries from your machine to start the upgrade. If you have not yet compiled the application on your local machine, please do so once before starting the upgrade. Install Maven to ensure all module dependencies are picked for Transformation.'

--- a/packages/toolkit/src/codewhisperer/models/model.ts
+++ b/packages/toolkit/src/codewhisperer/models/model.ts
@@ -240,6 +240,7 @@ export enum JDKVersion {
     JDK8 = '8',
     JDK11 = '11',
     JDK17 = '17',
+    UNSUPPORTED = 'UNSUPPORTED',
 }
 
 export enum BuildSystem {
@@ -254,6 +255,11 @@ export class ZipManifest {
     version: string = '1.0'
 }
 
+export enum DropdownStep {
+    STEP_1 = 1,
+    STEP_2 = 2,
+}
+
 export class TransformByQState {
     private transformByQState: TransformByQStatus = TransformByQStatus.NotStarted
 
@@ -262,7 +268,7 @@ export class TransformByQState {
 
     private jobId: string = ''
 
-    private sourceJDKVersion: JDKVersion = JDKVersion.JDK8
+    private sourceJDKVersion: JDKVersion | undefined = undefined
 
     private targetJDKVersion: JDKVersion = JDKVersion.JDK17
 
@@ -406,16 +412,12 @@ export class TransformByQState {
         this.jobId = id
     }
 
-    public setSourceJDKVersionToJDK8() {
-        this.sourceJDKVersion = JDKVersion.JDK8
+    public setSourceJDKVersion(version: JDKVersion | undefined) {
+        this.sourceJDKVersion = version
     }
 
-    public setSourceJDKVersionToJDK11() {
-        this.sourceJDKVersion = JDKVersion.JDK11
-    }
-
-    public setTargetJDKVersionToJDK17() {
-        this.targetJDKVersion = JDKVersion.JDK17
+    public setTargetJDKVersion(version: JDKVersion) {
+        this.targetJDKVersion = version
     }
 
     public setPlanFilePath(filePath: string) {

--- a/packages/toolkit/src/codewhisperer/service/transformByQHandler.ts
+++ b/packages/toolkit/src/codewhisperer/service/transformByQHandler.ts
@@ -83,7 +83,7 @@ export async function getOpenProjects() {
  * and we allow the user to specify the Java version.
  */
 export async function validateOpenProjects(projects: vscode.QuickPickItem[]) {
-    let javaProjects = []
+    const javaProjects = []
     for (const project of projects) {
         const projectPath = project.description
         const javaFiles = await vscode.workspace.findFiles(
@@ -105,7 +105,7 @@ export async function validateOpenProjects(projects: vscode.QuickPickItem[]) {
         })
         throw new ToolkitError('No Java projects found', { code: 'CouldNotFindJavaProject' })
     }
-    let mavenJavaProjects = []
+    const mavenJavaProjects = []
     let containsGradle = false
     for (const project of javaProjects) {
         const projectPath = project.description
@@ -132,7 +132,7 @@ export async function validateOpenProjects(projects: vscode.QuickPickItem[]) {
      * here we try to get the Java version of each project so that we
      * can pre-select a default version in the QuickPick for them
      */
-    let projectsValidToTransform = new Map<vscode.QuickPickItem, JDKVersion | undefined>()
+    const projectsValidToTransform = new Map<vscode.QuickPickItem, JDKVersion | undefined>()
     for (const project of mavenJavaProjects) {
         let detectedJavaVersion = undefined
         const projectPath = project.description


### PR DESCRIPTION
## Problem

UX request to change the way we validate input: rather than letting user select a project, then run all validation checks, we want to run all validation checks on all open projects to filter valid projects for the user, plus pre-select the Java version for them if we were able to detect it and it's a supported version (8 or 11).

## Solution

Implement what is described above.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
