### PR TITLE
tests: Allow Amazon Q e2e tests to call the backend

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -420,7 +420,7 @@ Unlike the user setting overrides, not all of these environment variables have t
 
 #### Lambda
 
--   `AUTH_UTIL_LAMBDA_ARN`: The Amazon Resource Name (ARN) of the lambda function
+-   `AUTH_UTIL_LAMBDA_ARN`: The Auth Util Lambda is used to log into using Builder ID/IdC automatically when running e2e tests. This is the arn that points to the auth util lambda.
 
 #### ECS
 
@@ -436,8 +436,10 @@ Unlike the user setting overrides, not all of these environment variables have t
 -   `GITHUB_ACTION`: The name of the current GitHub Action workflow step that is running
 -   `CODEBUILD_BUILD_ID`: The unique ID of the current CodeBuild build that is executing
 -   `AWS_TOOLKIT_AUTOMATION`: If tests are currently being ran
--   `DEVELOPMENT_PATH`: The path to the aws toolkit vscode project
+-   `TEST_SSO_STARTURL`: The start url you want to use on E2E tests
+-   `TEST_SSO_REGION`: The region for the start url you want to use on E2E tests
 -   `AWS_TOOLKIT_TEST_NO_COLOR`: If the tests should include colour in their output
+-   `DEVELOPMENT_PATH`: The path to the aws toolkit vscode project
 -   `TEST_DIR` - The directory where the test runner should find the tests
 
 ### SAM/CFN ("goformation") JSON schema

--- a/packages/toolkit/src/testE2E/amazonq/framework/text.ts
+++ b/packages/toolkit/src/testE2E/amazonq/framework/text.ts
@@ -12,10 +12,11 @@ import { ChatItem } from '@aws/mynah-ui'
  * @param expectedText An array of expected text items in order
  * @returns true if the items in expectedText are found in the correct order in chatItems otherwise false
  */
-export function verifyTextOrder(chatItems: ChatItem[], expectedText: string[]) {
+export function verifyTextOrder(chatItems: ChatItem[], expectedText: RegExp[]) {
     let currInd = 0
     for (const item of chatItems) {
-        if (item.body?.includes(expectedText[currInd])) {
+        const currentExpected = expectedText[currInd]
+        if (currentExpected && item.body?.match(currentExpected)) {
             currInd++
         }
     }

--- a/packages/toolkit/src/testE2E/amazonq/utils/setup.ts
+++ b/packages/toolkit/src/testE2E/amazonq/utils/setup.ts
@@ -1,0 +1,26 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { AuthUtil, getChatAuthState } from '../../../codewhisperer/util/authUtil'
+
+export async function loginToIdC() {
+    const authState = await getChatAuthState()
+    if (process.env['AWS_TOOLKIT_AUTOMATION'] === 'local') {
+        if (authState.amazonQ !== 'connected') {
+            throw new Error('You will need to login manually before running tests.')
+        }
+        return
+    }
+
+    const startUrl = process.env['TEST_SSO_STARTURL']
+    const region = process.env['TEST_SSO_REGION']
+
+    if (!startUrl || !region) {
+        throw new Error(
+            'TEST_SSO_STARTURL and TEST_SSO_REGION are required environment variables when running Amazon Q E2E tests'
+        )
+    }
+
+    await AuthUtil.instance.connectToEnterpriseSso(startUrl, region)
+}


### PR DESCRIPTION
_pending creation of amazonq-test-account secret_

## Problem
- Amazon Q e2e tests currently use mocked responses instead of calling the backend directly

## Solution
- Allow Amazon Q e2e tests to call the backend directly

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
