### PR TITLE
refactor: remove 'glob' from CW

### DIFF
--- a/packages/toolkit/src/codewhisperer/util/supplementalContext/utgUtils.ts
+++ b/packages/toolkit/src/codewhisperer/util/supplementalContext/utgUtils.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { glob } from 'glob'
 import * as fs from 'fs-extra'
 import * as path from 'path'
 import * as vscode from 'vscode'
@@ -190,9 +189,6 @@ async function findSourceFileByName(
     languageConfig: utgLanguageConfig,
     cancellationToken: vscode.CancellationToken
 ): Promise<string | undefined> {
-    const uri = editor.document.uri
-    const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri)
-    const projectPath = workspaceFolder ? workspaceFolder.uri.fsPath : path.dirname(uri.fsPath)
     const testFileName = path.basename(editor.document.fileName)
 
     let basenameSuffix = testFileName
@@ -222,23 +218,14 @@ async function findSourceFileByName(
 
     throwIfCancelled(cancellationToken)
 
-    // TODO: vscode.workspace.findFiles is preferred but doesn't seems to be working for now.
-    // TODO: Enable this later.
-    //const sourceFiles =
-    //    await vscode.workspace.findFiles(`${projectPath}/**/${basenameSuffix}${languageConfig.extension}`);
-    const sourceFiles = await globPromise(`${projectPath}/**/${basenameSuffix}${languageConfig.extension}`)
+    const sourceFiles = await vscode.workspace.findFiles(`**/${basenameSuffix}${languageConfig.extension}`)
 
     throwIfCancelled(cancellationToken)
 
     if (sourceFiles.length > 0) {
-        return sourceFiles[0]
+        return sourceFiles[0].toString()
     }
     return undefined
-}
-
-// TODO: Replace this by vscode.workspace.findFiles
-function globPromise(pattern: string): Promise<string[]> {
-    return glob(pattern)
 }
 
 function throwIfCancelled(token: vscode.CancellationToken): void | never {

--- a/packages/toolkit/src/codewhisperer/util/supplementalContext/utgUtils.ts
+++ b/packages/toolkit/src/codewhisperer/util/supplementalContext/utgUtils.ts
@@ -114,7 +114,7 @@ function generateSupplementalContextFromFocalFile(
     strategy: UtgStrategy,
     cancellationToken: vscode.CancellationToken
 ): CodeWhispererSupplementalContextItem[] {
-    const fileContent = fs.readFileSync(vscode.Uri.file(filePath!).fsPath, 'utf-8')
+    const fileContent = fs.readFileSync(vscode.Uri.parse(filePath!).fsPath, 'utf-8')
 
     // DO NOT send code chunk with empty content
     if (fileContent.trim().length === 0) {


### PR DESCRIPTION
## Problem:
We cannot use 'glob' in browser mode since it breaks if not in nodejs

## Solution:
Use `vscode.workspace.findFiles` which simply searches the entire workspace (or current folder
if no workspace was selected)

Note the previous comments about it not working, which was due to us needing to use a relative path since it searches the workspace/root folder only

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
