### PR TITLE
fix: release buildspec .ymls need to be updated for monorepo change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,7 @@ jobs:
               run: |
                   npm run createRelease  # Generate CHANGELOG.md
                   cp ./README.quickstart.vscode.md ./README.md
-                  cd packages/toolkit
-                  npm run package -- --feature "$FEAT_NAME"
+                  npm run -w packages/toolkit package -- --feature "$FEAT_NAME"
             - uses: actions/upload-artifact@v4
               with:
                   name: artifacts
@@ -65,7 +64,7 @@ jobs:
               run: |
                   echo "feature=$FEAT_NAME" >> $GITHUB_OUTPUT
                   echo "tagname=$TAG_NAME" >> $GITHUB_OUTPUT
-                  echo "version=$(grep -m 1 version package.json | grep -o '[0-9][^\"]\+' | sed 's/-SNAPSHOT//')" >> $GITHUB_OUTPUT
+                  echo "version=$(grep -m 1 version packages/toolkit/package.json | grep -o '[0-9][^\"]\+' | sed 's/-SNAPSHOT//')" >> $GITHUB_OUTPUT
                   echo 'changes<<EOF' >> $GITHUB_OUTPUT
                   cat CHANGELOG.md | perl -ne 'BEGIN{$/="\n\n"} print; exit if $. == 2' >> $GITHUB_OUTPUT
                   echo 'EOF' >> $GITHUB_OUTPUT

--- a/buildspec/release/10changeversion.yml
+++ b/buildspec/release/10changeversion.yml
@@ -15,15 +15,15 @@ phases:
                 echo "Removing SNAPSHOT from version string"
                 git config --global user.name "aws-toolkit-automation"
                 git config --global user.email "<>"
-                VERSION=$(node -e "console.log(require('./package.json').version);" | (IFS="-"; read -r version unused && echo "$version"))
+                VERSION=$(node -e "console.log(require('./packages/toolkit/package.json').version);" | (IFS="-"; read -r version unused && echo "$version"))
                 DATE=$(date)
-                npm version --no-git-tag-version "$VERSION"
+                npm version --no-git-tag-version "$VERSION" -w packages/toolkit
                 # Call npm ci because 'createRelease' uses ts-node
                 npm ci
             - |
                 npm run createRelease
             - |
-                git add package.json
+                git add packages/toolkit/package.json
                 git add package-lock.json
                 git commit -m "Release $VERSION"
                 echo "tagging commit"

--- a/buildspec/release/20buildrelease.yml
+++ b/buildspec/release/20buildrelease.yml
@@ -27,5 +27,5 @@ phases:
 artifacts:
     files:
         - aws-toolkit-vscode*
-        - package.json
+        - packages/toolkit/package.json
     discard-paths: true

--- a/buildspec/release/40pushtogithub.yml
+++ b/buildspec/release/40pushtogithub.yml
@@ -24,11 +24,11 @@ phases:
                 git remote add originWithCreds "$REPO_URL"
                 echo "Adding SNAPSHOT to next version string"
                 # Increase minor version
-                npm version --no-git-tag-version minor
-                VERSION=$(node -e "console.log(require('./package.json').version);")
+                npm version --no-git-tag-version minor -w packages/toolkit
+                VERSION=$(node -e "console.log(require('./packages/toolkit/package.json').version);")
                 # Append -SNAPSHOT
-                npm version --no-git-tag-version "${VERSION}-SNAPSHOT"
-                git add package.json
+                npm version --no-git-tag-version "${VERSION}-SNAPSHOT" -w packages/toolkit
+                git add packages/toolkit/package.json
                 git add package-lock.json
                 git commit -m "Update version to snapshot version: ${VERSION}-SNAPSHOT"
             - |

--- a/buildspec/release/50githubrelease.yml
+++ b/buildspec/release/50githubrelease.yml
@@ -25,7 +25,7 @@ phases:
         commands:
             # pull in the build artifacts
             - cp -r ${CODEBUILD_SRC_DIR_buildPipeline}/* .
-            - VERSION=$(node -e "console.log(require('./package.json').version);")
+            - VERSION=$(node -e "console.log(require('./packages/toolkit/package.json').version);")
             - UPLOAD_TARGET=$(ls aws-toolkit-vscode*.vsix)
             - HASH_UPLOAD_TARGET=${UPLOAD_TARGET}.sha384
             - 'HASH=$(sha384sum -b $UPLOAD_TARGET | cut -d" " -f1)'


### PR DESCRIPTION
Problem: Release pipeline not behaving as expected, not updating the proper package.json version.

Solution: Update for new paths/npm workspaces.

### Testing:
Tested some of the commands locally, they seem to be working fine for updating the version, committing now.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
