### PR TITLE
refactor: reorder initialize since breaks in C9

### DIFF
--- a/packages/toolkit/src/extensionShared.ts
+++ b/packages/toolkit/src/extensionShared.ts
@@ -58,6 +58,10 @@ export async function activateShared(
 ): Promise<ExtContext> {
     localize = nls.loadMessageBundle()
 
+    // some "initialize" functions
+    await initializeComputeRegion()
+    initialize(context)
+
     registerCommandErrorHandler((info, error) => {
         const defaultMessage = localize('AWS.generic.message.error', 'Failed to run command: {0}', info.id)
         void logAndShowError(error, info.id, defaultMessage)
@@ -94,10 +98,6 @@ export async function activateShared(
     globals.awsContext = new DefaultAwsContext()
     globals.sdkClientBuilder = new DefaultAWSClientBuilder(globals.awsContext)
     globals.loginManager = new LoginManager(globals.awsContext, new CredentialsStore())
-
-    // some "initialize" functions
-    await initializeComputeRegion()
-    initialize(context)
 
     // order matters here
     globals.manifestPaths.endpoints = context.asAbsolutePath(join('resources', 'endpoints.json'))


### PR DESCRIPTION
The order of the intialize methods caused issues in C9 due to the order of execution.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
