### PR TITLE
fix: create output channel before registering with c9 progress

### DIFF
--- a/packages/toolkit/src/extensionShared.ts
+++ b/packages/toolkit/src/extensionShared.ts
@@ -71,6 +71,11 @@ export async function activateShared(
         logAndShowWebviewError(error, webviewId, command)
     })
 
+    // Setup the logger
+    const toolkitOutputChannel = vscode.window.createOutputChannel('AWS Toolkit', { log: true })
+    await activateLogger(context, toolkitOutputChannel)
+    globals.outputChannel = toolkitOutputChannel
+
     if (isCloud9()) {
         vscode.window.withProgress = wrapWithProgressForCloud9(globals.outputChannel)
         context.subscriptions.push(
@@ -87,11 +92,6 @@ export async function activateShared(
     globals.invokeOutputChannel = vscode.window.createOutputChannel(
         localize('AWS.channel.aws.remoteInvoke', '{0} Remote Invocations', getIdeProperties().company)
     )
-
-    // Setup the logger
-    const toolkitOutputChannel = vscode.window.createOutputChannel('AWS Toolkit', { log: true })
-    await activateLogger(context, toolkitOutputChannel)
-    globals.outputChannel = toolkitOutputChannel
 
     //setup globals
     globals.machineId = await getMachineId()


### PR DESCRIPTION
Output channel is used inside a c9 wrapper before it is created.

### Testing
Packaged and things that use progress in c9 (e.g. upload lambda, upload s3) no longer fails.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
