### PR TITLE
fix(c9): use 'fs' for c9 when calling `writeFile`

### DIFF
--- a/packages/toolkit/src/srcShared/fs.ts
+++ b/packages/toolkit/src/srcShared/fs.ts
@@ -105,6 +105,13 @@ export class FileSystemCommon {
      */
     async writeFile(path: Uri | string, data: string | Uint8Array): Promise<void> {
         path = FileSystemCommon.getUri(path)
+
+        // vscode.workspace.writeFile is stubbed in C9 has limited functionality,
+        // e.g. cannot write outside of open workspace
+        if (isCloud9()) {
+            await fsPromises.writeFile(path.fsPath, FileSystemCommon.asArray(data))
+            return
+        }
         return fs.writeFile(path, FileSystemCommon.asArray(data))
     }
 


### PR DESCRIPTION
Problem: the C9 stub for the vscode api's writeFile does not support writing outside of the workspace dir, which can happen when adding new IAM credentials.

Solution: Fall back to a standard fs library for C9.

#### Testing
Tested on C9

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
