### PR TITLE
DoNotReview: remove polling for token in new auth flow

### DIFF
--- a/packages/core/scripts/build/generateServiceClient.ts
+++ b/packages/core/scripts/build/generateServiceClient.ts
@@ -245,6 +245,10 @@ void (async () => {
             serviceJsonPath: 'src/amazonqFeatureDev/client/codewhispererruntime-2022-11-11.json',
             serviceName: 'FeatureDevProxyClient',
         },
+        {
+            serviceJsonPath: 'src/auth/sso/service-2.json',
+            serviceName: 'OidcClientPKCE',
+        },
     ]
     await generateServiceClients(serviceClientDefinitions)
 })()

--- a/packages/core/src/auth/sso/service-2.json
+++ b/packages/core/src/auth/sso/service-2.json
@@ -1,0 +1,656 @@
+{
+    "version": "2.0",
+    "metadata": {
+        "apiVersion": "2019-06-10",
+        "endpointPrefix": "oidc",
+        "jsonVersion": "1.1",
+        "protocol": "rest-json",
+        "serviceAbbreviation": "SSO OIDC",
+        "serviceFullName": "AWS SSO OIDC",
+        "serviceId": "SSO OIDC",
+        "signatureVersion": "v4",
+        "signingName": "sso-oauth",
+        "uid": "sso-oidc-2019-06-10"
+    },
+    "operations": {
+        "CreateToken": {
+            "name": "CreateToken",
+            "http": {
+                "method": "POST",
+                "requestUri": "/token"
+            },
+            "input": { "shape": "CreateTokenRequest" },
+            "output": { "shape": "CreateTokenResponse" },
+            "errors": [
+                { "shape": "InvalidRequestException" },
+                { "shape": "InvalidClientException" },
+                { "shape": "InvalidGrantException" },
+                { "shape": "UnauthorizedClientException" },
+                { "shape": "UnsupportedGrantTypeException" },
+                { "shape": "InvalidScopeException" },
+                { "shape": "AuthorizationPendingException" },
+                { "shape": "SlowDownException" },
+                { "shape": "AccessDeniedException" },
+                { "shape": "ExpiredTokenException" },
+                { "shape": "InternalServerException" }
+            ],
+            "documentation": "<p>Creates and returns access and refresh tokens for clients that are authenticated using client secrets. The access token can be used to fetch short-term credentials for the assigned AWS accounts or to access application APIs using <code>bearer</code> authentication.</p>",
+            "authtype": "none"
+        },
+        "CreateTokenWithIAM": {
+            "name": "CreateTokenWithIAM",
+            "http": {
+                "method": "POST",
+                "requestUri": "/token?aws_iam=t"
+            },
+            "input": { "shape": "CreateTokenWithIAMRequest" },
+            "output": { "shape": "CreateTokenWithIAMResponse" },
+            "errors": [
+                { "shape": "InvalidRequestException" },
+                { "shape": "InvalidClientException" },
+                { "shape": "InvalidGrantException" },
+                { "shape": "UnauthorizedClientException" },
+                { "shape": "UnsupportedGrantTypeException" },
+                { "shape": "InvalidScopeException" },
+                { "shape": "AuthorizationPendingException" },
+                { "shape": "SlowDownException" },
+                { "shape": "AccessDeniedException" },
+                { "shape": "ExpiredTokenException" },
+                { "shape": "InternalServerException" },
+                { "shape": "InvalidRequestRegionException" }
+            ],
+            "documentation": "<p>Creates and returns access and refresh tokens for clients and applications that are authenticated using IAM entities. The access token can be used to fetch short-term credentials for the assigned Amazon Web Services accounts or to access application APIs using <code>bearer</code> authentication.</p>"
+        },
+        "RegisterClient": {
+            "name": "RegisterClient",
+            "http": {
+                "method": "POST",
+                "requestUri": "/client/register"
+            },
+            "input": { "shape": "RegisterClientRequest" },
+            "output": { "shape": "RegisterClientResponse" },
+            "errors": [
+                { "shape": "InvalidRequestException" },
+                { "shape": "InvalidScopeException" },
+                { "shape": "InvalidClientMetadataException" },
+                { "shape": "InternalServerException" },
+                { "shape": "InvalidRedirectUriException" }
+            ],
+            "documentation": "<p>Registers a client with IAM Identity Center. This allows clients to initiate device authorization. The output should be persisted for reuse through many authentication requests.</p>",
+            "authtype": "none"
+        },
+        "StartDeviceAuthorization": {
+            "name": "StartDeviceAuthorization",
+            "http": {
+                "method": "POST",
+                "requestUri": "/device_authorization"
+            },
+            "input": { "shape": "StartDeviceAuthorizationRequest" },
+            "output": { "shape": "StartDeviceAuthorizationResponse" },
+            "errors": [
+                { "shape": "InvalidRequestException" },
+                { "shape": "InvalidClientException" },
+                { "shape": "UnauthorizedClientException" },
+                { "shape": "SlowDownException" },
+                { "shape": "InternalServerException" }
+            ],
+            "documentation": "<p>Initiates device authorization by requesting a pair of verification codes from the authorization service.</p>",
+            "authtype": "none"
+        }
+    },
+    "shapes": {
+        "AccessDeniedException": {
+            "type": "structure",
+            "members": {
+                "error": {
+                    "shape": "Error",
+                    "documentation": "<p>Single error code. For this exception the value will be <code>access_denied</code>.</p>"
+                },
+                "error_description": {
+                    "shape": "ErrorDescription",
+                    "documentation": "<p>Human-readable text providing additional information, used to assist the client developer in understanding the error that occurred.</p>"
+                }
+            },
+            "documentation": "<p>You do not have sufficient access to perform this action.</p>",
+            "error": { "httpStatusCode": 400 },
+            "exception": true
+        },
+        "AccessToken": {
+            "type": "string",
+            "sensitive": true
+        },
+        "ArnType": { "type": "string" },
+        "Assertion": {
+            "type": "string",
+            "sensitive": true
+        },
+        "AuthCode": { "type": "string" },
+        "AuthorizationPendingException": {
+            "type": "structure",
+            "members": {
+                "error": {
+                    "shape": "Error",
+                    "documentation": "<p>Single error code. For this exception the value will be <code>authorization_pending</code>.</p>"
+                },
+                "error_description": {
+                    "shape": "ErrorDescription",
+                    "documentation": "<p>Human-readable text providing additional information, used to assist the client developer in understanding the error that occurred.</p>"
+                }
+            },
+            "documentation": "<p>Indicates that a request to authorize a client with an access user session token is pending.</p>",
+            "error": { "httpStatusCode": 400 },
+            "exception": true
+        },
+        "ClientId": { "type": "string" },
+        "ClientName": { "type": "string" },
+        "ClientSecret": {
+            "type": "string",
+            "sensitive": true
+        },
+        "ClientType": { "type": "string" },
+        "CodeVerifier": {
+            "type": "string",
+            "sensitive": true
+        },
+        "CreateTokenRequest": {
+            "type": "structure",
+            "required": ["clientId", "clientSecret", "grantType"],
+            "members": {
+                "clientId": {
+                    "shape": "ClientId",
+                    "documentation": "<p>The unique identifier string for the client or application. This value comes from the result of the <a>RegisterClient</a> API.</p>"
+                },
+                "clientSecret": {
+                    "shape": "ClientSecret",
+                    "documentation": "<p>A secret string generated for the client. This value should come from the persisted result of the <a>RegisterClient</a> API.</p>"
+                },
+                "grantType": {
+                    "shape": "GrantType",
+                    "documentation": "<p>Supports the following OAuth grant types: Device Code and Refresh Token. Specify either of the following values, depending on the grant type that you want:</p> <p>* Device Code - <code>urn:ietf:params:oauth:grant-type:device_code</code> </p> <p>* Refresh Token - <code>refresh_token</code> </p> <p>For information about how to obtain the device code, see the <a>StartDeviceAuthorization</a> topic.</p>"
+                },
+                "deviceCode": {
+                    "shape": "DeviceCode",
+                    "documentation": "<p>Used only when calling this API for the Device Code grant type. This short-term code is used to identify this authorization request. This comes from the result of the <a>StartDeviceAuthorization</a> API.</p>"
+                },
+                "code": {
+                    "shape": "AuthCode",
+                    "documentation": "<p>Used only when calling this API for the Authorization Code grant type. The short-term code is used to identify this authorization request. This grant type is currently unsupported for the <a>CreateToken</a> API.</p>"
+                },
+                "refreshToken": {
+                    "shape": "RefreshToken",
+                    "documentation": "<p>Used only when calling this API for the Refresh Token grant type. This token is used to refresh short-term tokens, such as the access token, that might expire.</p> <p>For more information about the features and limitations of the current IAM Identity Center OIDC implementation, see <i>Considerations for Using this Guide</i> in the <a href=\"https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/Welcome.html\">IAM Identity Center OIDC API Reference</a>.</p>"
+                },
+                "scope": {
+                    "shape": "Scopes",
+                    "documentation": "<p>The list of scopes for which authorization is requested. The access token that is issued is limited to the scopes that are granted. If this value is not specified, IAM Identity Center authorizes all scopes that are configured for the client during the call to <a>RegisterClient</a>.</p>"
+                },
+                "redirectUri": {
+                    "shape": "URI",
+                    "documentation": "<p>Used only when calling this API for the Authorization Code grant type. This value specifies the location of the client or application that has registered to receive the authorization code.</p>"
+                },
+                "codeVerifier": {
+                    "shape": "CodeVerifier",
+                    "documentation": "<p>Used only when calling this API for the Authorization Code grant type. This value is generated by the client and presented to validate the original code challenge value the client passed at authorization time.</p>"
+                }
+            }
+        },
+        "CreateTokenResponse": {
+            "type": "structure",
+            "members": {
+                "accessToken": {
+                    "shape": "AccessToken",
+                    "documentation": "<p>A bearer token to access Amazon Web Services accounts and applications assigned to a user.</p>"
+                },
+                "tokenType": {
+                    "shape": "TokenType",
+                    "documentation": "<p>Used to notify the client that the returned token is an access token. The supported token type is <code>Bearer</code>.</p>"
+                },
+                "expiresIn": {
+                    "shape": "ExpirationInSeconds",
+                    "documentation": "<p>Indicates the time in seconds when an access token will expire.</p>"
+                },
+                "refreshToken": {
+                    "shape": "RefreshToken",
+                    "documentation": "<p>A token that, if present, can be used to refresh a previously issued access token that might have expired.</p> <p>For more information about the features and limitations of the current IAM Identity Center OIDC implementation, see <i>Considerations for Using this Guide</i> in the <a href=\"https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/Welcome.html\">IAM Identity Center OIDC API Reference</a>.</p>"
+                },
+                "idToken": {
+                    "shape": "IdToken",
+                    "documentation": "<p>The <code>idToken</code> is not implemented or supported. For more information about the features and limitations of the current IAM Identity Center OIDC implementation, see <i>Considerations for Using this Guide</i> in the <a href=\"https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/Welcome.html\">IAM Identity Center OIDC API Reference</a>.</p> <p>A JSON Web Token (JWT) that identifies who is associated with the issued access token. </p>"
+                }
+            }
+        },
+        "CreateTokenWithIAMRequest": {
+            "type": "structure",
+            "required": ["clientId", "grantType"],
+            "members": {
+                "clientId": {
+                    "shape": "ClientId",
+                    "documentation": "<p>The unique identifier string for the client or application. This value is an application ARN that has OAuth grants configured.</p>"
+                },
+                "grantType": {
+                    "shape": "GrantType",
+                    "documentation": "<p>Supports the following OAuth grant types: Authorization Code, Refresh Token, JWT Bearer, and Token Exchange. Specify one of the following values, depending on the grant type that you want:</p> <p>* Authorization Code - <code>authorization_code</code> </p> <p>* Refresh Token - <code>refresh_token</code> </p> <p>* JWT Bearer - <code>urn:ietf:params:oauth:grant-type:jwt-bearer</code> </p> <p>* Token Exchange - <code>urn:ietf:params:oauth:grant-type:token-exchange</code> </p>"
+                },
+                "code": {
+                    "shape": "AuthCode",
+                    "documentation": "<p>Used only when calling this API for the Authorization Code grant type. This short-term code is used to identify this authorization request. The code is obtained through a redirect from IAM Identity Center to a redirect URI persisted in the Authorization Code GrantOptions for the application.</p>"
+                },
+                "refreshToken": {
+                    "shape": "RefreshToken",
+                    "documentation": "<p>Used only when calling this API for the Refresh Token grant type. This token is used to refresh short-term tokens, such as the access token, that might expire.</p> <p>For more information about the features and limitations of the current IAM Identity Center OIDC implementation, see <i>Considerations for Using this Guide</i> in the <a href=\"https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/Welcome.html\">IAM Identity Center OIDC API Reference</a>.</p>"
+                },
+                "assertion": {
+                    "shape": "Assertion",
+                    "documentation": "<p>Used only when calling this API for the JWT Bearer grant type. This value specifies the JSON Web Token (JWT) issued by a trusted token issuer. To authorize a trusted token issuer, configure the JWT Bearer GrantOptions for the application.</p>"
+                },
+                "scope": {
+                    "shape": "Scopes",
+                    "documentation": "<p>The list of scopes for which authorization is requested. The access token that is issued is limited to the scopes that are granted. If the value is not specified, IAM Identity Center authorizes all scopes configured for the application, including the following default scopes: <code>openid</code>, <code>aws</code>, <code>sts:identity_context</code>.</p>"
+                },
+                "redirectUri": {
+                    "shape": "URI",
+                    "documentation": "<p>Used only when calling this API for the Authorization Code grant type. This value specifies the location of the client or application that has registered to receive the authorization code. </p>"
+                },
+                "subjectToken": {
+                    "shape": "SubjectToken",
+                    "documentation": "<p>Used only when calling this API for the Token Exchange grant type. This value specifies the subject of the exchange. The value of the subject token must be an access token issued by IAM Identity Center to a different client or application. The access token must have authorized scopes that indicate the requested application as a target audience.</p>"
+                },
+                "subjectTokenType": {
+                    "shape": "TokenTypeURI",
+                    "documentation": "<p>Used only when calling this API for the Token Exchange grant type. This value specifies the type of token that is passed as the subject of the exchange. The following value is supported:</p> <p>* Access Token - <code>urn:ietf:params:oauth:token-type:access_token</code> </p>"
+                },
+                "requestedTokenType": {
+                    "shape": "TokenTypeURI",
+                    "documentation": "<p>Used only when calling this API for the Token Exchange grant type. This value specifies the type of token that the requester can receive. The following values are supported:</p> <p>* Access Token - <code>urn:ietf:params:oauth:token-type:access_token</code> </p> <p>* Refresh Token - <code>urn:ietf:params:oauth:token-type:refresh_token</code> </p>"
+                },
+                "codeVerifier": {
+                    "shape": "CodeVerifier",
+                    "documentation": "<p>Used only when calling this API for the Authorization Code grant type. This value is generated by the client and presented to validate the original code challenge value the client passed at authorization time.</p>"
+                }
+            }
+        },
+        "CreateTokenWithIAMResponse": {
+            "type": "structure",
+            "members": {
+                "accessToken": {
+                    "shape": "AccessToken",
+                    "documentation": "<p>A bearer token to access Amazon Web Services accounts and applications assigned to a user.</p>"
+                },
+                "tokenType": {
+                    "shape": "TokenType",
+                    "documentation": "<p>Used to notify the requester that the returned token is an access token. The supported token type is <code>Bearer</code>.</p>"
+                },
+                "expiresIn": {
+                    "shape": "ExpirationInSeconds",
+                    "documentation": "<p>Indicates the time in seconds when an access token will expire.</p>"
+                },
+                "refreshToken": {
+                    "shape": "RefreshToken",
+                    "documentation": "<p>A token that, if present, can be used to refresh a previously issued access token that might have expired.</p> <p>For more information about the features and limitations of the current IAM Identity Center OIDC implementation, see <i>Considerations for Using this Guide</i> in the <a href=\"https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/Welcome.html\">IAM Identity Center OIDC API Reference</a>.</p>"
+                },
+                "idToken": {
+                    "shape": "IdToken",
+                    "documentation": "<p>A JSON Web Token (JWT) that identifies the user associated with the issued access token. </p>"
+                },
+                "issuedTokenType": {
+                    "shape": "TokenTypeURI",
+                    "documentation": "<p>Indicates the type of tokens that are issued by IAM Identity Center. The following values are supported: </p> <p>* Access Token - <code>urn:ietf:params:oauth:token-type:access_token</code> </p> <p>* Refresh Token - <code>urn:ietf:params:oauth:token-type:refresh_token</code> </p>"
+                },
+                "scope": {
+                    "shape": "Scopes",
+                    "documentation": "<p>The list of scopes for which authorization is granted. The access token that is issued is limited to the scopes that are granted.</p>"
+                }
+            }
+        },
+        "DeviceCode": { "type": "string" },
+        "Error": { "type": "string" },
+        "ErrorDescription": { "type": "string" },
+        "ExpirationInSeconds": { "type": "integer" },
+        "ExpiredTokenException": {
+            "type": "structure",
+            "members": {
+                "error": {
+                    "shape": "Error",
+                    "documentation": "<p>Single error code. For this exception the value will be <code>expired_token</code>.</p>"
+                },
+                "error_description": {
+                    "shape": "ErrorDescription",
+                    "documentation": "<p>Human-readable text providing additional information, used to assist the client developer in understanding the error that occurred.</p>"
+                }
+            },
+            "documentation": "<p>Indicates that the token issued by the service is expired and is no longer valid.</p>",
+            "error": { "httpStatusCode": 400 },
+            "exception": true
+        },
+        "GrantType": { "type": "string" },
+        "GrantTypes": {
+            "type": "list",
+            "member": { "shape": "GrantType" }
+        },
+        "IdToken": {
+            "type": "string",
+            "sensitive": true
+        },
+        "InternalServerException": {
+            "type": "structure",
+            "members": {
+                "error": {
+                    "shape": "Error",
+                    "documentation": "<p>Single error code. For this exception the value will be <code>server_error</code>.</p>"
+                },
+                "error_description": {
+                    "shape": "ErrorDescription",
+                    "documentation": "<p>Human-readable text providing additional information, used to assist the client developer in understanding the error that occurred.</p>"
+                }
+            },
+            "documentation": "<p>Indicates that an error from the service occurred while trying to process a request.</p>",
+            "error": { "httpStatusCode": 500 },
+            "exception": true,
+            "fault": true
+        },
+        "IntervalInSeconds": { "type": "integer" },
+        "InvalidClientException": {
+            "type": "structure",
+            "members": {
+                "error": {
+                    "shape": "Error",
+                    "documentation": "<p>Single error code. For this exception the value will be <code>invalid_client</code>.</p>"
+                },
+                "error_description": {
+                    "shape": "ErrorDescription",
+                    "documentation": "<p>Human-readable text providing additional information, used to assist the client developer in understanding the error that occurred.</p>"
+                }
+            },
+            "documentation": "<p>Indicates that the <code>clientId</code> or <code>clientSecret</code> in the request is invalid. For example, this can occur when a client sends an incorrect <code>clientId</code> or an expired <code>clientSecret</code>.</p>",
+            "error": { "httpStatusCode": 401 },
+            "exception": true
+        },
+        "InvalidClientMetadataException": {
+            "type": "structure",
+            "members": {
+                "error": {
+                    "shape": "Error",
+                    "documentation": "<p>Single error code. For this exception the value will be <code>invalid_client_metadata</code>.</p>"
+                },
+                "error_description": {
+                    "shape": "ErrorDescription",
+                    "documentation": "<p>Human-readable text providing additional information, used to assist the client developer in understanding the error that occurred.</p>"
+                }
+            },
+            "documentation": "<p>Indicates that the client information sent in the request during registration is invalid.</p>",
+            "error": { "httpStatusCode": 400 },
+            "exception": true
+        },
+        "InvalidGrantException": {
+            "type": "structure",
+            "members": {
+                "error": {
+                    "shape": "Error",
+                    "documentation": "<p>Single error code. For this exception the value will be <code>invalid_grant</code>.</p>"
+                },
+                "error_description": {
+                    "shape": "ErrorDescription",
+                    "documentation": "<p>Human-readable text providing additional information, used to assist the client developer in understanding the error that occurred.</p>"
+                }
+            },
+            "documentation": "<p>Indicates that a request contains an invalid grant. This can occur if a client makes a <a>CreateToken</a> request with an invalid grant type.</p>",
+            "error": { "httpStatusCode": 400 },
+            "exception": true
+        },
+        "InvalidRedirectUriException": {
+            "type": "structure",
+            "members": {
+                "error": {
+                    "shape": "Error",
+                    "documentation": "<p>Single error code. For this exception the value will be <code>invalid_redirect_uri</code>.</p>"
+                },
+                "error_description": {
+                    "shape": "ErrorDescription",
+                    "documentation": "<p>Human-readable text providing additional information, used to assist the client developer in understanding the error that occurred.</p>"
+                }
+            },
+            "documentation": "<p>Indicates that one or more redirect URI in the request is not supported for this operation.</p>",
+            "error": { "httpStatusCode": 400 },
+            "exception": true
+        },
+        "InvalidRequestException": {
+            "type": "structure",
+            "members": {
+                "error": {
+                    "shape": "Error",
+                    "documentation": "<p>Single error code. For this exception the value will be <code>invalid_request</code>.</p>"
+                },
+                "error_description": {
+                    "shape": "ErrorDescription",
+                    "documentation": "<p>Human-readable text providing additional information, used to assist the client developer in understanding the error that occurred.</p>"
+                }
+            },
+            "documentation": "<p>Indicates that something is wrong with the input to the request. For example, a required parameter might be missing or out of range.</p>",
+            "error": { "httpStatusCode": 400 },
+            "exception": true
+        },
+        "InvalidRequestRegionException": {
+            "type": "structure",
+            "members": {
+                "error": {
+                    "shape": "Error",
+                    "documentation": "<p>Single error code. For this exception the value will be <code>invalid_request</code>.</p>"
+                },
+                "error_description": {
+                    "shape": "ErrorDescription",
+                    "documentation": "<p>Human-readable text providing additional information, used to assist the client developer in understanding the error that occurred.</p>"
+                },
+                "endpoint": {
+                    "shape": "Location",
+                    "documentation": "<p>Indicates the IAM Identity Center endpoint which the requester may call with this token.</p>"
+                },
+                "region": {
+                    "shape": "Region",
+                    "documentation": "<p>Indicates the region which the requester may call with this token.</p>"
+                }
+            },
+            "documentation": "<p>Indicates that a token provided as input to the request was issued by and is only usable by calling IAM Identity Center endpoints in another region.</p>",
+            "error": { "httpStatusCode": 400 },
+            "exception": true
+        },
+        "InvalidScopeException": {
+            "type": "structure",
+            "members": {
+                "error": {
+                    "shape": "Error",
+                    "documentation": "<p>Single error code. For this exception the value will be <code>invalid_scope</code>.</p>"
+                },
+                "error_description": {
+                    "shape": "ErrorDescription",
+                    "documentation": "<p>Human-readable text providing additional information, used to assist the client developer in understanding the error that occurred.</p>"
+                }
+            },
+            "documentation": "<p>Indicates that the scope provided in the request is invalid.</p>",
+            "error": { "httpStatusCode": 400 },
+            "exception": true
+        },
+        "Location": { "type": "string" },
+        "LongTimeStampType": { "type": "long" },
+        "RedirectUris": {
+            "type": "list",
+            "member": { "shape": "URI" }
+        },
+        "RefreshToken": {
+            "type": "string",
+            "sensitive": true
+        },
+        "Region": { "type": "string" },
+        "RegisterClientRequest": {
+            "type": "structure",
+            "required": ["clientName", "clientType"],
+            "members": {
+                "clientName": {
+                    "shape": "ClientName",
+                    "documentation": "<p>The friendly name of the client.</p>"
+                },
+                "clientType": {
+                    "shape": "ClientType",
+                    "documentation": "<p>The type of client. The service supports only <code>public</code> as a client type. Anything other than public will be rejected by the service.</p>"
+                },
+                "scopes": {
+                    "shape": "Scopes",
+                    "documentation": "<p>The list of scopes that are defined by the client. Upon authorization, this list is used to restrict permissions when granting an access token.</p>"
+                },
+                "redirectUris": {
+                    "shape": "RedirectUris",
+                    "documentation": "<p>The list of redirect URI that are defined by the client. At completion of authorization, this list is used to restrict what locations the user agent can be redirected back to.</p>"
+                },
+                "grantTypes": {
+                    "shape": "GrantTypes",
+                    "documentation": "<p>The list of OAuth 2.0 grant types that are defined by the client. This list is used to restrict the token granting flows available to the client.</p>"
+                },
+                "issuerUrl": {
+                    "shape": "URI",
+                    "documentation": "<p>This is the Identity Center Issuer URL associated with users Identity Center instance and is used for user access to resources through the client.</p>"
+                },
+                "entitledApplicationArn": {
+                    "shape": "ArnType",
+                    "documentation": "<p>This Identity Center Application ARN is used to define administrator managed configuration for public client access to resources. At authorization, the scopes, grants, and redirect URI available to this client will be restricted by this Application resource.</p>"
+                }
+            }
+        },
+        "RegisterClientResponse": {
+            "type": "structure",
+            "members": {
+                "clientId": {
+                    "shape": "ClientId",
+                    "documentation": "<p>The unique identifier string for each client. This client uses this identifier to get authenticated by the service in subsequent calls.</p>"
+                },
+                "clientSecret": {
+                    "shape": "ClientSecret",
+                    "documentation": "<p>A secret string generated for the client. The client will use this string to get authenticated by the service in subsequent calls.</p>"
+                },
+                "clientIdIssuedAt": {
+                    "shape": "LongTimeStampType",
+                    "documentation": "<p>Indicates the time at which the <code>clientId</code> and <code>clientSecret</code> were issued.</p>"
+                },
+                "clientSecretExpiresAt": {
+                    "shape": "LongTimeStampType",
+                    "documentation": "<p>Indicates the time at which the <code>clientId</code> and <code>clientSecret</code> will become invalid.</p>"
+                },
+                "authorizationEndpoint": {
+                    "shape": "URI",
+                    "documentation": "<p>An endpoint that the client can use to request authorization.</p>"
+                },
+                "tokenEndpoint": {
+                    "shape": "URI",
+                    "documentation": "<p>An endpoint that the client can use to create tokens.</p>"
+                }
+            }
+        },
+        "Scope": { "type": "string" },
+        "Scopes": {
+            "type": "list",
+            "member": { "shape": "Scope" }
+        },
+        "SlowDownException": {
+            "type": "structure",
+            "members": {
+                "error": {
+                    "shape": "Error",
+                    "documentation": "<p>Single error code. For this exception the value will be <code>slow_down</code>.</p>"
+                },
+                "error_description": {
+                    "shape": "ErrorDescription",
+                    "documentation": "<p>Human-readable text providing additional information, used to assist the client developer in understanding the error that occurred.</p>"
+                }
+            },
+            "documentation": "<p>Indicates that the client is making the request too frequently and is more than the service can handle. </p>",
+            "error": { "httpStatusCode": 400 },
+            "exception": true
+        },
+        "StartDeviceAuthorizationRequest": {
+            "type": "structure",
+            "required": ["clientId", "clientSecret", "startUrl"],
+            "members": {
+                "clientId": {
+                    "shape": "ClientId",
+                    "documentation": "<p>The unique identifier string for the client that is registered with IAM Identity Center. This value should come from the persisted result of the <a>RegisterClient</a> API operation.</p>"
+                },
+                "clientSecret": {
+                    "shape": "ClientSecret",
+                    "documentation": "<p>A secret string that is generated for the client. This value should come from the persisted result of the <a>RegisterClient</a> API operation.</p>"
+                },
+                "startUrl": {
+                    "shape": "URI",
+                    "documentation": "<p>The URL for the Amazon Web Services access portal. For more information, see <a href=\"https://docs.aws.amazon.com/singlesignon/latest/userguide/using-the-portal.html\">Using the Amazon Web Services access portal</a> in the <i>IAM Identity Center User Guide</i>.</p>"
+                }
+            }
+        },
+        "StartDeviceAuthorizationResponse": {
+            "type": "structure",
+            "members": {
+                "deviceCode": {
+                    "shape": "DeviceCode",
+                    "documentation": "<p>The short-lived code that is used by the device when polling for a session token.</p>"
+                },
+                "userCode": {
+                    "shape": "UserCode",
+                    "documentation": "<p>A one-time user verification code. This is needed to authorize an in-use device.</p>"
+                },
+                "verificationUri": {
+                    "shape": "URI",
+                    "documentation": "<p>The URI of the verification page that takes the <code>userCode</code> to authorize the device.</p>"
+                },
+                "verificationUriComplete": {
+                    "shape": "URI",
+                    "documentation": "<p>An alternate URL that the client can use to automatically launch a browser. This process skips the manual step in which the user visits the verification page and enters their code.</p>"
+                },
+                "expiresIn": {
+                    "shape": "ExpirationInSeconds",
+                    "documentation": "<p>Indicates the number of seconds in which the verification code will become invalid.</p>"
+                },
+                "interval": {
+                    "shape": "IntervalInSeconds",
+                    "documentation": "<p>Indicates the number of seconds the client must wait between attempts when polling for a session.</p>"
+                }
+            }
+        },
+        "SubjectToken": {
+            "type": "string",
+            "sensitive": true
+        },
+        "TokenType": { "type": "string" },
+        "TokenTypeURI": { "type": "string" },
+        "URI": { "type": "string" },
+        "UnauthorizedClientException": {
+            "type": "structure",
+            "members": {
+                "error": {
+                    "shape": "Error",
+                    "documentation": "<p>Single error code. For this exception the value will be <code>unauthorized_client</code>.</p>"
+                },
+                "error_description": {
+                    "shape": "ErrorDescription",
+                    "documentation": "<p>Human-readable text providing additional information, used to assist the client developer in understanding the error that occurred.</p>"
+                }
+            },
+            "documentation": "<p>Indicates that the client is not currently authorized to make the request. This can happen when a <code>clientId</code> is not issued for a public client.</p>",
+            "error": { "httpStatusCode": 400 },
+            "exception": true
+        },
+        "UnsupportedGrantTypeException": {
+            "type": "structure",
+            "members": {
+                "error": {
+                    "shape": "Error",
+                    "documentation": "<p>Single error code. For this exception the value will be <code>unsupported_grant_type</code>.</p>"
+                },
+                "error_description": {
+                    "shape": "ErrorDescription",
+                    "documentation": "<p>Human-readable text providing additional information, used to assist the client developer in understanding the error that occurred.</p>"
+                }
+            },
+            "documentation": "<p>Indicates that the grant type in the request is not supported by the service.</p>",
+            "error": { "httpStatusCode": 400 },
+            "exception": true
+        },
+        "UserCode": { "type": "string" }
+    },
+    "documentation": "<p>IAM Identity Center OpenID Connect (OIDC) is a web service that enables a client (such as CLI or a native application) to register with IAM Identity Center. The service also enables the client to fetch the user’s access token upon successful authentication and authorization with IAM Identity Center.</p> <note> <p>IAM Identity Center uses the <code>sso</code> and <code>identitystore</code> API namespaces.</p> </note> <p> <b>Considerations for Using This Guide</b> </p> <p>Before you begin using this guide, we recommend that you first review the following important information about how the IAM Identity Center OIDC service works.</p> <ul> <li> <p>The IAM Identity Center OIDC service currently implements only the portions of the OAuth 2.0 Device Authorization Grant standard (<a href=\"https://tools.ietf.org/html/rfc8628\">https://tools.ietf.org/html/rfc8628</a>) that are necessary to enable single sign-on authentication with the CLI. </p> </li> <li> <p>With older versions of the CLI, the service only emits OIDC access tokens, so to obtain a new token, users must explicitly re-authenticate. To access the OIDC flow that supports token refresh and doesn’t require re-authentication, update to the latest CLI version (1.27.10 for CLI V1 and 2.9.0 for CLI V2) with support for OIDC token refresh and configurable IAM Identity Center session durations. For more information, see <a href=\"https://docs.aws.amazon.com/singlesignon/latest/userguide/configure-user-session.html\">Configure Amazon Web Services access portal session duration </a>. </p> </li> <li> <p>The access tokens provided by this service grant access to all Amazon Web Services account entitlements assigned to an IAM Identity Center user, not just a particular application.</p> </li> <li> <p>The documentation in this guide does not describe the mechanism to convert the access token into Amazon Web Services Auth (“sigv4”) credentials for use with IAM-protected Amazon Web Services service endpoints. For more information, see <a href=\"https://docs.aws.amazon.com/singlesignon/latest/PortalAPIReference/API_GetRoleCredentials.html\">GetRoleCredentials</a> in the <i>IAM Identity Center Portal API Reference Guide</i>.</p> </li> </ul> <p>For general information about IAM Identity Center, see <a href=\"https://docs.aws.amazon.com/singlesignon/latest/userguide/what-is.html\">What is IAM Identity Center?</a> in the <i>IAM Identity Center User Guide</i>.</p>"
+}

--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -8,11 +8,11 @@ const localize = nls.loadMessageBundle()
 
 import globals from '../../shared/extensionGlobals'
 import * as vscode from 'vscode'
-import { AuthorizationPendingException, SlowDownException, SSOOIDCServiceException } from '@aws-sdk/client-sso-oidc'
+import { SSOOIDCServiceException } from '@aws-sdk/client-sso-oidc'
 import { openSsoPortalLink, SsoToken, ClientRegistration, isExpired, SsoProfile, builderIdStartUrl } from './model'
 import { getCache } from './cache'
-import { hasProps, hasStringProps, RequiredProps, selectFrom } from '../../shared/utilities/tsUtils'
-import { CancellationError, sleep } from '../../shared/utilities/timeoutUtils'
+import { hasProps, RequiredProps, selectFrom } from '../../shared/utilities/tsUtils'
+import { CancellationError } from '../../shared/utilities/timeoutUtils'
 import { OidcClient } from './clients'
 import { loadOr } from '../../shared/utilities/cacheUtils'
 import {
@@ -21,12 +21,12 @@ import {
     getTelemetryResult,
     isClientFault,
     isNetworkError,
-    ToolkitError,
 } from '../../shared/errors'
 import { getLogger } from '../../shared/logger'
 import { AwsRefreshCredentials, telemetry } from '../../shared/telemetry/telemetry'
 import { getIdeProperties, isCloud9 } from '../../shared/extensionUtilities'
 import { indent } from '../../shared/utilities/textUtilities'
+import { UriHandler } from '../../shared/vscode/uriHandler'
 
 const clientRegistrationType = 'public'
 const deviceGrantType = 'urn:ietf:params:oauth:grant-type:device_code'
@@ -195,7 +195,8 @@ export class SsoAccessTokenProvider {
             grantType: deviceGrantType,
         }
 
-        const token = await pollForTokenWithProgress(() => this.oidc.createToken(tokenRequest), authorization)
+        await waitForUser()
+        const token = await this.oidc.createToken(tokenRequest)
         return this.formatToken(token, registration)
     }
 
@@ -228,57 +229,41 @@ export class SsoAccessTokenProvider {
     public static create(profile: Pick<SsoProfile, 'startUrl' | 'region' | 'scopes' | 'identifier'>) {
         return new this(profile)
     }
+
+    /**
+     * The URL we pass to the authorization request, so that once the user is done setup in the browser
+     * it will redirect to this URL and open back up VS Code. {@link SsoAccessTokenProvider.waitUntilAuthenticated}
+     * must be used for the browser to automatically open VS Code.
+     */
+    static get onAuthenticatedUrl() {
+        return UriHandler.buildUri('sso/authenticated')
+    }
 }
 
-const backoffDelayMs = 5000
-async function pollForTokenWithProgress<T>(
-    fn: () => Promise<T>,
-    authorization: Awaited<ReturnType<OidcClient['startDeviceAuthorization']>>,
-    interval = authorization.interval ?? backoffDelayMs
-) {
-    async function poll(token: vscode.CancellationToken) {
-        while (
-            authorization.expiresAt.getTime() - globals.clock.Date.now() > interval &&
-            !token.isCancellationRequested
-        ) {
-            try {
-                return await fn()
-            } catch (err) {
-                if (!hasStringProps(err, 'name')) {
-                    throw err
-                }
-
-                if (err instanceof SlowDownException) {
-                    interval += backoffDelayMs
-                } else if (!(err instanceof AuthorizationPendingException)) {
-                    throw err
-                }
-            }
-
-            await sleep(interval)
-        }
-
-        throw new ToolkitError('Timed-out waiting for browser login flow to complete', {
-            code: 'TimedOut',
-        })
-    }
-
+/**
+ *
+ */
+async function waitForUser<T>() {
     return vscode.window.withProgress(
         {
-            title: localize(
-                'AWS.auth.loginWithBrowser.messageDetail',
-                'Confirm code "{0}" in the login page opened in your web browser.',
-                authorization.userCode
-            ),
+            title: localize('AWS.auth.loginWithBrowser.messageDetail', 'Complete login in the browser.'),
             cancellable: true,
             location: vscode.ProgressLocation.Notification,
         },
         (_, token) =>
             Promise.race([
-                poll(token),
-                new Promise<never>((_, reject) =>
-                    token.onCancellationRequested(() => reject(new CancellationError('user')))
-                ),
+                new Promise<void>((resolve, reject) => {
+                    token.onCancellationRequested(reject)
+
+                    const disposable: vscode.Disposable = globals.uriHandler.onPath(
+                        SsoAccessTokenProvider.onAuthenticatedUrl.path,
+                        () => {
+                            // We remove this path from the uri handler
+                            disposable.dispose()
+                            resolve()
+                        }
+                    )
+                }),
             ])
     )
 }

--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -27,10 +27,12 @@ import { AwsRefreshCredentials, telemetry } from '../../shared/telemetry/telemet
 import { getIdeProperties, isCloud9 } from '../../shared/extensionUtilities'
 import { indent } from '../../shared/utilities/textUtilities'
 import { UriHandler } from '../../shared/vscode/uriHandler'
+import OidcClientPKCE from './oidcclientpkce'
 
 const clientRegistrationType = 'public'
 const deviceGrantType = 'urn:ietf:params:oauth:grant-type:device_code'
 const refreshGrantType = 'refresh_token'
+const authorizationGrantType = 'authorization_code'
 
 /**
  *  SSO flow (RFC: https://tools.ietf.org/html/rfc8628)
@@ -188,11 +190,10 @@ export class SsoAccessTokenProvider {
             throw new CancellationError('user')
         }
 
-        const tokenRequest = {
+        const tokenRequest: OidcClientPKCE.CreateTokenRequest = {
             clientId: registration.clientId,
             clientSecret: registration.clientSecret,
-            deviceCode: authorization.deviceCode,
-            grantType: deviceGrantType,
+            grantType: authorizationGrantType,
         }
 
         await waitForUser()
@@ -223,6 +224,7 @@ export class SsoAccessTokenProvider {
             clientName: isCloud9() ? `${companyName} Cloud9` : `${companyName} Toolkit for VSCode`,
             clientType: clientRegistrationType,
             scopes: this.profile.scopes,
+            grantTypes: [authorizationGrantType, refreshGrantType],
         })
     }
 

--- a/packages/core/src/shared/vscode/uriHandler.ts
+++ b/packages/core/src/shared/vscode/uriHandler.ts
@@ -9,6 +9,7 @@ import { getLogger } from '../logger/logger'
 import * as nls from 'vscode-nls'
 import { showViewLogsMessage } from '../utilities/messages'
 import { URL, URLSearchParams } from 'whatwg-url'
+import { VSCODE_EXTENSION_ID } from '../extensions'
 
 const localize = nls.loadMessageBundle()
 
@@ -96,6 +97,10 @@ export class UriHandler implements vscode.UriHandler {
 
         this.handlers.set(path, { handler, parser })
         return { dispose: () => this.handlers.delete(path) }
+    }
+
+    static buildUri(path: string) {
+        return vscode.Uri.parse(`vscode://${VSCODE_EXTENSION_ID.awstoolkit}/${path}`)
     }
 }
 


### PR DESCRIPTION
This is what the new flow will kind of look like now that we do not need to worry about a device code, as well as a redirect URI being used once the user has successfully authenticated. Using the redirect URI we can automatically callback to vscode and continue the auth flow, no more need to poll

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
