### PR TITLE
fix(cdk): re-enable refresh button for cdk explorer

### DIFF
--- a/.changes/next-release/Bug Fix-7858d5db-fde1-4db1-860f-5be3b0bce411.json
+++ b/.changes/next-release/Bug Fix-7858d5db-fde1-4db1-860f-5be3b0bce411.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "CDK Explorer: Refresh button is now visible."
+}

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1374,6 +1374,11 @@
                     "group": "navigation@5"
                 },
                 {
+                    "command": "aws.cdk.refresh",
+                    "when": "view == aws.cdk",
+                    "group": "navigation@1"
+                },
+                {
                     "command": "aws.login",
                     "when": "view == aws.explorer",
                     "group": "1_account@1"


### PR DESCRIPTION
The cdk refresh button was inadvertently disabled in this commit: https://github.com/aws/aws-toolkit-vscode/commit/4e72ba7102b7d59058729c592fb6d234deb1e9ed

This restores the button.
![image](https://github.com/aws/aws-toolkit-vscode/assets/149123719/9516af10-86d5-43e8-a9b9-c3d163ecee0a)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
