### PR TITLE
refactor: move some gumby out of CW files

### DIFF
--- a/packages/toolkit/src/amazonq/explorer/amazonQChildrenNodes.ts
+++ b/packages/toolkit/src/amazonq/explorer/amazonQChildrenNodes.ts
@@ -7,13 +7,14 @@ import * as vscode from 'vscode'
 import * as nls from 'vscode-nls'
 import { Commands, placeholder } from '../../shared/vscode/commands2'
 import { getIcon } from '../../shared/icons'
-import { reconnect, showTransformByQ } from '../../codewhisperer/commands/basicCommands'
+import { reconnect } from '../../codewhisperer/commands/basicCommands'
 import { transformByQState } from '../../codewhisperer/models/model'
 import * as CodeWhispererConstants from '../../codewhisperer/models/constants'
 import { amazonQHelpUrl } from '../../shared/constants'
 import { cwTreeNodeSource } from '../../codewhisperer/commands/types'
 import { telemetry } from '../../shared/telemetry/telemetry'
 import { focusAmazonQPanel } from '../../auth/ui/vue/show'
+import { showTransformByQ } from '../../amazonqGumby/commands'
 
 const localize = nls.loadMessageBundle()
 

--- a/packages/toolkit/src/amazonqGumby/activation.ts
+++ b/packages/toolkit/src/amazonqGumby/activation.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode'
 import { Commands } from '../shared/vscode/commands2'
 import { TransformationHubViewProvider } from '../codewhisperer/service/transformationHubViewProvider'
-import { showTransformByQ, showTransformationHub } from '../codewhisperer/commands/basicCommands'
+import { showTransformByQ, showTransformationHub } from './commands'
 import { ExtContext } from '../shared/extensions'
 import { startTransformByQWithProgress, confirmStopTransformByQ } from '../codewhisperer/commands/startTransformByQ'
 import { transformByQState } from '../codewhisperer/models/model'

--- a/packages/toolkit/src/amazonqGumby/commands.ts
+++ b/packages/toolkit/src/amazonqGumby/commands.ts
@@ -1,0 +1,47 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { telemetry } from '../shared/telemetry/telemetry'
+import { ExtContext } from '../shared/extensions'
+import { Commands } from '../shared/vscode/commands2'
+import * as CodeWhispererConstants from '../codewhisperer/models/constants'
+import { startTransformByQWithProgress, confirmStopTransformByQ } from '../codewhisperer/commands/startTransformByQ'
+import { transformByQState } from '../codewhisperer/models/model'
+import { AuthUtil } from '../codewhisperer/util/authUtil'
+import { CancelActionPositions, logCodeTransformInitiatedMetric } from './telemetry/codeTransformTelemetry'
+
+export const showTransformByQ = Commands.declare(
+    { id: 'aws.awsq.transform', compositeKey: { 0: 'source' } },
+    (context: ExtContext) => async (source: string) => {
+        if (AuthUtil.instance.isConnectionExpired()) {
+            await AuthUtil.instance.notifyReauthenticate()
+        }
+
+        if (transformByQState.isNotStarted()) {
+            logCodeTransformInitiatedMetric(source)
+            await startTransformByQWithProgress()
+        } else if (transformByQState.isCancelled()) {
+            void vscode.window.showInformationMessage(CodeWhispererConstants.cancellationInProgressMessage)
+        } else if (transformByQState.isRunning()) {
+            await confirmStopTransformByQ(transformByQState.getJobId(), CancelActionPositions.DevToolsSidePanel)
+        }
+        // emit telemetry if clicked from tree node
+        if (source === CodeWhispererConstants.transformTreeNode) {
+            telemetry.ui_click.emit({
+                elementId: 'amazonq_transform',
+                passive: false,
+            })
+        }
+        await Commands.tryExecute('aws.codeWhisperer.refresh')
+    }
+)
+
+export const showTransformationHub = Commands.declare(
+    { id: 'aws.amazonq.showTransformationHub', compositeKey: { 0: 'source' } },
+    () => async (source: string) => {
+        await vscode.commands.executeCommand('workbench.view.extension.aws-codewhisperer-transformation-hub')
+    }
+)


### PR DESCRIPTION
This moves gumby commands to their own file.
- We are doing this since CW unintentionally imports gumby, but gumby code uses fs-extra which breaks browser mode.
- In the future we need make sure to keep CW and Gumby code separate where possible

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
