### PR TITLE
refactor: extract codewhisperer tree view setup

### DIFF
--- a/packages/toolkit/src/awsexplorer/activationShared.ts
+++ b/packages/toolkit/src/awsexplorer/activationShared.ts
@@ -1,0 +1,51 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode'
+import { createToolView, ToolView } from './toolView'
+import { telemetry } from '../shared/telemetry/telemetry'
+import { cdkNode, CdkRootNode } from '../cdk/explorer/rootNode'
+import {
+    CodeWhispererNode,
+    getCodewhispererNode,
+    refreshCodeWhisperer,
+    refreshCodeWhispererRootNode,
+} from '../codewhisperer/explorer/codewhispererNode'
+import { once } from '../shared/utilities/functionUtils'
+
+/**
+ * Activates vscode Views (eg tree view) that work in any vscode environment (nodejs or browser).
+ */
+export async function activateViewsShared(context: vscode.ExtensionContext): Promise<void> {
+    registerToolView(getCodeWhispererToolView(), context)
+}
+
+export function getCodeWhispererToolView(): ToolView {
+    return {
+        nodes: [getCodewhispererNode()],
+        view: 'aws.codewhisperer',
+        refreshCommands: [refreshCodeWhisperer, refreshCodeWhispererRootNode],
+    }
+}
+
+export function registerToolView(viewNode: ToolView, context: vscode.ExtensionContext) {
+    const toolView = createToolView(viewNode)
+    context.subscriptions.push(toolView)
+    if (viewNode.view === 'aws.cdk') {
+        // Legacy CDK behavior. Mostly useful for C9 as they do not have inline buttons.
+        toolView.onDidChangeVisibility(({ visible }) => visible && cdkNode.refresh())
+    }
+
+    toolView.onDidExpandElement(e => {
+        if (e.element.resource instanceof CdkRootNode) {
+            // Legacy CDK metric, remove this when we add something generic
+            const recordExpandCdkOnce = once(() => telemetry.cdk_appExpanded.emit())
+            recordExpandCdkOnce()
+        } else if (e.element.resource instanceof CodeWhispererNode) {
+            const onDidExpandCodeWhisperer = once(() => telemetry.ui_click.emit({ elementId: 'cw_parentNode' }))
+            onDidExpandCodeWhisperer()
+        }
+    })
+}

--- a/packages/toolkit/src/extensionShared.ts
+++ b/packages/toolkit/src/extensionShared.ts
@@ -19,6 +19,7 @@ import { getIdeProperties, aboutToolkit, isCloud9 } from './shared/extensionUtil
 import { telemetry } from './shared/telemetry/telemetry'
 import { openUrl } from './shared/utilities/vsCodeUtils'
 import { activate as activateCodeWhisperer, shutdown as codewhispererShutdown } from './codewhisperer/activation'
+import { activateViewsShared } from './awsexplorer/activationShared'
 
 import { activate as activateLogger } from './shared/logger/activation'
 import { initializeComputeRegion } from './shared/extensionUtilities'
@@ -134,6 +135,8 @@ export async function activateShared(
         uriHandler: globals.uriHandler,
         credentialsStore: globals.loginManager.store,
     }
+
+    await activateViewsShared(extContext.extensionContext)
 
     await activateCodeWhisperer(extContext)
 


### PR DESCRIPTION
## Problem:
We want to use the CodeWhisperer tree view during browser mode. The issue is when enabling it the current code will try and enable the other tree views such as the Resource Explorer.

Additionally, web mode breaks due to imports in `activation.ts`.

## Solution:
Extract the logic for the tree view that we want to work in both node and browser environments in to its own shared activate function. We then have more control over what we enable and they are guaranteed to work in the browser.

Now we can use that shared activation for both environments.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
