### PR TITLE
fix(CodeTransform): prompt user for JAVA_HOME

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3749,9 +3749,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.184",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.184.tgz",
-            "integrity": "sha512-838YWGTPcblidmS9BHZ/MQXFUCWSec6/VEQpLMVkfkeKBhn5WWhDw5+wqfUDIUYGpcKz6stTQHpautg6WiCdkA==",
+            "version": "1.0.186",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.186.tgz",
+            "integrity": "sha512-qTVxNlRr0RYUfHh3Ft09CYcDqWBc9lZGc5ir0yFMSR35cP9LaoUFqcgq0RZjkJPAohtUxIH+0Sli0PshlSGd5g==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",
@@ -19137,7 +19137,7 @@
             },
             "devDependencies": {
                 "@aws-sdk/types": "^3.13.1",
-                "@aws-toolkits/telemetry": "^1.0.184",
+                "@aws-toolkits/telemetry": "^1.0.186",
                 "@aws/fully-qualified-names": "^2.1.1",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^10.0.2",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -4264,7 +4264,7 @@
     },
     "devDependencies": {
         "@aws-sdk/types": "^3.13.1",
-        "@aws-toolkits/telemetry": "^1.0.184",
+        "@aws-toolkits/telemetry": "^1.0.186",
         "@aws/fully-qualified-names": "^2.1.1",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^10.0.2",

--- a/packages/toolkit/src/codewhisperer/models/constants.ts
+++ b/packages/toolkit/src/codewhisperer/models/constants.ts
@@ -278,6 +278,9 @@ export const newCustomizationAvailableKey = 'CODEWHISPERER_NEW_CUSTOMIZATION_AVA
 
 export const selectProjectPrompt = 'Select the project you want to transform'
 
+export const unsupportedJavaVersionSelectedMessage =
+    'Thank you for trying our product. We currently only support Java 8 and 11. We appreciate you taking the time to use the product, and hope to expand support to more Java versions in the future.'
+
 export const transformByQWindowTitle = 'Amazon Q Code Transformation'
 
 export const stopTransformByQMessage = 'Stop Transformation?'
@@ -331,6 +334,8 @@ export const planIntroductionMessage =
 
 export const planDisclaimerMessage = '**Proposed transformation changes** \n\n\n'
 
+export const enterJavaHomeMessage = 'Enter the value of JAVA_HOME for Java'
+
 export const JDK8VersionNumber = '52'
 
 export const JDK11VersionNumber = '55'
@@ -356,10 +361,6 @@ export const transformationJobPollingIntervalSeconds = 10
 export const transformationJobTimeoutSeconds = 72000
 
 export const progressIntervalMs = 1000
-
-export const targetLanguages = ['Java']
-
-export const targetVersions = new Map<string, string[]>([['Java', ['JDK17']]])
 
 export const defaultLanguage = 'Java'
 

--- a/packages/toolkit/src/codewhisperer/models/model.ts
+++ b/packages/toolkit/src/codewhisperer/models/model.ts
@@ -252,6 +252,7 @@ export enum BuildSystem {
 export class ZipManifest {
     sourcesRoot: string = 'sources/'
     dependenciesRoot: string | undefined = 'dependencies/'
+    buildLogs: string = 'build-logs.txt'
     version: string = '1.0'
 }
 
@@ -287,6 +288,10 @@ export class TransformByQState {
     private jobFailureErrorMessage: string = ''
 
     private errorLog: string = ''
+
+    private mavenName: string = ''
+
+    private javaHome: string | undefined = undefined
 
     public isNotStarted() {
         return this.transformByQState === TransformByQStatus.NotStarted
@@ -372,6 +377,14 @@ export class TransformByQState {
         return this.errorLog
     }
 
+    public getMavenName() {
+        return this.mavenName
+    }
+
+    public getJavaHome() {
+        return this.javaHome
+    }
+
     public appendToErrorLog(message: string) {
         this.errorLog += `${message}\n\n`
     }
@@ -450,6 +463,14 @@ export class TransformByQState {
 
     public setJobFailureErrorMessage(errorMessage: string) {
         this.jobFailureErrorMessage = errorMessage
+    }
+
+    public setMavenName(mavenName: string) {
+        this.mavenName = mavenName
+    }
+
+    public setJavaHome(javaHome: string) {
+        this.javaHome = javaHome
     }
 
     public getPrefixTextForButton() {

--- a/packages/toolkit/src/codewhisperer/service/transformationResultsViewProvider.ts
+++ b/packages/toolkit/src/codewhisperer/service/transformationResultsViewProvider.ts
@@ -409,6 +409,7 @@ export class ProposedTransformationExplorer {
             telemetry.codeTransform_vcsViewerSubmitted.emit({
                 codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
                 codeTransformJobId: transformByQState.getJobId(),
+                codeTransformStatus: transformByQState.getStatus(),
                 result: MetadataResult.Pass,
             })
         })
@@ -426,6 +427,7 @@ export class ProposedTransformationExplorer {
                 codeTransformPatchViewerCancelSrcComponents: 'cancelButton',
                 codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
                 codeTransformJobId: transformByQState.getJobId(),
+                codeTransformStatus: transformByQState.getStatus(),
                 result: MetadataResult.Pass,
             })
         })

--- a/packages/toolkit/src/testE2E/amazonqGumby/transformByQ.test.ts
+++ b/packages/toolkit/src/testE2E/amazonqGumby/transformByQ.test.ts
@@ -13,6 +13,7 @@ import * as path from 'path'
 import * as fs from 'fs-extra'
 import AdmZip from 'adm-zip'
 import { setValidConnection, skipTestIfNoValidConn } from '../util/amazonQUtil'
+import { transformByQState } from '../../codewhisperer/models/model'
 
 describe('transformByQ', async function () {
     let tempDir = ''
@@ -28,7 +29,8 @@ describe('transformByQ', async function () {
         tempFileName = `testfile-${Date.now()}.txt`
         tempFilePath = path.join(tempDir, tempFileName)
         fs.writeFileSync(tempFilePath, 'sample content for the test file')
-        zippedCodePath = await zipCode(tempDir)
+        transformByQState.setProjectPath(tempDir)
+        zippedCodePath = await zipCode()
     })
 
     beforeEach(function () {


### PR DESCRIPTION
## Problem

Our `Maven` shell commands sometimes fail and we suspect it is because we are not running those commands with the proper JAVA_HOME (needs to match the project JDK).

## Solution

If the Maven wrapper executable exists in the project directory, use that for both `Maven` shell commands, else use regular `mvn` -- and if the Java version used by Maven differs from the project's Java version, prompt the user for JAVA_HOME and use that when running the shell commands.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
