### PR TITLE
test: use latest version of python extension in CI

### DIFF
--- a/packages/toolkit/scripts/test/launchTestUtilities.ts
+++ b/packages/toolkit/scripts/test/launchTestUtilities.ts
@@ -168,13 +168,6 @@ async function invokeVSCodeCli(vsCodeExecutablePath: string, args: string[]): Pr
 }
 
 async function installVSCodeExtension(vsCodeExecutablePath: string, extensionIdentifier: string): Promise<void> {
-    // HACK: `sam.test.ts` Codelens test was failing for python due to bug in newer version, so lock to last working version.
-    // Edge Case: This specific python version does not work with the "minimum" vscode version, so we do not override it as it
-    // will choose its own python extension version that works.
-    if (extensionIdentifier === VSCODE_EXTENSION_ID.python && process.env[envvarVscodeTestVersion] !== minimum) {
-        extensionIdentifier = `${VSCODE_EXTENSION_ID.python}@2023.20.0`
-    }
-
     console.log(`Installing VS Code Extension: ${extensionIdentifier}`)
     console.log(await invokeVSCodeCli(vsCodeExecutablePath, ['--install-extension', extensionIdentifier]))
 }

--- a/packages/toolkit/src/test/techdebt.test.ts
+++ b/packages/toolkit/src/test/techdebt.test.ts
@@ -42,16 +42,4 @@ describe('tech debt', function () {
             'with node16+, we can use crypto.randomUUID and remove the "uuid" dependency'
         )
     })
-
-    it('stop not using latest python extension version in integration CI tests', function () {
-        /**
-         * The explicitly set version is done in launchTestUtilities.ts#installVSCodeExtension
-         * The parent ticket for SAM test issues: IDE-12295
-         * Python Extension Bug Issue (if this is fixed, then this should be too): https://github.com/microsoft/vscode-python/issues/22659
-         */
-        assert(
-            new Date() < new Date(2024, 1, 15),
-            'Re-evaluate if we can use the latest python extension version in CI integration tests'
-        )
-    })
 })

--- a/packages/toolkit/src/testE2E/amazonqGumby/transformByQ.test.ts
+++ b/packages/toolkit/src/testE2E/amazonqGumby/transformByQ.test.ts
@@ -12,7 +12,7 @@ import * as os from 'os'
 import * as path from 'path'
 import * as fs from 'fs-extra'
 import AdmZip from 'adm-zip'
-import { setValidConnection, skipTestIfNoValidConn } from '../util/amazonQUtil'
+import { setValidConnection } from '../util/amazonQUtil'
 import { transformByQState } from '../../codewhisperer/models/model'
 
 describe('transformByQ', async function () {
@@ -24,6 +24,9 @@ describe('transformByQ', async function () {
 
     before(async function () {
         validConnection = await setValidConnection()
+        if (!validConnection) {
+            this.skip()
+        }
         tempDir = path.join(os.tmpdir(), 'gumby-test')
         fs.mkdirSync(tempDir)
         tempFileName = `testfile-${Date.now()}.txt`
@@ -31,10 +34,6 @@ describe('transformByQ', async function () {
         fs.writeFileSync(tempFilePath, 'sample content for the test file')
         transformByQState.setProjectPath(tempDir)
         zippedCodePath = await zipCode()
-    })
-
-    beforeEach(function () {
-        skipTestIfNoValidConn(validConnection, this) // need valid IdC connection
     })
 
     after(async function () {


### PR DESCRIPTION
In PR #4170 we locked the python extension to a specific version since a newer version of the extension broke CI.

The fix should be available now, so we are removing the code that locked us to a specific version and will now use whatever the latest version is.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
