### PR TITLE
AmazonQ: Add cwsprCredentialStartUrl field to chat telemetry events

### DIFF
--- a/packages/toolkit/src/codewhispererChat/controllers/chat/telemetryHelper.ts
+++ b/packages/toolkit/src/codewhispererChat/controllers/chat/telemetryHelper.ts
@@ -34,6 +34,7 @@ import { codeWhispererClient } from '../../../codewhisperer/client/codewhisperer
 import { isAwsError } from '../../../shared/errors'
 import { ChatMessageInteractionType } from '../../../codewhisperer/client/codewhispereruserclient'
 import { supportedLanguagesList } from '../chat/chatRequest/converter'
+import { AuthUtil } from '../../../codewhisperer/util/authUtil'
 
 const performance = globalThis.performance ?? require('perf_hooks').performance
 
@@ -149,6 +150,7 @@ export class CWCTelemetryHelper {
                 message = message as InsertCodeAtCursorPosition
                 event = {
                     cwsprChatConversationId: conversationId ?? '',
+                    credentialStartUrl: AuthUtil.instance.startUrl,
                     cwsprChatMessageId: message.messageId,
                     cwsprChatInteractionType: 'insertAtCursor',
                     cwsprChatAcceptedCharactersLength: message.code.length,
@@ -160,6 +162,7 @@ export class CWCTelemetryHelper {
                 message = message as CopyCodeToClipboard
                 event = {
                     cwsprChatConversationId: conversationId ?? '',
+                    credentialStartUrl: AuthUtil.instance.startUrl,
                     cwsprChatMessageId: message.messageId,
                     cwsprChatInteractionType: 'copySnippet',
                     cwsprChatAcceptedCharactersLength: message.code.length,
@@ -171,6 +174,7 @@ export class CWCTelemetryHelper {
                 message = message as PromptMessage
                 event = {
                     cwsprChatConversationId: conversationId ?? '',
+                    credentialStartUrl: AuthUtil.instance.startUrl,
                     cwsprChatMessageId: message.messageId,
                     cwsprChatInteractionType: 'clickFollowUp',
                 }
@@ -180,6 +184,7 @@ export class CWCTelemetryHelper {
                 event = {
                     cwsprChatMessageId: message.messageId,
                     cwsprChatConversationId: conversationId ?? '',
+                    credentialStartUrl: AuthUtil.instance.startUrl,
                     cwsprChatInteractionType: message.vote,
                 }
                 break
@@ -188,6 +193,7 @@ export class CWCTelemetryHelper {
                 event = {
                     cwsprChatMessageId: message.messageId,
                     cwsprChatConversationId: conversationId ?? '',
+                    credentialStartUrl: AuthUtil.instance.startUrl,
                     cwsprChatInteractionType: 'clickLink',
                     cwsprChatInteractionTarget: message.link,
                 }
@@ -197,6 +203,7 @@ export class CWCTelemetryHelper {
                 event = {
                     cwsprChatMessageId: message.messageId,
                     cwsprChatConversationId: conversationId ?? '',
+                    credentialStartUrl: AuthUtil.instance.startUrl,
                     cwsprChatInteractionType: 'clickBodyLink',
                     cwsprChatInteractionTarget: message.link,
                 }
@@ -206,6 +213,7 @@ export class CWCTelemetryHelper {
                 event = {
                     cwsprChatMessageId: 'footer',
                     cwsprChatConversationId: conversationId ?? '',
+                    credentialStartUrl: AuthUtil.instance.startUrl,
                     cwsprChatInteractionType: 'clickBodyLink',
                     cwsprChatInteractionTarget: message.link,
                 }

--- a/packages/toolkit/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/toolkit/src/shared/telemetry/vscodeTelemetry.json
@@ -625,6 +625,10 @@
                     "type": "cwsprChatConversationId"
                 },
                 {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
                     "type": "cwsprChatTriggerInteraction"
                 },
                 {
@@ -650,6 +654,10 @@
             "metadata": [
                 {
                     "type": "cwsprChatConversationId"
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
                 },
                 {
                     "type": "cwsprChatMessageId"
@@ -726,6 +734,10 @@
                     "required": false
                 },
                 {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
                     "type": "cwsprChatTriggerInteraction"
                 },
                 {
@@ -771,6 +783,10 @@
                     "type": "cwsprChatConversationId"
                 },
                 {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
                     "type": "cwsprChatMessageId"
                 },
                 {
@@ -798,6 +814,10 @@
                     "type": "cwsprChatConversationId"
                 },
                 {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
                     "type": "cwsprChatMessageId"
                 },
                 {
@@ -811,6 +831,10 @@
             "metadata": [
                 {
                     "type": "cwsprChatConversationId"
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
                 }
             ]
         },
@@ -820,6 +844,10 @@
             "metadata": [
                 {
                     "type": "cwsprChatConversationId"
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
                 }
             ]
         },


### PR DESCRIPTION
The new field contains the start URL of the current SSO connection. This will allow tracing back chat events to the originating SSO session.

## Problem
We missed this field for the AmazonQ experience

## Solution
New field introduced

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
