### PR TITLE
Upgrade mynah-ui to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3808,9 +3808,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-3.3.3.tgz",
-            "integrity": "sha512-Ug00BA0/ee6qbjileTNx48CnJbJ6rCw246aiszMVEtvD2RCOBqrU6Spbe4DsA+PWwOsGhrF02boPuaxyhSC97g==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.0.3.tgz",
+            "integrity": "sha512-gQwkZCEOMoa1Vvyq8VIs55XTA51kRuAbqNAV7tRvMrZ82wli92xbPFuu5rGsD+9+USnBIfWdra9VVyuW2SpfXA==",
             "dependencies": {
                 "marked": "^7.0.3",
                 "prismjs": "1.29.0",
@@ -19080,7 +19080,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "3.3.3",
+                "@aws/mynah-ui": "4.0.3",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/shared-ini-file-loader": "^2.2.8",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -4340,7 +4340,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "3.3.3",
+        "@aws/mynah-ui": "4.0.3",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/shared-ini-file-loader": "^2.2.8",

--- a/packages/toolkit/src/amazonq/webview/ui/apps/amazonqCommonsConnector.ts
+++ b/packages/toolkit/src/amazonq/webview/ui/apps/amazonqCommonsConnector.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChatItemFollowUp } from '@aws/mynah-ui'
+import { ChatItemAction } from '@aws/mynah-ui'
 import { ExtensionMessage } from '../commands'
 import { AuthFollowUpType } from '../followUps/generator'
 
@@ -32,7 +32,7 @@ export class Connector {
         this.onWelcomeFollowUpClicked = props.onWelcomeFollowUpClicked
     }
 
-    followUpClicked = (tabID: string, followUp: ChatItemFollowUp): void => {
+    followUpClicked = (tabID: string, followUp: ChatItemAction): void => {
         if (followUp.type !== undefined && followUp.type === 'continue-to-chat') {
             this.onWelcomeFollowUpClicked(tabID, followUp.type)
         }

--- a/packages/toolkit/src/amazonq/webview/ui/apps/cwChatConnector.ts
+++ b/packages/toolkit/src/amazonq/webview/ui/apps/cwChatConnector.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChatItem, ChatItemFollowUp, ChatItemType, FeedbackPayload } from '@aws/mynah-ui'
+import { ChatItem, ChatItemAction, ChatItemType, FeedbackPayload } from '@aws/mynah-ui'
 import { ExtensionMessage } from '../commands'
 import { CodeReference } from './amazonqCommonsConnector'
 import { TabOpenType, TabsStorage } from '../storages/tabsStorage'
@@ -68,7 +68,7 @@ export class Connector {
         })
     }
 
-    followUpClicked = (tabID: string, messageId: string, followUp: ChatItemFollowUp): void => {
+    followUpClicked = (tabID: string, messageId: string, followUp: ChatItemAction): void => {
         this.sendMessageToExtension({
             command: 'follow-up-was-clicked',
             followUp,

--- a/packages/toolkit/src/amazonq/webview/ui/apps/featureDevChatConnector.ts
+++ b/packages/toolkit/src/amazonq/webview/ui/apps/featureDevChatConnector.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChatItem, ChatItemFollowUp, ChatItemType, FeedbackPayload } from '@aws/mynah-ui'
+import { ChatItem, ChatItemAction, ChatItemType, FeedbackPayload } from '@aws/mynah-ui'
 import { ExtensionMessage } from '../commands'
 import { TabType, TabsStorage } from '../storages/tabsStorage'
 import { CodeReference } from './amazonqCommonsConnector'
@@ -93,7 +93,7 @@ export class Connector {
         })
     }
 
-    followUpClicked = (tabID: string, followUp: ChatItemFollowUp): void => {
+    followUpClicked = (tabID: string, followUp: ChatItemAction): void => {
         this.sendMessageToExtension({
             command: 'follow-up-was-clicked',
             followUp,

--- a/packages/toolkit/src/amazonq/webview/ui/connector.ts
+++ b/packages/toolkit/src/amazonq/webview/ui/connector.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChatItem, ChatItemFollowUp, FeedbackPayload, Engagement } from '@aws/mynah-ui'
+import { ChatItem, FeedbackPayload, Engagement, ChatItemAction } from '@aws/mynah-ui'
 import { Connector as CWChatConnector } from './apps/cwChatConnector'
 import { Connector as FeatureDevChatConnector } from './apps/featureDevChatConnector'
 import { Connector as AmazonQCommonsConnector } from './apps/amazonqCommonsConnector'
@@ -280,7 +280,7 @@ export class Connector {
         }
     }
 
-    onFollowUpClicked = (tabID: string, messageId: string, followUp: ChatItemFollowUp): void => {
+    onFollowUpClicked = (tabID: string, messageId: string, followUp: ChatItemAction): void => {
         switch (this.tabsStorage.getTab(tabID)?.type) {
             // TODO: We cannot rely on the tabType here,
             // It can come up at a later point depending on the future UX designs,

--- a/packages/toolkit/src/amazonq/webview/ui/followUps/handler.ts
+++ b/packages/toolkit/src/amazonq/webview/ui/followUps/handler.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChatItemFollowUp, ChatItemType, MynahUI } from '@aws/mynah-ui'
+import { ChatItemAction, ChatItemType, MynahUI } from '@aws/mynah-ui'
 import { Connector } from '../connector'
 import { TabsStorage } from '../storages/tabsStorage'
 import { WelcomeFollowupType } from '../apps/amazonqCommonsConnector'
@@ -26,7 +26,7 @@ export class FollowUpInteractionHandler {
         this.tabsStorage = props.tabsStorage
     }
 
-    public onFollowUpClicked(tabID: string, messageId: string, followUp: ChatItemFollowUp) {
+    public onFollowUpClicked(tabID: string, messageId: string, followUp: ChatItemAction) {
         if (
             followUp.type !== undefined &&
             ['full-auth', 're-auth', 'missing_scopes', 'use-supported-auth'].includes(followUp.type)

--- a/packages/toolkit/src/amazonq/webview/ui/followUps/model.ts
+++ b/packages/toolkit/src/amazonq/webview/ui/followUps/model.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChatItemFollowUp } from '@aws/mynah-ui'
+import { ChatItemAction } from '@aws/mynah-ui'
 
 export interface FollowUpsBlock {
     text?: string
-    options?: ChatItemFollowUp[]
+    options?: ChatItemAction[]
 }

--- a/packages/toolkit/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/toolkit/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChatItemFollowUp } from '@aws/mynah-ui'
+import { ChatItemAction } from '@aws/mynah-ui'
 import { existsSync } from 'fs'
 import * as path from 'path'
 import * as vscode from 'vscode'
@@ -266,7 +266,7 @@ export class FeatureDevController {
         }
     }
 
-    private getFollowUpOptions(phase: SessionStatePhase | undefined): ChatItemFollowUp[] {
+    private getFollowUpOptions(phase: SessionStatePhase | undefined): ChatItemAction[] {
         switch (phase) {
             case 'Approach':
                 return [

--- a/packages/toolkit/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
+++ b/packages/toolkit/src/amazonqFeatureDev/controllers/chat/messenger/messenger.ts
@@ -17,7 +17,7 @@ import {
     OpenNewTabMessage,
 } from '../../../views/connector/connector'
 import { AppToWebViewMessageDispatcher } from '../../../views/connector/connector'
-import { ChatItemFollowUp } from '@aws/mynah-ui'
+import { ChatItemAction } from '@aws/mynah-ui'
 
 export class Messenger {
     public constructor(private readonly dispatcher: AppToWebViewMessageDispatcher) {}
@@ -25,7 +25,7 @@ export class Messenger {
     public sendAnswer(params: {
         message?: string
         type: 'answer' | 'answer-part' | 'answer-stream' | 'system-prompt'
-        followUps?: ChatItemFollowUp[]
+        followUps?: ChatItemAction[]
         tabID: string
         canBeVoted?: boolean
     }) {

--- a/packages/toolkit/src/amazonqFeatureDev/views/connector/connector.ts
+++ b/packages/toolkit/src/amazonqFeatureDev/views/connector/connector.ts
@@ -7,7 +7,7 @@ import { AuthFollowUpType } from '../../../amazonq/auth/model'
 import { MessagePublisher } from '../../../amazonq/messages/messagePublisher'
 import { featureDevChat } from '../../constants'
 import { ChatItemType } from '../../models'
-import { ChatItemFollowUp, SourceLink } from '@aws/mynah-ui'
+import { ChatItemAction, SourceLink } from '@aws/mynah-ui'
 
 class UiMessage {
     readonly time: number = Date.now()
@@ -95,7 +95,7 @@ export class AuthNeededException extends UiMessage {
 export interface ChatMessageProps {
     readonly message: string | undefined
     readonly messageType: ChatItemType
-    readonly followUps: ChatItemFollowUp[] | undefined
+    readonly followUps: ChatItemAction[] | undefined
     readonly relatedSuggestions: SourceLink[] | undefined
     readonly canBeVoted: boolean
 }
@@ -103,7 +103,7 @@ export interface ChatMessageProps {
 export class ChatMessage extends UiMessage {
     readonly message: string | undefined
     readonly messageType: ChatItemType
-    readonly followUps: ChatItemFollowUp[] | undefined
+    readonly followUps: ChatItemAction[] | undefined
     readonly relatedSuggestions: SourceLink[] | undefined
     readonly canBeVoted: boolean
     readonly requestID!: string


### PR DESCRIPTION
## Problem
To support future chat features, it is necessary to update the dependent library responsible for rendering the chat UI, `mynah-ui`. 

The only breaking change that affects this codebase from upgrading from `3.x` to `4.x` is that `ChatItemFollowUp` [is renamed to](https://github.com/aws/mynah-ui/commit/631d87af733877a29df3d55f00f1d1273dc75537) `ChatItemAction`

## Testing

Manually tested Q chat and `/dev` functionality, paying particular attention to behavior around the follow-up items 

`npm run testE2E` passed

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
