### PR TITLE
browser: remove fs-extra usage in CodeWhisperer logic

### DIFF
--- a/docs/browser.md
+++ b/docs/browser.md
@@ -80,8 +80,8 @@ to help us visualize the imports and determine which module is importing a certa
 
 ### How to use
 
-1. Install the `graphiz` cli, this provides the `dot` cli command
-    - Mac: `brew install graphiz`
+1. Install the `graphviz` cli, this provides the `dot` cli command
+    - Mac: `brew install graphviz`
     - Others: [See documentation](https://www.graphviz.org/download/)
 2. Run `npx depcruise {RELATIVE_PATH_TO_FILE}  --output-type dot | dot -T svg > dependency-graph.svg`
     - For example, `npx depcruise src/srcShared/fs.ts  --output-type dot | dot -T svg > dependency-graph.svg` generates the following which shows `fs-extra` is imported by `fileSystemUtilities.ts`:

--- a/packages/toolkit/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/toolkit/src/codewhisperer/commands/startSecurityScan.ts
@@ -141,7 +141,7 @@ export async function startSecurityScan(
             getLogger().error('Failed to upload code artifacts', error)
             throw error
         } finally {
-            dependencyGraph.removeTmpFiles(truncation)
+            await dependencyGraph.removeTmpFiles(truncation)
             codeScanTelemetryEntry.artifactsUploadDuration = performance.now() - uploadStartTime
         }
 

--- a/packages/toolkit/src/codewhisperer/util/dependencyGraph/cloudformationDependencyGraph.ts
+++ b/packages/toolkit/src/codewhisperer/util/dependencyGraph/cloudformationDependencyGraph.ts
@@ -59,7 +59,7 @@ export class cloudformationDependencyGraph extends DependencyGraph {
             }
             await sleep(1000)
             const truncDirPath = this.getTruncDirPath(uri)
-            this.copyFilesToTmpDir(this._pickedSourceFiles, truncDirPath)
+            await this.copyFilesToTmpDir(this._pickedSourceFiles, truncDirPath)
             const zipFilePath = this.zipDir(truncDirPath, CodeWhispererConstants.codeScanZipExt)
             const zipFileSize = statSync(zipFilePath).size
             return {

--- a/packages/toolkit/src/codewhisperer/util/dependencyGraph/csharpDependencyGraph.ts
+++ b/packages/toolkit/src/codewhisperer/util/dependencyGraph/csharpDependencyGraph.ts
@@ -171,7 +171,7 @@ export class CsharpDependencyGraph extends DependencyGraph {
             }
             await sleep(1000)
             const truncDirPath = this.getTruncDirPath(uri)
-            this.copyFilesToTmpDir(this._pickedSourceFiles, truncDirPath)
+            await this.copyFilesToTmpDir(this._pickedSourceFiles, truncDirPath)
             const zipFilePath = this.zipDir(truncDirPath, CodeWhispererConstants.codeScanZipExt)
             const zipFileSize = statSync(zipFilePath).size
             return {

--- a/packages/toolkit/src/codewhisperer/util/dependencyGraph/dependencyGraph.ts
+++ b/packages/toolkit/src/codewhisperer/util/dependencyGraph/dependencyGraph.ts
@@ -152,12 +152,6 @@ export abstract class DependencyGraph {
         return dir + extension
     }
 
-    protected async removeZip(zipFilePath: string) {
-        if (await fsCommon.exists(zipFilePath)) {
-            await fsCommon.unlink(zipFilePath)
-        }
-    }
-
     protected getTruncDirPath(uri: vscode.Uri) {
         if (this._truncDir === '') {
             this._truncDir = path.join(
@@ -182,7 +176,7 @@ export abstract class DependencyGraph {
 
     public async removeTmpFiles(truncation: Truncation) {
         getLogger().verbose(`Cleaning up temporary files...`)
-        await this.removeZip(truncation.zipFilePath)
+        await fsCommon.delete(truncation.zipFilePath)
         await fsCommon.delete(truncation.rootDir)
         getLogger().verbose(`Complete cleaning up temporary files.`)
     }

--- a/packages/toolkit/src/codewhisperer/util/dependencyGraph/dependencyGraph.ts
+++ b/packages/toolkit/src/codewhisperer/util/dependencyGraph/dependencyGraph.ts
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as fs from 'fs-extra'
+import { fsCommon } from '../../../srcShared/fs'
 import * as vscode from 'vscode'
 import admZip from 'adm-zip'
-import { existsSync, statSync } from 'fs'
 import { asyncCallWithTimeout } from '../commonUtil'
 import * as path from 'path'
 import { tempDirPath } from '../../../shared/filesystemUtilities'
@@ -137,12 +136,12 @@ export abstract class DependencyGraph {
         return paths
     }
 
-    protected copyFileToTmp(uri: vscode.Uri, destDir: string) {
+    protected async copyFileToTmp(uri: vscode.Uri, destDir: string) {
         const projectName = this.getProjectName(uri)
         if (projectName) {
             const pos = uri.path.indexOf(projectName)
             const dest = path.join(destDir, uri.path.substring(pos))
-            fs.copySync(uri.fsPath, dest)
+            await fsCommon.copy(uri.fsPath, dest)
         }
     }
 
@@ -153,15 +152,9 @@ export abstract class DependencyGraph {
         return dir + extension
     }
 
-    protected removeDir(dir: string) {
-        if (existsSync(dir)) {
-            fs.removeSync(dir)
-        }
-    }
-
-    protected removeZip(zipFilePath: string) {
-        if (existsSync(zipFilePath)) {
-            fs.unlinkSync(zipFilePath)
+    protected async removeZip(zipFilePath: string) {
+        if (await fsCommon.exists(zipFilePath)) {
+            await fsCommon.unlink(zipFilePath)
         }
     }
 
@@ -175,20 +168,22 @@ export abstract class DependencyGraph {
         return this._truncDir
     }
 
-    protected getFilesTotalSize(files: string[]) {
-        return files.map(file => statSync(file)).reduce((accumulator, { size }) => accumulator + size, 0)
+    protected async getFilesTotalSize(files: string[]) {
+        const statsPromises = files.map(file => fsCommon.stat(file))
+        const stats = await Promise.all(statsPromises)
+        return stats.reduce((accumulator, stat) => accumulator + stat.size, 0)
     }
 
-    protected copyFilesToTmpDir(files: Set<string> | string[], dir: string) {
-        files.forEach(filePath => {
-            this.copyFileToTmp(vscode.Uri.file(filePath), dir)
-        })
+    protected async copyFilesToTmpDir(files: Set<string> | string[], dir: string) {
+        for (const filePath of files) {
+            await this.copyFileToTmp(vscode.Uri.file(filePath), dir)
+        }
     }
 
-    public removeTmpFiles(truncation: Truncation) {
+    public async removeTmpFiles(truncation: Truncation) {
         getLogger().verbose(`Cleaning up temporary files...`)
-        this.removeZip(truncation.zipFilePath)
-        this.removeDir(truncation.rootDir)
+        await this.removeZip(truncation.zipFilePath)
+        await fsCommon.delete(truncation.rootDir)
         getLogger().verbose(`Complete cleaning up temporary files.`)
     }
 

--- a/packages/toolkit/src/codewhisperer/util/dependencyGraph/goDependencyGraph.ts
+++ b/packages/toolkit/src/codewhisperer/util/dependencyGraph/goDependencyGraph.ts
@@ -69,7 +69,7 @@ export class GoDependencyGraph extends DependencyGraph {
             await sleep(1000)
             getLogger().verbose(`CodeWhisperer: Picked source files: [${[...this._pickedSourceFiles].join(', ')}]`)
             const truncDirPath = this.getTruncDirPath(uri)
-            this.copyFilesToTmpDir(this._pickedSourceFiles, truncDirPath)
+            await this.copyFilesToTmpDir(this._pickedSourceFiles, truncDirPath)
             const zipFilePath = this.zipDir(truncDirPath, CodeWhispererConstants.codeScanZipExt)
             const zipFileSize = statSync(zipFilePath).size
             return {

--- a/packages/toolkit/src/codewhisperer/util/dependencyGraph/javaDependencyGraph.ts
+++ b/packages/toolkit/src/codewhisperer/util/dependencyGraph/javaDependencyGraph.ts
@@ -342,9 +342,9 @@ export class JavaDependencyGraph extends DependencyGraph {
             const buildFiles: string[] = this.generateBuildFilePaths()
             const truncDirPath = this.getTruncDirPath(uri)
             getLogger().debug(`Picked source files: [${[...this._pickedSourceFiles].join(', ')}]`)
-            this.copyFilesToTmpDir(this._pickedSourceFiles, truncDirPath)
+            await this.copyFilesToTmpDir(this._pickedSourceFiles, truncDirPath)
             getLogger().debug(`Picked build artifacts: [${buildFiles}]`)
-            this.copyFilesToTmpDir(buildFiles, truncDirPath)
+            await this.copyFilesToTmpDir(buildFiles, truncDirPath)
             const totalBuildSize = this.getFilesTotalSize(Array.from(buildFiles.values()))
             const zipFilePath = this.zipDir(truncDirPath, CodeWhispererConstants.codeScanZipExt)
             const zipFileSize = statSync(zipFilePath).size

--- a/packages/toolkit/src/codewhisperer/util/dependencyGraph/javaDependencyGraph.ts
+++ b/packages/toolkit/src/codewhisperer/util/dependencyGraph/javaDependencyGraph.ts
@@ -345,7 +345,7 @@ export class JavaDependencyGraph extends DependencyGraph {
             await this.copyFilesToTmpDir(this._pickedSourceFiles, truncDirPath)
             getLogger().debug(`Picked build artifacts: [${buildFiles}]`)
             await this.copyFilesToTmpDir(buildFiles, truncDirPath)
-            const totalBuildSize = this.getFilesTotalSize(Array.from(buildFiles.values()))
+            const totalBuildSize = await this.getFilesTotalSize(Array.from(buildFiles.values()))
             const zipFilePath = this.zipDir(truncDirPath, CodeWhispererConstants.codeScanZipExt)
             const zipFileSize = statSync(zipFilePath).size
             return {

--- a/packages/toolkit/src/codewhisperer/util/dependencyGraph/javascriptDependencyGraph.ts
+++ b/packages/toolkit/src/codewhisperer/util/dependencyGraph/javascriptDependencyGraph.ts
@@ -187,7 +187,7 @@ export class JavascriptDependencyGraph extends DependencyGraph {
             }
             await sleep(1000)
             const truncDirPath = this.getTruncDirPath(uri)
-            this.copyFilesToTmpDir(this._pickedSourceFiles, truncDirPath)
+            await this.copyFilesToTmpDir(this._pickedSourceFiles, truncDirPath)
             const zipFilePath = this.zipDir(truncDirPath, CodeWhispererConstants.codeScanZipExt)
             const zipFileSize = statSync(zipFilePath).size
             return {

--- a/packages/toolkit/src/codewhisperer/util/dependencyGraph/pythonDependencyGraph.ts
+++ b/packages/toolkit/src/codewhisperer/util/dependencyGraph/pythonDependencyGraph.ts
@@ -185,7 +185,7 @@ export class PythonDependencyGraph extends DependencyGraph {
             }
             await sleep(1000)
             const truncDirPath = this.getTruncDirPath(uri)
-            this.copyFilesToTmpDir(this._pickedSourceFiles, truncDirPath)
+            await this.copyFilesToTmpDir(this._pickedSourceFiles, truncDirPath)
             const zipFilePath = this.zipDir(truncDirPath, CodeWhispererConstants.codeScanZipExt)
             const zipFileSize = statSync(zipFilePath).size
             return {

--- a/packages/toolkit/src/codewhisperer/util/dependencyGraph/rubyDependencyGraph.ts
+++ b/packages/toolkit/src/codewhisperer/util/dependencyGraph/rubyDependencyGraph.ts
@@ -196,7 +196,7 @@ export class RubyDependencyGraph extends DependencyGraph {
             }
             await sleep(1000)
             const truncDirPath = this.getTruncDirPath(uri)
-            this.copyFilesToTmpDir(this._pickedSourceFiles, truncDirPath)
+            await this.copyFilesToTmpDir(this._pickedSourceFiles, truncDirPath)
             const zipFilePath = this.zipDir(truncDirPath, CodeWhispererConstants.codeScanZipExt)
             const zipFileSize = statSync(zipFilePath).size
             return {

--- a/packages/toolkit/src/codewhisperer/util/dependencyGraph/terraformDependencyGraph.ts
+++ b/packages/toolkit/src/codewhisperer/util/dependencyGraph/terraformDependencyGraph.ts
@@ -56,7 +56,7 @@ export class terraformDependencyGraph extends DependencyGraph {
             }
             await sleep(1000)
             const truncDirPath = this.getTruncDirPath(uri)
-            this.copyFilesToTmpDir(this._pickedSourceFiles, truncDirPath)
+            await this.copyFilesToTmpDir(this._pickedSourceFiles, truncDirPath)
             const zipFilePath = this.zipDir(truncDirPath, CodeWhispererConstants.codeScanZipExt)
             const zipFileSize = statSync(zipFilePath).size
             return {

--- a/packages/toolkit/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
+++ b/packages/toolkit/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
@@ -4,7 +4,7 @@
  */
 
 import * as vscode from 'vscode'
-import * as fs from 'fs-extra'
+import { fsCommon } from '../../../srcShared/fs'
 import path = require('path')
 import { BM25Document, BM25Okapi } from './rankBm25'
 import { ToolkitError } from '../../../shared/errors'
@@ -78,7 +78,7 @@ export async function fetchSupplementalContextForSrc(
     let chunkList: Chunk[] = []
     for (const relevantFile of relevantCrossFilePaths) {
         throwIfCancelled(cancellationToken)
-        const chunks: Chunk[] = splitFileToChunks(relevantFile, crossFileContextConfig.numberOfLinesEachChunk)
+        const chunks: Chunk[] = await splitFileToChunks(relevantFile, crossFileContextConfig.numberOfLinesEachChunk)
         const linkedChunks = linkChunks(chunks)
         chunkList.push(...linkedChunks)
         if (chunkList.length >= codeChunksCalculated) {
@@ -196,10 +196,10 @@ function linkChunks(chunks: Chunk[]) {
     return updatedChunks
 }
 
-export function splitFileToChunks(filePath: string, chunkSize: number): Chunk[] {
+export async function splitFileToChunks(filePath: string, chunkSize: number): Promise<Chunk[]> {
     const chunks: Chunk[] = []
 
-    const fileContent = fs.readFileSync(filePath, 'utf-8').trimEnd()
+    const fileContent = (await fsCommon.readFileAsString(filePath)).trimEnd()
     const lines = fileContent.split('\n')
 
     for (let i = 0; i < lines.length; i += chunkSize) {

--- a/packages/toolkit/src/srcShared/fs.ts
+++ b/packages/toolkit/src/srcShared/fs.ts
@@ -149,6 +149,17 @@ export class FileSystemCommon {
         return await fs.readDirectory(path)
     }
 
+    async copy(source: vscode.Uri | string, target: vscode.Uri | string): Promise<void> {
+        const sourcePath = FileSystemCommon.getUri(source)
+        const targetPath = FileSystemCommon.getUri(target)
+        return await fs.copy(sourcePath, targetPath)
+    }
+
+    async unlink(uri: vscode.Uri | string): Promise<void> {
+        const path = FileSystemCommon.getUri(uri)
+        return await fsPromises.unlink(path.fsPath)
+    }
+
     // -------- private methods --------
     static readonly #decoder = new TextDecoder()
     static readonly #encoder = new TextEncoder()

--- a/packages/toolkit/src/srcShared/fs.ts
+++ b/packages/toolkit/src/srcShared/fs.ts
@@ -132,7 +132,15 @@ export class FileSystemCommon {
             return
         }
 
-        return fs.delete(path, { recursive: true })
+        try {
+            await fs.delete(path, { recursive: true })
+        } catch (e) {
+            // The latest vscode version will never throw this error, but the current min version can
+            if (vscode.FileSystemError.FileNotFound().code === (e as vscode.FileSystemError).code) {
+                return
+            }
+            throw e
+        }
     }
 
     async readdir(uri: vscode.Uri | string): Promise<[string, vscode.FileType][]> {
@@ -152,12 +160,7 @@ export class FileSystemCommon {
     async copy(source: vscode.Uri | string, target: vscode.Uri | string): Promise<void> {
         const sourcePath = FileSystemCommon.getUri(source)
         const targetPath = FileSystemCommon.getUri(target)
-        return await fs.copy(sourcePath, targetPath)
-    }
-
-    async unlink(uri: vscode.Uri | string): Promise<void> {
-        const path = FileSystemCommon.getUri(uri)
-        return await fsPromises.unlink(path.fsPath)
+        return await fs.copy(sourcePath, targetPath, { overwrite: true })
     }
 
     // -------- private methods --------

--- a/packages/toolkit/src/test/codewhisperer/util/crossFileContextUtil.test.ts
+++ b/packages/toolkit/src/test/codewhisperer/util/crossFileContextUtil.test.ts
@@ -247,7 +247,7 @@ describe('crossFileContextUtil', function () {
             const filePath = path.join(tempFolder, 'file.txt')
             await toFile('line_1\nline_2\nline_3\nline_4\nline_5\nline_6\nline_7', filePath)
 
-            const chunks = crossFile.splitFileToChunks(filePath, 2)
+            const chunks = await crossFile.splitFileToChunks(filePath, 2)
 
             assert.strictEqual(chunks.length, 4)
             assert.strictEqual(chunks[0].content, 'line_1\nline_2')
@@ -260,7 +260,7 @@ describe('crossFileContextUtil', function () {
             const filePath = path.join(tempFolder, 'file.txt')
             await toFile('line_1\nline_2\nline_3\nline_4\nline_5\nline_6\nline_7', filePath)
 
-            const chunks = crossFile.splitFileToChunks(filePath, 5)
+            const chunks = await crossFile.splitFileToChunks(filePath, 5)
 
             assert.strictEqual(chunks.length, 2)
             assert.strictEqual(chunks[0].content, 'line_1\nline_2\nline_3\nline_4\nline_5')
@@ -271,7 +271,7 @@ describe('crossFileContextUtil', function () {
             const filePath = path.join(tempFolder, 'file.txt')
             await toFile(sampleFileOf60Lines, filePath)
 
-            const chunks = crossFile.splitFileToChunks(filePath, crossFileContextConfig.numberOfLinesEachChunk)
+            const chunks = await crossFile.splitFileToChunks(filePath, crossFileContextConfig.numberOfLinesEachChunk)
             assert.strictEqual(chunks.length, 6)
         })
     })

--- a/packages/toolkit/src/test/srcShared/fs.test.ts
+++ b/packages/toolkit/src/test/srcShared/fs.test.ts
@@ -6,13 +6,14 @@
 import assert from 'assert'
 import * as vscode from 'vscode'
 import * as path from 'path'
-import { existsSync, mkdirSync, promises as fsPromises, readFileSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, promises as fsPromises, readFileSync, rmSync } from 'fs'
 import { FakeExtensionContext } from '../fakeExtensionContext'
 import { fsCommon } from '../../srcShared/fs'
 import * as os from 'os'
 import { isMinimumVersion } from '../../shared/vscode/env'
 import Sinon from 'sinon'
 import * as extensionUtilities from '../../shared/extensionUtilities'
+import { toFile } from '../testUtil'
 
 function isWin() {
     return os.platform() === 'win32'
@@ -239,6 +240,20 @@ describe('FileSystem', function () {
         })
     })
 
+    describe('copy()', function () {
+        it('copies files and folders from one dir to another', async function () {
+            const targetDir = await makeFolder('targetDir')
+            await makeFile('targetDir/a.txt', 'I am A')
+            await makeFile('targetDir/dirB/b.txt', 'I am B')
+
+            const destDir = path.join(testRootPath(), 'destDir')
+            await fsCommon.copy(targetDir, destDir)
+
+            assert.strictEqual(await fsCommon.readFileAsString(path.join(destDir, 'a.txt')), 'I am A')
+            assert.strictEqual(await fsCommon.readFileAsString(path.join(destDir, 'dirB/b.txt')), 'I am B')
+        })
+    })
+
     describe('delete()', function () {
         it('deletes a file', async function () {
             const filePath = await makeFile('test.txt', 'hello world')
@@ -253,6 +268,12 @@ describe('FileSystem', function () {
             await fsCommon.delete(dirPath)
 
             assert.ok(!existsSync(dirPath))
+        })
+
+        it('does not error if the file to delete does not exist', async function () {
+            const nonExistantFilePath = 'does/not/exist'
+            await fsCommon.delete(nonExistantFilePath)
+            assert.ok(!existsSync(nonExistantFilePath))
         })
 
         it('uses the "fs" rm method if in C9', async function () {
@@ -286,7 +307,13 @@ describe('FileSystem', function () {
 
     async function makeFile(relativePath: string, content?: string, options?: { mode?: number }): Promise<string> {
         const filePath = path.join(testRootPath(), relativePath)
-        writeFileSync(filePath, content ?? '', { mode: options?.mode })
+
+        await toFile(content ?? '', filePath)
+
+        if (options?.mode !== undefined) {
+            await fsPromises.chmod(filePath, options.mode)
+        }
+
         return filePath
     }
 

--- a/packages/toolkit/src/testE2E/codewhisperer/securityScan.test.ts
+++ b/packages/toolkit/src/testE2E/codewhisperer/securityScan.test.ts
@@ -9,7 +9,6 @@ import * as codewhispererClient from '../../codewhisperer/client/codewhisperer'
 import * as CodeWhispererConstants from '../../codewhisperer/models/constants'
 import * as path from 'path'
 import * as testutil from '../../test/testUtil'
-import * as fs from 'fs-extra'
 import { setValidConnection, skiptTestIfNoValidConn } from '../util/codewhispererUtil'
 import { resetCodeWhispererGlobalVariables } from '../../test/codewhisperer/testUtil'
 import { getTestWorkspaceFolder } from '../../testInteg/integrationTestsUtilities'
@@ -23,6 +22,7 @@ import {
     listScanResults,
 } from '../../codewhisperer/service/securityScanHandler'
 import { makeTemporaryToolkitFolder } from '../../shared/filesystemUtilities'
+import { fsCommon } from '../../srcShared/fs'
 
 const filePromptWithSecurityIssues = `from flask import app
 
@@ -64,7 +64,7 @@ describe('CodeWhisperer security scan', async function () {
 
     afterEach(async function () {
         if (tempFolder !== undefined) {
-            await fs.remove(tempFolder)
+            await fsCommon.delete(tempFolder)
         }
     })
 
@@ -113,7 +113,7 @@ describe('CodeWhisperer security scan', async function () {
         try {
             artifactMap = await getPresignedUrlAndUpload(client, truncation)
         } finally {
-            dependencyGraph.removeTmpFiles(truncation)
+            await dependencyGraph.removeTmpFiles(truncation)
         }
         return {
             artifactMap: artifactMap,


### PR DESCRIPTION
Adds additional changes on top of #4421 from @andrewyuq (I wasn't able to add my commit and github autoclosed his PR).

This PR removes fs-extra logic from CodeWhisperer logic so that it can run in web mode.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
