### PR TITLE
perf(cloud9): "Upload Lambda" is slow since Toolkit 2.x

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -337,7 +337,14 @@ Abstractly, a 'wizard' is a collection of discrete, linear steps (subroutines), 
 
 ### Creating a Wizard (Quick Picks)
 
-A new wizard can be created by extending off the base `Wizard` class, using the template type to specify the shape of the wizard state. All wizards have an internal 'form' property that is used to assign steps. We can assign UI elements (namely, quick picks) using the `bindPrompter` method on form elements. This method accepts a callback that should return a `Prompter` given the current state. For this example, we will use `createQuickPick` and `createInputBox` for our prompters:
+Create a new wizard by extending the base `Wizard` class, using the template type to specify the
+shape of the wizard state. All wizards have an internal `form` property that is used to assign
+steps. You can assign UI elements (namely, quickpicks) using the `bindPrompter` method on form
+elements. This method accepts a callback that should return a `Prompter` given the current state.
+For this example, we will use `createQuickPick` and `createInputBox` for our prompters:
+
+If you need to call async functions to construct your `Wizard` subclass, define your init logic in
+the `init()` method instead of the constructor.
 
 ```ts
 interface ExampleState {
@@ -382,7 +389,7 @@ Note that all wizards can potentially return `undefined` if the workflow was can
 Use `createWizardTester` on an instance of a wizard. Tests can then be constructed by asserting both the user-defined and internal state. Using the above `ExampleWizard`:
 
 ```ts
-const tester = createWizardTester(new ExampleWizard())
+const tester = await createWizardTester(new ExampleWizard())
 tester.foo.assertShowFirst() // Fails if `foo` is not shown (or not shown first)
 tester.bar.assertDoesNotShow() // True since `foo` is not assigned an explicit value
 tester.foo.applyInput('Hello, world!') // Manipulate 'user' state

--- a/packages/toolkit/src/shared/clients/lambdaClient.ts
+++ b/packages/toolkit/src/shared/clients/lambdaClient.ts
@@ -98,7 +98,7 @@ export class DefaultLambdaClient {
         }
     }
 
-    public async updateFunctionCode(name: string, zipFile: Buffer): Promise<Lambda.FunctionConfiguration> {
+    public async updateFunctionCode(name: string, zipFile: Uint8Array): Promise<Lambda.FunctionConfiguration> {
         getLogger().debug(`updateFunctionCode called for function: ${name}`)
         const client = await this.createSdkClient()
 

--- a/packages/toolkit/src/shared/filesystemUtilities.ts
+++ b/packages/toolkit/src/shared/filesystemUtilities.ts
@@ -42,6 +42,7 @@ export async function getDirSize(
             return getDirSize(filePath, startTime, duration, fileExt)
         }
         if (type === vscode.FileType.File && fileName.endsWith(fileExt)) {
+            // TODO: This is SLOW on Cloud9.
             const stat = await fsCommon.stat(filePath)
             return stat.size
         }
@@ -271,6 +272,7 @@ export async function hasFileWithSuffix(dir: string, suffix: string, exclude?: v
  * @returns  List of one or zero Uris (for compat with vscode.workspace.findFiles())
  */
 export async function cloud9Findfile(dir: string, fileName: string): Promise<vscode.Uri[]> {
+    getLogger().debug('cloud9Findfile: %s', dir)
     const files = await fsCommon.readdir(dir)
     const subDirs: vscode.Uri[] = []
     for (const file of files) {

--- a/packages/toolkit/src/test/apprunner/wizards/codeRepositoryWizard.test.ts
+++ b/packages/toolkit/src/test/apprunner/wizards/codeRepositoryWizard.test.ts
@@ -22,10 +22,10 @@ describe('AppRunnerCodeRepositoryWizard', function () {
     let tester: WizardTester<AppRunner.SourceConfiguration>
     let repoTester: WizardTester<AppRunner.CodeRepository>
 
-    beforeEach(function () {
+    beforeEach(async function () {
         // apprunner client and git api will never be called
         const wizard = new AppRunnerCodeRepositoryWizard({} as any, {} as any)
-        tester = createWizardTester(wizard)
+        tester = await createWizardTester(wizard)
         repoTester = tester.CodeRepository
     })
 

--- a/packages/toolkit/src/test/apprunner/wizards/createServiceWizard.test.ts
+++ b/packages/toolkit/src/test/apprunner/wizards/createServiceWizard.test.ts
@@ -14,7 +14,7 @@ import { DefaultAppRunnerClient } from '../../../shared/clients/apprunnerClient'
 describe('CreateServiceWizard', function () {
     let tester: WizardTester<AppRunner.CreateServiceRequest>
 
-    beforeEach(function () {
+    beforeEach(async function () {
         const regionCode = 'us-east-1'
         const wizard = new CreateAppRunnerServiceWizard(
             regionCode,
@@ -27,7 +27,7 @@ describe('CreateServiceWizard', function () {
             }
         )
 
-        tester = createWizardTester(wizard)
+        tester = await createWizardTester(wizard)
     })
 
     describe('CreateAppRunnerServiceWizard', function () {

--- a/packages/toolkit/src/test/apprunner/wizards/imageRepositoryWizard.test.ts
+++ b/packages/toolkit/src/test/apprunner/wizards/imageRepositoryWizard.test.ts
@@ -15,9 +15,9 @@ describe('AppRunnerImageRepositoryWizard', function () {
     let tester: WizardTester<AppRunner.SourceConfiguration>
     let repoTester: WizardTester<AppRunner.ImageRepository>
 
-    beforeEach(function () {
+    beforeEach(async function () {
         const wizard = new AppRunnerImageRepositoryWizard({} as any, {} as any) // the clients will never be called
-        tester = createWizardTester(wizard)
+        tester = await createWizardTester(wizard)
         repoTester = tester.ImageRepository
     })
 
@@ -52,9 +52,9 @@ describe('AppRunnerImageRepositoryWizard', function () {
 describe('ImageIdentifierForm', function () {
     let tester: WizardTester<{ repo: TaggedEcrRepository }>
 
-    beforeEach(function () {
+    beforeEach(async function () {
         const form = new ImageIdentifierForm({} as any) // ecr will never be called
-        tester = createWizardTester(form)
+        tester = await createWizardTester(form)
     })
 
     it('asks for tag if not provided', function () {

--- a/packages/toolkit/src/test/cloudWatchLogs/commands/searchLogGroup.test.ts
+++ b/packages/toolkit/src/test/cloudWatchLogs/commands/searchLogGroup.test.ts
@@ -13,15 +13,15 @@ import { createWizardTester } from '../../shared/wizards/wizardTestUtils'
 
 describe('searchLogGroup', async function () {
     describe('Wizard', async function () {
-        it('shows steps in correct order', function () {
-            const testWizard = createWizardTester(new SearchLogGroupWizard())
+        it('shows steps in correct order', async function () {
+            const testWizard = await createWizardTester(new SearchLogGroupWizard())
             testWizard.submenuResponse.assertShowFirst()
             testWizard.timeRange.assertShowSecond()
             testWizard.filterPattern.assertShowThird()
         })
 
         it('skips steps if parameters are given', async function () {
-            const nodeTestWizard = createWizardTester(
+            const nodeTestWizard = await createWizardTester(
                 new SearchLogGroupWizard({
                     groupName: 'group-test',
                     regionName: 'region-test',

--- a/packages/toolkit/src/test/credentials/wizards/createProfile.test.ts
+++ b/packages/toolkit/src/test/credentials/wizards/createProfile.test.ts
@@ -30,23 +30,23 @@ class TestPrompter extends Prompter<string | undefined> {
 }
 
 describe('CreateProfileWizard', function () {
-    it('prompts for profile name, access key, secret, and then validates (static)', function () {
-        const tester = createWizardTester(new CreateProfileWizard({ foo: {} }, staticCredentialsTemplate))
+    it('prompts for profile name, access key, secret, and then validates (static)', async function () {
+        const tester = await createWizardTester(new CreateProfileWizard({ foo: {} }, staticCredentialsTemplate))
         tester.name.assertShowFirst()
         tester.profile[SharedCredentialsKeys.AWS_ACCESS_KEY_ID].assertShowSecond()
         tester.profile[SharedCredentialsKeys.AWS_SECRET_ACCESS_KEY].assertShowThird()
         tester.accountId.assertShow(4)
     })
 
-    it('prompts for profile name, command, and then validates (credential_process)', function () {
-        const tester = createWizardTester(new CreateProfileWizard({ foo: {} }, processCredentialsTemplate))
+    it('prompts for profile name, command, and then validates (credential_process)', async function () {
+        const tester = await createWizardTester(new CreateProfileWizard({ foo: {} }, processCredentialsTemplate))
         tester.name.assertShowFirst()
         tester.profile[SharedCredentialsKeys.CREDENTIAL_PROCESS].assertShowSecond()
         tester.accountId.assertShowThird()
     })
 
-    it('skips profile name step (and uses "default") if starting with no profiles', function () {
-        const tester = createWizardTester(new CreateProfileWizard({}, processCredentialsTemplate))
+    it('skips profile name step (and uses "default") if starting with no profiles', async function () {
+        const tester = await createWizardTester(new CreateProfileWizard({}, processCredentialsTemplate))
         tester.name.assertDoesNotShow()
         tester.name.assertValue('default')
         tester.assertShowCount(2)

--- a/packages/toolkit/src/test/credentials/wizards/sso.test.ts
+++ b/packages/toolkit/src/test/credentials/wizards/sso.test.ts
@@ -9,8 +9,8 @@ import { SsoWizard, SsoWizardState } from '../../../auth/wizards/sso'
 describe('SSO Wizard', function () {
     let tester: WizardTester<SsoWizardState>
 
-    beforeEach(function () {
-        tester = createWizardTester(new SsoWizard())
+    beforeEach(async function () {
+        tester = await createWizardTester(new SsoWizard())
     })
 
     it('prompts for region, start URL, account ID, and role name', function () {

--- a/packages/toolkit/src/test/ecs/wizards/executeCommand.test.ts
+++ b/packages/toolkit/src/test/ecs/wizards/executeCommand.test.ts
@@ -15,8 +15,8 @@ describe('CreateServiceWizard', function () {
     const createContainer = () =>
         new Container(stub(DefaultEcsClient, { regionCode: '' }), '', { clusterArn: '', taskRoleArn: '' })
 
-    beforeEach(function () {
-        tester = createWizardTester(new CommandWizard(createContainer(), false))
+    beforeEach(async function () {
+        tester = await createWizardTester(new CommandWizard(createContainer(), false))
     })
 
     it('should prompt for tasks and then command', function () {
@@ -24,8 +24,8 @@ describe('CreateServiceWizard', function () {
         tester.command.assertShowSecond()
     })
 
-    it('should ask for confirmation last', function () {
-        tester = createWizardTester(new CommandWizard(createContainer(), true))
+    it('should ask for confirmation last', async function () {
+        tester = await createWizardTester(new CommandWizard(createContainer(), true))
         tester.task.assertShowFirst()
         tester.command.assertShowSecond()
         tester.confirmation.assertShowThird()

--- a/packages/toolkit/src/test/lambda/commands/uploadLambda.test.ts
+++ b/packages/toolkit/src/test/lambda/commands/uploadLambda.test.ts
@@ -74,8 +74,8 @@ describe('uploadLambda', async function () {
     it('lists functions from .application.json', async function () {
         const filePath = path.join(tempFolder, '.application.json')
         await toFile(dotApplicationJsonData, filePath)
-        const foundFunctions1 = getFunctionNames(vscode.Uri.file(filePath), 'us-west-2')
-        const foundFunctions2 = getFunctionNames(vscode.Uri.file(filePath), 'us-east-1')
+        const foundFunctions1 = await getFunctionNames(vscode.Uri.file(filePath), 'us-west-2')
+        const foundFunctions2 = await getFunctionNames(vscode.Uri.file(filePath), 'us-east-1')
         assert.deepStrictEqual(foundFunctions1, ['sampleFunction-w2'])
         assert.deepStrictEqual(foundFunctions2, ['sampleFunction-e1', 'differentFunction-e1'])
     })
@@ -84,7 +84,7 @@ describe('uploadLambda', async function () {
         const filePath = path.join(tempFolder, '.application.json')
         const invalidJson = '{ "DeploymentMethod": "lambda", "Functions": { ?? } }'
         await toFile(invalidJson, filePath)
-        assert.deepStrictEqual(getFunctionNames(vscode.Uri.file(filePath), 'us-west-2'), undefined)
-        assert.deepStrictEqual(getFunctionNames(vscode.Uri.file(filePath), 'us-east-1'), undefined)
+        assert.deepStrictEqual(await getFunctionNames(vscode.Uri.file(filePath), 'us-west-2'), undefined)
+        assert.deepStrictEqual(await getFunctionNames(vscode.Uri.file(filePath), 'us-east-1'), undefined)
     })
 })

--- a/packages/toolkit/src/test/lambda/wizards/samInitWizard.test.ts
+++ b/packages/toolkit/src/test/lambda/wizards/samInitWizard.test.ts
@@ -10,8 +10,8 @@ import { createWizardTester, WizardTester } from '../../shared/wizards/wizardTes
 describe('CreateNewSamAppWizard', async function () {
     let tester: WizardTester<CreateNewSamAppWizardForm>
 
-    beforeEach(function () {
-        tester = createWizardTester(new CreateNewSamAppWizard({ samCliVersion: '1.0.0', schemaRegions: [] }))
+    beforeEach(async function () {
+        tester = await createWizardTester(new CreateNewSamAppWizard({ samCliVersion: '1.0.0', schemaRegions: [] }))
     })
 
     it('prompts for runtime first', function () {
@@ -54,8 +54,8 @@ describe('CreateNewSamAppWizard', async function () {
     })
 
     describe('architecture', function () {
-        beforeEach(function () {
-            tester = createWizardTester(new CreateNewSamAppWizard({ samCliVersion: '1.33.0', schemaRegions: [] }))
+        beforeEach(async function () {
+            tester = await createWizardTester(new CreateNewSamAppWizard({ samCliVersion: '1.33.0', schemaRegions: [] }))
         })
 
         it('prompts for architecture after runtime (no dependency manager) if SAM CLI >= 1.33', function () {
@@ -69,8 +69,8 @@ describe('CreateNewSamAppWizard', async function () {
             tester.architecture.assertShowSecond()
         })
 
-        it('skips prompt for earlier versions of SAM CLI', function () {
-            tester = createWizardTester(new CreateNewSamAppWizard({ samCliVersion: '1.32.0', schemaRegions: [] }))
+        it('skips prompt for earlier versions of SAM CLI', async function () {
+            tester = await createWizardTester(new CreateNewSamAppWizard({ samCliVersion: '1.32.0', schemaRegions: [] }))
             tester.runtimeAndPackage.applyInput({ runtime: 'java11', packageType: 'Zip' })
             tester.architecture.assertDoesNotShow()
         })

--- a/packages/toolkit/src/test/lambda/wizards/uploadLambdaWizard.test.ts
+++ b/packages/toolkit/src/test/lambda/wizards/uploadLambdaWizard.test.ts
@@ -16,8 +16,8 @@ describe('UploadLambdaWizard', function () {
     let tester: WizardTester<UploadLambdaWizardState>
 
     describe('invoked from command palette', function () {
-        beforeEach(function () {
-            tester = createWizardTester(new UploadLambdaWizard())
+        beforeEach(async () => {
+            tester = await createWizardTester(new UploadLambdaWizard())
         })
 
         it('shows all but build prompts', function () {
@@ -30,8 +30,8 @@ describe('UploadLambdaWizard', function () {
     })
 
     describe('invoked from lambda node', function () {
-        beforeEach(function () {
-            tester = createWizardTester(
+        beforeEach(async function () {
+            tester = await createWizardTester(
                 new UploadLambdaWizard({ name: 'lambdaName', region: 'us-east-1', configuration: {} } as LambdaFunction)
             )
         })
@@ -56,7 +56,7 @@ describe('UploadLambdaWizard', function () {
         beforeEach(async function () {
             tempDir = await makeTemporaryToolkitFolder()
             invokePath = vscode.Uri.file(tempDir)
-            tester = createWizardTester(new UploadLambdaWizard(undefined, invokePath))
+            tester = await createWizardTester(new UploadLambdaWizard(undefined, invokePath))
         })
         afterEach(async function () {
             await fs.remove(tempDir)
@@ -82,7 +82,7 @@ describe('UploadLambdaWizard', function () {
             tempDirUri = vscode.Uri.file(tempDir)
             writeFileSync(path.join(tempDir, 'template.yaml'), '')
             invokePath = vscode.Uri.file(path.join(tempDir, 'template.yaml'))
-            tester = createWizardTester(new UploadLambdaWizard(undefined, invokePath))
+            tester = await createWizardTester(new UploadLambdaWizard(undefined, invokePath))
         })
         afterEach(async function () {
             await fs.remove(tempDir)

--- a/packages/toolkit/src/test/redshift/wizards/connectionWizard.test.ts
+++ b/packages/toolkit/src/test/redshift/wizards/connectionWizard.test.ts
@@ -36,8 +36,8 @@ describe('redshiftNodeConnectionWizard', async function () {
         )
     })
 
-    it('shows all steps for provisionedNode and database username connection type', function () {
-        const testWizard = createWizardTester(new RedshiftNodeConnectionWizard(provisionedNode))
+    it('shows all steps for provisionedNode and database username connection type', async function () {
+        const testWizard = await createWizardTester(new RedshiftNodeConnectionWizard(provisionedNode))
         testWizard.connectionType.assertShowFirst()
         testWizard.connectionType.applyInput(ConnectionType.TempCreds)
         testWizard.database.assertShowFirst()
@@ -45,16 +45,16 @@ describe('redshiftNodeConnectionWizard', async function () {
         testWizard.username.assertShowFirst()
     })
 
-    it('shows only database as input for serverlessNode and database username connection type', function () {
-        const testWizard = createWizardTester(new RedshiftNodeConnectionWizard(serverlessNode))
+    it('shows only database as input for serverlessNode and database username connection type', async function () {
+        const testWizard = await createWizardTester(new RedshiftNodeConnectionWizard(serverlessNode))
         testWizard.connectionType.assertShowFirst()
         testWizard.connectionType.applyInput(ConnectionType.TempCreds)
         testWizard.database.assertShowFirst()
         testWizard.username.assertDoesNotShow()
     })
 
-    it('shows all steps for provisionedNode and secrets manager connection type', function () {
-        const testWizard = createWizardTester(new RedshiftNodeConnectionWizard(provisionedNode))
+    it('shows all steps for provisionedNode and secrets manager connection type', async function () {
+        const testWizard = await createWizardTester(new RedshiftNodeConnectionWizard(provisionedNode))
         testWizard.connectionType.assertShowFirst()
         testWizard.connectionType.applyInput(ConnectionType.SecretsManager)
         testWizard.database.assertShowFirst()
@@ -63,8 +63,8 @@ describe('redshiftNodeConnectionWizard', async function () {
         testWizard.secret.applyInput('SecretTest')
     })
 
-    it('shows all steps for serverlessNode and secrets manager connection type', function () {
-        const testWizard = createWizardTester(new RedshiftNodeConnectionWizard(serverlessNode))
+    it('shows all steps for serverlessNode and secrets manager connection type', async function () {
+        const testWizard = await createWizardTester(new RedshiftNodeConnectionWizard(serverlessNode))
         testWizard.connectionType.assertShowFirst()
         testWizard.connectionType.applyInput(ConnectionType.SecretsManager)
         testWizard.database.assertShowFirst()
@@ -77,8 +77,8 @@ describe('redshiftNodeConnectionWizard', async function () {
 describe('NotebookConnectionWizard', async () => {
     const mockRegionProvider: RegionProvider = <RegionProvider>{}
 
-    it('shows all steps for database username connection type', function () {
-        const testWizard = createWizardTester(new NotebookConnectionWizard(mockRegionProvider))
+    it('shows all steps for database username connection type', async function () {
+        const testWizard = await createWizardTester(new NotebookConnectionWizard(mockRegionProvider))
         testWizard.region.assertShowFirst()
         testWizard.region.applyInput({ id: 'US East - 1', name: 'us-east-1' })
         testWizard.warehouseIdentifier.assertShowFirst()
@@ -92,8 +92,8 @@ describe('NotebookConnectionWizard', async () => {
         testWizard.warehouseType.assertDoesNotShow()
     })
 
-    it('shows all steps for secrets manager connection type', function () {
-        const testWizard = createWizardTester(new NotebookConnectionWizard(mockRegionProvider))
+    it('shows all steps for secrets manager connection type', async function () {
+        const testWizard = await createWizardTester(new NotebookConnectionWizard(mockRegionProvider))
         testWizard.region.assertShowFirst()
         testWizard.region.applyInput({ id: 'US East - 1', name: 'us-east-1' })
         testWizard.warehouseIdentifier.assertShowFirst()

--- a/packages/toolkit/src/test/shared/sam/sync.test.ts
+++ b/packages/toolkit/src/test/shared/sam/sync.test.ts
@@ -20,36 +20,36 @@ import globals from '../../../shared/extensionGlobals'
 
 describe('SyncWizard', async function () {
     const registry = await globals.templateRegistry
-    const createTester = (params?: Partial<SyncParams>) =>
+    const createTester = async (params?: Partial<SyncParams>) =>
         createWizardTester(new SyncWizard({ deployType: 'code', ...params }, registry))
 
-    it('shows steps in correct order', function () {
-        const tester = createTester()
+    it('shows steps in correct order', async function () {
+        const tester = await createTester()
         tester.region.assertShowFirst()
         tester.template.assertShowSecond()
         tester.stackName.assertShowThird()
         tester.bucketName.assertShow(4)
     })
 
-    it('prompts for ECR repo if template has image-based resource', function () {
+    it('prompts for ECR repo if template has image-based resource', async function () {
         const template = { uri: vscode.Uri.file('/'), data: createBaseImageTemplate() }
-        const tester = createTester({ template })
+        const tester = await createTester({ template })
         tester.ecrRepoUri.assertShow()
     })
 
-    it('skips prompt for ECR repo if template has no image-based resources', function () {
+    it('skips prompt for ECR repo if template has no image-based resources', async function () {
         const template = { uri: vscode.Uri.file('/'), data: createBaseTemplate() }
-        const tester = createTester({ template })
+        const tester = await createTester({ template })
         tester.ecrRepoUri.assertDoesNotShow()
     })
 
-    it("uses the template's workspace as the project root is not set", function () {
+    it("uses the template's workspace as the project root is not set", async function () {
         const workspaceUri = vscode.workspace.workspaceFolders?.[0]?.uri
         assert.ok(workspaceUri)
 
         const templateUri = vscode.Uri.joinPath(workspaceUri, 'my', 'template.yaml')
         const template = { uri: templateUri, data: createBaseTemplate() }
-        const tester = createTester({ template })
+        const tester = await createTester({ template })
         tester.projectRoot.assertValue(workspaceUri)
     })
 })

--- a/packages/toolkit/src/test/shared/wizards/wizardForm.test.ts
+++ b/packages/toolkit/src/test/shared/wizards/wizardForm.test.ts
@@ -25,10 +25,10 @@ describe('WizardForm', function () {
     let testForm: Wizard<TestState>['form']
     let tester: WizardTester<TestState>
 
-    beforeEach(function () {
+    beforeEach(async function () {
         testWizard = new Wizard()
         testForm = testWizard.form
-        tester = createWizardTester(testWizard)
+        tester = await createWizardTester(testWizard)
     })
 
     it('can add prompter', function () {

--- a/packages/toolkit/src/test/shared/wizards/wizardTestUtils.ts
+++ b/packages/toolkit/src/test/shared/wizards/wizardTestUtils.ts
@@ -61,7 +61,14 @@ function failIf(cond: boolean, message?: string): void {
     }
 }
 
-export function createWizardTester<T extends Partial<T>>(wizard: Wizard<T> | WizardForm<T>): Tester<T> {
+/** Wraps the `WizardForm` of a `Wizard` so you can assert its state. */
+export async function createWizardTester<T extends Partial<T>>(wizard: Wizard<T> | WizardForm<T>): Promise<Tester<T>> {
+    if (wizard instanceof Wizard && wizard.init) {
+        // Ensure that init() was called. Needed because createWizardTester() does not call run().
+        await wizard.init()
+        delete wizard.init
+    }
+
     const form = wizard instanceof Wizard ? wizard.boundForm : wizard
     const state = (wizard instanceof Wizard ? JSON.parse(JSON.stringify(wizard.initialState ?? {})) : {}) as T
 

--- a/packages/toolkit/src/test/shared/wizards/wizardTestUtils.ts
+++ b/packages/toolkit/src/test/shared/wizards/wizardTestUtils.ts
@@ -65,6 +65,7 @@ function failIf(cond: boolean, message?: string): void {
 export async function createWizardTester<T extends Partial<T>>(wizard: Wizard<T> | WizardForm<T>): Promise<Tester<T>> {
     if (wizard instanceof Wizard && wizard.init) {
         // Ensure that init() was called. Needed because createWizardTester() does not call run().
+        ;(wizard as any)._ready = true
         await wizard.init()
         delete wizard.init
     }

--- a/packages/toolkit/src/test/ssmDocument/wizards/publishDocumentWizard.test.ts
+++ b/packages/toolkit/src/test/ssmDocument/wizards/publishDocumentWizard.test.ts
@@ -12,9 +12,9 @@ import {
 describe('AppRunnerCodeRepositoryWizard', function () {
     let tester: WizardTester<PublishSSMDocumentWizardResponse>
 
-    beforeEach(function () {
+    beforeEach(async function () {
         const wizard = new PublishSSMDocumentWizard()
-        tester = createWizardTester(wizard)
+        tester = await createWizardTester(wizard)
     })
 
     it('has 3 steps by default', function () {
@@ -32,9 +32,9 @@ describe('AppRunnerCodeRepositoryWizard', function () {
         tester.name.assertShowThird()
     })
 
-    it('skips the region prompt if provided a region', function () {
+    it('skips the region prompt if provided a region', async function () {
         const wizard = new PublishSSMDocumentWizard('us-west-2')
-        tester = createWizardTester(wizard)
+        tester = await createWizardTester(wizard)
         tester.region.assertDoesNotShow()
         tester.assertShowCount(2)
     })

--- a/packages/toolkit/src/test/stepFunctions/wizards/createStateMachineWizard.test.ts
+++ b/packages/toolkit/src/test/stepFunctions/wizards/createStateMachineWizard.test.ts
@@ -9,8 +9,8 @@ import { createWizardTester, WizardTester } from '../../shared/wizards/wizardTes
 describe('CreateStateMachineWizard', function () {
     let tester: WizardTester<CreateStateMachineWizard>
 
-    beforeEach(function () {
-        tester = createWizardTester(new CreateStateMachineWizard())
+    beforeEach(async function () {
+        tester = await createWizardTester(new CreateStateMachineWizard())
     })
 
     it('prompts for a file name and format', async function () {

--- a/packages/toolkit/src/test/stepFunctions/wizards/previewStateMachineCDKWizard.test.ts
+++ b/packages/toolkit/src/test/stepFunctions/wizards/previewStateMachineCDKWizard.test.ts
@@ -84,8 +84,8 @@ describe('getStateMachines', function () {
 describe('PreviewStateMachineCDKWizard', async function () {
     let tester: WizardTester<PreviewStateMachineCDKWizard>
 
-    beforeEach(function () {
-        tester = createWizardTester(new PreviewStateMachineCDKWizard())
+    beforeEach(async function () {
+        tester = await createWizardTester(new PreviewStateMachineCDKWizard())
     })
 
     it('prompts for location then a state machine', function () {

--- a/packages/toolkit/src/test/stepFunctions/wizards/publishStateMachineWizard.test.ts
+++ b/packages/toolkit/src/test/stepFunctions/wizards/publishStateMachineWizard.test.ts
@@ -12,8 +12,8 @@ import { WizardTester, createWizardTester } from '../../shared/wizards/wizardTes
 describe('PublishStateMachineWizard', async function () {
     let tester: WizardTester<PublishStateMachineWizard>
 
-    beforeEach(function () {
-        tester = createWizardTester(new PublishStateMachineWizard())
+    beforeEach(async function () {
+        tester = await createWizardTester(new PublishStateMachineWizard())
     })
 
     it('only shows two steps until an action is selected', function () {


### PR DESCRIPTION
# Problem:
In Cloud9, using the "Upload Lambda" action on even a small directory, takes 5+ seconds. Example trace:

    2024-02-16 15:45:44 [DEBUG]: createRegionPrompter: selected { id: 'us-west-2', name: 'US West (Oregon)' }
    2024-02-16 15:45:44 [DEBUG]: findApplicationJsonFile (cloud9: true)
    2024-02-16 15:45:44 [DEBUG]: cloud9Findfile: /home/ec2-user/environment/
    2024-02-16 15:45:46 [DEBUG]: cloud9Findfile: /home/ec2-user/environment/.c9
    2024-02-16 15:45:49 [DEBUG]: cloud9Findfile: /home/ec2-user/environment/.c9/amazonwebservices.aws-toolkit-vscode
    2024-02-16 15:45:50 [DEBUG]: cloud9Findfile: /home/ec2-user/environment/.c9/metadata
    2024-02-16 15:45:52 [DEBUG]: cloud9Findfile: /home/ec2-user/environment/.c9/test 4
    2024-02-16 15:45:52 [DEBUG]: uploadLambda: .application.json not found in: "/home/ec2-user/environment/"

# Solution:
The vscode `stat()` API is very slow, especially on the Cloud9 VFS. Avoid it by special-casing the implementation of `fsCommon.exists()` on Cloud9.

    2024-02-16 16:12:14 [DEBUG]: createRegionPrompter: selected { id: 'us-west-2', name: 'US West (Oregon)' }
    2024-02-16 16:12:14 [DEBUG]: findApplicationJsonFile (cloud9: true)
    2024-02-16 16:12:14 [DEBUG]: cloud9Findfile: /home/ec2-user/environment/
    2024-02-16 16:12:14 [DEBUG]: cloud9Findfile: /home/ec2-user/environment/.c9
    2024-02-16 16:12:14 [DEBUG]: cloud9Findfile: /home/ec2-user/environment/.c9/amazonwebservices.aws-toolkit-vscode
    2024-02-16 16:12:14 [DEBUG]: cloud9Findfile: /home/ec2-user/environment/.c9/metadata
    2024-02-16 16:12:14 [DEBUG]: cloud9Findfile: /home/ec2-user/environment/.c9/test 4
    2024-02-16 16:12:14 [DEBUG]: uploadLambda: .application.json not found in: "/home/ec2-user/environment/"

TODO: the following functions which loop through `readdir` results are also potentially slow:

    getDirSize
    cleanLogFiles


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
