### PR TITLE
logging: suppress AWS SDK v2 warning

### DIFF
--- a/packages/toolkit/src/extensionShared.ts
+++ b/packages/toolkit/src/extensionShared.ts
@@ -42,6 +42,9 @@ import { showQuickStartWebview } from './shared/extensionStartup'
 import { ExtContext } from './shared/extensions'
 import { getSamCliContext } from './shared/sam/cli/samCliContext'
 import { UriHandler } from './shared/vscode/uriHandler'
+import { disableAwsSdkWarning } from './shared/awsClientBuilder'
+
+disableAwsSdkWarning()
 
 let localize: nls.LocalizeFunc
 

--- a/packages/toolkit/src/shared/awsClientBuilder.ts
+++ b/packages/toolkit/src/shared/awsClientBuilder.ts
@@ -11,6 +11,12 @@ import { DevSettings } from './settings'
 import { getUserAgent } from './telemetry/util'
 import { telemetry } from './telemetry/telemetry'
 
+/** Suppresses a very noisy warning printed by AWS SDK v2, which clutters local debugging output, CI logs, etc. */
+export function disableAwsSdkWarning() {
+    // See https://github.com/aws/aws-sdk-js/issues/4354
+    require('aws-sdk/lib/maintenance_mode_message').suppress = true
+}
+
 // These are not on the public API but are very useful for logging purposes.
 // Tests guard against the possibility that these values change unexpectedly.
 // Since the field names are not prepended with `_` to signify visibility, the

--- a/packages/toolkit/src/test/globalSetup.test.ts
+++ b/packages/toolkit/src/test/globalSetup.test.ts
@@ -25,6 +25,9 @@ import * as testUtil from './testUtil'
 import { getTestWindow, resetTestWindow } from './shared/vscode/window'
 import { mapTestErrors, normalizeError, setRunnableTimeout } from './setupUtil'
 import { TelemetryDebounceInfo } from '../shared/vscode/commands2'
+import { disableAwsSdkWarning } from '../shared/awsClientBuilder'
+
+disableAwsSdkWarning()
 
 const testReportDir = join(__dirname, '../../../../../.test-reports') // Root project, not subproject
 const testLogOutput = join(testReportDir, 'testLog.log')


### PR DESCRIPTION
Problem:
AWS JS SDK v2 shows a very noisy warning. This warning appears in local debugging, in the CI logs, etc.

    NOTE: We are formalizing our plans to enter AWS SDK for JavaScript (v2) into maintenance mode in 2023.
    Please migrate your code to use AWS SDK for JavaScript (v3).
    For more information, check the migration guide at https://a.co/7PzMCcy
    (Use `Code Helper (Plugin) --trace-warnings ...` to show where the warning was created)

Solution:
Suppress the warning (see https://github.com/aws/aws-sdk-js/issues/4354). Updating to SDK v3 is in our backlog, so we don't need the warning.

Fix #4371



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
