### PR TITLE
deps: remove "sanitize-html" dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6025,86 +6025,6 @@
             "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
             "dev": true
         },
-        "node_modules/@types/sanitize-html": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.3.1.tgz",
-            "integrity": "sha512-+UT/XRluJuCunRftwO6OzG6WOBgJ+J3sROIoSJWX+7PB2FtTJTEJLrHCcNwzCQc0r60bej3WAbaigK+VZtZCGw==",
-            "dev": true,
-            "dependencies": {
-                "htmlparser2": "^6.0.0"
-            }
-        },
-        "node_modules/@types/sanitize-html/node_modules/dom-serializer": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-            "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-            "dev": true,
-            "dependencies": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.2.0",
-                "entities": "^2.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-            }
-        },
-        "node_modules/@types/sanitize-html/node_modules/domhandler": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-            "dev": true,
-            "dependencies": {
-                "domelementtype": "^2.2.0"
-            },
-            "engines": {
-                "node": ">= 4"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domhandler?sponsor=1"
-            }
-        },
-        "node_modules/@types/sanitize-html/node_modules/domutils": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-            "dev": true,
-            "dependencies": {
-                "dom-serializer": "^1.0.1",
-                "domelementtype": "^2.2.0",
-                "domhandler": "^4.2.0"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domutils?sponsor=1"
-            }
-        },
-        "node_modules/@types/sanitize-html/node_modules/entities": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-            "dev": true,
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "node_modules/@types/sanitize-html/node_modules/htmlparser2": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-            "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-            "dev": true,
-            "funding": [
-                "https://github.com/fb55/htmlparser2?sponsor=1",
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fb55"
-                }
-            ],
-            "dependencies": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.0.0",
-                "domutils": "^2.5.2",
-                "entities": "^2.0.0"
-            }
-        },
         "node_modules/@types/semver": {
             "version": "7.5.0",
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
@@ -9321,6 +9241,7 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
             "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9542,6 +9463,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
             "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "dev": true,
             "dependencies": {
                 "domelementtype": "^2.3.0",
                 "domhandler": "^5.0.2",
@@ -9555,6 +9477,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
             "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -9566,6 +9489,7 @@
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
             "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+            "dev": true,
             "dependencies": {
                 "domelementtype": "^2.3.0"
             },
@@ -9580,6 +9504,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
             "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+            "dev": true,
             "dependencies": {
                 "dom-serializer": "^2.0.0",
                 "domelementtype": "^2.3.0",
@@ -9739,6 +9664,7 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
             "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
             "engines": {
                 "node": ">=0.12"
             },
@@ -9983,6 +9909,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -11362,6 +11289,7 @@
             "version": "8.0.2",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
             "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+            "dev": true,
             "funding": [
                 "https://github.com/fb55/htmlparser2?sponsor=1",
                 {
@@ -14292,11 +14220,6 @@
                 "semver": "bin/semver"
             }
         },
-        "node_modules/parse-srcset": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-            "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
-        },
         "node_modules/parse5": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
@@ -15761,27 +15684,6 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-        },
-        "node_modules/sanitize-html": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.11.0.tgz",
-            "integrity": "sha512-BG68EDHRaGKqlsNjJ2xUB7gpInPA8gVx/mvjO743hZaeMCZ2DwzW7xvsqZ+KNU4QKwj86HJ3uu2liISf2qBBUA==",
-            "dependencies": {
-                "deepmerge": "^4.2.2",
-                "escape-string-regexp": "^4.0.0",
-                "htmlparser2": "^8.0.0",
-                "is-plain-object": "^5.0.0",
-                "parse-srcset": "^1.0.2",
-                "postcss": "^8.3.11"
-            }
-        },
-        "node_modules/sanitize-html/node_modules/is-plain-object": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/sass": {
             "version": "1.69.5",
@@ -19107,7 +19009,6 @@
                 "mime-types": "^2.1.32",
                 "node-fetch": "^2.7.0",
                 "portfinder": "^1.0.32",
-                "sanitize-html": "^2.3.3",
                 "semver": "^7.5.4",
                 "strip-ansi": "^5.2.0",
                 "tcp-port-used": "^1.0.1",
@@ -19148,7 +19049,6 @@
                 "@types/node-fetch": "^2.6.8",
                 "@types/prismjs": "^1.26.0",
                 "@types/readline-sync": "^1.4.3",
-                "@types/sanitize-html": "2.3.1",
                 "@types/semver": "^7.5.0",
                 "@types/sinon": "^10.0.5",
                 "@types/sinonjs__fake-timers": "^8.1.2",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -4293,7 +4293,6 @@
         "@types/node-fetch": "^2.6.8",
         "@types/prismjs": "^1.26.0",
         "@types/readline-sync": "^1.4.3",
-        "@types/sanitize-html": "2.3.1",
         "@types/semver": "^7.5.0",
         "@types/sinon": "^10.0.5",
         "@types/sinonjs__fake-timers": "^8.1.2",
@@ -4321,12 +4320,12 @@
         "sass-loader": "^12.6.0",
         "sinon": "^14.0.0",
         "style-loader": "^3.3.1",
+        "ts-node": "^10.9.1",
+        "typescript": "^5.0.4",
         "umd-compat-loader": "^2.1.2",
         "vue-loader": "^17.2.2",
         "vue-style-loader": "^4.1.3",
-        "webfont": "^11.2.26",
-        "typescript": "^5.0.4",
-        "ts-node": "^10.9.1"
+        "webfont": "^11.2.26"
     },
     "dependencies": {
         "@amzn/codewhisperer-streaming": "file:../../src.gen/@amzn/codewhisperer-streaming",
@@ -4367,7 +4366,6 @@
         "mime-types": "^2.1.32",
         "node-fetch": "^2.7.0",
         "portfinder": "^1.0.32",
-        "sanitize-html": "^2.3.3",
         "semver": "^7.5.4",
         "strip-ansi": "^5.2.0",
         "tcp-port-used": "^1.0.1",

--- a/packages/toolkit/src/amazonqFeatureDev/session/sessionState.ts
+++ b/packages/toolkit/src/amazonqFeatureDev/session/sessionState.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import sanitizeHtml from 'sanitize-html'
 import * as vscode from 'vscode'
 import { ToolkitError } from '../../shared/errors'
 import { getLogger } from '../../shared/logger'
@@ -12,6 +11,7 @@ import { IllegalStateTransition, UserMessageNotFoundError } from '../errors'
 import { SessionState, SessionStateAction, SessionStateConfig, SessionStateInteraction } from '../types'
 import { prepareRepoData } from '../util/files'
 import { uploadCode } from '../util/upload'
+import { encodeHTML } from '../../shared/utilities/textUtilities'
 
 export class ConversationNotStartedState implements Omit<SessionState, 'uploadId'> {
     public tokenSource: vscode.CancellationTokenSource
@@ -90,10 +90,9 @@ export class RefinementState implements SessionState {
                     action.msg
                 )
 
-                this.approach = sanitizeHtml(
+                this.approach = encodeHTML(
                     approach ??
-                        'There has been a problem generating an approach. Please open a conversation in a new tab',
-                    {}
+                        'There has been a problem generating an approach. Please open a conversation in a new tab'
                 )
                 getLogger().debug(`Approach response: %O`, this.approach)
 

--- a/packages/toolkit/src/test/amazonqFeatureDev/session/sessionState.test.ts
+++ b/packages/toolkit/src/test/amazonqFeatureDev/session/sessionState.test.ts
@@ -135,7 +135,8 @@ describe('sessionState', () => {
             const state = new RefinementState(testConfig, invalidHTMLApproach, tabId, 0)
             const result = await state.interact(testAction)
 
-            const expectedApproach = `<h1>hello world</h1>`
+            const expectedApproach =
+                '&lt;head&gt;&lt;script src="https://foo"&gt;&lt;/script&gt;&lt;/head&gt;&lt;body&gt;&lt;h1&gt;hello world&lt;/h1&gt;&lt;/body&gt;'
             assert.deepStrictEqual(result, {
                 nextState: new RefinementState(testConfig, expectedApproach, tabId, 1),
                 interaction: {


### PR DESCRIPTION
## Problem

This package was added in 9e8976b38ca13286e14b919a145b75515a0d565d to guard against unexpected server response, but it has a lot more features (and transitive dependencies) that we aren't using. It's also adding a maintenance cost: https://github.com/aws/aws-toolkit-vscode/pull/4435

## Solution
- Use `encodeHTML` instead.
- Remove unnecessary dependencies.





<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
