### PR TITLE
telemetry: add fix rate metrics for hover events

### DIFF
--- a/.changes/next-release/Feature-acb30000-5eeb-4a1a-85ce-1df104b9cc86.json
+++ b/.changes/next-release/Feature-acb30000-5eeb-4a1a-85ce-1df104b9cc86.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Security issue hover telemetry includes additional metadata"
+}

--- a/.changes/next-release/Feature-acb30000-5eeb-4a1a-85ce-1df104b9cc86.json
+++ b/.changes/next-release/Feature-acb30000-5eeb-4a1a-85ce-1df104b9cc86.json
@@ -1,4 +1,0 @@
-{
-	"type": "Feature",
-	"description": "Security issue hover telemetry includes additional metadata"
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3555,9 +3555,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.188",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.188.tgz",
-            "integrity": "sha512-VOmbILPWdAZjCaBNkCCKCRIEMecbrnfZ5weiDET9QBLHjaG8G7SpvVFrXZRbeK5ctTNkNwJ5KB6W3f/v5nmzAg==",
+            "version": "1.0.191",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.191.tgz",
+            "integrity": "sha512-gATuELOUWkFiZAgvNAu8iC/+aLDyPjMfLfBuveBBojWT/qwjUpAzJeaHoH78S+JzMRSiaB/C4eBz3ZWE/Gu6yw==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",
@@ -18825,7 +18825,7 @@
             },
             "devDependencies": {
                 "@aws-sdk/types": "^3.13.1",
-                "@aws-toolkits/telemetry": "^1.0.188",
+                "@aws-toolkits/telemetry": "^1.0.190",
                 "@aws/fully-qualified-names": "^2.1.1",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^10.0.2",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -4271,7 +4271,7 @@
     },
     "devDependencies": {
         "@aws-sdk/types": "^3.13.1",
-        "@aws-toolkits/telemetry": "^1.0.188",
+        "@aws-toolkits/telemetry": "^1.0.190",
         "@aws/fully-qualified-names": "^2.1.1",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^10.0.2",

--- a/packages/toolkit/src/codewhisperer/service/securityIssueHoverProvider.ts
+++ b/packages/toolkit/src/codewhisperer/service/securityIssueHoverProvider.ts
@@ -36,6 +36,7 @@ export class SecurityIssueHoverProvider extends SecurityIssueProvider implements
                         findingId: issue.findingId,
                         detectorId: issue.detectorId,
                         ruleId: issue.ruleId,
+                        includesFix: !!issue.suggestedFixes.length,
                     })
                 }
             }

--- a/packages/toolkit/src/test/codewhisperer/service/securityIssueHoverProvider.test.ts
+++ b/packages/toolkit/src/test/codewhisperer/service/securityIssueHoverProvider.test.ts
@@ -91,8 +91,8 @@ describe('securityIssueHoverProvider', () => {
                 )} 'Open "CodeWhisperer Security Issue"')\n`
         )
         assertTelemetry('codewhisperer_codeScanIssueHover', [
-            { findingId: 'finding-1', detectorId: 'language/detector-1', ruleId: 'Rule-123' },
-            { findingId: 'finding-2', detectorId: 'language/detector-2', ruleId: 'Rule-456' },
+            { findingId: 'finding-1', detectorId: 'language/detector-1', ruleId: 'Rule-123', includesFix: false },
+            { findingId: 'finding-2', detectorId: 'language/detector-2', ruleId: 'Rule-456', includesFix: false },
         ])
     })
 

--- a/packages/toolkit/src/test/codewhisperer/service/securityIssueHoverProvider.test.ts
+++ b/packages/toolkit/src/test/codewhisperer/service/securityIssueHoverProvider.test.ts
@@ -22,12 +22,7 @@ describe('securityIssueHoverProvider', () => {
 
     it('should return hover for each issue for the current position', () => {
         const issues = [
-            createCodeScanIssue({
-                findingId: 'finding-1',
-                detectorId: 'language/detector-1',
-                suggestedFixes: [],
-                ruleId: 'Rule-123',
-            }),
+            createCodeScanIssue({ findingId: 'finding-1', detectorId: 'language/detector-1', ruleId: 'Rule-123' }),
             createCodeScanIssue({
                 findingId: 'finding-2',
                 detectorId: 'language/detector-2',
@@ -96,7 +91,7 @@ describe('securityIssueHoverProvider', () => {
                 )} 'Open "CodeWhisperer Security Issue"')\n`
         )
         assertTelemetry('codewhisperer_codeScanIssueHover', [
-            { findingId: 'finding-1', detectorId: 'language/detector-1', ruleId: 'Rule-123', includesFix: false },
+            { findingId: 'finding-1', detectorId: 'language/detector-1', ruleId: 'Rule-123', includesFix: true },
             { findingId: 'finding-2', detectorId: 'language/detector-2', ruleId: 'Rule-456', includesFix: false },
         ])
     })

--- a/packages/toolkit/src/test/codewhisperer/service/securityIssueHoverProvider.test.ts
+++ b/packages/toolkit/src/test/codewhisperer/service/securityIssueHoverProvider.test.ts
@@ -22,7 +22,12 @@ describe('securityIssueHoverProvider', () => {
 
     it('should return hover for each issue for the current position', () => {
         const issues = [
-            createCodeScanIssue({ findingId: 'finding-1', detectorId: 'language/detector-1', ruleId: 'Rule-123' }),
+            createCodeScanIssue({
+                findingId: 'finding-1',
+                detectorId: 'language/detector-1',
+                suggestedFixes: [],
+                ruleId: 'Rule-123',
+            }),
             createCodeScanIssue({
                 findingId: 'finding-2',
                 detectorId: 'language/detector-2',


### PR DESCRIPTION
## Problem

We want to capture ACR fix generation rate.

## Solution

Report the ratio of hover events for issues with and without fix.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
