### PR TITLE
fix(appcomposer): add null checks to parsed JSON files

### DIFF
--- a/packages/toolkit/src/shared/cloudformation/cloudformation.ts
+++ b/packages/toolkit/src/shared/cloudformation/cloudformation.ts
@@ -439,9 +439,9 @@ export async function tryLoad(
 
     // Check if the template is a SAM template, using the same heuristic as the cfn-lint team:
     // https://github.com/aws-cloudformation/aws-cfn-lint-visual-studio-code/blob/629de0bac4f36cfc6534e409a6f6766a2240992f/client/src/yaml-support/yaml-schema.ts#L39-L51
-    if (rv.template.AWSTemplateFormatVersion || rv.template.Resources) {
+    if (rv.template?.AWSTemplateFormatVersion || rv.template?.Resources) {
         rv.kind =
-            rv.template.Transform && rv.template.Transform.toString().startsWith('AWS::Serverless') ? 'sam' : 'cfn'
+            rv.template?.Transform && rv.template.Transform.toString().startsWith('AWS::Serverless') ? 'sam' : 'cfn'
 
         return rv
     }


### PR DESCRIPTION
## Problem

`js-yaml` can parse JSON, but a JSON string without braces (such as an empty JSON file) will return undefined. 

## Solution

This adds null checks so that we don't try to access members of a `null` or `undefined` parsed template.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
