### PR TITLE
test: get better understanding of flaky test

### DIFF
--- a/packages/toolkit/src/test/srcShared/fs.test.ts
+++ b/packages/toolkit/src/test/srcShared/fs.test.ts
@@ -176,7 +176,7 @@ describe('FileSystem', function () {
                 await fsCommon.mkdir(dirPath)
 
                 assert(existsSync(dirPath))
-                assert.strictEqual(mkdirSpy.callCount, 1)
+                assert.deepStrictEqual(mkdirSpy.args, [[dirPath, { recursive: true }]])
             })
         })
     })


### PR DESCRIPTION
## Problem

This test is flaky and sometimes fails in CI where the spy shows that the method was invoked 2 times, when it should have been 1 time.

#4390 

## Solution

Instead test against the actual args and then we should hopefully get more information regarding who is causing the second call.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
