### PR TITLE
Amazon Q: update FQN extractor

### DIFF
--- a/.changes/next-release/Bug Fix-3c1e992b-b24d-418d-a91b-a0cf4d2e7b66.json
+++ b/.changes/next-release/Bug Fix-3c1e992b-b24d-418d-a91b-a0cf4d2e7b66.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Static analysis of document symbols used as context in Q requests must filter tree-sitter \"extra\" CST nodes (comments) in order to avoid crashes which freeze the Q chat panel"
+	"description": "Amazon Q: Static analysis of document symbols used as context in Amazon Q requests must filter tree-sitter \"extra\" CST nodes (comments) in order to avoid crashes which freeze the chat panel"
 }

--- a/.changes/next-release/Bug Fix-3c1e992b-b24d-418d-a91b-a0cf4d2e7b66.json
+++ b/.changes/next-release/Bug Fix-3c1e992b-b24d-418d-a91b-a0cf4d2e7b66.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Static analysis of document symbols used as context in Q requests must filter tree-sitter \"extra\" CST nodes (comments) in order to avoid crashes which freeze the Q chat panel"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3598,12 +3598,12 @@
             }
         },
         "node_modules/@aws/fully-qualified-names": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@aws/fully-qualified-names/-/fully-qualified-names-2.1.2.tgz",
-            "integrity": "sha512-65i/ev55qoWweMiwgjz1hkZxKBTZ51pYTav6CQ0GlpzPAdAxRYSmFlsMvFIEDb5PlXQ7XuTtRcuANEU5TDc3Qw==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@aws/fully-qualified-names/-/fully-qualified-names-2.1.4.tgz",
+            "integrity": "sha512-+fR0mMvfRwde6wwbyF69igeIzqQx7g/HCfjt6Mi6D6MblU538gmJl29EKxJcRXhDFolH20sXbtMosbyMIRhs2w==",
             "dev": true,
             "dependencies": {
-                "web-tree-sitter": "^0.20.7"
+                "web-tree-sitter": "^0.20.8"
             }
         },
         "node_modules/@aws/mynah-ui": {
@@ -18815,7 +18815,7 @@
                 "vscode-languageserver-protocol": "^3.15.3",
                 "vscode-languageserver-textdocument": "^1.0.8",
                 "vue": "^3.3.4",
-                "web-tree-sitter": "^0.20.7",
+                "web-tree-sitter": "^0.20.8",
                 "whatwg-url": "^14.0.0",
                 "winston": "^3.11.0",
                 "winston-transport": "^4.6.0",
@@ -18825,7 +18825,7 @@
             "devDependencies": {
                 "@aws-sdk/types": "^3.13.1",
                 "@aws-toolkits/telemetry": "^1.0.190",
-                "@aws/fully-qualified-names": "^2.1.1",
+                "@aws/fully-qualified-names": "^2.1.4",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^10.0.2",
                 "@types/adm-zip": "^0.4.34",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -4272,7 +4272,7 @@
     "devDependencies": {
         "@aws-sdk/types": "^3.13.1",
         "@aws-toolkits/telemetry": "^1.0.190",
-        "@aws/fully-qualified-names": "^2.1.1",
+        "@aws/fully-qualified-names": "^2.1.4",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/adm-zip": "^0.4.34",
@@ -4375,7 +4375,7 @@
         "vscode-languageserver-protocol": "^3.15.3",
         "vscode-languageserver-textdocument": "^1.0.8",
         "vue": "^3.3.4",
-        "web-tree-sitter": "^0.20.7",
+        "web-tree-sitter": "^0.20.8",
         "whatwg-url": "^14.0.0",
         "winston": "^3.11.0",
         "winston-transport": "^4.6.0",


### PR DESCRIPTION
## Problem

The previous version of FQN extraction contains some subtle bugs, which lead to crashes on syntax elements like line continuations in Python.

## Solution

Updating to the latest version fixes those.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
