### PR TITLE
fix: "Failed to access settings" when restarting multiple vscode instances

### DIFF
--- a/.changes/next-release/Bug Fix-ae8ef2c1-9969-45f9-bda9-0249ee124c46.json
+++ b/.changes/next-release/Bug Fix-ae8ef2c1-9969-45f9-bda9-0249ee124c46.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "\"Failed to access settings\" error when restarting multiple vscode instances"
+}

--- a/packages/core/src/shared/sam/cli/samCliDetection.ts
+++ b/packages/core/src/shared/sam/cli/samCliDetection.ts
@@ -37,14 +37,12 @@ export async function detectSamCli(args: { passive: boolean; showMessage: boolea
     // conflicts with VSCode "remote": each VSCode instance will update the
     // setting based on its local environment, but the user settings are
     // shared across VSCode instances...
-    if (!args.passive && sam.autoDetected && sam.path) {
-        await config.update('location', sam.path)
-    }
+    const update = !args.passive && sam.autoDetected && sam.path && (await config.update('location', sam.path))
 
     if (args.showMessage !== false || !found) {
         if (!found) {
             notifyUserSamCliNotDetected(config)
-        } else if (args.showMessage === true) {
+        } else if (update && args.showMessage === true) {
             void vscode.window.showInformationMessage(getSettingsUpdatedMessage(sam.path ?? '?'))
         }
     }

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -110,12 +110,14 @@ export class Settings {
      * `vscode.ConfigurationTarget.Workspace` target requires a workspace).
      */
     public async update(key: string, value: unknown): Promise<boolean> {
+        const config = this.getConfig()
         try {
-            await this.getConfig().update(key, value, this.updateTarget)
+            await config.update(key, value, this.updateTarget)
 
             return true
         } catch (e) {
-            showSettingsUpdateFailedMsgOnce(key)
+            const fqkey = config.inspect(key)?.key
+            showSettingsUpdateFailedMsgOnce(fqkey ?? key)
             getLogger().warn('settings: failed to update "%s": %s', key, (e as Error).message)
 
             return false

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -40,7 +40,7 @@ export async function showSettingsFailedMsg(kind: 'read' | 'update', key?: strin
 }
 
 /**
- * Shows an error message if we could't update settings, unless the last message was for the same `key`.
+ * Shows an error message if we couldn't update settings, unless the last message was for the same `key`.
  */
 const showSettingsUpdateFailedMsgOnce = onceChanged(key => {
     // Edge cases:
@@ -116,9 +116,9 @@ export class Settings {
 
             return true
         } catch (e) {
-            const fullKey = config.inspect(key)?.key
+            const fullKey = config.inspect(key)?.key ?? key
             getLogger().warn('settings: failed to update "%s": %s', fullKey, (e as Error).message)
-            showSettingsUpdateFailedMsgOnce(fullKey ?? key)
+            showSettingsUpdateFailedMsgOnce(fullKey)
 
             return false
         }

--- a/packages/core/src/shared/settings.ts
+++ b/packages/core/src/shared/settings.ts
@@ -116,9 +116,9 @@ export class Settings {
 
             return true
         } catch (e) {
-            const fqkey = config.inspect(key)?.key
-            showSettingsUpdateFailedMsgOnce(fqkey ?? key)
-            getLogger().warn('settings: failed to update "%s": %s', key, (e as Error).message)
+            const fullKey = config.inspect(key)?.key
+            getLogger().warn('settings: failed to update "%s": %s', fullKey, (e as Error).message)
+            showSettingsUpdateFailedMsgOnce(fullKey ?? key)
 
             return false
         }
@@ -338,7 +338,8 @@ function createSettingsClass<T extends TypeDescriptor>(section: string, descript
 
                 return true
             } catch (e) {
-                showSettingsUpdateFailedMsgOnce(key)
+                const fullKey = `${section}.${key}`
+                showSettingsUpdateFailedMsgOnce(fullKey)
                 this._log('failed to update "%s": %s', key, (e as Error).message)
 
                 return false
@@ -351,7 +352,8 @@ function createSettingsClass<T extends TypeDescriptor>(section: string, descript
 
                 return true
             } catch (e) {
-                showSettingsUpdateFailedMsgOnce(key)
+                const fullKey = `${section}.${key}`
+                showSettingsUpdateFailedMsgOnce(fullKey)
                 this._log('failed to delete "%s": %s', key, (e as Error).message)
 
                 return false

--- a/packages/core/src/test/shared/settingsConfiguration.test.ts
+++ b/packages/core/src/test/shared/settingsConfiguration.test.ts
@@ -136,6 +136,9 @@ describe('Settings', function () {
                     // Do nothing (success).
                     // (fakeSettings as any)[key] = val
                 },
+                inspect: (key: string) => {
+                    return {}
+                },
             } as unknown as vscode.WorkspaceConfiguration
             sinon.stub(vscode.workspace, 'getConfiguration').returns(fake)
 

--- a/packages/core/src/test/shared/settingsConfiguration.test.ts
+++ b/packages/core/src/test/shared/settingsConfiguration.test.ts
@@ -6,11 +6,19 @@
 import assert from 'assert'
 import * as sinon from 'sinon'
 import * as vscode from 'vscode'
-import { DevSettings, Experiments, fromExtensionManifest, PromptSettings, Settings } from '../../shared/settings'
+import {
+    DevSettings,
+    Experiments,
+    fromExtensionManifest,
+    PromptSettings,
+    Settings,
+    testSetting,
+} from '../../shared/settings'
 import { TestSettings } from '../utilities/testSettingsConfiguration'
 import { ClassToInterfaceType } from '../../shared/utilities/tsUtils'
 import { Optional } from '../../shared/utilities/typeConstructors'
 import { ToolkitError } from '../../shared/errors'
+import { getTestWindow } from './vscode/window'
 
 const settingsTarget = vscode.ConfigurationTarget.Workspace
 
@@ -46,10 +54,13 @@ describe('Settings', function () {
         // Note: we don't test undefined because retrieval returns the package.json configured default value, if there is one
     ]
 
-    it('isValid()', async () => {
+    it('isReadable()', async () => {
         // TODO: could avoid sinon if we can force vscode to use a dummy settings.json file.
         const fake = {
-            get: async () => {
+            get: (key: string) => {
+                if (key === testSetting) {
+                    throw Error()
+                }
                 return 'setting-value'
             },
             update: async () => {
@@ -58,17 +69,7 @@ describe('Settings', function () {
         } as unknown as vscode.WorkspaceConfiguration
         sinon.stub(vscode.workspace, 'getConfiguration').returns(fake)
 
-        assert.deepStrictEqual(await sut.isValid(), 'invalid')
-
-        fake.update = async () => {
-            throw Error('EACCES')
-        }
-        assert.deepStrictEqual(await sut.isValid(), 'nowrite')
-
-        fake.update = async () => {
-            throw Error('xxx the file has unsaved changes xxx')
-        }
-        assert.deepStrictEqual(await sut.isValid(), 'nowrite')
+        assert.deepStrictEqual(await sut.isReadable(), false)
     })
 
     describe('get', function () {
@@ -121,6 +122,40 @@ describe('Settings', function () {
 
                 assert.deepStrictEqual(savedValue, scenario.testValue)
             })
+        })
+
+        it('shows message on failure', async () => {
+            // TODO: could avoid sinon if we can force vscode to use a dummy settings.json file.
+            // const fakeSettings = {}
+            const fake = {
+                lastValue: 'x',
+                get: (key: string) => {
+                    return `${key}-value`
+                },
+                update: async (key: string, val: any) => {
+                    // Do nothing (success).
+                    // (fakeSettings as any)[key] = val
+                },
+            } as unknown as vscode.WorkspaceConfiguration
+            sinon.stub(vscode.workspace, 'getConfiguration').returns(fake)
+
+            assert.deepStrictEqual(await sut.update(testSetting, 91234), true)
+            // No errors.
+            assert.deepStrictEqual(getTestWindow().shownMessages.length, 0)
+
+            fake.update = async () => {
+                throw Error('EACCES')
+            }
+            assert.deepStrictEqual(await sut.update(testSetting, 91234), false)
+            getTestWindow()
+                .getFirstMessage()
+                .assertError(
+                    `Failed to update settings (key: "${testSetting}"). Check settings.json for syntax errors or insufficient permissions.`
+                )
+
+            // Message skipped for duplicate error.
+            assert.deepStrictEqual(await sut.update(testSetting, 91234), false)
+            assert.deepStrictEqual(getTestWindow().shownMessages.length, 1)
         })
     })
 

--- a/packages/core/src/test/utilities/testSettingsConfiguration.ts
+++ b/packages/core/src/test/utilities/testSettingsConfiguration.ts
@@ -48,8 +48,8 @@ export class TestSettings implements ClassToInterfaceType<Settings> {
         return !type || value === undefined ? value : cast(value, type)
     }
 
-    public async isValid(): Promise<'ok' | 'invalid' | 'nowrite'> {
-        return 'ok'
+    public async isReadable(): Promise<boolean> {
+        return true
     }
 
     public async update(key: string, value: unknown): Promise<boolean> {


### PR DESCRIPTION
## Problem:
Shutdown-and-restart VS Code with multiple windows opened, causes AWS Toolkit to show a "Failed to access settings" error. #4453

### Steps to reproduce:
1. open a bunch of different vscode instances/workspaces.
2. close all vscode instances.
3. start vscode (which resumes all the previously-closed instances).

## Solution:
Verifying settings on startup causes too many problems, so drop it in favor of verifying just-in-time.

<img width="532" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/55561878/705669c9-852e-4c16-8fa8-614384a8c47f">




<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
