### PR TITLE
fix(CodeTransform): show link to docs after errors

### DIFF
--- a/.changes/next-release/Feature-29b29159-d661-4ffe-ae03-2f5473dd6dec.json
+++ b/.changes/next-release/Feature-29b29159-d661-4ffe-ae03-2f5473dd6dec.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Amazon Q CodeTransform: show link to documentation after errors"
+}

--- a/packages/toolkit/src/codewhisperer/models/constants.ts
+++ b/packages/toolkit/src/codewhisperer/models/constants.ts
@@ -274,18 +274,18 @@ export const newCustomizationMessage = 'You have access to new CodeWhisperer cus
 
 export const newCustomizationAvailableKey = 'CODEWHISPERER_NEW_CUSTOMIZATION_AVAILABLE'
 
-// Transform by Q
+// Amazon Q CodeTransformation
 
 export const selectProjectPrompt = 'Select the project you want to transform'
 
 export const unsupportedJavaVersionSelectedMessage =
-    'Thank you for trying our product. We currently only support Java 8 and 11. We appreciate you taking the time to use the product, and hope to expand support to more Java versions in the future. Please see: https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html'
+    'Thank you for trying our product. We currently only support Java 8 and 11. We appreciate you taking the time to use the product, and hope to expand support to more Java versions in the future. Please see: https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html#prerequisites'
 
 export const transformByQWindowTitle = 'Amazon Q Code Transformation'
 
-export const stopTransformByQMessage = 'Stop Transformation?'
+export const stopTransformByQMessage = 'Stop transformation?'
 
-export const stoppingTransformByQMessage = 'Stopping Transformation...'
+export const stoppingTransformByQMessage = 'Stopping transformation...'
 
 export const transformByQFailedMessage = 'Transformation failed'
 
@@ -296,10 +296,10 @@ export const transformByQCompletedMessage = 'Transformation completed'
 export const transformByQPartiallyCompletedMessage = 'Transformation partially completed'
 
 export const noPomXmlFoundMessage =
-    'None of your open Java projects are supported by Amazon Q Code Transformation. We were unable to find a pom.xml in any of your Java projects. We only support Java projects built on Maven at the moment. Please see: https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html'
+    'None of your open Java projects are supported by Amazon Q Code Transformation. We were unable to find a pom.xml in any of your Java projects. We only support Java projects built on Maven at the moment. Please see: https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html#prerequisites'
 
 export const noActiveIdCMessage =
-    'Amazon Q Code Transformation requires an active IAM Identity Center connection. Please see: https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html'
+    'Amazon Q Code Transformation requires an active IAM Identity Center connection. Please see: https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html#prerequisites'
 
 export const noOngoingJobMessage = 'No job is in-progress at the moment'
 
@@ -309,7 +309,14 @@ export const cancellationInProgressMessage = 'Cancellation is in-progress'
 
 export const errorStoppingJobMessage = 'Error stopping job'
 
-export const errorDownloadingDiffMessage = 'Amazon Q Code Transformation experienced an error when downloading the diff'
+export const errorDownloadingDiffMessage =
+    'Amazon Q Code Transformation experienced an error when downloading the diff. Please see: https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/troubleshooting-code-transformation.html#w24aac14c20c19c11'
+
+export const errorDeserializingDiffMessage =
+    'Amazon Q Code Transformation experienced an error during the deserialization of the downloaded result archive. Please see: https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/troubleshooting-code-transformation.html#w24aac14c20c19c11'
+
+export const buildLogsDocumentationMessage =
+    'Please also see https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/troubleshooting-code-transformation.html#w24aac14c20c19b7'
 
 export const viewProposedChangesMessage =
     'Transformation job completed. You can view the transformation summary along with the proposed changes and accept or reject them in the Proposed Changes panel.'
@@ -317,18 +324,16 @@ export const viewProposedChangesMessage =
 export const changesAppliedMessage = 'Changes applied'
 
 export const noSupportedJavaProjectsFoundMessage =
-    'None of your open projects are supported by Amazon Q Code Transformation. We were unable to find a Java project. We only support Java projects built on Maven at the moment. Please see: https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html'
+    'None of your open projects are supported by Amazon Q Code Transformation. We were unable to find a Java project. We only support Java projects built on Maven at the moment. Please see: https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html#prerequisites'
 
 export const dependencyDisclaimer =
     'Please confirm you are ready to proceed with the transformation. Amazon Q Code Transformation will upload the application code and its dependency binaries from your machine to start the upgrade. If you have not yet compiled the application on your local machine, please do so once before starting the upgrade. Install Maven to ensure all module dependencies are picked for Transformation.'
 
 export const dependencyFolderName = 'transformation_dependencies_temp_'
 
-export const installErrorMessage =
-    'Failed to execute Maven install. Please see: https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html'
+export const installErrorMessage = 'Failed to execute Maven install.'
 
-export const dependencyErrorMessage =
-    'Failed to execute Maven copy-dependencies. Please see: https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html'
+export const dependencyErrorMessage = 'Failed to execute Maven copy-dependencies.'
 
 export const planIntroductionMessage =
     'We reviewed your Java JAVA_VERSION_HERE application and generated a transformation plan. Any code changes made to your application will be done in the sandbox so as to not interfere with your working repository. Once the transformation job is done, we will share the new code which you can review before acccepting the code changes. In the meantime, you can work on your codebase and invoke Q Chat to answer questions about your codebase.'
@@ -347,7 +352,7 @@ export const nonWindowsJava11HomeHelpMessage =
     'Try running "/usr/libexec/java_home -v 11" in a terminal to find this. It should look something like "/Library/Java/JavaVirtualMachines/jdk-11.jdk/Contents/Home"'
 
 export const projectSizeTooLargeMessage =
-    'Your project size exceeds the Amazon Q Code Transformation upload limit of 1GB. Please see: https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html'
+    'Your project size exceeds the Amazon Q Code Transformation upload limit of 1GB. Please see: https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/code-transformation.html#prerequisites'
 
 export const JDK8VersionNumber = '52'
 

--- a/packages/toolkit/src/codewhisperer/models/model.ts
+++ b/packages/toolkit/src/codewhisperer/models/model.ts
@@ -281,7 +281,7 @@ export class TransformByQState {
 
     private polledJobStatus: string = ''
 
-    private jobFailureReason: string = ''
+    private jobFailureMetadata: string = ''
 
     private payloadFilePath: string = ''
 
@@ -361,8 +361,8 @@ export class TransformByQState {
         return this.projectCopyFilePath
     }
 
-    public getJobFailureReason() {
-        return this.jobFailureReason
+    public getJobFailureMetadata() {
+        return this.jobFailureMetadata
     }
 
     public getPayloadFilePath() {
@@ -453,8 +453,8 @@ export class TransformByQState {
         this.projectCopyFilePath = filePath
     }
 
-    public setJobFailureReason(reason: string) {
-        this.jobFailureReason = reason
+    public setJobFailureMetadata(data: string) {
+        this.jobFailureMetadata = data
     }
 
     public setPayloadFilePath(payloadFilePath: string) {

--- a/packages/toolkit/src/codewhisperer/service/transformByQHandler.ts
+++ b/packages/toolkit/src/codewhisperer/service/transformByQHandler.ts
@@ -14,7 +14,7 @@ import * as fs from 'fs-extra'
 import * as path from 'path'
 import * as os from 'os'
 import * as vscode from 'vscode'
-import { spawnSync } from 'child_process' // TO-DO: consider using ChildProcess once we finalize all spawnSync calls
+import { spawnSync } from 'child_process' // Consider using ChildProcess once we finalize all spawnSync calls
 import AdmZip from 'adm-zip'
 import globals from '../../shared/extensionGlobals'
 import { CodeTransformMavenBuildCommand, telemetry } from '../../shared/telemetry/telemetry'
@@ -24,7 +24,7 @@ import { calculateTotalLatency, javapOutputToTelemetryValue } from '../../amazon
 import { MetadataResult } from '../../shared/telemetry/telemetryClient'
 import request from '../../common/request'
 
-/* TODO: once supported in all browsers and past "experimental" mode, use Intl DurationFormat:
+/* Once supported in all browsers and past "experimental" mode, use Intl DurationFormat:
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DurationFormat#browser_compatibility
  * Current functionality: given number of milliseconds elapsed (ex. 4,500,000) return hr / min / sec it represents (ex. 1 hr 15 min)
  */
@@ -232,7 +232,7 @@ export function getHeadersObj(sha256: string, kmsKeyArn: string | undefined) {
     return headersObj
 }
 
-// TODO: later, consider enhancing the S3 client to include this functionality
+// Consider enhancing the S3 client to include this functionality
 export async function uploadArtifactToS3(fileName: string, resp: CreateUploadUrlResponse) {
     const sha256 = getSha256(fileName)
     const headersObj = getHeadersObj(sha256, resp.kmsKeyArn)

--- a/packages/toolkit/src/codewhisperer/service/transformByQHandler.ts
+++ b/packages/toolkit/src/codewhisperer/service/transformByQHandler.ts
@@ -255,7 +255,7 @@ export async function uploadArtifactToS3(fileName: string, resp: CreateUploadUrl
         getLogger().info(`CodeTransformation: Status from S3 Upload = ${response.status}`)
     } catch (e: any) {
         const errorMessage = (e as Error).message ?? 'Error in S3 UploadZip API call'
-        getLogger().error('CodeTransformation: UploadZip error = ', errorMessage)
+        getLogger().error(`CodeTransformation: UploadZip error = ${errorMessage}`)
         telemetry.codeTransform_logApiError.emit({
             codeTransformApiNames: 'UploadZip',
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
@@ -285,10 +285,14 @@ export async function stopJob(jobId: string) {
                     codeTransformRequestId: response.$response.requestId,
                     result: MetadataResult.Pass,
                 })
+                // always store request ID, but it will only show up in a notification if an error occurs
+                if (response.$response.requestId) {
+                    transformByQState.setJobFailureMetadata(`(request ID: ${response.$response.requestId})`)
+                }
             }
         } catch (e: any) {
             const errorMessage = (e as Error).message ?? 'Error stopping job'
-            getLogger().error('CodeTransformation: StopTransformation error = ', errorMessage)
+            getLogger().error(`CodeTransformation: StopTransformation error = ${errorMessage}`)
             telemetry.codeTransform_logApiError.emit({
                 codeTransformApiNames: 'StopTransformation',
                 codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
@@ -314,6 +318,9 @@ export async function uploadPayload(payloadFileName: string) {
             contentChecksumType: CodeWhispererConstants.contentChecksumType,
             uploadIntent: CodeWhispererConstants.uploadIntent,
         })
+        if (response.$response.requestId) {
+            transformByQState.setJobFailureMetadata(`(request ID: ${response.$response.requestId})`)
+        }
         telemetry.codeTransform_logApiLatency.emit({
             codeTransformApiNames: 'CreateUploadUrl',
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
@@ -324,7 +331,7 @@ export async function uploadPayload(payloadFileName: string) {
         })
     } catch (e: any) {
         const errorMessage = (e as Error).message ?? 'Error in CreateUploadUrl API call'
-        getLogger().error('CodeTransformation: CreateUploadUrl error: = ', errorMessage)
+        getLogger().error(`CodeTransformation: CreateUploadUrl error: = ${errorMessage}`)
         telemetry.codeTransform_logApiError.emit({
             codeTransformApiNames: 'CreateUploadUrl',
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
@@ -340,7 +347,7 @@ export async function uploadPayload(payloadFileName: string) {
         await uploadArtifactToS3(payloadFileName, response)
     } catch (e: any) {
         const errorMessage = (e as Error).message ?? 'Error in uploadArtifactToS3 call'
-        getLogger().error('CodeTransformation: UploadArtifactToS3 error: = ', errorMessage)
+        getLogger().error(`CodeTransformation: UploadArtifactToS3 error: = ${errorMessage}`)
         throw new ToolkitError(errorMessage, { cause: e as Error })
     }
     return response.uploadId
@@ -513,7 +520,8 @@ function copyProjectDependencies(): string[] {
 
 export async function writeLogs() {
     const logFilePath = path.join(os.tmpdir(), 'build-logs.txt')
-    fs.writeFileSync(logFilePath, transformByQState.getErrorLog())
+    const content = `${CodeWhispererConstants.buildLogsDocumentationMessage}\n\n${transformByQState.getErrorLog()}`
+    fs.writeFileSync(logFilePath, content)
     return logFilePath
 }
 
@@ -634,6 +642,9 @@ export async function startJob(uploadId: string) {
                 target: { language: targetLanguageVersion },
             },
         })
+        if (response.$response.requestId) {
+            transformByQState.setJobFailureMetadata(`(request ID: ${response.$response.requestId})`)
+        }
         telemetry.codeTransform_logApiLatency.emit({
             codeTransformApiNames: 'StartTransformation',
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
@@ -645,7 +656,7 @@ export async function startJob(uploadId: string) {
         return response.transformationJobId
     } catch (e: any) {
         const errorMessage = (e as Error).message ?? 'Error in StartTransformation API call'
-        getLogger().error('CodeTransformation: StartTransformation error = ', errorMessage)
+        getLogger().error(`CodeTransformation: StartTransformation error = ${errorMessage}`)
         telemetry.codeTransform_logApiError.emit({
             codeTransformApiNames: 'StartTransformation',
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
@@ -670,6 +681,9 @@ export async function getTransformationPlan(jobId: string) {
         const response = await codeWhisperer.codeWhispererClient.codeModernizerGetCodeTransformationPlan({
             transformationJobId: jobId,
         })
+        if (response.$response.requestId) {
+            transformByQState.setJobFailureMetadata(`(request ID: ${response.$response.requestId})`)
+        }
         telemetry.codeTransform_logApiLatency.emit({
             codeTransformApiNames: 'GetTransformationPlan',
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
@@ -682,7 +696,7 @@ export async function getTransformationPlan(jobId: string) {
             path.join('resources', 'icons', 'aws', 'amazonq', 'transform-landing-page-icon.svg')
         )
         const logoBase64 = getImageAsBase64(logoAbsolutePath)
-        let plan = `![Transform by Q](${logoBase64}) \n # Code Transformation Plan by Amazon Q \n\n`
+        let plan = `![Amazon Q Code Transformation](${logoBase64}) \n # Code Transformation Plan by Amazon Q \n\n`
         plan += CodeWhispererConstants.planIntroductionMessage.replace(
             'JAVA_VERSION_HERE',
             transformByQState.getSourceJDKVersion()!
@@ -696,7 +710,7 @@ export async function getTransformationPlan(jobId: string) {
         return plan
     } catch (e: any) {
         const errorMessage = (e as Error).message ?? 'Error in GetTransformationPlan API call'
-        getLogger().error('CodeTransformation: GetTransformationPlan error = ', errorMessage)
+        getLogger().error(`CodeTransformation: GetTransformationPlan error = ${errorMessage}`)
         telemetry.codeTransform_logApiError.emit({
             codeTransformApiNames: 'GetTransformationPlan',
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
@@ -718,6 +732,9 @@ export async function getTransformationSteps(jobId: string) {
         const response = await codeWhisperer.codeWhispererClient.codeModernizerGetCodeTransformationPlan({
             transformationJobId: jobId,
         })
+        if (response.$response.requestId) {
+            transformByQState.setJobFailureMetadata(`(request ID: ${response.$response.requestId})`)
+        }
         telemetry.codeTransform_logApiLatency.emit({
             codeTransformApiNames: 'GetTransformationPlan',
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
@@ -729,7 +746,7 @@ export async function getTransformationSteps(jobId: string) {
         return response.transformationPlan.transformationSteps
     } catch (e: any) {
         const errorMessage = (e as Error).message ?? 'Error in GetTransformationPlan API call'
-        getLogger().error('CodeTransformation: GetTransformationPlan error = ', errorMessage)
+        getLogger().error(`CodeTransformation: GetTransformationPlan error = ${errorMessage}`)
         telemetry.codeTransform_logApiError.emit({
             codeTransformApiNames: 'GetTransformationPlan',
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
@@ -762,13 +779,7 @@ export async function pollTransformationJob(jobId: string, validStates: string[]
                 result: MetadataResult.Pass,
             })
             status = response.transformationJob.status!
-            if (response.transformationJob.reason) {
-                transformByQState.setJobFailureReason(
-                    `${response.transformationJob.reason} (request ID: ${response.$response.requestId})`
-                )
-            }
-            // Conditional check to verify when state changes during polling and log
-            // these state changes during transformation
+            // emit metric when job status changes
             if (status !== transformByQState.getPolledJobStatus()) {
                 telemetry.codeTransform_jobStatusChanged.emit({
                     codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
@@ -783,16 +794,19 @@ export async function pollTransformationJob(jobId: string, validStates: string[]
                 break
             }
             if (CodeWhispererConstants.failureStates.includes(status)) {
-                throw new Error('Job failed')
+                transformByQState.setJobFailureMetadata(
+                    `${response.transformationJob.reason} (request ID: ${response.$response.requestId})`
+                )
+                throw new ToolkitError('Transformation job failed')
             }
             await sleep(CodeWhispererConstants.transformationJobPollingIntervalSeconds * 1000)
             timer += CodeWhispererConstants.transformationJobPollingIntervalSeconds
             if (timer > CodeWhispererConstants.transformationJobTimeoutSeconds) {
-                throw new Error('Transform by Q timed out')
+                throw new ToolkitError('Transformation job timed out')
             }
         } catch (e: any) {
             const errorMessage = (e as Error).message ?? 'Error in GetTransformation API call'
-            getLogger().error('CodeTransformation: GetTransformation error = ', errorMessage)
+            getLogger().error(`CodeTransformation: GetTransformation error = ${errorMessage}`)
             telemetry.codeTransform_logApiError.emit({
                 codeTransformApiNames: 'GetTransformation',
                 codeTransformSessionId: codeTransformTelemetryState.getSessionId(),

--- a/packages/toolkit/src/codewhisperer/service/transformationResultsViewProvider.ts
+++ b/packages/toolkit/src/codewhisperer/service/transformationResultsViewProvider.ts
@@ -170,9 +170,9 @@ export class DiffModel {
             },
             complete: function (err) {
                 if (err) {
-                    getLogger().error(`CodeTransform: ${err} when applying patch`)
+                    getLogger().error(`CodeTransformation: ${err} when applying patch`)
                 } else {
-                    getLogger().info('CodeTransform: Patch applied successfully')
+                    getLogger().info('CodeTransformation: Patch applied successfully')
                 }
             },
         })
@@ -327,8 +327,8 @@ export class ProposedTransformationExplorer {
                     'gumby.reviewState',
                     TransformByQReviewStatus.NotStarted
                 )
-                const errorMessage = 'There was a problem fetching the transformed code.'
-                getLogger().error('CodeTransform: ExportResultArchive error = ', errorMessage)
+                const errorMessage = CodeWhispererConstants.errorDownloadingDiffMessage
+                getLogger().error(`CodeTransformation: ExportResultArchive error = ${errorMessage}`)
                 telemetry.codeTransform_logApiError.emit({
                     codeTransformApiNames: 'ExportResultArchive',
                     codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
@@ -378,11 +378,9 @@ export class ProposedTransformationExplorer {
                 void vscode.window.showInformationMessage(CodeWhispererConstants.viewProposedChangesMessage)
                 await vscode.commands.executeCommand('aws.amazonq.transformationHub.summary.reveal')
             } catch (e: any) {
-                deserializeErrorMessage =
-                    (e as Error).message ??
-                    'Transform by Q experienced an error during the deserialization of the downloaded result archive'
-                getLogger().error('CodeTransform: ParseDiff error = ', deserializeErrorMessage)
-                void vscode.window.showErrorMessage(deserializeErrorMessage)
+                deserializeErrorMessage = (e as Error).message ?? CodeWhispererConstants.errorDeserializingDiffMessage
+                getLogger().error(`CodeTransformation: ParseDiff error = ${deserializeErrorMessage}`)
+                void vscode.window.showErrorMessage(CodeWhispererConstants.errorDeserializingDiffMessage)
             } finally {
                 telemetry.codeTransform_jobArtifactDownloadAndDeserializeTime.emit({
                     codeTransformSessionId: codeTransformTelemetryState.getSessionId(),


### PR DESCRIPTION
## Problem

Wanted to clean up our logging / messages, include link to docs when error occurs, and include request ID in error notifications when APIs fail.

## Solution

Implement the above.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
