### PR TITLE
feat(cwspr): Improve percentage code written metrics to include some user multi character input

### DIFF
--- a/.changes/next-release/Feature-742cb7ff-2139-4c0f-9b9e-22d72c960f60.json
+++ b/.changes/next-release/Feature-742cb7ff-2139-4c0f-9b9e-22d72c960f60.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Improve percentage code written metrics to include user multi character input"
+}

--- a/packages/toolkit/src/codewhisperer/service/inlineCompletionItemProvider.ts
+++ b/packages/toolkit/src/codewhisperer/service/inlineCompletionItemProvider.ts
@@ -104,6 +104,7 @@ export class CWInlineCompletionItemProvider implements vscode.InlineCompletionIt
             }
             return undefined
         }
+        TelemetryHelper.instance.lastSuggestionInDisplay = truncatedSuggestion
         return {
             insertText: truncatedSuggestion,
             range: new vscode.Range(start, end),

--- a/packages/toolkit/src/codewhisperer/util/telemetryHelper.ts
+++ b/packages/toolkit/src/codewhisperer/util/telemetryHelper.ts
@@ -48,6 +48,9 @@ export class TelemetryHelper {
     private classifierResult?: number = undefined
     private classifierThreshold?: number = undefined
 
+    // use this to distinguish DocumentChangeEvent from CWSPR or from other sources
+    public lastSuggestionInDisplay = ''
+
     constructor() {}
 
     static #instance: TelemetryHelper

--- a/packages/toolkit/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/toolkit/src/shared/telemetry/vscodeTelemetry.json
@@ -271,6 +271,11 @@
             "name": "cwsprChatCommandName",
             "type": "string",
             "description": "Type of chat command name executed"
+        },
+        {
+            "name": "codewhispererUserInputDetails",
+            "type": "string",
+            "description": "A JSON serialized string of user input details."
         }
     ],
     "metrics": [
@@ -989,6 +994,47 @@
                     "required": false
                 }
             ]
+        },
+        {
+            "name": "codewhisperer_codePercentage",
+            "description": "Percentage of user tokens against suggestions until 5 mins of time",
+            "metadata": [
+                {
+                    "type": "codewhispererAcceptedTokens"
+                },
+                {
+                    "type": "codewhispererLanguage"
+                },
+                {
+                    "type": "codewhispererPercentage"
+                },
+                {
+                    "type": "codewhispererTotalTokens"
+                },
+                {
+                    "type": "codewhispererUserInputDetails",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererUserGroup"
+                },
+                {
+                    "type": "reason",
+                    "required": false
+                },
+                {
+                    "type": "successCount"
+                },
+                {
+                    "type": "codewhispererCustomizationArn",
+                    "required": false
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                }
+            ],
+            "passive": true
         }
     ]
 }

--- a/packages/toolkit/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
+++ b/packages/toolkit/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
@@ -232,7 +232,7 @@ describe('codewhispererCodecoverageTracker', function () {
             CodeWhispererCodeCoverageTracker.instances.clear()
         })
 
-        it('Should skip when content change size is not 1', function () {
+        it('Should skip when content change size is more than 500', function () {
             if (!tracker) {
                 assert.fail()
             }
@@ -241,16 +241,33 @@ describe('codewhispererCodecoverageTracker', function () {
                 document: createMockDocument(),
                 contentChanges: [
                     {
-                        range: new vscode.Range(0, 0, 0, 30),
+                        range: new vscode.Range(0, 0, 0, 600),
                         rangeOffset: 0,
-                        rangeLength: 30,
-                        text: 'def twoSum(nums, target):\nfor',
+                        rangeLength: 600,
+                        text: 'def twoSum(nums, target):\nfor '.repeat(20),
                     },
                 ],
             })
+            assert.strictEqual(Object.keys(tracker.totalTokens).length, 0)
+        })
 
-            const startedSpy = sinon.spy(CodeWhispererCodeCoverageTracker.prototype, 'addTotalTokens')
-            assert.ok(!startedSpy.called)
+        it('Should not skip when content change size is less than 500', function () {
+            if (!tracker) {
+                assert.fail()
+            }
+            tracker.countTotalTokens({
+                reason: undefined,
+                document: createMockDocument(),
+                contentChanges: [
+                    {
+                        range: new vscode.Range(0, 0, 0, 300),
+                        rangeOffset: 0,
+                        rangeLength: 300,
+                        text: 'def twoSum(nums, target):\nfor '.repeat(10),
+                    },
+                ],
+            })
+            assert.strictEqual(tracker.totalTokens['/test.py'], 300)
         })
 
         it('Should skip when CodeWhisperer is editing', function () {

--- a/packages/toolkit/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
+++ b/packages/toolkit/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
@@ -267,7 +267,8 @@ describe('codewhispererCodecoverageTracker', function () {
                     },
                 ],
             })
-            assert.strictEqual(tracker.totalTokens['/test.py'], 300)
+            assert.strictEqual(Object.keys(tracker.totalTokens).length, 1)
+            assert.strictEqual(Object.values(tracker.totalTokens)[0], 300)
         })
 
         it('Should skip when CodeWhisperer is editing', function () {

--- a/packages/toolkit/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
+++ b/packages/toolkit/src/test/codewhisperer/tracker/codewhispererCodeCoverageTracker.test.ts
@@ -263,7 +263,7 @@ describe('codewhispererCodecoverageTracker', function () {
                         range: new vscode.Range(0, 0, 0, 300),
                         rangeOffset: 0,
                         rangeLength: 300,
-                        text: 'def twoSum(nums, target):\nfor '.repeat(10),
+                        text: 'def twoSum(nums, target): for '.repeat(10),
                     },
                 ],
             })


### PR DESCRIPTION
## Problem

Previously when we count user written code we only count user keystroke input, which contributes to a higher than expected % code written metric.

However, if we include all multi character user inputs from copy & paste or other sources, the % code written metric will be very low, providing little value to customers.

We discovered that if a user copy a large file, it will generate huge total user input, which is not what we want to track. Instead, small user multi character input are indeed considered as user written code. For example, copy code snippet from Stackoverflow, copy another function signature, accepting IntelliSense suggestion, etc.

## Solution

1. Add multi char user input less than 500 as total user written code. We believe 500 is a good middle ground to begin with. 
2. Add temporary telemetry field to also report the user multi char input for different thresholds, we will use this data to adjust the cut off threshold. (these code is meant to be removed in the future once we finalize the threshold)


This one-off data collection is VS Code only, once the threshold is finalized, JetBrains toolkit will adopt same threshold. Therefore the telemetry changes are checked in to the override.json

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
