### PR TITLE
fix(toolkit): Improve text description in login page

### DIFF
--- a/.changes/next-release/Feature-e6bbf14f-90d8-4b30-8e63-7ff522fd855a.json
+++ b/.changes/next-release/Feature-e6bbf14f-90d8-4b30-8e63-7ff522fd855a.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Improve text description in login page"
+}

--- a/.changes/next-release/Feature-e6bbf14f-90d8-4b30-8e63-7ff522fd855a.json
+++ b/.changes/next-release/Feature-e6bbf14f-90d8-4b30-8e63-7ff522fd855a.json
@@ -1,4 +1,4 @@
 {
 	"type": "Feature",
-	"description": "Improve text description in login page"
+	"description": "UI: Improve text description in login page"
 }

--- a/packages/toolkit/src/auth/ui/vue/authForms/manageBuilderId.vue
+++ b/packages/toolkit/src/auth/ui/vue/authForms/manageBuilderId.vue
@@ -170,7 +170,9 @@ abstract class BaseBuilderIdState implements AuthForm {
      */
     async getSubmitButtonText(): Promise<string> {
         if (!(await this.anyBuilderIdConnected())) {
-            return 'Use for free with AWS Builder ID'
+            return this.name === 'CodeWhisperer'
+                ? 'Use for free, no AWS Account required'
+                : 'Use for free with AWS Builder ID'
         } else {
             return `Connect AWS Builder ID with ${this.name}`
         }

--- a/packages/toolkit/src/auth/ui/vue/authForms/manageBuilderId.vue
+++ b/packages/toolkit/src/auth/ui/vue/authForms/manageBuilderId.vue
@@ -170,7 +170,7 @@ abstract class BaseBuilderIdState implements AuthForm {
      */
     async getSubmitButtonText(): Promise<string> {
         if (!(await this.anyBuilderIdConnected())) {
-            return 'Use for free with AWS Builder ID'
+            return 'Use for free, no AWS Account required'
         } else {
             return `Connect AWS Builder ID with ${this.name}`
         }

--- a/packages/toolkit/src/auth/ui/vue/authForms/manageBuilderId.vue
+++ b/packages/toolkit/src/auth/ui/vue/authForms/manageBuilderId.vue
@@ -170,7 +170,7 @@ abstract class BaseBuilderIdState implements AuthForm {
      */
     async getSubmitButtonText(): Promise<string> {
         if (!(await this.anyBuilderIdConnected())) {
-            return 'Use for free, no AWS Account required'
+            return 'Use for free with AWS Builder ID'
         } else {
             return `Connect AWS Builder ID with ${this.name}`
         }

--- a/packages/toolkit/src/auth/ui/vue/authForms/manageIdentityCenter.vue
+++ b/packages/toolkit/src/auth/ui/vue/authForms/manageIdentityCenter.vue
@@ -150,7 +150,8 @@ export default defineComponent({
             if (this.isConnected && !this.checkIfConnected) {
                 this.buttonText = 'Add an IAM Identity Center profile'
             } else {
-                this.buttonText = 'Sign in with IAM Identity Center (SSO)'
+                this.buttonText =
+                    this.authName === 'CodeWhisperer' ? 'Use Professional License' : 'Use Single Sign-on (SSO)'
             }
         },
         async emitUpdate(cause?: ConnectionUpdateCause) {

--- a/packages/toolkit/src/auth/ui/vue/authForms/manageIdentityCenter.vue
+++ b/packages/toolkit/src/auth/ui/vue/authForms/manageIdentityCenter.vue
@@ -150,8 +150,7 @@ export default defineComponent({
             if (this.isConnected && !this.checkIfConnected) {
                 this.buttonText = 'Add an IAM Identity Center profile'
             } else {
-                this.buttonText =
-                    this.authName === 'CodeWhisperer' ? 'Use Professional License' : 'Use Single Sign-on (SSO)'
+                this.buttonText = this.authName === 'Sign in with IAM Identity Center (SSO)'
             }
         },
         async emitUpdate(cause?: ConnectionUpdateCause) {

--- a/packages/toolkit/src/auth/ui/vue/authForms/manageIdentityCenter.vue
+++ b/packages/toolkit/src/auth/ui/vue/authForms/manageIdentityCenter.vue
@@ -150,7 +150,7 @@ export default defineComponent({
             if (this.isConnected && !this.checkIfConnected) {
                 this.buttonText = 'Add an IAM Identity Center profile'
             } else {
-                this.buttonText = this.authName === 'Sign in with IAM Identity Center (SSO)'
+                this.buttonText = 'Sign in with IAM Identity Center (SSO)'
             }
         },
         async emitUpdate(cause?: ConnectionUpdateCause) {

--- a/packages/toolkit/src/auth/ui/vue/authForms/sharedAuthForms.css
+++ b/packages/toolkit/src/auth/ui/vue/authForms/sharedAuthForms.css
@@ -19,6 +19,14 @@
     flex-direction: column;
 }
 
+.auth-container-section button {
+    font-size: 1.3rem;
+}
+
+.auth-container > div > button {
+    font-size: 1.3rem;
+}
+
 .auth-form-container {
     display: flex;
     flex-direction: column;

--- a/packages/toolkit/src/auth/ui/vue/featurePanel/awsExplorerContent.vue
+++ b/packages/toolkit/src/auth/ui/vue/featurePanel/awsExplorerContent.vue
@@ -1,7 +1,7 @@
 <template>
     <div :id="panelId" class="feature-panel-container border-common" :class="isActive ? 'feature-panel-selected' : ''">
         <div class="feature-panel-container-upper">
-            <div class="feature-panel-container-title">AWS Explorer</div>
+            <div class="feature-panel-container-title">Resource Explorer</div>
 
             <img
                 class="feature-panel-image"

--- a/packages/toolkit/src/auth/ui/vue/featurePanel/codeCatalystContent.vue
+++ b/packages/toolkit/src/auth/ui/vue/featurePanel/codeCatalystContent.vue
@@ -35,6 +35,10 @@
                 ></IdentityCenterForm>
 
                 <button v-if="connectedAuth" v-on:click="showCodeCatalystNode()">Open CodeCatalyst in Toolkit</button>
+                <div v-if="!connectedAuth">
+                    Don't have a CodeCatalyst account?
+                    <a href="https://codecatalyst.aws/onboarding/view">Get started with creating a Space.</a>
+                </div>
             </div>
         </template>
     </div>

--- a/packages/toolkit/src/auth/ui/vue/root.vue
+++ b/packages/toolkit/src/auth/ui/vue/root.vue
@@ -75,7 +75,7 @@
             </div>
         </div>
         <div>
-            <div style="font-size: 1.6rem; font-weight: bold">Sign in to Get Started</div>
+            <div style="font-size: 2.1rem; font-weight: bold">Select a sign-in option to continue:</div>
             <hr style="margin: 1em 0 1em 0; border-color: var(--vscode-textBlockQuote-border)" />
             <div style="display: flex; flex-direction: row; justify-content: space-between; gap: 1em">
                 <CodeWhispererContent

--- a/packages/toolkit/src/auth/ui/vue/root.vue
+++ b/packages/toolkit/src/auth/ui/vue/root.vue
@@ -46,8 +46,8 @@
                     </svg>
                 </div>
                 <div>
-                    <div style="font-size: 1.4rem; font-weight: bold">AWS Toolkit for VS Code</div>
-                    <div style="font-size: 1rem; font-weight: bold">
+                    <div style="font-size: 1.4rem">AWS Toolkit for VS Code</div>
+                    <div style="font-size: 1rem">
                         <a href="https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html"
                             >Documentation</a
                         >

--- a/packages/toolkit/src/auth/ui/vue/root.vue
+++ b/packages/toolkit/src/auth/ui/vue/root.vue
@@ -46,7 +46,7 @@
                     </svg>
                 </div>
                 <div>
-                    <div style="font-size: 1.8rem; font-weight: bold">AWS Toolkit for VS Code</div>
+                    <div style="font-size: 1.4rem; font-weight: bold">AWS Toolkit for VS Code</div>
                     <div style="font-size: 1rem; font-weight: bold">
                         <a href="https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html"
                             >Documentation</a


### PR DESCRIPTION
## Problem
Users are sometimes confused when logging in to aws toolkit. 

## Solution

1. Changed button text for both the builder ID and IAM Identity Center
2. Changed the title of the page to be more descriptive
3. Made the title of the page and the 'AWS Toolkit for VSCode' different sizes so the title stands out more.

<img width="1316" alt="Screenshot 2024-02-28 at 2 48 21 PM" src="https://github.com/aws/aws-toolkit-vscode/assets/97199248/d801b6bd-1e0b-4f80-99f7-d42bb710bc30">

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
