### PR TITLE
fix: build @amzn/codewhisperer-streaming on install instead of during core lib compiling

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4234,7 +4234,7 @@
         "format": "prettier --ignore-path ../../.prettierignore --check src scripts",
         "formatfix": "prettier --ignore-path ../../.prettierignore --write src scripts",
         "lint": "ts-node ./scripts/lint/testLint.ts && npm run format",
-        "generateClients": "npm run build -w @amzn/codewhisperer-streaming && ts-node ./scripts/build/generateServiceClient.ts ",
+        "generateClients": "ts-node ./scripts/build/generateServiceClient.ts ",
         "generatePackage": "ts-node ./scripts/build/generateIcons.ts",
         "generateTelemetry": "node ../../node_modules/@aws-toolkits/telemetry/lib/generateTelemetry.js --extraInput=src/shared/telemetry/vscodeTelemetry.json --output=src/shared/telemetry/telemetry.gen.ts",
         "serve": "webpack serve --config-name vue-hmr --mode development"

--- a/src.gen/@amzn/codewhisperer-streaming/package.json
+++ b/src.gen/@amzn/codewhisperer-streaming/package.json
@@ -3,6 +3,7 @@
     "description": "@amzn/codewhisperer-streaming client",
     "version": "0.0.1",
     "scripts": {
+        "postinstall": "npm run build",
         "build": "concurrently 'npm:build:cjs' 'npm:build:es' 'npm:build:types'",
         "build:cjs": "tsc -p tsconfig.cjs.json",
         "build:docs": "typedoc",


### PR DESCRIPTION
Brand new workspaces will not have src.gen/ compiled, which previously only compiled when compiling the core library. Now it just builds after installing in the workspace.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
