### PR TITLE
build: update extension-id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7015,7 +7015,7 @@
                 "vscode-languageserver-types": "3.17.3"
             }
         },
-        "node_modules/amazonq": {
+        "node_modules/amazon-q-vscode": {
             "resolved": "packages/amazonq",
             "link": true
         },

--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "amazonq",
+    "name": "amazon-q-vscode",
     "displayName": "Amazon Q (Preview) + CodeWhisperer",
     "description": "Amazon Q (Preview) + CodeWhisperer",
     "version": "1.0.0-SNAPSHOT",

--- a/packages/core/src/shared/extensions.ts
+++ b/packages/core/src/shared/extensions.ts
@@ -14,6 +14,7 @@ import { UriHandler } from './vscode/uriHandler'
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const VSCODE_EXTENSION_ID = {
     awstoolkit: 'amazonwebservices.aws-toolkit-vscode',
+    amazonq: 'amazonwebservices.amazon-q-vscode',
     awstoolkitcore: 'amazonwebservices.aws-core-vscode', // Core "extension" for tests - not a real extension.
     python: 'ms-python.python',
     // python depends on jupyter plugin


### PR DESCRIPTION
Problem:
Our extensions for vscode, visual studio, etc., all share a single marketplace org (and thus "publisher" id).

Solution:
Add `-vscode` suffix to disambiguate from other extensions.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
