### PR TITLE
fix(CodeTransform): Updating commands for copying dependencies

### DIFF
--- a/.changes/next-release/Bug Fix-240f643e-f2f5-4a3b-81bf-477f76429423.json
+++ b/.changes/next-release/Bug Fix-240f643e-f2f5-4a3b-81bf-477f76429423.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "fix(CodeTransform): Updating commands for copying dependencies"
+}

--- a/packages/core/src/codewhisperer/service/transformByQHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQHandler.ts
@@ -24,6 +24,11 @@ import { calculateTotalLatency, javapOutputToTelemetryValue } from '../../amazon
 import { MetadataResult } from '../../shared/telemetry/telemetryClient'
 import request from '../../common/request'
 
+interface FolderInfo {
+    path: string
+    name: string
+}
+
 /* Once supported in all browsers and past "experimental" mode, use Intl DurationFormat:
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DurationFormat#browser_compatibility
  * Current functionality: given number of milliseconds elapsed (ex. 4,500,000) return hr / min / sec it represents (ex. 1 hr 15 min)
@@ -383,7 +388,7 @@ function getFilesRecursively(dir: string, isDependenciesFolder: boolean): string
 }
 
 // run 'install' with either 'mvnw.cmd', './mvnw', or 'mvn' (if wrapper exists, we use that, otherwise we use regular 'mvn')
-function installProjectDependencies() {
+function installProjectDependencies(dependenciesFolder: FolderInfo) {
     // baseCommand will be one of: '.\mvnw.cmd', './mvnw', 'mvn'
     const baseCommand = transformByQState.getMavenName()
     const modulePath = transformByQState.getProjectPath()
@@ -391,7 +396,7 @@ function installProjectDependencies() {
     transformByQState.appendToErrorLog(`Running command ${baseCommand} clean install`)
 
     // Note: IntelliJ runs 'clean' separately from 'install'. Evaluate benefits (if any) of this.
-    const args = ['clean', 'install', '-q']
+    const args = [`-Dmaven.repo.local=${dependenciesFolder.path}`, 'clean', 'install']
     let environment = process.env
     // if JAVA_HOME not found or not matching project JDK, get user input for it and set here
     if (transformByQState.getJavaHome() !== undefined) {
@@ -446,11 +451,7 @@ function installProjectDependencies() {
     }
 }
 
-function copyProjectDependencies(): string[] {
-    // Make temp directory
-    const folderName = `${CodeWhispererConstants.dependencyFolderName}${Date.now()}`
-    const folderPath = path.join(os.tmpdir(), folderName)
-
+function copyProjectDependencies(dependenciesFolder: FolderInfo) {
     // baseCommand will be one of: '.\mvnw.cmd', './mvnw', 'mvn'
     const baseCommand = transformByQState.getMavenName()
     const modulePath = transformByQState.getProjectPath()
@@ -459,11 +460,10 @@ function copyProjectDependencies(): string[] {
 
     const args = [
         'dependency:copy-dependencies',
-        '-DoutputDirectory=' + folderPath,
+        `-DoutputDirectory=${dependenciesFolder.path}`,
         '-Dmdep.useRepositoryLayout=true',
         '-Dmdep.copyPom=true',
         '-Dmdep.addParentPoms=true',
-        '-q',
     ]
     let environment = process.env
     // if JAVA_HOME not found or not matching project JDK, get user input for it and set here
@@ -514,8 +514,15 @@ function copyProjectDependencies(): string[] {
     } else {
         transformByQState.appendToErrorLog(`${baseCommand} copy-dependencies succeeded`)
     }
+}
 
-    return [folderPath, folderName]
+function getDependenciesFolderInfo(): FolderInfo {
+    const dependencyFolderName = `${CodeWhispererConstants.dependencyFolderName}${Date.now()}`
+    const dependencyFolderPath = path.join(os.tmpdir(), dependencyFolderName)
+    return {
+        name: dependencyFolderName,
+        path: dependencyFolderPath,
+    }
 }
 
 export async function writeLogs() {
@@ -531,9 +538,18 @@ export async function zipCode() {
     const zipStartTime = Date.now()
     const sourceFolder = modulePath
     const sourceFiles = getFilesRecursively(sourceFolder, false)
+    const dependenciesFolder: FolderInfo = getDependenciesFolderInfo()
 
     try {
-        installProjectDependencies()
+        copyProjectDependencies(dependenciesFolder)
+    } catch (err) {
+        // continue in case of errors
+    }
+
+    throwIfCancelled()
+
+    try {
+        installProjectDependencies(dependenciesFolder)
     } catch (err) {
         void vscode.window.showErrorMessage(CodeWhispererConstants.installErrorMessage)
         // open build-logs.txt file to show user error logs
@@ -542,23 +558,6 @@ export async function zipCode() {
         await vscode.window.showTextDocument(doc)
         throw err
     }
-
-    throwIfCancelled()
-
-    let dependencyFolderInfo: string[] = []
-    try {
-        dependencyFolderInfo = copyProjectDependencies()
-    } catch (err) {
-        void vscode.window.showErrorMessage(CodeWhispererConstants.dependencyErrorMessage)
-        // open build-logs.txt file to show user error logs
-        const logFilePath = await writeLogs()
-        const doc = await vscode.workspace.openTextDocument(logFilePath)
-        await vscode.window.showTextDocument(doc)
-        throw err
-    }
-
-    const dependencyFolderPath = dependencyFolderInfo[0]
-    const dependencyFolderName = dependencyFolderInfo[1]
 
     throwIfCancelled()
 
@@ -574,17 +573,17 @@ export async function zipCode() {
     throwIfCancelled()
 
     let dependencyFiles: string[] = []
-    if (fs.existsSync(dependencyFolderPath)) {
-        dependencyFiles = getFilesRecursively(dependencyFolderPath, true)
+    if (fs.existsSync(dependenciesFolder.path)) {
+        dependencyFiles = getFilesRecursively(dependenciesFolder.path, true)
     }
 
     if (dependencyFiles.length > 0) {
         for (const file of dependencyFiles) {
-            const relativePath = path.relative(dependencyFolderPath, file)
-            const paddedPath = path.join(`dependencies/${dependencyFolderName}`, relativePath)
+            const relativePath = path.relative(dependenciesFolder.path, file)
+            const paddedPath = path.join(`dependencies/${dependenciesFolder.name}`, relativePath)
             zip.addLocalFile(file, path.dirname(paddedPath))
         }
-        zipManifest.dependenciesRoot += `${dependencyFolderName}/`
+        zipManifest.dependenciesRoot += `${dependenciesFolder.name}/`
         telemetry.codeTransform_dependenciesCopied.emit({
             codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
             result: MetadataResult.Pass,
@@ -603,8 +602,8 @@ export async function zipCode() {
 
     const tempFilePath = path.join(os.tmpdir(), 'zipped-code.zip')
     fs.writeFileSync(tempFilePath, zip.toBuffer())
-    if (fs.existsSync(dependencyFolderPath)) {
-        fs.rmSync(dependencyFolderPath, { recursive: true, force: true })
+    if (fs.existsSync(dependenciesFolder.path)) {
+        fs.rmSync(dependenciesFolder.path, { recursive: true, force: true })
     }
     fs.rmSync(logFilePath) // will always exist here
 

--- a/packages/core/src/codewhisperer/service/transformByQHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQHandler.ts
@@ -396,7 +396,7 @@ function installProjectDependencies(dependenciesFolder: FolderInfo) {
     transformByQState.appendToErrorLog(`Running command ${baseCommand} clean install`)
 
     // Note: IntelliJ runs 'clean' separately from 'install'. Evaluate benefits (if any) of this.
-    const args = [`-Dmaven.repo.local=${dependenciesFolder.path}`, 'clean', 'install']
+    const args = [`-Dmaven.repo.local=${dependenciesFolder.path}`, 'clean', 'install', '-q']
     let environment = process.env
     // if JAVA_HOME not found or not matching project JDK, get user input for it and set here
     if (transformByQState.getJavaHome() !== undefined) {
@@ -464,6 +464,7 @@ function copyProjectDependencies(dependenciesFolder: FolderInfo) {
         '-Dmdep.useRepositoryLayout=true',
         '-Dmdep.copyPom=true',
         '-Dmdep.addParentPoms=true',
+        '-q',
     ]
     let environment = process.env
     // if JAVA_HOME not found or not matching project JDK, get user input for it and set here


### PR DESCRIPTION
## Problem
The current mechanism to copy dependencies is faulty and often results in cases where dependencies are only partially copied or the command execution fails, both of which results in users being unable to transform their code.

## Solution
Using `mvn install` as the primary mechanism to copy dependencies. The order of execution is as follows:
1. Run `mvn dependency:copy-dependencies` to copy any locally persisted dependencies into an empty dependencies directory. We will continue execution even if this command fails as this is just an optimization to avoid downloading any locally available dependencies which can be copied with this command.
2. Run` mvn clean install` with the `-Dmaven.repo.local` arg pointing to the dependencies directory created in step 1. This is the primary command we are going to depend on to gather dependencies. If this command fails, fail the submission.

## Testing
Created a debug build with `npm run package -- --debug`. Used this to verify by running a test job that dependencies were generated and uploaded.

![Job screenshot](https://github.com/aws/aws-toolkit-vscode/assets/13169283/1b7fab5a-fdd0-45d3-8bee-5cf67ba1e804)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
