### PR TITLE
fix(ci): artifacts includes irrelevant files

### DIFF
--- a/buildspec/packageTestVsix.yml
+++ b/buildspec/packageTestVsix.yml
@@ -32,5 +32,5 @@ phases:
 
 artifacts:
     files:
-        - aws-toolkit-vscode*
+        - aws-toolkit-vscode*vsix
     discard-paths: true


### PR DESCRIPTION
Problem:
The build artifacts zip includes the `aws-toolkit-vscode.code-workspace` file.

Solution:
Adjust the include pattern.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
