### PR TITLE
fix: Temporarily disable amazon q tests

### DIFF
--- a/packages/core/src/testE2E/amazonq/featureDev.test.ts
+++ b/packages/core/src/testE2E/amazonq/featureDev.test.ts
@@ -12,7 +12,7 @@ import { examples } from '../../amazonqFeatureDev/userFacingText'
 import { registerAuthHook, using } from '../../test/setupUtil'
 import { loginToIdC } from './utils/setup'
 
-describe('Amazon Q Feature Dev', function () {
+describe.skip('Amazon Q Feature Dev', function () {
     let framework: qTestingFramework
 
     before(async function () {


### PR DESCRIPTION
## Problem
- The test infra isn't fully setup so these tests will always fail

## Solution
- Wait until the test infra is fully setup again before unskipping these tests

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
