### PR TITLE
fix: changeVersion is running out of memory

### DIFF
--- a/buildspec/release/10changeversion.yml
+++ b/buildspec/release/10changeversion.yml
@@ -1,5 +1,9 @@
 version: 0.2
 
+env:
+    variables:
+        NODE_OPTIONS: '--max-old-space-size=8192'
+
 phases:
     pre_build:
         commands:


### PR DESCRIPTION
## Problem:

In the release pipeline we are getting an error during this stage.

The phase `SetVersionForRelease` is showing this error:
`npm ERR! FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory`

## Solution:

Add more memory

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
