### PR TITLE
build: minify license headers

### DIFF
--- a/packages/webpack.base.config.js
+++ b/packages/webpack.base.config.js
@@ -101,6 +101,13 @@ const baseConfig = {
         minimizer: [
             new ESBuildMinifyPlugin({
                 target: 'es2021',
+                // Are these enabled by default?
+                // minify: true,
+                // treeShaking: true,
+
+                // De-duplicate license headers and list them at end of file.
+                legalComments: 'eof',
+                // sourcemap: 'external',
             }),
         ],
     },


### PR DESCRIPTION
Problem:
The webpack'd main.js is very big. "legal" comments are not removed by default, which bloats the code size.

Solution:
Set `legalComments=eof`. This de-duplicates license headers and lists them at the end of the file. Reduces the size by ~100 KiB.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
