### PR TITLE
telemetry: Add result: 'Succeeded' to all featureDev telemetry

### DIFF
--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -159,11 +159,13 @@ export class FeatureDevController {
                     telemetry.amazonq_codeGenerationThumbsUp.emit({
                         amazonqConversationId: session?.conversationId,
                         value: 1,
+                        result: 'Succeeded',
                     })
                 } else if (vote === 'downvote') {
                     telemetry.amazonq_codeGenerationThumbsDown.emit({
                         amazonqConversationId: session?.conversationId,
                         value: 1,
+                        result: 'Succeeded',
                     })
                 }
                 break

--- a/packages/core/src/amazonqFeatureDev/session/session.ts
+++ b/packages/core/src/amazonqFeatureDev/session/session.ts
@@ -116,7 +116,11 @@ export class Session {
         )
         this._latestMessage = ''
 
-        telemetry.amazonq_isApproachAccepted.emit({ amazonqConversationId: this.conversationId, enabled: true })
+        telemetry.amazonq_isApproachAccepted.emit({
+            amazonqConversationId: this.conversationId,
+            enabled: true,
+            result: 'Succeeded',
+        })
     }
 
     async send(msg: string): Promise<Interaction> {


### PR DESCRIPTION
## Problem
- A couple events were missing result: 'Succeeded'

## Solution
- Add it
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
