### PR TITLE
fix: respect test timeout for max duration

### DIFF
--- a/packages/core/src/test/setupUtil.ts
+++ b/packages/core/src/test/setupUtil.ts
@@ -51,7 +51,7 @@ export function setRunnableTimeout(test: Mocha.Runnable, maxTestDuration: number
         test.fn = fn
     }
 
-    Object.assign(test.fn!, { [runnableTimeout]: maxTestDuration })
+    Object.assign(test.fn!, { [runnableTimeout]: Math.max(maxTestDuration, test.timeout()) })
 
     return test
 }


### PR DESCRIPTION
## Problem
- Right now the max duration for e2e tests is always set to 300000 milliseconds. This presents a problem when certain e2e tests want a longer test timeout for retries to run, etc. This causes tests to always timeout at 300000 milliseconds regardless of whether or not a user has configured this.timeout in mocha.

## Solution
- Respect the max of the default max test duration and the timeout that the user has set inside of the test

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
