### PR TITLE
fix(amazonq): prompt input sends with enter when IME enabled

### DIFF
--- a/.changes/next-release/Bug Fix-b28584d3-e664-4851-9d25-0949db6ca0ac.json
+++ b/.changes/next-release/Bug Fix-b28584d3-e664-4851-9d25-0949db6ca0ac.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "Amazon Q: Fixed prompt input submit with enter if IME enabled (issues/4125), requires shift+enter while IME enabled"
+	"description": "Amazon Q: Fixed prompt input submit with enter if IME enabled [#4125](https://github.com/aws/aws-toolkit-vscode/issues/4125), requires shift+enter while IME enabled"
 }

--- a/.changes/next-release/Bug Fix-b28584d3-e664-4851-9d25-0949db6ca0ac.json
+++ b/.changes/next-release/Bug Fix-b28584d3-e664-4851-9d25-0949db6ca0ac.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Amazon Q: Fixed prompt input submit with enter if IME enabled (issues/4125), requires shift+enter while IME enabled"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3607,9 +3607,9 @@
             }
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.3.0.tgz",
-            "integrity": "sha512-ppu4APWVxqulO/xman2sCqy6C8V0a3RUagJejaOVkmY7HBEF86BC2pLN6gSDSUyJoCytVm+N3LNfBsksqn7WKg==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.3.2.tgz",
+            "integrity": "sha512-rGVBuW7j6+AA6jcI5K5fsI3S90oIHw3+UhpUfPIey9lukH/DdzhhYJfSVXXlrKF9KsMnEaWQSQsHsb3S9cKMHg==",
             "hasInstallScript": true,
             "dependencies": {
                 "marked": "^7.0.3",
@@ -18774,7 +18774,7 @@
                 "@aws-sdk/property-provider": "3.46.0",
                 "@aws-sdk/smithy-client": "^3.46.0",
                 "@aws-sdk/util-arn-parser": "^3.46.0",
-                "@aws/mynah-ui": "4.3.0",
+                "@aws/mynah-ui": "4.3.2",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
                 "@smithy/shared-ini-file-loader": "^2.2.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4309,7 +4309,7 @@
         "@aws-sdk/property-provider": "3.46.0",
         "@aws-sdk/smithy-client": "^3.46.0",
         "@aws-sdk/util-arn-parser": "^3.46.0",
-        "@aws/mynah-ui": "4.3.0",
+        "@aws/mynah-ui": "4.3.2",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
         "@smithy/shared-ini-file-loader": "^2.2.8",


### PR DESCRIPTION
## Problem
[Amazon Q chat input does not work well with IME enabled #4125](https://github.com/aws/aws-toolkit-vscode/issues/4125)
## Solution
Version [**4.3.2**](https://github.com/aws/mynah-ui/releases/tag/v4.3.2) of [mynah-ui](https://github.com/aws/mynah-ui) includes the check if the IME enabled when user hits enter while the prompt input is focused. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
