### PR TITLE
fix: Toolkit creates too many Output channels

### DIFF
--- a/packages/core/src/codewhisperer/commands/basicCommands.ts
+++ b/packages/core/src/codewhisperer/commands/basicCommands.ts
@@ -33,6 +33,7 @@ import { CodeWhispererSource } from './types'
 import { showManageConnections } from '../../auth/ui/vue/show'
 import { FeatureConfigProvider } from '../service/featureConfigProvider'
 import { TelemetryHelper } from '../util/telemetryHelper'
+import { isTextEditor } from '../../shared/utilities/editorUtilities'
 
 export const toggleCodeSuggestions = Commands.declare(
     { id: 'aws.codeWhisperer.toggleCodeSuggestion', compositeKey: { 1: 'source' } },
@@ -86,7 +87,7 @@ export const showSecurityScan = Commands.declare(
                 await AuthUtil.instance.notifyReauthenticate()
             }
             const editor = vscode.window.activeTextEditor
-            if (editor) {
+            if (editor && isTextEditor(editor)) {
                 if (codeScanState.isNotStarted()) {
                     // User intends to start as "Start Security Scan" is shown in the explorer tree
                     codeScanState.setToRunning()

--- a/packages/core/src/codewhisperer/commands/startSecurityScan.ts
+++ b/packages/core/src/codewhisperer/commands/startSecurityScan.ts
@@ -34,14 +34,26 @@ import { openUrl } from '../../shared/utilities/vsCodeUtils'
 import { AuthUtil } from '../util/authUtil'
 import { DependencyGraphConstants } from '../util/dependencyGraph/dependencyGraph'
 import path from 'path'
+import { once } from '../../shared/utilities/functionUtils'
 
 const performance = globalThis.performance ?? require('perf_hooks').performance
-const securityScanOutputChannel = vscode.window.createOutputChannel('CodeWhisperer Security Scan Logs')
-const codeScanLogger = makeLogger({
-    outputChannels: [securityScanOutputChannel],
-})
 const localize = nls.loadMessageBundle()
 export const stopScanButton = localize('aws.codewhisperer.stopscan', 'Stop Scan')
+
+/**
+ * Creates the vscode OutputChannel and Toolkit logger used by Security Scan, exactly once.
+ *
+ * To avoid cluttering the Output channels list, do not call this until it's actually needed.
+ *
+ * @returns Logger and OutputChannel created on the first invocation.
+ */
+const getLogOutputChan = once(() => {
+    const codeScanOutpuChan = vscode.window.createOutputChannel('CodeWhisperer Security Scan Logs')
+    const codeScanLogger = makeLogger({
+        outputChannels: [codeScanOutpuChan],
+    })
+    return [codeScanLogger, codeScanOutpuChan] as const
+})
 
 export function startSecurityScanWithProgress(
     securityPanelViewProvider: SecurityPanelViewProvider,
@@ -263,9 +275,10 @@ export function errorPromptHelper(error: Error) {
 }
 
 function populateCodeScanLogStream(scannedFiles: Set<string>) {
-    // Clear log
-    securityScanOutputChannel.clear()
+    const [codeScanLogger, codeScanOutpuChan] = getLogOutputChan()
     const numScannedFiles = scannedFiles.size
+    // Clear log
+    codeScanOutpuChan.clear()
     if (numScannedFiles === 1) {
         codeScanLogger.info(`${numScannedFiles} file was scanned during the last Security Scan.`)
     } else {
@@ -276,6 +289,7 @@ function populateCodeScanLogStream(scannedFiles: Set<string>) {
         const uri = vscode.Uri.file(file)
         codeScanLogger.info(`File scanned: ${uri.fsPath}`)
     }
+    codeScanOutpuChan.show()
 }
 
 export async function confirmStopSecurityScan() {
@@ -287,7 +301,7 @@ export async function confirmStopSecurityScan() {
     }
 }
 
-export function showScanCompletedNotification(total: number, scannedFiles: Set<string>, isProjectTruncated: boolean) {
+function showScanCompletedNotification(total: number, scannedFiles: Set<string>, isProjectTruncated: boolean) {
     const totalFiles = `${scannedFiles.size} ${scannedFiles.size === 1 ? 'file' : 'files'}`
     const totalIssues = `${total} ${total === 1 ? 'issue was' : 'issues were'}`
     const fileSizeLimitReached = isProjectTruncated ? 'File size limit reached.' : ''
@@ -303,7 +317,8 @@ export function showScanCompletedNotification(total: number, scannedFiles: Set<s
         )
         .then(value => {
             if (value === CodeWhispererConstants.showScannedFilesMessage) {
-                void vscode.commands.executeCommand(CodeWhispererConstants.codeScanLogsOutputChannelId)
+                const [, codeScanOutpuChan] = getLogOutputChan()
+                codeScanOutpuChan.show()
             } else if (value === learnMore) {
                 void openUrl(vscode.Uri.parse(CodeWhispererConstants.securityScanLearnMoreUri))
             }

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -264,15 +264,6 @@ export const connectionExpired = `Connection expired. To continue using Amazon Q
 
 export const DoNotShowAgain = `Don\'t Show Again`
 
-// Not const so that tests can set replace this with aws-core-vscode dummy extension name.
-// Temporary until we can move this out of the core library.
-export let codeScanLogsOutputChannelId =
-    'workbench.action.output.show.extension-output-amazonwebservices.aws-toolkit-vscode-#1-CodeWhisperer Security Scan Logs'
-
-export function setCodeScanLogsOutputChannelId(val: string) {
-    codeScanLogsOutputChannelId = val
-}
-
 export const stopScanMessage =
     'Stop security scan? This scan will be counted as one complete scan towards your monthly security scan limits.'
 

--- a/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -51,6 +51,7 @@ import { listCodeWhispererCommands } from '../../../codewhisperer/ui/statusBarMe
 import { CodeSuggestionsState } from '../../../codewhisperer/models/model'
 import { cwQuickPickSource } from '../../../codewhisperer/commands/types'
 import { switchToAmazonQNode } from '../../../amazonq/explorer/amazonQChildrenNodes'
+import { isTextEditor } from '../../../shared/utilities/editorUtilities'
 
 describe('CodeWhisperer-basicCommands', function () {
     let targetCommand: Command<any> & vscode.Disposable
@@ -215,7 +216,7 @@ describe('CodeWhisperer-basicCommands', function () {
 
             sinon.stub(AuthUtil.instance, 'isConnectionExpired').returns(false)
 
-            assert.ok(vscode.window.activeTextEditor === undefined)
+            assert.ok(!vscode.window.activeTextEditor || !isTextEditor(vscode.window.activeTextEditor))
             await targetCommand.execute(placeholder, cwQuickPickSource)
             assert.strictEqual(getTestWindow().shownMessages[0].message, 'Open a valid file to scan.')
         })

--- a/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/startSecurityScan.test.ts
@@ -20,11 +20,7 @@ import { HttpResponse } from 'aws-sdk'
 import { getTestWindow } from '../../shared/vscode/window'
 import { SeverityLevel } from '../../shared/vscode/message'
 import { cancel } from '../../../shared/localizedText'
-import {
-    codeScanLogsOutputChannelId,
-    showScannedFilesMessage,
-    stopScanMessage,
-} from '../../../codewhisperer/models/constants'
+import { showScannedFilesMessage, stopScanMessage } from '../../../codewhisperer/models/constants'
 import * as model from '../../../codewhisperer/models/model'
 import { CodewhispererSecurityScan } from '../../../shared/telemetry/telemetry.gen'
 import { getFetchStubWithResponse } from '../../common/request.test'
@@ -246,7 +242,6 @@ describe('startSecurityScan', function () {
         if (semver.lt(vscode.version, '1.78.0')) {
             this.skip()
         }
-        const commandSpy = sinon.spy(vscode.commands, 'executeCommand')
         getFetchStubWithResponse({ status: 200, statusText: 'testing stub' })
         const testWindow = getTestWindow()
         testWindow.onDidShowMessage(message => {
@@ -260,7 +255,6 @@ describe('startSecurityScan', function () {
             createClient(),
             extensionContext
         )
-        assert.ok(commandSpy.calledWith(codeScanLogsOutputChannelId))
         assertTelemetry('codewhisperer_securityScan', {
             codewhispererLanguage: 'python',
             codewhispererCodeScanTotalIssues: 1,

--- a/packages/core/src/test/globalSetup.test.ts
+++ b/packages/core/src/test/globalSetup.test.ts
@@ -26,7 +26,6 @@ import { getTestWindow, resetTestWindow } from './shared/vscode/window'
 import { mapTestErrors, normalizeError, setRunnableTimeout } from './setupUtil'
 import { TelemetryDebounceInfo } from '../shared/vscode/commands2'
 import { disableAwsSdkWarning } from '../shared/awsClientBuilder'
-import { setCodeScanLogsOutputChannelId, codeScanLogsOutputChannelId } from '../codewhisperer/models/constants'
 
 disableAwsSdkWarning()
 
@@ -53,9 +52,6 @@ export async function mochaGlobalSetup(this: Mocha.Runner) {
     // Extension activation has many side-effects such as changing globals
     // For stability in tests we will wait until the extension has activated prior to injecting mocks
     const activationLogger = (msg: string, ...meta: any[]) => console.log(format(msg, ...meta))
-    setCodeScanLogsOutputChannelId(
-        codeScanLogsOutputChannelId.replace(VSCODE_EXTENSION_ID.awstoolkit, VSCODE_EXTENSION_ID.awstoolkitcore)
-    )
     await activateExtension(VSCODE_EXTENSION_ID.awstoolkitcore, false, activationLogger)
     const fakeContext = await FakeExtensionContext.create()
     fakeContext.globalStorageUri = (await testUtil.createTestWorkspaceFolder('globalStoragePath')).uri

--- a/packages/core/src/testInteg/globalSetup.test.ts
+++ b/packages/core/src/testInteg/globalSetup.test.ts
@@ -13,7 +13,6 @@ import { WinstonToolkitLogger } from '../shared/logger/winstonToolkitLogger'
 import { activateExtension } from '../shared/utilities/vsCodeUtils'
 import { mapTestErrors, normalizeError, patchObject, setRunnableTimeout } from '../test/setupUtil'
 import { getTestWindow, resetTestWindow } from '../test/shared/vscode/window'
-import { setCodeScanLogsOutputChannelId, codeScanLogsOutputChannelId } from '../codewhisperer/models/constants'
 
 // ASSUMPTION: Tests are not run concurrently
 
@@ -34,9 +33,6 @@ export async function mochaGlobalSetup(this: Mocha.Runner) {
     patchWindow()
 
     // Needed for getLogger().
-    setCodeScanLogsOutputChannelId(
-        codeScanLogsOutputChannelId.replace(VSCODE_EXTENSION_ID.awstoolkit, VSCODE_EXTENSION_ID.awstoolkitcore)
-    )
     await activateExtension(VSCODE_EXTENSION_ID.awstoolkitcore, false)
 
     // Log as much as possible, useful for debugging integration tests.

--- a/packages/core/src/testWeb/testRunner.ts
+++ b/packages/core/src/testWeb/testRunner.ts
@@ -10,7 +10,6 @@
 import 'mocha' // Imports mocha for the browser, defining the `mocha` global.
 import * as vscode from 'vscode'
 import { VSCODE_EXTENSION_ID } from '../shared/extensions'
-import { setCodeScanLogsOutputChannelId, codeScanLogsOutputChannelId } from '../codewhisperer/models/constants'
 
 export async function run(): Promise<void> {
     await activateToolkitExtension()
@@ -47,9 +46,6 @@ function gatherTestFiles() {
  * So this function ensures the extension has fully activated.
  */
 async function activateToolkitExtension() {
-    setCodeScanLogsOutputChannelId(
-        codeScanLogsOutputChannelId.replace(VSCODE_EXTENSION_ID.awstoolkit, VSCODE_EXTENSION_ID.awstoolkitcore)
-    )
     await vscode.extensions.getExtension(VSCODE_EXTENSION_ID.awstoolkitcore)?.activate()
 }
 


### PR DESCRIPTION
## Problem

- UI cost: Security Scan feature creates vscode Output channel on startup. This is unnecessary for users that aren't currently using that feature.
    - ![image](https://github.com/aws/aws-toolkit-vscode/assets/55561878/e7e2437e-3dbc-4c4c-80a4-918a27558cd3)


## Solution

- create Security Scan channel on-demand, instead of in module-scope.
    - ![image](https://github.com/aws/aws-toolkit-vscode/assets/55561878/405feaaa-405b-4bbc-b3b1-bb98889cbe49)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
