### PR TITLE
perf(ssm,stepfunctions): start LSP clients/servers lazily

### DIFF
--- a/.changes/next-release/Feature-2d9d80f7-b515-47ff-9cbd-514efb4cca49.json
+++ b/.changes/next-release/Feature-2d9d80f7-b515-47ff-9cbd-514efb4cca49.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Improved performance: SSM Documents and Step Functions LSP clients/servers are now started only when they are needed."
+}

--- a/packages/core/src/ssmDocument/activation.ts
+++ b/packages/core/src/ssmDocument/activation.ts
@@ -16,6 +16,8 @@ import { deleteDocument } from './commands/deleteDocument'
 import { DocumentItemNodeWriteable } from './explorer/documentItemNodeWriteable'
 import { updateDocumentVersion } from './commands/updateDocumentVersion'
 import { Commands } from '../shared/vscode/commands2'
+import * as constants from '../shared/constants'
+import { PerfLog } from '../shared/logger/logger'
 
 // Activate SSM Document related functionality for the extension.
 export async function activate(
@@ -25,7 +27,19 @@ export async function activate(
     outputChannel: vscode.OutputChannel
 ): Promise<void> {
     await registerSsmDocumentCommands(extensionContext, awsContext, regionProvider, outputChannel)
-    await activateSSMLanguageServer(extensionContext)
+
+    let onDidOpenSsmDoc: vscode.Disposable
+    // PERFORMANCE: Start the LSP client/server _only_ when the first SSM document is opened.
+    // eslint-disable-next-line prefer-const
+    onDidOpenSsmDoc = vscode.window.onDidChangeActiveTextEditor(async e => {
+        if (e?.document.languageId === constants.ssmJson || e?.document.languageId === constants.ssmYaml) {
+            const perflog = new PerfLog('ssmDocument: start LSP client/server')
+            await activateSSMLanguageServer(extensionContext)
+            perflog.done()
+            onDidOpenSsmDoc?.dispose() // Handler should only run once.
+        }
+    })
+    extensionContext.subscriptions.push(onDidOpenSsmDoc)
 }
 
 async function registerSsmDocumentCommands(

--- a/packages/core/src/ssmDocument/ssm/ssmClient.ts
+++ b/packages/core/src/ssmDocument/ssm/ssmClient.ts
@@ -51,6 +51,9 @@ async function getLanguageServerDebuggerPort(extensionContext: ExtensionContext)
     return getPortPromise({ port: port })
 }
 
+/**
+ * Starts the SSM Documents LSP client/server and creates related resources (vscode `OutputChannel`).
+ */
 export async function activate(extensionContext: ExtensionContext) {
     const toDispose = extensionContext.subscriptions
 

--- a/packages/core/src/stepFunctions/asl/client.ts
+++ b/packages/core/src/stepFunctions/asl/client.ts
@@ -51,6 +51,10 @@ interface Settings {
     }
 }
 
+/**
+ * Starts the ASL LSP client/server and creates related resources (vscode `OutputChannel`,
+ * `registerDocumentRangeFormattingEditProvider`, …).
+ */
 export async function activate(extensionContext: ExtensionContext) {
     const config = new StepFunctionsSettings()
     const toDispose = extensionContext.subscriptions


### PR DESCRIPTION
## Problem

Toolkit starts LSP servers eagerly on startup, which slows startup (even for users that never use the SSM Documents or StepFunctions features).

## Solution

- Start SSM Documents LSP client/server on first use, instead of on startup.
- Start StepFunctions LSP client/server on first use, instead of on startup.
- This also avoids 2 unnecessary Output channels (see https://github.com/aws/aws-toolkit-vscode/pull/4527).

before:

    | Extension                            | Eager | Load Code | Call Activate | Finish Activate | Event                          | By                                   |
    | ------------------------------------ | ----- | --------- | ------------- | --------------- | ------------------------------ | ------------------------------------ |
    | amazonwebservices.aws-toolkit-vscode | false | 210       | 0             | 1303            | onStartupFinished              | amazonwebservices.aws-toolkit-vscode |

after:

    | Extension                            | Eager | Load Code | Call Activate | Finish Activate | Event                          | By                                   |
    | ------------------------------------ | ----- | --------- | ------------- | --------------- | ------------------------------ | ------------------------------------ |
    | amazonwebservices.aws-toolkit-vscode | false | 213       | 0             | 1184            | onStartupFinished              | amazonwebservices.aws-toolkit-vscode |


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
