### PR TITLE
codewhisperer: add auto scans trigger

### DIFF
--- a/packages/core/src/codewhisperer/activation.ts
+++ b/packages/core/src/codewhisperer/activation.ts
@@ -9,7 +9,7 @@ import { KeyStrokeHandler } from './service/keyStrokeHandler'
 import * as EditorContext from './util/editorContext'
 import * as CodeWhispererConstants from './models/constants'
 import { getCompletionItems } from './service/completionProvider'
-import { vsCodeState, ConfigurationEntry, CodeSuggestionsState } from './models/model'
+import { vsCodeState, ConfigurationEntry, CodeSuggestionsState, CodeScansState } from './models/model'
 import { invokeRecommendation } from './commands/invokeRecommendation'
 import { acceptSuggestion } from './commands/onInlineAcceptance'
 import { resetIntelliSenseState } from './util/globalStateUtil'
@@ -40,6 +40,7 @@ import {
     signoutCodeWhisperer,
     showManageCwConnections,
     fetchFeatureConfigsCmd,
+    toggleCodeScans,
 } from './commands/basicCommands'
 import { sleep } from '../shared/utilities/timeoutUtils'
 import { ReferenceLogViewProvider } from './service/referenceLogViewProvider'
@@ -177,6 +178,8 @@ export async function activate(context: ExtContext): Promise<void> {
         connectWithCustomization.register(),
         // toggle code suggestions
         toggleCodeSuggestions.register(CodeSuggestionsState.instance),
+        // toggle code scans
+        toggleCodeScans.register(CodeScansState.instance),
         // enable code suggestions
         enableCodeSuggestions.register(context),
         // code scan

--- a/packages/core/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
+++ b/packages/core/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
@@ -91,7 +91,7 @@ export function createAutoScans(type: 'item' | 'tree', pause: boolean): any {
             return {
                 data: 'autoScans',
                 label: pause ? codicon`${iconPause} ${labelPause}` : codicon`${iconResume} ${labelResume}`,
-                description: pause ? 'Currently RUNNING' : 'Currently PAUSED',
+                description: pause ? 'RUNNING' : 'PAUSED',
                 onClick: () => toggleCodeScans.execute(placeholder, cwQuickPickSource),
             } as DataQuickPickItem<'autoScans'>
     }

--- a/packages/core/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
+++ b/packages/core/src/codewhisperer/explorer/codewhispererChildrenNodes.ts
@@ -20,6 +20,7 @@ import {
     selectCustomizationPrompt,
     signoutCodeWhisperer,
     showManageCwConnections,
+    toggleCodeScans,
 } from '../commands/basicCommands'
 import { CodeWhispererCommandDeclarations } from '../commands/gettingStartedPageCommands'
 import { codeScanState } from '../models/model'
@@ -58,6 +59,41 @@ export function createAutoSuggestions(type: 'item' | 'tree', pause: boolean): an
                 description: pause ? 'Currently RUNNING' : 'Currently PAUSED',
                 onClick: () => toggleCodeSuggestions.execute(placeholder, cwQuickPickSource),
             } as DataQuickPickItem<'autoSuggestions'>
+    }
+}
+
+export function createAutoScans(type: 'item', pause: boolean): DataQuickPickItem<'autoScans'>
+export function createAutoScans(type: 'tree', pause: boolean): TreeNode<Command>
+export function createAutoScans(
+    type: 'item' | 'tree',
+    pause: boolean
+): DataQuickPickItem<'autoScans'> | TreeNode<Command>
+export function createAutoScans(type: 'item' | 'tree', pause: boolean): any {
+    const labelResume = localize('AWS.codewhisperer.resumeCodeWhispererNode.label', 'Resume Auto-Scans')
+    const iconResume = getIcon('vscode-debug-alt')
+    const labelPause = localize('AWS.codewhisperer.pauseCodeWhispererNode.label', 'Pause Auto-Scans')
+    const iconPause = getIcon('vscode-debug-pause')
+
+    switch (type) {
+        case 'tree':
+            return toggleCodeScans.build(placeholder, cwTreeNodeSource).asTreeNode(
+                pause
+                    ? {
+                          label: labelPause,
+                          iconPath: iconPause,
+                      }
+                    : {
+                          label: labelResume,
+                          iconPath: iconResume,
+                      }
+            )
+        case 'item':
+            return {
+                data: 'autoScans',
+                label: pause ? codicon`${iconPause} ${labelPause}` : codicon`${iconResume} ${labelResume}`,
+                description: pause ? 'Currently RUNNING' : 'Currently PAUSED',
+                onClick: () => toggleCodeScans.execute(placeholder, cwQuickPickSource),
+            } as DataQuickPickItem<'autoScans'>
     }
 }
 

--- a/packages/core/src/codewhisperer/explorer/codewhispererNode.ts
+++ b/packages/core/src/codewhisperer/explorer/codewhispererNode.ts
@@ -16,13 +16,14 @@ import {
     createGettingStarted,
     createSignout,
     createSeparator,
+    createAutoScans,
 } from './codewhispererChildrenNodes'
 import { Command, Commands } from '../../shared/vscode/commands2'
 import { hasVendedIamCredentials } from '../../auth/auth'
 import { AuthUtil } from '../util/authUtil'
 import { ResourceTreeDataProvider, TreeNode } from '../../shared/treeview/resourceTreeDataProvider'
 import { DataQuickPickItem } from '../../shared/ui/pickerPrompter'
-import { CodeSuggestionsState } from '../models/model'
+import { CodeScansState, CodeSuggestionsState } from '../models/model'
 
 export class CodeWhispererNode implements TreeNode {
     public readonly id = 'codewhisperer'
@@ -81,6 +82,7 @@ export class CodeWhispererNode implements TreeNode {
     public getChildren(type: 'tree' | 'item' = 'tree'): any[] {
         const _getChildren = () => {
             const autoTriggerEnabled = CodeSuggestionsState.instance.isSuggestionsEnabled()
+            const autoScansEnabled = CodeScansState.instance.isScansEnabled()
             if (AuthUtil.instance.isConnectionExpired()) {
                 return [createReconnect(type), createLearnMore(type)]
             }
@@ -91,7 +93,12 @@ export class CodeWhispererNode implements TreeNode {
                 if (hasVendedIamCredentials()) {
                     return [createFreeTierLimitMet(type), createOpenReferenceLog(type)]
                 } else {
-                    return [createFreeTierLimitMet(type), createSecurityScan(type), createOpenReferenceLog(type)]
+                    return [
+                        createFreeTierLimitMet(type),
+                        createSecurityScan(type),
+                        createAutoScans(type, autoScansEnabled),
+                        createOpenReferenceLog(type),
+                    ]
                 }
             } else {
                 if (hasVendedIamCredentials()) {
@@ -103,6 +110,7 @@ export class CodeWhispererNode implements TreeNode {
                     ) {
                         return [
                             createAutoSuggestions(type, autoTriggerEnabled),
+                            createAutoScans(type, autoScansEnabled),
                             createSecurityScan(type),
                             createSelectCustomization(type),
                             createOpenReferenceLog(type),
@@ -111,6 +119,7 @@ export class CodeWhispererNode implements TreeNode {
                     }
                     return [
                         createAutoSuggestions(type, autoTriggerEnabled),
+                        createAutoScans(type, autoScansEnabled),
                         createSecurityScan(type),
                         createOpenReferenceLog(type),
                         createGettingStarted(type), // "Learn" node : opens Learn CodeWhisperer page

--- a/packages/core/src/codewhisperer/models/constants.ts
+++ b/packages/core/src/codewhisperer/models/constants.ts
@@ -30,6 +30,12 @@ export const autoSuggestionConfig = {
     deactivated: 'Deactivated',
 }
 
+export const autoScansConfig = {
+    settingId: 'codewhisperer_autoScansActivation',
+    activated: 'Activated',
+    deactivated: 'Deactivated',
+}
+
 /**
  * EditorCon context
  */
@@ -136,6 +142,8 @@ export const unsupportedLanguagesCacheTTL = 10 * 60 * 60 * 1000
 export const unsupportedLanguagesKey = 'CODEWHISPERER_UNSUPPORTED_LANGUAGES_KEY'
 
 export const autoTriggerEnabledKey = 'CODEWHISPERER_AUTO_TRIGGER_ENABLED'
+
+export const autoScansEnabledKey = 'CODEWHISPERER_AUTO_SCANS_ENABLED'
 
 export const serviceActiveKey = 'CODEWHISPERER_SERVICE_ACTIVE'
 
@@ -440,3 +448,8 @@ export const utgConfig = {
 }
 
 export const transformTreeNode = 'qTreeNode'
+
+export enum SecurityScanType {
+    File = 'File',
+    Project = 'Project',
+}

--- a/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
+++ b/packages/core/src/test/codewhisperer/commands/basicCommands.test.ts
@@ -32,6 +32,7 @@ import { MockDocument } from '../../fake/fakeDocument'
 import { FileSystemCommon } from '../../../srcShared/fs'
 import { getLogger } from '../../../shared/logger/logger'
 import {
+    createAutoScans,
     createAutoSuggestions,
     createGettingStarted,
     createLearnMore,
@@ -329,6 +330,7 @@ describe('CodeWhisperer-basicCommands', function () {
             getTestWindow().onDidShowQuickPick(e => {
                 e.assertItems([
                     createAutoSuggestions('item', false),
+                    createAutoScans('item', false),
                     createSecurityScan('item'),
                     createOpenReferenceLog('item'),
                     createGettingStarted('item'),
@@ -349,6 +351,7 @@ describe('CodeWhisperer-basicCommands', function () {
             getTestWindow().onDidShowQuickPick(e => {
                 e.assertItems([
                     createAutoSuggestions('item', false),
+                    createAutoScans('item', false),
                     createSecurityScan('item'),
                     createSelectCustomization('item'),
                     createOpenReferenceLog('item'),

--- a/packages/core/src/test/codewhisperer/explorer/codewhispererNode.test.ts
+++ b/packages/core/src/test/codewhisperer/explorer/codewhispererNode.test.ts
@@ -109,6 +109,7 @@ describe('codewhispererNode', function () {
             const ids = node.getChildren().map(o => o.resource.id)
             assert.deepStrictEqual(ids, [
                 'aws.codeWhisperer.toggleCodeSuggestion',
+                'aws.codeWhisperer.toggleCodeScan',
                 'aws.codeWhisperer.security.scan',
                 'aws.codeWhisperer.openReferencePanel',
                 'aws.codeWhisperer.gettingStarted',


### PR DESCRIPTION
## Problem

Users should be able to enable/disable auto scanning feature

## Solution

Add Pause/Resume button for auto scans

<img width="343" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/16008563/95bfec5b-a933-4423-a120-2df21f02bf61">


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
