### PR TITLE
chore: Re-enable amazon q e2e tests

### DIFF
--- a/packages/core/src/testE2E/amazonq/featureDev.test.ts
+++ b/packages/core/src/testE2E/amazonq/featureDev.test.ts
@@ -14,7 +14,7 @@ import { FollowUpTypes } from '../../amazonqFeatureDev/types'
 import { examples, newTaskChanges, sessionClosed } from '../../amazonqFeatureDev/userFacingText'
 import { ChatItem } from '@aws/mynah-ui'
 
-describe.skip('Amazon Q Feature Dev', function () {
+describe('Amazon Q Feature Dev', function () {
     let framework: qTestingFramework
     let tab: Messenger
 


### PR DESCRIPTION
## Problem
- We disabled the tests because the infra to run them wasn't fully set up yet

## Solution
- Remove the skip now that the infra is setup

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
