### PR TITLE
Q CodeTransform: Emit projectId telemetry when starting new transformation.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3556,9 +3556,9 @@
             }
         },
         "node_modules/@aws-toolkits/telemetry": {
-            "version": "1.0.193",
-            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.193.tgz",
-            "integrity": "sha512-j2SgGPeM7d4jTO5mHRUVR0SS7x3+REBocuAitV6pY0evre8CGEoZ1NPK0kM2DYC12m/QtxhJ2AhtbrO+s/u6iw==",
+            "version": "1.0.196",
+            "resolved": "https://registry.npmjs.org/@aws-toolkits/telemetry/-/telemetry-1.0.196.tgz",
+            "integrity": "sha512-DU2Jeyaw+1aowIJKXntKJUIiknUFbFFzDOCksTY5LhtTNhbyanYVi91rggVYDDadQEWht0Lf9VaYffbxec6rHw==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.6",
@@ -18819,7 +18819,7 @@
             },
             "devDependencies": {
                 "@aws-sdk/types": "^3.13.1",
-                "@aws-toolkits/telemetry": "^1.0.193",
+                "@aws-toolkits/telemetry": "^1.0.196",
                 "@aws/fully-qualified-names": "^2.1.4",
                 "@cspotcode/source-map-support": "^0.8.1",
                 "@sinonjs/fake-timers": "^10.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4241,7 +4241,7 @@
     },
     "devDependencies": {
         "@aws-sdk/types": "^3.13.1",
-        "@aws-toolkits/telemetry": "^1.0.193",
+        "@aws-toolkits/telemetry": "^1.0.196",
         "@aws/fully-qualified-names": "^2.1.4",
         "@cspotcode/source-map-support": "^0.8.1",
         "@sinonjs/fake-timers": "^10.0.2",

--- a/packages/core/src/amazonqGumby/telemetry/codeTransformTelemetry.ts
+++ b/packages/core/src/amazonqGumby/telemetry/codeTransformTelemetry.ts
@@ -16,6 +16,8 @@ import * as CodeWhispererConstants from '../../codewhisperer/models/constants'
 import { codeTransformTelemetryState } from './codeTransformTelemetryState'
 import { MetadataResult } from '../../shared/telemetry/telemetryClient'
 
+export const telemetryUndefined = 'undefined'
+
 export enum CancelActionPositions {
     ApiError = 'apiError',
     LoadingPanel = 'loadingPanelStopButton',

--- a/packages/core/src/auth/secondaryAuth.ts
+++ b/packages/core/src/auth/secondaryAuth.ts
@@ -159,9 +159,12 @@ export class SecondaryAuth<T extends Connection = Connection> {
     public get isConnectionExpired() {
         if (this.activeConnection) {
             getLogger().info(
-                indent(`secondaryAuth connection id = ${this.activeConnection.id}
+                indent(
+                    `secondaryAuth connection id = ${this.activeConnection.id}
             secondaryAuth connection status = ${this.auth.getConnectionState(this.activeConnection)}`,
-            4, true)
+                    4,
+                    true
+                )
             )
         }
         return !!this.activeConnection && this.auth.getConnectionState(this.activeConnection) === 'invalid'

--- a/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
+++ b/packages/core/src/auth/sso/ssoAccessTokenProvider.ts
@@ -87,9 +87,13 @@ export class SsoAccessTokenProvider {
     public async getToken(): Promise<SsoToken | undefined> {
         const data = await this.cache.token.load(this.tokenCacheKey)
         getLogger().info(
-            indent(`current client registration id=${data?.registration?.clientId}, 
+            indent(
+                `current client registration id=${data?.registration?.clientId}, 
                             expires at ${data?.registration?.expiresAt}, 
-                            key = ${this.tokenCacheKey}`, 4, true)
+                            key = ${this.tokenCacheKey}`,
+                4,
+                true
+            )
         )
         if (!data || !isExpired(data.token)) {
             return data?.token

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -41,6 +41,7 @@ import {
     CancelActionPositions,
     JDKToTelemetryValue,
     calculateTotalLatency,
+    telemetryUndefined,
 } from '../../amazonqGumby/telemetry/codeTransformTelemetry'
 import { MetadataResult } from '../../shared/telemetry/telemetryClient'
 
@@ -443,7 +444,7 @@ export async function setTransformationToRunningState(userInputState: UserInputS
     codeTransformTelemetryState.setStartTime()
 
     const projectPath = userInputState.project?.label
-    let projectId = 'undefined'
+    let projectId = telemetryUndefined
     if (projectPath !== undefined) {
         projectId = getStringHash(projectPath)
     }

--- a/packages/core/src/codewhisperer/commands/startTransformByQ.ts
+++ b/packages/core/src/codewhisperer/commands/startTransformByQ.ts
@@ -28,7 +28,7 @@ import { QuickPickItem } from 'vscode'
 import { MultiStepInputFlowController } from '../../shared//multiStepInputFlowController'
 import path from 'path'
 import { sleep } from '../../shared/utilities/timeoutUtils'
-import { encodeHTML } from '../../shared/utilities/textUtilities'
+import { encodeHTML, getStringHash } from '../../shared/utilities/textUtilities'
 import {
     CodeTransformJavaSourceVersionsAllowed,
     CodeTransformJavaTargetVersionsAllowed,
@@ -93,6 +93,7 @@ async function collectInput(validProjects: Map<vscode.QuickPickItem, JDKVersion 
                 transformByQState.getTargetJDKVersion()
             ) as CodeTransformJavaTargetVersionsAllowed,
             result: MetadataResult.Fail,
+            codeTransformProjectId: getStringHash(state.project.label),
         })
         await vscode.window.showErrorMessage(CodeWhispererConstants.unsupportedJavaVersionSelectedMessage, {
             modal: true,
@@ -441,6 +442,12 @@ export async function setTransformationToRunningState(userInputState: UserInputS
 
     codeTransformTelemetryState.setStartTime()
 
+    const projectPath = userInputState.project?.label
+    let projectId = 'undefined'
+    if (projectPath !== undefined) {
+        projectId = getStringHash(projectPath)
+    }
+
     telemetry.codeTransform_jobStartedCompleteFromPopupDialog.emit({
         codeTransformSessionId: codeTransformTelemetryState.getSessionId(),
         codeTransformJavaSourceVersionsAllowed: JDKToTelemetryValue(
@@ -449,6 +456,7 @@ export async function setTransformationToRunningState(userInputState: UserInputS
         codeTransformJavaTargetVersionsAllowed: JDKToTelemetryValue(
             transformByQState.getTargetJDKVersion()
         ) as CodeTransformJavaTargetVersionsAllowed,
+        codeTransformProjectId: projectId,
         result: MetadataResult.Pass,
     })
 

--- a/packages/core/src/codewhisperer/service/transformByQHandler.ts
+++ b/packages/core/src/codewhisperer/service/transformByQHandler.ts
@@ -786,6 +786,7 @@ export async function pollTransformationJob(jobId: string, validStates: string[]
                     codeTransformJobId: jobId,
                     codeTransformStatus: status,
                     result: MetadataResult.Pass,
+                    codeTransformPreviousStatus: transformByQState.getPolledJobStatus(),
                 })
             }
             transformByQState.setPolledJobStatus(status)


### PR DESCRIPTION
## Problem
It is complicated to track if failures when running Q CodeTransform on customer machines are due to repeated tries of the same project or for different projects. This complicates for us to understand if errors we see are only for specific projects or for all projects for a specific clientId.

## Solution
Emit a projectHash that uniquely identifies the project selected for transform by a user. This allows us to differentiate between repeated submissions of the same project or unique submissions of different projects. Thus allowing us to fix issues faster.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
