### PR TITLE
fix(cwspr): Fix cw api call failure in sm code editor

### DIFF
--- a/.changes/next-release/Bug Fix-d70cbb8e-491a-439e-9cbb-b155431e3743.json
+++ b/.changes/next-release/Bug Fix-d70cbb8e-491a-439e-9cbb-b155431e3743.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Fix CodeWhisperer API call failure in SageMaker Code Editor"
+}

--- a/packages/core/src/codewhisperer/service/recommendationHandler.ts
+++ b/packages/core/src/codewhisperer/service/recommendationHandler.ts
@@ -181,7 +181,7 @@ export class RecommendationHandler {
         ).language
         session.taskType = await this.getTaskTypeFromEditorFileName(editor.document.fileName)
 
-        if (pagination) {
+        if (pagination && !isSM) {
             if (page === 0) {
                 session.requestContext = await EditorContext.buildListRecommendationRequest(
                     editor as vscode.TextEditor,
@@ -198,7 +198,7 @@ export class RecommendationHandler {
                     supplementalMetadata: session.requestContext.supplementalMetadata,
                 }
             }
-        } else if (!pagination) {
+        } else {
             session.requestContext = await EditorContext.buildGenerateRecommendationRequest(editor as vscode.TextEditor)
         }
         const request = session.requestContext.request


### PR DESCRIPTION
## Problem

In Sage Maker Code Editor, CWSPR should create request in type GenerateRecommendation for SigV4 API invocation. Otherwise there will be a Unexpected key 'optOutPreference' found in params

## Solution

Add extra if else for Sage Maker Code Editor to let the recommendation Handler use GenerateRecommendation Request payload instead of using the ListRecommendation. 

Tested in SageMaker Code Editor and it works. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
