### PR TITLE
fix: Disable the main toolkit extension when launching tests in core

### DIFF
--- a/packages/core/.vscode/launch.json
+++ b/packages/core/.vscode/launch.json
@@ -48,6 +48,7 @@
             "debugWebWorkerHost": true,
             "request": "launch",
             "args": [
+                "--disable-extension=amazonwebservices.aws-toolkit-vscode",
                 "--extensionDevelopmentPath=${workspaceFolder}",
                 "--extensionDevelopmentKind=web",
                 "--extensionTestsPath=${workspaceFolder}/dist/src/testWeb/testRunner",
@@ -63,6 +64,7 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": [
+                "--disable-extension=amazonwebservices.aws-toolkit-vscode",
                 "${workspaceFolder}/dist/src/testFixtures/workspaceFolder",
                 "--extensionDevelopmentPath=${workspaceFolder}",
                 "--extensionTestsPath=${workspaceFolder}/dist/src/testInteg/index.js"
@@ -80,6 +82,7 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": [
+                "--disable-extension=amazonwebservices.aws-toolkit-vscode",
                 "${workspaceFolder}/dist/src/testFixtures/workspaceFolder",
                 "--extensionDevelopmentPath=${workspaceFolder}",
                 "--extensionTestsPath=${workspaceFolder}/dist/src/testInteg/index.js"
@@ -98,6 +101,7 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": [
+                "--disable-extension=amazonwebservices.aws-toolkit-vscode",
                 "${workspaceFolder}/dist/src/testFixtures/workspaceFolder",
                 "--extensionDevelopmentPath=${workspaceFolder}",
                 "--extensionTestsPath=${workspaceFolder}/dist/src/testE2E/index.js"


### PR DESCRIPTION
## Problem
- When launching tests in "core" there is a registration conflict when you have the current toolkit installed locally and the tests are running/loading in the extension host. This seems to be because the tests are launching under the "core" id/version of the toolkit so instead of replacing the toolkit extension itself when loading in the extension host it runs a second seperate extension instance. This means that the "core" toolkit and the actual toolkit are running inside of the extension host at the same time, causing registration conflicts

## Solution
- Just disable the toolkit extension that comes from the local instance when debugging

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
